### PR TITLE
update to Havoc’s latest config lib from the serializable branch

### DIFF
--- a/akka-actor/src/main/java/com/typesafe/config/ConfigValue.java
+++ b/akka-actor/src/main/java/com/typesafe/config/ConfigValue.java
@@ -18,7 +18,7 @@ package com.typesafe.config;
  * interface is likely to grow new methods over time, so third-party
  * implementations will break.
  */
-public interface ConfigValue extends ConfigMergeable, java.io.Serializable {
+public interface ConfigValue extends ConfigMergeable {
     /**
      * The origin of the value (file, line number, etc.), for debugging and
      * error messages.

--- a/akka-actor/src/main/java/com/typesafe/config/impl/AbstractConfigValue.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/AbstractConfigValue.java
@@ -3,6 +3,8 @@
  */
 package com.typesafe.config.impl;
 
+import java.io.Serializable;
+
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigMergeable;
 import com.typesafe.config.ConfigOrigin;
@@ -16,7 +18,7 @@ import com.typesafe.config.ConfigValue;
  * improperly-factored and non-modular code. Please don't add parent().
  *
  */
-abstract class AbstractConfigValue implements ConfigValue, MergeableValue {
+abstract class AbstractConfigValue implements ConfigValue, MergeableValue, Serializable {
 
     final private SimpleConfigOrigin origin;
 

--- a/akka-actor/src/main/java/com/typesafe/config/impl/ConfigDelayedMerge.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/ConfigDelayedMerge.java
@@ -3,6 +3,7 @@
  */
 package com.typesafe.config.impl;
 
+import java.io.ObjectStreamException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -227,5 +228,15 @@ final class ConfigDelayedMerge extends AbstractConfigValue implements
             indent(sb, indent);
             sb.append("# ) end of unresolved merge\n");
         }
+    }
+
+    // This ridiculous hack is because some JDK versions apparently can't
+    // serialize an array, which is used to implement ArrayList and EmptyList.
+    // maybe
+    // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6446627
+    private Object writeReplace() throws ObjectStreamException {
+        // switch to LinkedList
+        return new ConfigDelayedMerge(origin(),
+                new java.util.LinkedList<AbstractConfigValue>(stack), ignoresFallbacks);
     }
 }

--- a/akka-actor/src/main/java/com/typesafe/config/impl/ConfigDelayedMergeObject.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/ConfigDelayedMergeObject.java
@@ -3,6 +3,7 @@
  */
 package com.typesafe.config.impl;
 
+import java.io.ObjectStreamException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -191,5 +192,15 @@ class ConfigDelayedMergeObject extends AbstractConfigObject implements
     @Override
     protected AbstractConfigValue peek(String key) {
         throw notResolved();
+    }
+
+    // This ridiculous hack is because some JDK versions apparently can't
+    // serialize an array, which is used to implement ArrayList and EmptyList.
+    // maybe
+    // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6446627
+    private Object writeReplace() throws ObjectStreamException {
+        // switch to LinkedList
+        return new ConfigDelayedMergeObject(origin(),
+                new java.util.LinkedList<AbstractConfigValue>(stack), ignoresFallbacks);
     }
 }

--- a/akka-actor/src/main/java/com/typesafe/config/impl/ConfigSubstitution.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/ConfigSubstitution.java
@@ -3,6 +3,7 @@
  */
 package com.typesafe.config.impl;
 
+import java.io.ObjectStreamException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -283,5 +284,15 @@ final class ConfigSubstitution extends AbstractConfigValue implements
                 sb.append(ConfigImplUtil.renderJsonString((String) p));
             }
         }
+    }
+
+    // This ridiculous hack is because some JDK versions apparently can't
+    // serialize an array, which is used to implement ArrayList and EmptyList.
+    // maybe
+    // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6446627
+    private Object writeReplace() throws ObjectStreamException {
+        // switch to LinkedList
+        return new ConfigSubstitution(origin(), new java.util.LinkedList<Object>(pieces),
+                prefixLength, ignoresFallbacks);
     }
 }

--- a/akka-actor/src/main/java/com/typesafe/config/impl/Path.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/Path.java
@@ -3,12 +3,13 @@
  */
 package com.typesafe.config.impl;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 
 import com.typesafe.config.ConfigException;
 
-final class Path {
+final class Path implements Serializable {
 
     final private String first;
     final private Path remainder;

--- a/akka-actor/src/main/java/com/typesafe/config/impl/SimpleConfig.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/SimpleConfig.java
@@ -3,6 +3,7 @@
  */
 package com.typesafe.config.impl;
 
+import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,7 +29,7 @@ import com.typesafe.config.ConfigValueType;
  * with a one-level java.util.Map from paths to non-null values. Null values are
  * not "in" the map.
  */
-final class SimpleConfig implements Config, MergeableValue, java.io.Serializable {
+final class SimpleConfig implements Config, MergeableValue, Serializable {
 
     final private AbstractConfigObject object;
 

--- a/akka-actor/src/main/java/com/typesafe/config/impl/SimpleConfigList.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/SimpleConfigList.java
@@ -3,6 +3,7 @@
  */
 package com.typesafe.config.impl;
 
+import java.io.ObjectStreamException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -21,7 +22,8 @@ final class SimpleConfigList extends AbstractConfigValue implements ConfigList {
     final private boolean resolved;
 
     SimpleConfigList(ConfigOrigin origin, List<AbstractConfigValue> value) {
-        this(origin, value, ResolveStatus.fromValues(value));
+        this(origin, value, ResolveStatus
+                .fromValues(value));
     }
 
     SimpleConfigList(ConfigOrigin origin, List<AbstractConfigValue> value,
@@ -365,5 +367,15 @@ final class SimpleConfigList extends AbstractConfigValue implements ConfigList {
     @Override
     protected SimpleConfigList newCopy(boolean ignoresFallbacks, ConfigOrigin newOrigin) {
         return new SimpleConfigList(newOrigin, value);
+    }
+
+    // This ridiculous hack is because some JDK versions apparently can't
+    // serialize an array, which is used to implement ArrayList and EmptyList.
+    // maybe
+    // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6446627
+    private Object writeReplace() throws ObjectStreamException {
+        // switch to LinkedList
+        return new SimpleConfigList(origin(), new java.util.LinkedList<AbstractConfigValue>(value),
+                resolveStatus());
     }
 }

--- a/akka-actor/src/main/java/com/typesafe/config/impl/SimpleConfigOrigin.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/SimpleConfigOrigin.java
@@ -4,6 +4,7 @@
 package com.typesafe.config.impl;
 
 import java.io.File;
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -17,7 +18,7 @@ import com.typesafe.config.ConfigOrigin;
 
 // it would be cleaner to have a class hierarchy for various origin types,
 // but was hoping this would be enough simpler to be a little messy. eh.
-final class SimpleConfigOrigin implements ConfigOrigin, java.io.Serializable {
+final class SimpleConfigOrigin implements ConfigOrigin, Serializable {
     final private String description;
     final private int lineNumber;
     final private int endLineNumber;

--- a/akka-actor/src/main/java/com/typesafe/config/impl/SubstitutionExpression.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/SubstitutionExpression.java
@@ -1,6 +1,8 @@
 package com.typesafe.config.impl;
 
-final class SubstitutionExpression {
+import java.io.Serializable;
+
+final class SubstitutionExpression implements Serializable {
 
     final private Path path;
     final private boolean optional;


### PR DESCRIPTION
Havoc made Config properly serializable (much more thorough than the band-aid I applied earlier).
