### PR TITLE
FaultHandler as method in Actor instead of in Props. See #1711

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
@@ -80,7 +80,7 @@ class ActorFireForgetRequestReplySpec extends AkkaSpec with BeforeAndAfterEach w
 
     "should shutdown crashed temporary actor" in {
       filterEvents(EventFilter[Exception]("Expected exception")) {
-        val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Exception]), Some(0))))
+        val supervisor = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Exception]), Some(0)))))
         val actor = Await.result((supervisor ? Props[CrashingActor]).mapTo[ActorRef], timeout.duration)
         actor.isTerminated must be(false)
         actor ! "Die"

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -35,7 +35,7 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
     "invoke preRestart, preStart, postRestart when using OneForOneStrategy" in {
       filterException[ActorKilledException] {
         val id = newUuid().toString
-        val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Exception]), Some(3))))
+        val supervisor = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Exception]), Some(3)))))
         val gen = new AtomicInteger(0)
         val restarterProps = Props(new LifeCycleTestActor(testActor, id, gen) {
           override def preRestart(reason: Throwable, message: Option[Any]) { report("preRestart") }
@@ -69,7 +69,7 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
     "default for preRestart and postRestart is to call postStop and preStart respectively" in {
       filterException[ActorKilledException] {
         val id = newUuid().toString
-        val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Exception]), Some(3))))
+        val supervisor = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Exception]), Some(3)))))
         val gen = new AtomicInteger(0)
         val restarterProps = Props(new LifeCycleTestActor(testActor, id, gen))
         val restarter = Await.result((supervisor ? restarterProps).mapTo[ActorRef], timeout.duration)
@@ -99,7 +99,7 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
 
     "not invoke preRestart and postRestart when never restarted using OneForOneStrategy" in {
       val id = newUuid().toString
-      val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Exception]), Some(3))))
+      val supervisor = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Exception]), Some(3)))))
       val gen = new AtomicInteger(0)
       val props = Props(new LifeCycleTestActor(testActor, id, gen))
       val a = Await.result((supervisor ? props).mapTo[ActorRef], timeout.duration)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -374,6 +374,8 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
 
         val boss = system.actorOf(Props(new Actor {
 
+          override val supervisorStrategy = OneForOneStrategy(List(classOf[Throwable]), 2, 1000)
+
           val ref = context.actorOf(
             Props(new Actor {
               def receive = { case _ ⇒ }
@@ -382,7 +384,7 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
             }))
 
           protected def receive = { case "sendKill" ⇒ ref ! Kill }
-        }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), 2, 1000)))
+        }))
 
         boss ! "sendKill"
         Await.ready(latch, 5 seconds)

--- a/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
@@ -23,7 +23,7 @@ trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout â‡
 
   import DeathWatchSpec._
 
-  lazy val supervisor = system.actorOf(Props(new Supervisor(FaultHandlingStrategy.defaultFaultHandler)), "watchers")
+  lazy val supervisor = system.actorOf(Props(new Supervisor(SupervisorStrategy.defaultStrategy)), "watchers")
 
   def startWatching(target: ActorRef) = Await.result((supervisor ? props(target, testActor)).mapTo[ActorRef], 3 seconds)
 
@@ -115,7 +115,7 @@ trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout â‡
     "fail a monitor which does not handle Terminated()" in {
       filterEvents(EventFilter[ActorKilledException](), EventFilter[DeathPactException]()) {
         case class FF(fail: Failed)
-        val strategy = new OneForOneStrategy(FaultHandlingStrategy.makeDecider(List(classOf[Exception])), Some(0)) {
+        val strategy = new OneForOneStrategy(SupervisorStrategy.makeDecider(List(classOf[Exception])), Some(0)) {
           override def handleFailure(context: ActorContext, child: ActorRef, cause: Throwable, stats: ChildRestartStats, children: Iterable[ChildRestartStats]) = {
             testActor.tell(FF(Failed(cause)), child)
             super.handleFailure(context, child, cause, stats, children)

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -72,8 +72,9 @@ class FSMTransitionSpec extends AkkaSpec with ImplicitSender {
       val fsm = system.actorOf(Props(new MyFSM(testActor)))
       val sup = system.actorOf(Props(new Actor {
         context.watch(fsm)
+        override val supervisorStrategy = OneForOneStrategy(List(classOf[Throwable]), None, None)
         def receive = { case _ ⇒ }
-      }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), None, None)))
+      }))
 
       within(300 millis) {
         fsm ! SubscribeTransitionCallBack(forward)

--- a/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
@@ -28,7 +28,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
   "A RestartStrategy" must {
 
     "ensure that slave stays dead after max restarts within time range" in {
-      val boss = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), 2, 1000)))
+      val boss = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Throwable]), 2, 1000))))
 
       val restartLatch = new TestLatch
       val secondRestartLatch = new TestLatch
@@ -74,7 +74,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
     }
 
     "ensure that slave is immortal without max restarts and time range" in {
-      val boss = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), None, None)))
+      val boss = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Throwable]), None, None))))
 
       val countDownLatch = new TestLatch(100)
 
@@ -96,7 +96,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
     }
 
     "ensure that slave restarts after number of crashes not within time range" in {
-      val boss = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), 2, 500)))
+      val boss = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Throwable]), 2, 500))))
 
       val restartLatch = new TestLatch
       val secondRestartLatch = new TestLatch
@@ -153,7 +153,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
     }
 
     "ensure that slave is not restarted after max retries" in {
-      val boss = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), Some(2), None)))
+      val boss = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Throwable]), Some(2), None))))
 
       val restartLatch = new TestLatch
       val secondRestartLatch = new TestLatch
@@ -208,11 +208,12 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
       val countDownLatch = new TestLatch(2)
 
       val boss = system.actorOf(Props(new Actor {
+        override val supervisorStrategy = OneForOneStrategy(List(classOf[Throwable]), None, Some(1000))
         def receive = {
           case p: Props      ⇒ sender ! context.watch(context.actorOf(p))
           case t: Terminated ⇒ maxNoOfRestartsLatch.open()
         }
-      }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), None, Some(1000))))
+      }))
 
       val slaveProps = Props(new Actor {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -133,7 +133,7 @@ class SchedulerSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout
       val restartLatch = new TestLatch
       val pingLatch = new TestLatch(6)
 
-      val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(AllForOneStrategy(List(classOf[Exception]), 3, 1000)))
+      val supervisor = system.actorOf(Props(new Supervisor(AllForOneStrategy(List(classOf[Exception]), 3, 1000))))
       val props = Props(new Actor {
         def receive = {
           case Ping  ⇒ pingLatch.countDown()

--- a/akka-actor-tests/src/test/scala/akka/actor/Supervisor.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/Supervisor.scala
@@ -3,7 +3,12 @@
  */
 package akka.actor
 
-class Supervisor extends Actor {
+/**
+ * For testing Supervisor behavior, normally you don't supply the strategy
+ * from the outside like this.
+ */
+class Supervisor(override val supervisorStrategy: FaultHandlingStrategy) extends Actor {
+
   def receive = {
     case x: Props ⇒ sender ! context.actorOf(x)
   }

--- a/akka-actor-tests/src/test/scala/akka/actor/Supervisor.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/Supervisor.scala
@@ -7,7 +7,7 @@ package akka.actor
  * For testing Supervisor behavior, normally you don't supply the strategy
  * from the outside like this.
  */
-class Supervisor(override val supervisorStrategy: FaultHandlingStrategy) extends Actor {
+class Supervisor(override val supervisorStrategy: SupervisorStrategy) extends Actor {
 
   def receive = {
     case x: Props ⇒ sender ! context.actorOf(x)

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -12,7 +12,12 @@ import akka.dispatch.Await
 object SupervisorHierarchySpec {
   class FireWorkerException(msg: String) extends Exception(msg)
 
-  class CountDownActor(countDown: CountDownLatch) extends Actor {
+  /**
+   * For testing Supervisor behavior, normally you don't supply the strategy
+   * from the outside like this.
+   */
+  class CountDownActor(countDown: CountDownLatch, override val supervisorStrategy: FaultHandlingStrategy) extends Actor {
+
     protected def receive = {
       case p: Props ⇒ sender ! context.actorOf(p)
     }
@@ -33,12 +38,12 @@ class SupervisorHierarchySpec extends AkkaSpec with DefaultTimeout {
     "restart manager and workers in AllForOne" in {
       val countDown = new CountDownLatch(4)
 
-      val boss = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Exception]), None, None)))
+      val boss = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Exception]), None, None))))
 
-      val managerProps = Props(new CountDownActor(countDown)).withFaultHandler(AllForOneStrategy(List(), None, None))
+      val managerProps = Props(new CountDownActor(countDown, AllForOneStrategy(List(), None, None)))
       val manager = Await.result((boss ? managerProps).mapTo[ActorRef], timeout.duration)
 
-      val workerProps = Props(new CountDownActor(countDown))
+      val workerProps = Props(new CountDownActor(countDown, FaultHandlingStrategy.defaultFaultHandler))
       val workerOne, workerTwo, workerThree = Await.result((manager ? workerProps).mapTo[ActorRef], timeout.duration)
 
       filterException[ActorKilledException] {
@@ -55,13 +60,15 @@ class SupervisorHierarchySpec extends AkkaSpec with DefaultTimeout {
       val countDownMessages = new CountDownLatch(1)
       val countDownMax = new CountDownLatch(1)
       val boss = system.actorOf(Props(new Actor {
-        val crasher = context.watch(context.actorOf(Props(new CountDownActor(countDownMessages))))
+        override val supervisorStrategy = OneForOneStrategy(List(classOf[Throwable]), 1, 5000)
+
+        val crasher = context.watch(context.actorOf(Props(new CountDownActor(countDownMessages, FaultHandlingStrategy.defaultFaultHandler))))
 
         protected def receive = {
           case "killCrasher" ⇒ crasher ! Kill
           case Terminated(_) ⇒ countDownMax.countDown()
         }
-      }).withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), 1, 5000)))
+      }))
 
       filterException[ActorKilledException] {
         boss ! "killCrasher"

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
@@ -28,7 +28,7 @@ class SupervisorMiscSpec extends AkkaSpec(SupervisorMiscSpec.config) with Defaul
       filterEvents(EventFilter[Exception]("Kill")) {
         val countDownLatch = new CountDownLatch(4)
 
-        val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(OneForOneStrategy(List(classOf[Exception]), 3, 5000)))
+        val supervisor = system.actorOf(Props(new Supervisor(OneForOneStrategy(List(classOf[Exception]), 3, 5000))))
 
         val workerProps = Props(new Actor {
           override def postRestart(cause: Throwable) { countDownLatch.countDown() }

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorTreeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorTreeSpec.scala
@@ -22,11 +22,12 @@ class SupervisorTreeSpec extends AkkaSpec with ImplicitSender with DefaultTimeou
       EventFilter[ActorKilledException](occurrences = 1) intercept {
         within(5 seconds) {
           val p = Props(new Actor {
+            override val supervisorStrategy = OneForOneStrategy(List(classOf[Exception]), 3, 1000)
             def receive = {
               case p: Props ⇒ sender ! context.actorOf(p)
             }
             override def preRestart(cause: Throwable, msg: Option[Any]) { testActor ! self.path }
-          }).withFaultHandler(OneForOneStrategy(List(classOf[Exception]), 3, 1000))
+          })
           val headActor = system.actorOf(p)
           val middleActor = Await.result((headActor ? p).mapTo[ActorRef], timeout.duration)
           val lastActor = Await.result((middleActor ? p).mapTo[ActorRef], timeout.duration)

--- a/akka-actor-tests/src/test/scala/akka/actor/Ticket669Spec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/Ticket669Spec.scala
@@ -24,7 +24,7 @@ class Ticket669Spec extends AkkaSpec with BeforeAndAfterAll with ImplicitSender 
   "A supervised actor with lifecycle PERMANENT" should {
     "be able to reply on failure during preRestart" in {
       filterEvents(EventFilter[Exception]("test", occurrences = 1)) {
-        val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(AllForOneStrategy(List(classOf[Exception]), 5, 10000)))
+        val supervisor = system.actorOf(Props(new Supervisor(AllForOneStrategy(List(classOf[Exception]), 5, 10000))))
         val supervised = Await.result((supervisor ? Props[Supervised]).mapTo[ActorRef], timeout.duration)
 
         supervised.!("test")(testActor)
@@ -35,7 +35,7 @@ class Ticket669Spec extends AkkaSpec with BeforeAndAfterAll with ImplicitSender 
 
     "be able to reply on failure during postStop" in {
       filterEvents(EventFilter[Exception]("test", occurrences = 1)) {
-        val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(AllForOneStrategy(List(classOf[Exception]), Some(0), None)))
+        val supervisor = system.actorOf(Props(new Supervisor(AllForOneStrategy(List(classOf[Exception]), Some(0), None))))
         val supervised = Await.result((supervisor ? Props[Supervised]).mapTo[ActorRef], timeout.duration)
 
         supervised.!("test")(testActor)

--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -300,7 +300,7 @@ class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
       filterEvents(EventFilter[IllegalStateException]("expected")) {
         val boss = system.actorOf(Props(new Actor {
           override val supervisorStrategy = OneForOneStrategy {
-            case e: IllegalStateException if e.getMessage == "expected" ⇒ FaultHandlingStrategy.Resume
+            case e: IllegalStateException if e.getMessage == "expected" ⇒ SupervisorStrategy.Resume
           }
           def receive = {
             case p: TypedProps[_] ⇒ context.sender ! TypedActor(context).typedActorOf(p)

--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -298,10 +298,13 @@ class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
 
     "be able to handle exceptions when calling methods" in {
       filterEvents(EventFilter[IllegalStateException]("expected")) {
-        val boss = system.actorOf(Props(context ⇒ {
-          case p: TypedProps[_] ⇒ context.sender ! TypedActor(context).typedActorOf(p)
-        }).withFaultHandler(OneForOneStrategy {
-          case e: IllegalStateException if e.getMessage == "expected" ⇒ FaultHandlingStrategy.Resume
+        val boss = system.actorOf(Props(new Actor {
+          override val supervisorStrategy = OneForOneStrategy {
+            case e: IllegalStateException if e.getMessage == "expected" ⇒ FaultHandlingStrategy.Resume
+          }
+          def receive = {
+            case p: TypedProps[_] ⇒ context.sender ! TypedActor(context).typedActorOf(p)
+          }
         }))
         val t = Await.result((boss ? TypedProps[Bar](classOf[Foo], classOf[Bar]).withTimeout(2 seconds)).mapTo[Foo], timeout.duration)
 

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -15,6 +15,7 @@ import akka.actor._
 
 object LoggingReceiveSpec {
   class TestLogActor extends Actor {
+    override val supervisorStrategy = OneForOneStrategy(List(classOf[Throwable]), 5, 5000)
     def receive = { case _ ⇒ }
   }
 }
@@ -149,7 +150,7 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterEach with BeforeAnd
         within(3 seconds) {
           val lifecycleGuardian = appLifecycle.asInstanceOf[ActorSystemImpl].guardian
           val lname = lifecycleGuardian.path.toString
-          val supervisor = TestActorRef[TestLogActor](Props[TestLogActor].withFaultHandler(OneForOneStrategy(List(classOf[Throwable]), 5, 5000)))
+          val supervisor = TestActorRef[TestLogActor](Props[TestLogActor])
           val sname = supervisor.path.toString
           val sclass = classOf[TestLogActor]
 

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -141,6 +141,14 @@ object Actor {
  *
  * {{{
  * class ExampleActor extends Actor {
+ *
+ *   override val supervisorStrategy = OneForOneStrategy({
+ *     case _: ArithmeticException      ⇒ Resume
+ *     case _: NullPointerException     ⇒ Restart
+ *     case _: IllegalArgumentException ⇒ Stop
+ *     case _: Exception                ⇒ Escalate
+ *   }: Decider, maxNrOfRetries = Some(10), withinTimeRange = Some(60000))
+ *
  *   def receive = {
  *                                      // directly calculated reply
  *     case Request(r)               => sender ! calculate(r)
@@ -223,6 +231,12 @@ trait Actor {
    * with the actor logic.
    */
   protected def receive: Receive
+
+  /**
+   * User overridable definition the strategy to use for supervising
+   * child actors.
+   */
+  def supervisorStrategy(): FaultHandlingStrategy = FaultHandlingStrategy.defaultFaultHandler
 
   /**
    * User overridable callback.

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -236,7 +236,7 @@ trait Actor {
    * User overridable definition the strategy to use for supervising
    * child actors.
    */
-  def supervisorStrategy(): FaultHandlingStrategy = FaultHandlingStrategy.defaultFaultHandler
+  def supervisorStrategy(): SupervisorStrategy = SupervisorStrategy.defaultStrategy
 
   /**
    * User overridable callback.

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -334,6 +334,16 @@ class LocalActorRefProvider(
    * exceptions which might have occurred.
    */
   private class Guardian extends Actor {
+
+    override val supervisorStrategy = {
+      import akka.actor.FaultHandlingStrategy._
+      OneForOneStrategy {
+        case _: ActorKilledException         ⇒ Stop
+        case _: ActorInitializationException ⇒ Stop
+        case _: Exception                    ⇒ Restart
+      }
+    }
+
     def receive = {
       case Terminated(_)                ⇒ context.stop(self)
       case CreateChild(child, name)     ⇒ sender ! (try context.actorOf(child, name) catch { case e: Exception ⇒ e })
@@ -366,15 +376,7 @@ class LocalActorRefProvider(
     override def preRestart(cause: Throwable, msg: Option[Any]) {}
   }
 
-  private val guardianFaultHandlingStrategy = {
-    import akka.actor.FaultHandlingStrategy._
-    OneForOneStrategy {
-      case _: ActorKilledException         ⇒ Stop
-      case _: ActorInitializationException ⇒ Stop
-      case _: Exception                    ⇒ Restart
-    }
-  }
-  private val guardianProps = Props(new Guardian).withFaultHandler(guardianFaultHandlingStrategy)
+  private val guardianProps = Props(new Guardian)
 
   /*
    * The problem is that ActorRefs need a reference to the ActorSystem to

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -336,7 +336,7 @@ class LocalActorRefProvider(
   private class Guardian extends Actor {
 
     override val supervisorStrategy = {
-      import akka.actor.FaultHandlingStrategy._
+      import akka.actor.SupervisorStrategy._
       OneForOneStrategy {
         case _: ActorKilledException         ⇒ Stop
         case _: ActorInitializationException ⇒ Stop
@@ -376,8 +376,6 @@ class LocalActorRefProvider(
     override def preRestart(cause: Throwable, msg: Option[Any]) {}
   }
 
-  private val guardianProps = Props(new Guardian)
-
   /*
    * The problem is that ActorRefs need a reference to the ActorSystem to
    * provide their service. Hence they cannot be created while the
@@ -402,6 +400,8 @@ class LocalActorRefProvider(
    * or before you start your own auto-spawned actors.
    */
   def registerExtraNames(_extras: Map[String, InternalActorRef]): Unit = extraNames ++= _extras
+
+  private val guardianProps = Props(new Guardian)
 
   lazy val rootGuardian: InternalActorRef =
     new LocalActorRef(system, guardianProps, theOneWhoWalksTheBubblesOfSpaceTime, rootPath, true) {

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -95,6 +95,16 @@ object FaultHandlingStrategy {
    */
   def escalate = Escalate
 
+  final val defaultFaultHandler: FaultHandlingStrategy = {
+    def defaultDecider: Decider = {
+      case _: ActorInitializationException ⇒ Stop
+      case _: ActorKilledException         ⇒ Stop
+      case _: Exception                    ⇒ Restart
+      case _                               ⇒ Escalate
+    }
+    OneForOneStrategy(defaultDecider, None, None)
+  }
+
   type Decider = PartialFunction[Throwable, Action]
   type JDecider = akka.japi.Function[Throwable, Action]
   type CauseAction = (Class[_ <: Throwable], Action)

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -44,7 +44,7 @@ case class ChildRestartStats(val child: ActorRef, var maxNrOfRetriesCount: Int =
   }
 }
 
-object FaultHandlingStrategy {
+object SupervisorStrategy {
   sealed trait Action
 
   /**
@@ -95,7 +95,7 @@ object FaultHandlingStrategy {
    */
   def escalate = Escalate
 
-  final val defaultFaultHandler: FaultHandlingStrategy = {
+  final val defaultStrategy: SupervisorStrategy = {
     def defaultDecider: Decider = {
       case _: ActorInitializationException ⇒ Stop
       case _: ActorKilledException         ⇒ Stop
@@ -158,9 +158,9 @@ object FaultHandlingStrategy {
     }
 }
 
-abstract class FaultHandlingStrategy {
+abstract class SupervisorStrategy {
 
-  import FaultHandlingStrategy._
+  import SupervisorStrategy._
 
   def decider: Decider
 
@@ -200,12 +200,12 @@ abstract class FaultHandlingStrategy {
 
 object AllForOneStrategy {
   def apply(trapExit: List[Class[_ <: Throwable]], maxNrOfRetries: Int, withinTimeRange: Int): AllForOneStrategy =
-    new AllForOneStrategy(FaultHandlingStrategy.makeDecider(trapExit),
+    new AllForOneStrategy(SupervisorStrategy.makeDecider(trapExit),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries), if (withinTimeRange < 0) None else Some(withinTimeRange))
   def apply(trapExit: List[Class[_ <: Throwable]], maxNrOfRetries: Option[Int], withinTimeRange: Option[Int]): AllForOneStrategy =
-    new AllForOneStrategy(FaultHandlingStrategy.makeDecider(trapExit), maxNrOfRetries, withinTimeRange)
+    new AllForOneStrategy(SupervisorStrategy.makeDecider(trapExit), maxNrOfRetries, withinTimeRange)
   def apply(trapExit: List[Class[_ <: Throwable]], maxNrOfRetries: Option[Int]): AllForOneStrategy =
-    new AllForOneStrategy(FaultHandlingStrategy.makeDecider(trapExit), maxNrOfRetries, None)
+    new AllForOneStrategy(SupervisorStrategy.makeDecider(trapExit), maxNrOfRetries, None)
 }
 
 /**
@@ -214,22 +214,22 @@ object AllForOneStrategy {
  * maxNrOfRetries = the number of times an actor is allowed to be restarted
  * withinTimeRange = millisecond time window for maxNrOfRetries, negative means no window
  */
-case class AllForOneStrategy(decider: FaultHandlingStrategy.Decider,
+case class AllForOneStrategy(decider: SupervisorStrategy.Decider,
                              maxNrOfRetries: Option[Int] = None,
-                             withinTimeRange: Option[Int] = None) extends FaultHandlingStrategy {
+                             withinTimeRange: Option[Int] = None) extends SupervisorStrategy {
 
-  def this(decider: FaultHandlingStrategy.JDecider, maxNrOfRetries: Int, withinTimeRange: Int) =
-    this(FaultHandlingStrategy.makeDecider(decider),
+  def this(decider: SupervisorStrategy.JDecider, maxNrOfRetries: Int, withinTimeRange: Int) =
+    this(SupervisorStrategy.makeDecider(decider),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries),
       if (withinTimeRange < 0) None else Some(withinTimeRange))
 
   def this(trapExit: JIterable[Class[_ <: Throwable]], maxNrOfRetries: Int, withinTimeRange: Int) =
-    this(FaultHandlingStrategy.makeDecider(trapExit),
+    this(SupervisorStrategy.makeDecider(trapExit),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries),
       if (withinTimeRange < 0) None else Some(withinTimeRange))
 
   def this(trapExit: Array[Class[_ <: Throwable]], maxNrOfRetries: Int, withinTimeRange: Int) =
-    this(FaultHandlingStrategy.makeDecider(trapExit),
+    this(SupervisorStrategy.makeDecider(trapExit),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries),
       if (withinTimeRange < 0) None else Some(withinTimeRange))
 
@@ -257,12 +257,12 @@ case class AllForOneStrategy(decider: FaultHandlingStrategy.Decider,
 
 object OneForOneStrategy {
   def apply(trapExit: List[Class[_ <: Throwable]], maxNrOfRetries: Int, withinTimeRange: Int): OneForOneStrategy =
-    new OneForOneStrategy(FaultHandlingStrategy.makeDecider(trapExit),
+    new OneForOneStrategy(SupervisorStrategy.makeDecider(trapExit),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries), if (withinTimeRange < 0) None else Some(withinTimeRange))
   def apply(trapExit: List[Class[_ <: Throwable]], maxNrOfRetries: Option[Int], withinTimeRange: Option[Int]): OneForOneStrategy =
-    new OneForOneStrategy(FaultHandlingStrategy.makeDecider(trapExit), maxNrOfRetries, withinTimeRange)
+    new OneForOneStrategy(SupervisorStrategy.makeDecider(trapExit), maxNrOfRetries, withinTimeRange)
   def apply(trapExit: List[Class[_ <: Throwable]], maxNrOfRetries: Option[Int]): OneForOneStrategy =
-    new OneForOneStrategy(FaultHandlingStrategy.makeDecider(trapExit), maxNrOfRetries, None)
+    new OneForOneStrategy(SupervisorStrategy.makeDecider(trapExit), maxNrOfRetries, None)
 }
 
 /**
@@ -271,22 +271,22 @@ object OneForOneStrategy {
  * maxNrOfRetries = the number of times an actor is allowed to be restarted
  * withinTimeRange = millisecond time window for maxNrOfRetries, negative means no window
  */
-case class OneForOneStrategy(decider: FaultHandlingStrategy.Decider,
+case class OneForOneStrategy(decider: SupervisorStrategy.Decider,
                              maxNrOfRetries: Option[Int] = None,
-                             withinTimeRange: Option[Int] = None) extends FaultHandlingStrategy {
+                             withinTimeRange: Option[Int] = None) extends SupervisorStrategy {
 
-  def this(decider: FaultHandlingStrategy.JDecider, maxNrOfRetries: Int, withinTimeRange: Int) =
-    this(FaultHandlingStrategy.makeDecider(decider),
+  def this(decider: SupervisorStrategy.JDecider, maxNrOfRetries: Int, withinTimeRange: Int) =
+    this(SupervisorStrategy.makeDecider(decider),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries),
       if (withinTimeRange < 0) None else Some(withinTimeRange))
 
   def this(trapExit: JIterable[Class[_ <: Throwable]], maxNrOfRetries: Int, withinTimeRange: Int) =
-    this(FaultHandlingStrategy.makeDecider(trapExit),
+    this(SupervisorStrategy.makeDecider(trapExit),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries),
       if (withinTimeRange < 0) None else Some(withinTimeRange))
 
   def this(trapExit: Array[Class[_ <: Throwable]], maxNrOfRetries: Int, withinTimeRange: Int) =
-    this(FaultHandlingStrategy.makeDecider(trapExit),
+    this(SupervisorStrategy.makeDecider(trapExit),
       if (maxNrOfRetries < 0) None else Some(maxNrOfRetries),
       if (withinTimeRange < 0) None else Some(withinTimeRange))
 

--- a/akka-actor/src/main/scala/akka/actor/Props.scala
+++ b/akka-actor/src/main/scala/akka/actor/Props.scala
@@ -18,19 +18,11 @@ import akka.routing._
  * Used when creating new actors through; <code>ActorSystem.actorOf</code> and <code>ActorContext.actorOf</code>.
  */
 object Props {
-  import FaultHandlingStrategy._
 
   final val defaultCreator: () ⇒ Actor = () ⇒ throw new UnsupportedOperationException("No actor creator specified!")
-  final val defaultDecider: Decider = {
-    case _: ActorInitializationException ⇒ Stop
-    case _: ActorKilledException         ⇒ Stop
-    case _: Exception                    ⇒ Restart
-    case _                               ⇒ Escalate
-  }
 
   final val defaultRoutedProps: RouterConfig = NoRouter
 
-  final val defaultFaultHandler: FaultHandlingStrategy = OneForOneStrategy(defaultDecider, None, None)
   final val noHotSwap: Stack[Actor.Receive] = Stack.empty
   final val empty = new Props(() ⇒ new Actor { def receive = Actor.emptyBehavior })
 
@@ -79,8 +71,6 @@ object Props {
   def apply(behavior: ActorContext ⇒ Actor.Receive): Props =
     apply(new Actor { def receive = behavior(context) })
 
-  def apply(faultHandler: FaultHandlingStrategy): Props =
-    apply(new Actor { def receive = { case _ ⇒ } }).withFaultHandler(faultHandler)
 }
 
 /**
@@ -94,14 +84,10 @@ object Props {
  *  val props = Props(
  *    creator = ..,
  *    dispatcher = ..,
- *    faultHandler = ..,
  *    routerConfig = ..
  *  )
  *  val props = Props().withCreator(new MyActor)
  *  val props = Props[MyActor].withRouter(RoundRobinRouter(..))
- *  val props = Props[MyActor].withFaultHandler(OneForOneStrategy {
- *    case e: IllegalStateException ⇒ Resume
- *  })
  * }}}
  *
  * Examples on Java API:
@@ -114,14 +100,12 @@ object Props {
  *    }
  *  });
  *  Props props = new Props().withCreator(new UntypedActorFactory() { ... });
- *  Props props = new Props(MyActor.class).withFaultHandler(new OneForOneStrategy(...));
  *  Props props = new Props(MyActor.class).withRouter(new RoundRobinRouter(..));
  * }}}
  */
 case class Props(
   creator: () ⇒ Actor = Props.defaultCreator,
   dispatcher: String = Dispatchers.DefaultDispatcherId,
-  faultHandler: FaultHandlingStrategy = Props.defaultFaultHandler,
   routerConfig: RouterConfig = Props.defaultRoutedProps) {
 
   /**
@@ -129,16 +113,14 @@ case class Props(
    */
   def this() = this(
     creator = Props.defaultCreator,
-    dispatcher = Dispatchers.DefaultDispatcherId,
-    faultHandler = Props.defaultFaultHandler)
+    dispatcher = Dispatchers.DefaultDispatcherId)
 
   /**
    * Java API.
    */
   def this(factory: UntypedActorFactory) = this(
     creator = () ⇒ factory.create(),
-    dispatcher = Dispatchers.DefaultDispatcherId,
-    faultHandler = Props.defaultFaultHandler)
+    dispatcher = Dispatchers.DefaultDispatcherId)
 
   /**
    * Java API.
@@ -146,7 +128,6 @@ case class Props(
   def this(actorClass: Class[_ <: Actor]) = this(
     creator = () ⇒ actorClass.newInstance,
     dispatcher = Dispatchers.DefaultDispatcherId,
-    faultHandler = Props.defaultFaultHandler,
     routerConfig = Props.defaultRoutedProps)
 
   /**
@@ -174,11 +155,6 @@ case class Props(
    * Returns a new Props with the specified dispatcher set.
    */
   def withDispatcher(d: String) = copy(dispatcher = d)
-
-  /**
-   * Returns a new Props with the specified faulthandler set.
-   */
-  def withFaultHandler(f: FaultHandlingStrategy) = copy(faultHandler = f)
 
   /**
    * Returns a new Props with the specified router config set.

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -218,9 +218,9 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
       TypedActor.currentContext set null
     }
 
-    override def supervisorStrategy: FaultHandlingStrategy = me match {
-      case l: SupervisorStrategy ⇒ l.supervisorStrategy
-      case _                     ⇒ super.supervisorStrategy
+    override def supervisorStrategy(): SupervisorStrategy = me match {
+      case l: Supervisor ⇒ l.supervisorStrategy
+      case _             ⇒ super.supervisorStrategy
     }
 
     override def preStart(): Unit = me match {
@@ -283,12 +283,12 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
   /**
    * Mix this into your TypedActor to be able to define supervisor strategy
    */
-  trait SupervisorStrategy {
+  trait Supervisor {
     /**
      * User overridable definition the strategy to use for supervising
      * child actors.
      */
-    def supervisorStrategy: FaultHandlingStrategy = FaultHandlingStrategy.defaultFaultHandler
+    def supervisorStrategy(): SupervisorStrategy = SupervisorStrategy.defaultStrategy
   }
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
@@ -37,6 +37,26 @@ import akka.dispatch.{ MessageDispatcher, Promise }
  *      }
  *    }
  *
+ *   private static FaultHandlingStrategy strategy = new OneForOneStrategy(new Function<Throwable, Action>() {
+ *     @Override
+ *     public Action apply(Throwable t) {
+ *       if (t instanceof ArithmeticException) {
+ *         return resume();
+ *       } else if (t instanceof NullPointerException) {
+ *         return restart();
+ *       } else if (t instanceof IllegalArgumentException) {
+ *         return stop();
+ *       } else {
+ *         return escalate();
+ *       }
+ *     }
+ *   }, 10, 60000);
+ *
+ *   @Override
+ *   public FaultHandlingStrategy supervisorStrategy() {
+ *     return strategy;
+ *    }
+ *
  *    public void onReceive(Object message) throws Exception {
  *      if (message instanceof String) {
  *        String msg = (String)message;
@@ -91,6 +111,12 @@ abstract class UntypedActor extends Actor {
    * for the reply, in which case it will be sent to the dead letter mailbox.
    */
   def getSender(): ActorRef = sender
+
+  /**
+   * User overridable definition the strategy to use for supervising
+   * child actors.
+   */
+  override def supervisorStrategy(): FaultHandlingStrategy = super.supervisorStrategy()
 
   /**
    * User overridable callback.

--- a/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
@@ -37,7 +37,7 @@ import akka.dispatch.{ MessageDispatcher, Promise }
  *      }
  *    }
  *
- *   private static FaultHandlingStrategy strategy = new OneForOneStrategy(new Function<Throwable, Action>() {
+ *   private static SupervisorStrategy strategy = new OneForOneStrategy(new Function<Throwable, Action>() {
  *     @Override
  *     public Action apply(Throwable t) {
  *       if (t instanceof ArithmeticException) {
@@ -53,7 +53,7 @@ import akka.dispatch.{ MessageDispatcher, Promise }
  *   }, 10, 60000);
  *
  *   @Override
- *   public FaultHandlingStrategy supervisorStrategy() {
+ *   public SupervisorStrategy supervisorStrategy() {
  *     return strategy;
  *    }
  *
@@ -116,7 +116,7 @@ abstract class UntypedActor extends Actor {
    * User overridable definition the strategy to use for supervising
    * child actors.
    */
-  override def supervisorStrategy(): FaultHandlingStrategy = super.supervisorStrategy()
+  override def supervisorStrategy(): SupervisorStrategy = super.supervisorStrategy()
 
   /**
    * User overridable callback.

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -272,7 +272,7 @@ object Future {
    * in blocking calls after the call to this method, giving the system a
    * chance to spawn new threads, reuse old threads or otherwise, to prevent
    * starvation and/or unfairness.
-   * 
+   *
    * Assures that any Future tasks initiated in the current thread will be
    * executed asynchronously, including any tasks currently queued to be
    * executed in the current thread. This is needed if the current task may

--- a/akka-docs/general/actor-systems.rst
+++ b/akka-docs/general/actor-systems.rst
@@ -3,90 +3,90 @@
 Actor Systems
 =============
 
-Actors are objects which encapsulate state and behavior, they communicate 
-exclusively by exchanging messages which are placed into the recipient’s 
-mailbox. In a sense, actors are the most strigent form of object-oriented 
-programming, but it serves better to view them as persons: while modeling a 
-solution with actors, envision a group of people and assign sub-tasks to them, 
-arrange their functions into an organizational structure and think about how to 
-escalate failure (all with the benefit of not actually dealing with people, 
-which means that we need not concern ourselves with their emotional state or 
-moral issues). The result can then serve as a mental scaffolding for building 
+Actors are objects which encapsulate state and behavior, they communicate
+exclusively by exchanging messages which are placed into the recipient’s
+mailbox. In a sense, actors are the most strigent form of object-oriented
+programming, but it serves better to view them as persons: while modeling a
+solution with actors, envision a group of people and assign sub-tasks to them,
+arrange their functions into an organizational structure and think about how to
+escalate failure (all with the benefit of not actually dealing with people,
+which means that we need not concern ourselves with their emotional state or
+moral issues). The result can then serve as a mental scaffolding for building
 the software implementation.
 
 Hierarchical Structure
 ----------------------
 
-Like in an economic organization, actors naturally form hierarchies. One actor, 
-which is to oversee a certain function in the program might want to split up 
-its task into smaller, more manageable pieces. For this purpose it starts child 
-actors which it supervises. While the details of supervision are explained 
-:ref:`here <supervision>`, we shall concentrate on the underlying concepts in 
-this section. The only prerequisite is to know that each actor has exactly one 
+Like in an economic organization, actors naturally form hierarchies. One actor,
+which is to oversee a certain function in the program might want to split up
+its task into smaller, more manageable pieces. For this purpose it starts child
+actors which it supervises. While the details of supervision are explained
+:ref:`here <supervision>`, we shall concentrate on the underlying concepts in
+this section. The only prerequisite is to know that each actor has exactly one
 supervisor, which is the actor that created it.
 
-The quintessential feature of actor systems is that tasks are split up and 
-delegated until they become small enough to be handled in one piece. In doing 
-so, not only is the task itself clearly structured, but the resulting actors 
-can be reasoned about in terms of which messages they should process, how they 
-should react nominally and how failure should be handled. If one actor does not 
-have the means for dealing with a certain situation, it sends a corresponding 
-failure message to its supervisor, asking for help. The recursive structure 
-then allows to handle failure at the right level. 
+The quintessential feature of actor systems is that tasks are split up and
+delegated until they become small enough to be handled in one piece. In doing
+so, not only is the task itself clearly structured, but the resulting actors
+can be reasoned about in terms of which messages they should process, how they
+should react nominally and how failure should be handled. If one actor does not
+have the means for dealing with a certain situation, it sends a corresponding
+failure message to its supervisor, asking for help. The recursive structure
+then allows to handle failure at the right level.
 
-Compare this to layered software design which easily devolves into defensive 
-programming with the aim of not leaking any failure out: if the problem is 
-communicated to the right person, a better solution can be found than if 
+Compare this to layered software design which easily devolves into defensive
+programming with the aim of not leaking any failure out: if the problem is
+communicated to the right person, a better solution can be found than if
 trying to keep everything “under the carpet”.
 
-Now, the difficulty in designing such a system is how to decide who should 
-supervise what. There is of course no single best solution, but there are a few 
+Now, the difficulty in designing such a system is how to decide who should
+supervise what. There is of course no single best solution, but there are a few
 guide lines which might be helpful:
 
- - If one actor manages the work another actor is doing, e.g. by passing on 
-   sub-tasks, then the manager should supervise the child. The reason is that 
-   the manager knows which kind of failures are expected and how to handle 
+ - If one actor manages the work another actor is doing, e.g. by passing on
+   sub-tasks, then the manager should supervise the child. The reason is that
+   the manager knows which kind of failures are expected and how to handle
    them.
 
- - If one actor carries very important data (i.e. its state shall not be lost 
-   if avoidable), this actor should source out any possibly dangerous sub-tasks 
-   to children it supervises and handle failures of these children as 
-   appropriate. Depending on the nature of the requests, it may be best to 
-   create a new child for each request, which simplifies state management for 
-   collecting the replies. This is known as the “Error Kernel Pattern” from 
+ - If one actor carries very important data (i.e. its state shall not be lost
+   if avoidable), this actor should source out any possibly dangerous sub-tasks
+   to children it supervises and handle failures of these children as
+   appropriate. Depending on the nature of the requests, it may be best to
+   create a new child for each request, which simplifies state management for
+   collecting the replies. This is known as the “Error Kernel Pattern” from
    Erlang.
 
- - If one actor depends on another actor for carrying out its duty, it should 
-   watch that other actor’s liveness and act upon receiving a termination 
-   notice. This is different from supervision, as the watching party has no 
-   influence on the supervision strategy, and it should be noted that a 
-   functional dependency alone is not a criterion for deciding where to place a 
+ - If one actor depends on another actor for carrying out its duty, it should
+   watch that other actor’s liveness and act upon receiving a termination
+   notice. This is different from supervision, as the watching party has no
+   influence on the supervisor strategy, and it should be noted that a
+   functional dependency alone is not a criterion for deciding where to place a
    certain child actor in the hierarchy.
 
-There are of course always exceptions to these rules, but no matter whether you 
+There are of course always exceptions to these rules, but no matter whether you
 follow the rules or break them, you should always have a reason.
 
 Configuration Container
 -----------------------
 
-The actor system as a collaborating ensemble of actors is the natural unit for 
-managing shared facilities like scheduling services, configuration, logging, 
-etc. Several actor systems with different configuration may co-exist within the 
-same JVM without problems, there is no global shared state within Akka itself. 
-Couple this with the transparent communication between actor systems—within one 
-node or across a network connection—to see that actor systems themselves can be 
+The actor system as a collaborating ensemble of actors is the natural unit for
+managing shared facilities like scheduling services, configuration, logging,
+etc. Several actor systems with different configuration may co-exist within the
+same JVM without problems, there is no global shared state within Akka itself.
+Couple this with the transparent communication between actor systems—within one
+node or across a network connection—to see that actor systems themselves can be
 used as building blocks in a functional hierarchy.
 
 Actor Best Practices
 --------------------
 
-#. Actors should be like nice co-workers: do their job efficiently without 
-   bothering everyone else needlessly and avoid hogging resources. Translated 
-   to programming this means to process events and generate responses (or more 
-   requests) in an event-driven manner. Actors should not block (i.e. passively 
-   wait while occupying a Thread) on some external entity, which might be a 
-   lock, a network socket, etc. The blocking operations should be done in some 
-   special-cased thread which sends messages to the actors which shall act on 
+#. Actors should be like nice co-workers: do their job efficiently without
+   bothering everyone else needlessly and avoid hogging resources. Translated
+   to programming this means to process events and generate responses (or more
+   requests) in an event-driven manner. Actors should not block (i.e. passively
+   wait while occupying a Thread) on some external entity, which might be a
+   lock, a network socket, etc. The blocking operations should be done in some
+   special-cased thread which sends messages to the actors which shall act on
    them.
 
 #. Do not pass mutable objects between actors. In order to ensure that, prefer
@@ -94,21 +94,21 @@ Actor Best Practices
    their mutable state to the outside, you are back in normal Java concurrency
    land with all the drawbacks.
 
-#. Actors are made to be containers for behavior and state, embracing this 
-   means to not routinely send behavior within messages (which may be tempting 
-   using Scala closures). One of the risks is to accidentally share mutable 
-   state between actors, and this violation of the actor model unfortunately 
-   breaks all the properties which make programming in actors such a nice 
+#. Actors are made to be containers for behavior and state, embracing this
+   means to not routinely send behavior within messages (which may be tempting
+   using Scala closures). One of the risks is to accidentally share mutable
+   state between actors, and this violation of the actor model unfortunately
+   breaks all the properties which make programming in actors such a nice
    experience.
 
 What you should not concern yourself with
 -----------------------------------------
 
-An actor system manages the resources it is configured to use in order to run 
-the actors which it contains. There may be millions of actors within one such 
-system, after all the mantra is to view them as abundant and they weigh in at 
-an overhead of only roughly 300 bytes per instance. Naturally, the exact order 
-in which messages are processed in large systems is not controllable by the 
-application author, but this is also not intended. Take a step back and relax 
+An actor system manages the resources it is configured to use in order to run
+the actors which it contains. There may be millions of actors within one such
+system, after all the mantra is to view them as abundant and they weigh in at
+an overhead of only roughly 300 bytes per instance. Naturally, the exact order
+in which messages are processed in large systems is not controllable by the
+application author, but this is also not intended. Take a step back and relax
 while Akka does the heavy lifting under the hood.
 

--- a/akka-docs/general/actors.rst
+++ b/akka-docs/general/actors.rst
@@ -3,123 +3,121 @@
 What is an Actor?
 =================
 
-The previous section about :ref:`actor-systems` explained how actors form 
-hierarchies and are the smallest unit when building an application. This 
-section looks at one such actor in isolation, explaining the concepts you 
-encounter while implementing it. For more an in depth reference with all the 
+The previous section about :ref:`actor-systems` explained how actors form
+hierarchies and are the smallest unit when building an application. This
+section looks at one such actor in isolation, explaining the concepts you
+encounter while implementing it. For more an in depth reference with all the
 details please refer to :ref:`actors-scala` and :ref:`untyped-actors-java`.
 
-An actor is a container for `State`_, `Behavior`_, a `Mailbox`_, `Children`_ 
-and a `Fault Handling Strategy`_. All of this is encapsulated behind an `Actor 
+An actor is a container for `State`_, `Behavior`_, a `Mailbox`_, `Children`_
+and a `Supervisor Strategy`_. All of this is encapsulated behind an `Actor
 Reference`_. Finally, this happens `When an Actor Terminates`_.
 
 Actor Reference
 ---------------
 
-As detailed below, an actor object needs to be shielded from the outside in 
-order to benefit from the actor model. Therefore, actors are represented to the 
-outside using actor references, which are objects that can be passed around 
-freely and without restriction. This split into inner and outer object enables 
-transparency for all the desired operations: restarting an actor without 
-needing to update references elsewhere, placing the actual actor object on 
-remote hosts, sending messages to actors in completely different applications. 
-But the most important aspect is that it is not possible to look inside an 
-actor and get hold of its state from the outside, unless the actor unwisely 
+As detailed below, an actor object needs to be shielded from the outside in
+order to benefit from the actor model. Therefore, actors are represented to the
+outside using actor references, which are objects that can be passed around
+freely and without restriction. This split into inner and outer object enables
+transparency for all the desired operations: restarting an actor without
+needing to update references elsewhere, placing the actual actor object on
+remote hosts, sending messages to actors in completely different applications.
+But the most important aspect is that it is not possible to look inside an
+actor and get hold of its state from the outside, unless the actor unwisely
 publishes this information itself.
 
 State
 -----
 
-Actor objects will typically contain some variables which reflect possible 
-states the actor may be in. This can be an explicit state machine (e.g. using 
-the :ref:`fsm` module), or it could be a counter, set of listeners, pending 
-requests, etc. These data are what make an actor valuable, and they must be 
-protected from corruption by other actors. The good news is that Akka actors 
-conceptually each have their own light-weight thread, which is completely 
-shielded from the rest of the system. This means that instead of having to 
-synchronize access using locks you can just write your actor code without 
+Actor objects will typically contain some variables which reflect possible
+states the actor may be in. This can be an explicit state machine (e.g. using
+the :ref:`fsm` module), or it could be a counter, set of listeners, pending
+requests, etc. These data are what make an actor valuable, and they must be
+protected from corruption by other actors. The good news is that Akka actors
+conceptually each have their own light-weight thread, which is completely
+shielded from the rest of the system. This means that instead of having to
+synchronize access using locks you can just write your actor code without
 worrying about concurrency at all.
 
-Behind the scenes Akka will run sets of actors on sets of real threads, where 
-typically many actors share one thread, and subsequent invocations of one actor 
-may end up being processed on different threads. Akka ensures that this 
-implementation detail does not affect the single-threadedness of handling the 
+Behind the scenes Akka will run sets of actors on sets of real threads, where
+typically many actors share one thread, and subsequent invocations of one actor
+may end up being processed on different threads. Akka ensures that this
+implementation detail does not affect the single-threadedness of handling the
 actor’s state.
 
-Because the internal state is vital to an actor’s operations, having 
-inconsistent state is fatal. Thus, when the actor fails and is restarted by its 
-supervisor, the state will be created from scratch, like upon first creating 
+Because the internal state is vital to an actor’s operations, having
+inconsistent state is fatal. Thus, when the actor fails and is restarted by its
+supervisor, the state will be created from scratch, like upon first creating
 the actor. This is to enable the ability of self-healing of the system.
 
 Behavior
 --------
 
-Every time a message is processed, it is matched against the current behavior 
-of the actor. Behavior means a function which defines the actions to be taken 
-in reaction to the message at that point in time, say forward a request if the 
-client is authorized, deny it otherwise. This behavior may change over time, 
-e.g. because different clients obtain authorization over time, or because the 
-actor may go into an “out-of-service” mode and later come back. These changes 
-are achieved by either encoding them in state variables which are read from the 
-behavior logic, or the function itself may be swapped out at runtime, see the 
-``become`` and ``unbecome`` operations. However, the initial behavior defined 
-during construction of the actor object is special in the sense that a restart 
+Every time a message is processed, it is matched against the current behavior
+of the actor. Behavior means a function which defines the actions to be taken
+in reaction to the message at that point in time, say forward a request if the
+client is authorized, deny it otherwise. This behavior may change over time,
+e.g. because different clients obtain authorization over time, or because the
+actor may go into an “out-of-service” mode and later come back. These changes
+are achieved by either encoding them in state variables which are read from the
+behavior logic, or the function itself may be swapped out at runtime, see the
+``become`` and ``unbecome`` operations. However, the initial behavior defined
+during construction of the actor object is special in the sense that a restart
 of the actor will reset its behavior to this initial one.
 
 Mailbox
 -------
 
-An actor’s purpose is the processing of messages, and these messages were sent 
-to the actor from other actors (or from outside the actor system). The piece 
-which connects sender and receiver is the actor’s mailbox: each actor has 
-exactly one mailbox to which all senders enqueue their messages. Enqueuing 
-happens in the time-order of send operations, which means that messages sent 
-from different actors may not have a defined order at runtime due to the 
-apparent randomness of distributing actors across threads. Sending multiple 
-messages to the same target from the same actor, on the other hand, will 
+An actor’s purpose is the processing of messages, and these messages were sent
+to the actor from other actors (or from outside the actor system). The piece
+which connects sender and receiver is the actor’s mailbox: each actor has
+exactly one mailbox to which all senders enqueue their messages. Enqueuing
+happens in the time-order of send operations, which means that messages sent
+from different actors may not have a defined order at runtime due to the
+apparent randomness of distributing actors across threads. Sending multiple
+messages to the same target from the same actor, on the other hand, will
 enqueue them in the same order.
 
-There are different mailbox implementations to choose from, the default being a 
-FIFO: the order of the messages processed by the actor matches the order in 
-which they were enqueued. This is usually a good default, but applications may 
-need to prioritize some messages over others. In this case, a priority mailbox 
-will enqueue not always at the end but at a position as given by the message 
-priority, which might even be at the front. While using such a queue, the order 
-of messages processed will naturally be defined by the queue’s algorithm and in 
+There are different mailbox implementations to choose from, the default being a
+FIFO: the order of the messages processed by the actor matches the order in
+which they were enqueued. This is usually a good default, but applications may
+need to prioritize some messages over others. In this case, a priority mailbox
+will enqueue not always at the end but at a position as given by the message
+priority, which might even be at the front. While using such a queue, the order
+of messages processed will naturally be defined by the queue’s algorithm and in
 general not be FIFO.
 
-An important feature in which Akka differs from some other actor model 
-implementations is that the current behavior must always handle the next 
-dequeued message, there is no scanning the mailbox for the next matching one. 
-Failure to handle a message will typically be treated as a failure, unless this 
+An important feature in which Akka differs from some other actor model
+implementations is that the current behavior must always handle the next
+dequeued message, there is no scanning the mailbox for the next matching one.
+Failure to handle a message will typically be treated as a failure, unless this
 behavior is overridden.
 
 Children
 --------
 
-Each actor is potentially a supervisor: if it creates children for delegating 
-sub-tasks, it will automatically supervise them. The list of children is 
-maintained within the actor’s context and the actor has access to it. 
-Modifications to the list are done by creating (``context.actorOf(...)``) or 
-stopping (``context.stop(child)``) children and these actions are reflected 
-immediately. The actual creation and termination actions happen behind the 
+Each actor is potentially a supervisor: if it creates children for delegating
+sub-tasks, it will automatically supervise them. The list of children is
+maintained within the actor’s context and the actor has access to it.
+Modifications to the list are done by creating (``context.actorOf(...)``) or
+stopping (``context.stop(child)``) children and these actions are reflected
+immediately. The actual creation and termination actions happen behind the
 scenes in an asynchronous way, so they do not “block” their supervisor.
 
-Fault Handling Strategy
------------------------
+Supervisor Strategy
+-------------------
 
-The final piece of an actor is its strategy for handling faults of its 
-children. To keep it simple and robust, this is declared outside of the actor’s 
-code and has no access to the actor’s state. Fault handling is then done 
-transparently by Akka, applying one of the strategies described in 
-:ref:`supervision` for each incoming failure. As this strategy is fundamental 
-to how an actor system is structured, it cannot be changed once an actor has 
-been created.
+The final piece of an actor is its strategy for handling faults of its
+children. Fault handling is then done transparently by Akka, applying one
+of the strategies described in :ref:`supervision` for each incoming failure.
+As this strategy is fundamental to how an actor system is structured, it
+cannot be changed once an actor has been created.
 
-Considering that there is only one such strategy for each actor, this means 
-that if different strategies apply to the various children of an actor, the 
-children should be grouped beneath intermediate supervisors with matching 
-strategies, preferring once more the structuring of actor systems according to 
+Considering that there is only one such strategy for each actor, this means
+that if different strategies apply to the various children of an actor, the
+children should be grouped beneath intermediate supervisors with matching
+strategies, preferring once more the structuring of actor systems according to
 the splitting of tasks into sub-tasks.
 
 When an Actor Terminates

--- a/akka-docs/java/code/akka/docs/actor/FaultHandlingTestBase.java
+++ b/akka-docs/java/code/akka/docs/actor/FaultHandlingTestBase.java
@@ -6,8 +6,8 @@ package akka.docs.actor;
 //#testkit
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import akka.actor.FaultHandlingStrategy;
-import static akka.actor.FaultHandlingStrategy.*;
+import akka.actor.SupervisorStrategy;
+import static akka.actor.SupervisorStrategy.*;
 import akka.actor.OneForOneStrategy;
 import akka.actor.Props;
 import akka.actor.Terminated;
@@ -38,7 +38,7 @@ public class FaultHandlingTestBase {
   static public class Supervisor extends UntypedActor {
 
     //#strategy
-    private static FaultHandlingStrategy strategy = new OneForOneStrategy(new Function<Throwable, Action>() {
+    private static SupervisorStrategy strategy = new OneForOneStrategy(new Function<Throwable, Action>() {
       @Override
       public Action apply(Throwable t) {
         if (t instanceof ArithmeticException) {
@@ -54,7 +54,7 @@ public class FaultHandlingTestBase {
     }, 10, 60000);
 
     @Override
-    public FaultHandlingStrategy supervisorStrategy() {
+    public SupervisorStrategy supervisorStrategy() {
       return strategy;
     }
 
@@ -75,7 +75,7 @@ public class FaultHandlingTestBase {
   static public class Supervisor2 extends UntypedActor {
 
     //#strategy2
-    private static FaultHandlingStrategy strategy = new OneForOneStrategy(new Function<Throwable, Action>() {
+    private static SupervisorStrategy strategy = new OneForOneStrategy(new Function<Throwable, Action>() {
       @Override
       public Action apply(Throwable t) {
         if (t instanceof ArithmeticException) {
@@ -91,7 +91,7 @@ public class FaultHandlingTestBase {
     }, 10, 60000);
 
     @Override
-    public FaultHandlingStrategy supervisorStrategy() {
+    public SupervisorStrategy supervisorStrategy() {
       return strategy;
     }
 
@@ -147,7 +147,7 @@ public class FaultHandlingTestBase {
   }
 
   @Test
-  public void mustEmployFaultHandler() {
+  public void mustEmploySupervisorStrategy() {
     // code here
     //#testkit
     EventFilter ex1 = (EventFilter) new ErrorFilter(ArithmeticException.class);

--- a/akka-docs/java/fault-tolerance.rst
+++ b/akka-docs/java/fault-tolerance.rst
@@ -8,9 +8,9 @@ Fault Handling Strategies (Java)
    .. contents:: :local:
 
 As explained in :ref:`actor-systems` each actor is the supervisor of its
-children, and as such each actor is given a fault handling strategy when it is
-created. This strategy cannot be changed afterwards as it is an integral part
-of the actor system’s structure.
+children, and as such each actor defines fault handling supervisor strategy.
+This strategy cannot be changed afterwards as it is an integral part of the
+actor system’s structure.
 
 Creating a Fault Handling Strategy
 ----------------------------------
@@ -26,7 +26,7 @@ First off, it is a one-for-one strategy, meaning that each child is treated
 separately (an all-for-one strategy works very similarly, the only difference
 is that any decision is applied to all children of the supervisor, not only the
 failing one). There are limits set on the restart frequency, namely maximum 10
-restarts per minute; each of these settings defaults to could be left out, which means
+restarts per minute; each of these settings could be left out, which means
 that the respective limit does not apply, leaving the possibility to specify an
 absolute upper limit on the restarts or to make the restarts work infinitely.
 
@@ -50,7 +50,7 @@ where ``TestProbe`` provides an actor ref useful for receiving and inspecting re
 .. includecode:: code/akka/docs/actor/FaultHandlingTestBase.java
    :include: testkit
 
-Using the strategy shown above let us create actors:
+Let us create actors:
 
 .. includecode:: code/akka/docs/actor/FaultHandlingTestBase.java
    :include: create

--- a/akka-docs/java/fault-tolerance.rst
+++ b/akka-docs/java/fault-tolerance.rst
@@ -1,7 +1,7 @@
 .. _fault-tolerance-java:
 
-Fault Handling Strategies (Java)
-=================================
+Fault Tolerance (Java)
+======================
 
 .. sidebar:: Contents
 
@@ -12,8 +12,8 @@ children, and as such each actor defines fault handling supervisor strategy.
 This strategy cannot be changed afterwards as it is an integral part of the
 actor system’s structure.
 
-Creating a Fault Handling Strategy
-----------------------------------
+Creating a Supervisor Strategy
+------------------------------
 
 For the sake of demonstration let us consider the following strategy:
 

--- a/akka-docs/java/typed-actors.rst
+++ b/akka-docs/java/typed-actors.rst
@@ -30,7 +30,7 @@ it's located in ``akka.actor.TypedActor``.
    :include: typed-actor-extension-tools
 
 .. warning::
-    
+
     Same as not exposing ``this`` of an Akka Actor, it's important not to expose ``this`` of a Typed Actor,
     instead you should pass the external proxy reference, which is obtained from within your Typed Actor as
     ``TypedActor.self()``, this is your external identity, as the ``ActorRef`` is the external identity of
@@ -127,7 +127,7 @@ Request-reply-with-future message send
 .. includecode:: code/akka/docs/actor/TypedActorDocTestBase.java
    :include: typed-actor-call-future
 
-This call is asynchronous, and the Future returned can be used for asynchronous composition. 
+This call is asynchronous, and the Future returned can be used for asynchronous composition.
 
 Stopping Typed Actors
 ---------------------
@@ -152,6 +152,13 @@ Since you can obtain a contextual Typed Actor Extension by passing in an ``Actor
 you can create child Typed Actors by invoking ``typedActorOf(..)`` on that.
 
 This also works for creating child Typed Actors in regular Akka Actors.
+
+Supervisor Strategy
+-------------------
+
+By having your Typed Actor implementation class implement ``TypedActor.Supervisor``
+you can define the strategy to use for supervising child actors, as described in
+:ref:`supervision` and :ref:`fault-tolerance-java`.
 
 Lifecycle callbacks
 -------------------

--- a/akka-docs/java/untyped-actors.rst
+++ b/akka-docs/java/untyped-actors.rst
@@ -129,6 +129,7 @@ In addition, it offers:
 
 * :obj:`getSelf()` reference to the :class:`ActorRef` of the actor
 * :obj:`getSender()` reference sender Actor of the last received message, typically used as described in :ref:`UntypedActor.Reply`
+* :obj:`supervisorStrategy()` user overridable definition the strategy to use for supervising child actors
 * :obj:`getContext()` exposes contextual information for the actor and the current message, such as:
 
   * factory methods to create child actors (:meth:`actorOf`)

--- a/akka-docs/project/migration-guide-1.3.x-2.0.x.rst
+++ b/akka-docs/project/migration-guide-1.3.x-2.0.x.rst
@@ -403,7 +403,7 @@ v2.0::
 
   context.parent
 
-*Fault handling strategy*
+*Supervisor Strategy*
 
 v1.3::
 
@@ -420,14 +420,18 @@ v1.3::
 
 v2.0::
 
-  val strategy = OneForOneStrategy({
-    case _: ArithmeticException      ⇒ Resume
-    case _: NullPointerException     ⇒ Restart
-    case _: IllegalArgumentException ⇒ Stop
-    case _: Exception                ⇒ Escalate
-  }: Decider, maxNrOfRetries = Some(10), withinTimeRange = Some(60000))
+  class MyActor extends Actor {
+    override val supervisorStrategy = OneForOneStrategy({
+        case _: ArithmeticException      ⇒ Resume
+        case _: NullPointerException     ⇒ Restart
+        case _: IllegalArgumentException ⇒ Stop
+        case _: Exception                ⇒ Escalate
+      }: Decider, maxNrOfRetries = Some(10), withinTimeRange = Some(60000))
 
-  val supervisor = system.actorOf(Props[Supervisor].withFaultHandler(strategy), "supervisor")
+    def receive = {
+      case x =>
+    }
+  }
 
 Documentation:
 

--- a/akka-docs/scala/actors.rst
+++ b/akka-docs/scala/actors.rst
@@ -154,6 +154,7 @@ In addition, it offers:
 
 * :obj:`self` reference to the :class:`ActorRef` of the actor
 * :obj:`sender` reference sender Actor of the last received message, typically used as described in :ref:`Actor.Reply`
+* :obj:`supervisorStrategy` user overridable definition the strategy to use for supervising child actors
 * :obj:`context` exposes contextual information for the actor and the current message, such as:
 
   * factory methods to create child actors (:meth:`actorOf`)

--- a/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
@@ -19,7 +19,7 @@ object FaultHandlingDocSpec {
   class Supervisor extends Actor {
     //#strategy
     import akka.actor.OneForOneStrategy
-    import akka.actor.FaultHandlingStrategy._
+    import akka.actor.SupervisorStrategy._
 
     override val supervisorStrategy = OneForOneStrategy({
       case _: ArithmeticException      ⇒ Resume
@@ -39,7 +39,7 @@ object FaultHandlingDocSpec {
   class Supervisor2 extends Actor {
     //#strategy2
     import akka.actor.OneForOneStrategy
-    import akka.actor.FaultHandlingStrategy._
+    import akka.actor.SupervisorStrategy._
 
     override val supervisorStrategy = OneForOneStrategy({
       case _: ArithmeticException      ⇒ Resume

--- a/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
@@ -17,6 +17,18 @@ object FaultHandlingDocSpec {
   //#supervisor
   //#supervisor
   class Supervisor extends Actor {
+    //#strategy
+    import akka.actor.OneForOneStrategy
+    import akka.actor.FaultHandlingStrategy._
+
+    override val supervisorStrategy = OneForOneStrategy({
+      case _: ArithmeticException      ⇒ Resume
+      case _: NullPointerException     ⇒ Restart
+      case _: IllegalArgumentException ⇒ Stop
+      case _: Exception                ⇒ Escalate
+    }: Decider, maxNrOfRetries = Some(10), withinTimeRange = Some(60000))
+    //#strategy
+
     def receive = {
       case p: Props ⇒ sender ! context.actorOf(p)
     }
@@ -25,6 +37,18 @@ object FaultHandlingDocSpec {
 
   //#supervisor2
   class Supervisor2 extends Actor {
+    //#strategy2
+    import akka.actor.OneForOneStrategy
+    import akka.actor.FaultHandlingStrategy._
+
+    override val supervisorStrategy = OneForOneStrategy({
+      case _: ArithmeticException      ⇒ Resume
+      case _: NullPointerException     ⇒ Restart
+      case _: IllegalArgumentException ⇒ Stop
+      case _: Exception                ⇒ Escalate
+    }: Decider, maxNrOfRetries = Some(10), withinTimeRange = Some(60000))
+    //#strategy2
+
     def receive = {
       case p: Props ⇒ sender ! context.actorOf(p)
     }
@@ -56,21 +80,9 @@ class FaultHandlingDocSpec extends AkkaSpec with ImplicitSender {
 
     "apply the chosen strategy for its child" in {
       //#testkit
-      //#strategy
-      import akka.actor.OneForOneStrategy
-      import akka.actor.FaultHandlingStrategy._
 
-      val strategy = OneForOneStrategy({
-        case _: ArithmeticException      ⇒ Resume
-        case _: NullPointerException     ⇒ Restart
-        case _: IllegalArgumentException ⇒ Stop
-        case _: Exception                ⇒ Escalate
-      }: Decider, maxNrOfRetries = Some(10), withinTimeRange = Some(60000))
-
-      //#strategy
       //#create
-      val superprops = Props[Supervisor].withFaultHandler(strategy)
-      val supervisor = system.actorOf(superprops, "supervisor")
+      val supervisor = system.actorOf(Props[Supervisor], "supervisor")
 
       supervisor ! Props[Child]
       val child = expectMsgType[ActorRef] // retrieve answer from TestKit’s testActor
@@ -114,8 +126,7 @@ class FaultHandlingDocSpec extends AkkaSpec with ImplicitSender {
         expectMsg(Terminated(child2))
         //#escalate-kill
         //#escalate-restart
-        val superprops2 = Props[Supervisor2].withFaultHandler(strategy)
-        val supervisor2 = system.actorOf(superprops2, "supervisor2")
+        val supervisor2 = system.actorOf(Props[Supervisor2], "supervisor2")
 
         supervisor2 ! Props[Child]
         val child3 = expectMsgType[ActorRef]

--- a/akka-docs/scala/fault-tolerance.rst
+++ b/akka-docs/scala/fault-tolerance.rst
@@ -1,7 +1,7 @@
 .. _fault-tolerance-scala:
 
-Fault Handling Strategies (Scala)
-=================================
+Fault Tolerance (Scala)
+=======================
 
 .. sidebar:: Contents
 
@@ -12,8 +12,8 @@ children, and as such each actor defines fault handling supervisor strategy.
 This strategy cannot be changed afterwards as it is an integral part of the
 actor system’s structure.
 
-Creating a Fault Handling Strategy
-----------------------------------
+Creating a Supervisor Strategy
+------------------------------
 
 For the sake of demonstration let us consider the following strategy:
 

--- a/akka-docs/scala/fault-tolerance.rst
+++ b/akka-docs/scala/fault-tolerance.rst
@@ -8,9 +8,9 @@ Fault Handling Strategies (Scala)
    .. contents:: :local:
 
 As explained in :ref:`actor-systems` each actor is the supervisor of its
-children, and as such each actor is given a fault handling strategy when it is
-created. This strategy cannot be changed afterwards as it is an integral part
-of the actor system’s structure.
+children, and as such each actor defines fault handling supervisor strategy.
+This strategy cannot be changed afterwards as it is an integral part of the
+actor system’s structure.
 
 Creating a Fault Handling Strategy
 ----------------------------------
@@ -56,7 +56,7 @@ MustMatchers``
 .. includecode:: code/akka/docs/actor/FaultHandlingDocSpec.scala
    :include: testkit
 
-Using the strategy shown above let us create actors:
+Let us create actors:
 
 .. includecode:: code/akka/docs/actor/FaultHandlingDocSpec.scala
    :include: create

--- a/akka-docs/scala/typed-actors.rst
+++ b/akka-docs/scala/typed-actors.rst
@@ -30,7 +30,7 @@ it's located in ``akka.actor.TypedActor``.
    :include: typed-actor-extension-tools
 
 .. warning::
-    
+
     Same as not exposing ``this`` of an Akka Actor, it's important not to expose ``this`` of a Typed Actor,
     instead you should pass the external proxy reference, which is obtained from within your Typed Actor as
     ``TypedActor.self``, this is your external identity, as the ``ActorRef`` is the external identity of
@@ -127,7 +127,7 @@ Request-reply-with-future message send
 .. includecode:: code/akka/docs/actor/TypedActorDocSpec.scala
    :include: typed-actor-call-future
 
-This call is asynchronous, and the Future returned can be used for asynchronous composition. 
+This call is asynchronous, and the Future returned can be used for asynchronous composition.
 
 Stopping Typed Actors
 ---------------------
@@ -152,6 +152,13 @@ Since you can obtain a contextual Typed Actor Extension by passing in an ``Actor
 you can create child Typed Actors by invoking ``typedActorOf(..)`` on that.
 
 This also works for creating child Typed Actors in regular Akka Actors.
+
+Supervisor Strategy
+-------------------
+
+By having your Typed Actor implementation class implement ``TypedActor.Supervisor``
+you can define the strategy to use for supervising child actors, as described in
+:ref:`supervision` and :ref:`fault-tolerance-scala`.
 
 Lifecycle callbacks
 -------------------

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -181,8 +181,10 @@ class TestActorRefSpec extends AkkaSpec("disp1.type=Dispatcher") with BeforeAndA
             override def postRestart(reason: Throwable) { counter -= 1 }
           }), self, "child")
 
+          override def supervisorStrategy = OneForOneStrategy(List(classOf[ActorKilledException]), 5, 1000)
+
           def receiveT = { case "sendKill" ⇒ ref ! Kill }
-        }).withFaultHandler(OneForOneStrategy(List(classOf[ActorKilledException]), 5, 1000)))
+        }))
 
         boss ! "sendKill"
 


### PR DESCRIPTION
- Moved faultHandler from Props to overridable method supervisorStrategy in Actor. 
- New trait SupervisorStrategy for TypedActors
- Adjustments of docs
- Updated tests
