### PR TITLE
Add note about conflicting versions between play-mini and akka 

### DIFF
--- a/akka-docs/modules/http.rst
+++ b/akka-docs/modules/http.rst
@@ -21,6 +21,9 @@ In SBT you just have to add the following to your _libraryDependencies_::
 
   libraryDependencies += "com.typesafe" %% "play-mini" % "2.0-RC3-SNAPSHOT"
 
+Note: At the time of this writing play-mini version 2.0-RC3-SNAPSHOT (the current snapshot) only works with
+Akka versions 2.0-RC1 and below in the 2.x series.
+
 Sample Application
 ------------------
 


### PR DESCRIPTION
As of Akka version 2.0-RC2 release play-mini version 2.0-RC3-SNAPSHOT will compile but not run. See the following akka-users Google Group thread for more information:
http://groups.google.com/group/akka-user/browse_thread/thread/2ace8e084488c0e
