### PR TITLE
#2358 - Explicitly excluding the slf4j-api dependency from Camel to only...

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -521,7 +521,7 @@ object Dependencies {
 object Dependency {
   // Compile
   val config        = "com.typesafe"                % "config"                       % "0.4.1"       // ApacheV2
-  val camelCore     = "org.apache.camel"            % "camel-core"                   % "2.8.0"       // ApacheV2
+  val camelCore     = "org.apache.camel"            % "camel-core"                   % "2.8.0" exclude("org.slf4j", "slf4j-api")      // ApacheV2
   val netty         = "io.netty"                    % "netty"                        % "3.5.1.Final" // ApacheV2
   val protobuf      = "com.google.protobuf"         % "protobuf-java"                % "2.4.1"       // New BSD
   val scalaStm      = "org.scala-tools"            %% "scala-stm"                    % "0.6"         // Modified BSD (Scala)


### PR DESCRIPTION
... use Akkas slf4j version
