### PR TITLE
remove non-user API from ActorContext, see #1516

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -307,7 +307,8 @@ trait Actor {
   // =========================================
 
   private[akka] final def apply(msg: Any) = {
-    val behaviorStack = context.hotswap
+    // FIXME this should all go into ActorCell
+    val behaviorStack = context.asInstanceOf[ActorCell].hotswap
     msg match {
       case msg if behaviorStack.nonEmpty && behaviorStack.head.isDefinedAt(msg) ⇒ behaviorStack.head.apply(msg)
       case msg if behaviorStack.isEmpty && processingBehavior.isDefinedAt(msg) ⇒ processingBehavior.apply(msg)

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -67,7 +67,7 @@ trait ActorContext extends ActorRefFactory {
   def setReceiveTimeout(timeout: Duration): Unit
 
   /**
-   * Resets the current receive timeout.
+   * Clears the receive timeout, i.e. deactivates this feature.
    */
   def resetReceiveTimeout(): Unit
 
@@ -84,16 +84,6 @@ trait ActorContext extends ActorRefFactory {
   def unbecome(): Unit
 
   /**
-   * Returns the current message envelope.
-   */
-  def currentMessage: Envelope
-
-  /**
-   * Returns a stack with the hotswapped behaviors (as Scala PartialFunction).
-   */
-  def hotswap: Stack[PartialFunction[Any, Unit]]
-
-  /**
    * Returns the sender 'ActorRef' of the current message.
    */
   def sender: ActorRef
@@ -108,10 +98,6 @@ trait ActorContext extends ActorRefFactory {
    * Importing this member will place a implicit MessageDispatcher in scope.
    */
   implicit def dispatcher: MessageDispatcher
-
-  def handleFailure(child: ActorRef, cause: Throwable): Unit
-
-  def handleChildTerminated(child: ActorRef): Unit
 
   /**
    * The system that the actor belongs to.

--- a/akka-actor/src/main/scala/akka/actor/IO.scala
+++ b/akka-actor/src/main/scala/akka/actor/IO.scala
@@ -46,15 +46,15 @@ object IO {
     override def asReadable = this
 
     def read(len: Int)(implicit actor: Actor with IO): ByteString @cps[IOSuspendable[Any]] = shift { cont: (ByteString ⇒ IOSuspendable[Any]) ⇒
-      ByteStringLength(cont, this, actor.context.currentMessage, len)
+      ByteStringLength(cont, this, actor.context.asInstanceOf[ActorCell].currentMessage, len)
     }
 
     def read()(implicit actor: Actor with IO): ByteString @cps[IOSuspendable[Any]] = shift { cont: (ByteString ⇒ IOSuspendable[Any]) ⇒
-      ByteStringAny(cont, this, actor.context.currentMessage)
+      ByteStringAny(cont, this, actor.context.asInstanceOf[ActorCell].currentMessage)
     }
 
     def read(delimiter: ByteString, inclusive: Boolean = false)(implicit actor: Actor with IO): ByteString @cps[IOSuspendable[Any]] = shift { cont: (ByteString ⇒ IOSuspendable[Any]) ⇒
-      ByteStringDelimited(cont, this, actor.context.currentMessage, delimiter, inclusive, 0)
+      ByteStringDelimited(cont, this, actor.context.asInstanceOf[ActorCell].currentMessage, delimiter, inclusive, 0)
     }
   }
 
@@ -158,7 +158,7 @@ trait IO {
       }
       run()
     case msg if _next ne Idle ⇒
-      _messages enqueue context.currentMessage
+      _messages enqueue context.asInstanceOf[ActorCell].currentMessage
     case msg if _receiveIO.isDefinedAt(msg) ⇒
       _next = reset { _receiveIO(msg); Idle }
       run()


### PR DESCRIPTION
- handleChildTerminated/handleFailure: no discussion
- currentMessage was (ab)used by IO, fixed by down-casting which IO
  already does for writing to currentMessage (ewww)
- Actor.apply() could now as well be moved to ActorCell, leaving Actor
  as user-API-only, which would be nice but not for M1

https://www.assembla.com/spaces/akka/tickets/1516
