### PR TITLE
SupervisorSpec implicitly relied on a loss of a message

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
@@ -403,14 +403,19 @@ class SupervisorSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSende
           case l: TestLatch                          ⇒ child ! l
           case "test"                                ⇒ sender ! "green"
           case "testchild"                           ⇒ child forward "test"
+          case "testchildAndAck"                     ⇒ child forward "test"; sender ! "ack"
         }
       }))
 
       val latch = TestLatch()
       parent ! latch
-      EventFilter[IllegalStateException]("OHNOES", occurrences = 1) intercept {
-        latch.countDown()
-      }
+      parent ! "testchildAndAck"
+      expectMsg("ack")
+      filterEvents(
+        EventFilter[IllegalStateException]("OHNOES", occurrences = 1),
+        EventFilter.warning(pattern = "dead.*test", occurrences = 1)) {
+          latch.countDown()
+        }
       expectMsg("parent restarted")
       expectMsg("child terminated")
       parent ! "test"

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
@@ -408,7 +408,6 @@ class SupervisorSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitSende
 
       val latch = TestLatch()
       parent ! latch
-      parent ! "testchild"
       EventFilter[IllegalStateException]("OHNOES", occurrences = 1) intercept {
         latch.countDown()
       }


### PR DESCRIPTION
If the "testchild" message is still in the parent's mailbox while the parent is restarted, it will be delivered for the parent's brand new child after restart who will reply.

I think the race came out because Failed is now a system message and the timing has changed.
