### PR TITLE
include bound localAddress in Bound message, see #3230

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
@@ -22,7 +22,7 @@ class CapacityLimitSpec extends AkkaSpec("akka.loglevel = ERROR\nakka.io.tcp.max
       val commander = TestProbe()
       val addresses = temporaryServerAddresses(2)
       commander.send(IO(Tcp), Bind(bindHandler.ref, addresses(0)))
-      commander.expectMsg(Bound)
+      commander.expectMsg(Bound(addresses(0)))
 
       // we are now at the configured max-channel capacity of 4
 

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
@@ -24,7 +24,7 @@ trait TcpIntegrationSpecSupport { _: AkkaSpec ⇒
     def bindServer(): Unit = {
       val bindCommander = TestProbe()
       bindCommander.send(IO(Tcp), Bind(bindHandler.ref, endpoint, options = bindOptions))
-      bindCommander.expectMsg(Bound)
+      bindCommander.expectMsg(Bound(endpoint))
     }
 
     def establishNewClientConnection(): (TestProbe, ActorRef, TestProbe, ActorRef) = {

--- a/akka-actor-tests/src/test/scala/akka/io/TcpListenerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpListenerSpec.scala
@@ -23,7 +23,7 @@ class TcpListenerSpec extends AkkaSpec("akka.io.tcp.batch-accept-limit = 2") {
 
     "let the Bind commander know when binding is completed" in new TestSetup {
       listener ! ChannelRegistered
-      bindCommander.expectMsg(Bound)
+      bindCommander.expectMsgType[Bound]
     }
 
     "accept acceptable connections and register them with its parent" in new TestSetup {
@@ -102,7 +102,7 @@ class TcpListenerSpec extends AkkaSpec("akka.io.tcp.batch-accept-limit = 2") {
 
     def bindListener() {
       listener ! ChannelRegistered
-      bindCommander.expectMsg(Bound)
+      bindCommander.expectMsgType[Bound]
     }
 
     def attemptConnectionToEndpoint(): Unit = new Socket(endpoint.getHostName, endpoint.getPort)

--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
@@ -17,7 +17,7 @@ class UdpConnectedIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with 
   def bindUdp(address: InetSocketAddress, handler: ActorRef): ActorRef = {
     val commander = TestProbe()
     commander.send(IO(Udp), Udp.Bind(handler, address))
-    commander.expectMsg(Udp.Bound)
+    commander.expectMsg(Udp.Bound(address))
     commander.sender
   }
 

--- a/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
@@ -17,7 +17,7 @@ class UdpIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with ImplicitS
   def bindUdp(address: InetSocketAddress, handler: ActorRef): ActorRef = {
     val commander = TestProbe()
     commander.send(IO(Udp), Bind(handler, address))
-    commander.expectMsg(Bound)
+    commander.expectMsg(Bound(address))
     commander.sender
   }
 

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -117,8 +117,7 @@ object Tcp extends ExtensionKey[TcpExt] {
   case class Connected(remoteAddress: InetSocketAddress, localAddress: InetSocketAddress) extends Event
   case class CommandFailed(cmd: Command) extends Event
 
-  sealed trait Bound extends Event
-  case object Bound extends Bound
+  case class Bound(localAddress: InetSocketAddress) extends Event
   sealed trait Unbound extends Event
   case object Unbound extends Unbound
 

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -54,8 +54,7 @@ object Udp extends ExtensionKey[UdpExt] {
   case class Received(data: ByteString, sender: InetSocketAddress) extends Event
   case class CommandFailed(cmd: Command) extends Event
 
-  sealed trait Bound extends Event
-  case object Bound extends Bound
+  case class Bound(localAddress: InetSocketAddress) extends Event
 
   sealed trait SimpleSendReady extends Event
   case object SimpleSendReady extends SimpleSendReady


### PR DESCRIPTION
- done for Tcp & Udp in the same way
- also try to fix TcpConnectionSpec on my Mac
