### PR TITLE
API adjustments to ClusterClient, see #3264

### DIFF
--- a/akka-contrib/docs/cluster-client.rst
+++ b/akka-contrib/docs/cluster-client.rst
@@ -18,9 +18,27 @@ or as an ordinary actor.
 
 You can send messages via the ``ClusterClient`` to any actor in the cluster that is registered
 in the ``DistributedPubSubMediator`` used by the ``ClusterReceptionist``.
-Messages are wrapped in ``DistributedPubSubMediator.Send``, ``DistributedPubSubMediator.SendToAll``
-or ``DistributedPubSubMediator.Publish`` with the semantics described in
-:ref:`distributed-pub-sub`.
+The ``ClusterReceptionistExtension`` provides methods for registration of actors that
+should be reachable from the client. Messages are wrapped in ``ClusterClient.Send``,
+``ClusterClient.SendToAll`` or ``ClusterClient.Publish``.
+
+**1. ClusterClient.Send**
+
+The message will be delivered to one recipient with a matching path, if any such
+exists. If several entries match the path the message will be delivered
+to one random destination. The sender of the message can specify that local
+affinity is preferred, i.e. the message is sent to an actor in the same local actor
+system as the used receptionist actor, if any such exists, otherwise random to any other
+matching entry.
+
+**2. ClusterClient.SendToAll**
+
+The message will be delivered to all recipients with a matching path.
+
+**3. ClusterClient.Publish**
+
+The message will be delivered to all recipients Actors that have been registered as subscribers
+to the named topic.
 
 Response messages from the destination actor are tunneled via the receptionist
 to avoid inbound connections from other cluster nodes to the client, i.e.
@@ -55,7 +73,7 @@ ClusterReceptionistExtension
 
 In the example above the receptionist is started and accessed with the ``akka.contrib.pattern.ClusterReceptionistExtension``.
 That is convenient and perfectly fine in most cases, but it can be good to know that it is possible to
-start the ````akka.contrib.pattern.ClusterReceptionist`` actor as an ordinary actor and you can have several
+start the ``akka.contrib.pattern.ClusterReceptionist`` actor as an ordinary actor and you can have several
 different receptionists at the same time, serving different types of clients.
 
 The ``ClusterReceptionistExtension`` can be configured with the following properties:


### PR DESCRIPTION
Based on feedback from @jboner 
- Message wrappers in ClusterClient, so that DistributedPubSubMediator
  is not leaking to the client api
- Register methods in ClusterReceptionistExtension, for convenience and
  clarity
