### PR TITLE
Add receiveN to JavaTestKit. Fixes #3029

### DIFF
--- a/akka-docs/rst/java/code/docs/testkit/TestKitDocTest.java
+++ b/akka-docs/rst/java/code/docs/testkit/TestKitDocTest.java
@@ -206,6 +206,11 @@ public class TestKitDocTest {
       final Number j     = expectMsgAnyClassOf(Integer.class, Long.class);
       expectNoMsg();
       //#test-expect
+      getRef().tell("receveN-1", null);
+      getRef().tell("receveN-2", null);
+      //#test-expect
+      final Object[] two = receiveN(2);
+      //#test-expect
       assertEquals("hello", hello);
       assertEquals("hello", any);
       assertEquals(42, i);

--- a/akka-docs/rst/java/testing.rst
+++ b/akka-docs/rst/java/testing.rst
@@ -235,6 +235,11 @@ obey the innermost enclosing :class:`Within` as detailed :ref:`below
     message has been received before calling this method which has not been
     removed from the queue using one of the other methods.
 
+  * :meth:`Object[] receiveN(int n, Duration max)`
+
+    ``n`` messages must be received within the given time; the received
+    messages are returned.
+
 For cases which require more refined conditions there are constructs which take
 code blocks:
 

--- a/akka-testkit/src/main/java/akka/testkit/JavaTestKit.java
+++ b/akka-testkit/src/main/java/akka/testkit/JavaTestKit.java
@@ -227,6 +227,14 @@ public class JavaTestKit {
     p.expectNoMsg(max);
   }
 
+  public Object[] receiveN(int n) {
+    return (Object[]) p.receiveN(n).toArray(Util.classTag(Object.class));
+  }
+
+  public Object[] receiveN(int n, FiniteDuration max) {
+    return (Object[]) p.receiveN(n, max).toArray(Util.classTag(Object.class));
+  }
+
   public abstract class ReceiveWhile<T> {
     abstract protected T match(Object msg) throws Exception;
 
@@ -264,10 +272,6 @@ public class JavaTestKit {
     }
   }
 
-  public Object[] receiveN(int n, FiniteDuration max) {
-    return (Object[]) p.receiveN(n, max).toArray(Util.classTag(Object.class));
-  }
-  
   public abstract class EventFilter<T> {
     abstract protected T run();
     

--- a/akka-testkit/src/test/scala/akka/testkit/JavaTestKitSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/JavaTestKitSpec.scala
@@ -1,0 +1,38 @@
+package akka.testkit
+
+import language.postfixOps
+
+import org.scalatest.WordSpec
+import org.scalatest.matchers.MustMatchers
+import org.scalatest.{ BeforeAndAfterEach, WordSpec }
+import akka.actor._
+import scala.concurrent.{ Future, Await }
+import scala.concurrent.duration._
+import akka.pattern.ask
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class JavaTestKitSpec extends AkkaSpec with DefaultTimeout {
+
+  "JavaTestKit" must {
+
+    "be able to receiveN messages" in {
+      new JavaTestKit(system) {
+        val sent = List(1, 2, 3, 4, 5)
+        for (m ← sent) { getRef() ! m }
+        val received = receiveN(sent.size, 5 seconds);
+        sent.toSet must be(received.toSet)
+      }
+    }
+
+    "be able to receiveN messages with default duration" in {
+      new JavaTestKit(system) {
+        val sent = List(1, 2, 3)
+        for (m ← sent) { getRef() ! m }
+        val received = receiveN(sent.size);
+        sent.toSet must be(received.toSet)
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
receiveN was already available for Scala testing.

As part of the router documentation work I added a partial, undocumented receiveN implementation for Java. This PR finishes off the implementation.
