### PR TITLE
Allow allow-core-timeout=off conf of PinnedDispatcher, see #2856

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
@@ -26,7 +26,7 @@ class PinnedDispatcher(
     Int.MaxValue,
     Duration.Zero,
     _mailboxType,
-    _threadPoolConfig.copy(allowCorePoolTimeout = true, corePoolSize = 1, maxPoolSize = 1),
+    _threadPoolConfig.copy(corePoolSize = 1, maxPoolSize = 1),
     _shutdownTimeout) {
 
   @volatile

--- a/akka-docs/rst/java/dispatchers.rst
+++ b/akka-docs/rst/java/dispatchers.rst
@@ -123,6 +123,15 @@ And then using it:
 
 .. includecode:: ../java/code/docs/dispatcher/DispatcherDocTestBase.java#defining-pinned-dispatcher
 
+Note that ``thread-pool-executor`` configuration as per the above ``my-thread-pool-dispatcher`` example is
+NOT applicable. This is because every actor will have its own thread pool when using ``PinnedDispatcher``,
+and that pool will have only one thread.
+
+Note that it's not guaranteed that the *same* thread is used over time, since the core pool timeout
+is used for ``PinnedDispatcher`` to keep resource usage down in case of idle actors. To use the same
+thread all the time you need to add ``thread-pool-executor.allow-core-timeout=off`` to the
+configuration of the ``PinnedDispatcher``.
+
 Mailboxes
 ---------
 

--- a/akka-docs/rst/scala/dispatchers.rst
+++ b/akka-docs/rst/scala/dispatchers.rst
@@ -129,6 +129,11 @@ Note that ``thread-pool-executor`` configuration as per the above ``my-thread-po
 NOT applicable. This is because every actor will have its own thread pool when using ``PinnedDispatcher``,
 and that pool will have only one thread.
 
+Note that it's not guaranteed that the *same* thread is used over time, since the core pool timeout
+is used for ``PinnedDispatcher`` to keep resource usage down in case of idle actors. To use the same
+thread all the time you need to add ``thread-pool-executor.allow-core-timeout=off`` to the
+configuration of the ``PinnedDispatcher``.
+
 Mailboxes
 ---------
 


### PR DESCRIPTION
This is for master. Do you think it should be backported to 2.1.x (not 2.1.0)?
