### PR TITLE
Wip 2368 supervisorhierarchyspec failures ban

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -4,7 +4,7 @@
 
 package akka.actor
 
-import cell.ChildrenContainer.{ Creation, Recreation }
+import cell.ChildrenContainer.{ WaitingForChildren }
 import java.io.{ ObjectOutputStream, NotSerializableException }
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeSet
@@ -332,21 +332,18 @@ private[akka] class ActorCell(
         case Unwatch(watchee, watcher) ⇒ remWatcher(watchee, watcher)
         case Recreate(cause) ⇒
           waitingForChildrenOrNull match {
-            case null          ⇒ faultRecreate(cause)
-            case r: Recreation ⇒ message.next = r.todo; r.todo = message
-            case c: Creation   ⇒ message.next = c.todo; c.todo = message
+            case null                  ⇒ faultRecreate(cause)
+            case w: WaitingForChildren ⇒ w.enqueue(message)
           }
         case Suspend() ⇒
           waitingForChildrenOrNull match {
-            case null          ⇒ faultSuspend()
-            case r: Recreation ⇒ message.next = r.todo; r.todo = message
-            case c: Creation   ⇒ message.next = c.todo; c.todo = message
+            case null                  ⇒ faultSuspend()
+            case w: WaitingForChildren ⇒ w.enqueue(message)
           }
         case Resume(inRespToFailure) ⇒
           waitingForChildrenOrNull match {
-            case null          ⇒ faultResume(inRespToFailure)
-            case r: Recreation ⇒ message.next = r.todo; r.todo = message
-            case c: Creation   ⇒ message.next = c.todo; c.todo = message
+            case null                  ⇒ faultResume(inRespToFailure)
+            case w: WaitingForChildren ⇒ w.enqueue(message)
           }
         case Terminate()            ⇒ terminate()
         case Supervise(child, uid)  ⇒ supervise(child, uid)
@@ -449,22 +446,19 @@ private[akka] class ActorCell(
       checkReceiveTimeout
       if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(created), "started (" + created + ")"))
     } catch {
-      case NonFatal(i: InstantiationException) ⇒
-        if (actor != null) {
-          clearActorFields(actor)
-          actor = null // ensure that we know that we failed during creation
-        }
-        throw ActorInitializationException(self,
-          """exception during creation, this problem is likely to occur because the class of the Actor you tried to create is either,
-               a non-static inner class (in which case make it a static inner class or use Props(new ...) or Props( new UntypedActorFactory ... )
-               or is missing an appropriate, reachable no-args constructor.
-            """, i.getCause)
       case NonFatal(e) ⇒
         if (actor != null) {
           clearActorFields(actor)
           actor = null // ensure that we know that we failed during creation
         }
-        throw ActorInitializationException(self, "exception during creation", e)
+        e match {
+          case i: InstantiationException ⇒ throw ActorInitializationException(self,
+            """exception during creation, this problem is likely to occur because the class of the Actor you tried to create is either,
+               a non-static inner class (in which case make it a static inner class or use Props(new ...) or Props( new UntypedActorFactory ... )
+               or is missing an appropriate, reachable no-args constructor.
+              """, i.getCause)
+          case x ⇒ throw ActorInitializationException(self, "exception during creation", x)
+        }
     }
 
   private def supervise(child: ActorRef, uid: Int): Unit = if (!isTerminating) {

--- a/akka-actor/src/main/scala/akka/actor/cell/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Children.scala
@@ -120,8 +120,9 @@ private[akka] trait Children { this: ActorCell ⇒
 
   protected def isTerminating = childrenRefs.isTerminating
 
-  protected def recreationOrNull = childrenRefs match {
+  protected def waitingForChildrenOrNull = childrenRefs match {
     case TerminatingChildrenContainer(_, _, r: Recreation) ⇒ r
+    case TerminatingChildrenContainer(_, _, c: Creation) ⇒ c
     case _ ⇒ null
   }
 

--- a/akka-actor/src/main/scala/akka/actor/cell/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/Children.scala
@@ -121,8 +121,7 @@ private[akka] trait Children { this: ActorCell ⇒
   protected def isTerminating = childrenRefs.isTerminating
 
   protected def waitingForChildrenOrNull = childrenRefs match {
-    case TerminatingChildrenContainer(_, _, r: Recreation) ⇒ r
-    case TerminatingChildrenContainer(_, _, c: Creation) ⇒ c
+    case TerminatingChildrenContainer(_, _, w: WaitingForChildren) ⇒ w
     case _ ⇒ null
   }
 

--- a/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
@@ -50,7 +50,7 @@ private[akka] object ChildrenContainer {
   case object Termination extends SuspendReason
 
   trait WaitingForChildren {
-    var todo: SystemMessage = null
+    private var todo: SystemMessage = null
     def enqueue(message: SystemMessage) = { message.next = todo; todo = message }
     def dequeueAll(): SystemMessage = { val ret = SystemMessage.reverse(todo); todo = null; ret }
   }

--- a/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
@@ -46,6 +46,7 @@ private[akka] object ChildrenContainer {
   case object UserRequest extends SuspendReason
   // careful with those system messages, all handling to be taking place in ActorCell.scala!
   case class Recreation(cause: Throwable, var todo: SystemMessage = null) extends SuspendReason
+  case class Creation(var todo: SystemMessage = null) extends SuspendReason
   case object Termination extends SuspendReason
 
   trait EmptyChildrenContainer extends ChildrenContainer {

--- a/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/ChildrenContainer.scala
@@ -45,9 +45,15 @@ private[akka] object ChildrenContainer {
   sealed trait SuspendReason
   case object UserRequest extends SuspendReason
   // careful with those system messages, all handling to be taking place in ActorCell.scala!
-  case class Recreation(cause: Throwable, var todo: SystemMessage = null) extends SuspendReason
-  case class Creation(var todo: SystemMessage = null) extends SuspendReason
+  case class Recreation(cause: Throwable) extends SuspendReason with WaitingForChildren
+  case class Creation() extends SuspendReason with WaitingForChildren
   case object Termination extends SuspendReason
+
+  trait WaitingForChildren {
+    var todo: SystemMessage = null
+    def enqueue(message: SystemMessage) = { message.next = todo; todo = message }
+    def dequeueAll(): SystemMessage = { val ret = SystemMessage.reverse(todo); todo = null; ret }
+  }
 
   trait EmptyChildrenContainer extends ChildrenContainer {
     val emptyStats = TreeMap.empty[String, ChildStats]

--- a/akka-actor/src/main/scala/akka/actor/cell/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/cell/FaultHandling.scala
@@ -133,12 +133,9 @@ private[akka] trait FaultHandling { this: ActorCell ⇒
   }
 
   private def finishCreate(): Unit = {
-    try {
-      create(uid)
-    } finally {
-      try resumeNonRecursive()
-      finally clearFailed()
-    }
+    try resumeNonRecursive()
+    finally clearFailed()
+    create(uid)
   }
 
   protected def terminate() {


### PR DESCRIPTION
When failing during the creation of an actor, ensure that both Resume and Restart actually do a Create instead.
