### PR TITLE
akka-zeromq: Add ZeroMQ#version for accessing the version of ZeroMQ

### DIFF
--- a/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQ.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQ.scala
@@ -5,9 +5,10 @@ package akka.zeromq
 
 import akka.actor.{Actor, ActorRef}
 import akka.dispatch.{Dispatchers, MessageDispatcher}
-import akka.zeromq.SocketType._
 import akka.util.Duration
 import akka.util.duration._
+import akka.zeromq.SocketType._
+import org.zeromq.{ZMQ => JZMQ}
 
 case class SocketParameters(
   context: Context, 
@@ -17,13 +18,26 @@ case class SocketParameters(
   pollTimeoutDuration: Duration = 100 millis
 )
 
+case class ZeroMQVersion(major: Int, minor: Int, patch: Int) {
+  override def toString = "%d.%d.%d".format(major, minor, patch)
+}
+
 object ZeroMQ {
+  def version = {
+    ZeroMQVersion(JZMQ.getMajorVersion, JZMQ.getMinorVersion, JZMQ.getPatchVersion)  
+  }
   def newContext(numIoThreads: Int = 1) = {
+    verifyZeroMQVersion
     new Context(numIoThreads)
   }
   def newSocket(params: SocketParameters, supervisor: Option[ActorRef] = None, dispatcher: MessageDispatcher = Dispatchers.defaultGlobalDispatcher) = {
+    verifyZeroMQVersion
     val socket = Actor.actorOf(new ConcurrentSocketActor(params, dispatcher))
     supervisor.foreach(_.link(socket))
     socket.start
+  }
+  private def verifyZeroMQVersion = {
+    if (JZMQ.getFullVersion < JZMQ.makeVersion(2, 1, 0))
+      throw new RuntimeException("Unsupported ZeroMQ version: %s".format(JZMQ.getVersionString))
   }
 }

--- a/project/build/AkkaProject.scala
+++ b/project/build/AkkaProject.scala
@@ -130,7 +130,7 @@ class AkkaParentProject(info: ProjectInfo) extends ParentProject(info) with Exec
 
     lazy val protobuf = "com.google.protobuf" % "protobuf-java" % "2.4.1" % "compile" //New BSD
 
-    lazy val zeromq = "org.zeromq" %% "zeromq-scala-binding" % "0.0.2" // ApacheV2
+    lazy val zeromq = "org.zeromq" %% "zeromq-scala-binding" % "0.0.3" // ApacheV2
 
     lazy val sjson      = "net.debasishg" % "sjson_2.9.0" % "0.11" % "compile" //ApacheV2
     lazy val sjson_test = "net.debasishg" % "sjson_2.9.0" % "0.11" % "test" //ApacheV2


### PR DESCRIPTION
Moreover, if ZeroMQ is not installed, do not run any of the test cases
in ConcurrentSocketActorSpec. Instead, mark the tests pending and inform
about the missing installation.

Signed-off-by: Karim Osman karim@iki.fi
