### PR TITLE
Release 1.3

### DIFF
--- a/project/build/AkkaProject.scala
+++ b/project/build/AkkaProject.scala
@@ -75,6 +75,8 @@ class AkkaParentProject(info: ProjectInfo) extends ParentProject(info) with Exec
   lazy val zeromqModuleConfig      = ModuleConfiguration("org.zeromq", TypesafeRepo)
   lazy val twitterModuleConfig     = ModuleConfiguration("com.twitter", "util-core", TwitterRepo)
   lazy val mongoModuleConfig       = ModuleConfiguration("com.mongodb.casbah", ScalaToolsSnapshotRepo)
+ 
+  lazy val scalaLibrary            = ModuleConfiguration("org.scala-lang", ScalaToolsRelRepo)
 
   lazy val localMavenRepo          = LocalMavenRepo // Second exception, also fast! ;-)
 


### PR DESCRIPTION
I don't know if this ought to be necessary, or why, but it fixes a build problem I was having:

```
Error running deliver: sbt.ResolveException: unresolved dependency:
org.scala-lang#scala-library;2.9.1: configuration not found in
org.scala-lang#scala-library;2.9.1: 'compile'. It was required from
se.scalablesolutions.akka#akka-actor;1.3-SNAPSHOT compile
```

After adding this module to the build file, it compiled fine. Perhaps the 2.9.1 version of scala-library just wasn't in my local maven repo yet? 
