### PR TITLE
Fix startup timing issue in cluster sample tests, see #2630

### DIFF
--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -85,7 +85,7 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
     }
 
     "show usage of the statsFacade" in within(5 seconds) {
-      val facade = system.actorFor(RootActorPath(node(third).address) / "user" / "statsFacade")
+      val facade = system.actorFor("/user/statsFacade")
 
       // eventually the service should be ok,
       // worker nodes might not be up yet

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -108,7 +108,7 @@ abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
     //#test-statsService
     "show usage of the statsService from one node" in within(5 seconds) {
       runOn(second) {
-        val service = system.actorFor(node(third) / "user" / "statsService")
+        val service = system.actorFor("/user/statsService")
         service ! StatsJob("this is the text that will be analyzed")
         val meanWordLength = expectMsgPF() {
           case StatsResult(meanWordLength) ⇒ meanWordLength
@@ -121,14 +121,14 @@ abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
     //#test-statsService
     
     "show usage of the statsService from all nodes" in within(5 seconds) {
-      val service = system.actorFor(node(third) / "user" / "statsService")
+      val service = system.actorFor("/user/statsService")
       service ! StatsJob("this is the text that will be analyzed")
       val meanWordLength = expectMsgPF() {
         case StatsResult(meanWordLength) ⇒ meanWordLength
       }
       meanWordLength must be(3.875 plusOrMinus 0.001)
 
-      testConductor.enter("done-2")
+      testConductor.enter("done-3")
     }
 
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
@@ -91,7 +91,7 @@ abstract class StatsSampleJapiSpec extends MultiNodeSpec(StatsSampleJapiSpecConf
 
     "show usage of the statsService from one node" in within(5 seconds) {
       runOn(second) {
-        val service = system.actorFor(node(third) / "user" / "statsService")
+        val service = system.actorFor("/user/statsService")
         service ! new StatsJob("this is the text that will be analyzed")
         val meanWordLength = expectMsgPF() {
           case r: StatsResult ⇒ r.getMeanWordLength
@@ -104,7 +104,7 @@ abstract class StatsSampleJapiSpec extends MultiNodeSpec(StatsSampleJapiSpecConf
     //#test-statsService
     
     "show usage of the statsService from all nodes" in within(5 seconds) {
-      val service = system.actorFor(node(third) / "user" / "statsService")
+      val service = system.actorFor("/user/statsService")
       service ! new StatsJob("this is the text that will be analyzed")
       val meanWordLength = expectMsgPF() {
         case r: StatsResult ⇒ r.getMeanWordLength

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
@@ -84,7 +84,7 @@ abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSample
     }
 
     "show usage of the statsFacade" in within(5 seconds) {
-      val facade = system.actorFor(RootActorPath(node(third).address) / "user" / "statsFacade")
+      val facade = system.actorFor("/user/statsFacade")
 
       // eventually the service should be ok,
       // worker nodes might not be up yet

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
@@ -106,7 +106,7 @@ abstract class TransformationSampleSpec extends MultiNodeSpec(TransformationSamp
   }
 
   def assertServiceOk: Unit = {
-    val transformationFrontend = system.actorFor("akka://" + system.name + "/user/frontend")
+    val transformationFrontend = system.actorFor("/user/frontend")
     // eventually the service should be ok,
     // backends might not have registered initially
     awaitCond {

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
@@ -107,7 +107,7 @@ abstract class TransformationSampleJapiSpec extends MultiNodeSpec(Transformation
   }
 
   def assertServiceOk: Unit = {
-    val transformationFrontend = system.actorFor("akka://" + system.name + "/user/frontend")
+    val transformationFrontend = system.actorFor("/user/frontend")
     // eventually the service should be ok,
     // backends might not have registered initially
     awaitCond {


### PR DESCRIPTION
- In the log the StatsJob was sent to deadLetters and that is because
  the target facade is not started yet.
- Simplify the tests by using actorFor of the local actor as entry point.
