### PR TITLE
EventBus now handles adding and removal better. See #2561

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
@@ -56,9 +56,11 @@ object EventStreamSpec {
 
   trait T
   trait AT extends T
+  trait ATT extends AT
   trait BT extends T
-  class TA
-  class TAATBT extends TA with AT with BT
+  trait BTT extends BT
+  class CC
+  class CCATBT extends CC with ATT with BTT
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
@@ -151,75 +153,75 @@ class EventStreamSpec extends AkkaSpec(EventStreamSpec.config) {
 
     "manage sub-channels using classes and traits (update on subscribe)" in {
       val es = new EventStream(false)
-      val tm1 = new TA
-      val tm2 = new TAATBT
+      val tm1 = new CC
+      val tm2 = new CCATBT
       val a1, a2, a3, a4 = TestProbe()
 
       es.subscribe(a1.ref, classOf[AT]) must be === true
       es.subscribe(a2.ref, classOf[BT]) must be === true
-      es.subscribe(a3.ref, classOf[TA]) must be === true
-      es.subscribe(a4.ref, classOf[TAATBT]) must be === true
+      es.subscribe(a3.ref, classOf[CC]) must be === true
+      es.subscribe(a4.ref, classOf[CCATBT]) must be === true
       es.publish(tm1)
       es.publish(tm2)
       a1.expectMsgType[AT] must be === tm2
       a2.expectMsgType[BT] must be === tm2
-      a3.expectMsgType[TA] must be === tm1
-      a3.expectMsgType[TA] must be === tm2
-      a4.expectMsgType[TAATBT] must be === tm2
+      a3.expectMsgType[CC] must be === tm1
+      a3.expectMsgType[CC] must be === tm2
+      a4.expectMsgType[CCATBT] must be === tm2
       es.unsubscribe(a1.ref, classOf[AT]) must be === true
       es.unsubscribe(a2.ref, classOf[BT]) must be === true
-      es.unsubscribe(a3.ref, classOf[TA]) must be === true
-      es.unsubscribe(a4.ref, classOf[TAATBT]) must be === true
+      es.unsubscribe(a3.ref, classOf[CC]) must be === true
+      es.unsubscribe(a4.ref, classOf[CCATBT]) must be === true
     }
 
     "manage sub-channels using classes and traits (update on unsubscribe)" in {
       val es = new EventStream(false)
-      val tm1 = new TA
-      val tm2 = new TAATBT
+      val tm1 = new CC
+      val tm2 = new CCATBT
       val a1, a2, a3, a4 = TestProbe()
 
       es.subscribe(a1.ref, classOf[AT]) must be === true
       es.subscribe(a2.ref, classOf[BT]) must be === true
-      es.subscribe(a3.ref, classOf[TA]) must be === true
-      es.subscribe(a4.ref, classOf[TAATBT]) must be === true
-      es.unsubscribe(a3.ref, classOf[TA]) must be === true
+      es.subscribe(a3.ref, classOf[CC]) must be === true
+      es.subscribe(a4.ref, classOf[CCATBT]) must be === true
+      es.unsubscribe(a3.ref, classOf[CC]) must be === true
       es.publish(tm1)
       es.publish(tm2)
       a1.expectMsgType[AT] must be === tm2
       a2.expectMsgType[BT] must be === tm2
       a3.expectNoMsg(1 second)
-      a4.expectMsgType[TAATBT] must be === tm2
+      a4.expectMsgType[CCATBT] must be === tm2
       es.unsubscribe(a1.ref, classOf[AT]) must be === true
       es.unsubscribe(a2.ref, classOf[BT]) must be === true
-      es.unsubscribe(a4.ref, classOf[TAATBT]) must be === true
+      es.unsubscribe(a4.ref, classOf[CCATBT]) must be === true
     }
 
     "manage sub-channels using classes and traits (update on unsubscribe all)" in {
       val es = new EventStream(false)
-      val tm1 = new TA
-      val tm2 = new TAATBT
+      val tm1 = new CC
+      val tm2 = new CCATBT
       val a1, a2, a3, a4 = TestProbe()
 
       es.subscribe(a1.ref, classOf[AT]) must be === true
       es.subscribe(a2.ref, classOf[BT]) must be === true
-      es.subscribe(a3.ref, classOf[TA]) must be === true
-      es.subscribe(a4.ref, classOf[TAATBT]) must be === true
+      es.subscribe(a3.ref, classOf[CC]) must be === true
+      es.subscribe(a4.ref, classOf[CCATBT]) must be === true
       es.unsubscribe(a3.ref)
       es.publish(tm1)
       es.publish(tm2)
       a1.expectMsgType[AT] must be === tm2
       a2.expectMsgType[BT] must be === tm2
       a3.expectNoMsg(1 second)
-      a4.expectMsgType[TAATBT] must be === tm2
+      a4.expectMsgType[CCATBT] must be === tm2
       es.unsubscribe(a1.ref, classOf[AT]) must be === true
       es.unsubscribe(a2.ref, classOf[BT]) must be === true
-      es.unsubscribe(a4.ref, classOf[TAATBT]) must be === true
+      es.unsubscribe(a4.ref, classOf[CCATBT]) must be === true
     }
 
     "manage sub-channels using classes and traits (update on publish)" in {
       val es = new EventStream(false)
-      val tm1 = new TA
-      val tm2 = new TAATBT
+      val tm1 = new CC
+      val tm2 = new CCATBT
       val a1, a2 = TestProbe()
 
       es.subscribe(a1.ref, classOf[AT]) must be === true
@@ -232,6 +234,44 @@ class EventStreamSpec extends AkkaSpec(EventStreamSpec.config) {
       es.unsubscribe(a2.ref, classOf[BT]) must be === true
     }
 
+    "manage sub-channels using classes and traits (unsubscribe classes used with trait)" in {
+      val es = new EventStream(false)
+      val tm1 = new CC
+      val tm2 = new CCATBT
+      val a1, a2, a3 = TestProbe()
+
+      es.subscribe(a1.ref, classOf[AT]) must be === true
+      es.subscribe(a2.ref, classOf[BT]) must be === true
+      es.subscribe(a2.ref, classOf[CC]) must be === true
+      es.subscribe(a3.ref, classOf[CC]) must be === true
+      es.unsubscribe(a2.ref, classOf[CC]) must be === true
+      es.unsubscribe(a3.ref, classOf[CCATBT]) must be === true
+      es.publish(tm1)
+      es.publish(tm2)
+      a1.expectMsgType[AT] must be === tm2
+      a2.expectMsgType[BT] must be === tm2
+      a3.expectMsgType[CC] must be === tm1
+      es.unsubscribe(a1.ref, classOf[AT]) must be === true
+      es.unsubscribe(a2.ref, classOf[BT]) must be === true
+      es.unsubscribe(a3.ref, classOf[CC]) must be === true
+    }
+
+    "manage sub-channels using classes and traits (subscribe after publish)" in {
+      val es = new EventStream(false)
+      val tm1 = new CCATBT
+      val a1, a2 = TestProbe()
+
+      es.subscribe(a1.ref, classOf[AT]) must be === true
+      es.publish(tm1)
+      a1.expectMsgType[AT] must be === tm1
+      a2.expectNoMsg(1 second)
+      es.subscribe(a2.ref, classOf[BTT]) must be === true
+      es.publish(tm1)
+      a1.expectMsgType[AT] must be === tm1
+      a2.expectMsgType[BTT] must be === tm1
+      es.unsubscribe(a1.ref, classOf[AT]) must be === true
+      es.unsubscribe(a2.ref, classOf[BTT]) must be === true
+    }
   }
 
   private def verifyLevel(bus: LoggingBus, level: Logging.LogLevel) {

--- a/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
+++ b/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
@@ -132,11 +132,14 @@ private[akka] class SubclassifiedIndex[K, V] private (private var values: Set[V]
   /**
    * Remove value from all keys which are subclasses of the given key.
    *
-   * @return the complete changes that should be inserted in the cache
+   * @return the complete changes that should be updated in the cache
    */
   def removeValue(key: K, value: V): Changes =
+    // the reason for not using the values in the returned diff is that we need to
+    // go through the whole tree to find all values for the "changed" keys in other
+    // parts of the tree as well, since new nodes might have been created
     mergeChangesByKey(innerRemoveValue(key, value)) map {
-      case (k, v) ⇒ (k, findValues(k))
+      case (k, _) ⇒ (k, findValues(k))
     }
 
   // this will return the keys and values to be removed from the cache


### PR DESCRIPTION
- Removing a subscription no longer removes other subscribers from other tree paths by mistake
- Adding a subscription to a super trait after publication of an subclass now correctly registers the subscriber
