### PR TITLE
Change wrong netty port conf in tests

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
@@ -29,7 +29,7 @@ object ClusterDeployerSpec {
           cluster.routees-path = "/user/myservice"
         }
       }
-      akka.remote.netty.port = 0
+      akka.remoting.transports.tcp.port = 0
       """, ConfigParseOptions.defaults)
 
   class RecipeActor extends Actor {

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
@@ -27,7 +27,7 @@ object ClusterSpec {
     }
     akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
     akka.remote.log-remote-lifecycle-events = off
-    akka.remote.netty.port = 0
+    akka.remoting.transports.tcp.port = 0
     # akka.loglevel = DEBUG
     """
 

--- a/akka-cluster/src/test/scala/akka/cluster/routing/WeightedRouteesSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/routing/WeightedRouteesSpec.scala
@@ -13,7 +13,7 @@ import akka.testkit.AkkaSpec
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class WeightedRouteesSpec extends AkkaSpec(ConfigFactory.parseString("""
       akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
-      akka.remote.netty.port = 0
+      akka.remoting.transports.tcp.port = 0
       """)) {
 
   val a1 = Address("tcp.akka", "sys", "a1", 2551)

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -13,10 +13,8 @@ import akka.util.Helpers
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class RemoteConfigSpec extends AkkaSpec(
   """
-  akka {
-    actor.provider = "akka.remote.RemoteActorRefProvider"
-    remote.netty.port = 0
-  }
+    akka.actor.provider = "akka.remote.RemoteActorRefProvider"
+    akka.remoting.transports.tcp.port = 0
   """) {
 
   // FIXME: These tests are ignored as it tests configuration specific to the old remoting.


### PR DESCRIPTION
Other config changes are in the pipeline but this is a bit urgent to avoid false test failures.
