### PR TITLE
closes #2019: Use parentheses for arity-0 methods which are not referent...

### DIFF
--- a/akka-actor-migration/src/main/scala/akka/actor/OldActor.scala
+++ b/akka-actor-migration/src/main/scala/akka/actor/OldActor.scala
@@ -95,7 +95,7 @@ abstract class OldActor extends Actor {
     @deprecated("Use context.setReceiveTimeout instead", "2.0")
     def receiveTimeout_=(timeout: Option[Long]) = setReceiveTimeout(timeout.getOrElse(0L))
 
-    @deprecated("Use self.isTerminated instead", "2.0")
+    @deprecated("Use self.isTerminated() instead", "2.0")
     def isShutdown: Boolean = self.isTerminated
 
     @deprecated("Use sender instead", "2.0")

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorFireForgetRequestReplySpec.scala
@@ -84,11 +84,11 @@ class ActorFireForgetRequestReplySpec extends AkkaSpec with BeforeAndAfterEach w
         val supervisor = system.actorOf(Props(new Supervisor(
           OneForOneStrategy(maxNrOfRetries = 0)(List(classOf[Exception])))))
         val actor = Await.result((supervisor ? Props[CrashingActor]).mapTo[ActorRef], timeout.duration)
-        actor.isTerminated must be(false)
+        actor.isTerminated() must be(false)
         actor ! "Die"
         state.finished.await
         1.second.dilated.sleep()
-        actor.isTerminated must be(true)
+        actor.isTerminated() must be(true)
         system.stop(supervisor)
       }
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
@@ -132,14 +132,14 @@ class ActorLookupSpec extends AkkaSpec with DefaultTimeout {
       system.actorFor(a.path.toString) must be === a
       system.actorFor(a.path.elements) must be === a
       system.actorFor(a.path.toString + "/") must be === a
-      system.actorFor(a.path.toString + "/hallo").isTerminated must be === true
-      f.isCompleted must be === false
-      a.isTerminated must be === false
+      system.actorFor(a.path.toString + "/hallo").isTerminated() must be === true
+      f.isCompleted() must be === false
+      a.isTerminated() must be === false
       a ! 42
-      f.isCompleted must be === true
+      f.isCompleted() must be === true
       Await.result(f, timeout.duration) must be === 42
       // clean-up is run as onComplete callback, i.e. dispatched on another thread
-      awaitCond(system.actorFor(a.path).isTerminated, 1 second)
+      awaitCond(system.actorFor(a.path).isTerminated(), 1 second)
     }
 
   }
@@ -247,13 +247,13 @@ class ActorLookupSpec extends AkkaSpec with DefaultTimeout {
       Await.result(c2 ? LookupString("../../" + a.path.elements.mkString("/") + "/"), timeout.duration) must be === a
       Await.result(c2 ? LookupElems(Seq("..", "..") ++ a.path.elements), timeout.duration) must be === a
       Await.result(c2 ? LookupElems(Seq("..", "..") ++ a.path.elements :+ ""), timeout.duration) must be === a
-      f.isCompleted must be === false
-      a.isTerminated must be === false
+      f.isCompleted() must be === false
+      a.isTerminated() must be === false
       a ! 42
-      f.isCompleted must be === true
+      f.isCompleted() must be === true
       Await.result(f, timeout.duration) must be === 42
       // clean-up is run as onComplete callback, i.e. dispatched on another thread
-      awaitCond(Await.result(c2 ? LookupPath(a.path), timeout.duration).asInstanceOf[ActorRef].isTerminated, 1 second)
+      awaitCond(Await.result(c2 ? LookupPath(a.path), timeout.duration).asInstanceOf[ActorRef].isTerminated(), 1 second)
     }
 
   }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -374,7 +374,7 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
       Await.result(ffive, timeout.duration) must be("five")
       Await.result(fnull, timeout.duration) must be("null")
 
-      awaitCond(ref.isTerminated, 2000 millis)
+      awaitCond(ref.isTerminated(), 2000 millis)
     }
 
     "restart when Kill:ed" in {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -94,12 +94,12 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
       callbackWasRun must be(true)
     }
 
-    "return isTerminated status correctly" in {
+    "return isTerminated() status correctly" in {
       val system = ActorSystem()
-      system.isTerminated must be(false)
+      system.isTerminated() must be(false)
       system.shutdown()
       system.awaitTermination()
-      system.isTerminated must be(true)
+      system.isTerminated() must be(true)
     }
 
     "throw RejectedExecutionException when shutdown" in {

--- a/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
@@ -108,7 +108,7 @@ trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout â‡
         terminal ! Kill
 
         expectTerminationOf(terminal)
-        terminal.isTerminated must be === true
+        terminal.isTerminated() must be === true
 
         system.stop(supervisor)
       }
@@ -139,7 +139,7 @@ trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout â‡
           case FF(Failed(DeathPactException(`failed`))) if lastSender eq brother â‡’ 2
           case Terminated(`brother`) â‡’ 3
         }
-        testActor.isTerminated must not be true
+        testActor.isTerminated() must not be true
         result must be(Seq(1, 2, 3))
       }
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
@@ -95,7 +95,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
 
       (1 to 100) foreach { _ ⇒ slave ! Crash }
       Await.ready(countDownLatch, 2 minutes)
-      assert(!slave.isTerminated)
+      assert(!slave.isTerminated())
     }
 
     "ensure that slave restarts after number of crashes not within time range" in {
@@ -153,7 +153,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
 
       Await.ready(thirdRestartLatch, 1 second)
 
-      assert(!slave.isTerminated)
+      assert(!slave.isTerminated())
     }
 
     "ensure that slave is not restarted after max retries" in {
@@ -190,7 +190,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
       // test restart and post restart ping
       Await.ready(restartLatch, 10 seconds)
 
-      assert(!slave.isTerminated)
+      assert(!slave.isTerminated())
 
       // now crash again... should not restart
       slave ! Crash
@@ -204,7 +204,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
       slave ! Crash
       Await.ready(stopLatch, 10 seconds)
       sleep(500L)
-      assert(slave.isTerminated)
+      assert(slave.isTerminated())
     }
 
     "ensure that slave is not restarted within time range" in {
@@ -243,7 +243,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
       // test restart and post restart ping
       Await.ready(restartLatch, 10 seconds)
 
-      assert(!slave.isTerminated)
+      assert(!slave.isTerminated())
 
       // now crash again... should not restart
       slave ! Crash
@@ -259,7 +259,7 @@ class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
 
       Await.ready(maxNoOfRestartsLatch, 10 seconds)
       sleep(500L)
-      assert(slave.isTerminated)
+      assert(slave.isTerminated())
     }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
@@ -76,7 +76,7 @@ class SupervisorMiscSpec extends AkkaSpec(SupervisorMiscSpec.config) with Defaul
       }
       expectMsg("preStart")
       expectMsg("preStart")
-      a.isTerminated must be(false)
+      a.isTerminated() must be(false)
     }
 
     "be able to recreate child when old child is Terminated" in {
@@ -88,8 +88,8 @@ class SupervisorMiscSpec extends AkkaSpec(SupervisorMiscSpec.config) with Defaul
               val newKid = context.actorOf(Props.empty, "foo")
               val result =
                 if (newKid eq kid) "Failure: context.actorOf returned the same instance!"
-                else if (!kid.isTerminated) "Kid is zombie"
-                else if (newKid.isTerminated) "newKid was stillborn"
+                else if (!kid.isTerminated()) "Kid is zombie"
+                else if (newKid.isTerminated()) "newKid was stillborn"
                 else if (kid.path != newKid.path) "The kids do not share the same path"
                 else "green"
               testActor ! result

--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -276,7 +276,7 @@ class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
     "be able to call Future-returning methods non-blockingly" in {
       val t = newFooBar
       val f = t.futurePigdog(200)
-      f.isCompleted must be(false)
+      f.isCompleted() must be(false)
       Await.result(f, timeout.duration) must be("Pigdog")
       mustStop(t)
     }
@@ -307,7 +307,7 @@ class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
     "be able to compose futures without blocking" in {
       val t, t2 = newFooBar(Duration(2, "s"))
       val f = t.futureComposePigdogFrom(t2)
-      f.isCompleted must be(false)
+      f.isCompleted() must be(false)
       Await.result(f, timeout.duration) must equal("PIGDOG")
       mustStop(t)
       mustStop(t2)
@@ -354,8 +354,8 @@ class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
       val t: Foo = TypedActor(system).typedActorOf(TypedProps[Bar]())
       val f = t.futurePigdog(200)
       val f2 = t.futurePigdog(0)
-      f2.isCompleted must be(false)
-      f.isCompleted must be(false)
+      f2.isCompleted() must be(false)
+      f.isCompleted() must be(false)
       Await.result(f, timeout.duration) must equal(Await.result(f2, timeout.duration))
       mustStop(t)
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -374,7 +374,7 @@ abstract class ActorModelSpec(config: String) extends AkkaSpec(config) with Defa
                   def compare(l: AnyRef, r: AnyRef) = (l, r) match { case (ll: ActorCell, rr: ActorCell) ⇒ ll.self.path compareTo rr.self.path }
                 } foreach {
                   case cell: ActorCell ⇒
-                    System.err.println(" - " + cell.self.path + " " + cell.isTerminated + " " + cell.mailbox.status + " " + cell.mailbox.numberOfMessages + " " + SystemMessage.size(cell.mailbox.systemDrain()))
+                    System.err.println(" - " + cell.self.path + " " + cell.isTerminated() + " " + cell.mailbox.status + " " + cell.mailbox.numberOfMessages + " " + SystemMessage.size(cell.mailbox.systemDrain()))
                 }
 
                 System.err.println("Mailbox: " + mq.numberOfMessages + " " + mq.hasMessages)
@@ -507,7 +507,7 @@ class DispatcherModelSpec extends ActorModelSpec(DispatcherModelSpec.config) {
       system.stop(a)
       system.stop(b)
 
-      while (!a.isTerminated && !b.isTerminated) {} //Busy wait for termination
+      while (!a.isTerminated() && !b.isTerminated()) {} //Busy wait for termination
 
       assertRefDefaultZero(a)(registers = 1, unregisters = 1, msgsReceived = 1, msgsProcessed = 1)
       assertRefDefaultZero(b)(registers = 1, unregisters = 1, msgsReceived = 1, msgsProcessed = 1)
@@ -581,7 +581,7 @@ class BalancingDispatcherModelSpec extends ActorModelSpec(BalancingDispatcherMod
       system.stop(a)
       system.stop(b)
 
-      while (!a.isTerminated && !b.isTerminated) {} //Busy wait for termination
+      while (!a.isTerminated() && !b.isTerminated()) {} //Busy wait for termination
 
       assertRefDefaultZero(a)(registers = 1, unregisters = 1, msgsReceived = 1, msgsProcessed = 1)
       assertRefDefaultZero(b)(registers = 1, unregisters = 1, msgsReceived = 1, msgsProcessed = 1)

--- a/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
@@ -647,20 +647,20 @@ class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with Defa
           one() + two()
         }
 
-        assert(List(one, two, simpleResult).forall(_.isCompleted == false))
+        assert(List(one, two, simpleResult).forall(_.isCompleted() == false))
 
         flow { one << 1 }
 
         Await.ready(one, 1 minute)
 
-        assert(one.isCompleted)
-        assert(List(two, simpleResult).forall(_.isCompleted == false))
+        assert(one.isCompleted())
+        assert(List(two, simpleResult).forall(_.isCompleted() == false))
 
         flow { two << 9 }
 
         Await.ready(two, 1 minute)
 
-        assert(List(one, two).forall(_.isCompleted == true))
+        assert(List(one, two).forall(_.isCompleted() == true))
         assert(Await.result(simpleResult, timeout.duration) === 10)
 
       }
@@ -680,7 +680,7 @@ class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with Defa
         Await.ready(lx, 2 seconds)
         assert(!ly.isOpen)
         assert(!lz.isOpen)
-        assert(List(x1, x2, y1, y2).forall(_.isCompleted == false))
+        assert(List(x1, x2, y1, y2).forall(_.isCompleted() == false))
 
         flow { y1 << 1 } // When this is set, it should cascade down the line
 
@@ -693,7 +693,7 @@ class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with Defa
         Await.ready(lz, 2 seconds)
         assert(Await.result(x2, 1 minute) === 9)
 
-        assert(List(x1, x2, y1, y2).forall(_.isCompleted))
+        assert(List(x1, x2, y1, y2).forall(_.isCompleted()))
 
         assert(Await.result(result, 1 minute) === 10)
       }
@@ -710,7 +710,7 @@ class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with Defa
 
         assert(!s1.isOpen)
         assert(!s2.isOpen)
-        assert(!result.isCompleted)
+        assert(!result.isCompleted())
         Await.ready(i1, 2 seconds)
         Await.ready(i2, 2 seconds)
         s1.open()
@@ -757,7 +757,7 @@ class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with Defa
           Some(future()).filter(_ == "Hello")
         }
 
-        assert(!result.isCompleted)
+        assert(!result.isCompleted())
 
         latch.open()
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
@@ -109,7 +109,7 @@ abstract class MailboxSpec extends AkkaSpec with BeforeAndAfterAll with BeforeAn
 
     def createConsumer: Future[Vector[Envelope]] = spawn {
       var r = Vector[Envelope]()
-      while (producers.exists(_.isCompleted == false) || q.hasMessages) {
+      while (producers.exists(_.isCompleted() == false) || q.hasMessages) {
         q.dequeue match {
           case null    ⇒
           case message ⇒ r = r :+ message

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -137,7 +137,7 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterEach with BeforeAnd
         expectMsgPF() {
           case Logging.Debug(`name`, _, msg: String) if msg startsWith "received AutoReceiveMessage Envelope(PoisonPill" ⇒ true
         }
-        awaitCond(actor.isTerminated, 100 millis)
+        awaitCond(actor.isTerminated(), 100 millis)
       }
     }
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -14,7 +14,7 @@ class AskSpec extends AkkaSpec with DefaultTimeout {
     "return broken promises on DeadLetters" in {
       val dead = system.actorFor("/system/deadLetters")
       val f = dead.ask(42)(1 second)
-      f.isCompleted must be(true)
+      f.isCompleted() must be(true)
       f.value.get match {
         case Left(_: AskTimeoutException) ⇒
         case v                            ⇒ fail(v + " was not Left(AskTimeoutException)")
@@ -24,7 +24,7 @@ class AskSpec extends AkkaSpec with DefaultTimeout {
     "return broken promises on EmptyLocalActorRefs" in {
       val empty = system.actorFor("unknown")
       val f = empty ? 3.14
-      f.isCompleted must be(true)
+      f.isCompleted() must be(true)
       f.value.get match {
         case Left(_: AskTimeoutException) ⇒
         case v                            ⇒ fail(v + " was not Left(AskTimeoutException)")

--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -172,7 +172,7 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
   "no router" must {
     "be started when constructed" in {
       val routedActor = system.actorOf(Props[TestActor].withRouter(NoRouter))
-      routedActor.isTerminated must be(false)
+      routedActor.isTerminated() must be(false)
     }
 
     "send message to connection" in {
@@ -200,7 +200,7 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
   "round robin router" must {
     "be started when constructed" in {
       val routedActor = system.actorOf(Props[TestActor].withRouter(RoundRobinRouter(nrOfInstances = 1)))
-      routedActor.isTerminated must be(false)
+      routedActor.isTerminated() must be(false)
     }
 
     //In this test a bunch of actors are created and each actor has its own counter.
@@ -281,7 +281,7 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
 
     "be started when constructed" in {
       val routedActor = system.actorOf(Props[TestActor].withRouter(RandomRouter(nrOfInstances = 1)))
-      routedActor.isTerminated must be(false)
+      routedActor.isTerminated() must be(false)
     }
 
     "deliver a broadcast message" in {
@@ -318,7 +318,7 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
   "smallest mailbox router" must {
     "be started when constructed" in {
       val routedActor = system.actorOf(Props[TestActor].withRouter(SmallestMailboxRouter(nrOfInstances = 1)))
-      routedActor.isTerminated must be(false)
+      routedActor.isTerminated() must be(false)
     }
 
     "deliver messages to idle actor" in {
@@ -373,7 +373,7 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
   "broadcast router" must {
     "be started when constructed" in {
       val routedActor = system.actorOf(Props[TestActor].withRouter(BroadcastRouter(nrOfInstances = 1)))
-      routedActor.isTerminated must be(false)
+      routedActor.isTerminated() must be(false)
     }
 
     "broadcast message using !" in {
@@ -442,7 +442,7 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
     "be started when constructed" in {
       val routedActor = system.actorOf(Props[TestActor].withRouter(
         ScatterGatherFirstCompletedRouter(routees = List(newActor(0)), within = 1 seconds)))
-      routedActor.isTerminated must be(false)
+      routedActor.isTerminated() must be(false)
     }
 
     "deliver a broadcast message using the !" in {
@@ -525,14 +525,14 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
     }
     "support custom router" in {
       val myrouter = system.actorOf(Props().withRouter(FromConfig), "myrouter")
-      myrouter.isTerminated must be(false)
+      myrouter.isTerminated() must be(false)
     }
   }
 
   "custom router" must {
     "be started when constructed" in {
       val routedActor = system.actorOf(Props[TestActor].withRouter(VoteCountRouter()))
-      routedActor.isTerminated must be(false)
+      routedActor.isTerminated() must be(false)
     }
 
     "count votes as intended - not as in Florida" in {

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -231,7 +231,7 @@ trait Actor {
    * Is defined if the message was sent from another Actor,
    * else `deadLetters` in [[akka.actor.ActorSystem]].
    */
-  final def sender: ActorRef = context.sender
+  final def sender(): ActorRef = context.sender
 
   /**
    * This defines the initial actor behavior, it must return a partial function

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -90,7 +90,7 @@ trait ActorContext extends ActorRefFactory {
   /**
    * Returns the sender 'ActorRef' of the current message.
    */
-  def sender: ActorRef
+  def sender(): ActorRef
 
   /**
    * Returns all supervised children; this method returns a view onto the
@@ -422,7 +422,7 @@ private[akka] class ActorCell(
    */
   final def getDispatcher(): MessageDispatcher = dispatcher
 
-  final def isTerminated: Boolean = mailbox.isClosed
+  final def isTerminated(): Boolean = mailbox.isClosed
 
   final def start(): Unit = {
     /*
@@ -474,7 +474,7 @@ private[akka] class ActorCell(
   final def tell(message: Any, sender: ActorRef): Unit =
     dispatcher.dispatch(this, Envelope(message, if (sender eq null) system.deadLetters else sender)(system))
 
-  final def sender: ActorRef = currentMessage match {
+  final def sender(): ActorRef = currentMessage match {
     case null                      ⇒ system.deadLetters
     case msg if msg.sender ne null ⇒ msg.sender
     case _                         ⇒ system.deadLetters

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -117,7 +117,7 @@ abstract class ActorRef extends java.lang.Comparable[ActorRef] with Serializable
    * The contract is that if this method returns true, then it will never be false again.
    * But you cannot rely on that it is alive if it returns true, since this by nature is a racy method.
    */
-  def isTerminated: Boolean
+  def isTerminated(): Boolean
 
   // FIXME RK check if we should scramble the bits or whether they can stay the same
   final override def hashCode: Int = path.hashCode
@@ -161,11 +161,11 @@ trait ScalaActorRef { ref: ActorRef ⇒
  * is the only method provided on the scope.
  */
 trait ActorRefScope {
-  def isLocal: Boolean
+  def isLocal(): Boolean
 }
 
 trait LocalRef extends ActorRefScope {
-  final def isLocal = true
+  final def isLocal() = true
 }
 
 /**
@@ -208,7 +208,7 @@ private[akka] abstract class InternalActorRef extends ActorRef with ScalaActorRe
    * Scope: if this ref points to an actor which resides within the same JVM,
    * i.e. whose mailbox is directly reachable etc.
    */
-  def isLocal: Boolean
+  def isLocal(): Boolean
 }
 
 /**
@@ -259,7 +259,7 @@ private[akka] class LocalActorRef private[akka] (
    * If this method returns true, it will never return false again, but if it
    * returns false, you cannot be sure if it's alive still (race condition)
    */
-  override def isTerminated: Boolean = actorCell.isTerminated
+  override def isTerminated(): Boolean = actorCell.isTerminated
 
   /**
    * Suspends the actor so that it will not process messages until resumed. The
@@ -376,7 +376,7 @@ private[akka] trait MinimalActorRef extends InternalActorRef with LocalRef {
 
   def stop(): Unit = ()
 
-  def isTerminated = false
+  def isTerminated() = false
 
   def !(message: Any)(implicit sender: ActorRef = null): Unit = ()
 

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -352,7 +352,7 @@ class LocalActorRefProvider(
       terminationFuture.complete(causeOfTermination.toLeft(()))
     }
 
-    override def isTerminated = stopped.isOn
+    override def isTerminated() = stopped.isOn
 
     override def !(message: Any)(implicit sender: ActorRef = null): Unit = stopped.ifOff(message match {
       case Failed(ex) if sender ne null ⇒ causeOfTermination = Some(ex); sender.asInstanceOf[InternalActorRef].stop()

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -352,7 +352,7 @@ abstract class ActorSystem extends ActorRefFactory {
    * returns `false`, the status is actually unknown, since it might have
    * changed since you queried it.
    */
-  def isTerminated: Boolean
+  def isTerminated(): Boolean
 
   /**
    * Registers the provided extension and creates its payload, if this extension isn't already registered
@@ -572,7 +572,7 @@ class ActorSystemImpl protected[akka] (val name: String, applicationConfig: Conf
   def registerOnTermination(code: Runnable) { terminationCallbacks.add(code) }
   def awaitTermination(timeout: Duration) { Await.ready(terminationCallbacks, timeout) }
   def awaitTermination() = awaitTermination(Duration.Inf)
-  def isTerminated = terminationCallbacks.isTerminated
+  def isTerminated() = terminationCallbacks.isTerminated
 
   def shutdown(): Unit = guardian.stop()
 
@@ -709,6 +709,6 @@ class ActorSystemImpl protected[akka] (val name: String, applicationConfig: Conf
 
     final def result(atMost: Duration)(implicit permit: CanAwait): Unit = ready(atMost)
 
-    final def isTerminated: Boolean = latch.getCount == 0
+    final def isTerminated(): Boolean = latch.getCount == 0
   }
 }

--- a/akka-actor/src/main/scala/akka/actor/IO.scala
+++ b/akka-actor/src/main/scala/akka/actor/IO.scala
@@ -932,7 +932,7 @@ final class IOManagerActor extends Actor {
       case Some(channel) ⇒
         channel.close
         channels -= handle
-        if (!handle.owner.isTerminated) handle.owner ! IO.Closed(handle, cause)
+        if (!handle.owner.isTerminated()) handle.owner ! IO.Closed(handle, cause)
       case None ⇒
     }
   }

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -125,7 +125,7 @@ class DefaultScheduler(hashedWheelTimer: HashedWheelTimer,
       def run(timeout: HWTimeout) {
         receiver ! message
         // Check if the receiver is still alive and kicking before reschedule the task
-        if (receiver.isTerminated) {
+        if (receiver.isTerminated()) {
           log.debug("Could not reschedule message to be sent because receiving actor has been terminated.")
         } else {
           scheduleNext(timeout, delay, continuousCancellable)

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -191,7 +191,7 @@ object MessageDispatcher {
       val c = println(d + " inhabitants: " + d.inhabitants)
       a ← actors.valueIterator(d)
     } {
-      val status = if (a.isTerminated) " (terminated)" else " (alive)"
+      val status = if (a.isTerminated()) " (terminated)" else " (alive)"
       val messages = a match {
         case l: LocalActorRef ⇒ " " + l.underlying.mailbox.numberOfMessages + " messages"
         case _                ⇒ " " + a.getClass

--- a/akka-actor/src/main/scala/akka/dispatch/PromiseStream.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PromiseStream.scala
@@ -167,7 +167,7 @@ class PromiseStream[A](implicit val dispatcher: MessageDispatcher, val timeout: 
         } else {
           if (_pendOut.compareAndSet(po, po.tail)) {
             po.head success elem
-            if (!po.head.isCompleted) enqueue(elem)
+            if (!po.head.isCompleted()) enqueue(elem)
           } else enqueue(elem)
         }
       }

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -204,7 +204,7 @@ trait ExecutorServiceDelegate extends ExecutorService {
 
   def isShutdown = executor.isShutdown
 
-  def isTerminated = executor.isTerminated
+  def isTerminated() = executor.isTerminated
 
   def awaitTermination(l: Long, timeUnit: TimeUnit) = executor.awaitTermination(l, timeUnit)
 

--- a/akka-actor/src/main/scala/akka/event/EventBus.scala
+++ b/akka-actor/src/main/scala/akka/event/EventBus.scala
@@ -245,19 +245,19 @@ trait ActorClassification { this: ActorEventBus with ActorClassifier ⇒
     val current = mappings get monitored
     current match {
       case null ⇒
-        if (monitored.isTerminated) false
+        if (monitored.isTerminated()) false
         else {
           if (mappings.putIfAbsent(monitored, empty + monitor) ne null) associate(monitored, monitor)
-          else if (monitored.isTerminated) !dissociate(monitored, monitor) else true
+          else if (monitored.isTerminated()) !dissociate(monitored, monitor) else true
         }
       case raw: TreeSet[_] ⇒
         val v = raw.asInstanceOf[TreeSet[ActorRef]]
-        if (monitored.isTerminated) false
+        if (monitored.isTerminated()) false
         if (v.contains(monitor)) true
         else {
           val added = v + monitor
           if (!mappings.replace(monitored, v, added)) associate(monitored, monitor)
-          else if (monitored.isTerminated) !dissociate(monitored, monitor) else true
+          else if (monitored.isTerminated()) !dissociate(monitored, monitor) else true
         }
     }
   }

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -33,7 +33,7 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
   protected def classify(event: AnyRef): Class[_] = event.getClass
 
   protected def publish(event: AnyRef, subscriber: ActorRef) = {
-    if (subscriber.isTerminated) unsubscribe(subscriber)
+    if (subscriber.isTerminated()) unsubscribe(subscriber)
     else subscriber ! event
   }
 

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -71,7 +71,7 @@ trait AskSupport {
    * [see [[akka.dispatch.Future]] for a description of `flow`]
    */
   def ask(actorRef: ActorRef, message: Any)(implicit timeout: Timeout): Future[Any] = actorRef match {
-    case ref: InternalActorRef if ref.isTerminated ⇒
+    case ref: InternalActorRef if ref.isTerminated() ⇒
       actorRef.tell(message)
       Promise.failed(new AskTimeoutException("sending to terminated ref breaks promises"))(ref.provider.dispatcher)
     case ref: InternalActorRef ⇒
@@ -234,7 +234,7 @@ private[akka] final class PromiseActorRef private (val provider: ActorRefProvide
     case _            ⇒
   }
 
-  override def isTerminated = state match {
+  override def isTerminated() = state match {
     case Stopped | _: StoppedWithPath ⇒ true
     case _                            ⇒ false
   }
@@ -242,7 +242,7 @@ private[akka] final class PromiseActorRef private (val provider: ActorRefProvide
   @tailrec
   override def stop(): Unit = {
     def ensurePromiseCompleted(): Unit =
-      if (!result.isCompleted) result.tryComplete(Left(new ActorKilledException("Stopped")))
+      if (!result.isCompleted()) result.tryComplete(Left(new ActorKilledException("Stopped")))
     state match {
       case null ⇒
         // if path was never queried nobody can possibly be watching us, so we don't have to publish termination either

--- a/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
@@ -20,7 +20,7 @@ trait GracefulStopSupport {
    * is completed with failure [[akka.actor.ActorTimeoutException]].
    */
   def gracefulStop(target: ActorRef, timeout: Duration)(implicit system: ActorSystem): Future[Boolean] = {
-    if (target.isTerminated) {
+    if (target.isTerminated()) {
       Promise.successful(true)
     } else {
       val result = Promise[Boolean]()

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -866,7 +866,7 @@ trait SmallestMailboxLike { this: RouterConfig ⇒
                          deep: Boolean = false): ActorRef =
       if (at >= targets.size) {
         if (deep) {
-          if (proposedTarget.isTerminated) targets(ThreadLocalRandom.current.nextInt(targets.size)) else proposedTarget
+          if (proposedTarget.isTerminated()) targets(ThreadLocalRandom.current.nextInt(targets.size)) else proposedTarget
         } else getNext(targets, proposedTarget, currentScore, 0, deep = true)
       } else {
         val target = targets(at)

--- a/akka-camel/src/main/scala/akka/camel/internal/component/ActorComponent.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/component/ActorComponent.scala
@@ -235,7 +235,7 @@ private[camel] case class ActorEndpointPath private (actorPath: String) {
 
   def findActorIn(system: ActorSystem): Option[ActorRef] = {
     val ref = system.actorFor(actorPath)
-    if (ref.isTerminated) None else Some(ref)
+    if (ref.isTerminated()) None else Some(ref)
   }
 }
 

--- a/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/actor/FaultHandlingDocSpec.scala
@@ -112,7 +112,7 @@ class FaultHandlingDocSpec extends AkkaSpec with ImplicitSender {
         watch(child) // have testActor watch “child”
         child ! new IllegalArgumentException // break it
         expectMsg(Terminated(child))
-        child.isTerminated must be(true)
+        child.isTerminated() must be(true)
         //#stop
       }
       EventFilter[Exception]("CRASH", occurrences = 4) intercept {

--- a/akka-docs/scala/code/akka/docs/dispatcher/DispatcherDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/dispatcher/DispatcherDocSpec.scala
@@ -216,7 +216,7 @@ class DispatcherDocSpec extends AkkaSpec(DispatcherDocSpec.config) {
     */
     //#prio-dispatcher
 
-    awaitCond(a.isTerminated, 5 seconds)
+    awaitCond(a.isTerminated(), 5 seconds)
   }
 
   "defining balancing dispatcher" in {

--- a/akka-docs/scala/code/akka/docs/testkit/TestkitDocSpec.scala
+++ b/akka-docs/scala/code/akka/docs/testkit/TestkitDocSpec.scala
@@ -209,7 +209,7 @@ class TestkitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     val future = probe.ref ? "hello"
     probe.expectMsg(0 millis, "hello") // TestActor runs on CallingThreadDispatcher
     probe.sender ! "world"
-    assert(future.isCompleted && future.value == Some(Right("world")))
+    assert(future.isCompleted() && future.value == Some(Right("world")))
     //#test-probe-reply
   }
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -212,7 +212,7 @@ class RemoteActorRefProvider(
 }
 
 trait RemoteRef extends ActorRefScope {
-  final def isLocal = false
+  final def isLocal() = false
 }
 
 /**
@@ -238,7 +238,7 @@ private[akka] class RemoteActorRef private[akka] (
   @volatile
   private var running: Boolean = true
 
-  def isTerminated: Boolean = !running
+  def isTerminated(): Boolean = !running
 
   def sendSystemMessage(message: SystemMessage): Unit = remote.send(message, None, this)
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
@@ -65,7 +65,7 @@ class TestActorRef[T <: Actor](
    */
   def underlyingActor: T = {
     // volatile mailbox read to bring in actor field
-    if (isTerminated) throw new IllegalActorStateException("underlying actor is terminated")
+    if (isTerminated()) throw new IllegalActorStateException("underlying actor is terminated")
     underlying.actor.asInstanceOf[T] match {
       case null ⇒
         val t = TestKitExtension(_system).DefaultTimeout

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -114,9 +114,9 @@ class AkkaSpecSpec extends WordSpec with MustMatchers {
       val spec = new AkkaSpec(system) {
         val ref = Seq(testActor, system.actorOf(Props.empty, "name"))
       }
-      spec.ref foreach (_.isTerminated must not be true)
+      spec.ref foreach (_.isTerminated() must not be true)
       system.shutdown()
-      spec.awaitCond(spec.ref forall (_.isTerminated), 2 seconds)
+      spec.awaitCond(spec.ref forall (_.isTerminated()), 2 seconds)
     }
 
     "must stop correctly when sending PoisonPill to rootGuardian" in {

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -173,7 +173,7 @@ class TestActorRefSpec extends AkkaSpec("disp1.type=Dispatcher") with BeforeAndA
         expectMsgPF(5 seconds) {
           case Terminated(`a`) ⇒ true
         }
-        a.isTerminated must be(true)
+        a.isTerminated() must be(true)
         assertThread
       }
     }
@@ -249,7 +249,7 @@ class TestActorRefSpec extends AkkaSpec("disp1.type=Dispatcher") with BeforeAndA
     "proxy receive for the underlying actor" in {
       val ref = TestActorRef[WorkerActor]
       ref.receive("work")
-      ref.isTerminated must be(true)
+      ref.isTerminated() must be(true)
     }
 
   }

--- a/akka-zeromq/src/test/scala/akka/zeromq/ConcurrentSocketActorSpec.scala
+++ b/akka-zeromq/src/test/scala/akka/zeromq/ConcurrentSocketActorSpec.scala
@@ -66,8 +66,8 @@ class ConcurrentSocketActorSpec extends AkkaSpec with DefaultTimeout {
         subscriberProbe.receiveWhile(1 seconds) {
           case msg ⇒ msg
         }.last must equal(Closed)
-        awaitCond(publisher.isTerminated)
-        awaitCond(subscriber.isTerminated)
+        awaitCond(publisher.isTerminated())
+        awaitCond(subscriber.isTerminated())
         context.term
       }
     }


### PR DESCRIPTION
...ially transparent
