### PR TITLE
fix implementation of PromiseStream.<<(elem1,elem2,elems)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/dispatch/PromiseStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/PromiseStreamSpec.scala
@@ -95,6 +95,17 @@ class PromiseStreamSpec extends AkkaSpec with DefaultTimeout {
       assert(Await.result(c, timeout.duration) === 4)
     }
 
+    "map futures" in {
+      val q = PromiseStream[String]()
+      flow {
+        q << (Future("a"), Future("b"), Future("c"))
+      }
+      val a, b, c = q.dequeue
+      Await.result(a, timeout.duration) must be("a")
+      Await.result(b, timeout.duration) must be("b")
+      Await.result(c, timeout.duration) must be("c")
+    }
+
     "not fail under concurrent stress" in {
       implicit val timeout = Timeout(60 seconds)
       val q = PromiseStream[Long](timeout.duration.toMillis)

--- a/akka-actor/src/main/scala/akka/dispatch/PromiseStream.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PromiseStream.scala
@@ -246,7 +246,10 @@ class PromiseStream[A](implicit val dispatcher: MessageDispatcher, val timeout: 
     shift { cont: (PromiseStream[A] ⇒ Future[Any]) ⇒ elem map (a ⇒ cont(this += a)) }
 
   final def <<(elem1: Future[A], elem2: Future[A], elems: Future[A]*): PromiseStream[A] @cps[Future[Any]] =
-    shift { cont: (PromiseStream[A] ⇒ Future[Any]) ⇒ Future.flow(this << elem1 << elem2 <<< Future.sequence(elems.toSeq)) map cont }
+    shift { cont: (PromiseStream[A] ⇒ Future[Any]) ⇒
+      val seq = Future.sequence(elem1 +: elem2 +: elems)
+      seq map (a ⇒ cont(this ++= a))
+    }
 
   final def <<<(elems: Traversable[A]): PromiseStream[A] @cps[Future[Any]] =
     shift { cont: (PromiseStream[A] ⇒ Future[Any]) ⇒ cont(this ++= elems) }


### PR DESCRIPTION
- was doing the first two item specially and the sequencing the rest,
  which makes for some weird semantics
