### PR TITLE
WIP2316 Make multi-jvm-tests compile with normal tests (again)

### DIFF
--- a/akka-docs/dev/multi-jvm-testing.rst
+++ b/akka-docs/dev/multi-jvm-testing.rst
@@ -18,7 +18,7 @@ http://github.com/typesafehub/sbt-multi-jvm
 
 You can add it as a plugin by adding the following to your project/plugins.sbt::
 
-   addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.2.0")
+   addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.0")
 
 You can then add multi-JVM testing to ``project/Build.scala`` by including the ``MultiJvm``
 settings and config. For example, here is an example of how the akka-remote-tests project adds
@@ -47,7 +47,7 @@ multi-JVM testing (Simplified for clarity):
       )
     ) configs (MultiJvm)
 
-    lazy val buildSettings = Defaults.defaultSettings ++ SbtMultiJvm.settings ++ Seq(
+    lazy val buildSettings = Defaults.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ Seq(
       organization := "com.typesafe.akka",
       version      := "2.1-SNAPSHOT",
       scalaVersion := "|scalaVersion|",

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -471,7 +471,7 @@ object AkkaBuild extends Build {
     .setPreference(AlignSingleLineCaseStatements, true)
   }
 
-  lazy val multiJvmSettings = SbtMultiJvm.settings ++ inConfig(MultiJvm)(ScalariformPlugin.scalariformSettings) ++ Seq(
+  lazy val multiJvmSettings = SbtMultiJvm.multiJvmSettings ++ inConfig(MultiJvm)(ScalariformPlugin.scalariformSettings) ++ Seq(
     compileInputs in MultiJvm <<= (compileInputs in MultiJvm) dependsOn (ScalariformKeys.format in MultiJvm),
     compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in Test),
     ScalariformKeys.preferences in MultiJvm := formattingPreferences) ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 resolvers += Classpaths.typesafeResolver
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.2.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.0")
 
 addSbtPlugin("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.4.0")
 


### PR DESCRIPTION
The real change was in the MultiJvmPlugin that was made a "proper" Plugin when I cleaned it up for 0.2.0. That had some unfortunate side effects, like forcing some settings onto the whole project just by being loaded.

Now fixed to behave nicely.
