### PR TITLE
Join seed nodes before becoming singleton cluster, see #2267

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -18,7 +18,8 @@ akka {
     # how long to wait for one of the seed nodes to reply to initial join request
     seed-node-timeout = 5s
 
-    # automatic join the seed-nodes at startup
+    # Automatic join the seed-nodes at startup.
+    # If seed-nodes is empty it will join itself and become a single node cluster.
     auto-join = on
 
     # should the 'leader' in the cluster be allowed to automatically mark unreachable nodes as DOWN?

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
@@ -16,7 +16,9 @@ object JoinSeedNodeMultiJvmSpec extends MultiNodeConfig {
   val ordinary1 = role("ordinary1")
   val ordinary2 = role("ordinary2")
 
-  commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfig))
+  commonConfig(debugConfig(on = false).
+    withFallback(ConfigFactory.parseString("akka.cluster.auto-join = on")).
+    withFallback(MultiNodeClusterSpec.clusterConfig))
 }
 
 class JoinSeedNodeMultiJvmNode1 extends JoinSeedNodeSpec with FailureDetectorPuppetStrategy

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
@@ -25,6 +25,7 @@ object SunnyWeatherMultiJvmSpec extends MultiNodeConfig {
     akka.cluster {
       # FIXME remove this (use default) when ticket #2239 has been fixed
       gossip-interval = 400 ms
+      auto-join = off
     }
     akka.loglevel = INFO
     """))

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
@@ -86,11 +86,13 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with BeforeAndAfter {
 
     "use the address of the remote transport" in {
       cluster.selfAddress must be(selfAddress)
-      cluster.self.address must be(selfAddress)
     }
 
-    "initially be singleton cluster and reach convergence immediately" in {
-      cluster.isSingletonCluster must be(true)
+    "initially become singleton cluster when joining itself and reach convergence" in {
+      cluster.isSingletonCluster must be(false) // auto-join = off
+      cluster.join(selfAddress)
+      awaitCond(cluster.isSingletonCluster)
+      cluster.self.address must be(selfAddress)
       cluster.latestGossip.members.map(_.address) must be(Set(selfAddress))
       memberStatus(selfAddress) must be(Some(MemberStatus.Joining))
       cluster.convergence.isDefined must be(true)


### PR DESCRIPTION
- self is initially not member (in gossip state)
- if the join to seed nodes timeout it joins itself, and becomes
  singleton cluster
- remove the special case handling of singelton cluster in gossip
  merge, since singleton cluster is not the normal state when joining
  any more
