### PR TITLE
Terminate zeromq context after actors have terminated

### DIFF
--- a/akka-zeromq/src/test/scala/akka/zeromq/ConcurrentSocketActorSpec.scala
+++ b/akka-zeromq/src/test/scala/akka/zeromq/ConcurrentSocketActorSpec.scala
@@ -99,6 +99,8 @@ class ConcurrentSocketActorSpec extends AkkaSpec {
         system stop requester
         system stop replier
         replierProbe.expectMsg(Closed)
+        awaitCond(requester.isTerminated)
+        awaitCond(replier.isTerminated)
         context.term
       }
     }
@@ -120,6 +122,8 @@ class ConcurrentSocketActorSpec extends AkkaSpec {
         system stop pusher
         system stop puller
         pullerProbe.expectMsg(Closed)
+        awaitCond(pusher.isTerminated)
+        awaitCond(puller.isTerminated)
         context.term
       }
     }


### PR DESCRIPTION
So the test just destroys the zeromq context right under the feet of the actors, that it has just done stop on without waiting for their termination.
