### PR TITLE
Tone down error logging by explicitly handling handler termination in TcpConnection

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -33,7 +33,8 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
   // Needed to send the ConnectionClosed message in the postStop handler.
   var closedMessage: CloseInformation = null
 
-  var keepOpenOnPeerClosed: Boolean = false
+  private[this] var peerClosed = false
+  private[this] var keepOpenOnPeerClosed = false
 
   def writePending = pendingWrite ne null
 
@@ -211,7 +212,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       // report that peer closed the connection
       handler ! PeerClosed
       // used to check if peer already closed its side later
-      channel.socket().shutdownInput()
+      peerClosed = true
       context.become(peerSentEOF(handler))
     case _ if writePending ⇒ // finish writing first
       if (TraceLogging) log.debug("Got Close command but write is still pending.")
@@ -220,7 +221,7 @@ private[io] abstract class TcpConnection(val channel: SocketChannel,
       if (TraceLogging) log.debug("Got ConfirmedClose command, sending FIN.")
       channel.socket.shutdownOutput()
 
-      if (channel.socket().isInputShutdown) // if peer closed first, the socket is now fully closed
+      if (peerClosed) // if peer closed first, the socket is now fully closed
         doCloseConnection(handler, closeCommander, closedEvent)
       else context.become(closing(handler, closeCommander))
     case _ ⇒ // close now

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -32,8 +32,6 @@ private[io] class TcpListener(val selectorRouter: ActorRef,
                               val tcp: TcpExt,
                               val bindCommander: ActorRef,
                               val bind: Bind) extends Actor with ActorLogging {
-
-  def selector: ActorRef = context.parent
   import TcpListener._
   import tcp.Settings._
   import bind._

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -56,6 +56,8 @@ private[io] class TcpListener(val selectorRouter: ActorRef,
   context.parent ! RegisterChannel(channel, SelectionKey.OP_ACCEPT)
   log.debug("Successfully bound to {}", endpoint)
 
+  override def supervisorStrategy = IO.connectionSupervisorStrategy
+
   def receive: Receive = {
     case ChannelRegistered ⇒
       bindCommander ! Bound

--- a/akka-actor/src/main/scala/akka/io/UdpConnectedManager.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnectedManager.scala
@@ -15,7 +15,7 @@ private[io] class UdpConnectedManager(udpConn: UdpConnectedExt) extends Selector
   def receive = workerForCommandHandler {
     case c: Connect ⇒
       val commander = sender
-      Props(new UdpConnectedection(udpConn, commander, c))
+      Props(new UdpConnection(udpConn, commander, c))
   }
 
 }

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -16,9 +16,9 @@ import scala.util.control.NonFatal
 /**
  * INTERNAL API
  */
-private[io] class UdpConnectedection(val udpConn: UdpConnectedExt,
-                                     val commander: ActorRef,
-                                     val connect: Connect) extends Actor with ActorLogging {
+private[io] class UdpConnection(val udpConn: UdpConnectedExt,
+                                val commander: ActorRef,
+                                val connect: Connect) extends Actor with ActorLogging {
 
   def selector: ActorRef = context.parent
 

--- a/akka-actor/src/main/scala/akka/io/UdpSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpSender.scala
@@ -12,8 +12,6 @@ import akka.io.Inet.SocketOption
 import scala.util.control.NonFatal
 
 /**
- * Base class for TcpIncomingConnection and TcpOutgoingConnection.
- *
  * INTERNAL API
  */
 private[io] class UdpSender(val udp: UdpExt, options: immutable.Traversable[SocketOption], val commander: ActorRef)
@@ -45,9 +43,5 @@ private[io] class UdpSender(val udp: UdpExt, options: immutable.Traversable[Sock
       case NonFatal(e) ⇒ log.error(e, "Error closing DatagramChannel")
     }
   }
-
-  override def postRestart(reason: Throwable): Unit =
-    throw new IllegalStateException("Restarting not supported for connection actors.")
-
 }
 


### PR DESCRIPTION
Without this patch it is impossible to avoid `DeathPactException` error level log messages resulting from a terminated connection handler if this handler doesn't itself watch the connection actor and only stops itself after having received the respective `Terminated` event.

While this is not wrong per se it complicates API usage since most users simply want to stop their handler after having seen a `Tcp.ConnectionClosed` event (and therefore avoid the additional step of waiting for `Terminated(connection)`).

This patch adds explicit handling of `Terminated(handler)` events in the `TcpConnection` and reduces logging to one respective `debug` level log message.
