### PR TITLE
Hardened flushing by sending a final "null" message

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
@@ -32,7 +32,8 @@ private[remote] trait TcpHandlers extends CommonHandlers {
   }
 
   override def onMessage(ctx: ChannelHandlerContext, e: MessageEvent) {
-    notifyListener(e.getChannel, InboundPayload(ByteString(e.getMessage.asInstanceOf[ChannelBuffer].array())))
+    val bytes: Array[Byte] = e.getMessage.asInstanceOf[ChannelBuffer].array()
+    if (bytes.length > 0) notifyListener(e.getChannel, InboundPayload(ByteString(bytes)))
   }
 
   override def onException(ctx: ChannelHandlerContext, e: ExceptionEvent) {

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/UdpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/UdpSupport.scala
@@ -34,7 +34,8 @@ private[remote] trait UdpHandlers extends CommonHandlers {
         initUdp(e.getChannel, e.getRemoteAddress, e.getMessage.asInstanceOf[ChannelBuffer])
       } else {
         val listener = transport.udpConnectionTable.get(inetSocketAddress)
-        listener notify InboundPayload(ByteString(e.getMessage.asInstanceOf[ChannelBuffer].array()))
+        val bytes: Array[Byte] = e.getMessage.asInstanceOf[ChannelBuffer].array()
+        if (bytes.length > 0)listener notify InboundPayload(ByteString(bytes))
       }
     case _ ⇒
   }


### PR DESCRIPTION
To ensure proper flushing of the Netty transport a "null" message is written to the channel first, and we proceed with the release of the resources after that operation is finished.
