### PR TITLE
add Java API for Future.recover

### DIFF
--- a/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTest.scala
+++ b/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTest.scala
@@ -1,0 +1,3 @@
+package akka.dispatch
+
+class JavaFutureTest extends JavaFutureTestBase with org.scalatest.junit.JUnitSuite

--- a/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
@@ -40,9 +40,6 @@ object FutureSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class JavaFutureSpec extends JavaFutureTests with JUnitSuite
-
-@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with DefaultTimeout {
   import FutureSpec._
 

--- a/akka-actor/src/main/scala/akka/dispatch/japi/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/japi/Future.scala
@@ -33,6 +33,13 @@ trait Future[+T] { self: akka.dispatch.Future[T] ⇒
   private[japi] final def map[A >: T, B](f: JFunc[A, B]): akka.dispatch.Future[B] = self.map(f(_))
 
   /**
+   * Apply this transformation in case the future is completed with a failure.
+   * The supplied Function should rethrow the exception if recovery is not possible.
+   */
+  private[japi] final def recover[A >: T](f: JFunc[Throwable, A]): akka.dispatch.Future[A] =
+    self recover ({ case x ⇒ f(x) }: PartialFunction[Throwable, A])
+
+  /**
    * Asynchronously applies the provided function to the (if any) successful result of this Future and flattens it.
    * Any failure of this Future will be propagated to the Future returned by this method.
    */

--- a/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
+++ b/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
@@ -10,6 +10,7 @@ import scala.Some
  * A Function interface. Used to create first-class-functions is Java.
  */
 trait Function[T, R] {
+  @throws(classOf[Throwable])
   def apply(param: T): R
 }
 


### PR DESCRIPTION
- also, fix JavaFutureTest to actually be run, thereby
- find and fix bug in JavaFutureTest
- had to declare akka.japi.Function.apply as
  “@throws(classOf[Throwable])”
