### PR TITLE
change serialization to strictly rely on subtyping

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -179,14 +179,10 @@ class SerializeSpec extends AkkaSpec(SerializeSpec.config) {
       ser.serializerFor(classOf[ExtendedPlainMessage]).getClass must be(classOf[TestSerializer])
     }
 
-    "resolve serializer for message with several bindings" in {
-      ser.serializerFor(classOf[Both]).getClass must be(classOf[TestSerializer])
-    }
-
-    "resolve serializer in the order of the bindings" in {
-      ser.serializerFor(classOf[A]).getClass must be(classOf[JavaSerializer])
-      ser.serializerFor(classOf[B]).getClass must be(classOf[TestSerializer])
-      ser.serializerFor(classOf[C]).getClass must be(classOf[JavaSerializer])
+    "throw exception for message with several bindings" in {
+      intercept[java.io.NotSerializableException] {
+        ser.serializerFor(classOf[Both])
+      }
     }
 
     "resolve serializer in the order of most specific binding first" in {

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -272,8 +272,8 @@ akka {
     }
 
     # Class to Serializer binding. You only need to specify the name of an interface
-    # or abstract base class of the messages. In case of ambiguity it is 
-    # using the most specific configured class, throwing an exception otherwise.
+    # or abstract base class of the messages. In case of ambiguity it is using the 
+    # most specific configured class, or giving a warning and choosing the “first” one.
     #
     # To disable one of the default serializers, assign its class to "none", like
     # "java.io.Serializable" = none

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -269,15 +269,16 @@ akka {
     # Entries for pluggable serializers and their bindings.
     serializers {
       java = "akka.serialization.JavaSerializer"
-      # proto = "akka.serialization.ProtobufSerializer"
     }
 
     # Class to Serializer binding. You only need to specify the name of an interface
-    # or abstract base class of the messages. In case of ambiguity it is primarily
-    # using the most specific configured class, and secondly the entry configured first.
+    # or abstract base class of the messages. In case of ambiguity it is 
+    # using the most specific configured class, throwing an exception otherwise.
+    #
+    # To disable one of the default serializers, assign its class to "none", like
+    # "java.io.Serializable" = none
     serialization-bindings {
       "java.io.Serializable" = java
-      #"com.google.protobuf.Message" = proto
     }
   }
 

--- a/akka-docs/java/serialization.rst
+++ b/akka-docs/java/serialization.rst
@@ -32,14 +32,26 @@ should be serialized using which ``Serializer``, this is done in the "akka.actor
 
 .. includecode:: ../scala/code/akka/docs/serialization/SerializationDocSpec.scala#serialization-bindings-config
 
-You only need to specify the name of an interface or abstract base class of the messages. In case of ambiguity,
-i.e. the message implements several of the configured classes, it is primarily using the most specific
-configured class, and secondly the entry configured first.
+You only need to specify the name of an interface or abstract base class of the
+messages. In case of ambiguity, i.e. the message implements several of the
+configured classes, the most specific configured class will be used, i.e. the
+one of which all other candidates are superclasses. If this condition cannot be
+met, because e.g. ``java.io.Serializable`` and ``MyOwnSerializable`` both apply
+and neither is a subtype of the other, an exception will be thrown during
+serialization.
 
-Akka provides serializers for ``java.io.Serializable`` and `protobuf <http://code.google.com/p/protobuf/>`_
-``com.google.protobuf.Message`` by default, so normally you don't need to add configuration for that, but
-it can be done to force a specific serializer in case messages implements both ``java.io.Serializable``
-and ``com.google.protobuf.Message``.
+Akka provides serializers for :class:`java.io.Serializable` and `protobuf
+<http://code.google.com/p/protobuf/>`_
+:class:`com.google.protobuf.GeneratedMessage` by default (the latter only if
+depending on the akka-remote module), so normally you don't need to add
+configuration for that; since :class:`com.google.protobuf.GeneratedMessage`
+implements :class:`java.io.Serializable`, protobuf messages will always by
+serialized using the protobuf protocol unless specifically overridden. In order
+to disable a default serializer, map its marker type to “none”::
+
+  akka.actor.serialization-bindings {
+    "java.io.Serializable" = none
+  }
 
 Verification
 ------------

--- a/akka-docs/java/serialization.rst
+++ b/akka-docs/java/serialization.rst
@@ -37,8 +37,7 @@ messages. In case of ambiguity, i.e. the message implements several of the
 configured classes, the most specific configured class will be used, i.e. the
 one of which all other candidates are superclasses. If this condition cannot be
 met, because e.g. ``java.io.Serializable`` and ``MyOwnSerializable`` both apply
-and neither is a subtype of the other, an exception will be thrown during
-serialization.
+and neither is a subtype of the other, a warning will be issued.
 
 Akka provides serializers for :class:`java.io.Serializable` and `protobuf
 <http://code.google.com/p/protobuf/>`_

--- a/akka-docs/scala/serialization.rst
+++ b/akka-docs/scala/serialization.rst
@@ -32,14 +32,26 @@ should be serialized using which ``Serializer``, this is done in the "akka.actor
 
 .. includecode:: code/akka/docs/serialization/SerializationDocSpec.scala#serialization-bindings-config
 
-You only need to specify the name of an interface or abstract base class of the messages. In case of ambiguity,
-i.e. the message implements several of the configured classes, it is primarily using the most specific
-configured class, and secondly the entry configured first.
+You only need to specify the name of an interface or abstract base class of the
+messages. In case of ambiguity, i.e. the message implements several of the
+configured classes, the most specific configured class will be used, i.e. the
+one of which all other candidates are superclasses. If this condition cannot be
+met, because e.g. ``java.io.Serializable`` and ``MyOwnSerializable`` both apply
+and neither is a subtype of the other, an exception will be thrown during
+serialization.
 
-Akka provides serializers for ``java.io.Serializable`` and `protobuf <http://code.google.com/p/protobuf/>`_
-``com.google.protobuf.Message`` by default, so normally you don't need to add configuration for that, but
-it can be done to force a specific serializer in case messages implements both ``java.io.Serializable``
-and ``com.google.protobuf.Message``.
+Akka provides serializers for :class:`java.io.Serializable` and `protobuf
+<http://code.google.com/p/protobuf/>`_
+:class:`com.google.protobuf.GeneratedMessage` by default (the latter only if
+depending on the akka-remote module), so normally you don't need to add
+configuration for that; since :class:`com.google.protobuf.GeneratedMessage`
+implements :class:`java.io.Serializable`, protobuf messages will always by
+serialized using the protobuf protocol unless specifically overridden. In order
+to disable a default serializer, map its marker type to “none”::
+
+  akka.actor.serialization-bindings {
+    "java.io.Serializable" = none
+  }
 
 Verification
 ------------

--- a/akka-docs/scala/serialization.rst
+++ b/akka-docs/scala/serialization.rst
@@ -37,8 +37,7 @@ messages. In case of ambiguity, i.e. the message implements several of the
 configured classes, the most specific configured class will be used, i.e. the
 one of which all other candidates are superclasses. If this condition cannot be
 met, because e.g. ``java.io.Serializable`` and ``MyOwnSerializable`` both apply
-and neither is a subtype of the other, an exception will be thrown during
-serialization.
+and neither is a subtype of the other, a warning will be issued
 
 Akka provides serializers for :class:`java.io.Serializable` and `protobuf
 <http://code.google.com/p/protobuf/>`_

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -5,20 +5,18 @@
 # This the reference config file has all the default settings.
 # Make your edits/overrides in your application.conf.
 
+# comments above akka.actor settings left out where they are already in akka-
+# actor.jar, because otherwise they would be repeated in config rendering.
+
 akka {
 
   actor {
 
-    # Entries for pluggable serializers and their bindings.
     serializers {
       proto = "akka.serialization.ProtobufSerializer"
     }
 
 
-    # Class to Serializer binding. You only need to specify the name of an interface
-    # or abstract base class of the messages. In case of ambiguity it is 
-    # using the most specific configured class, giving an error if two mappings are found
-    # which cannot be decided by sub-typing relation.
     serialization-bindings {
       # Since com.google.protobuf.Message does not extend Serializable but GeneratedMessage
       # does, need to use the more specific one here in order to avoid ambiguity

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -11,17 +11,18 @@ akka {
 
     # Entries for pluggable serializers and their bindings.
     serializers {
-      java = "akka.serialization.JavaSerializer"
       proto = "akka.serialization.ProtobufSerializer"
     }
 
 
     # Class to Serializer binding. You only need to specify the name of an interface
-    # or abstract base class of the messages. In case of ambiguity it is primarily
-    # using the most specific configured class, and secondly the entry configured first.
+    # or abstract base class of the messages. In case of ambiguity it is 
+    # using the most specific configured class, giving an error if two mappings are found
+    # which cannot be decided by sub-typing relation.
     serialization-bindings {
-      "com.google.protobuf.Message" = proto
-      "java.io.Serializable" = java
+      # Since com.google.protobuf.Message does not extend Serializable but GeneratedMessage
+      # does, need to use the more specific one here in order to avoid ambiguity
+      "com.google.protobuf.GeneratedMessage" = proto
     }
 
     deployment {


### PR DESCRIPTION
- when encountering new message type, check all bindings which map apply
- if multiple are found, choose the most specific one if that exists or
  verify that all mappings yield the same serializer
- in case of remaining ambiguity, throw exception
- also add special handling for “none” serializer mapping: turn off a
  default
