### PR TITLE
Update polling for compatibility with ZMQ 

### DIFF
--- a/akka-zeromq/src/main/scala/akka/zeromq/ConcurrentSocketActor.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ConcurrentSocketActor.scala
@@ -176,7 +176,7 @@ private[zeromq] class ConcurrentSocketActor(params: Seq[SocketOption]) extends A
     val duration = fromConfig getOrElse ZeroMQExtension(context.system).DefaultPollTimeout
     if (duration > Duration.Zero) { (msg: PollMsg) ⇒
       // for positive timeout values, do poll (i.e. block this thread)
-      poller.poll(duration.toMicros)
+      ZeroMQExtension(context.system).poll(poller, duration)
       self ! msg
     } else {
       val d = -duration

--- a/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
@@ -48,9 +48,7 @@ class ZeroMQExtension(system: ActorSystem) extends Extension {
   val DefaultPollTimeout: Duration = Duration(system.settings.config.getMilliseconds("akka.zeromq.poll-timeout"), TimeUnit.MILLISECONDS)
   val NewSocketTimeout: Timeout = Timeout(Duration(system.settings.config.getMilliseconds("akka.zeromq.new-socket-timeout"), TimeUnit.MILLISECONDS))
 
-  val poll =
-    if (version.major >= 3) (poller: Poller, duration: Duration) ⇒ poller.poll(duration.toMillis)
-    else (poller: Poller, duration: Duration) ⇒ poller.poll(duration.toMicros)
+  val pollTimeUnit = if (version.major >= 3) TimeUnit.MILLISECONDS else TimeUnit.MICROSECONDS
 
   /**
    * The version of the ZeroMQ library

--- a/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
@@ -4,6 +4,7 @@
 package akka.zeromq
 
 import org.zeromq.{ ZMQ ⇒ JZMQ }
+import org.zeromq.ZMQ.Poller
 import akka.actor._
 import akka.dispatch.{ Await }
 import akka.pattern.ask
@@ -46,6 +47,10 @@ class ZeroMQExtension(system: ActorSystem) extends Extension {
 
   val DefaultPollTimeout: Duration = Duration(system.settings.config.getMilliseconds("akka.zeromq.poll-timeout"), TimeUnit.MILLISECONDS)
   val NewSocketTimeout: Timeout = Timeout(Duration(system.settings.config.getMilliseconds("akka.zeromq.new-socket-timeout"), TimeUnit.MILLISECONDS))
+
+  val poll =
+    if (version.major >= 3) (poller: Poller, duration: Duration) ⇒ poller.poll(duration.toMillis)
+    else (poller: Poller, duration: Duration) ⇒ poller.poll(duration.toMicros)
 
   /**
    * The version of the ZeroMQ library


### PR DESCRIPTION
ZMQ 2.0 poll() accepts its duration in microseconds, but 3.0+ accepts
milliseconds, causing poll to block for 1000 times as long as it should.
