### PR TITLE
Following up on ML discussion

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -858,9 +858,9 @@ private[akka] class ActorCell(
   }
 
   final def handleInvokeFailure(t: Throwable, message: String): Unit = try {
-    dispatcher.reportFailure(new LogEventException(Error(t, self.path.toString, clazz(actor), message), t))
-    // prevent any further messages to be processed until the actor has been restarted
-    dispatcher.suspend(this)
+    dispatcher.reportFailure(new LogEventException(Warning(t, self.path.toString, clazz(actor), message), t))
+    // disabled: prevent any further messages to be processed until the actor has been restarted
+    //dispatcher.suspend(this)
     if (actor ne null) actor.supervisorStrategy.handleSupervisorFailing(self, children)
   } finally {
     t match { // Wrap InterruptedExceptions and rethrow


### PR DESCRIPTION
Changing the Error to Warning means that log messages could be suppressed.

The remote actor might come back online, so the complaining actor may have reason to re-issue log.warning() messages should the remote actor disappear again - provided that the log level was high enough to display those messages.

https://groups.google.com/forum/#!msg/akka-user/hLGkCjnGQZc/zfpHwyIQmCUJ

Mike
