### PR TITLE
Add warning about passing mutable state into the constructor of an Actor

### DIFF
--- a/akka-docs/scala/actors.rst
+++ b/akka-docs/scala/actors.rst
@@ -108,6 +108,8 @@ Here is an example:
   meaning of an actor restart, which is described here:
   :ref:`supervision-restart`.
 
+.. warning::
+
   Also avoid passing mutable state into the constructor of the Actor, since
   the call-by-name block can be executed by another thread.
 

--- a/akka-docs/scala/actors.rst
+++ b/akka-docs/scala/actors.rst
@@ -108,6 +108,9 @@ Here is an example:
   meaning of an actor restart, which is described here:
   :ref:`supervision-restart`.
 
+  Also avoid passing mutable state into the constructor of the Actor, since
+  the call-by-name block can be executed by another thread.
+
 Props
 -----
 


### PR DESCRIPTION
I was bitten by this when I created actors as a reaction in receive, passing sender as parameter to the new Actor.
