### PR TITLE
Allow escape sequences in actor names, see #2123.

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -79,6 +79,8 @@ class LocalActorRefProviderSpec extends AkkaSpec(LocalActorRefProviderSpec.confi
       intercept[InvalidActorNameException](system.actorOf(Props.empty, "")).getMessage.contains("empty") must be(true)
       intercept[InvalidActorNameException](system.actorOf(Props.empty, "$hallo")).getMessage.contains("conform") must be(true)
       intercept[InvalidActorNameException](system.actorOf(Props.empty, "a%")).getMessage.contains("conform") must be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%3")).getMessage.contains("conform") must be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%1t")).getMessage.contains("conform") must be(true)
       intercept[InvalidActorNameException](system.actorOf(Props.empty, "a?")).getMessage.contains("conform") must be(true)
       intercept[InvalidActorNameException](system.actorOf(Props.empty, "üß")).getMessage.contains("conform") must be(true)
     }

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -19,7 +19,7 @@ object ActorPath {
    * Since Actors form a tree, it is addressable using an URL, therefor an Actor Name has to conform to:
    * http://www.ietf.org/rfc/rfc2396.txt
    */
-  val ElementRegex = """[-\w:@&=+,.!~*'_;][-\w:@&=+,.!~*'$_;]*""".r
+  val ElementRegex = """(?:[-\w:@&=+,.!~*'_;]|%\p{XDigit}{2})(?:[-\w:@&=+,.!~*'$_;]|%\p{XDigit}{2})*""".r
 }
 
 /**

--- a/akka-docs/java/untyped-actors.rst
+++ b/akka-docs/java/untyped-actors.rst
@@ -81,7 +81,8 @@ a top level actor, that is supervised by the system (internal guardian actor).
 
 The name parameter is optional, but you should preferably name your actors, since
 that is used in log messages and for identifying actors. The name must not be empty
-or start with ``$``. If the given name is already in use by another child to the
+or start with ``$``, but it may contain URL encoded characters (eg. ``%20`` for a blank space).
+If the given name is already in use by another child to the
 same parent actor an `InvalidActorNameException` is thrown.
 
 Actors are automatically started asynchronously when created.

--- a/akka-docs/scala/actors.rst
+++ b/akka-docs/scala/actors.rst
@@ -75,7 +75,8 @@ a top level actor, that is supervised by the system (internal guardian actor).
 
 The name parameter is optional, but you should preferably name your actors, since
 that is used in log messages and for identifying actors. The name must not be empty
-or start with ``$``. If the given name is already in use by another child to the
+or start with ``$``, but it may contain URL encoded characters (eg. ``%20`` for a blank space).
+If the given name is already in use by another child to the
 same parent actor an `InvalidActorNameException` is thrown.
 
 Actors are automatically started asynchronously when created.


### PR DESCRIPTION
Hi,
This PR extends `ActorPath.ElementRegex` to also accept escape sequences, as defined by rfc2369, in form of `"%" hex hex`.
I also added two test cases for invalid escape sequences to `LocalActorRefProviderSpec`.

The user is responsible to encode the name before passing it to `actorOf`. The lookup later also has to be encoded (although there the name is not checked, the lookup just won't find the desired actor).

Let me know if you need more work done.

Cheers,
  Gerolf
