### PR TITLE
Misc docs

### DIFF
--- a/akka-docs/rst/cluster/cluster-usage-java.rst
+++ b/akka-docs/rst/cluster/cluster-usage-java.rst
@@ -623,7 +623,7 @@ introduce the extra overhead of another thread.
 ::
 
   # shorter tick-duration of default scheduler when using cluster
-  akka.scheduler.tick-duration.tick-duration = 33ms
+  akka.scheduler.tick-duration = 33ms
 
 
 

--- a/akka-docs/rst/cluster/cluster-usage-scala.rst
+++ b/akka-docs/rst/cluster/cluster-usage-scala.rst
@@ -629,7 +629,7 @@ introduce the extra overhead of another thread.
 ::
 
   # shorter tick-duration of default scheduler when using cluster
-  akka.scheduler.tick-duration.tick-duration = 33ms
+  akka.scheduler.tick-duration = 33ms
 
 
 

--- a/akka-docs/rst/java/microkernel.rst
+++ b/akka-docs/rst/java/microkernel.rst
@@ -19,11 +19,7 @@ Put your application jar in the ``deploy`` directory to have it automatically
 loaded.
 
 To start the kernel use the scripts in the ``bin`` directory, passing the boot
-classes for your application.
-
-There is a simple example of an application setup for running with the
-microkernel included in the akka download. This can be run with the following
-command (on a unix-based system):
+classes for your application. Example command (on a unix-based system):
 
 .. code-block:: none
 

--- a/akka-docs/rst/scala/io.rst
+++ b/akka-docs/rst/scala/io.rst
@@ -138,9 +138,9 @@ Receiving messages from the ``IOManager``:
 IO.Iteratee
 ^^^^^^^^^^^
 
-Included with Akka's IO support is a basic implementation of ``Iteratee``\s. ``Iteratee``\s are an effective way of handling a stream of data without needing to wait for all the data to arrive. This is especially useful when dealing with non blocking IO since we will usually receive data in chunks which may not include enough information to process, or it may contain much more data then we currently need.
+Included with Akka's IO support is a basic implementation of ``Iteratee``\s. ``Iteratee``\s are an effective way of handling a stream of data without needing to wait for all the data to arrive. This is especially useful when dealing with non blocking IO since we will usually receive data in chunks which may not include enough information to process, or it may contain much more data than we currently need.
 
-This ``Iteratee`` implementation is much more basic then what is usually found. There is only support for ``ByteString`` input, and enumerators aren't used. The reason for this limited implementation is to reduce the amount of explicit type signatures needed and to keep things simple. It is important to note that Akka's ``Iteratee``\s are completely optional, incoming data can be handled in any way, including other ``Iteratee`` libraries.
+This ``Iteratee`` implementation is much more basic than what is usually found. There is only support for ``ByteString`` input, and enumerators aren't used. The reason for this limited implementation is to reduce the amount of explicit type signatures needed and to keep things simple. It is important to note that Akka's ``Iteratee``\s are completely optional, incoming data can be handled in any way, including other ``Iteratee`` libraries.
 
 ``Iteratee``\s work by processing the data that it is given and returning either the result (with any unused input) or a continuation if more input is needed. They are monadic, so methods like ``flatMap`` can be used to pass the result of an ``Iteratee`` to another.
 
@@ -204,7 +204,7 @@ Following the path we read in the query (if it exists):
 .. includecode:: code/docs/io/HTTPServer.scala
    :include: read-query
 
-It is much simpler then reading the path since we aren't doing any parsing of the query since there is no standard format of the query string.
+It is much simpler than reading the path since we aren't doing any parsing of the query since there is no standard format of the query string.
 
 Both the path and query used the ``readUriPart`` ``Iteratee``, which is next:
 

--- a/akka-docs/rst/scala/microkernel.rst
+++ b/akka-docs/rst/scala/microkernel.rst
@@ -19,11 +19,7 @@ Put your application jar in the ``deploy`` directory to have it automatically
 loaded.
 
 To start the kernel use the scripts in the ``bin`` directory, passing the boot
-classes for your application.
-
-There is a simple example of an application setup for running with the
-microkernel included in the akka download. This can be run with the following
-command (on a unix-based system):
+classes for your application. Example command (on a unix-based system):
 
 .. code-block:: none
 

--- a/akka-sbt-plugin/sample/project/Build.scala
+++ b/akka-sbt-plugin/sample/project/Build.scala
@@ -7,7 +7,7 @@ import akka.sbt.AkkaKernelPlugin.{ Dist, outputDirectory, distJvmOptions}
 object HelloKernelBuild extends Build {
   val Organization = "akka.sample"
   val Version      = "2.2-SNAPSHOT"
-  val ScalaVersion = "2.10.0-RC1"
+  val ScalaVersion = "2.10.0-RC3"
 
   lazy val HelloKernel = Project(
     id = "hello-kernel",

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -30,6 +30,7 @@ object AkkaBuild extends Build {
     organization := "com.typesafe.akka",
     version      := "2.2-SNAPSHOT",
     // FIXME: use 2.10.0 for final
+    // Also change ScalaVersion in akka-sbt-plugin/sample/project/Build.scala
     scalaVersion := System.getProperty("akka.scalaVersion", "2.10.0-RC3")
   )
 


### PR DESCRIPTION
- tick-duration.tick-duration, see #2748
- Remove reference to non-existing bundled sample, see #2753
- Correct ScalaVersion in microkernel Build sample, see #2758
- corr then -> than, see #2757

Should be backported to release-2.1
