### PR TITLE
tighten static type of Duration factories

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
@@ -53,11 +53,12 @@ class DurationSpec extends WordSpec with MustMatchers {
     "support fromNow" in {
       val dead = 2.seconds.fromNow
       val dead2 = 2 seconds fromNow
-      dead.timeLeft must be > 1.second
-      dead2.timeLeft must be > 1.second
+      // view bounds vs. very local type inference vs. operator precedence: sigh
+      dead.timeLeft must be > (1 second: Duration)
+      dead2.timeLeft must be > (1 second: Duration)
       1.second.sleep
-      dead.timeLeft must be < 1.second
-      dead2.timeLeft must be < 1.second
+      dead.timeLeft must be < (1 second: Duration)
+      dead2.timeLeft must be < (1 second: Duration)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/util/duration/package.scala
+++ b/akka-actor/src/main/scala/akka/util/duration/package.scala
@@ -9,19 +9,19 @@ import java.util.concurrent.TimeUnit
 package object duration {
   trait Classifier[C] {
     type R
-    def convert(d: Duration): R
+    def convert(d: FiniteDuration): R
   }
 
   object span
   implicit object spanConvert extends Classifier[span.type] {
-    type R = Duration
-    def convert(d: Duration) = d
+    type R = FiniteDuration
+    def convert(d: FiniteDuration) = d
   }
 
   object fromNow
   implicit object fromNowConvert extends Classifier[fromNow.type] {
     type R = Deadline
-    def convert(d: Duration) = Deadline.now + d
+    def convert(d: FiniteDuration) = Deadline.now + d
   }
 
   implicit def intToDurationInt(n: Int) = new DurationInt(n)
@@ -32,13 +32,21 @@ package object duration {
   implicit def pairLongToDuration(p: (Long, TimeUnit)) = Duration(p._1, p._2)
   implicit def durationToPair(d: Duration) = (d.length, d.unit)
 
-  implicit def intMult(i: Int) = new {
+  /*
+   * avoid reflection based invocation by using non-duck type
+   */
+  class IntMult(i: Int) {
     def *(d: Duration) = d * i
   }
-  implicit def longMult(l: Long) = new {
+  implicit def intMult(i: Int) = new IntMult(i)
+
+  class LongMult(l: Long) {
     def *(d: Duration) = d * l
   }
-  implicit def doubleMult(f: Double) = new {
+  implicit def longMult(l: Long) = new LongMult(l)
+
+  class DoubleMult(f: Double) {
     def *(d: Duration) = d * f
   }
+  implicit def doubleMult(f: Double) = new DoubleMult(f)
 }


### PR DESCRIPTION
- return FiniteDuration whenever possible to allow statically guarding
  against infinities
- add Ordering[Duration] and Ordering[FiniteDuration] instances
- avoid use of structural types in multiplication enrichments
- had to fix type inference problem due to too precise type in
  DurationSpec (view bounds vs. local type inference vs. operator
  precedence)

Include in M3 if you wish.
