### PR TITLE
1529 removed hardcoded timeout value from SGFCR

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/DeployerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeployerSpec.scala
@@ -8,6 +8,7 @@ import akka.testkit.AkkaSpec
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
 import akka.routing._
+import akka.util.duration._
 
 object DeployerSpec {
   val deployerConf = ConfigFactory.parseString("""
@@ -35,6 +36,7 @@ object DeployerSpec {
         }
         /user/service-scatter-gather {
           router = scatter-gather
+          within = 2 seconds
         }
       }
       """, ConfigParseOptions.defaults)
@@ -116,7 +118,7 @@ class DeployerSpec extends AkkaSpec(DeployerSpec.deployerConf) {
     }
 
     "be able to parse 'akka.actor.deployment._' with scatter-gather router" in {
-      assertRouting(ScatterGatherFirstCompletedRouter(1), "/user/service-scatter-gather")
+      assertRouting(ScatterGatherFirstCompletedRouter(nrOfInstances = 1, within = 2 seconds), "/user/service-scatter-gather")
     }
 
     def assertRouting(expected: RouterConfig, service: String) {

--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -373,12 +373,12 @@ class RoutingSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
   "custom router" must {
     "be started when constructed" in {
-      val routedActor = system.actorOf(Props[TestActor].withRouter(new VoteCountRouter))
+      val routedActor = system.actorOf(Props[TestActor].withRouter(VoteCountRouter))
       routedActor.isTerminated must be(false)
     }
 
     "count votes as intended - not as in Florida" in {
-      val routedActor = system.actorOf(Props[TestActor].withRouter(new VoteCountRouter))
+      val routedActor = system.actorOf(Props[TestActor].withRouter(VoteCountRouter))
       routedActor ! DemocratVote
       routedActor ! DemocratVote
       routedActor ! RepublicanVote
@@ -422,7 +422,7 @@ class RoutingSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     //#crActors
 
     //#crRouter
-    class VoteCountRouter extends RouterConfig {
+    object VoteCountRouter extends RouterConfig {
 
       //#crRoute
       def createRoute(props: Props,

--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -373,12 +373,12 @@ class RoutingSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
   "custom router" must {
     "be started when constructed" in {
-      val routedActor = system.actorOf(Props[TestActor].withRouter(VoteCountRouter()))
+      val routedActor = system.actorOf(Props[TestActor].withRouter(new VoteCountRouter))
       routedActor.isTerminated must be(false)
     }
 
     "count votes as intended - not as in Florida" in {
-      val routedActor = system.actorOf(Props[TestActor].withRouter(VoteCountRouter()))
+      val routedActor = system.actorOf(Props[TestActor].withRouter(new VoteCountRouter))
       routedActor ! DemocratVote
       routedActor ! DemocratVote
       routedActor ! RepublicanVote
@@ -422,11 +422,7 @@ class RoutingSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     //#crActors
 
     //#crRouter
-    case class VoteCountRouter(
-      nrOfInstances: Int = 0,
-      routees: Iterable[String] = Nil,
-      within: Duration = Duration.Zero)
-      extends RouterConfig {
+    class VoteCountRouter extends RouterConfig {
 
       //#crRoute
       def createRoute(props: Props,

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -78,6 +78,9 @@ akka {
         # is ignored if routees.paths is given
         nr-of-instances = 1
 
+        # within is the timeout used for routers containing future calls
+        within = 5 seconds
+
         # FIXME document 'create-as', ticket 1511
         create-as {
           # fully qualified class name of recipe implementation

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -167,8 +167,6 @@ case class Destination(sender: ActorRef, recipient: ActorRef)
  * Oxymoron style.
  */
 case object NoRouter extends RouterConfig {
-  def nrOfInstances: Int = 0
-  def routees: Iterable[String] = Nil
   def createRoute(props: Props, actorContext: ActorContext, ref: RoutedActorRef): Route = null
 }
 
@@ -207,9 +205,9 @@ case class RoundRobinRouter(nrOfInstances: Int = 0, routees: Iterable[String] = 
 
 trait RoundRobinLike { this: RouterConfig ⇒
 
-  val nrOfInstances: Int
+  def nrOfInstances: Int
 
-  val routees: Iterable[String]
+  def routees: Iterable[String]
 
   def createRoute(props: Props, context: ActorContext, ref: RoutedActorRef): Route = {
     createAndRegisterRoutees(props, context, nrOfInstances, routees)
@@ -267,9 +265,9 @@ trait RandomLike { this: RouterConfig ⇒
 
   import java.security.SecureRandom
 
-  val nrOfInstances: Int
+  def nrOfInstances: Int
 
-  val routees: Iterable[String]
+  def routees: Iterable[String]
 
   private val random = new ThreadLocal[SecureRandom] {
     override def initialValue = SecureRandom.getInstance("SHA1PRNG")
@@ -327,9 +325,9 @@ case class BroadcastRouter(nrOfInstances: Int = 0, routees: Iterable[String] = N
 
 trait BroadcastLike { this: RouterConfig ⇒
 
-  val nrOfInstances: Int
+  def nrOfInstances: Int
 
-  val routees: Iterable[String]
+  def routees: Iterable[String]
 
   def createRoute(props: Props, context: ActorContext, ref: RoutedActorRef): Route = {
     createAndRegisterRoutees(props, context, nrOfInstances, routees)
@@ -379,11 +377,11 @@ case class ScatterGatherFirstCompletedRouter(nrOfInstances: Int = 0, routees: It
 
 trait ScatterGatherFirstCompletedLike { this: RouterConfig ⇒
 
-  val nrOfInstances: Int
+  def nrOfInstances: Int
 
-  val routees: Iterable[String]
+  def routees: Iterable[String]
 
-  val within: Duration
+  def within: Duration
 
   def createRoute(props: Props, context: ActorContext, ref: RoutedActorRef): Route = {
     createAndRegisterRoutees(props, context, nrOfInstances, routees)

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -79,12 +79,6 @@ private[akka] class RoutedActorRef(_system: ActorSystemImpl, _props: Props, _sup
  */
 trait RouterConfig {
 
-  def nrOfInstances: Int
-
-  def routees: Iterable[String]
-
-  def within: Duration
-
   def createRoute(props: Props, actorContext: ActorContext, ref: RoutedActorRef): Route
 
   def createActor(): Router = new Router {}
@@ -173,9 +167,8 @@ case class Destination(sender: ActorRef, recipient: ActorRef)
  * Oxymoron style.
  */
 case object NoRouter extends RouterConfig {
-  def nrOfInstances = 0
-  def routees = Nil
-  def within = Duration.Zero
+  def nrOfInstances: Int = 0
+  def routees: Iterable[String] = Nil
   def createRoute(props: Props, actorContext: ActorContext, ref: RoutedActorRef): Route = null
 }
 
@@ -193,7 +186,7 @@ object RoundRobinRouter {
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RoundRobinRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil, within: Duration = Duration.Zero) extends RouterConfig with RoundRobinLike {
+case class RoundRobinRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil) extends RouterConfig with RoundRobinLike {
 
   /**
    * Constructor that sets nrOfInstances to be created.
@@ -213,6 +206,11 @@ case class RoundRobinRouter(nrOfInstances: Int = 0, routees: Iterable[String] = 
 }
 
 trait RoundRobinLike { this: RouterConfig ⇒
+
+  val nrOfInstances: Int
+
+  val routees: Iterable[String]
+
   def createRoute(props: Props, context: ActorContext, ref: RoutedActorRef): Route = {
     createAndRegisterRoutees(props, context, nrOfInstances, routees)
 
@@ -246,7 +244,7 @@ object RandomRouter {
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RandomRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil, within: Duration = Duration.Zero) extends RouterConfig with RandomLike {
+case class RandomRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil) extends RouterConfig with RandomLike {
 
   /**
    * Constructor that sets nrOfInstances to be created.
@@ -268,6 +266,10 @@ case class RandomRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil,
 trait RandomLike { this: RouterConfig ⇒
 
   import java.security.SecureRandom
+
+  val nrOfInstances: Int
+
+  val routees: Iterable[String]
 
   private val random = new ThreadLocal[SecureRandom] {
     override def initialValue = SecureRandom.getInstance("SHA1PRNG")
@@ -304,7 +306,7 @@ object BroadcastRouter {
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class BroadcastRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil, within: Duration = Duration.Zero) extends RouterConfig with BroadcastLike {
+case class BroadcastRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil) extends RouterConfig with BroadcastLike {
 
   /**
    * Constructor that sets nrOfInstances to be created.
@@ -324,6 +326,11 @@ case class BroadcastRouter(nrOfInstances: Int = 0, routees: Iterable[String] = N
 }
 
 trait BroadcastLike { this: RouterConfig ⇒
+
+  val nrOfInstances: Int
+
+  val routees: Iterable[String]
+
   def createRoute(props: Props, context: ActorContext, ref: RoutedActorRef): Route = {
     createAndRegisterRoutees(props, context, nrOfInstances, routees)
 
@@ -371,6 +378,13 @@ case class ScatterGatherFirstCompletedRouter(nrOfInstances: Int = 0, routees: It
 }
 
 trait ScatterGatherFirstCompletedLike { this: RouterConfig ⇒
+
+  val nrOfInstances: Int
+
+  val routees: Iterable[String]
+
+  val within: Duration
+
   def createRoute(props: Props, context: ActorContext, ref: RoutedActorRef): Route = {
     createAndRegisterRoutees(props, context, nrOfInstances, routees)
 

--- a/akka-docs/scala/code/akka/docs/routing/RouterTypeExample.scala
+++ b/akka-docs/scala/code/akka/docs/routing/RouterTypeExample.scala
@@ -68,7 +68,7 @@ class ParentActor extends Actor {
     case "sgfcr" ⇒
       //#scatterGatherFirstCompletedRouter
       val scatterGatherFirstCompletedRouter = context.actorOf(
-        Props[FibonacciActor].withRouter(ScatterGatherFirstCompletedRouter()),
+        Props[FibonacciActor].withRouter(ScatterGatherFirstCompletedRouter(within = 2 seconds)),
         "router")
       implicit val timeout = context.system.settings.ActorTimeout
       val futureResult = scatterGatherFirstCompletedRouter ? FibonacciNumber(10)

--- a/akka-remote/src/main/scala/akka/remote/RemoteDeployer.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDeployer.scala
@@ -26,10 +26,10 @@ class RemoteDeployer(_settings: ActorSystem.Settings) extends Deployer(_settings
             if (nodes.isEmpty || deploy.routing == NoRouter) d
             else {
               val r = deploy.routing match {
-                case RoundRobinRouter(x, _)                  ⇒ RemoteRoundRobinRouter(x, nodes)
-                case RandomRouter(x, _)                      ⇒ RemoteRandomRouter(x, nodes)
-                case BroadcastRouter(x, _)                   ⇒ RemoteBroadcastRouter(x, nodes)
-                case ScatterGatherFirstCompletedRouter(x, _) ⇒ RemoteScatterGatherFirstCompletedRouter(x, nodes)
+                case RoundRobinRouter(x, _, w)                  ⇒ RemoteRoundRobinRouter(x, nodes, w)
+                case RandomRouter(x, _, w)                      ⇒ RemoteRandomRouter(x, nodes, w)
+                case BroadcastRouter(x, _, w)                   ⇒ RemoteBroadcastRouter(x, nodes, w)
+                case ScatterGatherFirstCompletedRouter(x, _, w) ⇒ RemoteScatterGatherFirstCompletedRouter(x, nodes, w)
               }
               Some(deploy.copy(routing = r))
             }

--- a/akka-remote/src/main/scala/akka/remote/RemoteDeployer.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDeployer.scala
@@ -26,9 +26,9 @@ class RemoteDeployer(_settings: ActorSystem.Settings) extends Deployer(_settings
             if (nodes.isEmpty || deploy.routing == NoRouter) d
             else {
               val r = deploy.routing match {
-                case RoundRobinRouter(x, _, w)                  ⇒ RemoteRoundRobinRouter(x, nodes, w)
-                case RandomRouter(x, _, w)                      ⇒ RemoteRandomRouter(x, nodes, w)
-                case BroadcastRouter(x, _, w)                   ⇒ RemoteBroadcastRouter(x, nodes, w)
+                case RoundRobinRouter(x, _)                     ⇒ RemoteRoundRobinRouter(x, nodes)
+                case RandomRouter(x, _)                         ⇒ RemoteRandomRouter(x, nodes)
+                case BroadcastRouter(x, _)                      ⇒ RemoteBroadcastRouter(x, nodes)
                 case ScatterGatherFirstCompletedRouter(x, _, w) ⇒ RemoteScatterGatherFirstCompletedRouter(x, nodes, w)
               }
               Some(deploy.copy(routing = r))

--- a/akka-remote/src/main/scala/akka/routing/RemoteRouters.scala
+++ b/akka-remote/src/main/scala/akka/routing/RemoteRouters.scala
@@ -6,9 +6,9 @@ package akka.routing
 import akka.actor._
 import akka.remote._
 import scala.collection.JavaConverters._
-import java.util.concurrent.atomic.AtomicInteger
 import com.typesafe.config.ConfigFactory
 import akka.config.ConfigurationException
+import akka.util.Duration
 
 trait RemoteRouterConfig extends RouterConfig {
   override protected def createRoutees(props: Props, context: ActorContext, nrOfInstances: Int, routees: Iterable[String]): Vector[ActorRef] = (nrOfInstances, routees) match {
@@ -39,13 +39,13 @@ trait RemoteRouterConfig extends RouterConfig {
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RemoteRoundRobinRouter(nrOfInstances: Int, routees: Iterable[String]) extends RemoteRouterConfig with RoundRobinLike {
+case class RemoteRoundRobinRouter(nrOfInstances: Int, routees: Iterable[String], within: Duration) extends RemoteRouterConfig with RoundRobinLike {
 
   /**
    * Constructor that sets the routees to be used.
    * Java API
    */
-  def this(n: Int, t: java.util.Collection[String]) = this(n, t.asScala)
+  def this(n: Int, t: java.util.Collection[String], w: Duration) = this(n, t.asScala, w)
 }
 
 /**
@@ -59,13 +59,13 @@ case class RemoteRoundRobinRouter(nrOfInstances: Int, routees: Iterable[String])
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RemoteRandomRouter(nrOfInstances: Int, routees: Iterable[String]) extends RemoteRouterConfig with RandomLike {
+case class RemoteRandomRouter(nrOfInstances: Int, routees: Iterable[String], within: Duration) extends RemoteRouterConfig with RandomLike {
 
   /**
    * Constructor that sets the routees to be used.
    * Java API
    */
-  def this(n: Int, t: java.util.Collection[String]) = this(n, t.asScala)
+  def this(n: Int, t: java.util.Collection[String], w: Duration) = this(n, t.asScala, w)
 }
 
 /**
@@ -79,13 +79,13 @@ case class RemoteRandomRouter(nrOfInstances: Int, routees: Iterable[String]) ext
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RemoteBroadcastRouter(nrOfInstances: Int, routees: Iterable[String]) extends RemoteRouterConfig with BroadcastLike {
+case class RemoteBroadcastRouter(nrOfInstances: Int, routees: Iterable[String], within: Duration) extends RemoteRouterConfig with BroadcastLike {
 
   /**
    * Constructor that sets the routees to be used.
    * Java API
    */
-  def this(n: Int, t: java.util.Collection[String]) = this(n, t.asScala)
+  def this(n: Int, t: java.util.Collection[String], w: Duration) = this(n, t.asScala, w)
 }
 
 /**
@@ -99,12 +99,12 @@ case class RemoteBroadcastRouter(nrOfInstances: Int, routees: Iterable[String]) 
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RemoteScatterGatherFirstCompletedRouter(nrOfInstances: Int, routees: Iterable[String])
+case class RemoteScatterGatherFirstCompletedRouter(nrOfInstances: Int, routees: Iterable[String], within: Duration)
   extends RemoteRouterConfig with ScatterGatherFirstCompletedLike {
 
   /**
    * Constructor that sets the routees to be used.
    * Java API
    */
-  def this(n: Int, t: java.util.Collection[String]) = this(n, t.asScala)
+  def this(n: Int, t: java.util.Collection[String], w: Duration) = this(n, t.asScala, w)
 }

--- a/akka-remote/src/main/scala/akka/routing/RemoteRouters.scala
+++ b/akka-remote/src/main/scala/akka/routing/RemoteRouters.scala
@@ -39,13 +39,13 @@ trait RemoteRouterConfig extends RouterConfig {
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RemoteRoundRobinRouter(nrOfInstances: Int, routees: Iterable[String], within: Duration) extends RemoteRouterConfig with RoundRobinLike {
+case class RemoteRoundRobinRouter(nrOfInstances: Int, routees: Iterable[String]) extends RemoteRouterConfig with RoundRobinLike {
 
   /**
    * Constructor that sets the routees to be used.
    * Java API
    */
-  def this(n: Int, t: java.util.Collection[String], w: Duration) = this(n, t.asScala, w)
+  def this(n: Int, t: java.util.Collection[String]) = this(n, t.asScala)
 }
 
 /**
@@ -59,13 +59,13 @@ case class RemoteRoundRobinRouter(nrOfInstances: Int, routees: Iterable[String],
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RemoteRandomRouter(nrOfInstances: Int, routees: Iterable[String], within: Duration) extends RemoteRouterConfig with RandomLike {
+case class RemoteRandomRouter(nrOfInstances: Int, routees: Iterable[String]) extends RemoteRouterConfig with RandomLike {
 
   /**
    * Constructor that sets the routees to be used.
    * Java API
    */
-  def this(n: Int, t: java.util.Collection[String], w: Duration) = this(n, t.asScala, w)
+  def this(n: Int, t: java.util.Collection[String]) = this(n, t.asScala)
 }
 
 /**
@@ -79,13 +79,13 @@ case class RemoteRandomRouter(nrOfInstances: Int, routees: Iterable[String], wit
  * if you provide either 'nrOfInstances' or 'routees' to during instantiation they will
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
-case class RemoteBroadcastRouter(nrOfInstances: Int, routees: Iterable[String], within: Duration) extends RemoteRouterConfig with BroadcastLike {
+case class RemoteBroadcastRouter(nrOfInstances: Int, routees: Iterable[String]) extends RemoteRouterConfig with BroadcastLike {
 
   /**
    * Constructor that sets the routees to be used.
    * Java API
    */
-  def this(n: Int, t: java.util.Collection[String], w: Duration) = this(n, t.asScala, w)
+  def this(n: Int, t: java.util.Collection[String]) = this(n, t.asScala)
 }
 
 /**


### PR DESCRIPTION
DYT that we should require a "within" for SGFCR or should we have a internal default value to simplify? Right now I have made it mandatory for a user of such a router to provide a timeout duration.
