### PR TITLE
Change member prio for Joining/Up, see #3239

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -127,18 +127,17 @@ object Member {
    * Picks the Member with the highest "priority" MemberStatus.
    */
   def highestPriorityOf(m1: Member, m2: Member): Member = (m1.status, m2.status) match {
-    case (Removed, _)       ⇒ m1
-    case (_, Removed)       ⇒ m2
-    case (Down, _)          ⇒ m1
-    case (_, Down)          ⇒ m2
-    case (Exiting, _)       ⇒ m1
-    case (_, Exiting)       ⇒ m2
-    case (Leaving, _)       ⇒ m1
-    case (_, Leaving)       ⇒ m2
-    case (Up, Joining)      ⇒ m2
-    case (Joining, Up)      ⇒ m1
-    case (Joining, Joining) ⇒ m1
-    case (Up, Up)           ⇒ m1
+    case (Removed, _) ⇒ m1
+    case (_, Removed) ⇒ m2
+    case (Down, _)    ⇒ m1
+    case (_, Down)    ⇒ m2
+    case (Exiting, _) ⇒ m1
+    case (_, Exiting) ⇒ m2
+    case (Leaving, _) ⇒ m1
+    case (_, Leaving) ⇒ m2
+    case (Joining, _) ⇒ m2
+    case (_, Joining) ⇒ m1
+    case (Up, Up)     ⇒ m1
   }
 
 }

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -39,11 +39,11 @@ class GossipSpec extends WordSpec with MustMatchers {
 
       val merged1 = g1 merge g2
       merged1.members must be(SortedSet(a2, c1, e1))
-      merged1.members.toSeq.map(_.status) must be(Seq(Joining, Leaving, Joining))
+      merged1.members.toSeq.map(_.status) must be(Seq(Up, Leaving, Up))
 
       val merged2 = g2 merge g1
       merged2.members must be(SortedSet(a2, c1, e1))
-      merged2.members.toSeq.map(_.status) must be(Seq(Joining, Leaving, Joining))
+      merged2.members.toSeq.map(_.status) must be(Seq(Up, Leaving, Up))
 
     }
 
@@ -53,11 +53,11 @@ class GossipSpec extends WordSpec with MustMatchers {
 
       val merged1 = g1 merge g2
       merged1.overview.unreachable must be(Set(a2, b2, c1, d2))
-      merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Joining, Removed, Leaving, Removed))
+      merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
 
       val merged2 = g2 merge g1
       merged2.overview.unreachable must be(Set(a2, b2, c1, d2))
-      merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Joining, Removed, Leaving, Removed))
+      merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Up, Removed, Leaving, Removed))
 
     }
 
@@ -67,13 +67,13 @@ class GossipSpec extends WordSpec with MustMatchers {
 
       val merged1 = g1 merge g2
       merged1.members must be(SortedSet(a2))
-      merged1.members.toSeq.map(_.status) must be(Seq(Joining))
+      merged1.members.toSeq.map(_.status) must be(Seq(Up))
       merged1.overview.unreachable must be(Set(b2, c1, d2))
       merged1.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Removed, Leaving, Removed))
 
       val merged2 = g2 merge g1
       merged2.members must be(SortedSet(a2))
-      merged2.members.toSeq.map(_.status) must be(Seq(Joining))
+      merged2.members.toSeq.map(_.status) must be(Seq(Up))
       merged2.overview.unreachable must be(Set(b2, c1, d2))
       merged2.overview.unreachable.toSeq.sorted.map(_.status) must be(Seq(Removed, Leaving, Removed))
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -80,14 +80,8 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
 
       Cluster(system) join firstAddress
 
-      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
-      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
-      import akka.actor.Address
-      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
-        val members = got + expectMsgType[MemberUp].member.address
-        if (members != expected) awaitMembersUp(expected, members)
-      }
-      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
+       receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
+           Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -97,14 +97,8 @@ abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
       system.actorOf(Props[StatsWorker], "statsWorker")
       system.actorOf(Props[StatsService], "statsService")
 
-      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
-      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
-      import akka.actor.Address
-      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
-        val members = got + expectMsgType[MemberUp].member.address
-        if (members != expected) awaitMembersUp(expected, members)
-      }
-      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
+      receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
+           Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
@@ -82,14 +82,8 @@ abstract class StatsSampleJapiSpec extends MultiNodeSpec(StatsSampleJapiSpecConf
       system.actorOf(Props[StatsWorker], "statsWorker")
       system.actorOf(Props[StatsService], "statsService")
 
-      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
-      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
-      import akka.actor.Address
-      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
-        val members = got + expectMsgType[MemberUp].member.address
-        if (members != expected) awaitMembersUp(expected, members)
-      }
-      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
+      receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
+           Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
@@ -80,14 +80,8 @@ abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSample
 
       Cluster(system) join firstAddress
 
-      // FIXME ticket 3239 duplicate MemberUp events, it should be possible to use
-      // receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (Set(firstAddress, secondAddress, thirdAddress))
-      import akka.actor.Address
-      @scala.annotation.tailrec def awaitMembersUp(expected: Set[Address], got: Set[Address] = Set.empty): Unit = {
-        val members = got + expectMsgType[MemberUp].member.address
-        if (members != expected) awaitMembersUp(expected, members)
-      }
-      awaitMembersUp(Set(firstAddress, secondAddress, thirdAddress))
+      receiveN(3).collect { case MemberUp(m) => m.address }.toSet must be (
+           Set(firstAddress, secondAddress, thirdAddress))
 
       Cluster(system).unsubscribe(testActor)
 


### PR DESCRIPTION
- Sometimes caused duplicate MemberUp events, after conflicting gossips

This is what is going on:

first: first join first
members=[first:J] vclock=[first:1]

first: second join first
members=[first:J, second:J] vclock=[first:2]

first: third join first
members=[first:J, second:J, third:J] vclock=[first:3]

second: leader actions second -> Up, first -> Up
(note that third is not here yet)
members=[first:U, second:U] vclock=[first:2, second:1]

second: receive gossip from first
merge conflict
expected merged result: members=[first:U, second:U, third:J] vclock=[first:3, second:1]
but got merged result: members=[first:J, second:J, third:J] vclock=[first:3, second:1]

second: leader actions second -> Up, first -> Up, third -> Up
members=[first:U, second:U, third:U] vclock=[first:3, second:2]

WHAT, why are Joining higher priority than Up?

The reason was probably to support the previous (broken) re-joining.
