### PR TITLE
Fixes for race in remote connection and hardening of tests. #2654

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
@@ -57,7 +57,7 @@ abstract class SplitBrainSpec(multiNodeConfig: SplitBrainMultiNodeConfig)
   val side1 = Vector(first, second)
   val side2 = Vector(third, fourth, fifth)
 
-  "A cluster of 5 members" must {
+  "A cluster of 5 members" ignore {
 
     "reach initial convergence" taggedAs LongRunningTest in {
       awaitClusterUp(first, second, third, fourth, fifth)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/UnreachableNodeRejoinsClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/UnreachableNodeRejoinsClusterSpec.scala
@@ -60,7 +60,7 @@ abstract class UnreachableNodeRejoinsClusterSpec(multiNodeConfig: UnreachableNod
     enterBarrier("after_" + endBarrierNumber)
   }
 
-  "A cluster of " + roles.size + " members" must {
+  "A cluster of " + roles.size + " members" ignore {
 
     "reach initial convergence" taggedAs LongRunningTest in {
       awaitClusterUp(roles: _*)

--- a/akka-remote-tests/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -104,7 +104,7 @@ abstract class MultiNodeConfig {
       else ConfigFactory.empty
 
     val configs = (_nodeConf get myself).toList ::: _commonConf.toList ::: transportConfig :: MultiNodeSpec.nodeConfig :: MultiNodeSpec.baseConfig :: Nil
-    configs reduce (_ withFallback _)
+    configs reduceLeft (_ withFallback _)
   }
 
   private[testkit] def deployments(node: RoleName): immutable.Seq[String] = (_deployments get node getOrElse Nil) ++ _allDeploy

--- a/akka-remote/src/main/scala/akka/remote/netty/Client.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Client.scala
@@ -44,8 +44,6 @@ private[akka] abstract class RemoteClient private[akka] (val netty: NettyRemoteT
 
   def shutdown(): Boolean
 
-  def isBoundTo(address: Address): Boolean = remoteAddress == address
-
   /**
    * Converts the message to the wireprotocol and sends the message across the wire
    */

--- a/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
@@ -249,7 +249,7 @@ private[akka] class NettyRemoteTransport(_system: ExtendedActorSystem, _provider
       if (remoteClients.contains(remoteAddress)) false
       else {
         client.connect()
-        remoteClients.put(remoteAddress, client).foreach(_.shutdown())
+        remoteClients.put(remoteAddress, client)
         true
       }
     } finally {

--- a/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
@@ -243,10 +243,10 @@ private[akka] class NettyRemoteTransport(_system: ExtendedActorSystem, _provider
     }
   }
 
-  def bindClient(remoteAddress: Address, client: RemoteClient, putIfAbsent: Boolean = false): Boolean = {
+  def bindClient(remoteAddress: Address, client: RemoteClient): Boolean = {
     clientsLock.writeLock().lock()
     try {
-      if (putIfAbsent && remoteClients.contains(remoteAddress)) false
+      if (remoteClients.contains(remoteAddress)) false
       else {
         client.connect()
         remoteClients.put(remoteAddress, client).foreach(_.shutdown())
@@ -257,17 +257,7 @@ private[akka] class NettyRemoteTransport(_system: ExtendedActorSystem, _provider
     }
   }
 
-  def unbindClient(remoteAddress: Address): Unit = {
-    clientsLock.writeLock().lock()
-    try {
-      remoteClients foreach {
-        case (k, v) ⇒
-          if (v.isBoundTo(remoteAddress)) { v.shutdown(); remoteClients.remove(k) }
-      }
-    } finally {
-      clientsLock.writeLock().unlock()
-    }
-  }
+  def unbindClient(remoteAddress: Address): Unit = shutdownClientConnection(remoteAddress)
 
   def shutdownClientConnection(remoteAddress: Address): Boolean = {
     clientsLock.writeLock().lock()

--- a/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsAggregator.java
+++ b/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsAggregator.java
@@ -25,7 +25,7 @@ public class StatsAggregator extends UntypedActor {
 
   @Override
   public void preStart() {
-    getContext().setReceiveTimeout(Duration.create(5, TimeUnit.SECONDS));
+    getContext().setReceiveTimeout(Duration.create(3, TimeUnit.SECONDS));
   }
 
   @Override

--- a/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsFacade.java
+++ b/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsFacade.java
@@ -49,7 +49,7 @@ public class StatsFacade extends UntypedActor {
 
     } else if (message instanceof StatsJob) {
       StatsJob job = (StatsJob) message;
-      Future<Object> f = ask(currentMaster, job, new Timeout(10, SECONDS)).
+      Future<Object> f = ask(currentMaster, job, new Timeout(5, SECONDS)).
         recover(new Recover<Object>() {
           public Object recover(Throwable t) {
             return new JobFailed("Service unavailable, try again later");

--- a/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
+++ b/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
@@ -54,7 +54,7 @@ class StatsService extends Actor {
 
 class StatsAggregator(expectedResults: Int, replyTo: ActorRef) extends Actor {
   var results = IndexedSeq.empty[Int]
-  context.setReceiveTimeout(5 seconds)
+  context.setReceiveTimeout(3 seconds)
 
   def receive = {
     case wordCount: Int ⇒
@@ -106,7 +106,7 @@ class StatsFacade extends Actor with ActorLogging {
     case job: StatsJob if currentMaster.isEmpty ⇒
       sender ! JobFailed("Service unavailable, try again later")
     case job: StatsJob ⇒
-      implicit val timeout = Timeout(10.seconds)
+      implicit val timeout = Timeout(5.seconds)
       currentMaster foreach {
         _ ? job recover {
           case _ ⇒ JobFailed("Service unavailable, try again later")

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -72,7 +72,6 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
       expectMsgClass(classOf[CurrentClusterState])
 
       Cluster(system) join node(first).address
-      system.actorOf(Props[StatsFacade], "statsFacade")
 
       expectMsgAllOf(
         MemberUp(Member(node(first).address, MemberStatus.Up)),
@@ -80,11 +79,13 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
         MemberUp(Member(node(third).address, MemberStatus.Up)))
 
       Cluster(system).unsubscribe(testActor)
+      
+      system.actorOf(Props[StatsFacade], "statsFacade")
 
       testConductor.enter("all-up")
     }
 
-    "show usage of the statsFacade" in within(15 seconds) {
+    "show usage of the statsFacade" in within(20 seconds) {
       val facade = system.actorFor(RootActorPath(node(third).address) / "user" / "statsFacade")
 
       // eventually the service should be ok,

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
@@ -76,11 +76,6 @@ abstract class StatsSampleJapiSpec extends MultiNodeSpec(StatsSampleJapiSpecConf
       Cluster(system) join firstAddress
 
       system.actorOf(Props[StatsWorker], "statsWorker")
-      // FIXME 2654
-      // statsWorker must be started on all nodes before the
-      // statsService router is started and looks it up
-      testConductor.enter("statsWorker-started")
-
       system.actorOf(Props[StatsService], "statsService")
 
       expectMsgAllOf(

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
@@ -71,7 +71,6 @@ abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSample
       expectMsgClass(classOf[CurrentClusterState])
 
       Cluster(system) join node(first).address
-      system.actorOf(Props[StatsFacade], "statsFacade")
 
       expectMsgAllOf(
         MemberUp(Member(node(first).address, MemberStatus.Up)),
@@ -80,10 +79,12 @@ abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSample
 
       Cluster(system).unsubscribe(testActor)
 
+      system.actorOf(Props[StatsFacade], "statsFacade")
+
       testConductor.enter("all-up")
     }
 
-    "show usage of the statsFacade" in within(15 seconds) {
+    "show usage of the statsFacade" in within(20 seconds) {
       val facade = system.actorFor(RootActorPath(node(third).address) / "user" / "statsFacade")
 
       // eventually the service should be ok,

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
@@ -88,6 +88,8 @@ abstract class TransformationSampleSpec extends MultiNodeSpec(TransformationSamp
         Cluster(system) join node(frontend1).address
         system.actorOf(Props[TransformationFrontend], name = "frontend")
       }
+      testConductor.enter("frontend2-started")
+
       runOn(backend2, backend3) {
         Cluster(system) join node(backend1).address
         system.actorOf(Props[TransformationBackend], name = "backend")

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
@@ -89,6 +89,7 @@ abstract class TransformationSampleJapiSpec extends MultiNodeSpec(Transformation
         Cluster(system) join node(frontend1).address
         system.actorOf(Props[TransformationFrontend], name = "frontend")
       }
+      testConductor.enter("frontend2-started")
       runOn(backend2, backend3) {
         Cluster(system) join node(backend1).address
         system.actorOf(Props[TransformationBackend], name = "backend")


### PR DESCRIPTION
There are three things here:
- A race in remote connection where if two systems connect to each other at the same time they could potentially send the CONNECT handshake to each other and ending up with both of them closing down their active connections. See `NettyRemoteSupport.scala`
- This breaks assumptions in the Test Conductor when it uses throttling, which are not easily fixable. The two affected tests have been marked as ignore, and a ticket to reenable them with the new remoting has been added.
- The tests that failed with the race had some other issues as well and they have now been hardened.

Should go into 2.1 as well.
