### PR TITLE
Added setIssueHandshake() to enable auto-handshake #2388

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.Config
 import java.net.{ UnknownHostException, SocketAddress, InetAddress, InetSocketAddress, ConnectException }
 import java.util.concurrent.{ ConcurrentHashMap, Executor, Executors, CancellationException }
 import org.jboss.netty.bootstrap.{ ConnectionlessBootstrap, Bootstrap, ClientBootstrap, ServerBootstrap }
-import org.jboss.netty.buffer.{ChannelBuffers, ChannelBuffer}
+import org.jboss.netty.buffer.{ ChannelBuffers, ChannelBuffer }
 import org.jboss.netty.channel._
 import org.jboss.netty.channel.group.{ ChannelGroupFuture, ChannelGroupFutureListener }
 import org.jboss.netty.channel.socket.nio.{ NioDatagramChannelFactory, NioServerSocketChannelFactory, NioClientSocketChannelFactory }
@@ -241,7 +241,7 @@ class NettyTransport(private val settings: NettyTransportSettings, private val s
   private val serverPipelineFactory: ChannelPipelineFactory = new ChannelPipelineFactory {
     override def getPipeline: ChannelPipeline = {
       val pipeline = newPipeline
-      if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(false))
+      if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(isClient = false))
       val handler = if (isDatagram) new UdpServerHandler(NettyTransport.this, associationListenerPromise.future)
       else new TcpServerHandler(NettyTransport.this, associationListenerPromise.future)
       pipeline.addLast("ServerHandler", handler)
@@ -252,7 +252,7 @@ class NettyTransport(private val settings: NettyTransportSettings, private val s
   private def clientPipelineFactory(statusPromise: Promise[AssociationHandle]): ChannelPipelineFactory = new ChannelPipelineFactory {
     override def getPipeline: ChannelPipeline = {
       val pipeline = newPipeline
-      if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(true))
+      if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(isClient = true))
       val handler = if (isDatagram) new UdpClientHandler(NettyTransport.this, statusPromise)
       else new TcpClientHandler(NettyTransport.this, statusPromise)
       pipeline.addLast("clienthandler", handler)

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -23,6 +23,7 @@ import util.control.{ NoStackTrace, NonFatal }
 import akka.dispatch.ThreadPoolConfig
 import akka.remote.transport.AssociationHandle.HandleEventListener
 import java.util.concurrent.atomic.AtomicInteger
+import org.jboss.netty.handler.ssl.SslHandler
 
 object NettyTransportSettings {
   sealed trait Mode
@@ -230,10 +231,17 @@ class NettyTransport(private val settings: NettyTransportSettings, private val s
   }
 
   private val associationListenerPromise: Promise[AssociationEventListener] = Promise()
+
+  private def sslHandler(isClient: Boolean): SslHandler = {
+    val handler = NettySSLSupport(settings.SslSettings.get, log, isClient)
+    handler.setIssueHandshake(true)
+    handler
+  }
+
   private val serverPipelineFactory: ChannelPipelineFactory = new ChannelPipelineFactory {
     override def getPipeline: ChannelPipeline = {
       val pipeline = newPipeline
-      if (EnableSsl) pipeline.addFirst("SslHandler", NettySSLSupport(settings.SslSettings.get, log, false))
+      if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(false))
       val handler = if (isDatagram) new UdpServerHandler(NettyTransport.this, associationListenerPromise.future)
       else new TcpServerHandler(NettyTransport.this, associationListenerPromise.future)
       pipeline.addLast("ServerHandler", handler)
@@ -244,7 +252,7 @@ class NettyTransport(private val settings: NettyTransportSettings, private val s
   private def clientPipelineFactory(statusPromise: Promise[AssociationHandle]): ChannelPipelineFactory = new ChannelPipelineFactory {
     override def getPipeline: ChannelPipeline = {
       val pipeline = newPipeline
-      if (EnableSsl) pipeline.addFirst("SslHandler", NettySSLSupport(settings.SslSettings.get, log, true))
+      if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(true))
       val handler = if (isDatagram) new UdpClientHandler(NettyTransport.this, statusPromise)
       else new TcpClientHandler(NettyTransport.this, statusPromise)
       pipeline.addLast("clienthandler", handler)

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/UdpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/UdpSupport.scala
@@ -35,7 +35,7 @@ private[remote] trait UdpHandlers extends CommonHandlers {
       } else {
         val listener = transport.udpConnectionTable.get(inetSocketAddress)
         val bytes: Array[Byte] = e.getMessage.asInstanceOf[ChannelBuffer].array()
-        if (bytes.length > 0)listener notify InboundPayload(ByteString(bytes))
+        if (bytes.length > 0) listener notify InboundPayload(ByteString(bytes))
       }
     case _ ⇒
   }


### PR DESCRIPTION
Attempt to fix the failed SSL tests. 

Netty docs says that "You must make sure not to write a message while the handshake is in progress unless you are renegotiating. You will be notified by the ChannelFuture which is returned by the handshake() method when the handshake process succeeds or fails."

And "If isIssueHandshake() is false (default) you will need to take care of calling handshake() by your own. In most situations were SslHandler is used in 'client mode' you want to issue a handshake once the connection was established. if setIssueHandshake(boolean) is set to true you don't need to worry about this as the SslHandler will take care of it."
