### PR TITLE
Don't await the write of shutdownSignal to openChannels when shutting netty, see #2535

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/netty/Server.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Server.scala
@@ -72,7 +72,7 @@ private[akka] class NettyRemoteServer(val netty: NettyRemoteTransport) {
           b.setCookie(settings.SecureCookie.get)
         b.build
       }
-      openChannels.write(netty.createControlEnvelope(shutdownSignal)).awaitUninterruptibly
+      openChannels.write(netty.createControlEnvelope(shutdownSignal))
       openChannels.disconnect
       openChannels.close.awaitUninterruptibly
       bootstrap.releaseExternalResources()


### PR DESCRIPTION
- The multi node tests triggered shutdown ordering issue
