### PR TITLE
Removed a couple of println outputs in Logger

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -116,10 +116,8 @@ trait LoggingBus extends ActorEventBus {
       try {
         if (system.settings.DebugUnhandledMessage)
           subscribe(system.systemActorOf(Props(new Actor {
-            println("started" + self)
             def receive = {
               case UnhandledMessage(msg, sender, rcp) ⇒
-                println("got it")
                 publish(Debug(rcp.path.toString, rcp.getClass, "unhandled message from " + sender + ": " + msg))
             }
           }), "UnhandledMessageForwarder"), classOf[UnhandledMessage])


### PR DESCRIPTION
Removed a couple of println methods, we shouldn't be writing random 
stuff to standard output. Especially not stuff like "got it".
