### PR TITLE
Increase time limits in CircuitBreakerMTSpec, see #3243

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerMTSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerMTSpec.scala
@@ -12,8 +12,8 @@ import scala.annotation.tailrec
 class CircuitBreakerMTSpec extends AkkaSpec {
   implicit val ec = system.dispatcher
   "A circuit breaker being called by many threads" must {
-    val callTimeout = 1.second.dilated
-    val resetTimeout = 2.seconds.dilated
+    val callTimeout = 2.second.dilated
+    val resetTimeout = 3.seconds.dilated
     val maxFailures = 5
     val breaker = new CircuitBreaker(system.scheduler, maxFailures, callTimeout, resetTimeout)
     val numberOfTestCalls = 100


### PR DESCRIPTION
The test failure was:

```
[info] - allow many calls while in closed state with no errors *** FAILED *** (1 second, 66 milliseconds)
[info] Set(succeed, CBO) was not equal to Set(succeed) (CircuitBreakerMTSpec.scala:52)
```

That is in the very first, simple scenario, and it can be explained by that it takes more than 1 second for one of the 100 Futures to complete. 

Increasing the callTimeout to 2 seconds should make it less sensitive (well it has not failed in months).
