### PR TITLE
Publish AddressTerminated after a node is Down, not when unreachable, see #2779

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -82,7 +82,8 @@ case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
  * INTERNAL API
  *
  * Used for remote death watch. Failure detector publish this to the
- * `eventStream` when a remote node is detected to be unreachable.
+ * `eventStream` when a remote node is detected to be unreachable and/or decided to
+ * be removed.
  * The watcher ([[akka.actor.DeathWatch]]) subscribes to the `eventStream`
  * and translates this event to [[akka.actor.Terminated]], which is sent itself.
  */

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -296,9 +296,16 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
           }
           publish(event)
 
-        case MemberUnreachable(m) ⇒
+        case MemberDowned(m) ⇒
+          // TODO this case might be collapsed with MemberRemoved, see ticket #2788
+          //   but right now we don't change Downed to Removed
           publish(event)
-          // notify DeathWatch about unreachable node
+          // notify DeathWatch about downed node
+          publish(AddressTerminated(m.address))
+
+        case MemberRemoved(m) ⇒
+          publish(event)
+          // notify DeathWatch about removed node
           publish(AddressTerminated(m.address))
 
         case _ ⇒


### PR DESCRIPTION
- Note that ClusterRouterConfig is not changed, i.e. routees will be removed
  when unreachable
- Routers that are not wrapped by ClusterRouterConfig will watch as usual, i.e.
  remove routees when Terminated, i.e. node down
