### PR TITLE
Shutdown/cleanup cluster extension if actor init fails, see #3162

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
@@ -131,7 +131,7 @@ private[akka] object ChildrenContainer {
 
     override def reserve(name: String): ChildrenContainer =
       if (c contains name)
-        throw new InvalidActorNameException("actor name " + name + " is not unique!")
+        throw new InvalidActorNameException(s"actor name [$name] is not unique!")
       else new NormalChildrenContainer(c.updated(name, ChildNameReserved))
 
     override def unreserve(name: String): ChildrenContainer = c.get(name) match {
@@ -193,7 +193,7 @@ private[akka] object ChildrenContainer {
       case Termination ⇒ throw new IllegalStateException("cannot reserve actor name '" + name + "': terminating")
       case _ ⇒
         if (c contains name)
-          throw new InvalidActorNameException("actor name " + name + " is not unique!")
+          throw new InvalidActorNameException(s"actor name [$name] is not unique!")
         else copy(c = c.updated(name, ChildNameReserved))
     }
 

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -29,6 +29,7 @@ import akka.remote.FailureDetector
 import com.typesafe.config.Config
 import akka.event.LoggingAdapter
 import java.util.concurrent.ThreadFactory
+import scala.util.control.NonFatal
 
 /**
  * Cluster Extension Id and factory for creating Cluster extension.
@@ -86,6 +87,8 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
 
   private val _isTerminated = new AtomicBoolean(false)
   private val log = Logging(system, "Cluster")
+  // ClusterJmx is initialized as the last thing in the constructor
+  private var clusterJmx: Option[ClusterJmx] = None
 
   log.info("Cluster Node [{}] - is starting up...", selfAddress)
 
@@ -157,7 +160,14 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    */
   private[cluster] val clusterCore: ActorRef = {
     implicit val timeout = system.settings.CreationTimeout
-    Await.result((clusterDaemons ? InternalClusterAction.GetClusterCoreRef).mapTo[ActorRef], timeout.duration)
+    try {
+      Await.result((clusterDaemons ? InternalClusterAction.GetClusterCoreRef).mapTo[ActorRef], timeout.duration)
+    } catch {
+      case NonFatal(e) ⇒
+        log.error(e, "Failed to startup Cluster")
+        shutdown()
+        throw e
+    }
   }
 
   @volatile
@@ -170,11 +180,12 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
 
   system.registerOnTermination(shutdown())
 
-  private val clusterJmx: Option[ClusterJmx] = {
-    val jmx = new ClusterJmx(this, log)
-    jmx.createMBean()
-    Some(jmx)
-  }
+  if (JmxEnabled)
+    clusterJmx = {
+      val jmx = new ClusterJmx(this, log)
+      jmx.createMBean()
+      Some(jmx)
+    }
 
   log.info("Cluster Node [{}] - has started up successfully", selfAddress)
 


### PR DESCRIPTION
- Stop ClusterDaemon if init of core actor fails.
- Activate jmx-enabled setting
- Adjust the err msg of InvalidActorNameException to match conventions
