### PR TITLE
add ActorRefProvider.getDefaultAddress, see #2732

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -146,6 +146,11 @@ trait ActorRefProvider {
    * attempt is made to verify actual reachability).
    */
   def getExternalAddressFor(addr: Address): Option[Address]
+
+  /**
+   * Obtain the external address of the default transport.
+   */
+  def getDefaultAddress: Address
 }
 
 /**
@@ -597,4 +602,6 @@ class LocalActorRefProvider(
   }
 
   def getExternalAddressFor(addr: Address): Option[Address] = if (addr == rootPath.address) Some(addr) else None
+
+  def getDefaultAddress: Address = rootPath.address
 }

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -42,8 +42,7 @@ trait ActorRefProvider {
   def deadLetters: ActorRef
 
   /**
-   * The root path for all actors within this actor system, including remote
-   * address if enabled.
+   * The root path for all actors within this actor system, not including any remote address information.
    */
   def rootPath: ActorPath
 
@@ -322,6 +321,10 @@ private[akka] object SystemGuardian {
 
 /**
  * Local ActorRef provider.
+ * 
+ * INTERNAL API!
+ * 
+ * Depending on this class is not supported, only the [[ActorRefProvider]] interface is supported.
  */
 class LocalActorRefProvider(
   _systemName: String,

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashingRouter.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashingRouter.scala
@@ -237,7 +237,7 @@ trait ConsistentHashingLike { this: RouterConfig ⇒
     }
 
     val log = Logging(routeeProvider.context.system, routeeProvider.context.self)
-    val selfAddress = routeeProvider.context.system.asInstanceOf[ExtendedActorSystem].provider.rootPath.address
+    val selfAddress = routeeProvider.context.system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
     val vnodes =
       if (virtualNodesFactor == 0) routeeProvider.context.system.settings.DefaultVirtualNodesFactor
       else virtualNodesFactor

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -14,6 +14,10 @@ import scala.util.control.NonFatal
 
 /**
  * Remote ActorRefProvider. Starts up actor on remote node and creates a RemoteActorRef representing it.
+ * 
+ * INTERNAL API!
+ * 
+ * Depending on this class is not supported, only the [[ActorRefProvider]] interface is supported.
  */
 class RemoteActorRefProvider(
   val systemName: String,


### PR DESCRIPTION
must be backported to 2.1
- use it in ConsistentHashingRouter instead of relying on
  provider.rootPath.address
- remove transport.address from RemoteActorRefProvider.rootPath
