### PR TITLE
Test and improve gossip in large cluster

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -52,6 +52,11 @@ akka {
     # of the cluster within this deadline.
     join-timeout = 60s
 
+    # Gossip to random node with newer or older state information, if any with some
+    # this probability. Otherwise Gossip to any random live node.
+    # Probability value is between 0.0 and 1.0. 0.0 means never, 1.0 means always.
+    gossip-different-view-probability = 0.8
+
     failure-detector {
 
       # defines the failure detector threshold

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -1066,8 +1066,6 @@ class Cluster(system: ExtendedActorSystem, val failureDetector: FailureDetector)
     }
   }
 
-  private def gossipToDifferentViewProbability: Double = 0.8
-
   /**
    * INTERNAL API.
    *
@@ -1099,7 +1097,7 @@ class Cluster(system: ExtendedActorSystem, val failureDetector: FailureDetector)
         } yield address
       }
       val gossipedToAlive =
-        if (nodesWithdifferentView.nonEmpty && ThreadLocalRandom.current.nextDouble() < gossipToDifferentViewProbability)
+        if (nodesWithdifferentView.nonEmpty && ThreadLocalRandom.current.nextDouble() < GossipDifferentViewProbability)
           gossipToRandomNodeOf(nodesWithdifferentView.toIndexedSeq)
         else
           gossipToRandomNodeOf(localMemberAddresses)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -36,6 +36,7 @@ class ClusterSettings(val config: Config, val systemName: String) {
   final val AutoJoin: Boolean = getBoolean("akka.cluster.auto-join")
   final val AutoDown: Boolean = getBoolean("akka.cluster.auto-down")
   final val JoinTimeout: Duration = Duration(getMilliseconds("akka.cluster.join-timeout"), MILLISECONDS)
+  final val GossipDifferentViewProbability: Double = getDouble("akka.cluster.gossip-different-view-probability")
   final val SchedulerTickDuration: Duration = Duration(getMilliseconds("akka.cluster.scheduler.tick-duration"), MILLISECONDS)
   final val SchedulerTicksPerWheel: Int = getInt("akka.cluster.scheduler.ticks-per-wheel")
 }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeClusterSpec.scala
@@ -1,0 +1,267 @@
+/**
+ *  Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import com.typesafe.config.ConfigFactory
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+import akka.util.duration._
+import akka.actor.ActorSystem
+import akka.util.Deadline
+import java.util.concurrent.TimeoutException
+import scala.collection.immutable.SortedSet
+import akka.dispatch.Await
+import akka.util.Duration
+import java.util.concurrent.TimeUnit
+import akka.remote.testconductor.RoleName
+
+object LargeClusterMultiJvmSpec extends MultiNodeConfig {
+  // each jvm simulates a datacenter with many nodes
+  val firstDatacenter = role("first-datacenter")
+  val secondDatacenter = role("second-datacenter")
+  val thirdDatacenter = role("third-datacenter")
+  val fourthDatacenter = role("fourth-datacenter")
+  val fifthDatacenter = role("fifth-datacenter")
+
+  // Note that this test uses default configuration,
+  // not MultiNodeClusterSpec.clusterConfig
+  commonConfig(ConfigFactory.parseString("""
+    # Number of ActorSystems in each jvm, can be specified as
+    # system property when running real tests. Many nodes
+    # will take long time.
+    akka.test.large-cluster-spec.nodes-per-datacenter = 2
+    akka.cluster {
+      gossip-interval = 500 ms
+      auto-join = off
+      failure-detector.threshold = 4
+    }
+    akka.loglevel = INFO
+    akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 2
+    akka.scheduler.tick-duration = 33 ms
+    akka.remote.netty.execution-pool-size = 1
+    """))
+}
+
+class LargeClusterMultiJvmNode1 extends LargeClusterSpec with AccrualFailureDetectorStrategy
+class LargeClusterMultiJvmNode2 extends LargeClusterSpec with AccrualFailureDetectorStrategy
+class LargeClusterMultiJvmNode3 extends LargeClusterSpec with AccrualFailureDetectorStrategy
+class LargeClusterMultiJvmNode4 extends LargeClusterSpec with AccrualFailureDetectorStrategy
+class LargeClusterMultiJvmNode5 extends LargeClusterSpec with AccrualFailureDetectorStrategy
+
+abstract class LargeClusterSpec
+  extends MultiNodeSpec(LargeClusterMultiJvmSpec)
+  with MultiNodeClusterSpec {
+
+  import LargeClusterMultiJvmSpec._
+
+  var systems: IndexedSeq[ActorSystem] = IndexedSeq(system)
+  val nodesPerDatacenter = system.settings.config.getInt(
+    "akka.test.large-cluster-spec.nodes-per-datacenter")
+
+  /**
+   * Since we start some ActorSystems/Clusters outside of the
+   * MultiNodeClusterSpec control we can't use use the mechanism
+   * defined in MultiNodeClusterSpec to inject failure detector etc.
+   * Use ordinary Cluster extension with default AccrualFailureDetector.
+   */
+  override def cluster: Cluster = Cluster(system)
+
+  override def atTermination(): Unit = {
+    systems foreach { _.shutdown }
+    val shutdownTimeout = 20.seconds
+    val deadline = Deadline.now + shutdownTimeout
+    systems.foreach { sys ⇒
+      if (sys.isTerminated)
+        () // already done
+      else if (deadline.isOverdue)
+        sys.log.warning("Failed to shutdown [{}] within [{}]", sys.name, shutdownTimeout)
+      else {
+        try sys.awaitTermination(deadline.timeLeft) catch {
+          case _: TimeoutException ⇒ sys.log.warning("Failed to shutdown [{}] within [{}]", sys.name, shutdownTimeout)
+        }
+      }
+    }
+  }
+
+  def startupSystems(): Unit = {
+    // one system is already started by the multi-node test
+    for (n ← 2 to nodesPerDatacenter)
+      systems :+= ActorSystem(myself.name + "-" + n, system.settings.config)
+
+    // Initialize the Cluster extensions, i.e. startup the clusters
+    systems foreach { Cluster(_) }
+  }
+
+  def expectedMaxDuration(totalNodes: Int): Duration =
+    5.seconds + (2.seconds * totalNodes)
+
+  def joinAll(from: RoleName, to: RoleName, totalNodes: Int, runOnRoles: RoleName*): Unit = {
+    val joiningClusters = systems.map(Cluster(_)).toSet
+    join(joiningClusters, from, to, totalNodes, runOnRoles: _*)
+  }
+
+  def join(joiningClusterNodes: Set[Cluster], from: RoleName, to: RoleName, totalNodes: Int, runOnRoles: RoleName*): Unit = {
+    runOnRoles must contain(from)
+    runOnRoles must contain(to)
+
+    runOn(runOnRoles: _*) {
+      systems.size must be(nodesPerDatacenter) // make sure it is initialized
+
+      val clusterNodes = ifNode(from)(joiningClusterNodes)(systems.map(Cluster(_)).toSet)
+      val startGossipCounts = Map.empty[Cluster, Long] ++
+        clusterNodes.map(c ⇒ (c -> c.receivedGossipCount))
+      def gossipCount(c: Cluster): Long = c.receivedGossipCount - startGossipCounts(c)
+      val startTime = System.nanoTime
+      def tookMillis: String = TimeUnit.NANOSECONDS.toMillis(System.nanoTime - startTime) + " ms"
+
+      val latch = TestLatch(clusterNodes.size)
+      clusterNodes foreach { c ⇒
+        c.registerListener(new MembershipChangeListener {
+          override def notify(members: SortedSet[Member]): Unit = {
+            if (!latch.isOpen && members.size == totalNodes && members.forall(_.status == MemberStatus.Up)) {
+              log.debug("All [{}] nodes Up in [{}], it took [{}], received [{}] gossip messages",
+                totalNodes, c.selfAddress, tookMillis, gossipCount(c))
+              latch.countDown()
+            }
+          }
+        })
+      }
+
+      runOn(from) {
+        clusterNodes foreach { _ join to }
+      }
+
+      Await.ready(latch, remaining)
+
+      awaitCond(clusterNodes.forall(_.convergence.isDefined))
+      val counts = clusterNodes.map(gossipCount(_))
+      val formattedStats = "mean=%s min=%s max=%s".format(counts.sum / clusterNodes.size, counts.min, counts.max)
+      log.info("Convergence of [{}] nodes reached, it took [{}], received [{}] gossip messages per node",
+        totalNodes, tookMillis, formattedStats)
+
+    }
+  }
+
+  "A large cluster" must {
+
+    "join all nodes in first-datacenter to first-datacenter" taggedAs LongRunningTest in {
+      runOn(firstDatacenter) {
+        startupSystems()
+        startClusterNode()
+      }
+      enterBarrier("first-datacenter-started")
+
+      val totalNodes = nodesPerDatacenter
+      within(expectedMaxDuration(totalNodes)) {
+        joinAll(from = firstDatacenter, to = firstDatacenter, totalNodes, runOnRoles = firstDatacenter)
+        enterBarrier("first-datacenter-joined")
+      }
+    }
+
+    "join all nodes in second-datacenter to first-datacenter" taggedAs LongRunningTest in {
+      runOn(secondDatacenter) {
+        startupSystems()
+      }
+      enterBarrier("second-datacenter-started")
+
+      val totalNodes = nodesPerDatacenter * 2
+      within(expectedMaxDuration(totalNodes)) {
+        joinAll(from = secondDatacenter, to = firstDatacenter, totalNodes, runOnRoles = firstDatacenter, secondDatacenter)
+        enterBarrier("second-datacenter-joined")
+      }
+    }
+
+    "join all nodes in third-datacenter to first-datacenter" taggedAs LongRunningTest in {
+      runOn(thirdDatacenter) {
+        startupSystems()
+      }
+      enterBarrier("third-datacenter-started")
+
+      val totalNodes = nodesPerDatacenter * 3
+      within(expectedMaxDuration(totalNodes)) {
+        joinAll(from = thirdDatacenter, to = firstDatacenter, totalNodes,
+          runOnRoles = firstDatacenter, secondDatacenter, thirdDatacenter)
+        enterBarrier("third-datacenter-joined")
+      }
+    }
+
+    "join all nodes in fourth-datacenter to first-datacenter" taggedAs LongRunningTest in {
+      runOn(fourthDatacenter) {
+        startupSystems()
+      }
+      enterBarrier("fourth-datacenter-started")
+
+      val totalNodes = nodesPerDatacenter * 4
+      within(expectedMaxDuration(totalNodes)) {
+        joinAll(from = fourthDatacenter, to = firstDatacenter, totalNodes,
+          runOnRoles = firstDatacenter, secondDatacenter, thirdDatacenter, fourthDatacenter)
+        enterBarrier("fourth-datacenter-joined")
+      }
+    }
+
+    "join nodes one by one from fifth-datacenter to first-datacenter" taggedAs LongRunningTest in {
+      runOn(fifthDatacenter) {
+        startupSystems()
+      }
+      enterBarrier("fifth-datacenter-started")
+
+      for (i ← 0 until nodesPerDatacenter) {
+        val totalNodes = nodesPerDatacenter * 4 + i + 1
+        within(expectedMaxDuration(totalNodes)) {
+          val joiningClusters = ifNode(fifthDatacenter)(Set(Cluster(systems(i))))(Set.empty)
+          join(joiningClusters, from = fifthDatacenter, to = firstDatacenter, totalNodes,
+            runOnRoles = firstDatacenter, secondDatacenter, thirdDatacenter, fourthDatacenter, fifthDatacenter)
+          enterBarrier("fifth-datacenter-joined-" + i)
+        }
+      }
+    }
+
+    // FIXME sometimes this fails, FD marks nodes from other than second-datacenter as unavailable
+    "detect failure and auto-down crashed nodes in second-datacenter" taggedAs LongRunningTest ignore {
+      val unreachableNodes = nodesPerDatacenter
+      val liveNodes = nodesPerDatacenter * 4
+
+      within(20.seconds + expectedMaxDuration(liveNodes)) {
+        val startGossipCounts = Map.empty[Cluster, Long] ++
+          systems.map(sys ⇒ (Cluster(sys) -> Cluster(sys).receivedGossipCount))
+        def gossipCount(c: Cluster): Long = c.receivedGossipCount - startGossipCounts(c)
+        val startTime = System.nanoTime
+        def tookMillis: String = TimeUnit.NANOSECONDS.toMillis(System.nanoTime - startTime) + " ms"
+
+        val latch = TestLatch(nodesPerDatacenter)
+        systems foreach { sys ⇒
+          Cluster(sys).registerListener(new MembershipChangeListener {
+            override def notify(members: SortedSet[Member]): Unit = {
+              if (!latch.isOpen && members.size == liveNodes && Cluster(sys).latestGossip.overview.unreachable.size == unreachableNodes) {
+                log.info("Detected [{}] unreachable nodes in [{}], it took [{}], received [{}] gossip messages",
+                  unreachableNodes, Cluster(sys).selfAddress, tookMillis, gossipCount(Cluster(sys)))
+                latch.countDown()
+              }
+            }
+          })
+        }
+
+        runOn(firstDatacenter) {
+          testConductor.shutdown(secondDatacenter, 0)
+        }
+
+        enterBarrier("second-datacenter-shutdown")
+
+        runOn(firstDatacenter, thirdDatacenter, fourthDatacenter, fifthDatacenter) {
+          Await.ready(latch, remaining)
+          awaitCond(systems.forall(Cluster(_).convergence.isDefined))
+          val counts = systems.map(sys ⇒ gossipCount(Cluster(sys)))
+          val formattedStats = "mean=%s min=%s max=%s".format(counts.sum / nodesPerDatacenter, counts.min, counts.max)
+          log.info("Convergence of [{}] nodes reached after failure, it took [{}], received [{}] gossip messages per node",
+            liveNodes, tookMillis, formattedStats)
+        }
+
+        enterBarrier("after-6")
+      }
+
+    }
+
+  }
+}

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
@@ -23,8 +23,6 @@ object SunnyWeatherMultiJvmSpec extends MultiNodeConfig {
   // not MultiNodeClusterSpec.clusterConfig
   commonConfig(ConfigFactory.parseString("""
     akka.cluster {
-      # FIXME remove this (use default) when ticket #2239 has been fixed
-      gossip-interval = 400 ms
       auto-join = off
     }
     akka.loglevel = INFO

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
@@ -32,6 +32,7 @@ class ClusterConfigSpec extends AkkaSpec {
       NrOfGossipDaemons must be(4)
       AutoJoin must be(true)
       AutoDown must be(true)
+      GossipDifferentViewProbability must be(0.8 plusOrMinus 0.0001)
       SchedulerTickDuration must be(33 millis)
       SchedulerTicksPerWheel must be(512)
     }

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
@@ -105,12 +105,14 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with BeforeAndAfter {
       cluster.latestGossip.members.map(_.address) must be(Set(selfAddress, addresses(1)))
       memberStatus(addresses(1)) must be(Some(MemberStatus.Joining))
       cluster.convergence.isDefined must be(false)
+      expectMsg(GossipTo(addresses(1)))
     }
 
     "accept a few more joining nodes" in {
       for (a ← addresses.drop(2)) {
         cluster.joining(a)
         memberStatus(a) must be(Some(MemberStatus.Joining))
+        expectMsg(GossipTo(a))
       }
       cluster.latestGossip.members.map(_.address) must be(addresses.toSet)
     }
@@ -121,7 +123,6 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with BeforeAndAfter {
     }
 
     "gossip to random live node" in {
-      cluster.latestGossip.members
       cluster.gossip()
       cluster.gossip()
       cluster.gossip()

--- a/akka-docs/cluster/cluster.rst
+++ b/akka-docs/cluster/cluster.rst
@@ -138,7 +138,7 @@ implementation of `The Phi Accrual Failure Detector`_ by Hayashibara et al.
 An accrual failure detector decouple monitoring and interpretation. That makes
 them applicable to a wider area of scenarios and more adequate to build generic
 failure detection services. The idea is that it is keeping a history of failure
-statistics, calculated from heartbeats received from the gossip protocol, and is
+statistics, calculated from heartbeats received from other nodes, and is
 trying to do educated guesses by taking multiple factors, and how they
 accumulate over time, into account in order to come up with a better guess if a
 specific node is up or down. Rather than just answering "yes" or "no" to the
@@ -232,14 +232,13 @@ breaking logical partitions as seen in the gossip algorithm defined below.
 
 During each round of gossip exchange the following process is used:
 
-1. Gossip to random live node (if any)
+1. Gossip to random node with newer or older state information, if any, based on the
+   current gossip overview, with some probability. Otherwise Gossip to any random 
+   live node.
 
 2. If the node gossiped to at (1) was not a ``deputy`` node, or the number of live
    nodes is less than number of ``deputy`` nodes, gossip to random ``deputy`` node with
    certain probability depending on number of unreachable, ``deputy``, and live nodes.
-
-3. Gossip to random node with newer or older state information, based on the
-   current gossip overview, with some probability (?)
 
 The gossiper only sends the gossip overview to the chosen node. The recipient of
 the gossip can use the gossip overview to determine whether:

--- a/akka-remote-tests/src/test/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -138,7 +138,8 @@ abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles:
   import MultiNodeSpec._
 
   def this(config: MultiNodeConfig) =
-    this(config.myself, ActorSystem(AkkaSpec.getCallerName(classOf[MultiNodeSpec]), config.config), config.roles, config.deployments)
+    this(config.myself, ActorSystem(AkkaSpec.getCallerName(classOf[MultiNodeSpec]), ConfigFactory.load(config.config)),
+      config.roles, config.deployments)
 
   /*
    * Test Class Interface

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -59,7 +59,8 @@ object AkkaSpec {
 abstract class AkkaSpec(_system: ActorSystem)
   extends TestKit(_system) with WordSpec with MustMatchers with BeforeAndAfterAll {
 
-  def this(config: Config) = this(ActorSystem(AkkaSpec.getCallerName(getClass), config.withFallback(AkkaSpec.testConf)))
+  def this(config: Config) = this(ActorSystem(AkkaSpec.getCallerName(getClass),
+    ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -310,11 +310,11 @@ object AkkaBuild extends Build {
   val defaultExcludedTags = Set("timing", "long-running")
 
   lazy val defaultMultiJvmOptions: Seq[String] = {
-    (System.getProperty("akka.test.timefactor") match {
-      case null => Nil
-      case x => List("-Dakka.test.timefactor=" + x)
-    }) :::
-    (if (getBoolean("sbt.log.noformat")) List("-Dakka.test.nocolor=true") else Nil)
+    import scala.collection.JavaConverters._
+    val akkaProperties = System.getProperties.propertyNames.asScala.toList.collect {
+      case key: String if key.startsWith("akka.") => "-D" + key + "=" + System.getProperty(key)
+    }
+    akkaProperties ::: (if (getBoolean("sbt.log.noformat")) List("-Dakka.test.nocolor=true") else Nil)
   }
 
   // for excluding tests by name use system property: -Dakka.test.names.exclude=TimingSpec


### PR DESCRIPTION
This pull requests consists of 3 commits:

Test gossip in large cluster, see #2239

Improve efficiency of gossip, see #2193 and #2253
- Essentially as already described in cluster specification,
  but now fully implemented and tested with LargeClusterSpec
- Gossip to nodes with different view (using seen table)
  with certain probability
- Gossip chat, gossip back to sender
- Immediate gossip to joining node

Propagate akka system properties to multi-node tests, see #2280
- Change build to propagate all system properties starting with 'akka.'
  to multi-jvm and multi-node tests.
- Adjusted AkkaSpec and MultiNodeSpec to use load of the config, which
  means that default overrides (system properties) are used.
