### PR TITLE
Revert "Upgrade Netty to 3.6.1 and don't release the dispatcher. See #2956

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/NettyRemoteSupport.scala
@@ -199,11 +199,7 @@ private[akka] class NettyRemoteTransport(_system: ExtendedActorSystem, _provider
         try {
           timer.stop()
         } finally {
-          // Release the selectors, but don't try to kill the dispatcher
-          if (settings.UseDispatcherForIO.isDefined)
-            clientChannelFactory.shutdown()
-          else
-            clientChannelFactory.releaseExternalResources()
+          clientChannelFactory.releaseExternalResources()
           // Shut down the execution handler as well
           PipelineFactory.executionHandler.foreach(_.releaseExternalResources())
         }

--- a/akka-remote/src/main/scala/akka/remote/netty/Server.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Server.scala
@@ -71,11 +71,7 @@ private[akka] class NettyRemoteServer(val netty: NettyRemoteTransport) {
       openChannels.write(netty.createControlEnvelope(shutdownSignal))
       openChannels.disconnect
       openChannels.close.awaitUninterruptibly
-      // Release the selectors, but don't try to kill the dispatcher
-      if (settings.UseDispatcherForIO.isDefined)
-        bootstrap.shutdown()
-      else
-        bootstrap.releaseExternalResources()
+      bootstrap.releaseExternalResources()
       netty.notifyListeners(RemoteServerShutdown(netty))
     } catch {
       case e: Exception ⇒ netty.notifyListeners(RemoteServerError(e, netty))

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -685,7 +685,7 @@ object Dependencies {
     val camelCore     = "org.apache.camel"            % "camel-core"                   % "2.10.0" exclude("org.slf4j", "slf4j-api") // ApacheV2
 
     val config        = "com.typesafe"                % "config"                       % "1.0.0"       // ApacheV2
-    val netty         = "io.netty"                    % "netty"                        % "3.6.1.Final" // ApacheV2
+    val netty         = "io.netty"                    % "netty"                        % "3.5.8.Final" // ApacheV2
     val protobuf      = "com.google.protobuf"         % "protobuf-java"                % "2.4.1"       // New BSD
     val scalaStm      = "org.scala-stm"              %% "scala-stm"                    % "0.7"         // Modified BSD (Scala)
 


### PR DESCRIPTION
This reverts commit 800aa5286f0d91270a2ef269a3833d196d5bce26.

The commit above was violating binary compatibility by requiring a newer
Netty version which is incompatible.

review by @drewhk
