### PR TITLE
Fix bug where ActorSystems created via OsgiActorSystemFactory(ctx).creat...

### DIFF
--- a/akka-osgi-aries/src/main/scala/akka/osgi/aries/blueprint/BlueprintActorSystemFactory.scala
+++ b/akka-osgi-aries/src/main/scala/akka/osgi/aries/blueprint/BlueprintActorSystemFactory.scala
@@ -15,7 +15,9 @@ import com.typesafe.config.{ Config, ConfigFactory }
  * If you're looking for a way to set up Akka using Blueprint without the namespace handler, you should use
  * [[akka.osgi.OsgiActorSystemFactory]] instead.
  */
-class BlueprintActorSystemFactory(context: BundleContext, name: String) extends OsgiActorSystemFactory(context) {
+class BlueprintActorSystemFactory(context: BundleContext, name: String, fallbackClassLoader: Option[ClassLoader]) extends OsgiActorSystemFactory(context, fallbackClassLoader) {
+
+  def this(context: BundleContext, name: String) = this(context, name, Some(OsgiActorSystemFactory.akkaActorClassLoader))
 
   var config: Option[String] = None
 

--- a/akka-osgi/src/main/scala/akka/osgi/OsgiActorSystemFactory.scala
+++ b/akka-osgi/src/main/scala/akka/osgi/OsgiActorSystemFactory.scala
@@ -17,7 +17,7 @@ class OsgiActorSystemFactory(val context: BundleContext) {
   /*
    * Classloader that delegates to the bundle for which the factory is creating an ActorSystem
    */
-  private val classloader = BundleDelegatingClassLoader(context)
+  private val classloader = new BundleDelegatingClassLoader(context.getBundle, Some(classOf[ActorSystem].getClassLoader))
 
   /**
    * Creates the [[akka.actor.ActorSystem]], using the name specified

--- a/akka-osgi/src/main/scala/akka/osgi/OsgiActorSystemFactory.scala
+++ b/akka-osgi/src/main/scala/akka/osgi/OsgiActorSystemFactory.scala
@@ -37,7 +37,7 @@ class OsgiActorSystemFactory(val context: BundleContext, val fallbackClassLoader
    * loaded from the akka-actor bundle.
    */
   def actorSystemConfig(context: BundleContext): Config =
-    ConfigFactory.load(classloader).withFallback(ConfigFactory.defaultReference(classOf[ActorSystem].getClassLoader))
+    ConfigFactory.load(classloader).withFallback(ConfigFactory.defaultReference(OsgiActorSystemFactory.akkaActorClassLoader))
 
   /**
    * Determine the name for the [[akka.actor.ActorSystem]]
@@ -49,8 +49,13 @@ class OsgiActorSystemFactory(val context: BundleContext, val fallbackClassLoader
 }
 
 object OsgiActorSystemFactory {
+  /**
+   * Class loader of akka-actor bundle.
+   */
+  def akkaActorClassLoader = classOf[ActorSystem].getClassLoader
+
   /*
    * Create an [[OsgiActorSystemFactory]] instance to set up Akka in an OSGi environment
    */
-  def apply(context: BundleContext): OsgiActorSystemFactory = new OsgiActorSystemFactory(context, Some(classOf[ActorSystem].getClassLoader))
+  def apply(context: BundleContext): OsgiActorSystemFactory = new OsgiActorSystemFactory(context, Some(akkaActorClassLoader))
 }

--- a/akka-osgi/src/main/scala/akka/osgi/OsgiActorSystemFactory.scala
+++ b/akka-osgi/src/main/scala/akka/osgi/OsgiActorSystemFactory.scala
@@ -12,12 +12,12 @@ import org.osgi.framework.BundleContext
  * Factory class to create ActorSystem implementations in an OSGi environment.  This mainly involves dealing with
  * bundle classloaders appropriately to ensure that configuration files and classes get loaded properly
  */
-class OsgiActorSystemFactory(val context: BundleContext) {
+class OsgiActorSystemFactory(val context: BundleContext, val fallbackClassLoader: Option[ClassLoader]) {
 
   /*
    * Classloader that delegates to the bundle for which the factory is creating an ActorSystem
    */
-  private val classloader = new BundleDelegatingClassLoader(context.getBundle, Some(classOf[ActorSystem].getClassLoader))
+  private val classloader = new BundleDelegatingClassLoader(context.getBundle, fallbackClassLoader)
 
   /**
    * Creates the [[akka.actor.ActorSystem]], using the name specified
@@ -52,5 +52,5 @@ object OsgiActorSystemFactory {
   /*
    * Create an [[OsgiActorSystemFactory]] instance to set up Akka in an OSGi environment
    */
-  def apply(context: BundleContext): OsgiActorSystemFactory = new OsgiActorSystemFactory(context)
+  def apply(context: BundleContext): OsgiActorSystemFactory = new OsgiActorSystemFactory(context, Some(classOf[ActorSystem].getClassLoader))
 }


### PR DESCRIPTION
...eActorSystem fail to load akka.event classes unless bundle imports akka.event package.

Specifically, when using OsgiActorSystemFactory(ctx).createActorSystem(Some("name")) in a bundle who does not import akka.event, I get the following exception:

Caused by: akka.ConfigurationException: Could not start Event Handler due to [9962cf05-ca32-48e6-9643-417e51494acfakka.ConfigurationException: Event Handler specified in config can't be loaded [akka.event.Logging$DefaultLogger] due to [java.lang.ClassNotFoundException: akka.event.Logging$DefaultLogger from bundle 19 (my-bundle-name)]]
        at akka.event.LoggingBus$class.startDefaultLoggers(Logging.scala:135) ~[na:na]
        at akka.event.EventStream.startDefaultLoggers(EventStream.scala:26) ~[na:na]
        at akka.actor.LocalActorRefProvider.init(ActorRefProvider.scala:549) ~[na:na]
        at akka.actor.ActorSystemImpl._start$lzycompute(ActorSystem.scala:584) ~[na:na]
        at akka.actor.ActorSystemImpl._start(ActorSystem.scala:582) ~[na:na]
        at akka.actor.ActorSystemImpl.start(ActorSystem.scala:591) ~[na:na]
        at akka.actor.ActorSystem$.apply(ActorSystem.scala:111) ~[na:na]
        at akka.osgi.OsgiActorSystemFactory.createActorSystem(OsgiActorSystemFactory.scala:33) ~[na:na]

This is using Scala 2.10.0-RC2 with Akka 2.1.0-RC2 on Equinox 3.7.

The patch fixes this by backing the bundle classloader with the classloader of akka-actor.  The patch is for the 2.1 branch but it cleanly applies to master as well.
