### PR TITLE
 #2799 - Making sure that 'null' is boxed when going across TypedActors ...

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -88,6 +88,14 @@ object TypedActorSpec {
 
     def joptionPigdog(delay: Long): JOption[String]
 
+    def nullFuture(): Future[Any] = null
+
+    def nullJOption(): JOption[Any] = null
+
+    def nullOption(): Option[Any] = null
+
+    def nullReturn(): Any = null
+
     def incr()
 
     def read(): Int
@@ -274,6 +282,14 @@ class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
       val t = newFooBar
       t.pigdog() must be("Pigdog")
       mustStop(t)
+    }
+
+    "be able to call null returning methods" in {
+      val t = newFooBar
+      t.nullJOption() must be === JOption.none
+      t.nullOption() must be === None
+      t.nullReturn() must be === null
+      Await.result(t.nullFuture(), remaining) must be === null
     }
 
     "be able to call Future-returning methods non-blockingly" in {


### PR DESCRIPTION
...to make sure that it also works over remoting

WARNING: I am not convinced this is the best solution, imo it's better to make sure that nulls can travel across the wire, it will also be a less intrusive change, and a more performant change. But it's ultimately up to the Akka team
