### PR TITLE
Hardened flushing code in Remoting #3036

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -454,7 +454,7 @@ private[remote] class EndpointManager(conf: Config, log: LoggingAdapter) extends
       // Shutdown all endpoints and signal to sender when ready (and whether all endpoints were shut down gracefully)
       val sys = context.system // Avoid closing over context
       Future sequence endpoints.allEndpoints.map {
-        gracefulStop(_, settings.FlushWait)(sys)
+        gracefulStop(_, settings.FlushWait, EndpointWriter.FlushAndStop)(sys)
       } map { _.foldLeft(true) { _ && _ } } pipeTo sender
       // Ignore all other writes
       context.become(flushing)

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
@@ -35,7 +35,7 @@ private[remote] trait TcpHandlers extends CommonHandlers {
                                 remoteSocketAddress: InetSocketAddress): Unit = ChannelLocalActor.set(channel, Some(listener))
 
   override def createHandle(channel: Channel, localAddress: Address, remoteAddress: Address): AssociationHandle =
-    new TcpAssociationHandle(localAddress, remoteAddress, channel)
+    new TcpAssociationHandle(localAddress, remoteAddress, transport, channel)
 
   override def onDisconnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit =
     notifyListener(e.getChannel, Disassociated)
@@ -76,8 +76,12 @@ private[remote] class TcpClientHandler(_transport: NettyTransport, remoteAddress
 /**
  * INTERNAL API
  */
-private[remote] class TcpAssociationHandle(val localAddress: Address, val remoteAddress: Address, private val channel: Channel)
+private[remote] class TcpAssociationHandle(val localAddress: Address,
+                                           val remoteAddress: Address,
+                                           val transport: NettyTransport,
+                                           private val channel: Channel)
   extends AssociationHandle {
+  import transport.executionContext
 
   override val readHandlerPromise: Promise[HandleEventListener] = Promise()
 


### PR DESCRIPTION
- More robust flushing in TCP driver
- Proper flushing of stashed sends in EndpointWriter
