### PR TITLE
Fix for "#2579: Scheduler drifts away"

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -146,7 +146,7 @@ class DefaultScheduler(hashedWheelTimer: HashedWheelTimer, log: LoggingAdapter) 
                 if (receiver.isTerminated) log.debug("Could not reschedule message to be sent because receiving actor {} has been terminated.", receiver)
                 else {
                   val driftNanos = System.nanoTime - getAndAdd(delay.toNanos)
-                  scheduleNext(timeout, Duration.fromNanos((delay.toNanos - driftNanos) max 1), continuousCancellable)
+                  scheduleNext(timeout, Duration.fromNanos(Math.max(delay.toNanos - driftNanos, 1)), continuousCancellable)
                 }
               }
             }
@@ -170,7 +170,7 @@ class DefaultScheduler(hashedWheelTimer: HashedWheelTimer, log: LoggingAdapter) 
             override def run = {
               runnable.run()
               val driftNanos = System.nanoTime - getAndAdd(delay.toNanos)
-              scheduleNext(timeout, Duration.fromNanos((delay.toNanos - driftNanos) max 1), continuousCancellable)
+              scheduleNext(timeout, Duration.fromNanos(Math.max(delay.toNanos - driftNanos, 1)), continuousCancellable)
             }
           })
         },


### PR DESCRIPTION
This patch fixes a problem with recurrent scheduling in the akka.
Here is the simple test application: https://github.com/akshaal/akka-scheduler-test

Without the patch, output is:

```
Ticks: 171
Expected: 200
Frequency was 350 instead of 300 milliseconds
Accuracy: 85%
```

With the patch, output is:

```
Ticks: 200
Expected: 200
Actual frequency was 300 instead of expected 300 milliseconds
Accuracy: 100%
```
