### PR TITLE
Terminate remote deployed actors when parent node goes down, see #2551

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -5,7 +5,7 @@
 package akka.remote
 
 import scala.annotation.tailrec
-import akka.actor.{ VirtualPathContainer, Terminated, Deploy, Props, Nobody, LocalActorRef, InternalActorRef, Address, ActorSystemImpl, ActorRef, ActorPathExtractor, ActorPath, Actor }
+import akka.actor.{ VirtualPathContainer, Terminated, Deploy, Props, Nobody, LocalActorRef, InternalActorRef, Address, ActorSystemImpl, ActorRef, ActorPathExtractor, ActorPath, Actor, AddressTerminated }
 import akka.event.LoggingAdapter
 import akka.dispatch.Watch
 import akka.actor.ActorRefWithCell
@@ -26,9 +26,11 @@ private[akka] class RemoteSystemDaemon(system: ActorSystemImpl, _path: ActorPath
 
   import akka.actor.Guardian._
 
+  @volatile private var terminating = false
+
   system.provider.systemGuardian.tell(RegisterTerminationHook, this)
 
-  @volatile private var terminating = false
+  system.eventStream.subscribe(this, classOf[AddressTerminated])
 
   /**
    * Find the longest matching path which we know about and return that ref
@@ -88,6 +90,9 @@ private[akka] class RemoteSystemDaemon(system: ActorSystemImpl, _path: ActorPath
       terminating = true
       terminationHookDoneWhenNoChildren()
       allChildren foreach system.stop
+
+    case AddressTerminated(address) ⇒
+      allChildren filter { _.asInstanceOf[InternalActorRef].getParent.path.address == address } foreach system.stop
 
     case unknown ⇒ log.warning("Unknown message {} received by {}", unknown, this)
   }

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -92,7 +92,7 @@ private[akka] class RemoteSystemDaemon(system: ActorSystemImpl, _path: ActorPath
       allChildren foreach system.stop
 
     case AddressTerminated(address) ⇒
-      allChildren filter { _.asInstanceOf[InternalActorRef].getParent.path.address == address } foreach system.stop
+      allChildren foreach { case a: InternalActorRef if a.getParent.path.address == address ⇒ system.stop(a) }
 
     case unknown ⇒ log.warning("Unknown message {} received by {}", unknown, this)
   }


### PR DESCRIPTION
- RemoteSystemDaemon listens to AddressTerminated and stops matching children
