### PR TITLE
Upgrade Netty from 3.5.3 to 3.5.4

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -535,7 +535,7 @@ object Dependency {
     val Jackson      = "1.8.0"
     val Jetty        = "7.4.0.v20110414"
     val Logback      = "1.0.4"
-    val Netty        = "3.5.3.Final"
+    val Netty        = "3.5.4.Final"
     val Protobuf     = "2.4.1"
     val Rabbit       = "2.3.1"
     val ScalaStm     = "0.5"


### PR DESCRIPTION
Done at trunk (https://github.com/akka/akka/pull/628), I want to see it in 2.0.4 so proposing the same here. :)
