### PR TITLE
Unique barriers for each round in StressSpec.exerciseSupervision, see #2905

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -832,7 +832,6 @@ abstract class StressSpec
 
         step += 1
         loop(counter + 1, nextAS, nextAddresses)
-
       }
     }
 
@@ -926,6 +925,7 @@ abstract class StressSpec
         }
 
         awaitClusterResult
+        step += 1
       }
     }
 


### PR DESCRIPTION
- Looks like the issue was caused by a mixup of barriers and/or name
  of the result aggregator actor
