### PR TITLE
Migration kit and start of migration documentation. See #1406.

### DIFF
--- a/akka-actor-migration/src/main/scala/akka/actor/GlobalActorSystem.scala
+++ b/akka-actor-migration/src/main/scala/akka/actor/GlobalActorSystem.scala
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import java.io.File
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigParseOptions
+import com.typesafe.config.ConfigResolveOptions
+
+@deprecated("use ActorSystem instead", "2.0")
+object GlobalActorSystem extends ActorSystemImpl("GlobalSystem", OldConfigurationLoader.defaultConfig) {
+  start()
+}
+
+/**
+ * Loads configuration (akka.conf) from same location as Akka 1.x
+ */
+@deprecated("use default config location or write your own configuration loader", "2.0")
+object OldConfigurationLoader {
+
+  val defaultConfig: Config = {
+    val cfg = fromProperties orElse fromClasspath orElse fromHome getOrElse emptyConfig
+    val config = cfg.withFallback(ConfigFactory.defaultReference)
+    config.checkValid(ConfigFactory.defaultReference, "akka")
+    config
+  }
+
+  // file extensions (.conf, .json, .properties), are handled by parseFileAnySyntax
+  val defaultLocation: String = (systemMode orElse envMode).map("akka." + _).getOrElse("akka")
+
+  private def envMode = System.getenv("AKKA_MODE") match {
+    case null | "" ⇒ None
+    case value     ⇒ Some(value)
+  }
+
+  private def systemMode = System.getProperty("akka.mode") match {
+    case null | "" ⇒ None
+    case value     ⇒ Some(value)
+  }
+
+  private def configParseOptions = ConfigParseOptions.defaults.setAllowMissing(false)
+
+  private def fromProperties = try {
+    val property = Option(System.getProperty("akka.config"))
+    property.map(p ⇒
+      ConfigFactory.systemProperties.withFallback(
+        ConfigFactory.parseFileAnySyntax(new File(p), configParseOptions)))
+  } catch { case _ ⇒ None }
+
+  private def fromClasspath = try {
+    Option(ConfigFactory.systemProperties.withFallback(
+      ConfigFactory.parseResourcesAnySyntax(ActorSystem.getClass, "/" + defaultLocation, configParseOptions)))
+  } catch { case _ ⇒ None }
+
+  private def fromHome = try {
+    Option(ConfigFactory.systemProperties.withFallback(
+      ConfigFactory.parseFileAnySyntax(new File(ActorSystem.GlobalHome.get + "/config/" + defaultLocation), configParseOptions)))
+  } catch { case _ ⇒ None }
+
+  private def emptyConfig = ConfigFactory.systemProperties
+}

--- a/akka-actor-migration/src/main/scala/akka/actor/OldActor.scala
+++ b/akka-actor-migration/src/main/scala/akka/actor/OldActor.scala
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import akka.japi.Creator
+import akka.util.Timeout
+import akka.dispatch.Future
+import akka.dispatch.OldFuture
+import akka.util.Duration
+import java.util.concurrent.TimeUnit
+import java.net.InetSocketAddress
+
+/**
+ * Migration replacement for `object akka.actor.Actor`.
+ */
+@deprecated("use ActorRefFactory (ActorSystem or ActorContext) to create actors", "2.0")
+object OldActor {
+
+  /**
+   *  Creates an ActorRef out of the Actor with type T.
+   *  It will be automatically started, i.e. remove old call to `start()`.
+   *
+   */
+  @deprecated("use ActorRefFactory (ActorSystem or ActorContext) to create actors", "2.0")
+  def actorOf[T <: Actor: Manifest]: ActorRef = actorOf(manifest[T].erasure.asInstanceOf[Class[_ <: Actor]])
+
+  /**
+   * Creates an ActorRef out of the Actor of the specified Class.
+   * It will be automatically started, i.e. remove old call to `start()`.
+   */
+  @deprecated("use ActorRefFactory (ActorSystem or ActorContext) to create actors", "2.0")
+  def actorOf(clazz: Class[_ <: Actor]): ActorRef = GlobalActorSystem.actorOf(Props(clazz))
+
+  /**
+   * Creates an ActorRef out of the Actor. Allows you to pass in a factory function
+   * that creates the Actor. Please note that this function can be invoked multiple
+   * times if for example the Actor is supervised and needs to be restarted.
+   *
+   * It will be automatically started, i.e. remove old call to `start()`.
+   */
+  @deprecated("use ActorRefFactory (ActorSystem or ActorContext) to create actors", "2.0")
+  def actorOf(factory: ⇒ Actor): ActorRef = GlobalActorSystem.actorOf(Props(factory))
+
+  /**
+   * Creates an ActorRef out of the Actor. Allows you to pass in a factory (Creator<Actor>)
+   * that creates the Actor. Please note that this function can be invoked multiple
+   * times if for example the Actor is supervised and needs to be restarted.
+   * <p/>
+   * JAVA API
+   */
+  @deprecated("use ActorRefFactory (ActorSystem or ActorContext) to create actors", "2.0")
+  def actorOf(creator: Creator[Actor]): ActorRef = GlobalActorSystem.actorOf(Props(creator))
+
+  @deprecated("OldActor.remote should not be used", "2.0")
+  lazy val remote: OldRemoteSupport = new OldRemoteSupport
+
+}
+
+@deprecated("use Actor", "2.0")
+abstract class OldActor extends Actor {
+
+  implicit def askTimeout: Timeout = akka.migration.askTimeout
+
+  implicit def future2OldFuture[T](future: Future[T]): OldFuture[T] = akka.migration.future2OldFuture(future)
+
+  implicit def actorRef2OldActorRef(actorRef: ActorRef) = new OldActorRef(actorRef)
+
+  @deprecated("Use context.become instead", "2.0")
+  def become(behavior: Receive, discardOld: Boolean = true) = context.become(behavior, discardOld)
+
+  @deprecated("Use context.unbecome instead", "2.0")
+  def unbecome() = context.unbecome()
+
+  class OldActorRef(actorRef: ActorRef) {
+    @deprecated("Actors are automatically started when creatd, i.e. remove old call to start()", "2.0")
+    def start(): ActorRef = actorRef
+
+    @deprecated("Stop with ActorSystem or ActorContext instead", "2.0")
+    def exit() = stop()
+
+    @deprecated("Stop with ActorSystem or ActorContext instead", "2.0")
+    def stop(): Unit = context.stop(actorRef)
+
+    @deprecated("Use context.getReceiveTimeout instead", "2.0")
+    def getReceiveTimeout(): Option[Long] = context.receiveTimeout.map(_.toMillis)
+
+    @deprecated("Use context.setReceiveTimeout instead", "2.0")
+    def setReceiveTimeout(timeout: Long) = context.setReceiveTimeout(Duration(timeout, TimeUnit.MILLISECONDS))
+
+    @deprecated("Use context.getReceiveTimeout instead", "2.0")
+    def receiveTimeout: Option[Long] = getReceiveTimeout()
+
+    @deprecated("Use context.setReceiveTimeout instead", "2.0")
+    def receiveTimeout_=(timeout: Option[Long]) = setReceiveTimeout(timeout.getOrElse(0L))
+
+    @deprecated("Use self.isTerminated instead", "2.0")
+    def isShutdown: Boolean = self.isTerminated
+
+    @deprecated("Use sender instead", "2.0")
+    def channel() = context.sender
+
+    @deprecated("Use sender instead", "2.0")
+    def sender() = Some(context.sender)
+
+    @deprecated("Use sender ! instead", "2.0")
+    def reply(message: Any) = context.sender.!(message, context.self)
+
+    @deprecated("Use sender ! instead", "2.0")
+    def tryReply(message: Any): Boolean = {
+      reply(message)
+      true
+    }
+
+    @deprecated("Use sender ! instead", "2.0")
+    def tryTell(message: Any)(implicit sender: ActorRef = context.self): Boolean = {
+      actorRef.!(message)(sender)
+      true
+    }
+
+    @deprecated("Use sender ! akka.actor.Status.Failure(e) instead", "2.0")
+    def sendException(ex: Throwable): Boolean = {
+      context.sender.!(akka.actor.Status.Failure(ex), context.self)
+      true
+    }
+  }
+}
+
+class OldRemoteSupport {
+
+  @deprecated("remote.start is not needed", "2.0")
+  def start() {}
+
+  @deprecated("remote.start is not needed, use configuration to specify RemoteActorRefProvider, host and port", "2.0")
+  def start(host: String, port: Int) {}
+
+  @deprecated("remote.start is not needed, use configuration to specify RemoteActorRefProvider, host and port", "2.0")
+  def start(host: String, port: Int, loader: ClassLoader) {}
+
+  @deprecated("remote.shutdown is not needed", "2.0")
+  def shutdown() {}
+
+  @deprecated("use actorFor in ActorRefProvider (ActorSystem or ActorContext) instead", "2.0")
+  def actorFor(classNameOrServiceId: String, hostname: String, port: Int): ActorRef =
+    GlobalActorSystem.actorFor("akka://%s@%s:%s/user/%s".format(GlobalActorSystem.name, hostname, port, classNameOrServiceId))
+
+  @deprecated("use actorFor in ActorRefProvider (ActorSystem or ActorContext) instead", "2.0")
+  def actorFor(classNameOrServiceId: String, hostname: String, port: Int, loader: ClassLoader): ActorRef =
+    actorFor(classNameOrServiceId, hostname, port)
+
+  @deprecated("use actorFor in ActorRefProvider (ActorSystem or ActorContext) instead", "2.0")
+  def actorFor(serviceId: String, className: String, hostname: String, port: Int): ActorRef =
+    actorFor(serviceId, hostname, port)
+
+  @deprecated("use actorFor in ActorRefProvider (ActorSystem or ActorContext) instead", "2.0")
+  def actorFor(serviceId: String, className: String, hostname: String, port: Int, loader: ClassLoader): ActorRef =
+    actorFor(serviceId, hostname, port)
+
+  @deprecated("use actorFor in ActorRefProvider (ActorSystem or ActorContext) instead", "2.0")
+  def actorFor(classNameOrServiceId: String, timeout: Long, hostname: String, port: Int): ActorRef =
+    actorFor(classNameOrServiceId, hostname, port)
+
+  @deprecated("use actorFor in ActorRefProvider (ActorSystem or ActorContext) instead", "2.0")
+  def actorFor(classNameOrServiceId: String, timeout: Long, hostname: String, port: Int, loader: ClassLoader): ActorRef =
+    actorFor(classNameOrServiceId, hostname, port)
+
+  @deprecated("use actorFor in ActorRefProvider (ActorSystem or ActorContext) instead", "2.0")
+  def actorFor(serviceId: String, className: String, timeout: Long, hostname: String, port: Int): ActorRef =
+    actorFor(serviceId, hostname, port)
+
+}

--- a/akka-actor-migration/src/main/scala/akka/actor/OldScheduler.scala
+++ b/akka-actor-migration/src/main/scala/akka/actor/OldScheduler.scala
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import java.util.concurrent.TimeUnit
+import akka.util.Duration
+
+/**
+ * Migration replacement for `object akka.actor.Scheduler`.
+ */
+@deprecated("use ActorSystem.scheduler instead", "2.0")
+object OldScheduler {
+
+  /**
+   * Schedules to send the specified message to the receiver after initialDelay and then repeated after delay
+   */
+  @deprecated("use ActorSystem.scheduler instead", "2.0")
+  def schedule(receiver: ActorRef, message: Any, initialDelay: Long, delay: Long, timeUnit: TimeUnit): Cancellable =
+    GlobalActorSystem.scheduler.schedule(
+      Duration(initialDelay, timeUnit),
+      Duration(delay, timeUnit),
+      receiver,
+      message)
+
+  /**
+   * Schedules to run specified function to the receiver after initialDelay and then repeated after delay
+   */
+  @deprecated("use ActorSystem.scheduler instead", "2.0")
+  def schedule(f: () ⇒ Unit, initialDelay: Long, delay: Long, timeUnit: TimeUnit): Cancellable =
+    GlobalActorSystem.scheduler.schedule(
+      Duration(initialDelay, timeUnit),
+      Duration(delay, timeUnit),
+      new Runnable { def run = f() })
+
+  /**
+   * Schedules to run specified runnable to the receiver after initialDelay and then repeated after delay.
+   */
+  @deprecated("use ActorSystem.scheduler instead", "2.0")
+  def schedule(runnable: Runnable, initialDelay: Long, delay: Long, timeUnit: TimeUnit): Cancellable =
+    GlobalActorSystem.scheduler.schedule(
+      Duration(initialDelay, timeUnit),
+      Duration(delay, timeUnit),
+      runnable)
+
+  /**
+   * Schedules to send the specified message to the receiver after delay
+   */
+  @deprecated("use ActorSystem.scheduler instead", "2.0")
+  def scheduleOnce(receiver: ActorRef, message: Any, delay: Long, timeUnit: TimeUnit): Cancellable =
+    GlobalActorSystem.scheduler.scheduleOnce(
+      Duration(delay, timeUnit),
+      receiver,
+      message)
+
+  /**
+   * Schedules a function to be run after delay.
+   */
+  @deprecated("use ActorSystem.scheduler instead", "2.0")
+  def scheduleOnce(f: () ⇒ Unit, delay: Long, timeUnit: TimeUnit): Cancellable =
+    GlobalActorSystem.scheduler.scheduleOnce(
+      Duration(delay, timeUnit),
+      new Runnable { def run = f() })
+
+  /**
+   * Schedules a runnable to be run after delay,
+   */
+  @deprecated("use ActorSystem.scheduler instead", "2.0")
+  def scheduleOnce(runnable: Runnable, delay: Long, timeUnit: TimeUnit): Cancellable =
+    GlobalActorSystem.scheduler.scheduleOnce(
+      Duration(delay, timeUnit),
+      runnable)
+
+}
+

--- a/akka-actor-migration/src/main/scala/akka/config/OldConfig.scala
+++ b/akka-actor-migration/src/main/scala/akka/config/OldConfig.scala
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.config
+import akka.actor.GlobalActorSystem
+import com.typesafe.config.Config
+
+/**
+ * Migration replacement for `object akka.config.Config`.
+ */
+@deprecated("use ActorSystem.settings.config instead", "2.0")
+object OldConfig {
+
+  val config = new OldConfiguration(GlobalActorSystem.settings.config)
+
+}
+
+/**
+ * Migration adapter for `akka.config.Configuration`
+ */
+@deprecated("use ActorSystem.settings.config (com.typesafe.config.Config) instead", "2.0")
+class OldConfiguration(config: Config) {
+
+  import scala.collection.JavaConverters._
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def contains(key: String): Boolean = config.hasPath(key)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def keys: Iterable[String] = config.root.keySet.asScala
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getAny(key: String): Option[Any] = {
+    try {
+      Option(config.getAnyRef(key))
+    } catch {
+      case _ ⇒ None
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getAny(key: String, defaultValue: Any): Any = getAny(key).getOrElse(defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getSeqAny(key: String): Seq[Any] = {
+    try {
+      config.getAnyRefList(key).asScala
+    } catch {
+      case _ ⇒ Seq.empty[Any]
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getString(key: String): Option[String] =
+    try {
+      Option(config.getString(key))
+    } catch {
+      case _ ⇒ None
+    }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getString(key: String, defaultValue: String): String = getString(key).getOrElse(defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getList(key: String): Seq[String] = {
+    try {
+      config.getStringList(key).asScala
+    } catch {
+      case _ ⇒ Seq.empty[String]
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getInt(key: String): Option[Int] = {
+    try {
+      Option(config.getInt(key))
+    } catch {
+      case _ ⇒ None
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getInt(key: String, defaultValue: Int): Int = getInt(key).getOrElse(defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getLong(key: String): Option[Long] = {
+    try {
+      Option(config.getLong(key))
+    } catch {
+      case _ ⇒ None
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getLong(key: String, defaultValue: Long): Long = getLong(key).getOrElse(defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getFloat(key: String): Option[Float] = {
+    try {
+      Option(config.getDouble(key).toFloat)
+    } catch {
+      case _ ⇒ None
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getFloat(key: String, defaultValue: Float): Float = getFloat(key).getOrElse(defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getDouble(key: String): Option[Double] = {
+    try {
+      Option(config.getDouble(key))
+    } catch {
+      case _ ⇒ None
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getDouble(key: String, defaultValue: Double): Double = getDouble(key).getOrElse(defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getBoolean(key: String): Option[Boolean] = {
+    try {
+      Option(config.getBoolean(key))
+    } catch {
+      case _ ⇒ None
+    }
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getBoolean(key: String, defaultValue: Boolean): Boolean = getBoolean(key).getOrElse(defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getBool(key: String): Option[Boolean] = getBoolean(key)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getBool(key: String, defaultValue: Boolean): Boolean = getBoolean(key, defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def apply(key: String): String = getString(key) match {
+    case None    ⇒ throw new ConfigurationException("undefined config: " + key)
+    case Some(v) ⇒ v
+  }
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def apply(key: String, defaultValue: String) = getString(key, defaultValue)
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def apply(key: String, defaultValue: Int) = getInt(key, defaultValue)
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def apply(key: String, defaultValue: Long) = getLong(key, defaultValue)
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def apply(key: String, defaultValue: Boolean) = getBool(key, defaultValue)
+
+  @deprecated("use new com.typesafe.config.Config API instead", "2.0")
+  def getSection(name: String): Option[OldConfiguration] = {
+    try {
+      Option(new OldConfiguration(config.getConfig(name)))
+    } catch {
+      case _ ⇒ None
+    }
+  }
+}

--- a/akka-actor-migration/src/main/scala/akka/dispatch/OldFuture.scala
+++ b/akka-actor-migration/src/main/scala/akka/dispatch/OldFuture.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.dispatch
+
+import java.util.concurrent.TimeoutException
+import akka.util.duration._
+import akka.AkkaException
+import akka.util.BoxedType
+import akka.util.Duration
+import akka.actor.GlobalActorSystem
+
+/**
+ * Some old methods made available through implicit conversion in
+ * [[akka.migration]].
+ */
+@deprecated("use new Future api instead", "2.0")
+class OldFuture[T](future: Future[T]) {
+
+  @deprecated("use akka.dispatch.Await.result instead", "2.0")
+  def get: T = try {
+    Await.result(future, GlobalActorSystem.settings.ActorTimeout.duration)
+  } catch {
+    case e: TimeoutException ⇒ throw new FutureTimeoutException(e.getMessage, e)
+  }
+
+  @deprecated("use akka.dispatch.Await.ready instead", "2.0")
+  def await: Future[T] = await(GlobalActorSystem.settings.ActorTimeout.duration)
+
+  @deprecated("use akka.dispatch.Await.ready instead", "2.0")
+  def await(atMost: Duration) = try {
+    Await.ready(future, atMost)
+    future
+  } catch {
+    case e: TimeoutException ⇒ throw new FutureTimeoutException(e.getMessage, e)
+  }
+
+  @deprecated("use new Future api instead", "2.0")
+  def as[A](implicit m: Manifest[A]): Option[A] = {
+    try await catch { case _: FutureTimeoutException ⇒ }
+    future.value match {
+      case None           ⇒ None
+      case Some(Left(ex)) ⇒ throw ex
+      case Some(Right(v)) ⇒ Some(BoxedType(m.erasure).cast(v).asInstanceOf[A])
+    }
+  }
+
+  @deprecated("use new Future api instead", "2.0")
+  def asSilently[A](implicit m: Manifest[A]): Option[A] = {
+    try await catch { case _: FutureTimeoutException ⇒ }
+    future.value match {
+      case None           ⇒ None
+      case Some(Left(ex)) ⇒ throw ex
+      case Some(Right(v)) ⇒
+        try Some(BoxedType(m.erasure).cast(v).asInstanceOf[A])
+        catch { case _: ClassCastException ⇒ None }
+    }
+  }
+
+}
+
+@deprecated("Await throws java.util.concurrent.TimeoutException", "2.0")
+class FutureTimeoutException(message: String, cause: Throwable = null) extends AkkaException(message, cause) {
+  def this(message: String) = this(message, null)
+}

--- a/akka-actor-migration/src/main/scala/akka/event/OldEventHandler.scala
+++ b/akka-actor-migration/src/main/scala/akka/event/OldEventHandler.scala
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.event
+
+import akka.actor.GlobalActorSystem
+
+/**
+ * Migration replacement for `akka.event.EventHandler`
+ */
+@deprecated("use Logging instead", "2.0")
+object OldEventHandler {
+
+  @deprecated("use Logging instead", "2.0")
+  def error(cause: Throwable, instance: AnyRef, message: ⇒ String) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isErrorEnabled) log.error(cause, message)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def error(cause: Throwable, instance: AnyRef, message: Any) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isErrorEnabled) log.error(cause, message.toString)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def error(instance: AnyRef, message: ⇒ String) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isErrorEnabled) log.error(message.toString)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def error(instance: AnyRef, message: Any) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isErrorEnabled) log.error(message.toString)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def warning(instance: AnyRef, message: ⇒ String) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isWarningEnabled) log.warning(message)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def warning(instance: AnyRef, message: Any) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isWarningEnabled) log.warning(message.toString)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def info(instance: AnyRef, message: ⇒ String) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isInfoEnabled) log.info(message)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def info(instance: AnyRef, message: Any) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isInfoEnabled) log.info(message.toString)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def debug(instance: AnyRef, message: ⇒ String) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isDebugEnabled) log.debug(message)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def debug(instance: AnyRef, message: Any) {
+    val log = Logging.getLogger(GlobalActorSystem, instance)
+    if (log.isDebugEnabled) log.debug(message.toString)
+  }
+
+  @deprecated("use Logging instead", "2.0")
+  def isInfoEnabled = Logging.getLogger(GlobalActorSystem, this).isInfoEnabled
+
+  @deprecated("use Logging instead", "2.0")
+  def isDebugEnabled = Logging.getLogger(GlobalActorSystem, this).isDebugEnabled
+
+}

--- a/akka-actor-migration/src/main/scala/akka/migration/package.scala
+++ b/akka-actor-migration/src/main/scala/akka/migration/package.scala
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka
+
+import akka.dispatch.Future
+import akka.dispatch.OldFuture
+import akka.util.Timeout
+import akka.actor.GlobalActorSystem
+import akka.dispatch.MessageDispatcher
+import akka.actor.ActorRef
+
+package object migration {
+
+  implicit def future2OldFuture[T](future: Future[T]): OldFuture[T] = new OldFuture[T](future)
+
+  implicit def askTimeout: Timeout = GlobalActorSystem.settings.ActorTimeout
+
+  implicit def defaultDispatcher: MessageDispatcher = GlobalActorSystem.dispatcher
+
+  implicit def actorRef2OldActorRef(actorRef: ActorRef) = new OldActorRef(actorRef)
+
+  class OldActorRef(actorRef: ActorRef) {
+    @deprecated("Actors are automatically started when creatd, i.e. remove old call to start()", "2.0")
+    def start(): ActorRef = actorRef
+
+    @deprecated("Stop with ActorSystem or ActorContext instead", "2.0")
+    def exit() = stop()
+
+    @deprecated("Stop with ActorSystem or ActorContext instead", "2.0")
+    def stop(): Unit = GlobalActorSystem.stop(actorRef)
+  }
+
+}

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -515,7 +515,7 @@ object ScatterGatherFirstCompletedRouter {
  * be ignored if the 'nrOfInstances' is defined in the configuration file for the actor being used.
  */
 case class ScatterGatherFirstCompletedRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil, within: Duration,
-  override val resizer: Option[Resizer] = None)
+                                             override val resizer: Option[Resizer] = None)
   extends RouterConfig with ScatterGatherFirstCompletedLike {
 
   /**
@@ -593,57 +593,57 @@ case class DefaultResizer(
    */
   lowerBound: Int = 1,
   /**
-   * The most number of routees the router should ever have.
-   * Must be greater than or equal to `lowerBound`.
-   */
+ * The most number of routees the router should ever have.
+ * Must be greater than or equal to `lowerBound`.
+ */
   upperBound: Int = 10,
   /**
-   * Threshold to evaluate if routee is considered to be busy (under pressure).
-   * Implementation depends on this value (default is 1).
-   * <ul>
-   * <li> 0:   number of routees currently processing a message.</li>
-   * <li> 1:   number of routees currently processing a message has
-   *           some messages in mailbox.</li>
-   * <li> > 1: number of routees with at least the configured `pressureThreshold`
-   *           messages in their mailbox. Note that estimating mailbox size of
-   *           default UnboundedMailbox is O(N) operation.</li>
-   * </ul>
-   */
+ * Threshold to evaluate if routee is considered to be busy (under pressure).
+ * Implementation depends on this value (default is 1).
+ * <ul>
+ * <li> 0:   number of routees currently processing a message.</li>
+ * <li> 1:   number of routees currently processing a message has
+ *           some messages in mailbox.</li>
+ * <li> > 1: number of routees with at least the configured `pressureThreshold`
+ *           messages in their mailbox. Note that estimating mailbox size of
+ *           default UnboundedMailbox is O(N) operation.</li>
+ * </ul>
+ */
   pressureThreshold: Int = 1,
   /**
-   * Percentage to increase capacity whenever all routees are busy.
-   * For example, 0.2 would increase 20% (rounded up), i.e. if current
-   * capacity is 6 it will request an increase of 2 more routees.
-   */
+ * Percentage to increase capacity whenever all routees are busy.
+ * For example, 0.2 would increase 20% (rounded up), i.e. if current
+ * capacity is 6 it will request an increase of 2 more routees.
+ */
   rampupRate: Double = 0.2,
   /**
-   * Minimum fraction of busy routees before backing off.
-   * For example, if this is 0.3, then we'll remove some routees only when
-   * less than 30% of routees are busy, i.e. if current capacity is 10 and
-   * 3 are busy then the capacity is unchanged, but if 2 or less are busy
-   * the capacity is decreased.
-   *
-   * Use 0.0 or negative to avoid removal of routees.
-   */
+ * Minimum fraction of busy routees before backing off.
+ * For example, if this is 0.3, then we'll remove some routees only when
+ * less than 30% of routees are busy, i.e. if current capacity is 10 and
+ * 3 are busy then the capacity is unchanged, but if 2 or less are busy
+ * the capacity is decreased.
+ *
+ * Use 0.0 or negative to avoid removal of routees.
+ */
   backoffThreshold: Double = 0.3,
   /**
-   * Fraction of routees to be removed when the resizer reaches the
-   * backoffThreshold.
-   * For example, 0.1 would decrease 10% (rounded up), i.e. if current
-   * capacity is 9 it will request an decrease of 1 routee.
-   */
+ * Fraction of routees to be removed when the resizer reaches the
+ * backoffThreshold.
+ * For example, 0.1 would decrease 10% (rounded up), i.e. if current
+ * capacity is 9 it will request an decrease of 1 routee.
+ */
   backoffRate: Double = 0.1,
   /**
-   * When the resizer reduce the capacity the abandoned routee actors are stopped
-   * with PoisonPill after this delay. The reason for the delay is to give concurrent
-   * messages a chance to be placed in mailbox before sending PoisonPill.
-   * Use 0 seconds to skip delay.
-   */
+ * When the resizer reduce the capacity the abandoned routee actors are stopped
+ * with PoisonPill after this delay. The reason for the delay is to give concurrent
+ * messages a chance to be placed in mailbox before sending PoisonPill.
+ * Use 0 seconds to skip delay.
+ */
   stopDelay: Duration = 1.second,
   /**
-   * Number of messages between resize operation.
-   * Use 1 to resize before each message.
-   */
+ * Number of messages between resize operation.
+ * Use 1 to resize before each message.
+ */
   messagesPerResize: Int = 10) extends Resizer {
 
   /**

--- a/akka-docs/general/jmm.rst
+++ b/akka-docs/general/jmm.rst
@@ -1,3 +1,5 @@
+.. _jmm:
+
 Akka and the Java Memory Model
 ================================
 

--- a/akka-docs/scala/code/akka/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/ActorDocSpec.scala
@@ -7,6 +7,9 @@ package akka.docs.actor
 import akka.actor.Actor
 import akka.actor.Props
 import akka.event.Logging
+
+//#imports1
+
 import akka.dispatch.Future
 import akka.actor.ActorSystem
 import org.scalatest.{ BeforeAndAfterAll, WordSpec }

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -30,7 +30,7 @@ object AkkaBuild extends Build {
       Unidoc.unidocExclude := Seq(samples.id, tutorials.id),
       Dist.distExclude := Seq(actorTests.id, akkaSbtPlugin.id, docs.id)
     ),
-    aggregate = Seq(actor, testkit, actorTests, remote, slf4j, agent, transactor, mailboxes, kernel, akkaSbtPlugin, samples, tutorials, docs)
+    aggregate = Seq(actor, testkit, actorTests, remote, slf4j, agent, transactor, mailboxes, kernel, akkaSbtPlugin, actorMigration, samples, tutorials, docs)
   )
 
   lazy val actor = Project(
@@ -210,6 +210,13 @@ object AkkaBuild extends Build {
     settings = defaultSettings ++ Seq(
       libraryDependencies ++= Dependencies.kernel
     )
+  )
+
+  lazy val actorMigration = Project(
+    id = "akka-actor-migration",
+    base = file("akka-actor-migration"),
+    dependencies = Seq(actor, testkit % "test->test"),
+    settings = defaultSettings
   )
 
   lazy val akkaSbtPlugin = Project(


### PR DESCRIPTION
- Documentation of migration kit
- Documentation of some of the changes
- akka-actor-migration module containing GlobalActorSystem, OldXxx classes and some implicit conversions
- Tried migration of WebWords sample
- Tried migration of akka-samples/async-workers
- Tried migration of akka-samples-trading
