### PR TITLE
Remote Class Loading

### DIFF
--- a/akka-remote-rcl/src/main/java/akka/remote/netty/rcl/ThreadLocalReflectiveDynamicAccess.java
+++ b/akka-remote-rcl/src/main/java/akka/remote/netty/rcl/ThreadLocalReflectiveDynamicAccess.java
@@ -1,0 +1,19 @@
+package akka.remote.netty.rcl;
+
+import akka.actor.ReflectiveDynamicAccess;
+import scala.util.DynamicVariable;
+
+public class ThreadLocalReflectiveDynamicAccess extends ReflectiveDynamicAccess {
+
+    public final DynamicVariable<ClassLoader> dynamicVariable;
+
+    public ThreadLocalReflectiveDynamicAccess(ClassLoader classLoader) {
+        super(classLoader);
+        dynamicVariable = new DynamicVariable<ClassLoader>(classLoader);
+    }
+
+    @Override
+    public ClassLoader classLoader() {
+        return dynamicVariable.value();
+    }
+}

--- a/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/ByteCodeInspector.scala
+++ b/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/ByteCodeInspector.scala
@@ -1,0 +1,87 @@
+package akka.remote.netty.rcl
+
+import java.io.DataInputStream;
+
+object ByteCodeInspector {
+
+  val magic = 0xCAFEBABE
+
+  val utf8_tag = 1
+  val int_tag = 3
+  val float_tag = 4
+  val long_tag = 5
+  val double_tag = 6
+  val class_ref_tag = 7
+  val string_ref_tag = 8
+  val field_ref_tag = 9
+  val method_ref_tag = 10
+  val intfce_ref_tag = 11
+  val name_type_desc_tag = 12
+
+  def findReferencedClassesFor(klass: Class[_]): List[String] = {
+    // we will analyse just the constant pool no need to load the whole file
+    val resource = klass.getClassLoader.getResource(klass.getName.replace('.', '/') + ".class");
+    val input = new DataInputStream(resource.openStream());
+
+    try {
+
+      input.readInt match {
+        case 0xCAFEBABE ⇒ // good
+        case _          ⇒ throw new RuntimeException("Not a bytecode file.")
+      }
+
+      input.readUnsignedShort(); // minor
+      input.readUnsignedShort(); // major
+
+      // this values is equal to the number entries in the constants pool + 1
+      val constantPoolEntries = input.readUnsignedShort() - 1;
+
+      // we will fill this Map with UTF8 tags
+      val utfTags = scala.collection.mutable.HashMap[Int, String]()
+
+      // we will mark which utf8 tags point to class and to name_and_type
+      val classTags = scala.collection.mutable.ArrayBuffer[Int]()
+      val descTags = scala.collection.mutable.ArrayBuffer[Int]()
+
+      // loop over all entries in the constants pool
+      var i = 0
+      while (i < constantPoolEntries) {
+        i += 1
+        // the tag to identify the record type
+        input.readUnsignedByte() match {
+          case 1 ⇒ utfTags += i -> input.readUTF
+          case 7 ⇒ classTags += input.readUnsignedShort
+          case 12 ⇒ {
+            input.readUnsignedShort // don't care about the name
+            descTags += input.readUnsignedShort
+          }
+          case 3 | 4 | 9 | 10 | 11 ⇒ {
+            // this tags take 4 bytes and we don't care about them
+            input.readInt
+          }
+          case 5 | 6 ⇒ {
+            input.readLong // this take 8 bytes
+            i += 1 // entry takes 2 slots
+          }
+          case 8 ⇒ input.readUnsignedShort // and this 2 bytes
+          case _ ⇒ throw new RuntimeException("Encountered unknow constant pool tag. Corrupt bytecode or new format.")
+        }
+      }
+
+      val answer = scala.collection.mutable.HashSet[String]()
+
+      // read the utf8 tags for fqn class names
+      classTags.foreach { answer += utfTags(_) replaceAll ("/", ".") }
+
+      descTags.foreach {
+        answer ++= """L[^;]+;""".r findAllIn utfTags(_) map {
+          (s: String) ⇒ s drop (1) dropRight (1) replaceAll ("/", ".")
+        }
+      }
+
+      answer.toList
+    } finally {
+      input.close
+    }
+  }
+}

--- a/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/IOUtil.scala
+++ b/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/IOUtil.scala
@@ -1,0 +1,30 @@
+package akka.remote.netty.rcl
+
+import java.net.URL
+import java.io.{ OutputStream, InputStream, ByteArrayOutputStream }
+
+object IOUtil {
+
+  // 4K
+  val BUF_SIZE = 0x1000;
+
+  def toByteArray(url: URL): Array[Byte] = {
+    val out = new ByteArrayOutputStream();
+    copy(url.openStream(), out);
+    return out.toByteArray();
+  }
+
+  def copy(from: InputStream, to: OutputStream): Long = {
+    val buf = new Array[Byte](BUF_SIZE);
+    var total = 0;
+    while (true) {
+      var r = from.read(buf);
+      if (r == -1) {
+        return total;
+      }
+      to.write(buf, 0, r);
+      total += r;
+    }
+    return total;
+  }
+}

--- a/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/ReflectionUtil.scala
+++ b/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/ReflectionUtil.scala
@@ -1,0 +1,85 @@
+package akka.remote.netty.rcl
+
+import akka.remote.RemoteMessage
+import java.lang.reflect.{ Field, Method }
+
+object ReflectionUtil {
+
+  def getAccessibleField(name: String, clazz: Class[RemoteMessage]): Field = {
+    var currentClass: Class[_] = clazz
+    while (currentClass != classOf[java.lang.Object]) {
+      val declaredField = currentClass.getDeclaredField(name)
+      if (declaredField != null) {
+        val accessible = declaredField.isAccessible
+        try {
+          declaredField.setAccessible(true)
+          return declaredField
+        } finally {
+          declaredField.setAccessible(accessible)
+        }
+      }
+      currentClass = currentClass.getSuperclass;
+    }
+    throw new RuntimeException("Failed to find field " + name + " in " + clazz.getName)
+  }
+
+  def setField(name: String, of: AnyRef, withValue: AnyRef) {
+    var currentClass: Class[_] = of.getClass
+    while (currentClass != classOf[java.lang.Object]) {
+      val declaredField = currentClass.getDeclaredField(name)
+      if (declaredField != null) {
+        val accessible = declaredField.isAccessible
+        try {
+          declaredField.setAccessible(true)
+          declaredField.set(of, withValue)
+          return
+        } finally {
+          declaredField.setAccessible(accessible)
+        }
+      }
+      currentClass = currentClass.getSuperclass;
+    }
+    throw new RuntimeException("Failed to set field " + name + " on " + of.getClass.getName)
+  }
+
+  def getFieldValue(name: String, of: AnyRef): Any = {
+    var currentClass: Class[_] = of.getClass
+    while (currentClass != classOf[java.lang.Object]) {
+      val declaredField = currentClass.getDeclaredField(name)
+      if (declaredField != null) {
+        val accessible = declaredField.isAccessible
+        try {
+          declaredField.setAccessible(true)
+          return declaredField.get(of)
+        } finally {
+          declaredField.setAccessible(accessible)
+        }
+      }
+      currentClass = currentClass.getSuperclass;
+    }
+    throw new RuntimeException("Failed to get field " + name + " on " + of.getClass.getName)
+  }
+
+  def invokeMethod(name: String, of: AnyRef): Any = {
+    var currentClass: Class[_] = of.getClass
+    while (currentClass != classOf[java.lang.Object]) {
+      import scala.collection.JavaConversions._
+      currentClass.getDeclaredMethods.find(_.getName.equals(name)) match {
+        case Some(method) ⇒
+          {
+            val accessible = method.isAccessible
+            try {
+              method.setAccessible(true)
+              return method.invoke(of)
+            } finally {
+              method.setAccessible(accessible)
+            }
+          };
+        case _ ⇒ // ignore
+      }
+
+      currentClass = currentClass.getSuperclass;
+    }
+    throw new RuntimeException("Failed to find method " + name + " on " + of.getClass.getName)
+  }
+}

--- a/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/ReflectionUtil.scala
+++ b/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/ReflectionUtil.scala
@@ -1,85 +1,36 @@
 package akka.remote.netty.rcl
 
-import akka.remote.RemoteMessage
-import java.lang.reflect.{ Field, Method }
+import java.lang.reflect.Field
+import akka.util.NonFatal
 
 object ReflectionUtil {
 
-  def getAccessibleField(name: String, clazz: Class[RemoteMessage]): Field = {
-    var currentClass: Class[_] = clazz
-    while (currentClass != classOf[java.lang.Object]) {
-      val declaredField = currentClass.getDeclaredField(name)
-      if (declaredField != null) {
-        val accessible = declaredField.isAccessible
-        try {
-          declaredField.setAccessible(true)
-          return declaredField
-        } finally {
-          declaredField.setAccessible(accessible)
-        }
-      }
-      currentClass = currentClass.getSuperclass;
+  def getField(name: String, klass: Class[_]): Field = {
+    try {
+      klass.getDeclaredField(name)
+    } catch {
+      case NonFatal(_) ⇒ getField(name, klass.getSuperclass)
     }
-    throw new RuntimeException("Failed to find field " + name + " in " + clazz.getName)
   }
 
-  def setField(name: String, of: AnyRef, withValue: AnyRef) {
-    var currentClass: Class[_] = of.getClass
-    while (currentClass != classOf[java.lang.Object]) {
-      val declaredField = currentClass.getDeclaredField(name)
-      if (declaredField != null) {
-        val accessible = declaredField.isAccessible
-        try {
-          declaredField.setAccessible(true)
-          declaredField.set(of, withValue)
-          return
-        } finally {
-          declaredField.setAccessible(accessible)
-        }
-      }
-      currentClass = currentClass.getSuperclass;
+  def getFieldValue(fieldName: String, onInstance: AnyRef): AnyRef = {
+    getField(fieldName, onInstance.getClass) match {
+      case f: Field ⇒
+        f.setAccessible(true)
+        f.get(onInstance)
     }
-    throw new RuntimeException("Failed to set field " + name + " on " + of.getClass.getName)
   }
 
-  def getFieldValue(name: String, of: AnyRef): Any = {
-    var currentClass: Class[_] = of.getClass
-    while (currentClass != classOf[java.lang.Object]) {
-      val declaredField = currentClass.getDeclaredField(name)
-      if (declaredField != null) {
-        val accessible = declaredField.isAccessible
-        try {
-          declaredField.setAccessible(true)
-          return declaredField.get(of)
-        } finally {
-          declaredField.setAccessible(accessible)
-        }
-      }
-      currentClass = currentClass.getSuperclass;
+  def setFieldValue(fieldName: String, onInstance: AnyRef, setTo: Any) {
+    getField(fieldName, onInstance.getClass) match {
+      case f: Field ⇒
+        f.setAccessible(true)
+        f.set(onInstance, setTo)
     }
-    throw new RuntimeException("Failed to get field " + name + " on " + of.getClass.getName)
   }
 
-  def invokeMethod(name: String, of: AnyRef): Any = {
-    var currentClass: Class[_] = of.getClass
-    while (currentClass != classOf[java.lang.Object]) {
-      import scala.collection.JavaConversions._
-      currentClass.getDeclaredMethods.find(_.getName.equals(name)) match {
-        case Some(method) ⇒
-          {
-            val accessible = method.isAccessible
-            try {
-              method.setAccessible(true)
-              return method.invoke(of)
-            } finally {
-              method.setAccessible(accessible)
-            }
-          };
-        case _ ⇒ // ignore
-      }
-
-      currentClass = currentClass.getSuperclass;
-    }
-    throw new RuntimeException("Failed to find method " + name + " on " + of.getClass.getName)
+  def invokeMethod(methodName: String, onInstance: AnyRef): AnyRef = {
+    onInstance.getClass.getMethods.find(_.getName == methodName).get.invoke(onInstance)
   }
+
 }

--- a/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/RemoteClassLoadingTransport.scala
+++ b/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/RemoteClassLoadingTransport.scala
@@ -1,0 +1,342 @@
+package akka.remote.netty.rcl
+
+import akka.remote.RemoteSettings
+import akka.remote.netty.NettyRemoteTransport
+import org.jboss.netty.channel._
+import org.jboss.netty.handler.execution._
+import akka.remote.{ RemoteMessage, RemoteActorRefProvider }
+import com.google.protobuf.ByteString
+import akka.remote.RemoteProtocol.{ RemoteMessageProtocol, AkkaRemoteProtocol }
+import collection.immutable.HashSet
+import collection.mutable.HashMap
+import akka.dispatch.Await
+import java.net.URL
+import akka.actor.{ Props, Actor, ActorRef, ExtendedActorSystem }
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import akka.event.{ LoggingAdapter, Logging }
+import scala.collection._
+import akka.util.NonFatal
+
+class RemoteClassLoadingTransport(system: ExtendedActorSystem, provider: RemoteActorRefProvider) extends NettyRemoteTransport(system, provider) {
+
+  // 1 thread should be plenty
+  val nrOfRclThreads = 1;
+
+  // the RCL stuff has to be processed by a separate thread because we might block in the classloader or the user might block
+  override def createPipeline(endpoint: ⇒ ChannelHandler, withTimeout: Boolean): ChannelPipelineFactory = {
+    new ChannelPipelineFactory {
+      def getPipeline = PipelineFactory(PipelineFactory.defaultStack(withTimeout).dropRight(1).toSeq ++ Seq(sedaRclPriorityHandler, endpoint))
+    }
+  }
+
+  lazy val rclExecutor = new OrderedMemoryAwareThreadPoolExecutor(
+    nrOfRclThreads,
+    settings.MaxChannelMemorySize,
+    settings.MaxTotalMemorySize,
+    settings.ExecutionPoolKeepalive.length,
+    settings.ExecutionPoolKeepalive.unit,
+    system.threadFactory)
+
+  lazy val superExecutor = new OrderedMemoryAwareThreadPoolExecutor(
+    settings.ExecutionPoolSize,
+    settings.MaxChannelMemorySize,
+    settings.MaxTotalMemorySize,
+    settings.ExecutionPoolKeepalive.length,
+    settings.ExecutionPoolKeepalive.unit,
+    system.threadFactory)
+
+  lazy val sedaRclPriorityHandler = new ExecutionHandler(new ChainedExecutor(new ChannelEventRunnableFilter {
+    def filter(event: ChannelEventRunnable) = {
+      event.getEvent match {
+        case me: MessageEvent ⇒ me.getMessage match {
+          case arp: AkkaRemoteProtocol ⇒ RclMetadata.isRclChatMsg(arp)
+          case _                       ⇒ false
+        }
+        case _ ⇒ false
+      }
+    }
+  }, rclExecutor, superExecutor))
+
+  val systemClassLoader = system.dynamicAccess.classLoader
+
+  val systemClassLoaderChain: HashSet[ClassLoader] = {
+    var clChain = new HashSet[ClassLoader]()
+    var currentCl = systemClassLoader
+    while (currentCl != null) {
+      clChain += currentCl
+      currentCl = currentCl.getParent
+    }
+    clChain
+  }
+
+  // replace dynamic access with our thread local dynamic access
+  val threadLocalDynamicAccess = new ThreadLocalReflectiveDynamicAccess(systemClassLoader)
+  ReflectionUtil.setField("_pm", system, threadLocalDynamicAccess)
+
+  lazy val originAddressByteString = ByteString.copyFrom(address.toString, "utf-8")
+
+  val remoteClassLoaders: HashMap[ByteString, RemoteClassLoader] = HashMap()
+
+  private val remoteClassLoadersLock = new ReentrantReadWriteLock
+
+  // this is the actor we query for RCL stuff that is process by seperated thread
+  system.actorOf(Props { new RclActor(systemClassLoader) }, "Rcl-Service")
+
+  // on received just make sure the "context" has the correct classloader set
+  override def receiveMessage(remoteMessage: RemoteMessage) {
+    RclMetadata.getOrigin(remoteMessage) match {
+      case `originAddressByteString` ⇒ {
+        threadLocalDynamicAccess.dynamicVariable.withValue(systemClassLoader) {
+          super.receiveMessage(remoteMessage)
+        }
+      }
+      case someOrigin: ByteString ⇒ {
+        val rcl = getClassLoaderForOrigin(someOrigin)
+
+        threadLocalDynamicAccess.dynamicVariable.withValue(rcl) {
+          super.receiveMessage(remoteMessage)
+        }
+      }
+      case _ ⇒ {
+        threadLocalDynamicAccess.dynamicVariable.withValue(systemClassLoader) {
+          super.receiveMessage(remoteMessage)
+        }
+      }
+    }
+  }
+
+  def getClassLoaderForOrigin(someOrigin: ByteString): RemoteClassLoader = {
+    remoteClassLoadersLock.readLock.lock
+    try {
+      remoteClassLoaders.get(someOrigin) match {
+        case Some(cl) ⇒ cl
+        case None ⇒
+          remoteClassLoadersLock.readLock.unlock
+          remoteClassLoadersLock.writeLock.lock //Lock upgrade, not supported natively
+          try {
+            try {
+              remoteClassLoaders.get(someOrigin) match {
+                //Recheck for addition, race between upgrades
+                case Some(cl) ⇒ cl //If already populated by other writer
+                case None ⇒ //Populate map
+                  log.debug("Creating new Remote Class Loader with Origin {}.", someOrigin.toStringUtf8)
+                  val cl = new RemoteClassLoader(systemClassLoader, system.actorFor(someOrigin.toStringUtf8 + "/user/Rcl-Service"), someOrigin, log, new RemoteSettings(system.settings.config, system.name))
+                  remoteClassLoaders += someOrigin -> cl
+                  cl
+              }
+            } finally {
+              remoteClassLoadersLock.readLock.lock
+            } //downgrade
+          } finally {
+            remoteClassLoadersLock.writeLock.unlock
+          }
+      }
+    } finally {
+      remoteClassLoadersLock.readLock().unlock()
+    }
+  }
+
+  // just tag the message with the origin and in case of RCL messages with RCL tag
+  override def createRemoteMessageProtocolBuilder(recipient: ActorRef, message: Any, senderOption: Option[ActorRef]) = {
+    val pb = super.createRemoteMessageProtocolBuilder(recipient, message, senderOption)
+
+    message match {
+      case rcl: RclChatMsg ⇒ RclMetadata.addRclChatTag(pb)
+      case ref: AnyRef ⇒ {
+        val name = ref.getClass.getName
+        if (!name.startsWith("java.") && !name.startsWith("scala.")) {
+          ref.getClass.getClassLoader match {
+            case rcl: RemoteClassLoader ⇒ {
+              RclMetadata.addOrigin(pb, rcl.originAddress)
+            }
+            case cl: ClassLoader ⇒ systemClassLoaderChain(cl) match {
+              case true ⇒ RclMetadata.addOrigin(pb, originAddressByteString)
+              case _    ⇒ log.warning("Remote Class Loading does not support sending messages loaded outside Actor System's classloader.\n{}", message)
+            }
+            case null ⇒ // null ClassLoader e.g. java.lang.String this is fine
+          }
+        }
+      }
+
+      case _ ⇒ // not AnyRef even less of a problem
+    }
+    pb
+  }
+}
+
+import akka.util.Timeout
+import akka.util.duration._
+import akka.pattern.ask
+
+class RemoteClassLoader(parent: ClassLoader, origin: ActorRef, val originAddress: ByteString, log: LoggingAdapter, settings: RemoteSettings) extends ClassLoader(parent) {
+
+  implicit val timeout = Timeout(settings.RemoteSystemDaemonAckTimeout)
+
+  val preloadedClasses = new mutable.HashMap[String, Array[Byte]]()
+
+  var innerCall = false
+
+  // normally it is not possible to block in here as this will in fact block the netty dispatcher i.e. no new stuff on this channel
+  // but we are using a special thread just for this so this is safe
+  override def findClass(fqn: String): Class[_] = {
+    if (innerCall) throw new ClassNotFoundException(fqn)
+
+    log.debug("ClassLoader#findClass({}) from {}.", fqn, origin.path.address)
+
+    preloadedClasses remove (fqn) orNull match {
+      case null ⇒ doRcl(fqn)
+      case bytecode: Array[Byte] ⇒ {
+        log.debug("Bytecode for {} found in preloaded cache from {}.", fqn, origin.path.address)
+        defineClass(fqn, bytecode, 0, bytecode.length)
+      }
+    }
+  }
+
+  def doRcl(fqn: String): Class[_] = {
+    try {
+      log.debug("Initiated RCL for {} from {}.", fqn, origin.path.address)
+      val referencedClasses = Await.result(origin ? GiveMeReferencedClassesOf(fqn), timeout.duration) match {
+        case r: ReferencedClassesOf ⇒ r.refs
+        case _ ⇒ {
+          // if we can't get references we are sure we cannot get the bytecode or is corrupt
+          log.warning("Failed to find referenced classes for {}.")
+          throw new ClassNotFoundException(fqn)
+        }
+      }
+      log.debug("Got list of referenced classes for {} from {}.\n{}", fqn, origin.path.address, referencedClasses deepToString)
+      val withoutAlreadyAvailable = referencedClasses filter (!isAlreadyLoaded(_)) filter (_ != fqn)
+      log.debug("Requesting only the following bytecodes from {}.\n{}", origin.path.address, withoutAlreadyAvailable deepToString)
+
+      val bytecodes = Await.result(origin ? GiveMeByteCodesFor(fqn, withoutAlreadyAvailable), timeout.duration).asInstanceOf[ByteCodesFor]
+
+      log.debug("Got bytecodes from {}.\n{}", origin.path.address, bytecodes.entries deepToString)
+
+      bytecodes.entries foreach (_ match {
+        case ByteCodeFor(fqn, bytecode) ⇒ preloadedClasses += fqn -> bytecode
+        case _                          ⇒ log.error("Bug in RCL code. ByteCodesFor contained invalid entries.")
+      })
+      val bytecode = bytecodes.first.bytecode
+      defineClass(fqn, bytecode, 0, bytecode.length)
+    } catch {
+      case e: Exception ⇒ {
+        log.debug("Failed to get requested bytecode for class {} from {}.\n{}", fqn, origin.path.address, e)
+        throw new ClassNotFoundException(fqn)
+      }
+    }
+  }
+
+  def isAlreadyLoaded(fqn: String): Boolean = {
+    try {
+      innerCall = true
+      loadClass(fqn)
+      return true
+    } catch {
+      case NonFatal(_) ⇒ false
+    } finally {
+      innerCall = false
+    }
+  }
+}
+
+object RclMetadata {
+
+  def isRclChatMsg(arp: AkkaRemoteProtocol): Boolean = {
+    if (arp.hasInstruction) false
+    import scala.collection.JavaConversions._
+    arp.getMessage.getMetadataList.collectFirst({
+      case entry if entry.getKey == "rclChatMsg" ⇒ true
+    }).getOrElse(false)
+  }
+
+  def addRclChatTag(pb: RemoteMessageProtocol.Builder) {
+    val metadataBuilder = pb.addMetadataBuilder()
+    metadataBuilder.setKey("rclChatMsg")
+    metadataBuilder.setValue(ByteString.EMPTY)
+  }
+
+  def addOrigin(pb: RemoteMessageProtocol.Builder, origin: ByteString) {
+    val metadataBuilder = pb.addMetadataBuilder()
+    metadataBuilder.setKey("origin")
+    metadataBuilder.setValue(origin)
+  }
+
+  def getOrigin(rm: RemoteMessage): ByteString = {
+    val rmp: RemoteMessageProtocol = rm.input
+    import scala.collection.JavaConversions._
+    rmp.getMetadataList.collectFirst({
+      case entry if entry.getKey == "origin" ⇒ entry.getValue
+    }).orNull
+  }
+
+}
+
+class RclActor(val cl: ClassLoader) extends Actor {
+
+  val log = Logging(context.system, this)
+
+  def receive = {
+    case GiveMeByteCodeFor(fqn) ⇒ {
+      try {
+        log.debug("Recieved bytecode request for {} from {}.", fqn, sender.path.address)
+        sender ! ByteCodeFor(fqn, getBytecode(fqn))
+      } catch {
+        case NonFatal(_) ⇒
+          log.warning("Cannot find bytecode for {}.", fqn)
+          sender ! ByteCodeNotAvailable(fqn)
+
+      }
+    }
+
+    case GiveMeByteCodesFor(fqn, fqns) ⇒ {
+      try {
+        log.debug("Recieved bytecodes request for {} from {}.", fqns, sender.path.address)
+        sender ! ByteCodesFor(ByteCodeFor(fqn, getBytecode(fqn)), fqns.map((fqn) ⇒ ByteCodeFor(fqn, getBytecode(fqn))) toArray)
+      } catch {
+        case NonFatal(_) ⇒
+          log.warning("Cannot find bytecode for {}.", fqns)
+          sender ! ByteCodeNotAvailable("")
+
+      }
+    }
+
+    case GiveMeReferencedClassesOf(fqn) ⇒ {
+      log.debug("Recieved request for all references of {} from {}.", fqn, sender.path.address)
+      try {
+        // this should always unless we don't have the class or is corrupt
+        // but we consider if is corrupt that the bytecode is not available
+        sender ! ReferencedClassesOf(fqn, ByteCodeInspector.findReferencedClassesFor(cl.loadClass(fqn)) toArray)
+      } catch {
+        case NonFatal(_) ⇒
+          log.warning("Cannot find referenced classes of of {}.", fqn)
+
+          sender ! ByteCodeNotAvailable(fqn)
+      }
+
+    }
+
+    case _ ⇒ log.warning("RCL actor received unknown message. Might indicate a bug present.")
+  }
+
+  def getBytecode(fqn: String): Array[Byte] = {
+    val resourceName = fqn.replaceAll("\\.", "/") + ".class"
+    cl.getResource(resourceName) match {
+      case url: URL ⇒ IOUtil.toByteArray(url)
+      case _        ⇒ throw new ClassNotFoundException(fqn)
+    }
+  }
+
+}
+
+sealed trait RclChatMsg
+
+// RCL Questions
+case class GiveMeByteCodeFor(fqn: String) extends RclChatMsg
+case class GiveMeByteCodesFor(fqn: String, fqns: Array[String]) extends RclChatMsg
+case class GiveMeReferencedClassesOf(fqn: String) extends RclChatMsg
+
+// RCL Answers
+case class ByteCodeFor(fqn: String, bytecode: Array[Byte]) extends RclChatMsg
+case class ByteCodesFor(first: ByteCodeFor, entries: Array[ByteCodeFor]) extends RclChatMsg
+case class ReferencedClassesOf(fromFqn: String, refs: Array[String]) extends RclChatMsg
+
+case class ByteCodeNotAvailable(fqn: String) extends RclChatMsg

--- a/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/RemoteClassLoadingTransport.scala
+++ b/akka-remote-rcl/src/main/scala/akka/remote/netty/rcl/RemoteClassLoadingTransport.scala
@@ -71,7 +71,7 @@ class RemoteClassLoadingTransport(system: ExtendedActorSystem, provider: RemoteA
 
   // replace dynamic access with our thread local dynamic access
   val threadLocalDynamicAccess = new ThreadLocalReflectiveDynamicAccess(systemClassLoader)
-  ReflectionUtil.setField("_pm", system, threadLocalDynamicAccess)
+  ReflectionUtil.setFieldValue("_pm", system, threadLocalDynamicAccess)
 
   lazy val originAddressByteString = ByteString.copyFrom(address.toString, "utf-8")
 

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/AbstractRemoteActorMultiJvmSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/AbstractRemoteActorMultiJvmSpec.scala
@@ -1,0 +1,28 @@
+package akka.remote
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+trait AbstractRemoteActorMultiJvmSpec {
+  def NrOfNodes: Int
+  def commonConfig: Config
+
+  def PortRangeStart = 1990
+  def NodeRange = 1 to NrOfNodes
+
+  private[this] val remotes: IndexedSeq[String] = {
+    val nodesOpt = Option(AkkaRemoteSpec.testNodes).map(_.split(",").toIndexedSeq)
+    nodesOpt getOrElse IndexedSeq.fill(NrOfNodes)("localhost")
+  }
+
+  val nodeConfigs = (NodeRange.toList zip remotes) map {
+    case (port, host) =>
+      ConfigFactory.parseString("""
+        akka {
+          remote.netty.hostname="%s"
+          remote.netty.port = "%d"
+        }""".format(host, PortRangeStart + port, port)) withFallback commonConfig
+  }
+
+  def akkaSpec(port: Int) = "AkkaRemoteSpec@%s:%d".format(remotes(port), PortRangeStart + 1 + port)
+  def akkaURIs(count: Int): String = 0 until count map {idx => "\"akka://" + akkaSpec(idx) + "\""} mkString ","
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/AkkaRemoteSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/AkkaRemoteSpec.scala
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.remote
+
+import akka.testkit._
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigParseOptions
+import com.typesafe.config.ConfigResolveOptions
+import java.io.File
+import akka.actor.ActorSystem
+
+object AkkaRemoteSpec {
+  private def configParseOptions = ConfigParseOptions.defaults.setAllowMissing(false)
+
+  val testConf: Config = {
+    System.getProperty("akka.config") match {
+      case null ⇒ AkkaSpec.testConf
+      case location ⇒
+        ConfigFactory.systemProperties
+          .withFallback(ConfigFactory.parseFileAnySyntax(new File(location), configParseOptions))
+          .withFallback(ConfigFactory.defaultReference(ActorSystem.findClassLoader())).resolve(ConfigResolveOptions.defaults)
+    }
+  }
+
+  val testNodes = System.getProperty("test.hosts")
+}
+
+abstract class AkkaRemoteSpec(config: Config)
+  extends AkkaSpec(config.withFallback(AkkaRemoteSpec.testConf))
+  with MultiJvmSync

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/AkkaSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/AkkaSpec.scala
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit;
+
+import org.scalatest.{ WordSpec, BeforeAndAfterAll, Tag }
+import org.scalatest.matchers.MustMatchers
+import akka.actor.ActorSystem
+import akka.actor.{ Actor, Props }
+import akka.event.{ Logging, LoggingAdapter }
+import akka.util.duration._
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import akka.actor.PoisonPill
+import akka.actor.DeadLetter
+import java.util.concurrent.TimeoutException
+import akka.dispatch.Await
+import akka.dispatch.Dispatchers
+import akka.pattern.ask
+
+object TimingTest extends Tag("timing")
+object LongRunningTest extends Tag("long-running")
+
+object AkkaSpec {
+  val testConf: Config = ConfigFactory.parseString("""
+      akka {
+        event-handlers = ["akka.testkit.TestEventListener"]
+        loglevel = "WARNING"
+        stdout-loglevel = "WARNING"
+        actor {
+          default-dispatcher {
+            executor = "fork-join-executor"
+            fork-join-executor {
+              parallelism-min = 8
+              parallelism-factor = 2.0
+              parallelism-max = 8
+            }
+          }
+        }
+      }
+      """)
+
+  def mapToConfig(map: Map[String, Any]): Config = {
+    import scala.collection.JavaConverters._
+    ConfigFactory.parseMap(map.asJava)
+  }
+
+  def getCallerName: String = {
+    val s = Thread.currentThread.getStackTrace map (_.getClassName) drop 1 dropWhile (_ matches ".*AkkaSpec.?$")
+    s.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
+  }
+
+}
+
+abstract class AkkaSpec(_system: ActorSystem)
+  extends TestKit(_system) with WordSpec with MustMatchers with BeforeAndAfterAll {
+
+  def this(config: Config) = this(ActorSystem(AkkaSpec.getCallerName, config.withFallback(AkkaSpec.testConf)))
+
+  def this(s: String) = this(ConfigFactory.parseString(s))
+
+  def this(configMap: Map[String, _]) = this(AkkaSpec.mapToConfig(configMap))
+
+  def this() = this(ActorSystem(AkkaSpec.getCallerName, AkkaSpec.testConf))
+
+  val log: LoggingAdapter = Logging(system, this.getClass)
+
+  final override def beforeAll {
+    atStartup()
+  }
+
+  final override def afterAll {
+    system.shutdown()
+    try system.awaitTermination(5 seconds) catch {
+      case _: TimeoutException ⇒ system.log.warning("Failed to stop [{}] within 5 seconds", system.name)
+    }
+    atTermination()
+  }
+
+  protected def atStartup() {}
+
+  protected def atTermination() {}
+
+  def spawn(dispatcherId: String = Dispatchers.DefaultDispatcherId)(body: ⇒ Unit) {
+    system.actorOf(Props(ctx ⇒ { case "go" ⇒ try body finally ctx.stop(ctx.self) }).withDispatcher(dispatcherId)) ! "go"
+  }
+}
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class AkkaSpecSpec extends WordSpec with MustMatchers {
+
+  "An AkkaSpec" must {
+
+    "warn about unhandled messages" in {
+      implicit val system = ActorSystem("AkkaSpec0", AkkaSpec.testConf)
+      try {
+        val a = system.actorOf(Props.empty)
+        EventFilter.warning(start = "unhandled message", occurrences = 1) intercept {
+          a ! 42
+        }
+      } finally {
+        system.shutdown()
+      }
+    }
+
+    "terminate all actors" in {
+      // verbose config just for demonstration purposes, please leave in in case of debugging
+      import scala.collection.JavaConverters._
+      val conf = Map(
+        "akka.actor.debug.lifecycle" -> true, "akka.actor.debug.event-stream" -> true,
+        "akka.loglevel" -> "DEBUG", "akka.stdout-loglevel" -> "DEBUG")
+      val system = ActorSystem("AkkaSpec1", ConfigFactory.parseMap(conf.asJava).withFallback(AkkaSpec.testConf))
+      val spec = new AkkaSpec(system) {
+        val ref = Seq(testActor, system.actorOf(Props.empty, "name"))
+      }
+      spec.ref foreach (_.isTerminated must not be true)
+      system.shutdown()
+      spec.awaitCond(spec.ref forall (_.isTerminated), 2 seconds)
+    }
+
+    "must stop correctly when sending PoisonPill to rootGuardian" in {
+      val system = ActorSystem("AkkaSpec2", AkkaSpec.testConf)
+      val spec = new AkkaSpec(system) {}
+      val latch = new TestLatch(1)(system)
+      system.registerOnTermination(latch.countDown())
+
+      system.actorFor("/") ! PoisonPill
+
+      Await.ready(latch, 2 seconds)
+    }
+
+    "must enqueue unread messages from testActor to deadLetters" in {
+      val system, otherSystem = ActorSystem("AkkaSpec3", AkkaSpec.testConf)
+
+      try {
+        var locker = Seq.empty[DeadLetter]
+        implicit val timeout = TestKitExtension(system).DefaultTimeout
+        implicit val davyJones = otherSystem.actorOf(Props(new Actor {
+          def receive = {
+            case m: DeadLetter ⇒ locker :+= m
+            case "Die!"        ⇒ sender ! "finally gone"; context.stop(self)
+          }
+        }), "davyJones")
+
+        system.eventStream.subscribe(davyJones, classOf[DeadLetter])
+
+        val probe = new TestProbe(system)
+        probe.ref ! 42
+        /*
+       * this will ensure that the message is actually received, otherwise it
+       * may happen that the system.stop() suspends the testActor before it had
+       * a chance to put the message into its private queue
+       */
+        probe.receiveWhile(1 second) {
+          case null ⇒
+        }
+
+        val latch = new TestLatch(1)(system)
+        system.registerOnTermination(latch.countDown())
+        system.shutdown()
+        Await.ready(latch, 2 seconds)
+        Await.result(davyJones ? "Die!", timeout.duration) must be === "finally gone"
+
+        // this will typically also contain log messages which were sent after the logger shutdown
+        locker must contain(DeadLetter(42, davyJones, probe.ref))
+      } finally {
+        system.shutdown()
+        otherSystem.shutdown()
+      }
+    }
+
+  }
+}
+

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/Barrier.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/Barrier.scala
@@ -1,0 +1,19 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.remote
+
+trait Barrier {
+  def await() = { enter(); leave() }
+
+  def apply(body: ⇒ Unit) {
+    enter()
+    body
+    leave()
+  }
+
+  def enter(): Unit
+
+  def leave(): Unit
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/FileBasedBarrier.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/FileBasedBarrier.scala
@@ -1,0 +1,82 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.remote
+
+import akka.util.duration._
+import akka.util.Duration
+import System.{ currentTimeMillis ⇒ now }
+
+import java.io.File
+
+class BarrierTimeoutException(message: String) extends RuntimeException(message)
+
+object FileBasedBarrier {
+  val HomeDir = ".multi-jvm"
+  val DefaultTimeout = 30.seconds
+  val DefaultSleep = 100.millis
+}
+
+
+class FileBasedBarrier(
+  name: String,
+  count: Int,
+  group: String,
+  node: String,
+  timeout: Duration = FileBasedBarrier.DefaultTimeout,
+  sleep: Duration = FileBasedBarrier.DefaultSleep) extends Barrier {
+
+  val barrierDir = {
+    val dir = new File(new File(new File(FileBasedBarrier.HomeDir), group), name)
+    dir.mkdirs()
+    dir
+  }
+
+  val nodeFile = new File(barrierDir, node)
+
+  val readyFile = new File(barrierDir, "ready")
+
+  def enter() = {
+    createNode()
+    if (nodesPresent >= count) createReady()
+    val ready = waitFor(readyFile.exists, timeout, sleep)
+    if (!ready) expire("entry")
+  }
+
+  def leave() = {
+    removeNode()
+    val empty = waitFor(nodesPresent <= 1, timeout, sleep)
+    removeReady()
+    if (!empty) expire("exit")
+  }
+
+  def nodesPresent = barrierDir.list.size
+
+  def createNode() = nodeFile.createNewFile()
+
+  def removeNode() = nodeFile.delete()
+
+  def createReady() = readyFile.createNewFile()
+
+  def removeReady() = readyFile.delete()
+
+  def waitFor(test: ⇒ Boolean, timeout: Duration, sleep: Duration): Boolean = {
+    val start = now
+    val limit = start + timeout.toMillis
+    var passed = test
+    var expired = false
+    while (!passed && !expired) {
+      if (now > limit) expired = true
+      else {
+        Thread.sleep(sleep.toMillis)
+        passed = test
+      }
+    }
+    passed
+  }
+
+  def expire(barrier: String) = {
+    throw new BarrierTimeoutException("Timeout (%s) waiting for %s barrier" format (timeout, barrier))
+  }
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/MultiJvmSync.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/MultiJvmSync.scala
@@ -1,0 +1,46 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.remote
+
+import akka.testkit.AkkaSpec
+import akka.util.Duration
+
+trait MultiJvmSync extends AkkaSpec {
+  def nodes: Int
+
+  override def atStartup() = {
+    onStart()
+    MultiJvmSync.start(getClass.getName, nodes)
+  }
+
+  def onStart() {}
+
+  override def atTermination() = {
+    MultiJvmSync.end(getClass.getName, nodes)
+    onEnd()
+  }
+
+  def onEnd() {}
+
+  def barrier(name: String, timeout: Duration = FileBasedBarrier.DefaultTimeout) = {
+    MultiJvmSync.barrier(name, nodes, getClass.getName, timeout)
+  }
+}
+
+object MultiJvmSync {
+  val TestMarker = "MultiJvm"
+  val StartBarrier = "multi-jvm-start"
+  val EndBarrier = "multi-jvm-end"
+
+  def start(className: String, count: Int) = barrier(StartBarrier, count, className)
+
+  def end(className: String, count: Int) = barrier(EndBarrier, count, className)
+
+  def barrier(name: String, count: Int, className: String, timeout: Duration = FileBasedBarrier.DefaultTimeout) = {
+    val Array(testName, nodeName) = className split TestMarker
+    val barrier = new FileBasedBarrier(name, count, testName, nodeName, timeout)
+    barrier.await()
+  }
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/FrowardMultiJvmSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/FrowardMultiJvmSpec.scala
@@ -1,0 +1,128 @@
+package akka.remote.netty.rcl
+
+import akka.remote.{AkkaRemoteSpec, AbstractRemoteActorMultiJvmSpec}
+import akka.util.Timeout
+import akka.actor.{ActorRef, Actor, Props}
+import akka.dispatch.Await
+
+// Node 1 forwards Node1Ping msg to Node 2 forwards to Node 3 and then Node 3 sends Node3 Pong back to Node 1
+object ForwardMultiJvmSpec extends AbstractRemoteActorMultiJvmSpec {
+  override def NrOfNodes = 3
+
+  class ForwardActor(forwardTo: ActorRef) extends Actor with Serializable {
+    def receive = {
+      case msg => forwardTo.tell(msg, sender)
+    }
+  }
+
+  class PongActor extends Actor with Serializable {
+    def receive = {
+      case msg => sender ! Node3Pong
+    }
+  }
+
+  val NODE1_PING_FQN = "akka.remote.netty.rcl.ForwardMultiJvmSpec$Node1Ping$"
+  // case objects have $ at the end
+  val NODE3_PONG_FQN = "akka.remote.netty.rcl.ForwardMultiJvmSpec$Node3Pong$"
+  // case objects have $ at the end
+
+  case object Node1Ping
+  case object Node3Pong
+
+
+  import com.typesafe.config.ConfigFactory
+
+  override def commonConfig = ConfigFactory.parseString( """
+    akka {
+      loglevel = "WARNING"
+      actor {
+        provider = "akka.remote.RemoteActorRefProvider"
+      }
+      remote.transport = akka.remote.netty.rcl.RemoteClassLoadingTransport
+    }""")
+}
+
+import ForwardMultiJvmSpec._
+
+class ForwardMultiJvmNode1 extends AkkaRemoteSpec(nodeConfigs(0)) {
+
+  import ForwardMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  System.setProperty("path_hole.filter", "*Node2*,*Node3*")
+  System.setProperty("path_hole.unfiltered.cls", "akka.remote.netty.rcl.RemoteClassLoader")
+
+
+  import akka.util.duration._
+  import akka.pattern.ask
+
+  implicit val timeout = Timeout(20 seconds)
+
+  "___" must {
+    "___" in {
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE3_PONG_FQN)
+      }
+      barrier("start")
+      val node2EchoActor = system.actorFor("akka://" + akkaSpec(1) + "/user/service-forward")
+      Await.result(node2EchoActor ? Node1Ping, timeout.duration).asInstanceOf[AnyRef].getClass.getName must equal(NODE3_PONG_FQN)
+      barrier("done")
+    }
+  }
+}
+
+
+class ForwardMultiJvmNode2 extends AkkaRemoteSpec(nodeConfigs(1)) {
+
+  import ForwardMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  import akka.util.duration._
+
+  System.setProperty("path_hole.filter", "*Node1*,*Node3*")
+  System.setProperty("path_hole.unfiltered.cls", "akka.remote.netty.rcl.RemoteClassLoader")
+
+  implicit val timeout = Timeout(20 seconds)
+
+  "Remote class loading" must {
+    "properly work with messages that contain methods" in {
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE1_PING_FQN)
+        Class.forName(NODE3_PONG_FQN)
+      }
+      barrier("start")
+      val node3PongActor = system.actorFor("akka://" + akkaSpec(2) + "/user/service-echo")
+      system.actorOf(Props {
+        new ForwardActor(node3PongActor)
+      }, "service-forward")
+      barrier("done")
+    }
+  }
+}
+
+class ForwardMultiJvmNode3 extends AkkaRemoteSpec(nodeConfigs(2)) {
+
+  import ForwardMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  import akka.util.duration._
+
+  implicit val timeout = Timeout(20 seconds)
+
+  System.setProperty("path_hole.filter", "*Node1*,*Node2*")
+  System.setProperty("path_hole.unfiltered.cls", "akka.remote.netty.rcl.RemoteClassLoader")
+
+  "Remote class loading" must {
+    "properly work with messages that contain methods" in {
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE1_PING_FQN)
+      }
+      barrier("start")
+      system.actorOf(Props[PongActor], "service-echo")
+      barrier("done")
+    }
+  }
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/MsgWithCycleMultiJvmSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/MsgWithCycleMultiJvmSpec.scala
@@ -1,0 +1,125 @@
+package akka.remote.netty.rcl
+
+import akka.actor.{Actor, Props}
+import akka.dispatch.Await
+import akka.pattern.ask
+import akka.remote.{AbstractRemoteActorMultiJvmSpec, AkkaRemoteSpec}
+import org.scalatest.matchers.MustMatchers
+import reflect.BeanProperty
+
+object MsgWithCycleMultiJvmSpec extends AbstractRemoteActorMultiJvmSpec {
+  override def NrOfNodes = 2
+
+
+  val NODE2_BAZ_FQN = "akka.remote.netty.rcl.MsgWithCycleMultiJvmSpec$Node2Baz"
+  val NODE2_BAR_FQN = "akka.remote.netty.rcl.MsgWithCycleMultiJvmSpec$Node2Bar"
+
+  // cycles
+ case class Node2Baz(@BeanProperty val bar: Node2Bar, value:String) {
+    override def toString = null
+    override def equals(p1: Any) = false
+  }
+ case class Node2Bar(@BeanProperty var baz:Node2Baz, value:String)  {
+   override def toString = null
+   override def equals(p1: Any) = false
+ }
+
+  class VerifyActor extends Actor with Serializable with MustMatchers {
+    def receive = {
+      case msg:AnyRef => {
+        try {
+          // class name must match
+          msg.getClass.getName must equal(NODE2_BAZ_FQN)
+          val bar = ReflectionUtil.invokeMethod("getBar", msg)
+          msg must be(ReflectionUtil.invokeMethod("getBaz", bar.asInstanceOf[AnyRef]))
+          sender ! msg
+        } catch {
+          case e => {
+            e.printStackTrace()
+            sender ! e
+          }
+        }
+
+      }
+      case _ => // drop
+    }
+  }
+
+  import com.typesafe.config.ConfigFactory
+
+  override def commonConfig = ConfigFactory.parseString( """
+    akka {
+      loglevel = "WARNING"
+      actor {
+        provider = "akka.remote.RemoteActorRefProvider"
+        deployment {
+          /service-verify.remote = %s
+        }
+      }
+      remote {
+        transport = "akka.remote.netty.rcl.RemoteClassLoadingTransport"
+      }
+    }""" format akkaURIs(1))
+}
+
+import MsgWithCycleMultiJvmSpec._
+
+class MsgWithCycleMultiJvmNode1 extends AkkaRemoteSpec(nodeConfigs(0)) {
+
+  import MsgWithCycleMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  // make sure Node1 classes are unavailable at Node2
+  System.setProperty("path_hole.filter", "*Node2*")
+  System.setProperty("path_hole.unfiltered.cls", "akka.remote.netty.rcl.RemoteClassLoader")
+
+  "___" must {
+    "___" in {
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE2_BAZ_FQN)
+      }
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE2_BAR_FQN)
+      }
+      barrier("start")
+      barrier("done")
+    }
+  }
+
+}
+
+class MsgWithCycleMultiJvmNode2 extends AkkaRemoteSpec(nodeConfigs(1)) {
+
+  import MsgWithCycleMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  import akka.util.duration._
+  implicit val timeout: akka.util.Timeout = 5 seconds
+
+  "Sending a message from Node1 to Node2" must {
+
+    "work even if the message class is not available on Node2" in {
+      barrier("start")
+
+      val verifyActor = system.actorOf(Props[VerifyActor], "service-verify")
+
+      val bar = new Node2Bar(null,"Bar")
+      val baz = new Node2Baz(bar,"Baz");
+      bar.baz = baz
+
+      // first the easy part just make sure if what we send is properly serialized back
+      val backBaz = Await.result(verifyActor ? baz, timeout.duration).asInstanceOf[Node2Baz]
+
+      backBaz.value must equal(baz.value)
+      backBaz.bar.value must equal(baz.bar.value)
+
+      // shut down the actor before we let the other node(s) shut down so we don't try to send
+      // "Terminate" to a shut down node
+      system.stop(verifyActor)
+      barrier("done")
+    }
+  }
+
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/MsgWithFieldsMultiJvmSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/MsgWithFieldsMultiJvmSpec.scala
@@ -1,0 +1,113 @@
+package akka.remote.netty.rcl
+
+import akka.actor.{Actor, Props}
+import akka.dispatch.Await
+import akka.pattern.ask
+import akka.remote.{AbstractRemoteActorMultiJvmSpec, AkkaRemoteSpec}
+import org.scalatest.matchers.MustMatchers
+
+object MsgWithFieldsMultiJvmSpec extends AbstractRemoteActorMultiJvmSpec {
+  override def NrOfNodes = 2
+
+  case class Node2ValueObject(r: Int, g: Int, b: Int)
+  case class Node2MsgWithFields(foo: String, baz: Node2ValueObject)
+
+  // pretty lame to have to do it this way but other-wize we'd load the class we are trying to load via RCL
+  val  NODE2_VALUE_OBJECT_FQN = "akka.remote.netty.rcl.MsgWithFieldsMultiJvmSpec$Node2ValueObject"
+  val  NODE2_MSG_WITH_FIELDS_FQN = "akka.remote.netty.rcl.MsgWithFieldsMultiJvmSpec$Node2MsgWithFields"
+
+  class VerifyActor extends Actor with Serializable with MustMatchers {
+    def receive = {
+      case msg: AnyRef => {
+        try {
+          // class name must match
+          msg.getClass.getName must equal(NODE2_MSG_WITH_FIELDS_FQN)
+          // the field values must match
+          ReflectionUtil.getFieldValue("foo", msg)  must equal("a")
+          // the same CL that loaded the MSG should load the value object
+          val innerValue = ReflectionUtil.getFieldValue("baz", msg).asInstanceOf[AnyRef]
+          innerValue.getClass.getClassLoader must be(msg.getClass.getClassLoader)
+          // inner value fields must match
+
+          ReflectionUtil.getFieldValue("r", innerValue)  must equal(0)
+          ReflectionUtil.getFieldValue("g", innerValue)  must equal(122)
+          ReflectionUtil.getFieldValue("b", innerValue)  must equal(255)
+          sender ! msg
+        } catch {
+          case e => {
+            e.printStackTrace()
+            sender ! e
+          }
+        }
+
+      }
+
+      case _ => sender ! Right(new IllegalArgumentException("Expected AnyRef."))
+    }
+  }
+  import com.typesafe.config.ConfigFactory
+
+  override def commonConfig = ConfigFactory.parseString( """
+    akka {
+      loglevel = "WARNING"
+      actor {
+        provider = "akka.remote.RemoteActorRefProvider"
+        deployment {
+          /service-verify.remote = %s
+        }
+      }
+      remote {
+        transport = "akka.remote.netty.rcl.RemoteClassLoadingTransport"
+        netty.message-frame-size = 10 MiB
+      }
+    }""" format akkaURIs(1))
+}
+
+import MsgWithFieldsMultiJvmSpec._
+
+class MsgWithFieldsMultiJvmNode1 extends AkkaRemoteSpec(nodeConfigs(0)) {
+
+  import MsgWithFieldsMultiJvmSpec._
+
+  System.setProperty("path_hole.filter", "*Node2*")
+  System.setProperty("path_hole.unfiltered.cls", "akka.remote.netty.rcl.RemoteClassLoader")
+
+  val nodes = NrOfNodes
+
+  "___" must {
+    "___" in {
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE2_VALUE_OBJECT_FQN)
+      }
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE2_MSG_WITH_FIELDS_FQN)
+      }
+      barrier("start")
+      barrier("done")
+    }
+  }
+}
+
+class MsgWithFieldsMultiJvmNode2 extends AkkaRemoteSpec(nodeConfigs(1)) {
+
+  import MsgWithFieldsMultiJvmSpec._
+  val nodes = NrOfNodes
+
+  import akka.util.duration._
+  implicit val timeout: akka.util.Timeout = 15 seconds
+
+  "Sending a message from Node1 to Node2" must {
+
+    "work even if the message class is not available on Node2" in {
+      barrier("start")
+      val verifyActor = system.actorOf(Props[VerifyActor], "service-verify")
+      val msg = Node2MsgWithFields("a", Node2ValueObject(0, 122, 255))
+      // first the easy part just make sure if what we send is properly serialized back
+      // we make sure stuff looks on the remote node as it looks on our node
+      Await.result(verifyActor ? msg, timeout.duration).asInstanceOf[Node2MsgWithFields] must equal(msg)
+      system.stop(verifyActor)
+      barrier("done")
+    }
+  }
+
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/MsgWithMethodMultiJvmSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/MsgWithMethodMultiJvmSpec.scala
@@ -1,0 +1,109 @@
+package akka.remote.netty.rcl
+
+import akka.remote.{RemoteActorRef, AkkaRemoteSpec, AbstractRemoteActorMultiJvmSpec}
+import akka.dispatch.Await
+import akka.pattern.ask
+import akka.util.Timeout
+import akka.actor.{Actor, Props}
+
+object MsgWithMethodMultiJvmSpec extends AbstractRemoteActorMultiJvmSpec {
+  override def NrOfNodes = 2
+
+  class SomeActor extends Actor with Serializable {
+
+    def receive = {
+      case bo: BinaryOperation => {
+        sender ! bo.doIt(7, 9)
+      }
+      case _ => // drop it
+    }
+  }
+
+  trait BinaryOperation extends Serializable {
+    def doIt(a: Int, b: Int): Int
+  }
+
+  class Node2AddOperation extends BinaryOperation {
+    def doIt(a: Int, b: Int) = a + b
+  }
+
+  class Node2MultiplyOperation extends BinaryOperation {
+    def doIt(a: Int, b: Int) = a * b
+  }
+
+  val NODE2_ADD_OP_FQN = "akka.remote.netty.rcl.MsgWithMethodMultiJvmSpec$Node2AddOperation"
+  val NODE2_MULTIPLY_OP_FQN = "akka.remote.netty.rcl.MsgWithMethodMultiJvmSpec$Node2MultiplyOperation"
+
+  import com.typesafe.config.ConfigFactory
+
+  override def commonConfig = ConfigFactory.parseString( """
+    akka {
+      loglevel = "WARNING"
+      actor {
+        provider = "akka.remote.RemoteActorRefProvider"
+        deployment {
+          /service-hello.remote = %s
+        }
+      }
+      remote.transport = akka.remote.netty.rcl.RemoteClassLoadingTransport
+      remote.netty.message-frame-size = 10 MiB
+    }""" format akkaURIs(1))
+}
+
+import MsgWithMethodMultiJvmSpec._
+
+class MsgWithMethodMultiJvmNode1 extends AkkaRemoteSpec(nodeConfigs(0)) {
+
+  import MsgWithMethodMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  // need to make sure Node1 does NOT have Node2* classes on the classpath
+  // this requires a bit of heavy lifting since Multi-JVM plugin starts 2 JVMs but both point to the same classpath on disk
+  // lets use the path-hole agent to hide the classes from the classpath
+  // this will make any ClassLoaders exept for the unfiltered ones to throw CNFE even if the class is on the classpath
+  System.setProperty("path_hole.filter", "*Node2*")
+  System.setProperty("path_hole.unfiltered.cls", "akka.remote.netty.rcl.RemoteClassLoader")
+
+  "___" must {
+    "___" in {
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE2_ADD_OP_FQN)
+      }
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE2_MULTIPLY_OP_FQN)
+      }
+      barrier("start")
+      barrier("done")
+    }
+  }
+}
+
+
+class MsgWithMethodMultiJvmNode2 extends AkkaRemoteSpec(nodeConfigs(1)) {
+
+  import MsgWithMethodMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  import akka.util.duration._
+
+  implicit val timeout = Timeout(20 seconds)
+
+
+  "Remote class loading" must {
+    "properly work with messages that contain methods" in {
+      barrier("start")
+      val actor = system.actorOf(Props[SomeActor], "service-hello")
+      actor.isInstanceOf[RemoteActorRef] must be(true)
+
+      Await.result(actor ? new Node2AddOperation, timeout.duration).asInstanceOf[Int] must equal(16)
+      Await.result(actor ? new Node2MultiplyOperation, timeout.duration).asInstanceOf[Int] must equal(63)
+
+      // shut down the actor before we let the other node(s) shut down so we don't try to send
+      // "Terminate" to a shut down node
+      system.stop(actor)
+      barrier("done")
+    }
+  }
+}

--- a/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/RemoteActorDeployMultiJvmSpec.scala
+++ b/akka-remote-rcl/src/multi-jvm/scala/akka/remote/netty/rcl/RemoteActorDeployMultiJvmSpec.scala
@@ -1,0 +1,81 @@
+package akka.remote.netty.rcl
+
+import akka.actor.{Actor, Props}
+import akka.dispatch.Await
+import akka.pattern.ask
+import akka.remote.{AbstractRemoteActorMultiJvmSpec, AkkaRemoteSpec}
+
+object RemoteActorDeployMultiJvmSpec extends AbstractRemoteActorMultiJvmSpec {
+  override def NrOfNodes = 2
+
+  val NODE2_ACTOR_FQN = "akka.remote.netty.rcl.RemoteActorDeployMultiJvmSpec$Node2EchoActor"
+
+  class Node2EchoActor extends Actor {
+    def receive = {
+      case x => sender ! x
+    }
+  }
+
+  import com.typesafe.config.ConfigFactory
+
+  override def commonConfig = ConfigFactory.parseString( """
+    akka {
+      loglevel = "WARNING"
+      actor {
+        provider = "akka.remote.RemoteActorRefProvider"
+        deployment {
+          /service-echo.remote = %s
+        }
+      }
+      remote {
+        transport = "akka.remote.netty.rcl.RemoteClassLoadingTransport"
+        netty.message-frame-size = 10 MiB
+      }
+    }""" format akkaURIs(1))
+}
+
+import RemoteActorDeployMultiJvmSpec._
+
+class RemoteActorDeployMultiJvmNode1 extends AkkaRemoteSpec(nodeConfigs(0)) {
+
+  import RemoteActorDeployMultiJvmSpec._
+
+  System.setProperty("path_hole.filter", "*Node2*")
+  System.setProperty("path_hole.unfiltered.cls", "akka.remote.netty.rcl.RemoteClassLoader")
+
+  val nodes = NrOfNodes
+
+  "___" must {
+    "___" in {
+      intercept[ClassNotFoundException] {
+        Class.forName(NODE2_ACTOR_FQN)
+      }
+      barrier("start")
+      barrier("done")
+    }
+  }
+}
+
+class RemoteActorDeployMultiJvmNode2 extends AkkaRemoteSpec(nodeConfigs(1)) {
+
+  import RemoteActorDeployMultiJvmSpec._
+
+  val nodes = NrOfNodes
+
+  import akka.util.duration._
+
+  implicit val timeout: akka.util.Timeout = 15 seconds
+
+  "Sending a message from Node1 to Node2" must {
+
+    "work even if the message class is not available on Node2" in {
+      barrier("start")
+      val verifyActor = system.actorOf(Props[Node2EchoActor], "service-echo")
+      // we make sure stuff looks on the remote node as it looks on our node
+      Await.result(verifyActor ? "foo", timeout.duration).asInstanceOf[String] must equal("foo")
+      system.stop(verifyActor)
+      barrier("done")
+    }
+  }
+
+}

--- a/akka-remote-rcl/src/test/scala/akka/remote/netty/rcl/ByteCodeInspectorSpec.scala
+++ b/akka-remote-rcl/src/test/scala/akka/remote/netty/rcl/ByteCodeInspectorSpec.scala
@@ -1,0 +1,43 @@
+package akka.remote.netty.rcl
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers._
+
+class ByteCodeInspectorSpec extends FlatSpec with ShouldMatchers {
+
+  "ByteCodeInspector" should "be able to list fqn of *most* of the classes the given class references" in {
+    val refs = ByteCodeInspector.findReferencedClassesFor(classOf[ToInspect]) toSet
+
+    refs should contain("java.math.BigDecimal") // fields
+    refs should contain("java.util.Calendar") // referenced methods 
+    refs should contain("java.util.TimeZone") // and
+    refs should contain("java.util.Locale") // params
+    refs should contain("java.util.ArrayList") // params
+
+    // should contain itself
+    refs should contain("akka.remote.netty.rcl.ByteCodeInspectorSpec$ToInspect")
+
+    // this is where *most* comes from, constant pool does not include methods the class defines
+    // it makes sense as this information is available in the method pool
+    // we are not parsing the method pool therefore we lack to get the references from our method definitions
+    // but the same class could be referenced elswhere
+    refs should not contain ("java.lang.String")
+    refs should not contain ("java.util.Date")
+  }
+
+  class ToInspect() {
+
+    val field: java.math.BigDecimal = null
+
+    def methodParamsRefsNotAvailable(a: String) {
+      java.util.Calendar.getInstance(null /*TimeZone*/ , null /*Locale*/ )
+    }
+
+    def returningNotAvailable(): java.util.Date = null
+
+    def referenced() {
+      val available = new java.util.ArrayList()
+    }
+  }
+
+}

--- a/akka-remote-rcl/src/test/scala/akka/remote/netty/rcl/ReflectionUtilTest.scala
+++ b/akka-remote-rcl/src/test/scala/akka/remote/netty/rcl/ReflectionUtilTest.scala
@@ -1,0 +1,42 @@
+package akka.remote.netty.rcl
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+
+class ReflectionUtilTest extends FlatSpec with ShouldMatchers {
+
+  class Foo(var foo: String)
+  class Bar(foo: String, var bar: String) extends Foo(foo)
+
+  "ReflectionUtil" should "be able to get a private field" in {
+    ReflectionUtil.getField("foo", classOf[Foo]) should not be null
+    ReflectionUtil.getField("foo", classOf[Bar]) should not be null
+    ReflectionUtil.getField("bar", classOf[Bar]) should not be null
+  }
+
+  "ReflectionUtil" should "be able to get a private field value" in {
+    val bar = new Bar("foo", "bar")
+    ReflectionUtil.getFieldValue("foo", bar) should equal("foo")
+    ReflectionUtil.getFieldValue("bar", bar) should equal("bar")
+  }
+
+  "ReflectionUtil" should "be able to set a private field value" in {
+    val bar = new Bar("foo", "bar")
+    bar.foo should equal("foo")
+    bar.bar should equal("bar")
+    ReflectionUtil.setFieldValue("foo", bar, "boom")
+    ReflectionUtil.setFieldValue("bar", bar, "bam")
+    bar.foo should equal("boom")
+    bar.bar should equal("bam")
+  }
+
+  "ReflectionUtil" should "be able to invoke a public method with no args" in {
+    val bar = new Bar("foo", "bar")
+    ReflectionUtil.invokeMethod("foo", bar) should equal("foo")
+    ReflectionUtil.invokeMethod("bar", bar) should equal("bar")
+    intercept[NoSuchElementException] {
+      ReflectionUtil.invokeMethod("notHere", bar)
+    }
+  }
+
+}

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -294,7 +294,7 @@ abstract class RemoteTransport(val system: ExtendedActorSystem, val provider: Re
  * it allows to easily obtain references to the deserialized message, its intended recipient
  * and the sender.
  */
-class RemoteMessage(input: RemoteMessageProtocol, system: ExtendedActorSystem) {
+class RemoteMessage(val input: RemoteMessageProtocol, system: ExtendedActorSystem) {
   /**
    * Returns a String-representation of the ActorPath that this RemoteMessage is destined for
    */

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -43,7 +43,7 @@ object AkkaBuild extends Build {
       sphinxLatex <<= sphinxLatex in LocalProject(docs.id),
       sphinxPdf <<= sphinxPdf in LocalProject(docs.id)
     ),
-    aggregate = Seq(actor, testkit, actorTests, remote, remoteTests, camel, cluster, slf4j, agent, transactor, mailboxes, zeroMQ, kernel, akkaSbtPlugin, samples, tutorials, docs)
+    aggregate = Seq(actor, testkit, actorTests, remote, remoteTests, remoteRcl, camel, cluster, slf4j, agent, transactor, mailboxes, zeroMQ, kernel, akkaSbtPlugin, samples, tutorials, docs)
   )
 
   lazy val actor = Project(
@@ -107,6 +107,23 @@ object AkkaBuild extends Build {
       },
       scalatestOptions in MultiJvm := defaultMultiJvmScalatestOptions,
       jvmOptions in MultiJvm := defaultMultiJvmOptions,
+      previousArtifact := akkaPreviousArtifact("akka-remote")
+    )
+  ) configs (MultiJvm)
+
+  lazy val remoteRcl = Project(
+    id = "akka-remote-rcl",
+    base = file("akka-remote-rcl"),
+    dependencies = Seq(remote, remoteTests % "compile;test->test;multi-jvm->multi-jvm", testkit % "test->test"),
+    settings = defaultSettings ++ multiJvmSettings ++ OSGi.remoteRcl ++ Seq(
+      libraryDependencies ++= Dependencies.remoteRcl,
+      // disable parallel tests
+      parallelExecution in Test := false,
+      extraOptions in MultiJvm <<= (sourceDirectory in MultiJvm) { src =>
+        (name: String) => (src ** (name + ".conf")).get.headOption.map("-Dakka.config=" + _.absolutePath).toSeq
+      },
+      scalatestOptions in MultiJvm := defaultMultiJvmScalatestOptions,
+      jvmOptions in MultiJvm := defaultMultiJvmOptions ++ Seq("-javaagent:" + System.getProperty("user.home") + "/.ivy2/cache/com.typesafe/path-hole/jars/path-hole-1.0.jar"),
       previousArtifact := akkaPreviousArtifact("akka-remote")
     )
   ) configs (MultiJvm)
@@ -455,6 +472,8 @@ object Dependencies {
     netty, protobuf, Test.junit, Test.scalatest
   )
 
+  val remoteRcl = Seq(Test.path_hole, Test.junit, Test.scalatest)
+
   val cluster = Seq(Test.junit, Test.scalatest)
 
   val slf4j = Seq(slf4jApi, Test.logback)
@@ -512,6 +531,7 @@ object Dependency {
     val scalatest   = "org.scalatest"               % "scalatest_2.9.1"     % V.Scalatest  % "test" // ApacheV2
     val scalacheck  = "org.scala-tools.testing"     % "scalacheck_2.9.1"    % "1.9"        % "test" // New BSD
     val specs2      = "org.specs2"                  % "specs2_2.9.1"        % "1.9"        % "test" // Modified BSD / ApacheV2
+    val path_hole   = "com.typesafe"                % "path-hole"           % "1.0"        % "test" from "https://github.com/avrecko/path-hole/raw/master/repository/com/typesafe/path-hole/1.0/path-hole-1.0.jar" // Ours
   }
 }
 
@@ -532,6 +552,8 @@ object OSGi {
   val mailboxesCommon = exports(Seq("akka.actor.mailbox.*"))
 
   val remote = exports(Seq("akka.remote.*", "akka.routing.*", "akka.serialization.*"))
+
+  val remoteRcl = exports(Seq("akka.remote.*"))
 
   val slf4j = exports(Seq("akka.event.slf4j.*"))
 


### PR DESCRIPTION
Modified as per feedback.
- All RCL stuff is in akka-remote-rcl
- No extra dependencies are needed except for Path_hole but that is special
- ASM functionality done via custom constant pool inspection*
- For communication the same netty is used but all RCL comm is done with special Executor.
- What is the great part of blocking in the classloader is that our inspection of required class doesn't need to be 100% precise. If we miss something no worries.

Looking forward to some more feedback.
- Tests are a bit DRY. The new refacture of the test you guys did for remote-tests is pretty cool. But I don't think the RCL can use the Testing Transport...
