### PR TITLE
Avoid AtomicInteger overflow in RoundRobinRouter. See #1610

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -234,11 +234,12 @@ trait RoundRobinLike { this: RouterConfig ⇒
     val next = new AtomicInteger(-1)
 
     def getNext(): ActorRef = {
-      def size = ref.routees.size
+      val _routees = ref.routees
+      val size = _routees.size
 
       @tailrec
       def reduce(n: Int) {
-        val safetyValue = size * 100000
+        val safetyValue = if (size >= 10000) size else (size * 100000)
         if (n >= safetyValue) {
           // decrease with multiple of the modulus, so that it doesn't change the modulus value
           val newValue = n - safetyValue
@@ -251,7 +252,7 @@ trait RoundRobinLike { this: RouterConfig ⇒
       // make sure we don't exceed Int.MaxValue
       reduce(n)
 
-      ref.routees(n % size)
+      _routees(n % size)
     }
 
     {

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -3,6 +3,8 @@
  */
 package akka.routing
 
+import scala.annotation.tailrec
+
 import akka.actor._
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.JavaConversions._
@@ -229,10 +231,27 @@ trait RoundRobinLike { this: RouterConfig ⇒
   def createRoute(props: Props, context: ActorContext, ref: RoutedActorRef): Route = {
     createAndRegisterRoutees(props, context, nrOfInstances, routees)
 
-    val next = new AtomicInteger(0)
+    val next = new AtomicInteger(-1)
 
     def getNext(): ActorRef = {
-      ref.routees(next.getAndIncrement % ref.routees.size)
+      def size = ref.routees.size
+
+      @tailrec
+      def reduce(n: Int) {
+        val safetyValue = size * 100000
+        if (n >= safetyValue) {
+          // decrease with multiple of the modulus, so that it doesn't change the modulus value
+          val newValue = n - safetyValue
+          next.compareAndSet(n, newValue)
+          reduce(next.get)
+        }
+      }
+
+      val n = next.incrementAndGet()
+      // make sure we don't exceed Int.MaxValue
+      reduce(n)
+
+      ref.routees(n % size)
     }
 
     {


### PR DESCRIPTION
Please review with concurrency mind turned on.
