### PR TITLE
#3100 - allow sending more than one udp packet with UdpFF

### DIFF
--- a/akka-actor/src/main/scala/akka/io/WithUdpFFSend.scala
+++ b/akka-actor/src/main/scala/akka/io/WithUdpFFSend.scala
@@ -68,7 +68,12 @@ private[io] trait WithUdpFFSend {
           selector ! WriteInterest
           retriedSend = true
         }
-      } else if (pendingSend.wantsAck) pendingCommander ! pendingSend.ack
+      } else {
+        if (pendingSend.wantsAck) pendingCommander ! pendingSend.ack
+        retriedSend = false
+        pendingSend = null
+        pendingCommander = null
+      }
 
     } finally {
       udpFF.bufferPool.release(buffer)


### PR DESCRIPTION
After a packet was sent successfully the state of the actor was never
reset so that all further sends failed.
