### PR TITLE
Fix half-closed TCP connection if peer closed first, see #3185

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
@@ -23,6 +23,8 @@ class TcpIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with TcpIntegr
       clientHandler.send(clientConnection, Close)
       clientHandler.expectMsg(Closed)
       serverHandler.expectMsg(PeerClosed)
+      serverHandler.send(serverConnection, Close)
+      serverHandler.expectMsg(Closed)
       verifyActorTermination(clientConnection)
       verifyActorTermination(serverConnection)
     }
@@ -52,6 +54,8 @@ class TcpIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with TcpIntegr
       serverHandler.send(serverConnection, Close)
       serverHandler.expectMsg(Closed)
       clientHandler.expectMsg(PeerClosed)
+      clientHandler.send(clientConnection, Close)
+      clientHandler.expectMsg(Closed)
 
       verifyActorTermination(clientConnection)
       verifyActorTermination(serverConnection)

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
@@ -23,8 +23,6 @@ class TcpIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with TcpIntegr
       clientHandler.send(clientConnection, Close)
       clientHandler.expectMsg(Closed)
       serverHandler.expectMsg(PeerClosed)
-      serverHandler.send(serverConnection, Close)
-      serverHandler.expectMsg(Closed)
       verifyActorTermination(clientConnection)
       verifyActorTermination(serverConnection)
     }
@@ -54,8 +52,6 @@ class TcpIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with TcpIntegr
       serverHandler.send(serverConnection, Close)
       serverHandler.expectMsg(Closed)
       clientHandler.expectMsg(PeerClosed)
-      clientHandler.send(clientConnection, Close)
-      clientHandler.expectMsg(Closed)
 
       verifyActorTermination(clientConnection)
       verifyActorTermination(serverConnection)

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -217,6 +217,7 @@ object TcpMessage {
            backlog: Int): Command = Bind(handler, endpoint, backlog, Nil)
 
   def register(handler: ActorRef): Command = Register(handler)
+  def register(handler: ActorRef, keepOpenOnPeerClosed: Boolean): Command = Register(handler, keepOpenOnPeerClosed)
   def unbind: Command = Unbind
 
   def close: Command = Close

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -73,7 +73,7 @@ object Tcp extends ExtensionKey[TcpExt] {
                   backlog: Int = 100,
                   options: immutable.Traversable[SocketOption] = Nil) extends Command
 
-  case class Register(handler: ActorRef) extends Command
+  case class Register(handler: ActorRef, keepOpenOnPeerClosed: Boolean = false) extends Command
   case object Unbind extends Command
 
   sealed trait CloseCommand extends Command {

--- a/akka-docs/rst/java/io.rst
+++ b/akka-docs/rst/java/io.rst
@@ -442,7 +442,10 @@ successful, the listener will be notified with ``ConfirmedClosed``.
 ``Abort`` will immediately terminate the connection by sending a ``RST`` message to the remote endpoint. Pending
 writes will be not flushed. If the close is successful, the listener will be notified with ``Aborted``.
 
-``PeerClosed`` will be sent to the listener if the connection has been closed by the remote endpoint.
+``PeerClosed`` will be sent to the listener if the connection has been closed by the remote endpoint. Per default, the
+connection will then automatically be closed from this endpoint as well. To support half-closed connections set the
+``keepOpenOnPeerClosed`` member of the ``Register`` message to ``true`` in which case the connection stays open until
+it receives one of the above close commands.
 
 ``ErrorClosed`` will be sent to the listener whenever an error happened that forced the connection to be closed.
 

--- a/akka-docs/rst/scala/io.rst
+++ b/akka-docs/rst/scala/io.rst
@@ -485,7 +485,10 @@ successful, the listener will be notified with ``ConfirmedClosed``.
 ``Abort`` will immediately terminate the connection by sending a ``RST`` message to the remote endpoint. Pending
 writes will be not flushed. If the close is successful, the listener will be notified with ``Aborted``.
 
-``PeerClosed`` will be sent to the listener if the connection has been closed by the remote endpoint.
+``PeerClosed`` will be sent to the listener if the connection has been closed by the remote endpoint. Per default, the
+connection will then automatically be closed from this endpoint as well. To support half-closed connections set the
+``keepOpenOnPeerClosed`` member of the ``Register`` message to ``true`` in which case the connection stays open until
+it receives one of the above close commands.
 
 ``ErrorClosed`` will be sent to the listener whenever an error happened that forced the connection to be closed.
 


### PR DESCRIPTION
This allows to send data back to the peer even if the peer already has sent EOF/FIN as specified for TCP. To fully close a connection, the handler now has to close its side of the connection actively when it is finished with writing even if it received a `PeerClosed` message before.

One thing that should be discussed is if it should be mandatory that a connection has to be actively closed from the other side after a `PeerClosed` was received (and consequentially if `PeerClosed` should derive from `ConnectionClosed`) or if there should be a timeout that automatically fully closes the connection some time after the peer closed the connection and something was last sent to the peer (I've got a commit which would add this timeout). The question is then how to configure the timeout, globally or per connection.
