### PR TITLE
Request send/publish of CurrentClusterState, see #2438

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -190,6 +190,24 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
     clusterCore ! InternalClusterAction.Unsubscribe(subscriber)
 
   /**
+   * Publish current (full) state of the cluster to subscribers,
+   * that are subscribing to [[akka.cluster.ClusterEvent.ClusterDomainEvent]]
+   * or [[akka.cluster.ClusterEvent.CurrentClusterState]].
+   * If you want this to happen periodically you need to schedule a call to
+   * this method yourself.
+   */
+  def publishCurrentClusterState(): Unit =
+    clusterCore ! InternalClusterAction.PublishCurrentClusterState(None)
+
+  /**
+   * Publish current (full) state of the cluster to the specified
+   * receiver. If you want this to happen periodically you need to schedule
+   * a call to this method yourself.
+   */
+  def sendCurrentClusterState(receiver: ActorRef): Unit =
+    clusterCore ! InternalClusterAction.PublishCurrentClusterState(Some(receiver))
+
+  /**
    * Try to join this cluster node with the node specified by 'address'.
    * A 'Join(thisNodeAddress)' command is sent to the node to join.
    */

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -177,6 +177,7 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
   def receive = {
     case PublishChanges(oldGossip, newGossip) ⇒ publishChanges(oldGossip, newGossip)
     case currentStats: CurrentInternalStats   ⇒ publishInternalStats(currentStats)
+    case PublishCurrentClusterState(receiver) ⇒ publishCurrentClusterState(receiver)
     case Subscribe(subscriber, to)            ⇒ subscribe(subscriber, to)
     case Unsubscribe(subscriber)              ⇒ unsubscribe(subscriber)
     case PublishDone                          ⇒ sender ! PublishDone
@@ -184,13 +185,21 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
 
   def eventStream: EventStream = context.system.eventStream
 
-  def subscribe(subscriber: ActorRef, to: Class[_]): Unit = {
-    subscriber ! CurrentClusterState(
+  def publishCurrentClusterState(receiver: Option[ActorRef]): Unit = {
+    val state = CurrentClusterState(
       members = latestGossip.members,
       unreachable = latestGossip.overview.unreachable,
       convergence = latestGossip.convergence,
       seenBy = latestGossip.seenBy,
       leader = latestGossip.leader)
+    receiver match {
+      case Some(ref) ⇒ ref ! state
+      case None      ⇒ eventStream publish state
+    }
+  }
+
+  def subscribe(subscriber: ActorRef, to: Class[_]): Unit = {
+    publishCurrentClusterState(Some(subscriber))
     eventStream.subscribe(subscriber, to)
   }
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
@@ -67,21 +67,11 @@ abstract class TransitionSpec
     memberStatus(address) == status
   }
 
-  def leaderActions(): Unit = {
+  def leaderActions(): Unit =
     cluster.clusterCore ! LeaderActionsTick
-    awaitPing()
-  }
 
-  def reapUnreachable(): Unit = {
+  def reapUnreachable(): Unit =
     cluster.clusterCore ! ReapUnreachableTick
-    awaitPing()
-  }
-
-  def awaitPing(): Unit = {
-    val ping = Ping()
-    cluster.clusterCore ! ping
-    expectMsgPF() { case pong @ Pong(`ping`, _) ⇒ pong }
-  }
 
   // DSL sugar for `role1 gossipTo role2`
   implicit def roleExtras(role: RoleName): RoleWrapper = new RoleWrapper(role)


### PR DESCRIPTION
- Added publishCurrentClusterState and sendCurrentClusterState
- Removed Ping/Pong that was used for some tests, since awaitCond is
  now needed anyway, since publish to eventStream is done afterwards
