### PR TITLE
Voldemort persistence with BDB removed as a test-runtime dependency

### DIFF
--- a/akka-persistence/akka-persistence-voldemort/src/test/resources/config/server.properties
+++ b/akka-persistence/akka-persistence-voldemort/src/test/resources/config/server.properties
@@ -1,2 +1,4 @@
 node.id=0
 enable.rebalancing=false
+enable.bdb.engine=false
+slop.enable=false

--- a/akka-persistence/akka-persistence-voldemort/src/test/resources/config/stores.xml
+++ b/akka-persistence/akka-persistence-voldemort/src/test/resources/config/stores.xml
@@ -6,7 +6,7 @@
         <required-reads>1</required-reads>
         <preferred-writes>1</preferred-writes>
         <required-writes>1</required-writes>
-        <persistence>bdb</persistence>
+        <persistence>memory</persistence>
         <routing>client</routing>
         <key-serializer>
             <type>string</type>
@@ -23,7 +23,7 @@
         <required-reads>1</required-reads>
         <preferred-writes>1</preferred-writes>
         <required-writes>1</required-writes>
-        <persistence>bdb</persistence>
+        <persistence>memory</persistence>
         <routing>client</routing>
         <key-serializer>
             <type>identity</type>
@@ -39,7 +39,7 @@
         <required-reads>1</required-reads>
         <preferred-writes>1</preferred-writes>
         <required-writes>1</required-writes>
-        <persistence>bdb</persistence>
+        <persistence>memory</persistence>
         <routing>client</routing>
         <key-serializer>
             <type>string</type>
@@ -56,7 +56,7 @@
         <required-reads>1</required-reads>
         <preferred-writes>1</preferred-writes>
         <required-writes>1</required-writes>
-        <persistence>bdb</persistence>
+        <persistence>memory</persistence>
         <routing>client</routing>
         <key-serializer>
             <type>identity</type>
@@ -72,7 +72,7 @@
         <required-reads>1</required-reads>
         <preferred-writes>1</preferred-writes>
         <required-writes>1</required-writes>
-        <persistence>bdb</persistence>
+        <persistence>memory</persistence>
         <routing>client</routing>
         <key-serializer>
             <type>string</type>

--- a/akka-persistence/akka-persistence-voldemort/src/test/scala/EmbeddedVoldemort.scala
+++ b/akka-persistence/akka-persistence-voldemort/src/test/scala/EmbeddedVoldemort.scala
@@ -8,6 +8,8 @@ import org.scalatest.junit.JUnitRunner
 import voldemort.utils.Utils
 import java.io.File
 import se.scalablesolutions.akka.util.{Logging, UUID}
+import collection.JavaConversions
+import voldemort.store.memory.InMemoryStorageConfiguration
 
 @RunWith(classOf[JUnitRunner])
 trait EmbeddedVoldemort extends BeforeAndAfterAll with Logging {
@@ -21,6 +23,7 @@ trait EmbeddedVoldemort extends BeforeAndAfterAll with Logging {
       val home = new File(dir)
       log.info("Creating Voldemort Config")
       val config = VoldemortConfig.loadFromVoldemortHome(home.getCanonicalPath)
+      config.setStorageConfigurations(JavaConversions.asList(List(classOf[InMemoryStorageConfiguration].getName)))
       log.info("Starting Voldemort")
       server = new VoldemortServer(config)
       server.start

--- a/project/build/AkkaProject.scala
+++ b/project/build/AkkaProject.scala
@@ -52,7 +52,6 @@ class AkkaParentProject(info: ProjectInfo) extends DefaultProject(info) {
     lazy val SonatypeSnapshotRepo = MavenRepository("Sonatype OSS Repo", "http://oss.sonatype.org/content/repositories/releases")
     lazy val SunJDMKRepo          = MavenRepository("Sun JDMK Repo", "http://wp5.e-taxonomy.eu/cdmlib/mavenrepo")
     lazy val ClojarsRepo          = MavenRepository("Clojars Repo", "http://clojars.org/repo")
-    lazy val OracleRepo           = MavenRepository("Oracle Repo", "http://download.oracle.com/maven")
   }
 
   // -------------------------------------------------------------------------------------------------------------------
@@ -82,7 +81,6 @@ class AkkaParentProject(info: ProjectInfo) extends DefaultProject(info) {
   lazy val casbahModuleConfig      = ModuleConfiguration("com.novus", CasbahRepo)
   lazy val timeModuleConfig        = ModuleConfiguration("org.scala-tools", "time", CasbahSnapshotRepo)
   lazy val voldemortModuleConfig   = ModuleConfiguration("voldemort", ClojarsRepo)
-  lazy val sleepycatModuleConfig   = ModuleConfiguration("com.sleepycat", OracleRepo)
   lazy val embeddedRepo            = EmbeddedRepo // This is the only exception, because the embedded repo is fast!
 
   // -------------------------------------------------------------------------------------------------------------------
@@ -230,7 +228,6 @@ class AkkaParentProject(info: ProjectInfo) extends DefaultProject(info) {
     lazy val jdom = "org.jdom" % "jdom" % "1.1" % "test"
     lazy val vold_jetty = "org.mortbay.jetty" % "jetty" % "6.1.18" % "test"
     lazy val velocity = "org.apache.velocity" % "velocity" % "1.6.2" % "test"
-    lazy val bdb = "com.sleepycat" % "je" % "4.0.103" % "test"
     lazy val dbcp = "commons-dbcp" % "commons-dbcp" % "1.2.2" % "test"
   }
 
@@ -543,7 +540,6 @@ class AkkaParentProject(info: ProjectInfo) extends DefaultProject(info) {
     val jdom = Dependencies.jdom
     val jetty = Dependencies.vold_jetty
     val velocity = Dependencies.velocity
-    val bdb = Dependencies.bdb
     val dbcp = Dependencies.dbcp
     val sjson = Dependencies.sjson_test
 


### PR DESCRIPTION
Removed BDB as a test-runtime dependency and configured the EmbeddedVoldemort test server to stop attempting to load BDB classes
