### PR TITLE
IOManager connect and accept failure handling. Fixes #3035

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
@@ -380,6 +380,28 @@ class IOActorSpec extends AkkaSpec with DefaultTimeout {
         if (!s.isClosed) s.close()
       }
     }
+
+    "fail when listening on an invalid address" in {
+      implicit val self = testActor
+      val address = new InetSocketAddress("irate.elephant", 9999)
+      IOManager(system).listen(address)
+      expectMsgType[Status.Failure](1 seconds)
+    }
+
+    "fail when listening on a privileged port" in {
+      implicit val self = testActor
+      val address = new InetSocketAddress("localhost", 80) // Assumes test not run as root
+      IOManager(system).listen(address)
+      expectMsgType[Status.Failure](1 seconds)
+    }
+
+    "fail when connecting to an invalid address" in {
+      implicit val self = testActor
+      val address = new InetSocketAddress("irate.elephant", 80)
+      IOManager(system).connect(address)
+      expectMsgType[Status.Failure](1 seconds)
+    }
+
   }
 
 }


### PR DESCRIPTION
Cherry-picked from release-2.1.

I also made a couple of tiny improvements over the 2.1 fix, using a variable (`sock`) that is available, instead of accessing a property (`channel.socket`). Is it important to keep the changes consistent over versions?
