### PR TITLE
Added libraryDependencies info for sbt users below 0.12.x

### DIFF
--- a/akka-docs/rst/intro/getting-started.rst
+++ b/akka-docs/rst/intro/getting-started.rst
@@ -128,6 +128,13 @@ SBT installation instructions on `https://github.com/harrah/xsbt/wiki/Setup <htt
     libraryDependencies +=
       "com.typesafe.akka" %% "akka-actor" % "@version@" @crossString@
 
+**Note**: the libraryDependencies setting above is specific to SBT v0.12.x and higher.  If you are using an older version of SBT, the libraryDependencies should look like this:
+
+.. parsed-literal::
+
+    libraryDependencies +=
+      "com.typesafe.akka" % "akka-actor_@binVersion@" % "@version@"
+
 
 Using Akka with Eclipse
 -----------------------


### PR DESCRIPTION
Docs don't tell people what to do if they're using an older version of sbt than 0.12.x.  This update to the getting started page should help with that.
