### PR TITLE
Support load of extensions without specifying trailing $, see #2496

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
@@ -64,6 +64,7 @@ public class JavaExtension {
 
   @Test
   public void mustBeAccessible() {
+    assertTrue(system.hasExtension((TestExtensionId.TestExtensionProvider)));
     assertSame(system.extension(TestExtensionId.TestExtensionProvider).system, system);
     assertSame(TestExtensionId.TestExtensionProvider.apply(system).system, system);
   }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -70,7 +70,7 @@ object ActorSystemSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExtension$"]""") with ImplicitSender {
+class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExtension"]""") with ImplicitSender {
 
   "An ActorSystem" must {
 
@@ -95,9 +95,10 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
     }
 
     "support extensions" in {
+      // TestExtension is configured and should be loaded at startup
+      system.hasExtension(TestExtension) must be(true)
       TestExtension(system).system must be === system
       system.extension(TestExtension).system must be === system
-      system.hasExtension(TestExtension) must be(true)
     }
 
     "run termination callbacks in order" in {

--- a/akka-actor/src/main/scala/akka/actor/DynamicAccess.scala
+++ b/akka-actor/src/main/scala/akka/actor/DynamicAccess.scala
@@ -85,7 +85,10 @@ class ReflectiveDynamicAccess(val classLoader: ClassLoader) extends DynamicAcces
     getClassFor(fqcn) flatMap { c ⇒ createInstanceFor(c, args) }
 
   override def getObjectFor[T: ClassTag](fqcn: String): Try[T] = {
-    getClassFor(fqcn) flatMap { c ⇒
+    val classTry =
+      if (fqcn.endsWith("$")) getClassFor(fqcn)
+      else getClassFor(fqcn + "$") recoverWith { case NonFatal(_) ⇒ getClassFor(fqcn) }
+    classTry flatMap { c ⇒
       Try {
         val module = c.getDeclaredField("MODULE$")
         module.setAccessible(true)

--- a/akka-actor/src/main/scala/akka/actor/DynamicAccess.scala
+++ b/akka-actor/src/main/scala/akka/actor/DynamicAccess.scala
@@ -87,7 +87,7 @@ class ReflectiveDynamicAccess(val classLoader: ClassLoader) extends DynamicAcces
   override def getObjectFor[T: ClassTag](fqcn: String): Try[T] = {
     val classTry =
       if (fqcn.endsWith("$")) getClassFor(fqcn)
-      else getClassFor(fqcn + "$") recoverWith { case NonFatal(_) ⇒ getClassFor(fqcn) }
+      else getClassFor(fqcn + "$") recoverWith { case _ ⇒ getClassFor(fqcn) }
     classTry flatMap { c ⇒
       Try {
         val module = c.getDeclaredField("MODULE$")

--- a/akka-docs/scala/code/docs/extension/ExtensionDocSpec.scala
+++ b/akka-docs/scala/code/docs/extension/ExtensionDocSpec.scala
@@ -45,7 +45,7 @@ object ExtensionDocSpec {
   val config = """
     //#config
     akka {
-      extensions = ["docs.extension.CountExtension$"]
+      extensions = ["docs.extension.CountExtension"]
     }
     //#config
     """

--- a/akka-docs/scala/extending-akka.rst
+++ b/akka-docs/scala/extending-akka.rst
@@ -58,8 +58,6 @@ in the ``akka.extensions`` section of the config you provide to your ``ActorSyst
 .. includecode:: code/docs/extension/ExtensionDocSpec.scala
    :include: config
 
-Note that in this case ``CountExtension`` is an object and therefore the class name ends with ``$``.
-
 Applicability
 =============
 

--- a/akka-samples/akka-sample-cluster/src/main/resources/application.conf
+++ b/akka-samples/akka-sample-cluster/src/main/resources/application.conf
@@ -10,7 +10,7 @@ akka {
     }
   }
 
-  extensions = ["akka.cluster.Cluster$"]
+  extensions = ["akka.cluster.Cluster"]
 
   cluster {
     seed-nodes = [


### PR DESCRIPTION
- Backwards compatible, i.e. still possible to use $
- DynamicAccess tries first with $ in getObjectFor, then falls back
  to fqcn as is
