### PR TITLE
[Ticket 2001] Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: scala
+
+# Override Travis CI default 'script' and 'scala' values for following reasons:
+#  - Each branch will dynamically builds against Scala version required in project/AkkaBuild.scala
+#  - Add extra option to sbt (-XX:ReservedCodeCacheSize=64M) to prevent memory troubles during build
+#  - Run the tests in parallel, as described in http://doc.akka.io/docs/akka/snapshot/dev/building-akka.html
+
+scala: "'version defined in project/AkkaBuild.scala'"
+script: "$CUSTOM_SBT compile && $CUSTOM_SBT -Dakka.parallelExecution=true test"
+
+env:
+  - CUSTOM_SBT="java -Xms256M -Xmx512M -Xss1M -XX:ReservedCodeCacheSize=64M -XX:+CMSClassUnloadingEnabled -XX:PermSize=256M -XX:MaxPermSize=512M -jar /usr/lib/sbt-0.11.2/sbt-launch.jar"
+
+branches:
+  only:
+    - master
+    - /^release-2\..+$/
+
+notifications:
+  # Email notifications are disabled to not annoy anybody.
+  # See http://about.travis-ci.org/docs/user/build-configuration/ to learn more
+  # about configuring notification recipients and more (e.g. IRC notifications).
+  email: false


### PR DESCRIPTION
This pull request is related to http://www.assembla.com/spaces/akka/tickets/2001-proposal--integrate-github-akka-akka-repository-with-travis-ci-service.

Since Travis CI now [officially supports Scala](http://about.travis-ci.org/blog/announcing_support_for_java_scala_and_groovy_on_travis_ci/), I invite you to configure main (active) branches, to get all the benefits of this amazing Continuous Integration platform.
### Mini-HowTo plug a github project to Travis CI

(excerpt from [Travis documentation](http://about.travis-ci.org/docs/user/getting-started/)
1. Sign in http://travis-ci.org/ through GitHub OAuth (follow the Sign In link)
2. Activate GitHub Service Hook from you [profile page](http://travis-ci.org/profile)
3. Add .travis.yml file to your repository

Since Akka branches support only one specific version of Scala, I had to override defaults in `.travis.yml`. If in the future a same branch supports a matrix of Scala versions, you can easily configure Travis to run a specific build for each version (see [Scalatra example](https://github.com/scalatra/scalatra/commit/3ddbf152b4ab33872cd8f7a0efa9b0b3b77f81c1) or [Guide: Building a Scala project with Travis](http://about.travis-ci.org/docs/user/languages/scala/)).
### Some test examples randomly fail

I observed that on **the absolutely same code (e.g. a tag)** some tests may randomly fail. Is it a known issue on you dev/test platforms ? Actually I found following issue about non-deterministic build failures, that would be interesting to compare/discuss:
- http://www.assembla.com/spaces/akka/tickets/1021-jenkins-unreliable

See these two examples that builds recent release 2.0.1:
- [Failure](http://travis-ci.org/#!/gildegoma/akka/builds/1100609) (see errors on ResizerSpec execution)
- [Success](http://travis-ci.org/#!/gildegoma/akka/builds/1119015)

Other _random failure_ example can be seen in Test runs 32 (failed) and 33 (succeed) in the [Travis Build History](http://travis-ci.org/#!/gildegoma/akka/builds)

Could warnings like _[...] received dead letter from Actor[akka://ResizerSpec/deadLetters]_ related to the problem ?
### Last but not least: Thanks to Akka Team!

My Akka fork has been heavily used during the creation of Travis builder for Scala (especially for SBT/JVM memory tuning). I take the opportunity of this PR to congratulate all Akka contributors. With such nice set of Tests/Specifications, I think it really makes sense to take advantage of Travis and effortless continuous integration.
### Notes
- I already signed the CLA (even if changes proposed here are not influencing Akka source code, I guess it would be expected)
