### PR TITLE
Tcp: introduce WriteFile to support zero-copy writing of files, fixes #2896

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -258,8 +258,8 @@ class TcpConnectionSpec extends AkkaSpec("akka.io.tcp.register-timeout = 500ms")
         writer.expectMsg(CommandFailed(secondWrite))
 
         // reject even empty writes
-        writer.send(connectionActor, Write.Empty)
-        writer.expectMsg(CommandFailed(Write.Empty))
+        writer.send(connectionActor, Write.empty)
+        writer.expectMsg(CommandFailed(Write.empty))
 
         // there will be immediately more space in the send buffer because
         // some data will have been sent by now, so we assume we can write

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -483,6 +483,10 @@ akka {
       # Fully qualified config path which holds the dispatcher configuration
       # for the selector management actors
       management-dispatcher = "akka.actor.default-dispatcher"
+
+      # Fully qualified config path which holds the dispatcher configuration
+      # on which file IO tasks are scheduled
+      file-io-dispatcher = "akka.io.pinned-dispatcher"
     }
 
     udp {

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -486,7 +486,14 @@ akka {
 
       # Fully qualified config path which holds the dispatcher configuration
       # on which file IO tasks are scheduled
-      file-io-dispatcher = "akka.io.pinned-dispatcher"
+      file-io-dispatcher = "akka.actor.default-dispatcher"
+
+      # The maximum number of bytes (or "unlimited") to transfer in one batch when using
+      # `WriteFile` command which uses `FileChannel.transferTo` to pipe files to a TCP socket.
+      # On some OS like Linux `FileChannel.transferTo` may block for a long time when network
+      # IO is faster than file IO. Decreasing the value may improve fairness while increasing
+      # may improve throughput.
+      file-io-transferTo-limit = 512 KiB
     }
 
     udp {

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -110,6 +110,12 @@ object Tcp extends ExtensionKey[TcpExt] {
       if (data.isEmpty) Empty else Write(data, NoAck)
   }
 
+  /**
+   * Write `count` bytes starting at `position` from file at `filePath` to the connection.
+   * When write is finished acknowledge with `ack`. If no ack is needed use `NoAck`.
+   */
+  case class WriteFile(filePath: String, position: Long, count: Long, ack: Any) extends WriteCommand
+
   case object StopReading extends Command
   case object ResumeReading extends Command
 
@@ -168,6 +174,7 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
       case x           ⇒ getIntBytes("received-message-size-limit")
     }
     val ManagementDispatcher = getString("management-dispatcher")
+    val FileIODispatcher = getString("file-io-dispatcher")
 
     require(NrOfSelectors > 0, "nr-of-selectors must be > 0")
     require(MaxChannels == -1 || MaxChannels > 0, "max-channels must be > 0 or 'unlimited'")
@@ -191,6 +198,7 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
   }
 
   val bufferPool: BufferPool = new DirectByteBufferPool(Settings.DirectBufferSize, Settings.MaxDirectBufferPoolSize)
+  val fileIoDispatcher = system.dispatchers.lookup(Settings.FileIODispatcher)
 }
 
 object TcpSO extends SoJavaFactories {

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -92,15 +92,18 @@ object Tcp extends ExtensionKey[TcpExt] {
   case class NoAck(token: Any)
   object NoAck extends NoAck(null)
 
+  sealed trait WriteCommand extends Command {
+    require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
+
+    def ack: Any
+    def wantsAck: Boolean = !ack.isInstanceOf[NoAck]
+  }
+
   /**
    * Write data to the TCP connection. If no ack is needed use the special
    * `NoAck` object.
    */
-  case class Write(data: ByteString, ack: Any) extends Command {
-    require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
-
-    def wantsAck: Boolean = !ack.isInstanceOf[NoAck]
-  }
+  case class Write(data: ByteString, ack: Any) extends WriteCommand
   object Write {
     val Empty: Write = Write(ByteString.empty, NoAck)
     def apply(data: ByteString): Write =

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -189,6 +189,10 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
     }
     val ManagementDispatcher = getString("management-dispatcher")
     val FileIODispatcher = getString("file-io-dispatcher")
+    val TransferToLimit = getString("file-io-transferTo-limit") match {
+      case "unlimited" ⇒ Int.MaxValue
+      case _           ⇒ getIntBytes("file-io-transferTo-limit")
+    }
 
     require(NrOfSelectors > 0, "nr-of-selectors must be > 0")
     require(MaxChannels == -1 || MaxChannels > 0, "max-channels must be > 0 or 'unlimited'")

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -344,7 +344,8 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     new Runnable {
       def run() {
         import pendingWrite._
-        val writtenBytes = fileChannel.transferTo(currentPosition, remainingBytes, channel)
+        val toWrite = math.min(remainingBytes, tcp.Settings.TransferToLimit)
+        val writtenBytes = fileChannel.transferTo(currentPosition, toWrite, channel)
 
         if (writtenBytes < remainingBytes) self ! SendBufferFull(pendingWrite.updatedWrite(alreadyWritten + writtenBytes))
         else { // finished

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -5,8 +5,8 @@
 package akka.io
 
 import java.net.InetSocketAddress
-import java.io.IOException
-import java.nio.channels.SocketChannel
+import java.io.{ FileInputStream, IOException }
+import java.nio.channels.{ FileChannel, SocketChannel }
 import java.nio.ByteBuffer
 import scala.annotation.tailrec
 import scala.collection.immutable
@@ -88,8 +88,10 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       doWrite(handler)
       if (!writePending) // writing is now finished
         handleClose(handler, closeCommander, closedEvent)
+    case SendBufferFull(remaining) ⇒ pendingWrite = remaining; selector ! WriteInterest
+    case WriteFileFinished         ⇒ pendingWrite = null; handleClose(handler, closeCommander, closedEvent)
 
-    case Abort ⇒ handleClose(handler, Some(sender), Aborted)
+    case Abort                     ⇒ handleClose(handler, Some(sender), Aborted)
   }
 
   /** connection is closed on our side and we're waiting from confirmation from the other side */
@@ -114,6 +116,9 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     case write: WriteCommand ⇒
       pendingWrite = createWrite(write)
       doWrite(handler)
+
+    case SendBufferFull(remaining) ⇒ pendingWrite = remaining; selector ! WriteInterest
+    case WriteFileFinished         ⇒ pendingWrite = null
   }
 
   // AUXILIARIES and IMPLEMENTATION
@@ -253,6 +258,18 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
   override def postRestart(reason: Throwable): Unit =
     throw new IllegalStateException("Restarting not supported for connection actors.")
 
+  /** Create a pending write from a WriteCommand */
+  private[io] def createWrite(write: WriteCommand): PendingWrite = write match {
+    case write: Write ⇒
+      val buffer = bufferPool.acquire()
+      val copied = write.data.copyToBuffer(buffer)
+      buffer.flip()
+
+      PendingBufferWrite(sender, write.ack, write.data.drop(copied), buffer)
+    case write: WriteFile ⇒
+      PendingWriteFile(sender, write, new FileInputStream(write.filePath).getChannel, 0L)
+  }
+
   private[io] case class PendingBufferWrite(
     commander: ActorRef,
     ack: Any,
@@ -297,14 +314,44 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
         copy(remainingData = remainingData.drop(copied))
       } else this
   }
-  def createWrite(write: WriteCommand): PendingWrite = write match {
-    case write: Write ⇒
-      val buffer = bufferPool.acquire()
-      val copied = write.data.copyToBuffer(buffer)
-      buffer.flip()
+  private[io] case class PendingWriteFile(
+    commander: ActorRef,
+    write: WriteFile,
+    fileChannel: FileChannel,
+    alreadyWritten: Long) extends PendingWrite {
+    def doWrite(handler: ActorRef): PendingWrite = {
+      tcp.fileIoDispatcher.execute(writeFileRunnable(this))
+      this
+    }
 
-      PendingBufferWrite(sender, write.ack, write.data.drop(copied), buffer)
+    def ack: Any = write.ack
+
+    /** Release any open resources */
+    def release() { fileChannel.close() }
+
+    def updatedWrite(nowWritten: Long): PendingWriteFile = {
+      require(nowWritten < write.count)
+      copy(alreadyWritten = nowWritten)
+    }
+
+    def remainingBytes = write.count - alreadyWritten
+    def currentPosition = write.position + alreadyWritten
   }
+  private[io] def writeFileRunnable(pendingWrite: PendingWriteFile): Runnable =
+    new Runnable {
+      def run() {
+        import pendingWrite._
+        val writtenBytes = fileChannel.transferTo(currentPosition, remainingBytes, channel)
+
+        if (writtenBytes < remainingBytes) self ! SendBufferFull(pendingWrite.updatedWrite(alreadyWritten + writtenBytes))
+        else { // finished
+          if (wantsAck) commander ! write.ack
+          self ! WriteFileFinished
+
+          pendingWrite.release()
+        }
+      }
+    }
 }
 
 /**
@@ -323,6 +370,13 @@ private[io] object TcpConnection {
   case class CloseInformation(
     notificationsTo: Set[ActorRef],
     closedEvent: Event)
+
+  // INTERNAL MESSAGES
+
+  /** Informs actor that no writing was possible but there is still work remaining */
+  case class SendBufferFull(remainingWrite: PendingWrite)
+  /** Informs actor that a pending file write has finished */
+  case object WriteFileFinished
 
   /** Abstraction over pending writes */
   trait PendingWrite {

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -169,32 +169,8 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     } finally bufferPool.release(buffer)
   }
 
-  final def doWrite(handler: ActorRef): Unit = {
-    @tailrec def innerWrite(): Unit = {
-      val toWrite = pendingWrite.buffer.remaining()
-      require(toWrite != 0)
-      val writtenBytes = channel.write(pendingWrite.buffer)
-      if (TraceLogging) log.debug("Wrote [{}] bytes to channel", writtenBytes)
-
-      pendingWrite = pendingWrite.consume(writtenBytes)
-
-      if (pendingWrite.hasData)
-        if (writtenBytes == toWrite) innerWrite() // wrote complete buffer, try again now
-        else selector ! WriteInterest // try again later
-      else { // everything written
-        if (pendingWrite.wantsAck)
-          pendingWrite.commander ! pendingWrite.ack
-
-        val buffer = pendingWrite.buffer
-        pendingWrite = null
-
-        bufferPool.release(buffer)
-      }
-    }
-
-    try innerWrite()
-    catch { case e: IOException ⇒ handleError(handler, e) }
-  }
+  def doWrite(handler: ActorRef): Unit =
+    pendingWrite = pendingWrite.doWrite(handler)
 
   def closeReason =
     if (channel.socket.isOutputShutdown) ConfirmedClosed
@@ -234,7 +210,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     context.stop(self)
   }
 
-  def handleError(handler: ActorRef, exception: IOException): Unit = {
+  def handleError(handler: ActorRef, exception: IOException): Nothing = {
     closedMessage = CloseInformation(Set(handler), ErrorClosed(extractMsg(exception)))
 
     throw exception
@@ -263,8 +239,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
     if (channel.isOpen)
       abort()
 
-    if (writePending)
-      bufferPool.release(pendingWrite.buffer)
+    if (writePending) pendingWrite.release()
 
     if (closedMessage != null) {
       val interestedInClose =
@@ -278,29 +253,56 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
   override def postRestart(reason: Throwable): Unit =
     throw new IllegalStateException("Restarting not supported for connection actors.")
 
-  private[io] case class PendingWrite(
+  private[io] case class PendingBufferWrite(
     commander: ActorRef,
     ack: Any,
     remainingData: ByteString,
-    buffer: ByteBuffer) {
+    buffer: ByteBuffer) extends PendingWrite {
 
-    def consume(writtenBytes: Int): PendingWrite =
+    def release(): Unit = bufferPool.release(buffer)
+
+    def doWrite(handler: ActorRef): PendingWrite = {
+      @tailrec def innerWrite(pendingWrite: PendingBufferWrite): PendingWrite = {
+        val toWrite = pendingWrite.buffer.remaining()
+        require(toWrite != 0)
+        val writtenBytes = channel.write(pendingWrite.buffer)
+        if (TraceLogging) log.debug("Wrote [{}] bytes to channel", writtenBytes)
+
+        val nextWrite = pendingWrite.consume(writtenBytes)
+
+        if (pendingWrite.hasData)
+          if (writtenBytes == toWrite) innerWrite(nextWrite) // wrote complete buffer, try again now
+          else {
+            selector ! WriteInterest
+            nextWrite
+          } // try again later
+        else { // everything written
+          if (pendingWrite.wantsAck)
+            pendingWrite.commander ! pendingWrite.ack
+
+          pendingWrite.release()
+          null
+        }
+      }
+
+      try innerWrite(this)
+      catch { case e: IOException ⇒ handleError(handler, e) }
+    }
+    def hasData = buffer.remaining() > 0 || remainingData.size > 0
+    def consume(writtenBytes: Int): PendingBufferWrite =
       if (buffer.remaining() == 0) {
         buffer.clear()
         val copied = remainingData.copyToBuffer(buffer)
         buffer.flip()
         copy(remainingData = remainingData.drop(copied))
       } else this
-
-    def hasData = buffer.remaining() > 0 || remainingData.size > 0
-    def wantsAck = !ack.isInstanceOf[NoAck]
   }
   def createWrite(write: Write): PendingWrite = {
     val buffer = bufferPool.acquire()
     val copied = write.data.copyToBuffer(buffer)
     buffer.flip()
 
-    PendingWrite(sender, write.ack, write.data.drop(copied), buffer)
+    PendingBufferWrite(sender, write.ack, write.data.drop(copied), buffer)
   }
 }
 
@@ -320,4 +322,16 @@ private[io] object TcpConnection {
   case class CloseInformation(
     notificationsTo: Set[ActorRef],
     closedEvent: Event)
+
+  /** Abstraction over pending writes */
+  trait PendingWrite {
+    def commander: ActorRef
+    def ack: Any
+
+    def wantsAck = !ack.isInstanceOf[NoAck]
+    def doWrite(handler: ActorRef): PendingWrite
+
+    /** Release any open resources */
+    def release(): Unit
+  }
 }


### PR DESCRIPTION
This is the rebased version of PR #1061.

In relation to the previous PR following has changed:
- rebased to master
- test case now doesn't create test file any more but tries to take existing jar file from the classpath
- we are still using one dedicated file IO thread for scheduling all file IO operations
