### PR TITLE
Made message conversions on producer more user friendly by renaming it a...

### DIFF
--- a/akka-camel/src/main/scala/akka/camel/Producer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Producer.scala
@@ -88,13 +88,13 @@ trait ProducerSupport { this: Actor ⇒
    * @see Producer#produce(Any, ExchangePattern)
    */
   protected def produce: Receive = {
-    case res: MessageResult ⇒ receiveAfterProduce(res.message)
-    case res: FailureResult ⇒ receiveAfterProduce(res.failure)
+    case res: MessageResult ⇒ routeResponse(res.message)
+    case res: FailureResult ⇒ routeResponse(res.failure)
     case msg ⇒ {
       if (oneway)
-        produce(receiveBeforeProduce(msg), ExchangePattern.InOnly)
+        produce(transformOutgoingMessage(msg), ExchangePattern.InOnly)
       else
-        produce(receiveBeforeProduce(msg), ExchangePattern.InOut)
+        produce(transformOutgoingMessage(msg), ExchangePattern.InOut)
     }
   }
 
@@ -103,7 +103,16 @@ trait ProducerSupport { this: Actor ⇒
    * message is passed as argument. By default, this method simply returns the argument but may be overridden
    * by subtraits or subclasses.
    */
-  protected def receiveBeforeProduce: PartialFunction[Any, Any] = {
+  protected def transformOutgoingMessage: PartialFunction[Any, Any] = {
+    case msg ⇒ msg
+  }
+
+  /**
+   * Called before the response message is sent to the original sender. The original
+   * message is passed as argument. By default, this method simply returns the argument but may be overridden
+   * by subtraits or subclasses.
+   */
+  protected def transformResponse: PartialFunction[Any, Any] = {
     case msg ⇒ msg
   }
 
@@ -114,8 +123,9 @@ trait ProducerSupport { this: Actor ⇒
    * done. This method may be overridden by subtraits or subclasses (e.g. to forward responses to another
    * actor).
    */
-  protected def receiveAfterProduce: Receive = {
-    case msg ⇒ if (!oneway) sender ! msg
+
+  protected def routeResponse: Receive = {
+    case msg ⇒ if (!oneway) sender ! transformResponse(msg)
   }
 
 }

--- a/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
+++ b/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
@@ -19,7 +19,14 @@ abstract class UntypedProducerActor extends UntypedActor with ProducerSupport {
    * message is passed as argument. By default, this method simply returns the argument but may be overridden
    * by subclasses.
    */
-  def onReceiveBeforeProduce(message: AnyRef): AnyRef = message
+  def onTransformOutgoingMessage(message: AnyRef): AnyRef = message
+
+  /**
+   * Called before the response message is sent to original sender. The original
+   * message is passed as argument. By default, this method simply returns the argument but may be overridden
+   * by subclasses.
+   */
+  def onTransformResponse(message: AnyRef): AnyRef = message
 
   /**
    * Called after a response was received from the endpoint specified by <code>endpointUri</code>. The
@@ -27,14 +34,18 @@ abstract class UntypedProducerActor extends UntypedActor with ProducerSupport {
    * if <code>oneway</code> is <code>false</code>. If <code>oneway</code> is <code>true</code>, nothing is
    * done. This method may be overridden by subclasses (e.g. to forward responses to another actor).
    */
-  def onReceiveAfterProduce(message: AnyRef): Unit = super.routeResponse(message)
+  def onRouteResponse(message: AnyRef): Unit = super.routeResponse(message)
 
   final override def transformOutgoingMessage = {
-    case msg: AnyRef ⇒ onReceiveBeforeProduce(msg)
+    case msg: AnyRef ⇒ onTransformOutgoingMessage(msg)
+  }
+
+  final override def transformResponse = {
+    case msg: AnyRef ⇒ onTransformResponse(msg)
   }
 
   final override def routeResponse = {
-    case msg: AnyRef ⇒ onReceiveAfterProduce(msg)
+    case msg: AnyRef ⇒ onRouteResponse(msg)
   }
 
   final override def endpointUri = getEndpointUri

--- a/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
+++ b/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
@@ -27,13 +27,13 @@ abstract class UntypedProducerActor extends UntypedActor with ProducerSupport {
    * if <code>oneway</code> is <code>false</code>. If <code>oneway</code> is <code>true</code>, nothing is
    * done. This method may be overridden by subclasses (e.g. to forward responses to another actor).
    */
-  def onReceiveAfterProduce(message: AnyRef): Unit = super.receiveAfterProduce(message)
+  def onReceiveAfterProduce(message: AnyRef): Unit = super.routeResponse(message)
 
-  final override def receiveBeforeProduce = {
+  final override def transformOutgoingMessage = {
     case msg: AnyRef ⇒ onReceiveBeforeProduce(msg)
   }
 
-  final override def receiveAfterProduce = {
+  final override def routeResponse = {
     case msg: AnyRef ⇒ onReceiveAfterProduce(msg)
   }
 

--- a/akka-camel/src/test/java/akka/camel/SampleUntypedForwardingProducer.java
+++ b/akka-camel/src/test/java/akka/camel/SampleUntypedForwardingProducer.java
@@ -15,7 +15,7 @@ public class SampleUntypedForwardingProducer extends UntypedProducerActor {
     }
 
     @Override
-    public void onReceiveAfterProduce(Object message) {
+    public void onRouteResponse(Object message) {
         CamelMessage msg = (CamelMessage)message;
         String body = msg.getBodyAs(String.class,getCamelContext());
         getProducerTemplate().sendBody("direct:forward-test-1", body);

--- a/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
@@ -266,7 +266,7 @@ object ProducerFeatureTest {
   class TestProducer(uri: String, upper: Boolean = false) extends Actor with Producer {
     def endpointUri = uri
 
-    override protected def receiveBeforeProduce = {
+    override protected def transformOutgoingMessage = {
       case msg: CamelMessage ⇒ if (upper) msg.mapBody {
         body: String ⇒ body.toUpperCase
       }
@@ -277,7 +277,7 @@ object ProducerFeatureTest {
   class TestForwarder(uri: String, target: ActorRef) extends Actor with Producer {
     def endpointUri = uri
 
-    override protected def receiveAfterProduce = {
+    override protected def routeResponse = {
       case msg ⇒ target forward msg
     }
   }


### PR DESCRIPTION
This is a proposal of new naming as the reciveAfterProduce etc. were expressing implementation details and confusing for the user.
