### PR TITLE
Reduce unwanted logging from remoting, see #2826

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -81,6 +81,9 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
 
       Seq(".*received dead letter from.*ClientDisconnected",
         ".*received dead letter from.*deadLetters.*PoisonPill",
+        ".*received dead letter from.*Disassociated",
+        ".*received dead letter from.*DisassociateUnderlying",
+        ".*received dead letter from.*HandleListenerRegistered",
         ".*installing context org.jboss.netty.channel.DefaultChannelPipeline.*") foreach { s ⇒
           sys.eventStream.publish(Mute(EventFilter.warning(pattern = s)))
         }

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -126,7 +126,7 @@ akka {
     # If this is "on", Akka will log all RemoteLifeCycleEvents at the level
     # defined for each, if off then they are not logged. Failures to deserialize
     # received messages also fall under this flag.
-    log-remote-lifecycle-events = off
+    log-remote-lifecycle-events = on
 
     ### Failure detection and recovery
 

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -21,24 +21,30 @@ class RemoteConfigSpec extends AkkaSpec(
   // FIXME: These tests are ignored as it tests configuration specific to the old remoting.
   "Remoting" must {
 
-    "be able to parse generic remote config elements" in {
-      val settings = RARP(system).provider.remoteSettings
-      import settings._
+    "contain correct configuration values in reference.conf" in {
+      val remoteSettings = RARP(system).provider.remoteSettings
+      import remoteSettings._
 
-      StartupTimeout must be === Timeout(10.seconds)
-      ShutdownTimeout must be === Timeout(10.seconds)
-      FlushWait must be === 2.seconds
-      UsePassiveConnections must be(true)
-      UntrustedMode must be(false)
-      LogRemoteLifecycleEvents must be(false)
       LogReceive must be(false)
       LogSend must be(false)
-      RetryGateClosedFor must be === 0.seconds
-      UnknownAddressGateClosedFor must be === 60.seconds
-      MaximumRetriesInWindow must be === 5
-      RetryWindow must be === 3.seconds
-      BackoffPeriod must be === 10.milliseconds
-      CommandAckTimeout must be === Timeout(30.seconds)
+      UntrustedMode must be(false)
+      LogRemoteLifecycleEvents must be(true)
+      ShutdownTimeout.duration must be(10 seconds)
+      FlushWait must be(2 seconds)
+      StartupTimeout.duration must be(10 seconds)
+      RetryGateClosedFor must be(Duration.Zero)
+      UnknownAddressGateClosedFor must be(1 minute)
+      UsePassiveConnections must be(true)
+      MaximumRetriesInWindow must be(5)
+      RetryWindow must be(3 seconds)
+      BackoffPeriod must be(10 millis)
+      CommandAckTimeout.duration must be(30 seconds)
+      Transports.size must be(1)
+      Transports.head._1 must be(classOf[akka.remote.transport.netty.NettyTransport].getName)
+      Transports.head._2 must be(Nil)
+      Adapters must be(Map(
+        "gremlin" -> classOf[akka.remote.transport.FailureInjectorProvider].getName,
+        "trttl" -> classOf[akka.remote.transport.ThrottlerProvider].getName))
 
     }
 
@@ -56,33 +62,6 @@ class RemoteConfigSpec extends AkkaSpec(
       FailureDetectorConfig.getDouble("threshold") must be(7.0 plusOrMinus 0.0001)
       FailureDetectorConfig.getInt("max-sample-size") must be(100)
       Duration(FailureDetectorConfig.getMilliseconds("min-std-deviation"), MILLISECONDS) must be(100 millis)
-
-    }
-
-    "contain correct configuration values in reference.conf" in {
-      val remoteSettings = RARP(system).provider.remoteSettings
-      import remoteSettings._
-
-      LogReceive must be(false)
-      LogSend must be(false)
-      UntrustedMode must be(false)
-      LogRemoteLifecycleEvents must be(false)
-      ShutdownTimeout.duration must be(10 seconds)
-      FlushWait must be(2 seconds)
-      StartupTimeout.duration must be(10 seconds)
-      RetryGateClosedFor must be(Duration.Zero)
-      UnknownAddressGateClosedFor must be(1 minute)
-      UsePassiveConnections must be(true)
-      MaximumRetriesInWindow must be(5)
-      RetryWindow must be(3 seconds)
-      BackoffPeriod must be(10 millis)
-      CommandAckTimeout.duration must be(30 seconds)
-      Transports.size must be(1)
-      Transports.head._1 must be(classOf[akka.remote.transport.netty.NettyTransport].getName)
-      Transports.head._2 must be(Nil)
-      Adapters must be(Map(
-        "gremlin" -> classOf[akka.remote.transport.FailureInjectorProvider].getName,
-        "trttl" -> classOf[akka.remote.transport.ThrottlerProvider].getName))
 
     }
 

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -137,9 +137,10 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
     }
 
     "send error message for wrong address" in {
-      filterEvents(EventFilter[EndpointException](occurrences = 6), EventFilter.error(start = "Association", occurrences = 6)) {
-        system.actorFor("akka.test://nonexistingsystem@localhost:12346/user/echo") ! "ping"
-      }
+      filterEvents(EventFilter.error(start = "Association", occurrences = 6),
+        EventFilter.warning(pattern = ".*dead letter.*echo.*", occurrences = 1)) {
+          system.actorFor("akka.test://nonexistingsystem@localhost:12346/user/echo") ! "ping"
+        }
     }
 
     "support ask" in {


### PR DESCRIPTION
- Handle logging in EndpointManager supervisorStrategy
- Added some more exception types to be able to differentiate
  failures

NOTE: I'm not sure at all if this mutes all unwanted logging, or if it mutes too much. We must collaborate on this one.
