### PR TITLE
Adding implicits and diagrams to scaladoc. See #2880

### DIFF
--- a/akka-docs/rst/dev/building-akka.rst
+++ b/akka-docs/rst/dev/building-akka.rst
@@ -103,6 +103,12 @@ to use from an sbt project) use the ``publish-local`` command::
 
    sbt publish-local
 
+.. note::
+
+   Akka generates class diagrams for the API documentation using ScalaDoc. This needs the ``dot`` command from
+   the Graphviz software package to be installed to avoid errors. You can disable the diagram generation by
+   adding the flag ``-Dakka.scaladoc.diagrams=false``
+
 
 sbt Interactive Mode
 --------------------


### PR DESCRIPTION
- This generates diagrams if the `dot` command from Graphviz is installed, but there is no way to fail the build if it doesn't find `dot`.
- We now check the generated HTML for diagram tags, and fail the build if we don't find any.

:exclamation: **You need to have Graphviz installed if you intend to run `package` or `unidoc`, or they will return an error**
