### PR TITLE
#2820 TransformationSampleJapiSpec failure

### DIFF
--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
@@ -85,7 +85,7 @@ abstract class TransformationSampleSpec extends MultiNodeSpec(TransformationSamp
       testConductor.enter("frontend1-backend1-ok")
     }
 
-    "illustrate how more nodes registers" in within(15 seconds) {
+    "illustrate how more nodes registers" in within(20 seconds) {
       runOn(frontend2) {
         Cluster(system) join node(frontend1).address
         system.actorOf(Props[TransformationFrontend], name = "frontend")

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
@@ -72,7 +72,7 @@ abstract class TransformationSampleJapiSpec extends MultiNodeSpec(Transformation
       testConductor.enter("frontend1-started")
     }
 
-    "illustrate how a backend automatically registers" in within(15 seconds) {
+    "illustrate how a backend automatically registers" in within(20 seconds) {
       runOn(backend1) {
         Cluster(system) join node(frontend1).address
         system.actorOf(Props[TransformationBackend], name = "backend")


### PR DESCRIPTION
Bump allowed times to 20 seconds since MemberUp comes later now.

From the debug logs of the single failure in  ~ 120 runs, it's evident that joining takes 11 seconds and subsequent convergence and back end registration takes about 4 more seconds which is more or less the total 15 seconds.
