### PR TITLE
Problem with address already in use in udp tests, see #3084

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
@@ -19,12 +19,13 @@ class CapacityLimitSpec extends AkkaSpec("akka.loglevel = ERROR\nakka.io.tcp.max
       // we now have three channels registered: a listener, a server connection and a client connection
       // so register one more channel
       val commander = TestProbe()
-      commander.send(IO(Tcp), Bind(bindHandler.ref, temporaryServerAddress()))
+      val addresses = temporaryServerAddresses(2)
+      commander.send(IO(Tcp), Bind(bindHandler.ref, addresses(0)))
       commander.expectMsg(Bound)
 
       // we are now at the configured max-channel capacity of 4
 
-      val bindToFail = Bind(bindHandler.ref, temporaryServerAddress())
+      val bindToFail = Bind(bindHandler.ref, addresses(1))
       commander.send(IO(Tcp), bindToFail)
       commander.expectMsgType[CommandFailed].cmd must be theSameInstanceAs (bindToFail)
 


### PR DESCRIPTION
- Subsequent bind to dynamic port might result in same port if
  the socket is closed inbetween
