### PR TITLE
Await leader in awaitUpConvergence, see #2752

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -224,6 +224,9 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec { self: MultiNodeS
       awaitCond(clusterView.members.size == numberOfMembers)
       awaitCond(clusterView.members.forall(_.status == MemberStatus.Up))
       awaitCond(clusterView.convergence)
+      // clusterView.leader is updated by LeaderChanged, await that to be updated also
+      val expectedLeader = clusterView.members.headOption.map(_.address)
+      awaitCond(clusterView.leader == expectedLeader)
       if (!canNotBePartOfMemberRing.isEmpty) // don't run this on an empty set
         awaitCond(
           canNotBePartOfMemberRing forall (address ⇒ !(clusterView.members exists (_.address == address))))


### PR DESCRIPTION
It's a glitch in how ClusterReadView (used in tests) is updated.
First we do awaitUpConvergence, which checks readView.members and
readView.convergence. Then we do assertLeader, which checks
readView.leader. The problem is that readView.leader might not
have been updated yet (if there already was convergence).
Solution is to await the expected leader in awaitUpConvergence,
so that readView is in a consistent state after awaitUpConvergence.

We will change the semantics in ticket #2692, but this change will
be needed and should work with that as well.
