### PR TITLE
Cleanup of TestActorRef constructor, see #2728

### DIFF
--- a/akka-docs/rst/scala/testing.rst
+++ b/akka-docs/rst/scala/testing.rst
@@ -82,11 +82,10 @@ Due to a limitation in Scala’s type inference, there is only the factory metho
 shown above, so you will probably write code like ``TestFSMRef(new MyFSM)``
 instead of the hypothetical :class:`ActorRef`-inspired ``TestFSMRef[MyFSM]``.
 All methods shown above directly access the FSM state without any
-synchronization; this is perfectly alright if the
-:class:`CallingThreadDispatcher` is used (which is the default for
-:class:`TestFSMRef`) and no other threads are involved, but it may lead to
-surprises if you were to actually exercise timer events, because those are
-executed on the :obj:`Scheduler` thread.
+synchronization; this is perfectly alright if the :class:`CallingThreadDispatcher` 
+is used and no other threads are involved, but it may lead to surprises if you
+were to actually exercise timer events, because those are executed on the 
+:obj:`Scheduler` thread.
 
 Testing the Actor's Behavior
 ----------------------------

--- a/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
@@ -19,10 +19,10 @@ import akka.pattern.ask
  * @since 1.1
  */
 class TestActorRef[T <: Actor](
-  _system: ActorSystemImpl,
+  _system: ActorSystem,
   _prerequisites: DispatcherPrerequisites,
   _props: Props,
-  _supervisor: InternalActorRef,
+  _supervisor: ActorRef,
   name: String)
   extends {
     private val disregard = _supervisor match {
@@ -35,11 +35,11 @@ class TestActorRef[T <: Actor](
       case s ⇒ _system.log.error("trying to attach child {} to unknown type of supervisor {}, this is not going to end well", name, s.getClass)
     }
   } with LocalActorRef(
-    _system,
+    _system.asInstanceOf[ActorSystemImpl],
     _props.withDispatcher(
       if (_props.dispatcher == Dispatchers.DefaultDispatcherId) CallingThreadDispatcher.Id
       else _props.dispatcher),
-    _supervisor,
+    _supervisor.asInstanceOf[InternalActorRef],
     _supervisor.path / name) {
 
   // we need to start ourselves since the creation of an actor has been split into initialization and starting

--- a/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
@@ -34,10 +34,10 @@ import scala.concurrent.duration.FiniteDuration
  * @since 1.2
  */
 class TestFSMRef[S, D, T <: Actor](
-  system: ActorSystemImpl,
+  system: ActorSystem,
   _prerequisites: DispatcherPrerequisites,
   props: Props,
-  supervisor: InternalActorRef,
+  supervisor: ActorRef,
   name: String)(implicit ev: T <:< FSM[S, D])
   extends TestActorRef(system, _prerequisites, props, supervisor, name) {
 


### PR DESCRIPTION
- Don't expose internal classes in public constructor
