### PR TITLE
Remove work-around for sending to broken connections, see #2909

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -167,13 +167,6 @@ akka {
       ticks-per-wheel = 512
     }
 
-    # Netty blocks when sending to broken connections, and this circuit breaker
-    # is used to reduce connect attempts to broken connections.
-    send-circuit-breaker {
-      max-failures = 3
-      call-timeout = 2 s
-      reset-timeout = 30 s
-    }
   }
 
   # Default configuration for routers

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -72,10 +72,6 @@ class ClusterSettings(val config: Config, val systemName: String) {
   final val MaxGossipMergeRate: Double = getDouble("akka.cluster.max-gossip-merge-rate")
   final val SchedulerTickDuration: FiniteDuration = Duration(getMilliseconds("akka.cluster.scheduler.tick-duration"), MILLISECONDS)
   final val SchedulerTicksPerWheel: Int = getInt("akka.cluster.scheduler.ticks-per-wheel")
-  final val SendCircuitBreakerSettings: CircuitBreakerSettings = CircuitBreakerSettings(
-    maxFailures = getInt("akka.cluster.send-circuit-breaker.max-failures"),
-    callTimeout = Duration(getMilliseconds("akka.cluster.send-circuit-breaker.call-timeout"), MILLISECONDS),
-    resetTimeout = Duration(getMilliseconds("akka.cluster.send-circuit-breaker.reset-timeout"), MILLISECONDS))
   final val MetricsEnabled: Boolean = getBoolean("akka.cluster.metrics.enabled")
   final val MetricsCollectorClass: String = getString("akka.cluster.metrics.collector-class")
   final val MetricsInterval: FiniteDuration = {
@@ -87,4 +83,3 @@ class ClusterSettings(val config: Config, val systemName: String) {
   } requiring (_ > Duration.Zero, "metrics.moving-average-half-life must be > 0")
 }
 
-case class CircuitBreakerSettings(maxFailures: Int, callTimeout: FiniteDuration, resetTimeout: FiniteDuration)

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
@@ -45,10 +45,6 @@ class ClusterConfigSpec extends AkkaSpec {
       MaxGossipMergeRate must be(5.0 plusOrMinus 0.0001)
       SchedulerTickDuration must be(33 millis)
       SchedulerTicksPerWheel must be(512)
-      SendCircuitBreakerSettings must be(CircuitBreakerSettings(
-        maxFailures = 3,
-        callTimeout = 2 seconds,
-        resetTimeout = 30 seconds))
       MetricsEnabled must be(true)
       MetricsCollectorClass must be(classOf[SigarMetricsCollector].getName)
       MetricsInterval must be(3 seconds)


### PR DESCRIPTION
- Previous work-around was introduced because Netty blocks when sending
  to broken connections. This is supposed to be solved by the non-blocking
  new remoting.
- Removed HeartbeatSender and CoreSender in cluster
- Added tests to verify that broken connections don't disturb live connection
