### PR TITLE
add Deadline support

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
@@ -40,6 +40,16 @@ class DurationSpec extends WordSpec with MustMatchers {
       (minf + minf) must be(minf)
     }
 
+    "support fromNow" in {
+      val dead = 2.seconds.fromNow
+      val dead2 = 2 seconds fromNow
+      (dead: Duration) must be > 1.second
+      (dead2: Duration) must be > 1.second
+      1.second.sleep
+      (dead: Duration) must be < 1.second
+      (dead2: Duration) must be < 1.second
+    }
+
   }
 
 }

--- a/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
@@ -43,11 +43,11 @@ class DurationSpec extends WordSpec with MustMatchers {
     "support fromNow" in {
       val dead = 2.seconds.fromNow
       val dead2 = 2 seconds fromNow
-      (dead: Duration) must be > 1.second
-      (dead2: Duration) must be > 1.second
+      dead.timeLeft must be > 1.second
+      dead2.timeLeft must be > 1.second
       1.second.sleep
-      (dead: Duration) must be < 1.second
-      (dead2: Duration) must be < 1.second
+      dead.timeLeft must be < 1.second
+      dead2.timeLeft must be < 1.second
     }
 
   }

--- a/akka-actor/src/main/scala/akka/util/duration/package.scala
+++ b/akka-actor/src/main/scala/akka/util/duration/package.scala
@@ -21,7 +21,7 @@ package object duration {
   object fromNow
   implicit object fromNowConvert extends Classifier[fromNow.type] {
     type R = Deadline
-    def convert(d: Duration) = Deadline(Deadline.now + d)
+    def convert(d: Duration) = Deadline.now + d
   }
 
   implicit def intToDurationInt(n: Int) = new DurationInt(n)

--- a/akka-actor/src/main/scala/akka/util/duration/package.scala
+++ b/akka-actor/src/main/scala/akka/util/duration/package.scala
@@ -7,6 +7,23 @@ package akka.util
 import java.util.concurrent.TimeUnit
 
 package object duration {
+  trait Classifier[C] {
+    type R
+    def convert(d: Duration): R
+  }
+
+  object span
+  implicit object spanConvert extends Classifier[span.type] {
+    type R = Duration
+    def convert(d: Duration) = d
+  }
+
+  object fromNow
+  implicit object fromNowConvert extends Classifier[fromNow.type] {
+    type R = Deadline
+    def convert(d: Duration) = Deadline(Deadline.now + d)
+  }
+
   implicit def intToDurationInt(n: Int) = new DurationInt(n)
   implicit def longToDurationLong(n: Long) = new DurationLong(n)
   implicit def doubleToDurationDouble(d: Double) = new DurationDouble(d)

--- a/akka-docs/common/duration.rst
+++ b/akka-docs/common/duration.rst
@@ -48,4 +48,18 @@ method calls instead:
    assert (diff.lt(fivesec));
    assert (Duration.Zero().lt(Duration.Inf()));
 
+Deadline
+========
 
+Durations have a brother name :class:`Deadline`, which is a class holding a representation
+of an absolute point in time, and support deriving a duration from this by calculating the
+difference between now and the deadline. This is useful when you want to keep one overall
+deadline without having to take care of the book-keeping wrt. the passing of time yourself::
+
+  val deadline = 10 seconds fromNow
+  // do something which takes time
+  awaitCond(..., deadline.timeLeft)
+
+In Java you create these from durations::
+
+  final Deadline d = Duration.create(5, "seconds").fromNow();


### PR DESCRIPTION
```
val deadline = 10 seconds fromNow
val f = Future { doSomething }
Block.on(f, deadline.timeLeft)
```

Also supports providing `implicit Duration` given an `implicit Deadline`. I didn’t want an always-on view to Duration because then the compiler would accept `Deadline.now * 3`, but what does that mean?
