### PR TITLE
Eliminate glitch that caused job to be sent to deadletters, see #2630

### DIFF
--- a/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsAggregator.java
+++ b/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsAggregator.java
@@ -25,7 +25,7 @@ public class StatsAggregator extends UntypedActor {
 
   @Override
   public void preStart() {
-    getContext().setReceiveTimeout(Duration.create(10, TimeUnit.SECONDS));
+    getContext().setReceiveTimeout(Duration.create(5, TimeUnit.SECONDS));
   }
 
   @Override

--- a/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
+++ b/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
@@ -22,6 +22,9 @@ import akka.cluster.ClusterEvent.MemberUp
 import akka.cluster.MemberStatus
 import akka.routing.FromConfig
 import akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope
+import akka.pattern.ask
+import akka.pattern.pipe
+import akka.util.Timeout
 //#imports
 
 //#messages
@@ -51,7 +54,7 @@ class StatsService extends Actor {
 
 class StatsAggregator(expectedResults: Int, replyTo: ActorRef) extends Actor {
   var results = IndexedSeq.empty[Int]
-  context.setReceiveTimeout(10 seconds)
+  context.setReceiveTimeout(5 seconds)
 
   def receive = {
     case wordCount: Int ⇒
@@ -88,6 +91,7 @@ class StatsWorker extends Actor {
 
 //#facade
 class StatsFacade extends Actor with ActorLogging {
+  import context.dispatcher
   val cluster = Cluster(context.system)
 
   var currentMaster: Option[ActorRef] = None
@@ -102,7 +106,12 @@ class StatsFacade extends Actor with ActorLogging {
     case job: StatsJob if currentMaster.isEmpty ⇒
       sender ! JobFailed("Service unavailable, try again later")
     case job: StatsJob ⇒
-      currentMaster foreach { _ forward job }
+      implicit val timeout = Timeout(10.seconds)
+      currentMaster foreach {
+        _ ? job recover {
+          case _ ⇒ JobFailed("Service unavailable, try again later")
+        } pipeTo sender
+      }
     case state: CurrentClusterState ⇒
       state.leader foreach updateCurrentMaster
     case LeaderChanged(Some(leaderAddress)) ⇒

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -84,11 +84,11 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
       testConductor.enter("all-up")
     }
 
-    "show usage of the statsFacade" in within(5 seconds) {
+    "show usage of the statsFacade" in within(15 seconds) {
       val facade = system.actorFor(RootActorPath(node(third).address) / "user" / "statsFacade")
 
       // eventually the service should be ok,
-      // worker nodes might not be up yet
+      // service and worker nodes might not be up yet
       awaitCond {
         facade ! StatsJob("this is the text that will be analyzed")
         expectMsgPF() {

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -128,7 +128,7 @@ abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
       }
       meanWordLength must be(3.875 plusOrMinus 0.001)
 
-      testConductor.enter("done-2")
+      testConductor.enter("done-3")
     }
 
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
@@ -111,7 +111,7 @@ abstract class StatsSampleJapiSpec extends MultiNodeSpec(StatsSampleJapiSpecConf
       }
       meanWordLength must be(3.875 plusOrMinus 0.001)
 
-      testConductor.enter("done-2")
+      testConductor.enter("done-3")
     }
 
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
@@ -83,11 +83,11 @@ abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSample
       testConductor.enter("all-up")
     }
 
-    "show usage of the statsFacade" in within(5 seconds) {
+    "show usage of the statsFacade" in within(15 seconds) {
       val facade = system.actorFor(RootActorPath(node(third).address) / "user" / "statsFacade")
 
       // eventually the service should be ok,
-      // worker nodes might not be up yet
+      // service and worker nodes might not be up yet
       awaitCond {
         facade ! new StatsJob("this is the text that will be analyzed")
         expectMsgPF() {


### PR DESCRIPTION
- Cluster sample
- The problem was that the sent job was sometimes sent to deadLetters
- The reason was that statsService was not created when a facade
  at another node forwared the job to the statsService, i.e.
  deadLetters
- Solved by using ask and recover with JobFailed in case of
  timeout in the facade, so that the facade always sends back
  JobResult or JobFailed
