### PR TITLE
We can't set the SHA1PRNG random source reliably from within Akka. See #2977

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -48,7 +48,6 @@ object RemotingSpec {
       protocol = "TLSv1"
       random-number-generator = "AES128CounterSecureRNG"
       enabled-algorithms = [TLS_RSA_WITH_AES_128_CBC_SHA]
-      sha1prng-random-source = "/dev/./urandom"
     }
 
     akka {

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
@@ -48,7 +48,6 @@ object Configuration {
           protocol = "TLSv1"
           random-number-generator = "%s"
           enabled-algorithms = [%s]
-          sha1prng-random-source = "/dev/./urandom"
         }
       }
     }
@@ -65,8 +64,7 @@ object Configuration {
       val fullConfig = config.withFallback(AkkaSpec.testConf).withFallback(ConfigFactory.load).getConfig("akka.remote.netty.ssl.ssl")
       val settings = new SSLSettings(fullConfig)
 
-      val rng = NettySSLSupport.initializeCustomSecureRandom(settings.SSLRandomNumberGenerator,
-        settings.SSLRandomSource, NoLogging)
+      val rng = NettySSLSupport.initializeCustomSecureRandom(settings.SSLRandomNumberGenerator, NoLogging)
 
       rng.nextInt() // Has to work
       settings.SSLRandomNumberGenerator foreach {

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978ConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978ConfigSpec.scala
@@ -19,7 +19,6 @@ class Ticket1978ConfigSpec extends AkkaSpec with ImplicitSender with DefaultTime
       protocol = "TLSv1"
       random-number-generator = "AES128CounterSecureRNG"
       enabled-algorithms = [TLS_RSA_WITH_AES_128_CBC_SHA]
-      sha1prng-random-source = "/dev/./urandom"
     }""")
 
   "SSL Remoting" must {
@@ -32,7 +31,6 @@ class Ticket1978ConfigSpec extends AkkaSpec with ImplicitSender with DefaultTime
       settings.SSLTrustStorePassword must be(Some("changeme"))
       settings.SSLProtocol must be(Some("TLSv1"))
       settings.SSLEnabledAlgorithms must be(Set("TLS_RSA_WITH_AES_128_CBC_SHA"))
-      settings.SSLRandomSource must be(Some("/dev/./urandom"))
       settings.SSLRandomNumberGenerator must be(Some("AES128CounterSecureRNG"))
     }
   }


### PR DESCRIPTION
Relying on the code to set a system property that is only used during the first load of a (Sun) Oracle private class to ensure that we use the correct random source just doesn't cut it.

Depending on test execution order and entropy on the Linux box SSL tests can fail.

I've reconfigured the Jenkins jobs on jenkins.typesafe.com to set the property on the command line.
