### PR TITLE
Remove mention of Dispatcher from DefaultScheduler scaladoc. Fixes #2759

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -124,9 +124,7 @@ trait Cancellable {
 //#cancellable
 
 /**
- * Scheduled tasks (Runnable and functions) are executed with the supplied dispatcher.
- * Note that dispatcher is by-name parameter, because dispatcher might not be initialized
- * when the scheduler is created.
+ * A scheduler implementation based on a HashedWheelTimer.
  *
  * The HashedWheelTimer used by this class MUST throw an IllegalStateException
  * if it does not enqueue a task. Once a task is queued, it MUST be executed or


### PR DESCRIPTION
Dispatcher is no longer taken as an argument.
