### PR TITLE
[community pattern] refreshing "cache" with actors

### DIFF
--- a/akka-docs/scala/code/docs/actor/ActorSelfRefreshingCache.scala
+++ b/akka-docs/scala/code/docs/actor/ActorSelfRefreshingCache.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package docs.actor
+
+//#cache-actor
+import akka.util.NonFatal
+import akka.util.Duration
+import akka.actor.Actor
+
+object RefreshCache
+
+class CacheRefreshException(msg: String, thr: Throwable) extends RuntimeException(msg, thr)
+
+class CacheRefresher(cache: RefreshableCache[_], refreshEvery: Duration) extends Actor {
+
+  override def preStart() {
+    self ! RefreshCache
+  }
+
+  protected def receive = {
+    case RefreshCache => try {
+      cache.refresh()
+
+      context.system.scheduler.scheduleOnce(refreshEvery, self, RefreshCache)
+    } catch {
+      case NonFatal(ex) => throw new CacheRefreshException("Unable to refresh cache!", ex)
+    }
+  }
+}
+
+//#cache-actor
+
+//#refreshable-cache-trait
+
+import java.util.concurrent.atomic.AtomicReference
+
+trait RefreshableCache[T] {
+  protected def cached: AtomicReference[T]
+
+  def refresh()
+}
+
+//#refreshable-cache-trait
+
+//#example-cache
+trait DataCache {
+  def isValid(valueToCheck: String): Boolean
+}
+
+class FromDbDataCache extends RefreshableCache[Set[String]] with DataCache {
+
+  private val mockData = Set("valid") // just for our example
+
+  override protected val cached = new AtomicReference[Set[String]](mockData)
+
+  override def refresh() {
+    val updatedValues = { Thread.sleep(300) /* act busy */; mockData }
+    cached set updatedValues
+  }
+
+  override def isValid(valueToCheck: String) = cached.get contains valueToCheck
+}
+
+//#example-cache
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.BeforeAndAfterAll
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+
+class FromDbDataCacheSpec(_system: ActorSystem) extends TestKit(_system)
+  with FlatSpec with ShouldMatchers with BeforeAndAfterAll {
+
+  def this() = this(ActorSystem("FromDbDataCacheSpec"))
+
+  it should "validate expected values" in {
+    //#cache-actor-setup
+    import akka.actor.Props
+    import akka.actor.ActorSystem
+
+    // given
+    val cache = new FromDbDataCache
+    val system = ActorSystem.create()
+
+    import akka.util.duration._
+    system.actorOf(
+      Props(new CacheRefresher(cache, refreshEvery = 60.seconds)),
+      name = "data-cache-refresher"
+    )
+    
+    // when
+    val anything = cache.isValid("anything")
+    val valid = cache.isValid("valid")
+
+    // then
+    anything should be (false)
+    valid should be (true)
+
+    //#cache-actor-setup
+
+    // finally
+    system.shutdown()
+  }
+}

--- a/akka-docs/scala/code/docs/actor/ActorSelfRefreshingCache.scala
+++ b/akka-docs/scala/code/docs/actor/ActorSelfRefreshingCache.scala
@@ -32,9 +32,6 @@ class CacheRefresher(cache: RefreshableCache, refreshEvery: Duration) extends Ac
 //#cache-actor
 
 //#refreshable-cache-trait
-
-import java.util.concurrent.atomic.AtomicReference
-
 trait RefreshableCache { 
   def refresh()
 }
@@ -42,6 +39,8 @@ trait RefreshableCache {
 //#refreshable-cache-trait
 
 //#example-cache
+import java.util.concurrent.atomic.AtomicReference
+
 trait DataCache {
   def isValid(valueToCheck: String): Boolean
 }

--- a/akka-docs/scala/howto.rst
+++ b/akka-docs/scala/howto.rst
@@ -21,12 +21,10 @@ Periodic update of a shared read-only resource using Actors
 
 The following pattern may be used in any kind of situation where you want to periodically refresh/update some otherwise read-only shared resource. We'll show an implementation using a Cache as example, but you can easily imagine other situations where this kind of pattern might prove to be useful.
 
-Our cache trait will define a refresh method, which will be called by a so-called "Refresher", and an abstact :class:`AtomicReference` field, which we will use as the holder of our "to be refreshed" data.
+Our cache trait will define a refresh method, which will be called by a so-called "Refresher":
 
 .. includecode:: code/docs/actor/ActorSelfRefreshingCache.scala
    :include: refreshable-cache-trait
-
-Using an :class:`AtomicReference` here makes it safe to share the Cache among other threads / actors. The update to the cache's state will happen atomically when the CacheRefresher triggers the :meth:`refresh()` method.
 
 The implementation of the metioned :class:`CacheRefresher` is quite simple. In the preStart method we trigger one initial refresh of the cache. Note that consequent updates will be triggered by the scheduler, or other actors sending a RefreshCache message, not by this actor by itself.
 
@@ -35,7 +33,7 @@ The implementation of the metioned :class:`CacheRefresher` is quite simple. In t
 
 It's important to note that we use Akka's :class:`NonFatal` extractor instead of just :class:`Throwable`, which will extract all but "fatal" exceptions, which would be for example :class:`OutOfMemoryError` and his friends. Other exceptions are wrapped and thrown up again - the reason for wrapping them is tha this way it's easier to define custom SupervisionStrategies, for details on this topic see: :ref:`fault-tolerance-scala`.
 
-The Cache implementation is just a class implementing the :class:`RefreshableCache`, so all it needs to do it fetch the new data when refresh is called, and update the atomic reference:
+The Cache implementation is just a class implementing the :class:`RefreshableCache`, so all it needs to do it fetch the new data when refresh is called, and update the atomic reference which we use in order to make the cache thread-safe:
 
 .. includecode:: code/docs/actor/ActorSelfRefreshingCache.scala
    :include: example-cache

--- a/akka-docs/scala/howto.rst
+++ b/akka-docs/scala/howto.rst
@@ -14,6 +14,41 @@ code could share it for the profit of all. Where applicable it might also make
 sense to add to the ``akka.pattern`` package for creating an `OTP-like library
 <http://www.erlang.org/doc/man_index.html>`_.
 
+Periodic update of a shared read-only resource using Actors
+===========================================================
+
+*Contributed by: Konrad Malawski, Adam Warski*
+
+The following pattern may be used in any kind of situation where you want to periodically refresh/update some otherwise read-only shared resource. We'll show an implementation using a Cache as example, but you can easily imagine other situations where this kind of pattern might prove to be useful.
+
+Our cache trait will define a refresh method, which will be called by a so-called "Refresher", and an abstact :class:`AtomicReference` field, which we will use as the holder of our "to be refreshed" data.
+
+.. includecode:: code/docs/actor/ActorSelfRefreshingCache.scala
+   :include: refreshable-cache-trait
+
+Using an :class:`AtomicReference` here makes it safe to share the Cache among other threads / actors. The update to the cache's state will happen atomically when the CacheRefresher triggers the :meth:`refresh()` method.
+
+The implementation of the metioned :class:`CacheRefresher` is quite simple. In the preStart method we trigger one initial refresh of the cache. Note that consequent updates will be triggered by the scheduler, or other actors sending a RefreshCache message, not by this actor by itself.
+
+.. includecode:: code/docs/actor/ActorSelfRefreshingCache.scala
+   :include: cache-actor
+
+It's important to note that we use Akka's :class:`NonFatal` extractor instead of just :class:`Throwable`, which will extract all but "fatal" exceptions, which would be for example :class:`OutOfMemoryError` and his friends. Other exceptions are wrapped and thrown up again - the reason for wrapping them is tha this way it's easier to define custom SupervisionStrategies, for details on this topic see: :ref:`fault-tolerance-scala`.
+
+The Cache implementation is just a class implementing the :class:`RefreshableCache`, so all it needs to do it fetch the new data when refresh is called, and update the atomic reference:
+
+.. includecode:: code/docs/actor/ActorSelfRefreshingCache.scala
+   :include: example-cache
+
+Since we don't want other users of the cache to accidentally trigger refreshes, we introduced the :class:`DataCache` trait, which, which hides the fact that this cache can refresh itself, and provides a nice API for other developers. 
+
+To wire it all together we only have to create the cache and start the Refresher, providing it with some Duration, so it knows how often it should refresh. Remember that you can always send it an extra :class:`RefreshCache` message if you really need to.
+
+.. includecode:: code/docs/actor/ActorSelfRefreshingCache.scala
+   :include: cache-actor-setup
+
+Note that the default behaviour when an exception would be thrown in an actor is that it will be restarted - so the CacheRefresher will always try to refresh the cache, even if it fails once for example. For more details about the default Supervision Strategy in Akka see: :ref:`fault-tolerance-scala`. 
+
 Template Pattern
 ================
 
@@ -30,4 +65,3 @@ This is an especially nice pattern, since it does even come with some empty exam
    Spread the word: this is the easiest way to get famous!
 
 Please keep this pattern at the end of this file.
-


### PR DESCRIPTION
Hi all,
I noticed Roland's "call for patterns" today and went on with preparing an example of how we implemented a Cache in one of our projects. It essentialy can be used anywhere you want to _"periodically refresh/update some shared read-only resource"_.

A (scalatest) unit test is included, and it's code is the example use-case shown in the docs,
I have validated it runs fine with akka 2.0. The docs compile with no warnings.

By the way, should the doc of the community patterns just be "pasted in" into `howto.rst` or should I do it the same way as index files (using `.. toctree::`)? If so, should I refactor it to be contained in a subdirectory "howto/"?
## 

Cheers,
Konrad
