### PR TITLE
Added sbt documentation for users on version older than 0.12.x

### DIFF
--- a/akka-docs/rst/intro/getting-started.rst
+++ b/akka-docs/rst/intro/getting-started.rst
@@ -128,6 +128,13 @@ SBT installation instructions on `https://github.com/harrah/xsbt/wiki/Setup <htt
     libraryDependencies +=
       "com.typesafe.akka" %% "akka-actor" % "@version@" @crossString@
 
+**Note**: the libraryDependencies setting above is specific to SBT v0.12.x and higher.  If you are using an older version of SBT, it that line should look like this:
+
+.. parsed-literal::
+
+    libraryDependencies +=
+      "com.typesafe.akka" % "akka-actor_@binVersion@" % "@version@"
+
 
 Using Akka with Eclipse
 -----------------------


### PR DESCRIPTION
Same pull request as was submitted for master from branch wip-2984-sbt-documentation, but also without the crossString.
