### PR TITLE
Scheduler shutdown timeout needs to be longer on slow machines. See #3027

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -485,6 +485,8 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
           // println(s"clock=$time")
           time
         }
+        override protected def getShutdownTimeout: FiniteDuration = super.getShutdownTimeout.dilated
+
         override protected def waitNanos(ns: Long): Unit = {
           // println(s"waiting $ns")
           prb.ref ! ns

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -215,6 +215,11 @@ class LightArrayRevolverScheduler(config: Config,
   /**
    * Overridable for tests
    */
+  protected def getShutdownTimeout: FiniteDuration = ShutdownTimeout
+
+  /**
+   * Overridable for tests
+   */
   protected def waitNanos(nanos: Long): Unit = {
     // see http://www.javamex.com/tutorials/threads/sleep_issues.shtml
     val sleepMs = if (Helpers.isWindows) (nanos + 4999999) / 10000000 * 10 else (nanos + 999999) / 1000000
@@ -276,7 +281,7 @@ class LightArrayRevolverScheduler(config: Config,
     }
   }
 
-  override def close(): Unit = Await.result(stop(), ShutdownTimeout) foreach execDirectly
+  override def close(): Unit = Await.result(stop(), getShutdownTimeout) foreach execDirectly
 
   override val maxFrequency: Double = 1.second / TickDuration
 


### PR DESCRIPTION
If I slow down the timer thread slightly, trying to handle all the scheduled tasks in the test will make the shutdown time out.

Changed so that the shutdown time out is dilated in this test.
