### PR TITLE
Support concurrent startup of seed nodes, see #2270

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -850,17 +850,14 @@ private[cluster] final class JoinSeedNodeProcess(environment: ClusterEnvironment
 
   context.setReceiveTimeout(environment.settings.SeedNodeTimeout)
 
-  override def preStart(): Unit = {
-    self ! JoinSeedNode
-  }
+  override def preStart(): Unit = self ! JoinSeedNode
 
   def receive = {
     case JoinSeedNode ⇒
       // send InitJoin to all seed nodes (except myself)
-      val seedRefs = environment.seedNodes.collect {
+      environment.seedNodes.collect {
         case a if a != selfAddress ⇒ context.system.actorFor(context.parent.path.toStringWithAddress(a))
-      }
-      seedRefs foreach { _ ! InitJoin }
+      } foreach { _ ! InitJoin }
     case InitJoinAck(address) ⇒
       // first InitJoinAck reply
       context.parent ! JoinTo(address)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -75,7 +75,7 @@ private[cluster] object InternalClusterAction {
   /**
    * Marker interface for periodic tick messages
    */
-  trait Tick
+  sealed trait Tick
 
   case object GossipTick extends Tick
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
@@ -13,6 +13,7 @@ import scala.concurrent.util.duration._
 object JoinSeedNodeMultiJvmSpec extends MultiNodeConfig {
   val seed1 = role("seed1")
   val seed2 = role("seed2")
+  val seed3 = role("seed3")
   val ordinary1 = role("ordinary1")
   val ordinary2 = role("ordinary2")
 
@@ -25,6 +26,7 @@ class JoinSeedNodeMultiJvmNode1 extends JoinSeedNodeSpec with FailureDetectorPup
 class JoinSeedNodeMultiJvmNode2 extends JoinSeedNodeSpec with FailureDetectorPuppetStrategy
 class JoinSeedNodeMultiJvmNode3 extends JoinSeedNodeSpec with FailureDetectorPuppetStrategy
 class JoinSeedNodeMultiJvmNode4 extends JoinSeedNodeSpec with FailureDetectorPuppetStrategy
+class JoinSeedNodeMultiJvmNode5 extends JoinSeedNodeSpec with FailureDetectorPuppetStrategy
 
 abstract class JoinSeedNodeSpec
   extends MultiNodeSpec(JoinSeedNodeMultiJvmSpec)
@@ -32,37 +34,22 @@ abstract class JoinSeedNodeSpec
 
   import JoinSeedNodeMultiJvmSpec._
 
-  override def seedNodes = IndexedSeq(seed1, seed2)
+  override def seedNodes = IndexedSeq(seed3, seed2, seed1)
 
   "A cluster with configured seed nodes" must {
-    "start the seed nodes sequentially" taggedAs LongRunningTest in {
+    "be able to start the seed nodes concurrently" taggedAs LongRunningTest in {
       // without looking up the addresses first there might be
       // [akka://JoinSeedNodeSpec/user/TestConductorClient] cannot write GetAddress(RoleName(seed2)) while waiting for seed1
-      roles foreach address
+      //      roles foreach address
 
-      runOn(seed1) {
-        startClusterNode()
-      }
-      enterBarrier("seed1-started")
-
-      runOn(seed2) {
-        startClusterNode()
-      }
-      enterBarrier("seed2-started")
-
-      runOn(seed1, seed2) {
-        awaitUpConvergence(2)
+      runOn(seed1, seed2, seed3) {
+        awaitUpConvergence(3)
       }
       enterBarrier("after-1")
     }
 
     "join the seed nodes at startup" taggedAs LongRunningTest in {
-
-      startClusterNode()
-      enterBarrier("all-started")
-
-      awaitUpConvergence(4)
-
+      awaitUpConvergence(roles.size)
       enterBarrier("after-2")
     }
   }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
@@ -34,13 +34,15 @@ abstract class JoinSeedNodeSpec
 
   import JoinSeedNodeMultiJvmSpec._
 
-  override def seedNodes = IndexedSeq(seed3, seed2, seed1)
+  override def seedNodes = IndexedSeq(seed1, seed2, seed3)
 
   "A cluster with configured seed nodes" must {
     "be able to start the seed nodes concurrently" taggedAs LongRunningTest in {
-      // without looking up the addresses first there might be
-      // [akka://JoinSeedNodeSpec/user/TestConductorClient] cannot write GetAddress(RoleName(seed2)) while waiting for seed1
-      //      roles foreach address
+
+      runOn(seed1) {
+        // test that first seed doesn't have to be started first
+        Thread.sleep(3000)
+      }
 
       runOn(seed1, seed2, seed3) {
         awaitUpConvergence(3)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -22,7 +22,7 @@ import akka.actor.RootActorPath
 object MultiNodeClusterSpec {
   def clusterConfig: Config = ConfigFactory.parseString("""
     akka.cluster {
-      auto-join                         = off
+      auto-join                         = on
       auto-down                         = off
       gossip-interval                   = 200 ms
       heartbeat-interval                = 400 ms


### PR DESCRIPTION
- Implemented the startup sequence of seed nodes as
  described in #2305
- Test that verifies concurrent startup of seed nodes
