### PR TITLE
Race in LeaderLeavingSpec, see #2549

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderLeavingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderLeavingSpec.scala
@@ -56,9 +56,6 @@ abstract class LeaderLeavingSpec
           cluster.leave(oldLeaderAddress)
           enterBarrier("leader-left")
 
-          // verify that a NEW LEADER have taken over
-          awaitCond(!clusterView.isLeader)
-
           // verify that the LEADER is shut down
           awaitCond(!cluster.isRunning)
 


### PR DESCRIPTION
- Since the leaving cluster is shutdown it's not
  possible to use the readView to assert that thing.
- Removed the check, enough verification in other parts of the test
  anyway
