### PR TITLE
Avoid TestConductorTransport unless needed, see #2586

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
@@ -27,6 +27,8 @@ case class SplitBrainMultiNodeConfig(failureDetectorPuppet: Boolean) extends Mul
           failure-detector.threshold = 4
         }""")).
     withFallback(MultiNodeClusterSpec.clusterConfig(failureDetectorPuppet)))
+
+  testTransport(on = true)
 }
 
 class SplitBrainWithFailureDetectorPuppetMultiJvmNode1 extends SplitBrainSpec(failureDetectorPuppet = true)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/UnreachableNodeRejoinsClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/UnreachableNodeRejoinsClusterSpec.scala
@@ -21,6 +21,8 @@ case class UnreachableNodeRejoinsClusterMultiNodeConfig(failureDetectorPuppet: B
   val fourth = role("fourth")
 
   commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfig))
+
+  testTransport(on = true)
 }
 
 class UnreachableNodeRejoinsClusterWithFailureDetectorPuppetMultiJvmNode1 extends UnreachableNodeRejoinsClusterSpec(failureDetectorPuppet = true)

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -22,6 +22,8 @@ import akka.testkit.TestProbe
 object ReliableProxySpec extends MultiNodeConfig {
   val local = role("local")
   val remote = role("remote")
+
+  testTransport(on = true)
 }
 
 class ReliableProxyMultiJvmNode1 extends ReliableProxySpec

--- a/akka-docs/rst/dev/multi-node-testing.rst
+++ b/akka-docs/rst/dev/multi-node-testing.rst
@@ -207,6 +207,9 @@ surprising ways.
 
   * Don't issue a shutdown of the first node. The first node is the controller and if it shuts down your test will break.
 
+  * To be able to use ``blackhole``, ``passThrough``, and ``throttle`` you must activate the ``TestConductorTranport`` 
+    by specifying ``testTransport(on = true)`` in your MultiNodeConfig.
+
   * Throttling, shutdown and other failure injections can only be done from the first node, which again is the controller.
 
   * Don't ask for the address of a node using ``node(address)`` after the node has been shut down. Grab the address before

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -103,9 +103,6 @@ trait Conductor { this: TestConductorExt ⇒
   }
 
   /**
-   * To use this feature you must activate the TestConductorTranport by
-   * specifying `testTransport(on = true)` in your MultiNodeConfig.
-   *
    * Make the remoting pipeline on the node throttle data sent to or received
    * from the given remote peer. Throttling works by delaying packet submission
    * within the netty pipeline until the packet would have been completely sent
@@ -117,6 +114,10 @@ trait Conductor { this: TestConductorExt ⇒
    * on average), but that is countered by using the actual execution time for
    * determining how much to send, leading to the correct output rate, but with
    * increased latency.
+   *
+   * ====Note====
+   * To use this feature you must activate the `TestConductorTranport`
+   * by specifying `testTransport(on = true)` in your MultiNodeConfig.
    *
    * @param node is the symbolic name of the node which is to be affected
    * @param target is the symbolic name of the other node to which connectivity shall be throttled
@@ -130,13 +131,14 @@ trait Conductor { this: TestConductorExt ⇒
   }
 
   /**
-   * To use this feature you must activate the TestConductorTranport by
-   * specifying `testTransport(on = true)` in your MultiNodeConfig.
-   *
    * Switch the Netty pipeline of the remote support into blackhole mode for
    * sending and/or receiving: it will just drop all messages right before
    * submitting them to the Socket or right after receiving them from the
    * Socket.
+   *
+   * ====Note====
+   * To use this feature you must activate the `TestConductorTranport`
+   * by specifying `testTransport(on = true)` in your MultiNodeConfig.
    *
    * @param node is the symbolic name of the node which is to be affected
    * @param target is the symbolic name of the other node to which connectivity shall be impeded
@@ -154,11 +156,12 @@ trait Conductor { this: TestConductorExt ⇒
         "specifying `testTransport(on = true)` in your MultiNodeConfig.")
 
   /**
-   * To use this feature you must activate the TestConductorTranport by
-   * specifying `testTransport(on = true)` in your MultiNodeConfig.
-   *
    * Switch the Netty pipeline of the remote support into pass through mode for
    * sending and/or receiving.
+   *
+   * ====Note====
+   * To use this feature you must activate the `TestConductorTranport`
+   * by specifying `testTransport(on = true)` in your MultiNodeConfig.
    *
    * @param node is the symbolic name of the node which is to be affected
    * @param target is the symbolic name of the other node to which connectivity shall be impeded

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Extension.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Extension.scala
@@ -29,8 +29,14 @@ object TestConductor extends ExtensionKey[TestConductorExt] {
  * [[akka.actor.Extension]]. Please follow the aforementioned links for
  * more information.
  *
- * <b>This extension requires the `akka.actor.provider`
- * to be a [[akka.remote.RemoteActorRefProvider]].</b>
+ * ====Note====
+ * This extension requires the `akka.actor.provider`
+ * to be a [[akka.remote.RemoteActorRefProvider]].
+ *
+ * To use ``blackhole``, ``passThrough``, and ``throttle`` you must activate the
+ * `TestConductorTranport` by specifying `testTransport(on = true)` in your
+ * MultiNodeConfig.
+ *
  */
 class TestConductorExt(val system: ExtendedActorSystem) extends Extension with Conductor with Player {
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/testconductor/TestConductorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/testconductor/TestConductorSpec.scala
@@ -23,6 +23,8 @@ object TestConductorMultiJvmSpec extends MultiNodeConfig {
 
   val master = role("master")
   val slave = role("slave")
+
+  testTransport(on = true)
 }
 
 class TestConductorMultiJvmNode1 extends TestConductorSpec


### PR DESCRIPTION
- Due to the shutdown issues the TestConductorTransport is by
  default not active, but it's easy to activate it and exception
  will be thrown if trying to use the featues that require it, i.e
  blackhole, passThrow and throttle
- Documented
