### PR TITLE
We should always handle ThrottleMode messages. #3179

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -434,11 +434,15 @@ private[transport] class ThrottledAssociation(
   }
 
   whenUnhandled {
+    // we should always set the throttling mode
+    case Event(mode: ThrottleMode, _) ⇒
+      inboundThrottleMode = mode
+      sender ! SetThrottleAck
+      stay()
     case Event(Disassociated, _) ⇒
       if (upstreamListener ne null) upstreamListener notify Disassociated
       originalHandle.disassociate()
       stop()
-
   }
 
   // This method captures ASSOCIATE packets and extracts the origin address


### PR DESCRIPTION
When we enter some states on the way to `Throttling` we can start receiving `ThrottleMode` messages. They should always be handled.

Thanks for walking through the state machine with me Endre.
