### PR TITLE
Prepare Cluster StressSpec for heavy testing, see #2787

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -72,7 +72,7 @@ class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with 
   implicit val ec = system.dispatcher
   import akka.routing.RoutingSpec._
 
-  muteDeadLetters("DeathWatchNotification.*")()
+  muteDeadLetters(classOf[akka.dispatch.sysmsg.DeathWatchNotification])()
 
   "routers in general" must {
 

--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -99,7 +99,15 @@ message GossipEnvelope {
   required UniqueAddress from = 1;
   required UniqueAddress to = 2;
   required Gossip gossip = 3;
-  required bool conversation = 4;
+}
+
+/**
+ * Gossip Status
+ */
+message GossipStatus {
+  required UniqueAddress from = 1;
+  repeated string allHashes = 2;
+  required VectorClock version = 3;
 }
 
 /**

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -850,7 +850,7 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
       val localUnreachableMembers = localGossip.overview.unreachable
 
       val newlyDetectedUnreachableMembers = localMembers filterNot { member ⇒
-        member.uniqueAddress == selfUniqueAddress || failureDetector.isAvailable(member.address)
+        member.uniqueAddress == selfUniqueAddress || member.status == Exiting || failureDetector.isAvailable(member.address)
       }
 
       if (newlyDetectedUnreachableMembers.nonEmpty) {

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -299,7 +299,6 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
     case ClusterUserAction.JoinTo(address) ⇒ join(address)
     case JoinSeedNodes(seedNodes)          ⇒ joinSeedNodes(seedNodes)
     case msg: SubscriptionMessage          ⇒ publisher forward msg
-    case _: Tick                           ⇒ // ignore periodic tasks until initialized
   }
 
   def tryingToJoin(joinWith: Address, deadline: Option[Deadline]): Actor.Receive = {
@@ -322,6 +321,7 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
   def initialized: Actor.Receive = {
     case msg: GossipEnvelope              ⇒ receiveGossip(msg)
+    case msg: GossipStatus                ⇒ receiveGossipStatus(msg)
     case GossipTick                       ⇒ gossip()
     case ReapUnreachableTick              ⇒ reapUnreachableMembers()
     case LeaderActionsTick                ⇒ leaderActions()
@@ -341,10 +341,16 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
   def removed: Actor.Receive = {
     case msg: SubscriptionMessage ⇒ publisher forward msg
-    case _: Tick                  ⇒ // ignore periodic tasks
   }
 
   def receive = uninitialized
+
+  override def unhandled(message: Any): Unit = message match {
+    case _: Tick           ⇒
+    case _: GossipEnvelope ⇒
+    case _: GossipStatus   ⇒
+    case other             ⇒ super.unhandled(other)
+  }
 
   def initJoin(): Unit = sender ! InitJoinAck(selfAddress)
 
@@ -448,7 +454,7 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
         log.info("Cluster Node [{}] - Node [{}] is JOINING, roles [{}]", selfAddress, node.address, roles.mkString(", "))
         if (node != selfUniqueAddress) {
-          clusterCore(node.address) ! Welcome(selfUniqueAddress, latestGossip)
+          sender ! Welcome(selfUniqueAddress, latestGossip)
         }
 
         publish(latestGossip)
@@ -468,7 +474,7 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
       latestGossip = gossip seen selfUniqueAddress
       publish(latestGossip)
       if (from != selfUniqueAddress)
-        oneWayGossipTo(from)
+        gossipTo(from, sender)
       context.become(initialized)
     }
   }
@@ -564,6 +570,21 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
     publish(latestGossip)
   }
 
+  def receiveGossipStatus(status: GossipStatus): Unit = {
+    val from = status.from
+    if (latestGossip.overview.unreachable.exists(_.uniqueAddress == from))
+      log.info("Ignoring received gossip status from unreachable [{}] ", from)
+    else if (latestGossip.members.forall(_.uniqueAddress != from))
+      log.info("Ignoring received gossip status from unknown [{}]", from)
+    else {
+      (status.version tryCompareTo latestGossip.version) match {
+        case Some(0)          ⇒ // same version
+        case Some(x) if x > 0 ⇒ gossipStatusTo(from, sender) // remote is newer
+        case _                ⇒ gossipTo(from, sender) // conflicting or local is newer
+      }
+    }
+  }
+
   /**
    * Receive new gossip.
    */
@@ -585,7 +606,6 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
     else {
 
       val comparison = remoteGossip.version tryCompareTo localGossip.version
-      val conflict = comparison.isEmpty
 
       val (winningGossip, talkback, newStats) = comparison match {
         case None ⇒
@@ -612,7 +632,7 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
       log.debug("Cluster Node [{}] - Receiving gossip from [{}]", selfAddress, from)
 
-      if (conflict) {
+      if (comparison.isEmpty) {
         log.debug(
           """Couldn't establish a causal relationship between "remote" gossip and "local" gossip - Remote[{}] - Local[{}] - merged them into [{}]""",
           remoteGossip, localGossip, winningGossip)
@@ -621,10 +641,10 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
       stats = stats.incrementReceivedGossipCount
       publish(latestGossip)
 
-      if (envelope.conversation && talkback) {
+      if (talkback) {
         // send back gossip to sender when sender had different view, i.e. merge, or sender had
         // older or sender had newer
-        gossipTo(from)
+        gossipTo(from, sender)
       }
     }
   }
@@ -640,7 +660,7 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
     if (!isSingletonCluster && isAvailable) {
       val localGossip = latestGossip
 
-      val preferredGossipTargets =
+      val preferredGossipTargets: Vector[UniqueAddress] =
         if (ThreadLocalRandom.current.nextDouble() < GossipDifferentViewProbability) { // If it's time to try to gossip to some nodes with a different view
           // gossip to a random alive member with preference to a member with older or newer gossip version
           val localMemberAddressesSet = localGossip.members map { _.uniqueAddress }
@@ -650,13 +670,23 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
             if version != localGossip.version
           } yield node
 
-          nodesWithDifferentView.toIndexedSeq
+          nodesWithDifferentView.toVector
         } else Vector.empty[UniqueAddress]
 
-      gossipToRandomNodeOf(
-        if (preferredGossipTargets.nonEmpty) preferredGossipTargets
-        else localGossip.members.toIndexedSeq.map(_.uniqueAddress) // Fall back to localGossip; important to not accidentally use `map` of the SortedSet, since the original order is not preserved)
-        )
+      if (preferredGossipTargets.nonEmpty) {
+        val peer = selectRandomNode(preferredGossipTargets filterNot (_ == selfUniqueAddress))
+        // send full gossip because it has different view
+        peer foreach gossipTo
+      } else {
+        // Fall back to localGossip; important to not accidentally use `map` of the SortedSet, since the original order is not preserved)
+        val peer = selectRandomNode(localGossip.members.toIndexedSeq.collect {
+          case m if m.uniqueAddress != selfUniqueAddress ⇒ m.uniqueAddress
+        })
+        peer foreach { node ⇒
+          if (localGossip.seenByNode(node)) gossipStatusTo(node)
+          else gossipTo(node)
+        }
+      }
     }
   }
 
@@ -882,18 +912,6 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
   def isAvailable: Boolean = !latestGossip.isUnreachable(selfUniqueAddress)
 
-  /**
-   * Gossips latest gossip to a random member in the set of members passed in as argument.
-   *
-   * @return the used [[UniqueAddress]] if any
-   */
-  private def gossipToRandomNodeOf(nodes: immutable.IndexedSeq[UniqueAddress]): Option[UniqueAddress] = {
-    // filter out myself
-    val peer = selectRandomNode(nodes filterNot (_ == selfUniqueAddress))
-    peer foreach gossipTo
-    peer
-  }
-
   // needed for tests
   def sendGossipTo(address: Address): Unit = {
     latestGossip.members.foreach(m ⇒
@@ -905,14 +923,23 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
    * Gossips latest gossip to a node.
    */
   def gossipTo(node: UniqueAddress): Unit =
-    gossipTo(node, GossipEnvelope(selfUniqueAddress, node, latestGossip, conversation = true))
+    if (validNodeForGossip(node))
+      clusterCore(node.address) ! GossipEnvelope(selfUniqueAddress, node, latestGossip)
 
-  def oneWayGossipTo(node: UniqueAddress): Unit =
-    gossipTo(node, GossipEnvelope(selfUniqueAddress, node, latestGossip, conversation = false))
+  def gossipTo(node: UniqueAddress, destination: ActorRef): Unit =
+    if (validNodeForGossip(node))
+      destination ! GossipEnvelope(selfUniqueAddress, node, latestGossip)
 
-  def gossipTo(node: UniqueAddress, gossipMsg: GossipEnvelope): Unit =
-    if (node != selfUniqueAddress && gossipMsg.gossip.members.exists(_.uniqueAddress == node))
-      clusterCore(node.address) ! gossipMsg
+  def gossipStatusTo(node: UniqueAddress, destination: ActorRef): Unit =
+    if (validNodeForGossip(node))
+      destination ! GossipStatus(selfUniqueAddress, latestGossip.version)
+
+  def gossipStatusTo(node: UniqueAddress): Unit =
+    if (validNodeForGossip(node))
+      clusterCore(node.address) ! GossipStatus(selfUniqueAddress, latestGossip.version)
+
+  def validNodeForGossip(node: UniqueAddress): Boolean =
+    (node != selfUniqueAddress && latestGossip.members.exists(_.uniqueAddress == node))
 
   def publish(newGossip: Gossip): Unit = {
     publisher ! PublishChanges(newGossip)

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -239,4 +239,14 @@ private[cluster] case class GossipOverview(
  * different in that case.
  */
 @SerialVersionUID(1L)
-private[cluster] case class GossipEnvelope(from: UniqueAddress, to: UniqueAddress, gossip: Gossip, conversation: Boolean = true) extends ClusterMessage
+private[cluster] case class GossipEnvelope(from: UniqueAddress, to: UniqueAddress, gossip: Gossip) extends ClusterMessage
+
+/**
+ * INTERNAL API
+ * When there are no known changes to the node ring a `GossipStatus`
+ * initiates a gossip chat between two members. If the receiver has a newer
+ * version it replies with a `GossipEnvelope`. If receiver has older version
+ * it replies with its `GossipStatus`. Same versions ends the chat immediately.
+ */
+@SerialVersionUID(1L)
+private[cluster] case class GossipStatus(from: UniqueAddress, version: VectorClock) extends ClusterMessage

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -37,6 +37,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     classOf[ClusterHeartbeatReceiver.Heartbeat] -> (bytes ⇒ ClusterHeartbeatReceiver.Heartbeat(addressFromBinary(bytes))),
     classOf[ClusterHeartbeatReceiver.EndHeartbeat] -> (bytes ⇒ ClusterHeartbeatReceiver.EndHeartbeat(addressFromBinary(bytes))),
     classOf[ClusterHeartbeatSender.HeartbeatRequest] -> (bytes ⇒ ClusterHeartbeatSender.HeartbeatRequest(addressFromBinary(bytes))),
+    classOf[GossipStatus] -> gossipStatusFromBinary,
     classOf[GossipEnvelope] -> gossipEnvelopeFromBinary,
     classOf[MetricsGossipEnvelope] -> metricsGossipEnvelopeFromBinary)
 
@@ -49,6 +50,8 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
       addressToProto(from)
     case m: GossipEnvelope ⇒
       gossipEnvelopeToProto(m)
+    case m: GossipStatus ⇒
+      gossipStatusToProto(m)
     case m: MetricsGossipEnvelope ⇒
       metricsGossipEnvelopeToProto(m)
     case InternalClusterAction.Join(node, roles) ⇒
@@ -140,20 +143,14 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
 
     def mapUniqueAddress(uniqueAddress: UniqueAddress) = mapWithErrorMessage(addressMapping, uniqueAddress, "address")
     def mapRole(role: String) = mapWithErrorMessage(roleMapping, role, "role")
-    def mapHash(hash: String) = mapWithErrorMessage(hashMapping, hash, "hash")
 
     def memberToProto(member: Member) = {
       msg.Member(mapUniqueAddress(member.uniqueAddress), msg.MemberStatus.valueOf(memberStatusToInt(member.status)), member.roles.map(mapRole).to[Vector])
     }
 
-    def vectorClockToProto(version: VectorClock) = {
-      msg.VectorClock(version.timestamp.time,
-        version.versions.map { case (n, t) ⇒ msg.VectorClock.Version(mapHash(n.hash), t.time) }.to[Vector])
-    }
-
     def seenToProto(seen: (UniqueAddress, VectorClock)) = seen match {
       case (address: UniqueAddress, version: VectorClock) ⇒
-        msg.GossipOverview.Seen(mapUniqueAddress(address), vectorClockToProto(version))
+        msg.GossipOverview.Seen(mapUniqueAddress(address), vectorClockToProto(version, hashMapping))
     }
 
     val unreachable = gossip.overview.unreachable.map(memberToProto).to[Vector]
@@ -163,16 +160,32 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     val overview = msg.GossipOverview(seen, unreachable)
 
     msg.Gossip(allAddresses.map(uniqueAddressToProto),
-      allRoles, allHashes, members, overview, vectorClockToProto(gossip.version))
+      allRoles, allHashes, members, overview, vectorClockToProto(gossip.version, hashMapping))
+  }
+
+  private def vectorClockToProto(version: VectorClock, hashMapping: Map[String, Int]): msg.VectorClock = {
+    def mapHash(hash: String) = mapWithErrorMessage(hashMapping, hash, "hash")
+    msg.VectorClock(version.timestamp.time,
+      version.versions.map { case (n, t) ⇒ msg.VectorClock.Version(mapHash(n.hash), t.time) }.to[Vector])
   }
 
   private def gossipEnvelopeToProto(envelope: GossipEnvelope): msg.GossipEnvelope = {
     msg.GossipEnvelope(uniqueAddressToProto(envelope.from), uniqueAddressToProto(envelope.to),
-      gossipToProto(envelope.gossip), envelope.conversation)
+      gossipToProto(envelope.gossip))
+  }
+
+  private def gossipStatusToProto(status: GossipStatus): msg.GossipStatus = {
+    val allHashes: Vector[String] = status.version.versions.keys.map(_.hash)(collection.breakOut)
+    val hashMapping = allHashes.zipWithIndex.toMap
+    msg.GossipStatus(uniqueAddressToProto(status.from), allHashes, vectorClockToProto(status.version, hashMapping))
   }
 
   private def gossipEnvelopeFromBinary(bytes: Array[Byte]): GossipEnvelope = {
     gossipEnvelopeFromProto(msg.GossipEnvelope.defaultInstance.mergeFrom(bytes))
+  }
+
+  private def gossipStatusFromBinary(bytes: Array[Byte]): GossipStatus = {
+    gossipStatusFromProto(msg.GossipStatus.defaultInstance.mergeFrom(bytes))
   }
 
   private def gossipFromProto(gossip: msg.Gossip): Gossip = {
@@ -185,28 +198,33 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
         member.rolesIndexes.map(roleMapping).to[Set])
     }
 
-    def vectorClockFromProto(version: msg.VectorClock) = {
-      VectorClock(VectorClock.Timestamp(version.timestamp),
-        version.versions.map {
-          case msg.VectorClock.Version(h, t) ⇒
-            (VectorClock.Node.fromHash(hashMapping(h)), VectorClock.Timestamp(t))
-        }.toMap)
-    }
-
     def seenFromProto(seen: msg.GossipOverview.Seen) =
-      (addressMapping(seen.addressIndex), vectorClockFromProto(seen.version))
+      (addressMapping(seen.addressIndex), vectorClockFromProto(seen.version, hashMapping))
 
     val members = gossip.members.map(memberFromProto).to[immutable.SortedSet]
     val unreachable = gossip.overview.unreachable.map(memberFromProto).toSet
     val seen = gossip.overview.seen.map(seenFromProto).toMap
     val overview = GossipOverview(seen, unreachable)
 
-    Gossip(members, overview, vectorClockFromProto(gossip.version))
+    Gossip(members, overview, vectorClockFromProto(gossip.version, hashMapping))
+  }
+
+  private def vectorClockFromProto(version: msg.VectorClock, hashMapping: immutable.Seq[String]) = {
+    VectorClock(VectorClock.Timestamp(version.timestamp),
+      version.versions.map {
+        case msg.VectorClock.Version(h, t) ⇒
+          (VectorClock.Node.fromHash(hashMapping(h)), VectorClock.Timestamp(t))
+      }.toMap)
   }
 
   private def gossipEnvelopeFromProto(envelope: msg.GossipEnvelope): GossipEnvelope = {
     GossipEnvelope(uniqueAddressFromProto(envelope.from), uniqueAddressFromProto(envelope.to),
       gossipFromProto(envelope.gossip))
+  }
+
+  private def gossipStatusFromProto(status: msg.GossipStatus): GossipStatus = {
+    val hashMapping = status.allHashes
+    GossipStatus(uniqueAddressFromProto(status.from), vectorClockFromProto(status.version, hashMapping))
   }
 
   private def metricsGossipEnvelopeToProto(envelope: MetricsGossipEnvelope): msg.MetricsGossipEnvelope = {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -108,6 +108,7 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
         classOf[ClusterHeartbeatReceiver.Heartbeat],
         classOf[ClusterHeartbeatReceiver.EndHeartbeat],
         classOf[GossipEnvelope],
+        classOf[GossipStatus],
         classOf[MetricsGossipEnvelope],
         classOf[ClusterEvent.ClusterMetricsChanged],
         classOf[InternalClusterAction.Tick],

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -105,16 +105,18 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
         }
 
       muteDeadLetters(
-        "Heartbeat.*",
-        "GossipEnvelope.*",
-        "ClusterMetricsChanged.*",
-        "Disassociated.*",
-        "DisassociateUnderlying.*",
-        "HandleListenerRegistered.*",
-        "PoisonPill.*",
-        "DeathWatchNotification.*",
-        "NullMessage.*",
-        "InboundPayload.*")(sys)
+        classOf[ClusterHeartbeatReceiver.Heartbeat],
+        classOf[ClusterHeartbeatReceiver.EndHeartbeat],
+        classOf[GossipEnvelope],
+        classOf[MetricsGossipEnvelope],
+        classOf[ClusterEvent.ClusterMetricsChanged],
+        classOf[InternalClusterAction.Tick],
+        classOf[akka.actor.PoisonPill],
+        classOf[akka.dispatch.sysmsg.DeathWatchNotification],
+        akka.dispatch.NullMessage.getClass,
+        akka.remote.transport.AssociationHandle.Disassociated.getClass,
+        akka.remote.transport.ActorTransportAdapter.DisassociateUnderlying.getClass,
+        classOf[akka.remote.transport.AssociationHandle.InboundPayload])(sys)
 
     }
   }
@@ -289,6 +291,8 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
       awaitAssert(clusterView.leader must be(expectedLeader))
     }
   }
+
+  def awaitAllReachable(): Unit = awaitAssert(clusterView.unreachableMembers.isEmpty)
 
   /**
    * Wait until the specified nodes have seen the same gossip overview.

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -1191,40 +1191,40 @@ abstract class StressSpec
           workResult.sendCount must be > (0L)
           workResult.ackCount must be > (0L)
         }
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "use routers with normal throughput" taggedAs LongRunningTest in {
       if (exerciseActors) {
         exerciseRouters("use routers with normal throughput", normalThroughputDuration,
           batchInterval = workBatchInterval, expectDroppedMessages = false, tree = false)
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "use routers with high throughput" taggedAs LongRunningTest in {
       if (exerciseActors) {
         exerciseRouters("use routers with high throughput", highThroughputDuration,
           batchInterval = Duration.Zero, expectDroppedMessages = false, tree = false)
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "use many actors with normal throughput" taggedAs LongRunningTest in {
       if (exerciseActors) {
         exerciseRouters("use many actors with normal throughput", normalThroughputDuration,
           batchInterval = workBatchInterval, expectDroppedMessages = false, tree = true)
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "use many actors with high throughput" taggedAs LongRunningTest in {
       if (exerciseActors) {
         exerciseRouters("use many actors with high throughput", highThroughputDuration,
           batchInterval = Duration.Zero, expectDroppedMessages = false, tree = true)
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "exercise join/remove/join/remove" taggedAs LongRunningTest in {
@@ -1235,8 +1235,8 @@ abstract class StressSpec
     "exercise supervision" taggedAs LongRunningTest in {
       if (exerciseActors) {
         exerciseSupervision("exercise supervision", supervisionDuration, supervisionOneIteration)
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "gossip when idle" taggedAs LongRunningTest in {
@@ -1250,8 +1250,8 @@ abstract class StressSpec
           system.actorOf(Props(classOf[Master], settings, settings.workBatchInterval, false),
             name = "master-" + myself.name) ! Begin
         }
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "leave nodes one-by-one from large cluster" taggedAs LongRunningTest in {
@@ -1296,15 +1296,15 @@ abstract class StressSpec
           workResult.sendCount must be > (0L)
           workResult.ackCount must be > (0L)
         }
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
     "log jvm info" taggedAs LongRunningTest in {
       if (infolog) {
         log.info("StressSpec JVM:\n{}", jvmInfo)
-        enterBarrier("after-" + step)
       }
+      enterBarrier("after-" + step)
     }
 
   }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -38,6 +38,8 @@ import akka.testkit._
 import akka.testkit.TestEvent._
 import akka.actor.Identify
 import akka.actor.ActorIdentity
+import akka.util.Helpers.Requiring
+import java.lang.management.ManagementFactory
 
 /**
  * This test is intended to be used as long running stress test
@@ -50,27 +52,38 @@ import akka.actor.ActorIdentity
  * 4. exercise cluster aware routers, including high throughput
  * 5. exercise many actors in a tree structure
  * 6. exercise remote supervision
- * 7. leave and shutdown nodes in various ways
- * 8. while nodes are removed remote death watch is also exercised
- * 9. while nodes are removed a few cluster aware routers are also working
+ * 7. gossip without any changes to the membership
+ * 8. leave and shutdown nodes in various ways
+ * 9. while nodes are removed remote death watch is also exercised
+ * 10. while nodes are removed a few cluster aware routers are also working
+ *
+ * By default it uses 13 nodes.
+ * Example of sbt command line parameters to double that:
+ * `-DMultiJvm.akka.cluster.Stress.nrOfNodes=26 -Dmultinode.Dakka.test.cluster-stress-spec.nr-of-nodes-factor=2`
  */
 private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
+
+  val totalNumberOfNodes =
+    System.getProperty("MultiJvm.akka.cluster.Stress.nrOfNodes") match {
+      case null  ⇒ 13
+      case value ⇒ value.toInt requiring (_ >= 10, "nrOfNodes must be >= 10")
+    }
+
+  for (n ← 1 to totalNumberOfNodes) role("node-" + n)
 
   // Note that this test uses default configuration,
   // not MultiNodeClusterSpec.clusterConfig
   commonConfig(ConfigFactory.parseString("""
     akka.test.cluster-stress-spec {
-      log-stats = off
+      infolog = off
       # scale the nr-of-nodes* settings with this factor
       nr-of-nodes-factor = 1
-      nr-of-nodes = 13
       # not scaled
       nr-of-seed-nodes = 3
       nr-of-nodes-joining-to-seed-initally = 2
       nr-of-nodes-joining-one-by-one-small = 2
       nr-of-nodes-joining-one-by-one-large = 2
       nr-of-nodes-joining-to-one = 2
-      nr-of-nodes-joining-to-seed = 2
       nr-of-nodes-leaving-one-by-one-small = 1
       nr-of-nodes-leaving-one-by-one-large = 2
       nr-of-nodes-leaving = 2
@@ -89,6 +102,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       high-throughput-duration = 10s
       supervision-duration = 10s
       supervision-one-iteration = 2.5s
+      idle-gossip-duration = 10s
       expected-test-duration = 600s
       # actors are created in a tree structure defined
       # by tree-width (number of children for each actor) and
@@ -99,6 +113,8 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       report-metrics-interval = 10s
       # scale convergence within timeouts with this factor
       convergence-within-factor = 1.0
+      # set to off to only test cluster membership
+      exercise-actors = on
     }
 
     akka.actor.provider = akka.cluster.ClusterActorRefProvider
@@ -110,6 +126,12 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
     akka.loggers = ["akka.testkit.TestEventListener"]
     akka.loglevel = INFO
     akka.remote.log-remote-lifecycle-events = off
+
+    #akka.scheduler.tick-duration = 33 ms
+    akka.actor.default-dispatcher.fork-join-executor {
+      parallelism-min = 8
+      parallelism-max = 8
+    }
 
     akka.actor.deployment {
       /master-node-1/workers {
@@ -148,16 +170,18 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
 
     private def getDuration(name: String): FiniteDuration = Duration(getMilliseconds(name), MILLISECONDS)
 
-    val logStats = getBoolean("log-stats")
+    val infolog = getBoolean("infolog")
     val nFactor = getInt("nr-of-nodes-factor")
-    val totalNumberOfNodes = getInt("nr-of-nodes") * nFactor ensuring (
-      _ >= 10, "nr-of-nodes must be >= 10")
     val numberOfSeedNodes = getInt("nr-of-seed-nodes") // not scaled by nodes factor
     val numberOfNodesJoiningToSeedNodesInitially = getInt("nr-of-nodes-joining-to-seed-initally") * nFactor
     val numberOfNodesJoiningOneByOneSmall = getInt("nr-of-nodes-joining-one-by-one-small") * nFactor
     val numberOfNodesJoiningOneByOneLarge = getInt("nr-of-nodes-joining-one-by-one-large") * nFactor
     val numberOfNodesJoiningToOneNode = getInt("nr-of-nodes-joining-to-one") * nFactor
-    val numberOfNodesJoiningToSeedNodes = getInt("nr-of-nodes-joining-to-seed") * nFactor
+    // remaining will join to seed nodes
+    val numberOfNodesJoiningToSeedNodes = (totalNumberOfNodes - numberOfSeedNodes -
+      numberOfNodesJoiningToSeedNodesInitially - numberOfNodesJoiningOneByOneSmall -
+      numberOfNodesJoiningOneByOneLarge - numberOfNodesJoiningToOneNode) requiring (_ >= 0,
+        s"too many configured nr-of-nodes-joining-*, total must be <= ${totalNumberOfNodes}")
     val numberOfNodesLeavingOneByOneSmall = getInt("nr-of-nodes-leaving-one-by-one-small") * nFactor
     val numberOfNodesLeavingOneByOneLarge = getInt("nr-of-nodes-leaving-one-by-one-large") * nFactor
     val numberOfNodesLeaving = getInt("nr-of-nodes-leaving") * nFactor
@@ -175,11 +199,13 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
     val highThroughputDuration = getDuration("high-throughput-duration") * dFactor
     val supervisionDuration = getDuration("supervision-duration") * dFactor
     val supervisionOneIteration = getDuration("supervision-one-iteration") * dFactor
+    val idleGossipDuration = getDuration("idle-gossip-duration") * dFactor
     val expectedTestDuration = getDuration("expected-test-duration") * dFactor
     val treeWidth = getInt("tree-width")
     val treeLevels = getInt("tree-levels")
     val reportMetricsInterval = getDuration("report-metrics-interval")
     val convergenceWithinFactor = getDouble("convergence-within-factor")
+    val exerciseActors = getBoolean("exercise-actors")
 
     require(numberOfSeedNodes + numberOfNodesJoiningToSeedNodesInitially + numberOfNodesJoiningOneByOneSmall +
       numberOfNodesJoiningOneByOneLarge + numberOfNodesJoiningToOneNode + numberOfNodesJoiningToSeedNodes <= totalNumberOfNodes,
@@ -191,10 +217,11 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       s"specified number of leaving/shutdown nodes <= ${totalNumberOfNodes - 3}")
 
     require(numberOfNodesJoinRemove <= totalNumberOfNodes, s"nr-of-nodes-join-remove must be <= ${totalNumberOfNodes}")
-  }
 
-  // FIXME configurable number of nodes
-  for (n ← 1 to 13) role("node-" + n)
+    override def toString: String = {
+      testConfig.withFallback(ConfigFactory.parseString(s"nrOfNodes=${totalNumberOfNodes}")).root.render
+    }
+  }
 
   implicit class FormattedDouble(val d: Double) extends AnyVal {
     def form: String = d.formatted("%.2f")
@@ -215,7 +242,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
    */
   class ClusterResultAggregator(title: String, expectedResults: Int, settings: Settings) extends Actor with ActorLogging {
     import settings.reportMetricsInterval
-    import settings.logStats
+    import settings.infolog
     val cluster = Cluster(context.system)
     var reportTo: Option[ActorRef] = None
     var results = Vector.empty[ClusterResult]
@@ -246,13 +273,13 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       case PhiResult(from, phiValues)            ⇒ phiValuesObservedByNode += from -> phiValues
       case StatsResult(from, stats)              ⇒ clusterStatsObservedByNode += from -> stats
       case ReportTick ⇒
-        if (logStats)
+        if (infolog)
           log.info(s"[${title}] in progress\n${formatMetrics}\n\n${formatPhi}\n\n${formatStats}")
       case r: ClusterResult ⇒
         results :+= r
         if (results.size == expectedResults) {
           val aggregated = AggregatedClusterResult(title, maxDuration, totalClusterStats)
-          if (logStats)
+          if (infolog)
             log.info(s"[${title}] completed in [${aggregated.duration.toMillis}] ms\n${aggregated.clusterStats}\n${formatMetrics}\n\n${formatPhi}\n\n${formatStats}")
           reportTo foreach { _ ! aggregated }
           context stop self
@@ -270,7 +297,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       (formatMetricsHeader +: (nodeMetrics.toSeq.sortBy(_.address) map formatMetricsLine)).mkString("\n")
     }
 
-    def formatMetricsHeader: String = "Node\tHeap (MB)\tCPU (%)\tLoad"
+    def formatMetricsHeader: String = "[Node]\t[Heap (MB)]\t[CPU (%)]\t[Load]"
 
     def formatMetricsLine(nodeMetrics: NodeMetrics): String = {
       val heap = nodeMetrics match {
@@ -305,14 +332,14 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       }
     }
 
-    def formatPhiHeader: String = "Monitor\tSubject\tcount\tcount phi > 1.0\tmax phi"
+    def formatPhiHeader: String = "[Monitor]\t[Subject]\t[count]\t[count phi > 1.0]\t[max phi]"
 
     def formatPhiLine(monitor: Address, subject: Address, phi: PhiValue): String =
       s"${monitor}\t${subject}\t${phi.count}\t${phi.countAboveOne}\t${phi.max.form}"
 
     def formatStats: String =
       (clusterStatsObservedByNode map { case (monitor, stats) ⇒ s"${monitor}\t${stats}" }).
-        mkString("ClusterStats\n", "\n", "")
+        mkString("ClusterStats(gossip, merge, same, newer, older)\n", "\n", "")
   }
 
   /**
@@ -332,7 +359,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
     def formatHistory: String =
       (formatHistoryHeader +: (history map formatHistoryLine)).mkString("\n")
 
-    def formatHistoryHeader: String = "title\tduration (ms)\tcluster stats"
+    def formatHistoryHeader: String = "[Title]\t[Duration (ms)]\t[ClusterStats(gossip, merge, same, newer, older)]"
 
     def formatHistoryLine(result: AggregatedClusterResult): String =
       s"${result.title}\t${result.duration.toMillis}\t${result.clusterStats}"
@@ -385,7 +412,15 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
         reportTo foreach { _ ! PhiResult(cluster.selfAddress, phiSet) }
       case state: CurrentClusterState ⇒ nodes = state.members.map(_.address)
       case memberEvent: MemberEvent   ⇒ nodes += memberEvent.member.address
-      case ReportTo(ref)              ⇒ reportTo = ref
+      case ReportTo(ref) ⇒
+        reportTo foreach context.unwatch
+        reportTo = ref
+        reportTo foreach context.watch
+      case Terminated(ref) ⇒
+        reportTo match {
+          case Some(`ref`) ⇒ reportTo = None
+          case _           ⇒
+        }
       case Reset ⇒
         phiByNode = emptyPhiByNode
         nodes = Set.empty[Address]
@@ -414,7 +449,14 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
         val res = StatsResult(cluster.selfAddress, cluster.readView.latestStats :- startStats)
         reportTo foreach { _ ! res }
       case ReportTo(ref) ⇒
+        reportTo foreach context.unwatch
         reportTo = ref
+        reportTo foreach context.watch
+      case Terminated(ref) ⇒
+        reportTo match {
+          case Some(`ref`) ⇒ reportTo = None
+          case _           ⇒
+        }
       case Reset ⇒
         startStats = cluster.readView.latestStats
     }
@@ -527,7 +569,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       case TreeJob(id, payload, idx, levels, width) ⇒
         // create the actors when first TreeJob message is received
         val totalActors = ((width * math.pow(width, levels) - 1) / (width - 1)).toInt
-        log.info("Creating [{}] actors in a tree structure of [{}] levels and each actor has [{}] children",
+        log.debug("Creating [{}] actors in a tree structure of [{}] levels and each actor has [{}] children",
           totalActors, levels, width)
         val tree = context.actorOf(Props(classOf[TreeNode], levels, width), "tree")
         tree forward ((idx, SimpleJob(id, payload)))
@@ -665,13 +707,48 @@ abstract class StressSpec
 
   override def expectedTestDuration = settings.expectedTestDuration
 
+  override def shutdownTimeout: FiniteDuration = 30.seconds.dilated
+
   override def muteLog(sys: ActorSystem = system): Unit = {
     super.muteLog(sys)
     sys.eventStream.publish(Mute(EventFilter[RuntimeException](pattern = ".*Simulated exception.*")))
-    sys.eventStream.publish(Mute(EventFilter.warning(pattern = ".*PhiResult.*")))
-    sys.eventStream.publish(Mute(EventFilter.warning(pattern = ".*SendBatch.*")))
-    sys.eventStream.publish(Mute(EventFilter.warning(pattern = ".*ClusterStats.*")))
-    muteDeadLetters("SimpleJob.*", "Tick.*", "AggregatedClusterResult.*")(sys)
+    muteDeadLetters(classOf[SimpleJob], classOf[AggregatedClusterResult], SendBatch.getClass,
+      classOf[StatsResult], classOf[PhiResult], RetryTick.getClass)(sys)
+  }
+
+  def jvmInfo(): String = {
+    val runtime = ManagementFactory.getRuntimeMXBean
+    val os = ManagementFactory.getOperatingSystemMXBean
+    val threads = ManagementFactory.getThreadMXBean
+    val mem = ManagementFactory.getMemoryMXBean
+    val heap = mem.getHeapMemoryUsage
+
+    val sb = new StringBuilder
+
+    sb.append("Operating system: ").append(os.getName).append(", ").append(os.getArch).append(", ").append(os.getVersion)
+    sb.append("\n")
+    sb.append("JVM: ").append(runtime.getVmName).append(" ").append(runtime.getVmVendor).
+      append(" ").append(runtime.getVmVersion)
+    sb.append("\n")
+    sb.append("Processors: ").append(os.getAvailableProcessors)
+    sb.append("\n")
+    sb.append("Load average: ").append(os.getSystemLoadAverage)
+    sb.append("\n")
+    sb.append("Thread count: ").append(threads.getThreadCount).append(" (").append(threads.getPeakThreadCount).append(")")
+    sb.append("\n")
+    sb.append("Heap: ").append((heap.getUsed.toDouble / 1024 / 1024).form).
+      append(" (").append((heap.getInit.toDouble / 1024 / 1024).form).
+      append(" - ").
+      append((heap.getMax.toDouble / 1024 / 1024).form).
+      append(")").append(" MB")
+    sb.append("\n")
+
+    import scala.collection.JavaConverters._
+    val args = runtime.getInputArguments.asScala.filterNot(_.contains("classpath")).mkString("\n  ")
+    sb.append("Args:\n  ").append(args)
+    sb.append("\n")
+
+    sb.toString
   }
 
   val seedNodes = roles.take(numberOfSeedNodes)
@@ -689,7 +766,7 @@ abstract class StressSpec
     runOn(roles.head) {
       val aggregator = system.actorOf(Props(classOf[ClusterResultAggregator], title, expectedResults, settings),
         name = "result" + step)
-      if (includeInHistory) aggregator ! ReportTo(Some(clusterResultHistory))
+      if (includeInHistory && infolog) aggregator ! ReportTo(Some(clusterResultHistory))
       else aggregator ! ReportTo(None)
     }
     enterBarrier("result-aggregator-created-" + step)
@@ -706,7 +783,7 @@ abstract class StressSpec
   }
 
   lazy val clusterResultHistory =
-    if (settings.logStats) system.actorOf(Props[ClusterResultHistory], "resultHistory")
+    if (settings.infolog) system.actorOf(Props[ClusterResultHistory], "resultHistory")
     else system.deadLetters
 
   lazy val phiObserver = system.actorOf(Props[PhiObserver], "phiObserver")
@@ -803,11 +880,13 @@ abstract class StressSpec
       reportResult {
         runOn(roles.head) {
           if (shutdown) {
-            log.info("Shutting down [{}]", removeAddress)
+            if (infolog)
+              log.info("Shutting down [{}]", removeAddress)
             testConductor.exit(removeRole, 0).await
           }
         }
         awaitMembersUp(currentRoles.size, timeout = remaining)
+        awaitAllReachable()
       }
     }
 
@@ -836,11 +915,13 @@ abstract class StressSpec
         reportResult {
           runOn(roles.head) {
             if (shutdown) removeRoles.foreach { r ⇒
-              log.info("Shutting down [{}]", address(r))
+              if (infolog)
+                log.info("Shutting down [{}]", address(r))
               testConductor.exit(r, 0).await
             }
           }
           awaitMembersUp(currentRoles.size, timeout = remaining)
+          awaitAllReachable()
         }
       }
       awaitClusterResult()
@@ -891,6 +972,7 @@ abstract class StressSpec
                 nbrUsedRoles + activeRoles.size,
                 canNotBePartOfMemberRing = allPreviousAddresses,
                 timeout = remaining)
+              awaitAllReachable()
             }
             val nextAddresses = clusterView.members.map(_.address) -- usedAddresses
             runOn(usedRoles: _*) {
@@ -912,6 +994,7 @@ abstract class StressSpec
     within(loopDuration) {
       runOn(usedRoles: _*) {
         awaitMembersUp(nbrUsedRoles, timeout = remaining)
+        awaitAllReachable()
         phiObserver ! Reset
         statsObserver ! Reset
       }
@@ -930,6 +1013,7 @@ abstract class StressSpec
   def exerciseRouters(title: String, duration: FiniteDuration, batchInterval: FiniteDuration,
                       expectDroppedMessages: Boolean, tree: Boolean): Unit =
     within(duration + 10.seconds) {
+      nbrUsedRoles must be(totalNumberOfNodes)
       createResultAggregator(title, expectedResults = nbrUsedRoles, includeInHistory = false)
 
       val (masterRoles, otherRoles) = roles.take(nbrUsedRoles).splitAt(3)
@@ -962,7 +1046,7 @@ abstract class StressSpec
 
   def awaitWorkResult: WorkResult = {
     val workResult = expectMsgType[WorkResult]
-    if (settings.logStats)
+    if (settings.infolog)
       log.info("{} result, [{}] jobs/s, retried [{}] of [{}] msg", masterName,
         workResult.jobsPerSecond.form,
         workResult.retryCount, workResult.sendCount)
@@ -982,30 +1066,40 @@ abstract class StressSpec
       for (count ← 0 until rounds) {
         createResultAggregator(title, expectedResults = nbrUsedRoles, includeInHistory = false)
 
-        reportResult {
-          roles.take(nbrUsedRoles) foreach { r ⇒
-            supervisor ! Props[RemoteChild].withDeploy(Deploy(scope = RemoteScope(address(r))))
-          }
-          supervisor ! GetChildrenCount
-          expectMsgType[ChildrenCount] must be(ChildrenCount(nbrUsedRoles, 0))
-
-          1 to 5 foreach { _ ⇒ supervisor ! new RuntimeException("Simulated exception") }
-          awaitAssert {
+        val (masterRoles, otherRoles) = roles.take(nbrUsedRoles).splitAt(3)
+        runOn(masterRoles: _*) {
+          reportResult {
+            roles.take(nbrUsedRoles) foreach { r ⇒
+              supervisor ! Props[RemoteChild].withDeploy(Deploy(scope = RemoteScope(address(r))))
+            }
             supervisor ! GetChildrenCount
-            val c = expectMsgType[ChildrenCount]
-            c must be(ChildrenCount(nbrUsedRoles, 5 * nbrUsedRoles))
-          }
+            expectMsgType[ChildrenCount] must be(ChildrenCount(nbrUsedRoles, 0))
 
-          // after 5 restart attempts the children should be stopped
-          supervisor ! new RuntimeException("Simulated exception")
-          awaitAssert {
-            supervisor ! GetChildrenCount
-            val c = expectMsgType[ChildrenCount]
-            // zero children
-            c must be(ChildrenCount(0, 6 * nbrUsedRoles))
-          }
-          supervisor ! Reset
+            1 to 5 foreach { _ ⇒ supervisor ! new RuntimeException("Simulated exception") }
+            awaitAssert {
+              supervisor ! GetChildrenCount
+              val c = expectMsgType[ChildrenCount]
+              c must be(ChildrenCount(nbrUsedRoles, 5 * nbrUsedRoles))
+            }
 
+            // after 5 restart attempts the children should be stopped
+            supervisor ! new RuntimeException("Simulated exception")
+            awaitAssert {
+              supervisor ! GetChildrenCount
+              val c = expectMsgType[ChildrenCount]
+              // zero children
+              c must be(ChildrenCount(0, 6 * nbrUsedRoles))
+            }
+            supervisor ! Reset
+
+          }
+          enterBarrier("supervision-done-" + step)
+        }
+
+        runOn(otherRoles: _*) {
+          reportResult {
+            enterBarrier("supervision-done-" + step)
+          }
         }
 
         awaitClusterResult()
@@ -1013,7 +1107,27 @@ abstract class StressSpec
       }
     }
 
+  def idleGossip(title: String): Unit = {
+    createResultAggregator(title, expectedResults = nbrUsedRoles, includeInHistory = true)
+    reportResult {
+      clusterView.members.size must be(nbrUsedRoles)
+      Thread.sleep(idleGossipDuration.toMillis)
+      clusterView.members.size must be(nbrUsedRoles)
+    }
+    awaitClusterResult()
+  }
+
   "A cluster under stress" must {
+
+    "log settings" taggedAs LongRunningTest in {
+      if (infolog) {
+        log.info("StressSpec JVM:\n{}", jvmInfo)
+        runOn(roles.head) {
+          log.info("StressSpec settings:\n{}", settings)
+        }
+      }
+      enterBarrier("after-" + step)
+    }
 
     "join seed nodes" taggedAs LongRunningTest in within(30 seconds) {
 
@@ -1040,7 +1154,6 @@ abstract class StressSpec
         system.actorOf(Props(classOf[Master], settings, settings.workBatchInterval, false),
           name = "master-" + myself.name) ! Begin
       }
-      enterBarrier("after-" + step)
     }
 
     "join nodes one-by-one to small cluster" taggedAs LongRunningTest in {
@@ -1055,8 +1168,10 @@ abstract class StressSpec
     }
 
     "join several nodes to seed nodes" taggedAs LongRunningTest in {
-      joinSeveral(numberOfNodesJoiningToOneNode, toSeedNodes = true)
-      nbrUsedRoles += numberOfNodesJoiningToSeedNodes
+      if (numberOfNodesJoiningToSeedNodes > 0) {
+        joinSeveral(numberOfNodesJoiningToSeedNodes, toSeedNodes = true)
+        nbrUsedRoles += numberOfNodesJoiningToSeedNodes
+      }
       enterBarrier("after-" + step)
     }
 
@@ -1066,40 +1181,50 @@ abstract class StressSpec
     }
 
     "end routers that are running while nodes are joining" taggedAs LongRunningTest in within(30.seconds) {
-      runOn(roles.take(3): _*) {
-        val m = master
-        m must not be (None)
-        m.get.tell(End, testActor)
-        val workResult = awaitWorkResult
-        workResult.retryCount must be(0)
-        workResult.sendCount must be > (0L)
-        workResult.ackCount must be > (0L)
+      if (exerciseActors) {
+        runOn(roles.take(3): _*) {
+          val m = master
+          m must not be (None)
+          m.get.tell(End, testActor)
+          val workResult = awaitWorkResult
+          workResult.retryCount must be(0)
+          workResult.sendCount must be > (0L)
+          workResult.ackCount must be > (0L)
+        }
+        enterBarrier("after-" + step)
       }
-      enterBarrier("after-" + step)
     }
 
     "use routers with normal throughput" taggedAs LongRunningTest in {
-      exerciseRouters("use routers with normal throughput", normalThroughputDuration,
-        batchInterval = workBatchInterval, expectDroppedMessages = false, tree = false)
-      enterBarrier("after-" + step)
+      if (exerciseActors) {
+        exerciseRouters("use routers with normal throughput", normalThroughputDuration,
+          batchInterval = workBatchInterval, expectDroppedMessages = false, tree = false)
+        enterBarrier("after-" + step)
+      }
     }
 
     "use routers with high throughput" taggedAs LongRunningTest in {
-      exerciseRouters("use routers with high throughput", highThroughputDuration,
-        batchInterval = Duration.Zero, expectDroppedMessages = false, tree = false)
-      enterBarrier("after-" + step)
+      if (exerciseActors) {
+        exerciseRouters("use routers with high throughput", highThroughputDuration,
+          batchInterval = Duration.Zero, expectDroppedMessages = false, tree = false)
+        enterBarrier("after-" + step)
+      }
     }
 
     "use many actors with normal throughput" taggedAs LongRunningTest in {
-      exerciseRouters("use many actors with normal throughput", normalThroughputDuration,
-        batchInterval = workBatchInterval, expectDroppedMessages = false, tree = true)
-      enterBarrier("after-" + step)
+      if (exerciseActors) {
+        exerciseRouters("use many actors with normal throughput", normalThroughputDuration,
+          batchInterval = workBatchInterval, expectDroppedMessages = false, tree = true)
+        enterBarrier("after-" + step)
+      }
     }
 
     "use many actors with high throughput" taggedAs LongRunningTest in {
-      exerciseRouters("use many actors with high throughput", highThroughputDuration,
-        batchInterval = Duration.Zero, expectDroppedMessages = false, tree = true)
-      enterBarrier("after-" + step)
+      if (exerciseActors) {
+        exerciseRouters("use many actors with high throughput", highThroughputDuration,
+          batchInterval = Duration.Zero, expectDroppedMessages = false, tree = true)
+        enterBarrier("after-" + step)
+      }
     }
 
     "exercise join/remove/join/remove" taggedAs LongRunningTest in {
@@ -1108,16 +1233,25 @@ abstract class StressSpec
     }
 
     "exercise supervision" taggedAs LongRunningTest in {
-      exerciseSupervision("exercise supervision", supervisionDuration, supervisionOneIteration)
+      if (exerciseActors) {
+        exerciseSupervision("exercise supervision", supervisionDuration, supervisionOneIteration)
+        enterBarrier("after-" + step)
+      }
+    }
+
+    "gossip when idle" taggedAs LongRunningTest in {
+      idleGossip("idle gossip")
       enterBarrier("after-" + step)
     }
 
     "start routers that are running while nodes are removed" taggedAs LongRunningTest in {
-      runOn(roles.take(3): _*) {
-        system.actorOf(Props(classOf[Master], settings, settings.workBatchInterval, false),
-          name = "master-" + myself.name) ! Begin
+      if (exerciseActors) {
+        runOn(roles.take(3): _*) {
+          system.actorOf(Props(classOf[Master], settings, settings.workBatchInterval, false),
+            name = "master-" + myself.name) ! Begin
+        }
+        enterBarrier("after-" + step)
       }
-      enterBarrier("after-" + step)
     }
 
     "leave nodes one-by-one from large cluster" taggedAs LongRunningTest in {
@@ -1142,26 +1276,35 @@ abstract class StressSpec
       enterBarrier("after-" + step)
     }
 
-    "leave nodes one-by-one from small cluster" taggedAs LongRunningTest in {
-      removeOneByOne(numberOfNodesLeavingOneByOneSmall, shutdown = false)
-      enterBarrier("after-" + step)
-    }
-
     "shutdown nodes one-by-one from small cluster" taggedAs LongRunningTest in {
       removeOneByOne(numberOfNodesShutdownOneByOneSmall, shutdown = true)
       enterBarrier("after-" + step)
     }
 
-    "end routers that are running while nodes are removed" taggedAs LongRunningTest in within(30.seconds) {
-      runOn(roles.take(3): _*) {
-        val m = master
-        m must not be (None)
-        m.get.tell(End, testActor)
-        val workResult = awaitWorkResult
-        workResult.sendCount must be > (0L)
-        workResult.ackCount must be > (0L)
-      }
+    "leave nodes one-by-one from small cluster" taggedAs LongRunningTest in {
+      removeOneByOne(numberOfNodesLeavingOneByOneSmall, shutdown = false)
       enterBarrier("after-" + step)
+    }
+
+    "end routers that are running while nodes are removed" taggedAs LongRunningTest in within(30.seconds) {
+      if (exerciseActors) {
+        runOn(roles.take(3): _*) {
+          val m = master
+          m must not be (None)
+          m.get.tell(End, testActor)
+          val workResult = awaitWorkResult
+          workResult.sendCount must be > (0L)
+          workResult.ackCount must be > (0L)
+        }
+        enterBarrier("after-" + step)
+      }
+    }
+
+    "log jvm info" taggedAs LongRunningTest in {
+      if (infolog) {
+        log.info("StressSpec JVM:\n{}", jvmInfo)
+        enterBarrier("after-" + step)
+      }
     }
 
   }

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -54,9 +54,14 @@ class ClusterMessageSerializerSpec extends AkkaSpec {
       val node4 = VectorClock.Node("node4")
       val g1 = (Gossip(SortedSet(a1, b1, c1, d1)) :+ node1 :+ node2).seen(a1.uniqueAddress).seen(b1.uniqueAddress)
       val g2 = (g1 :+ node3 :+ node4).seen(a1.uniqueAddress).seen(c1.uniqueAddress)
+      val g3 = g2.copy(overview = g2.overview.copy(unreachable = Set(e1, f1)))
       checkSerialization(GossipEnvelope(a1.uniqueAddress, uniqueAddress2, g1))
       checkSerialization(GossipEnvelope(a1.uniqueAddress, uniqueAddress2, g2))
-      checkSerialization(GossipEnvelope(a1.uniqueAddress, uniqueAddress2, g2.copy(overview = g2.overview.copy(unreachable = Set(e1, f1)))))
+      checkSerialization(GossipEnvelope(a1.uniqueAddress, uniqueAddress2, g3))
+
+      checkSerialization(GossipStatus(a1.uniqueAddress, g1.version))
+      checkSerialization(GossipStatus(a1.uniqueAddress, g2.version))
+      checkSerialization(GossipStatus(a1.uniqueAddress, g3.version))
 
       checkSerialization(InternalClusterAction.Welcome(uniqueAddress, g2))
 

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -50,8 +50,12 @@ class ClusterMessageSerializerSpec extends AkkaSpec {
 
       val node1 = VectorClock.Node("node1")
       val node2 = VectorClock.Node("node2")
-      val g1 = (Gossip(SortedSet(a1, b1, c1, d1)) :+ node1).seen(a1.uniqueAddress).seen(b1.uniqueAddress)
-      val g2 = (g1 :+ node2).seen(a1.uniqueAddress).seen(c1.uniqueAddress)
+      val node3 = VectorClock.Node("node3")
+      val node4 = VectorClock.Node("node4")
+      val g1 = (Gossip(SortedSet(a1, b1, c1, d1)) :+ node1 :+ node2).seen(a1.uniqueAddress).seen(b1.uniqueAddress)
+      val g2 = (g1 :+ node3 :+ node4).seen(a1.uniqueAddress).seen(c1.uniqueAddress)
+      checkSerialization(GossipEnvelope(a1.uniqueAddress, uniqueAddress2, g1))
+      checkSerialization(GossipEnvelope(a1.uniqueAddress, uniqueAddress2, g2))
       checkSerialization(GossipEnvelope(a1.uniqueAddress, uniqueAddress2, g2.copy(overview = g2.overview.copy(unreachable = Set(e1, f1)))))
 
       checkSerialization(InternalClusterAction.Welcome(uniqueAddress, g2))

--- a/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
@@ -91,7 +91,10 @@ class RemoteWatcherSpec extends AkkaSpec(
   val remoteAddress = remoteSystem.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
   def remoteAddressUid = AddressUidExtension(remoteSystem).addressUid
 
-  Seq(system, remoteSystem).foreach(muteDeadLetters("Disassociated.*", "DisassociateUnderlying.*")(_))
+  Seq(system, remoteSystem).foreach(muteDeadLetters(
+    akka.remote.transport.AssociationHandle.Disassociated.getClass,
+    akka.remote.transport.ActorTransportAdapter.DisassociateUnderlying.getClass,
+    akka.dispatch.NullMessage.getClass)(_))
 
   override def afterTermination() {
     remoteSystem.shutdown()

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -4,7 +4,6 @@
 package akka.testkit
 
 import language.existentials
-
 import scala.util.matching.Regex
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
@@ -16,6 +15,7 @@ import akka.event.Logging
 import akka.actor.NoSerializationVerificationNeeded
 import akka.japi.Util.immutableSeq
 import java.lang.{ Iterable ⇒ JIterable }
+import akka.util.BoxedType
 
 /**
  * Implementation helpers of the EventFilter facilities: send `Mute`
@@ -445,6 +445,25 @@ case class CustomEventFilter(test: PartialFunction[LogEvent, Boolean])(occurrenc
   }
 }
 
+object DeadLettersFilter {
+  def apply[T](implicit t: ClassTag[T]): DeadLettersFilter =
+    new DeadLettersFilter(t.runtimeClass.asInstanceOf[Class[T]])(Int.MaxValue)
+}
+/**
+ * Filter which matches DeadLetter events, if the wrapped message conforms to the
+ * given type.
+ */
+case class DeadLettersFilter(val messageClass: Class[_])(occurrences: Int) extends EventFilter(occurrences) {
+
+  def matches(event: LogEvent) = {
+    event match {
+      case Warning(_, _, msg) ⇒ BoxedType(messageClass) isInstance msg
+      case _                  ⇒ false
+    }
+  }
+
+}
+
 /**
  * EventListener for running tests, which allows selectively filtering out
  * expected messages. To use it, include something like this into
@@ -469,15 +488,16 @@ class TestEventListener extends Logging.DefaultLogger {
     case Mute(filters)   ⇒ filters foreach addFilter
     case UnMute(filters) ⇒ filters foreach removeFilter
     case event: LogEvent ⇒ if (!filter(event)) print(event)
-    case DeadLetter(msg: SystemMessage, _, rcp) ⇒
-      if (!msg.isInstanceOf[Terminate]) {
-        val event = Warning(rcp.path.toString, rcp.getClass, "received dead system message: " + msg)
-        if (!filter(event)) print(event)
-      }
     case DeadLetter(msg, snd, rcp) ⇒
-      if (!msg.isInstanceOf[Terminated]) {
-        val event = Warning(rcp.path.toString, rcp.getClass, "received dead letter from " + snd + ": " + msg)
-        if (!filter(event)) print(event)
+      if (!msg.isInstanceOf[Terminate]) {
+        val event = Warning(rcp.path.toString, rcp.getClass, msg)
+        if (!filter(event)) {
+          val msgStr =
+            if (msg.isInstanceOf[SystemMessage]) "received dead system message: " + msg
+            else "received dead letter from " + snd + ": " + msg
+          val event2 = Warning(rcp.path.toString, rcp.getClass, msgStr)
+          if (!filter(event2)) print(event2)
+        }
       }
     case UnhandledMessage(msg, sender, rcp) ⇒
       val event = Warning(rcp.path.toString, rcp.getClass, "unhandled message from " + sender + ": " + msg)

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -238,7 +238,7 @@ trait TestKitBase {
    * Note that the timeout is scaled using Duration.dilated,
    * which uses the configuration entry "akka.test.timefactor".
    */
-  def awaitAssert(a: ⇒ Any, max: Duration = Duration.Undefined, interval: Duration = 100.millis) {
+  def awaitAssert(a: ⇒ Any, max: Duration = Duration.Undefined, interval: Duration = 800.millis) {
     val _max = remainingOrDilated(max)
     val stop = now + _max
 

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -94,12 +94,12 @@ abstract class AkkaSpec(_system: ActorSystem)
 
   override def expectedTestDuration: FiniteDuration = 60 seconds
 
-  def muteDeadLetters(endPatterns: String*)(sys: ActorSystem = system): Unit =
+  def muteDeadLetters(messageClasses: Class[_]*)(sys: ActorSystem = system): Unit =
     if (!sys.log.isDebugEnabled) {
-      def mute(suffix: String): Unit =
-        sys.eventStream.publish(Mute(EventFilter.warning(pattern = ".*received dead.*" + suffix)))
-      if (endPatterns.isEmpty) mute("")
-      else endPatterns foreach mute
+      def mute(clazz: Class[_]): Unit =
+        sys.eventStream.publish(Mute(DeadLettersFilter(clazz)(occurrences = Int.MaxValue)))
+      if (messageClasses.isEmpty) mute(classOf[AnyRef])
+      else messageClasses foreach mute
     }
 
 }

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -580,13 +580,14 @@ object AkkaBuild extends Build {
     // multinode.D= and multinode.X= makes it possible to pass arbitrary
     // -D or -X arguments to the forked jvm, e.g.
     // -Dmultinode.Djava.net.preferIPv4Stack=true -Dmultinode.Xmx512m -Dmultinode.XX:MaxPermSize=256M
+    // -DMultiJvm.akka.cluster.Stress.nrOfNodes=15
     val MultinodeJvmArgs = "multinode\\.(D|X)(.*)".r
+    val knownPrefix = Set("multnode.", "akka.", "MultiJvm.")
     val akkaProperties = System.getProperties.propertyNames.asScala.toList.collect {
       case MultinodeJvmArgs(a, b) =>
         val value = System.getProperty("multinode." + a + b)
         "-" + a + b + (if (value == "") "" else "=" + value)
-      case key: String if key.startsWith("multinode.") => "-D" + key + "=" + System.getProperty(key)
-      case key: String if key.startsWith("akka.") => "-D" + key + "=" + System.getProperty(key)
+      case key: String if knownPrefix.exists(pre => key.startsWith(pre)) => "-D" + key + "=" + System.getProperty(key)
     }
 
     "-Xmx256m" :: akkaProperties :::


### PR DESCRIPTION
This makes it possible for us to start the real testing of large and long running clusters.
- Enable usage of MultiJvm nrOfNodes in cluster StressSpec, see #2787
- Adjustments to StressSpec for testing large clusters
- Performance improvement of mute deadLetters
- Quick fix for unreachable exiting, see #3266

This review should also include to verify the configuration of the jenkins job that I have added. It is using a0, a2, a3, a4, a5, a6. It is confugred with following jvm arguments

```
-XX:+UseCompressedOops -XX:MaxPermSize=384M -Xms256m -Xmx1g -Xss2m -Djava.security.egd=file:/dev/./urandom -Dakka.test.multi-node.java=/usr/lib/jvm/java-7-openjdk-amd64/bin/java -XX:ReservedCodeCacheSize=96M -Dmultinode.XX:+UseParallelGC -Dmultinode.XX:+UseNUMA -Dmultinode.XX:+UseCondCardMark -Dmultinode.XX:-UseBiasedLocking -Dmultinode.XX:+UseCompressedOops -Dmultinode.Xms128M -Dmultinode.Xmx256M

-Dakka.remote.netty.tcp.maximum-frame-size=256000b -DMultiJvm.akka.cluster.Stress.nrOfNodes=100 -Dmultinode.Dakka.test.cluster-stress-spec.nr-of-nodes-factor=8 -Dmultinode.Dakka.test.cluster-stress-spec.duration-factor=1 -Dmultinode.Dakka.test.cluster-stress-spec.idle-gossip-duration=120s -Dmultinode.Dakka.test.cluster-stress-spec.exercise-actors=on -Dmultinode.Dakka.test.cluster-stress-spec.infolog=on -Dakka.test.timefactor=1 -Dmultinode.Dakka.test.cluster-stress-spec.expected-test-duration=3600s -Dsbt.ivy.home=/localhome/jenkinsakka/.ivy2 -Dsbt.override.build.repos=true -Dakka.publish.credentials=/home/jenkinsakka/.sbt/moxie-nexus.credentials -Dakka.test.multi-node=true -Dakka.test.multi-node.targetDirName=/localhome/jenkinsakka/akka-cluster-stress1
```

The summary results for a cluster of 100 nodes running on 6 machines (144 cores in total):

```
[JVM-1] [INFO] [04/26/2013 16:20:16.265] [StressSpec-akka.actor.default-dispatcher-10] [akka://StressSpec/user/resultHistory] Cluster result history
[JVM-1] [Title] [Duration (ms)] [ClusterStats(gossip, merge, same, newer, older)]
[JVM-1] join seed nodes 15301   ClusterStats(376,4,254,50,68)
[JVM-1] join one to 19 nodes cluster    8819    ClusterStats(245,0,197,11,37)
[JVM-1] join one to 20 nodes cluster    7218    ClusterStats(237,0,181,17,39)
[JVM-1] join one to 21 nodes cluster    8866    ClusterStats(302,0,245,16,41)
[JVM-1] join one to 22 nodes cluster    8821    ClusterStats(317,0,254,20,43)
[JVM-1] join one to 23 nodes cluster    11220   ClusterStats(366,0,303,18,45)
[JVM-1] join one to 24 nodes cluster    8820    ClusterStats(330,0,269,14,47)
[JVM-1] join one to 25 nodes cluster    7217    ClusterStats(319,0,252,18,49)
[JVM-1] join one to 26 nodes cluster    11218   ClusterStats(419,0,351,17,51)
[JVM-1] join one to 27 nodes cluster    8818    ClusterStats(352,0,277,22,53)
[JVM-1] join one to 28 nodes cluster    8018    ClusterStats(361,0,282,24,55)
[JVM-1] join one to 29 nodes cluster    10463   ClusterStats(452,0,368,27,57)
[JVM-1] join one to 30 nodes cluster    8819    ClusterStats(445,0,362,24,59)
[JVM-1] join one to 31 nodes cluster    8815    ClusterStats(440,0,354,25,61)
[JVM-1] join one to 32 nodes cluster    9655    ClusterStats(499,0,406,30,63)
[JVM-1] join one to 33 nodes cluster    9621    ClusterStats(485,0,397,23,65)
[JVM-1] join one to 34 nodes cluster    10418   ClusterStats(541,0,446,28,67)
[JVM-1] join 16 to one node, in 35 nodes cluster    11222   ClusterStats(789,0,625,65,99)
[JVM-1] join 33 to seed nodes, in 51 nodes cluster  12023   ClusterStats(1564,18,1133,157,256)
[JVM-1] join one to 84 nodes cluster    12027   ClusterStats(1601,0,1368,66,167)
[JVM-1] join one to 85 nodes cluster    12023   ClusterStats(1618,0,1386,63,169)
[JVM-1] join one to 86 nodes cluster    12023   ClusterStats(1604,0,1366,67,171)
[JVM-1] join one to 87 nodes cluster    13629   ClusterStats(1782,0,1539,70,173)
[JVM-1] join one to 88 nodes cluster    12832   ClusterStats(1691,0,1439,77,175)
[JVM-1] join one to 89 nodes cluster    13625   ClusterStats(1795,0,1553,65,177)
[JVM-1] join one to 90 nodes cluster    12823   ClusterStats(1727,0,1462,86,179)
[JVM-1] join one to 91 nodes cluster    12822   ClusterStats(1725,0,1462,82,181)
[JVM-1] join one to 92 nodes cluster    11221   ClusterStats(1653,0,1382,88,183)
[JVM-1] join one to 93 nodes cluster    14430   ClusterStats(2005,0,1747,73,185)
[JVM-1] join one to 94 nodes cluster    13624   ClusterStats(1878,0,1612,79,187)
[JVM-1] join one to 95 nodes cluster    13629   ClusterStats(1864,0,1600,75,189)
[JVM-1] join one to 96 nodes cluster    12824   ClusterStats(1839,0,1561,87,191)
[JVM-1] join one to 97 nodes cluster    13627   ClusterStats(2010,0,1748,69,193)
[JVM-1] join one to 98 nodes cluster    12026   ClusterStats(1843,0,1565,83,195)
[JVM-1] join one to 99 nodes cluster    13682   ClusterStats(2018,0,1752,69,197)
[JVM-1] exercise join/remove round 1    13651   ClusterStats(2295,12,1879,151,253)
[JVM-1] idle gossip 120014  ClusterStats(12539,0,12381,61,97)
[JVM-1] remove one from 100 nodes cluster   21633   ClusterStats(3162,0,2725,142,295)
[JVM-1] remove one from 99 nodes cluster    22432   ClusterStats(3422,0,2985,145,292)
[JVM-1] remove one from 98 nodes cluster    19231   ClusterStats(3044,0,2609,146,289)
[JVM-1] remove one from 97 nodes cluster    22433   ClusterStats(3255,0,2822,147,286)
[JVM-1] remove one from 96 nodes cluster    20825   ClusterStats(2995,0,2583,130,282)
[JVM-1] remove one from 95 nodes cluster    23234   ClusterStats(3282,0,2882,120,280)
[JVM-1] remove one from 94 nodes cluster    22437   ClusterStats(3277,0,2878,122,277)
[JVM-1] remove one from 93 nodes cluster    20833   ClusterStats(2984,0,2588,123,273)
[JVM-1] remove one from 92 nodes cluster    18428   ClusterStats(2681,0,2284,126,271)
[JVM-1] remove one from 91 nodes cluster    22433   ClusterStats(3062,0,2659,135,268)
[JVM-1] remove one from 90 nodes cluster    21629   ClusterStats(2950,0,2560,125,265)
[JVM-1] remove one from 89 nodes cluster    17628   ClusterStats(2574,0,2175,138,261)
[JVM-1] remove one from 88 nodes cluster    20030   ClusterStats(2758,0,2363,136,259)
[JVM-1] remove one from 87 nodes cluster    19231   ClusterStats(2655,0,2271,128,256)
[JVM-1] remove one from 86 nodes cluster    20833   ClusterStats(2772,0,2396,123,253)
[JVM-1] remove one from 85 nodes cluster    20834   ClusterStats(2796,0,2428,118,250)
[JVM-1] shutdown one from 84 nodes cluster  8016    ClusterStats(826,9,716,16,85)
[JVM-1] shutdown one from 83 nodes cluster  11217   ClusterStats(947,6,714,67,160)
[JVM-1] shutdown one from 82 nodes cluster  8016    ClusterStats(989,10,819,44,116)
[JVM-1] shutdown one from 81 nodes cluster  8014    ClusterStats(823,11,687,27,98)
[JVM-1] shutdown one from 80 nodes cluster  8813    ClusterStats(842,7,717,29,89)
[JVM-1] shutdown one from 79 nodes cluster  10420   ClusterStats(736,5,610,21,100)
[JVM-1] shutdown one from 78 nodes cluster  7214    ClusterStats(823,5,590,76,152)
[JVM-1] shutdown one from 77 nodes cluster  8014    ClusterStats(820,8,674,36,102)
[JVM-1] shutdown one from 76 nodes cluster  8015    ClusterStats(858,9,710,35,104)
[JVM-1] shutdown one from 75 nodes cluster  7214    ClusterStats(820,8,649,41,122)
[JVM-1] shutdown one from 74 nodes cluster  8818    ClusterStats(884,8,730,36,110)
[JVM-1] shutdown one from 73 nodes cluster  8363    ClusterStats(789,9,674,28,78)
[JVM-1] shutdown one from 72 nodes cluster  7214    ClusterStats(819,13,620,52,134)
[JVM-1] shutdown one from 71 nodes cluster  7216    ClusterStats(769,5,628,32,104)
[JVM-1] shutdown one from 70 nodes cluster  10418   ClusterStats(674,7,556,16,95)
[JVM-1] shutdown one from 69 nodes cluster  8014    ClusterStats(775,8,641,27,99)
[JVM-1] leave 16 in 68 nodes cluster    20828   ClusterStats(1837,111,1309,105,312)
[JVM-1] shutdown 16 in 52 nodes cluster 12822   ClusterStats(721,144,359,38,180)
[JVM-1] shutdown one from 36 nodes cluster  8814    ClusterStats(352,12,267,15,58)
[JVM-1] shutdown one from 35 nodes cluster  8012    ClusterStats(328,5,234,24,65)
[JVM-1] shutdown one from 34 nodes cluster  9616    ClusterStats(308,0,228,20,60)
[JVM-1] shutdown one from 33 nodes cluster  7213    ClusterStats(319,7,244,19,49)
[JVM-1] shutdown one from 32 nodes cluster  7213    ClusterStats(290,4,217,16,53)
[JVM-1] shutdown one from 31 nodes cluster  8816    ClusterStats(278,3,211,16,48)
[JVM-1] shutdown one from 30 nodes cluster  7213    ClusterStats(302,6,236,15,45)
[JVM-1] shutdown one from 29 nodes cluster  8013    ClusterStats(299,4,243,12,40)
[JVM-1] remove one from 28 nodes cluster    14426   ClusterStats(654,2,521,42,89)
[JVM-1] remove one from 27 nodes cluster    14430   ClusterStats(607,0,490,41,76)
[JVM-1] remove one from 26 nodes cluster    13621   ClusterStats(567,0,457,37,73)
[JVM-1] remove one from 25 nodes cluster    14421   ClusterStats(562,0,460,32,70)
[JVM-1] remove one from 24 nodes cluster    14418   ClusterStats(509,0,412,30,67)
[JVM-1] remove one from 23 nodes cluster    14423   ClusterStats(486,0,390,32,64)
[JVM-1] remove one from 22 nodes cluster    14420   ClusterStats(461,0,371,29,61)
```

The full log can be seen here: https://jenkins.akka.io:8498/job/akka-cluster-stress1/34/consoleText
