### PR TITLE
add serialVersionUID to ConfigSubstitution

### DIFF
--- a/akka-actor/src/main/java/com/typesafe/config/impl/ConfigSubstitution.java
+++ b/akka-actor/src/main/java/com/typesafe/config/impl/ConfigSubstitution.java
@@ -23,6 +23,8 @@ import com.typesafe.config.ConfigValueType;
 final class ConfigSubstitution extends AbstractConfigValue implements
         Unmergeable {
 
+    private static final long serialVersionUID = 1L;
+
     // this is a list of String and SubstitutionExpression where the
     // SubstitutionExpression has to be resolved to values, then if there's more
     // than one piece everything is stringified and concatenated


### PR DESCRIPTION
Maybe this is finally all the needed serialVersionUID!

This is a cherry pick from the config lib, does not
correspond to any specific commit ID of the lib.

(There are other fixes to config lib but they are
either risky or not super important.)
