### PR TITLE
2.1 Cherry Pick 2862 Leaking Netty threads causes file handle exhaustion

### DIFF
--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -476,6 +476,10 @@ private[akka] class Controller(private var initialParticipants: Int, controllerP
     case GetNodes    ⇒ sender ! nodes.keys
     case GetSockAddr ⇒ sender ! connection.getLocalAddress
   }
+
+  override def postStop() {
+    RemoteConnection.shutdown(connection)
+  }
 }
 
 /**

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/Player.scala
@@ -298,6 +298,7 @@ private[akka] class PlayerHandler(
     val channel = event.getChannel
     log.debug("disconnected from {}", getAddrString(channel))
     fsm ! PoisonPill
+    RemoteConnection.shutdown(channel)
   }
 
   override def messageReceived(ctx: ChannelHandlerContext, event: MessageEvent) = {

--- a/akka-remote-tests/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
+++ b/akka-remote-tests/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
@@ -70,4 +70,8 @@ private[akka] object RemoteConnection {
     case i: InetSocketAddress ⇒ i.toString
     case _                    ⇒ "[unknown]"
   }
+
+  def shutdown(channel: Channel) = {
+    channel.getFactory.releaseExternalResources()
+  }
 }

--- a/akka-remote-tests/src/test/scala/akka/remote/testconductor/BarrierSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testconductor/BarrierSpec.scala
@@ -5,7 +5,7 @@ package akka.remote.testconductor
 
 import language.postfixOps
 
-import akka.actor.{ Props, AddressFromURIString, ActorRef, Actor, OneForOneStrategy, SupervisorStrategy }
+import akka.actor.{ Props, AddressFromURIString, ActorRef, Actor, OneForOneStrategy, SupervisorStrategy, PoisonPill }
 import akka.testkit.{ AkkaSpec, ImplicitSender, EventFilter, TestProbe, TimingTest }
 import scala.concurrent.duration._
 import akka.event.Logging
@@ -244,6 +244,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       EventFilter[BarrierEmpty](occurrences = 1) intercept {
         b ! Remove(A)
       }
+      b ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "register clients and disconnect them" taggedAs TimingTest in {
@@ -254,12 +255,14 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       expectNoMsg(1 second)
       b ! ClientDisconnected(A)
       expectNoMsg(1 second)
+      b ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail entering barrier when nobody registered" taggedAs TimingTest in {
       val b = getController(0)
       b ! EnterBarrier("b", None)
       expectMsg(ToClient(BarrierResult("b", false)))
+      b ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "enter barrier" taggedAs TimingTest in {
@@ -276,6 +279,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
         a.expectMsg(ToClient(BarrierResult("bar11", true)))
         b.expectMsg(ToClient(BarrierResult("bar11", true)))
       }
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "enter barrier with joining node" taggedAs TimingTest in {
@@ -296,6 +300,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
         b.expectMsg(ToClient(BarrierResult("bar12", true)))
         c.expectMsg(ToClient(BarrierResult("bar12", true)))
       }
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "enter barrier with leaving node" taggedAs TimingTest in {
@@ -318,6 +323,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       }
       barrier ! ClientDisconnected(C)
       expectNoMsg(1 second)
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "leave barrier when last “arrived” is removed" taggedAs TimingTest in {
@@ -331,6 +337,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       barrier ! Remove(A)
       b.send(barrier, EnterBarrier("foo", None))
       b.expectMsg(ToClient(BarrierResult("foo", true)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail barrier with disconnecing node" taggedAs TimingTest in {
@@ -348,6 +355,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
         barrier ! ClientDisconnected(B)
       }
       a.expectMsg(ToClient(BarrierResult("bar15", false)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail barrier with disconnecing node who already arrived" taggedAs TimingTest in {
@@ -367,6 +375,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
         barrier ! ClientDisconnected(B)
       }
       a.expectMsg(ToClient(BarrierResult("bar16", false)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail when entering wrong barrier" taggedAs TimingTest in {
@@ -384,6 +393,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       }
       a.expectMsg(ToClient(BarrierResult("bar17", false)))
       b.expectMsg(ToClient(BarrierResult("foo", false)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail after barrier timeout" taggedAs TimingTest in {
@@ -402,6 +412,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       b.send(barrier, EnterBarrier("bar18", None))
       a.expectMsg(ToClient(BarrierResult("bar18", false)))
       b.expectMsg(ToClient(BarrierResult("bar18", false)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail if a node registers twice" taggedAs TimingTest in {
@@ -415,6 +426,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       }
       a.expectMsg(ToClient(BarrierResult("initial startup", false)))
       b.expectMsg(ToClient(BarrierResult("initial startup", false)))
+      controller ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail subsequent barriers if a node registers twice" taggedAs TimingTest in {
@@ -430,6 +442,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       }
       a.send(controller, EnterBarrier("bar19", None))
       a.expectMsg(ToClient(BarrierResult("bar19", false)))
+      controller ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail subsequent barriers after foreced failure" taggedAs TimingTest in {
@@ -451,6 +464,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       b.send(barrier, EnterBarrier("bar21", None))
       a.expectMsg(ToClient(BarrierResult("bar21", false)))
       b.expectMsg(ToClient(BarrierResult("bar21", false)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "timeout within the shortest timeout if the new timeout is shorter" taggedAs TimingTest in {
@@ -474,6 +488,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       a.expectMsg(ToClient(BarrierResult("bar22", false)))
       b.expectMsg(ToClient(BarrierResult("bar22", false)))
       c.expectMsg(ToClient(BarrierResult("bar22", false)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "timeout within the shortest timeout if the new timeout is longer" taggedAs TimingTest in {
@@ -497,6 +512,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
       a.expectMsg(ToClient(BarrierResult("bar23", false)))
       b.expectMsg(ToClient(BarrierResult("bar23", false)))
       c.expectMsg(ToClient(BarrierResult("bar23", false)))
+      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "finally have no failure messages left" taggedAs TimingTest in {

--- a/akka-remote-tests/src/test/scala/akka/remote/testconductor/BarrierSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testconductor/BarrierSpec.scala
@@ -236,283 +236,283 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
   "A Controller with BarrierCoordinator" must {
 
     "register clients and remove them" taggedAs TimingTest in {
-      val b = getController(1)
-      b ! NodeInfo(A, AddressFromURIString("akka://sys"), testActor)
-      expectMsg(ToClient(Done))
-      b ! Remove(B)
-      b ! Remove(A)
-      EventFilter[BarrierEmpty](occurrences = 1) intercept {
+      withController(1) { b ⇒
+        b ! NodeInfo(A, AddressFromURIString("akka://sys"), testActor)
+        expectMsg(ToClient(Done))
+        b ! Remove(B)
         b ! Remove(A)
+        EventFilter[BarrierEmpty](occurrences = 1) intercept {
+          b ! Remove(A)
+        }
       }
-      b ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "register clients and disconnect them" taggedAs TimingTest in {
-      val b = getController(1)
-      b ! NodeInfo(A, AddressFromURIString("akka://sys"), testActor)
-      expectMsg(ToClient(Done))
-      b ! ClientDisconnected(B)
-      expectNoMsg(1 second)
-      b ! ClientDisconnected(A)
-      expectNoMsg(1 second)
-      b ! PoisonPill // clean up so network connections don't accumulate during test run
+      withController(1) { b ⇒
+        b ! NodeInfo(A, AddressFromURIString("akka://sys"), testActor)
+        expectMsg(ToClient(Done))
+        b ! ClientDisconnected(B)
+        expectNoMsg(1 second)
+        b ! ClientDisconnected(A)
+        expectNoMsg(1 second)
+      }
     }
 
     "fail entering barrier when nobody registered" taggedAs TimingTest in {
-      val b = getController(0)
-      b ! EnterBarrier("b", None)
-      expectMsg(ToClient(BarrierResult("b", false)))
-      b ! PoisonPill // clean up so network connections don't accumulate during test run
+      withController(0) { b ⇒
+        b ! EnterBarrier("b", None)
+        expectMsg(ToClient(BarrierResult("b", false)))
+      }
     }
 
     "enter barrier" taggedAs TimingTest in {
-      val barrier = getController(2)
-      val a, b = TestProbe()
-      barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar11", None))
-      noMsg(a, b)
-      within(2 seconds) {
-        b.send(barrier, EnterBarrier("bar11", None))
-        a.expectMsg(ToClient(BarrierResult("bar11", true)))
-        b.expectMsg(ToClient(BarrierResult("bar11", true)))
+      withController(2) { barrier ⇒
+        val a, b = TestProbe()
+        barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar11", None))
+        noMsg(a, b)
+        within(2 seconds) {
+          b.send(barrier, EnterBarrier("bar11", None))
+          a.expectMsg(ToClient(BarrierResult("bar11", true)))
+          b.expectMsg(ToClient(BarrierResult("bar11", true)))
+        }
       }
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "enter barrier with joining node" taggedAs TimingTest in {
-      val barrier = getController(2)
-      val a, b, c = TestProbe()
-      barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar12", None))
-      barrier ! NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
-      c.expectMsg(ToClient(Done))
-      b.send(barrier, EnterBarrier("bar12", None))
-      noMsg(a, b, c)
-      within(2 seconds) {
-        c.send(barrier, EnterBarrier("bar12", None))
-        a.expectMsg(ToClient(BarrierResult("bar12", true)))
-        b.expectMsg(ToClient(BarrierResult("bar12", true)))
-        c.expectMsg(ToClient(BarrierResult("bar12", true)))
+      withController(2) { barrier ⇒
+        val a, b, c = TestProbe()
+        barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar12", None))
+        barrier ! NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
+        c.expectMsg(ToClient(Done))
+        b.send(barrier, EnterBarrier("bar12", None))
+        noMsg(a, b, c)
+        within(2 seconds) {
+          c.send(barrier, EnterBarrier("bar12", None))
+          a.expectMsg(ToClient(BarrierResult("bar12", true)))
+          b.expectMsg(ToClient(BarrierResult("bar12", true)))
+          c.expectMsg(ToClient(BarrierResult("bar12", true)))
+        }
       }
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "enter barrier with leaving node" taggedAs TimingTest in {
-      val barrier = getController(3)
-      val a, b, c = TestProbe()
-      barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      barrier ! NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      c.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar13", None))
-      b.send(barrier, EnterBarrier("bar13", None))
-      barrier ! Remove(A)
-      barrier ! ClientDisconnected(A)
-      noMsg(a, b, c)
-      b.within(2 seconds) {
-        barrier ! Remove(C)
-        b.expectMsg(ToClient(BarrierResult("bar13", true)))
+      withController(3) { barrier ⇒
+        val a, b, c = TestProbe()
+        barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        barrier ! NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        c.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar13", None))
+        b.send(barrier, EnterBarrier("bar13", None))
+        barrier ! Remove(A)
+        barrier ! ClientDisconnected(A)
+        noMsg(a, b, c)
+        b.within(2 seconds) {
+          barrier ! Remove(C)
+          b.expectMsg(ToClient(BarrierResult("bar13", true)))
+        }
+        barrier ! ClientDisconnected(C)
+        expectNoMsg(1 second)
       }
-      barrier ! ClientDisconnected(C)
-      expectNoMsg(1 second)
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "leave barrier when last “arrived” is removed" taggedAs TimingTest in {
-      val barrier = getController(2)
-      val a, b = TestProbe()
-      barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar14", None))
-      barrier ! Remove(A)
-      b.send(barrier, EnterBarrier("foo", None))
-      b.expectMsg(ToClient(BarrierResult("foo", true)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
+      withController(2) { barrier ⇒
+        val a, b = TestProbe()
+        barrier ! NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar14", None))
+        barrier ! Remove(A)
+        b.send(barrier, EnterBarrier("foo", None))
+        b.expectMsg(ToClient(BarrierResult("foo", true)))
+      }
     }
 
     "fail barrier with disconnecing node" taggedAs TimingTest in {
-      val barrier = getController(2)
-      val a, b = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      barrier ! nodeA
-      barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar15", None))
-      barrier ! ClientDisconnected(RoleName("unknown"))
-      noMsg(a)
-      EventFilter[ClientLost](occurrences = 1) intercept {
-        barrier ! ClientDisconnected(B)
+      withController(2) { barrier ⇒
+        val a, b = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        barrier ! nodeA
+        barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar15", None))
+        barrier ! ClientDisconnected(RoleName("unknown"))
+        noMsg(a)
+        EventFilter[ClientLost](occurrences = 1) intercept {
+          barrier ! ClientDisconnected(B)
+        }
+        a.expectMsg(ToClient(BarrierResult("bar15", false)))
       }
-      a.expectMsg(ToClient(BarrierResult("bar15", false)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail barrier with disconnecing node who already arrived" taggedAs TimingTest in {
-      val barrier = getController(3)
-      val a, b, c = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      val nodeC = NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
-      barrier ! nodeA
-      barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      barrier ! nodeC
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      c.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar16", None))
-      b.send(barrier, EnterBarrier("bar16", None))
-      EventFilter[ClientLost](occurrences = 1) intercept {
-        barrier ! ClientDisconnected(B)
+      withController(3) { barrier ⇒
+        val a, b, c = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        val nodeC = NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
+        barrier ! nodeA
+        barrier ! NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        barrier ! nodeC
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        c.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar16", None))
+        b.send(barrier, EnterBarrier("bar16", None))
+        EventFilter[ClientLost](occurrences = 1) intercept {
+          barrier ! ClientDisconnected(B)
+        }
+        a.expectMsg(ToClient(BarrierResult("bar16", false)))
       }
-      a.expectMsg(ToClient(BarrierResult("bar16", false)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail when entering wrong barrier" taggedAs TimingTest in {
-      val barrier = getController(2)
-      val a, b = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      barrier ! nodeA
-      val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      barrier ! nodeB
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar17", None))
-      EventFilter[WrongBarrier](occurrences = 1) intercept {
-        b.send(barrier, EnterBarrier("foo", None))
+      withController(2) { barrier ⇒
+        val a, b = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        barrier ! nodeA
+        val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        barrier ! nodeB
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar17", None))
+        EventFilter[WrongBarrier](occurrences = 1) intercept {
+          b.send(barrier, EnterBarrier("foo", None))
+        }
+        a.expectMsg(ToClient(BarrierResult("bar17", false)))
+        b.expectMsg(ToClient(BarrierResult("foo", false)))
       }
-      a.expectMsg(ToClient(BarrierResult("bar17", false)))
-      b.expectMsg(ToClient(BarrierResult("foo", false)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail after barrier timeout" taggedAs TimingTest in {
-      val barrier = getController(2)
-      val a, b = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      barrier ! nodeA
-      barrier ! nodeB
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar18", Option(2 seconds)))
-      EventFilter[BarrierTimeout](occurrences = 1) intercept {
-        Thread.sleep(4000)
+      withController(2) { barrier ⇒
+        val a, b = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        barrier ! nodeA
+        barrier ! nodeB
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar18", Option(2 seconds)))
+        EventFilter[BarrierTimeout](occurrences = 1) intercept {
+          Thread.sleep(4000)
+        }
+        b.send(barrier, EnterBarrier("bar18", None))
+        a.expectMsg(ToClient(BarrierResult("bar18", false)))
+        b.expectMsg(ToClient(BarrierResult("bar18", false)))
       }
-      b.send(barrier, EnterBarrier("bar18", None))
-      a.expectMsg(ToClient(BarrierResult("bar18", false)))
-      b.expectMsg(ToClient(BarrierResult("bar18", false)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail if a node registers twice" taggedAs TimingTest in {
-      val controller = getController(2)
-      val a, b = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      val nodeB = NodeInfo(A, AddressFromURIString("akka://sys"), b.ref)
-      controller ! nodeA
-      EventFilter[DuplicateNode](occurrences = 1) intercept {
-        controller ! nodeB
+      withController(2) { controller ⇒
+        val a, b = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        val nodeB = NodeInfo(A, AddressFromURIString("akka://sys"), b.ref)
+        controller ! nodeA
+        EventFilter[DuplicateNode](occurrences = 1) intercept {
+          controller ! nodeB
+        }
+        a.expectMsg(ToClient(BarrierResult("initial startup", false)))
+        b.expectMsg(ToClient(BarrierResult("initial startup", false)))
       }
-      a.expectMsg(ToClient(BarrierResult("initial startup", false)))
-      b.expectMsg(ToClient(BarrierResult("initial startup", false)))
-      controller ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail subsequent barriers if a node registers twice" taggedAs TimingTest in {
-      val controller = getController(1)
-      val a, b = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      val nodeB = NodeInfo(A, AddressFromURIString("akka://sys"), b.ref)
-      controller ! nodeA
-      a.expectMsg(ToClient(Done))
-      EventFilter[DuplicateNode](occurrences = 1) intercept {
-        controller ! nodeB
-        b.expectMsg(ToClient(BarrierResult("initial startup", false)))
+      withController(1) { controller ⇒
+        val a, b = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        val nodeB = NodeInfo(A, AddressFromURIString("akka://sys"), b.ref)
+        controller ! nodeA
+        a.expectMsg(ToClient(Done))
+        EventFilter[DuplicateNode](occurrences = 1) intercept {
+          controller ! nodeB
+          b.expectMsg(ToClient(BarrierResult("initial startup", false)))
+        }
+        a.send(controller, EnterBarrier("bar19", None))
+        a.expectMsg(ToClient(BarrierResult("bar19", false)))
       }
-      a.send(controller, EnterBarrier("bar19", None))
-      a.expectMsg(ToClient(BarrierResult("bar19", false)))
-      controller ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "fail subsequent barriers after foreced failure" taggedAs TimingTest in {
-      val barrier = getController(2)
-      val a, b = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      barrier ! nodeA
-      barrier ! nodeB
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar20", Option(2 seconds)))
-      EventFilter[FailedBarrier](occurrences = 1) intercept {
-        b.send(barrier, FailBarrier("bar20"))
-        a.expectMsg(ToClient(BarrierResult("bar20", false)))
-        b.expectNoMsg(1 second)
+      withController(2) { barrier ⇒
+        val a, b = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        barrier ! nodeA
+        barrier ! nodeB
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar20", Option(2 seconds)))
+        EventFilter[FailedBarrier](occurrences = 1) intercept {
+          b.send(barrier, FailBarrier("bar20"))
+          a.expectMsg(ToClient(BarrierResult("bar20", false)))
+          b.expectNoMsg(1 second)
+        }
+        a.send(barrier, EnterBarrier("bar21", None))
+        b.send(barrier, EnterBarrier("bar21", None))
+        a.expectMsg(ToClient(BarrierResult("bar21", false)))
+        b.expectMsg(ToClient(BarrierResult("bar21", false)))
       }
-      a.send(barrier, EnterBarrier("bar21", None))
-      b.send(barrier, EnterBarrier("bar21", None))
-      a.expectMsg(ToClient(BarrierResult("bar21", false)))
-      b.expectMsg(ToClient(BarrierResult("bar21", false)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "timeout within the shortest timeout if the new timeout is shorter" taggedAs TimingTest in {
-      val barrier = getController(3)
-      val a, b, c = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      val nodeC = NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
-      barrier ! nodeA
-      barrier ! nodeB
-      barrier ! nodeC
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      c.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar22", Option(10 seconds)))
-      b.send(barrier, EnterBarrier("bar22", Option(2 seconds)))
-      EventFilter[BarrierTimeout](occurrences = 1) intercept {
-        Thread.sleep(4000)
+      withController(3) { barrier ⇒
+        val a, b, c = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        val nodeC = NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
+        barrier ! nodeA
+        barrier ! nodeB
+        barrier ! nodeC
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        c.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar22", Option(10 seconds)))
+        b.send(barrier, EnterBarrier("bar22", Option(2 seconds)))
+        EventFilter[BarrierTimeout](occurrences = 1) intercept {
+          Thread.sleep(4000)
+        }
+        c.send(barrier, EnterBarrier("bar22", None))
+        a.expectMsg(ToClient(BarrierResult("bar22", false)))
+        b.expectMsg(ToClient(BarrierResult("bar22", false)))
+        c.expectMsg(ToClient(BarrierResult("bar22", false)))
       }
-      c.send(barrier, EnterBarrier("bar22", None))
-      a.expectMsg(ToClient(BarrierResult("bar22", false)))
-      b.expectMsg(ToClient(BarrierResult("bar22", false)))
-      c.expectMsg(ToClient(BarrierResult("bar22", false)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "timeout within the shortest timeout if the new timeout is longer" taggedAs TimingTest in {
-      val barrier = getController(3)
-      val a, b, c = TestProbe()
-      val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
-      val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
-      val nodeC = NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
-      barrier ! nodeA
-      barrier ! nodeB
-      barrier ! nodeC
-      a.expectMsg(ToClient(Done))
-      b.expectMsg(ToClient(Done))
-      c.expectMsg(ToClient(Done))
-      a.send(barrier, EnterBarrier("bar23", Option(2 seconds)))
-      b.send(barrier, EnterBarrier("bar23", Option(10 seconds)))
-      EventFilter[BarrierTimeout](occurrences = 1) intercept {
-        Thread.sleep(4000)
+      withController(3) { barrier ⇒
+        val a, b, c = TestProbe()
+        val nodeA = NodeInfo(A, AddressFromURIString("akka://sys"), a.ref)
+        val nodeB = NodeInfo(B, AddressFromURIString("akka://sys"), b.ref)
+        val nodeC = NodeInfo(C, AddressFromURIString("akka://sys"), c.ref)
+        barrier ! nodeA
+        barrier ! nodeB
+        barrier ! nodeC
+        a.expectMsg(ToClient(Done))
+        b.expectMsg(ToClient(Done))
+        c.expectMsg(ToClient(Done))
+        a.send(barrier, EnterBarrier("bar23", Option(2 seconds)))
+        b.send(barrier, EnterBarrier("bar23", Option(10 seconds)))
+        EventFilter[BarrierTimeout](occurrences = 1) intercept {
+          Thread.sleep(4000)
+        }
+        c.send(barrier, EnterBarrier("bar23", None))
+        a.expectMsg(ToClient(BarrierResult("bar23", false)))
+        b.expectMsg(ToClient(BarrierResult("bar23", false)))
+        c.expectMsg(ToClient(BarrierResult("bar23", false)))
       }
-      c.send(barrier, EnterBarrier("bar23", None))
-      a.expectMsg(ToClient(BarrierResult("bar23", false)))
-      b.expectMsg(ToClient(BarrierResult("bar23", false)))
-      c.expectMsg(ToClient(BarrierResult("bar23", false)))
-      barrier ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
     "finally have no failure messages left" taggedAs TimingTest in {
@@ -521,7 +521,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
 
   }
 
-  private def getController(participants: Int): ActorRef = {
+  private def withController(participants: Int)(f: (ActorRef) ⇒ Unit): Unit = {
     system.actorOf(Props(new Actor {
       val controller = context.actorOf(Props(new Controller(participants, new InetSocketAddress(InetAddress.getLocalHost, 0))))
       controller ! GetSockAddr
@@ -532,7 +532,9 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
         case x: InetSocketAddress ⇒ testActor ! controller
       }
     }))
-    expectMsgType[ActorRef]
+    val actor = expectMsgType[ActorRef]
+    f(actor)
+    actor ! PoisonPill // clean up so network connections don't accumulate during test run
   }
 
   /**

--- a/akka-remote-tests/src/test/scala/akka/remote/testconductor/ControllerSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testconductor/ControllerSpec.scala
@@ -4,10 +4,9 @@
 package akka.remote.testconductor
 
 import akka.testkit.AkkaSpec
-import akka.actor.Props
+import akka.actor.{ PoisonPill, Props, AddressFromURIString }
 import akka.testkit.ImplicitSender
 import akka.remote.testconductor.Controller.NodeInfo
-import akka.actor.AddressFromURIString
 import java.net.InetSocketAddress
 import java.net.InetAddress
 
@@ -36,6 +35,7 @@ class ControllerSpec extends AkkaSpec(ControllerSpec.config) with ImplicitSender
       expectMsg(ToClient(Done))
       c ! Controller.GetNodes
       expectMsgType[Iterable[RoleName]].toSet must be(Set(A, B))
+      c ! PoisonPill // clean up so network connections don't accumulate during test run
     }
 
   }


### PR DESCRIPTION
Cherry picking the 2.1 related commit.
Making test more dry as suggested in comments (after close)
