### PR TITLE
Only client should issue an SSL handshake #2833

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -248,7 +248,7 @@ class NettyTransport(private val settings: NettyTransportSettings, private val s
 
   private def sslHandler(isClient: Boolean): SslHandler = {
     val handler = NettySSLSupport(settings.SslSettings.get, log, isClient)
-    handler.setIssueHandshake(true)
+    if (isClient) handler.setIssueHandshake(true)
     handler
   }
 


### PR DESCRIPTION
I _think_ this is a problem of the current SSL tests on jenkins.typesafe.com. We can however open a separate job if we want to be sure before merge.
