### PR TITLE
Correction of within time in TransformationSampleJapiSpec, see #2875

### DIFF
--- a/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/transformation/japi/TransformationBackend.java
+++ b/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/transformation/japi/TransformationBackend.java
@@ -7,7 +7,6 @@ import sample.cluster.transformation.japi.TransformationMessages.TransformationR
 import akka.actor.UntypedActor;
 import akka.cluster.Cluster;
 import akka.cluster.ClusterEvent.CurrentClusterState;
-import akka.cluster.ClusterEvent.MemberEvent;
 import akka.cluster.ClusterEvent.MemberUp;
 import akka.cluster.Member;
 import akka.cluster.MemberStatus;
@@ -18,10 +17,10 @@ public class TransformationBackend extends UntypedActor {
 
   Cluster cluster = Cluster.get(getContext().system());
 
-  //subscribe to cluster changes, MemberEvent
+  //subscribe to cluster changes, MemberUp
   @Override
   public void preStart() {
-    cluster.subscribe(getSelf(), MemberEvent.class);
+    cluster.subscribe(getSelf(), MemberUp.class);
   }
 
   //re-subscribe when restart

--- a/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/transformation/TransformationSample.scala
+++ b/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/transformation/TransformationSample.scala
@@ -12,7 +12,6 @@ import akka.actor.RootActorPath
 import akka.actor.Terminated
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.CurrentClusterState
-import akka.cluster.ClusterEvent.MemberEvent
 import akka.cluster.ClusterEvent.MemberUp
 import akka.cluster.Member
 import akka.cluster.MemberStatus
@@ -90,9 +89,9 @@ class TransformationBackend extends Actor {
 
   val cluster = Cluster(context.system)
 
-  // subscribe to cluster changes, MemberEvent
+  // subscribe to cluster changes, MemberUp
   // re-subscribe when restart
-  override def preStart(): Unit = cluster.subscribe(self, classOf[MemberEvent])
+  override def preStart(): Unit = cluster.subscribe(self, classOf[MemberUp])
   override def postStop(): Unit = cluster.unsubscribe(self)
 
   def receive = {

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
@@ -72,7 +72,7 @@ abstract class TransformationSampleJapiSpec extends MultiNodeSpec(Transformation
       testConductor.enter("frontend1-started")
     }
 
-    "illustrate how a backend automatically registers" in within(20 seconds) {
+    "illustrate how a backend automatically registers" in within(15 seconds) {
       runOn(backend1) {
         Cluster(system) join node(frontend1).address
         system.actorOf(Props[TransformationBackend], name = "backend")
@@ -86,7 +86,7 @@ abstract class TransformationSampleJapiSpec extends MultiNodeSpec(Transformation
       testConductor.enter("frontend1-backend1-ok")
     }
 
-    "illustrate how more nodes registers" in within(15 seconds) {
+    "illustrate how more nodes registers" in within(20 seconds) {
       runOn(frontend2) {
         Cluster(system) join node(frontend1).address
         system.actorOf(Props[TransformationFrontend], name = "frontend")


### PR DESCRIPTION
- We had the same issue in ticket 2820 and then the conclusion was that
  the within timeout should be increased due to "publish on convergence",
  but it was not done correctly in TransformationSampleJapiSpec, see
  https://github.com/akka/akka/commit/8bf7c03158cd4e064d3eecef1b331d14c2990775
- Also fixed the wrong (but harmless) subscribe in TransformationBackend
