### PR TITLE
Merge gossip seen table when versions are the same. See #3115

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -100,7 +100,7 @@ private[cluster] case class Gossip(
    * Map with the VectorClock (version) for the new gossip.
    */
   def seen(address: Address): Gossip = {
-    if (overview.seen.contains(address) && overview.seen(address) == version) this
+    if (hasSeen(address)) this
     else this copy (overview = overview copy (seen = overview.seen + (address -> version)))
   }
 
@@ -111,6 +111,28 @@ private[cluster] case class Gossip(
     overview.seen.collect {
       case (address, vclock) if vclock == version ⇒ address
     }.toSet
+  }
+
+  /**
+   * Has this Gossip been seen by this address.
+   */
+  def hasSeen(address: Address): Boolean = {
+    overview.seen.get(address).fold { false } { _ == version }
+  }
+
+  /**
+   * Merges the seen table of two Gossip instances.
+   */
+  def mergeSeen(that: Gossip): Gossip = {
+    val mergedSeen = (overview.seen /: that.overview.seen) {
+      case (merged, (address, version)) ⇒
+        val curr = merged.getOrElse(address, version)
+        if (curr > version)
+          merged + (address -> curr)
+        else
+          merged + (address -> version)
+    }
+    this copy (overview = overview copy (seen = mergedSeen))
   }
 
   /**

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -117,7 +117,7 @@ private[cluster] case class Gossip(
    * Has this Gossip been seen by this address.
    */
   def hasSeen(address: Address): Boolean = {
-    overview.seen.get(address).fold { false } { _ == version }
+    overview.seen.get(address).exists(_ == version)
   }
 
   /**


### PR DESCRIPTION
So the reason why gossip doesn't seem to propagate as fast as it should boils down to us not merging the seen table when the gossip versions are equal.

Here are some stats from my machine with and without the merge:
The gossip counts are in the ClusterStats in this order ClusterStats(received, mergeConflict, merge, mergeDetected, same, newer, older)

<pre><code>
Results without seen merge
[JVM-1] title                            duration (ms)  cluster stats
[JVM-1] join seed nodes                          11415  ClusterStats(69,0,1,0,48,6,14)
[JVM-1] join one to 5 nodes cluster               5676  ClusterStats(55,0,0,0,41,4,10)
[JVM-1] join one to 6 nodes cluster               9041  ClusterStats(107,0,0,0,87,8,12)
[JVM-1] join 2 to one node, in 7 nodes cluster   10557  ClusterStats(159,0,0,0,135,7,17)
[JVM-1] join 2 to seed nodes, in 9 nodes cluster 17135  ClusterStats(303,0,0,0,271,11,21)
[JVM-1] join one to 11 nodes cluster             16398  ClusterStats(325,0,0,0,290,13,22)
[JVM-1] join one to 12 nodes cluster             20457  ClusterStats(414,0,0,0,375,15,24)
[JVM-1] exercise join/remove round 1             23314  ClusterStats(556,0,0,0,513,19,24)
[JVM-1] remove one from 13 nodes cluster         28456  ClusterStats(534,0,0,0,488,12,34)
[JVM-1] remove one from 12 nodes cluster         25437  ClusterStats(476,0,0,0,431,13,32)
[JVM-1] shutdown one from 11 nodes cluster        5455  ClusterStats(48,1,1,0,42,0,5)
[JVM-1] shutdown one from 10 nodes cluster        5964  ClusterStats(50,1,0,1,42,1,7)
[JVM-1] leave 2 in 9 nodes cluster           17350  ClusterStats(209,0,0,1,168,15,26)
[JVM-1] shutdown 2 in 7 nodes cluster             5101  ClusterStats(17,0,1,0,15,0,1)
[JVM-1] remove one from 5 nodes cluster           8592  ClusterStats(62,0,3,3,40,6,13)
[JVM-1] shutdown one from 4 nodes cluster         5254  ClusterStats(16,1,0,1,14,0,2)

Results with seen merge
[JVM-1] title                            duration (ms)  cluster stats
[JVM-1] join seed nodes                           9088  ClusterStats(60,0,4,3,30,12,14)
[JVM-1] join one to 5 nodes cluster               6144  ClusterStats(58,0,0,0,46,2,10)
[JVM-1] join one to 6 nodes cluster               4814  ClusterStats(59,0,0,0,40,7,12)
[JVM-1] join 2 to one node, in 7 nodes cluster    6804  ClusterStats(100,0,0,0,75,8,17)
[JVM-1] join 2 to seed nodes, in 9 nodes cluster  9345  ClusterStats(158,0,1,2,113,17,27)
[JVM-1] join one to 11 nodes cluster              7217  ClusterStats(149,0,0,0,118,9,22)
[JVM-1] join one to 12 nodes cluster              7317  ClusterStats(166,0,0,0,128,14,24)
[JVM-1] exercise join/remove round 1             12222  ClusterStats(250,0,1,0,198,19,32)
[JVM-1] remove one from 13 nodes cluster         12110  ClusterStats(243,0,0,0,192,18,33)
[JVM-1] remove one from 12 nodes cluster         15540  ClusterStats(264,0,0,0,216,17,31)
[JVM-1] shutdown one from 11 nodes cluster        5152  ClusterStats(49,2,1,1,40,1,7)
[JVM-1] shutdown one from 10 nodes cluster        4964  ClusterStats(37,0,0,0,31,0,6)
[JVM-1] leave 2 in 9 nodes cluster                9789  ClusterStats(114,0,1,0,76,12,25)
[JVM-1] shutdown 2 in 7 nodes cluster             6472  ClusterStats(37,1,4,3,21,2,10)
[JVM-1] remove one from 5 nodes cluster           5847  ClusterStats(44,0,0,0,28,6,10)
[JVM-1] shutdown one from 4 nodes cluster         3997  ClusterStats(12,4,2,2,6,1,3)
</code></pre>
