### PR TITLE
aggregate received data as long as there's data in kernel buffers or 're...

### DIFF
--- a/akka-io/src/main/resources/reference.conf
+++ b/akka-io/src/main/resources/reference.conf
@@ -52,7 +52,7 @@ akka {
 
       # The number of bytes per direct buffer in the pool used to read or write
       # network data from the kernel.
-      direct-buffer-size = 131072 # 128 KiB
+      direct-buffer-size = 128 KiB
 
       # The maximal number of direct buffers kept in the direct buffer pool for
       # reuse.

--- a/akka-io/src/main/resources/reference.conf
+++ b/akka-io/src/main/resources/reference.conf
@@ -52,7 +52,7 @@ akka {
 
       # The number of bytes per direct buffer in the pool used to read or write
       # network data from the kernel.
-      direct-buffer-size = 131072
+      direct-buffer-size = 131072 # 128 KiB
 
       # The maximal number of direct buffers kept in the direct buffer pool for
       # reuse.
@@ -61,6 +61,11 @@ akka {
       # The duration a connection actor waits for a `Register` message from
       # its commander before aborting the connection.
       register-timeout = 5s
+
+      # The maximum number of bytes delivered by a `Received` message. Before
+      # more data is read from the network the connection actor will try to
+      # do other work.
+      received-message-size-limit = unlimited
 
       # Enable fine grained logging of what goes on inside the implementation.
       # Be aware that this may log more than once per message sent to the actors

--- a/akka-io/src/main/scala/akka/io/Tcp.scala
+++ b/akka-io/src/main/scala/akka/io/Tcp.scala
@@ -199,6 +199,10 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
       case "infinite" ⇒ Duration.Undefined
       case x          ⇒ Duration(x)
     }
+    val ReceivedMessageSizeLimit = getString("received-message-size-limit") match {
+      case "unlimited" ⇒ Int.MaxValue
+      case x           ⇒ getInt("received-message-size-limit")
+    }
     val SelectorDispatcher = getString("selector-dispatcher")
     val WorkerDispatcher = getString("worker-dispatcher")
     val ManagementDispatcher = getString("management-dispatcher")

--- a/akka-io/src/main/scala/akka/io/Tcp.scala
+++ b/akka-io/src/main/scala/akka/io/Tcp.scala
@@ -193,7 +193,7 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
     }
     val SelectorAssociationRetries = getInt("selector-association-retries")
     val BatchAcceptLimit = getInt("batch-accept-limit")
-    val DirectBufferSize = getInt("direct-buffer-size")
+    val DirectBufferSize = getIntBytes("direct-buffer-size")
     val MaxDirectBufferPoolSize = getInt("max-direct-buffer-pool-size")
     val RegisterTimeout = getString("register-timeout") match {
       case "infinite" ⇒ Duration.Undefined
@@ -201,7 +201,7 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
     }
     val ReceivedMessageSizeLimit = getString("received-message-size-limit") match {
       case "unlimited" ⇒ Int.MaxValue
-      case x           ⇒ getInt("received-message-size-limit")
+      case x           ⇒ getIntBytes("received-message-size-limit")
     }
     val SelectorDispatcher = getString("selector-dispatcher")
     val WorkerDispatcher = getString("worker-dispatcher")
@@ -215,6 +215,12 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
     require(BatchAcceptLimit > 0, "batch-accept-limit must be > 0")
 
     val MaxChannelsPerSelector = if (MaxChannels == -1) -1 else math.max(MaxChannels / NrOfSelectors, 1)
+
+    private[this] def getIntBytes(path: String): Int = {
+      val size = getBytes(path)
+      require(size < Int.MaxValue, s"$path must be < 2 GiB")
+      size.toInt
+    }
   }
 
   val manager = {

--- a/akka-io/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-io/src/main/scala/akka/io/TcpConnection.scala
@@ -120,14 +120,15 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       if (remainingLimit > 0) {
         // never read more than the configured limit
         buffer.clear()
-        buffer.limit(math.min(DirectBufferSize, remainingLimit))
+        val maxBufferSpace = math.min(DirectBufferSize, remainingLimit)
+        buffer.limit(maxBufferSpace)
         val readBytes = channel.read(buffer)
         buffer.flip()
 
         val totalData = receivedData ++ ByteString(buffer)
 
         readBytes match {
-          case DirectBufferSize          ⇒ innerRead(buffer, totalData, remainingLimit - DirectBufferSize)
+          case `maxBufferSpace`          ⇒ innerRead(buffer, totalData, remainingLimit - maxBufferSpace)
           case x if totalData.length > 0 ⇒ GotCompleteData(totalData)
           case 0                         ⇒ NoData
           case -1                        ⇒ EndOfStream

--- a/akka-io/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-io/src/main/scala/akka/io/TcpConnection.scala
@@ -23,6 +23,7 @@ import TcpSelector._
 private[io] abstract class TcpConnection(val channel: SocketChannel,
                                          val tcp: TcpExt) extends Actor with ActorLogging with WithBufferPool {
   import tcp.Settings._
+  import TcpConnection._
   var pendingWrite: PendingWrite = null
 
   // Needed to send the ConnectionClosed message in the postStop handler.
@@ -115,32 +116,47 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
   }
 
   def doRead(handler: ActorRef, closeCommander: Option[ActorRef]): Unit = {
+    @tailrec def innerRead(buffer: ByteBuffer, receivedData: ByteString, remainingLimit: Int): ReadResult =
+      if (remainingLimit > 0) {
+        // never read more than the configured limit
+        buffer.clear()
+        buffer.limit(math.min(DirectBufferSize, remainingLimit))
+        val readBytes = channel.read(buffer)
+        buffer.flip()
+
+        val totalData = receivedData ++ ByteString(buffer)
+
+        readBytes match {
+          case DirectBufferSize          ⇒ innerRead(buffer, totalData, remainingLimit - DirectBufferSize)
+          case x if totalData.length > 0 ⇒ GotCompleteData(totalData)
+          case 0                         ⇒ NoData
+          case -1                        ⇒ EndOfStream
+          case _ ⇒
+            throw new IllegalStateException("Unexpected value returned from read: " + readBytes)
+        }
+      } else MoreDataWaiting(receivedData)
+
     val buffer = acquireBuffer()
-
-    try {
-      val readBytes = channel.read(buffer)
-      buffer.flip()
-
-      if (readBytes > 0) {
-        if (TraceLogging) log.debug("Read {} bytes", readBytes)
-        handler ! Received(ByteString(buffer))
-        releaseBuffer(buffer)
-
-        if (readBytes == buffer.capacity())
-          // directly try reading more because we exhausted our buffer
-          self ! ChannelReadable
-        else selector ! ReadInterest
-      } else if (readBytes == 0) {
-        if (TraceLogging) log.debug("Read nothing. Registering read interest with selector")
+    try innerRead(buffer, ByteString.empty, ReceivedMessageSizeLimit) match {
+      case NoData ⇒
+        if (TraceLogging) log.debug("Read nothing.")
         selector ! ReadInterest
-      } else if (readBytes == -1) {
+      case GotCompleteData(data) ⇒
+        if (TraceLogging) log.debug("Read {} bytes.", data.length)
+
+        handler ! Received(data)
+        selector ! ReadInterest
+      case MoreDataWaiting(data) ⇒
+        if (TraceLogging) log.debug("Read {} bytes. More data waiting.", data.length)
+
+        handler ! Received(data)
+        self ! ChannelReadable
+      case EndOfStream ⇒
         if (TraceLogging) log.debug("Read returned end-of-stream")
         doCloseConnection(handler, closeCommander, closeReason)
-      } else throw new IllegalStateException("Unexpected value returned from read: " + readBytes)
-
     } catch {
       case e: IOException ⇒ handleError(handler, e)
-    }
+    } finally releaseBuffer(buffer)
   }
 
   final def doWrite(handler: ActorRef): Unit = {
@@ -277,12 +293,20 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
 
     PendingWrite(sender, write.ack, write.data.drop(copied), buffer)
   }
+}
+
+private[io] object TcpConnection {
+  sealed trait ReadResult
+  object NoData extends ReadResult
+  object EndOfStream extends ReadResult
+  case class GotCompleteData(data: ByteString) extends ReadResult
+  case class MoreDataWaiting(data: ByteString) extends ReadResult
 
   /**
    * Used to transport information to the postStop method to notify
    * interested party about a connection close.
    */
-  private[TcpConnection] case class CloseInformation(
+  case class CloseInformation(
     notificationsTo: Set[ActorRef],
     closedEvent: ConnectionClosed)
 }


### PR DESCRIPTION
...ceived-message-size-limit' is reached, see #2886

Here's another pull request to reduce the number of `Received` messages by aggregating more data when a ByteBuffer is exhausted while reading from a channel and thus it is likely that more data is available.
