### PR TITLE
Added imports for things moved to akka.pattern._

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -28,6 +28,8 @@ import akka.event.LoggingAdapter
  *
  * Scala:
  * {{{
+ * import akka.pattern.ask
+ *
  * class ExampleActor extends Actor {
  *   val other = context.actorOf(Props[OtherActor], "childName") // will be destroyed and re-created upon restart by default
  *
@@ -41,6 +43,8 @@ import akka.event.LoggingAdapter
  *
  * Java:
  * {{{
+ * import static akka.pattern.Patterns.ask;
+ *
  * public class ExampleActor Extends UntypedActor {
  *   // this child will be destroyed and re-created upon restart by default
  *   final ActorRef other = getContext().actorOf(new Props(OtherActor.class), "childName");


### PR DESCRIPTION
The ask/? methods of ActorRefs were moved into akka.pattern, this patch adds the import in the Scaladoc so that there is at least a reference to akka.pattern.ask from ActorRef.

Should there also be a note with regards to that in the documentation?
