### PR TITLE
Wip channel transform ∂π

### DIFF
--- a/akka-channels-tests/src/test/scala/akka/channels/ChannelSpec.scala
+++ b/akka-channels-tests/src/test/scala/akka/channels/ChannelSpec.scala
@@ -471,6 +471,15 @@ class ChannelSpec extends AkkaSpec(ActorSystem("ChannelSpec", AkkaSpec.testConf,
       lastSender must be === t.actorRef
     }
 
+    "be able to transform Futures" in {
+      val client = new ChannelRef[(Any, Nothing) :+: TNil](testActor)
+      val someActor = ChannelExt(system).actorOf(new Tester, "t26b")
+      implicit val timeout = Timeout(1.second)
+      implicit val ec = system.dispatcher
+      A -?-> someActor -*-> (_ map (_.value match { case C ⇒ B })) -?-> someActor -!-> client
+      expectMsg(D)
+    }
+
   }
 
   "A WrappedMessage" must {

--- a/akka-channels/src/main/scala/akka/channels/ChannelRef.scala
+++ b/akka-channels/src/main/scala/akka/channels/ChannelRef.scala
@@ -32,7 +32,7 @@ class ChannelRef[+T <: ChannelList](val actorRef: ActorRef) extends AnyVal {
    * which will be completed with the reply message or a TimeoutException.
    * If the message is a Future itself, eventually send the Future’s value.
    */
-  def <-?-[M](msg: M): Future[_] = macro macros.Ask.impl[ChannelList, Any, T, M]
+  def <-?-[M](msg: M): Future[_] = macro macros.Ask.impl[ChannelList, Any, Any, T, M]
 
   /**
    * Narrow this ChannelRef by removing channels or narrowing input types or

--- a/akka-channels/src/main/scala/akka/channels/Channels.scala
+++ b/akka-channels/src/main/scala/akka/channels/Channels.scala
@@ -104,7 +104,7 @@ trait Channels[P <: ChannelList, C <: ChannelList] { this: Actor ⇒
       else
         F2(recv.asInstanceOf[(Any, ChannelRef[ChannelList]) ⇒ Unit])
     def apply(recv: R): Unit = {
-      val tt = implicitly[ru.TypeTag[Ch]]
+      val tt = ru.typeTag[Ch]
       behavior ++= (for (t ← inputChannels(ru)(tt.tpe)) yield tt.mirror.runtimeClass(t.widen) -> ff(recv))
     }
   }

--- a/akka-channels/src/main/scala/akka/channels/Ops.scala
+++ b/akka-channels/src/main/scala/akka/channels/Ops.scala
@@ -56,6 +56,7 @@ class ActorRefOps(val ref: ActorRef) extends AnyVal {
 class FutureOps[T](val future: Future[T]) extends AnyVal {
   def -!->[C <: ChannelList](channel: ChannelRef[C]): Future[T] = macro macros.Tell.futureOpsImpl[C, T]
   def -?->[C <: ChannelList](channel: ChannelRef[C]): Future[_] = macro macros.Ask.futureImpl[ChannelList, Any, C, T]
+  def -*->[U](f: Future[T] ⇒ Future[U]): Future[U] = f(future)
   def lub[LUB](implicit ev: T <:< WrappedMessage[_, LUB]): Future[LUB] = {
     implicit val ec = ExecutionContexts.sameThreadExecutionContext
     future map (ev(_).value)

--- a/akka-docs/rst/scala/code/docs/channels/ChannelDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/channels/ChannelDocSpec.scala
@@ -57,10 +57,12 @@ class ChannelDocSpec extends AkkaSpec {
 
   import ChannelDocSpec._
 
-  class MsgA
-  class MsgB
-  class MsgC
-  class MsgD
+  trait Msg
+
+  class MsgA extends Msg
+  class MsgB extends Msg
+  class MsgC extends Msg
+  class MsgD extends Msg
 
   "demonstrate why Typed Channels" in {
     def someActor = testActor
@@ -115,6 +117,7 @@ class ChannelDocSpec extends AkkaSpec {
     implicit val timeout: Timeout = ??? // for the ask operations
 
     val channelA: ChannelRef[(MsgA, MsgB) :+: TNil] = ???
+    val channelA2: ChannelRef[(MsgA, MsgB) :+: (MsgA, MsgC) :+: TNil] = ???
     val channelB: ChannelRef[(MsgB, MsgC) :+: TNil] = ???
     val channelC: ChannelRef[(MsgC, MsgD) :+: TNil] = ???
 
@@ -127,11 +130,14 @@ class ChannelDocSpec extends AkkaSpec {
     channelA <-!- fA // eventually send the future’s value to channelA
     fA -!-> channelA // same thing as above
 
-    // ask the actor; return type given in full for illustration
-    val fB: Future[WrappedMessage[(MsgB, Nothing) :+: TNil, MsgB]] = channelA <-?- a
-    val fBunwrapped: Future[MsgB] = fB.lub
-
+    val fB: Future[MsgB] = channelA <-?- a // ask the actor
     a -?-> channelA // same thing as above
+
+    // ask the actor with multiple reply types
+    // return type given in full for illustration
+    val fM: Future[WrappedMessage[ //
+    (MsgB, Nothing) :+: (MsgC, Nothing) :+: TNil, Msg]] = channelA2 <-?- a
+    val fMunwrapped: Future[Msg] = fM.lub
 
     channelA <-?- fA // eventually ask the actor, return the future
     fA -?-> channelA // same thing as above

--- a/akka-docs/rst/scala/typed-channels.rst
+++ b/akka-docs/rst/scala/typed-channels.rst
@@ -169,10 +169,10 @@ Operations on typed channels are composable and obey a few simple rules:
 * the operators are fully symmetric, i.e. ``-!->`` and ``<-!-`` do the same
   thing provided the arguments also switch places
 
-* sending with ``-?->`` or ``<-?-`` always returns a
-  ``Future[WrappedMessage[_, _]]`` representing all possible reply channels,
-  even if there is only one (use ``.lub`` to get a :class:`Future[_]` with the
-  most precise single type for the value)
+* sending with ``-?->`` or ``<-?-`` returns a ``Future[WrappedMessage[_, _]]``
+  representing all possible reply channels if there is more than one (use
+  ``.lub`` to get a :class:`Future[_]` with the most precise single type for
+  the value)
 
 * sending a :class:`Future[_]` with ``-!->`` or ``<-!-`` returns a new
   :class:`Future[_]` which will be completed with the value after it has been


### PR DESCRIPTION
two improvements I found desirable while preparing the NEScala talk:
– add DSL element to allow chaining of composition including Future transformations
– avoid WrappedMessage when ask() returns a single response type
