### PR TITLE
Rename FSM and TestFSMRef's timerActive_? to isTimerActive. Fixes #2766

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -238,7 +238,7 @@ object FSM {
  *   setTimer("tock", TockMsg, 1 second, true) // repeating
  *   setTimer("lifetime", TerminateMsg, 1 hour, false) // single-shot
  *   cancelTimer("tock")
- *   timerActive_? ("tock")
+ *   isTimerActive("tock")
  * </pre>
  */
 trait FSM[S, D] extends Listeners with ActorLogging {
@@ -372,7 +372,15 @@ trait FSM[S, D] extends Listeners with ActorLogging {
    * timer does not exist, has previously been canceled or if it was a
    * single-shot timer whose message was already received.
    */
-  final def timerActive_?(name: String) = timers contains name
+  @deprecated("Use isTimerActive() instead.", "2.2")
+  final def timerActive_?(name: String) = isTimerActive(name)
+
+  /**
+   * Inquire whether the named timer is still active. Returns true unless the
+   * timer does not exist, has previously been canceled or if it was a
+   * single-shot timer whose message was already received.
+   */
+  final def isTimerActive(name: String) = timers contains name
 
   /**
    * Set state timeout explicitly. This method can safely be used from within a

--- a/akka-docs/rst/scala/code/docs/testkit/TestkitDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/testkit/TestkitDocSpec.scala
@@ -110,11 +110,11 @@ class TestkitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     fsm.setState(stateName = 1)
     assert(fsm.stateName == 1)
 
-    assert(fsm.timerActive_?("test") == false)
+    assert(fsm.isTimerActive("test") == false)
     fsm.setTimer("test", 12, 10 millis, true)
-    assert(fsm.timerActive_?("test") == true)
+    assert(fsm.isTimerActive("test") == true)
     fsm.cancelTimer("test")
-    assert(fsm.timerActive_?("test") == false)
+    assert(fsm.isTimerActive("test") == false)
     //#test-fsm-ref
   }
 

--- a/akka-docs/rst/scala/fsm.rst
+++ b/akka-docs/rst/scala/fsm.rst
@@ -371,7 +371,7 @@ which is guaranteed to work immediately, meaning that the scheduled message
 will not be processed after this call even if the timer already fired and
 queued it. The status of any timer may be inquired with
 
-  :func:`timerActive_?(name)`
+  :func:`isTimerActive(name)`
 
 These named timers complement state timeouts because they are not affected by
 intervening reception of other messages.

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/NetworkFailureInjector.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/NetworkFailureInjector.scala
@@ -302,7 +302,7 @@ private[akka] class ThrottleActor(channelContext: ChannelHandlerContext)
       log.debug("sending msg (Tick): {}", s.msg)
       send(s)
     }
-    if (!timerActive_?("send"))
+    if (!isTimerActive("send"))
       for (time ← toTick) {
         log.debug("scheduling next Tick in {}", time)
         setTimer("send", Tick, time, false)

--- a/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
@@ -78,7 +78,13 @@ class TestFSMRef[S, D, T <: Actor](
   /**
    * Proxy for FSM.timerActive_?.
    */
-  def timerActive_?(name: String) = fsm.timerActive_?(name)
+  @deprecated("Use isTimerActive() instead.", "2.2")
+  def timerActive_?(name: String) = isTimerActive(name)
+
+  /**
+   * Proxy for FSM.isTimerActive.
+   */
+  def isTimerActive(name: String) = fsm.isTimerActive(name)
 
 }
 

--- a/akka-testkit/src/test/scala/akka/testkit/TestFSMRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestFSMRefSpec.scala
@@ -51,11 +51,11 @@ class TestFSMRefSpec extends AkkaSpec {
           case x ⇒ stay
         }
       }, "test-fsm-ref-2")
-      fsm.timerActive_?("test") must be(false)
+      fsm.isTimerActive("test") must be(false)
       fsm.setTimer("test", 12, 10 millis, true)
-      fsm.timerActive_?("test") must be(true)
+      fsm.isTimerActive("test") must be(true)
       fsm.cancelTimer("test")
-      fsm.timerActive_?("test") must be(false)
+      fsm.isTimerActive("test") must be(false)
     }
   }
 }


### PR DESCRIPTION
Rename and deprecate old method, as discussed in pull request 915.

Assumed deprecation would happen in 2.2.

Disclaimer: At the time of this change I'm getting intermittent failures in SupervisorHierarchySpec (I _think_ also in master, but not sure). But this change is so trivial that I doubt it is the cause.
