### PR TITLE
 #2974 – Making ControlThrowable and NotImplementedError not treated as ...

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -9,17 +9,16 @@ import akka.dispatch._
 import akka.pattern.ask
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.annotation.tailrec
-import scala.concurrent.duration.Duration
 import java.io.Closeable
 import scala.concurrent.{ Await, Awaitable, CanAwait, Future }
-import scala.util.control.NonFatal
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.control.{ NonFatal, ControlThrowable }
 import akka.util._
 import akka.util.internal.{ HashedWheelTimer, ConcurrentIdentityHashMap }
 import java.util.concurrent.{ ThreadFactory, CountDownLatch, TimeoutException, RejectedExecutionException }
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import akka.actor.dungeon.ChildrenContainer
-import scala.concurrent.duration.FiniteDuration
-import util.{ Failure, Success }
+import scala.util.{ Failure, Success }
 
 object ActorSystem {
 
@@ -468,7 +467,7 @@ private[akka] class ActorSystemImpl(val name: String, applicationConfig: Config,
     new Thread.UncaughtExceptionHandler() {
       def uncaughtException(thread: Thread, cause: Throwable): Unit = {
         cause match {
-          case NonFatal(_) | _: InterruptedException ⇒ log.error(cause, "Uncaught error from thread [{}]", thread.getName)
+          case NonFatal(_) | _: InterruptedException | _: NotImplementedError | _: ControlThrowable ⇒ log.error(cause, "Uncaught error from thread [{}]", thread.getName)
           case _ ⇒
             if (settings.JvmExitOnFatalError) {
               try {


### PR DESCRIPTION
...fatal in the Akka UEH and making sure that exceptions thrown by executed tasks on the FJP are passed into the UEH
