### PR TITLE
add Actor.aroundReceive to support mixin traits

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -78,7 +78,8 @@ trait ActorContext extends ActorRefFactory {
   /**
    * Changes the Actor's behavior to become the new 'Receive' (PartialFunction[Any, Unit]) handler.
    * Puts the behavior on top of the hotswap stack.
-   * If "discardOld" is true, an unbecome will be issued prior to pushing the new behavior to the stack
+   * If "discardOld" is true, an unbecome will be issued prior to pushing the new behavior to the stack.
+   * The new behavior will be transformed by the actor's `Actor.aroundReceive` method.
    */
   def become(behavior: Actor.Receive, discardOld: Boolean = true): Unit
 
@@ -507,6 +508,7 @@ private[akka] class ActorCell(
         case `behaviorStackPlaceHolder` ⇒ Stack.empty.push(instance.receive)
         case newBehaviors               ⇒ Stack.empty.push(instance.receive).pushAll(newBehaviors.reverse.drop(1))
       }
+      behaviorStack = behaviorStack.map(instance.aroundReceive(_))
       instance
     } finally {
       val stackAfter = contextStack.get
@@ -647,7 +649,12 @@ private[akka] class ActorCell(
 
   def become(behavior: Actor.Receive, discardOld: Boolean = true): Unit = {
     if (discardOld) unbecome()
-    behaviorStack = behaviorStack.push(behavior)
+    // actor is null during construction of the actor
+    val wrappedBehavior = if (actor ne null)
+      actor.aroundReceive(behavior)
+    else
+      behavior
+    behaviorStack = behaviorStack.push(wrappedBehavior)
   }
 
   /**

--- a/akka-docs/scala/actors.rst
+++ b/akka-docs/scala/actors.rst
@@ -675,15 +675,27 @@ state of the failing actor instance is lost if you don't store and restore it in
 ``preRestart`` and ``postRestart`` callbacks.
 
 
-Extending Actors using PartialFunction chaining
-===============================================
+Extending Actors using aroundReceive and PartialFunction chaining
+===============================================================
 
-A bit advanced but very useful way of defining a base message handler and then
-extend that, either through inheritance or delegation, is to use
-``PartialFunction.orElse`` chaining.
+You can create "mixin" traits or abstract classes using the
+``aroundReceive`` method on ``Actor``. This method modifies the
+standard actor behavior as defined by ``receive`` or ``become``.
+To allow multiple traits to be mixed in to one actor, when you
+override ``aroundReceive`` you should always chain up and allow
+supertypes to run their ``aroundReceive`` as well.
 
-.. includecode:: code/docs/actor/ActorDocSpec.scala#receive-orElse
+.. includecode:: code/docs/actor/ActorDocSpec.scala#receive-aroundReceive
 
-Or:
+Multiple traits that implement ``aroundReceive`` in this way can be
+mixed in to the same concrete class. The concrete class need not
+do anything special, it implements ``receive`` as usual.
 
-.. includecode:: code/docs/actor/ActorDocSpec.scala#receive-orElse2
+There are more ways to use ``aroundReceive``; for example you could
+intercept some messages and transform them before passing the
+transformed messages on to the original behavior.
+
+``PartialFunction.orElse`` chaining can also be used for more
+complex scenarios, like dynamic runtime registration of handlers:
+
+.. includecode:: code/akka/docs/actor/ActorDocSpec.scala#receive-orElse

--- a/akka-docs/scala/code/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/scala/code/docs/actor/ActorDocSpec.scala
@@ -114,41 +114,58 @@ object SwapperApp extends App {
 }
 //#swapper
 
-//#receive-orElse
+//#receive-aroundReceive
 
-abstract class GenericActor extends Actor {
-  // to be defined in subclassing actor
-  def specificMessageHandler: Receive
-
+// trait providing a generic fallback message handler
+trait GenericActor extends Actor {
   // generic message handler
-  def genericMessageHandler: Receive = {
+  private def genericMessageHandler: Receive = {
     case event ⇒ printf("generic: %s\n", event)
   }
 
-  def receive = specificMessageHandler orElse genericMessageHandler
+  // because we chain up to super.aroundReceive,
+  // multiple traits like this can be mixed in.
+  override def aroundReceive(behavior: Receive): Receive =
+    super.aroundReceive(behavior) orElse genericMessageHandler
 }
 
 class SpecificActor extends GenericActor {
-  def specificMessageHandler = {
+  def receive = {
     case event: MyMsg ⇒ printf("specific: %s\n", event.subject)
   }
 }
 
 case class MyMsg(subject: String)
-//#receive-orElse
+//#receive-aroundReceive
 
-//#receive-orElse2
+//#receive-orElse
 trait ComposableActor extends Actor {
   private var receives: List[Receive] = List()
+  private var composedReceives: Receive = Map.empty // in Scala 2.10, PartialFunction.empty
+
   protected def registerReceive(receive: Receive) {
+    // keep a list (allows unregistration)
     receives = receive :: receives
+    // cache the composition of all receives
+    composedReceives = receives reduce { _ orElse _ }
   }
 
-  def receive = receives reduce { _ orElse _ }
+  // this indirection is because aroundReceive is only called
+  // once, but we want to allow registration post-construct,
+  // so we need a constant Receive that forwards to our
+  // dynamic Receive
+  private def handleRegisteredReceives: Receive = new PartialFunction[Any, Unit]() {
+    override def apply(x: Any) = composedReceives.apply(x)
+    override def isDefinedAt(x: Any) = composedReceives.isDefinedAt(x)
+  }
+
+  override def aroundReceive(behavior: Receive) =
+    super.aroundReceive(behavior orElse handleRegisteredReceives)
 }
 
 class MyComposableActor extends ComposableActor {
   override def preStart() {
+    // register some handlers dynamically
     registerReceive({
       case "foo" ⇒ /* Do something */
     })
@@ -157,9 +174,15 @@ class MyComposableActor extends ComposableActor {
       case "bar" ⇒ /* Do something */
     })
   }
+
+  // Runs after the dynamically-registered handlers,
+  // which are added with preReceive
+  def receive = {
+    case "baz" ⇒
+  }
 }
 
-//#receive-orElse2
+//#receive-orElse
 class ActorDocSpec extends AkkaSpec(Map("akka.loglevel" -> "INFO")) {
 
   "import context" in {


### PR DESCRIPTION
aroundReceive allows a trait or abstract base class
to modify each behavior pushed onto the behavior
stack, including the initial receive and any
behaviors that we become later.

A common use of aroundReceive would be to add
another partial function in front of or
after the normal behavior, with `orElse`.

Implementations of aroundReceive are expected to
chain up to supertype implementations, so if
multiple mixed-in traits or classes call
aroundReceive, they will all co-exist.

This leaves the receive method available for
concrete classes, keeping mixin traits completely
orthogonal (the class you mixin to doesn't need
any changes).
