### PR TITLE
Throw startup exception from Remoting, see #2872

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -202,8 +202,12 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
           eventPublisher.notifyListeners(RemotingListenEvent(addresses))
 
         } catch {
-          case e: TimeoutException ⇒ notifyError("Startup timed out", e)
-          case NonFatal(e)         ⇒ notifyError("Startup failed", e)
+          case e: TimeoutException ⇒
+            notifyError("Startup timed out", e)
+            throw e
+          case NonFatal(e) ⇒
+            notifyError("Startup failed", e)
+            throw e
         }
 
       case Some(_) ⇒


### PR DESCRIPTION
- The problem with NPE of defaultAddress was because if the
  init of the transport takes long time (network timeout) the
  defaultAddress was never set
