### PR TITLE
make lifecycle hooks work when using Stash, see #3199

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dsl/Creators.scala
+++ b/akka-actor/src/main/scala/akka/actor/dsl/Creators.scala
@@ -151,7 +151,7 @@ trait Creators { this: ActorDSL.type ⇒
    * since just using `actor()(new Act with Stash{})` will not be able to see the
    * Stash component due to type erasure.
    */
-  trait ActWithStash extends Act with Stash
+  trait ActWithStash extends Actor with Stash with Act
 
   private def mkProps(classOfActor: Class[_], ctor: () ⇒ Actor): Props =
     if (classOf[Stash].isAssignableFrom(classOfActor))


### PR DESCRIPTION
The original fix for 2.2+ is not BC, hence this only does the minimal
thing (i.e. it does not make Stash or FSM well-behaved).
