### PR TITLE
IO layer: Java API and docs, make Write accept NoAck aux data

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnIntegrationSpec.scala
@@ -21,7 +21,7 @@ class UdpConnIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with Impli
 
   def connectUdp(localAddress: Option[InetSocketAddress], remoteAddress: InetSocketAddress, handler: ActorRef): ActorRef = {
     val commander = TestProbe()
-    commander.send(IO(UdpConn), UdpConn.Connect(handler, localAddress, remoteAddress, Nil))
+    commander.send(IO(UdpConn), UdpConn.Connect(handler, remoteAddress, localAddress, Nil))
     commander.expectMsg(UdpConn.Connected)
     commander.sender
   }

--- a/akka-actor/src/main/scala/akka/io/Inet.scala
+++ b/akka-actor/src/main/scala/akka/io/Inet.scala
@@ -86,4 +86,12 @@ object Inet {
     val TrafficClass = SO.TrafficClass
   }
 
+  trait SoJavaFactories {
+    import SO._
+    def receiveBufferSize(size: Int) = ReceiveBufferSize(size)
+    def reuseAddress(on: Boolean) = ReuseAddress(on)
+    def sendBufferSize(size: Int) = SendBufferSize(size)
+    def trafficClass(tc: Int) = TrafficClass(tc)
+  }
+
 }

--- a/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
+++ b/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2009-2012 Typesafe Inc. <http://www.typesafe.com>
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
  */
 
 package akka.io

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -106,8 +106,11 @@ object Tcp extends ExtensionKey[TcpExt] {
   case class Received(data: ByteString) extends Event
   case class Connected(remoteAddress: InetSocketAddress, localAddress: InetSocketAddress) extends Event
   case class CommandFailed(cmd: Command) extends Event
-  case object Bound extends Event
-  case object Unbound extends Event
+
+  sealed trait Bound extends Event
+  case object Bound extends Bound
+  sealed trait Unbound extends Event
+  case object Unbound extends Unbound
 
   sealed trait ConnectionClosed extends Event {
     def isAborted: Boolean = false
@@ -190,34 +193,34 @@ object TcpMessage {
 
   def connect(remoteAddress: InetSocketAddress,
               localAddress: InetSocketAddress,
-              options: JIterable[SocketOption]) = Connect(remoteAddress, Some(localAddress), options)
+              options: JIterable[SocketOption]): Command = Connect(remoteAddress, Some(localAddress), options)
   def connect(remoteAddress: InetSocketAddress,
-              options: JIterable[SocketOption]) = Connect(remoteAddress, None, options)
-  def connect(remoteAddress: InetSocketAddress) = Connect(remoteAddress, None, Nil)
+              options: JIterable[SocketOption]): Command = Connect(remoteAddress, None, options)
+  def connect(remoteAddress: InetSocketAddress): Command = Connect(remoteAddress, None, Nil)
 
   def bind(handler: ActorRef,
            endpoint: InetSocketAddress,
            backlog: Int,
-           options: JIterable[SocketOption]) = Bind(handler, endpoint, backlog, options)
+           options: JIterable[SocketOption]): Command = Bind(handler, endpoint, backlog, options)
   def bind(handler: ActorRef,
            endpoint: InetSocketAddress,
-           backlog: Int) = Bind(handler, endpoint, backlog, Nil)
+           backlog: Int): Command = Bind(handler, endpoint, backlog, Nil)
 
-  def register(handler: ActorRef) = Register(handler)
-  def unbind = Unbind
+  def register(handler: ActorRef): Command = Register(handler)
+  def unbind: Command = Unbind
 
-  def close = Close
-  def confirmedClose = ConfirmedClose
-  def abort = Abort
+  def close: Command = Close
+  def confirmedClose: Command = ConfirmedClose
+  def abort: Command = Abort
 
-  def noAck = NoAck
-  def noAck(token: AnyRef) = NoAck(token)
+  def noAck: NoAck = NoAck
+  def noAck(token: AnyRef): NoAck = NoAck(token)
 
-  def write(data: ByteString) = Write(data)
-  def write(data: ByteString, ack: AnyRef) = Write(data, ack)
+  def write(data: ByteString): Command = Write(data)
+  def write(data: ByteString, ack: AnyRef): Command = Write(data, ack)
 
-  def stopReading = StopReading
-  def resumeReading = ResumeReading
+  def stopReading: Command = StopReading
+  def resumeReading: Command = ResumeReading
 
   implicit private def fromJava[T](coll: JIterable[T]): immutable.Traversable[T] = {
     import scala.collection.JavaConverters._

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -289,7 +289,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       } else this
 
     def hasData = buffer.remaining() > 0 || remainingData.size > 0
-    def wantsAck = ack != NoAck
+    def wantsAck = !ack.isInstanceOf[NoAck]
   }
   def createWrite(write: Write): PendingWrite = {
     val buffer = bufferPool.acquire()

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -20,6 +20,8 @@ import akka.io.SelectionHandler._
 
 /**
  * Base class for TcpIncomingConnection and TcpOutgoingConnection.
+ *
+ * INTERNAL API
  */
 private[io] abstract class TcpConnection(val channel: SocketChannel,
                                          val tcp: TcpExt) extends Actor with ActorLogging {
@@ -298,6 +300,9 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
   }
 }
 
+/**
+ * INTERNAL API
+ */
 private[io] object TcpConnection {
   sealed trait ReadResult
   object NoData extends ReadResult

--- a/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
@@ -13,6 +13,8 @@ import akka.io.SelectionHandler.{ ChannelRegistered, RegisterChannel }
 /**
  * An actor handling the connection state machine for an incoming, already connected
  * SocketChannel.
+ *
+ * INTERNAL API
  */
 private[io] class TcpIncomingConnection(_channel: SocketChannel,
                                         _tcp: TcpExt,

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -15,6 +15,9 @@ import akka.io.Inet.SocketOption
 import akka.io.Tcp._
 import akka.io.IO.HasFailureMessage
 
+/**
+ * INTERNAL API
+ */
 private[io] object TcpListener {
 
   case class RegisterIncoming(channel: SocketChannel) extends HasFailureMessage {
@@ -25,6 +28,9 @@ private[io] object TcpListener {
 
 }
 
+/**
+ * INTERNAL API
+ */
 private[io] class TcpListener(val selectorRouter: ActorRef,
                               val tcp: TcpExt,
                               val bindCommander: ActorRef,

--- a/akka-actor/src/main/scala/akka/io/TcpManager.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpManager.scala
@@ -9,6 +9,8 @@ import akka.actor.{ ActorLogging, Props }
 import akka.io.IO.SelectorBasedManager
 
 /**
+ * INTERNAL API
+ *
  * TcpManager is a facade for accepting commands ([[akka.io.Tcp.Command]]) to open client or server TCP connections.
  *
  * TcpManager is obtainable by calling {{{ IO(Tcp) }}} (see [[akka.io.IO]] and [[akka.io.Tcp]])

--- a/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -15,6 +15,8 @@ import scala.collection.immutable
 /**
  * An actor handling the connection state machine for an outgoing connection
  * to be established.
+ *
+ * INTERNAL API
  */
 private[io] class TcpOutgoingConnection(_tcp: TcpExt,
                                         commander: ActorRef,
@@ -53,7 +55,10 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
 
 }
 
-object TcpOutgoingConnection {
+/**
+ * INTERNAL API
+ */
+private[io] object TcpOutgoingConnection {
   private def newSocketChannel() = {
     val channel = SocketChannel.open()
     channel.configureBlocking(false)

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -4,7 +4,7 @@
 package akka.io
 
 import java.net.DatagramSocket
-import akka.io.Inet.SocketOption
+import akka.io.Inet.{ SoJavaFactories, SocketOption }
 import com.typesafe.config.Config
 import akka.actor.{ Props, ActorSystemImpl }
 
@@ -45,4 +45,9 @@ object Udp {
     }
   }
 
+}
+
+object UdpSO extends SoJavaFactories {
+  import Udp.SO._
+  def broadcast(on: Boolean) = Broadcast(on)
 }

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -44,7 +44,11 @@ object Udp {
       size.toInt
     }
   }
+}
 
+object UdpSO extends SoJavaFactories {
+  import Udp.SO._
+  def broadcast(on: Boolean) = Broadcast(on)
 }
 
 object UdpSO extends SoJavaFactories {

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -50,8 +50,3 @@ object UdpSO extends SoJavaFactories {
   import Udp.SO._
   def broadcast(on: Boolean) = Broadcast(on)
 }
-
-object UdpSO extends SoJavaFactories {
-  import Udp.SO._
-  def broadcast(on: Boolean) = Broadcast(on)
-}

--- a/akka-actor/src/main/scala/akka/io/UdpConnManager.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnManager.scala
@@ -7,7 +7,10 @@ import akka.actor.Props
 import akka.io.IO.SelectorBasedManager
 import akka.io.UdpConn.Connect
 
-class UdpConnManager(udpConn: UdpConnExt) extends SelectorBasedManager(udpConn.settings, udpConn.settings.NrOfSelectors) {
+/**
+ * INTERNAL API
+ */
+private[io] class UdpConnManager(udpConn: UdpConnExt) extends SelectorBasedManager(udpConn.settings, udpConn.settings.NrOfSelectors) {
 
   def receive = workerForCommandHandler {
     case c: Connect ⇒

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -13,6 +13,9 @@ import java.nio.channels.SelectionKey._
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
+/**
+ * INTERNAL API
+ */
 private[io] class UdpConnection(val udpConn: UdpConnExt,
                                 val commander: ActorRef,
                                 val connect: Connect) extends Actor with ActorLogging {

--- a/akka-actor/src/main/scala/akka/io/UdpFF.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpFF.scala
@@ -66,21 +66,21 @@ object UdpFFMessage {
   import scala.collection.JavaConverters._
   import language.implicitConversions
 
-  def send(payload: ByteString, target: InetSocketAddress) = Send(payload, target)
-  def send(payload: ByteString, target: InetSocketAddress, ack: Any) = Send(payload, target, ack)
+  def send(payload: ByteString, target: InetSocketAddress): Send = Send(payload, target)
+  def send(payload: ByteString, target: InetSocketAddress, ack: Any): Send = Send(payload, target, ack)
 
-  def bind(handler: ActorRef, endpoint: InetSocketAddress, options: JIterable[SocketOption]) =
+  def bind(handler: ActorRef, endpoint: InetSocketAddress, options: JIterable[SocketOption]): Bind =
     Bind(handler, endpoint, options.asScala.to)
 
-  def bind(handler: ActorRef, endpoint: InetSocketAddress) = Bind(handler, endpoint, Nil)
+  def bind(handler: ActorRef, endpoint: InetSocketAddress): Bind = Bind(handler, endpoint, Nil)
 
-  def simpleSender(options: JIterable[SocketOption]) = SimpleSender(options.asScala.to)
-  def simpleSender = SimpleSender
+  def simpleSender(options: JIterable[SocketOption]): SimpleSender = SimpleSender(options.asScala.to)
+  def simpleSender: SimpleSender = SimpleSender
 
-  def unbind = Unbind
+  def unbind: Unbind.type = Unbind
 
-  def stopReading = StopReading
-  def resumeReading = ResumeReading
+  def stopReading: StopReading.type = StopReading
+  def resumeReading: ResumeReading.type = ResumeReading
 }
 
 class UdpFFExt(system: ExtendedActorSystem) extends IO.Extension {

--- a/akka-actor/src/main/scala/akka/io/UdpFF.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpFF.scala
@@ -19,11 +19,13 @@ object UdpFF extends ExtensionKey[UdpFFExt] {
     def failureMessage = CommandFailed(this)
   }
 
-  case object NoAck
+  case class NoAck(token: Any)
+  object NoAck extends NoAck(null)
+
   case class Send(payload: ByteString, target: InetSocketAddress, ack: Any) extends Command {
     require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
 
-    def wantsAck: Boolean = ack != NoAck
+    def wantsAck: Boolean = !ack.isInstanceOf[NoAck]
   }
   object Send {
     def apply(data: ByteString, target: InetSocketAddress): Send = Send(data, target, NoAck)
@@ -44,12 +46,41 @@ object UdpFF extends ExtensionKey[UdpFFExt] {
 
   case class Received(data: ByteString, sender: InetSocketAddress) extends Event
   case class CommandFailed(cmd: Command) extends Event
-  case object Bound extends Event
-  case object SimpleSendReady extends Event
-  case object Unbound extends Event
+
+  sealed trait Bound extends Event
+  case object Bound extends Bound
+
+  sealed trait SimpleSendReady extends Event
+  case object SimpleSendReady extends SimpleSendReady
+
+  sealed trait Unbound
+  case object Unbound extends Unbound
 
   case class SendFailed(cause: Throwable) extends Event
 
+}
+
+object UdpFFMessage {
+  import UdpFF._
+  import java.lang.{ Iterable ⇒ JIterable }
+  import scala.collection.JavaConverters._
+  import language.implicitConversions
+
+  def send(payload: ByteString, target: InetSocketAddress) = Send(payload, target)
+  def send(payload: ByteString, target: InetSocketAddress, ack: Any) = Send(payload, target, ack)
+
+  def bind(handler: ActorRef, endpoint: InetSocketAddress, options: JIterable[SocketOption]) =
+    Bind(handler, endpoint, options.asScala.to)
+
+  def bind(handler: ActorRef, endpoint: InetSocketAddress) = Bind(handler, endpoint, Nil)
+
+  def simpleSender(options: JIterable[SocketOption]) = SimpleSender(options.asScala.to)
+  def simpleSender = SimpleSender
+
+  def unbind = Unbind
+
+  def stopReading = StopReading
+  def resumeReading = ResumeReading
 }
 
 class UdpFFExt(system: ExtendedActorSystem) extends IO.Extension {

--- a/akka-actor/src/main/scala/akka/io/UdpFFListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpFFListener.scala
@@ -14,6 +14,9 @@ import java.nio.channels.SelectionKey._
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
+/**
+ * INTERNAL API
+ */
 private[io] class UdpFFListener(val udpFF: UdpFFExt,
                                 val bindCommander: ActorRef,
                                 val bind: Bind)

--- a/akka-actor/src/main/scala/akka/io/UdpFFManager.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpFFManager.scala
@@ -8,6 +8,8 @@ import akka.io.IO.SelectorBasedManager
 import akka.io.UdpFF._
 
 /**
+ * INTERNAL API
+ *
  * UdpFFManager is a facade for simple fire-and-forget style UDP operations
  *
  * UdpFFManager is obtainable by calling {{{ IO(UdpFF) }}} (see [[akka.io.IO]] and [[akka.io.UdpFF]])

--- a/akka-actor/src/main/scala/akka/io/UdpFFSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpFFSender.scala
@@ -13,6 +13,8 @@ import scala.util.control.NonFatal
 
 /**
  * Base class for TcpIncomingConnection and TcpOutgoingConnection.
+ *
+ * INTERNAL API
  */
 private[io] class UdpFFSender(val udpFF: UdpFFExt, options: immutable.Traversable[SocketOption], val commander: ActorRef)
   extends Actor with ActorLogging with WithUdpFFSend {

--- a/akka-actor/src/main/scala/akka/io/WithUdpFFSend.scala
+++ b/akka-actor/src/main/scala/akka/io/WithUdpFFSend.scala
@@ -8,6 +8,9 @@ import akka.io.UdpFF.{ CommandFailed, Send }
 import akka.io.SelectionHandler._
 import java.nio.channels.DatagramChannel
 
+/**
+ * INTERNAL API
+ */
 private[io] trait WithUdpFFSend {
   me: Actor with ActorLogging ⇒
 

--- a/akka-docs/rst/java/code/docs/io/IODocTest.java
+++ b/akka-docs/rst/java/code/docs/io/IODocTest.java
@@ -87,13 +87,5 @@ public class IODocTest {
 
   static ActorSystem system;
 
-  @BeforeClass
-  static public void setup() {
-    system = ActorSystem.create("IODocTest");
-  }
-
-  @Test
-  public void demonstrateConnect() {
-  }
-
+  // This is currently only a compilation test, nothing is run
 }

--- a/akka-docs/rst/java/code/docs/io/IODocTest.java
+++ b/akka-docs/rst/java/code/docs/io/IODocTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package docs.io;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import akka.actor.ActorSystem;
+import akka.actor.UntypedActor;
+//#imports
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import akka.actor.ActorRef;
+import akka.io.Inet;
+import akka.io.Tcp;
+import akka.io.TcpExt;
+import akka.io.TcpMessage;
+import akka.io.TcpSO;
+import akka.util.ByteString;
+//#imports
+
+public class IODocTest {
+
+  static public class Demo extends UntypedActor {
+    ActorRef connectionActor = null;
+    ActorRef listener = getSelf();
+
+    @Override
+    public void onReceive(Object msg) {
+      if ("connect".equals(msg)) {
+        //#manager
+        final ActorRef tcp = Tcp.get(system).manager();
+        //#manager
+        //#connect
+        final InetSocketAddress remoteAddr = new InetSocketAddress("127.0.0.1",
+            12345);
+        tcp.tell(TcpMessage.connect(remoteAddr), getSelf());
+        // or with socket options
+        final InetSocketAddress localAddr = new InetSocketAddress("127.0.0.1",
+            1234);
+        final List<Inet.SocketOption> options = new ArrayList<Inet.SocketOption>();
+        options.add(TcpSO.keepAlive(true));
+        tcp.tell(TcpMessage.connect(remoteAddr, localAddr, options), getSelf());
+        //#connect
+      } else
+      //#connected
+      if (msg instanceof Tcp.Connected) {
+        final Tcp.Connected conn = (Tcp.Connected) msg;
+        connectionActor = getSender();
+        connectionActor.tell(TcpMessage.register(listener), getSelf());
+      }
+      //#connected
+      else
+      //#received
+      if (msg instanceof Tcp.Received) {
+        final Tcp.Received recv = (Tcp.Received) msg;
+        final ByteString data = recv.data();
+        // and do something with the received data ...
+      } else if (msg instanceof Tcp.CommandFailed) {
+        final Tcp.CommandFailed failed = (Tcp.CommandFailed) msg;
+        final Tcp.Command command = failed.cmd();
+        // react to failed connect, bind, write, etc.
+      } else if (msg instanceof Tcp.ConnectionClosed) {
+        final Tcp.ConnectionClosed closed = (Tcp.ConnectionClosed) msg;
+        if (closed.isAborted()) {
+          // handle close reasons like this
+        }
+      }
+      //#received
+      else
+      if ("bind".equals(msg)) {
+        final ActorRef handler = getSelf();
+        //#bind
+        final ActorRef tcp = Tcp.get(system).manager();
+        final InetSocketAddress localAddr = new InetSocketAddress("127.0.0.1",
+            1234);
+        final List<Inet.SocketOption> options = new ArrayList<Inet.SocketOption>();
+        options.add(TcpSO.reuseAddress(true));
+        tcp.tell(TcpMessage.bind(handler, localAddr, 10, options), getSelf());
+        //#bind
+      }
+    }
+  }
+
+  static ActorSystem system;
+
+  @BeforeClass
+  static public void setup() {
+    system = ActorSystem.create("IODocTest");
+  }
+
+  @Test
+  public void demonstrateConnect() {
+  }
+
+}

--- a/akka-docs/rst/java/code/docs/io/IOUdpFFDocTest.java
+++ b/akka-docs/rst/java/code/docs/io/IOUdpFFDocTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package docs.io;
+
+//#imports
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.UntypedActor;
+import akka.io.Inet;
+import akka.io.UdpFF;
+import akka.io.UdpFFMessage;
+import akka.io.UdpSO;
+import akka.util.ByteString;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+//#imports
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+public class IOUdpFFDocTest {
+    static public class Demo extends UntypedActor {
+        public void onReceive(Object message) {
+            //#manager
+            final ActorRef udpFF = UdpFF.get(system).manager();
+            //#manager
+
+            //#simplesend
+            udpFF.tell(UdpFFMessage.simpleSender(), getSelf());
+
+            // ... or with socket options:
+            final List<Inet.SocketOption> options = new ArrayList<Inet.SocketOption>();
+            options.add(UdpSO.broadcast(true));
+            udpFF.tell(UdpFFMessage.simpleSender(), getSelf());
+            //#simplesend
+
+            ActorRef simpleSender = null;
+
+            //#simplesend-finish
+            if (message instanceof UdpFF.SimpleSendReady) {
+                simpleSender = getSender();
+            }
+            //#simplesend-finish
+
+            final ByteString data = ByteString.empty();
+
+            //#simplesend-send
+            simpleSender.tell(UdpFFMessage.send(data, new InetSocketAddress("127.0.0.1", 7654)), getSelf());
+            //#simplesend-send
+
+            final ActorRef handler = getSelf();
+
+            //#bind
+            udpFF.tell(UdpFFMessage.bind(handler, new InetSocketAddress("127.0.0.1", 9876)), getSelf());
+            //#bind
+
+            ActorRef udpWorker = null;
+
+            //#bind-finish
+            if (message instanceof UdpFF.Bound) {
+                udpWorker = getSender();
+            }
+            //#bind-finish
+
+            //#bind-receive
+            if (message instanceof UdpFF.Received) {
+                final UdpFF.Received rcvd = (UdpFF.Received) message;
+                final ByteString payload = rcvd.data();
+                final InetSocketAddress sender = rcvd.sender();
+            }
+            //#bind-receive
+
+            //#bind-send
+            udpWorker.tell(UdpFFMessage.send(data, new InetSocketAddress("127.0.0.1", 7654)), getSelf());
+            //#bind-send
+        }
+    }
+
+    static ActorSystem system;
+
+    @BeforeClass
+    static public void setup() {
+        system = ActorSystem.create("IODocTest");
+    }
+
+    @AfterClass
+    static public void teardown() {
+        system.shutdown();
+    }
+
+    @Test
+    public void demonstrateConnect() {
+    }
+
+}

--- a/akka-docs/rst/java/code/docs/io/UdpConnDocTest.java
+++ b/akka-docs/rst/java/code/docs/io/UdpConnDocTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package docs.io;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import akka.actor.ActorSystem;
+import akka.actor.UntypedActor;
+//#imports
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import akka.actor.ActorRef;
+import akka.io.Inet;
+import akka.io.UdpConn;
+import akka.io.UdpConnMessage;
+import akka.io.UdpSO;
+import akka.util.ByteString;
+//#imports
+
+public class UdpConnDocTest {
+
+  static public class Demo extends UntypedActor {
+    ActorRef connectionActor = null;
+    ActorRef handler = getSelf();
+
+    @Override
+    public void onReceive(Object msg) {
+      if ("connect".equals(msg)) {
+        //#manager
+        final ActorRef udp = UdpConn.get(system).manager();
+        //#manager
+        //#connect
+        final InetSocketAddress remoteAddr =
+            new InetSocketAddress("127.0.0.1", 12345);
+        udp.tell(UdpConnMessage.connect(handler, remoteAddr), getSelf());
+        // or with socket options
+        final InetSocketAddress localAddr =
+            new InetSocketAddress("127.0.0.1", 1234);
+        final List<Inet.SocketOption> options =
+            new ArrayList<Inet.SocketOption>();
+        options.add(UdpSO.broadcast(true));
+        udp.tell(UdpConnMessage.connect(handler, remoteAddr, localAddr, options), getSelf());
+        //#connect
+      } else
+        //#connected
+        if (msg instanceof UdpConn.Connected) {
+          final UdpConn.Connected conn = (UdpConn.Connected) msg;
+          connectionActor = getSender(); // Save the worker ref for later use
+        }
+        //#connected
+        else
+          //#received
+          if (msg instanceof UdpConn.Received) {
+            final UdpConn.Received recv = (UdpConn.Received) msg;
+            final ByteString data = recv.data();
+            // and do something with the received data ...
+          } else if (msg instanceof UdpConn.CommandFailed) {
+            final UdpConn.CommandFailed failed = (UdpConn.CommandFailed) msg;
+            final UdpConn.Command command = failed.cmd();
+            // react to failed connect, etc.
+          } else if (msg instanceof UdpConn.Disconnected) {
+            // do something on disconnect
+          }
+          //#received
+          else
+          if ("send".equals(msg)) {
+            ByteString data = ByteString.empty();
+            //#send
+            connectionActor.tell(UdpConnMessage.send(data), getSelf());
+            //#send
+          }
+    }
+  }
+
+  static ActorSystem system;
+
+  @BeforeClass
+  static public void setup() {
+    system = ActorSystem.create("UdpConnDocTest");
+  }
+
+  @AfterClass
+  static public void teardown() {
+    system.shutdown();
+  }
+
+  @Test
+  public void demonstrateConnect() {
+  }
+
+}

--- a/akka-docs/rst/java/index.rst
+++ b/akka-docs/rst/java/index.rst
@@ -20,6 +20,7 @@ Java API
    stm
    agents
    transactors
+   io
    fsm
    extending-akka
    zeromq

--- a/akka-docs/rst/java/io.rst
+++ b/akka-docs/rst/java/io.rst
@@ -177,19 +177,16 @@ Using UDP
 
 UDP support comes in two flavors: connectionless, and connection based:
 
-.. code-block:: scala
-
-  import akka.io.IO
-  import akka.io.UdpFF
-  val connectionLessUdp = IO(UdpFF)
-  // ... or ...
-  import akka.io.UdpConn
-  val connectionBasedUdp = IO(UdpConn)
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#manager
 
 UDP servers can be only implemented by the connectionless API, but clients can use both.
 
 Connectionless UDP
 ^^^^^^^^^^^^^^^^^^
+
+The following imports are assumed in the following sections:
+
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#imports
 
 Simple Send
 ............
@@ -197,26 +194,16 @@ Simple Send
 To simply send a UDP datagram without listening to an answer one needs to send the ``SimpleSender`` command to the
 manager:
 
-.. code-block:: scala
-
-  IO(UdpFF) ! SimpleSender
-  // or with socket options:
-  import akka.io.Udp._
-  IO(UdpFF) ! SimpleSender(List(SO.Broadcast(true)))
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#simplesend
 
 The manager will create a worker for sending, and the worker will reply with a ``SimpleSendReady`` message:
 
-.. code-block:: scala
-
-  case SimpleSendReady =>
-    simpleSender = sender
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#simplesend-finish
 
 After saving the sender of the ``SimpleSendReady`` message it is possible to send out UDP datagrams with a simple
 message send:
 
-.. code-block:: scala
-
-  simpleSender ! Send(data, serverAddress)
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#simplesend-send
 
 
 Bind (and Send)
@@ -225,31 +212,23 @@ Bind (and Send)
 To listen for UDP datagrams arriving on a given port, the ``Bind`` command has to be sent to the connectionless UDP
 manager
 
-.. code-block:: scala
-
-  IO(UdpFF) ! Bind(handler, localAddress)
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#bind
 
 After the bind succeeds, the sender of the ``Bind`` command will be notified with a ``Bound`` message. The sender of
 this message is the worker for the UDP channel bound to the local address.
 
-.. code-block:: scala
-
-  case Bound =>
-    udpWorker = sender // Save the worker ref for later use
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#bind-finish
 
 The actor passed in the ``handler`` parameter will receive inbound UDP datagrams sent to the bound address:
 
-.. code-block:: scala
-
-  case Received(dataByteString, remoteAddress) => // Do something with the data
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#bind-receive
 
 The ``Received`` message contains the payload of the datagram and the address of the sender.
 
 It is also possible to send UDP datagrams using the ``ActorRef`` of the worker saved in ``udpWorker``:
 
-.. code-block:: scala
+.. includecode:: code/docs/io/IOUdpFFDocTest.java#bind-send
 
- udpWorker ! Send(data, serverAddress)
 
 .. note::
   The difference between using a bound UDP worker to send instead of a simple-send worker is that in the former case

--- a/akka-docs/rst/java/io.rst
+++ b/akka-docs/rst/java/io.rst
@@ -244,34 +244,23 @@ receive datagrams only from that address.
 
 Connecting is similar to what we have seen in the previous section:
 
-.. code-block:: scala
-
-  IO(UdpConn) ! Connect(handler, remoteAddress)
-  // or, with more options:
-  IO(UdpConn) ! Connect(handler, Some(localAddress), remoteAddress, List(SO.Broadcast(true)))
+.. includecode:: code/docs/io/UdpConnDocTest.java#connect
 
 After the connect succeeds, the sender of the ``Connect`` command will be notified with a ``Connected`` message. The sender of
 this message is the worker for the UDP connection.
 
-.. code-block:: scala
-
-  case Connected =>
-    udpConnectionActor = sender // Save the worker ref for later use
+.. includecode:: code/docs/io/UdpConnDocTest.java#connected
 
 The actor passed in the ``handler`` parameter will receive inbound UDP datagrams sent to the bound address:
 
-.. code-block:: scala
-
-  case Received(dataByteString) => // Do something with the data
+.. includecode:: code/docs/io/UdpConnDocTest.java#received
 
 The ``Received`` message contains the payload of the datagram but unlike in the connectionless case, no sender address
 will be provided, as an UDP connection only receives messages from the endpoint it has been connected to.
 
 It is also possible to send UDP datagrams using the ``ActorRef`` of the worker saved in ``udpWorker``:
 
-.. code-block:: scala
-
- udpConnectionActor ! Send(data)
+.. includecode:: code/docs/io/UdpConnDocTest.java#send
 
 Again, the send does not contain a remote address, as it is always the endpoint we have been connected to.
 


### PR DESCRIPTION
Java API and docs for IO, at first only for TCP. Also allow NoAck to take a token which can be used to store a value with the Write which will not trigger an ACK but can be used in case of NACK.
- [x] add UdpFF, including NoAck()
- [x] add UdpConn, including NoAck()
