### PR TITLE
now that was a nice journey (related to #1804)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -15,6 +15,7 @@ import com.typesafe.config.ConfigFactory
 import akka.pattern.ask
 import java.util.concurrent.ConcurrentHashMap
 import com.typesafe.config.Config
+import akka.dispatch.Dispatchers
 
 object RoutingSpec {
 
@@ -51,6 +52,7 @@ object RoutingSpec {
         case (sender, message) ⇒ Nil
       }
     }
+    def routerDispatcher: String = Dispatchers.DefaultDispatcherId
   }
 
 }
@@ -538,6 +540,8 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
 
     //#crRouter
     case class VoteCountRouter() extends RouterConfig {
+
+      def routerDispatcher: String = Dispatchers.DefaultDispatcherId
 
       //#crRoute
       def createRoute(routeeProps: Props, routeeProvider: RouteeProvider): Route = {

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -796,7 +796,7 @@ class DefaultPromise[T](implicit val executor: ExecutionContext) extends Abstrac
 
   def result(atMost: Duration)(implicit permit: CanAwait): T =
     ready(atMost).value.get match {
-      case Left(e: AskTimeoutException) ⇒ throw new AskTimeoutException(e.getMessage, e)
+      case Left(e: AskTimeoutException) ⇒ throw new AskTimeoutException(e.getMessage, e) // to get meaningful stack trace
       case Left(e)                      ⇒ throw e
       case Right(r)                     ⇒ r
     }

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -189,7 +189,7 @@ private[akka] abstract class Mailbox(val actor: ActorCell) extends MessageQueue 
   final def processAllSystemMessages() {
     var nextMessage = systemDrain()
     try {
-      while (nextMessage ne null) {
+      while ((nextMessage ne null) && !isClosed) {
         if (debug) println(actor.self + " processing system message " + nextMessage + " with children " + actor.childrenRefs)
         actor systemInvoke nextMessage
         nextMessage = nextMessage.next

--- a/akka-docs/java/code/akka/docs/jrouting/CustomRouterDocTestBase.java
+++ b/akka-docs/java/code/akka/docs/jrouting/CustomRouterDocTestBase.java
@@ -17,6 +17,7 @@ import akka.util.Duration;
 import akka.util.Timeout;
 import akka.dispatch.Await;
 import akka.dispatch.Future;
+import akka.dispatch.Dispatchers;
 import akka.testkit.AkkaSpec;
 import com.typesafe.config.ConfigFactory;
 import static akka.pattern.Patterns.ask;
@@ -37,6 +38,19 @@ public class CustomRouterDocTestBase {
   @After
   public void tearDown() {
     system.shutdown();
+  }
+  
+  public static class MyActor extends UntypedActor {
+    @Override public void onReceive(Object o) {}
+  }
+  
+  @Test
+  public void demonstrateDispatchers() {
+    //#dispatchers
+    final ActorRef router = system.actorOf(new Props(MyActor.class)
+      .withRouter(new RoundRobinRouter(5).withDispatcher("head")) // “head” router runs on "head" dispatcher
+      .withDispatcher("workers")); // MyActor “workers” run on "workers" dispatcher
+    //#dispatchers
   }
 
   //#crTest
@@ -105,6 +119,10 @@ public class CustomRouterDocTestBase {
 
   //#crRouter
   public static class VoteCountRouter extends CustomRouterConfig {
+    
+    @Override public String routerDispatcher() {
+      return Dispatchers.DefaultDispatcherId();
+    }
 
     //#crRoute
     @Override

--- a/akka-docs/scala/code/akka/docs/routing/RouterDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/routing/RouterDocSpec.scala
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.docs.routing
+
+import RouterDocSpec.MyActor
+import akka.actor.{ Props, Actor }
+import akka.testkit.AkkaSpec
+import akka.routing.RoundRobinRouter
+
+object RouterDocSpec {
+  class MyActor extends Actor {
+    def receive = {
+      case _ ⇒
+    }
+  }
+}
+
+class RouterDocSpec extends AkkaSpec {
+
+  import RouterDocSpec._
+
+  //#dispatchers
+  val router = system.actorOf(Props[MyActor]
+    .withRouter(RoundRobinRouter(5, routerDispatcher = "router")) // “head” will run on "router" dispatcher
+    .withDispatcher("workers")) // MyActor workers will run on "workers" dispatcher
+  //#dispatchers
+
+}

--- a/akka-docs/scala/routing.rst
+++ b/akka-docs/scala/routing.rst
@@ -8,11 +8,6 @@ Routing (Scala)
 
    .. contents:: :local:
 
-Akka-core includes some building blocks to build more complex message flow handlers, they are listed and explained below:
-
-Router
-------
-
 A Router is an actor that routes incoming messages to outbound actors.
 The router routes the messages sent to it to its underlying actors called 'routees'.
 
@@ -250,6 +245,16 @@ This is an example of how to programatically create a resizable router:
 *It is also worth pointing out that if you define the ``router`` in the configuration file then this value
 will be used instead of any programmatically sent parameters.*
 
+.. note::
+
+  Resizing is triggered by sending messages to the actor pool, but it is not
+  completed synchronously; instead a message is sent to the “head”
+  :class:`Router` to perform the size change. Thus you cannot rely on resizing
+  to instantaneously create new workers when all others are busy, because the
+  message just sent will be queued to the mailbox of a busy actor. To remedy
+  this, configure the pool to use a balancing dispatcher, see `Configuring
+  Dispatchers`_ for more information.
+
 Custom Router
 ^^^^^^^^^^^^^
 
@@ -310,4 +315,24 @@ Custom Resizer
 A router with dynamically resizable number of routees is implemented by providing a ``akka.routing.Resizer``
 in ``resizer`` method of the ``RouterConfig``. See ``akka.routing.DefaultResizer`` for inspiration
 of how to write your own resize strategy.
+
+Configuring Dispatchers
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The dispatcher for created children of the router will be taken from
+:class:`Props` as described in :ref:`dispatchers-scala`. For a dynamic pool it
+makes sense to configure the :class:`BalancingDispatcher` if the precise
+routing is not so important (i.e. no consistent hashing or round-robin is
+required); this enables newly created routees to pick up work immediately by
+stealing it from their siblings.
+
+The “head” router, of couse, cannot run on the same balancing dispatcher,
+because it does not process the same messages, hence this special actor does
+not use the dispatcher configured in :class:`Props`, but takes the
+``routerDispatcher`` from the :class:`RouterConfig` instead, which defaults to
+the actor system’s default dispatcher. All standard routers allow setting this
+property in their constructor or factory method, custom routers have to
+implement the method in a suitable way.
+
+.. includecode:: code/akka/docs/routing/RouterDocSpec.scala#dispatchers
 

--- a/akka-remote/src/main/scala/akka/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/routing/RemoteRouterConfig.scala
@@ -30,6 +30,8 @@ case class RemoteRouterConfig(local: RouterConfig, nodes: Iterable[String]) exte
 
   override def createActor(): Router = local.createActor()
 
+  override def routerDispatcher: String = local.routerDispatcher
+
   override def resizer: Option[Resizer] = local.resizer
 
   override def withFallback(other: RouterConfig): RouterConfig = other match {


### PR DESCRIPTION
- first, fix quite some data races in RoutedActorRef wrt. the contained
  ActorCell’s childrenRef field (which is not even @volatile)
- then notice that there still are double-deregistrations happening in
  the dispatcher
- coming finally to the conclusion that the Mailbox should not really
  process all system messages in processAllSystemMessages(): we should
  really really stop after having closed the mailbox ;-)
- added simple test case which stops self twice to keep this fixed
