### PR TITLE
Fix issue in ResizeSpec, see #2566

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
@@ -6,6 +6,7 @@ package akka.routing
 import language.postfixOps
 import akka.actor.Actor
 import akka.testkit._
+import akka.testkit.TestEvent._
 import akka.actor.Props
 import scala.concurrent.Await
 import scala.concurrent.util.duration._
@@ -15,6 +16,7 @@ import akka.pattern.ask
 import scala.concurrent.util.Duration
 import java.util.concurrent.TimeoutException
 import scala.concurrent.util.FiniteDuration
+import scala.util.Try
 
 object ResizerSpec {
 
@@ -39,20 +41,20 @@ object ResizerSpec {
     }
   }
 
-  class BusyActor extends Actor {
-    def receive = {
-      case (latch: TestLatch, busy: TestLatch) ⇒
-        latch.countDown()
-        Await.ready(busy, 5 seconds)
-    }
-  }
-
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with ImplicitSender {
 
   import akka.routing.ResizerSpec._
+
+  override def atStartup: Unit = {
+    // when shutting down some Resize messages might hang around
+    system.eventStream.publish(Mute(EventFilter.warning(pattern = ".*Resize")))
+  }
+
+  def routeeSize(router: ActorRef): Int =
+    Await.result(router ? CurrentRoutees, remaining).asInstanceOf[RouterRoutees].routees.size
 
   "DefaultResizer" must {
 
@@ -97,7 +99,6 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
     }
 
     "be possible to define programmatically" in {
-
       val latch = new TestLatch(3)
 
       val resizer = DefaultResizer(
@@ -109,10 +110,10 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       router ! latch
       router ! latch
 
-      Await.ready(latch, 5 seconds)
+      Await.ready(latch, remaining)
 
-      val current = Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees]
-      current.routees.size must be(2)
+      // messagesPerResize is 10 so there is no risk of additional resize
+      routeeSize(router) must be(2)
     }
 
     "be possible to define in configuration" in {
@@ -124,39 +125,9 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       router ! latch
       router ! latch
 
-      Await.ready(latch, 5 seconds)
+      Await.ready(latch, remaining)
 
-      val current = Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees]
-      current.routees.size must be(2)
-    }
-
-    "resize when busy" ignore {
-
-      val busy = new TestLatch(1)
-
-      val resizer = DefaultResizer(
-        lowerBound = 1,
-        upperBound = 3,
-        pressureThreshold = 0,
-        messagesPerResize = 1)
-
-      val router = system.actorOf(Props[BusyActor].withRouter(RoundRobinRouter(resizer = Some(resizer))).withDispatcher("bal-disp"))
-
-      val latch1 = new TestLatch(1)
-      router ! (latch1, busy)
-      Await.ready(latch1, 2 seconds)
-
-      val latch2 = new TestLatch(1)
-      router ! (latch2, busy)
-      Await.ready(latch2, 2 seconds)
-
-      val latch3 = new TestLatch(1)
-      router ! (latch3, busy)
-      Await.ready(latch3, 2 seconds)
-
-      Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees].routees.size must be(3)
-
-      busy.countDown()
+      routeeSize(router) must be(2)
     }
 
     "grow as needed under pressure" in {
@@ -183,29 +154,26 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       router ! "echo"
       expectMsg("reply")
 
-      def routees(r: ActorRef): Int = {
-        r ! CurrentRoutees
-        expectMsgType[RouterRoutees].routees.size
-      }
-
-      routees(router) must be(3)
+      routeeSize(router) must be(resizer.lowerBound)
 
       def loop(loops: Int, d: FiniteDuration) = {
-        for (m ← 0 until loops) router ! d
-        for (m ← 0 until loops) expectMsg(d * 3, "done")
+        for (m ← 0 until loops) {
+          router ! d
+          // sending in too quickly will result in skipped resize due to many resizeInProgress conflicts
+          Thread.sleep(20.millis.dilated.toMillis)
+        }
+        within((((d * loops).asInstanceOf[FiniteDuration] / resizer.lowerBound) + 2.seconds.dilated).asInstanceOf[FiniteDuration]) {
+          for (m ← 0 until loops) expectMsg("done")
+        }
       }
 
       // 2 more should go thru without triggering more
       loop(2, 200 millis)
-
-      routees(router) must be(3)
+      routeeSize(router) must be(resizer.lowerBound)
 
       // a whole bunch should max it out
-      loop(10, 500 millis)
-      awaitCond(routees(router) > 3)
-
-      loop(10, 500 millis)
-      awaitCond(routees(router) == 5)
+      loop(20, 500 millis)
+      routeeSize(router) must be(resizer.upperBound)
     }
 
     "backoff" in {
@@ -228,10 +196,10 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       // put some pressure on the router
       for (m ← 0 to 5) {
         router ! 100
-        Thread.sleep((5 millis).dilated.toMillis)
+        Thread.sleep((20 millis).dilated.toMillis)
       }
 
-      val z = Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees].routees.size
+      val z = routeeSize(router)
       z must be >= (2)
 
       Thread.sleep((300 millis).dilated.toMillis)
@@ -242,12 +210,7 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
         Thread.sleep((500 millis).dilated.toMillis)
       }
 
-      awaitCond(
-        try {
-          Await.result(router ? CurrentRoutees, 5 seconds).asInstanceOf[RouterRoutees].routees.size < (z)
-        } catch {
-          case _: TimeoutException ⇒ false
-        }, 1 minute)
+      awaitCond(Try(routeeSize(router) < (z)).getOrElse(false))
     }
 
   }


### PR DESCRIPTION
- The problem was (probably) that grow under pressure
  was sending in messages too quickly, which caused skipped
  resize due to many resizeInProgress conflicts
- Overall cleanup
