### PR TITLE
make timing requirements for lenient for ReliableProxySpec, see #2637

### DIFF
--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -122,8 +122,8 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
       enterBarrier("test2b")
       
       runOn(local) {
-        testConductor.throttle(local, remote, Direction.Send, -1)
-        expectTransition(Active, Idle)
+        testConductor.throttle(local, remote, Direction.Send, -1).await
+        within(5 seconds) { expectTransition(Active, Idle) }
       }
       runOn(remote) {
         within(1 second) {
@@ -152,8 +152,8 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
       enterBarrier("test3a")
       
       runOn(local) {
-        testConductor.throttle(local, remote, Direction.Receive, -1)
-        expectTransition(Active, Idle)
+        testConductor.throttle(local, remote, Direction.Receive, -1).await
+        within(5 seconds) { expectTransition(Active, Idle) }
       }
       
       enterBarrier("test3b")


### PR DESCRIPTION
I came to the conclusion that the failure mode was entirely compatible with the test just taking a bit longer than the allotted three seconds (for the failing expectMsg), so
- start the expectMsg only when it can possibly be fulfilled (i.e. add the `.await` for the unthrottling)
- prolong to 5 seconds undilated
