### PR TITLE
Fix HashedWheelTimer to properly handle timeouts that are multiple of wheel period

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala
@@ -5,34 +5,11 @@ package akka.util
 
 import language.postfixOps
 
-import org.scalatest.WordSpec
-import org.scalatest.matchers.MustMatchers
 import scala.concurrent.duration._
-import scala.concurrent.Await
 
-import java.util.concurrent.TimeUnit._
 import akka.testkit.AkkaSpec
-import akka.testkit.TestLatch
-import java.util.concurrent.TimeoutException
-import akka.testkit.LongRunningTest
 
 class DurationSpec extends AkkaSpec {
-
-  "A HashedWheelTimer" must {
-
-    "not mess up long timeouts" taggedAs LongRunningTest in {
-      val longish = Long.MaxValue.nanos
-      val barrier = TestLatch()
-      import system.dispatcher
-      val job = system.scheduler.scheduleOnce(longish)(barrier.countDown())
-      intercept[TimeoutException] {
-        // this used to fire after 46 seconds due to wrap-around
-        Await.ready(barrier, 90 seconds)
-      }
-      job.cancel()
-    }
-
-  }
 
   "Duration" must {
 

--- a/akka-actor/src/main/java/akka/util/internal/HashedWheelTimer.java
+++ b/akka-actor/src/main/java/akka/util/internal/HashedWheelTimer.java
@@ -268,6 +268,8 @@ public class HashedWheelTimer implements Timer {
         // one tick early; that shouldn’t matter since we’re talking 270 years here
         if (relativeIndex < 0) relativeIndex = delay / tickDuration;
         if (relativeIndex == 0) relativeIndex = 1;
+        // if an integral number of wheel rotations, schedule one tick earlier
+        if ((relativeIndex & mask) == 0) relativeIndex--;
         final long remainingRounds = relativeIndex / wheel.length;
 
         // Add the timeout to the wheel.


### PR DESCRIPTION
see ticket: https://www.assembla.com/spaces/akka/tickets/2898-hashedwheeltimer-incorrectly-schedules-events-when-delay-is-a-multiple-of-the-wheel-period#/activity/ticket:

applies to both 2.1.0 and 2.0.5 (although HWT source is in a different location in 2.0.5)
