### PR TITLE
Simplified check for existence of actor child. See #2343

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -418,7 +418,7 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
             def receive = { case _ ⇒ }
           }), "child")
 
-        def receive = { case name: String ⇒ sender ! context.childExists(name) }
+        def receive = { case name: String ⇒ sender ! context.child(name).isDefined }
       }), "parent")
 
       assert(Await.result((parent ? "child"), remaining) === true)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -409,5 +409,20 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
         Await.ready(latch, 5 seconds)
       }
     }
+
+    "be able to check for existence of children" in {
+      val parent = system.actorOf(Props(new Actor {
+
+        val child = context.actorOf(
+          Props(new Actor {
+            def receive = { case _ ⇒ }
+          }), "child")
+
+        def receive = { case name: String ⇒ sender ! context.childExists(name) }
+      }), "parent")
+
+      assert(Await.result((parent ? "child"), remaining) === true)
+      assert(Await.result((parent ? "whatnot"), remaining) === false)
+    }
   }
 }

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -103,6 +103,11 @@ trait ActorContext extends ActorRefFactory {
   def children: Iterable[ActorRef]
 
   /**
+   * Returns true if a child with the given name exists.
+   */
+  def childExists(name: String): Boolean
+
+  /**
    * Returns the dispatcher (MessageDispatcher) that is used for this Actor.
    * Importing this member will place a implicit MessageDispatcher in scope.
    */

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -103,7 +103,7 @@ trait ActorContext extends ActorRefFactory {
   def children: Iterable[ActorRef]
 
   /**
-   * Returns true if a child with the given name exists.
+   * Get the child with the given name if it exists.
    */
   def child(name: String): Option[ActorRef]
 

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -105,7 +105,7 @@ trait ActorContext extends ActorRefFactory {
   /**
    * Returns true if a child with the given name exists.
    */
-  def childExists(name: String): Boolean
+  def child(name: String): Option[ActorRef]
 
   /**
    * Returns the dispatcher (MessageDispatcher) that is used for this Actor.
@@ -154,6 +154,12 @@ trait UntypedActorContext extends ActorContext {
    * please note that the backing map is thread-safe but not immutable
    */
   def getChildren(): java.lang.Iterable[ActorRef]
+
+  /**
+   * Returns a reference to the named child or null if no child with
+   * that name exists.
+   */
+  def getChild(name: String): ActorRef
 
   /**
    * Changes the Actor's behavior to become the new 'Procedure' handler.

--- a/akka-actor/src/main/scala/akka/actor/cell/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Children.scala
@@ -27,7 +27,11 @@ private[akka] trait Children { this: ActorCell ⇒
   final def children: Iterable[ActorRef] = childrenRefs.children
   final def getChildren(): java.lang.Iterable[ActorRef] = children.asJava
 
-  final def childExists(name: String): Boolean = childrenRefs.getByName(name).isDefined
+  final def child(name: String): Option[ActorRef] = childrenRefs.getByName(name).flatMap({
+    case s: ChildRestartStats ⇒ Some(s.child)
+    case ChildNameReserved    ⇒ None
+  })
+  final def getChild(name: String): ActorRef = child(name).getOrElse(null)
 
   def actorOf(props: Props): ActorRef =
     makeChild(this, props, randomName(), async = false, systemService = false)

--- a/akka-actor/src/main/scala/akka/actor/cell/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Children.scala
@@ -27,6 +27,8 @@ private[akka] trait Children { this: ActorCell ⇒
   final def children: Iterable[ActorRef] = childrenRefs.children
   final def getChildren(): java.lang.Iterable[ActorRef] = children.asJava
 
+  final def childExists(name: String): Boolean = childrenRefs.getByName(name).isDefined
+
   def actorOf(props: Props): ActorRef =
     makeChild(this, props, randomName(), async = false, systemService = false)
   def actorOf(props: Props, name: String): ActorRef =

--- a/akka-actor/src/main/scala/akka/actor/cell/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Children.scala
@@ -27,11 +27,11 @@ private[akka] trait Children { this: ActorCell ⇒
   final def children: Iterable[ActorRef] = childrenRefs.children
   final def getChildren(): java.lang.Iterable[ActorRef] = children.asJava
 
-  final def child(name: String): Option[ActorRef] = childrenRefs.getByName(name).flatMap({
-    case s: ChildRestartStats ⇒ Some(s.child)
-    case ChildNameReserved    ⇒ None
-  })
-  final def getChild(name: String): ActorRef = child(name).getOrElse(null)
+  final def child(name: String): Option[ActorRef] = Option(getChild(name))
+  final def getChild(name: String): ActorRef = childrenRefs.getByName(name) match {
+    case Some(s: ChildRestartStats) ⇒ s.child
+    case _                          ⇒ null
+  }
 
   def actorOf(props: Props): ActorRef =
     makeChild(this, props, randomName(), async = false, systemService = false)


### PR DESCRIPTION
Added a childExists(name) method to ActorCell.

Stopped at the ChildrenContainer level. Thought it premature to push the existence down there to avoid the Option creation.
