### PR TITLE
Removed TOC for old IO in the new docs. Reported by rit.

### DIFF
--- a/akka-docs/rst/scala/io.rst
+++ b/akka-docs/rst/scala/io.rst
@@ -13,10 +13,6 @@ more general consumption as an actor-based service.
 
 This documentation is in progress and some sections may be incomplete. More will be coming.
 
-.. toctree::
-
-  io-old
-
 .. note::
   The old I/O implementation has been deprecated and its documentation has been moved: :ref:`io-scala-old`
 


### PR DESCRIPTION
(It looks really confusing)
