### PR TITLE
Fixes a number of issues with the concurrent socket actor

### DIFF
--- a/akka-zeromq/src/main/scala/akka/zeromq/ConcurrentSocketActor.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ConcurrentSocketActor.scala
@@ -3,17 +3,26 @@
  */
 package akka.zeromq
 
-import akka.actor.{Actor, ReceiveTimeout}
-import akka.dispatch.MessageDispatcher
 import org.zeromq.ZMQ.{Socket, Poller}
 import org.zeromq.{ZMQ => JZMQ}
+import akka.event.EventHandler
+import akka.actor._
+import akka.dispatch.{CompletableFuture, Dispatchers, MessageDispatcher, Future}
+
+private[zeromq] sealed trait PollLifeCycle
+private[zeromq] case object NoResults extends PollLifeCycle
+private[zeromq] case object Results extends PollLifeCycle
+private[zeromq] case object Closing extends PollLifeCycle
+
 
 private[zeromq] class ConcurrentSocketActor(params: SocketParameters, dispatcher: MessageDispatcher) extends Actor {
+
   private val noBytes = Array[Byte]()
   private val socket: Socket = params.context.socket(params.socketType)
   private val poller: Poller = params.context.poller
-  self.receiveTimeout = Some(params.pollTimeoutDuration.toMillis)
-  self.dispatcher = dispatcher
+
+  self.dispatcher = Dispatchers.newThreadBasedDispatcher(self)
+
   override def receive: Receive = {
     case Send(frames) =>
       sendFrames(frames)
@@ -24,13 +33,15 @@ private[zeromq] class ConcurrentSocketActor(params: SocketParameters, dispatcher
     case Connect(endpoint) =>
       socket.connect(endpoint)
       notifyListener(Connecting)
+      pollAndReceiveFrames()
     case Bind(endpoint) =>
       socket.bind(endpoint)
+      pollAndReceiveFrames()
     case Subscribe(topic) =>
       socket.subscribe(topic.toArray)
+      pollAndReceiveFrames()
     case Unsubscribe(topic) =>
       socket.unsubscribe(topic.toArray)
-    case ReceiveTimeout =>
       pollAndReceiveFrames()
     case Linger(value) =>
       socket.setLinger(value)
@@ -60,8 +71,6 @@ private[zeromq] class ConcurrentSocketActor(params: SocketParameters, dispatcher
       self.reply(socket.getRcvHWM)
     case RcvHWM(value) =>
       socket.setRcvHWM(value)
-    /* case HWM =>
-      self.reply(socket.getHWM) */
     case HWM(value) =>
       socket.setHWM(value)
     case Swap =>
@@ -112,15 +121,30 @@ private[zeromq] class ConcurrentSocketActor(params: SocketParameters, dispatcher
       self.reply(socket.hasReceiveMore)
     case FileDescriptor =>
       self.reply(socket.getFD)
+    case 'poll => {
+      currentPoll = None
+      pollAndReceiveFrames()
+    }
+    case 'receiveFrames => {
+      receiveFrames() match {
+        case Seq()  ⇒
+        case frames ⇒ notifyListener(params.deserializer(frames))
+      }
+      self ! 'poll
+    }
   }
+
   override def preStart {
     poller.register(socket, Poller.POLLIN)
   }
+
   override def postStop {
+    currentPoll foreach { _ completeWithResult Closing }
     poller.unregister(socket)
     socket.close
     notifyListener(Closed)
   }
+  
   private def sendFrames(frames: Seq[Frame]) {
     def sendBytes(bytes: Seq[Byte], flags: Int) {
       socket.send(bytes.toArray, flags)
@@ -132,23 +156,35 @@ private[zeromq] class ConcurrentSocketActor(params: SocketParameters, dispatcher
       sendBytes(payload, flags)
     }
   }
+  
+  private var currentPoll: Option[CompletableFuture[PollLifeCycle]] = None
   private def pollAndReceiveFrames() {
-    def pollSocket: Boolean = {
-      poller.poll(params.pollTimeoutDuration.toMillis) > 0 && poller.pollin(0)
-    }
-    if (pollSocket) {
-      receiveFrames() match {
-        case Seq() =>
-        case frames => notifyListener(params.deserializer(frames))
+    currentPoll = currentPoll orElse Some(newEventLoop.asInstanceOf[CompletableFuture[PollLifeCycle]])
+  }
+
+  private def newEventLoop = {
+    Future({
+      if(poller.poll(params.pollTimeoutDuration.toMillis) > 0 && poller.pollin(0)) Results else NoResults
+    }, params.pollTimeoutDuration.toMillis * 2)(dispatcher) onResult {
+      case Results => if (self.isRunning) self ! 'receiveFrames
+      case NoResults => if (self.isRunning) self ! 'poll
+      case _ => currentPoll = None
+    } onException {
+      case ex ⇒ {
+        EventHandler.error(ex, this, "There was an error receiving messages on the zeromq socket")
+        if (self.isRunning) self ! 'poll
       }
     }
   }
+  
   private def receiveFrames(): Seq[Frame] = {
+    
     @inline def receiveBytes(): Array[Byte] = socket.recv(0) match {
       case null => noBytes
       case bytes: Array[Byte] if bytes.length > 0 => bytes
       case _ => noBytes
     }
+
     receiveBytes() match {
       case `noBytes` => Vector.empty
       case someBytes =>
@@ -160,6 +196,7 @@ private[zeromq] class ConcurrentSocketActor(params: SocketParameters, dispatcher
         frames
     }
   }
+  
   private def notifyListener(message: Any) {
     params.listener.foreach { listener =>
       if (listener.isShutdown)

--- a/akka-zeromq/src/main/scala/akka/zeromq/Context.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/Context.scala
@@ -6,7 +6,7 @@ package akka.zeromq
 import org.zeromq.{ZMQ => JZMQ}
 import akka.zeromq.SocketType._
 
-private[zeromq] class Context(numIoThreads: Int) {
+class Context(numIoThreads: Int) {
   private var context = JZMQ.context(numIoThreads)
   def socket(socketType: SocketType) = {
     context.socket(socketType.id)

--- a/project/build/AkkaProject.scala
+++ b/project/build/AkkaProject.scala
@@ -288,6 +288,7 @@ class AkkaParentProject(info: ProjectInfo) extends ParentProject(info) with Exec
     override def bndImportPackage = "*" :: Nil
     val cont = compilerPlugin("org.scala-lang.plugins" % "continuations" % buildScalaVersion)
     override def compileOptions = super.compileOptions ++ compileOptions("-P:continuations:enable")
+
   }
 
   // -------------------------------------------------------------------------------------------------------------------
@@ -372,6 +373,7 @@ class AkkaParentProject(info: ProjectInfo) extends ParentProject(info) with Exec
     val protobuf   = Dependencies.protobuf
     val zeromq     = Dependencies.zeromq
     val scalatest  = Dependencies.scalatest
+
   }
 
   // -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I've been using akka-zeromq in our project but I keep running into a zeromq bug 

https://zeromq.jira.com/browse/LIBZMQ-292

So when using the global executor based dispatcher I run into this pretty frequently:
± ivan@gladrags:~MOJOLLY_HOME/backchat-borg  
git:(feature/loadbalancing) ✗ ! » sbt test
[info] Loading global plugins from /Users/ivan/.sbt/0.11.0/plugins
[info] Loading project definition from /Users/ivan/projects/mojolly/backchat-borg/project
[info] Set current project to backchat-borg (in build file:/Users/ivan/projects/mojolly/backchat-borg/)
Assertion failed: ok (mailbox.cpp:79)
[1]    22371 abort      sbt test

This is caused by concurrent access to the socket, so I've changed the dispatcher to a thread based dispatcher and that seems to work as then the socket is always accessed from the same thread, in 2.0 the pinned feature can be used.

http://zguide.zeromq.org/page:all#Multithreading-with-MQ

I've also made sure that the polling loop now uses a future with the supplied dispatcher for the polling of the socket instead of blocking the actor. 
