### PR TITLE
Correctly serialize local actor refs from other actor systems #3137

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/TestUtils.scala
+++ b/akka-actor-tests/src/test/scala/akka/TestUtils.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
  */
 
-package akka.io
+package akka
 
 import scala.collection.immutable
 import java.net.InetSocketAddress

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -6,9 +6,6 @@ package akka.actor
 
 import language.postfixOps
 
-import org.scalatest.WordSpec
-import org.scalatest.matchers.MustMatchers
-
 import akka.testkit._
 import akka.util.Timeout
 import scala.concurrent.duration._
@@ -17,6 +14,7 @@ import java.lang.IllegalStateException
 import scala.concurrent.Promise
 import akka.pattern.ask
 import akka.serialization.JavaSerializer
+import akka.TestUtils.verifyActorTermination
 
 object ActorRefSpec {
 
@@ -327,7 +325,8 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
       out.close
 
       ref ! PoisonPill
-      awaitCond(ref.isTerminated, 2 seconds)
+
+      verifyActorTermination(ref)
 
       JavaSerializer.currentSystem.withValue(sysImpl) {
         val in = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
@@ -406,7 +405,7 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
       Await.result(ffive, timeout.duration) must be("five")
       Await.result(fnull, timeout.duration) must be("null")
 
-      awaitCond(ref.isTerminated, 2 seconds)
+      verifyActorTermination(ref)
     }
 
     "restart when Kill:ed" in {

--- a/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
@@ -6,6 +6,7 @@ package akka.io
 
 import akka.testkit.{ TestProbe, AkkaSpec }
 import Tcp._
+import akka.TestUtils
 import TestUtils._
 
 class CapacityLimitSpec extends AkkaSpec("akka.loglevel = ERROR\nakka.io.tcp.max-channels = 4")

--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -16,6 +16,7 @@ import scala.util.control.NonFatal
 import org.scalatest.matchers._
 import akka.io.Tcp._
 import akka.io.SelectionHandler._
+import akka.TestUtils
 import TestUtils._
 import akka.actor.{ ActorRef, PoisonPill, Terminated }
 import akka.testkit.{ AkkaSpec, EventFilter, TestActorRef, TestProbe }

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
@@ -7,6 +7,7 @@ package akka.io
 import akka.testkit.AkkaSpec
 import akka.util.ByteString
 import Tcp._
+import akka.TestUtils
 import TestUtils._
 import akka.testkit.EventFilter
 import java.io.IOException

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
@@ -10,6 +10,7 @@ import akka.actor.ActorRef
 import scala.collection.immutable
 import akka.io.Inet.SocketOption
 import Tcp._
+import akka.TestUtils
 import TestUtils._
 
 trait TcpIntegrationSpecSupport { _: AkkaSpec ⇒

--- a/akka-actor-tests/src/test/scala/akka/io/TcpListenerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpListenerSpec.scala
@@ -13,6 +13,7 @@ import Tcp._
 import akka.testkit.EventFilter
 import akka.io.SelectionHandler._
 import akka.io.TcpListener.{ RegisterIncoming, FailedRegisterIncoming }
+import akka.TestUtils
 
 class TcpListenerSpec extends AkkaSpec("akka.io.tcp.batch-accept-limit = 2") {
 

--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnIntegrationSpec.scala
@@ -4,6 +4,7 @@
 package akka.io
 
 import akka.testkit.{ TestProbe, ImplicitSender, AkkaSpec }
+import akka.TestUtils
 import TestUtils._
 import akka.util.ByteString
 import java.net.InetSocketAddress

--- a/akka-actor-tests/src/test/scala/akka/io/UdpFFIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpFFIntegrationSpec.scala
@@ -5,6 +5,7 @@ package akka.io
 
 import akka.testkit.{ TestProbe, ImplicitSender, AkkaSpec }
 import akka.io.UdpFF._
+import akka.TestUtils
 import TestUtils._
 import akka.util.ByteString
 import java.net.InetSocketAddress

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -6,14 +6,12 @@ package akka.actor
 
 import akka.dispatch._
 import akka.dispatch.sysmsg._
-import akka.util._
 import java.lang.{ UnsupportedOperationException, IllegalStateException }
 import akka.serialization.{ Serialization, JavaSerializer }
 import akka.event.EventStream
 import scala.annotation.tailrec
 import java.util.concurrent.ConcurrentHashMap
 import akka.event.LoggingAdapter
-import scala.collection.JavaConverters
 
 /**
  * Immutable and serializable handle to an actor, which may or may not reside
@@ -381,7 +379,7 @@ private[akka] class LocalActorRef private[akka] (
   override def restart(cause: Throwable): Unit = actorCell.restart(cause)
 
   @throws(classOf[java.io.ObjectStreamException])
-  protected def writeReplace(): AnyRef = SerializedActorRef(path)
+  protected def writeReplace(): AnyRef = SerializedActorRef(this)
 }
 
 /**
@@ -407,11 +405,8 @@ private[akka] case class SerializedActorRef private (path: String) {
  * INTERNAL API
  */
 private[akka] object SerializedActorRef {
-  def apply(path: ActorPath): SerializedActorRef = {
-    Serialization.currentTransportAddress.value match {
-      case null ⇒ new SerializedActorRef(path.toSerializationFormat)
-      case addr ⇒ new SerializedActorRef(path.toSerializationFormatWithAddress(addr))
-    }
+  def apply(actorRef: ActorRef): SerializedActorRef = {
+    new SerializedActorRef(Serialization.serializedActorPath(actorRef))
   }
 }
 
@@ -437,7 +432,7 @@ private[akka] trait MinimalActorRef extends InternalActorRef with LocalRef {
   override def restart(cause: Throwable): Unit = ()
 
   @throws(classOf[java.io.ObjectStreamException])
-  protected def writeReplace(): AnyRef = SerializedActorRef(path)
+  protected def writeReplace(): AnyRef = SerializedActorRef(this)
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -390,6 +390,10 @@ private[akka] class LocalActorRef private[akka] (
 private[akka] case class SerializedActorRef private (path: String) {
   import akka.serialization.JavaSerializer.currentSystem
 
+  def this(actorRef: ActorRef) = {
+    this(Serialization.serializedActorPath(actorRef))
+  }
+
   @throws(classOf[java.io.ObjectStreamException])
   def readResolve(): AnyRef = currentSystem.value match {
     case null ⇒
@@ -406,7 +410,7 @@ private[akka] case class SerializedActorRef private (path: String) {
  */
 private[akka] object SerializedActorRef {
   def apply(actorRef: ActorRef): SerializedActorRef = {
-    new SerializedActorRef(Serialization.serializedActorPath(actorRef))
+    new SerializedActorRef(actorRef)
   }
 }
 

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -157,7 +157,7 @@ private[akka] class RepointableActorRef(
   def sendSystemMessage(message: SystemMessage) = underlying.sendSystemMessage(message)
 
   @throws(classOf[java.io.ObjectStreamException])
-  protected def writeReplace(): AnyRef = SerializedActorRef(path)
+  protected def writeReplace(): AnyRef = SerializedActorRef(this)
 }
 
 private[akka] class UnstartedCell(val systemImpl: ActorSystemImpl,

--- a/akka-docs/rst/java/code/docs/serialization/SerializationDocTestBase.java
+++ b/akka-docs/rst/java/code/docs/serialization/SerializationDocTestBase.java
@@ -57,17 +57,8 @@ public class SerializationDocTestBase {
     //#actorref-serializer
     // Serialize
     // (beneath toBinary)
-    final SerializationInformation info = Serialization.currentTransportInformation().value();
+    String identifier = Serialization.serializedActorPath(theActorRef);
 
-    String identifier;
-
-    // If there is no SerializationInformation,
-    // it means that this Serializer isn't called
-    // within a piece of code that sets it,
-    // so either you need to supply your own,
-    // or simply use the local path.
-    if (info == null) identifier = theActorRef.path().toSerializationFormat();
-    else identifier = Serialization.serializedActorPath(theActorRef);
     // Then just serialize the identifier however you like
 
     // Deserialize
@@ -116,15 +107,19 @@ public class SerializationDocTestBase {
   }
 
   //#external-address
-
-  public void demonstrateExternalAddress() {
-    // this is not meant to be run, only to be compiled
+  static
+  //#external-address
+  public class ExternalAddressExample {
+    //#external-address
     final ActorSystem system = ActorSystem.create();
-    final Address remoteAddr = new Address("", "");
-    // #external-address
-    final Address addr = ExternalAddress.ID.get(system).getAddressFor(remoteAddr);
-    // #external-address
+    //#external-address
+    public String serializeTo(ActorRef ref, Address remote) {
+      return ref.path().toSerializationFormatWithAddress(
+          ExternalAddress.ID.get(system).getAddressFor(remote));
+    }
   }
+
+  //#external-address
 
   static
   //#external-address-default

--- a/akka-docs/rst/java/code/docs/serialization/SerializationDocTestBase.java
+++ b/akka-docs/rst/java/code/docs/serialization/SerializationDocTestBase.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 //#imports
 import akka.actor.*;
-import akka.remote.RemoteActorRefProvider;
 import akka.serialization.*;
 
 //#imports
@@ -58,19 +57,18 @@ public class SerializationDocTestBase {
     //#actorref-serializer
     // Serialize
     // (beneath toBinary)
-    final Address transportAddress =
-      Serialization.currentTransportAddress().value();
+    final SerializationInformation info = Serialization.currentTransportInformation().value();
+
     String identifier;
 
-    // If there is no transportAddress,
-    // it means that either this Serializer isn't called
+    // If there is no SerializationInformation,
+    // it means that this Serializer isn't called
     // within a piece of code that sets it,
     // so either you need to supply your own,
     // or simply use the local path.
-    if (transportAddress == null) identifier = theActorRef.path().toSerializationFormat();
-    else identifier = theActorRef.path().toSerializationFormatWithAddress(transportAddress);
+    if (info == null) identifier = theActorRef.path().toSerializationFormat();
+    else identifier = Serialization.serializedActorPath(theActorRef);
     // Then just serialize the identifier however you like
-
 
     // Deserialize
     // (beneath fromBinary)

--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -109,14 +109,33 @@ list which classes that should be serialized using it.
 Serializing ActorRefs
 ---------------------
 
-All ActorRefs are serializable using JavaSerializer, but in case you are writing your own serializer,
-you might want to know how to serialize and deserialize them properly, here's the magic incantation:
+All ActorRefs are serializable using JavaSerializer, but in case you are writing your
+own serializer, you might want to know how to serialize and deserialize them properly.
+In the general case, the local address to be used depends on the type of remote
+address which shall be the recipient of the serialized information. Use
+:meth:`Serialization.serializedActorPath(actorRef)` like this:
 
 .. includecode:: code/docs/serialization/SerializationDocTestBase.java
    :include: imports
 
 .. includecode:: code/docs/serialization/SerializationDocTestBase.java
    :include: actorref-serializer
+
+This assumes that serialization happens in the context of sending a message
+through the remote transport. There are other uses of serialization, though,
+e.g. storing actor references outside of an actor application (database,
+durable mailbox, etc.). In this case, it is important to keep in mind that the
+address part of an actor’s path determines how that actor is communicated with.
+Storing a local actor path might be the right choice if the retrieval happens
+in the same logical context, but it is not enough when deserializing it on a
+different network host: for that it would need to include the system’s remote
+transport address. An actor system is not limited to having just one remote
+transport per se, which makes this question a bit more interesting. To find out
+the appropriate address to use when sending to ``remoteAddr`` you can use
+:meth:`ActorRefProvider.getExternalAddressFor(remoteAddr)` like this:
+
+.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+   :include: external-address
 
 .. note::
   
@@ -131,25 +150,6 @@ you might want to know how to serialize and deserialize them properly, here's th
   storage of the reference, you can use ``toStringWithAddress``, which does not
   include the unique id.
 
-
-This assumes that serialization happens in the context of sending a message
-through the remote transport. There are other uses of serialization, though,
-e.g. storing actor references outside of an actor application (database,
-durable mailbox, etc.). In this case, it is important to keep in mind that the
-address part of an actor’s path determines how that actor is communicated with.
-Storing a local actor path might be the right choice if the retrieval happens
-in the same logical context, but it is not enough when deserializing it on a
-different network host: for that it would need to include the system’s remote
-transport address. An actor system is not limited to having just one remote
-transport per se, which makes this question a bit more interesting.
-
-In the general case, the local address to be used depends on the type of remote
-address which shall be the recipient of the serialized information. Use
-:meth:`ActorRefProvider.getExternalAddressFor(remoteAddr)` to query the system
-for the appropriate address to use when sending to ``remoteAddr``:
-
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
-   :include: external-address
 
 This requires that you know at least which type of address will be supported by
 the system which will deserialize the resulting actor reference; if you have no

--- a/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
@@ -4,7 +4,6 @@
 
 package docs.serialization {
 
-  import org.scalatest.matchers.MustMatchers
   import akka.testkit._
   //#imports
   import akka.actor.{ ActorRef, ActorSystem }
@@ -16,7 +15,6 @@ package docs.serialization {
   import akka.actor.ExtendedActorSystem
   import akka.actor.Extension
   import akka.actor.Address
-  import akka.remote.RemoteActorRefProvider
 
   //#my-own-serializer
   class MyOwnSerializer extends Serializer {
@@ -164,16 +162,8 @@ package docs.serialization {
       //#actorref-serializer
       // Serialize
       // (beneath toBinary)
+      val identifier: String = Serialization.serializedActorPath(theActorRef)
 
-      // If there is no SerializationInformation,
-      // it means that this Serializer isn't called
-      // within a piece of code that sets it,
-      // so either you need to supply your own address,
-      // or simply use the local path.
-      val identifier: String = Serialization.currentTransportInformation.value match {
-        case null                        ⇒ theActorRef.path.toSerializationFormat
-        case _: SerializationInformation ⇒ Serialization.serializedActorPath(theActorRef)
-      }
       // Then just serialize the identifier however you like
 
       // Deserialize

--- a/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
@@ -165,14 +165,14 @@ package docs.serialization {
       // Serialize
       // (beneath toBinary)
 
-      // If there is no transportAddress,
-      // it means that either this Serializer isn't called
+      // If there is no SerializationInformation,
+      // it means that this Serializer isn't called
       // within a piece of code that sets it,
-      // so either you need to supply your own,
+      // so either you need to supply your own address,
       // or simply use the local path.
-      val identifier: String = Serialization.currentTransportAddress.value match {
-        case null    ⇒ theActorRef.path.toSerializationFormat
-        case address ⇒ theActorRef.path.toSerializationFormatWithAddress(address)
+      val identifier: String = Serialization.currentTransportInformation.value match {
+        case null                        ⇒ theActorRef.path.toSerializationFormat
+        case _: SerializationInformation ⇒ Serialization.serializedActorPath(theActorRef)
       }
       // Then just serialize the identifier however you like
 

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -101,11 +101,30 @@ list which classes that should be serialized using it.
 Serializing ActorRefs
 ---------------------
 
-All ActorRefs are serializable using JavaSerializer, but in case you are writing your own serializer,
-you might want to know how to serialize and deserialize them properly, here's the magic incantation:
+All ActorRefs are serializable using JavaSerializer, but in case you are writing your
+own serializer, you might want to know how to serialize and deserialize them properly.
+In the general case, the local address to be used depends on the type of remote
+address which shall be the recipient of the serialized information. Use
+:meth:`Serialization.serializedActorPath(actorRef)` like this:
 
 .. includecode:: code/docs/serialization/SerializationDocSpec.scala
    :include: imports,actorref-serializer
+
+This assumes that serialization happens in the context of sending a message
+through the remote transport. There are other uses of serialization, though,
+e.g. storing actor references outside of an actor application (database,
+durable mailbox, etc.). In this case, it is important to keep in mind that the
+address part of an actor’s path determines how that actor is communicated with.
+Storing a local actor path might be the right choice if the retrieval happens
+in the same logical context, but it is not enough when deserializing it on a
+different network host: for that it would need to include the system’s remote
+transport address. An actor system is not limited to having just one remote
+transport per se, which makes this question a bit more interesting. To find out
+the appropriate address to use when sending to ``remoteAddr`` you can use
+:meth:`ActorRefProvider.getExternalAddressFor(remoteAddr)` like this:
+
+.. includecode:: code/docs/serialization/SerializationDocSpec.scala
+   :include: external-address
 
 .. note::
   
@@ -120,24 +139,6 @@ you might want to know how to serialize and deserialize them properly, here's th
   storage of the reference, you can use ``toStringWithAddress``, which doesn't
   include the unique id.
 
-This assumes that serialization happens in the context of sending a message
-through the remote transport. There are other uses of serialization, though,
-e.g. storing actor references outside of an actor application (database,
-durable mailbox, etc.). In this case, it is important to keep in mind that the
-address part of an actor’s path determines how that actor is communicated with.
-Storing a local actor path might be the right choice if the retrieval happens
-in the same logical context, but it is not enough when deserializing it on a
-different network host: for that it would need to include the system’s remote
-transport address. An actor system is not limited to having just one remote
-transport per se, which makes this question a bit more interesting.
-
-In the general case, the local address to be used depends on the type of remote
-address which shall be the recipient of the serialized information. Use
-:meth:`ActorRefProvider.getExternalAddressFor(remoteAddr)` to query the system
-for the appropriate address to use when sending to ``remoteAddr``:
-
-.. includecode:: code/docs/serialization/SerializationDocSpec.scala
-   :include: external-address
 
 This requires that you know at least which type of address will be supported by
 the system which will deserialize the resulting actor reference; if you have no

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -13,7 +13,7 @@ import akka.remote.RemoteProtocol.MessageProtocol
 import akka.remote.transport.AkkaPduCodec._
 import akka.remote.transport.AssociationHandle._
 import akka.remote.transport.{ AkkaPduCodec, Transport, AssociationHandle }
-import akka.serialization.Serialization
+import akka.serialization.{ SerializationInformation, Serialization }
 import akka.util.ByteString
 import akka.remote.transport.Transport.InvalidAssociationException
 import java.io.NotSerializableException
@@ -332,7 +332,7 @@ private[remote] class EndpointWriter(
 
   private def serializeMessage(msg: Any): MessageProtocol = handle match {
     case Some(h) ⇒
-      Serialization.currentTransportAddress.withValue(h.localAddress) {
+      Serialization.currentTransportInformation.withValue(SerializationInformation(h.localAddress, context.system)) {
         (MessageSerializer.serialize(extendedSystem, msg.asInstanceOf[AnyRef]))
       }
     case None ⇒ throw new EndpointException("Internal error: No handle was present during serialization of" +

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -13,11 +13,11 @@ import akka.remote.RemoteProtocol.MessageProtocol
 import akka.remote.transport.AkkaPduCodec._
 import akka.remote.transport.AssociationHandle._
 import akka.remote.transport.{ AkkaPduCodec, Transport, AssociationHandle }
-import akka.serialization.{ SerializationInformation, Serialization }
+import akka.serialization.Serialization
 import akka.util.ByteString
+import scala.util.control.NonFatal
 import akka.remote.transport.Transport.InvalidAssociationException
 import java.io.NotSerializableException
-import scala.util.control.{ NoStackTrace, NonFatal }
 
 /**
  * INTERNAL API
@@ -332,7 +332,7 @@ private[remote] class EndpointWriter(
 
   private def serializeMessage(msg: Any): MessageProtocol = handle match {
     case Some(h) ⇒
-      Serialization.currentTransportInformation.withValue(SerializationInformation(h.localAddress, context.system)) {
+      Serialization.currentTransportInformation.withValue(Serialization.Information(h.localAddress, context.system)) {
         (MessageSerializer.serialize(extendedSystem, msg.asInstanceOf[AnyRef]))
       }
     case None ⇒ throw new EndpointException("Internal error: No handle was present during serialization of" +

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -22,7 +22,7 @@ class RemoteTransportException(message: String, cause: Throwable) extends AkkaEx
  *
  * The remote transport is responsible for sending and receiving messages.
  * Each transport has an address, which it should provide in
- * Serialization.currentTransportAddress (thread-local) while serializing
+ * Serialization.currentTransportInformation (thread-local) while serializing
  * actor references (which might also be part of messages). This address must
  * be available (i.e. fully initialized) by the time the first message is
  * received or when the start() method returns, whatever happens first.

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -74,7 +74,7 @@ private[remote] object Remoting {
               null)
         }
       case None ⇒ throw new RemoteTransportException(
-        s"No transport is loaded for protocol: [${remote.protocol}], available protocols: [${transportMapping.keys.mkString}]", null)
+        s"No transport is loaded for protocol: [${remote.protocol}], available protocols: [${transportMapping.keys.mkString(", ")}]", null)
     }
   }
 

--- a/akka-remote/src/main/scala/akka/remote/serialization/ProtobufSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ProtobufSerializer.scala
@@ -6,10 +6,8 @@ package akka.remote.serialization
 
 import akka.serialization.{ Serializer, Serialization }
 import com.google.protobuf.Message
-import akka.actor.DynamicAccess
+import akka.actor.{ ActorSystem, ActorRef }
 import akka.remote.RemoteProtocol.ActorRefProtocol
-import akka.actor.ActorSystem
-import akka.actor.ActorRef
 
 object ProtobufSerializer {
 
@@ -18,11 +16,7 @@ object ProtobufSerializer {
    * protobuf representation.
    */
   def serializeActorRef(ref: ActorRef): ActorRefProtocol = {
-    val identifier: String = Serialization.currentTransportAddress.value match {
-      case null    ⇒ ref.path.toSerializationFormat
-      case address ⇒ ref.path.toSerializationFormatWithAddress(address)
-    }
-    ActorRefProtocol.newBuilder.setPath(identifier).build
+    ActorRefProtocol.newBuilder.setPath(Serialization.serializedActorPath(ref)).build
   }
 
   /**

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -252,7 +252,6 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
       moreSystems foreach { sys ⇒
         sys.shutdown()
         sys.awaitTermination(5.seconds.dilated)
-        sys.isTerminated must be(true)
       }
 
       1 to n foreach { x ⇒
@@ -449,19 +448,18 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
         // check that we use the specified transport address instead of the default
         val otherGuyRemoteTcp = otherGuy.path.toSerializationFormatWithAddress(addr(otherSystem, "tcp"))
         val remoteEchoHereTcp = system.actorFor(s"akka.tcp://remote-sys@localhost:${port(remoteSystem, "tcp")}/user/echo")
-        val proxyTcp = system.actorOf(Props(new Proxy(remoteEchoHereTcp, self)), "proxy-tcp")
+        val proxyTcp = system.actorOf(Props(new Proxy(remoteEchoHereTcp, testActor)), "proxy-tcp")
         proxyTcp ! otherGuy
         expectMsg(3.seconds, ("pong", otherGuyRemoteTcp))
         // now check that we fall back to default when we haven't got a corresponding transport
         val otherGuyRemoteTest = otherGuy.path.toSerializationFormatWithAddress(addr(otherSystem, "test"))
         val remoteEchoHereSsl = system.actorFor(s"akka.ssl.tcp://remote-sys@localhost:${port(remoteSystem, "ssl.tcp")}/user/echo")
-        val proxySsl = system.actorOf(Props(new Proxy(remoteEchoHereSsl, self)), "proxy-ssl")
+        val proxySsl = system.actorOf(Props(new Proxy(remoteEchoHereSsl, testActor)), "proxy-ssl")
         proxySsl ! otherGuy
         expectMsg(3.seconds, ("pong", otherGuyRemoteTest))
       } finally {
         otherSystem.shutdown()
         otherSystem.awaitTermination(5.seconds.dilated)
-        otherSystem.isTerminated must be(true)
       }
     }
   }


### PR DESCRIPTION
- Use the correct address in the original system for the current systems transport type
- Fall back to the original systems default transport if no such transport is available
- Allow systems to deserialize actor refs for which they have no transport resulting in an EmptyLocalActorRef
