### PR TITLE
Remove unneeded word "that".

### DIFF
--- a/akka-docs/general/actors.rst
+++ b/akka-docs/general/actors.rst
@@ -132,7 +132,7 @@ Once an actor terminates, i.e. fails in a way which is not handled by a
 restart, stops itself or is stopped by its supervisor, it will free up its
 resources, draining all remaining messages from its mailbox into the system’s
 “dead letter mailbox”. The mailbox is then replaced within the actor reference
-with a that system mailbox, redirecting all new messages “into the drain”. This
+with a system mailbox, redirecting all new messages “into the drain”. This
 is done on a best effort basis, though, so do not rely on it in order to
 construct “guaranteed delivery”.
 


### PR DESCRIPTION
Extra word in this sentence that shouldn't be there.
