### PR TITLE
Cleanup of methods in Actor and ActorContext trait. See #1377

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/JavaAPITestActor.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaAPITestActor.java
@@ -1,7 +1,8 @@
 package akka.actor;
 
 public class JavaAPITestActor extends UntypedActor {
-    public void onReceive(Object msg) {
-        getSender().tell("got it!");
-    }
+  public void onReceive(Object msg) {
+    getSender().tell("got it!");
+    getContext().getChildren();
+  }
 }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
@@ -21,7 +21,7 @@ object ActorFireForgetRequestReplySpec {
   }
 
   class CrashingActor extends Actor {
-    implicit val system = context.system
+    import context.system
     def receive = {
       case "Die" ⇒
         state.finished.await
@@ -30,7 +30,7 @@ object ActorFireForgetRequestReplySpec {
   }
 
   class SenderActor(replyActor: ActorRef) extends Actor {
-    implicit val system = context.system
+    import context.system
     def receive = {
       case "Init" ⇒
         replyActor ! "Send"

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
@@ -21,6 +21,7 @@ object ActorFireForgetRequestReplySpec {
   }
 
   class CrashingActor extends Actor {
+    implicit val system = context.system
     def receive = {
       case "Die" ⇒
         state.finished.await
@@ -29,6 +30,7 @@ object ActorFireForgetRequestReplySpec {
   }
 
   class SenderActor(replyActor: ActorRef) extends Actor {
+    implicit val system = context.system
     def receive = {
       case "Init" ⇒
         replyActor ! "Send"
@@ -51,7 +53,7 @@ object ActorFireForgetRequestReplySpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ActorFireForgetRequestReplySpec extends AkkaSpec with BeforeAndAfterEach {
+class ActorFireForgetRequestReplySpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout {
   import ActorFireForgetRequestReplySpec._
 
   override def beforeEach() = {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -26,7 +26,7 @@ object ActorLifeCycleSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSender {
+class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSender with DefaultTimeout {
   import ActorLifeCycleSpec._
 
   "An Actor" must {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -37,6 +37,7 @@ object ActorRefSpec {
   }
 
   class WorkerActor() extends Actor {
+    implicit val system = context.system
     def receive = {
       case "work" ⇒ {
         work
@@ -111,7 +112,7 @@ object ActorRefSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ActorRefSpec extends AkkaSpec {
+class ActorRefSpec extends AkkaSpec with DefaultTimeout {
   import akka.actor.ActorRefSpec._
 
   def promiseIntercept(f: ⇒ Actor)(to: Promise[Actor]): Actor = try {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -37,7 +37,7 @@ object ActorRefSpec {
   }
 
   class WorkerActor() extends Actor {
-    implicit val system = context.system
+    import context.system
     def receive = {
       case "work" ⇒ {
         work

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorTimeoutSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorTimeoutSpec.scala
@@ -7,9 +7,10 @@ import org.scalatest.BeforeAndAfterAll
 import akka.dispatch.FutureTimeoutException
 import akka.util.duration._
 import akka.testkit.AkkaSpec
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ActorTimeoutSpec extends AkkaSpec with BeforeAndAfterAll {
+class ActorTimeoutSpec extends AkkaSpec with BeforeAndAfterAll with DefaultTimeout {
 
   def actorWithTimeout(t: Timeout): ActorRef = actorOf(Props(creator = () ⇒ new Actor {
     def receive = {

--- a/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic._
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class DeathWatchSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSender with DefaultTimeout {
   def startWatching(target: ActorRef) = actorOf(Props(new Actor {
-    context.startsWatching(target)
+    context.watch(target)
     def receive = { case x ⇒ testActor forward x }
   }))
 
@@ -52,8 +52,8 @@ class DeathWatchSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSende
       val terminal = actorOf(Props(context ⇒ { case _ ⇒ }))
       val monitor1, monitor3 = startWatching(terminal)
       val monitor2 = actorOf(Props(new Actor {
-        context.startsWatching(terminal)
-        context.stopsWatching(terminal)
+        context.watch(terminal)
+        context.unwatch(terminal)
         def receive = {
           case "ping"        ⇒ sender ! "pong"
           case t: Terminated ⇒ testActor ! t
@@ -62,7 +62,7 @@ class DeathWatchSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSende
 
       monitor2 ! "ping"
 
-      expectMsg("pong") //Needs to be here since startsWatching and stopsWatching are asynchronous
+      expectMsg("pong") //Needs to be here since watch and unwatch are asynchronous
 
       terminal ! PoisonPill
 
@@ -107,7 +107,7 @@ class DeathWatchSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSende
 
         val failed = (supervisor ? Props.empty).as[ActorRef].get
         val brother = (supervisor ? Props(new Actor {
-          context.startsWatching(failed)
+          context.watch(failed)
           def receive = Actor.emptyBehavior
         })).as[ActorRef].get
 

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -58,7 +58,7 @@ class FSMTransitionSpec extends AkkaSpec with ImplicitSender {
       val forward = actorOf(new Forwarder(testActor))
       val fsm = actorOf(new MyFSM(testActor))
       val sup = actorOf(Props(new Actor {
-        watch(fsm)
+        context.startsWatching(fsm)
         def receive = { case _ ⇒ }
       }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), None, None)))
 

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -58,7 +58,7 @@ class FSMTransitionSpec extends AkkaSpec with ImplicitSender {
       val forward = actorOf(new Forwarder(testActor))
       val fsm = actorOf(new MyFSM(testActor))
       val sup = actorOf(Props(new Actor {
-        context.startsWatching(fsm)
+        context.watch(fsm)
         def receive = { case _ ⇒ }
       }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), None, None)))
 

--- a/akka-actor-tests/src/test/scala/akka/actor/HotSwapSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/HotSwapSpec.scala
@@ -37,7 +37,7 @@ class HotSwapSpec extends AkkaSpec {
           case "init" ⇒
             _log += "init"
             barrier.await
-          case "swap" ⇒ become({
+          case "swap" ⇒ context.become({
             case _ ⇒
               _log += "swapped"
               barrier.await
@@ -113,12 +113,12 @@ class HotSwapSpec extends AkkaSpec {
             _log += "init"
             barrier.await
           case "swap" ⇒
-            become({
+            context.become({
               case "swapped" ⇒
                 _log += "swapped"
                 barrier.await
               case "revert" ⇒
-                unbecome()
+                context.unbecome()
             })
             barrier.await
         }

--- a/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
@@ -17,8 +17,8 @@ object IOActorSpec {
 
   class SimpleEchoServer(host: String, port: Int, ioManager: ActorRef, started: TestLatch) extends Actor {
 
+    import context.dispatcher
     implicit val timeout = context.system.settings.ActorTimeout
-    implicit val dispatcher = context.dispatcher
 
     override def preStart = {
       listen(ioManager, host, port)
@@ -66,8 +66,8 @@ object IOActorSpec {
   // Basic Redis-style protocol
   class KVStore(host: String, port: Int, ioManager: ActorRef, started: TestLatch) extends Actor {
 
+    import context.dispatcher
     implicit val timeout = context.system.settings.ActorTimeout
-    implicit val dispatcher = context.dispatcher
 
     var kvs: Map[String, ByteString] = Map.empty
 
@@ -123,8 +123,8 @@ object IOActorSpec {
 
   class KVClient(host: String, port: Int, ioManager: ActorRef) extends Actor with IO {
 
+    import context.dispatcher
     implicit val timeout = context.system.settings.ActorTimeout
-    implicit val dispatcher = context.dispatcher
 
     var socket: SocketHandle = _
 

--- a/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
@@ -17,6 +17,9 @@ object IOActorSpec {
 
   class SimpleEchoServer(host: String, port: Int, ioManager: ActorRef, started: TestLatch) extends Actor {
 
+    implicit val timeout = context.system.settings.ActorTimeout
+    implicit val dispatcher = context.dispatcher
+
     override def preStart = {
       listen(ioManager, host, port)
       started.open()
@@ -62,6 +65,9 @@ object IOActorSpec {
 
   // Basic Redis-style protocol
   class KVStore(host: String, port: Int, ioManager: ActorRef, started: TestLatch) extends Actor {
+
+    implicit val timeout = context.system.settings.ActorTimeout
+    implicit val dispatcher = context.dispatcher
 
     var kvs: Map[String, ByteString] = Map.empty
 
@@ -117,6 +123,9 @@ object IOActorSpec {
 
   class KVClient(host: String, port: Int, ioManager: ActorRef) extends Actor with IO {
 
+    implicit val timeout = context.system.settings.ActorTimeout
+    implicit val dispatcher = context.dispatcher
+
     var socket: SocketHandle = _
 
     override def preStart {
@@ -171,7 +180,7 @@ object IOActorSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class IOActorSpec extends AkkaSpec with BeforeAndAfterEach {
+class IOActorSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout {
   import IOActorSpec._
 
   "an IO Actor" must {

--- a/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
@@ -18,7 +18,7 @@ class ReceiveTimeoutSpec extends AkkaSpec {
       val timeoutLatch = TestLatch()
 
       val timeoutActor = actorOf(new Actor {
-        receiveTimeout = Some(500L)
+        context.receiveTimeout = Some(500 milliseconds)
 
         protected def receive = {
           case ReceiveTimeout ⇒ timeoutLatch.open
@@ -33,7 +33,7 @@ class ReceiveTimeoutSpec extends AkkaSpec {
       val timeoutLatch = TestLatch()
 
       val timeoutActor = actorOf(new Actor {
-        receiveTimeout = Some(500L)
+        context.receiveTimeout = Some(500 milliseconds)
 
         protected def receive = {
           case ReceiveTimeout ⇒ timeoutLatch.open
@@ -57,7 +57,7 @@ class ReceiveTimeoutSpec extends AkkaSpec {
       case object Tick
 
       val timeoutActor = actorOf(new Actor {
-        receiveTimeout = Some(500L)
+        context.receiveTimeout = Some(500 milliseconds)
 
         protected def receive = {
           case Tick           ⇒ ()
@@ -77,14 +77,14 @@ class ReceiveTimeoutSpec extends AkkaSpec {
       case object Tick
 
       val timeoutActor = actorOf(new Actor {
-        receiveTimeout = Some(500L)
+        context.receiveTimeout = Some(500 milliseconds)
 
         protected def receive = {
           case Tick ⇒ ()
           case ReceiveTimeout ⇒
             count.incrementAndGet
             timeoutLatch.open
-            receiveTimeout = None
+            context.receiveTimeout = None
         }
       })
 
@@ -109,7 +109,7 @@ class ReceiveTimeoutSpec extends AkkaSpec {
     }
 
     "have ReceiveTimeout eq to Actors ReceiveTimeout" in {
-      akka.actor.Actors.receiveTimeout() must be theSameInstanceAs (ReceiveTimeout)
+      akka.actor.Actors.receiveTimeout must be theSameInstanceAs (ReceiveTimeout)
     }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
@@ -11,9 +11,10 @@ import akka.testkit.EventFilter
 import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import org.multiverse.api.latches.StandardLatch
 import akka.testkit.AkkaSpec
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class RestartStrategySpec extends AkkaSpec {
+class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
 
   override def atStartup {
     system.eventStream.publish(Mute(EventFilter[Exception]("Crashing...")))
@@ -206,7 +207,7 @@ class RestartStrategySpec extends AkkaSpec {
 
       val boss = actorOf(Props(new Actor {
         def receive = {
-          case p: Props      ⇒ sender ! watch(context.actorOf(p))
+          case p: Props      ⇒ sender ! context.startsWatching(context.actorOf(p))
           case t: Terminated ⇒ maxNoOfRestartsLatch.open
         }
       }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), None, Some(1000))))

--- a/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
@@ -207,7 +207,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
 
       val boss = actorOf(Props(new Actor {
         def receive = {
-          case p: Props      ⇒ sender ! context.startsWatching(context.actorOf(p))
+          case p: Props      ⇒ sender ! context.watch(context.actorOf(p))
           case t: Terminated ⇒ maxNoOfRestartsLatch.open
         }
       }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), None, Some(1000))))

--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -6,9 +6,10 @@ import akka.testkit.AkkaSpec
 import akka.testkit.EventFilter
 import akka.util.duration._
 import java.util.concurrent.{ CountDownLatch, ConcurrentLinkedQueue, TimeUnit }
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class SchedulerSpec extends AkkaSpec with BeforeAndAfterEach {
+class SchedulerSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout {
   private val cancellables = new ConcurrentLinkedQueue[Cancellable]()
 
   def collectCancellable(c: Cancellable): Cancellable = {
@@ -96,6 +97,7 @@ class SchedulerSpec extends AkkaSpec with BeforeAndAfterEach {
      * ticket #307
      */
     "pick up schedule after actor restart" in {
+
       object Ping
       object Crash
 

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -22,7 +22,7 @@ object SupervisorHierarchySpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class SupervisorHierarchySpec extends AkkaSpec {
+class SupervisorHierarchySpec extends AkkaSpec with DefaultTimeout {
   import SupervisorHierarchySpec._
 
   "A Supervisor Hierarchy" must {
@@ -52,7 +52,7 @@ class SupervisorHierarchySpec extends AkkaSpec {
       val countDownMessages = new CountDownLatch(1)
       val countDownMax = new CountDownLatch(1)
       val boss = actorOf(Props(new Actor {
-        val crasher = watch(context.actorOf(Props(new CountDownActor(countDownMessages))))
+        val crasher = context.startsWatching(context.actorOf(Props(new CountDownActor(countDownMessages))))
 
         protected def receive = {
           case "killCrasher" ⇒ crasher ! Kill

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -52,7 +52,7 @@ class SupervisorHierarchySpec extends AkkaSpec with DefaultTimeout {
       val countDownMessages = new CountDownLatch(1)
       val countDownMax = new CountDownLatch(1)
       val boss = actorOf(Props(new Actor {
-        val crasher = context.startsWatching(context.actorOf(Props(new CountDownActor(countDownMessages))))
+        val crasher = context.watch(context.actorOf(Props(new CountDownActor(countDownMessages))))
 
         protected def receive = {
           case "killCrasher" ⇒ crasher ! Kill

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
@@ -7,9 +7,10 @@ import akka.testkit.{ filterEvents, EventFilter }
 import akka.dispatch.{ PinnedDispatcher, Dispatchers }
 import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import akka.testkit.AkkaSpec
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class SupervisorMiscSpec extends AkkaSpec {
+class SupervisorMiscSpec extends AkkaSpec with DefaultTimeout {
 
   "A Supervisor" must {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
@@ -50,7 +50,7 @@ object SupervisorSpec {
   }
 
   class Master(sendTo: ActorRef) extends Actor {
-    val temp = context.startsWatching(context.actorOf(Props(new PingPongActor(sendTo))))
+    val temp = context.watch(context.actorOf(Props(new PingPongActor(sendTo))))
 
     var s: ActorRef = _
 

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
@@ -50,7 +50,7 @@ object SupervisorSpec {
   }
 
   class Master(sendTo: ActorRef) extends Actor {
-    val temp = watch(context.actorOf(Props(new PingPongActor(sendTo))))
+    val temp = context.startsWatching(context.actorOf(Props(new PingPongActor(sendTo))))
 
     var s: ActorRef = _
 
@@ -63,7 +63,7 @@ object SupervisorSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class SupervisorSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSender {
+class SupervisorSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSender with DefaultTimeout {
 
   import SupervisorSpec._
 

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorTreeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorTreeSpec.scala
@@ -11,9 +11,10 @@ import akka.actor.Actor._
 import akka.testkit.{ TestKit, EventFilter, filterEvents, filterException }
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class SupervisorTreeSpec extends AkkaSpec with ImplicitSender {
+class SupervisorTreeSpec extends AkkaSpec with ImplicitSender with DefaultTimeout {
 
   "In a 3 levels deep supervisor tree (linked in the constructor) we" must {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/Ticket669Spec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/Ticket669Spec.scala
@@ -9,9 +9,10 @@ import org.scalatest.BeforeAndAfterAll
 import akka.testkit.{ TestKit, filterEvents, EventFilter }
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class Ticket669Spec extends AkkaSpec with BeforeAndAfterAll with ImplicitSender {
+class Ticket669Spec extends AkkaSpec with BeforeAndAfterAll with ImplicitSender with DefaultTimeout {
   import Ticket669Spec._
 
   // TODO: does this really make sense?

--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -16,6 +16,7 @@ import akka.serialization.SerializationExtension
 import akka.actor.TypedActor.{ PostRestart, PreRestart, PostStop, PreStart }
 import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import akka.japi.{ Creator, Option ⇒ JOption }
+import akka.testkit.DefaultTimeout
 
 object TypedActorSpec {
 
@@ -80,7 +81,7 @@ object TypedActorSpec {
 
   class Bar extends Foo with Serializable {
 
-    import TypedActor.{ dispatcher, timeout }
+    import TypedActor.dispatcher
 
     def pigdog = "Pigdog"
 
@@ -96,8 +97,10 @@ object TypedActorSpec {
       new KeptPromise(Right(pigdog + numbered))
     }
 
-    def futureComposePigdogFrom(foo: Foo): Future[String] =
+    def futureComposePigdogFrom(foo: Foo): Future[String] = {
+      implicit val timeout = TypedActor.system.settings.ActorTimeout
       foo.futurePigdog(500).map(_.toUpperCase)
+    }
 
     def optionPigdog(): Option[String] = Some(pigdog)
 
@@ -157,7 +160,7 @@ object TypedActorSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class TypedActorSpec extends AkkaSpec with BeforeAndAfterEach with BeforeAndAfterAll {
+class TypedActorSpec extends AkkaSpec with BeforeAndAfterEach with BeforeAndAfterAll with DefaultTimeout {
 
   import TypedActorSpec._
 

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -343,7 +343,7 @@ abstract class ActorModelSpec extends AkkaSpec with DefaultTimeout {
         val waitTime = (30 seconds).dilated.toMillis
         val boss = actorOf(Props(new Actor {
           def receive = {
-            case "run"             ⇒ for (_ ← 1 to num) (context.startsWatching(context.actorOf(props))) ! cachedMessage
+            case "run"             ⇒ for (_ ← 1 to num) (context.watch(context.actorOf(props))) ! cachedMessage
             case Terminated(child) ⇒ stopLatch.countDown()
           }
         }).withDispatcher(system.dispatcherFactory.newPinnedDispatcher("boss")))

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -53,7 +53,7 @@ object ActorModelSpec {
   class DispatcherActor extends Actor {
     private val busy = new Switch(false)
 
-    def interceptor = dispatcher.asInstanceOf[MessageDispatcherInterceptor]
+    def interceptor = context.dispatcher.asInstanceOf[MessageDispatcherInterceptor]
 
     def ack {
       if (!busy.switchOn()) {
@@ -223,7 +223,7 @@ object ActorModelSpec {
   }
 }
 
-abstract class ActorModelSpec extends AkkaSpec {
+abstract class ActorModelSpec extends AkkaSpec with DefaultTimeout {
 
   import ActorModelSpec._
 
@@ -343,7 +343,7 @@ abstract class ActorModelSpec extends AkkaSpec {
         val waitTime = (30 seconds).dilated.toMillis
         val boss = actorOf(Props(new Actor {
           def receive = {
-            case "run"             ⇒ for (_ ← 1 to num) (watch(context.actorOf(props))) ! cachedMessage
+            case "run"             ⇒ for (_ ← 1 to num) (context.startsWatching(context.actorOf(props))) ! cachedMessage
             case Terminated(child) ⇒ stopLatch.countDown()
           }
         }).withDispatcher(system.dispatcherFactory.newPinnedDispatcher("boss")))

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
@@ -7,6 +7,7 @@ import akka.dispatch.{ PinnedDispatcher, Dispatchers, Dispatcher }
 import akka.actor.{ Props, Actor }
 import akka.util.Duration
 import akka.util.duration._
+import akka.testkit.DefaultTimeout
 
 object DispatcherActorSpec {
   class TestActor extends Actor {
@@ -27,7 +28,7 @@ object DispatcherActorSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class DispatcherActorSpec extends AkkaSpec {
+class DispatcherActorSpec extends AkkaSpec with DefaultTimeout {
   import DispatcherActorSpec._
 
   private val unit = TimeUnit.MILLISECONDS

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/PinnedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/PinnedActorSpec.scala
@@ -18,7 +18,7 @@ object PinnedActorSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class PinnedActorSpec extends AkkaSpec with BeforeAndAfterEach {
+class PinnedActorSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout {
   import PinnedActorSpec._
 
   private val unit = TimeUnit.MILLISECONDS

--- a/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
+++ b/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
@@ -8,8 +8,9 @@ import akka.dispatch.Future
 import akka.actor.future2actor
 import akka.util.duration._
 import akka.testkit.AkkaSpec
+import akka.testkit.DefaultTimeout
 
-class Future2ActorSpec extends AkkaSpec {
+class Future2ActorSpec extends AkkaSpec with DefaultTimeout {
 
   "The Future2Actor bridge" must {
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
@@ -14,6 +14,7 @@ import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import akka.testkit.AkkaSpec
 import org.scalatest.junit.JUnitSuite
 import java.lang.ArithmeticException
+import akka.testkit.DefaultTimeout
 
 object FutureSpec {
   class TestActor extends Actor {
@@ -39,7 +40,7 @@ object FutureSpec {
 class JavaFutureSpec extends JavaFutureTests with JUnitSuite
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll {
+class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with DefaultTimeout {
   import FutureSpec._
 
   "A Promise" when {

--- a/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
@@ -3,9 +3,10 @@ package akka.dispatch
 import akka.actor.{ Props, LocalActorRef, Actor }
 import akka.testkit.AkkaSpec
 import akka.util.Duration
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class PriorityDispatcherSpec extends AkkaSpec {
+class PriorityDispatcherSpec extends AkkaSpec with DefaultTimeout {
 
   "A PriorityDispatcher" must {
     "Order it's messages according to the specified comparator using an unbounded mailbox" in {

--- a/akka-actor-tests/src/test/scala/akka/dispatch/PromiseStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/PromiseStreamSpec.scala
@@ -5,9 +5,10 @@ import akka.util.cps._
 import akka.actor.Timeout
 import akka.util.duration._
 import akka.testkit.AkkaSpec
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class PromiseStreamSpec extends AkkaSpec {
+class PromiseStreamSpec extends AkkaSpec with DefaultTimeout {
 
   "A PromiseStream" must {
 

--- a/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
@@ -25,7 +25,7 @@ object EventStreamSpec {
   case class SetTarget(ref: ActorRef)
 
   class MyLog extends Actor {
-    var dst: ActorRef = system.deadLetters
+    var dst: ActorRef = context.system.deadLetters
     def receive = {
       case Logging.InitializeLogger(bus) ⇒ bus.subscribe(context.self, classOf[SetTarget]); sender ! Logging.LoggerInitialized
       case SetTarget(ref)                ⇒ dst = ref; dst ! "OK"

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -174,13 +174,13 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterEach with BeforeAnd
           expectNoMsg(Duration.Zero)
           assert(set == Set(1, 2), set + " was not Set(1, 2)")
 
-          supervisor startsWatching actor
+          supervisor watch actor
           expectMsgPF(hint = "now monitoring") {
             case Logging.Debug(ref, msg: String) ⇒
               ref == supervisor.underlyingActor && msg.startsWith("now monitoring")
           }
 
-          supervisor stopsWatching actor
+          supervisor unwatch actor
           expectMsgPF(hint = "stopped monitoring") {
             case Logging.Debug(ref, msg: String) ⇒
               ref == supervisor.underlyingActor && msg.startsWith("stopped monitoring")

--- a/akka-actor-tests/src/test/scala/akka/routing/ActorPoolSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ActorPoolSpec.scala
@@ -25,7 +25,7 @@ object ActorPoolSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class TypedActorPoolSpec extends AkkaSpec {
+class TypedActorPoolSpec extends AkkaSpec with DefaultTimeout {
   import ActorPoolSpec._
   "Actor Pool (2)" must {
     "support typed actors" in {
@@ -55,7 +55,7 @@ class TypedActorPoolSpec extends AkkaSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ActorPoolSpec extends AkkaSpec {
+class ActorPoolSpec extends AkkaSpec with DefaultTimeout {
   import ActorPoolSpec._
 
   "Actor Pool" must {

--- a/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
@@ -7,9 +7,10 @@ import java.util.concurrent.{ CountDownLatch, TimeUnit }
 import akka.testkit.AkkaSpec
 import akka.actor.DeploymentConfig._
 import akka.routing.Routing.Broadcast
+import akka.testkit.DefaultTimeout
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ConfiguredLocalRoutingSpec extends AkkaSpec {
+class ConfiguredLocalRoutingSpec extends AkkaSpec with DefaultTimeout {
 
   val deployer = system.asInstanceOf[ActorSystemImpl].provider.deployer
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -20,7 +20,7 @@ object RoutingSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class RoutingSpec extends AkkaSpec {
+class RoutingSpec extends AkkaSpec with DefaultTimeout {
 
   val impl = system.asInstanceOf[ActorSystemImpl]
 

--- a/akka-actor-tests/src/test/scala/akka/util/IndexSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/IndexSpec.scala
@@ -7,8 +7,9 @@ import org.scalatest.matchers.MustMatchers
 import akka.dispatch.Future
 import akka.testkit.AkkaSpec
 import scala.util.Random
+import akka.testkit.DefaultTimeout
 
-class IndexSpec extends AkkaSpec with MustMatchers {
+class IndexSpec extends AkkaSpec with MustMatchers with DefaultTimeout {
 
   private def emptyIndex = new Index[String, Int](100, _ compareTo _)
 

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -73,13 +73,13 @@ trait ActorContext extends ActorRefFactory {
    * Registers this actor as a Monitor for the provided ActorRef
    * @return the provided ActorRef
    */
-  def startsWatching(subject: ActorRef): ActorRef
+  def watch(subject: ActorRef): ActorRef
 
   /**
    * Unregisters this actor as Monitor for the provided ActorRef
    * @return the provided ActorRef
    */
-  def stopsWatching(subject: ActorRef): ActorRef
+  def unwatch(subject: ActorRef): ActorRef
 }
 
 trait JavaActorContext extends ActorContext {
@@ -221,13 +221,13 @@ private[akka] class ActorCell(
   // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
   private[akka] def stop(): Unit = dispatcher.systemDispatch(this, Terminate())
 
-  override final def startsWatching(subject: ActorRef): ActorRef = {
+  override final def watch(subject: ActorRef): ActorRef = {
     // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
     dispatcher.systemDispatch(this, Link(subject))
     subject
   }
 
-  override final def stopsWatching(subject: ActorRef): ActorRef = {
+  override final def unwatch(subject: ActorRef): ActorRef = {
     // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
     dispatcher.systemDispatch(this, Unlink(subject))
     subject

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -139,7 +139,7 @@ class LocalActorRef private[akka] (
   _supervisor: ActorRef,
   val path: ActorPath,
   val systemService: Boolean = false,
-  _receiveTimeout: Option[Long] = None,
+  _receiveTimeout: Option[Duration] = None,
   _hotswap: Stack[PartialFunction[Any, Unit]] = Props.noHotSwap)
   extends ActorRef with ScalaActorRef with RefInternals {
 
@@ -216,7 +216,7 @@ class LocalActorRef private[akka] (
 
 /**
  * This trait represents the Scala Actor API
- * There are implicit conversions in ../actor/Implicits.scala
+ * There are implicit conversions in [[akka.actor]] package object
  * from ActorRef -> ScalaActorRef and back
  */
 trait ScalaActorRef { ref: ActorRef ⇒

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -120,7 +120,7 @@ trait ActorRefProvider {
 }
 
 /**
- * Interface implemented by ActorSystem and AkkaContext, the only two places 
+ * Interface implemented by ActorSystem and AkkaContext, the only two places
  * from which you can get fresh actors.
  */
 trait ActorRefFactory {

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -336,8 +336,7 @@ class ActorSystemImpl(val name: String, applicationConfig: Config) extends Actor
   }
 
   val dispatcherFactory = new Dispatchers(settings, DefaultDispatcherPrerequisites(eventStream, deadLetterMailbox, scheduler))
-  // TODO why implicit val dispatcher?
-  implicit val dispatcher = dispatcherFactory.defaultGlobalDispatcher
+  val dispatcher = dispatcherFactory.defaultGlobalDispatcher
 
   def terminationFuture: Future[Unit] = provider.terminationFuture
   def guardian: ActorRef = provider.guardian

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -158,20 +158,20 @@ object ActorSystem {
  * An actor system is a hierarchical group of actors which share common
  * configuration, e.g. dispatchers, deployments, remote capabilities and
  * addresses. It is also the entry point for creating or looking up actors.
- * 
+ *
  * There are several possibilities for creating actors (see [[akka.actor.Props]]
  * for details on `props`):
- * 
+ *
  * {{{
  * // Java or Scala
  * system.actorOf(props, "name")
  * system.actorOf(props)
- * 
+ *
  * // Scala
  * system.actorOf[MyActor]("name")
  * system.actorOf[MyActor]
  * system.actorOf(new MyActor(...))
- * 
+ *
  * // Java
  * system.actorOf(classOf[MyActor]);
  * system.actorOf(new Creator<MyActor>() {
@@ -181,7 +181,7 @@ object ActorSystem {
  *   public MyActor create() { ... }
  * }, "name");
  * }}}
- * 
+ *
  * Where no name is given explicitly, one will be automatically generated.
  */
 abstract class ActorSystem extends ActorRefFactory {

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -189,7 +189,7 @@ trait FSM[S, D] extends ListenerManagement {
   type Timeout = Option[Duration]
   type TransitionHandler = PartialFunction[(S, S), Unit]
 
-  val log = Logging(system, context.self)
+  val log = Logging(context.system, context.self)
 
   /**
    * ****************************************
@@ -279,7 +279,7 @@ trait FSM[S, D] extends ListenerManagement {
     if (timers contains name) {
       timers(name).cancel
     }
-    val timer = Timer(name, msg, repeat, timerGen.next)
+    val timer = Timer(name, msg, repeat, timerGen.next)(context.system)
     timer.schedule(self, timeout)
     timers(name) = timer
     stay
@@ -523,7 +523,7 @@ trait FSM[S, D] extends ListenerManagement {
       if (timeout.isDefined) {
         val t = timeout.get
         if (t.finite_? && t.length >= 0) {
-          timeoutFuture = Some(system.scheduler.scheduleOnce(t, self, TimeoutMarker(generation)))
+          timeoutFuture = Some(context.system.scheduler.scheduleOnce(t, self, TimeoutMarker(generation)))
         }
       }
     }
@@ -566,7 +566,7 @@ trait LoggingFSM[S, D] extends FSM[S, D] { this: Actor ⇒
 
   def logDepth: Int = 0
 
-  private val debugEvent = system.settings.FsmDebugEvent
+  private val debugEvent = context.system.settings.FsmDebugEvent
 
   private val events = new Array[Event](logDepth)
   private val states = new Array[AnyRef](logDepth)

--- a/akka-actor/src/main/scala/akka/actor/IO.scala
+++ b/akka-actor/src/main/scala/akka/actor/IO.scala
@@ -239,7 +239,7 @@ class IOManager(bufferSize: Int = 8192) extends Actor {
   var worker: IOWorker = _
 
   override def preStart {
-    worker = new IOWorker(system, self, bufferSize)
+    worker = new IOWorker(context.system, self, bufferSize)
     worker.start()
   }
 

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -293,11 +293,6 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
   implicit def dispatcher = system.dispatcher
 
   /**
-   * Returns the default timeout (for a TypedActor) when inside a method call in a TypedActor.
-   */
-  implicit def timeout = system.settings.ActorTimeout
-
-  /**
    * Implementation of TypedActor as an Actor
    */
   private[akka] class TypedActor[R <: AnyRef, T <: R](val proxyVar: AtomVar[R], createInstance: ⇒ T) extends Actor {
@@ -326,7 +321,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
     def receive = {
       case m: MethodCall ⇒
         TypedActor.selfReference set proxyVar.get
-        TypedActor.currentSystem set system
+        TypedActor.currentSystem set context.system
         try {
           if (m.isOneWay) m(me)
           else {

--- a/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
@@ -58,6 +58,8 @@ abstract class UntypedActor extends Actor {
   @throws(classOf[Exception])
   def onReceive(message: Any): Unit
 
+  def getContext(): JavaActorContext = context.asInstanceOf[JavaActorContext]
+
   /**
    * Returns the 'self' reference.
    */
@@ -68,43 +70,6 @@ abstract class UntypedActor extends Actor {
    * Is defined if the message was sent from another Actor, else None.
    */
   def getSender(): ActorRef = sender
-
-  /**
-   * Gets the current receive timeout
-   * When specified, the receive method should be able to handle a 'ReceiveTimeout' message.
-   */
-  def getReceiveTimeout: Option[Long] = receiveTimeout
-
-  /**
-   * Defines the default timeout for an initial receive invocation.
-   * When specified, the receive function should be able to handle a 'ReceiveTimeout' message.
-   */
-  def setReceiveTimeout(timeout: Long): Unit = receiveTimeout = Some(timeout)
-
-  /**
-   * Returns an unmodifiable Java Collection containing the linked actors,
-   * please note that the backing map is thread-safe but not immutable
-   */
-  def getChildren(): java.lang.Iterable[ActorRef] = {
-    import scala.collection.JavaConverters.asJavaIterableConverter
-    asJavaIterableConverter(context.children).asJava
-  }
-
-  /**
-   * Returns the dispatcher (MessageDispatcher) that is used for this Actor
-   */
-  def getDispatcher(): MessageDispatcher = dispatcher
-
-  /**
-   * Java API for become
-   */
-  def become(behavior: Procedure[Any]): Unit = become(behavior, false)
-
-  /*
-   * Java API for become with optional discardOld
-   */
-  def become(behavior: Procedure[Any], discardOld: Boolean): Unit =
-    super.become({ case msg ⇒ behavior.apply(msg) }, discardOld)
 
   /**
    * User overridable callback.

--- a/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
@@ -41,7 +41,8 @@ import akka.dispatch.{ MessageDispatcher, Promise }
  *    }
  *
  *    public static void main(String[] args) {
- *      ActorRef actor = Actors.actorOf(SampleUntypedActor.class);
+ *      ActorSystem system = ActorSystem.create("Sample");
+ *      ActorRef actor = system.actorOf(SampleUntypedActor.class);
  *      actor.tell("SendToSelf");
  *      actor.stop();
  *    }
@@ -58,7 +59,7 @@ abstract class UntypedActor extends Actor {
   @throws(classOf[Exception])
   def onReceive(message: Any): Unit
 
-  def getContext(): JavaActorContext = context.asInstanceOf[JavaActorContext]
+  def getContext(): UntypedActorContext = context.asInstanceOf[UntypedActorContext]
 
   /**
    * Returns the 'self' reference.

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -61,8 +61,8 @@ case class Suspend() extends SystemMessage // sent to self from ActorCell.suspen
 case class Resume() extends SystemMessage // sent to self from ActorCell.resume
 case class Terminate() extends SystemMessage // sent to self from ActorCell.stop
 case class Supervise(child: ActorRef) extends SystemMessage // sent to supervisor ActorRef from ActorCell.start
-case class Link(subject: ActorRef) extends SystemMessage // sent to self from ActorCell.startsWatching
-case class Unlink(subject: ActorRef) extends SystemMessage // sent to self from ActorCell.stopsWatching
+case class Link(subject: ActorRef) extends SystemMessage // sent to self from ActorCell.watch
+case class Unlink(subject: ActorRef) extends SystemMessage // sent to self from ActorCell.unwatch
 
 final case class TaskInvocation(eventStream: EventStream, function: () ⇒ Unit, cleanup: () ⇒ Unit) extends Runnable {
   def run() {

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -49,7 +49,7 @@ class EventStream(debug: Boolean = false) extends LoggingBus with SubchannelClas
   def start(system: ActorSystemImpl) {
     reaper = system.systemActorOf(Props(new Actor {
       def receive = {
-        case ref: ActorRef   ⇒ context.startsWatching(ref)
+        case ref: ActorRef   ⇒ context.watch(ref)
         case Terminated(ref) ⇒ unsubscribe(ref)
       }
     }), "MainBusReaper")

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -49,7 +49,7 @@ class EventStream(debug: Boolean = false) extends LoggingBus with SubchannelClas
   def start(system: ActorSystemImpl) {
     reaper = system.systemActorOf(Props(new Actor {
       def receive = {
-        case ref: ActorRef   ⇒ watch(ref)
+        case ref: ActorRef   ⇒ context.startsWatching(ref)
         case Terminated(ref) ⇒ unsubscribe(ref)
       }
     }), "MainBusReaper")

--- a/akka-actor/src/main/scala/akka/routing/Pool.scala
+++ b/akka-actor/src/main/scala/akka/routing/Pool.scala
@@ -120,7 +120,7 @@ trait DefaultActorPool extends ActorPool { this: Actor ⇒
     val requestedCapacity = capacity(_delegates)
     val newDelegates = requestedCapacity match {
       case qty if qty > 0 ⇒
-        _delegates ++ Vector.fill(requestedCapacity)(context.startsWatching(instance(defaultProps)))
+        _delegates ++ Vector.fill(requestedCapacity)(context.watch(instance(defaultProps)))
 
       case qty if qty < 0 ⇒
         _delegates.splitAt(_delegates.length + requestedCapacity) match {

--- a/akka-actor/src/main/scala/akka/routing/Pool.scala
+++ b/akka-actor/src/main/scala/akka/routing/Pool.scala
@@ -120,7 +120,7 @@ trait DefaultActorPool extends ActorPool { this: Actor ⇒
     val requestedCapacity = capacity(_delegates)
     val newDelegates = requestedCapacity match {
       case qty if qty > 0 ⇒
-        _delegates ++ Vector.fill(requestedCapacity)(watch(instance(defaultProps)))
+        _delegates ++ Vector.fill(requestedCapacity)(context.startsWatching(instance(defaultProps)))
 
       case qty if qty < 0 ⇒
         _delegates.splitAt(_delegates.length + requestedCapacity) match {

--- a/akka-docs/general/code/ConfigDocSpec.scala
+++ b/akka-docs/general/code/ConfigDocSpec.scala
@@ -15,7 +15,7 @@ class ConfigDocSpec extends WordSpec with MustMatchers {
     //#custom-config
     val customConf = ConfigFactory.parseString("""
       akka.actor.deployment {
-        /app/my-service {
+        /user/my-service {
           router = round-robin
           nr-of-instances = 3
         }

--- a/akka-docs/scala/code/ActorDocSpec.scala
+++ b/akka-docs/scala/code/ActorDocSpec.scala
@@ -13,7 +13,7 @@ import akka.event.Logging
 
 //#my-actor
 class MyActor extends Actor {
-  val log = Logging(system, this)
+  val log = Logging(context.system, this)
   def receive = {
     case "test" ⇒ log.info("received test")
     case _      ⇒ log.info("received unknown message")

--- a/akka-remote/src/multi-jvm/scala/akka/remote/direct_routed/DirectRoutedRemoteActorMultiJvmSpec.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/direct_routed/DirectRoutedRemoteActorMultiJvmSpec.scala
@@ -10,7 +10,7 @@ object DirectRoutedRemoteActorMultiJvmSpec {
 
   class SomeActor extends Actor with Serializable {
     def receive = {
-      case "identify" ⇒ sender ! system.nodename
+      case "identify" ⇒ sender ! context.system.nodename
     }
   }
 }
@@ -33,7 +33,7 @@ class DirectRoutedRemoteActorMultiJvmNode1 extends AkkaRemoteSpec {
   }
 }
 
-class DirectRoutedRemoteActorMultiJvmNode2 extends AkkaRemoteSpec {
+class DirectRoutedRemoteActorMultiJvmNode2 extends AkkaRemoteSpec with DefaultTimeout {
 
   import DirectRoutedRemoteActorMultiJvmSpec._
 

--- a/akka-remote/src/multi-jvm/scala/akka/remote/new_remote_actor/NewRemoteActorMultiJvmSpec.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/new_remote_actor/NewRemoteActorMultiJvmSpec.scala
@@ -2,13 +2,14 @@ package akka.remote.new_remote_actor
 
 import akka.actor.Actor
 import akka.remote._
+import akka.testkit.DefaultTimeout
 
 object NewRemoteActorMultiJvmSpec {
   val NrOfNodes = 2
 
   class SomeActor extends Actor with Serializable {
     def receive = {
-      case "identify" ⇒ sender ! system.nodename
+      case "identify" ⇒ sender ! context.system.nodename
     }
   }
 }
@@ -32,7 +33,7 @@ class NewRemoteActorMultiJvmNode1 extends AkkaRemoteSpec {
   }
 }
 
-class NewRemoteActorMultiJvmNode2 extends AkkaRemoteSpec {
+class NewRemoteActorMultiJvmNode2 extends AkkaRemoteSpec with DefaultTimeout {
 
   import NewRemoteActorMultiJvmSpec._
 

--- a/akka-remote/src/multi-jvm/scala/akka/remote/random_routed/RandomRoutedRemoteActorMultiJvmSpec.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/random_routed/RandomRoutedRemoteActorMultiJvmSpec.scala
@@ -4,12 +4,13 @@ import akka.actor.Actor
 import akka.remote._
 import akka.routing._
 import akka.routing.Routing.Broadcast
+import akka.testkit.DefaultTimeout
 
 object RandomRoutedRemoteActorMultiJvmSpec {
   val NrOfNodes = 4
   class SomeActor extends Actor with Serializable {
     def receive = {
-      case "hit" ⇒ sender ! system.nodename
+      case "hit" ⇒ sender ! context.system.nodename
       case "end" ⇒ self.stop()
     }
   }
@@ -60,7 +61,7 @@ class RandomRoutedRemoteActorMultiJvmNode3 extends AkkaRemoteSpec {
   }
 }
 
-class RandomRoutedRemoteActorMultiJvmNode4 extends AkkaRemoteSpec {
+class RandomRoutedRemoteActorMultiJvmNode4 extends AkkaRemoteSpec with DefaultTimeout {
   import RandomRoutedRemoteActorMultiJvmSpec._
   val nodes = NrOfNodes
   "A new remote actor configured with a Random router" must {

--- a/akka-remote/src/multi-jvm/scala/akka/remote/round_robin_routed/RoundRobinRoutedRemoteActorMultiJvmSpec.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/round_robin_routed/RoundRobinRoutedRemoteActorMultiJvmSpec.scala
@@ -4,12 +4,13 @@ import akka.actor.Actor
 import akka.remote._
 import akka.routing._
 import akka.routing.Routing.Broadcast
+import akka.testkit.DefaultTimeout
 
 object RoundRobinRoutedRemoteActorMultiJvmSpec {
   val NrOfNodes = 4
   class SomeActor extends Actor with Serializable {
     def receive = {
-      case "hit" ⇒ sender ! system.nodename
+      case "hit" ⇒ sender ! context.system.nodename
       case "end" ⇒ self.stop()
     }
   }
@@ -60,7 +61,7 @@ class RoundRobinRoutedRemoteActorMultiJvmNode3 extends AkkaRemoteSpec {
   }
 }
 
-class RoundRobinRoutedRemoteActorMultiJvmNode4 extends AkkaRemoteSpec {
+class RoundRobinRoutedRemoteActorMultiJvmNode4 extends AkkaRemoteSpec with DefaultTimeout {
   import RoundRobinRoutedRemoteActorMultiJvmSpec._
   val nodes = NrOfNodes
   "A new remote actor configured with a RoundRobin router" must {

--- a/akka-remote/src/multi-jvm/scala/akka/remote/scatter_gather_routed/ScatterGatherRoutedRemoteActorMultiJvmSpec.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/scatter_gather_routed/ScatterGatherRoutedRemoteActorMultiJvmSpec.scala
@@ -4,12 +4,13 @@ import akka.actor.Actor
 import akka.remote._
 import akka.routing._
 import akka.routing.Routing.Broadcast
+import akka.testkit.DefaultTimeout
 
 object ScatterGatherRoutedRemoteActorMultiJvmSpec {
   val NrOfNodes = 4
   class SomeActor extends Actor with Serializable {
     def receive = {
-      case "hit" ⇒ sender ! system.nodename
+      case "hit" ⇒ sender ! context.system.nodename
       case "end" ⇒ self.stop()
     }
   }
@@ -60,7 +61,7 @@ class ScatterGatherRoutedRemoteActorMultiJvmNode3 extends AkkaRemoteSpec {
   }
 }
 
-class ScatterGatherRoutedRemoteActorMultiJvmNode4 extends AkkaRemoteSpec {
+class ScatterGatherRoutedRemoteActorMultiJvmNode4 extends AkkaRemoteSpec with DefaultTimeout {
   import ScatterGatherRoutedRemoteActorMultiJvmSpec._
   val nodes = NrOfNodes
   "A new remote actor configured with a ScatterGather router" must {

--- a/akka-remote/src/test/scala/akka/remote/NetworkFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/NetworkFailureSpec.scala
@@ -9,12 +9,13 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 import akka.remote.netty.NettyRemoteSupport
 import akka.actor.Actor
 import akka.testkit.AkkaSpec
+import akka.testkit.DefaultTimeout
 import akka.dispatch.Future
 
 import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import java.util.concurrent.atomic.AtomicBoolean
 
-trait NetworkFailureSpec { self: AkkaSpec ⇒
+trait NetworkFailureSpec extends DefaultTimeout { self: AkkaSpec ⇒
   import Actor._
   import akka.util.Duration
 

--- a/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnBecome.scala
+++ b/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnBecome.scala
@@ -25,6 +25,8 @@ object Think extends DiningHakkerMessage
 */
 class Chopstick extends Actor {
 
+  import context._
+
   //When a Chopstick is taken by a hakker
   //It will refuse to be taken by other hakkers
   //But the owning hakker can put it back
@@ -50,6 +52,8 @@ class Chopstick extends Actor {
 * A hakker is an awesome dude or dudett who either thinks about hacking or has to eat ;-)
 */
 class Hakker(name: String, left: ActorRef, right: ActorRef) extends Actor {
+
+  import context._
 
   //When a hakker is thinking it can become hungry
   //and try to pick up its chopsticks and eat

--- a/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnFsm.scala
+++ b/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnFsm.scala
@@ -33,6 +33,7 @@ case class TakenBy(hakker: ActorRef)
 * A chopstick is an actor, it can be taken, and put back
 */
 class Chopstick extends Actor with FSM[ChopstickState, TakenBy] {
+  import context._
 
   // A chopstick begins its existence as available and taken by no one
   startWith(Available, TakenBy(system.deadLetters))

--- a/akka-samples/akka-sample-hello/src/main/scala/sample/hello/Main.scala
+++ b/akka-samples/akka-sample-hello/src/main/scala/sample/hello/Main.scala
@@ -15,12 +15,12 @@ object Main {
 }
 
 class HelloActor extends Actor {
-  val worldActor = system.actorOf[WorldActor]
+  val worldActor = context.actorOf[WorldActor]
   def receive = {
     case Start ⇒ worldActor ! "Hello"
     case s: String ⇒
       println("Received message: %s".format(s))
-      system.stop()
+      context.system.stop()
   }
 }
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
@@ -49,7 +49,7 @@ class TestActorRef[T <: Actor](
    *
    * @return the same ActorRef that is provided to it, to allow for cleaner invocations
    */
-  def startsWatching(subject: ActorRef): ActorRef = underlying.startsWatching(subject)
+  def watch(subject: ActorRef): ActorRef = underlying.watch(subject)
 
   /**
    * Deregisters this actor from being a death monitor of the provided ActorRef
@@ -58,7 +58,7 @@ class TestActorRef[T <: Actor](
    *
    * @return the same ActorRef that is provided to it, to allow for cleaner invocations
    */
-  def stopsWatching(subject: ActorRef): ActorRef = underlying.stopsWatching(subject)
+  def unwatch(subject: ActorRef): ActorRef = underlying.unwatch(subject)
 
   override def toString = "TestActor[" + address + "]"
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -613,3 +613,7 @@ object TestProbe {
 trait ImplicitSender { this: TestKit ⇒
   implicit def self = testActor
 }
+
+trait DefaultTimeout { this: TestKit ⇒
+  implicit val timeout = system.settings.ActorTimeout
+}

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -157,7 +157,7 @@ class TestActorRefSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTime
       EventFilter[ActorKilledException]() intercept {
         val a = TestActorRef(Props[WorkerActor])
         val forwarder = actorOf(Props(new Actor {
-          context.startsWatching(a)
+          context.watch(a)
           def receive = { case x ⇒ testActor forward x }
         }))
         a.!(PoisonPill)(testActor)

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -37,6 +37,7 @@ object TestActorRefSpec {
   }
 
   class ReplyActor extends TActor {
+    implicit val system = context.system
     var replyTo: ActorRef = null
 
     def receiveT = {
@@ -87,7 +88,7 @@ object TestActorRefSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class TestActorRefSpec extends AkkaSpec with BeforeAndAfterEach {
+class TestActorRefSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout {
 
   import TestActorRefSpec._
 
@@ -156,7 +157,7 @@ class TestActorRefSpec extends AkkaSpec with BeforeAndAfterEach {
       EventFilter[ActorKilledException]() intercept {
         val a = TestActorRef(Props[WorkerActor])
         val forwarder = actorOf(Props(new Actor {
-          watch(a)
+          context.startsWatching(a)
           def receive = { case x ⇒ testActor forward x }
         }))
         a.!(PoisonPill)(testActor)
@@ -216,7 +217,7 @@ class TestActorRefSpec extends AkkaSpec with BeforeAndAfterEach {
 
     "set receiveTimeout to None" in {
       val a = TestActorRef[WorkerActor]
-      a.underlyingActor.receiveTimeout must be(None)
+      a.underlyingActor.context.receiveTimeout must be(None)
     }
 
     "set CallingThreadDispatcher" in {

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -37,7 +37,7 @@ object TestActorRefSpec {
   }
 
   class ReplyActor extends TActor {
-    implicit val system = context.system
+    import context.system
     var replyTo: ActorRef = null
 
     def receiveT = {

--- a/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
@@ -8,7 +8,7 @@ import akka.dispatch.Future
 import akka.util.duration._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class TestProbeSpec extends AkkaSpec {
+class TestProbeSpec extends AkkaSpec with DefaultTimeout {
 
   "A TestProbe" must {
 

--- a/akka-tutorials/akka-tutorial-first/src/main/java/akka/tutorial/first/java/Pi.java
+++ b/akka-tutorials/akka-tutorial-first/src/main/java/akka/tutorial/first/java/Pi.java
@@ -106,16 +106,16 @@ public class Pi {
             this.latch = latch;
             Creator<Router> routerCreator = new Creator<Router>() {
                 public Router create() {
-                    return new RoundRobinRouter(dispatcher(), new akka.actor.Timeout(-1));
+                    return new RoundRobinRouter(getContext().dispatcher(), new akka.actor.Timeout(-1));
                 }
             };
             LinkedList<ActorRef> actors = new LinkedList<ActorRef>() {
                 {
-                    for (int i = 0; i < nrOfWorkers; i++) add(context().actorOf(Worker.class));
+                    for (int i = 0; i < nrOfWorkers; i++) add(getContext().actorOf(Worker.class));
                 }
             };
             RoutedProps props = new RoutedProps(routerCreator, new LocalConnectionManager(actors), new akka.actor.Timeout(-1), true);
-            router = new RoutedActorRef(system(), props, getSelf(), "pi");
+            router = new RoutedActorRef(getContext().system(), props, getSelf(), "pi");
         }
 
         // message handler

--- a/akka-tutorials/akka-tutorial-first/src/main/scala/Pi.scala
+++ b/akka-tutorials/akka-tutorial-first/src/main/scala/Pi.scala
@@ -52,11 +52,14 @@ object Pi extends App {
     var start: Long = _
 
     // create the workers
-    val workers = Vector.fill(nrOfWorkers)(system.actorOf[Worker])
+    val workers = Vector.fill(nrOfWorkers)(context.actorOf[Worker])
 
     // wrap them with a load-balancing router
+    // FIXME routers are intended to be used like this
+    implicit val timout = context.system.settings.ActorTimeout
+    implicit val dispatcher = context.dispatcher
     val props = RoutedProps(routerFactory = () ⇒ new RoundRobinRouter, connectionManager = new LocalConnectionManager(workers))
-    val router = new RoutedActorRef(system, props, self, "pi")
+    val router = new RoutedActorRef(context.system, props, self, "pi")
 
     // message handler
     def receive = {


### PR DESCRIPTION
- Added JavaActorContext, UntypedActor.getContext
- implicit val context in Actor needs to be implicit to support forward,
  it would be nice if it wasn't implicit because now I can't override context
  in UntypedActor
- Removed implicit def system in Actor
- Removed implicit def defaultTimeout in Actor
- Removed receiveTimeout, children, dispatcher, become, unbecome, watch,
  unwatch in Actor
- Removed corresponding as above from UntypedActor
- Removed implicit from dispatcher in ActorSystem
- Removed implicit def timeout in TypedActor
- Changed receiveTimeout to use Duration (in api)
- Changed many tests and samples to match new api
