### PR TITLE
Make karaf osgi-sample extract to target directory #3216

### DIFF
--- a/akka-samples/akka-sample-osgi-dining-hakkers/core/src/main/scala/akka/sample/osgi/internal/Table.scala
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/core/src/main/scala/akka/sample/osgi/internal/Table.scala
@@ -21,6 +21,6 @@ class Table extends Actor {
   val chopsticks = for (i ← 1 to 5) yield context.actorOf(Props[Chopstick], "Chopstick" + i)
 
   def receive = {
-    case x: Int ⇒ sender ! (chopsticks(x), chopsticks((x + 1) % 5))
+    case x: Int ⇒ sender ! ((chopsticks(x), chopsticks((x + 1) % 5)))
   }
 }

--- a/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/TestOptions.scala
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/TestOptions.scala
@@ -5,6 +5,7 @@ import org.ops4j.pax.exam.options.DefaultCompositeOption
 import org.ops4j.pax.exam.{Option => PaxOption}
 import org.apache.karaf.tooling.exam.options.LogLevelOption
 import org.apache.karaf.tooling.exam.options.KarafDistributionOption._
+import java.io.File
 
 /**
  * Re-usable PAX Exam option groups.
@@ -13,11 +14,12 @@ object TestOptions {
 
   val scalaDepVersion = System.getProperty("scala.dep.version")
 
-  def karafOptions(useDeployFolder: Boolean = false): PaxOption = {
-    new DefaultCompositeOption(
-      karafDistributionConfiguration.frameworkUrl(
-        maven.groupId("org.apache.karaf").artifactId("apache-karaf").`type`("zip").version(System.getProperty("karaf.version")))
-        .karafVersion(System.getProperty("karaf.version")).name("Apache Karaf").useDeployFolder(useDeployFolder),
+  def karafOptions(useDeployFolder: Boolean = false, extractInTargetFolder: Boolean = true): PaxOption = {
+    val kdc = karafDistributionConfiguration.frameworkUrl(
+      maven.groupId("org.apache.karaf").artifactId("apache-karaf").`type`("zip").version(System.getProperty("karaf.version")))
+      .karafVersion(System.getProperty("karaf.version")).name("Apache Karaf").useDeployFolder(useDeployFolder)
+
+    new DefaultCompositeOption(if (extractInTargetFolder) kdc.unpackDirectory(new File("target/paxexam/unpack/")) else kdc,
       editConfigurationFilePut("etc/config.properties", "karaf.framework", "equinox")
     )
   }
@@ -41,9 +43,9 @@ object TestOptions {
     )
   }
 
-  def karafOptionsWithTestBundles(useDeployFolder: Boolean = false): PaxOption = {
+  def karafOptionsWithTestBundles(useDeployFolder: Boolean = false, extractInTargetFolder: Boolean = true): PaxOption = {
     new DefaultCompositeOption(
-      karafOptions(useDeployFolder),
+      karafOptions(useDeployFolder, extractInTargetFolder),
       testBundles()
     )
   }


### PR DESCRIPTION
The osgi-sample now extracts files to the local target directory instead of the HOME/.pax directory.
The test is now optional as well, and needs to be enabled with the flag `-Dakka.osgi.sample.test=true`.

The jenkins jobs on jenkins.akka.io and jenkins.typesafe.com have been updated with the flag.

There is still a problem with mvn pulling down published SNAPSHOTS and not using the locally built stuff,
but that's in this ticket https://www.assembla.com/spaces/akka/tickets/3224, since we need to stop spurious
build failures.
