### PR TITLE
Resizer specified in code combined with other router config, see #2433

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -505,7 +505,9 @@ case class RoundRobinRouter(nrOfInstances: Int = 0, routees: Iterable[String] = 
   def withSupervisorStrategy(strategy: SupervisorStrategy): RoundRobinRouter = copy(supervisorStrategy = strategy)
 
   /**
-   * Override to use the resizer defined in code if not defined in config.
+   * Uses the resizer of the given Routerconfig if this RouterConfig
+   * doesn't have one, i.e. the resizer defined in code is used if
+   * resizer was not defined in config.
    */
   override def withFallback(other: RouterConfig): RouterConfig = {
     if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
@@ -632,7 +634,9 @@ case class RandomRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil,
   def withSupervisorStrategy(strategy: SupervisorStrategy): RandomRouter = copy(supervisorStrategy = strategy)
 
   /**
-   * Override to use the resizer defined in code if not defined in config.
+   * Uses the resizer of the given Routerconfig if this RouterConfig
+   * doesn't have one, i.e. the resizer defined in code is used if
+   * resizer was not defined in config.
    */
   override def withFallback(other: RouterConfig): RouterConfig = {
     if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
@@ -766,7 +770,9 @@ case class SmallestMailboxRouter(nrOfInstances: Int = 0, routees: Iterable[Strin
   def withSupervisorStrategy(strategy: SupervisorStrategy): SmallestMailboxRouter = copy(supervisorStrategy = strategy)
 
   /**
-   * Override to use the resizer defined in code if not defined in config.
+   * Uses the resizer of the given Routerconfig if this RouterConfig
+   * doesn't have one, i.e. the resizer defined in code is used if
+   * resizer was not defined in config.
    */
   override def withFallback(other: RouterConfig): RouterConfig = {
     if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
@@ -974,7 +980,9 @@ case class BroadcastRouter(nrOfInstances: Int = 0, routees: Iterable[String] = N
   def withSupervisorStrategy(strategy: SupervisorStrategy): BroadcastRouter = copy(supervisorStrategy = strategy)
 
   /**
-   * Override to use the resizer defined in code if not defined in config.
+   * Uses the resizer of the given Routerconfig if this RouterConfig
+   * doesn't have one, i.e. the resizer defined in code is used if
+   * resizer was not defined in config.
    */
   override def withFallback(other: RouterConfig): RouterConfig = {
     if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
@@ -1098,7 +1106,9 @@ case class ScatterGatherFirstCompletedRouter(nrOfInstances: Int = 0, routees: It
   def withSupervisorStrategy(strategy: SupervisorStrategy) = copy(supervisorStrategy = strategy)
 
   /**
-   * Override to use the resizer defined in code if not defined in config.
+   * Uses the resizer of the given Routerconfig if this RouterConfig
+   * doesn't have one, i.e. the resizer defined in code is used if
+   * resizer was not defined in config.
    */
   override def withFallback(other: RouterConfig): RouterConfig = {
     if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)

--- a/akka-actor/src/main/scala/akka/routing/Routing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Routing.scala
@@ -503,6 +503,14 @@ case class RoundRobinRouter(nrOfInstances: Int = 0, routees: Iterable[String] = 
    * Router actor.
    */
   def withSupervisorStrategy(strategy: SupervisorStrategy): RoundRobinRouter = copy(supervisorStrategy = strategy)
+
+  /**
+   * Override to use the resizer defined in code if not defined in config.
+   */
+  override def withFallback(other: RouterConfig): RouterConfig = {
+    if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
+    else this
+  }
 }
 
 trait RoundRobinLike { this: RouterConfig ⇒
@@ -622,6 +630,14 @@ case class RandomRouter(nrOfInstances: Int = 0, routees: Iterable[String] = Nil,
    * Router actor.
    */
   def withSupervisorStrategy(strategy: SupervisorStrategy): RandomRouter = copy(supervisorStrategy = strategy)
+
+  /**
+   * Override to use the resizer defined in code if not defined in config.
+   */
+  override def withFallback(other: RouterConfig): RouterConfig = {
+    if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
+    else this
+  }
 }
 
 trait RandomLike { this: RouterConfig ⇒
@@ -748,6 +764,14 @@ case class SmallestMailboxRouter(nrOfInstances: Int = 0, routees: Iterable[Strin
    * Router actor.
    */
   def withSupervisorStrategy(strategy: SupervisorStrategy): SmallestMailboxRouter = copy(supervisorStrategy = strategy)
+
+  /**
+   * Override to use the resizer defined in code if not defined in config.
+   */
+  override def withFallback(other: RouterConfig): RouterConfig = {
+    if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
+    else this
+  }
 }
 
 trait SmallestMailboxLike { this: RouterConfig ⇒
@@ -948,6 +972,14 @@ case class BroadcastRouter(nrOfInstances: Int = 0, routees: Iterable[String] = N
    * Router actor.
    */
   def withSupervisorStrategy(strategy: SupervisorStrategy): BroadcastRouter = copy(supervisorStrategy = strategy)
+
+  /**
+   * Override to use the resizer defined in code if not defined in config.
+   */
+  override def withFallback(other: RouterConfig): RouterConfig = {
+    if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
+    else this
+  }
 }
 
 trait BroadcastLike { this: RouterConfig ⇒
@@ -1064,6 +1096,14 @@ case class ScatterGatherFirstCompletedRouter(nrOfInstances: Int = 0, routees: It
    * Router actor.
    */
   def withSupervisorStrategy(strategy: SupervisorStrategy) = copy(supervisorStrategy = strategy)
+
+  /**
+   * Override to use the resizer defined in code if not defined in config.
+   */
+  override def withFallback(other: RouterConfig): RouterConfig = {
+    if (this.resizer.isEmpty && other.resizer.isDefined) copy(resizer = other.resizer)
+    else this
+  }
 }
 
 trait ScatterGatherFirstCompletedLike { this: RouterConfig ⇒

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/LookupRemoteActorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/LookupRemoteActorSpec.scala
@@ -13,7 +13,7 @@ import akka.testkit._
 
 object LookupRemoteActorMultiJvmSpec extends MultiNodeConfig {
 
-  class SomeActor extends Actor with Serializable {
+  class SomeActor extends Actor {
     def receive = {
       case "identify" ⇒ sender ! self
     }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/NewRemoteActorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/NewRemoteActorSpec.scala
@@ -15,7 +15,7 @@ import akka.testkit._
 
 object NewRemoteActorMultiJvmSpec extends MultiNodeConfig {
 
-  class SomeActor extends Actor with Serializable {
+  class SomeActor extends Actor {
     def receive = {
       case "identify" ⇒ sender ! self
     }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/RandomRoutedRemoteActorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/RandomRoutedRemoteActorSpec.scala
@@ -22,7 +22,7 @@ import scala.concurrent.util.duration._
 
 object RandomRoutedRemoteActorMultiJvmSpec extends MultiNodeConfig {
 
-  class SomeActor extends Actor with Serializable {
+  class SomeActor extends Actor {
     def receive = {
       case "hit" ⇒ sender ! self
     }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/RoundRobinRoutedRemoteActorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/RoundRobinRoutedRemoteActorSpec.scala
@@ -17,14 +17,24 @@ import akka.remote.testkit.MultiNodeSpec
 import akka.routing.Broadcast
 import akka.routing.RoundRobinRouter
 import akka.routing.RoutedActorRef
+import akka.routing.Resizer
+import akka.routing.RouteeProvider
 import akka.testkit._
 import scala.concurrent.util.duration._
 
 object RoundRobinRoutedRemoteActorMultiJvmSpec extends MultiNodeConfig {
 
-  class SomeActor extends Actor with Serializable {
+  class SomeActor extends Actor {
     def receive = {
       case "hit" ⇒ sender ! self
+    }
+  }
+
+  class TestResizer extends Resizer {
+    def isTimeForResize(messageCounter: Long): Boolean = messageCounter <= 10
+    def resize(props: Props, routeeProvider: RouteeProvider): Unit = {
+      val newRoutees = routeeProvider.createRoutees(props, nrOfInstances = 1, Nil)
+      routeeProvider.registerRoutees(newRoutees)
     }
   }
 
@@ -39,6 +49,9 @@ object RoundRobinRoutedRemoteActorMultiJvmSpec extends MultiNodeConfig {
       /service-hello.router = "round-robin"
       /service-hello.nr-of-instances = 3
       /service-hello.target.nodes = ["@first@", "@second@", "@third@"]
+
+      /service-hello2.router = "round-robin"
+      /service-hello2.target.nodes = ["@first@", "@second@", "@third@"]
     """)
 }
 
@@ -84,6 +97,50 @@ class RoundRobinRoutedRemoteActorSpec extends MultiNodeSpec(RoundRobinRoutedRemo
         enterBarrier("end")
         replies.values foreach { _ must be(iterationCount) }
         replies.get(node(fourth).address) must be(None)
+
+        // shut down the actor before we let the other node(s) shut down so we don't try to send
+        // "Terminate" to a shut down node
+        system.stop(actor)
+        enterBarrier("done")
+      }
+    }
+  }
+
+  "A new remote actor configured with a RoundRobin router and Resizer" must {
+    "be locally instantiated on a remote node after several resize rounds" taggedAs LongRunningTest in {
+
+      runOn(first, second, third) {
+        enterBarrier("start", "broadcast-end", "end", "done")
+      }
+
+      runOn(fourth) {
+        enterBarrier("start")
+        val actor = system.actorOf(Props[SomeActor].withRouter(RoundRobinRouter(
+          resizer = Some(new TestResizer))), "service-hello2")
+        actor.isInstanceOf[RoutedActorRef] must be(true)
+
+        val iterationCount = 9
+
+        val repliesFrom: Set[ActorRef] =
+          (for {
+            i ← 0 until iterationCount
+          } yield {
+            actor ! "hit"
+            receiveOne(5 seconds) match { case ref: ActorRef ⇒ ref }
+          }).toSet
+
+        enterBarrier("broadcast-end")
+        actor ! Broadcast(PoisonPill)
+
+        enterBarrier("end")
+        // at least more than one actor per node
+        repliesFrom.size must be > (3)
+        val repliesFromAddresses = repliesFrom.map(_.path.address)
+        repliesFromAddresses.size must be(3)
+        repliesFromAddresses must contain(node(first).address)
+        repliesFromAddresses must contain(node(second).address)
+        repliesFromAddresses must contain(node(third).address)
+        repliesFromAddresses must not contain (node(fourth).address)
 
         // shut down the actor before we let the other node(s) shut down so we don't try to send
         // "Terminate" to a shut down node

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/RoundRobinRoutedRemoteActorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/RoundRobinRoutedRemoteActorSpec.scala
@@ -136,11 +136,7 @@ class RoundRobinRoutedRemoteActorSpec extends MultiNodeSpec(RoundRobinRoutedRemo
         // at least more than one actor per node
         repliesFrom.size must be > (3)
         val repliesFromAddresses = repliesFrom.map(_.path.address)
-        repliesFromAddresses.size must be(3)
-        repliesFromAddresses must contain(node(first).address)
-        repliesFromAddresses must contain(node(second).address)
-        repliesFromAddresses must contain(node(third).address)
-        repliesFromAddresses must not contain (node(fourth).address)
+        repliesFromAddresses must be === (Set(node(first), node(second), node(third)).map(_.address))
 
         // shut down the actor before we let the other node(s) shut down so we don't try to send
         // "Terminate" to a shut down node

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/ScatterGatherRoutedRemoteActorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/router/ScatterGatherRoutedRemoteActorSpec.scala
@@ -22,7 +22,7 @@ import akka.actor.Address
 
 object ScatterGatherRoutedRemoteActorMultiJvmSpec extends MultiNodeConfig {
 
-  class SomeActor extends Actor with Serializable {
+  class SomeActor extends Actor {
     def receive = {
       case "hit" ⇒ sender ! self
     }

--- a/akka-remote/src/main/scala/akka/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/routing/RemoteRouterConfig.scala
@@ -15,8 +15,8 @@ import akka.remote.RemoteScope
 import akka.actor.AddressFromURIString
 import akka.actor.SupervisorStrategy
 import akka.actor.Address
-
 import scala.collection.JavaConverters._
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * [[akka.routing.RouterConfig]] implementation for remote deployment on defined
@@ -45,7 +45,7 @@ case class RemoteRouterConfig(local: RouterConfig, nodes: Iterable[Address]) ext
 
   override def withFallback(other: RouterConfig): RouterConfig = other match {
     case RemoteRouterConfig(local, nodes) ⇒ copy(local = this.local.withFallback(local))
-    case _                                ⇒ this
+    case _                                ⇒ copy(local = this.local.withFallback(other))
   }
 }
 
@@ -60,6 +60,8 @@ class RemoteRouteeProvider(nodes: Iterable[Address], _context: ActorContext, _re
 
   // need this iterator as instance variable since Resizer may call createRoutees several times
   private val nodeAddressIter: Iterator[Address] = Stream.continually(nodes).flatten.iterator
+  // need this counter as instance variable since Resizer may call createRoutees several times
+  private val childNameCounter = new AtomicInteger
 
   override def createRoutees(props: Props, nrOfInstances: Int, routees: Iterable[String]): IndexedSeq[ActorRef] =
     (nrOfInstances, routees, nodes) match {
@@ -69,7 +71,7 @@ class RemoteRouteeProvider(nodes: Iterable[Address], _context: ActorContext, _re
       case (n, Nil, ys) ⇒
         val impl = context.system.asInstanceOf[ActorSystemImpl] //TODO ticket #1559
         IndexedSeq.empty[ActorRef] ++ (for (i ← 1 to nrOfInstances) yield {
-          val name = "c" + i
+          val name = "c" + childNameCounter.incrementAndGet
           val deploy = Deploy("", ConfigFactory.empty(), props.routerConfig, RemoteScope(nodeAddressIter.next))
           impl.provider.actorOf(impl, props, context.self.asInstanceOf[InternalActorRef], context.self.path / name,
             systemService = false, Some(deploy), lookupDeploy = false, async = false)

--- a/akka-remote/src/main/scala/akka/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/routing/RemoteRouterConfig.scala
@@ -17,6 +17,7 @@ import akka.actor.SupervisorStrategy
 import akka.actor.Address
 import scala.collection.JavaConverters._
 import java.util.concurrent.atomic.AtomicInteger
+import java.lang.IllegalStateException
 
 /**
  * [[akka.routing.RouterConfig]] implementation for remote deployment on defined
@@ -44,6 +45,8 @@ case class RemoteRouterConfig(local: RouterConfig, nodes: Iterable[Address]) ext
   override def resizer: Option[Resizer] = local.resizer
 
   override def withFallback(other: RouterConfig): RouterConfig = other match {
+    case RemoteRouterConfig(local: RemoteRouterConfig, nodes) ⇒ throw new IllegalStateException(
+      "RemoteRouterConfig is not allowed to wrap a RemoteRouterConfig")
     case RemoteRouterConfig(local, nodes) ⇒ copy(local = this.local.withFallback(local))
     case _                                ⇒ copy(local = this.local.withFallback(other))
   }


### PR DESCRIPTION
- Use withFallback to use Resizer specified in code if not configured
- Use withFallback in RemoteRouterConfig also
- Fix bug of child name in RemoteRouteeProvider
