### PR TITLE
#2739 fix for producer bug in restart of producer

### DIFF
--- a/akka-camel/src/main/scala/akka/camel/ActorNotRegisteredException.scala
+++ b/akka-camel/src/main/scala/akka/camel/ActorNotRegisteredException.scala
@@ -3,7 +3,6 @@ package akka.camel
  * Thrown to indicate that the actor referenced by an endpoint URI cannot be
  * found in the actor system.
  *
- * @author Martin Krasser
  */
 class ActorNotRegisteredException(uri: String) extends RuntimeException {
   override def getMessage: String = "Actor [%s] doesn't exist" format uri

--- a/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
+++ b/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
@@ -14,7 +14,6 @@ import akka.dispatch.Mapper
 
 /**
  * An immutable representation of a Camel message.
- * @author Martin Krasser
  */
 case class CamelMessage(body: Any, headers: Map[String, Any]) {
   def this(body: Any, headers: JMap[String, Any]) = this(body, headers.toMap) //for Java
@@ -138,7 +137,6 @@ case class CamelMessage(body: Any, headers: Map[String, Any]) {
 /**
  * Companion object of CamelMessage class.
  *
- * @author Martin Krasser
  */
 object CamelMessage {
 
@@ -182,7 +180,7 @@ object CamelMessage {
 /**
  * Positive acknowledgement message (used for application-acknowledged message receipts).
  * When `autoAck` is set to false in the [[akka.camel.Consumer]], you can send an `Ack` to the sender of the CamelMessage.
- * @author Martin Krasser
+ *
  */
 case object Ack {
   /** Java API to get the Ack singleton */

--- a/akka-camel/src/main/scala/akka/camel/Consumer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Consumer.scala
@@ -13,7 +13,7 @@ import akka.dispatch.Mapper
 /**
  * Mixed in by Actor implementations that consume message from Camel endpoints.
  *
- * @author Martin Krasser
+ *
  */
 trait Consumer extends Actor with CamelSupport {
   import Consumer._

--- a/akka-camel/src/main/scala/akka/camel/Producer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Producer.scala
@@ -13,8 +13,6 @@ import org.apache.camel.processor.SendProcessor
 
 /**
  * Support trait for producing messages to Camel endpoints.
- *
- * @author Martin Krasser
  */
 trait ProducerSupport extends Actor with CamelSupport {
   private[this] var messages = Map[ActorRef, Any]()
@@ -160,20 +158,20 @@ trait Producer extends ProducerSupport { this: Actor ⇒
 
 /**
  * For internal use only.
- * @author Martin Krasser
+ *
  */
 private case class MessageResult(message: CamelMessage) extends NoSerializationVerificationNeeded
 
 /**
  * For internal use only.
- * @author Martin Krasser
+ *
  */
 private case class FailureResult(cause: Throwable, headers: Map[String, Any] = Map.empty) extends NoSerializationVerificationNeeded
 
 /**
  * A one-way producer.
  *
- * @author Martin Krasser
+ *
  */
 trait Oneway extends Producer { this: Actor ⇒
   override def oneway: Boolean = true

--- a/akka-camel/src/main/scala/akka/camel/internal/CamelExchangeAdapter.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/CamelExchangeAdapter.scala
@@ -11,7 +11,7 @@ import akka.camel.{ FailureResult, AkkaCamelException, CamelMessage }
  *  This adapter is used to convert to immutable messages to be used with Actors, and convert the immutable messages back
  *  to org.apache.camel.Message when using Camel.
  *
- * @author Martin Krasser
+ *
  */
 private[camel] class CamelExchangeAdapter(val exchange: Exchange) {
   /**

--- a/akka-camel/src/main/scala/akka/camel/internal/ConsumerActorRouteBuilder.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/ConsumerActorRouteBuilder.scala
@@ -16,7 +16,7 @@ import org.apache.camel.model.RouteDefinition
  *
  * @param endpointUri endpoint URI of the consumer actor.
  *
- * @author Martin Krasser
+ *
  */
 private[camel] class ConsumerActorRouteBuilder(endpointUri: String, consumer: ActorRef, config: ConsumerConfig, settings: CamelSettings) extends RouteBuilder {
 

--- a/akka-camel/src/main/scala/akka/camel/internal/component/ActorComponent.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/component/ActorComponent.scala
@@ -31,7 +31,7 @@ import scala.util.{ Failure, Success, Try }
  * Messages are sent to [[akka.camel.Consumer]] actors through a [[akka.camel.internal.component.ActorEndpoint]] that
  * this component provides.
  *
- * @author Martin Krasser
+ *
  */
 private[camel] class ActorComponent(camel: Camel, system: ActorSystem) extends DefaultComponent {
   /**
@@ -52,7 +52,7 @@ private[camel] class ActorComponent(camel: Camel, system: ActorSystem) extends D
  * <code>[actorPath]?[options]%s</code>,
  * where <code>[actorPath]</code> refers to the actor path to the actor.
  *
- * @author Martin Krasser
+ *
  */
 private[camel] class ActorEndpoint(uri: String,
                                    comp: ActorComponent,
@@ -104,7 +104,7 @@ private[camel] trait ActorEndpointConfig {
  * @see akka.camel.component.ActorComponent
  * @see akka.camel.component.ActorEndpoint
  *
- * @author Martin Krasser
+ *
  */
 private[camel] class ActorProducer(val endpoint: ActorEndpoint, camel: Camel) extends DefaultProducer(endpoint) with AsyncProcessor {
   /**

--- a/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
+++ b/akka-camel/src/main/scala/akka/camel/javaapi/UntypedProducerActor.scala
@@ -12,7 +12,7 @@ import org.apache.camel.impl.DefaultCamelContext
 /**
  * Subclass this abstract class to create an untyped producer actor. This class is meant to be used from Java.
  *
- * @author Martin Krasser
+ *
  */
 abstract class UntypedProducerActor extends UntypedActor with ProducerSupport {
   /**

--- a/akka-camel/src/test/java/akka/camel/ConsumerJavaTestBase.java
+++ b/akka-camel/src/test/java/akka/camel/ConsumerJavaTestBase.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 import akka.testkit.AkkaSpec;
 import static org.junit.Assert.*;
 /**
- * @author Martin Krasser
+ *
  */
 public class ConsumerJavaTestBase {
 

--- a/akka-camel/src/test/java/akka/camel/MessageJavaTestBase.java
+++ b/akka-camel/src/test/java/akka/camel/MessageJavaTestBase.java
@@ -18,7 +18,7 @@ import java.util.*;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Martin Krasser
+ *
  */
 public class MessageJavaTestBase {
     static Camel camel;

--- a/akka-camel/src/test/java/akka/camel/SampleErrorHandlingConsumer.java
+++ b/akka-camel/src/test/java/akka/camel/SampleErrorHandlingConsumer.java
@@ -15,7 +15,7 @@ import scala.Option;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
- * @author Martin Krasser
+ *
  */
 public class SampleErrorHandlingConsumer extends UntypedConsumerActor {
     private static Mapper<RouteDefinition, ProcessorDefinition<?>> mapper = new Mapper<RouteDefinition, ProcessorDefinition<?>>() {

--- a/akka-camel/src/test/java/akka/camel/SampleUntypedConsumer.java
+++ b/akka-camel/src/test/java/akka/camel/SampleUntypedConsumer.java
@@ -7,7 +7,7 @@ package akka.camel;
 import akka.camel.javaapi.UntypedConsumerActor;
 
 /**
- * @author Martin Krasser
+ *
  */
 public class SampleUntypedConsumer extends UntypedConsumerActor {
 

--- a/akka-camel/src/test/java/akka/camel/SampleUntypedForwardingProducer.java
+++ b/akka-camel/src/test/java/akka/camel/SampleUntypedForwardingProducer.java
@@ -6,7 +6,7 @@ package akka.camel;
 
 import akka.camel.javaapi.UntypedProducerActor;
 /**
- * @author Martin Krasser
+ *
  */
 public class SampleUntypedForwardingProducer extends UntypedProducerActor {
 

--- a/akka-camel/src/test/java/akka/camel/SampleUntypedReplyingProducer.java
+++ b/akka-camel/src/test/java/akka/camel/SampleUntypedReplyingProducer.java
@@ -7,7 +7,7 @@ package akka.camel;
 import akka.camel.javaapi.UntypedProducerActor;
 
 /**
- * @author Martin Krasser
+ *
  */
 public class SampleUntypedReplyingProducer extends UntypedProducerActor {
 

--- a/akka-camel/src/test/scala/akka/camel/ConsumerIntegrationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConsumerIntegrationTest.scala
@@ -30,7 +30,7 @@ class ConsumerIntegrationTest extends WordSpec with MustMatchers with NonSharedC
 
     "Consumer must throw FailedToCreateRouteException, while awaiting activation, if endpoint is invalid" in {
       filterEvents(EventFilter[ActorActivationException](occurrences = 1)) {
-        val actorRef = system.actorOf(Props(new TestActor(uri = "some invalid uri")))
+        val actorRef = system.actorOf(Props(new TestActor(uri = "some invalid uri")), "invalidActor")
         intercept[FailedToCreateRouteException] {
           Await.result(camel.activationFutureFor(actorRef), defaultTimeoutDuration)
         }

--- a/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
@@ -19,13 +19,20 @@ import scala.concurrent.duration._
 import akka.util.Timeout
 import org.scalatest.matchers.MustMatchers
 import akka.testkit._
+import akka.actor.Status.Failure
 
 /**
  * Tests the features of the Camel Producer.
  */
-class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAndAfterEach with SharedCamelSystem with MustMatchers {
+class ProducerFeatureTest extends TestKit(ActorSystem("test", AkkaSpec.testConf)) with WordSpec with BeforeAndAfterAll with BeforeAndAfterEach with MustMatchers {
 
   import ProducerFeatureTest._
+  implicit def camel = CamelExtension(system)
+
+  override protected def afterAll() {
+    super.afterAll()
+    system.shutdown()
+  }
 
   val camelContext = camel.context
   // to make testing equality of messages easier, otherwise the breadcrumb shows up in the result.
@@ -40,9 +47,8 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
     "produce a message and receive normal response" in {
       val producer = system.actorOf(Props(new TestProducer("direct:producer-test-2", true)), name = "direct-producer-2")
       val message = CamelMessage("test", Map(CamelMessage.MessageExchangeId -> "123"))
-      val future = producer.ask(message)(timeoutDuration)
-      val expected = CamelMessage("received TEST", Map(CamelMessage.MessageExchangeId -> "123"))
-      Await.result(future, timeoutDuration) must be === expected
+      producer.tell(message, testActor)
+      expectMsg(CamelMessage("received TEST", Map(CamelMessage.MessageExchangeId -> "123")))
       stopGracefully(producer)
     }
 
@@ -65,12 +71,17 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
           case _: AkkaCamelException ⇒ Stop
         }
       }), name = "prod-anonymous-supervisor")
-      val producer = Await.result[ActorRef](supervisor.ask(Props(new TestProducer("direct:producer-test-2"))).mapTo[ActorRef], timeoutDuration)
+
+      supervisor.tell(Props(new TestProducer("direct:producer-test-2")), testActor)
+      val producer = receiveOne(timeoutDuration).asInstanceOf[ActorRef]
       val message = CamelMessage("fail", Map(CamelMessage.MessageExchangeId -> "123"))
       filterEvents(EventFilter[AkkaCamelException](occurrences = 1)) {
-        val e = intercept[AkkaCamelException] { Await.result(producer.ask(message)(timeoutDuration), timeoutDuration) }
-        e.getMessage must be("failure")
-        e.headers must be(Map(CamelMessage.MessageExchangeId -> "123"))
+        producer.tell(message, testActor)
+        expectMsgPF(timeoutDuration) {
+          case Failure(e: AkkaCamelException) ⇒
+            e.getMessage must be("failure")
+            e.headers must be(Map(CamelMessage.MessageExchangeId -> "123"))
+        }
       }
       Await.ready(latch, timeoutDuration)
       deadActor must be(Some(producer))
@@ -101,15 +112,8 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
     "produce message to direct:producer-test-3 and receive normal response" in {
       val producer = system.actorOf(Props(new TestProducer("direct:producer-test-3")), name = "direct-producer-test-3")
       val message = CamelMessage("test", Map(CamelMessage.MessageExchangeId -> "123"))
-      val future = producer.ask(message)(timeoutDuration)
-
-      Await.result(future, timeoutDuration) match {
-        case result: CamelMessage ⇒
-          // a normal response must have been returned by the producer
-          val expected = CamelMessage("received test", Map(CamelMessage.MessageExchangeId -> "123"))
-          result must be(expected)
-        case unexpected ⇒ fail("Actor responded with unexpected message:" + unexpected)
-      }
+      producer.tell(message, testActor)
+      expectMsg(CamelMessage("received test", Map(CamelMessage.MessageExchangeId -> "123")))
       stopGracefully(producer)
     }
 
@@ -118,9 +122,12 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
       val message = CamelMessage("fail", Map(CamelMessage.MessageExchangeId -> "123"))
 
       filterEvents(EventFilter[AkkaCamelException](occurrences = 1)) {
-        val e = intercept[AkkaCamelException] { Await.result(producer.ask(message)(timeoutDuration), timeoutDuration) }
-        e.getMessage must be("failure")
-        e.headers must be(Map(CamelMessage.MessageExchangeId -> "123"))
+        producer.tell(message, testActor)
+        expectMsgPF(timeoutDuration) {
+          case Failure(e: AkkaCamelException) ⇒
+            e.getMessage must be("failure")
+            e.headers must be(Map(CamelMessage.MessageExchangeId -> "123"))
+        }
       }
       stopGracefully(producer)
     }
@@ -129,15 +136,8 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
       val target = system.actorOf(Props[ReplyingForwardTarget], name = "reply-forwarding-target")
       val producer = system.actorOf(Props(new TestForwarder("direct:producer-test-2", target)), name = "direct-producer-test-2-forwarder")
       val message = CamelMessage("test", Map(CamelMessage.MessageExchangeId -> "123"))
-      val future = producer.ask(message)(timeoutDuration)
-
-      Await.result(future, timeoutDuration) match {
-        case result: CamelMessage ⇒
-          // a normal response must have been returned by the forward target
-          val expected = CamelMessage("received test", Map(CamelMessage.MessageExchangeId -> "123", "test" -> "result"))
-          result must be(expected)
-        case unexpected ⇒ fail("Actor responded with unexpected message:" + unexpected)
-      }
+      producer.tell(message, testActor)
+      expectMsg(CamelMessage("received test", Map(CamelMessage.MessageExchangeId -> "123", "test" -> "result")))
       stopGracefully(target, producer)
     }
 
@@ -147,9 +147,12 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
       val message = CamelMessage("fail", Map(CamelMessage.MessageExchangeId -> "123"))
 
       filterEvents(EventFilter[AkkaCamelException](occurrences = 1)) {
-        val e = intercept[AkkaCamelException] { Await.result(producer.ask(message)(timeoutDuration), timeoutDuration) }
-        e.getMessage must be("failure")
-        e.headers must be(Map(CamelMessage.MessageExchangeId -> "123", "test" -> "failure"))
+        producer.tell(message, testActor)
+        expectMsgPF(timeoutDuration) {
+          case Failure(e: AkkaCamelException) ⇒
+            e.getMessage must be("failure")
+            e.headers must be(Map(CamelMessage.MessageExchangeId -> "123", "test" -> "failure"))
+        }
       }
       stopGracefully(target, producer)
     }
@@ -180,13 +183,8 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
       val producer = system.actorOf(Props(new TestForwarder("direct:producer-test-3", target)), name = "direct-producer-test-3-to-replying-actor")
       val message = CamelMessage("test", Map(CamelMessage.MessageExchangeId -> "123"))
 
-      val future = producer.ask(message)(timeoutDuration)
-      Await.result(future, timeoutDuration) match {
-        case message: CamelMessage ⇒
-          val expected = CamelMessage("received test", Map(CamelMessage.MessageExchangeId -> "123", "test" -> "result"))
-          message must be(expected)
-        case unexpected ⇒ fail("Actor responded with unexpected message:" + unexpected)
-      }
+      producer.tell(message, testActor)
+      expectMsg(CamelMessage("received test", Map(CamelMessage.MessageExchangeId -> "123", "test" -> "result")))
       stopGracefully(target, producer)
     }
 
@@ -196,9 +194,12 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
 
       val message = CamelMessage("fail", Map(CamelMessage.MessageExchangeId -> "123"))
       filterEvents(EventFilter[AkkaCamelException](occurrences = 1)) {
-        val e = intercept[AkkaCamelException] { Await.result(producer.ask(message)(timeoutDuration), timeoutDuration) }
-        e.getMessage must be("failure")
-        e.headers must be(Map(CamelMessage.MessageExchangeId -> "123", "test" -> "failure"))
+        producer.tell(message, testActor)
+        expectMsgPF(timeoutDuration) {
+          case Failure(e: AkkaCamelException) ⇒
+            e.getMessage must be("failure")
+            e.headers must be(Map(CamelMessage.MessageExchangeId -> "123", "test" -> "failure"))
+        }
       }
       stopGracefully(target, producer)
     }
@@ -224,6 +225,23 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
       }
       stopGracefully(target, producer)
     }
+
+    "keep producing messages after error" in {
+      import TestSupport._
+      val consumer = start(new IntermittentErrorConsumer("direct:intermittentTest-1"), "intermittentTest-error-consumer")
+      val producer = start(new SimpleProducer("direct:intermittentTest-1"), "intermittentTest-producer")
+      filterEvents(EventFilter[AkkaCamelException](occurrences = 1)) {
+        val futureFailed = producer.tell("fail", testActor)
+        expectMsgPF(timeoutDuration) {
+          case Failure(e) ⇒
+            e.getMessage must be("fail")
+        }
+        producer.tell("OK", testActor)
+        expectMsg("OK")
+      }
+      stop(consumer)
+      stop(producer)
+    }
   }
 
   private def mockEndpoint = camel.context.getEndpoint("mock:mock", classOf[MockEndpoint])
@@ -238,6 +256,11 @@ class ProducerFeatureTest extends WordSpec with BeforeAndAfterAll with BeforeAnd
 object ProducerFeatureTest {
   class TestProducer(uri: String, upper: Boolean = false) extends Actor with Producer {
     def endpointUri = uri
+
+    override def preRestart(reason: Throwable, message: Option[Any]) {
+      //overriding on purpose so it doesn't try to deRegister and reRegister at restart,
+      // which would cause a deadletter message in the test output.
+    }
 
     override protected def transformOutgoingMessage(msg: Any) = msg match {
       case msg: CamelMessage ⇒ if (upper) msg.mapBody {
@@ -300,6 +323,20 @@ object ProducerFeatureTest {
           }
         }
       })
+    }
+  }
+
+  class SimpleProducer(override val endpointUri: String) extends Producer {
+    override protected def transformResponse(msg: Any) = msg match {
+      case m: CamelMessage ⇒ m.bodyAs[String]
+      case m: Any          ⇒ m
+    }
+  }
+
+  class IntermittentErrorConsumer(override val endpointUri: String) extends Consumer {
+    def receive = {
+      case msg: CamelMessage if msg.bodyAs[String] == "fail" ⇒ sender ! Failure(new Exception("fail"))
+      case msg: CamelMessage                                 ⇒ sender ! msg
     }
   }
 

--- a/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
@@ -109,6 +109,14 @@ class ActivationTrackerTest extends TestKit(ActorSystem("test")) with WordSpec w
 
       awaiting.verifyActivated()
     }
+
+    "send activation message when an actor is activated, deactivated and activated again" taggedAs TimingTest in {
+      publish(EndpointActivated(actor.ref))
+      publish(EndpointDeActivated(actor.ref))
+      publish(EndpointActivated(actor.ref))
+      awaiting.awaitActivation()
+      awaiting.verifyActivated()
+    }
   }
 
   class Awaiting(actor: TestProbe) {


### PR DESCRIPTION
Added that the producer de-registers its endpoint when it is restarted at preRestart.

The problem was that the producerChild would not be (re)-initialized at restart because the registry thought the producer was already registered, so the producer never got a reference to the send processor again. de-registering at preRestart solves this problem because that way the preStart register will actually register, instead of thinking that it is already registered. Because of sending in order and order of preRestart and preStart we can be guaranteed that the endpoint will be de-registered and registered in order in the producer registry, which is an actor. Since the producer uses the producerChild to handle messages before the endpoint is registered there is no issue with losing messages during de-register and register. 

Experimented with the consumer working the same way, but that meant that a user would have to wait for de-activation and activation in order before sending messages to consumer at consumer restart or otherwise lose out on messages, so I have not changed that because you would rather have the consumer be able to receive messages as much as possible.  Maybe a feature for later to include a way to let the user indicate that the consumer should re-register endpoint at restart. For now the user can just stop a consumer and create a new one.
