### PR TITLE
EventStream.subscribe regression #2738

### DIFF
--- a/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
+++ b/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
@@ -30,7 +30,7 @@ private[akka] object SubclassifiedIndex {
       val kids = subkeys flatMap (_ addValue value)
       if (!(values contains value)) {
         values += value
-        kids :+ ((key, values))
+        kids :+ ((key, Set(value)))
       } else kids
     }
 


### PR DESCRIPTION
5000 actors subscribing:
- 2.0.4 ~200 ms
- 2.1.0-RC2 ~ 10500 ms
- fix ~300 ms

We returned to much from addVAlue in the SubclassifiedIndex, and not only the changes.
