### PR TITLE
Clean up remote-deployed children when target node goes down, see #2550

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -217,6 +217,7 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
       }
       val t = probe.expectMsg(Terminated(a)(existenceConfirmed = true, addressTerminated = false))
       t.existenceConfirmed must be(true)
+      t.addressTerminated must be(false)
     }
 
     "shut down when /user escalates" in {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -215,7 +215,7 @@ class ActorSystemSpec extends AkkaSpec("""akka.extensions = ["akka.actor.TestExt
       EventFilter[Exception]("hello", occurrences = 1) intercept {
         a ! "die"
       }
-      val t = probe.expectMsg(Terminated(a)(true))
+      val t = probe.expectMsg(Terminated(a)(existenceConfirmed = true, addressTerminated = false))
       t.existenceConfirmed must be(true)
     }
 

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -65,11 +65,18 @@ case object Kill extends Kill {
  * Terminated message can't be forwarded to another actor, since that actor
  * might not be watching the subject. Instead, if you need to forward Terminated
  * to another actor you should send the information in your own message.
+ *
+ * @param actor the watched actor that terminated
+ * @param existenceConfirmed is false when the Terminated message was not sent
+ *   directly from the watched actor, but derived from another source, such as
+ *   when watching a non-local ActorRef, which might not have been resolved
+ * @param addressTerminated the Terminated message was derived from
+ *   that the remote node hosting the watched actor was detected as unreachable
  */
 @SerialVersionUID(1L)
 case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
   @BeanProperty val existenceConfirmed: Boolean,
-  @BeanProperty val addressTerminated: Boolean = false) extends AutoReceivedMessage
+  @BeanProperty val addressTerminated: Boolean) extends AutoReceivedMessage
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -67,7 +67,9 @@ case object Kill extends Kill {
  * to another actor you should send the information in your own message.
  */
 @SerialVersionUID(1L)
-case class Terminated private[akka] (@BeanProperty actor: ActorRef)(@BeanProperty val existenceConfirmed: Boolean) extends AutoReceivedMessage
+case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
+  @BeanProperty val existenceConfirmed: Boolean,
+  @BeanProperty val addressTerminated: Boolean = false) extends AutoReceivedMessage
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -442,7 +442,7 @@ private[akka] class EmptyLocalActorRef(override val provider: ActorRefProvider,
   protected def specialHandle(msg: Any): Boolean = msg match {
     case w: Watch ⇒
       if (w.watchee == this && w.watcher != this)
-        w.watcher ! Terminated(w.watchee)(existenceConfirmed = false)
+        w.watcher ! Terminated(w.watchee)(existenceConfirmed = false, addressTerminated = false)
       true
     case _: Unwatch ⇒ true // Just ignore
     case _          ⇒ false
@@ -467,7 +467,7 @@ private[akka] class DeadLetterActorRef(_provider: ActorRefProvider,
   override protected def specialHandle(msg: Any): Boolean = msg match {
     case w: Watch ⇒
       if (w.watchee != this && w.watcher != this)
-        w.watcher ! Terminated(w.watchee)(existenceConfirmed = false)
+        w.watcher ! Terminated(w.watchee)(existenceConfirmed = false, addressTerminated = false)
       true
     case w: Unwatch  ⇒ true // Just ignore
     case NullMessage ⇒ true

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -118,7 +118,7 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
     // existenceConfirmed = false because we could have been watching a
     // non-local ActorRef that had never resolved before the other node went down
     for (a ← watching; if a.path.address == address) {
-      self ! Terminated(a)(existenceConfirmed = false)
+      self ! Terminated(a)(existenceConfirmed = false, addressTerminated = true)
     }
   }
 

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -49,7 +49,7 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
 
   protected def tellWatchersWeDied(actor: Actor): Unit = {
     if (!watchedBy.isEmpty) {
-      val terminated = Terminated(self)(existenceConfirmed = true)
+      val terminated = Terminated(self)(existenceConfirmed = true, addressTerminated = false)
       try {
         watchedBy foreach {
           watcher ⇒

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -261,7 +261,7 @@ private[akka] final class PromiseActorRef private (val provider: ActorRefProvide
     case _: Terminate ⇒ stop()
     case Watch(watchee, watcher) ⇒
       if (watchee == this && watcher != this) {
-        if (!addWatcher(watcher)) watcher ! Terminated(watchee)(existenceConfirmed = true)
+        if (!addWatcher(watcher)) watcher ! Terminated(watchee)(existenceConfirmed = true, addressTerminated = false)
       } else System.err.println("BUG: illegal Watch(%s,%s) for %s".format(watchee, watcher, this))
     case Unwatch(watchee, watcher) ⇒
       if (watchee == this && watcher != this) remWatcher(watcher)
@@ -280,7 +280,7 @@ private[akka] final class PromiseActorRef private (val provider: ActorRefProvide
       result tryComplete Failure(new ActorKilledException("Stopped"))
       val watchers = clearWatchers()
       if (!watchers.isEmpty) {
-        val termination = Terminated(this)(existenceConfirmed = true)
+        val termination = Terminated(this)(existenceConfirmed = true, addressTerminated = false)
         watchers foreach { w ⇒ try w.tell(termination, this) catch { case NonFatal(t) ⇒ /* FIXME LOG THIS */ } }
       }
     }

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -76,6 +76,8 @@ private[akka] class RemoteDeploymentWatcher extends Actor {
       // send extra ChildTerminated to the supervisor so that it will remove the child
       if (t.addressTerminated) supervisors(a).sendSystemMessage(ChildTerminated(a))
       supervisors -= a
+
+    case _: Terminated ⇒
   }
 }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -5,19 +5,30 @@ package akka.cluster
 
 import com.typesafe.config.Config
 import akka.ConfigurationException
+import akka.actor.Actor
+import akka.actor.ActorPath
+import akka.actor.ActorRef
 import akka.actor.ActorSystem
+import akka.actor.ActorSystemImpl
 import akka.actor.Deploy
 import akka.actor.DynamicAccess
+import akka.actor.InternalActorRef
 import akka.actor.NoScopeGiven
+import akka.actor.Props
 import akka.actor.Scheduler
 import akka.actor.Scope
+import akka.actor.Terminated
 import akka.cluster.routing.ClusterRouterConfig
+import akka.cluster.routing.ClusterRouterSettings
+import akka.dispatch.ChildTerminated
 import akka.event.EventStream
 import akka.remote.RemoteActorRefProvider
 import akka.remote.RemoteDeployer
 import akka.remote.routing.RemoteRouterConfig
-import akka.cluster.routing.ClusterRouterSettings
 
+/**
+ * INTERNAL API
+ */
 class ClusterActorRefProvider(
   _systemName: String,
   _settings: ActorSystem.Settings,
@@ -26,10 +37,53 @@ class ClusterActorRefProvider(
   _dynamicAccess: DynamicAccess) extends RemoteActorRefProvider(
   _systemName, _settings, _eventStream, _scheduler, _dynamicAccess) {
 
+  @volatile private var remoteDeploymentWatcher: ActorRef = _
+
+  override def init(system: ActorSystemImpl): Unit = {
+    super.init(system)
+
+    remoteDeploymentWatcher = system.systemActorOf(Props[RemoteDeploymentWatcher], "RemoteDeploymentWatcher")
+  }
+
   override val deployer: ClusterDeployer = new ClusterDeployer(settings, dynamicAccess)
+
+  /**
+   * This method is overridden here to keep track of remote deployed actors to
+   * be able to clean up corresponding child references.
+   */
+  override def useActorOnNode(path: ActorPath, props: Props, deploy: Deploy, supervisor: ActorRef): Unit = {
+    super.useActorOnNode(path, props, deploy, supervisor)
+    remoteDeploymentWatcher ! (actorFor(path), supervisor)
+  }
 
 }
 
+/**
+ * INTERNAL API
+ *
+ * Responsible for cleaning up child references of remote deployed actors when remote node
+ * goes down (jvm crash, network failure), i.e. triggered by [[akka.actor.AddressTerminated]].
+ */
+private[akka] class RemoteDeploymentWatcher extends Actor {
+  var supervisors = Map.empty[ActorRef, InternalActorRef]
+
+  def receive = {
+    case (a: ActorRef, supervisor: InternalActorRef) ⇒
+      supervisors += (a -> supervisor)
+      context.watch(a)
+
+    case t @ Terminated(a) if supervisors isDefinedAt a ⇒
+      // send extra ChildTerminated to the supervisor so that it will remove the child
+      if (t.addressTerminated) supervisors(a).sendSystemMessage(ChildTerminated(a))
+      supervisors -= a
+  }
+}
+
+/**
+ * INTERNAL API
+ *
+ * Deployer of cluster aware routers.
+ */
 private[akka] class ClusterDeployer(_settings: ActorSystem.Settings, _pm: DynamicAccess) extends RemoteDeployer(_settings, _pm) {
   override def parseConfig(path: String, config: Config): Option[Deploy] = {
     super.parseConfig(path, config) match {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -14,6 +14,9 @@ import akka.actor.Address
 import akka.actor.RootActorPath
 import akka.actor.Terminated
 import akka.actor.Address
+import akka.remote.RemoteActorRef
+import java.util.concurrent.TimeoutException
+import akka.actor.ActorSystemImpl
 
 object ClusterDeathWatchMultiJvmSpec extends MultiNodeConfig {
   val first = role("first")
@@ -22,6 +25,12 @@ object ClusterDeathWatchMultiJvmSpec extends MultiNodeConfig {
   val fourth = role("fourth")
 
   commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet))
+
+  deployOn(fourth, """/hello.remote = "@first@" """)
+
+  class Hello extends Actor {
+    def receive = Actor.emptyBehavior
+  }
 }
 
 class ClusterDeathWatchMultiJvmNode1 extends ClusterDeathWatchSpec
@@ -112,6 +121,42 @@ abstract class ClusterDeathWatchSpec
       }
 
       enterBarrier("after-3")
+    }
+
+    "be able to shutdown system when using remote deployed actor on node that crash" taggedAs LongRunningTest in {
+      runOn(fourth) {
+        val hello = system.actorOf(Props[Hello], "hello")
+        hello.isInstanceOf[RemoteActorRef] must be(true)
+        hello.path.address must be(address(first))
+        watch(hello)
+        enterBarrier("hello-deployed")
+
+        markNodeAsUnavailable(first)
+        val t = expectMsgType[Terminated]
+        t.actor must be(hello)
+
+        enterBarrier("first-unavailable")
+
+        system.shutdown()
+        val timeout = remaining
+        try system.awaitTermination(timeout) catch {
+          case _: TimeoutException ⇒
+            fail("Failed to stop [%s] within [%s] \n%s".format(system.name, timeout,
+              system.asInstanceOf[ActorSystemImpl].printTree))
+        }
+      }
+
+      runOn(first, second, third) {
+        enterBarrier("hello-deployed")
+        enterBarrier("first-unavailable")
+        runOn(first) {
+          // fourth system will be shutdown, remove to not participate in barriers any more
+          testConductor.removeNode(fourth)
+        }
+
+        enterBarrier("after-4")
+      }
+
     }
 
   }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
@@ -104,9 +104,24 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         expectMsg(destinationA)
       }
       enterBarrier("after-2")
+
+      runOn(first) {
+        testConductor.shutdown(second, 0)
+        enterBarrier("second-shutdown")
+
+        println("## sleeping in master")
+        Thread.sleep(15000)
+        println("## done sleeping in master")
+      }
+
+      runOn(second, third) {
+        enterBarrier("second-shutdown")
+        Thread.sleep(15000)
+      }
+
     }
 
-    "deploy routees to new member nodes in the cluster" taggedAs LongRunningTest in {
+    "deploy routees to new member nodes in the cluster" taggedAs LongRunningTest ignore {
 
       awaitClusterUp(first, second, third)
 
@@ -121,7 +136,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
       enterBarrier("after-3")
     }
 
-    "deploy programatically defined routees to the member nodes in the cluster" taggedAs LongRunningTest in {
+    "deploy programatically defined routees to the member nodes in the cluster" taggedAs LongRunningTest ignore {
       runOn(first) {
         val router2 = system.actorOf(Props[Echo].withRouter(ClusterRouterConfig(local = ConsistentHashingRouter(),
           settings = ClusterRouterSettings(totalInstances = 10, maxInstancesPerNode = 2))), "router2")
@@ -135,7 +150,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
       enterBarrier("after-4")
     }
 
-    "handle combination of configured router and programatically defined hashMapping" taggedAs LongRunningTest in {
+    "handle combination of configured router and programatically defined hashMapping" taggedAs LongRunningTest ignore {
       runOn(first) {
         def hashMapping: ConsistentHashMapping = {
           case s: String ⇒ s
@@ -149,7 +164,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
       enterBarrier("after-5")
     }
 
-    "handle combination of configured router and programatically defined hashMapping and ClusterRouterConfig" taggedAs LongRunningTest in {
+    "handle combination of configured router and programatically defined hashMapping and ClusterRouterConfig" taggedAs LongRunningTest ignore {
       runOn(first) {
         def hashMapping: ConsistentHashMapping = {
           case s: String ⇒ s

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
@@ -104,24 +104,9 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         expectMsg(destinationA)
       }
       enterBarrier("after-2")
-
-      runOn(first) {
-        testConductor.shutdown(second, 0)
-        enterBarrier("second-shutdown")
-
-        println("## sleeping in master")
-        Thread.sleep(15000)
-        println("## done sleeping in master")
-      }
-
-      runOn(second, third) {
-        enterBarrier("second-shutdown")
-        Thread.sleep(15000)
-      }
-
     }
 
-    "deploy routees to new member nodes in the cluster" taggedAs LongRunningTest ignore {
+    "deploy routees to new member nodes in the cluster" taggedAs LongRunningTest in {
 
       awaitClusterUp(first, second, third)
 
@@ -136,7 +121,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
       enterBarrier("after-3")
     }
 
-    "deploy programatically defined routees to the member nodes in the cluster" taggedAs LongRunningTest ignore {
+    "deploy programatically defined routees to the member nodes in the cluster" taggedAs LongRunningTest in {
       runOn(first) {
         val router2 = system.actorOf(Props[Echo].withRouter(ClusterRouterConfig(local = ConsistentHashingRouter(),
           settings = ClusterRouterSettings(totalInstances = 10, maxInstancesPerNode = 2))), "router2")
@@ -150,7 +135,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
       enterBarrier("after-4")
     }
 
-    "handle combination of configured router and programatically defined hashMapping" taggedAs LongRunningTest ignore {
+    "handle combination of configured router and programatically defined hashMapping" taggedAs LongRunningTest in {
       runOn(first) {
         def hashMapping: ConsistentHashMapping = {
           case s: String ⇒ s
@@ -164,7 +149,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
       enterBarrier("after-5")
     }
 
-    "handle combination of configured router and programatically defined hashMapping and ClusterRouterConfig" taggedAs LongRunningTest ignore {
+    "handle combination of configured router and programatically defined hashMapping and ClusterRouterConfig" taggedAs LongRunningTest in {
       runOn(first) {
         def hashMapping: ConsistentHashMapping = {
           case s: String ⇒ s

--- a/akka-remote/src/main/scala/akka/remote/netty/Client.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Client.scala
@@ -213,11 +213,12 @@ private[akka] class ActiveRemoteClient private[akka] (
       reconnectionTimeWindowStart = System.currentTimeMillis
       true
     } else {
-      val timeLeft = (settings.ReconnectionTimeWindow.toMillis - (System.currentTimeMillis - reconnectionTimeWindowStart)) > 0
-      if (timeLeft)
+      val timeLeft = (settings.ReconnectionTimeWindow.toMillis - (System.currentTimeMillis - reconnectionTimeWindowStart))
+      val hasTimeLeft = timeLeft > 0
+      if (hasTimeLeft)
         log.info("Will try to reconnect to remote server for another [{}] milliseconds", timeLeft)
 
-      timeLeft
+      hasTimeLeft
     }
   }
 


### PR DESCRIPTION
- ClusterActorRefProvider watch remote deployed actors and sends
  ChildTerminated when AddressTerminated
- Added addressTerminated flag to Terminated to know when the Terminated
  was generated from a AddressTerminated
- Extra removal of child when the Terminated originates from AddressTerminated
  to support immediate creation of child with same name
