### PR TITLE
Preparing Duration for the Standard Library

### DIFF
--- a/akka-actor-migration/src/main/scala/akka/actor/OldActor.scala
+++ b/akka-actor-migration/src/main/scala/akka/actor/OldActor.scala
@@ -4,10 +4,10 @@
 package akka.actor
 
 import akka.japi.Creator
-import akka.util.Timeout
+import scala.util.Timeout
 import akka.dispatch.Future
 import akka.dispatch.OldFuture
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit
 import java.net.InetSocketAddress
 import akka.migration.AskableActorRef

--- a/akka-actor-migration/src/main/scala/akka/actor/OldScheduler.scala
+++ b/akka-actor-migration/src/main/scala/akka/actor/OldScheduler.scala
@@ -4,7 +4,7 @@
 package akka.actor
 
 import java.util.concurrent.TimeUnit
-import akka.util.Duration
+import scala.util.Duration
 
 /**
  * Migration replacement for `object akka.actor.Scheduler`.

--- a/akka-actor-migration/src/main/scala/akka/dispatch/OldFuture.scala
+++ b/akka-actor-migration/src/main/scala/akka/dispatch/OldFuture.scala
@@ -4,10 +4,10 @@
 package akka.dispatch
 
 import java.util.concurrent.TimeoutException
-import akka.util.duration._
+import scala.util.duration._
 import akka.AkkaException
 import akka.util.BoxedType
-import akka.util.Duration
+import scala.util.Duration
 import akka.actor.GlobalActorSystem
 
 /**

--- a/akka-actor-migration/src/main/scala/akka/migration/AskableActorRef.scala
+++ b/akka-actor-migration/src/main/scala/akka/migration/AskableActorRef.scala
@@ -5,7 +5,7 @@ package akka.migration
 
 import akka.actor.ActorRef
 import akka.dispatch.Future
-import akka.util.Timeout
+import scala.util.Timeout
 
 /**
  * Implementation detail of the “ask” pattern enrichment of ActorRef

--- a/akka-actor-migration/src/main/scala/akka/migration/package.scala
+++ b/akka-actor-migration/src/main/scala/akka/migration/package.scala
@@ -5,7 +5,7 @@ package akka
 
 import akka.dispatch.Future
 import akka.dispatch.OldFuture
-import akka.util.Timeout
+import scala.util.Timeout
 import akka.actor.GlobalActorSystem
 import akka.dispatch.MessageDispatcher
 import akka.actor.ActorRef

--- a/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
+++ b/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
@@ -1,10 +1,10 @@
 package akka.dispatch;
 
-import akka.util.Timeout;
+import scala.util.Timeout;
 import akka.actor.ActorSystem;
 
 import akka.japi.*;
-import akka.util.Duration;
+import scala.util.Duration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
+++ b/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
@@ -4,6 +4,7 @@
 package akka.util;
 
 import org.junit.Test;
+import scala.util.Duration;
 
 public class JavaDuration {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
@@ -6,7 +6,7 @@ package akka.actor
 
 import akka.testkit._
 import org.scalatest.BeforeAndAfterEach
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.Await
 import akka.pattern.ask
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
@@ -87,7 +87,7 @@ class ActorFireForgetRequestReplySpec extends AkkaSpec with BeforeAndAfterEach w
         actor.isTerminated must be(false)
         actor ! "Die"
         state.finished.await
-        1.second.dilated.sleep()
+        Thread.sleep(1.second.dilated.toMillis)
         actor.isTerminated must be(true)
         system.stop(supervisor)
       }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.MustMatchers
 
 import akka.actor.Actor._
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import java.util.concurrent.atomic._
 import akka.dispatch.Await
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
@@ -4,7 +4,7 @@
 package akka.actor
 
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.Await
 import akka.pattern.ask
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -53,7 +53,7 @@ object ActorRefSpec {
     }
 
     private def work {
-      1.second.dilated.sleep
+      Thread.sleep(1.second.dilated.toMillis)
     }
   }
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -8,8 +8,8 @@ import org.scalatest.WordSpec
 import org.scalatest.matchers.MustMatchers
 
 import akka.testkit._
-import akka.util.Timeout
-import akka.util.duration._
+import scala.util.Timeout
+import scala.util.duration._
 import java.lang.IllegalStateException
 import akka.util.ReflectiveAccess
 import akka.serialization.Serialization

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -7,7 +7,7 @@ import akka.testkit._
 import org.scalatest.junit.JUnitSuite
 import com.typesafe.config.ConfigFactory
 import akka.dispatch.Await
-import akka.util.duration._
+import scala.util.duration._
 import scala.collection.JavaConverters
 import java.util.concurrent.{ TimeUnit, RejectedExecutionException, CountDownLatch, ConcurrentLinkedQueue }
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -42,7 +42,7 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
 
       for (i ← 1 to count) {
         system2.registerOnTermination {
-          (i % 3).millis.dilated.sleep()
+          Thread.sleep((i % 3).millis.dilated.toMillis)
           result add i
           latch.countDown()
         }
@@ -64,7 +64,7 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
       var callbackWasRun = false
 
       system2.registerOnTermination {
-        50.millis.dilated.sleep()
+        Thread.sleep(50.millis.dilated.toMillis)
         callbackWasRun = true
       }
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorTimeoutSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorTimeoutSpec.scala
@@ -4,12 +4,12 @@
 package akka.actor
 
 import org.scalatest.BeforeAndAfterAll
-import akka.util.duration._
+import scala.util.duration._
 import akka.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout
 import java.util.concurrent.TimeoutException
 import akka.dispatch.Await
-import akka.util.Timeout
+import scala.util.Timeout
 import akka.pattern.{ ask, AskTimeoutException }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-actor-tests/src/test/scala/akka/actor/ConsistencySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ConsistencySpec.scala
@@ -2,7 +2,7 @@ package akka.actor
 
 import akka.testkit.AkkaSpec
 import akka.dispatch.UnboundedMailbox
-import akka.util.duration._
+import scala.util.duration._
 
 object ConsistencySpec {
   val config = """

--- a/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
@@ -5,7 +5,7 @@
 package akka.actor
 
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import java.util.concurrent.atomic._
 import akka.dispatch.Await
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/actor/DeployerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeployerSpec.scala
@@ -8,7 +8,7 @@ import akka.testkit.AkkaSpec
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
 import akka.routing._
-import akka.util.duration._
+import scala.util.duration._
 
 object DeployerSpec {
   val deployerConf = ConfigFactory.parseString("""

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
@@ -8,11 +8,11 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 import akka.testkit._
 import TestEvent.Mute
 import FSM._
-import akka.util.duration._
+import scala.util.duration._
 import akka.event._
 import com.typesafe.config.ConfigFactory
 import akka.dispatch.Await
-import akka.util.{ Timeout, Duration }
+import scala.util.{ Timeout, Duration }
 
 object FSMActorSpec {
   val timeout = Timeout(2 seconds)

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
@@ -5,8 +5,8 @@
 package akka.actor
 
 import akka.testkit._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 import akka.event.Logging
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -4,9 +4,9 @@
 package akka.actor
 
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import FSM._
-import akka.util.Duration
+import scala.util.Duration
 
 object FSMTransitionSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ForwardActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ForwardActorSpec.scala
@@ -5,9 +5,9 @@
 package akka.actor
 
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import Actor._
-import akka.util.Duration
+import scala.util.Duration
 import akka.dispatch.Await
 import akka.pattern.ask
 

--- a/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
@@ -4,8 +4,9 @@
 
 package akka.actor
 
-import akka.util.{ ByteString, Duration, Timer }
-import akka.util.duration._
+import scala.util.Duration
+import akka.util.{ ByteString, Timer }
+import scala.util.duration._
 import scala.util.continuations._
 import akka.testkit._
 import akka.dispatch.{ Await, Future, Promise, ExecutionContext, MessageDispatcher }

--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -5,8 +5,8 @@
 package akka.actor
 
 import akka.testkit._
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import akka.dispatch.{ Await, Future }
 
 object LocalActorRefProviderSpec {

--- a/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
@@ -5,7 +5,7 @@
 package akka.actor
 
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 
 import java.util.concurrent.atomic.AtomicInteger
 import akka.dispatch.Await

--- a/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
@@ -13,8 +13,8 @@ import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import akka.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout
 import akka.testkit.TestLatch
-import akka.util.duration._
-import akka.util.Duration
+import scala.util.duration._
+import scala.util.Duration
 import akka.pattern.ask
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -101,9 +101,9 @@ class SchedulerSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout
       val timeout = collectCancellable(system.scheduler.schedule(initialDelay, delay) {
         ticks.incrementAndGet()
       })
-      10.milliseconds.dilated.sleep()
+      Thread.sleep(10.milliseconds.dilated.toMillis)
       timeout.cancel()
-      (initialDelay + 100.milliseconds.dilated).sleep()
+      Thread.sleep((initialDelay + 100.milliseconds.dilated).toMillis)
 
       ticks.get must be(0)
     }
@@ -116,9 +116,9 @@ class SchedulerSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout
       val timeout = collectCancellable(system.scheduler.schedule(initialDelay, delay) {
         ticks.incrementAndGet()
       })
-      (initialDelay + 100.milliseconds.dilated).sleep()
+      Thread.sleep((initialDelay + 100.milliseconds.dilated).toMillis)
       timeout.cancel()
-      (delay + 100.milliseconds.dilated).sleep()
+      Thread.sleep((delay + 100.milliseconds.dilated).toMillis)
 
       ticks.get must be(1)
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -1,7 +1,7 @@
 package akka.actor
 
 import org.scalatest.BeforeAndAfterEach
-import akka.util.duration._
+import scala.util.duration._
 import java.util.concurrent.{ CountDownLatch, ConcurrentLinkedQueue, TimeUnit }
 import akka.testkit._
 import akka.dispatch.Await

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -8,8 +8,8 @@ import akka.testkit._
 import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import akka.dispatch.Await
 import akka.pattern.ask
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 object SupervisorHierarchySpec {
   class FireWorkerException(msg: String) extends Exception(msg)

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import akka.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout
 import akka.pattern.ask
-import akka.util.duration._
+import scala.util.duration._
 
 object SupervisorMiscSpec {
   val config = """

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
@@ -5,7 +5,7 @@
 package akka.actor
 
 import org.scalatest.BeforeAndAfterEach
-import akka.util.duration._
+import scala.util.duration._
 import akka.{ Die, Ping }
 import akka.testkit.TestEvent._
 import akka.testkit._

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorTreeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorTreeSpec.scala
@@ -5,7 +5,7 @@ package akka.actor
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.MustMatchers
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor.Actor._
 import akka.testkit.{ TestKit, EventFilter, filterEvents, filterException }
 import akka.testkit.AkkaSpec

--- a/akka-actor-tests/src/test/scala/akka/actor/Ticket669Spec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/Ticket669Spec.scala
@@ -12,7 +12,7 @@ import akka.testkit.ImplicitSender
 import akka.testkit.DefaultTimeout
 import akka.dispatch.Await
 import akka.pattern.ask
-import akka.util.duration._
+import scala.util.duration._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class Ticket669Spec extends AkkaSpec with BeforeAndAfterAll with ImplicitSender with DefaultTimeout {

--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -5,9 +5,9 @@ package akka.actor
  */
 
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
-import akka.util.Duration
-import akka.util.Timeout
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.Timeout
+import scala.util.duration._
 import akka.serialization.Serialization
 import java.util.concurrent.atomic.AtomicReference
 import annotation.tailrec

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -6,7 +6,7 @@ package akka.actor.dispatch
 import org.scalatest.Assertions._
 import akka.testkit._
 import akka.dispatch._
-import akka.util.Timeout
+import scala.util.Timeout
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ ConcurrentHashMap, CountDownLatch, TimeUnit }
@@ -16,10 +16,10 @@ import org.junit.{ After, Test }
 import akka.actor._
 import util.control.NoStackTrace
 import akka.actor.ActorSystem
-import akka.util.duration._
+import scala.util.duration._
 import akka.event.Logging.Error
 import com.typesafe.config.Config
-import akka.util.Duration
+import scala.util.Duration
 import akka.pattern.ask
 
 object ActorModelSpec {

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
@@ -4,8 +4,8 @@ import java.util.concurrent.{ CountDownLatch, TimeUnit }
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 import akka.testkit.{ filterEvents, EventFilter, AkkaSpec }
 import akka.actor.{ Props, Actor }
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 import akka.testkit.DefaultTimeout
 import akka.dispatch.{ Await, PinnedDispatcher, Dispatchers, Dispatcher }
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -7,8 +7,8 @@ package akka.config
 import akka.testkit.AkkaSpec
 import com.typesafe.config.ConfigFactory
 import scala.collection.JavaConverters._
-import akka.util.duration._
-import akka.util.Duration
+import scala.util.duration._
+import scala.util.Duration
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference) {

--- a/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
+++ b/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
@@ -6,7 +6,7 @@ package akka.dataflow
 import akka.actor.{ Actor, Props }
 import akka.dispatch.{ Future, Await }
 import akka.actor.future2actor
-import akka.util.duration._
+import scala.util.duration._
 import akka.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
@@ -8,7 +8,7 @@ import org.scalacheck.Prop._
 import org.scalacheck.Gen._
 import akka.actor._
 import akka.testkit.{ EventFilter, filterEvents, filterException }
-import akka.util.duration._
+import scala.util.duration._
 import akka.testkit.AkkaSpec
 import org.scalatest.junit.JUnitSuite
 import akka.testkit.DefaultTimeout

--- a/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 import java.util.concurrent.{ TimeUnit, BlockingQueue }
 import java.util.concurrent.ConcurrentLinkedQueue
 import akka.util._
-import akka.util.duration._
+import scala.util.duration._
 import akka.testkit.AkkaSpec
 import akka.actor.ActorRef
 import akka.actor.ActorContext

--- a/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
@@ -3,7 +3,7 @@ package akka.dispatch
 import akka.actor.{ Props, LocalActorRef, Actor }
 import akka.testkit.AkkaSpec
 import akka.pattern.ask
-import akka.util.duration._
+import scala.util.duration._
 import akka.testkit.DefaultTimeout
 import com.typesafe.config.Config
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/PromiseStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/PromiseStreamSpec.scala
@@ -2,8 +2,8 @@ package akka.dispatch
 
 import Future.flow
 import akka.util.cps._
-import akka.util.Timeout
-import akka.util.duration._
+import scala.util.Timeout
+import scala.util.duration._
 import akka.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout
 

--- a/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
@@ -6,7 +6,7 @@ package akka.event
 
 import org.scalatest.BeforeAndAfterEach
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import java.util.concurrent.atomic._
 import akka.actor.{ Props, Actor, ActorRef, ActorSystem }
 import java.util.Comparator

--- a/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
@@ -4,7 +4,7 @@
 package akka.event
 
 import akka.testkit.AkkaSpec
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor.{ Actor, ActorRef, ActorSystemImpl }
 import com.typesafe.config.ConfigFactory
 import scala.collection.JavaConverters._

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -4,10 +4,10 @@
 package akka.event
 
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
-import akka.util.duration._
+import scala.util.duration._
 import akka.testkit._
 import org.scalatest.WordSpec
-import akka.util.Duration
+import scala.util.Duration
 import com.typesafe.config.ConfigFactory
 import scala.collection.JavaConverters._
 import java.util.Properties

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -4,7 +4,7 @@
 package akka.pattern
 
 import akka.testkit.AkkaSpec
-import akka.util.duration._
+import scala.util.duration._
 
 class AskSpec extends AkkaSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -9,8 +9,8 @@ import akka.actor.Props
 import akka.actor.Actor
 import akka.actor.ActorTimeoutException
 import akka.dispatch.Await
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 object PatternSpec {
   case class Work(duration: Duration)

--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -16,7 +16,7 @@ object PatternSpec {
   case class Work(duration: Duration)
   class TargetActor extends Actor {
     def receive = {
-      case Work(duration) ⇒ duration.sleep()
+      case Work(duration) ⇒ Thread.sleep(duration.toMillis)
     }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughput10000PerformanceSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughput10000PerformanceSpec.scala
@@ -8,8 +8,8 @@ import akka.dispatch._
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 // -server -Xms512M -Xmx1024M -XX:+UseParallelGC -Dbenchmark=true -Dbenchmark.repeatFactor=500
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughputComputationPerformanceSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughputComputationPerformanceSpec.scala
@@ -4,8 +4,8 @@ import akka.performance.workbench.PerformanceSpec
 import akka.actor._
 import java.util.concurrent.{ ThreadPoolExecutor, CountDownLatch, TimeUnit }
 import akka.dispatch._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 // -server -Xms512M -Xmx1024M -XX:+UseParallelGC -Dbenchmark=true -Dbenchmark.repeatFactor=500
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughputPerformanceSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughputPerformanceSpec.scala
@@ -4,8 +4,8 @@ import akka.performance.workbench.PerformanceSpec
 import akka.actor._
 import java.util.concurrent.{ ThreadPoolExecutor, CountDownLatch, TimeUnit }
 import akka.dispatch._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 // -server -Xms512M -Xmx1024M -XX:+UseParallelGC -Dbenchmark=true -Dbenchmark.repeatFactor=500
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughputPinnedDispatchersPerformanceSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/performance/microbench/TellThroughputPinnedDispatchersPerformanceSpec.scala
@@ -8,8 +8,8 @@ import akka.dispatch._
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 // -server -Xms512M -Xmx1024M -XX:+UseParallelGC -Dbenchmark=true -Dbenchmark.repeatFactor=500
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-actor-tests/src/test/scala/akka/performance/workbench/PerformanceSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/performance/workbench/PerformanceSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.BeforeAndAfterEach
 import akka.actor.simpleName
 import akka.testkit.AkkaSpec
 import akka.actor.ActorSystem
-import akka.util.Duration
+import scala.util.Duration
 import com.typesafe.config.Config
 import java.util.concurrent.TimeUnit
 

--- a/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
@@ -4,7 +4,7 @@ import akka.actor._
 import akka.routing._
 import java.util.concurrent.atomic.AtomicInteger
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.Await
 import akka.pattern.ask
 

--- a/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
@@ -7,7 +7,7 @@ import akka.actor.Actor
 import akka.testkit._
 import akka.actor.Props
 import akka.dispatch.Await
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor.ActorRef
 import java.util.concurrent.atomic.AtomicInteger
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
@@ -167,7 +167,7 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       val router = system.actorOf(Props(new Actor {
         def receive = {
           case (n: Int, latch: TestLatch, count: AtomicInteger) ⇒
-            (n millis).dilated.sleep
+            Thread.sleep((n millis).dilated.toMillis)
             count.incrementAndGet
             latch.countDown()
         }
@@ -179,10 +179,10 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees].routees.size must be(2)
 
       def loop(loops: Int, t: Int, latch: TestLatch, count: AtomicInteger) = {
-        (10 millis).dilated.sleep
+        Thread.sleep((10 millis).dilated.toMillis)
         for (m ← 0 until loops) {
           router.!((t, latch, count))
-          (10 millis).dilated.sleep
+          Thread.sleep((10 millis).dilated.toMillis)
         }
       }
 
@@ -220,25 +220,25 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       val router = system.actorOf(Props(new Actor {
         def receive = {
           case n: Int ⇒
-            (n millis).dilated.sleep
+            Thread.sleep((n millis).dilated.toMillis)
         }
       }).withRouter(RoundRobinRouter(resizer = Some(resizer))))
 
       // put some pressure on the router
       for (m ← 0 to 5) {
         router ! 100
-        (5 millis).dilated.sleep
+        Thread.sleep((5 millis).dilated.toMillis)
       }
 
       val z = Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees].routees.size
       z must be >= (2)
 
-      (300 millis).dilated.sleep
+      Thread.sleep((300 millis).dilated.toMillis)
 
       // let it cool down
       for (m ← 0 to 3) {
         router ! 1
-        (200 millis).dilated.sleep
+        Thread.sleep((200 millis).dilated.toMillis)
       }
 
       Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees].routees.size must be < (z)

--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -7,9 +7,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.actor._
 import scala.collection.mutable.LinkedList
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.Await
-import akka.util.Duration
+import scala.util.Duration
 import akka.config.ConfigurationException
 import com.typesafe.config.ConfigFactory
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -9,8 +9,8 @@ import com.typesafe.config.ConfigFactory
 import akka.actor._
 import java.io._
 import akka.dispatch.Await
-import akka.util.Timeout
-import akka.util.duration._
+import scala.util.Timeout
+import scala.util.duration._
 import scala.reflect.BeanInfo
 import com.google.protobuf.Message
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
@@ -5,7 +5,8 @@ package akka.util
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.MustMatchers
-import duration._
+import scala.util.duration._
+import scala.util.Duration
 
 class DurationSpec extends WordSpec with MustMatchers {
 

--- a/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
@@ -62,6 +62,23 @@ class DurationSpec extends WordSpec with MustMatchers {
       dead2.timeLeft must be < (1 second: Duration)
     }
 
+    "parse negative and positive time strings" in {
+      import java.util.concurrent.TimeUnit._
+
+      Duration("-1 millis") must be(Duration.fromNanos(MILLISECONDS.toNanos(1) * -1d))
+      Duration("+1 millis") must be(Duration.fromNanos(MILLISECONDS.toNanos(1) * 1d))
+      Duration(" +1.2 millis") must be(Duration.fromNanos(MILLISECONDS.toNanos(1) * 1.2d))
+      Duration("-1.2 millis") must be(Duration.fromNanos(MILLISECONDS.toNanos(1) * -1.2d))
+
+      // infinities      
+      assert(Duration.Inf == Duration("PlusInf"))
+      assert(Duration.Inf == Duration("+Inf"))
+      assert(Duration.Inf == Duration("Inf"))
+
+      assert(Duration.MinusInf == Duration("MinusInf"))
+      assert(Duration.MinusInf == Duration("-Inf"))
+
+    }
   }
 
 }

--- a/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
@@ -57,7 +57,7 @@ class DurationSpec extends WordSpec with MustMatchers {
       // view bounds vs. very local type inference vs. operator precedence: sigh
       dead.timeLeft must be > (1 second: Duration)
       dead2.timeLeft must be > (1 second: Duration)
-      1.second.sleep
+      Thread.sleep(1.second.toMillis)
       dead.timeLeft must be < (1 second: Duration)
       dead2.timeLeft must be < (1 second: Duration)
     }

--- a/akka-actor/src/main/java/org/jboss/netty/akka/util/HashedWheelTimer.java
+++ b/akka-actor/src/main/java/org/jboss/netty/akka/util/HashedWheelTimer.java
@@ -16,7 +16,7 @@
 package org.jboss.netty.akka.util;
 
 import akka.event.LoggingAdapter;
-import akka.util.Duration;
+import scala.util.Duration;
 import org.jboss.netty.akka.util.internal.ConcurrentIdentityHashMap;
 import org.jboss.netty.akka.util.internal.ReusableIterator;
 

--- a/akka-actor/src/main/java/org/jboss/netty/akka/util/Timer.java
+++ b/akka-actor/src/main/java/org/jboss/netty/akka/util/Timer.java
@@ -15,7 +15,7 @@
  */
 package org.jboss.netty.akka.util;
 
-import akka.util.Duration;
+import scala.util.Duration;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -6,7 +6,7 @@ package akka.actor
 
 import akka.dispatch._
 import akka.routing._
-import akka.util.Duration
+import scala.util.Duration
 import akka.japi.{ Creator, Procedure }
 import akka.serialization.{ Serializer, Serialization }
 import akka.event.Logging.Debug

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -7,10 +7,11 @@ package akka.actor
 import akka.dispatch._
 import scala.annotation.tailrec
 import scala.collection.immutable.{ Stack, TreeMap }
+import scala.util.{ Duration }
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.event.Logging.{ Debug, Warning, Error }
-import akka.util.{ Duration, Helpers }
+import akka.util.{ Helpers }
 import akka.japi.Procedure
 import java.io.{ NotSerializableException, ObjectOutputStream }
 import akka.serialization.SerializationExtension

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -7,6 +7,7 @@ package akka.actor
 import akka.dispatch._
 import akka.util._
 import scala.collection.immutable.Stack
+import scala.util.{ Duration, Timeout }
 import java.lang.{ UnsupportedOperationException, IllegalStateException }
 import akka.serialization.Serialization
 import java.util.concurrent.TimeUnit

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -5,11 +5,12 @@
 package akka.actor
 
 import java.util.concurrent.atomic.AtomicLong
+import scala.util.{ Duration, Timeout }
 import akka.config.ConfigurationException
 import akka.dispatch._
 import akka.routing._
 import akka.AkkaException
-import akka.util.{ Duration, Switch, Helpers, Timeout }
+import akka.util.{ Switch, Helpers }
 import akka.event._
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -7,8 +7,9 @@ import akka.config.ConfigurationException
 import akka.event._
 import akka.dispatch._
 import akka.pattern.ask
-import akka.util.duration._
-import akka.util.Timeout._
+import scala.util.duration._
+import scala.util.Timeout._
+import scala.util.{ Duration, Timeout }
 import org.jboss.netty.akka.util.HashedWheelTimer
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import com.typesafe.config.Config

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -8,7 +8,7 @@ import collection.immutable.Seq
 import akka.event.Logging
 import akka.AkkaException
 import akka.config.ConfigurationException
-import akka.util.Duration
+import scala.util.Duration
 import akka.event.EventStream
 import com.typesafe.config._
 import akka.routing._

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -4,10 +4,10 @@
 package akka.actor
 
 import akka.util._
-
 import scala.collection.mutable
 import akka.event.Logging
-import akka.util.Duration._
+import scala.util.Duration._
+import scala.util.Duration
 import akka.routing.{ Deafen, Listen, Listeners }
 
 object FSM {

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
 import java.lang.{ Iterable ⇒ JIterable }
-import akka.util.Duration
+import scala.util.Duration
 
 case class ChildRestartStats(val child: ActorRef, var maxNrOfRetriesCount: Int = 0, var restartTimeWindowStartNanos: Long = 0L) {
 

--- a/akka-actor/src/main/scala/akka/actor/Locker.scala
+++ b/akka-actor/src/main/scala/akka/actor/Locker.scala
@@ -4,8 +4,8 @@
 package akka.actor
 
 import akka.dispatch._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 import java.util.concurrent.ConcurrentHashMap
 import akka.event.DeathWatch
 

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -12,7 +12,7 @@
  */
 package akka.actor
 
-import akka.util.Duration
+import scala.util.Duration
 import org.jboss.netty.akka.util.{ Timer, TimerTask, HashedWheelTimer, Timeout ⇒ HWTimeout }
 import akka.event.LoggingAdapter
 import akka.dispatch.MessageDispatcher

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -6,7 +6,7 @@ package akka.actor
 
 import akka.japi.{ Creator, Option ⇒ JOption }
 import java.lang.reflect.{ InvocationTargetException, Method, InvocationHandler, Proxy }
-import akka.util.{ Duration, Timeout }
+import scala.util.{ Duration, Timeout }
 import java.util.concurrent.atomic.{ AtomicReference ⇒ AtomVar }
 import akka.serialization.{ Serializer, Serialization, SerializationExtension }
 import akka.dispatch._

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -6,7 +6,7 @@ package akka.dispatch
 
 import java.util.concurrent._
 import akka.event.Logging.Error
-import akka.util.Duration
+import scala.util.Duration
 import akka.actor._
 import akka.actor.ActorSystem
 import scala.annotation.tailrec

--- a/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
@@ -13,7 +13,7 @@ import akka.actor.ActorSystem
 import akka.event.EventStream
 import akka.actor.Scheduler
 import java.util.concurrent.atomic.AtomicBoolean
-import akka.util.Duration
+import scala.util.Duration
 
 /**
  * An executor based event driven dispatcher which will try to redistribute work from busy actors to idle actors. It is assumed

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -7,7 +7,7 @@ package akka.dispatch
 import akka.event.Logging.Warning
 import java.util.concurrent.atomic.AtomicReference
 import akka.actor.ActorCell
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent._
 
 /**

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -5,7 +5,8 @@
 package akka.dispatch
 
 import akka.actor.newUuid
-import akka.util.{ Duration, ReflectiveAccess }
+import scala.util.{ Duration }
+import akka.util.{ ReflectiveAccess }
 import akka.actor.ActorSystem
 import akka.event.EventStream
 import akka.actor.Scheduler

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -6,7 +6,7 @@ package akka.dispatch
 
 import akka.AkkaException
 import akka.event.Logging.Error
-import akka.util.Timeout
+import scala.util.Timeout
 import scala.Option
 import akka.japi.{ Procedure, Function ⇒ JFunc, Option ⇒ JOption }
 
@@ -18,7 +18,8 @@ import java.util.{ LinkedList ⇒ JLinkedList }
 
 import scala.annotation.tailrec
 import scala.collection.mutable.Stack
-import akka.util.{ Switch, Duration, BoxedType }
+import scala.util.{ Duration }
+import akka.util.{ Switch, BoxedType }
 import java.util.concurrent.atomic.{ AtomicReferenceFieldUpdater, AtomicInteger, AtomicBoolean }
 import akka.dispatch.Await.CanAwait
 import java.util.concurrent._

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -3,6 +3,7 @@
  */
 package akka.dispatch
 
+import scala.util.Duration
 import akka.AkkaException
 import java.util.{ Comparator, PriorityQueue, Queue }
 import akka.util._

--- a/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorCell
 import akka.actor.ActorSystem
 import akka.event.EventStream
 import akka.actor.Scheduler
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit
 
 /**

--- a/akka-actor/src/main/scala/akka/dispatch/PromiseStream.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PromiseStream.scala
@@ -7,7 +7,7 @@ package akka.dispatch
 import java.util.concurrent.atomic.AtomicReference
 import scala.util.continuations._
 import scala.annotation.{ tailrec }
-import akka.util.Timeout
+import scala.util.Timeout
 
 object PromiseStream {
   def apply[A]()(implicit dispatcher: MessageDispatcher, timeout: Timeout): PromiseStream[A] = new PromiseStream[A]

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -6,7 +6,7 @@ package akka.dispatch
 
 import java.util.Collection
 import java.util.concurrent.atomic.{ AtomicLong, AtomicInteger }
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent._
 
 object ThreadPoolConfig {

--- a/akka-actor/src/main/scala/akka/dispatch/japi/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/japi/Future.scala
@@ -3,7 +3,7 @@
  */
 package akka.dispatch.japi
 
-import akka.util.Timeout
+import scala.util.Timeout
 import akka.japi.{ Procedure2, Procedure, Function ⇒ JFunc, Option ⇒ JOption }
 
 /* Java API */

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -9,8 +9,8 @@ import akka.actor.ActorSystem.Settings
 import akka.util.ReflectiveAccess
 import akka.config.ConfigurationException
 import akka.util.ReentrantGuard
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import java.util.concurrent.atomic.AtomicInteger
 import scala.util.control.NoStackTrace
 import java.util.concurrent.TimeoutException

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -9,7 +9,7 @@ import akka.actor.{ Terminated, Status, MinimalActorRef, InternalActorRef, Actor
 import akka.dispatch.{ Promise, Terminate, SystemMessage, Future }
 import akka.event.DeathWatch
 import akka.actor.ActorRefProvider
-import akka.util.Timeout
+import scala.util.Timeout
 
 /**
  * This is what is used to complete a Future that is returned from an ask/? call,

--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -7,7 +7,7 @@ object Patterns {
   import akka.actor.{ ActorRef, ActorSystem }
   import akka.dispatch.Future
   import akka.pattern.{ ask ⇒ scalaAsk }
-  import akka.util.{ Timeout, Duration }
+  import scala.util.{ Timeout, Duration }
 
   /**
    * <i>Java API for `akka.pattern.ask`:</i>

--- a/akka-actor/src/main/scala/akka/pattern/package.scala
+++ b/akka-actor/src/main/scala/akka/pattern/package.scala
@@ -5,7 +5,7 @@ package akka
 
 import akka.actor._
 import akka.dispatch.{ Future, Promise }
-import akka.util.{ Timeout, Duration }
+import scala.util.{ Timeout, Duration }
 
 /**
  * == Commonly Used Patterns With Akka ==

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -8,8 +8,8 @@ import akka.dispatch.{ Future, Promise }
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.TimeUnit
-import akka.util.{ Duration, Timeout }
-import akka.util.duration._
+import scala.util.{ Duration, Timeout }
+import scala.util.duration._
 import com.typesafe.config.Config
 import akka.config.ConfigurationException
 import akka.pattern.AskSupport

--- a/akka-actor/src/main/scala/akka/util/Timer.scala
+++ b/akka-actor/src/main/scala/akka/util/Timer.scala
@@ -1,0 +1,32 @@
+package akka.util
+
+import scala.util.Duration
+
+/**
+ * Simple timer class.
+ * Usage:
+ * <pre>
+ *   import scala.util.duration._
+ *   import akka.util.Timer
+ *
+ *   val timer = Timer(30.seconds)
+ *   while (timer.isTicking) { ... }
+ * </pre>
+ */
+case class Timer(duration: Duration, throwExceptionOnTimeout: Boolean = false) {
+  val startTimeInMillis = System.currentTimeMillis
+  val timeoutInMillis = duration.toMillis
+
+  /**
+   * Returns true while the timer is ticking. After that it either throws and exception or
+   * returns false. Depending on if the 'throwExceptionOnTimeout' argument is true or false.
+   */
+  def isTicking: Boolean = {
+    if (!(timeoutInMillis > (System.currentTimeMillis - startTimeInMillis))) {
+      if (throwExceptionOnTimeout) throw new TimerException("Time out after " + duration)
+      else false
+    } else true
+  }
+}
+
+class TimerException(message: String) extends RuntimeException(message)

--- a/akka-actor/src/main/scala/akka/util/cps/package.scala
+++ b/akka-actor/src/main/scala/akka/util/cps/package.scala
@@ -4,6 +4,7 @@
 
 package akka.util
 
+import scala.util.Timeout
 import scala.util.continuations._
 import akka.dispatch.MessageDispatcher
 

--- a/akka-actor/src/main/scala/scala/util/Duration.scala
+++ b/akka-actor/src/main/scala/scala/util/Duration.scala
@@ -167,7 +167,6 @@ object Duration {
     def toDays: Long = throw new IllegalArgumentException("toDays not allowed on infinite Durations")
     def toUnit(unit: TimeUnit): Double = throw new IllegalArgumentException("toUnit not allowed on infinite Durations")
 
-    def printHMS = toString
   }
 
   /**
@@ -257,7 +256,7 @@ abstract class Duration extends Serializable with Ordered[Duration] {
   def toHours: Long
   def toDays: Long
   def toUnit(unit: TimeUnit): Double
-  def printHMS: String
+
   def +(other: Duration): Duration
   def -(other: Duration): Duration
   def *(factor: Double): Duration
@@ -267,7 +266,6 @@ abstract class Duration extends Serializable with Ordered[Duration] {
   def finite_? : Boolean
   def min(other: Duration): Duration = if (this < other) this else other
   def max(other: Duration): Duration = if (this > other) this else other
-  def sleep(): Unit = Thread.sleep(toMillis)
   def fromNow: Deadline = Deadline.now + this
 
   // Java API
@@ -320,8 +318,6 @@ class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duration {
     case Duration(1, NANOSECONDS)  ⇒ "1 nanosecond"
     case Duration(x, NANOSECONDS)  ⇒ x + " nanoseconds"
   }
-
-  def printHMS = "%02d:%02d:%06.3f".format(toHours, toMinutes % 60, toMillis / 1000d % 60)
 
   def compare(other: Duration) =
     if (other.finite_?) {

--- a/akka-actor/src/main/scala/scala/util/Duration.scala
+++ b/akka-actor/src/main/scala/scala/util/Duration.scala
@@ -2,41 +2,12 @@
  * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
  */
 
-package akka.util
+package scala.util
 
 import java.util.concurrent.TimeUnit
 import TimeUnit._
 import java.lang.{ Long ⇒ JLong, Double ⇒ JDouble }
 import akka.actor.ActorSystem
-
-class TimerException(message: String) extends RuntimeException(message)
-
-/**
- * Simple timer class.
- * Usage:
- * <pre>
- *   import akka.util.duration._
- *   import akka.util.Timer
- *
- *   val timer = Timer(30.seconds)
- *   while (timer.isTicking) { ... }
- * </pre>
- */
-case class Timer(duration: Duration, throwExceptionOnTimeout: Boolean = false) {
-  val startTimeInMillis = System.currentTimeMillis
-  val timeoutInMillis = duration.toMillis
-
-  /**
-   * Returns true while the timer is ticking. After that it either throws and exception or
-   * returns false. Depending on if the 'throwExceptionOnTimeout' argument is true or false.
-   */
-  def isTicking: Boolean = {
-    if (!(timeoutInMillis > (System.currentTimeMillis - startTimeInMillis))) {
-      if (throwExceptionOnTimeout) throw new TimerException("Time out after " + duration)
-      else false
-    } else true
-  }
-}
 
 case class Deadline(d: Duration) {
   def +(other: Duration): Deadline = copy(d = d + other)
@@ -221,7 +192,7 @@ object Duration {
  * <p/>
  * Examples of usage from Java:
  * <pre>
- * import akka.util.FiniteDuration;
+ * import scala.util.FiniteDuration;
  * import java.util.concurrent.TimeUnit;
  *
  * Duration duration = new FiniteDuration(100, MILLISECONDS);
@@ -233,7 +204,7 @@ object Duration {
  * <p/>
  * Examples of usage from Scala:
  * <pre>
- * import akka.util.Duration
+ * import scala.util.Duration
  * import java.util.concurrent.TimeUnit
  *
  * val duration = Duration(100, MILLISECONDS)
@@ -247,7 +218,7 @@ object Duration {
  * <p/>
  * Implicits are also provided for Int, Long and Double. Example usage:
  * <pre>
- * import akka.util.duration._
+ * import scala.util.duration._
  *
  * val duration = 100 millis
  * </pre>

--- a/akka-actor/src/main/scala/scala/util/duration/package.scala
+++ b/akka-actor/src/main/scala/scala/util/duration/package.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
  */
 
-package akka.util
+package scala.util
 
 import java.util.concurrent.TimeUnit
 

--- a/akka-agent/src/main/scala/akka/agent/Agent.scala
+++ b/akka-agent/src/main/scala/akka/agent/Agent.scala
@@ -8,7 +8,7 @@ import akka.actor._
 import akka.japi.{ Function ⇒ JFunc, Procedure ⇒ JProc }
 import akka.dispatch._
 import akka.pattern.ask
-import akka.util.Timeout
+import scala.util.Timeout
 import scala.concurrent.stm._
 
 /**

--- a/akka-agent/src/test/scala/akka/agent/AgentSpec.scala
+++ b/akka-agent/src/test/scala/akka/agent/AgentSpec.scala
@@ -1,9 +1,9 @@
 package akka.agent
 
 import akka.dispatch.Await
-import akka.util.Duration
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.Duration
+import scala.util.duration._
+import scala.util.Timeout
 import akka.testkit._
 import scala.concurrent.stm._
 import java.util.concurrent.CountDownLatch

--- a/akka-camel-typed/src/test/java/akka/camel/TypedConsumerJavaTestBase.java
+++ b/akka-camel-typed/src/test/java/akka/camel/TypedConsumerJavaTestBase.java
@@ -3,7 +3,7 @@ package akka.camel;
 import akka.actor.Actor;
 import akka.actor.TypedActor;
 import akka.actor.Props;
-import akka.util.Timeout;
+import scala.util.Timeout;
 import akka.dispatch.Dispatchers;
 import akka.japi.SideEffect;
 import akka.util.FiniteDuration;

--- a/akka-camel-typed/src/test/scala/akka/camel/TypedConsumerPublishRequestorTest.scala
+++ b/akka-camel-typed/src/test/scala/akka/camel/TypedConsumerPublishRequestorTest.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.{ CountDownLatch, TimeUnit }
 
 import org.junit.{ Before, After, Test }
 import org.scalatest.junit.JUnitSuite
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor._
 import akka.actor.Actor._
 import akka.camel.TypedCamelTestSupport.{ SetExpectedMessageCount ⇒ SetExpectedTestMessageCount, _ }

--- a/akka-cluster/src/main/scala/akka/cluster/metrics/LocalNodeMetricsManager.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/metrics/LocalNodeMetricsManager.scala
@@ -13,9 +13,10 @@ import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import java.util.concurrent.{ ConcurrentHashMap, ConcurrentSkipListSet }
 import java.util.concurrent.atomic.AtomicReference
-import akka.util.{ Duration, Switch }
+import scala.util.Duration
+import akka.util.Switch
 import akka.util.Helpers._
-import akka.util.duration._
+import scala.util.duration._
 import org.I0Itec.zkclient.exception.ZkNoNodeException
 import akka.event.EventHandler
 

--- a/akka-cluster/src/main/scala/akka/cluster/zookeeper/ZooKeeperBarrier.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/zookeeper/ZooKeeperBarrier.scala
@@ -3,8 +3,8 @@
  */
 package akka.cluster.zookeeper
 
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 import org.I0Itec.zkclient._
 import org.I0Itec.zkclient.exception._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/metrics/local/LocalMetricsMultiJvmSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/metrics/local/LocalMetricsMultiJvmSpec.scala
@@ -9,8 +9,8 @@ import akka.actor._
 import Actor._
 import Cluster._
 import akka.dispatch._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 import akka.cluster.metrics._
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/metrics/remote/RemoteMetricsMultiJvmSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/metrics/remote/RemoteMetricsMultiJvmSpec.scala
@@ -9,8 +9,8 @@ import akka.actor._
 import Actor._
 import Cluster._
 import akka.dispatch._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 import akka.cluster.metrics._
 import java.util.concurrent._
 import atomic.AtomicInteger

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/direct/failover/DirectRoutingFailoverMultiJvmSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/direct/failover/DirectRoutingFailoverMultiJvmSpec.scala
@@ -4,8 +4,8 @@ import akka.config.Config
 import scala.Predef._
 import akka.cluster.{ ClusterActorRef, Cluster, MasterClusterTestNode, ClusterTestNode }
 import akka.actor.{ ActorInitializationException, Actor, ActorRef }
-import akka.util.duration._
-import akka.util.{ Duration, Timer }
+import scala.util.duration._
+import scala.util.{ Duration, Timer }
 import akka.event.EventHandler
 import akka.testkit.{ EventFilter, TestEvent }
 import java.net.ConnectException

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/random/failover/RandomFailoverMultiJvmSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/random/failover/RandomFailoverMultiJvmSpec.scala
@@ -4,8 +4,8 @@ import akka.config.Config
 import akka.cluster._
 import akka.actor.{ ActorRef, Actor }
 import akka.event.EventHandler
-import akka.util.duration._
-import akka.util.{ Duration, Timer }
+import scala.util.duration._
+import scala.util.{ Duration, Timer }
 import akka.testkit.{ EventFilter, TestEvent }
 import java.util.{ Collections, Set ⇒ JSet }
 import java.net.ConnectException

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/roundrobin/failover/RoundRobinFailoverMultiJvmSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/roundrobin/failover/RoundRobinFailoverMultiJvmSpec.scala
@@ -5,8 +5,8 @@ import akka.cluster._
 import akka.actor.{ ActorRef, Actor }
 import akka.event.EventHandler
 import akka.testkit.{ EventFilter, TestEvent }
-import akka.util.duration._
-import akka.util.{ Duration, Timer }
+import scala.util.duration._
+import scala.util.{ Duration, Timer }
 import java.util.{ Collections, Set ⇒ JSet }
 import java.net.ConnectException
 import java.nio.channels.NotYetConnectedException

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/roundrobin/replicationfactor_2/RoundRobin2ReplicasMultiJvmSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/roundrobin/replicationfactor_2/RoundRobin2ReplicasMultiJvmSpec.scala
@@ -14,8 +14,8 @@ import akka.cluster.LocalCluster._
 import akka.actor._
 import akka.actor.Actor._
 import akka.config.Config
-import akka.util.duration._
-import akka.util.{ Duration, Timer }
+import scala.util.duration._
+import scala.util.{ Duration, Timer }
 import akka.cluster.LocalCluster._
 
 import java.util.concurrent.atomic.AtomicInteger

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/roundrobin/replicationfactor_3/RoundRobin3ReplicasMultiJvmSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/roundrobin/replicationfactor_3/RoundRobin3ReplicasMultiJvmSpec.scala
@@ -11,8 +11,8 @@
 // import akka.cluster._
 // import akka.actor._
 // import akka.actor.Actor._
-// import akka.util.duration._
-// import akka.util.{ Duration, Timer }
+// import scala.util.duration._
+// import scala.util.{ Duration, Timer }
 // import akka.config.Config
 // import akka.cluster.LocalCluster._
 // import Cluster._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/sample/PingPongMultiJvmExample.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/sample/PingPongMultiJvmExample.scala
@@ -7,7 +7,7 @@ package akka.cluster.sample
 import akka.cluster._
 
 import akka.actor._
-import akka.util.duration._
+import scala.util.duration._
 
 object PingPongMultiJvmExample {
   val PING_ADDRESS = "ping"

--- a/akka-docs/common/duration.rst
+++ b/akka-docs/common/duration.rst
@@ -16,7 +16,7 @@ In Scala durations are constructable using a mini-DSL and support all expected o
 
 .. code-block:: scala
 
-   import akka.util.duration._   // notice the small d
+   import scala.util.duration._   // notice the small d
 
    val fivesec = 5.seconds
    val threemillis = 3.millis

--- a/akka-docs/java/code/akka/docs/actor/FaultHandlingTestBase.java
+++ b/akka-docs/java/code/akka/docs/actor/FaultHandlingTestBase.java
@@ -14,7 +14,7 @@ import akka.actor.Terminated;
 import akka.actor.UntypedActor;
 import akka.dispatch.Await;
 import static akka.pattern.Patterns.ask;
-import akka.util.Duration;
+import scala.util.Duration;
 import akka.testkit.AkkaSpec;
 import akka.testkit.TestProbe;
 

--- a/akka-docs/java/code/akka/docs/actor/MyReceivedTimeoutUntypedActor.java
+++ b/akka-docs/java/code/akka/docs/actor/MyReceivedTimeoutUntypedActor.java
@@ -7,7 +7,7 @@ package akka.docs.actor;
 import akka.actor.Actors;
 import akka.actor.ReceiveTimeout;
 import akka.actor.UntypedActor;
-import akka.util.Duration;
+import scala.util.Duration;
 
 public class MyReceivedTimeoutUntypedActor extends UntypedActor {
 

--- a/akka-docs/java/code/akka/docs/actor/SchedulerDocTestBase.java
+++ b/akka-docs/java/code/akka/docs/actor/SchedulerDocTestBase.java
@@ -5,7 +5,7 @@ package akka.docs.actor;
 
 //#imports1
 import akka.actor.Props;
-import akka.util.Duration;
+import scala.util.Duration;
 import java.util.concurrent.TimeUnit;
 
 //#imports1

--- a/akka-docs/java/code/akka/docs/actor/TypedActorDocTestBase.java
+++ b/akka-docs/java/code/akka/docs/actor/TypedActorDocTestBase.java
@@ -8,7 +8,7 @@ package akka.docs.actor;
 import akka.dispatch.*;
 import akka.actor.*;
 import akka.japi.*;
-import akka.util.Duration;
+import scala.util.Duration;
 import java.util.concurrent.TimeUnit;
 
 //#imports

--- a/akka-docs/java/code/akka/docs/actor/UntypedActorDocTestBase.java
+++ b/akka-docs/java/code/akka/docs/actor/UntypedActorDocTestBase.java
@@ -13,8 +13,8 @@ import akka.actor.Props;
 import akka.dispatch.Future;
 import akka.dispatch.Futures;
 import akka.dispatch.Await;
-import akka.util.Duration;
-import akka.util.Timeout;
+import scala.util.Duration;
+import scala.util.Timeout;
 //#import-future
 
 //#import-actors
@@ -33,7 +33,7 @@ import akka.actor.Terminated;
 import static akka.pattern.Patterns.gracefulStop;
 import akka.dispatch.Future;
 import akka.dispatch.Await;
-import akka.util.Duration;
+import scala.util.Duration;
 import akka.actor.ActorTimeoutException;
 //#import-gracefulStop
 
@@ -42,8 +42,8 @@ import static akka.pattern.Patterns.ask;
 import static akka.pattern.Patterns.pipeTo;
 import akka.dispatch.Future;
 import akka.dispatch.Futures;
-import akka.util.Duration;
-import akka.util.Timeout;
+import scala.util.Duration;
+import scala.util.Timeout;
 import java.util.concurrent.TimeUnit;
 import java.util.ArrayList;
 //#import-askPipeTo

--- a/akka-docs/java/code/akka/docs/agent/AgentDocTest.java
+++ b/akka-docs/java/code/akka/docs/agent/AgentDocTest.java
@@ -23,7 +23,7 @@ import akka.japi.Function;
 //#import-function
 
 //#import-timeout
-import akka.util.Timeout;
+import scala.util.Timeout;
 import static java.util.concurrent.TimeUnit.SECONDS;
 //#import-timeout
 

--- a/akka-docs/java/code/akka/docs/extension/SettingsExtensionDocTestBase.java
+++ b/akka-docs/java/code/akka/docs/extension/SettingsExtensionDocTestBase.java
@@ -9,7 +9,7 @@ import akka.actor.AbstractExtensionId;
 import akka.actor.ExtensionIdProvider;
 import akka.actor.ActorSystem;
 import akka.actor.ExtendedActorSystem;
-import akka.util.Duration;
+import scala.util.Duration;
 import com.typesafe.config.Config;
 import java.util.concurrent.TimeUnit;
 

--- a/akka-docs/java/code/akka/docs/future/FutureDocTestBase.java
+++ b/akka-docs/java/code/akka/docs/future/FutureDocTestBase.java
@@ -7,14 +7,14 @@ package akka.docs.future;
 import akka.dispatch.Promise;
 import akka.japi.Procedure;
 import akka.japi.Procedure2;
-import akka.util.Timeout;
+import scala.util.Timeout;
 import akka.dispatch.Await;
 import akka.dispatch.Future;
 
 //#imports1
 
 //#imports2
-import akka.util.Duration;
+import scala.util.Duration;
 import akka.japi.Function;
 import java.util.concurrent.Callable;
 import static akka.dispatch.Futures.future;

--- a/akka-docs/java/code/akka/docs/jrouting/CustomRouterDocTestBase.java
+++ b/akka-docs/java/code/akka/docs/jrouting/CustomRouterDocTestBase.java
@@ -13,8 +13,8 @@ import static org.junit.Assert.assertEquals;
 
 import akka.actor.*;
 import akka.routing.*;
-import akka.util.Duration;
-import akka.util.Timeout;
+import scala.util.Duration;
+import scala.util.Timeout;
 import akka.dispatch.Await;
 import akka.dispatch.Future;
 import akka.testkit.AkkaSpec;

--- a/akka-docs/java/code/akka/docs/jrouting/ParentActor.java
+++ b/akka-docs/java/code/akka/docs/jrouting/ParentActor.java
@@ -11,8 +11,8 @@ import akka.routing.SmallestMailboxRouter;
 import akka.actor.UntypedActor;
 import akka.actor.ActorRef;
 import akka.actor.Props;
-import akka.util.Duration;
-import akka.util.Timeout;
+import scala.util.Duration;
+import scala.util.Timeout;
 import akka.dispatch.Future;
 import akka.dispatch.Await;
 

--- a/akka-docs/java/code/akka/docs/transactor/TransactorDocTest.java
+++ b/akka-docs/java/code/akka/docs/transactor/TransactorDocTest.java
@@ -12,8 +12,8 @@ import akka.actor.*;
 import akka.dispatch.Await;
 import static akka.pattern.Patterns.ask;
 import akka.transactor.Coordinated;
-import akka.util.Duration;
-import akka.util.Timeout;
+import scala.util.Duration;
+import scala.util.Timeout;
 import static java.util.concurrent.TimeUnit.SECONDS;
 //#imports
 

--- a/akka-docs/scala/actors.rst
+++ b/akka-docs/scala/actors.rst
@@ -390,7 +390,7 @@ taken from one of the following locations in order of precedence:
 
 .. includecode:: code/akka/docs/actor/ActorDocSpec.scala#using-explicit-timeout
 
-2. implicit argument of type :class:`akka.util.Timeout`, e.g.
+2. implicit argument of type :class:`scala.util.Timeout`, e.g.
 
 .. includecode:: code/akka/docs/actor/ActorDocSpec.scala#using-implicit-timeout
 

--- a/akka-docs/scala/code/akka/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/ActorDocSpec.scala
@@ -16,7 +16,8 @@ import org.scalatest.{ BeforeAndAfterAll, WordSpec }
 import org.scalatest.matchers.MustMatchers
 import akka.testkit._
 import akka.util._
-import akka.util.duration._
+import scala.util.Timeout
+import scala.util.duration._
 import akka.actor.Actor.Receive
 import akka.dispatch.Await
 
@@ -215,8 +216,8 @@ class ActorDocSpec extends AkkaSpec(Map("akka.loglevel" -> "INFO")) {
   "using implicit timeout" in {
     val myActor = system.actorOf(Props(new FirstActor))
     //#using-implicit-timeout
-    import akka.util.duration._
-    import akka.util.Timeout
+    import scala.util.duration._
+    import scala.util.Timeout
     import akka.pattern.ask
     implicit val timeout = Timeout(500 millis)
     val future = myActor ? "hello"
@@ -228,7 +229,7 @@ class ActorDocSpec extends AkkaSpec(Map("akka.loglevel" -> "INFO")) {
   "using explicit timeout" in {
     val myActor = system.actorOf(Props(new FirstActor))
     //#using-explicit-timeout
-    import akka.util.duration._
+    import scala.util.duration._
     import akka.pattern.ask
     val future = myActor.ask("hello")(500 millis)
     //#using-explicit-timeout
@@ -238,7 +239,7 @@ class ActorDocSpec extends AkkaSpec(Map("akka.loglevel" -> "INFO")) {
   "using receiveTimeout" in {
     //#receive-timeout
     import akka.actor.ReceiveTimeout
-    import akka.util.duration._
+    import scala.util.duration._
     class MyActor extends Actor {
       context.setReceiveTimeout(30 milliseconds)
       def receive = {

--- a/akka-docs/scala/code/akka/docs/actor/FSMDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/FSMDocSpec.scala
@@ -13,7 +13,7 @@ class FSMDocSpec extends AkkaSpec {
     //#fsm-code-elided
     //#simple-imports
     import akka.actor.{ Actor, ActorRef, FSM }
-    import akka.util.duration._
+    import scala.util.duration._
     //#simple-imports
     //#simple-events
     // received events

--- a/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSample.scala
+++ b/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSample.scala
@@ -6,9 +6,9 @@ package akka.docs.actor
 //#all
 import akka.actor._
 import akka.actor.SupervisorStrategy._
-import akka.util.duration._
-import akka.util.Duration
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Duration
+import scala.util.Timeout
 import akka.event.LoggingReceive
 import akka.pattern.ask
 import com.typesafe.config.ConfigFactory

--- a/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
@@ -20,7 +20,7 @@ object FaultHandlingDocSpec {
     //#strategy
     import akka.actor.OneForOneStrategy
     import akka.actor.SupervisorStrategy._
-    import akka.util.duration._
+    import scala.util.duration._
 
     override val supervisorStrategy = OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 1 minute) {
       case _: ArithmeticException      ⇒ Resume
@@ -41,7 +41,7 @@ object FaultHandlingDocSpec {
     //#strategy2
     import akka.actor.OneForOneStrategy
     import akka.actor.SupervisorStrategy._
-    import akka.util.duration._
+    import scala.util.duration._
 
     override val supervisorStrategy = OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 1 minute) {
       case _: ArithmeticException      ⇒ Resume

--- a/akka-docs/scala/code/akka/docs/actor/SchedulerDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/SchedulerDocSpec.scala
@@ -6,7 +6,7 @@ package akka.docs.actor
 //#imports1
 import akka.actor.Actor
 import akka.actor.Props
-import akka.util.duration._
+import scala.util.duration._
 
 //#imports1
 

--- a/akka-docs/scala/code/akka/docs/actor/TypedActorDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/TypedActorDocSpec.scala
@@ -5,7 +5,7 @@ package akka.docs.actor
 
 //#imports
 import akka.dispatch.{ Promise, Future, Await }
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor.{ ActorContext, TypedActor, TypedProps }
 
 //#imports

--- a/akka-docs/scala/code/akka/docs/agent/AgentDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/agent/AgentDocSpec.scala
@@ -4,8 +4,8 @@
 package akka.docs.agent
 
 import akka.agent.Agent
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import akka.testkit._
 
 class AgentDocSpec extends AkkaSpec {
@@ -97,8 +97,8 @@ class AgentDocSpec extends AkkaSpec {
     val agent = Agent(0)
 
     //#read-await
-    import akka.util.duration._
-    import akka.util.Timeout
+    import scala.util.duration._
+    import scala.util.Timeout
 
     implicit val timeout = Timeout(5 seconds)
     val result = agent.await
@@ -124,8 +124,8 @@ class AgentDocSpec extends AkkaSpec {
   "transfer example" in {
     //#transfer-example
     import akka.agent.Agent
-    import akka.util.duration._
-    import akka.util.Timeout
+    import scala.util.duration._
+    import scala.util.Timeout
     import scala.concurrent.stm._
 
     def transfer(from: Agent[Int], to: Agent[Int], amount: Int): Boolean = {

--- a/akka-docs/scala/code/akka/docs/dispatcher/DispatcherDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/dispatcher/DispatcherDocSpec.scala
@@ -10,7 +10,7 @@ import akka.actor.Props
 import akka.actor.Actor
 import akka.event.Logging
 import akka.event.LoggingAdapter
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor.PoisonPill
 import akka.dispatch.MessageDispatcherConfigurator
 import akka.dispatch.MessageDispatcher

--- a/akka-docs/scala/code/akka/docs/extension/SettingsExtensionDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/extension/SettingsExtensionDocSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.Extension
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.actor.ExtendedActorSystem
-import akka.util.Duration
+import scala.util.Duration
 import com.typesafe.config.Config
 import java.util.concurrent.TimeUnit
 

--- a/akka-docs/scala/code/akka/docs/future/FutureDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/future/FutureDocSpec.scala
@@ -11,7 +11,7 @@ import akka.actor.Props
 import akka.actor.Status.Failure
 import akka.dispatch.Future
 import akka.dispatch.Await
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.Promise
 
 object FutureDocSpec {
@@ -70,7 +70,7 @@ class FutureDocSpec extends AkkaSpec {
     //#future-eval
     import akka.dispatch.Await
     import akka.dispatch.Future
-    import akka.util.duration._
+    import scala.util.duration._
 
     val future = Future {
       "Hello" + "World"

--- a/akka-docs/scala/code/akka/docs/routing/RouterTypeExample.scala
+++ b/akka-docs/scala/code/akka/docs/routing/RouterTypeExample.scala
@@ -6,7 +6,7 @@ package akka.docs.routing
 import akka.routing.{ ScatterGatherFirstCompletedRouter, BroadcastRouter, RandomRouter, RoundRobinRouter }
 import annotation.tailrec
 import akka.actor.{ Props, Actor }
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.Await
 import akka.pattern.ask
 import akka.routing.SmallestMailboxRouter

--- a/akka-docs/scala/code/akka/docs/testkit/TestkitDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/testkit/TestkitDocSpec.scala
@@ -5,7 +5,7 @@ package akka.docs.testkit
 
 //#imports-test-probe
 import akka.testkit.TestProbe
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor._
 import akka.dispatch.Futures
 
@@ -85,7 +85,7 @@ class TestkitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     //#test-fsm-ref
     import akka.testkit.TestFSMRef
     import akka.actor.FSM
-    import akka.util.duration._
+    import scala.util.duration._
 
     val fsm = TestFSMRef(new Actor with FSM[Int, String] {
       startWith(1, "")
@@ -118,7 +118,7 @@ class TestkitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
     //#test-behavior
     import akka.testkit.TestActorRef
-    import akka.util.duration._
+    import scala.util.duration._
     import akka.dispatch.Await
     import akka.pattern.ask
 
@@ -156,7 +156,7 @@ class TestkitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     type Worker = MyActor
     //#test-within
     import akka.actor.Props
-    import akka.util.duration._
+    import scala.util.duration._
 
     val worker = system.actorOf(Props[Worker])
     within(200 millis) {
@@ -170,7 +170,7 @@ class TestkitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
   "demonstrate dilated duration" in {
     //#duration-dilation
-    import akka.util.duration._
+    import scala.util.duration._
     import akka.testkit._
     10.milliseconds.dilated
     //#duration-dilation
@@ -203,7 +203,7 @@ class TestkitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
   "demonstrate probe reply" in {
     import akka.testkit.TestProbe
-    import akka.util.duration._
+    import scala.util.duration._
     import akka.pattern.ask
     //#test-probe-reply
     val probe = TestProbe()

--- a/akka-docs/scala/code/akka/docs/transactor/TransactorDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/transactor/TransactorDocSpec.scala
@@ -6,8 +6,8 @@ package akka.docs.transactor
 
 import akka.actor._
 import akka.transactor._
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import akka.testkit._
 import scala.concurrent.stm._
 
@@ -139,8 +139,8 @@ class TransactorDocSpec extends AkkaSpec {
 
     //#run-coordinated-example
     import akka.dispatch.Await
-    import akka.util.duration._
-    import akka.util.Timeout
+    import scala.util.duration._
+    import scala.util.Timeout
     import akka.pattern.ask
 
     val system = ActorSystem("app")
@@ -166,8 +166,8 @@ class TransactorDocSpec extends AkkaSpec {
     import CoordinatedApi._
 
     //#implicit-timeout
-    import akka.util.duration._
-    import akka.util.Timeout
+    import scala.util.duration._
+    import scala.util.Timeout
 
     implicit val timeout = Timeout(5 seconds)
     //#implicit-timeout

--- a/akka-docs/scala/testkit-example.rst
+++ b/akka-docs/scala/testkit-example.rst
@@ -13,7 +13,7 @@ Ray Roestenburg's example code from `his blog <http://roestenburg.agilesquad.com
    import org.scalatest.matchers.ShouldMatchers
    import org.scalatest.{WordSpec, BeforeAndAfterAll}
    import akka.actor.Actor._
-   import akka.util.duration._
+   import scala.util.duration._
    import akka.testkit.TestKit
    import java.util.concurrent.TimeUnit
    import akka.actor.{ActorRef, Actor}

--- a/akka-durable-mailboxes/akka-beanstalk-mailbox/src/main/scala/akka/actor/mailbox/BeanstalkBasedMailbox.scala
+++ b/akka-durable-mailboxes/akka-beanstalk-mailbox/src/main/scala/akka/actor/mailbox/BeanstalkBasedMailbox.scala
@@ -6,7 +6,7 @@ package akka.actor.mailbox
 import com.surftools.BeanstalkClient._
 import com.surftools.BeanstalkClientImpl._
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import akka.util.Duration
+import scala.util.Duration
 import akka.AkkaException
 import akka.actor.ActorContext
 import akka.dispatch.Envelope

--- a/akka-durable-mailboxes/akka-beanstalk-mailbox/src/main/scala/akka/actor/mailbox/BeanstalkBasedMailboxExtension.scala
+++ b/akka-durable-mailboxes/akka-beanstalk-mailbox/src/main/scala/akka/actor/mailbox/BeanstalkBasedMailboxExtension.scala
@@ -4,7 +4,7 @@
 package akka.actor.mailbox
 
 import com.typesafe.config.Config
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.actor._
 

--- a/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/FileBasedMailboxExtension.scala
+++ b/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/FileBasedMailboxExtension.scala
@@ -4,7 +4,7 @@
 package akka.actor.mailbox
 
 import com.typesafe.config.Config
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.actor._
 

--- a/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/filequeue/PersistentQueue.scala
+++ b/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/filequeue/PersistentQueue.scala
@@ -20,7 +20,7 @@ package akka.actor.mailbox.filequeue
 import java.io._
 import scala.collection.mutable
 import akka.event.LoggingAdapter
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit
 import akka.actor.mailbox.FileBasedMailboxSettings
 

--- a/akka-durable-mailboxes/akka-mailboxes-common/src/test/scala/akka/actor/mailbox/DurableMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-mailboxes-common/src/test/scala/akka/actor/mailbox/DurableMailboxSpec.scala
@@ -10,7 +10,7 @@ import akka.actor.Props
 import akka.dispatch.Await
 import akka.testkit.AkkaSpec
 import akka.testkit.TestLatch
-import akka.util.duration._
+import scala.util.duration._
 
 object DurableMailboxSpecActorFactory {
 

--- a/akka-durable-mailboxes/akka-mongo-mailbox/src/main/scala/akka/actor/mailbox/MongoBasedMailboxExtension.scala
+++ b/akka-durable-mailboxes/akka-mongo-mailbox/src/main/scala/akka/actor/mailbox/MongoBasedMailboxExtension.scala
@@ -4,7 +4,7 @@
 package akka.actor.mailbox
 
 import com.typesafe.config.Config
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.actor._
 

--- a/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/actor/mailbox/ZooKeeperBasedMailbox.scala
+++ b/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/actor/mailbox/ZooKeeperBasedMailbox.scala
@@ -4,7 +4,7 @@
 package akka.actor.mailbox
 
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import akka.util.Duration
+import scala.util.Duration
 import akka.AkkaException
 import org.I0Itec.zkclient.serialize._
 import akka.actor.ActorContext

--- a/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/actor/mailbox/ZooKeeperBasedMailboxExtension.scala
+++ b/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/actor/mailbox/ZooKeeperBasedMailboxExtension.scala
@@ -4,7 +4,7 @@
 package akka.actor.mailbox
 
 import com.typesafe.config.Config
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.actor._
 

--- a/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/cluster/zookeeper/AkkaZkClient.scala
+++ b/akka-durable-mailboxes/akka-zookeeper-mailbox/src/main/scala/akka/cluster/zookeeper/AkkaZkClient.scala
@@ -6,7 +6,7 @@ package akka.cluster.zookeeper
 import org.I0Itec.zkclient._
 import org.I0Itec.zkclient.serialize._
 import org.I0Itec.zkclient.exception._
-import akka.util.Duration
+import scala.util.Duration
 
 /**
  * ZooKeeper client. Holds the ZooKeeper connection and manages its session.

--- a/akka-remote/src/main/scala/akka/remote/Gossiper.scala
+++ b/akka-remote/src/main/scala/akka/remote/Gossiper.scala
@@ -7,7 +7,7 @@ package akka.remote
 import akka.actor._
 import akka.actor.Status._
 import akka.event.Logging
-import akka.util.Duration
+import scala.util.Duration
 import akka.config.ConfigurationException
 import akka.serialization.SerializationExtension
 

--- a/akka-remote/src/main/scala/akka/remote/Remote.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remote.scala
@@ -7,7 +7,7 @@ package akka.remote
 import akka.actor._
 import akka.event._
 import akka.util._
-import akka.util.duration._
+import scala.util.duration._
 import akka.util.Helpers._
 import akka.serialization.{ JavaSerializer, Serialization, SerializationExtension }
 import akka.dispatch.MessageDispatcher

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -6,8 +6,8 @@ package akka.remote
 
 import akka.actor._
 import akka.dispatch._
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import akka.config.ConfigurationException
 import akka.event.{ DeathWatch, Logging }
 import akka.serialization.Compression.LZF

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -4,7 +4,7 @@
 package akka.remote
 
 import com.typesafe.config.Config
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.net.InetAddress
 import akka.config.ConfigurationException

--- a/akka-remote/src/multi-jvm/scala/akka/remote/FileBasedBarrier.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/FileBasedBarrier.scala
@@ -4,8 +4,8 @@
 
 package akka.remote
 
-import akka.util.duration._
-import akka.util.Duration
+import scala.util.duration._
+import scala.util.Duration
 import System.{ currentTimeMillis ⇒ now }
 
 import java.io.File

--- a/akka-remote/src/multi-jvm/scala/akka/remote/MultiJvmSync.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/MultiJvmSync.scala
@@ -5,7 +5,7 @@
 package akka.remote
 
 import akka.testkit.AkkaSpec
-import akka.util.Duration
+import scala.util.Duration
 
 trait MultiJvmSync extends AkkaSpec {
   def nodes: Int

--- a/akka-remote/src/multi-jvm/scala/akka/remote/NewRemoteActorMultiJvmSpec.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/NewRemoteActorMultiJvmSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.{ Actor, Props }
 import akka.remote._
 import akka.routing._
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.Await
 import akka.pattern.ask
 

--- a/akka-remote/src/multi-jvm/scala/akka/remote/ScatterGatherRoutedRemoteActorMultiJvmSpec.scala
+++ b/akka-remote/src/multi-jvm/scala/akka/remote/ScatterGatherRoutedRemoteActorMultiJvmSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.{ Actor, Props }
 import akka.remote._
 import akka.routing._
 import akka.testkit._
-import akka.util.duration._
+import scala.util.duration._
 
 object ScatterGatherRoutedRemoteActorMultiJvmSpec extends AbstractRemoteActorMultiJvmSpec {
   override def NrOfNodes = 4

--- a/akka-remote/src/test/scala/akka/remote/NetworkFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/NetworkFailureSpec.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 trait NetworkFailureSpec extends DefaultTimeout { self: AkkaSpec ⇒
   import Actor._
-  import akka.util.Duration
+  import scala.util.Duration
 
   val BytesPerSecond = "60KByte/s"
   val DelayMillis = "350ms"

--- a/akka-samples/akka-sample-fsm/src/main/scala/Buncher.scala
+++ b/akka-samples/akka-sample-fsm/src/main/scala/Buncher.scala
@@ -5,7 +5,7 @@ package sample.fsm.buncher
 
 import akka.actor.ActorRefFactory
 import scala.reflect.ClassManifest
-import akka.util.Duration
+import scala.util.Duration
 import akka.actor.{ FSM, Actor, ActorRef }
 
 /*

--- a/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnBecome.scala
+++ b/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnBecome.scala
@@ -7,7 +7,7 @@ package sample.fsm.dining.become
 //http://www.dalnefre.com/wp/2010/08/dining-philosophers-in-humus/
 
 import akka.actor._
-import akka.util.duration._
+import scala.util.duration._
 
 /*
 * First we define our messages, they basically speak for themselves

--- a/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnFsm.scala
+++ b/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnFsm.scala
@@ -5,8 +5,8 @@ package sample.fsm.dining.fsm
 
 import akka.actor._
 import akka.actor.FSM._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 
 /*
 * Some messages for the chopstick

--- a/akka-spring/src/main/scala/akka/spring/ActorFactoryBean.scala
+++ b/akka-spring/src/main/scala/akka/spring/ActorFactoryBean.scala
@@ -12,7 +12,7 @@ import org.springframework.util.StringUtils
 import akka.actor.{ ActorRef, ActorRegistry, AspectInitRegistry, TypedActorConfiguration, TypedActor, Actor }
 import akka.event.EventHandler
 import akka.dispatch.MessageDispatcher
-import akka.util.Duration
+import scala.util.Duration
 
 import scala.reflect.BeanProperty
 

--- a/akka-spring/src/main/scala/akka/spring/DispatcherFactoryBean.scala
+++ b/akka-spring/src/main/scala/akka/spring/DispatcherFactoryBean.scala
@@ -10,7 +10,7 @@ import akka.actor.ActorRef
 import java.util.concurrent.RejectedExecutionHandler
 import java.util.concurrent.ThreadPoolExecutor.{ DiscardPolicy, DiscardOldestPolicy, CallerRunsPolicy, AbortPolicy }
 import akka.dispatch._
-import akka.util.Duration
+import scala.util.Duration
 
 /**
  * Reusable factory method for dispatchers.

--- a/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
@@ -14,8 +14,9 @@ import com.typesafe.config.Config
 import CallingThreadDispatcher.Id
 import akka.actor.{ ExtensionIdProvider, ExtensionId, Extension, ExtendedActorSystem, ActorRef, ActorCell }
 import akka.dispatch.{ TaskInvocation, SystemMessage, Suspend, Resume, MessageDispatcherConfigurator, MessageDispatcher, Mailbox, Envelope, DispatcherPrerequisites, DefaultSystemMessageQueue }
-import akka.util.duration.intToDurationInt
-import akka.util.{ Switch, Duration }
+import scala.util.duration.intToDurationInt
+import scala.util.Duration
+import akka.util.{ Switch }
 
 /*
  * Locking rules:

--- a/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
@@ -5,7 +5,8 @@
 package akka.testkit
 
 import akka.actor._
-import akka.util.{ ReflectiveAccess, Duration }
+import scala.util.Duration
+import akka.util.{ ReflectiveAccess }
 import com.eaio.uuid.UUID
 import akka.actor.Props._
 import akka.actor.ActorSystem

--- a/akka-testkit/src/main/scala/akka/testkit/TestBarrier.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestBarrier.scala
@@ -4,7 +4,7 @@
 
 package akka.testkit
 
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.{ CyclicBarrier, TimeUnit, TimeoutException }
 import akka.actor.ActorSystem
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -10,7 +10,7 @@ import akka.dispatch.{ SystemMessage, Terminate }
 import akka.event.Logging.{ Warning, LogEvent, InitializeLogger, Info, Error, Debug, LoggerInitialized }
 import akka.event.Logging
 import akka.testkit.TestEvent.{ UnMute, Mute }
-import akka.util.Duration
+import scala.util.Duration
 
 /**
  * Implementation helpers of the EventFilter facilities: send `Mute`

--- a/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
@@ -5,6 +5,7 @@
 package akka.testkit
 
 import akka.actor._
+import scala.util.Duration
 import akka.util._
 import com.eaio.uuid.UUID
 import akka.actor.ActorSystem

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -5,8 +5,8 @@ package akka.testkit
 
 import akka.actor._
 import Actor._
-import akka.util.Duration
-import akka.util.duration._
+import scala.util.Duration
+import scala.util.duration._
 import java.util.concurrent.{ BlockingDeque, LinkedBlockingDeque, TimeUnit, atomic }
 import atomic.AtomicInteger
 import scala.annotation.tailrec

--- a/akka-testkit/src/main/scala/akka/testkit/TestKitExtension.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKitExtension.scala
@@ -4,7 +4,7 @@
 package akka.testkit
 
 import com.typesafe.config.Config
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.actor.{ ExtensionId, ActorSystem, Extension, ExtendedActorSystem }
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestLatch.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestLatch.scala
@@ -4,7 +4,7 @@
 
 package akka.testkit
 
-import akka.util.Duration
+import scala.util.Duration
 import akka.actor.ActorSystem
 import akka.dispatch.Await.{ CanAwait, Awaitable }
 import java.util.concurrent.{ TimeoutException, CountDownLatch, TimeUnit }

--- a/akka-testkit/src/main/scala/akka/testkit/package.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/package.scala
@@ -1,7 +1,7 @@
 package akka
 
 import akka.actor.ActorSystem
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
 package object testkit {
@@ -32,7 +32,7 @@ package object testkit {
    * Scala API. Scale timeouts (durations) during tests with the configured
    * 'akka.test.timefactor'.
    * Implicit conversion to add dilated function to Duration.
-   * import akka.util.duration._
+   * import scala.util.duration._
    * import akka.testkit._
    * 10.milliseconds.dilated
    *

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.MustMatchers
 import akka.actor.{ ActorSystem, ActorSystemImpl }
 import akka.actor.{ Actor, ActorRef, Props }
 import akka.event.{ Logging, LoggingAdapter }
-import akka.util.duration._
+import scala.util.duration._
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import akka.actor.PoisonPill

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.{ BeforeAndAfterEach, WordSpec }
 import akka.actor._
 import akka.event.Logging.Warning
 import akka.dispatch.{ Future, Promise, Await }
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor.ActorSystem
 import akka.pattern.ask
 import akka.dispatch.Dispatcher

--- a/akka-testkit/src/test/scala/akka/testkit/TestFSMRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestFSMRefSpec.scala
@@ -7,7 +7,7 @@ package akka.testkit
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.{ BeforeAndAfterEach, WordSpec }
 import akka.actor._
-import akka.util.duration._
+import scala.util.duration._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class TestFSMRefSpec extends AkkaSpec {

--- a/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.WordSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.{ BeforeAndAfterEach, WordSpec }
 import akka.actor._
-import akka.util.duration._
+import scala.util.duration._
 import akka.dispatch.{ Await, Future }
 import akka.pattern.ask
 

--- a/akka-testkit/src/test/scala/akka/testkit/TestTimeSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestTimeSpec.scala
@@ -2,7 +2,7 @@ package akka.testkit
 
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.{ BeforeAndAfterEach, WordSpec }
-import akka.util.Duration
+import scala.util.Duration
 import com.typesafe.config.Config
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-transactor/src/main/scala/akka/transactor/Coordinated.scala
+++ b/akka-transactor/src/main/scala/akka/transactor/Coordinated.scala
@@ -5,7 +5,7 @@
 package akka.transactor
 
 import akka.AkkaException
-import akka.util.Timeout
+import scala.util.Timeout
 import scala.concurrent.stm.{ CommitBarrier, InTxn }
 import java.util.concurrent.Callable
 

--- a/akka-transactor/src/test/java/akka/transactor/UntypedCoordinatedIncrementTest.java
+++ b/akka-transactor/src/test/java/akka/transactor/UntypedCoordinatedIncrementTest.java
@@ -23,7 +23,7 @@ import akka.testkit.AkkaSpec;
 import akka.testkit.EventFilter;
 import akka.testkit.ErrorFilter;
 import akka.testkit.TestEvent;
-import akka.util.Timeout;
+import scala.util.Timeout;
 
 import java.util.Arrays;
 import java.util.ArrayList;

--- a/akka-transactor/src/test/java/akka/transactor/UntypedTransactorTest.java
+++ b/akka-transactor/src/test/java/akka/transactor/UntypedTransactorTest.java
@@ -23,7 +23,7 @@ import akka.testkit.AkkaSpec;
 import akka.testkit.EventFilter;
 import akka.testkit.ErrorFilter;
 import akka.testkit.TestEvent;
-import akka.util.Timeout;
+import scala.util.Timeout;
 
 import java.util.Arrays;
 import java.util.ArrayList;

--- a/akka-transactor/src/test/scala/akka/transactor/CoordinatedIncrementSpec.scala
+++ b/akka-transactor/src/test/scala/akka/transactor/CoordinatedIncrementSpec.scala
@@ -8,8 +8,8 @@ import org.scalatest.BeforeAndAfterAll
 
 import akka.actor._
 import akka.dispatch.Await
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import akka.testkit._
 import scala.concurrent.stm._
 import akka.pattern.ask

--- a/akka-transactor/src/test/scala/akka/transactor/FickleFriendsSpec.scala
+++ b/akka-transactor/src/test/scala/akka/transactor/FickleFriendsSpec.scala
@@ -8,8 +8,8 @@ import org.scalatest.BeforeAndAfterAll
 
 import akka.actor._
 import akka.dispatch.Await
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import akka.testkit._
 import akka.testkit.TestEvent.Mute
 import scala.concurrent.stm._

--- a/akka-transactor/src/test/scala/akka/transactor/TransactorSpec.scala
+++ b/akka-transactor/src/test/scala/akka/transactor/TransactorSpec.scala
@@ -6,8 +6,8 @@ package akka.transactor
 
 import akka.actor._
 import akka.dispatch.Await
-import akka.util.duration._
-import akka.util.Timeout
+import scala.util.duration._
+import scala.util.Timeout
 import akka.testkit._
 import scala.concurrent.stm._
 import akka.pattern.ask

--- a/akka-tutorials/akka-tutorial-first/src/main/java/akka/tutorial/first/java/Pi.java
+++ b/akka-tutorials/akka-tutorial-first/src/main/java/akka/tutorial/first/java/Pi.java
@@ -13,7 +13,7 @@ import akka.actor.UntypedActor;
 import akka.actor.UntypedActorFactory;
 import akka.japi.Creator;
 import akka.routing.*;
-import akka.util.Timeout;
+import scala.util.Timeout;
 
 import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;

--- a/akka-zeromq/src/main/scala/akka/zeromq/ConcurrentSocketActor.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ConcurrentSocketActor.scala
@@ -8,9 +8,9 @@ import org.zeromq.{ ZMQ ⇒ JZMQ }
 import akka.actor._
 import akka.dispatch.{ Promise, Future }
 import akka.event.Logging
-import akka.util.duration._
+import scala.util.duration._
 import annotation.tailrec
-import akka.util.Duration
+import scala.util.Duration
 import java.util.concurrent.TimeUnit
 
 private[zeromq] sealed trait PollLifeCycle

--- a/akka-zeromq/src/main/scala/akka/zeromq/SocketOption.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/SocketOption.scala
@@ -6,8 +6,8 @@ package akka.zeromq
 import com.google.protobuf.Message
 import org.zeromq.{ ZMQ ⇒ JZMQ }
 import akka.actor.ActorRef
-import akka.util.duration._
-import akka.util.Duration
+import scala.util.duration._
+import scala.util.Duration
 import org.zeromq.ZMQ.{ Poller, Socket }
 
 /**

--- a/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
@@ -3,7 +3,7 @@
  */
 package akka.zeromq
 
-import akka.util.duration._
+import scala.util.duration._
 import org.zeromq.{ ZMQ ⇒ JZMQ }
 import akka.actor._
 import akka.dispatch.{ Await }

--- a/akka-zeromq/src/test/scala/akka/zeromq/ConcurrentSocketActorSpec.scala
+++ b/akka-zeromq/src/test/scala/akka/zeromq/ConcurrentSocketActorSpec.scala
@@ -5,7 +5,7 @@ package akka.zeromq
 
 import org.scalatest.matchers.MustMatchers
 import akka.testkit.{ TestProbe, DefaultTimeout, AkkaSpec }
-import akka.util.duration._
+import scala.util.duration._
 import akka.actor.{ Cancellable, Actor, Props, ActorRef }
 
 object ConcurrentSocketActorSpec {


### PR DESCRIPTION
Changes: 
- removed methods sleep and printHMS
- fixed issues with construction of Duration from a String
- moved Duration and Timeout to a separate package
- refactored imports
