### PR TITLE
Closing connections when decoding of message fails #3241

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/netty/Client.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Client.scala
@@ -18,7 +18,7 @@ import org.jboss.netty.handler.ssl.SslHandler
 import org.jboss.netty.handler.timeout.{ IdleState, IdleStateEvent, IdleStateAwareChannelHandler }
 import org.jboss.netty.util.{ Timeout, TimerTask, HashedWheelTimer }
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
+import scala.util.control.{NoStackTrace, NonFatal}
 
 /**
  * This is the abstract baseclass for netty remote clients, currently there's only an
@@ -305,7 +305,7 @@ private[akka] class ActiveRemoteClientHandler(
   }
 
   override def exceptionCaught(ctx: ChannelHandlerContext, event: ExceptionEvent) = {
-    val cause = if (event.getCause ne null) event.getCause else new Exception("Unknown cause")
+    val cause = if (event.getCause ne null) event.getCause else new Exception("Unknown cause") with NoStackTrace
     cause match {
       case _: ClosedChannelException ⇒ // Ignore
       case _ ⇒

--- a/akka-remote/src/main/scala/akka/remote/netty/Server.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Server.scala
@@ -14,6 +14,7 @@ import org.jboss.netty.bootstrap.ServerBootstrap
 import org.jboss.netty.channel._
 import org.jboss.netty.channel.group.ChannelGroup
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory
+import scala.util.control.NoStackTrace
 
 private[akka] class NettyRemoteServer(val netty: NettyRemoteTransport) {
 
@@ -175,7 +176,7 @@ private[akka] class RemoteServerHandler(
   }
 
   override def exceptionCaught(ctx: ChannelHandlerContext, event: ExceptionEvent) = {
-    val cause = if (event.getCause ne null) event.getCause else new Exception("Unknown cause")
+    val cause = if (event.getCause ne null) event.getCause else new Exception("Unknown cause") with NoStackTrace
     cause match {
       case _: ClosedChannelException ⇒ // Ignore
       case _ ⇒

--- a/akka-remote/src/main/scala/akka/remote/netty/Server.scala
+++ b/akka-remote/src/main/scala/akka/remote/netty/Server.scala
@@ -3,21 +3,17 @@
  */
 package akka.remote.netty
 
-import java.net.InetSocketAddress
-import java.util.concurrent.Executors
-import scala.Option.option2Iterable
-import org.jboss.netty.bootstrap.ServerBootstrap
-import org.jboss.netty.channel.ChannelHandler.Sharable
-import org.jboss.netty.channel.group.ChannelGroup
-import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory
-import org.jboss.netty.handler.codec.frame.{ LengthFieldPrepender, LengthFieldBasedFrameDecoder }
-import org.jboss.netty.handler.execution.ExecutionHandler
+import akka.actor.Address
 import akka.remote.RemoteProtocol.{ RemoteControlProtocol, CommandType, AkkaRemoteProtocol }
 import akka.remote.{ RemoteServerShutdown, RemoteServerError, RemoteServerClientDisconnected, RemoteServerClientConnected, RemoteServerClientClosed, RemoteProtocol, RemoteMessage }
-import akka.actor.Address
 import java.net.InetAddress
-import akka.actor.ActorSystemImpl
+import java.net.InetSocketAddress
+import java.nio.channels.ClosedChannelException
+import java.util.concurrent.Executors
+import org.jboss.netty.bootstrap.ServerBootstrap
 import org.jboss.netty.channel._
+import org.jboss.netty.channel.group.ChannelGroup
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory
 
 private[akka] class NettyRemoteServer(val netty: NettyRemoteTransport) {
 
@@ -179,8 +175,13 @@ private[akka] class RemoteServerHandler(
   }
 
   override def exceptionCaught(ctx: ChannelHandlerContext, event: ExceptionEvent) = {
-    netty.notifyListeners(RemoteServerError(event.getCause, netty))
-    event.getChannel.close()
+    val cause = if (event.getCause ne null) event.getCause else new Exception("Unknown cause")
+    cause match {
+      case _: ClosedChannelException ⇒ // Ignore
+      case _ ⇒
+        netty.notifyListeners(RemoteServerError(event.getCause, netty))
+        event.getChannel.close()
+    }
   }
 }
 


### PR DESCRIPTION
Force connection to be closed when a corrupt serialized message is received.
