### PR TITLE
Mark cluster as experimental, see #2455

### DIFF
--- a/akka-docs/cluster/cluster-usage.rst
+++ b/akka-docs/cluster/cluster-usage.rst
@@ -5,7 +5,7 @@
  Cluster Usage
 ###############
 
-.. note:: This module is :ref:`experimental <experimental>`. This document describes how to use the features implemented so far. More features are coming in Akka Coltrane.
+.. note:: This module is :ref:`experimental <experimental>`. This document describes how to use the features implemented so far. More features are coming in Akka Coltrane. Track progress of the Coltrane milestone in `Assembla <http://www.assembla.com/spaces/akka/tickets>`_ and the `Roadmap <https://docs.google.com/document/d/18W9-fKs55wiFNjXL9q50PYOnR7-nnsImzJqHOPPbM4E/edit?hl=en_US>`_.
 
 For introduction to the Akka Cluster concepts please see :ref:`cluster`.
 

--- a/akka-docs/cluster/cluster-usage.rst
+++ b/akka-docs/cluster/cluster-usage.rst
@@ -5,9 +5,7 @@
  Cluster Usage
 ###############
 
-.. note:: This document describes how to use the features implemented so far of the 
-  new clustering coming in Akka Coltrane and is not available in the latest stable release.
-  The API might change before it is released.
+.. note:: This module is :ref:`experimental <experimental>`. This document describes how to use the features implemented so far. More features are coming in Akka Coltrane.
 
 For introduction to the Akka Cluster concepts please see :ref:`cluster`.
 

--- a/akka-docs/cluster/cluster.rst
+++ b/akka-docs/cluster/cluster.rst
@@ -5,7 +5,7 @@
  Cluster Specification
 ######################
 
-.. note:: *This document describes the new clustering coming in Akka Coltrane and is not available in the latest stable release)*
+.. note:: This module is :ref:`experimental <experimental>`. This document describes the design concepts of the new clustering coming in Akka Coltrane. Not everything described here is implemented yet.
 
 Intro
 =====

--- a/akka-docs/experimental/index.rst
+++ b/akka-docs/experimental/index.rst
@@ -1,0 +1,26 @@
+.. _experimental:
+
+####################
+Experimental Modules
+####################
+
+The following modules of Akka are marked as experimental, which means
+that they are in early access mode. The purpose of releasing them
+early, as experimental, is to make them easily available and improve
+based on feedback, or even discover that the module wasn't useful.
+
+An experimental module doesn't have to obey the rule of staying binary
+compatible between minor releases. Breaking API changes may be introduced
+in minor releases without notice as we refine and simplify based on your
+feedback. An experimental module may be dropped in major releases without 
+prior deprecation.
+
+Another reason for marking a module as experimental is that it's too early
+to tell if the module has a maintainer that can take the responsibility
+of the module over time.
+
+.. toctree::
+   :maxdepth: 2
+
+   ../cluster/index
+

--- a/akka-docs/experimental/index.rst
+++ b/akka-docs/experimental/index.rst
@@ -5,9 +5,10 @@ Experimental Modules
 ####################
 
 The following modules of Akka are marked as experimental, which means
-that they are in early access mode. The purpose of releasing them
-early, as experimental, is to make them easily available and improve
-based on feedback, or even discover that the module wasn't useful.
+that they are in early access mode, which also means that they are not
+covered by commercial support. The purpose of releasing them early, as 
+experimental, is to make them easily available and improve based on 
+feedback, or even discover that the module wasn't useful.
 
 An experimental module doesn't have to obey the rule of staying binary
 compatible between minor releases. Breaking API changes may be introduced

--- a/akka-docs/index.rst
+++ b/akka-docs/index.rst
@@ -9,8 +9,8 @@ Contents
    common/index
    java/index
    scala/index
-   cluster/index
    modules/index
+   experimental/index
    dev/index
    project/index
    additional/index

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -129,7 +129,7 @@ object AkkaBuild extends Build {
   )
 
   lazy val remoteTests = Project(
-    id = "akka-remote-tests",
+    id = "akka-remote-tests-experimental",
     base = file("akka-remote-tests"),
     dependencies = Seq(remote, actorTests % "test->test", testkit % "test->test"),
     settings = defaultSettings ++ multiJvmSettings ++ Seq(
@@ -145,7 +145,7 @@ object AkkaBuild extends Build {
   ) configs (MultiJvm)
 
   lazy val cluster = Project(
-    id = "akka-cluster",
+    id = "akka-cluster-experimental",
     base = file("akka-cluster"),
     dependencies = Seq(remote, remoteTests % "compile;test->test;multi-jvm->multi-jvm", testkit % "test->test"),
     settings = defaultSettings ++ multiJvmSettings ++ OSGi.cluster ++ Seq(


### PR DESCRIPTION
- Speparate section in docs, explaining what experimental means
- Renamed the artifactId to akka-cluster-experimental and
  akka-remote-tests-experimental
