### PR TITLE
make guardian supervisorStrategy configurable, see #2376

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -227,7 +227,6 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
         }
       }))
       EventFilter[Exception]("hello") intercept {
-        Thread.sleep(250)
         a ! "die"
         awaitCond(system.isTerminated)
       }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -4,7 +4,6 @@
 package akka.actor
 
 import language.postfixOps
-
 import akka.testkit._
 import org.scalatest.junit.JUnitSuite
 import com.typesafe.config.ConfigFactory
@@ -12,9 +11,9 @@ import scala.concurrent.Await
 import scala.concurrent.util.duration._
 import scala.collection.JavaConverters
 import java.util.concurrent.{ TimeUnit, RejectedExecutionException, CountDownLatch, ConcurrentLinkedQueue }
-import akka.pattern.ask
 import akka.util.Timeout
 import scala.concurrent.Future
+import akka.pattern.ask
 
 class JavaExtensionSpec extends JavaExtension with JUnitSuite
 
@@ -59,6 +58,12 @@ object ActorSystemSpec {
   class Terminater extends Actor {
     def receive = {
       case "run" ⇒ context.stop(self)
+    }
+  }
+
+  class Strategy extends SupervisorStrategyConfigurator {
+    def create() = OneForOneStrategy() {
+      case _ ⇒ SupervisorStrategy.Escalate
     }
   }
 
@@ -185,6 +190,47 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
       }
 
       created filter (ref ⇒ !ref.isTerminated && !ref.asInstanceOf[ActorRefWithCell].underlying.isInstanceOf[UnstartedCell]) must be(Seq())
+    }
+
+    "shut down when /user fails" in {
+      implicit val system = ActorSystem("Stop", AkkaSpec.testConf)
+      EventFilter[ActorKilledException]() intercept {
+        system.actorFor("/user") ! Kill
+        awaitCond(system.isTerminated)
+      }
+    }
+
+    "allow configuration of guardian supervisor strategy" in {
+      implicit val system = ActorSystem("Stop",
+        ConfigFactory.parseString("akka.actor.guardian-supervisor-strategy=akka.actor.StoppingSupervisorStrategy")
+          .withFallback(AkkaSpec.testConf))
+      val a = system.actorOf(Props(new Actor {
+        def receive = {
+          case "die" ⇒ throw new Exception("hello")
+        }
+      }))
+      val probe = TestProbe()
+      probe.watch(a)
+      EventFilter[Exception]("hello", occurrences = 1) intercept {
+        a ! "die"
+      }
+      probe.expectMsg(Terminated(a)(true))
+    }
+
+    "shut down when /user escalates" in {
+      implicit val system = ActorSystem("Stop",
+        ConfigFactory.parseString("akka.actor.guardian-supervisor-strategy=\"akka.actor.ActorSystemSpec$Strategy\"")
+          .withFallback(AkkaSpec.testConf))
+      val a = system.actorOf(Props(new Actor {
+        def receive = {
+          case "die" ⇒ throw new Exception("hello")
+        }
+      }))
+      EventFilter[Exception]("hello") intercept {
+        Thread.sleep(250)
+        a ! "die"
+        awaitCond(system.isTerminated)
+      }
     }
 
   }

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -269,8 +269,8 @@ class VerifySerializabilitySpec extends AkkaSpec(VerifySerializabilitySpec.conf)
     val a = system.actorOf(Props[FooActor])
     Await.result(a ? "pigdog", timeout.duration) must be("pigdog")
 
-    intercept[NotSerializableException] {
-      Await.result(a ? new AnyRef, timeout.duration)
+    EventFilter[NotSerializableException](occurrences = 1) intercept {
+      a ! (new AnyRef)
     }
     system stop a
   }

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -46,7 +46,14 @@ akka {
 
   actor {
 
+    # FQCN of the ActorRefProvider to be used; the below is the built-in default,
+    # another one is akka.remote.RemoteActorRefProvider in the akka-remote bundle.
     provider = "akka.actor.LocalActorRefProvider"
+    
+    # The guardian "/user" will use this subclass of akka.actor.SupervisorStrategyConfigurator
+    # to obtain its supervisorstrategy. Besides the default there is
+    # akka.actor.StoppingSupervisorStrategy
+    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
 
     # Timeout for ActorSystem.actorOf
     creation-timeout = 20s

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -51,7 +51,7 @@ akka {
     provider = "akka.actor.LocalActorRefProvider"
     
     # The guardian "/user" will use this subclass of akka.actor.SupervisorStrategyConfigurator
-    # to obtain its supervisorstrategy. Besides the default there is
+    # to obtain its supervisorStrategy. Besides the default there is
     # akka.actor.StoppingSupervisorStrategy
     guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
 

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -217,7 +217,7 @@ case class DeathPactException private[akka] (dead: ActorRef)
  * avoid cascading interrupts to other threads than the originally interrupted one.
  */
 @SerialVersionUID(1L)
-class ActorInterruptedException private[akka] (cause: Throwable) extends AkkaException(cause.getMessage, cause) with NoStackTrace
+class ActorInterruptedException private[akka] (cause: Throwable) extends AkkaException(cause.getMessage, cause)
 
 /**
  * This message is published to the EventStream whenever an Actor receives a message it doesn't understand

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -261,14 +261,6 @@ private[akka] object ActorCell {
   final val emptyBehaviorStack: List[Actor.Receive] = Nil
 
   final val emptyActorRefSet: Set[ActorRef] = TreeSet.empty
-
-  final def catchingSend(system: ActorSystem, source: String, clazz: Class[_], code: ⇒ Unit): Unit = {
-    try code
-    catch {
-      case e @ (_: InterruptedException | NonFatal(_)) ⇒
-        system.eventStream.publish(Error(e, source, clazz, "swallowing exception during message send"))
-    }
-  }
 }
 
 //ACTORCELL IS 64bytes and should stay that way unless very good reason not to (machine sympathy, cache line fit)

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -306,8 +306,8 @@ private[akka] class LocalActorRef private[akka] (
    */
   protected def getSingleChild(name: String): InternalActorRef =
     actorCell.getChildByName(name) match {
-      case Some(crs) ⇒ crs.child.asInstanceOf[InternalActorRef]
-      case None      ⇒ Nobody
+      case Some(crs: ChildRestartStats) ⇒ crs.child.asInstanceOf[InternalActorRef]
+      case _                            ⇒ Nobody
     }
 
   override def getChild(names: Iterator[String]): InternalActorRef = {

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -429,7 +429,7 @@ class LocalActorRefProvider(
    */
   protected def systemGuardianStrategy: SupervisorStrategy = SupervisorStrategy.defaultStrategy
 
-  lazy val rootGuardian: InternalActorRef =
+  lazy val rootGuardian: LocalActorRef =
     new LocalActorRef(system, Props(new Guardian(rootGuardianStrategy)), theOneWhoWalksTheBubblesOfSpaceTime, rootPath) {
       override def getParent: InternalActorRef = this
       override def getSingleChild(name: String): InternalActorRef = name match {
@@ -438,11 +438,15 @@ class LocalActorRefProvider(
       }
     }
 
-  lazy val guardian: LocalActorRef =
+  lazy val guardian: LocalActorRef = {
+    rootGuardian.underlying.reserveChild("user")
     new LocalActorRef(system, Props(new Guardian(guardianStrategy)), rootGuardian, rootPath / "user")
+  }
 
-  lazy val systemGuardian: LocalActorRef =
+  lazy val systemGuardian: LocalActorRef = {
+    rootGuardian.underlying.reserveChild("system")
     new LocalActorRef(system, Props(new Guardian(systemGuardianStrategy)), rootGuardian, rootPath / "system")
+  }
 
   lazy val tempContainer = new VirtualPathContainer(system.provider, tempNode, rootGuardian, log)
 

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -295,16 +295,6 @@ trait ActorRefFactory {
 }
 
 /**
- * Internal Akka use only, used in implementation of system.actorOf.
- */
-private[akka] case class CreateChild(props: Props, name: String)
-
-/**
- * Internal Akka use only, used in implementation of system.actorOf.
- */
-private[akka] case class CreateRandomNameChild(props: Props)
-
-/**
  * Internal Akka use only, used in implementation of system.stop(child).
  */
 private[akka] case class StopChild(child: ActorRef)
@@ -317,6 +307,7 @@ class LocalActorRefProvider(
   override val settings: ActorSystem.Settings,
   val eventStream: EventStream,
   override val scheduler: Scheduler,
+  val dynamicAccess: DynamicAccess,
   override val deployer: Deployer) extends ActorRefProvider {
 
   // this is the constructor needed for reflectively instantiating the provider
@@ -329,6 +320,7 @@ class LocalActorRefProvider(
       settings,
       eventStream,
       scheduler,
+      dynamicAccess,
       new Deployer(settings, dynamicAccess))
 
   override val rootPath: ActorPath = RootActorPath(Address("akka", _systemName))
@@ -380,65 +372,12 @@ class LocalActorRefProvider(
     }
   }
 
-  /**
-   * Overridable supervision strategy to be used by the “/user” guardian.
-   */
-  protected def guardianSupervisionStrategy: SupervisorStrategy = {
-    import akka.actor.SupervisorStrategy._
-    OneForOneStrategy() {
-      case _: ActorKilledException         ⇒ Stop
-      case _: ActorInitializationException ⇒ Stop
-      case _: Exception                    ⇒ Restart
-    }
-  }
-
-  /*
-   * Guardians can be asked by ActorSystem to create children, i.e. top-level
-   * actors. Therefore these need to answer to these requests, forwarding any
-   * exceptions which might have occurred.
-   */
-  private class Guardian extends Actor {
-
-    override val supervisorStrategy: SupervisorStrategy = guardianSupervisionStrategy
+  private class Guardian(override val supervisorStrategy: SupervisorStrategy) extends Actor {
 
     def receive = {
-      case Terminated(_)                ⇒ context.stop(self)
-      case CreateChild(child, name)     ⇒ sender ! (try context.actorOf(child, name) catch { case NonFatal(e) ⇒ Status.Failure(e) })
-      case CreateRandomNameChild(child) ⇒ sender ! (try context.actorOf(child) catch { case NonFatal(e) ⇒ Status.Failure(e) })
-      case StopChild(child)             ⇒ context.stop(child)
-      case m                            ⇒ deadLetters ! DeadLetter(m, sender, self)
-    }
-
-    // guardian MUST NOT lose its children during restart
-    override def preRestart(cause: Throwable, msg: Option[Any]) {}
-  }
-
-  /**
-   * Overridable supervision strategy to be used by the “/system” guardian.
-   */
-  protected def systemGuardianSupervisionStrategy: SupervisorStrategy = {
-    import akka.actor.SupervisorStrategy._
-    OneForOneStrategy() {
-      case _: ActorKilledException | _: ActorInitializationException ⇒ Stop
-      case _: Exception ⇒ Restart
-    }
-  }
-
-  /*
-   * Guardians can be asked by ActorSystem to create children, i.e. top-level
-   * actors. Therefore these need to answer to these requests, forwarding any
-   * exceptions which might have occurred.
-   */
-  private class SystemGuardian extends Actor {
-
-    override val supervisorStrategy: SupervisorStrategy = systemGuardianSupervisionStrategy
-
-    def receive = {
-      case Terminated(_)                ⇒ eventStream.stopDefaultLoggers(); context.stop(self)
-      case CreateChild(child, name)     ⇒ sender ! (try context.actorOf(child, name) catch { case NonFatal(e) ⇒ Status.Failure(e) })
-      case CreateRandomNameChild(child) ⇒ sender ! (try context.actorOf(child) catch { case NonFatal(e) ⇒ Status.Failure(e) })
-      case StopChild(child)             ⇒ context.stop(child); sender ! "ok"
-      case m                            ⇒ deadLetters ! DeadLetter(m, sender, self)
+      case Terminated(_)    ⇒ if (context.self.path.name == "system") eventStream.stopDefaultLoggers(); context.stop(self)
+      case StopChild(child) ⇒ context.stop(child)
+      case m                ⇒ deadLetters ! DeadLetter(m, sender, self)
     }
 
     // guardian MUST NOT lose its children during restart
@@ -472,10 +411,26 @@ class LocalActorRefProvider(
    */
   def registerExtraNames(_extras: Map[String, InternalActorRef]): Unit = extraNames ++= _extras
 
-  private val guardianProps = Props(new Guardian)
+  private lazy val guardianSupervisorStrategyConfigurator =
+    dynamicAccess.createInstanceFor[SupervisorStrategyConfigurator](settings.SupervisorStrategyClass, Seq()).fold(throw _, x ⇒ x)
+
+  /**
+   * Overridable supervision strategy to be used by the “/user” guardian.
+   */
+  protected def rootGuardianStrategy: SupervisorStrategy = SupervisorStrategy.stoppingStrategy
+
+  /**
+   * Overridable supervision strategy to be used by the “/user” guardian.
+   */
+  protected def guardianStrategy: SupervisorStrategy = guardianSupervisorStrategyConfigurator.create()
+
+  /**
+   * Overridable supervision strategy to be used by the “/user” guardian.
+   */
+  protected def systemGuardianStrategy: SupervisorStrategy = SupervisorStrategy.defaultStrategy
 
   lazy val rootGuardian: InternalActorRef =
-    new LocalActorRef(system, guardianProps, theOneWhoWalksTheBubblesOfSpaceTime, rootPath) {
+    new LocalActorRef(system, Props(new Guardian(rootGuardianStrategy)), theOneWhoWalksTheBubblesOfSpaceTime, rootPath) {
       override def getParent: InternalActorRef = this
       override def getSingleChild(name: String): InternalActorRef = name match {
         case "temp" ⇒ tempContainer
@@ -483,10 +438,11 @@ class LocalActorRefProvider(
       }
     }
 
-  lazy val guardian: LocalActorRef = new LocalActorRef(system, guardianProps, rootGuardian, rootPath / "user")
+  lazy val guardian: LocalActorRef =
+    new LocalActorRef(system, Props(new Guardian(guardianStrategy)), rootGuardian, rootPath / "user")
 
   lazy val systemGuardian: LocalActorRef =
-    new LocalActorRef(system, guardianProps.withCreator(new SystemGuardian), rootGuardian, rootPath / "system")
+    new LocalActorRef(system, Props(new Guardian(systemGuardianStrategy)), rootGuardian, rootPath / "system")
 
   lazy val tempContainer = new VirtualPathContainer(system.provider, tempNode, rootGuardian, log)
 
@@ -559,4 +515,3 @@ class LocalActorRefProvider(
 
   def getExternalAddressFor(addr: Address): Option[Address] = if (addr == rootPath.address) Some(addr) else None
 }
-

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -411,7 +411,7 @@ class LocalActorRefProvider(
    */
   def registerExtraNames(_extras: Map[String, InternalActorRef]): Unit = extraNames ++= _extras
 
-  private lazy val guardianSupervisorStrategyConfigurator =
+  private def guardianSupervisorStrategyConfigurator =
     dynamicAccess.createInstanceFor[SupervisorStrategyConfigurator](settings.SupervisorStrategyClass, Seq()).fold(throw _, x ⇒ x)
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -417,7 +417,11 @@ class LocalActorRefProvider(
   /**
    * Overridable supervision strategy to be used by the “/user” guardian.
    */
-  protected def rootGuardianStrategy: SupervisorStrategy = SupervisorStrategy.stoppingStrategy
+  protected def rootGuardianStrategy: SupervisorStrategy = OneForOneStrategy() {
+    case ex ⇒
+      log.error(ex, "guardian failed, shutting down system")
+      SupervisorStrategy.Stop
+  }
 
   /**
    * Overridable supervision strategy to be used by the “/user” guardian.

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -133,6 +133,7 @@ object ActorSystem {
 
     final val ConfigVersion = getString("akka.version")
     final val ProviderClass = getString("akka.actor.provider")
+    final val SupervisorStrategyClass = getString("akka.actor.guardian-supervisor-strategy")
     final val CreationTimeout = Timeout(Duration(getMilliseconds("akka.actor.creation-timeout"), MILLISECONDS))
 
     final val SerializeAllMessages = getBoolean("akka.actor.serialize-messages")

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -27,7 +27,7 @@ private[akka] case object ChildNameReserved extends ChildStats
 case class ChildRestartStats(child: ActorRef, var maxNrOfRetriesCount: Int = 0, var restartTimeWindowStartNanos: Long = 0L)
   extends ChildStats {
 
-  var uid = 0
+  var uid: Int = 0
 
   //FIXME How about making ChildRestartStats immutable and then move these methods into the actual supervisor strategies?
   def requestRestartPermission(retriesWindow: (Option[Int], Option[Int])): Boolean =

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -70,11 +70,11 @@ trait SupervisorStrategyConfigurator {
   def create(): SupervisorStrategy
 }
 
-class DefaultSupervisorStrategy extends SupervisorStrategyConfigurator {
+final class DefaultSupervisorStrategy extends SupervisorStrategyConfigurator {
   override def create(): SupervisorStrategy = SupervisorStrategy.defaultStrategy
 }
 
-class StoppingSupervisorStrategy extends SupervisorStrategyConfigurator {
+final class StoppingSupervisorStrategy extends SupervisorStrategyConfigurator {
   override def create(): SupervisorStrategy = SupervisorStrategy.stoppingStrategy
 }
 
@@ -156,7 +156,7 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
 
   /**
    * This strategy resembles Erlang in that failing children are always
-   * terminated.
+   * terminated (one-for-one).
    */
   final val stoppingStrategy: SupervisorStrategy = {
     def stoppingDecider: Decider = {

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -24,8 +24,10 @@ private[akka] case object ChildNameReserved extends ChildStats
  * ChildRestartStats is the statistics kept by every parent Actor for every child Actor
  * and is used for SupervisorStrategies to know how to deal with problems that occur for the children.
  */
-case class ChildRestartStats(child: ActorRef, var uid: Int = 0, var maxNrOfRetriesCount: Int = 0, var restartTimeWindowStartNanos: Long = 0L)
+case class ChildRestartStats(child: ActorRef, var maxNrOfRetriesCount: Int = 0, var restartTimeWindowStartNanos: Long = 0L)
   extends ChildStats {
+
+  var uid = 0
 
   //FIXME How about making ChildRestartStats immutable and then move these methods into the actual supervisor strategies?
   def requestRestartPermission(retriesWindow: (Option[Int], Option[Int])): Boolean =

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -147,24 +147,16 @@ private[akka] class UnstartedCell(val systemImpl: ActorSystemImpl, val self: Rep
        * lock, double-tap (well, N-tap, really); concurrent modification is
        * still not possible because we’re the only thread accessing the queues.
        */
-      var interrupted = false
       while (systemQueue.nonEmpty || queue.nonEmpty) {
         while (systemQueue.nonEmpty) {
           val msg = systemQueue.dequeue()
-          try cell.sendSystemMessage(msg)
-          catch {
-            case _: InterruptedException ⇒ interrupted = true
-          }
+          cell.sendSystemMessage(msg)
         }
         if (queue.nonEmpty) {
           val envelope = queue.dequeue()
-          try cell.tell(envelope.message, envelope.sender)
-          catch {
-            case _: InterruptedException ⇒ interrupted = true
-          }
+          cell.tell(envelope.message, envelope.sender)
         }
       }
-      if (interrupted) throw new InterruptedException
     } finally try
       self.swapCell(cell)
     finally try

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -108,8 +108,8 @@ private[akka] class RepointableActorRef(
         case ""   ⇒ getChild(name)
         case other ⇒
           underlying.getChildByName(other) match {
-            case Some(crs) ⇒ crs.child.asInstanceOf[InternalActorRef].getChild(name)
-            case None      ⇒ Nobody
+            case Some(crs: ChildRestartStats) ⇒ crs.child.asInstanceOf[InternalActorRef].getChild(name)
+            case _                            ⇒ Nobody
           }
       }
     } else this

--- a/akka-actor/src/main/scala/akka/actor/cell/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Children.scala
@@ -7,11 +7,12 @@ package akka.actor.cell
 import scala.annotation.tailrec
 import scala.collection.JavaConverters.asJavaIterableConverter
 import scala.util.control.NonFatal
-import akka.actor.{ RepointableRef, Props, NoSerializationVerificationNeeded, InvalidActorNameException, InternalActorRef, ChildRestartStats, ActorRef }
+import akka.actor._
 import akka.actor.ActorCell
 import akka.actor.ActorPath.ElementRegex
 import akka.serialization.SerializationExtension
 import akka.util.{ Unsafe, Helpers }
+import akka.actor.ChildNameReserved
 
 private[akka] trait Children { this: ActorCell ⇒
 
@@ -57,7 +58,7 @@ private[akka] trait Children { this: ActorCell ⇒
   @inline private def swapChildrenRefs(oldChildren: ChildrenContainer, newChildren: ChildrenContainer): Boolean =
     Unsafe.instance.compareAndSwapObject(this, AbstractActorCell.childrenOffset, oldChildren, newChildren)
 
-  @tailrec final protected def reserveChild(name: String): Boolean = {
+  @tailrec final def reserveChild(name: String): Boolean = {
     val c = childrenRefs
     swapChildrenRefs(c, c.reserve(name)) || reserveChild(name)
   }
@@ -67,24 +68,16 @@ private[akka] trait Children { this: ActorCell ⇒
     swapChildrenRefs(c, c.unreserve(name)) || unreserveChild(name)
   }
 
-  final protected def addChild(ref: ActorRef): ChildRestartStats = {
-    @tailrec def rec(): ChildRestartStats = {
-      val c = childrenRefs
-      val nc = c.add(ref)
-      if (swapChildrenRefs(c, nc)) nc.getByName(ref.path.name).get else rec()
+  @tailrec final protected def initChild(ref: ActorRef): Option[ChildRestartStats] =
+    childrenRefs.getByName(ref.path.name) match {
+      case old @ Some(_: ChildRestartStats) ⇒ old.asInstanceOf[Option[ChildRestartStats]]
+      case Some(ChildNameReserved) ⇒
+        val crs = ChildRestartStats(ref)
+        val name = ref.path.name
+        val c = childrenRefs
+        if (swapChildrenRefs(c, c.add(name, crs))) Some(crs) else initChild(ref)
+      case None ⇒ None
     }
-    /*
-     * This does not need to check getByRef every tailcall, because the change 
-     * cannot happen in that direction as a race: the only entity removing a 
-     * child is the actor itself, and the only entity which could be racing is 
-     * somebody who calls attachChild, and there we are guaranteed that that 
-     * child cannot yet have died (since it has not yet been created).
-     */
-    childrenRefs.getByRef(ref) match {
-      case Some(old) ⇒ old
-      case None      ⇒ rec()
-    }
-  }
 
   @tailrec final protected def shallDie(ref: ActorRef): Boolean = {
     val c = childrenRefs
@@ -123,17 +116,17 @@ private[akka] trait Children { this: ActorCell ⇒
 
   protected def suspendChildren(exceptFor: Set[ActorRef] = Set.empty): Unit =
     childrenRefs.stats foreach {
-      case ChildRestartStats(child, _, _, _) if !(exceptFor contains child) ⇒ child.asInstanceOf[InternalActorRef].suspend()
+      case ChildRestartStats(child, _, _) if !(exceptFor contains child) ⇒ child.asInstanceOf[InternalActorRef].suspend()
       case _ ⇒
     }
 
   protected def resumeChildren(causedByFailure: Throwable, perp: ActorRef): Unit =
     childrenRefs.stats foreach {
-      case ChildRestartStats(child: InternalActorRef, _, _, _) ⇒
+      case ChildRestartStats(child: InternalActorRef, _, _) ⇒
         child.resume(if (perp == child) causedByFailure else null)
     }
 
-  def getChildByName(name: String): Option[ChildRestartStats] = childrenRefs.getByName(name)
+  def getChildByName(name: String): Option[ChildStats] = childrenRefs.getByName(name)
 
   protected def getChildByRef(ref: ActorRef): Option[ChildRestartStats] = childrenRefs.getByRef(ref)
 
@@ -193,7 +186,7 @@ private[akka] trait Children { this: ActorCell ⇒
         }
       // mailbox==null during RoutedActorCell constructor, where suspends are queued otherwise
       if (mailbox ne null) for (_ ← 1 to mailbox.suspendCount) actor.suspend()
-      addChild(actor)
+      initChild(actor)
       actor
     }
   }

--- a/akka-actor/src/main/scala/akka/actor/cell/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Dispatch.scala
@@ -63,20 +63,26 @@ private[akka] trait Dispatch { this: ActorCell ⇒
   }
 
   // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-  final def suspend(): Unit = dispatcher.systemDispatch(this, Suspend())
+  final def suspend(): Unit =
+    ActorCell.catchingSend(system, self.path.toString, clazz(actor), dispatcher.systemDispatch(this, Suspend()))
 
   // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-  final def resume(causedByFailure: Throwable): Unit = dispatcher.systemDispatch(this, Resume(causedByFailure))
+  final def resume(causedByFailure: Throwable): Unit =
+    ActorCell.catchingSend(system, self.path.toString, clazz(actor), dispatcher.systemDispatch(this, Resume(causedByFailure)))
 
   // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-  final def restart(cause: Throwable): Unit = dispatcher.systemDispatch(this, Recreate(cause))
+  final def restart(cause: Throwable): Unit =
+    ActorCell.catchingSend(system, self.path.toString, clazz(actor), dispatcher.systemDispatch(this, Recreate(cause)))
 
   // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-  final def stop(): Unit = dispatcher.systemDispatch(this, Terminate())
+  final def stop(): Unit =
+    ActorCell.catchingSend(system, self.path.toString, clazz(actor), dispatcher.systemDispatch(this, Terminate()))
 
   def tell(message: Any, sender: ActorRef): Unit =
-    dispatcher.dispatch(this, Envelope(message, if (sender eq null) system.deadLetters else sender, system))
+    ActorCell.catchingSend(system, self.path.toString, clazz(actor),
+      dispatcher.dispatch(this, Envelope(message, if (sender eq null) system.deadLetters else sender, system)))
 
-  override def sendSystemMessage(message: SystemMessage): Unit = dispatcher.systemDispatch(this, message)
+  override def sendSystemMessage(message: SystemMessage): Unit =
+    ActorCell.catchingSend(system, self.path.toString, clazz(actor), dispatcher.systemDispatch(this, message))
 
 }

--- a/akka-actor/src/main/scala/akka/actor/cell/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/FaultHandling.scala
@@ -201,7 +201,11 @@ private[akka] trait FaultHandling { this: ActorCell ⇒
        */
       case Some(stats) if stats.uid == uid ⇒
         if (!actor.supervisorStrategy.handleFailure(this, child, cause, stats, getAllChildStats)) throw cause
-      case _ ⇒ publish(Debug(self.path.toString, clazz(actor), "dropping Failed(" + cause + ") from unknown child " + child))
+      case Some(stats) ⇒
+        publish(Debug(self.path.toString, clazz(actor),
+          "dropping Failed(" + cause + ") from old child " + child + " (uid=" + stats.uid + " != " + uid + ")"))
+      case None ⇒
+        publish(Debug(self.path.toString, clazz(actor), "dropping Failed(" + cause + ") from unknown child " + child))
     }
 
   final protected def handleChildTerminated(child: ActorRef): SystemMessage = {

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -229,9 +229,11 @@ private[akka] class RemoteActorRef private[akka] (
 
   def isTerminated: Boolean = !running
 
-  def sendSystemMessage(message: SystemMessage): Unit = remote.send(message, None, this)
+  def sendSystemMessage(message: SystemMessage): Unit =
+    ActorCell.catchingSend(remote.system, path.toString, classOf[RemoteActorRef], remote.send(message, None, this))
 
-  override def !(message: Any)(implicit sender: ActorRef = null): Unit = remote.send(message, Option(sender), this)
+  override def !(message: Any)(implicit sender: ActorRef = null): Unit =
+    ActorCell.catchingSend(remote.system, path.toString, classOf[RemoteActorRef], remote.send(message, Option(sender), this))
 
   def suspend(): Unit = sendSystemMessage(Suspend())
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -24,7 +24,7 @@ private[akka] class RemoteActorRefProvider(
 
   val deployer: RemoteDeployer = new RemoteDeployer(settings, dynamicAccess)
 
-  private val local = new LocalActorRefProvider(systemName, settings, eventStream, scheduler, deployer)
+  private val local = new LocalActorRefProvider(systemName, settings, eventStream, scheduler, dynamicAccess, deployer)
 
   @volatile
   private var _log = local.log

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -14,6 +14,7 @@ import java.lang.{ Iterable ⇒ JIterable }
 import scala.collection.JavaConverters
 import scala.concurrent.util.Duration
 import scala.reflect.ClassTag
+import akka.actor.NoSerializationVerificationNeeded
 
 /**
  * Implementation helpers of the EventFilter facilities: send `Mute`
@@ -39,7 +40,7 @@ object TestEvent {
   object Mute {
     def apply(filter: EventFilter, filters: EventFilter*): Mute = new Mute(filter +: filters.toSeq)
   }
-  case class Mute(filters: Seq[EventFilter]) extends TestEvent {
+  case class Mute(filters: Seq[EventFilter]) extends TestEvent with NoSerializationVerificationNeeded {
     /**
      * Java API
      */
@@ -48,7 +49,7 @@ object TestEvent {
   object UnMute {
     def apply(filter: EventFilter, filters: EventFilter*): UnMute = new UnMute(filter +: filters.toSeq)
   }
-  case class UnMute(filters: Seq[EventFilter]) extends TestEvent {
+  case class UnMute(filters: Seq[EventFilter]) extends TestEvent with NoSerializationVerificationNeeded {
     /**
      * Java API
      */


### PR DESCRIPTION
And the reason is that it somehow changes timings, at least on my notebook, so that CallingThreadDispatcherModelSpec fails consistently because of wrong InterruptedException handling. My vote is to wait until https://www.assembla.com/spaces/akka/tickets/2385-revise-handling-of-interruptedexception is fixed with merging this.

But of course comments are welcome nonetheless
