### PR TITLE
ActorRef factory methods

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -1433,6 +1433,13 @@ trait ScalaActorRef extends ActorRefShared { ref: ActorRef =>
     spawn(manifest[T].erasure.asInstanceOf[Class[_ <: Actor]])
 
   /**
+   * Atomically create (from factory function) and start an actor.
+   * <p/>
+   * To be invoked from within the actor itself.
+   */
+  def spawn(factory: => Actor): ActorRef
+
+  /**
    * Atomically create (from actor class), start and make an actor remote.
    */
   def spawnRemote[T <: Actor: Manifest](hostname: String, port: Int, timeout: Long): ActorRef = {
@@ -1445,6 +1452,13 @@ trait ScalaActorRef extends ActorRefShared { ref: ActorRef =>
    */
   def spawnLink[T <: Actor: Manifest]: ActorRef =
     spawnLink(manifest[T].erasure.asInstanceOf[Class[_ <: Actor]])
+
+  /**
+   * Atomically create (from factory function), link and start an actor.
+   * <p/>
+   * To be invoked from within the actor itself.
+   */
+  def spawnLink(factory: => Actor): ActorRef
 
   /**
    * Atomically create (from actor class), start, link and make an actor remote.

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -442,6 +442,13 @@ trait ActorRef extends ActorRefShared with java.lang.Comparable[ActorRef] { scal
   def spawn(clazz: Class[_ <: Actor]): ActorRef
 
   /**
+   * Atomically create (from factory function) and start an actor.
+   * <p/>
+   * To be invoked from within the actor itself.
+   */
+  def spawn(factory: => Actor): ActorRef
+
+  /**
    * Atomically create (from actor class), make it remote and start an actor.
    * <p/>
    * To be invoked from within the actor itself.
@@ -454,6 +461,13 @@ trait ActorRef extends ActorRefShared with java.lang.Comparable[ActorRef] { scal
    * To be invoked from within the actor itself.
    */
   def spawnLink(clazz: Class[_ <: Actor]): ActorRef
+
+  /**
+   * Atomically create (from factory function), link and start an actor.
+   * <p/>
+   * To be invoked from within the actor itself.
+   */
+  def spawnLink(factory: => Actor): ActorRef
 
   /**
    * Atomically create (from actor class), make it remote, link and start an actor.
@@ -722,6 +736,15 @@ class LocalActorRef private[akka] (
   }
 
   /**
+   * Atomically create (from factory function) and start an actor.
+   * <p/>
+   * To be invoked from within the actor itself.
+   */
+  def spawn(factory: => Actor): ActorRef = guard.withGuard {
+    Actor.actorOf(factory).start
+  }
+
+  /**
    * Atomically create (from actor class), start and make an actor remote.
    * <p/>
    * To be invoked from within the actor itself.
@@ -740,6 +763,19 @@ class LocalActorRef private[akka] (
    */
   def spawnLink(clazz: Class[_ <: Actor]): ActorRef = guard.withGuard {
     val actor = Actor.actorOf(clazz)
+    link(actor)
+    actor.start
+    actor
+
+  }
+
+  /**
+   * Atomically create (from factory function), start and link an actor.
+   * <p/>
+   * To be invoked from within the actor itself.
+   */
+  def spawnLink(factory: => Actor): ActorRef = guard.withGuard {
+    val actor = Actor.actorOf(factory)
     link(actor)
     actor.start
     actor
@@ -1159,8 +1195,10 @@ private[akka] case class RemoteActorRef private[akka] (
   def unlink(actorRef: ActorRef): Unit = unsupported
   def startLink(actorRef: ActorRef): Unit = unsupported
   def spawn(clazz: Class[_ <: Actor]): ActorRef = unsupported
+  def spawn(factory: => Actor): ActorRef = unsupported
   def spawnRemote(clazz: Class[_ <: Actor], hostname: String, port: Int, timeout: Long): ActorRef = unsupported
   def spawnLink(clazz: Class[_ <: Actor]): ActorRef = unsupported
+  def spawnLink(factory: => Actor): ActorRef = unsupported
   def spawnLinkRemote(clazz: Class[_ <: Actor], hostname: String, port: Int, timeout: Long): ActorRef = unsupported
   def supervisor: Option[ActorRef] = unsupported
   def shutdownLinkedActors: Unit = unsupported

--- a/akka-actor/src/test/scala/akka/actor/actor/ActorRefSpec.scala
+++ b/akka-actor/src/test/scala/akka/actor/actor/ActorRefSpec.scala
@@ -123,5 +123,30 @@ class ActorRefSpec extends
       assert(ref.isRunning == false)
       assert(ref.isShutdown == true)
     }
+
+    it("should support spawning via manifest, class, and factory function") {
+      class SimpleActor extends Actor {
+        def receive = {
+          case _ =>
+        }
+      }
+
+      Actor.actorOf(
+        new Actor {
+          override def preStart {
+            self.spawn[SimpleActor]
+            self.spawn(classOf[SimpleActor])
+            self.spawn(new SimpleActor)
+
+            self.spawnLink[SimpleActor]
+            self.spawnLink(classOf[SimpleActor])
+            self.spawnLink(new SimpleActor)
+          }
+          def receive = {
+            case _ =>
+          }
+        }
+      )
+    }
   }
 }


### PR DESCRIPTION
Hello,

ActorRef currently has spawn and spawnLink that allow atomic creation and starting, and in the latter case, linking of a new actor.  When working with Actor classes that take constructor arguments, the factory function overloads are very useful.  This pull adds the factory function overloads for spawn and spawnLink.

Regards,
Michael
