### PR TITLE
allow switching off genjavadoc, see #3141

### DIFF
--- a/project/Unidoc.scala
+++ b/project/Unidoc.scala
@@ -8,14 +8,21 @@ object Unidoc {
 
   lazy val JavaDoc = config("genjavadoc") extend Compile
 
-  lazy val javadocSettings = inConfig(JavaDoc)(Defaults.configSettings) ++ Seq(
-    libraryDependencies += Dependencies.Compile.genjavadoc,
-    scalacOptions <+= target map (t => "-P:genjavadoc:out=" + t + "/java"),
-    packageDoc in Compile <<= packageDoc in JavaDoc,
-    sources in JavaDoc <<= (target, compile in Compile, sources in Compile) map ((t, c, s) => (t / "java" ** "*.java").get ++ s.filter(_.getName.endsWith(".java"))),
-    javacOptions in JavaDoc := Seq(),
-    artifactName in packageDoc in JavaDoc := ((sv, mod, art) => "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar")
-  )
+  lazy val GenJavaDocEnabled = Option(sys.props("akka.genjavadoc.enabled")) filter (_.toLowerCase == "true") map (_ => true) getOrElse false
+
+  lazy val javadocSettings =
+    inConfig(JavaDoc)(Defaults.configSettings) ++ Seq(
+      packageDoc in Compile <<= packageDoc in JavaDoc,
+      sources in JavaDoc <<= (target, compile in Compile, sources in Compile) map ((t, c, s) =>
+        if (GenJavaDocEnabled) (t / "java" ** "*.java").get ++ s.filter(_.getName.endsWith(".java"))
+        else throw new RuntimeException("cannot build java docs without -Dakka.genjavadoc.enabled=true")
+      ),
+      javacOptions in JavaDoc := Seq(),
+      artifactName in packageDoc in JavaDoc := ((sv, mod, art) => "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar")
+    ) ++ (if (GenJavaDocEnabled) Seq(
+        libraryDependencies += Dependencies.Compile.genjavadoc,
+        scalacOptions <+= target map (t => "-P:genjavadoc:out=" + t + "/java")
+      ) else Nil)
 
   val unidocDirectory = SettingKey[File]("unidoc-directory")
   val unidocExclude = SettingKey[Seq[String]]("unidoc-exclude")


### PR DESCRIPTION
we do want to keep it on by default so that jenkins and release scripts do not forget to turn it on, meanwhile Viktor can do

```
sbt -Dno.genjavadoc=true
```
