### PR TITLE
Leaking Netty threads causes file handle exhaustion

### DIFF
--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -448,6 +448,10 @@ private[akka] class Controller(private var initialParticipants: Int, controllerP
     case GetNodes    ⇒ sender ! nodes.keys
     case GetSockAddr ⇒ sender ! connection.getLocalAddress
   }
+
+  override def postStop() {
+    RemoteConnection.shutdown(connection)
+  }
 }
 
 /**

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Player.scala
@@ -313,6 +313,7 @@ private[akka] class PlayerHandler(
     val channel = event.getChannel
     log.debug("disconnected from {}", getAddrString(channel))
     fsm ! PoisonPill
+    RemoteConnection.shutdown(channel)
   }
 
   override def messageReceived(ctx: ChannelHandlerContext, event: MessageEvent) = {

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
@@ -70,4 +70,8 @@ private[akka] object RemoteConnection {
     case i: InetSocketAddress ⇒ i.toString
     case _                    ⇒ "[unknown]"
   }
+
+  def shutdown(channel: Channel) = {
+    channel.getFactory.releaseExternalResources()
+  }
 }

--- a/akka-remote-tests/src/test/scala/akka/remote/testconductor/ControllerSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testconductor/ControllerSpec.scala
@@ -4,10 +4,9 @@
 package akka.remote.testconductor
 
 import akka.testkit.AkkaSpec
-import akka.actor.Props
+import akka.actor.{ PoisonPill, Props, AddressFromURIString }
 import akka.testkit.ImplicitSender
 import akka.remote.testconductor.Controller.NodeInfo
-import akka.actor.AddressFromURIString
 import java.net.InetSocketAddress
 import java.net.InetAddress
 
@@ -35,6 +34,7 @@ class ControllerSpec extends AkkaSpec(ControllerSpec.config) with ImplicitSender
       expectMsg(ToClient(Done))
       c ! Controller.GetNodes
       expectMsgType[Iterable[RoleName]].toSet must be(Set(A, B))
+      c ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
   }

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -381,8 +381,13 @@ class NettyTransport(private val settings: NettyTransportSettings, private val s
       _ ← always(channelGroup.close())
     } {
       // Release the selectors, but don't try to kill the dispatcher
-      if (UseDispatcherForIo.isDefined) inboundBootstrap.shutdown()
-      else inboundBootstrap.releaseExternalResources()
+      if (UseDispatcherForIo.isDefined) {
+        clientChannelFactory.shutdown()
+        serverChannelFactory.shutdown()
+      } else {
+        clientChannelFactory.releaseExternalResources()
+        serverChannelFactory.releaseExternalResources()
+      }
     }
 
   }


### PR DESCRIPTION
As described in Ticket 2862 we buffer overflow in libnss_ldap sometimes during the test. This was due to the fact that we don't properly shut down Netty threads in some places.

There are two commits here, so the second can be cherry picked easily to release-2.1.

Thanks for the new remoting navigation help @drewhk
