### PR TITLE
add ref="..." to untyped-actor and typed-actor

### DIFF
--- a/akka-spring/src/main/resources/akka/spring/akka-1.0-SNAPSHOT.xsd
+++ b/akka-spring/src/main/resources/akka/spring/akka-1.0-SNAPSHOT.xsd
@@ -145,10 +145,17 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute name="implementation" type="xsd:string" use="required">
+    <xsd:attribute name="implementation" type="xsd:string">
       <xsd:annotation>
         <xsd:documentation>
           Name of the implementation class.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="ref" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          Bean instance behind the actor
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
@@ -191,10 +198,17 @@
       <xsd:element ref="beans:property" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="id" type="xsd:ID"/>
-    <xsd:attribute name="implementation" type="xsd:string" use="required">
+    <xsd:attribute name="implementation" type="xsd:string">
       <xsd:annotation>
         <xsd:documentation>
           Name of the implementation class.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="ref" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          Bean instance behind the actor
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>

--- a/akka-spring/src/main/scala/ActorParser.scala
+++ b/akka-spring/src/main/scala/ActorParser.scala
@@ -55,6 +55,12 @@ trait ActorParser extends BeanParser with DispatcherParser {
     objectProperties.timeoutStr = element.getAttribute(TIMEOUT)
     objectProperties.target = if (element.getAttribute(IMPLEMENTATION).isEmpty) null else element.getAttribute(IMPLEMENTATION)
     objectProperties.beanRef = if (element.getAttribute(BEANREF).isEmpty) null else element.getAttribute(BEANREF)
+
+    if (objectProperties.target == null && objectProperties.beanRef == null) {
+      throw new IllegalArgumentException("Mandatory attribute missing, you need to provide either implementation or ref  ")
+    }
+
+
     objectProperties.transactional = if (element.getAttribute(TRANSACTIONAL).isEmpty) false else element.getAttribute(TRANSACTIONAL).toBoolean
 
     if (element.hasAttribute(INTERFACE)) {

--- a/akka-spring/src/main/scala/ActorParser.scala
+++ b/akka-spring/src/main/scala/ActorParser.scala
@@ -53,7 +53,8 @@ trait ActorParser extends BeanParser with DispatcherParser {
     }
 
     objectProperties.timeoutStr = element.getAttribute(TIMEOUT)
-    objectProperties.target = mandatory(element, IMPLEMENTATION)
+    objectProperties.target = if (element.getAttribute(IMPLEMENTATION).isEmpty) null else element.getAttribute(IMPLEMENTATION)
+    objectProperties.beanRef = if (element.getAttribute(BEANREF).isEmpty) null else element.getAttribute(BEANREF)
     objectProperties.transactional = if (element.getAttribute(TRANSACTIONAL).isEmpty) false else element.getAttribute(TRANSACTIONAL).toBoolean
 
     if (element.hasAttribute(INTERFACE)) {

--- a/akka-spring/src/main/scala/ActorProperties.scala
+++ b/akka-spring/src/main/scala/ActorProperties.scala
@@ -15,6 +15,7 @@ import AkkaSpringConfigurationTags._
 class ActorProperties {
   var typed: String = ""
   var target: String = ""
+  var beanRef: String = ""
   var timeoutStr: String = ""
   var interface: String = ""
   var transactional: Boolean = false
@@ -40,6 +41,7 @@ class ActorProperties {
     builder.addPropertyValue("serviceName", serviceName)
     builder.addPropertyValue("timeoutStr", timeoutStr)
     builder.addPropertyValue(IMPLEMENTATION, target)
+    builder.addPropertyValue("beanRef", beanRef)
     builder.addPropertyValue(INTERFACE, interface)
     builder.addPropertyValue(TRANSACTIONAL, transactional)
     builder.addPropertyValue(LIFECYCLE, lifecycle)

--- a/akka-spring/src/main/scala/AkkaSpringConfigurationTags.scala
+++ b/akka-spring/src/main/scala/AkkaSpringConfigurationTags.scala
@@ -43,6 +43,7 @@ object AkkaSpringConfigurationTags {
   // actor attributes
   val TIMEOUT = "timeout"
   val IMPLEMENTATION = "implementation"
+  val BEANREF = "ref"
   val INTERFACE = "interface"
   val TRANSACTIONAL = "transactional"
   val HOST = "host"

--- a/akka-spring/src/test/resources/typed-actor-config.xml
+++ b/akka-spring/src/test/resources/typed-actor-config.xml
@@ -14,6 +14,14 @@ http://scalablesolutions.se/akka/akka-1.0-SNAPSHOT.xsd">
                       implementation="akka.spring.foo.MyPojo"
                       timeout="1000"/>
 
+  <bean id="myPojoBean" class="akka.spring.foo.MyPojo" scope="prototype"/>
+
+  <akka:typed-actor id="simple-typed-actor-of-bean"
+                      interface="akka.spring.foo.IMyPojo"
+                      ref="myPojoBean"
+                      timeout="1000"/>
+
+
   <akka:typed-actor id="simple-typed-actor-long-timeout"
                       interface="akka.spring.foo.IMyPojo"
                       implementation="akka.spring.foo.MyPojo"

--- a/akka-spring/src/test/resources/untyped-actor-config.xml
+++ b/akka-spring/src/test/resources/untyped-actor-config.xml
@@ -12,6 +12,11 @@ http://scalablesolutions.se/akka/akka-1.0-SNAPSHOT.xsd">
   <akka:untyped-actor id="simple-untyped-actor"
                       implementation="akka.spring.foo.PingActor"/>
 
+  <bean id="pingActorBean" class="akka.spring.foo.PingActor" scope="prototype"/>
+
+  <akka:untyped-actor id="simple-untyped-actor-of-bean"
+                      ref="pingActorBean"/>
+
   <akka:untyped-actor id="simple-untyped-actor-long-timeout"
                       implementation="akka.spring.foo.PingActor"
                       timeout="10000"/>

--- a/akka-spring/src/test/scala/TypedActorSpringFeatureTest.scala
+++ b/akka-spring/src/test/scala/TypedActorSpringFeatureTest.scala
@@ -81,6 +81,14 @@ class TypedActorSpringFeatureTest extends FeatureSpec with ShouldMatchers with B
       assert(MyPojo.lastOneWayMessage === "hello 1")
     }
 
+    scenario("get a typed actor of bean") {
+      val myPojo = getTypedActorFromContext("/typed-actor-config.xml", "simple-typed-actor-of-bean")
+      assert(myPojo.getFoo() === "foo")
+      myPojo.oneWay("hello 1")
+      MyPojo.latch.await
+      assert(MyPojo.lastOneWayMessage === "hello 1")
+    }
+
     scenario("FutureTimeoutException when timed out") {
       val myPojo = getTypedActorFromContext("/typed-actor-config.xml", "simple-typed-actor")
       evaluating {myPojo.longRunning()} should produce[FutureTimeoutException]

--- a/akka-spring/src/test/scala/UntypedActorSpringFeatureTest.scala
+++ b/akka-spring/src/test/scala/UntypedActorSpringFeatureTest.scala
@@ -67,6 +67,14 @@ class UntypedActorSpringFeatureTest extends FeatureSpec with ShouldMatchers with
       assert(myactor.isDefinedAt("some string message"))
     }
 
+    scenario("untyped-actor of provided bean") {
+      val myactor = getPingActorFromContext("/untyped-actor-config.xml", "simple-untyped-actor-of-bean")
+      myactor.sendOneWay("Hello")
+      PingActor.latch.await
+      assert(PingActor.lastMessage === "Hello")
+      assert(myactor.isDefinedAt("some string message"))
+    }
+
     scenario("untyped-actor with timeout") {
       val myactor = getPingActorFromContext("/untyped-actor-config.xml", "simple-untyped-actor-long-timeout")
       assert(myactor.getTimeout() === 10000)


### PR DESCRIPTION
This patch is for adding a ref="..." parameter to both typed-actor and untyped-actor, which allows to decouple class instance creation from actor creation. 

By doing this, you can use all the features of spring when creating the actor bean, such as constructor-arg, method injection, bean factories, AOP, etc...

use like this:

<pre><code>
&lt;bean id="myActorBean" class="MyActorClass" scope="prototype"&gt;
... &lt;!-- all the goodies that spring has --&gt;
&lt;/bean&gt;

&lt;akka:untyped-actor id="myActor" ref="myActorBean"/&gt;
</code></pre>
