### PR TITLE
Added implementation of the LEAVE command for a cluster node plus misc tests

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinTwoClustersSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinTwoClustersSpec.scala
@@ -18,7 +18,6 @@ object JoinTwoClustersMultiJvmSpec extends MultiNodeConfig {
   val c2 = role("c2")
 
   commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfig))
-
 }
 
 class JoinTwoClustersMultiJvmNode1 extends JoinTwoClustersSpec

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeaving.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeaving.scala
@@ -18,7 +18,7 @@ object NodeLeavingMultiJvmSpec extends MultiNodeConfig {
   commonConfig(
     debugConfig(on = false)
     .withFallback(ConfigFactory.parseString("""
-        akka.cluster.unreachable-nodes-reaper-frequency = 30000 # turn "off" reaping to unreachable node set
+        akka.cluster.unreachable-nodes-reaper-frequency = 30 s # turn "off" reaping to unreachable node set
       """))
     .withFallback(MultiNodeClusterSpec.clusterConfig))
 }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeaving.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeaving.scala
@@ -1,0 +1,71 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import scala.collection.immutable.SortedSet
+import org.scalatest.BeforeAndAfter
+import com.typesafe.config.ConfigFactory
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+
+object NodeLeavingMultiJvmSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(
+    debugConfig(on = false)
+    .withFallback(ConfigFactory.parseString("""
+        akka.cluster.unreachable-nodes-reaper-frequency = 30000 # turn "off" reaping to unreachable node set
+      """))
+    .withFallback(MultiNodeClusterSpec.clusterConfig))
+}
+
+class NodeLeavingMultiJvmNode1 extends NodeLeavingSpec
+class NodeLeavingMultiJvmNode2 extends NodeLeavingSpec
+class NodeLeavingMultiJvmNode3 extends NodeLeavingSpec
+
+abstract class NodeLeavingSpec extends MultiNodeSpec(NodeLeavingMultiJvmSpec)
+  with MultiNodeClusterSpec with ImplicitSender with BeforeAndAfter {
+  import NodeLeavingMultiJvmSpec._
+
+  override def initialParticipants = 3
+
+  lazy val firstAddress = node(first).address
+  lazy val secondAddress = node(second).address
+  lazy val thirdAddress = node(third).address
+
+  "A node that is LEAVING a non-singleton cluster" must {
+
+    "be marked as LEAVING in the converged membership table" taggedAs LongRunningTest in {
+
+      runOn(first) {
+        cluster.self
+      }
+      testConductor.enter("first-started")
+
+      runOn(second, third) {
+        cluster.join(firstAddress)
+      }
+      awaitUpConvergence(numberOfMembers = 3)
+      testConductor.enter("rest-started")
+
+      runOn(first) {
+        cluster.leave(secondAddress)
+      }
+      testConductor.enter("second-left")
+
+      runOn(first, third) {
+        awaitCond(cluster.latestGossip.members.exists(_.status == MemberStatus.Leaving))
+
+        val hasLeft = cluster.latestGossip.members.find(_.status == MemberStatus.Leaving)
+        hasLeft must be('defined)
+        hasLeft.get.address must be(secondAddress)
+      }
+
+      testConductor.enter("finished")
+    }
+  }
+}

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExiting.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExiting.scala
@@ -20,7 +20,7 @@ object NodeLeavingAndExitingMultiJvmSpec extends MultiNodeConfig {
     debugConfig(on = false)
     .withFallback(ConfigFactory.parseString("""
         akka.cluster {
-          leader-actions-frequency           = 5 s  # increase the leader action task frequency
+          leader-actions-frequency           = 5 s  # increase the leader action task frequency to make sure we get a chance to test the LEAVING state
           unreachable-nodes-reaper-frequency = 30 s # turn "off" reaping to unreachable node set
         }
       """)
@@ -64,6 +64,8 @@ abstract class NodeLeavingAndExitingSpec extends MultiNodeSpec(NodeLeavingAndExi
       runOn(first, third) {
 
         // 1. Verify that 'second' node is set to LEAVING
+        //   We have set the 'leader-actions-frequency' to 5 seconds to make sure that we get a
+        //   chance to test the LEAVING state before the leader moves the node to EXITING
         awaitCond(cluster.latestGossip.members.exists(_.status == MemberStatus.Leaving)) // wait on LEAVING
         val hasLeft = cluster.latestGossip.members.find(_.status == MemberStatus.Leaving) // verify node that left
         hasLeft must be('defined)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExiting.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExiting.scala
@@ -20,8 +20,8 @@ object NodeLeavingAndExitingMultiJvmSpec extends MultiNodeConfig {
     debugConfig(on = false)
     .withFallback(ConfigFactory.parseString("""
         akka.cluster {
-          leader-actions-frequency           = 5000 ms  # increase the leader action task frequency
-          unreachable-nodes-reaper-frequency = 30000 ms # turn "off" reaping to unreachable node set
+          leader-actions-frequency           = 5 s  # increase the leader action task frequency
+          unreachable-nodes-reaper-frequency = 30 s # turn "off" reaping to unreachable node set
         }
       """)
     .withFallback(MultiNodeClusterSpec.clusterConfig)))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExiting.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExiting.scala
@@ -1,0 +1,82 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import scala.collection.immutable.SortedSet
+import org.scalatest.BeforeAndAfter
+import com.typesafe.config.ConfigFactory
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+import akka.util.duration._
+
+object NodeLeavingAndExitingMultiJvmSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(
+    debugConfig(on = false)
+    .withFallback(ConfigFactory.parseString("""
+        akka.cluster {
+          leader-actions-frequency           = 5000 ms  # increase the leader action task frequency
+          unreachable-nodes-reaper-frequency = 30000 ms # turn "off" reaping to unreachable node set
+        }
+      """)
+    .withFallback(MultiNodeClusterSpec.clusterConfig)))
+}
+
+class NodeLeavingAndExitingMultiJvmNode1 extends NodeLeavingAndExitingSpec
+class NodeLeavingAndExitingMultiJvmNode2 extends NodeLeavingAndExitingSpec
+class NodeLeavingAndExitingMultiJvmNode3 extends NodeLeavingAndExitingSpec
+
+abstract class NodeLeavingAndExitingSpec extends MultiNodeSpec(NodeLeavingAndExitingMultiJvmSpec)
+  with MultiNodeClusterSpec with ImplicitSender with BeforeAndAfter {
+  import NodeLeavingAndExitingMultiJvmSpec._
+
+  override def initialParticipants = 3
+
+  lazy val firstAddress = node(first).address
+  lazy val secondAddress = node(second).address
+  lazy val thirdAddress = node(third).address
+
+  "A node that is LEAVING a non-singleton cluster" must {
+
+    "be moved to EXITING by the leader" taggedAs LongRunningTest in {
+
+      runOn(first) {
+        cluster.self
+      }
+      testConductor.enter("first-started")
+
+      runOn(second, third) {
+        cluster.join(firstAddress)
+      }
+      awaitUpConvergence(numberOfMembers = 3)
+      testConductor.enter("rest-started")
+
+      runOn(first) {
+        cluster.leave(secondAddress)
+      }
+      testConductor.enter("second-left")
+
+      runOn(first, third) {
+
+        // 1. Verify that 'second' node is set to LEAVING
+        awaitCond(cluster.latestGossip.members.exists(_.status == MemberStatus.Leaving)) // wait on LEAVING
+        val hasLeft = cluster.latestGossip.members.find(_.status == MemberStatus.Leaving) // verify node that left
+        hasLeft must be('defined)
+        hasLeft.get.address must be(secondAddress)
+
+        // 2. Verify that 'second' node is set to EXITING
+        awaitCond(cluster.latestGossip.members.exists(_.status == MemberStatus.Exiting)) // wait on EXITING
+        val hasExited = cluster.latestGossip.members.find(_.status == MemberStatus.Exiting) // verify node that exited
+        hasExited must be('defined)
+        hasExited.get.address must be(secondAddress)
+      }
+
+      testConductor.enter("finished")
+    }
+  }
+}

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemoved.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemoved.scala
@@ -33,7 +33,7 @@ abstract class NodeLeavingAndExitingAndBeingRemovedSpec extends MultiNodeSpec(No
   lazy val secondAddress = node(second).address
   lazy val thirdAddress = node(third).address
 
-  val reaperWaitingTime = 30 seconds
+  val reaperWaitingTime = 30.seconds.dilated
 
   "A node that is LEAVING a non-singleton cluster" must {
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemoved.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemoved.scala
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import scala.collection.immutable.SortedSet
+import org.scalatest.BeforeAndAfter
+import com.typesafe.config.ConfigFactory
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+import akka.util.duration._
+
+object NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfig))
+}
+
+class NodeLeavingAndExitingAndBeingRemovedMultiJvmNode1 extends NodeLeavingAndExitingAndBeingRemovedSpec
+class NodeLeavingAndExitingAndBeingRemovedMultiJvmNode2 extends NodeLeavingAndExitingAndBeingRemovedSpec
+class NodeLeavingAndExitingAndBeingRemovedMultiJvmNode3 extends NodeLeavingAndExitingAndBeingRemovedSpec
+
+abstract class NodeLeavingAndExitingAndBeingRemovedSpec extends MultiNodeSpec(NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec)
+  with MultiNodeClusterSpec with ImplicitSender with BeforeAndAfter {
+  import NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec._
+
+  override def initialParticipants = 3
+
+  lazy val firstAddress = node(first).address
+  lazy val secondAddress = node(second).address
+  lazy val thirdAddress = node(third).address
+
+  val reaperWaitingTime = 30 seconds
+
+  "A node that is LEAVING a non-singleton cluster" must {
+
+    "be moved to EXITING and then to REMOVED by the reaper" taggedAs LongRunningTest in {
+
+      runOn(first) {
+        cluster.self
+      }
+      testConductor.enter("first-started")
+
+      runOn(second, third) {
+        cluster.join(firstAddress)
+      }
+      awaitUpConvergence(numberOfMembers = 3)
+      testConductor.enter("rest-started")
+
+      runOn(first) {
+        cluster.leave(secondAddress)
+      }
+      testConductor.enter("second-left")
+
+      runOn(first, third) {
+        // verify that the 'second' node is no longer part of the 'members' set
+        awaitCond(cluster.latestGossip.members.forall(_.address != secondAddress), reaperWaitingTime)
+
+        // verify that the 'second' node is part of the 'unreachable' set
+        awaitCond(cluster.latestGossip.overview.unreachable.exists(_.status == MemberStatus.Removed), reaperWaitingTime)
+
+        // verify node that got removed is 'second' node
+        val isRemoved = cluster.latestGossip.overview.unreachable.find(_.status == MemberStatus.Removed)
+        isRemoved must be('defined)
+        isRemoved.get.address must be(secondAddress)
+      }
+
+      testConductor.enter("finished")
+    }
+  }
+}

--- a/akka-docs/cluster/cluster.rst
+++ b/akka-docs/cluster/cluster.rst
@@ -5,7 +5,8 @@
  Cluster Specification
 ######################
 
-.. note:: *This document describes the new clustering coming in Akka 2.1 (not 2.0)*
+.. note:: *This document describes the new clustering coming in Akka Coltrane and
+is not available in the latest stable release)*
 
 Intro
 =====


### PR DESCRIPTION
-- Cluster impl changes --
- Added implementation of the LEAVE command for a cluster node
- Changed the meaning of Member.isUnavailable to only DOWN and REMOVED
- Removed EXIT and UP as user commands
- Fixed Cluster.self to fall back to checking for itself in the gossip.overview.unreachable set.
- Added Leader action transitioning from LEAVING -> EXITING
- Improved comments

-- New tests -- 
- Added test for testing cluster node transitioning from UP -> LEAVING
- Added test for testing cluster node transitioning from UP -> LEAVING -> EXITING
- Added test for testing cluster node transitioning from UP -> LEAVING -> EXITING -> REMOVED
