### PR TITLE
Adding the ActorDSL and the MigrationSystem.

### DIFF
--- a/akka-actor-tests/src/test/java/akka/routing/CustomRouteTest.java
+++ b/akka-actor-tests/src/test/java/akka/routing/CustomRouteTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.routing;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.routing.RoundRobinRouter;
+import akka.testkit.ExtractRoute;
+
+public class CustomRouteTest {
+
+  static private ActorSystem system;
+
+  // only to test compilability
+  public void testRoute() {
+    final ActorRef ref = system.actorOf(new Props().withRouter(new RoundRobinRouter(1)));
+    final scala.Function1<scala.Tuple2<ActorRef, Object>, scala.collection.Iterable<Destination>> route = ExtractRoute.apply(ref);
+    route.apply(null);
+  }
+
+}

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorDSLSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorDSLSpec.scala
@@ -1,0 +1,233 @@
+/**
+ * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import language.postfixOps
+
+import akka.testkit._
+import akka.testkit.TestEvent._
+import java.util.Collection
+
+import scala.concurrent.Await
+import akka.pattern.ask
+import scala.concurrent.util.duration._
+
+import akka.actor.ActorSystem.Settings
+import akka.actor.ActorDSL._
+import scala.ref.WeakReference
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.junit.JUnitRunner
+
+@org.junit.runner.RunWith(classOf[JUnitRunner])
+class ActorDSLSpec extends AkkaSpec with DefaultTimeout with BeforeAndAfterEach {
+  import ActorWithBoundedStashSpec._
+  import java.util.concurrent.TimeUnit._
+  implicit val sys = system
+
+  "An actor created with the DSL" must {
+    "have a working context" in {
+      val latch = new TestLatch
+
+      val actor = actorOf { context ⇒
+        {
+          case m ⇒
+            m must be("hello")
+            context.become {
+              case m ⇒
+                m must be("hello")
+                latch.open()
+            }
+        }
+      }
+
+      actor ! "hello"
+      actor ! "hello"
+
+      Await.ready(latch, 10 seconds)
+
+      actor ! PoisonPill
+    }
+
+    "be able to exchange messages with a regular thread " in {
+      val tA = dynamicSelf
+      val actor = actorOf { context ⇒
+        {
+          case m ⇒
+            m must be("hello")
+            context.sender must be(tA)
+            context.sender ! m
+        }
+      }
+
+      actor ! "hello"
+
+      receive {
+        case m ⇒
+          m must be("hello")
+      }
+    }
+  }
+
+  "A thread actor" must {
+    "support nested receives" in {
+      val latch = new TestLatch
+      val tA = dynamicSelf
+      val actor = actorOf { context ⇒
+        {
+          case m ⇒
+            context.sender must be(tA)
+            context.sender ! m
+        }
+      }
+
+      actor ! "hello"
+      actor ! "world"
+
+      receive {
+        case "hello" ⇒
+          receive {
+            case "world" ⇒
+              latch.open()
+          }
+      }
+
+      Await.ready(latch, 10 seconds)
+    }
+
+    "only receive user messages" in {
+      val tA = dynamicSelf
+      val actor = actorOf { context ⇒
+        {
+          case "start" ⇒
+            context.sender must be(tA)
+            for (_ ← 0 until 1000)
+              context.sender ! "hello"
+        }
+      }
+
+      actor ! "start"
+
+      for (_ ← 0 until 1000) receive {
+        case m ⇒
+          m must be("hello")
+      }
+
+    }
+
+    "support the ask pattern" in {
+      val tA = dynamicSelf
+
+      val actor = actorOf { context ⇒
+        {
+          case m ⇒
+            // send message and wait for response
+            val f = context.sender ? "hello"
+        }
+      }
+
+      actor ! "whatever"
+
+      // wait for a response in a thread
+      receive {
+        case resp ⇒
+          resp must be("hello")
+      }
+    }
+
+    "support the sender method" in {
+      val tA = dynamicSelf
+      val latch = new java.util.concurrent.CountDownLatch(2)
+
+      val sender2 = actorOf { context ⇒
+        {
+          case "start" ⇒
+            context.sender ! "hello2"
+
+          case m ⇒
+            m must be("sender level 2")
+            latch.countDown()
+        }
+      }
+
+      val sender1 = actorOf { context ⇒
+        {
+          case "start" ⇒
+            // send message and wait for response
+            sender ! "hello"
+
+          case "sender level 1" ⇒
+            latch.countDown()
+        }
+      }
+
+      sender1 ! "start"
+
+      // wait for a response in a thread
+      receive {
+        case resp ⇒
+          resp must be("hello")
+          sender must be(sender1)
+          sender ! "sender level 1"
+          sender2 ! "start"
+          receive {
+            case resp ⇒
+              resp must be("hello2")
+              sender must be(sender2)
+              sender ! "sender level 2"
+          }
+          sender must be(sender1)
+      }
+      latch.await(2, SECONDS)
+    }
+
+    "must not leak memory" in {
+      import scala.collection.JavaConversions._
+
+      def startActors(nr: Int, coll: Collection[WeakReference[AnyRef]]) {
+        // create a bunch of thread actors
+        var threads = for (_ ← 0 until nr) yield new Thread {
+          override def run() = {
+            val tA = dynamicSelf
+            coll.add(new WeakReference(tA))
+          }
+        }
+
+        threads.foreach(_.start)
+        threads.foreach(_.join)
+        threads = null
+      }
+
+      // check the weak connection of the whole thread actor object graph
+      val threadActors = java.util.Collections.synchronizedCollection(new java.util.ArrayList[WeakReference[AnyRef]]())
+      startActors(100, threadActors)
+      scala.compat.Platform.collectGarbage()
+
+      threadActors.iterator.forall(x ⇒ x.get == None) must be(true)
+    }
+
+    "be reachable with `actorFor` method" in {
+      val latch = new TestLatch
+      val tA = dynamicSelf
+      val actor = actorOf { context ⇒
+        {
+          case id: Long ⇒
+            val threadActor = context.actorFor("/threads/thread-" + id)
+            threadActor ! "got your path"
+        }
+      }
+
+      // send the id by which the thread actor can be looked up
+      actor ! Thread.currentThread().getId()
+
+      receive {
+        case "got your path" ⇒
+          latch.open()
+      }
+
+      Await.ready(latch, 2 seconds)
+    }
+
+  }
+}

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithBoundedStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithBoundedStashSpec.scala
@@ -52,8 +52,6 @@ class ActorWithBoundedStashSpec extends AkkaSpec(ActorWithBoundedStashSpec.testC
 
   implicit val sys = system
 
-  override def atStartup { system.eventStream.publish(Mute(EventFilter[Exception]("Crashing..."))) }
-
   def myProps(creator: ⇒ Actor): Props = Props(creator).withDispatcher("my-dispatcher")
 
   "An Actor with Stash and BoundedDequeBasedMailbox" must {

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -157,6 +157,15 @@ akka {
       }
     }
 
+    # Default dispatcher for Actors that extend Stash
+    default-stash-dispatcher {
+      mailbox-type = "akka.dispatch.UnboundedDequeBasedMailbox"
+    }
+
+    # Empty config, so ThreadActorSystem configuration can be modified.
+    dsl-actor-system {
+    }
+
     default-dispatcher {
       # Must be one of the following
       # Dispatcher, (BalancingDispatcher, only valid when all actors using it are of
@@ -280,7 +289,7 @@ akka {
 
       # enable DEBUG logging of subscription changes on the eventStream
       event-stream = off
-      
+
       # enable DEBUG logging of unhandled messages
       unhandled = off
 

--- a/akka-actor/src/main/scala/akka/actor/ActorDSL.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorDSL.scala
@@ -1,0 +1,260 @@
+package akka.actor
+
+import akka.dispatch.SystemMessage
+import java.util.concurrent.atomic.AtomicLong
+import collection.mutable.Queue
+import com.typesafe.config.{ Config, ConfigFactory }
+import akka.event.LoggingAdapter
+import scala.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The ActorDSL object provides factory methods which allow creating actors
+ * using a very lightweight syntax which simplifies programming with actors
+ * in the interactive interpreter.
+ *
+ * Moreover, the ActorDSL object provides an actor interface for the current
+ * thread. By importing the `dynamicSelf` member, the current thread is treated
+ * as an implicit sender when sending messages outside of a regular actor.
+ * Using the `receive` method, the current thread can receive messages
+ * sent to its actor reference.
+ *
+ * NOTE: Thread actors created with this DSL can not pair the performance regular
+ * Akka actors and therefore should not be used in the performance critical code.
+ */
+object ActorDSL {
+  private val system = new DSLActorSystem
+  system.start
+
+  /* The ActorRef of the current thread with its message queue */
+  private val selfTl = new ThreadLocal[(ActorRef, Queue[(Any, ActorRef)])]
+  private val senderTl = new ThreadLocal[ActorRef]
+  private val poolSelfTl = new ThreadLocal[ActorRef]
+
+  /**
+   * Factory method for creating and starting an actor.
+   *
+   * @param  creator  The code block that creates the new actor
+   * @return          The newly created actor. Note that it is automatically started.
+   */
+  def actorOf(body: ActorContext ⇒ PartialFunction[Any, Unit]): ActorRef =
+    system actorOf Props(new Actor {
+      val receiveBody = new PartialFunction[Any, Unit] {
+        val bodyPf = body(context)
+
+        def assertTlsNull = {
+          assert(senderTl.get == null, "This partial function must only be used in the pool.")
+          assert(poolSelfTl.get == null, "This partial function must only be used in the pool.")
+        }
+
+        def isDefinedAt(v: Any) = {
+          assertTlsNull
+          // store the sender for use in body
+          senderTl.set(context.sender)
+          poolSelfTl.set(context.self)
+          val res = bodyPf.isDefinedAt(v)
+          senderTl.set(null)
+          poolSelfTl.set(null)
+          res
+        }
+
+        def apply(v: Any) = {
+          assertTlsNull
+          // store the sender for use in body
+          senderTl.set(context.sender)
+          poolSelfTl.set(context.self)
+          val res = bodyPf(v)
+          senderTl.set(null)
+          poolSelfTl.set(null)
+          res
+        }
+      }
+
+      def receive: Receive = receiveBody
+    })
+
+  /**
+   * Factory method for creating and starting an actor that loops trying to receive
+   * messages using a provided partial function. Note that the actor's behavior can be
+   * changed after the first message has been received.
+   *
+   * The parameter (of type `CT`) of the argument function (`body`) is used to provide
+   * access to the internal functionality of the actor (e.g., the underlying actor
+   * instance or the actor's context).
+   *
+   * @param  body  The function which returns the top-level message handler
+   * @return       The newly created actor. Note that it is automatically started.
+   */
+  def actorOf[T <: Actor](creator: ⇒ T): ActorRef =
+    system actorOf Props(creator = () ⇒ creator, dispatcher = "akka.actor.default-stash-dispatcher")
+
+  /**
+   * Receives a message from the mailbox of the current thread. Calling this method
+   * will block the current thread, until a matching message is received.
+   *
+   * @example {{{
+   * receive {
+   *   case "exit" => println("exiting")
+   *   case 42 => println("got the answer")
+   *   case x: Int => println("got an answer")
+   * }
+   * }}}
+   *
+   * @param  pf A partial function specifying patterns and actions
+   * @return    The result of processing the received message
+   */
+  def receive[T](pf: PartialFunction[Any, T]): T = {
+    val queue = selfTl.get._2
+    var done = false // guarded by queue
+    var msgOpt: Option[(Any, ActorRef)] = None // guarded by queue
+    val prevSender: ActorRef = senderTl.get
+
+    // wait for the message to arrive
+    while (!done) {
+      queue.synchronized {
+        // find (and remove) first message that matches any of the patterns in pf
+        msgOpt = queue.dequeueFirst(m ⇒ pf.isDefinedAt(m._1))
+        if (msgOpt.isEmpty) queue.wait()
+        else done = true
+      }
+    }
+
+    // apply partial function to message and keep the sender info
+    senderTl.set(msgOpt.get._2)
+    val res = pf(msgOpt.get._1)
+    senderTl.set(prevSender)
+
+    res
+  }
+
+  def sender: ActorRef = senderTl.get
+
+  /**
+   * The actor reference of the current thread or anonymous actor create .
+   */
+  implicit def dynamicSelf: ActorRef = if (poolSelfTl.get != null)
+    // if this is an Akka actor return the context.sender
+    poolSelfTl.get
+  else
+    // return thread actor
+    threadActor
+
+  private def threadActor: ActorRef = {
+    val s = selfTl.get
+    if (s ne null) s._1
+    else {
+      // initialize thread-local message queue
+      val queue = Queue[(Any, ActorRef)]()
+      // initialize thread-local ActorRef
+      val ref = system.provider.createThreadActor(queue)
+      selfTl set (ref, queue)
+
+      ref
+    }
+  }
+}
+
+/**
+ * Internal implementation detail used for threads. The container checks
+ * the existence of each thread, prior to invoking any CRUD operation. This ensures
+ * that the ThreadActor state observed will be consistent.
+ *
+ * NOTE: This class imposes significant performance penalty for each operation and should
+ * not be used for other use cases.
+ */
+private[akka] class ThreadPathContainer(
+  override val provider: ActorRefProvider,
+  override val path: ActorPath,
+  override val getParent: InternalActorRef,
+  val log: LoggingAdapter) extends MinimalActorRef {
+
+  private[this] val children = new ConcurrentHashMap[String, WeakReference[ThreadActorRef]]()
+
+  import scala.collection.JavaConversions._
+  def clearHangingThreadActors =
+    children.filter(_._2.get match {
+      case None      ⇒ true
+      case Some(ref) ⇒ ref.threadTerminated
+    }).map(_._1).foreach(children.remove(_))
+
+  def addChild(name: String, ref: ThreadActorRef): Unit = {
+    children.put(name, new WeakReference(ref)) match {
+      case null ⇒ // okay
+      case old  ⇒ log.warning("{} replacing child {} ({} -> {})", path, name, old, ref)
+    }
+  }
+
+  def removeChild(name: String): Unit = {
+    if (children.remove(name) eq null)
+      log.warning("{} trying to remove non-child {}", path, name)
+  }
+
+  def getChild(name: String): ActorRef = {
+    clearHangingThreadActors
+    getChildInternal(name)
+  }
+
+  private def getChildInternal(name: String) =
+    children.get(name) match {
+      case null ⇒ null
+      case x ⇒ x.get match {
+        case None      ⇒ null
+        case Some(ref) ⇒ ref
+      }
+    }
+
+  override def getChild(name: Iterator[String]): InternalActorRef = {
+    clearHangingThreadActors
+    if (name.isEmpty) this
+    else {
+      val n = name.next()
+      if (n.isEmpty) this
+      else getChildInternal(n) match {
+        case null ⇒ Nobody
+        case some ⇒
+          if (name.isEmpty) some
+          else some.getChild(name)
+      }
+    }
+  }
+
+}
+
+private class DSLActorSystem extends ActorSystemImpl("DSLActorSystem",
+  ConfigFactory.load().getConfig("akka.actor.dsl-actor-system"),
+  Thread.currentThread().getContextClassLoader())
+
+private class ThreadActorRef(
+  val provider: ActorRefProvider,
+  val path: ActorPath,
+  _queue: Queue[(Any, ActorRef)],
+  _thread: Thread) extends MinimalActorRef {
+
+  private val weakQueue = new WeakReference(_queue)
+  private val weakThread = new WeakReference(_thread)
+
+  private def queue = weakQueue.get.get
+  private def thread = weakThread.get.get
+
+  def threadTerminated: Boolean = weakThread.get match {
+    case None    ⇒ false
+    case Some(t) ⇒ t.getState == Thread.State.TERMINATED
+  }
+
+  override def isTerminated = threadTerminated
+
+  override def !(message: Any)(implicit sender: ActorRef = null): Unit = {
+    if (threadTerminated)
+      throw new RuntimeException("The Thread that owns this ActorRef has terminated and must not receive messages.")
+
+    /* put message into queue and notify receiving thread
+       note that we are ignoring the sender, because the current thread
+       does not have a context anyway
+    */
+    queue.synchronized {
+      queue += ((message, sender))
+      // notify the thread that's waiting
+      queue.notifyAll()
+    }
+  }
+}

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -485,7 +485,7 @@ private[akka] class VirtualPathContainer(
   override val getParent: InternalActorRef,
   val log: LoggingAdapter) extends MinimalActorRef {
 
-  private val children = new ConcurrentHashMap[String, InternalActorRef]
+  protected[this] val children = new ConcurrentHashMap[String, InternalActorRef]
 
   def addChild(name: String, ref: InternalActorRef): Unit = {
     children.put(name, ref) match {

--- a/akka-actor/src/main/scala/akka/actor/MigrationSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/MigrationSystem.scala
@@ -1,0 +1,33 @@
+package akka.actor
+
+import com.typesafe.config.{ Config, ConfigFactory }
+
+import scala.collection.JavaConverters._
+
+/**
+ * Singleton ActorSystem used for migration from Scala actors to Akka.
+ *
+ * The main difference between `MigrationSystem` and regular `ActorSystem` is that migration actors have a `Stop` policy for failure.
+ * Actors created with this system will not restart by default.
+ *
+ * `MigrationSystem` object embeds the ActorSystem with given behavior and provides delegate methods only for factory methods and shutdown.
+ * For other operations on `ActorSystem` use `MigrationSystem.system` field.
+ *
+ * MigrationSystem is not deamonic by default so if it is used in the project it needs to be shut down when terminating the application.
+ */
+object MigrationSystem {
+
+  private[this] val config =
+    ConfigFactory.parseMap(Map(
+      "akka.actor.provider" -> "akka.actor.MigrationLocalRefProvider").asJava)
+      .withFallback(ConfigFactory.load())
+
+  val system = ActorSystem("MigrationSystem", config)
+
+  def actorOf(props: Props): ActorRef = system.actorOf(props)
+
+  def actorOf(props: Props, name: String): ActorRef = system.actorOf(props, name)
+
+  def shutdown(): Unit = system.shutdown()
+
+}

--- a/akka-docs/scala/testing.rst
+++ b/akka-docs/scala/testing.rst
@@ -707,3 +707,16 @@ Some `Specs2 <http://specs2.org>`_ users have contributed examples of how to wor
 
 * Specifications are by default executed concurrently, which requires some care
   when writing the tests or alternatively the ``sequential`` keyword.
+
+Testing Custom Router Logic
+===========================
+
+Given the following custom (dummy) router:
+
+.. includecode:: ../../akka-actor-tests/src/test/scala/akka/routing/CustomRouteSpec.scala#custom-router
+
+This might be tested by dispatching messages and asserting their reception at
+the right destinations, but that can be inconvenient. Therefore exists the
+:obj:`ExtractRoute` extractor, which can be used like so:
+
+.. includecode:: ../../akka-actor-tests/src/test/scala/akka/routing/CustomRouteSpec.scala#test-route

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -39,6 +39,7 @@ private[akka] class RemoteActorRefProvider(
   override def systemGuardian: LocalActorRef = local.systemGuardian
   override def terminationFuture: Future[Unit] = local.terminationFuture
   override def dispatcher: MessageDispatcher = local.dispatcher
+  override def createThreadActor(queue: scala.collection.mutable.Queue[(Any, ActorRef)]): ActorRef = local.createThreadActor(queue)
   override def registerTempActor(actorRef: InternalActorRef, path: ActorPath): Unit = local.registerTempActor(actorRef, path)
   override def unregisterTempActor(path: ActorPath): Unit = local.unregisterTempActor(path)
   override def tempPath(): ActorPath = local.tempPath()

--- a/akka-testkit/src/main/scala/akka/testkit/Routing.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/Routing.scala
@@ -8,6 +8,18 @@ import scala.annotation.tailrec
 import akka.actor.{ UnstartedCell, ActorRef }
 import akka.routing.{ RoutedActorRef, RoutedActorCell, Route }
 
+/**
+ * This object can be used to extract the `Route` out of a RoutedActorRef.
+ * These are the refs which represent actors created from [[akka.actor.Props]]
+ * having a [[akka.routing.RouterConfig]]. Use this extractor if you want to
+ * test the routing directly, i.e. without actually dispatching messages.
+ *
+ * {{{
+ * val router = system.actorOf(Props[...].withRouter(new MyRouter))
+ * val route = ExtractRoute(router)
+ * route(sender -> message) must be(...)
+ * }}}
+ */
 object ExtractRoute {
   def apply(ref: ActorRef): Route = {
     @tailrec def rec(tries: Int = 10): Route = {


### PR DESCRIPTION
The actorDSL provides a lightweight syntax to actor creation and unifies threads and actors in the similar fashion to original Scala actors. It exhibits very low performance so it should be used only for prototyping and experimentation. The idea behind the ActorDSL is to provide the similar functionality to Scala ActorDSL in Akka and thus ease the migration.

MigrationSystem is used for the migration of Scala Actors to the Akka based implementation. After the transition is complete it should be deprecated and removed from Akka.
