### PR TITLE
Adjust timing in FutureDocTestBase, see #3112

### DIFF
--- a/akka-docs/rst/java/code/docs/future/FutureDocTestBase.java
+++ b/akka-docs/rst/java/code/docs/future/FutureDocTestBase.java
@@ -556,7 +556,7 @@ public class FutureDocTestBase {
     //#after
     final ExecutionContext ec = system.dispatcher();
     Future<String> failExc = Futures.failed(new IllegalStateException("OHNOES1"));
-    Future<String> delayed = Patterns.after(Duration.create(500, "millis"),
+    Future<String> delayed = Patterns.after(Duration.create(200, "millis"),
       system.scheduler(), ec,  failExc);
     Future<String> future = future(new Callable<String>() {
       public String call() throws InterruptedException {


### PR DESCRIPTION
- Corresponding scala test uses the same value

It can of course be something much more serious than a timing issue, but we have only seen it once.
