### PR TITLE
#2729 - Removing uses of Future.either in favor of firstCompletedOf

### DIFF
--- a/akka-docs/rst/java/code/docs/future/FutureDocTestBase.java
+++ b/akka-docs/rst/java/code/docs/future/FutureDocTestBase.java
@@ -43,10 +43,10 @@ import scala.concurrent.ExecutionContext$;
 
 //#imports8
 import static akka.pattern.Patterns.after;
+import java.util.Arrays;
 //#imports8
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -564,7 +564,7 @@ public class FutureDocTestBase {
         return "foo";
       }
     }, ec);
-    Future<String> result = future.either(delayed);
+    Future<String> result = Futures.firstCompletedOf(Arrays.asList(future, delayed), ec);
     //#after
     Await.result(result, Duration.create(2, SECONDS));
   }

--- a/akka-docs/rst/scala/code/docs/future/FutureDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/future/FutureDocSpec.scala
@@ -417,7 +417,7 @@ class FutureDocSpec extends AkkaSpec {
     val delayed = after(200 millis, using = system.scheduler)(Future.failed(
       new IllegalStateException("OHNOES")))
     val future = Future { Thread.sleep(1000); "foo" }
-    val result = future either delayed
+    val result = Future firstCompletedOf Seq(future, delayed)
     //#after
     intercept[IllegalStateException] { Await.result(result, 2 second) }
   }


### PR DESCRIPTION
Should be backported to 2.1
