### PR TITLE
Tickets #2387 #2383 #1214

### DIFF
--- a/akka-camel/src/main/scala/akka/camel/Camel.scala
+++ b/akka-camel/src/main/scala/akka/camel/Camel.scala
@@ -6,7 +6,8 @@ package akka.camel
 
 import internal._
 import akka.actor._
-import org.apache.camel.{ ProducerTemplate, CamelContext }
+import org.apache.camel.{ ProducerTemplate }
+import org.apache.camel.impl.DefaultCamelContext
 import com.typesafe.config.Config
 import scala.concurrent.util.Duration
 import java.util.concurrent.TimeUnit._
@@ -24,9 +25,9 @@ trait Camel extends ConsumerRegistry with ProducerRegistry with Extension with A
    * It can be used to configure camel manually, i.e. when the user wants to add new routes or endpoints,
    * i.e. {{{camel.context.addRoutes(...)}}}
    *
-   * @see [[org.apache.camel.CamelContext]]
+   * @see [[org.apache.camel.impl.DefaultCamelContext]]
    */
-  def context: CamelContext
+  def context: DefaultCamelContext
 
   /**
    * The Camel ProducerTemplate.

--- a/akka-camel/src/main/scala/akka/camel/internal/ConsumerRegistry.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/ConsumerRegistry.scala
@@ -30,7 +30,7 @@ private[camel] trait ConsumerRegistry { this: Activation ⇒
   /**
    * For internal use only.
    */
-  private[this] lazy val idempotentRegistry = system.actorOf(Props(new IdempotentCamelConsumerRegistry(context)))
+  private[this] lazy val idempotentRegistry = system.actorOf(Props(new IdempotentCamelConsumerRegistry(context)), name = "camelConsumerRegistry")
   /**
    * For internal use only. BLOCKING
    * @param endpointUri the URI to register the consumer on
@@ -58,7 +58,7 @@ private[camel] class IdempotentCamelConsumerRegistry(camelContext: CamelContext)
 
   val activated = new mutable.HashSet[ActorRef]
 
-  val registrator = context.actorOf(Props(new CamelConsumerRegistrator))
+  val registrator = context.actorOf(Props(new CamelConsumerRegistrator), name = "camelConsumerRegistrator")
 
   def receive = {
     case msg @ RegisterConsumer(_, consumer, _) ⇒

--- a/akka-camel/src/main/scala/akka/camel/internal/DefaultCamel.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/DefaultCamel.scala
@@ -26,7 +26,7 @@ private[camel] class DefaultCamel(val system: ActorSystem) extends Camel {
    */
   private[camel] implicit val log = Logging(system, "Camel")
 
-  lazy val context: CamelContext = {
+  lazy val context: DefaultCamelContext = {
     val ctx = new DefaultCamelContext
     if (!settings.jmxStatistics) ctx.disableJMX()
     ctx.setName(system.name)

--- a/akka-camel/src/main/scala/akka/camel/internal/ProducerRegistry.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/ProducerRegistry.scala
@@ -34,7 +34,7 @@ private case class RegisterProducer(actorRef: ActorRef)
  */
 private[camel] trait ProducerRegistry { this: Camel ⇒
   private val camelObjects = new ConcurrentHashMap[ActorRef, (Endpoint, SendProcessor)]()
-  private val watcher = system.actorOf(Props(new ProducerWatcher(this))) //FIXME should this really be top level?
+  private val watcher = system.actorOf(Props(new ProducerWatcher(this)), "camelProducerWatcher") //FIXME should this really be top level?
 
   private def registerWatch(actorRef: ActorRef): Unit = watcher ! RegisterProducer(actorRef)
 

--- a/akka-camel/src/main/scala/akka/camel/javaapi/UntypedConsumerActor.scala
+++ b/akka-camel/src/main/scala/akka/camel/javaapi/UntypedConsumerActor.scala
@@ -7,6 +7,7 @@ package akka.camel.javaapi
 import akka.actor.UntypedActor
 import akka.camel._
 import org.apache.camel.{ ProducerTemplate, CamelContext }
+import org.apache.camel.impl.DefaultCamelContext
 
 /**
  * Subclass this abstract class to create an MDB-style untyped consumer actor. This
@@ -21,10 +22,10 @@ abstract class UntypedConsumerActor extends UntypedActor with Consumer {
   def getEndpointUri(): String
 
   /**
-   * ''Java API'': Returns the [[org.apache.camel.CamelContext]]
+   * ''Java API'': Returns the [[org.apache.camel.impl.DefaultCamelContext]]
    * @return the CamelContext
    */
-  protected def getCamelContext(): CamelContext = camelContext
+  protected def getCamelContext(): DefaultCamelContext = camelContext
 
   /**
    * ''Java API'': Returns the [[org.apache.camel.ProducerTemplate]]

--- a/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
+++ b/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
@@ -7,6 +7,7 @@ package akka.camel.javaapi
 import akka.actor.UntypedActor
 import akka.camel._
 import org.apache.camel.{ CamelContext, ProducerTemplate }
+import org.apache.camel.impl.DefaultCamelContext
 
 /**
  * Subclass this abstract class to create an untyped producer actor. This class is meant to be used from Java.
@@ -64,7 +65,7 @@ abstract class UntypedProducerActor extends UntypedActor with ProducerSupport {
   /**
    * Returns the <code>CamelContext</code>.
    */
-  def getCamelContext(): CamelContext = camel.context
+  def getCamelContext(): DefaultCamelContext = camel.context
 
   /**
    * Returns the <code>ProducerTemplate</code>.

--- a/akka-camel/src/test/java/akka/camel/ConsumerJavaTestBase.java
+++ b/akka-camel/src/test/java/akka/camel/ConsumerJavaTestBase.java
@@ -42,7 +42,7 @@ public class ConsumerJavaTestBase {
                     ExecutionContext executionContext = system.dispatcher();
                     try {
                         ActorRef ref = Await.result(
-                                camel.activationFutureFor(system.actorOf(new Props(SampleErrorHandlingConsumer.class)), timeout, executionContext),
+                                camel.activationFutureFor(system.actorOf(new Props(SampleErrorHandlingConsumer.class), "sample-error-handling-consumer"), timeout, executionContext),
                                 timeout);
                         return camel.template().requestBody("direct:error-handler-test-java", "hello", String.class);
                     }

--- a/akka-camel/src/test/resources/logback-test.xml
+++ b/akka-camel/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/akka-camel.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="fatal">
+        <appender-ref ref="FILE" />
+    </root>
+
+</configuration>

--- a/akka-camel/src/test/scala/akka/camel/ActivationIntegrationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ActivationIntegrationTest.scala
@@ -10,11 +10,10 @@ import org.scalatest.matchers.MustMatchers
 import scala.concurrent.util.duration._
 import org.apache.camel.ProducerTemplate
 import akka.actor._
-import akka.util.Timeout
 import TestSupport._
 import org.scalatest.WordSpec
 import akka.testkit.TestLatch
-import scala.concurrent.Await
+import concurrent.Await
 import java.util.concurrent.TimeoutException
 
 class ActivationIntegrationTest extends WordSpec with MustMatchers with SharedCamelSystem {
@@ -24,7 +23,7 @@ class ActivationIntegrationTest extends WordSpec with MustMatchers with SharedCa
 
   "ActivationAware must be notified when endpoint is activated" in {
     val latch = new TestLatch(0)
-    val actor = system.actorOf(Props(new TestConsumer("direct:actor-1", latch)))
+    val actor = system.actorOf(Props(new TestConsumer("direct:actor-1", latch)), "act-direct-actor-1")
     Await.result(camel.activationFutureFor(actor), 10 seconds) must be === actor
 
     template.requestBody("direct:actor-1", "test") must be("received test")
@@ -40,32 +39,39 @@ class ActivationIntegrationTest extends WordSpec with MustMatchers with SharedCa
         super.postStop()
         latch.countDown()
       }
-    })
+    }, name = "direct-a3")
     Await.result(camel.activationFutureFor(actor), timeout)
 
     system.stop(actor)
     Await.result(camel.deactivationFutureFor(actor), timeout)
-    Await.ready(latch, 10 second)
+    Await.ready(latch, timeout)
   }
 
   "ActivationAware must time out when waiting for endpoint de-activation for too long" in {
     val latch = new TestLatch(0)
-    val actor = start(new TestConsumer("direct:a5", latch))
+    val actor = start(new TestConsumer("direct:a5", latch), name = "direct-a5")
     Await.result(camel.activationFutureFor(actor), timeout)
     intercept[TimeoutException] { Await.result(camel.deactivationFutureFor(actor), 1 millis) }
   }
 
   "activationFutureFor must fail if notification timeout is too short and activation is not complete yet" in {
     val latch = new TestLatch(1)
-    try {
-      val actor = system.actorOf(Props(new TestConsumer("direct:actor-4", latch)))
-      intercept[TimeoutException] { Await.result(camel.activationFutureFor(actor), 1 millis) }
-    } finally latch.countDown()
+    val actor = system.actorOf(Props(new TestConsumer("direct:actor-4", latch)), "direct-actor-4")
+    intercept[TimeoutException] { Await.result(camel.activationFutureFor(actor), 1 millis) }
+    latch.countDown()
+    // after the latch is removed, complete the wait for completion so this test does not later on
+    // print errors because of the registerConsumer timing out.
+    Await.result(camel.activationFutureFor(actor), timeout)
   }
 
   class TestConsumer(uri: String, latch: TestLatch) extends Consumer {
     def endpointUri = uri
-    Await.ready(latch, 60 seconds)
+
+    override def preStart() {
+      Await.ready(latch, 60 seconds)
+      super.preStart()
+    }
+
     override def receive = {
       case msg: CamelMessage ⇒ sender ! "received " + msg.body
     }

--- a/akka-camel/src/test/scala/akka/camel/ConsumerIntegrationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConsumerIntegrationTest.scala
@@ -13,12 +13,14 @@ import org.scalatest.WordSpec
 import akka.camel.TestSupport._
 import org.apache.camel.model.RouteDefinition
 import org.apache.camel.builder.Builder
-import org.apache.camel.{ FailedToCreateRouteException, CamelExecutionException }
+import org.apache.camel.{ Exchange, Processor, FailedToCreateRouteException, CamelExecutionException }
 import java.util.concurrent.{ ExecutionException, TimeUnit, TimeoutException }
 import akka.actor.Status.Failure
 import scala.concurrent.util.duration._
 import concurrent.{ ExecutionContext, Await }
 import akka.testkit._
+import javax.activation.DataHandler
+import java.net.URL
 
 class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedCamelSystem {
   "ConsumerIntegrationTest" must {
@@ -27,7 +29,7 @@ class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedC
 
     "Consumer must throw FailedToCreateRouteException, while awaiting activation, if endpoint is invalid" in {
       filterEvents(EventFilter[ActorInitializationException](occurrences = 1), EventFilter[FailedToCreateRouteException](occurrences = 1)) {
-        val actorRef = system.actorOf(Props(new TestActor(uri = "some invalid uri")))
+        val actorRef = system.actorOf(Props(new TestActor(uri = "some invalid uri")), "cons-invalid-test-actor")
         intercept[FailedToCreateRouteException] {
           Await.result(camel.activationFutureFor(actorRef), defaultTimeout)
         }
@@ -40,7 +42,7 @@ class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedC
         def receive = {
           case m: CamelMessage ⇒ sender ! "received " + m.bodyAs[String]
         }
-      })
+      }, name = "direct-a1")
       camel.sendTo("direct:a1", msg = "some message") must be("received some message")
     }
 
@@ -48,17 +50,18 @@ class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedC
       val SHORT_TIMEOUT = 10 millis
       val LONG_WAIT = 200 millis
 
-      start(new Consumer {
+      val ref = start(new Consumer {
         override def replyTimeout = SHORT_TIMEOUT
 
         def endpointUri = "direct:a3"
         def receive = { case _ ⇒ { Thread.sleep(LONG_WAIT.toMillis); sender ! "done" } }
-      })
+      }, name = "ignore-this-deadletter-timeout-consumer-reply")
 
       val exception = intercept[CamelExecutionException] {
         camel.sendTo("direct:a3", msg = "some msg 3")
       }
       exception.getCause.getClass must be(classOf[TimeoutException])
+      stop(ref)
     }
 
     "Consumer must process messages even after actor restart" in {
@@ -74,17 +77,18 @@ class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedC
         override def postRestart(reason: Throwable) {
           restarted.countDown()
         }
-      })
+      }, "direct-a2")
       filterEvents(EventFilter[TestException](occurrences = 1)) {
         consumer ! "throw"
         Await.ready(restarted, defaultTimeout)
 
         camel.sendTo("direct:a2", msg = "xyz") must be("received xyz")
       }
+      stop(consumer)
     }
 
     "Consumer must unregister itself when stopped" in {
-      val consumer = start(new TestActor())
+      val consumer = start(new TestActor(), name = "test-actor-unregister")
       Await.result(camel.activationFutureFor(consumer), defaultTimeout)
 
       camel.routeCount must be > (0)
@@ -96,7 +100,7 @@ class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedC
     }
 
     "Consumer must register on uri passed in through constructor" in {
-      val consumer = start(new TestActor("direct://test"))
+      val consumer = start(new TestActor("direct://test"), name = "direct-test")
       Await.result(camel.activationFutureFor(consumer), defaultTimeout)
 
       camel.routeCount must be > (0)
@@ -104,60 +108,66 @@ class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedC
       system.stop(consumer)
       Await.result(camel.deactivationFutureFor(consumer), defaultTimeout)
       camel.routeCount must be(0)
+      stop(consumer)
     }
 
     "Error passing consumer supports error handling through route modification" in {
-      start(new ErrorThrowingConsumer("direct:error-handler-test") with ErrorPassing {
+      val ref = start(new ErrorThrowingConsumer("direct:error-handler-test") with ErrorPassing {
         override def onRouteDefinition(rd: RouteDefinition) = {
           rd.onException(classOf[TestException]).handled(true).transform(Builder.exceptionMessage).end
         }
-      })
+      }, name = "direct-error-handler-test")
       filterEvents(EventFilter[TestException](occurrences = 1)) {
         camel.sendTo("direct:error-handler-test", msg = "hello") must be("error: hello")
       }
+      stop(ref)
     }
 
     "Error passing consumer supports redelivery through route modification" in {
-      start(new FailingOnceConsumer("direct:failing-once-concumer") with ErrorPassing {
+      val ref = start(new FailingOnceConsumer("direct:failing-once-concumer") with ErrorPassing {
         override def onRouteDefinition(rd: RouteDefinition) = {
           rd.onException(classOf[TestException]).maximumRedeliveries(1).end
         }
-      })
+      }, name = "direct-failing-once-consumer")
       filterEvents(EventFilter[TestException](occurrences = 1)) {
         camel.sendTo("direct:failing-once-concumer", msg = "hello") must be("accepted: hello")
       }
+      stop(ref)
     }
 
     "Consumer supports manual Ack" in {
-      start(new ManualAckConsumer() {
+      val ref = start(new ManualAckConsumer() {
         def endpointUri = "direct:manual-ack"
         def receive = { case _ ⇒ sender ! Ack }
-      })
+      }, name = "direct-manual-ack-1")
       camel.template.asyncSendBody("direct:manual-ack", "some message").get(defaultTimeout.toSeconds, TimeUnit.SECONDS) must be(null) //should not timeout
+      stop(ref)
     }
 
     "Consumer handles manual Ack failure" in {
       val someException = new Exception("e1")
-      start(new ManualAckConsumer() {
+      val ref = start(new ManualAckConsumer() {
         def endpointUri = "direct:manual-ack"
         def receive = { case _ ⇒ sender ! Failure(someException) }
-      })
+      }, name = "direct-manual-ack-2")
 
       intercept[ExecutionException] {
         camel.template.asyncSendBody("direct:manual-ack", "some message").get(defaultTimeout.toSeconds, TimeUnit.SECONDS)
       }.getCause.getCause must be(someException)
+      stop(ref)
     }
 
     "Consumer should time-out, if manual Ack not received within replyTimeout and should give a human readable error message" in {
-      start(new ManualAckConsumer() {
+      val ref = start(new ManualAckConsumer() {
         override def replyTimeout = 10 millis
         def endpointUri = "direct:manual-ack"
         def receive = { case _ ⇒ }
-      })
+      }, name = "direct-manual-ack-3")
 
       intercept[ExecutionException] {
         camel.template.asyncSendBody("direct:manual-ack", "some message").get(defaultTimeout.toSeconds, TimeUnit.SECONDS)
       }.getCause.getCause.getMessage must include("Failed to get Ack")
+      stop(ref)
     }
   }
 }

--- a/akka-camel/src/test/scala/akka/camel/DefaultCamelTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/DefaultCamelTest.scala
@@ -14,6 +14,8 @@ import org.scalatest.WordSpec
 import akka.event.LoggingAdapter
 import akka.actor.ActorSystem.Settings
 import com.typesafe.config.ConfigFactory
+import org.apache.camel.impl.DefaultCamelContext
+import org.apache.camel.spi.Registry
 
 class DefaultCamelTest extends WordSpec with SharedCamelSystem with MustMatchers with MockitoSugar {
 
@@ -26,7 +28,7 @@ class DefaultCamelTest extends WordSpec with SharedCamelSystem with MustMatchers
   def camelWithMocks = new DefaultCamel(sys) {
     override val log = mock[LoggingAdapter]
     override lazy val template = mock[ProducerTemplate]
-    override lazy val context = mock[CamelContext]
+    override lazy val context = mock[DefaultCamelContext]
     override val settings = mock[CamelSettings]
   }
 
@@ -62,5 +64,4 @@ class DefaultCamelTest extends WordSpec with SharedCamelSystem with MustMatchers
     verify(camel.context).stop()
 
   }
-
 }

--- a/akka-camel/src/test/scala/akka/camel/MultipartUploadTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/MultipartUploadTest.scala
@@ -1,0 +1,78 @@
+package akka.camel
+
+import org.scalatest.matchers.MustMatchers
+import org.scalatest.WordSpec
+import akka.camel.TestSupport._
+import org.apache.http.util.EntityUtils
+import java.io.{ IOException, File }
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.impl.client.DefaultHttpClient
+import org.apache.http.entity.mime.MultipartEntity
+import org.apache.http.entity.mime.content.{ FileBody, StringBody }
+import org.apache.commons.io.{ IOUtils, FileUtils }
+import concurrent.{ Promise, Await }
+import akka.util.Timeout
+import scala.concurrent.util.duration._
+import language.postfixOps
+import org.apache.camel.Exchange
+import akka.actor.{ Props, Actor, ActorRef }
+import util.{ Failure, Success }
+
+class MultipartUploadTest extends WordSpec with MustMatchers with SharedCamelSystem {
+
+  "A multipart/form-data POST to a camel-jetty Consumer" must {
+    "result in a message sent to the consumer including attachments" in {
+      implicit val ec = system.dispatcher
+      implicit val timeout = 10 seconds
+      val promise = Promise[List[Attachment]]()
+      val future = promise.future
+
+      val ref = start(new JettyConsumer(promise), "jetty-consumer")
+      val text = "some text data"
+      val textAttachment = createTmpFile("text-attachment.txt", text)
+      val xml = """<?xml version="1.0" encoding="UTF-8"?><element>some other data</element>"""
+      val xmlAttachment = createTmpFile("xml-attachment.xml", xml)
+      uploadFiles("http://localhost:8875/upload", List(xmlAttachment, textAttachment))
+
+      val attachments = Await.result(future, 10 seconds)
+      attachments.size must be(2)
+      attachments.filter(a ⇒ a.name == "text-attachment.txt" && a.contentType == "text/plain" && a.bytes.decodeString("UTF8") == text).size must be(1)
+      attachments.filter(a ⇒ a.name == "xml-attachment.xml" && a.contentType == "application/octet-stream" && a.bytes.decodeString("UTF8") == xml).size must be(1)
+
+      stop(ref)
+      camel.context.removeComponent("jetty")
+    }
+  }
+
+  def createTmpFile(name: String, data: String): File = {
+    val file = new File(FileUtils.getTempDirectory, name)
+    FileUtils.write(file, data)
+    file
+  }
+
+  def uploadFiles(url: String, files: List[File]) {
+    val http = new DefaultHttpClient()
+    try {
+      val post = new HttpPost(url)
+      val reqEntity = new MultipartEntity()
+      files.foreach(f ⇒ reqEntity.addPart(f.getName, new FileBody(f)))
+      post.setEntity(reqEntity)
+      val response = http.execute(post)
+      val resEntity = response.getEntity
+      EntityUtils.consume(resEntity)
+    } finally {
+      http.getConnectionManager.shutdown()
+      if (files.map(_.delete()).exists(!_)) throw new IOException("temporary files where not deleted")
+    }
+  }
+}
+
+class JettyConsumer(promise: Promise[List[Attachment]]) extends Consumer {
+  def endpointUri = "jetty://http://localhost:8875/upload"
+  def receive = {
+    case msg: CamelMessage ⇒
+      val headers = Map(Exchange.HTTP_RESPONSE_CODE -> "200")
+      sender ! CamelMessage("OK", headers)
+      promise.success(msg.attachments.values.toList)
+  }
+}

--- a/akka-camel/src/test/scala/akka/camel/TestSupport.scala
+++ b/akka-camel/src/test/scala/akka/camel/TestSupport.scala
@@ -20,10 +20,15 @@ import akka.testkit.AkkaSpec
 
 private[camel] object TestSupport {
 
-  def start(actor: ⇒ Actor)(implicit system: ActorSystem): ActorRef = {
-    val actorRef = system.actorOf(Props(actor))
+  def start(actor: ⇒ Actor, name: String)(implicit system: ActorSystem): ActorRef = {
+    val actorRef = system.actorOf(Props(actor), name = name)
     Await.result(CamelExtension(system).activationFutureFor(actorRef)(10 seconds, system.dispatcher), 10 seconds)
     actorRef
+  }
+
+  def stop(actorRef: ActorRef)(implicit system: ActorSystem) {
+    system.stop(actorRef)
+    Await.result(CamelExtension(system).deactivationFutureFor(actorRef)(10 seconds, system.dispatcher), 10 seconds)
   }
 
   private[camel] implicit def camelToTestWrapper(camel: Camel) = new CamelTestWrapper(camel)

--- a/akka-camel/src/test/scala/akka/camel/UntypedProducerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/UntypedProducerTest.scala
@@ -33,7 +33,7 @@ class UntypedProducerTest extends WordSpec with MustMatchers with BeforeAndAfter
   "An UntypedProducer producing a message to a sync Camel route" must {
 
     "produce a message and receive a normal response" in {
-      val producer = system.actorOf(Props[SampleUntypedReplyingProducer])
+      val producer = system.actorOf(Props[SampleUntypedReplyingProducer], name = "sample-untyped-replying-producer")
 
       val message = CamelMessage("test", Map(CamelMessage.MessageExchangeId -> "123"))
       val future = producer.ask(message)(timeout)
@@ -47,7 +47,7 @@ class UntypedProducerTest extends WordSpec with MustMatchers with BeforeAndAfter
     }
 
     "produce a message and receive a failure response" in {
-      val producer = system.actorOf(Props[SampleUntypedReplyingProducer])
+      val producer = system.actorOf(Props[SampleUntypedReplyingProducer], name = "sample-untyped-replying-producer-failure")
 
       val message = CamelMessage("fail", Map(CamelMessage.MessageExchangeId -> "123"))
       filterEvents(EventFilter[AkkaCamelException](occurrences = 1)) {
@@ -66,7 +66,7 @@ class UntypedProducerTest extends WordSpec with MustMatchers with BeforeAndAfter
   "An UntypedProducer producing a message to a sync Camel route and then forwarding the response" must {
 
     "produce a message and send a normal response to direct:forward-test-1" in {
-      val producer = system.actorOf(Props[SampleUntypedForwardingProducer])
+      val producer = system.actorOf(Props[SampleUntypedForwardingProducer], name = "sample-untyped-forwarding-producer")
 
       mockEndpoint.expectedBodiesReceived("received test")
       producer.tell(CamelMessage("test", Map[String, Any]()), producer)

--- a/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
@@ -25,7 +25,7 @@ class ActivationTrackerTest extends TestKit(ActorSystem("test")) with WordSpec w
     anotherAwaiting = new Awaiting(actor)
   }
 
-  val at = system.actorOf(Props[ActivationTracker])
+  val at = system.actorOf(Props[ActivationTracker], name = "activationTrackker")
 
   "ActivationTracker forwards activation message to all awaiting parties" taggedAs TimingTest in {
     awaiting.awaitActivation()

--- a/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
@@ -27,6 +27,7 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorSystem.Settings
 import akka.event.LoggingAdapter
 import akka.testkit.{ TimingTest, TestKit, TestProbe }
+import org.apache.camel.impl.DefaultCamelContext
 
 class ActorProducerTest extends TestKit(ActorSystem("test")) with WordSpec with MustMatchers with ActorProducerFixture {
 
@@ -284,7 +285,7 @@ trait ActorProducerFixture extends MockitoSugar with BeforeAndAfterAll with Befo
     def camelWithMocks = new DefaultCamel(sys) {
       override val log = mock[LoggingAdapter]
       override lazy val template = mock[ProducerTemplate]
-      override lazy val context = mock[CamelContext]
+      override lazy val context = mock[DefaultCamelContext]
       override val settings = mock[CamelSettings]
     }
     camel = camelWithMocks
@@ -351,6 +352,6 @@ trait ActorProducerFixture extends MockitoSugar with BeforeAndAfterAll with Befo
     def receive = {
       case msg ⇒ sender ! "received " + msg
     }
-  }))
+  }), name = "echoActor")
 
 }

--- a/akka-camel/src/test/scala/akka/camel/internal/component/DurationConverterTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/component/DurationConverterTest.scala
@@ -8,7 +8,8 @@ import org.scalatest.matchers.MustMatchers
 import scala.concurrent.util.duration._
 import scala.concurrent.util.Duration
 import org.scalatest.WordSpec
-import org.apache.camel.{ TypeConversionException, NoTypeConversionAvailableException }
+import org.apache.camel.TypeConversionException
+import language.postfixOps
 
 class DurationConverterSpec extends WordSpec with MustMatchers {
   import DurationTypeConverter._

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -566,7 +566,7 @@ object Dependencies {
 
   val kernel = Seq(Test.scalatest, Test.junit)
 
-  val camel = Seq(camelCore, Test.scalatest, Test.junit, Test.mockito)
+  val camel = Seq(camelCore, Test.scalatest, Test.junit, Test.mockito, Test.logback, Test.httpClient, Test.httpmime, Test.camelJetty, Test.commonsIo)
 
   val camelSample = Seq(CamelSample.camelJetty)
 
@@ -608,6 +608,9 @@ object Dependency {
     val tinybundles = "org.ops4j.pax.tinybundles"   % "tinybundles"                  % "1.0.0"            % "test" // ApacheV2
     val log4j       = "log4j"                       % "log4j"                        % "1.2.14"           % "test" // ApacheV2
     val junitIntf   = "com.novocode"                % "junit-interface"              % "0.8"              % "test" // MIT
+    val httpClient  = "org.apache.httpcomponents"   % "httpclient"                   % "4.2.1"            % "test" // ApacheV2
+    val httpmime    = "org.apache.httpcomponents"   % "httpmime"                     % "4.2.1"            % "test" // ApacheV2
+    val camelJetty  = "org.apache.camel"            % "camel-jetty"                  % "2.10.0"           % "test" // ApacheV2
   }
 
   // Camel Sample


### PR DESCRIPTION
Added attachments support using akka.util.ByteString to make attachments in CamelMessage immutable
Made the akka-camel tests run more silently
Exposed DefaultCamelContext instead of CamelContext so that the registry can be set
