### PR TITLE
make sure that InterruptExceptions are not swallowed, see #2963

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -414,9 +414,11 @@ abstract class ActorModelSpec(config: String) extends AkkaSpec(config) with Defa
         val a = newTestActor(dispatcher.id)
         val f1 = a ? Reply("foo")
         val f2 = a ? Reply("bar")
-        val f3 = try { a ? Interrupt } catch { case ie: InterruptedException ⇒ Promise.failed(new ActorInterruptedException(ie)).future }
+        val f3 = a ? Interrupt
+        Thread.interrupted() // CallingThreadDispatcher may necessitate this
         val f4 = a ? Reply("foo2")
-        val f5 = try { a ? Interrupt } catch { case ie: InterruptedException ⇒ Promise.failed(new ActorInterruptedException(ie)).future }
+        val f5 = a ? Interrupt
+        Thread.interrupted() // CallingThreadDispatcher may necessitate this
         val f6 = a ? Reply("bar2")
 
         assert(Await.result(f1, remaining) === "foo")

--- a/akka-docs/rst/java/testing.rst
+++ b/akka-docs/rst/java/testing.rst
@@ -546,6 +546,28 @@ production.
    scenarios, but keep in mind that it has may give false negatives as well as
    false positives.
 
+Thread Interruptions
+--------------------
+
+If the CallingThreadDispatcher sees that the current thread has its
+``isInterrupted()`` flag set when message processing returns, it will throw an
+:class:`InterruptedException` after finishing all its processing (i.e. all
+messages which need processing as described above are processed before this
+happens). As :meth:`tell` cannot throw exceptions due to its contract, this
+exception will then be caught and logged, and the thread’s interrupted status
+will be set again.
+
+If during message processing an :class:`InterruptedException` is thrown then it
+will be caught inside the CallingThreadDispatcher’s message handling loop, the
+thread’s interrupted flag will be set and processing continues normally.
+
+.. note::
+
+  The summary of these two paragraphs is that if the current thread is
+  interrupted while doing work under the CallingThreadDispatcher, then that
+  will result in the ``isInterrupted`` flag to be ``true`` when the message
+  send returns and no :class:`InterruptedException` will be thrown.
+
 Benefits
 --------
 

--- a/akka-docs/rst/scala/testing.rst
+++ b/akka-docs/rst/scala/testing.rst
@@ -614,6 +614,28 @@ production.
    scenarios, but keep in mind that it has may give false negatives as well as
    false positives.
 
+Thread Interruptions
+--------------------
+
+If the CallingThreadDispatcher sees that the current thread has its
+``isInterrupted()`` flag set when message processing returns, it will throw an
+:class:`InterruptedException` after finishing all its processing (i.e. all
+messages which need processing as described above are processed before this
+happens). As :meth:`tell` cannot throw exceptions due to its contract, this
+exception will then be caught and logged, and the thread’s interrupted status
+will be set again.
+
+If during message processing an :class:`InterruptedException` is thrown then it
+will be caught inside the CallingThreadDispatcher’s message handling loop, the
+thread’s interrupted flag will be set and processing continues normally.
+
+.. note::
+
+  The summary of these two paragraphs is that if the current thread is
+  interrupted while doing work under the CallingThreadDispatcher, then that
+  will result in the ``isInterrupted`` flag to be ``true`` when the message
+  send returns and no :class:`InterruptedException` will be thrown.
+
 Benefits
 --------
 


### PR DESCRIPTION
also remove an old work-around in CallingThreadDispatcherModelSpec and
describe the rules for interrupting in the testing docs
