### PR TITLE
Failing remote deployment, see #2983

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -408,10 +408,8 @@ private[akka] class ActorCell(
         publish(Debug(self.path.toString, clazz(actor), "received AutoReceiveMessage " + msg))
 
       msg.message match {
-        case Failed(cause, uid) ⇒ handleFailure(sender, cause, uid)
-        case t: Terminated ⇒
-          if (t.addressTerminated) removeChildWhenToAddressTerminated(t.actor)
-          watchedActorTerminated(t)
+        case Failed(cause, uid)         ⇒ handleFailure(sender, cause, uid)
+        case t: Terminated              ⇒ watchedActorTerminated(t)
         case AddressTerminated(address) ⇒ addressTerminated(address)
         case Kill                       ⇒ throw new ActorKilledException("Kill")
         case PoisonPill                 ⇒ self.stop()
@@ -420,18 +418,6 @@ private[akka] class ActorCell(
         case SelectChildPattern(p, m)   ⇒ for (c ← children if p.matcher(c.path.name).matches) c.tell(m, msg.sender)
       }
     }
-
-  /**
-   * When a parent is watching a child and it terminates due to AddressTerminated,
-   * it should be removed to support immediate creation of child with same name.
-   *
-   * For remote deployed actors ChildTerminated should be sent to the supervisor
-   * to clean up child references of remote deployed actors when remote node
-   * goes down, i.e. triggered by AddressTerminated, but that is the responsibility
-   * of the ActorRefProvider to handle that scenario.
-   */
-  private def removeChildWhenToAddressTerminated(child: ActorRef): Unit =
-    childrenRefs.getByRef(child) foreach { crs ⇒ removeChildAndGetStateChange(crs.child) }
 
   final def receiveMessage(msg: Any): Unit = behaviorStack.head.applyOrElse(msg, actor.unhandled)
 

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -5,7 +5,7 @@
 package akka.actor.dungeon
 
 import akka.actor.{ Terminated, InternalActorRef, ActorRef, ActorRefScope, ActorCell, Actor, Address, AddressTerminated }
-import akka.dispatch.{ Watch, Unwatch }
+import akka.dispatch.{ ChildTerminated, Watch, Unwatch }
 import akka.event.Logging.{ Warning, Error, Debug }
 import scala.util.control.NonFatal
 
@@ -130,7 +130,11 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
     // send Terminated to self for all matching subjects
     // existenceConfirmed = false because we could have been watching a
     // non-local ActorRef that had never resolved before the other node went down
+    // When a parent is watching a child and it terminates due to AddressTerminated
+    // it is removed by sending ChildTerminated to support immediate creation of child
+    // with same name.
     for (a ← watching; if a.path.address == address) {
+      childrenRefs.getByRef(a) foreach { _ ⇒ self.sendSystemMessage(ChildTerminated(a)) }
       self ! Terminated(a)(existenceConfirmed = false, addressTerminated = true)
     }
   }

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -94,7 +94,7 @@ private[akka] class RemoteDeploymentWatcher extends Actor {
 
     case t @ Terminated(a) if supervisors isDefinedAt a ⇒
       // send extra ChildTerminated to the supervisor so that it will remove the child
-      if (t.addressTerminated) supervisors(a).sendSystemMessage(ChildTerminated(a))
+      supervisors(a).sendSystemMessage(ChildTerminated(a))
       supervisors -= a
 
     case _: Terminated ⇒

--- a/akka-docs/rst/cluster/cluster-usage-java.rst
+++ b/akka-docs/rst/cluster/cluster-usage-java.rst
@@ -320,6 +320,16 @@ This is how the curve looks like for ``acceptable-heartbeat-pause`` configured t
 
 .. image:: images/phi3.png
 
+Death watch uses the cluster failure detector for nodes in the cluster, i.e. it 
+generates ``Terminated`` message from network failures and JVM crashes, in addition 
+to graceful termination of watched actor. 
+
+.. warning::
+
+  Creating a remote deployed child actor with the same name as the terminated 
+  actor is not fully supported. There is a race condition that potentially removes the new 
+  actor.
+
 Cluster Aware Routers
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/akka-docs/rst/cluster/cluster-usage-scala.rst
+++ b/akka-docs/rst/cluster/cluster-usage-scala.rst
@@ -293,6 +293,17 @@ This is how the curve looks like for ``acceptable-heartbeat-pause`` configured t
 
 .. image:: images/phi3.png
 
+
+Death watch uses the cluster failure detector for nodes in the cluster, i.e. it 
+generates ``Terminated`` message from network failures and JVM crashes, in addition 
+to graceful termination of watched actor. 
+
+.. warning::
+
+  Creating a remote deployed child actor with the same name as the terminated 
+  actor is not fully supported. There is a race condition that potentially removes the new 
+  actor.
+
 .. _cluster_aware_routers_scala:
 
 Cluster Aware Routers


### PR DESCRIPTION
- Share same instance of deadLetters between LARP and RARP
- Generate ChildTerminated from all Terminated in RemoteDeploymentWatcher
  - The problem is that we do remote deployment to a node that isn't alive and with ordinary
    remoting that is not detected at all, as we know. With cluster this was taken care of by
    a later AddressTerminated and ChildTerminated generated by
    RemoteDeploymentWatcher. With the new RemoteDeadLetters the additional watch
    triggers an immediate Terminate which is captured by RemoteDeploymentWatcher 
    but not acted upon since it's not an addressTerminated. RemoteDeploymentWatcher 
    unwatch and will therefor not act on later AddressTerminated.
  - The long term solution is to have reliable system messages and remote supervision 
    without explicit watch, so that we know that the remote deployment fails.
  - This short term solution is to let RemoteDeploymentWatcher always generate 
    ChildTerminated, also for non-addressTerminated.
  - It's possibly racy since ChildTerminated is not idempotent.
- FIXME question of how to handle removeChildWhenToAddressTerminated
