### PR TITLE
Adjust timeouts in LARS tests since processing can take a while. See #3091

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -280,7 +280,7 @@ trait SchedulerSpec extends BeforeAndAfterEach with DefaultTimeout with Implicit
           testActor ! (stop - now - next * 1000000L)
         }
       }
-      val latencies = within(5.seconds) {
+      val latencies = within(10.seconds) {
         for (i ← 1 to N) yield try expectMsgType[Long] catch {
           case NonFatal(e) ⇒ throw new Exception(s"failed expecting the $i-th latency", e)
         }
@@ -352,7 +352,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
       }
       val cancelled = cancellations.sum
       println(cancelled)
-      val latencies = within(5.seconds) {
+      val latencies = within(10.seconds) {
         for (i ← 1 to (N - cancelled)) yield try expectMsgType[Long] catch {
           case NonFatal(e) ⇒ throw new Exception(s"failed expecting the $i-th latency", e)
         }


### PR DESCRIPTION
So from number 0 in the log output you can see that we managed to cancel 0 of the tasks. This probably means that the machine is heavily loaded and the sleep in the test takes way more than 500 millis.

On my machine if I let all the tasks be scheduled before trying to cancel them. Just processing the resulting messages can take as long as 3.2 seconds.
