### PR TITLE
fixes missing logs for null messaged exceptions

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -49,7 +49,7 @@ class JavaLoggingEventHandler extends Actor {
   @inline
   def log(level: logging.Level, cause: Throwable, logSource: String, logClass: Class[_], message: Any, event: LogEvent) {
     val logger = logging.Logger.getLogger(logSource)
-    val record = new logging.LogRecord(level, if (message eq null) null else message.toString)
+    val record = new logging.LogRecord(level, if (message == null) null else message.toString)
     record.setLoggerName(logger.getName)
     record.setThrown(cause)
     record.setThreadID(event.thread.getId.toInt)

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JulEventHandler.scala
@@ -49,7 +49,7 @@ class JavaLoggingEventHandler extends Actor {
   @inline
   def log(level: logging.Level, cause: Throwable, logSource: String, logClass: Class[_], message: Any, event: LogEvent) {
     val logger = logging.Logger.getLogger(logSource)
-    val record = new logging.LogRecord(level, message.toString)
+    val record = new logging.LogRecord(level, if (message eq null) null else message.toString)
     record.setLoggerName(logger.getName)
     record.setThrown(cause)
     record.setThreadID(event.thread.getId.toInt)


### PR DESCRIPTION
Replaces https://github.com/akka/akka/pull/1142

This appears to be fixed for the new 2.2 structure, assuming `String.valueOf(event.message)` doesn't cause a problem.
