### PR TITLE
fix shutdown of remote routers, see #1872

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -256,10 +256,9 @@ private[akka] class ActorCell(
 
   final def stop(actor: ActorRef): Unit = {
     val a = actor.asInstanceOf[InternalActorRef]
-    if (childrenRefs contains actor.path.name) {
+    if (a.getParent == self && (childrenRefs contains actor.path.name)) {
       system.locker ! a
-      childrenRefs -= actor.path.name
-      handleChildTerminated(actor)
+      handleChildTerminated(actor) // will remove child from childrenRefs
     }
     a.stop()
   }

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -497,6 +497,7 @@ class ActorSystemImpl protected[akka] (val name: String, applicationConfig: Conf
   private lazy val _start: this.type = {
     // the provider is expected to start default loggers, LocalActorRefProvider does this
     provider.init(this)
+    registerOnTermination(locker.shutdown())
     registerOnTermination(stopScheduler())
     loadExtensions()
     if (LogConfigOnStart) logConfiguration()

--- a/akka-actor/src/main/scala/akka/actor/Locker.scala
+++ b/akka-actor/src/main/scala/akka/actor/Locker.scala
@@ -23,8 +23,8 @@ private[akka] class Locker(
       val iter = heap.entrySet.iterator
       while (iter.hasNext) {
         val soul = iter.next()
-        deathWatch.subscribe(Locker.this, soul.getKey) // in case Terminated got lost somewhere
-        soul.getKey match {
+        deathWatch.subscribe(Locker.this, soul.getValue) // in case Terminated got lost somewhere
+        soul.getValue match {
           case _: LocalRef ⇒ // nothing to do, they know what they signed up for
           case nonlocal    ⇒ nonlocal.stop() // try again in case it was due to a communications failure
         }
@@ -32,17 +32,17 @@ private[akka] class Locker(
     }
   }
 
-  private val heap = new ConcurrentHashMap[InternalActorRef, Long]
+  private val heap = new ConcurrentHashMap[ActorPath, InternalActorRef]
 
   scheduler.schedule(period, period, new DavyJones)
 
   override def sendSystemMessage(msg: SystemMessage): Unit = this.!(msg)
 
   override def !(msg: Any)(implicit sender: ActorRef = null): Unit = msg match {
-    case Terminated(soul)      ⇒ heap.remove(soul)
-    case ChildTerminated(soul) ⇒ heap.remove(soul)
+    case Terminated(soul)      ⇒ heap.remove(soul.path)
+    case ChildTerminated(soul) ⇒ heap.remove(soul.path)
     case soul: InternalActorRef ⇒
-      heap.put(soul, 0l) // wanted to put System.nanoTime and do something intelligent, but forgot what that was
+      heap.put(soul.path, soul)
       deathWatch.subscribe(this, soul)
       // now re-bind the soul so that it does not drown its parent
       soul match {
@@ -52,6 +52,23 @@ private[akka] class Locker(
         case _ ⇒
       }
     case _ ⇒ // ignore
+  }
+
+  def childTerminated(parent: ActorRef, ct: ChildTerminated): Unit = {
+    heap.get(parent.path) match {
+      case null ⇒
+      case ref  ⇒ ref.sendSystemMessage(ct)
+    }
+  }
+
+  def shutdown(): Unit = {
+    import scala.collection.JavaConverters._
+    for (soul ← heap.values.asScala) {
+      soul match {
+        case l: LocalActorRef ⇒ l.underlying.dispatcher.detach(l.underlying)
+        case _                ⇒
+      }
+    }
   }
 
 }

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -11,6 +11,7 @@ import akka.event.{ LoggingAdapter, Logging }
 import akka.AkkaException
 import akka.serialization.Serialization
 import akka.remote.RemoteProtocol._
+import akka.dispatch.ChildTerminated
 
 /**
  * Remote life-cycle events.
@@ -273,6 +274,7 @@ trait RemoteMarshallingOps {
       case l: LocalRef ⇒
         if (provider.remoteSettings.LogReceive) log.debug("received local message {}", remoteMessage)
         remoteMessage.payload match {
+          case ct: ChildTerminated if l.isTerminated ⇒ provider.locker.childTerminated(l, ct)
           case msg: SystemMessage ⇒
             if (useUntrustedMode)
               throw new SecurityException("RemoteModule server is operating is untrusted mode, can not send system message")


### PR DESCRIPTION
- ActorCell.stop(actor) removed the actor from childrenRefs before
  handleChildTerminated, leading to removing from Locker immediately
  after adding it in
- intercept ChildTerminated message in RemoteTransport.receive if
  destination is not found (i.e. isTerminate==true) and re-route to
  Locker, which was changed to support path-based lookup to find the
  parent and funnel the ChildTerminated to its intended destination
- add Locker.shutdown() to detach remaining actors from their
  dispatchers upon system termination.
