### PR TITLE
 #2755 - fixing the JMX_CLIENT_CLASSPATH

### DIFF
--- a/akka-kernel/src/main/dist/bin/akka-cluster
+++ b/akka-kernel/src/main/dist/bin/akka-cluster
@@ -16,7 +16,7 @@
 
 declare AKKA_HOME="$(cd "$(cd "$(dirname "$0")"; pwd -P)"/..; pwd)"
 
-[ -n "$JMX_CLIENT_CLASSPATH" ] || JMX_CLIENT_CLASSPATH="$AKKA_HOME/lib/akka/akka-kernel-*"
+[ -n "$JMX_CLIENT_CLASSPATH" ] || JMX_CLIENT_CLASSPATH="$AKKA_HOME/lib/akka/akka-kernel*"
 
 # NOTE: The 'cmdline-jmxclient' is available as part of the Akka distribution.
 JMX_CLIENT="java -cp $JMX_CLIENT_CLASSPATH akka.jmx.Client -"


### PR DESCRIPTION
Should be backported to release-2.1
