### PR TITLE
Include dispatcher id in thread name of pinned dispatcher, see #2585

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
@@ -25,6 +25,13 @@ object DispatchersSpec {
       thread-pool-dispatcher {
         executor = thread-pool-executor
       }
+      my-pinned-dispatcher {
+        executor = thread-pool-executor
+        type = PinnedDispatcher
+      }
+      balancing-dispatcher {
+        type = BalancingDispatcher
+      }
     }
     """
 
@@ -110,7 +117,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
     "include system name and dispatcher id in thread names for fork-join-executor" in {
       system.actorOf(Props[ThreadNameEcho].withDispatcher("myapp.mydispatcher")) ! "what's the name?"
       val Expected = "(DispatchersSpec-myapp.mydispatcher-[1-9][0-9]*)".r
-      expectMsgPF(5 seconds) {
+      expectMsgPF(remaining) {
         case Expected(x) ⇒
       }
     }
@@ -118,7 +125,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
     "include system name and dispatcher id in thread names for thread-pool-executor" in {
       system.actorOf(Props[ThreadNameEcho].withDispatcher("myapp.thread-pool-dispatcher")) ! "what's the name?"
       val Expected = "(DispatchersSpec-myapp.thread-pool-dispatcher-[1-9][0-9]*)".r
-      expectMsgPF(5 seconds) {
+      expectMsgPF(remaining) {
         case Expected(x) ⇒
       }
     }
@@ -126,7 +133,23 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
     "include system name and dispatcher id in thread names for default-dispatcher" in {
       system.actorOf(Props[ThreadNameEcho]) ! "what's the name?"
       val Expected = "(DispatchersSpec-akka.actor.default-dispatcher-[1-9][0-9]*)".r
-      expectMsgPF(5 seconds) {
+      expectMsgPF(remaining) {
+        case Expected(x) ⇒
+      }
+    }
+
+    "include system name and dispatcher id in thread names for pinned dispatcher" in {
+      system.actorOf(Props[ThreadNameEcho].withDispatcher("myapp.my-pinned-dispatcher")) ! "what's the name?"
+      val Expected = "(DispatchersSpec-myapp.my-pinned-dispatcher-[1-9][0-9]*)".r
+      expectMsgPF(remaining) {
+        case Expected(x) ⇒
+      }
+    }
+
+    "include system name and dispatcher id in thread names for balancing dispatcher" in {
+      system.actorOf(Props[ThreadNameEcho].withDispatcher("myapp.balancing-dispatcher")) ! "what's the name?"
+      val Expected = "(DispatchersSpec-myapp.balancing-dispatcher-[1-9][0-9]*)".r
+      expectMsgPF(remaining) {
         case Expected(x) ⇒
       }
     }

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -472,15 +472,8 @@ class ThreadPoolExecutorConfigurator(config: Config, prerequisites: DispatcherPr
         })(queueFactory ⇒ _.setQueueFactory(queueFactory)))
   }
 
-  def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
-    val tf = threadFactory match {
-      case m: MonitorableThreadFactory ⇒
-        // add the dispatcher id to the thread names
-        m.copy(m.name + "-" + id)
-      case other ⇒ other
-    }
-    threadPoolConfig.createExecutorServiceFactory(id, tf)
-  }
+  def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory =
+    threadPoolConfig.createExecutorServiceFactory(id, threadFactory)
 }
 
 object ForkJoinExecutorConfigurator {

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -88,8 +88,15 @@ case class ThreadPoolConfig(allowCorePoolTimeout: Boolean = ThreadPoolConfig.def
       service
     }
   }
-  final def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory =
-    new ThreadPoolExecutorServiceFactory(threadFactory)
+  final def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
+    val tf = threadFactory match {
+      case m: MonitorableThreadFactory ⇒
+        // add the dispatcher id to the thread names
+        m.copy(m.name + "-" + id)
+      case other ⇒ other
+    }
+    new ThreadPoolExecutorServiceFactory(tf)
+  }
 }
 
 object ThreadPoolConfigBuilder {


### PR DESCRIPTION
- Additional tests
- Moved id append from createExecutorServiceFactory in
  ThreadPoolExecutorConfigurator to ThreadPoolConfig

Review carefully.
I'm not sure if this has any bad implications, the structure of various factories is pretty complex.
It might be too late to do this kind of change for 2.1.
