### PR TITLE
Hardening of another corner case in cluster singleton, see #3017

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -339,7 +339,7 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
 
   var latestGossip: Gossip = Gossip.empty
   var latestConvergedGossip: Gossip = Gossip.empty
-  var memberEvents: immutable.Seq[MemberEvent] = immutable.Seq.empty
+  var bufferedEvents: immutable.IndexedSeq[ClusterDomainEvent] = Vector.empty
 
   def receive = {
     case PublishChanges(newGossip)            ⇒ publishChanges(newGossip)
@@ -401,14 +401,16 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
     val newMemberEvents = diffMemberEvents(oldGossip, newGossip)
     convertToInstantMemberEvents(newMemberEvents) foreach publish
     // buffer up the MemberEvents waiting for convergence
-    memberEvents ++= newMemberEvents
-    // if we have convergence then publish the MemberEvents and possibly a LeaderChanged
+    bufferedEvents ++= newMemberEvents
+    // buffer up the LeaderChanged waiting for convergence
+    bufferedEvents ++= diffLeader(oldGossip, newGossip)
+    // if we have convergence then publish the MemberEvents and LeaderChanged
     if (newGossip.convergence) {
       val previousConvergedGossip = latestConvergedGossip
       latestConvergedGossip = newGossip
-      memberEvents foreach { event ⇒
+      bufferedEvents foreach { event ⇒
         event match {
-          case m @ (MemberDowned(_) | MemberRemoved(_)) ⇒
+          case m: MemberEvent if m.isInstanceOf[MemberDowned] || m.isInstanceOf[MemberRemoved] ⇒
             // TODO MemberDowned match should probably be covered by MemberRemoved, see ticket #2788
             //   but right now we don't change Downed to Removed
             publish(event)
@@ -417,8 +419,7 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
           case _ ⇒ publish(event)
         }
       }
-      memberEvents = immutable.Seq.empty
-      diffLeader(previousConvergedGossip, latestConvergedGossip) foreach publish
+      bufferedEvents = Vector.empty
     }
     // publish internal SeenState for testing purposes
     diffSeen(oldGossip, newGossip) foreach publish

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSingletonManager.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSingletonManager.scala
@@ -65,7 +65,7 @@ object ClusterSingletonManager {
     case object TakeOverFromMe
 
     case class HandOverRetry(count: Int)
-    case class TakeOverRetry(leaderPeer: ActorRef, count: Int)
+    case class TakeOverRetry(count: Int)
     case object Cleanup
     case object StartLeaderChangedBuffer
 
@@ -83,7 +83,7 @@ object ClusterSingletonManager {
     case class LeaderData(singleton: ActorRef, singletonTerminated: Boolean = false,
                           handOverData: Option[Any] = None) extends Data
     case class WasLeaderData(singleton: ActorRef, singletonTerminated: Boolean, handOverData: Option[Any],
-                             newLeader: Address) extends Data
+                             newLeaderOption: Option[Address]) extends Data
     case class HandingOverData(singleton: ActorRef, handOverTo: Option[ActorRef], handOverData: Option[Any]) extends Data
 
     val HandOverRetryTimer = "hand-over-retry"
@@ -475,13 +475,13 @@ class ClusterSingletonManager(
           gotoHandingOver(singleton, singletonTerminated, handOverData, None)
         case Some(a) ⇒
           // send TakeOver request in case the new leader doesn't know previous leader
-          val leaderPeer = peer(a)
-          leaderPeer ! TakeOverFromMe
-          setTimer(TakeOverRetryTimer, TakeOverRetry(leaderPeer, 1), retryInterval, repeat = false)
-          goto(WasLeader) using WasLeaderData(singleton, singletonTerminated, handOverData, newLeader = a)
-        case _ ⇒
+          peer(a) ! TakeOverFromMe
+          setTimer(TakeOverRetryTimer, TakeOverRetry(1), retryInterval, repeat = false)
+          goto(WasLeader) using WasLeaderData(singleton, singletonTerminated, handOverData, newLeaderOption = Some(a))
+        case None ⇒
           // new leader will initiate the hand-over
-          stay
+          setTimer(TakeOverRetryTimer, TakeOverRetry(1), retryInterval, repeat = false)
+          goto(WasLeader) using WasLeaderData(singleton, singletonTerminated, handOverData, newLeaderOption = None)
       }
 
     case Event(HandOverToMe, LeaderData(singleton, singletonTerminated, handOverData)) ⇒
@@ -495,20 +495,19 @@ class ClusterSingletonManager(
   }
 
   when(WasLeader) {
-    case Event(TakeOverRetry(leaderPeer, count), _) ⇒
-      val newLeader = leaderPeer.path.address
+    case Event(TakeOverRetry(count), WasLeaderData(_, _, _, newLeaderOption)) ⇒
       if (count <= maxTakeOverRetries) {
-        logInfo("Retry [{}], sending TakeOverFromMe to [{}]", count, newLeader)
-        leaderPeer ! TakeOverFromMe
-        setTimer(TakeOverRetryTimer, TakeOverRetry(leaderPeer, count + 1), retryInterval, repeat = false)
+        logInfo("Retry [{}], sending TakeOverFromMe to [{}]", count, newLeaderOption)
+        newLeaderOption foreach { peer(_) ! TakeOverFromMe }
+        setTimer(TakeOverRetryTimer, TakeOverRetry(count + 1), retryInterval, repeat = false)
         stay
       } else
-        throw new ClusterSingletonManagerIsStuck(s"Expected hand-over to [${newLeader}] never occured")
+        throw new ClusterSingletonManagerIsStuck(s"Expected hand-over to [${newLeaderOption}] never occured")
 
     case Event(HandOverToMe, WasLeaderData(singleton, singletonTerminated, handOverData, _)) ⇒
       gotoHandingOver(singleton, singletonTerminated, handOverData, Some(sender))
 
-    case Event(MemberDowned(m), WasLeaderData(singleton, singletonTerminated, handOverData, newLeader)) if m.address == newLeader ⇒
+    case Event(MemberDowned(m), WasLeaderData(singleton, singletonTerminated, handOverData, Some(newLeader))) if m.address == newLeader ⇒
       addDowned(m.address)
       gotoHandingOver(singleton, singletonTerminated, handOverData, None)
 

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterSingletonManagerSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterSingletonManagerSpec.scala
@@ -155,12 +155,12 @@ object ClusterSingletonManagerSpec extends MultiNodeConfig {
 
     def receive = {
       case state: CurrentClusterState ⇒ leaderAddress = state.leader
-      case LeaderChanged(leader) ⇒ leaderAddress = leader
-      case other => consumer foreach { _ forward other }
+      case LeaderChanged(leader)      ⇒ leaderAddress = leader
+      case other                      ⇒ consumer foreach { _ forward other }
     }
 
     def consumer: Option[ActorRef] =
-      leaderAddress map (a => context.actorFor(RootActorPath(a) /
+      leaderAddress map (a ⇒ context.actorFor(RootActorPath(a) /
         "user" / "singleton" / "consumer"))
   }
   //#singleton-proxy
@@ -300,7 +300,7 @@ class ClusterSingletonManagerSpec extends MultiNodeSpec(ClusterSingletonManagerS
       verify(sortedClusterRoles(0), msg = 4, expectedCurrent = 3)
     }
 
-    "hand over when leader leaves in 6 nodes cluster " in within(20 seconds) {
+    "hand over when leader leaves in 6 nodes cluster " in within(30 seconds) {
       //#test-leave
       val leaveRole = sortedClusterRoles(0)
       val newLeaderRole = sortedClusterRoles(1)

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterSingletonManagerSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterSingletonManagerSpec.scala
@@ -283,8 +283,17 @@ class ClusterSingletonManagerSpec extends MultiNodeSpec(ClusterSingletonManagerS
       verify(newLeaderRole, msg = 3, expectedCurrent = 2)
     }
 
-    "hand over when adding three new potential leaders to 3 nodes cluster" in within(30 seconds) {
+    "hand over when adding three new potential leaders to 3 nodes cluster" in within(60 seconds) {
+      // this test will result in restart after retry timeout
+      // because the new leader will not know about the real previous leader and the
+      // previous leader sortedClusterRoles(3) will first think that sortedClusterRoles(2)
+      // is the new leader
+      runOn(controller) {
+        queue ! Reset
+        expectMsg(ResetOk)
+      }
       runOn(sortedClusterRoles(2)) {
+        // previous leader
         Cluster(system) join node(sortedClusterRoles(3)).address
         createSingleton()
       }
@@ -297,7 +306,7 @@ class ClusterSingletonManagerSpec extends MultiNodeSpec(ClusterSingletonManagerS
         createSingleton()
       }
 
-      verify(sortedClusterRoles(0), msg = 4, expectedCurrent = 3)
+      verify(sortedClusterRoles(0), msg = 4, expectedCurrent = 0)
     }
 
     "hand over when leader leaves in 6 nodes cluster " in within(30 seconds) {


### PR DESCRIPTION
- It was an unlikely situatation that was not covered,
  the new leader didn't know previous, because it transitioned
  from Start -> BecomeLeader, old leader was removed and got
  LeaderChanged(None), so none of them could request the other
  for hand-over or take-over.
- Taken care of with the retry timeouts, also when leader
  receives LeaderChanged(None)
- This also revealed a flaw in how LeaderChanged events are published.
  The leader should have received a proper LeaderChanged earlier, when 
  changing status from leaving -> exiting. The leader events must also be
  buffered, similar to member events. Otherwise all changes might not be
  published because it doesn't have to be convergence on _all_ nodes between
  transitions.
