### PR TITLE
 #2812 - Fixing PatternSpec for gracefulStop by testing for juc.TimeoutE...

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -8,6 +8,7 @@ import language.postfixOps
 
 import akka.testkit.AkkaSpec
 import akka.actor.{ Props, Actor }
+import java.util.concurrent.TimeoutException
 import scala.concurrent.{ Future, Promise, Await }
 import scala.concurrent.duration._
 
@@ -39,10 +40,10 @@ class PatternSpec extends AkkaSpec {
       Await.ready(gracefulStop(target, 1 millis), 1 second)
     }
 
-    "complete Future with AskTimeoutException when actor not terminated within timeout" in {
+    "complete Future with TimeoutException when actor not terminated within timeout" in {
       val target = system.actorOf(Props[TargetActor])
       target ! Work(250 millis)
-      intercept[AskTimeoutException] { Await.result(gracefulStop(target, 10 millis), 200 millis) }
+      intercept[TimeoutException] { Await.result(gracefulStop(target, 10 millis), 200 millis) }
     }
   }
 


### PR DESCRIPTION
...xception (common ancestor)
