### PR TITLE
Wip 1980 java case objects ∂π

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
@@ -32,18 +32,18 @@ public class JavaAPI {
   // compilation tests
   @SuppressWarnings("unused")
   public void mustCompile() {
-    final Kill kill = Kill.instance();
-    final PoisonPill pill = PoisonPill.instance();
-    final ReceiveTimeout t = ReceiveTimeout.instance();
+    final Kill kill = Kill.getInstance();
+    final PoisonPill pill = PoisonPill.getInstance();
+    final ReceiveTimeout t = ReceiveTimeout.getInstance();
 
-    final LocalScope ls = LocalScope.instance();
-    final NoScopeGiven noscope = NoScopeGiven.instance();
+    final LocalScope ls = LocalScope.getInstance();
+    final NoScopeGiven noscope = NoScopeGiven.getInstance();
     
     final LoggerInitialized x = Logging.loggerInitialized();
     
-    final CurrentRoutees r = CurrentRoutees.instance();
-    final NoRouter nr = NoRouter.instance();
-    final FromConfig fc = FromConfig.instance();
+    final CurrentRoutees r = CurrentRoutees.getInstance();
+    final NoRouter nr = NoRouter.getInstance();
+    final FromConfig fc = FromConfig.getInstance();
   }
 
   @Test

--- a/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
@@ -1,7 +1,12 @@
 package akka.actor;
 
 import akka.actor.ActorSystem;
+import akka.event.Logging;
+import akka.event.Logging.LoggerInitialized;
 import akka.japi.Creator;
+import akka.routing.CurrentRoutees;
+import akka.routing.FromConfig;
+import akka.routing.NoRouter;
 import akka.testkit.AkkaSpec;
 
 import org.junit.AfterClass;
@@ -22,6 +27,23 @@ public class JavaAPI {
   public static void afterAll() {
     system.shutdown();
     system = null;
+  }
+  
+  // compilation tests
+  @SuppressWarnings("unused")
+  public void mustCompile() {
+    final Kill kill = Kill.instance();
+    final PoisonPill pill = PoisonPill.instance();
+    final ReceiveTimeout t = ReceiveTimeout.instance();
+
+    final LocalScope ls = LocalScope.instance();
+    final NoScopeGiven noscope = NoScopeGiven.instance();
+    
+    final LoggerInitialized x = Logging.loggerInitialized();
+    
+    final CurrentRoutees r = CurrentRoutees.instance();
+    final NoRouter nr = NoRouter.instance();
+    final FromConfig fc = FromConfig.instance();
   }
 
   @Test

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -30,19 +30,28 @@ case class Failed(cause: Throwable) extends AutoReceivedMessage with PossiblyHar
 
 abstract class PoisonPill extends AutoReceivedMessage with PossiblyHarmful
 case object PoisonPill extends PoisonPill {
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }
 
 abstract class Kill extends AutoReceivedMessage with PossiblyHarmful
 case object Kill extends Kill {
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }
 
 case class Terminated(@BeanProperty actor: ActorRef) extends PossiblyHarmful
 
 abstract class ReceiveTimeout extends PossiblyHarmful
 case object ReceiveTimeout extends ReceiveTimeout {
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -28,13 +28,22 @@ trait NoSerializationVerificationNeeded
 
 case class Failed(cause: Throwable) extends AutoReceivedMessage with PossiblyHarmful
 
-case object PoisonPill extends AutoReceivedMessage with PossiblyHarmful
+abstract class PoisonPill extends AutoReceivedMessage with PossiblyHarmful
+case object PoisonPill extends PoisonPill {
+  def instance = this
+}
 
-case object Kill extends AutoReceivedMessage with PossiblyHarmful
+abstract class Kill extends AutoReceivedMessage with PossiblyHarmful
+case object Kill extends Kill {
+  def instance = this
+}
 
 case class Terminated(@BeanProperty actor: ActorRef) extends PossiblyHarmful
 
-case object ReceiveTimeout extends PossiblyHarmful
+abstract class ReceiveTimeout extends PossiblyHarmful
+case object ReceiveTimeout extends ReceiveTimeout {
+  def instance = this
+}
 
 /**
  * ActorRefFactory.actorSelection returns a special ref which sends these

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -71,7 +71,10 @@ case object LocalScope extends LocalScope {
   @deprecated("use instance() method instead", "2.0.1")
   def scope: Scope = this
 
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 
   def withFallback(other: Scope): Scope = this
 }
@@ -84,7 +87,10 @@ abstract class NoScopeGiven extends Scope
 case object NoScopeGiven extends NoScopeGiven {
   def withFallback(other: Scope): Scope = other
 
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -63,11 +63,15 @@ trait Scope {
 }
 
 //TODO add @SerialVersionUID(1L) when SI-4804 is fixed
-case object LocalScope extends Scope {
+abstract class LocalScope extends Scope
+case object LocalScope extends LocalScope {
   /**
    * Java API
    */
+  @deprecated("use instance() method instead", "2.0.1")
   def scope: Scope = this
+
+  def instance = this
 
   def withFallback(other: Scope): Scope = this
 }
@@ -76,8 +80,11 @@ case object LocalScope extends Scope {
  * This is the default value and as such allows overrides.
  */
 //TODO add @SerialVersionUID(1L) when SI-4804 is fixed
-case object NoScopeGiven extends Scope {
+abstract class NoScopeGiven extends Scope
+case object NoScopeGiven extends NoScopeGiven {
   def withFallback(other: Scope): Scope = other
+
+  def instance = this
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -590,7 +590,10 @@ object Logging {
    */
   abstract class LoggerInitialized
   case object LoggerInitialized extends LoggerInitialized {
-    def instance = this
+    /**
+     * Java API: get the singleton instance
+     */
+    def getInstance = this
   }
 
   /**

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -588,12 +588,16 @@ object Logging {
    * InitializeLogger request. If initialization takes longer, send the reply
    * as soon as subscriptions are set-up.
    */
-  case object LoggerInitialized
+  abstract class LoggerInitialized
+  case object LoggerInitialized extends LoggerInitialized {
+    def instance = this
+  }
 
   /**
    * Java API to create a LoggerInitialized message.
    */
-  def loggerInitialized() = LoggerInitialized
+  // weird return type due to binary compatibility
+  def loggerInitialized(): LoggerInitialized.type = LoggerInitialized
 
   class LoggerInitializationException(msg: String) extends AkkaException(msg)
 

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -17,7 +17,8 @@ import java.util.concurrent.locks.ReentrantLock
 import akka.jsr166y.ThreadLocalRandom
 import akka.util.Unsafe
 import akka.dispatch.Dispatchers
-import annotation.tailrec
+import scala.annotation.tailrec
+import scala.runtime.ScalaRunTime
 
 /**
  * A RoutedActorRef is an ActorRef that has a set of connected ActorRef and it uses a Router to
@@ -343,7 +344,10 @@ case class Broadcast(message: Any)
  * A RouterRoutees message is sent asynchronously to the "requester" containing information
  * about what routees the router is routing over.
  */
-case object CurrentRoutees
+abstract class CurrentRoutees
+case object CurrentRoutees extends CurrentRoutees {
+  def instance = this
+}
 
 /**
  * Message used to carry information about what routees the router is currently using.
@@ -365,21 +369,23 @@ case class Destination(sender: ActorRef, recipient: ActorRef)
  * router is taken in the LocalActorRefProvider based on Props.
  */
 //TODO add @SerialVersionUID(1L) when SI-4804 is fixed
-case object NoRouter extends RouterConfig {
+abstract class NoRouter extends RouterConfig
+case object NoRouter extends NoRouter {
   def createRoute(props: Props, routeeProvider: RouteeProvider): Route = null
   def routerDispatcher: String = ""
   def supervisorStrategy = null
   override def withFallback(other: RouterConfig): RouterConfig = other
+
+  def instance = this
 }
 
 /**
  * Router configuration which has no default, i.e. external configuration is required.
  */
-case object FromConfig extends RouterConfig {
-  def createRoute(props: Props, routeeProvider: RouteeProvider): Route =
-    throw new ConfigurationException("router " + routeeProvider.context.self + " needs external configuration from file (e.g. application.conf)")
-  def routerDispatcher: String = Dispatchers.DefaultDispatcherId
-  def supervisorStrategy: SupervisorStrategy = Router.defaultSupervisorStrategy
+case object FromConfig extends FromConfig {
+  def instance = this
+  def apply(routerDispatcher: String = Dispatchers.DefaultDispatcherId) = new FromConfig(routerDispatcher)
+  def unapply(fc: FromConfig): Option[String] = Some(fc.routerDispatcher)
 }
 
 /**
@@ -389,7 +395,11 @@ case object FromConfig extends RouterConfig {
  * (defaults to default-dispatcher).
  */
 //TODO add @SerialVersionUID(1L) when SI-4804 is fixed
-case class FromConfig(val routerDispatcher: String = Dispatchers.DefaultDispatcherId) extends RouterConfig {
+class FromConfig(val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
+  extends RouterConfig
+  with Product
+  with Serializable
+  with Equals {
 
   def this() = this(Dispatchers.DefaultDispatcherId)
 
@@ -397,6 +407,31 @@ case class FromConfig(val routerDispatcher: String = Dispatchers.DefaultDispatch
     throw new ConfigurationException("router " + routeeProvider.context.self + " needs external configuration from file (e.g. application.conf)")
 
   def supervisorStrategy: SupervisorStrategy = Router.defaultSupervisorStrategy
+
+  // open-coded case class to preserve binary compatibility, all deprecated for 2.1
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  override def productPrefix = "FromConfig"
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  def productArity = 1
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  def productElement(x: Int) = x match {
+    case 0 ⇒ routerDispatcher
+    case _ ⇒ throw new IndexOutOfBoundsException(x.toString)
+  }
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  def copy(d: String = Dispatchers.DefaultDispatcherId): FromConfig = new FromConfig(d)
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  def canEqual(o: Any) = o.isInstanceOf[FromConfig]
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  override def hashCode = ScalaRunTime._hashCode(this)
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  override def toString = "FromConfig(" + routerDispatcher + ")"
+  @deprecated("FromConfig does not make sense as case class", "2.0.1")
+  override def equals(other: Any): Boolean = other match {
+    case FromConfig(x) ⇒ x == routerDispatcher
+    case _             ⇒ false
+  }
+
 }
 
 object RoundRobinRouter {

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -346,7 +346,10 @@ case class Broadcast(message: Any)
  */
 abstract class CurrentRoutees
 case object CurrentRoutees extends CurrentRoutees {
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }
 
 /**
@@ -376,16 +379,22 @@ case object NoRouter extends NoRouter {
   def supervisorStrategy = null
   override def withFallback(other: RouterConfig): RouterConfig = other
 
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }
 
 /**
  * Router configuration which has no default, i.e. external configuration is required.
  */
 case object FromConfig extends FromConfig {
-  def instance = this
-  def apply(routerDispatcher: String = Dispatchers.DefaultDispatcherId) = new FromConfig(routerDispatcher)
-  def unapply(fc: FromConfig): Option[String] = Some(fc.routerDispatcher)
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
+  @inline final def apply(routerDispatcher: String = Dispatchers.DefaultDispatcherId) = new FromConfig(routerDispatcher)
+  @inline final def unapply(fc: FromConfig): Option[String] = Some(fc.routerDispatcher)
 }
 
 /**
@@ -411,21 +420,28 @@ class FromConfig(val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
   // open-coded case class to preserve binary compatibility, all deprecated for 2.1
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   override def productPrefix = "FromConfig"
+
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   def productArity = 1
+
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   def productElement(x: Int) = x match {
     case 0 ⇒ routerDispatcher
     case _ ⇒ throw new IndexOutOfBoundsException(x.toString)
   }
+
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   def copy(d: String = Dispatchers.DefaultDispatcherId): FromConfig = new FromConfig(d)
+
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   def canEqual(o: Any) = o.isInstanceOf[FromConfig]
+
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   override def hashCode = ScalaRunTime._hashCode(this)
+
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   override def toString = "FromConfig(" + routerDispatcher + ")"
+
   @deprecated("FromConfig does not make sense as case class", "2.0.1")
   override def equals(other: Any): Boolean = other match {
     case FromConfig(x) ⇒ x == routerDispatcher

--- a/akka-zeromq/src/main/scala/akka/zeromq/Response.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/Response.scala
@@ -11,8 +11,12 @@ sealed trait Response
 /**
  * When the ZeroMQ socket connects it sends this message to a listener
  */
-case object Connecting extends Response
+case object Connecting extends Response {
+  def instance = this
+}
 /**
  * When the ZeroMQ socket disconnects it sends this message to a listener
  */
-case object Closed extends Response
+case object Closed extends Response {
+  def instance = this
+}

--- a/akka-zeromq/src/main/scala/akka/zeromq/Response.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/Response.scala
@@ -12,11 +12,17 @@ sealed trait Response
  * When the ZeroMQ socket connects it sends this message to a listener
  */
 case object Connecting extends Response {
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }
 /**
  * When the ZeroMQ socket disconnects it sends this message to a listener
  */
 case object Closed extends Response {
-  def instance = this
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
 }


### PR DESCRIPTION
- “case object” will emit a concrete class without constructor, so put
  abstract class in its way in order to obtain an accessible type for
  Scala & Java (i.e. without $)
- add “def instance = this” to make access uniform from Java
- this does not work for nested case objects because of missing static
  forwarders, so keep those as they were
- fix issue with case object FromConfig colliding with case class
  FromConfig by open-coding the “case”iness in this case (should be
  thrown out in 2.1)
