### PR TITLE
Fixes in test transport and others #3099

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -276,8 +276,8 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
       stop()
 
     case Event(wrappedHandle: AssociationHandle, OutboundUnassociated(_, statusPromise, _)) ⇒
+      wrappedHandle.readHandlerPromise.trySuccess(ActorHandleEventListener(self))
       if (sendAssociate(wrappedHandle)) {
-        wrappedHandle.readHandlerPromise.success(ActorHandleEventListener(self))
         failureDetector.heartbeat()
         initTimers()
 

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -15,7 +15,7 @@ import akka.remote.transport.Transport._
 import akka.remote.{ AddressUrlEncoder, PhiAccrualFailureDetector, FailureDetector, RemoteActorRefProvider }
 import akka.util.ByteString
 import com.typesafe.config.Config
-import scala.concurrent.duration.{ Duration, FiniteDuration, MILLISECONDS }
+import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
 import scala.util.{ Success, Failure }
@@ -276,15 +276,20 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
       stop()
 
     case Event(wrappedHandle: AssociationHandle, OutboundUnassociated(_, statusPromise, _)) ⇒
-      wrappedHandle.readHandlerPromise.success(ActorHandleEventListener(self))
-      sendAssociate(wrappedHandle)
-      failureDetector.heartbeat()
-      initTimers()
+      if (sendAssociate(wrappedHandle)) {
+        wrappedHandle.readHandlerPromise.success(ActorHandleEventListener(self))
+        failureDetector.heartbeat()
+        initTimers()
 
-      if (settings.WaitActivityEnabled)
-        goto(WaitActivity) using OutboundUnderlyingAssociated(statusPromise, wrappedHandle)
-      else
-        goto(Open) using AssociatedWaitHandler(notifyOutboundHandler(wrappedHandle, statusPromise), wrappedHandle, immutable.Queue.empty)
+        if (settings.WaitActivityEnabled)
+          goto(WaitActivity) using OutboundUnderlyingAssociated(statusPromise, wrappedHandle)
+        else
+          goto(Open) using AssociatedWaitHandler(notifyOutboundHandler(wrappedHandle, statusPromise), wrappedHandle, immutable.Queue.empty)
+      } else {
+        // Underlying transport was busy -- Associate could not be sent
+        setTimer("associate-retry", wrappedHandle, 100.milliseconds, repeat = false)
+        stay()
+      }
 
     case Event(DisassociateUnderlying, _) ⇒
       stop()
@@ -487,8 +492,7 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
     case NonFatal(e) ⇒ throw new AkkaProtocolException("Error writing DISASSOCIATE to transport", e)
   }
 
-  // Associate should be the first message, so backoff is not needed
-  private def sendAssociate(wrappedHandle: AssociationHandle): Unit = try {
+  private def sendAssociate(wrappedHandle: AssociationHandle): Boolean = try {
     val cookie = if (settings.RequireCookie) Some(settings.SecureCookie) else None
     wrappedHandle.write(codec.constructAssociate(cookie, localAddress))
   } catch {

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -3,39 +3,24 @@
  */
 package akka.remote.transport
 
-import akka.{ OnlyCauseStackTrace, AkkaException }
+import akka.ConfigurationException
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor._
 import akka.pattern.pipe
+import akka.remote._
+import akka.remote.transport.ActorTransportAdapter._
 import akka.remote.transport.AkkaPduCodec._
 import akka.remote.transport.AkkaProtocolTransport._
 import akka.remote.transport.AssociationHandle._
 import akka.remote.transport.ProtocolStateActor._
 import akka.remote.transport.Transport._
-import akka.remote._
 import akka.util.ByteString
+import akka.{ OnlyCauseStackTrace, AkkaException }
 import com.typesafe.config.Config
+import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
-import scala.util.{ Success, Failure }
-import scala.collection.immutable
-import akka.remote.transport.ActorTransportAdapter._
-import akka.ConfigurationException
-import akka.remote.transport.ActorTransportAdapter.AssociateUnderlying
-import akka.remote.transport.Transport.InboundAssociation
-import scala.Some
-import akka.actor.OneForOneStrategy
-import akka.remote.transport.ProtocolStateActor.HandleListenerRegistered
-import akka.remote.transport.ProtocolStateActor.ListenerReady
-import akka.remote.transport.AkkaPduCodec.Payload
-import akka.remote.transport.ProtocolStateActor.AssociatedWaitHandler
-import akka.remote.transport.AssociationHandle.InboundPayload
-import akka.remote.transport.AkkaPduCodec.Associate
-import akka.remote.transport.ProtocolStateActor.OutboundUnassociated
-import akka.remote.transport.AssociationHandle.ActorHandleEventListener
-import akka.remote.transport.ProtocolStateActor.InboundUnassociated
-import akka.remote.transport.ProtocolStateActor.OutboundUnderlyingAssociated
 
 @SerialVersionUID(1L)
 class AkkaProtocolException(msg: String, cause: Throwable) extends AkkaException(msg, cause) with OnlyCauseStackTrace {

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -479,7 +479,7 @@ private[transport] case class ThrottlerHandle(_wrappedHandle: AssociationHandle,
       case bucket @ _ ⇒
         val success = tryConsume(outboundThrottleMode.get())
         if (success) wrappedHandle.write(payload) else false
-      // FIXME: this depletes the token bucket even when no write happened!!
+      // FIXME: this depletes the token bucket even when no write happened!! See #2825
     }
 
   }

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -478,8 +478,8 @@ private[transport] case class ThrottlerHandle(_wrappedHandle: AssociationHandle,
       case Blackhole ⇒ true
       case bucket @ _ ⇒
         val success = tryConsume(outboundThrottleMode.get())
-        if (success) wrappedHandle.write(payload)
-        success
+        if (success) wrappedHandle.write(payload) else false
+      // FIXME: this depletes the token bucket even when no write happened!!
     }
 
   }

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
@@ -395,8 +395,6 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
       wrappedHandle.readHandlerPromise.success(ActorHandleEventListener(testActor))
 
-      Thread.sleep(100) //FIXME: Remove this
-
       reader ! Disassociated
 
       expectMsg(Disassociated)

--- a/akka-remote/src/test/scala/akka/remote/transport/GenericTransportSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/GenericTransportSpec.scala
@@ -116,8 +116,7 @@ abstract class GenericTransportSpec(withAkkaProtocol: Boolean = false)
       }
 
       registry.logSnapshot.exists {
-        case WriteAttempt(sender, recipient, sentPdu) ⇒
-          sender == addressATest && recipient == addressBTest && sentPdu == pdu
+        case WriteAttempt(`addressATest`, `addressBTest`, sentPdu) ⇒ sentPdu == pdu
         case _ ⇒ false
       } must be(true)
     }
@@ -155,7 +154,7 @@ abstract class GenericTransportSpec(withAkkaProtocol: Boolean = false)
 
       awaitCond {
         registry.logSnapshot exists {
-          case DisassociateAttempt(requester, remote) if requester == addressATest && remote == addressBTest ⇒ true
+          case DisassociateAttempt(`addressATest`, `addressBTest`) ⇒ true
           case _ ⇒ false
         }
       }

--- a/akka-remote/src/test/scala/akka/remote/transport/GenericTransportSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/GenericTransportSpec.scala
@@ -153,10 +153,12 @@ abstract class GenericTransportSpec(withAkkaProtocol: Boolean = false)
 
       awaitCond(!registry.existsAssociation(addressATest, addressBTest))
 
-      registry.logSnapshot exists {
-        case DisassociateAttempt(requester, remote) if requester == addressATest && remote == addressBTest ⇒ true
-        case _ ⇒ false
-      } must be(true)
+      awaitCond {
+        registry.logSnapshot exists {
+          case DisassociateAttempt(requester, remote) if requester == addressATest && remote == addressBTest ⇒ true
+          case _ ⇒ false
+        }
+      }
     }
 
   }

--- a/akka-remote/src/test/scala/akka/remote/transport/TestTransportSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/TestTransportSpec.scala
@@ -76,11 +76,11 @@ class TestTransportSpec extends AkkaSpec with DefaultTimeout with ImplicitSender
         case InboundAssociation(handle) if handle.remoteAddress == addressA ⇒ handle
       }
 
+      handleB.readHandlerPromise.success(ActorHandleEventListener(self))
       val handleA = Await.result(associate, timeout.duration)
 
       // Initialize handles
       handleA.readHandlerPromise.success(ActorHandleEventListener(self))
-      handleB.readHandlerPromise.success(ActorHandleEventListener(self))
 
       val akkaPDU = ByteString("AkkaPDU")
 
@@ -113,11 +113,11 @@ class TestTransportSpec extends AkkaSpec with DefaultTimeout with ImplicitSender
         case InboundAssociation(handle) if handle.remoteAddress == addressA ⇒ handle
       }
 
+      handleB.readHandlerPromise.success(ActorHandleEventListener(self))
       val handleA = Await.result(associate, timeout.duration)
 
       // Initialize handles
       handleA.readHandlerPromise.success(ActorHandleEventListener(self))
-      handleB.readHandlerPromise.success(ActorHandleEventListener(self))
 
       awaitCond(registry.existsAssociation(addressA, addressB))
 


### PR DESCRIPTION
Several fixes here:
- TestTransport does not rely anymore on broken assumption about onComplete ordering
- ThrottlerTransportAdapter now correctly relays backpressure from lower layer
- AkkaProtocolTransport retries initial write of ASSOCIATION message in case of backpressure

Potentially fixes: #3032, #3045, #2930
