### PR TITLE
Script that generates statistics for release notes

### DIFF
--- a/scripts/release_stats.sh
+++ b/scripts/release_stats.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Generates statistics for release notes
+#
+
+# get the source location for this script; handles symlinks
+function get_script_path {
+  local source="${BASH_SOURCE[0]}"
+  while [ -h "${source}" ] ; do
+    source="$(readlink "${source}")";
+  done
+  echo ${source}
+}
+
+# path, name, and dir for this script
+declare -r script_path=$(get_script_path)
+declare -r script_name=$(basename "${script_path}")
+declare -r script_dir="$(cd -P "$(dirname "${script_path}")" && pwd)"
+
+# print usage info
+function usage {
+  echo "Usage: ${script_name} v2.1.0..v2.2.0 path_to_assembla_export.csv"
+}
+
+declare -r tag1=$1
+declare -r tag2=$2
+declare -r tickets_csv=$3
+
+if [ -z "$tickets_csv" ]; then
+  usage
+  exit 1
+fi
+
+declare -r tag_range="$tag1..$tag2"
+declare authors=$($script_dir/authors.pl $tag_range)
+declare author_count=$(echo "$authors" | wc -l | grep -o '[1-9].*')
+declare diff_short=$(git diff --shortstat $tag_range | grep -o '[1-9].*')
+declare tickets=$(tail -n +2 $tickets_csv | grep Fixed | cut -d ',' -f 1,2 | sed 's/","/  /g' | tr -d '"' | sort -n)
+declare ticket_count=$(echo "$tickets" | wc -l | grep -o '[1-9].*')
+
+echo "$tag1 compared to Akka $tag2":
+
+echo "* $ticket_count tickets closed"
+
+echo "* $diff_short"
+
+echo "* X pages of docs vs Y in $tag1"
+
+echo "* … and a total of $author_count committers!"
+
+echo ""
+echo "Fixed Tickets:"
+echo "$tickets"
+
+echo ""
+echo "Credits:"
+echo "commits added removed"
+echo "$authors"
+
+


### PR DESCRIPTION
Output looks like this:

```
$ scripts/release_stats.sh v2.1.0 v2.2-M1 ~/tmp/ticket_report-2.2-M2.csv 
v2.1.0 compared to Akka v2.2-M1:
* 121 tickets closed
* 744 files changed, 41156 insertions(+), 16523 deletions(-)
* X pages of docs vs Y in v2.1.0
* … and a total of 19 committers!

Fixed Tickets:
2018  Create tests for the Cluster JMX API
2053  create actor-based remote transport
2306  Add configuration option defining how many nodes the leader should wait for until moving nodes from JOINING to UP
2547  Create cluster metrics-aware Adaptive Load Balancing Routers 
2593  Document new configuration parameters for the new remoting
2664  MetricCollectorSpec fails on windows machine
2673  Move away from Seq[Byte] in Frame and ZMQMessage in favor of ByteString
2674  Remove ZMQMessage.firstFrameAsString
2690  Refactor clustering to use the refactored FailureDetector API
2704  Load Cluster extension when ClusterActorRefProvider is used
2721  retain message sender for Scheduler.schedule
2722  pattern.ask should be an implicit value class
2726  ReliableProxy still not reliable?
2742  Remote actors server should not use reuseAddress on Windows
2775  DOC: Migration: Promise doesn't extend Future
2776  Deprecate _? methods
2779  only trigger DeathWatch after a node is DOWN
2782  Improvement to ConcurrentIdentityHashMap
2785  2.1.x Backport #2692 Cluster: membership events should only be published for changes seen by everyone
2786  devise a cluster membership stress test
2791  configurable number of nodes in multi-node tests
2793  NodeMetricSpec possibly too strict?
2798  roll our own ensuring with require semantics
2801  Failure in ClusterRoundRobinRoutedActor
2803  Instant vs Converged Member Events
2810  Java api for JavaSerializer.currentSystem.withValue
2812  gracefulStop failed
2818  TypedActorSpec failed
2820  TransformationSampleJapiSpec failed
2821  CallingThreadDispatcherModelSpec failed on release-2.1 branch
2822  ResizerSpec failed
2823  CircuitBreakerMTSpec failed
2827  Ensure that public elements of the new remoting API are Java friendly
2829  rework config section structure for remote transports
2832  Failure when using blackhole feature on localhost
2833  RemotingSpec failed
2836  SupervisorHierarchySpec failed
2838  ZeroMQ test failure
2841  remove stack traces from new remoting exceptions
2843  remove all fixed port numbers from remoting tests
2844  Promise already completed in NettyTransport
2845  Fix occurences of default akka protocol in addresses where needed
2846  ReliableProxySpec doesn't terminate within 5 seconds
2848  Remove UUID from AkkaException
2849  ReliableProxy resend across a slow link failed
2853  UDP support in new Akka IO
2856  PinnedDispatcher should use same thread all the time
2862  Buffer overflow in libnss_ldap
2863  zeromq socket needs to be pinned to the thread that created it
2867  ThrottlerTransportAdapterSpec failed
2870  Remove try ... catch constructs around invokations of tell
2871  JoinTwoClusters failed
2872  NPE from transport.defaultAddress
2874  DOC: Router management for PoisonPill
2875  TransformationSampleJapiSpec failed
2876  SplitBrainSpec failed
2877  UnreachableNodeRejoinsClusterSpec failed
2878  AkkaProtocolStressTest failed
2879  Copyright (C) 2009-2013
2880  Add the -implicits and -diagrams flags to the scaladoc build
2881  Run tests with different settings of use-passive-connections
2882  DeadLetter sender may not be null
2883  ThrottlerTransportAdapterGenericSpec failed
2891  document TCP IO functionality
2895  Pattern: Singleton actor instance in cluster
2897  Logging in OSGi using the LogService
2898  HashedWheelTimer incorrectly schedules events when delay is a multiple of the wheel period
2899  LeaderElectionSpec failed
2904  write our own timer implementation
2905  StressSpec failed
2906  Update samples to work with the new remoting
2907  Failure detection also when no heartbeats sent
2909  Remove wokarounds for blocking issues when sending to broken connections
2910  IOManager connect should handle UnresolvedAddressException
2913  Have a ByteStrings method asByteBuffers to return a collection of wrapped readonly ByteBuffers
2914  Create SPI for IO Extension
2915  TestProbe.watch() fails if the watched actor is terminated in the moment one tries to watch it
2916  Deadlock when calling Testkit.watch
2919  We get lingering dispatchers in some tests
2921  Connection refused when secure-cookie is used in 2.1.0
2923  Terminated message cascade to Deadletter queue while escalation and watching
2928  log failures in postStop
2929  add Typed Channels
2931  Failure in FSMTransitionSpec
2934  DOC: Explain Agent send examples
2935  Agent could access Ref more efficiently
2938  Docs build failed on jenkins.typesafe.com
2940  make SystemMessage extend Serializable
2942  TypedActorSpec failed
2950  Failure in LARS
2953  CircuitBrakerMTSpec failed
2954  Remote transport startup timeout
2959  Connection failure when watch should trigger Deadletter(Watch)
2961  TestActorRefSpec failed
2963  make sure to set Thread.interrupt() when catching InterruptException in tell()
2972  Reimplementation of Agents to increase performance and remove warts
2974  ForkJoinPool.execute(Runnable) failures are swallowed
2975  Backport cluster features and improvement to 2.1.1
2977  RemotingSpec (SSL) failed
2978  remove all mention of “non-direct” from the repository
2979  rename akka.event-handlers setting to akka.loggers
2981  rename akka-remote-tests-experimental to akka-multi-node-testing
2983  Regression in watch?
2986  Deprecate ActorContext.dispatcher and introduce ActorContext.executor
2988  investigate zeromq needs for SPI
2995  ClusterDeathWatch failed
2997  First remote message sometimes takes 8 seconds
3005  LARS shutdown failure
3009  Make sure sender is preserved when sending something to deadLetters
3010  ScalaDoc diagrams not generated in akka-nightly
3016  Akka Dataflow only needs Scala Library
3017  Missing LeaderChanged - detected by ClusterSingletonManagerSpec
3022  Restore ssl settings in reference.conf
3026  Camel ProducerFeatureTest failed
3027  LightArrayRevolverSchedulerSpec failed
3028  DOC: Dataflow typo 'complimentary' -> 'complementary'
3029  Add receiveN to JavaTestKit
3030  Make cluster fault handling more robust
3031  IllegalArgumentException: Nodes not part of cluster have marked the Gossip as seen
3034  Use configured scheduler class as cluster scheduler
3041  ClusterDomainEventPublisherSpec failed

Credits:
commits added removed
   62    6476    3442 Roland
   59    8936    4487 Patrik Nordwall
   57   10824    6041 Endre Sándor Varga
   43    3040    4311 Viktor Klang
   17     819     440 Björn Antonsson
   11    1324     322 Johannes Rudolph
   10    1109     527 Mathias
    6    1108     289 Rich Dougherty
    5     311     139 RickLatrine
    2      83      20 Kaspar Fischer (hbf)
    2     127      66 Christophe Pache
    2     163      66 Raymond Roestenburg
    1      10       3 Michael Pilquist
    1     127     127 drewhk
    1     548      77 Helena Edelson
    1      38      24 Matthew Neeley
    1       8      10 Peter Vlugter
    1       3       3 Thomas Lockney
    1      36      35 Derek Mahar
```
