### PR TITLE
add nat-friendly remote support option

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -69,15 +69,22 @@ akka {
     # If this is "on", Akka will log all outbound messages at DEBUG level, if off then they are not logged
     log-sent-messages = off
 
-    # If this is true, messages
-    nat-friendly = false
+    # nat-firewall will allow/disallow incoming messages where the destination host and port in the message does not
+    # match the host and port of this node.
+    #
+    # This is useful in cases such as sending messages to an actor system that is for instance
+    # sitting behind an Elastic IP on EC2.
+    #
+    # Behavior:
+    #
+    # nat-firewall = "whitelist"  + nat-firewall-addresses is empty     == none allowed (default)
+    # nat-firewall = "blacklist"  + nat-firewall-addresses is empty     == all allowed
+    # nat-firewall = "whitelist"  + nat-firewall-addresses is not empty == only allow listed
+    # nat-firewall = "blacklist"  + nat-firewall-addresses is not empty == do not allow listed
 
-    # A list of hostnames and ports that this node can accept messages on behalf of
-              #
-              #   The format should be on "host:port", where:
-              #    - hostname is the 'public' side of the NAT, and can be either hostname or IP address
-              #    - port is the 'public' side of the NAT
-    nat-whitelist = []
+    nat-firewall = "whitelist"
+
+    nat-firewall-addresses = []
 
     # Each property is annotated with (I) or (O) or (I&O), where I stands for “inbound” and O for “outbound” connections.
     # The NettyRemoteTransport always starts the server role to allow inbound connections, and it starts

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -69,6 +69,16 @@ akka {
     # If this is "on", Akka will log all outbound messages at DEBUG level, if off then they are not logged
     log-sent-messages = off
 
+    # If this is true, messages
+    nat-friendly = false
+
+    # A list of hostnames and ports that this node can accept messages on behalf of
+              #
+              #   The format should be on "host:port", where:
+              #    - hostname is the 'public' side of the NAT, and can be either hostname or IP address
+              #    - port is the 'public' side of the NAT
+    nat-whitelist = []
+
     # Each property is annotated with (I) or (O) or (I&O), where I stands for “inbound” and O for “outbound” connections.
     # The NettyRemoteTransport always starts the server role to allow inbound connections, and it starts
     # active client connections whenever sending to a destination which is not yet connected; if configured

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -6,17 +6,22 @@ package akka.remote
 import com.typesafe.config.Config
 import akka.util.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import java.net.InetAddress
-import akka.config.ConfigurationException
-import scala.collection.JavaConverters._
-import akka.actor.Address
-import akka.actor.AddressFromURIString
+import collection.JavaConverters._
 
 class RemoteSettings(val config: Config, val systemName: String) {
+
   import config._
+
   val RemoteTransport = getString("akka.remote.transport")
   val LogReceive = getBoolean("akka.remote.log-received-messages")
   val LogSend = getBoolean("akka.remote.log-sent-messages")
   val RemoteSystemDaemonAckTimeout = Duration(getMilliseconds("akka.remote.remote-daemon-ack-timeout"), MILLISECONDS)
   val UntrustedMode = getBoolean("akka.remote.untrusted-mode")
+  val NATFriendly = getBoolean("akka.remote.nat-friendly")
+  val NATWhitelist = {
+    if (hasPath("akka.remote.nat-whitelist"))
+      getStringList("akka.remote.nat-whitelist").asScala.toList
+    else
+      List.empty[String]
+  }
 }

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -17,11 +17,9 @@ class RemoteSettings(val config: Config, val systemName: String) {
   val LogSend = getBoolean("akka.remote.log-sent-messages")
   val RemoteSystemDaemonAckTimeout = Duration(getMilliseconds("akka.remote.remote-daemon-ack-timeout"), MILLISECONDS)
   val UntrustedMode = getBoolean("akka.remote.untrusted-mode")
-  val NATFriendly = getBoolean("akka.remote.nat-friendly")
-  val NATWhitelist = {
-    if (hasPath("akka.remote.nat-whitelist"))
-      getStringList("akka.remote.nat-whitelist").asScala.toList
-    else
-      List.empty[String]
+  val NATFirewall = getString("akka.remote.nat-firewall") match {
+    case firewall if firewall == "whitelist" || firewall == "blacklist" ⇒ firewall
+    case bad ⇒ throw new IllegalArgumentException("akka.remote.nat-firewall was not set to whitelist or blacklist")
   }
+  val NATFirewallAddresses = Set() ++ getStringList("akka.remote.nat-firewall-addresses").asScala
 }

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -5,13 +5,12 @@
 package akka.remote
 
 import scala.reflect.BeanProperty
-import akka.actor.{ Terminated, LocalRef, InternalActorRef, AutoReceivedMessage, AddressFromURIString, Address, ActorSystemImpl, ActorSystem, ActorRef }
 import akka.dispatch.SystemMessage
 import akka.event.{ LoggingAdapter, Logging }
 import akka.AkkaException
 import akka.serialization.Serialization
 import akka.remote.RemoteProtocol._
-import akka.dispatch.ChildTerminated
+import akka.actor._
 
 /**
  * Remote life-cycle events.
@@ -32,6 +31,7 @@ case class RemoteClientError(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty remoteAddress: Address) extends RemoteClientLifeCycleEvent {
   override def logLevel = Logging.ErrorLevel
+
   override def toString =
     "RemoteClientError@" + remoteAddress + ": Error[" + cause + "]"
 }
@@ -40,6 +40,7 @@ case class RemoteClientDisconnected(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty remoteAddress: Address) extends RemoteClientLifeCycleEvent {
   override def logLevel = Logging.DebugLevel
+
   override def toString =
     "RemoteClientDisconnected@" + remoteAddress
 }
@@ -48,6 +49,7 @@ case class RemoteClientConnected(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty remoteAddress: Address) extends RemoteClientLifeCycleEvent {
   override def logLevel = Logging.DebugLevel
+
   override def toString =
     "RemoteClientConnected@" + remoteAddress
 }
@@ -56,6 +58,7 @@ case class RemoteClientStarted(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty remoteAddress: Address) extends RemoteClientLifeCycleEvent {
   override def logLevel = Logging.InfoLevel
+
   override def toString =
     "RemoteClientStarted@" + remoteAddress
 }
@@ -64,6 +67,7 @@ case class RemoteClientShutdown(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty remoteAddress: Address) extends RemoteClientLifeCycleEvent {
   override def logLevel = Logging.InfoLevel
+
   override def toString =
     "RemoteClientShutdown@" + remoteAddress
 }
@@ -74,6 +78,7 @@ case class RemoteClientWriteFailed(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty remoteAddress: Address) extends RemoteClientLifeCycleEvent {
   override def logLevel = Logging.WarningLevel
+
   override def toString =
     "RemoteClientWriteFailed@" + remoteAddress +
       ": MessageClass[" + (if (request ne null) request.getClass.getName else "no message") +
@@ -88,6 +93,7 @@ trait RemoteServerLifeCycleEvent extends RemoteLifeCycleEvent
 case class RemoteServerStarted(
   @transient @BeanProperty remote: RemoteTransport) extends RemoteServerLifeCycleEvent {
   override def logLevel = Logging.InfoLevel
+
   override def toString =
     "RemoteServerStarted@" + remote
 }
@@ -95,6 +101,7 @@ case class RemoteServerStarted(
 case class RemoteServerShutdown(
   @transient @BeanProperty remote: RemoteTransport) extends RemoteServerLifeCycleEvent {
   override def logLevel = Logging.InfoLevel
+
   override def toString =
     "RemoteServerShutdown@" + remote
 }
@@ -103,6 +110,7 @@ case class RemoteServerError(
   @BeanProperty val cause: Throwable,
   @transient @BeanProperty remote: RemoteTransport) extends RemoteServerLifeCycleEvent {
   override def logLevel = Logging.ErrorLevel
+
   override def toString =
     "RemoteServerError@" + remote + "] Error[" + cause + "]"
 }
@@ -111,6 +119,7 @@ case class RemoteServerClientConnected(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty val clientAddress: Option[Address]) extends RemoteServerLifeCycleEvent {
   override def logLevel = Logging.DebugLevel
+
   override def toString =
     "RemoteServerClientConnected@" + remote +
       ": Client[" + clientAddress.getOrElse("no address") + "]"
@@ -120,6 +129,7 @@ case class RemoteServerClientDisconnected(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty val clientAddress: Option[Address]) extends RemoteServerLifeCycleEvent {
   override def logLevel = Logging.DebugLevel
+
   override def toString =
     "RemoteServerClientDisconnected@" + remote +
       ": Client[" + clientAddress.getOrElse("no address") + "]"
@@ -129,6 +139,7 @@ case class RemoteServerClientClosed(
   @transient @BeanProperty remote: RemoteTransport,
   @BeanProperty val clientAddress: Option[Address]) extends RemoteServerLifeCycleEvent {
   override def logLevel = Logging.DebugLevel
+
   override def toString =
     "RemoteServerClientClosed@" + remote +
       ": Client[" + clientAddress.getOrElse("no address") + "]"
@@ -183,7 +194,7 @@ abstract class RemoteTransport {
    */
   def restartClientConnection(address: Address): Boolean
 
-  /** Methods that needs to be implemented by a transport **/
+  /**Methods that needs to be implemented by a transport **/
 
   protected[akka] def send(message: Any,
                            senderOption: Option[ActorRef],
@@ -288,9 +299,18 @@ trait RemoteMarshallingOps {
           case AddressFromURIString(address) if address == provider.transport.address ⇒
             // if it was originally addressed to us but is in fact remote from our point of view (i.e. remote-deployed)
             r.!(remoteMessage.payload)(remoteMessage.sender)
+          case ActorPathExtractor(natAddress, elements) if natOK(natAddress.host, natAddress.port) ⇒
+            //address akka://sys@host:port
+            system.actorFor(elements).tell(remoteMessage.payload, remoteMessage.sender)
           case r ⇒ log.error("dropping message {} for non-local recipient {} at {} local is {}", remoteMessage.payload, r, address, provider.transport.address)
         }
       case r ⇒ log.error("dropping message {} for non-local recipient {} of type {}", remoteMessage.payload, r, if (r ne null) r.getClass else "null")
     }
+  }
+
+  private def natOK(hostOpt: Option[String], portOpt: Option[Int]): Boolean = {
+    provider.remoteSettings.NATFriendly &&
+      (provider.remoteSettings.NATWhitelist.isEmpty ||
+        (hostOpt.isDefined && portOpt.isDefined && provider.remoteSettings.NATWhitelist.contains(hostOpt.get + ":" + portOpt.get)))
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,8 @@ resolvers ++= Seq(
   "coda" at "http://repo.codahale.com")
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.1")
+
+resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.0.0")
+


### PR DESCRIPTION
This is for ticket #1981, and would allow akka remoting to be used in many more scenarios than it can be currently, such as sending to actor systems sitting behind elastic IPs, load balancers, etc
