### PR TITLE
Use full address when hashing routees, see #2657

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/ConsistentHash.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHash.scala
@@ -120,8 +120,10 @@ object ConsistentHash {
     apply(nodes.asScala, virtualNodesFactor)(ClassTag(classOf[Any].asInstanceOf[Class[T]]))
   }
 
-  private def nodeHashFor(node: Any, vnode: Int): Int =
-    hashFor((node + ":" + vnode).getBytes("UTF-8"))
+  private def nodeHashFor(node: Any, vnode: Int): Int = {
+    val baseStr = node.toString + ":"
+    hashFor(baseStr + vnode)
+  }
 
   private def hashFor(bytes: Array[Byte]): Int = MurmurHash.arrayHash(bytes)
 


### PR DESCRIPTION
- Problem: ConsistentHashingRouter used on different nodes with remote
  and local routees doesn't route to same targets.
- Reason: Full address, with host and port was not used in the
  representation of the routees, which produced different  hash rings
  on different nodes.
- Solution: Fill in full address in the toString representation for
  LocalActorRef
- IMPORTANT: Discovered that rootPath of the provider didn't include the
  full address. It is documented that it should and I needed that to
  be able to grab the address without depending on remoting. This caused
  changes in RemoteActorRefProvider. Initialization order is a bit scary
  there.
