### PR TITLE
Make provider registration of PromiseActorRefs lazy + smaller fixes

### DIFF
--- a/akka-actor/src/main/java/akka/pattern/AbstractPromiseActorRef.java
+++ b/akka-actor/src/main/java/akka/pattern/AbstractPromiseActorRef.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.pattern;
+
+import akka.util.Unsafe;
+
+final class AbstractPromiseActorRef {
+    final static long stateOffset;
+
+    static {
+        try {
+            stateOffset = Unsafe.instance.objectFieldOffset(PromiseActorRef.class.getDeclaredField("_stateDoNotCallMeDirectly"));
+        } catch(Throwable t){
+            throw new ExceptionInInitializerError(t);
+        }
+    }
+}

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -166,10 +166,16 @@ trait AskSupport {
 
     final val running = new AtomicBoolean(true)
 
-    override def !(message: Any)(implicit sender: ActorRef = null): Unit = if (running.get) message match {
-      case Status.Success(r) ⇒ result.success(r)
-      case Status.Failure(f) ⇒ result.failure(f)
-      case other             ⇒ result.success(other)
+    override def !(message: Any)(implicit sender: ActorRef = null): Unit = {
+      try {
+        message match {
+          case Status.Success(r) ⇒ result.success(r)
+          case Status.Failure(f) ⇒ result.failure(f)
+          case other             ⇒ result.success(other)
+        }
+      } catch {
+        case _: IllegalStateException ⇒ // drop "already completed" error
+      }
     }
 
     override def sendSystemMessage(message: SystemMessage): Unit = message match {

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -1066,7 +1066,7 @@ trait ScatterGatherFirstCompletedLike { this: RouterConfig ⇒
     {
       case (sender, message) ⇒
         val provider: ActorRefProvider = routeeProvider.context.asInstanceOf[ActorCell].systemImpl.provider
-        val asker = akka.pattern.createAsker(provider, within)
+        val asker = akka.pattern.PromiseActorRef(provider, within)
         asker.result.pipeTo(sender)
         toAll(asker, routeeProvider.routees)
     }

--- a/akka-actor/src/main/scala/akka/util/Duration.scala
+++ b/akka-actor/src/main/scala/akka/util/Duration.scala
@@ -348,7 +348,7 @@ class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duration {
   def finite_? = true
 
   override def equals(other: Any) =
-    other.isInstanceOf[FiniteDuration] &&
+    (other.asInstanceOf[AnyRef] eq this) || other.isInstanceOf[FiniteDuration] &&
       toNanos == other.asInstanceOf[FiniteDuration].toNanos
 
   override def hashCode = toNanos.asInstanceOf[Int]


### PR DESCRIPTION
This pull request resulted from [this thread](http://groups.google.com/group/akka-user/browse_thread/thread/ffde93efdaa066cd) on the mailing list.

The central change is lazy registration of PromiseActorRefs with their ActorRefProvider reducing the overhead of a local `ask` by about 30%.

The two other commits fix a race condition in PromiseActorRef and add a tiny optimization to FiniteDuration.
