### PR TITLE
(Mist) Switch to using pathInfo instead of requestURI for hooks and providers

### DIFF
--- a/akka-http/src/main/scala/akka/http/Mist.scala
+++ b/akka-http/src/main/scala/akka/http/Mist.scala
@@ -251,7 +251,7 @@ trait Endpoint { this: Actor =>
     // dispatch the suspended requests
     //
     case req: RequestMethod => {
-      val uri = req.request.getRequestURI
+      val uri = req.request.getPathInfo
       val endpoints = _attachments.filter { _._1(uri) }
 
       if (!endpoints.isEmpty)


### PR DESCRIPTION
It is easier for Endpoint implementations to bind (through Endpoint.Attach(hook, provider)) to URIs if matching can be made on the pathInfo of the HTTP request instead of the full requestURI. This frees the endpoint from having to know which URI the AkkaMistServlet is bound to.
