### PR TITLE
Temp workaround in tests for the duplicate MemberUp events, see #3239

### DIFF
--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -80,8 +80,14 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
 
       Cluster(system) join firstAddress
 
-      receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
-          Set(firstAddress, secondAddress, thirdAddress))
+      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
+      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
+      import akka.actor.Address
+      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
+        val members = got + expectMsgType[MemberUp].member.address
+        if (members != expected) awaitMembersUp(expected, members)
+      }
+      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -97,8 +97,14 @@ abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
       system.actorOf(Props[StatsWorker], "statsWorker")
       system.actorOf(Props[StatsService], "statsService")
 
-      receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
-          Set(firstAddress, secondAddress, thirdAddress))
+      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
+      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
+      import akka.actor.Address
+      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
+        val members = got + expectMsgType[MemberUp].member.address
+        if (members != expected) awaitMembersUp(expected, members)
+      }
+      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
@@ -82,8 +82,14 @@ abstract class StatsSampleJapiSpec extends MultiNodeSpec(StatsSampleJapiSpecConf
       system.actorOf(Props[StatsWorker], "statsWorker")
       system.actorOf(Props[StatsService], "statsService")
 
-      receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
-          Set(firstAddress, secondAddress, thirdAddress))
+      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
+      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
+      import akka.actor.Address
+      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
+        val members = got + expectMsgType[MemberUp].member.address
+        if (members != expected) awaitMembersUp(expected, members)
+      }
+      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
@@ -80,8 +80,14 @@ abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSample
 
       Cluster(system) join firstAddress
 
-      receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
-          Set(firstAddress, secondAddress, thirdAddress))
+      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
+      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
+      import akka.actor.Address
+      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
+        val members = got + expectMsgType[MemberUp].member.address
+        if (members != expected) awaitMembersUp(expected, members)
+      }
+      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 


### PR DESCRIPTION
To avoid all know failures in the nightly builds.
