### PR TITLE
Wip 935 durable mailbox tests √

### DIFF
--- a/akka-durable-mailboxes/akka-beanstalk-mailbox/src/test/scala/akka/actor/mailbox/BeanstalkBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-beanstalk-mailbox/src/test/scala/akka/actor/mailbox/BeanstalkBasedMailboxSpec.scala
@@ -1,5 +1,7 @@
 package akka.actor.mailbox
 
+import akka.dispatch.Mailbox
+
 object BeanstalkBasedMailboxSpec {
   val config = """
     Beanstalkd-dispatcher {
@@ -25,6 +27,6 @@ class BeanstalkBasedMailboxSpec extends DurableMailboxSpec("Beanstalkd", Beansta
   }
 
   override def atTermination(): Unit = beanstalkd.destroy()
-
+  def isDurableMailbox(m: Mailbox): Boolean = m.messageQueue.isInstanceOf[BeanstalkBasedMessageQueue]
 }
 

--- a/akka-durable-mailboxes/akka-file-mailbox/src/test/scala/akka/actor/mailbox/FileBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-file-mailbox/src/test/scala/akka/actor/mailbox/FileBasedMailboxSpec.scala
@@ -2,6 +2,7 @@ package akka.actor.mailbox
 
 import org.apache.commons.io.FileUtils
 import com.typesafe.config.ConfigFactory
+import akka.dispatch.Mailbox
 
 object FileBasedMailboxSpec {
   val config = """
@@ -23,6 +24,8 @@ class FileBasedMailboxSpec extends DurableMailboxSpec("File", FileBasedMailboxSp
       queuePath must be("file-based")
     }
   }
+
+  def isDurableMailbox(m: Mailbox): Boolean = m.messageQueue.isInstanceOf[FileBasedMessageQueue]
 
   def clean {
     FileUtils.deleteDirectory(new java.io.File(queuePath))

--- a/akka-durable-mailboxes/akka-mongo-mailbox/src/test/scala/akka/actor/mailbox/MongoBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-mongo-mailbox/src/test/scala/akka/actor/mailbox/MongoBasedMailboxSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.{ BeforeAndAfterEach, BeforeAndAfterAll }
 import akka.actor._
 import akka.actor.Actor._
 import java.util.concurrent.CountDownLatch
-import akka.dispatch.MessageDispatcher
+import akka.dispatch.{ Mailbox, MessageDispatcher }
 
 object MongoBasedMailboxSpec {
   val config = """
@@ -27,6 +27,8 @@ class MongoBasedMailboxSpec extends DurableMailboxSpec("mongodb", MongoBasedMail
   lazy val mongod = new ProcessBuilder("mongod", "--dbpath", "mongoDB", "--bind_ip", "127.0.0.1", "--port", "27123").start()
   lazy val mongo = MongoConnection("localhost", 27123)("akka")
 
+  def isDurableMailbox(m: Mailbox): Boolean = m.messageQueue.isInstanceOf[MongoBasedMessageQueue]
+
   override def atStartup(): Unit = {
     // start MongoDB daemon
     new java.io.File("mongoDB").mkdir()
@@ -41,54 +43,4 @@ class MongoBasedMailboxSpec extends DurableMailboxSpec("mongodb", MongoBasedMail
   }
 
   override def atTermination(): Unit = mongod.destroy()
-
 }
-
-/*object DurableMongoMailboxSpecActorFactory {
-
-  class MongoMailboxTestActor extends Actor {
-    def receive = {
-      case "sum" => reply("sum")
-    }
-  }
-
-  def createMongoMailboxTestActor(id: String)(implicit dispatcher: MessageDispatcher): ActorRef = {
-    val queueActor = actorOf(Props[MongoMailboxTestActor]
-    queueActor.dispatcher = dispatcher
-    queueActor
-  }
-}*/
-
-/*class MongoBasedMailboxSpec extends WordSpec with MustMatchers with BeforeAndAfterEach with BeforeAndAfterAll {
-  import DurableMongoMailboxSpecActorFactory._
-
-  implicit val dispatcher = DurableDispatcher("mongodb", MongoNaiveDurableMailboxStorage, 1)
-
-  "A MongoDB based naive mailbox backed actor" should {
-    "should handle reply to ! for 1 message" in {
-      val latch = new CountDownLatch(1)
-      val queueActor = createMongoMailboxTestActor("mongoDB Backend should handle Reply to !")
-      val sender = actorOf(Props(new Actor { def receive = { case "sum" => latch.countDown } })
-
-      queueActor.!("sum")(Some(sender))
-      latch.await(10, TimeUnit.SECONDS) must be (true)
-    }
-
-    "should handle reply to ! for multiple messages" in {
-      val latch = new CountDownLatch(5)
-      val queueActor = createMongoMailboxTestActor("mongoDB Backend should handle reply to !")
-      val sender = actorOf( new Actor { def receive = { case "sum" => latch.countDown } } )
-
-      queueActor.!("sum")(Some(sender))
-      queueActor.!("sum")(Some(sender))
-      queueActor.!("sum")(Some(sender))
-      queueActor.!("sum")(Some(sender))
-      queueActor.!("sum")(Some(sender))
-      latch.await(10, TimeUnit.SECONDS) must be (true)
-    }
-  }
-
-  override def beforeEach() {
-    registry.local.shutdownAll
-  }
-}*/

--- a/akka-durable-mailboxes/akka-redis-mailbox/src/test/scala/akka/actor/mailbox/RedisBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-redis-mailbox/src/test/scala/akka/actor/mailbox/RedisBasedMailboxSpec.scala
@@ -1,5 +1,7 @@
 package akka.actor.mailbox
 
+import akka.dispatch.Mailbox
+
 object RedisBasedMailboxSpec {
   val config = """
     Redis-dispatcher {
@@ -40,5 +42,5 @@ class RedisBasedMailboxSpec extends DurableMailboxSpec("Redis", RedisBasedMailbo
   }
 
   override def atTermination(): Unit = redisServer.destroy()
-
+  def isDurableMailbox(m: Mailbox): Boolean = m.messageQueue.isInstanceOf[RedisBasedMessageQueue]
 }

--- a/akka-durable-mailboxes/akka-zookeeper-mailbox/src/test/scala/akka/actor/mailbox/ZooKeeperBasedMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-zookeeper-mailbox/src/test/scala/akka/actor/mailbox/ZooKeeperBasedMailboxSpec.scala
@@ -3,10 +3,10 @@ package akka.actor.mailbox
 import akka.actor.Actor
 import akka.cluster.zookeeper._
 import org.I0Itec.zkclient._
-import akka.dispatch.MessageDispatcher
 import akka.actor.ActorRef
 import com.typesafe.config.ConfigFactory
 import akka.util.duration._
+import akka.dispatch.{ Mailbox, MessageDispatcher }
 
 object ZooKeeperBasedMailboxSpec {
   val config = """
@@ -31,7 +31,7 @@ class ZooKeeperBasedMailboxSpec extends DurableMailboxSpec("ZooKeeper", ZooKeepe
   }
 
   var zkServer: ZkServer = _
-
+  def isDurableMailbox(m: Mailbox): Boolean = m.messageQueue.isInstanceOf[ZooKeeperBasedMessageQueue]
   override def atStartup() {
     zkServer = AkkaZooKeeper.startLocalServer(dataPath, logPath)
     super.atStartup()


### PR DESCRIPTION
Removed the old durable mailbox tests and added some additional tests to make sure that it creates the right instances and supports multiple actors and multiple messages.
