### PR TITLE
make lifecycle hooks work when using Stash, see #3199

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -242,8 +242,7 @@ object FSM {
  *   isTimerActive("tock")
  * </pre>
  */
-trait FSM[S, D] extends Listeners with ActorLogging {
-  this: Actor ⇒
+trait FSM[S, D] extends Actor with Listeners with ActorLogging {
 
   import FSM._
 
@@ -638,6 +637,7 @@ trait FSM[S, D] extends Listeners with ActorLogging {
      * since the new instance will initialize fresh using startWith()
      */
     terminate(stay withStopReason Shutdown)
+    super.postStop()
   }
 
   private def terminate(nextState: State): Unit = {

--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -47,8 +47,7 @@ import akka.AkkaException
  *  any trait/class that overrides the `preRestart` callback. This means it's not possible to write
  *  `Actor with MyActor with Stash` if `MyActor` overrides `preRestart`.
  */
-trait Stash {
-  this: Actor ⇒
+trait Stash extends Actor {
 
   /* The private stash of the actor. It is only accessible using `stash()` and
    * `unstashAll()`.
@@ -116,10 +115,7 @@ An (unbounded) deque-based mailbox can be configured as follows:
    *  clears the stash, stops all children and invokes the postStop() callback.
    */
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
-    try unstashAll() finally {
-      context.children foreach context.stop
-      postStop()
-    }
+    try unstashAll() finally super.preRestart(reason, message)
   }
 
   /**
@@ -127,7 +123,7 @@ An (unbounded) deque-based mailbox can be configured as follows:
    *  Must be called when overriding this method, otherwise stashed messages won't be propagated to DeadLetters
    *  when actor stops.
    */
-  override def postStop(): Unit = unstashAll()
+  override def postStop(): Unit = try unstashAll() finally super.postStop()
 
 }
 


### PR DESCRIPTION
Unfortunately the need to call super.postStop() and friends mandates
that Stash (and FSM had the same problem) extends Actor instead of just
declaring it as a self type. We cannot always win.
