### PR TITLE
Make method `dispatcher` in ActorRefFactory trait public (was protected)

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -141,7 +141,7 @@ trait ActorRefProvider {
 }
 
 /**
- * Interface implemented by ActorSystem and AkkaContext, the only two places
+ * Interface implemented by ActorSystem and ActorContext, the only two places
  * from which you can get fresh actors.
  */
 trait ActorRefFactory {
@@ -150,7 +150,10 @@ trait ActorRefFactory {
 
   protected def provider: ActorRefProvider
 
-  protected def dispatcher: MessageDispatcher
+  /**
+   * The dispatcher (MessageDispatcher) used by this ActorSystem or ActorContext.
+   */
+  def dispatcher: MessageDispatcher
 
   /**
    * Father of all children created by this interface.

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -153,7 +153,7 @@ trait ActorRefFactory {
   /**
    * The dispatcher (MessageDispatcher) used by this ActorSystem or ActorContext.
    */
-  def dispatcher: MessageDispatcher
+  implicit def dispatcher: MessageDispatcher
 
   /**
    * Father of all children created by this interface.


### PR DESCRIPTION
`ActorRefFactory` is only extended by `ActorSystem` and `ActorContext`, both of which make `dispatcher` public anyway. Writing code that requires access to the dispatcher (e.g. for Promise creation) and is supposed to work with ActorSystems as well as ActorContexts is easier if the ActorRefFactory allows public access to the dispatcher directly.

Otherwise one has to resort to ugly constructs such as this:

```
val promise = Promise[T]() {
  refFactory match {
    case x: ActorContext => x.dispatcher
    case x: ActorSystem => x.dispatcher
    case x => throw new IllegalArgumentException("Unsupported ActorRefFactory '" + x + "'")
  }
}
```
