### PR TITLE
 #2778 - make thread names unique (or at least more so) (for 2.0)

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -170,7 +170,7 @@ case class MonitorableThreadFactory(name: String,
                                     contextClassLoader: Option[ClassLoader],
                                     exceptionHandler: Thread.UncaughtExceptionHandler = MonitorableThreadFactory.doNothing)
   extends ThreadFactory with ForkJoinPool.ForkJoinWorkerThreadFactory {
-  protected val counter = new AtomicLong
+  protected val counter = new AtomicLong(MTF.tfCounter.getAndIncrement())
 
   def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
     val t = wire(ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool))
@@ -187,6 +187,14 @@ case class MonitorableThreadFactory(name: String,
     contextClassLoader foreach t.setContextClassLoader
     t
   }
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] object MTF {
+  // this is a hacky near-backport of the fix for #2778; real fix would not be binary compatible
+  private[akka] val tfCounter = new AtomicLong
 }
 
 /**


### PR DESCRIPTION
The real fix as applied to 2.1 and forward is not binary compatible; the
closest I could figure out was to seed the thread counter of the factory
such that each factory copy gets its own start value (using a global);
this solves it for the packaged dispatchers, which either reuse a thread
pool for a whole group of actors (Dispatcher, BalancingDispatcher) or
create only a single thread (PinnedDispatcher).
