### PR TITLE
Keep the dispatcher inhabitants count balanced. See #2919

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -274,6 +274,7 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
       val t = probe.expectMsg(Terminated(a)(existenceConfirmed = true, addressTerminated = false))
       t.existenceConfirmed must be(true)
       t.addressTerminated must be(false)
+      system.shutdown()
     }
 
     "shut down when /user escalates" in {

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -551,6 +551,7 @@ class LocalActorRefProvider(
 
   def init(_system: ActorSystemImpl) {
     system = _system
+    rootGuardian.start()
     // chain death watchers so that killing guardian stops the application
     systemGuardian.sendSystemMessage(Watch(guardian, systemGuardian))
     rootGuardian.sendSystemMessage(Watch(systemGuardian, rootGuardian))

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -191,6 +191,13 @@ abstract class MessageDispatcher(val prerequisites: DispatcherPrerequisites) ext
   @tailrec private final def addInhabitants(add: Long): Long = {
     val c = inhabitants
     val r = c + add
+    if (r < 0) {
+      // We haven't succeeded in decreasing the inhabitants yet but the simple fact that we're trying to
+      // go below zero means that there is an imbalance and we might as well throw the exception
+      val e = new IllegalStateException("ACTOR SYSTEM CORRUPTED!!! A dispatcher can't have less than 0 inhabitants!")
+      reportFailure(e)
+      throw e
+    }
     if (Unsafe.instance.compareAndSwapLong(this, inhabitantsOffset, c, r)) r else addInhabitants(add)
   }
 
@@ -243,18 +250,16 @@ abstract class MessageDispatcher(val prerequisites: DispatcherPrerequisites) ext
   }
 
   @tailrec
-  private final def ifSensibleToDoSoThenScheduleShutdown(): Unit = inhabitants match {
-    case 0 ⇒
-      shutdownSchedule match {
-        case UNSCHEDULED ⇒
-          if (updateShutdownSchedule(UNSCHEDULED, SCHEDULED)) scheduleShutdownAction()
-          else ifSensibleToDoSoThenScheduleShutdown()
-        case SCHEDULED ⇒
-          if (updateShutdownSchedule(SCHEDULED, RESCHEDULED)) ()
-          else ifSensibleToDoSoThenScheduleShutdown()
-        case RESCHEDULED ⇒
-      }
-    case _ ⇒
+  private final def ifSensibleToDoSoThenScheduleShutdown(): Unit = {
+    if (inhabitants <= 0) shutdownSchedule match {
+      case UNSCHEDULED ⇒
+        if (updateShutdownSchedule(UNSCHEDULED, SCHEDULED)) scheduleShutdownAction()
+        else ifSensibleToDoSoThenScheduleShutdown()
+      case SCHEDULED ⇒
+        if (updateShutdownSchedule(SCHEDULED, RESCHEDULED)) ()
+        else ifSensibleToDoSoThenScheduleShutdown()
+      case RESCHEDULED ⇒
+    }
   }
 
   private def scheduleShutdownAction(): Unit = {

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -80,6 +80,7 @@ private[akka] class RemoteSystemDaemon(
                   path, systemService = false, Some(deploy), lookupDeploy = true, async = false)
                 addChild(subpath.mkString("/"), actor)
                 actor.sendSystemMessage(Watch(actor, this))
+                actor.start()
               }
               if (isTerminating) log.error("Skipping [{}] to RemoteSystemDaemon on [{}] while terminating", message, path.address)
             case _ ⇒

--- a/akka-remote/src/test/scala/akka/remote/UntrustedSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/UntrustedSpec.scala
@@ -38,6 +38,10 @@ akka.loglevel = DEBUG
   val target1 = other.actorFor(RootActorPath(addr) / "remote")
   val target2 = other.actorFor(RootActorPath(addr) / testActor.path.elements)
 
+  override def atTermination() {
+    other.shutdown()
+  }
+
   // need to enable debug log-level without actually printing those messages
   system.eventStream.publish(TestEvent.Mute(EventFilter.debug()))
 


### PR DESCRIPTION
So I finally found the root cause of the lingering dispatchers to be that we don't register all actors that we unregister from the dispatcher, leading to shutdown to run early sometimes and not at all at other times.
- [x] forward port to master
