### PR TITLE
clean up DeathWatch semantics, see #3222

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -96,7 +96,7 @@ case class ActorIdentity(correlationId: Any, ref: Option[ActorRef]) {
 @SerialVersionUID(1L)
 case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
   @BeanProperty val existenceConfirmed: Boolean,
-  @BeanProperty val addressTerminated: Boolean) extends PossiblyHarmful
+  @BeanProperty val addressTerminated: Boolean) extends AutoReceivedMessage with PossiblyHarmful
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -470,6 +470,7 @@ private[akka] class ActorCell(
         publish(Debug(self.path.toString, clazz(actor), "received AutoReceiveMessage " + msg))
 
       msg.message match {
+        case t: Terminated              ⇒ receivedTerminated(t)
         case AddressTerminated(address) ⇒ addressTerminated(address)
         case Kill                       ⇒ throw new ActorKilledException("Kill")
         case PoisonPill                 ⇒ self.stop()

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -154,6 +154,7 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
     def defaultDecider: Decider = {
       case _: ActorInitializationException ⇒ Stop
       case _: ActorKilledException         ⇒ Stop
+      case _: DeathPactException           ⇒ Stop
       case _: Exception                    ⇒ Restart
     }
     OneForOneStrategy()(defaultDecider)

--- a/akka-docs/rst/java/untyped-actors.rst
+++ b/akka-docs/rst/java/untyped-actors.rst
@@ -196,9 +196,10 @@ monitoring of an already terminated actor leads to the immediate generation of
 the :class:`Terminated` message.
 
 It is also possible to deregister from watching another actor’s liveliness
-using ``context.unwatch(target)``, but obviously this cannot guarantee
-non-reception of the :class:`Terminated` message because that may already have
-been queued.
+using ``getContext().unwatch(target)``. This works even if the
+:class:`Terminated` message has already been enqueued in the mailbox; after
+calling :meth:`unwatch` no :class:`Terminated` message for that actor will be
+processed anymore.
 
 Start Hook
 ----------

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -310,9 +310,9 @@ monitoring of an already terminated actor leads to the immediate generation of
 the :class:`Terminated` message.
 
 It is also possible to deregister from watching another actor’s liveliness
-using ``context.unwatch(target)``, but obviously this cannot guarantee
-non-reception of the :class:`Terminated` message because that may already have
-been queued.
+using ``context.unwatch(target)``. This works even if the :class:`Terminated`
+message has already been enqueued in the mailbox; after calling :meth:`unwatch`
+no :class:`Terminated` message for that actor will be processed anymore.
 
 Start Hook
 ----------


### PR DESCRIPTION
- DeathPactException => Stop in defaultStrategy
- ensure that after calling `context unwatch ref` we will not process a
  Terminated(`ref`) anymore, even if it was already enqueued (i.e.
  unwatch() happens between DeathWatchNotification and Terminated)
