### PR TITLE
#2659 Limit the number of netty worker threads based on configuration.

### DIFF
--- a/akka-remote-tests/src/main/resources/reference.conf
+++ b/akka-remote-tests/src/main/resources/reference.conf
@@ -29,5 +29,37 @@ akka {
     
     # minimum time interval which is to be inserted between reconnect attempts
     reconnect-backoff = 1s
+
+    netty {
+      # (I&O) Used to configure the number of I/O worker threads on server sockets
+      server-socket-worker-pool {
+        # Min number of threads to cap factor-based number to
+        pool-size-min = 1
+
+        # The pool size factor is used to determine thread pool size
+        # using the following formula: ceil(available processors * factor).
+        # Resulting size is then bounded by the pool-size-min and
+        # pool-size-max values.
+        pool-size-factor = 1.0
+
+        # Max number of threads to cap factor-based number to
+        pool-size-max = 2
+      }
+
+      # (I&O) Used to configure the number of I/O worker threads on client sockets
+      client-socket-worker-pool {
+        # Min number of threads to cap factor-based number to
+        pool-size-min = 1
+
+        # The pool size factor is used to determine thread pool size
+        # using the following formula: ceil(available processors * factor).
+        # Resulting size is then bounded by the pool-size-min and
+        # pool-size-max values.
+        pool-size-factor = 1.0
+
+        # Max number of threads to cap factor-based number to
+        pool-size-max = 2
+      }
+    }
   }
 }

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -391,7 +391,7 @@ private[akka] class Controller(private var initialParticipants: Int, controllerP
   import BarrierCoordinator._
 
   val settings = TestConductor().Settings
-  val connection = RemoteConnection(Server, controllerPort,
+  val connection = RemoteConnection(Server, controllerPort, settings.ServerSocketWorkerPoolSize,
     new ConductorHandler(settings.QueryTimeout, self, Logging(context.system, "ConductorHandler")))
 
   /*

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Extension.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Extension.scala
@@ -6,6 +6,8 @@ import akka.util.Timeout
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.duration.Duration
+import com.typesafe.config.Config
+import akka.dispatch.ThreadPoolConfig
 
 /**
  * Access to the [[akka.remote.testconductor.TestConductorExt]] extension:
@@ -41,15 +43,25 @@ object TestConductor extends ExtensionKey[TestConductorExt] {
 class TestConductorExt(val system: ExtendedActorSystem) extends Extension with Conductor with Player {
 
   object Settings {
-    val config = system.settings.config
+    val config = system.settings.config.getConfig("akka.testconductor")
 
-    val ConnectTimeout = Duration(config.getMilliseconds("akka.testconductor.connect-timeout"), MILLISECONDS)
-    val ClientReconnects = config.getInt("akka.testconductor.client-reconnects")
-    val ReconnectBackoff = Duration(config.getMilliseconds("akka.testconductor.reconnect-backoff"), MILLISECONDS)
+    val ConnectTimeout = Duration(config.getMilliseconds("connect-timeout"), MILLISECONDS)
+    val ClientReconnects = config.getInt("client-reconnects")
+    val ReconnectBackoff = Duration(config.getMilliseconds("reconnect-backoff"), MILLISECONDS)
 
-    implicit val BarrierTimeout = Timeout(Duration(config.getMilliseconds("akka.testconductor.barrier-timeout"), MILLISECONDS))
-    implicit val QueryTimeout = Timeout(Duration(config.getMilliseconds("akka.testconductor.query-timeout"), MILLISECONDS))
-    val PacketSplitThreshold = Duration(config.getMilliseconds("akka.testconductor.packet-split-threshold"), MILLISECONDS)
+    implicit val BarrierTimeout = Timeout(Duration(config.getMilliseconds("barrier-timeout"), MILLISECONDS))
+    implicit val QueryTimeout = Timeout(Duration(config.getMilliseconds("query-timeout"), MILLISECONDS))
+    val PacketSplitThreshold = Duration(config.getMilliseconds("packet-split-threshold"), MILLISECONDS)
+
+    private def computeWPS(config: Config): Int =
+      ThreadPoolConfig.scaledPoolSize(
+        config.getInt("pool-size-min"),
+        config.getDouble("pool-size-factor"),
+        config.getInt("pool-size-max"))
+
+    val ServerSocketWorkerPoolSize = computeWPS(config.getConfig("netty.server-socket-worker-pool"))
+
+    val ClientSocketWorkerPoolSize = computeWPS(config.getConfig("netty.client-socket-worker-pool"))
   }
 
   /**

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
@@ -45,16 +45,18 @@ private[akka] case object Server extends Role
  * INTERNAL API.
  */
 private[akka] object RemoteConnection {
-  def apply(role: Role, sockaddr: InetSocketAddress, handler: ChannelUpstreamHandler): Channel = {
+  def apply(role: Role, sockaddr: InetSocketAddress, poolSize: Int, handler: ChannelUpstreamHandler): Channel = {
     role match {
       case Client ⇒
-        val socketfactory = new NioClientSocketChannelFactory(Executors.newCachedThreadPool, Executors.newCachedThreadPool)
+        val socketfactory = new NioClientSocketChannelFactory(Executors.newCachedThreadPool, Executors.newCachedThreadPool,
+          poolSize)
         val bootstrap = new ClientBootstrap(socketfactory)
         bootstrap.setPipelineFactory(new TestConductorPipelineFactory(handler))
         bootstrap.setOption("tcpNoDelay", true)
         bootstrap.connect(sockaddr).getChannel
       case Server ⇒
-        val socketfactory = new NioServerSocketChannelFactory(Executors.newCachedThreadPool, Executors.newCachedThreadPool)
+        val socketfactory = new NioServerSocketChannelFactory(Executors.newCachedThreadPool, Executors.newCachedThreadPool,
+          poolSize)
         val bootstrap = new ServerBootstrap(socketfactory)
         bootstrap.setPipelineFactory(new TestConductorPipelineFactory(handler))
         bootstrap.setOption("reuseAddress", true)

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -244,6 +244,36 @@ akka {
         # suite (see enabled-algorithms section above)
         random-number-generator = ""
       }
+
+      # (I&O) Used to configure the number of I/O worker threads on server sockets
+      server-socket-worker-pool {
+        # Min number of threads to cap factor-based number to
+        pool-size-min = 2
+
+        # The pool size factor is used to determine thread pool size
+        # using the following formula: ceil(available processors * factor).
+        # Resulting size is then bounded by the pool-size-min and
+        # pool-size-max values.
+        pool-size-factor = 1.0
+
+        # Max number of threads to cap factor-based number to
+        pool-size-max = 8
+      }
+
+      # (I&O) Used to configure the number of I/O worker threads on client sockets
+      client-socket-worker-pool {
+        # Min number of threads to cap factor-based number to
+        pool-size-min = 2
+
+        # The pool size factor is used to determine thread pool size
+        # using the following formula: ceil(available processors * factor).
+        # Resulting size is then bounded by the pool-size-min and
+        # pool-size-max values.
+        pool-size-factor = 1.0
+
+        # Max number of threads to cap factor-based number to
+        pool-size-max = 8
+      }
     }
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
@@ -45,7 +45,8 @@ private[akka] class NettyRemoteTransport(_system: ExtendedActorSystem, _provider
       val d = system.dispatchers.lookup(id)
       new NioClientSocketChannelFactory(d, d)
     case None ⇒
-      new NioClientSocketChannelFactory(Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
+      new NioClientSocketChannelFactory(Executors.newCachedThreadPool(), Executors.newCachedThreadPool(),
+        settings.ClientSocketWorkerPoolSize)
   }
 
   /**

--- a/akka-remote/src/main/scala/akka/remote/netty/Server.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Server.scala
@@ -31,7 +31,8 @@ private[akka] class NettyRemoteServer(val netty: NettyRemoteTransport) {
         val d = netty.system.dispatchers.lookup(id)
         new NioServerSocketChannelFactory(d, d)
       case None ⇒
-        new NioServerSocketChannelFactory(Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
+        new NioServerSocketChannelFactory(Executors.newCachedThreadPool(), Executors.newCachedThreadPool(),
+          settings.ServerSocketWorkerPoolSize)
     }
 
   // group of open channels, used for clean-up

--- a/akka-remote/src/main/scala/akka/remote/netty/Settings.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Settings.scala
@@ -10,6 +10,7 @@ import java.net.InetAddress
 import akka.ConfigurationException
 import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 import scala.concurrent.duration.FiniteDuration
+import akka.dispatch.ThreadPoolConfig
 
 private[akka] class NettySettings(config: Config, val systemName: String) {
 
@@ -139,4 +140,14 @@ private[akka] class NettySettings(config: Config, val systemName: String) {
     }
     enableSSL
   }
+
+  private def computeWPS(config: Config): Int =
+    ThreadPoolConfig.scaledPoolSize(
+      config.getInt("pool-size-min"),
+      config.getDouble("pool-size-factor"),
+      config.getInt("pool-size-max"))
+
+  val ServerSocketWorkerPoolSize = computeWPS(config.getConfig("server-socket-worker-pool"))
+
+  val ClientSocketWorkerPoolSize = computeWPS(config.getConfig("client-socket-worker-pool"))
 }

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -62,7 +62,32 @@ class RemoteConfigSpec extends AkkaSpec(
       WriteBufferLowWaterMark must be(None)
       SendBufferSize must be(None)
       ReceiveBufferSize must be(None)
+      ServerSocketWorkerPoolSize must be >= (2)
+      ServerSocketWorkerPoolSize must be <= (8)
+      ClientSocketWorkerPoolSize must be >= (2)
+      ClientSocketWorkerPoolSize must be <= (8)
     }
 
+    "contain correct configuration values in reference.conf" in {
+      val c = system.asInstanceOf[ExtendedActorSystem].
+        provider.asInstanceOf[RemoteActorRefProvider].
+        remoteSettings.config.getConfig("akka.remote.netty")
+
+      // server-socket-worker-pool
+      {
+        val pool = c.getConfig("server-socket-worker-pool")
+        pool.getInt("pool-size-min") must equal(2)
+        pool.getDouble("pool-size-factor") must equal(1.0)
+        pool.getInt("pool-size-max") must equal(8)
+      }
+
+      // client-socket-worker-pool
+      {
+        val pool = c.getConfig("client-socket-worker-pool")
+        pool.getInt("pool-size-min") must equal(2)
+        pool.getDouble("pool-size-factor") must equal(1.0)
+        pool.getInt("pool-size-max") must equal(8)
+      }
+    }
   }
 }


### PR DESCRIPTION
- The number of threads created by netty in the deafult `NioClientSocketChannelFactory` is 2*CPUs for every connection/server socket.
- I've added configuration options to set the number of worker threads in both the normal remote configuration and in the test conductor extension configuration.
