### PR TITLE
#2655 - Hardinging the LocalActorRefProviderSpec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -43,9 +43,10 @@ class LocalActorRefProviderSpec extends AkkaSpec(LocalActorRefProviderSpec.confi
       val childName = "akka%3A%2F%2FClusterSystem%40127.0.0.1%3A2552"
       val a = system.actorOf(Props(new Actor {
         val child = context.actorOf(Props.empty, name = childName)
-        assert(childName == child.path.name)
         def receive = {
-          case "lookup" ⇒ sender ! context.actorFor(childName)
+          case "lookup" ⇒
+            if (childName == child.path.name) sender ! context.actorFor(childName)
+            else sender ! s"§childName is not ${child.path.name}!"
         }
       }))
       a.tell("lookup", testActor)


### PR DESCRIPTION
Changing the test so that it deterministically fails and if it fails, it gives a decent error message so it can be debugged.
