### PR TITLE
Solve UnreachableNodeJoinsAgainSpec problem, see #3247

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -72,6 +72,8 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
   implicit val ec = system.dispatcher
   import akka.routing.RoutingSpec._
 
+  muteDeadLetters("DeathWatchNotification.*")()
+
   "routers in general" must {
 
     "evict terminated routees" in {

--- a/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
@@ -56,6 +56,8 @@ class RemoteWatcherSpec extends AkkaSpec(
   val remoteSystem = ActorSystem("RemoteSystem", system.settings.config)
   val remoteAddress = remoteSystem.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
 
+  Seq(system, remoteSystem).foreach(muteDeadLetters("Disassociated.*", "DisassociateUnderlying.*")(_))
+
   override def afterTermination() {
     remoteSystem.shutdown()
   }

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
@@ -54,8 +54,6 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
         startup-timeout = 5 s
 
-        retry-gate-closed-for = 0 s
-
         use-passive-connections = on
       }
   """)

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -16,7 +16,6 @@ object AkkaProtocolStressTest {
       #loglevel = DEBUG
       actor.provider = "akka.remote.RemoteActorRefProvider"
 
-      remote.retry-gate-closed-for = 0 s
       remote.log-remote-lifecycle-events = on
 
       remote.transport-failure-detector {

--- a/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
@@ -37,7 +37,6 @@ object SystemMessageDeliveryStressTest {
       #loglevel = DEBUG
       actor.provider = "akka.remote.RemoteActorRefProvider"
 
-      remote.retry-gate-closed-for = 0 s
       remote.log-remote-lifecycle-events = on
 
       remote.failure-detector {

--- a/akka-remote/src/test/scala/akka/remote/transport/ThrottlerTransportAdapterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/ThrottlerTransportAdapterSpec.scala
@@ -18,7 +18,6 @@ object ThrottlerTransportAdapterSpec {
       actor.provider = "akka.remote.RemoteActorRefProvider"
 
       remote.netty.tcp.hostname = "localhost"
-      remote.retry-gate-closed-for = 0 s
       remote.log-remote-lifecycle-events = off
 
       remote.netty.tcp.applied-adapters = ["trttl"]


### PR DESCRIPTION
- UnreachableNodeJoinsAgain failed because of gated connection
- Removed default test value of retry-gate-closed-for, instead
  default from reference.conf is used, i.e. 0s
- deadLetters logging love
