### PR TITLE
Enforcing ordering of Terminated wrt remote/local #2835

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Address.scala
+++ b/akka-actor/src/main/scala/akka/actor/Address.scala
@@ -19,10 +19,26 @@ import scala.collection.immutable
  */
 @SerialVersionUID(1L)
 final case class Address private (protocol: String, system: String, host: Option[String], port: Option[Int]) {
-  // Please note that local/non-local distinction must be preserved: host.isDefined == !isLocal
+  // Please note that local/non-local distinction must be preserved:
+  // host.isDefined == hasGlobalScope
+  // host.isEmpty == hasLocalScope
+  // hasLocalScope == !hasGlobalScope
 
   def this(protocol: String, system: String) = this(protocol, system, None, None)
   def this(protocol: String, system: String, host: String, port: Int) = this(protocol, system, Option(host), Some(port))
+
+  /**
+   * Returns true if this Address is only defined locally. It is not safe to send locally scoped addresses to remote
+   * hosts. See also [[akka.actor.Address#hasGlobalScope]].
+   */
+  def hasLocalScope: Boolean = host.isEmpty
+
+  /**
+   * Returns true if this Address is usable globally. Unlike locally defined addresses ([[akka.actor.Address#hasLocalScope]])
+   * addresses of global scope are safe to sent to other hosts, as they globally and uniquely identify an addressable
+   * entity.
+   */
+  def hasGlobalScope: Boolean = host.isDefined
 
   /**
    * Returns the canonical String representation of this Address formatted as:

--- a/akka-actor/src/main/scala/akka/actor/Address.scala
+++ b/akka-actor/src/main/scala/akka/actor/Address.scala
@@ -19,6 +19,7 @@ import scala.collection.immutable
  */
 @SerialVersionUID(1L)
 final case class Address private (protocol: String, system: String, host: Option[String], port: Option[Int]) {
+  // Please note that local/non-local distinction must be preserved: host.isDefined == !isLocal
 
   def this(protocol: String, system: String) = this(protocol, system, None, None)
   def this(protocol: String, system: String, host: String, port: Int) = this(protocol, system, Option(host), Some(port))

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -190,7 +190,11 @@ private[akka] trait FaultHandling { this: ActorCell ⇒
 
   private def finishTerminate() {
     val a = actor
-    // The following order is crucial for things to work properly. Only chnage this if you're very confident and lucky.
+    /* The following order is crucial for things to work properly. Only change this if you're very confident and lucky.
+     *
+     * Please note that if a parent is also a watcher then ChildTerminated and Terminated must be processed in this
+     * specific order.
+     */
     try if (a ne null) a.postStop()
     finally try dispatcher.detach(this)
     finally try parent.sendSystemMessage(ChildTerminated(self))


### PR DESCRIPTION
Due to the undefined ordering between Terminated messages it was possible for the RemoteDaemon to shut down and proceed with shutting down the Remoting before a Terminated was sent to remote watchers -- causing the message to be dropped.

I am not sure this is the best way to distinguish between local/remote ActorRefs, but the bug is confirmed to be fixed. Also, some feedback how this might affect cluster deployed actors is welcome.
