### PR TITLE
System.exit on fatal error and removed actor null check. See #1799 and #1768

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -34,6 +34,9 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference) {
 
         getMilliseconds("akka.scheduler.tickDuration") must equal(100)
         settings.SchedulerTickDuration must equal(100 millis)
+
+        settings.Daemonicity must be(false)
+        settings.JvmExitOnFatalError must be(true)
       }
 
       {

--- a/akka-actor-tests/src/test/scala/akka/util/NonFatalSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/NonFatalSpec.scala
@@ -19,18 +19,16 @@ class NonFatalSpec extends AkkaSpec with MustMatchers {
       }
     }
 
-    "not match StackOverflowError" in {
+    "match StackOverflowError" in {
       //not @tailrec
       def blowUp(n: Long): Long = {
         blowUp(n + 1) + 1
       }
 
-      intercept[StackOverflowError] {
-        try {
-          blowUp(0)
-        } catch {
-          case NonFatal(e) ⇒ assert(false)
-        }
+      try {
+        blowUp(0)
+      } catch {
+        case NonFatal(e) ⇒ // as expected
       }
     }
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -36,6 +36,9 @@ akka {
   # Toggles whether the threads created by this ActorSystem should be daemons or not
   daemonic = off
 
+  # JVM shutdown, System.exit(-1), in case of a fatal error, such as OutOfMemoryError
+  jvmExitOnFatalError = on
+
   actor {
 
     provider = "akka.actor.LocalActorRefProvider"
@@ -97,7 +100,7 @@ akka {
           paths = []
         }
 
-        # Routers with dynamically resizable number of routees; this feature is enabled 
+        # Routers with dynamically resizable number of routees; this feature is enabled
         # by including (parts of) this section in the deployment
         resizer {
 

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -476,10 +476,7 @@ private[akka] class ActorCell(
           cancelReceiveTimeout() // FIXME: leave this here???
           messageHandle.message match {
             case msg: AutoReceivedMessage ⇒ autoReceiveMessage(messageHandle)
-            // FIXME: actor can be null when creation fails with fatal error, why?
-            case msg if actor == null ⇒
-              system.eventStream.publish(Warning(self.path.toString, this.getClass, "Ignoring message due to null actor [%s]" format msg))
-            case msg ⇒ actor(msg)
+            case msg                      ⇒ actor(msg)
           }
           currentMessage = null // reset current message after successful invocation
         } catch {

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -92,6 +92,7 @@ object ActorSystem {
     final val SchedulerTickDuration = Duration(getMilliseconds("akka.scheduler.tickDuration"), MILLISECONDS)
     final val SchedulerTicksPerWheel = getInt("akka.scheduler.ticksPerWheel")
     final val Daemonicity = getBoolean("akka.daemonic")
+    final val JvmExitOnFatalError = getBoolean("akka.jvmExitOnFatalError")
 
     if (ConfigVersion != Version)
       throw new ConfigurationException("Akka JAR version [" + Version + "] does not match the provided config version [" + ConfigVersion + "]")
@@ -348,6 +349,7 @@ class ActorSystemImpl(val name: String, applicationConfig: Config) extends Exten
         log.error(cause, "Uncaught error from thread [{}]", thread.getName)
         cause match {
           case NonFatal(_) | _: InterruptedException ⇒
+          case _ if settings.JvmExitOnFatalError     ⇒ System.exit(-1)
           case _                                     ⇒ shutdown()
         }
       }

--- a/akka-actor/src/main/scala/akka/util/NonFatal.scala
+++ b/akka-actor/src/main/scala/akka/util/NonFatal.scala
@@ -5,8 +5,9 @@ package akka.util
 
 /**
  * Extractor of non-fatal Throwables. Will not match fatal errors
- * like VirtualMachineError (OutOfMemoryError, StackOverflowError)
- * ThreadDeath, and InterruptedException.
+ * like VirtualMachineError (OutOfMemoryError)
+ * ThreadDeath, LinkageError and InterruptedException.
+ * StackOverflowError is matched, i.e. considered non-fatal.
  *
  * Usage to catch all harmless throwables:
  * {{{
@@ -20,8 +21,9 @@ package akka.util
 object NonFatal {
 
   def unapply(t: Throwable): Option[Throwable] = t match {
-    // VirtualMachineError includes OutOfMemoryError, StackOverflowError and other fatal errors
-    case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException ⇒ None
+    case e: StackOverflowError ⇒ Some(e) // StackOverflowError ok even though it is a VirtualMachineError
+    // VirtualMachineError includes OutOfMemoryError and other fatal errors
+    case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException | _: LinkageError ⇒ None
     case e ⇒ Some(e)
   }
 


### PR DESCRIPTION
- Config property jvmExitOnFatalError
- System.exit in case of fatal error, such as OutOfMemoryError
- Adjusted NonFatal extractor, ok with StackOverflowError, not ok with LinkageError
- Removed the actor null check in ActorCell
