### PR TITLE
Test tags not working as expected, see #2145

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -48,7 +48,7 @@ class SchedulerSpec extends AkkaSpec with BeforeAndAfterEach with DefaultTimeout
       assert(countDownLatch2.await(2, TimeUnit.SECONDS))
     }
 
-    "should stop continuous scheduling if the receiving actor has been terminated" taggedAs TimingTest in {
+    "stop continuous scheduling if the receiving actor has been terminated" taggedAs TimingTest in {
       val actor = system.actorOf(Props(new Actor {
         def receive = {
           case x ⇒ testActor ! x

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -297,6 +297,7 @@ object AkkaBuild extends Build {
   val excludeTestNames = SettingKey[Seq[String]]("exclude-test-names")
   val excludeTestTags = SettingKey[Seq[String]]("exclude-test-tags")
   val includeTestTags = SettingKey[Seq[String]]("include-test-tags")
+  val onlyTestTags = SettingKey[Seq[String]]("only-test-tags")
 
   val defaultExcludedTags = Seq("timing", "long-running")
 
@@ -308,29 +309,37 @@ object AkkaBuild extends Build {
     (if (getBoolean("sbt.log.noformat")) List("-Dakka.test.nocolor=true") else Nil)
   }
 
-  // for excluding tests by name (or use system property: -Dakka.test.names.exclude=TimingSpec)
-  lazy val defaultExcludeTestNames: Seq[String] = {
-    val exclude = System.getProperty("akka.test.names.exclude", "")
-    if (exclude.isEmpty) Seq.empty else exclude.split(",").toSeq
+  // for excluding tests by name use system property: -Dakka.test.names.exclude=TimingSpec
+  // not supported by multi-jvm tests
+  lazy val useExcludeTestNames: Seq[String] = systemPropertyAsSeq("akka.test.names.exclude")
+
+  // for excluding tests by tag use system property: -Dakka.test.tags.exclude=<tag name>
+  // note that it will not be used if you specify -Dakka.test.tags.only
+  lazy val useExcludeTestTags: Seq[String] = {
+    if (useOnlyTestTags.isEmpty) systemPropertyAsSeq("akka.test.tags.exclude", defaultExcludedTags)
+    else Seq.empty
   }
 
-  // for excluding tests by tag (or use system property: -Dakka.test.tags.exclude=timing)
-  lazy val defaultExcludeTestTags: Seq[String] = {
-    val exclude = System.getProperty("akka.test.tags.exclude", "")
-    if (exclude.isEmpty) defaultExcludedTags else exclude.split(",").toSeq
+  // for including tests by tag use system property: -Dakka.test.tags.include=<tag name>
+  // note that it will not be used if you specify -Dakka.test.tags.only
+  lazy val useIncludeTestTags: Seq[String] = {
+    if (useOnlyTestTags.isEmpty) systemPropertyAsSeq("akka.test.tags.include")
+    else Seq.empty
   }
 
-  // for including tests by tag (or use system property: -Dakka.test.tags.include=timing)
-  lazy val defaultIncludeTestTags: Seq[String] = {
-    val include = System.getProperty("akka.test.tags.include", "")
-    if (include.isEmpty) Seq.empty else include.split(",").toSeq
+  // for running only tests by tag use system property: -Dakka.test.tags.only=<tag name>
+  lazy val useOnlyTestTags: Seq[String] = systemPropertyAsSeq("akka.test.tags.only")
+
+  def systemPropertyAsSeq(name: String, default: Seq[String] = Seq.empty): Seq[String] = {
+    val prop = System.getProperty(name, "")
+    if (prop.isEmpty) default else prop.split(",").toSeq
   }
 
   lazy val defaultMultiJvmScalatestOptions: Seq[String] = {
-    val excludeTags = (defaultExcludeTestTags.toSet -- defaultIncludeTestTags.toSet).toSeq
+    val excludeTags = (useExcludeTestTags.toSet -- useIncludeTestTags.toSet).toSeq
     Seq("-r", "org.scalatest.akka.QuietReporter") ++
     (if (excludeTags.isEmpty) Seq.empty else Seq("-l", excludeTags.mkString(" "))) ++
-    (if (defaultIncludeTestTags.isEmpty) Seq.empty else Seq("-n", defaultIncludeTestTags.mkString(" ")))
+    (if (useOnlyTestTags.isEmpty) Seq.empty else Seq("-n", useOnlyTestTags.mkString(" ")))
   }
 
   lazy val defaultSettings = baseSettings ++ formatSettings ++ Seq(
@@ -345,9 +354,10 @@ object AkkaBuild extends Build {
 
     parallelExecution in Test := System.getProperty("akka.parallelExecution", "false").toBoolean,
 
-    excludeTestNames := defaultExcludeTestNames,
-    excludeTestTags := defaultExcludeTestTags,
-    includeTestTags := defaultIncludeTestTags,
+    excludeTestNames := useExcludeTestNames,
+    excludeTestTags := useExcludeTestTags,
+    includeTestTags := useIncludeTestTags,
+    onlyTestTags := useOnlyTestTags,
 
     // add filters for tests excluded by name
     testOptions in Test <++= excludeTestNames map { _.map(exclude => Tests.Filter(test => !test.contains(exclude))) },
@@ -358,8 +368,8 @@ object AkkaBuild extends Build {
       if (tags.isEmpty) Seq.empty else Seq(Tests.Argument("-l", tags.mkString(" ")))
     },
 
-    // add arguments for tests included by tag
-    testOptions in Test <++= includeTestTags map { tags =>
+    // add arguments for running only tests by tag
+    testOptions in Test <++= onlyTestTags map { tags =>
       if (tags.isEmpty) Seq.empty else Seq(Tests.Argument("-n", tags.mkString(" ")))
     },
 


### PR DESCRIPTION
- Tests tagged with timing or long-running are excluded by default,
  as before
- Use -Dakka.test.tags.include=long-running,timing to run all
  untagged and also tests tagged with long-running or timing
- Use -Dakka.test.tags.only=timing,long-running to only run
  tests tagged with long-running or timing, i.e. untagged tests,
  or tests tagged with something else are not run
- I think the above two parameters covers our needs, but there is
  also -Dakka.test.tags.exclude=some-other to be able to exclude
  tests that are included by default
