### PR TITLE
Reduce amount of spurious exceptions during remoting shutdown

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -417,7 +417,8 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
     for {
       // Force flush by trying to write an empty buffer and wait for success
       _ ← always(channelGroup.write(ChannelBuffers.buffer(0)))
-      _ ← always({ channelGroup.unbind(); channelGroup.disconnect() })
+      _ ← always(channelGroup.unbind())
+      _ ← always(channelGroup.disconnect())
       _ ← always(channelGroup.close())
     } {
       // Release the selectors, but don't try to kill the dispatcher

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
@@ -91,5 +91,5 @@ private[remote] class TcpAssociationHandle(val localAddress: Address,
       true
     } else false
 
-  override def disassociate(): Unit = NettyTransport.gracefulClose(channel)
+  override def disassociate(): Unit = if (channel.isOpen) NettyTransport.gracefulClose(channel)
 }


### PR DESCRIPTION
If the remoting is already in flushing mode, and an inbound association arrives, we try to disassociate it immediately -- causing a spurious exception that is harmless, but annoying if the driver has been shut down already.

This fix attempts to reduce the window for that to happen. If someone could just check it and see if it happens again, that would be awesome.
