### PR TITLE
fix long ssl tests for linux

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -209,6 +209,7 @@ akka {
         # "" or SecureRandom => (default)
         # "SHA1PRNG" => Can be slow because of blocking issues on Linux
         # "AES128CounterSecureRNG" => fastest startup and based on AES encryption algorithm
+        # "AES256CounterSecureRNG"
         # The following use one of 3 possible seed sources, depending on availability: /dev/random, random.org and SecureRandom (provided by Java)
         # "AES128CounterInetRNG"
         # "AES256CounterInetRNG"  (Install JCE Unlimited Strength Jurisdiction Policy Files first)

--- a/akka-remote/src/main/scala/akka/remote/netty/NettySSLSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/NettySSLSupport.scala
@@ -38,7 +38,7 @@ private[akka] object NettySSLSupport {
     }
 
     val rng = rngName match {
-      case Some(r @ ("AES128CounterSecureRNG" | "AES128CounterInetRNG" | "AES256CounterInetRNG")) ⇒
+      case Some(r @ ("AES128CounterSecureRNG" | "AES256CounterSecureRNG" | "AES128CounterInetRNG" | "AES256CounterInetRNG")) ⇒
         log.debug("SSL random number generator set to: {}", r)
         SecureRandom.getInstance(r, AkkaProvider)
       case Some(s @ ("SHA1PRNG" | "NativePRNG")) ⇒

--- a/akka-remote/src/main/scala/akka/security/provider/AES128CounterInetRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES128CounterInetRNG.scala
@@ -4,6 +4,7 @@
 package akka.security.provider
 
 import org.uncommons.maths.random.{ AESCounterRNG }
+import SeedSize.Seed128
 
 /**
  * Internal API
@@ -13,7 +14,7 @@ import org.uncommons.maths.random.{ AESCounterRNG }
  * The only method used by netty ssl is engineNextBytes(bytes)
  */
 class AES128CounterInetRNG extends java.security.SecureRandomSpi {
-  private val rng = new AESCounterRNG(InternetSeedGenerator.getInstance.generateSeed(Seed128.size))
+  private val rng = new AESCounterRNG(engineGenerateSeed(Seed128))
 
   /**
    * This is managed internally by AESCounterRNG

--- a/akka-remote/src/main/scala/akka/security/provider/AES128CounterSecureRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES128CounterSecureRNG.scala
@@ -7,12 +7,18 @@ import org.uncommons.maths.random.{ AESCounterRNG, SecureRandomSeedGenerator }
 
 /**
  * Internal API
- * This class is a wrapper around the AESCounterRNG algorithm provided by http://maths.uncommons.org/ *
+ * This class is a wrapper around the 128-bit AESCounterRNG algorithm provided by http://maths.uncommons.org/
  * The only method used by netty ssl is engineNextBytes(bytes)
  * This RNG is good to use to prevent startup delay when you don't have Internet access to random.org
  */
 class AES128CounterSecureRNG extends java.security.SecureRandomSpi {
-  private val rng = new AESCounterRNG(new SecureRandomSeedGenerator())
+  /**Singleton instance. */
+  private final lazy val INSTANCE: SecureRandomSeedGenerator = new SecureRandomSeedGenerator
+
+  /**
+   * Make sure the seed generator is provided by a SecureRandom singleton and not default 'Random'
+   */
+  private val rng = new AESCounterRNG(INSTANCE.generateSeed(Seed128.size))
 
   /**
    * This is managed internally by AESCounterRNG
@@ -34,6 +40,6 @@ class AES128CounterSecureRNG extends java.security.SecureRandomSpi {
    * @param numBytes the number of seed bytes to generate.
    * @return the seed bytes.
    */
-  override protected def engineGenerateSeed(numBytes: Int): Array[Byte] = (new SecureRandomSeedGenerator()).generateSeed(numBytes)
+  override protected def engineGenerateSeed(numBytes: Int): Array[Byte] = INSTANCE.generateSeed(numBytes)
 }
 

--- a/akka-remote/src/main/scala/akka/security/provider/AES128CounterSecureRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES128CounterSecureRNG.scala
@@ -4,6 +4,7 @@
 package akka.security.provider
 
 import org.uncommons.maths.random.{ AESCounterRNG, SecureRandomSeedGenerator }
+import SeedSize.Seed128
 
 /**
  * Internal API
@@ -18,7 +19,7 @@ class AES128CounterSecureRNG extends java.security.SecureRandomSpi {
   /**
    * Make sure the seed generator is provided by a SecureRandom singleton and not default 'Random'
    */
-  private val rng = new AESCounterRNG(INSTANCE.generateSeed(Seed128.size))
+  private val rng = new AESCounterRNG(engineGenerateSeed(Seed128))
 
   /**
    * This is managed internally by AESCounterRNG

--- a/akka-remote/src/main/scala/akka/security/provider/AES128CounterSecureRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES128CounterSecureRNG.scala
@@ -13,7 +13,7 @@ import org.uncommons.maths.random.{ AESCounterRNG, SecureRandomSeedGenerator }
  */
 class AES128CounterSecureRNG extends java.security.SecureRandomSpi {
   /**Singleton instance. */
-  private final lazy val INSTANCE: SecureRandomSeedGenerator = new SecureRandomSeedGenerator
+  private final val INSTANCE: SecureRandomSeedGenerator = new SecureRandomSeedGenerator
 
   /**
    * Make sure the seed generator is provided by a SecureRandom singleton and not default 'Random'

--- a/akka-remote/src/main/scala/akka/security/provider/AES256CounterInetRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES256CounterInetRNG.scala
@@ -4,6 +4,7 @@
 package akka.security.provider
 
 import org.uncommons.maths.random.{ AESCounterRNG }
+import SeedSize.Seed256
 
 /**
  * Internal API
@@ -13,7 +14,7 @@ import org.uncommons.maths.random.{ AESCounterRNG }
  * The only method used by netty ssl is engineNextBytes(bytes)
  */
 class AES256CounterInetRNG extends java.security.SecureRandomSpi {
-  private val rng = new AESCounterRNG(InternetSeedGenerator.getInstance.generateSeed(Seed256.size))
+  private val rng = new AESCounterRNG(engineGenerateSeed(Seed256))
 
   /**
    * This is managed internally by AESCounterRNG

--- a/akka-remote/src/main/scala/akka/security/provider/AES256CounterInetRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES256CounterInetRNG.scala
@@ -3,23 +3,17 @@
  */
 package akka.security.provider
 
-import org.uncommons.maths.random.{ AESCounterRNG, DefaultSeedGenerator }
+import org.uncommons.maths.random.{ AESCounterRNG }
 
 /**
  * Internal API
  * This class is a wrapper around the 256-bit AESCounterRNG algorithm provided by http://maths.uncommons.org/
  * It uses the default seed generator which uses one of the following 3 random seed sources:
- * Depending on availability: /dev/random, random.org and SecureRandom (provided by Java)
+ * Depending on availability: random.org, /dev/random, and SecureRandom (provided by Java)
  * The only method used by netty ssl is engineNextBytes(bytes)
  */
 class AES256CounterInetRNG extends java.security.SecureRandomSpi {
-  /**
-   * From AESCounterRNG API docs:
-   * Valid values are 16 (128 bits), 24 (192 bits) and 32 (256 bits).
-   * Any other values will result in an exception from the AES implementation.
-   */
-  private val AES_256_BIT = 32 // Magic number is magic
-  private val rng = new AESCounterRNG(AES_256_BIT)
+  private val rng = new AESCounterRNG(InternetSeedGenerator.getInstance.generateSeed(Seed256.size))
 
   /**
    * This is managed internally by AESCounterRNG
@@ -41,6 +35,6 @@ class AES256CounterInetRNG extends java.security.SecureRandomSpi {
    * @param numBytes the number of seed bytes to generate.
    * @return the seed bytes.
    */
-  override protected def engineGenerateSeed(numBytes: Int): Array[Byte] = DefaultSeedGenerator.getInstance.generateSeed(numBytes)
+  override protected def engineGenerateSeed(numBytes: Int): Array[Byte] = InternetSeedGenerator.getInstance.generateSeed(numBytes)
 }
 

--- a/akka-remote/src/main/scala/akka/security/provider/AES256CounterSecureRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES256CounterSecureRNG.scala
@@ -13,7 +13,7 @@ import org.uncommons.maths.random.{ AESCounterRNG, SecureRandomSeedGenerator }
  */
 class AES256CounterSecureRNG extends java.security.SecureRandomSpi {
   /**Singleton instance. */
-  private final lazy val INSTANCE: SecureRandomSeedGenerator = new SecureRandomSeedGenerator
+  private final val INSTANCE: SecureRandomSeedGenerator = new SecureRandomSeedGenerator
 
   private val rng = new AESCounterRNG(INSTANCE.generateSeed(Seed256.size))
 

--- a/akka-remote/src/main/scala/akka/security/provider/AES256CounterSecureRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES256CounterSecureRNG.scala
@@ -3,17 +3,19 @@
  */
 package akka.security.provider
 
-import org.uncommons.maths.random.{ AESCounterRNG }
+import org.uncommons.maths.random.{ AESCounterRNG, SecureRandomSeedGenerator }
 
 /**
  * Internal API
- * This class is a wrapper around the 128-bit AESCounterRNG algorithm provided by http://maths.uncommons.org/
- * It uses the default seed generator which uses one of the following 3 random seed sources:
- * Depending on availability: random.org, /dev/random, and SecureRandom (provided by Java)
+ * This class is a wrapper around the 256-bit AESCounterRNG algorithm provided by http://maths.uncommons.org/
  * The only method used by netty ssl is engineNextBytes(bytes)
+ * This RNG is good to use to prevent startup delay when you don't have Internet access to random.org
  */
-class AES128CounterInetRNG extends java.security.SecureRandomSpi {
-  private val rng = new AESCounterRNG(InternetSeedGenerator.getInstance.generateSeed(Seed128.size))
+class AES256CounterSecureRNG extends java.security.SecureRandomSpi {
+  /**Singleton instance. */
+  private final lazy val INSTANCE: SecureRandomSeedGenerator = new SecureRandomSeedGenerator
+
+  private val rng = new AESCounterRNG(INSTANCE.generateSeed(Seed256.size))
 
   /**
    * This is managed internally by AESCounterRNG
@@ -35,6 +37,6 @@ class AES128CounterInetRNG extends java.security.SecureRandomSpi {
    * @param numBytes the number of seed bytes to generate.
    * @return the seed bytes.
    */
-  override protected def engineGenerateSeed(numBytes: Int): Array[Byte] = InternetSeedGenerator.getInstance.generateSeed(numBytes)
+  override protected def engineGenerateSeed(numBytes: Int): Array[Byte] = INSTANCE.generateSeed(numBytes)
 }
 

--- a/akka-remote/src/main/scala/akka/security/provider/AES256CounterSecureRNG.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AES256CounterSecureRNG.scala
@@ -4,6 +4,7 @@
 package akka.security.provider
 
 import org.uncommons.maths.random.{ AESCounterRNG, SecureRandomSeedGenerator }
+import SeedSize.Seed256
 
 /**
  * Internal API
@@ -15,7 +16,7 @@ class AES256CounterSecureRNG extends java.security.SecureRandomSpi {
   /**Singleton instance. */
   private final val INSTANCE: SecureRandomSeedGenerator = new SecureRandomSeedGenerator
 
-  private val rng = new AESCounterRNG(INSTANCE.generateSeed(Seed256.size))
+  private val rng = new AESCounterRNG(engineGenerateSeed(Seed256))
 
   /**
    * This is managed internally by AESCounterRNG

--- a/akka-remote/src/main/scala/akka/security/provider/AkkaProvider.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AkkaProvider.scala
@@ -13,7 +13,7 @@ object AkkaProvider extends Provider("Akka", 1.0, "Akka provider 1.0 that implem
     def run = {
       //SecureRandom
       put("SecureRandom.AES128CounterSecureRNG", classOf[AES128CounterSecureRNG].getName)
-      put("SecureRandom.AES256CounterSecureRNG", classOf[AES128CounterSecureRNG].getName)
+      put("SecureRandom.AES256CounterSecureRNG", classOf[AES256CounterSecureRNG].getName)
       put("SecureRandom.AES128CounterInetRNG", classOf[AES128CounterInetRNG].getName)
       put("SecureRandom.AES256CounterInetRNG", classOf[AES256CounterInetRNG].getName)
 

--- a/akka-remote/src/main/scala/akka/security/provider/AkkaProvider.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/AkkaProvider.scala
@@ -13,11 +13,13 @@ object AkkaProvider extends Provider("Akka", 1.0, "Akka provider 1.0 that implem
     def run = {
       //SecureRandom
       put("SecureRandom.AES128CounterSecureRNG", classOf[AES128CounterSecureRNG].getName)
+      put("SecureRandom.AES256CounterSecureRNG", classOf[AES128CounterSecureRNG].getName)
       put("SecureRandom.AES128CounterInetRNG", classOf[AES128CounterInetRNG].getName)
       put("SecureRandom.AES256CounterInetRNG", classOf[AES256CounterInetRNG].getName)
 
       //Implementation type: software or hardware
       put("SecureRandom.AES128CounterSecureRNG ImplementedIn", "Software")
+      put("SecureRandom.AES256CounterSecureRNG ImplementedIn", "Software")
       put("SecureRandom.AES128CounterInetRNG ImplementedIn", "Software")
       put("SecureRandom.AES256CounterInetRNG ImplementedIn", "Software")
       null //Magic null is magic

--- a/akka-remote/src/main/scala/akka/security/provider/InternetSeedGenerator.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/InternetSeedGenerator.scala
@@ -1,7 +1,18 @@
-/**
- * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
- * modified and converted to Scala from Daniel W. Dyer's DefaultSeedGenerator
- */
+// ============================================================================
+//   Copyright 2006-2010 Daniel W. Dyer
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// ============================================================================
 package akka.security.provider
 
 import org.uncommons.maths.random.{ SeedGenerator, SeedException, SecureRandomSeedGenerator, RandomDotOrgSeedGenerator, DevRandomSeedGenerator }

--- a/akka-remote/src/main/scala/akka/security/provider/InternetSeedGenerator.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/InternetSeedGenerator.scala
@@ -37,10 +37,8 @@ object InternetSeedGenerator {
   /**Delegate generators. */
   private final val GENERATORS: Seq[SeedGenerator] =
     new RandomDotOrgSeedGenerator :: // first try the Internet seed generator
-      new DevRandomSeedGenerator :: // try the local /dev/random
       new SecureRandomSeedGenerator :: // this is last because it always works
       Nil
-
 }
 
 final class InternetSeedGenerator extends SeedGenerator {
@@ -55,11 +53,13 @@ final class InternetSeedGenerator extends SeedGenerator {
   def generateSeed(length: Int): Array[Byte] = {
     for (generator ← InternetSeedGenerator.GENERATORS) {
       try {
-        generator.generateSeed(length)
+        return generator.generateSeed(length)
       } catch {
         case ex: SeedException ⇒ // Ignore and try the next generator...
       }
     }
+    // This shouldn't happen as at least one of the generators should be
+    // able to generate a seed.
     throw new IllegalStateException("All available seed generation strategies failed.")
   }
 }

--- a/akka-remote/src/main/scala/akka/security/provider/SeedSize.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/SeedSize.scala
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.security.provider
+
+/**
+ * Internal API
+ * From AESCounterRNG API docs:
+ * Valid values are 16 (128 bits), 24 (192 bits) and 32 (256 bits).
+ * Any other values will result in an exception from the AES implementation.
+ */
+sealed trait SeedSize { def size: Int }
+case object Seed128 extends SeedSize { val size = 16 }
+case object Seed192 extends SeedSize { val size = 24 }
+case object Seed256 extends SeedSize { val size = 32 }

--- a/akka-remote/src/main/scala/akka/security/provider/SeedSize.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/SeedSize.scala
@@ -10,8 +10,9 @@ package akka.security.provider
  * Valid values are 16 (128 bits), 24 (192 bits) and 32 (256 bits).
  * Any other values will result in an exception from the AES implementation.
  */
-sealed trait SeedSize { def size: Int }
-case object Seed128 extends SeedSize { val size = 16 }
-case object Seed192 extends SeedSize { val size = 24 }
-case object Seed256 extends SeedSize { val size = 32 }
+object SeedSize {
+  val Seed128 = 16
+  val Seed192 = 24
+  val Seed256 = 32
+}
 

--- a/akka-remote/src/main/scala/akka/security/provider/SeedSize.scala
+++ b/akka-remote/src/main/scala/akka/security/provider/SeedSize.scala
@@ -14,3 +14,4 @@ sealed trait SeedSize { def size: Int }
 case object Seed128 extends SeedSize { val size = 16 }
 case object Seed192 extends SeedSize { val size = 24 }
 case object Seed256 extends SeedSize { val size = 32 }
+

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
@@ -83,6 +83,9 @@ class Ticket1978SHA1PRNGSpec extends Ticket1978CommunicationSpec(getCipherConfig
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class Ticket1978AES128CounterSecureRNGSpec extends Ticket1978CommunicationSpec(getCipherConfig("AES128CounterSecureRNG", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"))
 
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class Ticket1978AES256CounterSecureRNGSpec extends Ticket1978CommunicationSpec(getCipherConfig("AES256CounterSecureRNG", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"))
+
 /**
  * Both of the <quote>Inet</quote> variants require access to the Internet to access random.org.
  */


### PR DESCRIPTION
Implemented a custom InternetSeedGenerator to override seed generator ordering to try and fix long waiting times on Linux because DefaultSeedGenerator uses /dev/random first instead of random.org

1) Added SeedSize to provide easier access to 'magic' numbers
2) Added AES256CounterSecureRNG
