### PR TITLE
Revert "Adjust scheduler isCancelled, see #2903"

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -32,6 +32,7 @@ class SchedulerSpec extends AkkaSpec(SchedulerSpec.testConf) with BeforeAndAfter
     while (cancellables.peek() ne null) {
       for (c ← Option(cancellables.poll())) {
         c.cancel()
+        c.isCancelled must be === true
       }
     }
   }
@@ -143,20 +144,6 @@ class SchedulerSpec extends AkkaSpec(SchedulerSpec.testConf) with BeforeAndAfter
       Thread.sleep((delay + 100.milliseconds.dilated).toMillis)
 
       ticks.get must be(1)
-    }
-
-    "be canceled if cancel is performed before execution" in {
-      val task = collectCancellable(system.scheduler.scheduleOnce(10 seconds)())
-      task.cancel()
-      task.isCancelled must be(true)
-    }
-
-    "not be canceled if cancel is performed after execution" in {
-      val latch = TestLatch(1)
-      val task = collectCancellable(system.scheduler.scheduleOnce(10 millis)(latch.countDown()))
-      Await.ready(latch, remaining)
-      task.cancel()
-      task.isCancelled must be(false)
     }
 
     /**

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -210,21 +210,20 @@ class DefaultScheduler(hashedWheelTimer: HashedWheelTimer, log: LoggingAdapter) 
 }
 
 private[akka] object ContinuousCancellable {
-  private class NullHWTimeout extends HWTimeout {
+  val initial: HWTimeout = new HWTimeout {
     override def getTimer: Timer = null
     override def getTask: TimerTask = null
     override def isExpired: Boolean = false
     override def isCancelled: Boolean = false
     override def cancel: Unit = ()
   }
-  val initial: HWTimeout = new NullHWTimeout
 
-  val cancelled: HWTimeout = new NullHWTimeout {
+  val cancelled: HWTimeout = new HWTimeout {
+    override def getTimer: Timer = null
+    override def getTask: TimerTask = null
+    override def isExpired: Boolean = false
     override def isCancelled: Boolean = true
-  }
-
-  val expired: HWTimeout = new NullHWTimeout {
-    override def isExpired: Boolean = true
+    override def cancel: Unit = ()
   }
 }
 /**
@@ -248,16 +247,6 @@ private[akka] class ContinuousCancellable extends AtomicReference[HWTimeout](Con
 }
 
 private[akka] class DefaultCancellable(timeout: HWTimeout) extends AtomicReference[HWTimeout](timeout) with Cancellable {
-  @tailrec final override def cancel(): Unit = {
-    get match {
-      case ContinuousCancellable.expired | ContinuousCancellable.cancelled ⇒ // already done
-      case x ⇒
-        val y =
-          if (!x.isCancelled && x.isExpired) ContinuousCancellable.expired
-          else ContinuousCancellable.cancelled
-        if (compareAndSet(x, y)) x.cancel()
-        else cancel()
-    }
-  }
+  override def cancel(): Unit = getAndSet(ContinuousCancellable.cancelled).cancel()
   override def isCancelled: Boolean = get().isCancelled
 }


### PR DESCRIPTION
- Reverting this for 2.1.x since someone might rely on
  the old behavior of always getting isCancelled == true
  after calling cancel

This reverts commit 0c93ca317ef9085c3928e761843aa6d60912741c.
