### PR TITLE
Members ordered by address only, see #2405

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -572,7 +572,7 @@ private[cluster] final class ClusterCoreDaemon(environment: ClusterEnvironment) 
     val localGossip = latestGossip
     val localMembers = localGossip.members
 
-    val isLeader = localMembers.nonEmpty && (selfAddress == localMembers.head.address)
+    val isLeader = localGossip.isLeader(selfAddress)
 
     if (isLeader && isAvailable) {
       // only run the leader actions if we are the LEADER and available

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
@@ -61,7 +61,7 @@ private[akka] class ClusterReadView(cluster: Cluster) extends Closeable {
   def isRunning: Boolean = cluster.isRunning
 
   /**
-   * Current cluster members, sorted with leader first.
+   * Current cluster members, sorted by address.
    */
   def members: SortedSet[Member] = state.members
 

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -163,7 +163,7 @@ private[cluster] case class Gossip(
 
   def isLeader(address: Address): Boolean = leader == Some(address)
 
-  def leader: Option[Address] = members.headOption.map(_.address)
+  def leader: Option[Address] = members.find(_.status != Exiting).orElse(members.headOption).map(_.address)
 
   def isSingletonCluster: Boolean = members.size == 1
 

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -40,13 +40,10 @@ object Member {
   }
 
   /**
-   * `Member` ordering type class, sorts members by host and port with the exception that
-   * it puts all members that are in MemberStatus.EXITING last.
+   * `Member` ordering type class, sorts members by host and port.
    */
-  implicit val ordering: Ordering[Member] = Ordering.fromLessThan[Member] { (a, b) ⇒
-    if (a.status == Exiting && b.status != Exiting) false
-    else if (a.status != Exiting && b.status == Exiting) true
-    else addressOrdering.compare(a.address, b.address) < 0
+  implicit val ordering: Ordering[Member] = new Ordering[Member] {
+    def compare(a: Member, b: Member): Int = addressOrdering.compare(a.address, b.address)
   }
 
   def apply(address: Address, status: MemberStatus): Member = new Member(address, status)

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -20,6 +20,7 @@ class GossipSpec extends WordSpec with MustMatchers {
   val b2 = Member(Address("akka", "sys", "b", 2552), Removed)
   val c1 = Member(Address("akka", "sys", "c", 2552), Leaving)
   val c2 = Member(Address("akka", "sys", "c", 2552), Up)
+  val c3 = Member(Address("akka", "sys", "c", 2552), Exiting)
   val d1 = Member(Address("akka", "sys", "d", 2552), Leaving)
   val d2 = Member(Address("akka", "sys", "d", 2552), Removed)
   val e1 = Member(Address("akka", "sys", "e", 2552), Joining)
@@ -98,6 +99,12 @@ class GossipSpec extends WordSpec with MustMatchers {
 
     "not have non cluster members in seen table" in intercept[IllegalArgumentException] {
       Gossip(members = SortedSet(a1, e1)).seen(a1.address).seen(e1.address).seen(b1.address)
+    }
+
+    "have leader as first member based on ordering, except Exiting status" in {
+      Gossip(members = SortedSet(c2, e2)).leader must be(Some(c2.address))
+      Gossip(members = SortedSet(c3, e2)).leader must be(Some(e2.address))
+      Gossip(members = SortedSet(c3)).leader must be(Some(c3.address))
     }
 
   }


### PR DESCRIPTION
- The special ordering of status Exiting makes ordering and equals
  inconsistent
- Take the Exiting status into account when looking for leader
