### PR TITLE
Test state transitions and actions step-by-step, see #2223

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -522,24 +522,28 @@ class Cluster(system: ExtendedActorSystem, val failureDetector: FailureDetector)
   }
 
   // start periodic gossip to random nodes in cluster
-  private val gossipTask = FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay, GossipInterval) {
-    gossip()
-  }
+  private val gossipTask =
+    FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay.max(GossipInterval), GossipInterval) {
+      gossip()
+    }
 
   // start periodic heartbeat to all nodes in cluster
-  private val heartbeatTask = FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay, HeartbeatInterval) {
-    heartbeat()
-  }
+  private val heartbeatTask =
+    FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay.max(HeartbeatInterval), HeartbeatInterval) {
+      heartbeat()
+    }
 
   // start periodic cluster failure detector reaping (moving nodes condemned by the failure detector to unreachable list)
-  private val failureDetectorReaperTask = FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay, UnreachableNodesReaperInterval) {
-    reapUnreachableMembers()
-  }
+  private val failureDetectorReaperTask =
+    FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay.max(UnreachableNodesReaperInterval), UnreachableNodesReaperInterval) {
+      reapUnreachableMembers()
+    }
 
   // start periodic leader action management (only applies for the current leader)
-  private val leaderActionsTask = FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay, LeaderActionsInterval) {
-    leaderActions()
-  }
+  private val leaderActionsTask =
+    FixedRateTask(clusterScheduler, PeriodicTasksInitialDelay.max(LeaderActionsInterval), LeaderActionsInterval) {
+      leaderActions()
+    }
 
   createMBean()
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ConvergenceSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ConvergenceSpec.scala
@@ -39,7 +39,7 @@ abstract class ConvergenceSpec
 
   "A cluster of 3 members" must {
 
-    "reach initial convergence" taggedAs LongRunningTest ignore {
+    "reach initial convergence" taggedAs LongRunningTest in {
       awaitClusterUp(first, second, third)
 
       runOn(fourth) {
@@ -49,7 +49,7 @@ abstract class ConvergenceSpec
       testConductor.enter("after-1")
     }
 
-    "not reach convergence while any nodes are unreachable" taggedAs LongRunningTest ignore {
+    "not reach convergence while any nodes are unreachable" taggedAs LongRunningTest in {
       val thirdAddress = node(third).address
       testConductor.enter("before-shutdown")
 
@@ -81,7 +81,7 @@ abstract class ConvergenceSpec
       testConductor.enter("after-2")
     }
 
-    "not move a new joining node to Up while there is no convergence" taggedAs LongRunningTest ignore {
+    "not move a new joining node to Up while there is no convergence" taggedAs LongRunningTest in {
       runOn(fourth) {
         // try to join
         cluster.join(node(first).address)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinTwoClustersSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinTwoClustersSpec.scala
@@ -17,7 +17,7 @@ object JoinTwoClustersMultiJvmSpec extends MultiNodeConfig {
   val c1 = role("c1")
   val c2 = role("c2")
 
-  commonConfig(debugConfig(on = true).withFallback(MultiNodeClusterSpec.clusterConfig))
+  commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfig))
 }
 
 class JoinTwoClustersMultiJvmNode1 extends JoinTwoClustersSpec with FailureDetectorPuppetStrategy

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerExitingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerExitingSpec.scala
@@ -21,7 +21,7 @@ object MembershipChangeListenerExitingMultiJvmSpec extends MultiNodeConfig {
       .withFallback(ConfigFactory.parseString("""
         akka.cluster {
           leader-actions-interval           = 5 s  # increase the leader action task interval
-          unreachable-nodes-reaper-interval = 30 s # turn "off" reaping to unreachable node set
+          unreachable-nodes-reaper-interval = 300 s # turn "off" reaping to unreachable node set
         }
       """)
         .withFallback(MultiNodeClusterSpec.clusterConfig)))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerLeavingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerLeavingSpec.scala
@@ -19,7 +19,7 @@ object MembershipChangeListenerLeavingMultiJvmSpec extends MultiNodeConfig {
     debugConfig(on = false)
       .withFallback(ConfigFactory.parseString("""
         akka.cluster.leader-actions-interval           = 5 s
-        akka.cluster.unreachable-nodes-reaper-interval = 30 s
+        akka.cluster.unreachable-nodes-reaper-interval = 300 s # turn "off"
       """))
       .withFallback(MultiNodeClusterSpec.clusterConfig))
 }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingSpec.scala
@@ -20,7 +20,7 @@ object NodeLeavingAndExitingMultiJvmSpec extends MultiNodeConfig {
       .withFallback(ConfigFactory.parseString("""
         akka.cluster {
           leader-actions-interval           = 5 s  # increase the leader action task frequency to make sure we get a chance to test the LEAVING state
-          unreachable-nodes-reaper-interval = 30 s
+          unreachable-nodes-reaper-interval = 300 s # turn "off"
         }
       """)
         .withFallback(MultiNodeClusterSpec.clusterConfig)))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
@@ -21,18 +21,17 @@ object SunnyWeatherMultiJvmSpec extends MultiNodeConfig {
 
   commonConfig(ConfigFactory.parseString("""
     akka.cluster {
-      gossip-interval    = 400 ms
       nr-of-deputy-nodes = 0
     }
     akka.loglevel = INFO
     """))
 }
 
-class SunnyWeatherMultiJvmNode1 extends SunnyWeatherSpec with FailureDetectorPuppetStrategy
-class SunnyWeatherMultiJvmNode2 extends SunnyWeatherSpec with FailureDetectorPuppetStrategy
-class SunnyWeatherMultiJvmNode3 extends SunnyWeatherSpec with FailureDetectorPuppetStrategy
-class SunnyWeatherMultiJvmNode4 extends SunnyWeatherSpec with FailureDetectorPuppetStrategy
-class SunnyWeatherMultiJvmNode5 extends SunnyWeatherSpec with FailureDetectorPuppetStrategy
+class SunnyWeatherMultiJvmNode1 extends SunnyWeatherSpec with AccrualFailureDetectorStrategy
+class SunnyWeatherMultiJvmNode2 extends SunnyWeatherSpec with AccrualFailureDetectorStrategy
+class SunnyWeatherMultiJvmNode3 extends SunnyWeatherSpec with AccrualFailureDetectorStrategy
+class SunnyWeatherMultiJvmNode4 extends SunnyWeatherSpec with AccrualFailureDetectorStrategy
+class SunnyWeatherMultiJvmNode5 extends SunnyWeatherSpec with AccrualFailureDetectorStrategy
 
 abstract class SunnyWeatherSpec
   extends MultiNodeSpec(SunnyWeatherMultiJvmSpec)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
@@ -20,11 +20,8 @@ object TransitionMultiJvmSpec extends MultiNodeConfig {
   val fifth = role("fifth")
 
   commonConfig(debugConfig(on = false).
-    withFallback(ConfigFactory.parseString("""
-      akka.cluster {
-        periodic-tasks-initial-delay = 300 s # turn "off" all periodic tasks
-      }
-      """)).
+    withFallback(ConfigFactory.parseString(
+      "akka.cluster.periodic-tasks-initial-delay = 300 s # turn off all periodic tasks")).
     withFallback(MultiNodeClusterSpec.clusterConfig))
 }
 
@@ -108,10 +105,10 @@ abstract class TransitionSpec
 
       startClusterNode()
       cluster.isSingletonCluster must be(true)
-      cluster.self.status must be(Joining)
+      cluster.status must be(Joining)
       cluster.convergence.isDefined must be(true)
       cluster.leaderActions()
-      cluster.self.status must be(Up)
+      cluster.status must be(Up)
 
       testConductor.enter("after-1")
     }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
@@ -1,0 +1,438 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.cluster
+
+import com.typesafe.config.ConfigFactory
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+import akka.actor.Address
+import akka.remote.testconductor.RoleName
+import MemberStatus._
+
+object TransitionMultiJvmSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+  val fourth = role("fourth")
+  val fifth = role("fifth")
+
+  commonConfig(debugConfig(on = false).
+    withFallback(ConfigFactory.parseString("""
+      akka.cluster {
+        periodic-tasks-initial-delay = 300 s # turn "off" all periodic tasks
+      }
+      """)).
+    withFallback(MultiNodeClusterSpec.clusterConfig))
+}
+
+class TransitionMultiJvmNode1 extends TransitionSpec with FailureDetectorPuppetStrategy
+class TransitionMultiJvmNode2 extends TransitionSpec with FailureDetectorPuppetStrategy
+class TransitionMultiJvmNode3 extends TransitionSpec with FailureDetectorPuppetStrategy
+class TransitionMultiJvmNode4 extends TransitionSpec with FailureDetectorPuppetStrategy
+class TransitionMultiJvmNode5 extends TransitionSpec with FailureDetectorPuppetStrategy
+
+abstract class TransitionSpec
+  extends MultiNodeSpec(TransitionMultiJvmSpec)
+  with MultiNodeClusterSpec {
+
+  import TransitionMultiJvmSpec._
+
+  // sorted in the order used by the cluster
+  def leader(roles: RoleName*) = roles.sorted.head
+  def nonLeader(roles: RoleName*) = roles.toSeq.sorted.tail
+
+  def memberStatus(address: Address): MemberStatus = {
+    val statusOption = (cluster.latestGossip.members ++ cluster.latestGossip.overview.unreachable).collectFirst {
+      case m if m.address == address ⇒ m.status
+    }
+    statusOption must not be (None)
+    statusOption.get
+  }
+
+  def memberAddresses: Set[Address] = cluster.latestGossip.members.map(_.address)
+
+  def members: Set[RoleName] = memberAddresses.flatMap(roleName(_))
+
+  def seenLatestGossip: Set[RoleName] = {
+    val gossip = cluster.latestGossip
+    gossip.overview.seen.collect {
+      case (address, v) if v == gossip.version ⇒ roleName(address)
+    }.flatten.toSet
+  }
+
+  def awaitSeen(addresses: Address*): Unit = awaitCond {
+    seenLatestGossip.map(node(_).address) == addresses.toSet
+  }
+
+  def awaitMembers(addresses: Address*): Unit = awaitCond {
+    memberAddresses == addresses.toSet
+  }
+
+  def awaitMemberStatus(address: Address, status: MemberStatus): Unit = awaitCond {
+    memberStatus(address) == Up
+  }
+
+  // implicit conversion from RoleName to Address
+  implicit def role2Address(role: RoleName): Address = node(role).address
+
+  // DSL sugar for `role1 gossipTo role2`
+  implicit def roleExtras(role: RoleName): RoleWrapper = new RoleWrapper(role)
+  var gossipBarrierCounter = 0
+  class RoleWrapper(fromRole: RoleName) {
+    def gossipTo(toRole: RoleName): Unit = {
+      gossipBarrierCounter += 1
+      runOn(toRole) {
+        val g = cluster.latestGossip
+        testConductor.enter("before-gossip-" + gossipBarrierCounter)
+        awaitCond(cluster.latestGossip != g) // received gossip
+        testConductor.enter("after-gossip-" + gossipBarrierCounter)
+      }
+      runOn(fromRole) {
+        testConductor.enter("before-gossip-" + gossipBarrierCounter)
+        cluster.gossipTo(node(toRole).address) // send gossip
+        testConductor.enter("after-gossip-" + gossipBarrierCounter)
+      }
+      runOn(roles.filterNot(r ⇒ r == fromRole || r == toRole): _*) {
+        testConductor.enter("before-gossip-" + gossipBarrierCounter)
+        testConductor.enter("after-gossip-" + gossipBarrierCounter)
+      }
+    }
+  }
+
+  "A Cluster" must {
+
+    "start nodes as singleton clusters" taggedAs LongRunningTest in {
+
+      startClusterNode()
+      cluster.isSingletonCluster must be(true)
+      cluster.self.status must be(Joining)
+      cluster.convergence.isDefined must be(true)
+      cluster.leaderActions()
+      cluster.self.status must be(Up)
+
+      testConductor.enter("after-1")
+    }
+
+    "perform correct transitions when second joining first" taggedAs LongRunningTest in {
+
+      runOn(second) {
+        cluster.join(first)
+      }
+      runOn(first) {
+        awaitMembers(first, second)
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Joining)
+        cluster.convergence.isDefined must be(false)
+      }
+      testConductor.enter("second-joined")
+
+      first gossipTo second
+      runOn(second) {
+        members must be(Set(first, second))
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Joining)
+        // we got a conflicting version in second, and therefore not convergence in second
+        seenLatestGossip must be(Set(second))
+        cluster.convergence.isDefined must be(false)
+      }
+
+      second gossipTo first
+      runOn(first) {
+        seenLatestGossip must be(Set(first, second))
+      }
+
+      first gossipTo second
+      runOn(second) {
+        seenLatestGossip must be(Set(first, second))
+      }
+
+      runOn(first, second) {
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Joining)
+        cluster.convergence.isDefined must be(true)
+      }
+      testConductor.enter("convergence-joining-2")
+
+      runOn(leader(first, second)) {
+        cluster.leaderActions()
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Up)
+      }
+      testConductor.enter("leader-actions-2")
+
+      leader(first, second) gossipTo nonLeader(first, second).head
+      runOn(nonLeader(first, second).head) {
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Up)
+        seenLatestGossip must be(Set(first, second))
+        cluster.convergence.isDefined must be(true)
+      }
+
+      nonLeader(first, second).head gossipTo leader(first, second)
+      runOn(first, second) {
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Up)
+        seenLatestGossip must be(Set(first, second))
+        cluster.convergence.isDefined must be(true)
+      }
+
+      testConductor.enter("after-2")
+    }
+
+    "perform correct transitions when third joins second" taggedAs LongRunningTest in {
+
+      runOn(third) {
+        cluster.join(second)
+      }
+      runOn(second) {
+        awaitMembers(first, second, third)
+        cluster.convergence.isDefined must be(false)
+        memberStatus(third) must be(Joining)
+        seenLatestGossip must be(Set(second))
+      }
+      testConductor.enter("third-joined-second")
+
+      second gossipTo first
+      runOn(first) {
+        members must be(Set(first, second, third))
+        cluster.convergence.isDefined must be(false)
+        memberStatus(third) must be(Joining)
+      }
+
+      first gossipTo third
+      runOn(third) {
+        members must be(Set(first, second, third))
+        cluster.convergence.isDefined must be(false)
+        memberStatus(third) must be(Joining)
+        // conflicting version
+        seenLatestGossip must be(Set(third))
+      }
+
+      third gossipTo first
+      third gossipTo second
+      runOn(first, second) {
+        seenLatestGossip must be(Set(myself, third))
+      }
+
+      first gossipTo second
+      runOn(second) {
+        seenLatestGossip must be(Set(first, second, third))
+        cluster.convergence.isDefined must be(true)
+      }
+
+      runOn(first, third) {
+        cluster.convergence.isDefined must be(false)
+      }
+
+      second gossipTo first
+      second gossipTo third
+      runOn(first, second, third) {
+        seenLatestGossip must be(Set(first, second, third))
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Up)
+        memberStatus(third) must be(Joining)
+        cluster.convergence.isDefined must be(true)
+      }
+
+      testConductor.enter("convergence-joining-3")
+
+      runOn(leader(first, second, third)) {
+        cluster.leaderActions()
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Up)
+        memberStatus(third) must be(Up)
+      }
+      testConductor.enter("leader-actions-3")
+
+      // leader gossipTo first non-leader
+      leader(first, second, third) gossipTo nonLeader(first, second, third).head
+      runOn(nonLeader(first, second, third).head) {
+        memberStatus(third) must be(Up)
+        seenLatestGossip must be(Set(leader(first, second, third), myself))
+        cluster.convergence.isDefined must be(false)
+      }
+
+      // first non-leader gossipTo the other non-leader
+      nonLeader(first, second, third).head gossipTo nonLeader(first, second, third).tail.head
+      runOn(nonLeader(first, second, third).head) {
+        cluster.gossipTo(node(nonLeader(first, second, third).tail.head).address)
+      }
+      runOn(nonLeader(first, second, third).tail.head) {
+        memberStatus(third) must be(Up)
+        seenLatestGossip must be(Set(first, second, third))
+        cluster.convergence.isDefined must be(true)
+      }
+
+      // and back again
+      nonLeader(first, second, third).tail.head gossipTo nonLeader(first, second, third).head
+      runOn(nonLeader(first, second, third).head) {
+        memberStatus(third) must be(Up)
+        seenLatestGossip must be(Set(first, second, third))
+        cluster.convergence.isDefined must be(true)
+      }
+
+      // first non-leader gossipTo the leader
+      nonLeader(first, second, third).head gossipTo leader(first, second, third)
+      runOn(first, second, third) {
+        memberStatus(first) must be(Up)
+        memberStatus(second) must be(Up)
+        memberStatus(third) must be(Up)
+        seenLatestGossip must be(Set(first, second, third))
+        cluster.convergence.isDefined must be(true)
+      }
+
+      testConductor.enter("after-3")
+    }
+
+    "startup a second separated cluster consisting of nodes fourth and fifth" taggedAs LongRunningTest in {
+      runOn(fourth) {
+        cluster.join(fifth)
+        awaitMembers(fourth, fifth)
+        cluster.gossipTo(fifth)
+        awaitSeen(fourth, fifth)
+        cluster.convergence.isDefined must be(true)
+      }
+      runOn(fifth) {
+        awaitMembers(fourth, fifth)
+        cluster.gossipTo(fourth)
+        awaitSeen(fourth, fifth)
+        cluster.gossipTo(fourth)
+        cluster.convergence.isDefined must be(true)
+      }
+      testConductor.enter("fourth-joined-fifth")
+
+      testConductor.enter("after-4")
+    }
+
+    "perform correct transitions when second cluster (node fourth) joins first cluster (node third)" taggedAs LongRunningTest in {
+
+      runOn(fourth) {
+        cluster.join(third)
+      }
+      runOn(third) {
+        awaitMembers(first, second, third, fourth)
+        seenLatestGossip must be(Set(third))
+      }
+      testConductor.enter("fourth-joined-third")
+
+      third gossipTo second
+      runOn(second) {
+        seenLatestGossip must be(Set(second, third))
+      }
+
+      second gossipTo fourth
+      runOn(fourth) {
+        members must be(roles.toSet)
+        // merge conflict
+        seenLatestGossip must be(Set(fourth))
+      }
+
+      fourth gossipTo first
+      fourth gossipTo second
+      fourth gossipTo third
+      fourth gossipTo fifth
+      runOn(first, second, third, fifth) {
+        members must be(roles.toSet)
+        seenLatestGossip must be(Set(fourth, myself))
+      }
+
+      first gossipTo fifth
+      runOn(fifth) {
+        seenLatestGossip must be(Set(first, fourth, fifth))
+      }
+
+      fifth gossipTo third
+      runOn(third) {
+        seenLatestGossip must be(Set(first, third, fourth, fifth))
+      }
+
+      third gossipTo second
+      runOn(second) {
+        seenLatestGossip must be(roles.toSet)
+        cluster.convergence.isDefined must be(true)
+      }
+
+      second gossipTo first
+      second gossipTo third
+      second gossipTo fourth
+      third gossipTo fifth
+
+      seenLatestGossip must be(roles.toSet)
+      memberStatus(first) must be(Up)
+      memberStatus(second) must be(Up)
+      memberStatus(third) must be(Up)
+      memberStatus(fourth) must be(Joining)
+      memberStatus(fifth) must be(Up)
+      cluster.convergence.isDefined must be(true)
+
+      testConductor.enter("convergence-joining-3")
+
+      runOn(leader(roles: _*)) {
+        cluster.leaderActions()
+        memberStatus(fourth) must be(Up)
+        seenLatestGossip must be(Set(myself))
+        cluster.convergence.isDefined must be(false)
+      }
+      // spread the word
+      for (x :: y :: Nil ← (roles.sorted ++ roles.sorted.dropRight(1)).toList.sliding(2)) {
+        x gossipTo y
+      }
+
+      testConductor.enter("spread-5")
+
+      seenLatestGossip must be(roles.toSet)
+      memberStatus(first) must be(Up)
+      memberStatus(second) must be(Up)
+      memberStatus(third) must be(Up)
+      memberStatus(fourth) must be(Up)
+      memberStatus(fifth) must be(Up)
+      cluster.convergence.isDefined must be(true)
+
+      testConductor.enter("after-5")
+    }
+
+    "perform correct transitions when second becomes unavailble" taggedAs LongRunningTest in {
+      runOn(fifth) {
+        markNodeAsUnavailable(second)
+        cluster.reapUnreachableMembers()
+        cluster.latestGossip.overview.unreachable must contain(Member(second, Up))
+        seenLatestGossip must be(Set(fifth))
+      }
+
+      // spread the word
+      val gossipRound = List(fifth, fourth, third, first, third, fourth, fifth)
+      for (x :: y :: Nil ← gossipRound.sliding(2)) {
+        x gossipTo y
+      }
+
+      runOn((roles.filterNot(_ == second)): _*) {
+        cluster.latestGossip.overview.unreachable must contain(Member(second, Up))
+        cluster.convergence.isDefined must be(false)
+      }
+
+      runOn(third) {
+        cluster.down(second)
+        awaitMemberStatus(second, Down)
+      }
+
+      // spread the word
+      val gossipRound2 = List(third, fourth, fifth, first, third, fourth, fifth)
+      for (x :: y :: Nil ← gossipRound2.sliding(2)) {
+        x gossipTo y
+      }
+
+      runOn((roles.filterNot(_ == second)): _*) {
+        cluster.latestGossip.overview.unreachable must contain(Member(second, Down))
+        memberStatus(second) must be(Down)
+        seenLatestGossip must be(Set(first, third, fourth, fifth))
+        cluster.convergence.isDefined must be(true)
+      }
+
+      testConductor.enter("after-6")
+    }
+
+  }
+}

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -33,12 +33,12 @@ class GossipSpec extends WordSpec with MustMatchers {
       val g2 = Gossip(members = SortedSet(a2, c2, e2))
 
       val merged1 = g1 merge g2
-      merged1.members must be(SortedSet(a1, c1, e2))
-      merged1.members.toSeq.map(_.status) must be(Seq(Up, Leaving, Up))
+      merged1.members must be(SortedSet(a2, c1, e1))
+      merged1.members.toSeq.map(_.status) must be(Seq(Joining, Leaving, Joining))
 
       val merged2 = g2 merge g1
-      merged2.members must be(SortedSet(a1, c1, e2))
-      merged2.members.toSeq.map(_.status) must be(Seq(Up, Leaving, Up))
+      merged2.members must be(SortedSet(a2, c1, e1))
+      merged2.members.toSeq.map(_.status) must be(Seq(Joining, Leaving, Joining))
 
     }
 
@@ -48,12 +48,12 @@ class GossipSpec extends WordSpec with MustMatchers {
       val g2 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = Set(a2, b2, c2, d2)))
 
       val merged1 = g1 merge g2
-      merged1.overview.unreachable must be(Set(a1, b2, c1, d2))
-      merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
+      merged1.overview.unreachable must be(Set(a2, b2, c1, d2))
+      merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Joining, Removed, Leaving, Removed))
 
       val merged2 = g2 merge g1
-      merged2.overview.unreachable must be(Set(a1, b2, c1, d2))
-      merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
+      merged2.overview.unreachable must be(Set(a2, b2, c1, d2))
+      merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Joining, Removed, Leaving, Removed))
 
     }
 
@@ -62,14 +62,14 @@ class GossipSpec extends WordSpec with MustMatchers {
       val g2 = Gossip(members = SortedSet(a2, c2), overview = GossipOverview(unreachable = Set(b2, d2)))
 
       val merged1 = g1 merge g2
-      merged1.members must be(SortedSet(a1))
-      merged1.members.toSeq.map(_.status) must be(Seq(Up))
+      merged1.members must be(SortedSet(a2))
+      merged1.members.toSeq.map(_.status) must be(Seq(Joining))
       merged1.overview.unreachable must be(Set(b2, c1, d2))
       merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Removed, Leaving, Removed))
 
       val merged2 = g2 merge g1
-      merged2.members must be(SortedSet(a1))
-      merged2.members.toSeq.map(_.status) must be(Seq(Up))
+      merged2.members must be(SortedSet(a2))
+      merged2.members.toSeq.map(_.status) must be(Seq(Joining))
       merged2.overview.unreachable must be(Set(b2, c1, d2))
       merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Removed, Leaving, Removed))
 


### PR DESCRIPTION
- New TransitionSpec, see #2223
- Correction of gossip merge when joining, see #2204
- Use max of periodic-tasks-initial-delay and the interval
- Fail fast in cluster tests if prevous step failed
- Real SunnyWeather, with 1s gossip interval and AccrualFailureDetector
