### PR TITLE
Fixed ByteStringBuilder.resizeTemp

### DIFF
--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -349,6 +349,7 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
     val newtemp = new Array[Byte](size)
     if (_tempLength > 0) Array.copy(_temp, 0, newtemp, 0, _tempLength)
     _temp = newtemp
+    _tempCapacity = _temp.length
   }
 
   private def ensureTempSize(size: Int) {


### PR DESCRIPTION
ByteStringBuilder single-byte addition (with +=) was unusable due to exponential time behaviour.
Reason: resizeTemp didn't update _tempCapacity, causing ByteStringBuilder to create a new _temp array on each call of +=.

Test case (took 30s to complete):

``` scala
val bld = new ByteStringBuilder()
for (i <- 0 to 300000) { bld += 0.toByte }
```
