### PR TITLE
introduce WriteFile to send a file to the network without having to read it into a userland buffer, see #2896

### DIFF
--- a/akka-io/src/main/resources/reference.conf
+++ b/akka-io/src/main/resources/reference.conf
@@ -78,6 +78,10 @@ akka {
       # Fully qualified config path which holds the dispatcher configuration
       # for the selector management actors
       management-dispatcher = "akka.actor.default-dispatcher"
+
+      # Fully qualified config path which holds the dispatcher configuration
+      # on which file IO tasks are scheduled
+      file-io-dispatcher = "akka.io.pinned-dispatcher"
     }
 
   }

--- a/akka-io/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-io/src/main/scala/akka/io/TcpConnection.scala
@@ -5,10 +5,10 @@
 package akka.io
 
 import java.net.InetSocketAddress
-import java.io.IOException
-import java.nio.channels.SocketChannel
+import java.io.{ FileInputStream, IOException }
 import java.nio.ByteBuffer
 import scala.annotation.tailrec
+import java.nio.channels.{ FileChannel, SocketChannel }
 import scala.collection.immutable
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
@@ -22,6 +22,7 @@ import TcpSelector._
  */
 private[io] abstract class TcpConnection(val channel: SocketChannel,
                                          val tcp: TcpExt) extends Actor with ActorLogging with WithBufferPool {
+  import TcpConnection._
   import tcp.Settings._
   var pendingWrite: PendingWrite = null
 
@@ -61,7 +62,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     case ResumeReading   ⇒ selector ! ReadInterest
     case ChannelReadable ⇒ doRead(handler, None)
 
-    case write: Write if writePending ⇒
+    case write: WriteCommand if writePending ⇒
       if (TraceLogging) log.debug("Dropping write because queue is full")
       sender ! CommandFailed(write)
 
@@ -69,13 +70,15 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       if (write.wantsAck)
         sender ! write.ack
 
-    case write: Write ⇒
+    case write: WriteCommand ⇒
       pendingWrite = createWrite(write)
-      doWrite(handler)
+      pendingWrite.doWrite(handler)
 
-    case ChannelWritable   ⇒ doWrite(handler)
+    case ChannelWritable           ⇒ pendingWrite.doWrite(handler)
+    case SendBufferFull(remaining) ⇒ pendingWrite = remaining; selector ! WriteInterest
+    case WriteFileFinished         ⇒ pendingWrite = null
 
-    case cmd: CloseCommand ⇒ handleClose(handler, Some(sender), closeResponse(cmd))
+    case cmd: CloseCommand         ⇒ handleClose(handler, Some(sender), closeResponse(cmd))
   }
 
   /** connection is closing but a write has to be finished first */
@@ -85,9 +88,14 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     case ChannelReadable ⇒ doRead(handler, closeCommander)
 
     case ChannelWritable ⇒
-      doWrite(handler)
+      pendingWrite.doWrite(handler)
       if (!writePending) // writing is now finished
         handleClose(handler, closeCommander, closedEvent)
+
+    case SendBufferFull(remaining) ⇒ pendingWrite = remaining; selector ! WriteInterest
+    case WriteFileFinished ⇒
+      pendingWrite = null
+      handleClose(handler, closeCommander, closedEvent)
 
     case Abort ⇒ handleClose(handler, Some(sender), Aborted)
   }
@@ -143,33 +151,6 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     }
   }
 
-  final def doWrite(handler: ActorRef): Unit = {
-    @tailrec def innerWrite(): Unit = {
-      val toWrite = pendingWrite.buffer.remaining()
-      require(toWrite != 0)
-      val writtenBytes = channel.write(pendingWrite.buffer)
-      if (TraceLogging) log.debug("Wrote {} bytes to channel", writtenBytes)
-
-      pendingWrite = pendingWrite.consume(writtenBytes)
-
-      if (pendingWrite.hasData)
-        if (writtenBytes == toWrite) innerWrite() // wrote complete buffer, try again now
-        else selector ! WriteInterest // try again later
-      else { // everything written
-        if (pendingWrite.wantsAck)
-          pendingWrite.commander ! pendingWrite.ack
-
-        val buffer = pendingWrite.buffer
-        pendingWrite = null
-
-        releaseBuffer(buffer)
-      }
-    }
-
-    try innerWrite()
-    catch { case e: IOException ⇒ handleError(handler, e) }
-  }
-
   def closeReason =
     if (channel.socket.isOutputShutdown) ConfirmedClosed
     else PeerClosed
@@ -209,7 +190,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       case ConfirmedClose ⇒ ConfirmedClosed
     }
 
-  def handleError(handler: ActorRef, exception: IOException): Unit = {
+  def handleError(handler: ActorRef, exception: IOException): Nothing = {
     closedMessage = CloseInformation(Set(handler), ErrorClosed(extractMsg(exception)))
 
     throw exception
@@ -239,7 +220,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       abort()
 
     if (writePending)
-      releaseBuffer(pendingWrite.buffer)
+      pendingWrite.release()
 
     if (closedMessage != null) {
       val interestedInClose =
@@ -253,13 +234,21 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
   override def postRestart(reason: Throwable): Unit =
     throw new IllegalStateException("Restarting not supported for connection actors.")
 
-  private[TcpConnection] case class PendingWrite(
+  /**
+   * Used to transport information to the postStop method to notify
+   * interested party about a connection close.
+   */
+  private[TcpConnection] case class CloseInformation(
+    notificationsTo: Set[ActorRef],
+    closedEvent: ConnectionClosed)
+
+  private[TcpConnection] case class PendingBufferWrite(
     commander: ActorRef,
     ack: Any,
     remainingData: ByteString,
-    buffer: ByteBuffer) {
+    buffer: ByteBuffer) extends PendingWrite {
 
-    def consume(writtenBytes: Int): PendingWrite =
+    def consume(writtenBytes: Int): PendingBufferWrite =
       if (buffer.remaining() == 0) {
         buffer.clear()
         val copied = remainingData.copyToBuffer(buffer)
@@ -268,21 +257,110 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       } else this
 
     def hasData = buffer.remaining() > 0 || remainingData.size > 0
+
+    final def doWrite(handler: ActorRef): Unit =
+      pendingWrite = doWriteBuffer(handler, this)
+
+    /** Release any open resources */
+    def release() {
+      releaseBuffer(buffer)
+    }
+  }
+  def createWrite(write: WriteCommand): PendingWrite = write match {
+    case write: Write ⇒
+      val buffer = acquireBuffer()
+      val copied = write.data.copyToBuffer(buffer)
+      buffer.flip()
+
+      PendingBufferWrite(sender, write.ack, write.data.drop(copied), buffer)
+    case write: WriteFile ⇒
+      PendingWriteFile(sender, write, new FileInputStream(write.filePath).getChannel, 0L)
+  }
+  private[TcpConnection] case class PendingWriteFile(
+    commander: ActorRef,
+    write: WriteFile,
+    channel: FileChannel,
+    alreadyWritten: Long) extends PendingWrite {
+    def doWrite(handler: ActorRef): Unit =
+      tcp.fileIoDispatcher.execute(writeFile(this))
+
+    def ack: Any = write.ack
+
+    /** Release any open resources */
+    def release() {
+      channel.close()
+    }
+
+    def updatedWrite(nowWritten: Long): PendingWriteFile = {
+      require(nowWritten < write.count)
+      copy(alreadyWritten = nowWritten)
+    }
+  }
+
+  def writeFile(pendingWrite: PendingWriteFile): Runnable =
+    new Runnable {
+      def run() {
+        import pendingWrite.{ channel ⇒ _, _ }
+        val remaining = write.count - alreadyWritten
+
+        val writtenBytes = pendingWrite.channel.transferTo(write.position + alreadyWritten, remaining, channel)
+
+        if (writtenBytes < remaining) self ! SendBufferFull(pendingWrite.updatedWrite(alreadyWritten + writtenBytes))
+        else { // finished
+          if (wantsAck) commander ! write.ack
+          self ! WriteFileFinished
+
+          pendingWrite.release()
+        }
+      }
+    }
+
+  final def doWriteBuffer(handler: ActorRef, currentWrite: PendingBufferWrite): PendingBufferWrite = {
+    @tailrec def innerWrite(currentWrite: PendingBufferWrite): PendingBufferWrite = {
+      val toWrite = currentWrite.buffer.remaining()
+      require(toWrite != 0)
+      val writtenBytes = channel.write(currentWrite.buffer)
+      if (TraceLogging) log.debug("Wrote {} bytes to channel", writtenBytes)
+
+      val nextWrite = currentWrite.consume(writtenBytes)
+
+      if (nextWrite.hasData)
+        if (writtenBytes == toWrite) innerWrite(nextWrite) // wrote complete buffer, try again now
+        else {
+          selector ! WriteInterest // try again later
+          nextWrite
+        }
+      else { // everything written
+        if (nextWrite.wantsAck)
+          nextWrite.commander ! nextWrite.ack
+
+        releaseBuffer(nextWrite.buffer)
+
+        null
+      }
+    }
+
+    try innerWrite(currentWrite)
+    catch { case e: IOException ⇒ handleError(handler, e) }
+  }
+}
+
+private[io] object TcpConnection {
+  trait PendingWrite {
+    def commander: ActorRef
+    def ack: Any
+
     def wantsAck = ack != NoAck
-  }
-  def createWrite(write: Write): PendingWrite = {
-    val buffer = acquireBuffer()
-    val copied = write.data.copyToBuffer(buffer)
-    buffer.flip()
+    def doWrite(handler: ActorRef): Unit
 
-    PendingWrite(sender, write.ack, write.data.drop(copied), buffer)
+    /** Release any open resources */
+    def release(): Unit
   }
 
-  /**
-   * Used to transport information to the postStop method to notify
-   * interested party about a connection close.
-   */
-  private[TcpConnection] case class CloseInformation(
-    notificationsTo: Set[ActorRef],
-    closedEvent: ConnectionClosed)
+  // INTERNAL MESSAGES
+
+  /** Informs actor that no writing was possible but there is still work remaining */
+  case class SendBufferFull(remainingWrite: PendingWrite)
+  /** Informs actor that a pending file write has finished */
+  case object WriteFileFinished
 }


### PR DESCRIPTION
Here's a proposal how zero-copy file sending could be handled.

Notes / open questions:
- How to address a file? `WriteFile` currently uses the file path. This could be a possible security leak when something manages to send a message to the connection actor (of course there are all kinds of security leaks if something manages to send messages around but this seems particularly easy). Before `WriteFile` just had a `FileChannel` parameter which, of course, isn't serializable. The question is if you should be able to use `WriteFile` if you aren't on the local machine.
-  A problem is that `FileChannel.transferTo` (or linux `sendfile`) may block on file IO when the network is faster than the disk. I'm currently using a single pinned dispatcher to schedule all of the IO operations on. It would probably make sense to have more than one thread executing file IO or in the best case a number IO threads per disk which isn't easy to achieve.

As an aside: Getting around synchronous disk IO on Linux seems to be quite hard. The support in the kernel for asynchronous disk IO on Linux is still lacking. The biggest problem probably seems to be that aio only works on files opened with O_DIRECT circumventing buffering (e.g. see http://www.lighttpd.net/2007/2/11/buffered-io-performance/).
