### PR TITLE
Logback and slf4j dependencies, see #2615

### DIFF
--- a/akka-docs/rst/java/logging.rst
+++ b/akka-docs/rst/java/logging.rst
@@ -194,8 +194,7 @@ It has one single dependency; the slf4j-api jar. In runtime you also need a SLF4
      <dependency>
        <groupId>ch.qos.logback</groupId>
        <artifactId>logback-classic</artifactId>
-       <version>1.0.4</version>
-       <scope>runtime</scope>
+       <version>1.0.7</version>
      </dependency>
 
 You need to enable the Slf4jEventHandler in the 'event-handlers' element in

--- a/akka-docs/rst/scala/logging.rst
+++ b/akka-docs/rst/scala/logging.rst
@@ -232,7 +232,7 @@ It has one single dependency; the slf4j-api jar. In runtime you also need a SLF4
 
   .. code-block:: scala
 
-     lazy val logback = "ch.qos.logback" % "logback-classic" % "1.0.4" % "runtime"
+     lazy val logback = "ch.qos.logback" % "logback-classic" % "1.0.7"
 
 
 You need to enable the Slf4jEventHandler in the 'event-handlers' element in

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -701,7 +701,7 @@ object Dependency {
   val protobuf      = "com.google.protobuf"         % "protobuf-java"                % "2.4.1"       // New BSD
   val scalaStm      = "org.scala-tools"             % "scala-stm"                    % "0.6" cross CrossVersion.full // Modified BSD (Scala)
 
-  val slf4jApi      = "org.slf4j"                   % "slf4j-api"                    % "1.6.6"       // MIT
+  val slf4jApi      = "org.slf4j"                   % "slf4j-api"                    % "1.7.2"       // MIT
   val zeroMQClient  = "org.zeromq"                  % "zeromq-scala-binding"         % "0.0.6" cross CrossVersion.full // ApacheV2
   val uncommonsMath = "org.uncommons.maths"         % "uncommons-maths"              % "1.2.2a"      // ApacheV2
   val ariesBlueprint = "org.apache.aries.blueprint" % "org.apache.aries.blueprint"   % "0.3.2"       // ApacheV2

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -701,7 +701,7 @@ object Dependency {
   val protobuf      = "com.google.protobuf"         % "protobuf-java"                % "2.4.1"       // New BSD
   val scalaStm      = "org.scala-tools"             % "scala-stm"                    % "0.6" cross CrossVersion.full // Modified BSD (Scala)
 
-  val slf4jApi      = "org.slf4j"                   % "slf4j-api"                    % "1.6.4"       // MIT
+  val slf4jApi      = "org.slf4j"                   % "slf4j-api"                    % "1.6.6"       // MIT
   val zeroMQClient  = "org.zeromq"                  % "zeromq-scala-binding"         % "0.0.6" cross CrossVersion.full // ApacheV2
   val uncommonsMath = "org.uncommons.maths"         % "uncommons-maths"              % "1.2.2a"      // ApacheV2
   val ariesBlueprint = "org.apache.aries.blueprint" % "org.apache.aries.blueprint"   % "0.3.2"       // ApacheV2
@@ -717,7 +717,7 @@ object Dependency {
     val commonsMath = "org.apache.commons"          % "commons-math"                 % "2.1"              % "test" // ApacheV2
     val commonsIo   = "commons-io"                  % "commons-io"                   % "2.0.1"            % "test" // ApacheV2
     val junit       = "junit"                       % "junit"                        % "4.10"             % "test" // Common Public License 1.0
-    val logback     = "ch.qos.logback"              % "logback-classic"              % "1.0.4"            % "test" // EPL 1.0 / LGPL 2.1
+    val logback     = "ch.qos.logback"              % "logback-classic"              % "1.0.7"            % "test" // EPL 1.0 / LGPL 2.1
     val mockito     = "org.mockito"                 % "mockito-all"                  % "1.8.1"            % "test" // MIT
     val scalatest   = "org.scalatest"               % "scalatest"                    % "1.9-2.10.0-M7-B1" % "test" cross CrossVersion.full // ApacheV2
     val scalacheck  = "org.scalacheck"              % "scalacheck"                   % "1.10.0"           % "test" cross CrossVersion.full // New BSD


### PR DESCRIPTION
- Latest slf4j 1.6.6
- Latest logback-classic 1.0.7
- Removed runtime scope for logback in docs
