### PR TITLE
java.util.logging support

### DIFF
--- a/akka-contrib/docs/jul.rst
+++ b/akka-contrib/docs/jul.rst
@@ -1,0 +1,17 @@
+Java Logging (JUL)
+=================
+
+This extension module provides a logging backend which uses the `java.util.logging` (j.u.l)
+API to do the endpoint logging for `akka.event.Logging`.
+
+Provided with this module is an implementation of `akka.event.LoggingAdapter` which is independent of any `ActorSystem` being in place. This means that j.u.l can be used as the backend, via the Akka Logging API, for both Actor and non-Actor codebases.
+
+To enable j.u.l as the `akka.event.Logging` backend, use the following Akka config:
+
+  event-handlers = ["akka.contrib.jul.JavaLoggingEventHandler"]
+
+To access the `akka.event.Logging` API from non-Actor code, mix in `akka.contrib.jul.JavaLogging`.
+
+This module is preferred over SLF4J with its JDK14 backend, due to integration issues resulting in the incorrect handling of `threadId`, `className` and `methodName`.
+
+This extension module was contributed by Sam Halliday.

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -15,8 +15,6 @@ import concurrent.{ ExecutionContext, Future }
  * logging API.
  *
  * For `Actor`s, use `ActorLogging` instead.
- *
- * @author Sam Halliday
  */
 trait JavaLogging {
 
@@ -28,8 +26,6 @@ trait JavaLogging {
 
 /**
  * `java.util.logging` EventHandler.
- *
- * @author Sam Halliday
  */
 class JavaLoggingEventHandler extends Actor {
 
@@ -100,7 +96,7 @@ trait JavaLoggingAdapter extends LoggingAdapter {
 
   @inline
   def log(level: logging.Level, cause: Throwable, message: String) {
-    val record = new logging.LogRecord(level, message.toString)
+    val record = new logging.LogRecord(level, message)
     record.setLoggerName(logger.getName)
     record.setThrown(cause)
     updateSource(record)
@@ -116,8 +112,7 @@ trait JavaLoggingAdapter extends LoggingAdapter {
 
   // it is unfortunate that this workaround is needed
   private def updateSource(record: logging.LogRecord) {
-    val throwable = new Throwable()
-    val stack = throwable.getStackTrace
+    val stack = Thread.currentThread.getStackTrace
     val source = stack.find {
       frame ⇒
         val cname = frame.getClassName

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -78,9 +78,9 @@ trait JavaLogging extends LoggingAdapter {
     val source = stack.find {
       frame =>
         val cname = frame.getClassName
+        cname != javaLoggerTraitName &&
         !cname.startsWith("java.lang.reflect.") &&
-          !cname.startsWith("sun.reflect.") &&
-          cname != javaLoggerTraitName
+        !cname.startsWith("sun.reflect.")
     }
     if (source.isDefined) {
       record.setSourceClassName(source.get.getClassName)

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -22,7 +22,7 @@ import concurrent.{ExecutionContext, Future}
 trait JavaLogging extends LoggingAdapter {
 
   @transient
-  protected lazy val logger = logging.Logger.getLogger(toScalaClassName(getClass.getName))
+  protected lazy val logger = logging.Logger.getLogger(getClass.getName)
 
   /** Override-able option for asynchronous logging */
   def loggingExecutionContext: Option[ExecutionContext] = None
@@ -85,7 +85,7 @@ trait JavaLogging extends LoggingAdapter {
       if (!cname.startsWith("java.lang.reflect.") &&
         !cname.startsWith("sun.reflect.") &&
         cname != javaLoggerTraitName) {
-        record.setSourceClassName(toScalaClassName(cname))
+        record.setSourceClassName(cname)
         record.setSourceMethodName(frame.getMethodName)
         return
       }
@@ -93,14 +93,7 @@ trait JavaLogging extends LoggingAdapter {
     }
   }
 
-  // can this be set automatically?
-  private final val javaLoggerTraitName = "akka.contrib.jul.JavaLogging$class"
-
-  @inline
-  private final def toScalaClassName(cname: String) =
-    if (cname.endsWith("$"))
-      cname.substring(0, cname.length - 1)
-    else cname
+  private final val javaLoggerTraitName = classOf[JavaLogging].getName + "$class"
 }
 
 /** `java.util.logging` EventHandler.

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -1,0 +1,150 @@
+package akka.contrib.jul
+
+import akka.event.Logging._
+import akka.actor._
+import akka.event.LoggingAdapter
+import java.util.logging
+import sun.misc.SharedSecrets
+import concurrent.{ExecutionContext, Future}
+
+/** Mix in `ActorPathLogging` to your `Actor` to easily obtain a reference
+  * to a logger, which registers the context path as the message source.
+  */
+trait ActorPathLogging {
+  this: Actor =>
+
+  val log = akka.event.Logging(context.system, self.path.name)
+}
+
+/** Makes `java.util.logging` available as a `logger` field
+  * and provides convenience logging methods that agree exactly
+  * with the `akka.event.Logging` API.
+  *
+  * Calling class and
+  *
+  * WARNING: Not suitable for use from an `Actor`. Instead, mixin
+  * `ActorLogging` or create an instance of `akka.event.Logging`.
+  *
+  * @author Sam Halliday
+  */
+trait JavaLogging extends LoggingAdapter {
+
+  @transient
+  protected lazy val logger = logging.Logger.getLogger(toScalaClassName(getClass.getName))
+
+  /** Override-able option for asynchronous logging */
+  def loggingExecutionContext: Option[ExecutionContext] = None
+
+  def isErrorEnabled = logger.isLoggable(logging.Level.SEVERE)
+
+  def isWarningEnabled = logger.isLoggable(logging.Level.WARNING)
+
+  def isInfoEnabled = logger.isLoggable(logging.Level.INFO)
+
+  def isDebugEnabled = logger.isLoggable(logging.Level.CONFIG)
+
+  protected def notifyError(message: String) {
+    log(logging.Level.SEVERE, null, message)
+  }
+
+  protected def notifyError(cause: Throwable, message: String) {
+    log(logging.Level.SEVERE, cause, message)
+  }
+
+  protected def notifyWarning(message: String) {
+    log(logging.Level.WARNING, null, message)
+  }
+
+  protected def notifyInfo(message: String) {
+    log(logging.Level.INFO, null, message)
+  }
+
+  protected def notifyDebug(message: String) {
+    log(logging.Level.CONFIG, null, message)
+  }
+
+  @inline
+  def log(level: logging.Level, cause: Throwable, message: String) {
+    val record = new logging.LogRecord(level, message.toString)
+    record.setLoggerName(logger.getName)
+    record.setThrown(cause)
+    updateSource(record)
+
+    if (loggingExecutionContext.isDefined) {
+      implicit val context = loggingExecutionContext.get
+      Future(logger.log(record)).onFailure {
+        case thrown: Throwable => thrown.printStackTrace()
+      }
+    }
+    else
+      logger.log(record)
+  }
+
+  // it is unfortunate that this workaround is needed
+  private def updateSource(record: logging.LogRecord) {
+    // code duplication with LogRecord
+    val access = SharedSecrets.getJavaLangAccess
+    val throwable = new Throwable()
+    val depth = access.getStackTraceDepth(throwable)
+    var i = 0
+    while (i < depth) {
+      val frame = access.getStackTraceElement(throwable, i)
+      val cname = frame.getClassName
+      if (!cname.startsWith("java.lang.reflect.") &&
+        !cname.startsWith("sun.reflect.") &&
+        cname != javaLoggerTraitName) {
+        record.setSourceClassName(toScalaClassName(cname))
+        record.setSourceMethodName(frame.getMethodName)
+        return
+      }
+      i += 1
+    }
+  }
+
+  // can this be set automatically?
+  private final val javaLoggerTraitName = "akka.contrib.jul.JavaLogging$class"
+
+  @inline
+  private final def toScalaClassName(cname: String) =
+    if (cname.endsWith("$"))
+      cname.substring(0, cname.length - 1)
+    else cname
+}
+
+/** `java.util.logging` EventHandler.
+  *
+  * @author Sam Halliday
+  */
+class JavaLoggingEventHandler extends Actor with JavaLogging {
+
+  def receive = {
+    case event@Error(cause, logSource, logClass, message) ⇒
+      log(logging.Level.SEVERE, cause, logSource, logClass, message, event)
+
+    case event@Warning(logSource, logClass, message) ⇒
+      log(logging.Level.WARNING, null, logSource, logClass, message, event)
+
+    case event@Info(logSource, logClass, message) ⇒
+      log(logging.Level.INFO, null, logSource, logClass, message, event)
+
+    case event@Debug(logSource, logClass, message) ⇒
+      log(logging.Level.CONFIG, null, logSource, logClass, message, event)
+
+    case InitializeLogger(_) ⇒
+      logger.config("starting")
+      sender ! LoggerInitialized
+  }
+
+  @inline
+  def log(level: logging.Level, cause: Throwable, logSource: String, logClass: Class[_], message: Any, event: LogEvent) {
+    val sourceLogger = logging.Logger.getLogger(logSource)
+    val record = new logging.LogRecord(level, message.toString)
+    record.setLoggerName(sourceLogger.getName)
+    record.setThrown(cause)
+    record.setThreadID(event.thread.getId.toInt)
+    record.setSourceClassName(logClass.getName)
+    record.setSourceMethodName("<unknown>") // lost forever
+    sourceLogger.log(record)
+  }
+}
+

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -9,13 +9,13 @@ import concurrent.{ExecutionContext, Future}
 
 
 /** Makes `java.util.logging` available as a `logger` field
-  * and provides convenience logging methods that agree exactly
-  * with the `akka.event.Logging` API.
+  * and provides convenience logging methods from the
+  * `akka.event.Logging` API. This trait does not require
+  * an `ActorSystem` and is encouraged to be used as a
+  * general purpose Scala logging API.
   *
-  * Calling class and
-  *
-  * WARNING: Not suitable for use from an `Actor`. Instead, mixin
-  * `ActorLogging` or create an instance of `akka.event.Logging`.
+  * WARNING: Use `ActorLogging` from `Actor`s to use
+  * the Akka Logging system.
   *
   * @author Sam Halliday
   */

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -4,20 +4,20 @@ import akka.event.Logging._
 import akka.actor._
 import akka.event.LoggingAdapter
 import java.util.logging
-import concurrent.{ExecutionContext, Future}
+import concurrent.{ ExecutionContext, Future }
 
-
-/** Makes `java.util.logging` available as a `logger` field
-  * and provides convenience logging methods from the
-  * `akka.event.Logging` API. This trait does not require
-  * an `ActorSystem` and is encouraged to be used as a
-  * general purpose Scala logging API.
-  *
-  * WARNING: Use `ActorLogging` from `Actor`s to use
-  * the Akka Logging system.
-  *
-  * @author Sam Halliday
-  */
+/**
+ * Makes `java.util.logging` available as a `logger` field
+ * and provides convenience logging methods from the
+ * `akka.event.Logging` API. This trait does not require
+ * an `ActorSystem` and is encouraged to be used as a
+ * general purpose Scala logging API.
+ *
+ * WARNING: Use `ActorLogging` from `Actor`s to use
+ * the Akka Logging system.
+ *
+ * @author Sam Halliday
+ */
 trait JavaLogging extends LoggingAdapter {
 
   @transient
@@ -64,10 +64,9 @@ trait JavaLogging extends LoggingAdapter {
     if (loggingExecutionContext.isDefined) {
       implicit val context = loggingExecutionContext.get
       Future(logger.log(record)).onFailure {
-        case thrown: Throwable => thrown.printStackTrace()
+        case thrown: Throwable ⇒ thrown.printStackTrace()
       }
-    }
-    else
+    } else
       logger.log(record)
   }
 
@@ -76,11 +75,11 @@ trait JavaLogging extends LoggingAdapter {
     val throwable = new Throwable()
     val stack = throwable.getStackTrace
     val source = stack.find {
-      frame =>
+      frame ⇒
         val cname = frame.getClassName
         cname != javaLoggerTraitName &&
-        !cname.startsWith("java.lang.reflect.") &&
-        !cname.startsWith("sun.reflect.")
+          !cname.startsWith("java.lang.reflect.") &&
+          !cname.startsWith("sun.reflect.")
     }
     if (source.isDefined) {
       record.setSourceClassName(source.get.getClassName)
@@ -91,23 +90,24 @@ trait JavaLogging extends LoggingAdapter {
   private final val javaLoggerTraitName = classOf[JavaLogging].getName + "$class"
 }
 
-/** `java.util.logging` EventHandler.
-  *
-  * @author Sam Halliday
-  */
+/**
+ * `java.util.logging` EventHandler.
+ *
+ * @author Sam Halliday
+ */
 class JavaLoggingEventHandler extends Actor with JavaLogging {
 
   def receive = {
-    case event@Error(cause, logSource, logClass, message) ⇒
+    case event @ Error(cause, logSource, logClass, message) ⇒
       log(logging.Level.SEVERE, cause, logSource, logClass, message, event)
 
-    case event@Warning(logSource, logClass, message) ⇒
+    case event @ Warning(logSource, logClass, message) ⇒
       log(logging.Level.WARNING, null, logSource, logClass, message, event)
 
-    case event@Info(logSource, logClass, message) ⇒
+    case event @ Info(logSource, logClass, message) ⇒
       log(logging.Level.INFO, null, logSource, logClass, message, event)
 
-    case event@Debug(logSource, logClass, message) ⇒
+    case event @ Debug(logSource, logClass, message) ⇒
       log(logging.Level.CONFIG, null, logSource, logClass, message, event)
 
     case InitializeLogger(_) ⇒

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -7,14 +7,6 @@ import java.util.logging
 import sun.misc.SharedSecrets
 import concurrent.{ExecutionContext, Future}
 
-/** Mix in `ActorPathLogging` to your `Actor` to easily obtain a reference
-  * to a logger, which registers the context path as the message source.
-  */
-trait ActorPathLogging {
-  this: Actor =>
-
-  val log = akka.event.Logging(context.system, self.path.name)
-}
 
 /** Makes `java.util.logging` available as a `logger` field
   * and provides convenience logging methods that agree exactly

--- a/akka-contrib/src/test/scala/akka/contrib/jul/JulEventHandlerSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/jul/JulEventHandlerSpec.scala
@@ -1,0 +1,85 @@
+package akka.contrib.jul
+
+import akka.actor.{ActorSystem, Actor, ActorLogging}
+import java.util.logging
+import akka.testkit.{TestActorRef, TestKit}
+import com.typesafe.config.ConfigFactory
+import org.specs2.mutable.{Before, Specification}
+import java.util.concurrent.{TimeUnit, LinkedBlockingQueue}
+
+
+object JavaLoggingEventHandlerSpec {
+
+  val config = ConfigFactory.parseString( """
+    akka {
+      loglevel = INFO
+      event-handlers = ["akka.contrib.jul.JavaLoggingEventHandler"]
+    }""")
+
+  class LogProducer extends Actor with ActorLogging {
+    def receive = {
+      case e: Exception ⇒
+        log.error(e, e.getMessage)
+      case (s: String, x: Int) ⇒
+        log.info(s, x)
+    }
+  }
+
+  val queue = new LinkedBlockingQueue[logging.LogRecord]
+  val logger = logging.Logger.getLogger("akka://test/user/log")
+  logger.addHandler(new logging.Handler {
+    def publish(record: logging.LogRecord) {
+      queue.add(record)
+    }
+
+    def flush() {}
+
+    def close() {}
+  })
+}
+
+import JavaLoggingEventHandlerSpec._
+
+class JavaLoggingEventHandlerSpec extends TestKit(ActorSystem("test", config))
+with Specification with Before {
+
+  val producer = TestActorRef[LogProducer]("log")
+
+  def before() {
+    queue.clear()
+  }
+
+  "JavaLoggingEventHandler" should {
+
+    "log error with stackTrace" in {
+      producer ! new RuntimeException("Simulated error")
+
+      val record = queue.poll(5, TimeUnit.SECONDS)
+
+      record mustNotEqual null
+      record.getMillis mustNotEqual 0
+      record.getThreadID mustNotEqual 0
+      record.getLevel mustEqual logging.Level.SEVERE
+      record.getMessage mustEqual "Simulated error"
+      record.getThrown must beAnInstanceOf[RuntimeException]
+      record.getSourceClassName mustEqual "akka.contrib.jul.JavaLoggingEventHandlerSpec$LogProducer"
+      record.getSourceMethodName mustEqual "<unknown>"
+    }
+
+    "log info without stackTrace" in {
+      producer ! ("{} is the magic number", 3)
+
+      val record = queue.poll(5, TimeUnit.SECONDS)
+
+      record mustNotEqual null
+      record.getMillis mustNotEqual 0
+      record.getThreadID mustNotEqual 0
+      record.getLevel mustEqual logging.Level.INFO
+      record.getMessage mustEqual "3 is the magic number"
+      record.getThrown mustEqual null
+      record.getSourceClassName mustEqual "akka.contrib.jul.JavaLoggingEventHandlerSpec$LogProducer"
+      record.getSourceMethodName mustEqual "<unknown>"
+    }
+  }
+
+}

--- a/akka-contrib/src/test/scala/akka/contrib/jul/JulEventHandlerSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/jul/JulEventHandlerSpec.scala
@@ -62,7 +62,7 @@ class JavaLoggingEventHandlerSpec extends AkkaSpec(JavaLoggingEventHandlerSpec.c
       record.getMessage must be("Simulated error (ignore the stacktrace)")
       record.getThrown.isInstanceOf[RuntimeException] must be(true)
       record.getSourceClassName must be("akka.contrib.jul.JavaLoggingEventHandlerSpec$LogProducer")
-      record.getSourceMethodName must be("<unknown>")
+      record.getSourceMethodName must be(null)
     }
 
     "log info without stackTrace" in {
@@ -77,7 +77,7 @@ class JavaLoggingEventHandlerSpec extends AkkaSpec(JavaLoggingEventHandlerSpec.c
       record.getMessage must be("3 is the magic number")
       record.getThrown must be(null)
       record.getSourceClassName must be("akka.contrib.jul.JavaLoggingEventHandlerSpec$LogProducer")
-      record.getSourceMethodName must be("<unknown>")
+      record.getSourceMethodName must be(null)
     }
   }
 


### PR DESCRIPTION
As discussed on the Akka Users mailing list

  https://groups.google.com/d/topic/akka-user/S1bwDHbju94/discussion

the SLF4J backend does not provide the correct information to the `java.util.logging` (j.u.l) backend, since j.u.l does not have an MDC.

Most importantly, the thread of the log message is set to the thread of the Akka logging Actor and the source class/method are set to the Akka logging interface.

This proposed Adapter has two purposes:
1. to allow any Scala class to have access to the same `Logging` API as used by `Actor`s. This is synchronous by default, but can be made asynchronous by providing an `ExecutionContext`.
2. to provide a direct link between the Akka Logging system and the j.u.l. This enables (almost) all `LogRecord` fields to be correctly filled out. Unfortunately, it is not possible to recover the name of the method in which the log was made, as it is apparently not recorded by Akka.

I was unable to `sbt run` the entire Akka source code, due to errors in the cluster package, and I was not able to build and run the tests for `contrib` with sbt – this meant I was unable to use the `AkkaSpec` trait used by many of the packages. Instead, I used Specs2.

It should be a trivial job for somebody who has a build environment that works to change the Spec to work with the internal AkkaSpec instead of Specifications.
