### PR TITLE
don’t use the testActor.queue for probe.watch(), see #2915

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -446,7 +446,10 @@ private[akka] class EmptyLocalActorRef(override val provider: ActorRefProvider,
 
   override def isTerminated(): Boolean = true
 
-  override def sendSystemMessage(message: SystemMessage): Unit = specialHandle(message)
+  override def sendSystemMessage(message: SystemMessage): Unit = {
+    if (Mailbox.debug) println(s"ELAR $path having enqueued $message")
+    specialHandle(message)
+  }
 
   override def !(message: Any)(implicit sender: ActorRef = Actor.noSender): Unit = message match {
     case d: DeadLetter ⇒

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -62,8 +62,8 @@ class TestActor(queue: BlockingDeque[TestActor.Message]) extends Actor {
 
   def receive = {
     case SetIgnore(ign)      ⇒ ignore = ign
-    case x @ Watch(ref)      ⇒ context.watch(ref); queue.offerLast(RealMessage(x, self))
-    case x @ UnWatch(ref)    ⇒ context.unwatch(ref); queue.offerLast(RealMessage(x, self))
+    case Watch(ref)          ⇒ context.watch(ref)
+    case UnWatch(ref)        ⇒ context.unwatch(ref)
     case SetAutoPilot(pilot) ⇒ autopilot = pilot
     case x: AnyRef ⇒
       autopilot = autopilot.run(sender, x) match {
@@ -146,23 +146,19 @@ trait TestKitBase {
   def ignoreNoMsg() { testActor ! TestActor.SetIgnore(None) }
 
   /**
-   * Have the testActor watch someone (i.e. `context.watch(...)`). Waits until
-   * the Watch message is received back using expectMsg.
+   * Have the testActor watch someone (i.e. `context.watch(...)`).
    */
   def watch(ref: ActorRef): ActorRef = {
-    val msg = TestActor.Watch(ref)
-    testActor ! msg
-    expectMsg(msg).ref
+    testActor ! TestActor.Watch(ref)
+    ref
   }
 
   /**
-   * Have the testActor stop watching someone (i.e. `context.unwatch(...)`). Waits until
-   * the Watch message is received back using expectMsg.
+   * Have the testActor stop watching someone (i.e. `context.unwatch(...)`).
    */
   def unwatch(ref: ActorRef): ActorRef = {
-    val msg = TestActor.UnWatch(ref)
-    testActor ! msg
-    expectMsg(msg).ref
+    testActor ! TestActor.UnWatch(ref)
+    ref
   }
 
   /**

--- a/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
@@ -85,6 +85,15 @@ class TestProbeSpec extends AkkaSpec with DefaultTimeout {
       expectMsg("pigdog")
     }
 
+    "watch actors when queue non-empty" in {
+      val probe = TestProbe()
+      val target = system.actorFor("/nonexistent") // deadLetters does not send Terminated
+      probe.ref ! "hello"
+      probe watch target
+      probe.expectMsg(1.seconds, "hello")
+      probe.expectMsg(1.seconds, Terminated(target)(false, false))
+    }
+
   }
 
 }


### PR DESCRIPTION
- [x] backport to 2.1
