### PR TITLE
fix wrong failure processing after child name reuse, see #2363

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
@@ -121,7 +121,7 @@ trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout �
         case class FF(fail: Failed)
         val strategy = new OneForOneStrategy(maxNrOfRetries = 0)(SupervisorStrategy.makeDecider(List(classOf[Exception]))) {
           override def handleFailure(context: ActorContext, child: ActorRef, cause: Throwable, stats: ChildRestartStats, children: Iterable[ChildRestartStats]) = {
-            testActor.tell(FF(Failed(cause)), child)
+            testActor.tell(FF(Failed(cause, 0)), child)
             super.handleFailure(context, child, cause, stats, children)
           }
         }
@@ -137,8 +137,8 @@ trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout �
 
         failed ! Kill
         val result = receiveWhile(3 seconds, messages = 3) {
-          case FF(Failed(_: ActorKilledException)) if lastSender eq failed ⇒ 1
-          case FF(Failed(DeathPactException(`failed`))) if lastSender eq brother ⇒ 2
+          case FF(Failed(_: ActorKilledException, _)) if lastSender eq failed ⇒ 1
+          case FF(Failed(DeathPactException(`failed`), _)) if lastSender eq brother ⇒ 2
           case Terminated(`brother`) ⇒ 3
         }
         testActor.isTerminated must not be true

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -30,8 +30,8 @@ trait NoSerializationVerificationNeeded
 /**
  * Internal use only
  */
-@SerialVersionUID(1L)
-private[akka] case class Failed(cause: Throwable) extends AutoReceivedMessage with PossiblyHarmful
+@SerialVersionUID(2L)
+private[akka] case class Failed(cause: Throwable, uid: Int) extends AutoReceivedMessage with PossiblyHarmful
 
 abstract class PoisonPill extends AutoReceivedMessage with PossiblyHarmful
 

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -443,6 +443,7 @@ private[akka] class ActorCell(
     }
 
   private def supervise(child: ActorRef, uid: Int): Unit = if (!isTerminating) {
+    // Supervise is the first thing we get from a new child, so store away the UID for later use in handleFailure()
     addChild(child).uid = uid
     handleSupervise(child)
     if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(actor), "now supervising " + child))

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -12,6 +12,7 @@ import akka.event.EventStream
 import scala.annotation.tailrec
 import java.util.concurrent.{ ConcurrentHashMap }
 import akka.event.LoggingAdapter
+import scala.concurrent.forkjoin.ThreadLocalRandom
 
 /**
  * Immutable and serializable handle to an actor, which may or may not reside
@@ -262,7 +263,7 @@ private[akka] class LocalActorRef private[akka] (
    * that is reached).
    */
   private val actorCell: ActorCell = newActorCell(_system, this, _props, _supervisor)
-  actorCell.start(sendSupervise = true)
+  actorCell.start(sendSupervise = true, ThreadLocalRandom.current.nextInt())
 
   protected def newActorCell(system: ActorSystemImpl, ref: InternalActorRef, props: Props, supervisor: InternalActorRef): ActorCell =
     new ActorCell(system, ref, props, supervisor)

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -367,13 +367,13 @@ class LocalActorRefProvider(
     override def isTerminated: Boolean = stopped.isOn
 
     override def !(message: Any)(implicit sender: ActorRef = null): Unit = stopped.ifOff(message match {
-      case Failed(ex) if sender ne null ⇒ causeOfTermination = Some(ex); sender.asInstanceOf[InternalActorRef].stop()
-      case _                            ⇒ log.error(this + " received unexpected message [" + message + "]")
+      case Failed(ex, _) if sender ne null ⇒ causeOfTermination = Some(ex); sender.asInstanceOf[InternalActorRef].stop()
+      case _                               ⇒ log.error(this + " received unexpected message [" + message + "]")
     })
 
     override def sendSystemMessage(message: SystemMessage): Unit = stopped ifOff {
       message match {
-        case Supervise(_)       ⇒ // TODO register child in some map to keep track of it and enable shutdown after all dead
+        case Supervise(_, _)    ⇒ // TODO register child in some map to keep track of it and enable shutdown after all dead
         case ChildTerminated(_) ⇒ stop()
         case _                  ⇒ log.error(this + " received unexpected system message [" + message + "]")
       }

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -24,7 +24,7 @@ private[akka] case object ChildNameReserved extends ChildStats
  * ChildRestartStats is the statistics kept by every parent Actor for every child Actor
  * and is used for SupervisorStrategies to know how to deal with problems that occur for the children.
  */
-case class ChildRestartStats(val child: ActorRef, var maxNrOfRetriesCount: Int = 0, var restartTimeWindowStartNanos: Long = 0L)
+case class ChildRestartStats(child: ActorRef, var uid: Int = 0, var maxNrOfRetriesCount: Int = 0, var restartTimeWindowStartNanos: Long = 0L)
   extends ChildStats {
 
   //FIXME How about making ChildRestartStats immutable and then move these methods into the actual supervisor strategies?

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -17,6 +17,7 @@ import java.util.concurrent.locks.ReentrantLock
 import akka.event.Logging.Warning
 import scala.collection.mutable.Queue
 import akka.actor.cell.ChildrenContainer
+import scala.concurrent.forkjoin.ThreadLocalRandom
 
 /**
  * This actor ref starts out with some dummy cell (by default just enqueuing
@@ -54,8 +55,9 @@ private[akka] class RepointableActorRef(
    * This is protected so that others can have different initialization.
    */
   def initialize(): this.type = {
-    swapCell(new UnstartedCell(system, this, props, supervisor))
-    supervisor.sendSystemMessage(Supervise(this))
+    val uid = ThreadLocalRandom.current.nextInt()
+    swapCell(new UnstartedCell(system, this, props, supervisor, uid))
+    supervisor.sendSystemMessage(Supervise(this, uid))
     this
   }
 
@@ -67,7 +69,7 @@ private[akka] class RepointableActorRef(
    */
   def activate(): this.type = {
     underlying match {
-      case u: UnstartedCell ⇒ u.replaceWith(newCell())
+      case u: UnstartedCell ⇒ u.replaceWith(newCell(u))
       case _                ⇒ // this happens routinely for things which were created async=false
     }
     this
@@ -77,7 +79,9 @@ private[akka] class RepointableActorRef(
    * This is called by activate() to obtain the cell which is to replace the
    * unstarted cell. The cell must be fully functional.
    */
-  def newCell(): Cell = new ActorCell(system, this, props, supervisor).start(sendSupervise = false)
+  def newCell(old: Cell): Cell =
+    new ActorCell(system, this, props, supervisor)
+      .start(sendSupervise = false, old.asInstanceOf[UnstartedCell].uid)
 
   def suspend(): Unit = underlying.suspend()
 
@@ -118,7 +122,7 @@ private[akka] class RepointableActorRef(
   protected def writeReplace(): AnyRef = SerializedActorRef(path)
 }
 
-private[akka] class UnstartedCell(val systemImpl: ActorSystemImpl, val self: RepointableActorRef, val props: Props, val supervisor: InternalActorRef)
+private[akka] class UnstartedCell(val systemImpl: ActorSystemImpl, val self: RepointableActorRef, val props: Props, val supervisor: InternalActorRef, val uid: Int)
   extends Cell {
 
   /*

--- a/akka-actor/src/main/scala/akka/actor/cell/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Children.scala
@@ -12,7 +12,6 @@ import akka.actor.ActorCell
 import akka.actor.ActorPath.ElementRegex
 import akka.serialization.SerializationExtension
 import akka.util.{ Unsafe, Helpers }
-import akka.actor.ChildRestartStats
 
 private[akka] trait Children { this: ActorCell ⇒
 
@@ -68,10 +67,11 @@ private[akka] trait Children { this: ActorCell ⇒
     swapChildrenRefs(c, c.unreserve(name)) || unreserveChild(name)
   }
 
-  final protected def addChild(ref: ActorRef): Boolean = {
-    @tailrec def rec(): Boolean = {
+  final protected def addChild(ref: ActorRef): ChildRestartStats = {
+    @tailrec def rec(): ChildRestartStats = {
       val c = childrenRefs
-      swapChildrenRefs(c, c.add(ref)) || rec()
+      val nc = c.add(ref)
+      if (swapChildrenRefs(c, nc)) nc.getByName(ref.path.name).get else rec()
     }
     /*
      * This does not need to check getByRef every tailcall, because the change 
@@ -80,7 +80,10 @@ private[akka] trait Children { this: ActorCell ⇒
      * somebody who calls attachChild, and there we are guaranteed that that 
      * child cannot yet have died (since it has not yet been created).
      */
-    if (childrenRefs.getByRef(ref).isEmpty) rec() else false
+    childrenRefs.getByRef(ref) match {
+      case Some(old) ⇒ old
+      case None      ⇒ rec()
+    }
   }
 
   @tailrec final protected def shallDie(ref: ActorRef): Boolean = {
@@ -120,13 +123,13 @@ private[akka] trait Children { this: ActorCell ⇒
 
   protected def suspendChildren(exceptFor: Set[ActorRef] = Set.empty): Unit =
     childrenRefs.stats foreach {
-      case ChildRestartStats(child, _, _) if !(exceptFor contains child) ⇒ child.asInstanceOf[InternalActorRef].suspend()
+      case ChildRestartStats(child, _, _, _) if !(exceptFor contains child) ⇒ child.asInstanceOf[InternalActorRef].suspend()
       case _ ⇒
     }
 
   protected def resumeChildren(causedByFailure: Throwable, perp: ActorRef): Unit =
     childrenRefs.stats foreach {
-      case ChildRestartStats(child: InternalActorRef, _, _) ⇒
+      case ChildRestartStats(child: InternalActorRef, _, _, _) ⇒
         child.resume(if (perp == child) causedByFailure else null)
     }
 

--- a/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
@@ -106,7 +106,7 @@ private[akka] object ChildrenContainer {
       case _ ⇒ None
     }
 
-    override def children: Iterable[ActorRef] = c.values.view.collect { case ChildRestartStats(child, _, _) ⇒ child }
+    override def children: Iterable[ActorRef] = c.values.view.collect { case ChildRestartStats(child, _, _, _) ⇒ child }
 
     override def stats: Iterable[ChildRestartStats] = c.values.view.collect { case c: ChildRestartStats ⇒ c }
 
@@ -167,7 +167,7 @@ private[akka] object ChildrenContainer {
       case _ ⇒ None
     }
 
-    override def children: Iterable[ActorRef] = c.values.view.collect { case ChildRestartStats(child, _, _) ⇒ child }
+    override def children: Iterable[ActorRef] = c.values.view.collect { case ChildRestartStats(child, _, _, _) ⇒ child }
 
     override def stats: Iterable[ChildRestartStats] = c.values.view.collect { case c: ChildRestartStats ⇒ c }
 

--- a/akka-actor/src/main/scala/akka/actor/cell/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Dispatch.scala
@@ -5,7 +5,6 @@
 package akka.actor.cell
 
 import scala.annotation.tailrec
-
 import akka.actor.{ ActorRef, ActorCell }
 import akka.dispatch.{ Terminate, SystemMessage, Suspend, Resume, Recreate, MessageDispatcher, Mailbox, Envelope, Create }
 import akka.util.Unsafe
@@ -35,7 +34,7 @@ private[akka] trait Dispatch { this: ActorCell ⇒
 
   final def isTerminated: Boolean = mailbox.isClosed
 
-  final def start(sendSupervise: Boolean): this.type = {
+  final def start(sendSupervise: Boolean, uid: Int): this.type = {
 
     /*
      * Create the mailbox and enqueue the Create() message to ensure that
@@ -45,11 +44,11 @@ private[akka] trait Dispatch { this: ActorCell ⇒
     mailbox.setActor(this)
 
     // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-    mailbox.systemEnqueue(self, Create())
+    mailbox.systemEnqueue(self, Create(uid))
 
     if (sendSupervise) {
       // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-      parent.sendSystemMessage(akka.dispatch.Supervise(self))
+      parent.sendSystemMessage(akka.dispatch.Supervise(self, uid))
     }
 
     // This call is expected to start off the actor by scheduling its mailbox.

--- a/akka-actor/src/main/scala/akka/actor/cell/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Dispatch.scala
@@ -34,6 +34,11 @@ private[akka] trait Dispatch { this: ActorCell ⇒
 
   final def isTerminated: Boolean = mailbox.isClosed
 
+  /**
+   * Start this cell, i.e. attach it to the dispatcher. The UID must reasonably
+   * be different from the previous UID of a possible actor with the same path,
+   * which can be achieved by using ThreadLocalRandom.current.nextInt().
+   */
   final def start(sendSupervise: Boolean, uid: Int): this.type = {
 
     /*

--- a/akka-actor/src/main/scala/akka/actor/cell/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/FaultHandling.scala
@@ -194,6 +194,11 @@ private[akka] trait FaultHandling { this: ActorCell ⇒
 
   final protected def handleFailure(child: ActorRef, cause: Throwable, uid: Int): Unit =
     getChildByRef(child) match {
+      /*
+       * only act upon the failure, if it comes from a currently known child;
+       * the UID protects against reception of a Failed from a child which was
+       * killed in preRestart and re-created in postRestart
+       */
       case Some(stats) if stats.uid == uid ⇒
         if (!actor.supervisorStrategy.handleFailure(this, child, cause, stats, getAllChildStats)) throw cause
       case _ ⇒ publish(Debug(self.path.toString, clazz(actor), "dropping Failed(" + cause + ") from unknown child " + child))

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -78,7 +78,7 @@ private[akka] sealed trait SystemMessage extends PossiblyHarmful {
 /**
  * INTERNAL API
  */
-private[akka] case class Create() extends SystemMessage // send to self from Dispatcher.register
+private[akka] case class Create(uid: Int) extends SystemMessage // send to self from Dispatcher.register
 /**
  * INTERNAL API
  */
@@ -98,7 +98,7 @@ private[akka] case class Terminate() extends SystemMessage // sent to self from 
 /**
  * INTERNAL API
  */
-private[akka] case class Supervise(child: ActorRef) extends SystemMessage // sent to supervisor ActorRef from ActorCell.start
+private[akka] case class Supervise(child: ActorRef, uid: Int) extends SystemMessage // sent to supervisor ActorRef from ActorCell.start
 /**
  * INTERNAL API
  */

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -35,11 +35,11 @@ private[akka] class RoutedActorRef(_system: ActorSystemImpl, _props: Props, _sup
 
   _props.routerConfig.verifyConfig()
 
-  override def newCell(): Cell = new RoutedActorCell(system, this, props, supervisor)
+  override def newCell(old: Cell): Cell = new RoutedActorCell(system, this, props, supervisor, old.asInstanceOf[UnstartedCell].uid)
 
 }
 
-private[akka] class RoutedActorCell(_system: ActorSystemImpl, _ref: InternalActorRef, _props: Props, _supervisor: InternalActorRef)
+private[akka] class RoutedActorCell(_system: ActorSystemImpl, _ref: InternalActorRef, _props: Props, _supervisor: InternalActorRef, _uid: Int)
   extends ActorCell(
     _system,
     _ref,
@@ -73,7 +73,7 @@ private[akka] class RoutedActorCell(_system: ActorSystemImpl, _ref: InternalActo
   if (routerConfig.resizer.isEmpty && _routees.isEmpty)
     throw ActorInitializationException("router " + routerConfig + " did not register routees!")
 
-  start(sendSupervise = false)
+  start(sendSupervise = false, _uid)
 
   /*
    * end of construction


### PR DESCRIPTION
- every ActorCell has a UID which is generated from ThreadLocalRandom
  and also sent with Supervise and Failed messages, and the supervisor
  simply does not act upon failures from children whose UID does not
  match
