### PR TITLE
Make MailboxType implementation configurable. See #1484

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -32,6 +32,7 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference) {
       getBoolean("akka.actor.default-dispatcher.allow-core-timeout") must equal(true)
       getInt("akka.actor.default-dispatcher.mailbox-capacity") must equal(-1)
       getMilliseconds("akka.actor.default-dispatcher.mailbox-push-timeout-time") must equal(10 * 1000)
+      getString("akka.actor.default-dispatcher.mailboxType") must be("")
       getMilliseconds("akka.actor.dispatcher-shutdown-timeout") must equal(1 * 1000)
       settings.DispatcherDefaultShutdown must equal(1 second)
       getInt("akka.actor.default-dispatcher.throughput") must equal(5)

--- a/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
@@ -1,12 +1,13 @@
 package akka.dispatch
+
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 import java.util.concurrent.{ TimeUnit, BlockingQueue }
+import java.util.concurrent.ConcurrentLinkedQueue
 import akka.util._
 import akka.util.duration._
 import akka.testkit.AkkaSpec
 import akka.actor.ActorRef
-import akka.actor.ActorCell
-import java.util.concurrent.ConcurrentLinkedQueue
+import akka.actor.ActorContext
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 abstract class MailboxSpec extends AkkaSpec with BeforeAndAfterAll with BeforeAndAfterEach {
@@ -155,7 +156,7 @@ object CustomMailboxSpec {
     }
     """
 
-  class MyMailbox(owner: ActorCell) extends Mailbox(owner)
+  class MyMailbox(owner: ActorContext) extends CustomMailbox(owner)
     with QueueBasedMessageQueue with UnboundedMessageQueueSemantics with DefaultSystemMessageQueue {
     final val queue = new ConcurrentLinkedQueue[Envelope]()
   }

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -29,7 +29,7 @@ akka {
   logConfigOnStart = off
 
   # List FQCN of extensions which shall be loaded at actor system startup.
-  # Should be on the format: 'extensions = ["foo", "bar"]' etc. 
+  # Should be on the format: 'extensions = ["foo", "bar"]' etc.
   # FIXME: clarify "extensions" here, "Akka Extensions (<link to docs>)"
   extensions = []
 
@@ -59,7 +59,7 @@ akka {
 
     deployment {
 
-      # deployment id pattern - on the format: /parent/child etc. 
+      # deployment id pattern - on the format: /parent/child etc.
       default {
 
         # routing (load-balance) scheme to use
@@ -160,6 +160,10 @@ akka {
       # Specifies the timeout to add a new message to a mailbox that is full -
       # negative number means infinite timeout
       mailbox-push-timeout-time = 10s
+
+      # FQCN of the MailboxType, if not specified the default bounded or unbounded
+      # mailbox is used.
+      mailboxType = ""
     }
 
     debug {

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -16,7 +16,6 @@ import akka.AkkaException
 import scala.reflect.BeanProperty
 import scala.util.control.NoStackTrace
 import com.eaio.uuid.UUID
-import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.TimeUnit
 import java.util.{ Collection ⇒ JCollection }
 import java.util.regex.Pattern

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -19,7 +19,6 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
 import com.typesafe.config.ConfigResolveOptions
 import com.typesafe.config.ConfigException
-import java.lang.reflect.InvocationTargetException
 import akka.util.{ Helpers, Duration, ReflectiveAccess }
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.{ CountDownLatch, Executors, ConcurrentHashMap }
@@ -409,9 +408,8 @@ class ActorSystemImpl(val name: String, applicationConfig: Config) extends Actor
     val values: Array[AnyRef] = arguments map (_._2) toArray
 
     ReflectiveAccess.createInstance[ActorRefProvider](providerClass, types, values) match {
-      case Left(e: InvocationTargetException) ⇒ throw e.getTargetException
-      case Left(e)                            ⇒ throw e
-      case Right(p)                           ⇒ p
+      case Left(e)  ⇒ throw e
+      case Right(p) ⇒ p
     }
   }
 

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -271,11 +271,15 @@ abstract class MessageDispatcherConfigurator() {
   def configure(config: Config, settings: Settings, prerequisites: DispatcherPrerequisites): MessageDispatcher
 
   def mailboxType(config: Config, settings: Settings): MailboxType = {
-    val capacity = config.getInt("mailbox-capacity")
-    if (capacity < 1) UnboundedMailbox()
-    else {
-      val duration = Duration(config.getNanoseconds("mailbox-push-timeout-time"), TimeUnit.NANOSECONDS)
-      BoundedMailbox(capacity, duration)
+    config.getString("mailboxType") match {
+      case "" ⇒
+        val capacity = config.getInt("mailbox-capacity")
+        if (capacity < 1) UnboundedMailbox()
+        else {
+          val duration = Duration(config.getNanoseconds("mailbox-push-timeout-time"), TimeUnit.NANOSECONDS)
+          BoundedMailbox(capacity, duration)
+        }
+      case fqn ⇒ new CustomMailboxType(fqn)
     }
   }
 

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -12,6 +12,7 @@ import annotation.tailrec
 import akka.event.Logging.Error
 import com.typesafe.config.Config
 import java.lang.reflect.InvocationTargetException
+import akka.actor.ActorContext
 
 class MessageQueueAppendFailedException(message: String, cause: Throwable = null) extends AkkaException(message, cause)
 
@@ -35,7 +36,17 @@ object Mailbox {
   final val debug = false
 }
 
-abstract class Mailbox(val actor: ActorCell) extends MessageQueue with SystemMessageQueue with Runnable {
+/**
+ * Custom mailbox implementations are implemented by extending this class.
+ */
+abstract class CustomMailbox(val actorContext: ActorContext) extends Mailbox(actorContext.asInstanceOf[ActorCell])
+
+/**
+ * Mailbox and InternalMailbox is separated in two classes because ActorCell is needed for implementation,
+ * but can't be exposed to user defined mailbox subclasses.
+ *
+ */
+private[akka] abstract class Mailbox(val actor: ActorCell) extends MessageQueue with SystemMessageQueue with Runnable {
   import Mailbox._
 
   @volatile
@@ -319,15 +330,15 @@ trait QueueBasedMessageQueue extends MessageQueue {
  * Mailbox configuration.
  */
 trait MailboxType {
-  def create(receiver: ActorCell): Mailbox
+  def create(receiver: ActorContext): Mailbox
 }
 
 /**
  * It's a case class for Java (new UnboundedMailbox)
  */
 case class UnboundedMailbox() extends MailboxType {
-  override def create(receiver: ActorCell) =
-    new Mailbox(receiver) with QueueBasedMessageQueue with UnboundedMessageQueueSemantics with DefaultSystemMessageQueue {
+  override def create(receiver: ActorContext) =
+    new Mailbox(receiver.asInstanceOf[ActorCell]) with QueueBasedMessageQueue with UnboundedMessageQueueSemantics with DefaultSystemMessageQueue {
       final val queue = new ConcurrentLinkedQueue[Envelope]()
     }
 }
@@ -337,16 +348,16 @@ case class BoundedMailbox( final val capacity: Int, final val pushTimeOut: Durat
   if (capacity < 0) throw new IllegalArgumentException("The capacity for BoundedMailbox can not be negative")
   if (pushTimeOut eq null) throw new IllegalArgumentException("The push time-out for BoundedMailbox can not be null")
 
-  override def create(receiver: ActorCell) =
-    new Mailbox(receiver) with QueueBasedMessageQueue with BoundedMessageQueueSemantics with DefaultSystemMessageQueue {
+  override def create(receiver: ActorContext) =
+    new Mailbox(receiver.asInstanceOf[ActorCell]) with QueueBasedMessageQueue with BoundedMessageQueueSemantics with DefaultSystemMessageQueue {
       final val queue = new LinkedBlockingQueue[Envelope](capacity)
       final val pushTimeOut = BoundedMailbox.this.pushTimeOut
     }
 }
 
 case class UnboundedPriorityMailbox( final val cmp: Comparator[Envelope]) extends MailboxType {
-  override def create(receiver: ActorCell) =
-    new Mailbox(receiver) with QueueBasedMessageQueue with UnboundedMessageQueueSemantics with DefaultSystemMessageQueue {
+  override def create(receiver: ActorContext) =
+    new Mailbox(receiver.asInstanceOf[ActorCell]) with QueueBasedMessageQueue with UnboundedMessageQueueSemantics with DefaultSystemMessageQueue {
       final val queue = new PriorityBlockingQueue[Envelope](11, cmp)
     }
 }
@@ -356,8 +367,8 @@ case class BoundedPriorityMailbox( final val cmp: Comparator[Envelope], final va
   if (capacity < 0) throw new IllegalArgumentException("The capacity for BoundedMailbox can not be negative")
   if (pushTimeOut eq null) throw new IllegalArgumentException("The push time-out for BoundedMailbox can not be null")
 
-  override def create(receiver: ActorCell) =
-    new Mailbox(receiver) with QueueBasedMessageQueue with BoundedMessageQueueSemantics with DefaultSystemMessageQueue {
+  override def create(receiver: ActorContext) =
+    new Mailbox(receiver.asInstanceOf[ActorCell]) with QueueBasedMessageQueue with BoundedMessageQueueSemantics with DefaultSystemMessageQueue {
       final val queue = new BoundedBlockingQueue[Envelope](capacity, new PriorityQueue[Envelope](11, cmp))
       final val pushTimeOut = BoundedPriorityMailbox.this.pushTimeOut
     }
@@ -365,8 +376,8 @@ case class BoundedPriorityMailbox( final val cmp: Comparator[Envelope], final va
 
 class CustomMailboxType(mailboxFQN: String) extends MailboxType {
 
-  def create(receiver: ActorCell): Mailbox = {
-    val constructorSignature = Array[Class[_]](classOf[ActorCell])
+  override def create(receiver: ActorContext): Mailbox = {
+    val constructorSignature = Array[Class[_]](classOf[ActorContext])
     ReflectiveAccess.createInstance[AnyRef](mailboxClass, constructorSignature, Array[AnyRef](receiver)) match {
       case Right(instance) ⇒ instance.asInstanceOf[Mailbox]
       case Left(exception) ⇒
@@ -379,7 +390,7 @@ class CustomMailboxType(mailboxFQN: String) extends MailboxType {
     }
   }
 
-  private def mailboxClass: Class[_] = ReflectiveAccess.getClassFor(mailboxFQN, classOf[ActorCell].getClassLoader) match {
+  private def mailboxClass: Class[_] = ReflectiveAccess.getClassFor(mailboxFQN, classOf[ActorContext].getClassLoader) match {
     case Right(clazz) ⇒ clazz
     case Left(exception) ⇒
       val cause = exception match {

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -11,7 +11,6 @@ import java.util.concurrent._
 import annotation.tailrec
 import akka.event.Logging.Error
 import com.typesafe.config.Config
-import java.lang.reflect.InvocationTargetException
 import akka.actor.ActorContext
 
 class MessageQueueAppendFailedException(message: String, cause: Throwable = null) extends AkkaException(message, cause)
@@ -393,12 +392,8 @@ class CustomMailboxType(mailboxFQN: String) extends MailboxType {
     ReflectiveAccess.createInstance[AnyRef](mailboxFQN, constructorSignature, Array[AnyRef](receiver)) match {
       case Right(instance) ⇒ instance.asInstanceOf[Mailbox]
       case Left(exception) ⇒
-        val cause = exception match {
-          case i: InvocationTargetException ⇒ i.getTargetException
-          case _                            ⇒ exception
-        }
         throw new IllegalArgumentException("Cannot instantiate mailbox [%s] due to: %s".
-          format(mailboxFQN, cause.toString))
+          format(mailboxFQN, exception.toString))
     }
   }
 

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -389,8 +389,8 @@ class CustomMailboxType(mailboxFQN: String) extends MailboxType {
 
   override def create(receiver: ActorContext): Mailbox = {
     val constructorSignature = Array[Class[_]](classOf[ActorContext])
-    ReflectiveAccess.createInstance[AnyRef](mailboxFQN, constructorSignature, Array[AnyRef](receiver)) match {
-      case Right(instance) ⇒ instance.asInstanceOf[Mailbox]
+    ReflectiveAccess.createInstance[Mailbox](mailboxFQN, constructorSignature, Array[AnyRef](receiver)) match {
+      case Right(instance) ⇒ instance
       case Left(exception) ⇒
         throw new IllegalArgumentException("Cannot instantiate mailbox [%s] due to: %s".
           format(mailboxFQN, exception.toString))

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -5,7 +5,6 @@ package akka.routing
 
 import akka.actor._
 import akka.japi.Creator
-import java.lang.reflect.InvocationTargetException
 import akka.config.ConfigurationException
 import java.util.concurrent.atomic.AtomicInteger
 import akka.util.{ ReflectiveAccess, Timeout }

--- a/akka-actor/src/main/scala/akka/util/ReflectiveAccess.scala
+++ b/akka-actor/src/main/scala/akka/util/ReflectiveAccess.scala
@@ -100,7 +100,8 @@ object ReflectiveAccess {
    * Unwraps `InvocationTargetException` if its getTargetException is an `Exception`.
    * Other `Throwable`, such as `Error` is thrown.
    */
-  private def withErrorHandling[T](body: ⇒ Either[Exception, T]): Either[Exception, T] = {
+  @inline
+  private final def withErrorHandling[T](body: ⇒ Either[Exception, T]): Either[Exception, T] = {
     try {
       body
     } catch {

--- a/akka-actor/src/main/scala/akka/util/ReflectiveAccess.scala
+++ b/akka-actor/src/main/scala/akka/util/ReflectiveAccess.scala
@@ -5,6 +5,7 @@
 package akka.util
 
 import akka.actor._
+import java.lang.reflect.InvocationTargetException
 
 object ReflectiveAccess {
 
@@ -14,22 +15,19 @@ object ReflectiveAccess {
 
   def createInstance[T](clazz: Class[_],
                         params: Array[Class[_]],
-                        args: Array[AnyRef]): Either[Exception, T] = try {
+                        args: Array[AnyRef]): Either[Exception, T] = withErrorHandling {
     assert(clazz ne null)
     assert(params ne null)
     assert(args ne null)
     val ctor = clazz.getDeclaredConstructor(params: _*)
     ctor.setAccessible(true)
     Right(ctor.newInstance(args: _*).asInstanceOf[T])
-  } catch {
-    case e: Exception ⇒
-      Left(e)
   }
 
   def createInstance[T](fqn: String,
                         params: Array[Class[_]],
                         args: Array[AnyRef],
-                        classloader: ClassLoader = loader): Either[Exception, T] = try {
+                        classloader: ClassLoader = loader): Either[Exception, T] = withErrorHandling {
     assert(params ne null)
     assert(args ne null)
     getClassFor(fqn, classloader) match {
@@ -39,9 +37,6 @@ object ReflectiveAccess {
         Right(ctor.newInstance(args: _*).asInstanceOf[T])
       case Left(exception) ⇒ Left(exception) //We could just cast this to Either[Exception, T] but it's ugly
     }
-  } catch {
-    case e: Exception ⇒
-      Left(e)
   }
 
   //Obtains a reference to fqn.MODULE$
@@ -98,6 +93,24 @@ object ReflectiveAccess {
     }
   } catch {
     case e: Exception ⇒ Left(e)
+  }
+
+  /**
+   * Caught exception is returned as Left(exception).
+   * Unwraps `InvocationTargetException` if its getTargetException is an `Exception`.
+   * Other `Throwable`, such as `Error` is thrown.
+   */
+  private def withErrorHandling[T](body: ⇒ Either[Exception, T]): Either[Exception, T] = {
+    try {
+      body
+    } catch {
+      case e: InvocationTargetException ⇒ e.getTargetException match {
+        case t: Exception ⇒ Left(t)
+        case t            ⇒ throw t
+      }
+      case e: Exception ⇒
+        Left(e)
+    }
   }
 
 }

--- a/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocSpec.scala
+++ b/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocSpec.scala
@@ -4,15 +4,18 @@
 package akka.docs.actor.mailbox
 
 //#imports
-import akka.actor.Actor
 import akka.actor.Props
-import akka.actor.mailbox.FileDurableMailboxType
 
 //#imports
+
+//#imports2
+import akka.actor.mailbox.FileDurableMailboxType
+//#imports2
 
 import org.scalatest.{ BeforeAndAfterAll, WordSpec }
 import org.scalatest.matchers.MustMatchers
 import akka.testkit.AkkaSpec
+import akka.actor.Actor
 
 class MyActor extends Actor {
   def receive = {
@@ -20,14 +23,31 @@ class MyActor extends Actor {
   }
 }
 
-class DurableMailboxDocSpec extends AkkaSpec {
+object DurableMailboxDocSpec {
+  val config = """
+    //#dispatcher-config
+    my-dispatcher {
+      mailboxType = akka.actor.mailbox.FileBasedMailbox
+    }
+    //#dispatcher-config
+    """
+}
 
-  "define dispatcher with durable mailbox" in {
-    //#define-dispatcher
+class DurableMailboxDocSpec extends AkkaSpec(DurableMailboxDocSpec.config) {
+
+  "configuration of dispatcher with durable mailbox" in {
+    //#dispatcher-config-use
+    val dispatcher = system.dispatcherFactory.lookup("my-dispatcher")
+    val myActor = system.actorOf(Props[MyActor].withDispatcher(dispatcher), name = "myactor")
+    //#dispatcher-config-use
+  }
+
+  "programatically define dispatcher with durable mailbox" in {
+    //#prog-define-dispatcher
     val dispatcher = system.dispatcherFactory.newDispatcher(
       "my-dispatcher", throughput = 1, mailboxType = FileDurableMailboxType).build
-    val myActor = system.actorOf(Props[MyActor].withDispatcher(dispatcher), name = "myactor")
-    //#define-dispatcher
+    val myActor = system.actorOf(Props[MyActor].withDispatcher(dispatcher))
+    //#prog-define-dispatcher
     myActor ! "hello"
   }
 

--- a/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocSpec.scala
+++ b/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocSpec.scala
@@ -8,10 +8,6 @@ import akka.actor.Props
 
 //#imports
 
-//#imports2
-import akka.actor.mailbox.FileDurableMailboxType
-//#imports2
-
 import org.scalatest.{ BeforeAndAfterAll, WordSpec }
 import org.scalatest.matchers.MustMatchers
 import akka.testkit.AkkaSpec
@@ -40,15 +36,6 @@ class DurableMailboxDocSpec extends AkkaSpec(DurableMailboxDocSpec.config) {
     val dispatcher = system.dispatcherFactory.lookup("my-dispatcher")
     val myActor = system.actorOf(Props[MyActor].withDispatcher(dispatcher), name = "myactor")
     //#dispatcher-config-use
-  }
-
-  "programatically define dispatcher with durable mailbox" in {
-    //#prog-define-dispatcher
-    val dispatcher = system.dispatcherFactory.newDispatcher(
-      "my-dispatcher", throughput = 1, mailboxType = FileDurableMailboxType).build
-    val myActor = system.actorOf(Props[MyActor].withDispatcher(dispatcher))
-    //#prog-define-dispatcher
-    myActor ! "hello"
   }
 
 }

--- a/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocTestBase.java
+++ b/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocTestBase.java
@@ -11,16 +11,11 @@ import akka.actor.Props;
 
 //#imports
 
-//#imports2
-import akka.actor.mailbox.DurableMailboxType;
-//#imports2
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import akka.testkit.AkkaSpec;
-import akka.docs.dispatcher.DispatcherDocSpec;
 import com.typesafe.config.ConfigFactory;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -55,22 +50,9 @@ public class DurableMailboxDocTestBase {
     myActor.tell("test");
   }
 
-  @Test
-  public void programaticallyDefinedDispatcher() {
-    //#prog-define-dispatcher
-    MessageDispatcher dispatcher = system.dispatcherFactory()
-        .newDispatcher("my-dispatcher", 1, DurableMailboxType.fileDurableMailboxType()).build();
-    ActorRef myActor = system.actorOf(new Props().withDispatcher(dispatcher).withCreator(new UntypedActorFactory() {
-      public UntypedActor create() {
-        return new MyUntypedActor();
-      }
-    }), "myactor");
-    //#prog-define-dispatcher
-    myActor.tell("test");
-  }
-
   public static class MyUntypedActor extends UntypedActor {
     public void onReceive(Object message) {
     }
   }
+
 }

--- a/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocTestBase.java
+++ b/akka-docs/modules/code/akka/docs/actor/mailbox/DurableMailboxDocTestBase.java
@@ -4,7 +4,6 @@
 package akka.docs.actor.mailbox;
 
 //#imports
-import akka.actor.mailbox.DurableMailboxType;
 import akka.dispatch.MessageDispatcher;
 import akka.actor.UntypedActorFactory;
 import akka.actor.UntypedActor;
@@ -12,8 +11,17 @@ import akka.actor.Props;
 
 //#imports
 
+//#imports2
+import akka.actor.mailbox.DurableMailboxType;
+//#imports2
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import akka.testkit.AkkaSpec;
+import akka.docs.dispatcher.DispatcherDocSpec;
+import com.typesafe.config.ConfigFactory;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 
@@ -21,20 +29,44 @@ import static org.junit.Assert.*;
 
 public class DurableMailboxDocTestBase {
 
+  ActorSystem system;
+
+  @Before
+  public void setUp() {
+    system = ActorSystem.create("MySystem",
+        ConfigFactory.parseString(DurableMailboxDocSpec.config()).withFallback(AkkaSpec.testConf()));
+  }
+
+  @After
+  public void tearDown() {
+    system.shutdown();
+  }
+
   @Test
-  public void defineDispatcher() {
-    ActorSystem system = ActorSystem.create("MySystem");
-    //#define-dispatcher
+  public void configDefinedDispatcher() {
+    //#dispatcher-config-use
+    MessageDispatcher dispatcher = system.dispatcherFactory().lookup("my-dispatcher");
+    ActorRef myActor = system.actorOf(new Props().withDispatcher(dispatcher).withCreator(new UntypedActorFactory() {
+      public UntypedActor create() {
+        return new MyUntypedActor();
+      }
+    }), "myactor");
+    //#dispatcher-config-use
+    myActor.tell("test");
+  }
+
+  @Test
+  public void programaticallyDefinedDispatcher() {
+    //#prog-define-dispatcher
     MessageDispatcher dispatcher = system.dispatcherFactory()
         .newDispatcher("my-dispatcher", 1, DurableMailboxType.fileDurableMailboxType()).build();
     ActorRef myActor = system.actorOf(new Props().withDispatcher(dispatcher).withCreator(new UntypedActorFactory() {
       public UntypedActor create() {
         return new MyUntypedActor();
       }
-    }));
-    //#define-dispatcher
+    }), "myactor");
+    //#prog-define-dispatcher
     myActor.tell("test");
-    system.shutdown();
   }
 
   public static class MyUntypedActor extends UntypedActor {

--- a/akka-docs/modules/durable-mailbox.rst
+++ b/akka-docs/modules/durable-mailbox.rst
@@ -62,15 +62,22 @@ The durable mailboxes and their configuration options reside in the
 
 You configure durable mailboxes through the dispatcher. The
 actor is oblivious to which type of mailbox it is using.
-Here is an example in Scala:
+
+In the configuration of the dispatcher you specify the fully qualified class name
+of the mailbox:
 
 .. includecode:: code/akka/docs/actor/mailbox/DurableMailboxDocSpec.scala
-   :include: imports,define-dispatcher
+   :include: dispatcher-config
+
+Here is an example of how to create an actor with a durable dispatcher, in Scala:
+
+.. includecode:: code/akka/docs/actor/mailbox/DurableMailboxDocSpec.scala
+   :include: imports,dispatcher-config-use
 
 Corresponding example in Java:
 
 .. includecode:: code/akka/docs/actor/mailbox/DurableMailboxDocTestBase.java
-   :include: imports,define-dispatcher
+   :include: imports,dispatcher-config-use
 
 The actor is oblivious to which type of mailbox it is using.
 
@@ -89,14 +96,11 @@ you need.
 You configure durable mailboxes through the dispatcher, as described in
 :ref:`DurableMailbox.General` with the following mailbox type.
 
-Scala::
+Config::
 
-  mailbox = akka.actor.mailbox.FileDurableMailboxType
-
-Java::
-
-  akka.actor.mailbox.DurableMailboxType.fileDurableMailboxType()
-
+  my-dispatcher {
+    mailboxType = akka.actor.mailbox.FileBasedMailbox
+  }
 
 You can also configure and tune the file-based durable mailbox. This is done in
 the ``akka.actor.mailbox.file-based`` section in the :ref:`configuration`.
@@ -117,14 +121,11 @@ mailboxes. Read more in the Redis documentation on how to do that.
 You configure durable mailboxes through the dispatcher, as described in
 :ref:`DurableMailbox.General` with the following mailbox type.
 
-Scala::
+Config::
 
-  mailbox = akka.actor.mailbox.RedisDurableMailboxType
-
-Java::
-
-  akka.actor.mailbox.DurableMailboxType.redisDurableMailboxType()
-
+  my-dispatcher {
+    mailboxType = akka.actor.mailbox.RedisBasedMailbox
+  }
 
 You also need to configure the IP and port for the Redis server. This is done in
 the ``akka.actor.mailbox.redis`` section in the :ref:`configuration`.
@@ -146,13 +147,11 @@ documentation on how to do that.
 You configure durable mailboxes through the dispatcher, as described in
 :ref:`DurableMailbox.General` with the following mailbox type.
 
-Scala::
+Config::
 
-  mailbox = akka.actor.mailbox.ZooKeeperDurableMailboxType
-
-Java::
-
-  akka.actor.mailbox.DurableMailboxType.zooKeeperDurableMailboxType()
+  my-dispatcher {
+    mailboxType = akka.actor.mailbox.ZooKeeperBasedMailbox
+  }
 
 You also need to configure ZooKeeper server addresses, timeouts, etc. This is
 done in the ``akka.actor.mailbox.zookeeper`` section in the :ref:`configuration`.
@@ -171,13 +170,11 @@ Beanstalk documentation on how to do that.
 You configure durable mailboxes through the dispatcher, as described in
 :ref:`DurableMailbox.General` with the following mailbox type.
 
-Scala::
+Config::
 
-  mailbox = akka.actor.mailbox.BeanstalkDurableMailboxType
-
-Java::
-
-  akka.actor.mailbox.DurableMailboxType.beanstalkDurableMailboxType()
+  my-dispatcher {
+    mailboxType = akka.actor.mailbox.BeanstalkBasedMailbox
+  }
 
 You also need to configure the IP, and port, and so on, for the Beanstalk
 server. This is done in the ``akka.actor.mailbox.beanstalk`` section in the
@@ -202,13 +199,11 @@ lightweight versus building on other MongoDB implementations such as
 You configure durable mailboxes through the dispatcher, as described in
 :ref:`DurableMailbox.General` with the following mailbox type.
 
-Scala::
+Config::
 
-  mailbox = akka.actor.mailbox.MongoDurableMailboxType
-
-Java::
-
-  akka.actor.mailbox.DurableMailboxType.mongoDurableMailboxType()
+  my-dispatcher {
+    mailboxType = akka.actor.mailbox.MongoBasedMailbox
+  }
 
 You will need to configure the URI for the MongoDB server, using the URI Format specified in the
 `MongoDB Documentation <http://www.mongodb.org/display/DOCS/Connections>`_. This is done in

--- a/akka-durable-mailboxes/akka-beanstalk-mailbox/src/main/scala/akka/actor/mailbox/BeanstalkBasedMailbox.scala
+++ b/akka-durable-mailboxes/akka-beanstalk-mailbox/src/main/scala/akka/actor/mailbox/BeanstalkBasedMailbox.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.actor.LocalActorRef
 import akka.util.Duration
 import akka.AkkaException
-import akka.actor.ActorCell
+import akka.actor.ActorContext
 import akka.dispatch.Envelope
 import akka.event.Logging
 import akka.actor.ActorRef
@@ -19,7 +19,7 @@ class BeanstalkBasedMailboxException(message: String) extends AkkaException(mess
 /**
  * @author <a href="http://jonasboner.com">Jonas Bon&#233;r</a>
  */
-class BeanstalkBasedMailbox(val owner: ActorCell) extends DurableMailbox(owner) with DurableMessageSerialization {
+class BeanstalkBasedMailbox(val owner: ActorContext) extends DurableMailbox(owner) with DurableMessageSerialization {
 
   private val settings = BeanstalkBasedMailboxExtension(owner.system)
   private val messageSubmitDelaySeconds = settings.MessageSubmitDelay.toSeconds.toInt
@@ -78,7 +78,7 @@ class BeanstalkBasedMailbox(val owner: ActorCell) extends DurableMailbox(owner) 
     // TODO PN: Why volatile on local variable?
     @volatile
     var connected = false
-    // TODO PN: attempts is not used. Should we have maxAttempts check? Note that this is called from ThreadLocal.initialValue 
+    // TODO PN: attempts is not used. Should we have maxAttempts check? Note that this is called from ThreadLocal.initialValue
     var attempts = 0
     var client: Client = null
     while (!connected) {

--- a/akka-durable-mailboxes/akka-beanstalk-mailbox/src/test/scala/akka/actor/mailbox/BeanstalkBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-beanstalk-mailbox/src/test/scala/akka/actor/mailbox/BeanstalkBasedMailboxSpec.scala
@@ -1,4 +1,7 @@
 package akka.actor.mailbox
 
+import akka.dispatch.CustomMailboxType
+
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class BeanstalkBasedMailboxSpec extends DurableMailboxSpec("Beanstalkd", BeanstalkDurableMailboxType)
+class BeanstalkBasedMailboxSpec extends DurableMailboxSpec("Beanstalkd",
+  new CustomMailboxType("akka.actor.mailbox.BeanstalkBasedMailbox"))

--- a/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/FiledBasedMailbox.scala
+++ b/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/FiledBasedMailbox.scala
@@ -5,12 +5,12 @@
 package akka.actor.mailbox
 
 import org.apache.commons.io.FileUtils
-import akka.actor.ActorCell
+import akka.actor.ActorContext
 import akka.dispatch.Envelope
 import akka.event.Logging
 import akka.actor.ActorRef
 
-class FileBasedMailbox(val owner: ActorCell) extends DurableMailbox(owner) with DurableMessageSerialization {
+class FileBasedMailbox(val owner: ActorContext) extends DurableMailbox(owner) with DurableMessageSerialization {
 
   val log = Logging(system, "FileBasedMailbox")
 

--- a/akka-durable-mailboxes/akka-file-mailbox/src/test/scala/akka/actor/mailbox/FileBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-file-mailbox/src/test/scala/akka/actor/mailbox/FileBasedMailboxSpec.scala
@@ -1,9 +1,11 @@
 package akka.actor.mailbox
 
 import org.apache.commons.io.FileUtils
+import akka.dispatch.CustomMailboxType
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class FileBasedMailboxSpec extends DurableMailboxSpec("File", FileDurableMailboxType) {
+class FileBasedMailboxSpec extends DurableMailboxSpec("File",
+  new CustomMailboxType("akka.actor.mailbox.FileBasedMailbox")) {
 
   def clean {
     val queuePath = FileBasedMailboxExtension(system).QueuePath

--- a/akka-durable-mailboxes/akka-mailboxes-common/src/main/scala/akka/actor/mailbox/DurableMailbox.scala
+++ b/akka-durable-mailboxes/akka-mailboxes-common/src/main/scala/akka/actor/mailbox/DurableMailbox.scala
@@ -4,7 +4,6 @@
 package akka.actor.mailbox
 
 import akka.util.ReflectiveAccess
-import java.lang.reflect.InvocationTargetException
 import akka.AkkaException
 import akka.actor.ActorContext
 import akka.actor.ActorRef

--- a/akka-durable-mailboxes/akka-mailboxes-common/src/main/scala/akka/actor/mailbox/DurableMailbox.scala
+++ b/akka-durable-mailboxes/akka-mailboxes-common/src/main/scala/akka/actor/mailbox/DurableMailbox.scala
@@ -74,23 +74,3 @@ trait DurableMessageSerialization {
 
 }
 
-case object RedisDurableMailboxType extends CustomMailboxType("akka.actor.mailbox.RedisBasedMailbox")
-case object MongoDurableMailboxType extends CustomMailboxType("akka.actor.mailbox.MongoBasedMailbox")
-case object BeanstalkDurableMailboxType extends CustomMailboxType("akka.actor.mailbox.BeanstalkBasedMailbox")
-case object FileDurableMailboxType extends CustomMailboxType("akka.actor.mailbox.FileBasedMailbox")
-case object ZooKeeperDurableMailboxType extends CustomMailboxType("akka.actor.mailbox.ZooKeeperBasedMailbox")
-
-/**
- * Java API for the mailbox types. Usage:
- * <pre><code>
- * MessageDispatcher dispatcher = system.dispatcherFactory()
- *   .newDispatcher("my-dispatcher", 1, DurableMailboxType.redisDurableMailboxType()).build();
- * </code></pre>
- */
-object DurableMailboxType {
-  def redisDurableMailboxType(): MailboxType = RedisDurableMailboxType
-  def mongoDurableMailboxType(): MailboxType = MongoDurableMailboxType
-  def beanstalkDurableMailboxType(): MailboxType = BeanstalkDurableMailboxType
-  def fileDurableMailboxType(): MailboxType = FileDurableMailboxType
-  def zooKeeperDurableMailboxType(): MailboxType = ZooKeeperDurableMailboxType
-}

--- a/akka-durable-mailboxes/akka-mailboxes-common/src/main/scala/akka/actor/mailbox/DurableMailbox.scala
+++ b/akka-durable-mailboxes/akka-mailboxes-common/src/main/scala/akka/actor/mailbox/DurableMailbox.scala
@@ -6,13 +6,13 @@ package akka.actor.mailbox
 import akka.util.ReflectiveAccess
 import java.lang.reflect.InvocationTargetException
 import akka.AkkaException
-import akka.actor.ActorCell
+import akka.actor.ActorContext
 import akka.actor.ActorRef
 import akka.actor.SerializedActorRef
 import akka.dispatch.Envelope
 import akka.dispatch.DefaultSystemMessageQueue
 import akka.dispatch.Dispatcher
-import akka.dispatch.Mailbox
+import akka.dispatch.CustomMailbox
 import akka.dispatch.MailboxType
 import akka.dispatch.MessageDispatcher
 import akka.dispatch.MessageQueue
@@ -34,7 +34,7 @@ class DurableMailboxException private[akka] (message: String, cause: Throwable) 
   def this(message: String) = this(message, null)
 }
 
-abstract class DurableMailbox(owner: ActorCell) extends Mailbox(owner) with DefaultSystemMessageQueue {
+abstract class DurableMailbox(owner: ActorContext) extends CustomMailbox(owner) with DefaultSystemMessageQueue {
   import DurableExecutableMailboxConfig._
 
   def system = owner.system
@@ -46,7 +46,7 @@ abstract class DurableMailbox(owner: ActorCell) extends Mailbox(owner) with Defa
 
 trait DurableMessageSerialization {
 
-  def owner: ActorCell
+  def owner: ActorContext
 
   def serialize(durableMessage: Envelope): Array[Byte] = {
 

--- a/akka-durable-mailboxes/akka-mailboxes-common/src/test/scala/akka/actor/mailbox/DurableMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-mailboxes-common/src/test/scala/akka/actor/mailbox/DurableMailboxSpec.scala
@@ -1,15 +1,16 @@
 package akka.actor.mailbox
 
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.CountDownLatch
 import org.scalatest.WordSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.{ BeforeAndAfterEach, BeforeAndAfterAll }
 import akka.actor._
 import akka.actor.Actor._
-import java.util.concurrent.CountDownLatch
 import akka.dispatch.MessageDispatcher
-import akka.testkit.AkkaSpec
 import akka.dispatch.Dispatchers
+import akka.dispatch.MailboxType
+import akka.testkit.AkkaSpec
 
 object DurableMailboxSpecActorFactory {
 
@@ -23,7 +24,7 @@ object DurableMailboxSpecActorFactory {
 
 }
 
-abstract class DurableMailboxSpec(val backendName: String, val mailboxType: DurableMailboxType) extends AkkaSpec with BeforeAndAfterEach {
+abstract class DurableMailboxSpec(val backendName: String, val mailboxType: MailboxType) extends AkkaSpec with BeforeAndAfterEach {
   import DurableMailboxSpecActorFactory._
 
   implicit val dispatcher = system.dispatcherFactory.newDispatcher(backendName, throughput = 1, mailboxType = mailboxType).build

--- a/akka-durable-mailboxes/akka-mongo-mailbox/src/main/scala/akka/actor/mailbox/MongoBasedMailbox.scala
+++ b/akka-durable-mailboxes/akka-mongo-mailbox/src/main/scala/akka/actor/mailbox/MongoBasedMailbox.scala
@@ -7,7 +7,7 @@ import akka.AkkaException
 import com.mongodb.async._
 import com.mongodb.async.futures.RequestFutures
 import org.bson.collection._
-import akka.actor.ActorCell
+import akka.actor.ActorContext
 import akka.event.Logging
 import akka.actor.ActorRef
 import akka.dispatch.{ Await, Promise, Envelope, DefaultPromise }
@@ -26,7 +26,7 @@ class MongoBasedMailboxException(message: String) extends AkkaException(message)
  *
  * @author <a href="http://evilmonkeylabs.com">Brendan W. McAdams</a>
  */
-class MongoBasedMailbox(val owner: ActorCell) extends DurableMailbox(owner) {
+class MongoBasedMailbox(val owner: ActorContext) extends DurableMailbox(owner) {
   // this implicit object provides the context for reading/writing things as MongoDurableMessage
   implicit val mailboxBSONSer = new BSONSerializableMailbox(system)
   implicit val safeWrite = WriteConcern.Safe // TODO - Replica Safe when appropriate!

--- a/akka-durable-mailboxes/akka-mongo-mailbox/src/test/scala/akka/actor/mailbox/MongoBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-mongo-mailbox/src/test/scala/akka/actor/mailbox/MongoBasedMailboxSpec.scala
@@ -1,18 +1,19 @@
 package akka.actor.mailbox
 
 import java.util.concurrent.TimeUnit
-
 import org.scalatest.WordSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.{ BeforeAndAfterEach, BeforeAndAfterAll }
-
 import akka.actor._
 import akka.actor.Actor._
 import java.util.concurrent.CountDownLatch
 import akka.dispatch.MessageDispatcher
+import akka.dispatch.CustomMailboxType
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class MongoBasedMailboxSpec extends DurableMailboxSpec("mongodb", MongoDurableMailboxType) {
+class MongoBasedMailboxSpec extends DurableMailboxSpec("mongodb",
+  new CustomMailboxType("akka.actor.mailbox.MongoBasedMailbox")) {
+
   import org.apache.log4j.{ Logger, Level }
   import com.mongodb.async._
 

--- a/akka-durable-mailboxes/akka-redis-mailbox/src/main/scala/akka/actor/mailbox/RedisBasedMailbox.scala
+++ b/akka-durable-mailboxes/akka-redis-mailbox/src/main/scala/akka/actor/mailbox/RedisBasedMailbox.scala
@@ -6,14 +6,14 @@ package akka.actor.mailbox
 import com.redis._
 import akka.actor.LocalActorRef
 import akka.AkkaException
-import akka.actor.ActorCell
+import akka.actor.ActorContext
 import akka.dispatch.Envelope
 import akka.event.Logging
 import akka.actor.ActorRef
 
 class RedisBasedMailboxException(message: String) extends AkkaException(message)
 
-class RedisBasedMailbox(val owner: ActorCell) extends DurableMailbox(owner) with DurableMessageSerialization {
+class RedisBasedMailbox(val owner: ActorContext) extends DurableMailbox(owner) with DurableMessageSerialization {
 
   private val settings = RedisBasedMailboxExtension(owner.system)
 

--- a/akka-durable-mailboxes/akka-redis-mailbox/src/test/scala/akka/actor/mailbox/RedisBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-redis-mailbox/src/test/scala/akka/actor/mailbox/RedisBasedMailboxSpec.scala
@@ -1,4 +1,6 @@
 package akka.actor.mailbox
+import akka.dispatch.CustomMailboxType
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class RedisBasedMailboxSpec extends DurableMailboxSpec("Redis", RedisDurableMailboxType)
+class RedisBasedMailboxSpec extends DurableMailboxSpec("Redis",
+  new CustomMailboxType("akka.actor.mailbox.RedisBasedMailbox"))

--- a/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/actor/mailbox/ZooKeeperBasedMailbox.scala
+++ b/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/actor/mailbox/ZooKeeperBasedMailbox.scala
@@ -8,7 +8,7 @@ import akka.actor.LocalActorRef
 import akka.util.Duration
 import akka.AkkaException
 import org.I0Itec.zkclient.serialize._
-import akka.actor.ActorCell
+import akka.actor.ActorContext
 import akka.cluster.zookeeper.AkkaZkClient
 import akka.dispatch.Envelope
 import akka.event.Logging
@@ -17,7 +17,7 @@ import akka.actor.ActorRef
 
 class ZooKeeperBasedMailboxException(message: String) extends AkkaException(message)
 
-class ZooKeeperBasedMailbox(val owner: ActorCell) extends DurableMailbox(owner) with DurableMessageSerialization {
+class ZooKeeperBasedMailbox(val owner: ActorContext) extends DurableMailbox(owner) with DurableMessageSerialization {
 
   private val settings = ZooKeeperBasedMailboxExtension(owner.system)
   val queueNode = "/queues"

--- a/akka-durable-mailboxes/akka-zookeeper-mailbox/src/test/scala/akka/actor/mailbox/ZooKeeperBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-zookeeper-mailbox/src/test/scala/akka/actor/mailbox/ZooKeeperBasedMailboxSpec.scala
@@ -4,10 +4,13 @@ import akka.actor.{ Actor, LocalActorRef }
 import akka.cluster.zookeeper._
 import org.I0Itec.zkclient._
 import akka.dispatch.MessageDispatcher
+import akka.dispatch.CustomMailboxType
 import akka.actor.ActorRef
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ZooKeeperBasedMailboxSpec extends DurableMailboxSpec("ZooKeeper", ZooKeeperDurableMailboxType) {
+class ZooKeeperBasedMailboxSpec extends DurableMailboxSpec("ZooKeeper",
+  new CustomMailboxType("akka.actor.mailbox.ZooKeeperBasedMailbox")) {
+
   val dataPath = "_akka_cluster/data"
   val logPath = "_akka_cluster/log"
 


### PR DESCRIPTION
- Added mailboxType property to dispatcher config
- Changed durable mailboxes to use this
- Updated docs for durable mailboxes
- Added CustomMailbox for user defined mailbox implementations with ActorContext instead of ActorCell.
- Mailbox is still there, with ActorCell, for internal use.
- Implemented durable mailboxes with CustomMailbox
