### PR TITLE
Upgrade Netty to 3.5.3

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -527,7 +527,7 @@ object Dependency {
     val Jackson      = "1.8.0"
     val Jetty        = "7.4.0.v20110414"
     val Logback      = "1.0.4"
-    val Netty        = "3.5.2.Final"
+    val Netty        = "3.5.3.Final"
     val Protobuf     = "2.4.1"
     val Rabbit       = "2.3.1"
     val ScalaStm     = "0.5"


### PR DESCRIPTION
Would be nice to get this in for 2.0.3 since some pretty serious bugs has been fixed in Netty. For instance:

https://github.com/netty/netty/issues/469
