### PR TITLE
Fixed wrongly configured retry-gate to avoid test-interference

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
@@ -24,7 +24,7 @@ case class SplitBrainMultiNodeConfig(failureDetectorPuppet: Boolean) extends Mul
 
   commonConfig(debugConfig(on = false).
     withFallback(ConfigFactory.parseString("""
-        akka.remote.retry-latch-closed-for = 3 s
+        akka.remote.retry-gate-closed-for = 3 s
         akka.cluster {
           auto-down = on
           failure-detector.threshold = 4

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -75,7 +75,7 @@ object RemotingSpec {
       remote {
         transport = "akka.remote.Remoting"
 
-        retry-latch-closed-for = 1 s
+        retry-gate-closed-for = 1 s
         log-remote-lifecycle-events = on
 
         enabled-transports = [
@@ -205,7 +205,7 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
     }
 
     "send error message for wrong address" in {
-      filterEvents(EventFilter.error(start = "Association", occurrences = 6),
+      filterEvents(EventFilter.error(start = "AssociationError", occurrences = 1),
         EventFilter.warning(pattern = ".*dead letter.*echo.*", occurrences = 1)) {
           system.actorFor("akka.test://nonexistingsystem@localhost:12346/user/echo") ! "ping"
         }

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
@@ -56,7 +56,7 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
         startup-timeout = 5 s
 
-        retry-latch-closed-for = 0 s
+        retry-gate-closed-for = 0 s
 
         use-passive-connections = on
       }

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -16,7 +16,7 @@ object AkkaProtocolStressTest {
       #loglevel = DEBUG
       actor.provider = "akka.remote.RemoteActorRefProvider"
 
-      remote.retry-latch-closed-for = 0 s
+      remote.retry-gate-closed-for = 0 s
       remote.log-remote-lifecycle-events = on
 
       remote.failure-detector {

--- a/akka-remote/src/test/scala/akka/remote/transport/ThrottlerTransportAdapterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/ThrottlerTransportAdapterSpec.scala
@@ -19,7 +19,7 @@ object ThrottlerTransportAdapterSpec {
       actor.provider = "akka.remote.RemoteActorRefProvider"
 
       remote.netty.tcp.hostname = "localhost"
-      remote.retry-latch-closed-for = 0 s
+      remote.retry-gate-closed-for = 0 s
       remote.log-remote-lifecycle-events = on
 
       remote.netty.tcp.applied-adapters = ["trttl"]


### PR DESCRIPTION
As a side-effect logging is reduced, too.
