### PR TITLE
Dead letters containing remote envelopes handled correctly #2959

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -106,22 +106,6 @@ abstract class ClusterDeathWatchSpec
 
     }
 
-    "receive Terminated when watched node is unknown host" taggedAs LongRunningTest in {
-      runOn(first) {
-        val path = RootActorPath(Address("akka", system.name, "unknownhost", 2552)) / "user" / "subject"
-        system.actorOf(Props(new Actor {
-          context.watch(context.actorFor(path))
-          def receive = {
-            case t: Terminated ⇒ testActor ! t.actor.path
-          }
-        }), name = "observer2")
-
-        expectMsg(path)
-      }
-
-      enterBarrier("after-2")
-    }
-
     "receive Terminated when watched path doesn't exist" taggedAs LongRunningTest in {
       runOn(first) {
         val path = RootActorPath(second) / "user" / "non-existing"
@@ -135,7 +119,7 @@ abstract class ClusterDeathWatchSpec
         expectMsg(path)
       }
 
-      enterBarrier("after-3")
+      enterBarrier("after-2")
     }
 
     "be able to shutdown system when using remote deployed actor on node that crash" taggedAs LongRunningTest in within(20 seconds) {
@@ -172,7 +156,7 @@ abstract class ClusterDeathWatchSpec
           testConductor.removeNode(fourth)
         }
 
-        enterBarrier("after-4")
+        enterBarrier("after-3")
       }
 
     }

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -179,6 +179,14 @@ akka {
     retry-window = 3 s
     maximum-retries-in-window = 5
 
+    # The length of time to gate an address whose name lookup has failed.
+    # No connection attempts will be made to an address while it remains
+    # gated. Any messages sent to a gated address will be directed to dead
+    # letters instead. Name lookups are costly, and the time to recovery
+    # is typically large, therefore this setting should be a value in the
+    # order of seconds or minutes.
+    gate-unknown-addresses-for = 60 s
+
     ### Transports and adapters
 
     # List of the transport drivers that will be loaded by the remoting.

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -172,7 +172,7 @@ private[remote] class EndpointWriter(
       stash()
       stay()
     case Event(Status.Failure(e: InvalidAssociationException), _) ⇒
-      log.error(e, "Tried to associate with invalid remote address [{}]. " +
+      log.error("Tried to associate with invalid remote address [{}]. " +
         "Address is now quarantined, all messages to this address will be delivered to dead letters.", remoteAddress)
       publishAndThrow(new InvalidAssociation(localAddress, remoteAddress, e))
     case Event(Status.Failure(e), _) ⇒

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -31,6 +31,8 @@ class RemoteSettings(val config: Config) {
 
   val RetryGateClosedFor: FiniteDuration = Duration(getMilliseconds("akka.remote.retry-gate-closed-for"), MILLISECONDS)
 
+  val UnknownAddressGateClosedFor: FiniteDuration = Duration(getMilliseconds("akka.remote.gate-unknown-addresses-for"), MILLISECONDS)
+
   val UsePassiveConnections: Boolean = getBoolean("akka.remote.use-passive-connections")
 
   val MaximumRetriesInWindow: Int = getInt("akka.remote.maximum-retries-in-window")

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -334,7 +334,7 @@ private[remote] class EndpointManager(conf: Config, log: LoggingAdapter) extends
 
   override val supervisorStrategy = OneForOneStrategy(settings.MaximumRetriesInWindow, settings.RetryWindow) {
     case InvalidAssociation(localAddress, remoteAddress, e) ⇒
-      endpoints.markAsQuarantined(remoteAddress, e)
+      endpoints.markAsFailed(sender, Deadline.now + settings.UnknownAddressGateClosedFor)
       Stop
 
     case NonFatal(e) ⇒

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -33,6 +33,8 @@ class RemoteConfigSpec extends AkkaSpec(
       LogRemoteLifecycleEvents must be(false)
       LogReceive must be(false)
       LogSend must be(false)
+      RetryGateClosedFor must be === 0.seconds
+      UnknownAddressGateClosedFor must be === 10.seconds
       MaximumRetriesInWindow must be === 5
       RetryWindow must be === 3.seconds
       BackoffPeriod must be === 10.milliseconds


### PR DESCRIPTION
- New DeadLetter class for handling remoting specific envelopes
- Fixed error handling of name lookups
- Name lookup is now handled via futures (future refactor opportunity)
- Moved relevant test-case from ClusterDeathWatchSpec to RemoteDeathWatchSpec
