### PR TITLE
Correct? implementation of merge and other actions, see #2077

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -194,15 +194,15 @@ object Gossip {
  * When failure detector consider a node as unavailble it will be moved from
  * `members` to `overview.unreachable`.
  *
- * When a node is downed, either manually or automatically, it is moved from `members`
- * to `overview.unreachable` (status Down). It is also removed from `overview.seen`
- * table. The node will reside as Down in the `overview.unreachable` set until joining
+ * When a node is downed, either manually or automatically, its status is changed to Down.
+ * It is also removed from `overview.seen` table.
+ * The node will reside as Down in the `overview.unreachable` set until joining
  * again and it will then go through the normal joining procedure.
  *
  * When a Gossip is received the version (vector clock) is used to determine if the
  * received Gossip is newer or older than the current local Gossip. The received Gossip
- * and local Gossip is merged in case of concurrent vector clocks, i.e. not same history.
- * When merged the seen table is cleared.
+ * and local Gossip is merged in case of conflicting version, i.e. vector clocks without
+ * same history. When merged the seen table is cleared.
  *
  * TODO document leaving, exiting and removed when that is implemented
  *

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -240,8 +240,8 @@ case class Gossip(
     val mergedMembers = Gossip.emptyMembers ++ reduceHighestPriority(this.members.toSeq, that.members.toSeq).
       filterNot(mergedUnreachable.contains)
 
-    // 5. merge seen (FIXME is this correct?)
-    val mergedSeen = this.overview.seen ++ that.overview.seen
+    // 5. fresh seen table
+    val mergedSeen = Map.empty[Address, VectorClock]
 
     Gossip(GossipOverview(mergedSeen, mergedUnreachable), mergedMembers, mergedMeta, mergedVClock)
   }

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -73,5 +73,17 @@ class GossipSpec extends WordSpec with MustMatchers {
 
     }
 
+    "start with fresh seen table after merge" in {
+      val g1 = Gossip(members = SortedSet(a1, b1, c1, d1)).seen(a1.address).seen(b1.address)
+      val g2 = Gossip(members = SortedSet(a2, b2, c2, d2)).seen(b2.address).seen(c2.address)
+
+      val merged1 = g1 merge g2
+      merged1.overview.seen.isEmpty must be(true)
+
+      val merged2 = g2 merge g1
+      merged2.overview.seen.isEmpty must be(true)
+
+    }
+
   }
 }

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -12,18 +12,20 @@ import scala.collection.immutable.SortedSet
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class GossipSpec extends WordSpec with MustMatchers {
 
+  import MemberStatus._
+
+  val a1 = Member(Address("akka", "sys", "a", 2552), Up)
+  val a2 = Member(Address("akka", "sys", "a", 2552), Joining)
+  val b1 = Member(Address("akka", "sys", "b", 2552), Up)
+  val b2 = Member(Address("akka", "sys", "b", 2552), Removed)
+  val c1 = Member(Address("akka", "sys", "c", 2552), Leaving)
+  val c2 = Member(Address("akka", "sys", "c", 2552), Up)
+  val d1 = Member(Address("akka", "sys", "d", 2552), Leaving)
+  val d2 = Member(Address("akka", "sys", "d", 2552), Removed)
+
   "A Gossip" must {
 
     "merge members by status priority" in {
-      import MemberStatus._
-      val a1 = Member(Address("akka", "sys", "a", 2552), Up)
-      val a2 = Member(Address("akka", "sys", "a", 2552), Joining)
-      val b1 = Member(Address("akka", "sys", "b", 2552), Up)
-      val b2 = Member(Address("akka", "sys", "b", 2552), Removed)
-      val c1 = Member(Address("akka", "sys", "c", 2552), Leaving)
-      val c2 = Member(Address("akka", "sys", "c", 2552), Up)
-      val d1 = Member(Address("akka", "sys", "d", 2552), Leaving)
-      val d2 = Member(Address("akka", "sys", "d", 2552), Removed)
 
       val g1 = Gossip(members = SortedSet(a1, b1, c1, d1))
       val g2 = Gossip(members = SortedSet(a2, b2, c2, d2))
@@ -35,6 +37,39 @@ class GossipSpec extends WordSpec with MustMatchers {
       val merged2 = g2 merge g1
       merged2.members must be(SortedSet(a1, b2, c1, d2))
       merged2.members.toSeq.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
+
+    }
+
+    "merge unreachable by status priority" in {
+
+      val g1 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = SortedSet(a1, b1, c1, d1)))
+      val g2 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = SortedSet(a2, b2, c2, d2)))
+
+      val merged1 = g1 merge g2
+      merged1.overview.unreachable must be(Set(a1, b2, c1, d2))
+      merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
+
+      val merged2 = g2 merge g1
+      merged2.overview.unreachable must be(Set(a1, b2, c1, d2))
+      merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
+
+    }
+
+    "merge by excluding unreachable from members" in {
+      val g1 = Gossip(members = SortedSet(a1, b1), overview = GossipOverview(unreachable = SortedSet(c1, d1)))
+      val g2 = Gossip(members = SortedSet(a2, c2), overview = GossipOverview(unreachable = SortedSet(b2, d2)))
+
+      val merged1 = g1 merge g2
+      merged1.members must be(SortedSet(a1))
+      merged1.members.toSeq.map(_.status) must be(Seq(Up))
+      merged1.overview.unreachable must be(Set(b2, c1, d2))
+      merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Removed, Leaving, Removed))
+
+      val merged2 = g2 merge g1
+      merged2.members must be(SortedSet(a1))
+      merged2.members.toSeq.map(_.status) must be(Seq(Up))
+      merged2.overview.unreachable must be(Set(b2, c1, d2))
+      merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Removed, Leaving, Removed))
 
     }
 

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -22,28 +22,30 @@ class GossipSpec extends WordSpec with MustMatchers {
   val c2 = Member(Address("akka", "sys", "c", 2552), Up)
   val d1 = Member(Address("akka", "sys", "d", 2552), Leaving)
   val d2 = Member(Address("akka", "sys", "d", 2552), Removed)
+  val e1 = Member(Address("akka", "sys", "e", 2552), Joining)
+  val e2 = Member(Address("akka", "sys", "e", 2552), Up)
 
   "A Gossip" must {
 
     "merge members by status priority" in {
 
-      val g1 = Gossip(members = SortedSet(a1, b1, c1, d1))
-      val g2 = Gossip(members = SortedSet(a2, b2, c2, d2))
+      val g1 = Gossip(members = SortedSet(a1, c1, e1))
+      val g2 = Gossip(members = SortedSet(a2, c2, e2))
 
       val merged1 = g1 merge g2
-      merged1.members must be(SortedSet(a1, b2, c1, d2))
-      merged1.members.toSeq.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
+      merged1.members must be(SortedSet(a1, c1, e2))
+      merged1.members.toSeq.map(_.status) must be(Seq(Up, Leaving, Up))
 
       val merged2 = g2 merge g1
-      merged2.members must be(SortedSet(a1, b2, c1, d2))
-      merged2.members.toSeq.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
+      merged2.members must be(SortedSet(a1, c1, e2))
+      merged2.members.toSeq.map(_.status) must be(Seq(Up, Leaving, Up))
 
     }
 
     "merge unreachable by status priority" in {
 
-      val g1 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = SortedSet(a1, b1, c1, d1)))
-      val g2 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = SortedSet(a2, b2, c2, d2)))
+      val g1 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = Set(a1, b1, c1, d1)))
+      val g2 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = Set(a2, b2, c2, d2)))
 
       val merged1 = g1 merge g2
       merged1.overview.unreachable must be(Set(a1, b2, c1, d2))
@@ -56,8 +58,8 @@ class GossipSpec extends WordSpec with MustMatchers {
     }
 
     "merge by excluding unreachable from members" in {
-      val g1 = Gossip(members = SortedSet(a1, b1), overview = GossipOverview(unreachable = SortedSet(c1, d1)))
-      val g2 = Gossip(members = SortedSet(a2, c2), overview = GossipOverview(unreachable = SortedSet(b2, d2)))
+      val g1 = Gossip(members = SortedSet(a1, b1), overview = GossipOverview(unreachable = Set(c1, d1)))
+      val g2 = Gossip(members = SortedSet(a2, c2), overview = GossipOverview(unreachable = Set(b2, d2)))
 
       val merged1 = g1 merge g2
       merged1.members must be(SortedSet(a1))
@@ -74,8 +76,8 @@ class GossipSpec extends WordSpec with MustMatchers {
     }
 
     "start with fresh seen table after merge" in {
-      val g1 = Gossip(members = SortedSet(a1, b1, c1, d1)).seen(a1.address).seen(b1.address)
-      val g2 = Gossip(members = SortedSet(a2, b2, c2, d2)).seen(b2.address).seen(c2.address)
+      val g1 = Gossip(members = SortedSet(a1, e1)).seen(a1.address).seen(a1.address)
+      val g2 = Gossip(members = SortedSet(a2, e2)).seen(e2.address).seen(e2.address)
 
       val merged1 = g1 merge g2
       merged1.overview.seen.isEmpty must be(true)
@@ -83,6 +85,19 @@ class GossipSpec extends WordSpec with MustMatchers {
       val merged2 = g2 merge g1
       merged2.overview.seen.isEmpty must be(true)
 
+    }
+
+    "not have node in both members and unreachable" in intercept[IllegalArgumentException] {
+      Gossip(members = SortedSet(a1, b1), overview = GossipOverview(unreachable = Set(b2)))
+    }
+
+    "not have live members with wrong status" in intercept[IllegalArgumentException] {
+      // b2 is Removed
+      Gossip(members = SortedSet(a2, b2))
+    }
+
+    "not have non cluster members in seen table" in intercept[IllegalArgumentException] {
+      Gossip(members = SortedSet(a1, e1)).seen(a1.address).seen(e1.address).seen(b1.address)
     }
 
   }


### PR DESCRIPTION
For discussion.
- Merge unreachable using  highestPriorityOf
- Avoid merge result in node existing in both members and unreachable
- Fix joining only allowed when !alreadyMember && !isUnreachable (non Down)
- Fix filter bug of unreachable in downing and leaderActions
- Minor cleanups

Missing is correct implementation of merge of seen table.
