### PR TITLE
Removed lots of deprecation warnings caused by usages of deprecated Props creators

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -39,8 +39,7 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
     "invoke preRestart, preStart, postRestart when using OneForOneStrategy" in {
       filterException[ActorKilledException] {
         val id = newUuid.toString
-        val supervisor = system.actorOf(Props(new Supervisor(
-          OneForOneStrategy(maxNrOfRetries = 3)(List(classOf[Exception])))))
+        val supervisor = system.actorOf(Props(classOf[Supervisor], OneForOneStrategy(maxNrOfRetries = 3)(List(classOf[Exception]))))
         val gen = new AtomicInteger(0)
         val restarterProps = Props(new LifeCycleTestActor(testActor, id, gen) {
           override def preRestart(reason: Throwable, message: Option[Any]) { report("preRestart") }
@@ -74,10 +73,9 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
     "default for preRestart and postRestart is to call postStop and preStart respectively" in {
       filterException[ActorKilledException] {
         val id = newUuid().toString
-        val supervisor = system.actorOf(Props(new Supervisor(
-          OneForOneStrategy(maxNrOfRetries = 3)(List(classOf[Exception])))))
+        val supervisor = system.actorOf(Props(classOf[Supervisor], OneForOneStrategy(maxNrOfRetries = 3)(List(classOf[Exception]))))
         val gen = new AtomicInteger(0)
-        val restarterProps = Props(new LifeCycleTestActor(testActor, id, gen))
+        val restarterProps = Props(classOf[LifeCycleTestActor], testActor, id, gen)
         val restarter = Await.result((supervisor ? restarterProps).mapTo[ActorRef], timeout.duration)
 
         expectMsg(("preStart", id, 0))
@@ -105,10 +103,10 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
 
     "not invoke preRestart and postRestart when never restarted using OneForOneStrategy" in {
       val id = newUuid().toString
-      val supervisor = system.actorOf(Props(new Supervisor(
-        OneForOneStrategy(maxNrOfRetries = 3)(List(classOf[Exception])))))
+      val supervisor = system.actorOf(Props(classOf[Supervisor],
+        OneForOneStrategy(maxNrOfRetries = 3)(List(classOf[Exception]))))
       val gen = new AtomicInteger(0)
-      val props = Props(new LifeCycleTestActor(testActor, id, gen))
+      val props = Props(classOf[LifeCycleTestActor], testActor, id, gen)
       val a = Await.result((supervisor ? props).mapTo[ActorRef], timeout.duration)
       expectMsg(("preStart", id, 0))
       a ! "status"

--- a/akka-actor/src/main/scala/akka/actor/IO.scala
+++ b/akka-actor/src/main/scala/akka/actor/IO.scala
@@ -822,7 +822,7 @@ final class IOManager private (system: ExtendedActorSystem) extends Extension { 
    * IO. It communicates with other actors using subclasses of
    * [[akka.actor.IO.IOMessage]].
    */
-  val actor: ActorRef = system.actorOf(Props(new IOManagerActor(settings)), "io-manager")
+  val actor: ActorRef = system.actorOf(Props(classOf[IOManagerActor], settings), "io-manager")
 
   /**
    * Create a ServerSocketChannel listening on an address. Messages will be

--- a/akka-actor/src/main/scala/akka/actor/Props.scala
+++ b/akka-actor/src/main/scala/akka/actor/Props.scala
@@ -13,6 +13,8 @@ import scala.annotation.varargs
 import Deploy.{ NoDispatcherGiven, NoMailboxGiven }
 import scala.collection.immutable
 
+import scala.language.existentials
+
 /**
  * Factory for Props instances.
  *

--- a/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
+++ b/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
@@ -27,7 +27,7 @@ trait Inbox { this: ActorDSL.type ⇒
     val DSLInboxQueueSize = config.getInt("inbox-size")
 
     val inboxNr = new AtomicInteger
-    val inboxProps = Props(new InboxActor(DSLInboxQueueSize))
+    val inboxProps = Props(classOf[InboxActor], DSLInboxQueueSize)
 
     def newReceiver: ActorRef = mkChild(inboxProps, "inbox-" + inboxNr.incrementAndGet)
   }

--- a/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
+++ b/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
@@ -27,7 +27,7 @@ trait Inbox { this: ActorDSL.type ⇒
     val DSLInboxQueueSize = config.getInt("inbox-size")
 
     val inboxNr = new AtomicInteger
-    val inboxProps = Props(classOf[InboxActor], DSLInboxQueueSize)
+    val inboxProps = Props(classOf[InboxActor], ActorDSL, DSLInboxQueueSize)
 
     def newReceiver: ActorRef = mkChild(inboxProps, "inbox-" + inboxNr.incrementAndGet)
   }

--- a/akka-actor/src/main/scala/akka/io/IO.scala
+++ b/akka-actor/src/main/scala/akka/io/IO.scala
@@ -27,7 +27,7 @@ object IO {
     override def supervisorStrategy = connectionSupervisorStrategy
 
     val selectorPool = context.actorOf(
-      props = Props(new SelectionHandler(self, selectorSettings)).withRouter(RandomRouter(nrOfSelectors)),
+      props = Props(classOf[SelectionHandler], self, selectorSettings).withRouter(RandomRouter(nrOfSelectors)),
       name = "selectors")
 
     private def createWorkerMessage(pf: PartialFunction[HasFailureMessage, Props]): PartialFunction[HasFailureMessage, WorkerForCommand] = {

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -222,7 +222,7 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
 
   val manager: ActorRef = {
     system.asInstanceOf[ActorSystemImpl].systemActorOf(
-      props = Props(new TcpManager(this)).withDispatcher(Settings.ManagementDispatcher),
+      props = Props(classOf[TcpManager], this).withDispatcher(Settings.ManagementDispatcher),
       name = "IO-TCP")
   }
 

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -96,7 +96,7 @@ private[io] class TcpListener(val selectorRouter: ActorRef,
     if (socketChannel != null) {
       log.debug("New connection accepted")
       socketChannel.configureBlocking(false)
-      selectorRouter ! WorkerForCommand(RegisterIncoming(socketChannel), self, Props(new TcpIncomingConnection(socketChannel, tcp, handler, options)))
+      selectorRouter ! WorkerForCommand(RegisterIncoming(socketChannel), self, Props(classOf[TcpIncomingConnection], socketChannel, tcp, handler, options))
       acceptAllPending(limit - 1)
     } else context.parent ! AcceptInterest
   }

--- a/akka-actor/src/main/scala/akka/io/TcpManager.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpManager.scala
@@ -50,10 +50,10 @@ private[io] class TcpManager(tcp: TcpExt) extends SelectorBasedManager(tcp.Setti
   def receive = workerForCommandHandler {
     case c: Connect ⇒
       val commander = sender
-      Props(new TcpOutgoingConnection(tcp, commander, c))
+      Props(classOf[TcpOutgoingConnection], tcp, commander, c)
     case b: Bind ⇒
       val commander = sender
-      Props(new TcpListener(selectorPool, tcp, commander, b))
+      Props(classOf[TcpListener], selectorPool, tcp, commander, b)
   }
 
 }

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -106,7 +106,7 @@ class UdpExt(system: ExtendedActorSystem) extends IO.Extension {
 
   val manager: ActorRef = {
     system.asInstanceOf[ActorSystemImpl].systemActorOf(
-      props = Props(new UdpManager(this)),
+      props = Props(classOf[UdpManager], this),
       name = "IO-UDP-FF")
   }
 

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -64,7 +64,7 @@ class UdpConnectedExt(system: ExtendedActorSystem) extends IO.Extension {
 
   val manager: ActorRef = {
     system.asInstanceOf[ActorSystemImpl].systemActorOf(
-      props = Props(new UdpConnectedManager(this)),
+      props = Props(classOf[UdpConnectedManager], this),
       name = "IO-UDP-CONN")
   }
 

--- a/akka-actor/src/main/scala/akka/io/UdpConnectedManager.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnectedManager.scala
@@ -15,7 +15,7 @@ private[io] class UdpConnectedManager(udpConn: UdpConnectedExt) extends Selector
   def receive = workerForCommandHandler {
     case c: Connect ⇒
       val commander = sender
-      Props(new UdpConnection(udpConn, commander, c))
+      Props(classOf[UdpConnection], udpConn, commander, c)
   }
 
 }

--- a/akka-actor/src/main/scala/akka/io/UdpManager.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpManager.scala
@@ -49,10 +49,10 @@ private[io] class UdpManager(udp: UdpExt) extends SelectorBasedManager(udp.setti
   def receive = workerForCommandHandler {
     case b: Bind ⇒
       val commander = sender
-      Props(new UdpListener(udp, commander, b))
+      Props(classOf[UdpListener], udp, commander, b)
     case SimpleSender(options) ⇒
       val commander = sender
-      Props(new UdpSender(udp, options, commander))
+      Props(classOf[UdpSender], udp, options, commander)
   }
 
 }

--- a/akka-camel/src/main/scala/akka/camel/internal/CamelSupervisor.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/CamelSupervisor.scala
@@ -20,7 +20,7 @@ import akka.camel.internal.ActivationProtocol._
  */
 private[camel] class CamelSupervisor extends Actor with CamelSupport {
   private val activationTracker = context.actorOf(Props[ActivationTracker], "activationTracker")
-  private val registry: ActorRef = context.actorOf(Props(new Registry(activationTracker)), "registry")
+  private val registry: ActorRef = context.actorOf(Props(classOf[Registry], activationTracker), "registry")
 
   override val supervisorStrategy = OneForOneStrategy() {
     case NonFatal(e) ⇒
@@ -90,8 +90,8 @@ private[camel] class ActorActivationException(val actorRef: ActorRef, cause: Thr
 private[camel] class Registry(activationTracker: ActorRef) extends Actor with CamelSupport {
   import context.{ stop, parent }
 
-  private val producerRegistrar = context.actorOf(Props(new ProducerRegistrar(activationTracker)), "producerRegistrar")
-  private val consumerRegistrar = context.actorOf(Props(new ConsumerRegistrar(activationTracker)), "consumerRegistrar")
+  private val producerRegistrar = context.actorOf(Props(classOf[ProducerRegistrar], activationTracker), "producerRegistrar")
+  private val consumerRegistrar = context.actorOf(Props(classOf[ConsumerRegistrar], activationTracker), "consumerRegistrar")
   private var producers = Set[ActorRef]()
   private var consumers = Set[ActorRef]()
 

--- a/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
@@ -39,7 +39,7 @@ class ConcurrentActivationTest extends WordSpec with MustMatchers with NonShared
         // future to all the futures of activation and deactivation
         val futureRegistrarLists = promiseRegistrarLists.future
 
-        val ref = system.actorOf(Props(new ConsumerBroadcast(promiseRegistrarLists)), name = "broadcaster")
+        val ref = system.actorOf(Props(classOf[ConsumerBroadcast], promiseRegistrarLists), name = "broadcaster")
         // create the registrars
         ref ! CreateRegistrars(number)
         // send a broadcast to all registrars, so that number * number messages are sent
@@ -95,7 +95,7 @@ class ConsumerBroadcast(promise: Promise[(Future[List[List[ActorRef]]], Future[L
 
         allActivationFutures = allActivationFutures :+ activationListFuture
         allDeactivationFutures = allDeactivationFutures :+ deactivationListFuture
-        context.actorOf(Props(new Registrar(i, number, activationListPromise, deactivationListPromise)), "registrar-" + i)
+        context.actorOf(Props(classOf[Registrar], i, number, activationListPromise, deactivationListPromise), "registrar-" + i)
       }
       promise.success(Future.sequence(allActivationFutures) -> Future.sequence(allDeactivationFutures))
 

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -149,7 +149,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
 
   // create supervisor for daemons under path "/system/cluster"
   private val clusterDaemons: ActorRef = {
-    system.asInstanceOf[ActorSystemImpl].systemActorOf(Props(new ClusterDaemon(settings)).
+    system.asInstanceOf[ActorSystemImpl].systemActorOf(Props(classOf[ClusterDaemon], settings).
       withDispatcher(UseDispatcher), name = "cluster")
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -188,12 +188,12 @@ private[cluster] final class ClusterDaemon(settings: ClusterSettings) extends Ac
   def receive = {
     case msg @ GetClusterCoreRef ⇒ coreSupervisor forward msg
     case AddOnMemberUpListener(code) ⇒
-      context.actorOf(Props(new OnMemberUpListener(code)))
+      context.actorOf(Props(classOf[OnMemberUpListener], code))
     case PublisherCreated(publisher) ⇒
       if (settings.MetricsEnabled) {
         // metrics must be started after core/publisher to be able
         // to inject the publisher ref to the ClusterMetricsCollector
-        context.actorOf(Props(new ClusterMetricsCollector(publisher)).
+        context.actorOf(Props(classOf[ClusterMetricsCollector], publisher).
           withDispatcher(context.props.dispatcher), name = "metrics")
       }
   }
@@ -211,7 +211,7 @@ private[cluster] final class ClusterCoreSupervisor extends Actor with ActorLoggi
 
   val publisher = context.actorOf(Props[ClusterDomainEventPublisher].
     withDispatcher(context.props.dispatcher), name = "publisher")
-  val coreDaemon = context.watch(context.actorOf(Props(new ClusterCoreDaemon(publisher)).
+  val coreDaemon = context.watch(context.actorOf(Props(classOf[ClusterCoreDaemon], publisher).
     withDispatcher(context.props.dispatcher), name = "daemon"))
 
   context.parent ! PublisherCreated(publisher)
@@ -355,10 +355,10 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
         self ! ClusterUserAction.JoinTo(selfAddress)
         None
       } else if (seedNodes.head == selfAddress) {
-        Some(context.actorOf(Props(new FirstSeedNodeProcess(seedNodes)).
+        Some(context.actorOf(Props(classOf[FirstSeedNodeProcess], seedNodes).
           withDispatcher(UseDispatcher), name = "firstSeedNodeProcess"))
       } else {
-        Some(context.actorOf(Props(new JoinSeedNodeProcess(seedNodes)).
+        Some(context.actorOf(Props(classOf[JoinSeedNodeProcess], seedNodes).
           withDispatcher(UseDispatcher), name = "joinSeedNodeProcess"))
       }
   }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -529,7 +529,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
         val totalActors = ((width * math.pow(width, levels) - 1) / (width - 1)).toInt
         log.info("Creating [{}] actors in a tree structure of [{}] levels and each actor has [{}] children",
           totalActors, levels, width)
-        val tree = context.actorOf(Props(new TreeNode(levels, width)), "tree")
+        val tree = context.actorOf(Props(classOf[TreeNode], levels, width), "tree")
         tree forward ((idx, SimpleJob(id, payload)))
         context.become(treeWorker(tree))
     }
@@ -687,7 +687,7 @@ abstract class StressSpec
 
   def createResultAggregator(title: String, expectedResults: Int, includeInHistory: Boolean): Unit = {
     runOn(roles.head) {
-      val aggregator = system.actorOf(Props(new ClusterResultAggregator(title, expectedResults, settings)),
+      val aggregator = system.actorOf(Props(classOf[ClusterResultAggregator], title, expectedResults, settings),
         name = "result" + step)
       if (includeInHistory) aggregator ! ReportTo(Some(clusterResultHistory))
       else aggregator ! ReportTo(None)
@@ -935,7 +935,7 @@ abstract class StressSpec
       val (masterRoles, otherRoles) = roles.take(nbrUsedRoles).splitAt(3)
       runOn(masterRoles: _*) {
         reportResult {
-          val m = system.actorOf(Props(new Master(settings, batchInterval, tree)),
+          val m = system.actorOf(Props(classOf[Master], settings, batchInterval, tree),
             name = "master-" + myself.name)
           m ! Begin
           import system.dispatcher
@@ -1037,7 +1037,7 @@ abstract class StressSpec
 
     "start routers that are running while nodes are joining" taggedAs LongRunningTest in {
       runOn(roles.take(3): _*) {
-        system.actorOf(Props(new Master(settings, settings.workBatchInterval, tree = false)),
+        system.actorOf(Props(classOf[Master], settings, settings.workBatchInterval, false),
           name = "master-" + myself.name) ! Begin
       }
       enterBarrier("after-" + step)
@@ -1114,7 +1114,7 @@ abstract class StressSpec
 
     "start routers that are running while nodes are removed" taggedAs LongRunningTest in {
       runOn(roles.take(3): _*) {
-        system.actorOf(Props(new Master(settings, settings.workBatchInterval, tree = false)),
+        system.actorOf(Props(classOf[Master], settings, settings.workBatchInterval, false),
           name = "master-" + myself.name) ! Begin
       }
       enterBarrier("after-" + step)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinRoutedActorSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinRoutedActorSpec.scala
@@ -160,7 +160,7 @@ abstract class ClusterRoundRobinRoutedActorSpec extends MultiNodeSpec(ClusterRou
 
       // cluster consists of first and second
 
-      system.actorOf(Props(new SomeActor(LookupRoutee)), "myservice")
+      system.actorOf(Props(classOf[SomeActor], LookupRoutee), "myservice")
       enterBarrier("myservice-started")
 
       runOn(first) {

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -45,7 +45,7 @@ object ReliableProxy {
   case class Ack(serial: Int)
   case object Tick
 
-  def receiver(target: ActorRef): Props = Props(new Receiver(target))
+  def receiver(target: ActorRef): Props = Props(classOf[Receiver], target)
 
   sealed trait State
   case object Idle extends State

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -71,7 +71,7 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
 
         system.actorSelection(node(remote) / "user" / "echo") ! Identify("echo")
         target = expectMsgType[ActorIdentity].ref.get
-        proxy = system.actorOf(Props(new ReliableProxy(target, 100.millis)), "proxy")
+        proxy = system.actorOf(Props(classOf[ReliableProxy], target, 100.millis), "proxy")
         //#demo
         proxy ! FSM.SubscribeTransitionCallBack(testActor)
         expectState(Idle)

--- a/akka-contrib/src/test/scala/akka/contrib/mailbox/PeekMailboxSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/mailbox/PeekMailboxSpec.scala
@@ -44,7 +44,7 @@ class PeekMailboxSpec extends AkkaSpec("""
   "A PeekMailbox" must {
 
     "retry messages" in {
-      val a = system.actorOf(Props(new PeekActor(1)).withDispatcher("peek-dispatcher"))
+      val a = system.actorOf(Props(classOf[PeekActor], 1).withDispatcher("peek-dispatcher"))
       a ! "hello"
       expectMsg("hello")
       EventFilter[RuntimeException]("DONTWANNA", occurrences = 1) intercept {
@@ -57,7 +57,7 @@ class PeekMailboxSpec extends AkkaSpec("""
     }
 
     "put a bound on retries" in {
-      val a = system.actorOf(Props(new PeekActor(0)).withDispatcher("peek-dispatcher"))
+      val a = system.actorOf(Props(classOf[PeekActor], 0).withDispatcher("peek-dispatcher"))
       EventFilter[RuntimeException]("DONTWANNA", occurrences = 3) intercept {
         a ! "hello"
       }
@@ -69,7 +69,7 @@ class PeekMailboxSpec extends AkkaSpec("""
     }
 
     "not waste messages on double-ack()" in {
-      val a = system.actorOf(Props(new PeekActor(0)).withDispatcher("peek-dispatcher"))
+      val a = system.actorOf(Props(classOf[PeekActor], 0).withDispatcher("peek-dispatcher"))
       a ! DoubleAck
       a ! Check
       expectMsg(Check)
@@ -77,7 +77,7 @@ class PeekMailboxSpec extends AkkaSpec("""
 
     "support cleanup" in {
       system.eventStream.subscribe(testActor, classOf[DeadLetter])
-      val a = system.actorOf(Props(new PeekActor(0)).withDispatcher("peek-dispatcher"))
+      val a = system.actorOf(Props(classOf[PeekActor], 0).withDispatcher("peek-dispatcher"))
       watch(a)
       EventFilter[RuntimeException]("DONTWANNA", occurrences = 1) intercept {
         a ! "DIE" // stays in the mailbox

--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -20,7 +20,7 @@ class ReliableProxyDocSpec extends AkkaSpec with ImplicitSender {
       val target = system.deadLetters
       val a = system.actorOf(Props(new Actor {
         //#demo-transition
-        val proxy = context.actorOf(Props(new ReliableProxy(target, 100.millis)))
+        val proxy = context.actorOf(Props(classOf[ReliableProxy], target, 100.millis))
         proxy ! FSM.SubscribeTransitionCallBack(self)
 
         var client: ActorRef = _

--- a/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
@@ -46,8 +46,8 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
         }
       }))
       // The throttler for this example, setting the rate
-      val throttler = system.actorOf(Props(new TimerBasedThrottler(
-        3 msgsPer (1.second.dilated))))
+      val throttler = system.actorOf(Props(classOf[TimerBasedThrottler],
+        3 msgsPer (1.second.dilated)))
       // Set the target
       throttler ! SetTarget(Some(printer))
       // These three messages will be sent to the echoer immediately
@@ -62,7 +62,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
 
     "keep messages until a target is set" in {
       val echo = system.actorOf(Props[TimerBasedThrottlerSpec.EchoActor])
-      val throttler = system.actorOf(Props(new TimerBasedThrottler(3 msgsPer (1.second.dilated))))
+      val throttler = system.actorOf(Props(classOf[TimerBasedThrottler], 3 msgsPer (1.second.dilated)))
       1 to 6 foreach { throttler ! _ }
       expectNoMsg(1 second)
       throttler ! SetTarget(Some(echo))
@@ -73,7 +73,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
 
     "send messages after a `SetTarget(None)` pause" in {
       val echo = system.actorOf(Props[TimerBasedThrottlerSpec.EchoActor])
-      val throttler = system.actorOf(Props(new TimerBasedThrottler(3 msgsPer (1.second.dilated))))
+      val throttler = system.actorOf(Props(classOf[TimerBasedThrottler], 3 msgsPer (1.second.dilated)))
       throttler ! SetTarget(Some(echo))
       1 to 3 foreach { throttler ! _ }
       throttler ! SetTarget(None)
@@ -91,7 +91,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
 
     "keep messages when the target is set to None" in {
       val echo = system.actorOf(Props[TimerBasedThrottlerSpec.EchoActor])
-      val throttler = system.actorOf(Props(new TimerBasedThrottler(3 msgsPer (1.second.dilated))))
+      val throttler = system.actorOf(Props(classOf[TimerBasedThrottler], 3 msgsPer (1.second.dilated)))
       throttler ! SetTarget(Some(echo))
       1 to 7 foreach { throttler ! _ }
       throttler ! SetTarget(None)
@@ -108,7 +108,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
 
     "respect the rate (3 msg/s)" in within(1.5 seconds, 2.5 seconds) {
       val echo = system.actorOf(Props[TimerBasedThrottlerSpec.EchoActor])
-      val throttler = system.actorOf(Props(new TimerBasedThrottler(3 msgsPer (1.second.dilated))))
+      val throttler = system.actorOf(Props(classOf[TimerBasedThrottler], 3 msgsPer (1.second.dilated)))
       throttler ! SetTarget(Some(echo))
       1 to 7 foreach { throttler ! _ }
       1 to 7 foreach { expectMsg(_) }
@@ -116,7 +116,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
 
     "respect the rate (4 msg/s)" in within(1.5 seconds, 2.5 seconds) {
       val echo = system.actorOf(Props[TimerBasedThrottlerSpec.EchoActor])
-      val throttler = system.actorOf(Props(new TimerBasedThrottler(4 msgsPer (1.second.dilated))))
+      val throttler = system.actorOf(Props(classOf[TimerBasedThrottler], 4 msgsPer (1.second.dilated)))
       throttler ! SetTarget(Some(echo))
       1 to 9 foreach { throttler ! _ }
       1 to 9 foreach { expectMsg(_) }

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -64,7 +64,7 @@ trait Conductor { this: TestConductorExt ⇒
    */
   def startController(participants: Int, name: RoleName, controllerPort: InetSocketAddress): Future[InetSocketAddress] = {
     if (_controller ne null) throw new RuntimeException("TestConductorServer was already started")
-    _controller = system.actorOf(Props(new Controller(participants, controllerPort)), "controller")
+    _controller = system.actorOf(Props(classOf[Controller], participants, controllerPort), "controller")
     import Settings.BarrierTimeout
     import system.dispatcher
     controller ? GetSockAddr flatMap { case sockAddr: InetSocketAddress ⇒ startClient(name, sockAddr) map (_ ⇒ sockAddr) }
@@ -413,7 +413,7 @@ private[akka] class Controller(private var initialParticipants: Int, controllerP
     case CreateServerFSM(channel) ⇒
       val (ip, port) = channel.getRemoteAddress match { case s: InetSocketAddress ⇒ (s.getAddress.getHostAddress, s.getPort) }
       val name = ip + ":" + port + "-server" + generation.next
-      sender ! context.actorOf(Props(new ServerFSM(self, channel)), name)
+      sender ! context.actorOf(Props(classOf[ServerFSM], self, channel), name)
     case c @ NodeInfo(name, addr, fsm) ⇒
       barrier forward c
       if (nodes contains name) {

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -48,7 +48,7 @@ trait Player { this: TestConductorExt ⇒
     import Settings.BarrierTimeout
 
     if (_client ne null) throw new IllegalStateException("TestConductorClient already started")
-    _client = system.actorOf(Props(new ClientFSM(name, controllerAddr)), "TestConductorClient")
+    _client = system.actorOf(Props(classOf[ClientFSM], name, controllerAddr), "TestConductorClient")
     val a = system.actorOf(Props(new Actor {
       var waiting: ActorRef = _
       def receive = {

--- a/akka-osgi/src/test/scala/akka/osgi/test/TestActivators.scala
+++ b/akka-osgi/src/test/scala/akka/osgi/test/TestActivators.scala
@@ -23,7 +23,7 @@ object TestActivators {
 class PingPongActorSystemActivator extends ActorSystemActivator {
 
   def configure(context: BundleContext, system: ActorSystem) {
-    system.actorOf(Props(new PongActor), name = "pong")
+    system.actorOf(Props[PongActor], name = "pong")
     registerService(context, system)
   }
 

--- a/akka-remote-tests/src/test/scala/akka/remote/testconductor/BarrierSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testconductor/BarrierSpec.scala
@@ -523,7 +523,7 @@ class BarrierSpec extends AkkaSpec(BarrierSpec.config) with ImplicitSender {
 
   private def withController(participants: Int)(f: (ActorRef) ⇒ Unit): Unit = {
     system.actorOf(Props(new Actor {
-      val controller = context.actorOf(Props(new Controller(participants, new InetSocketAddress(InetAddress.getLocalHost, 0))))
+      val controller = context.actorOf(Props(classOf[Controller], participants, new InetSocketAddress(InetAddress.getLocalHost, 0)))
       controller ! GetSockAddr
       override def supervisorStrategy = OneForOneStrategy() {
         case x ⇒ testActor ! Failed(controller, x); SupervisorStrategy.Restart

--- a/akka-remote-tests/src/test/scala/akka/remote/testconductor/ControllerSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testconductor/ControllerSpec.scala
@@ -27,7 +27,7 @@ class ControllerSpec extends AkkaSpec(ControllerSpec.config) with ImplicitSender
   "A Controller" must {
 
     "publish its nodes" in {
-      val c = system.actorOf(Props(new Controller(1, new InetSocketAddress(InetAddress.getLocalHost, 0))))
+      val c = system.actorOf(Props(classOf[Controller], 1, new InetSocketAddress(InetAddress.getLocalHost, 0)))
       c ! NodeInfo(A, AddressFromURIString("akka://sys"), testActor)
       expectMsg(ToClient(Done))
       c ! NodeInfo(B, AddressFromURIString("akka://sys"), testActor)

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -157,7 +157,7 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
       case None ⇒
         log.info("Starting remoting")
         val manager: ActorRef = system.asInstanceOf[ActorSystemImpl].systemActorOf(
-          Props(new EndpointManager(provider.remoteSettings.config, log)), Remoting.EndpointManagerName)
+          Props(classOf[EndpointManager], provider.remoteSettings.config, log), Remoting.EndpointManagerName)
         endpointManager = Some(manager)
 
         try {

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -90,7 +90,7 @@ private[remote] class AkkaProtocolTransport(
   protected def managerProps = {
     val wt = wrappedTransport
     val s = settings
-    Props(new AkkaProtocolManager(wt, s))
+    Props(classOf[AkkaProtocolManager], wt, s)
   }
 }
 
@@ -114,27 +114,27 @@ private[transport] class AkkaProtocolManager(
       val stateActorAssociationHandler = associationListener
       val stateActorSettings = settings
       val failureDetector = createTransportFailureDetector()
-      context.actorOf(Props(new ProtocolStateActor(
+      context.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(stateActorLocalAddress, AddressUidExtension(context.system).addressUid, stateActorSettings.SecureCookie),
         handle,
         stateActorAssociationHandler,
         stateActorSettings,
         AkkaPduProtobufCodec,
-        failureDetector)), actorNameFor(handle.remoteAddress))
+        failureDetector), actorNameFor(handle.remoteAddress))
 
     case AssociateUnderlying(remoteAddress, statusPromise) ⇒
       val stateActorLocalAddress = localAddress
       val stateActorSettings = settings
       val stateActorWrappedTransport = wrappedTransport
       val failureDetector = createTransportFailureDetector()
-      context.actorOf(Props(new ProtocolStateActor(
+      context.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(stateActorLocalAddress, AddressUidExtension(context.system).addressUid, stateActorSettings.SecureCookie),
         remoteAddress,
         statusPromise,
         stateActorWrappedTransport,
         stateActorSettings,
         AkkaPduProtobufCodec,
-        failureDetector)), actorNameFor(remoteAddress))
+        failureDetector), actorNameFor(remoteAddress))
   }
 
   private def createTransportFailureDetector(): FailureDetector = {

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -164,7 +164,7 @@ class ThrottlerTransportAdapter(_wrappedTransport: Transport, _system: ExtendedA
   protected def managerName: String = s"throttlermanager.${wrappedTransport.schemeIdentifier}${UniqueId.getAndIncrement}"
   protected def managerProps: Props = {
     val wt = wrappedTransport
-    Props(new ThrottlerManager(wt))
+    Props(classOf[ThrottlerManager], wt)
   }
 
   override def managementCommand(cmd: Any): Future[Boolean] = {
@@ -289,7 +289,7 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport) extends A
     val managerRef = self
     ThrottlerHandle(
       originalHandle,
-      context.actorOf(Props(new ThrottledAssociation(managerRef, listener, originalHandle, inbound)), "throttler" + nextId()))
+      context.actorOf(Props(classOf[ThrottledAssociation], managerRef, listener, originalHandle, inbound), "throttler" + nextId()))
   }
 }
 

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -519,13 +519,13 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
         // check that we use the specified transport address instead of the default
         val otherGuyRemoteTcp = otherGuy.path.toSerializationFormatWithAddress(addr(otherSystem, "tcp"))
         val remoteEchoHereTcp = system.actorFor(s"akka.tcp://remote-sys@localhost:${port(remoteSystem, "tcp")}/user/echo")
-        val proxyTcp = system.actorOf(Props(new Proxy(remoteEchoHereTcp, testActor)), "proxy-tcp")
+        val proxyTcp = system.actorOf(Props(classOf[Proxy], remoteEchoHereTcp, testActor), "proxy-tcp")
         proxyTcp ! otherGuy
         expectMsg(3.seconds, ("pong", otherGuyRemoteTcp))
         // now check that we fall back to default when we haven't got a corresponding transport
         val otherGuyRemoteTest = otherGuy.path.toSerializationFormatWithAddress(addr(otherSystem, "test"))
         val remoteEchoHereSsl = system.actorFor(s"akka.ssl.tcp://remote-sys@localhost:${port(remoteSystem, "ssl.tcp")}/user/echo")
-        val proxySsl = system.actorOf(Props(new Proxy(remoteEchoHereSsl, testActor)), "proxy-ssl")
+        val proxySsl = system.actorOf(Props(classOf[Proxy], remoteEchoHereSsl, testActor), "proxy-ssl")
         EventFilter[RemoteTransportException](start = "Error while resolving address", occurrences = 1).intercept {
           proxySsl ! otherGuy
           expectMsg(3.seconds, ("pong", otherGuyRemoteTest))

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolSpec.scala
@@ -123,13 +123,13 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
     "register itself as reader on injecteted handles" in {
       val (failureDetector, _, _, handle) = collaborators
 
-      system.actorOf(Props(new ProtocolStateActor(
+      system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         handle,
         ActorAssociationEventListener(testActor),
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       awaitCond(handle.readHandlerPromise.isCompleted)
     }
@@ -137,13 +137,13 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
     "in inbound mode accept payload after Associate PDU received" in {
       val (failureDetector, registry, _, handle) = collaborators
 
-      val reader = system.actorOf(Props(new ProtocolStateActor(
+      val reader = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         handle,
         ActorAssociationEventListener(testActor),
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       reader ! testAssociate(uid = 33, cookie = None)
 
@@ -172,13 +172,13 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
     "in inbound mode disassociate when an unexpected message arrives instead of Associate" in {
       val (failureDetector, registry, _, handle) = collaborators
 
-      val reader = system.actorOf(Props(new ProtocolStateActor(
+      val reader = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         handle,
         ActorAssociationEventListener(testActor),
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       // a stray message will force a disassociate
       reader ! testHeartbeat
@@ -198,14 +198,14 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
       val statusPromise: Promise[AssociationHandle] = Promise()
 
-      val reader = system.actorOf(Props(new ProtocolStateActor(
+      val reader = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         remoteAddress,
         statusPromise,
         transport,
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       awaitCond(lastActivityIsAssociate(registry, 42, None))
       failureDetector.called must be(true)
@@ -232,13 +232,13 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
     "ignore incoming associations with wrong cookie" in {
       val (failureDetector, registry, _, handle) = collaborators
 
-      val reader = system.actorOf(Props(new ProtocolStateActor(
+      val reader = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = Some("abcde")),
         handle,
         ActorAssociationEventListener(testActor),
         new AkkaProtocolSettings(ConfigFactory.parseString("akka.remote.require-cookie = on").withFallback(conf)),
         codec,
-        failureDetector)))
+        failureDetector))
 
       reader ! testAssociate(uid = 33, Some("xyzzy"))
 
@@ -251,13 +251,13 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
     "accept incoming associations with correct cookie" in {
       val (failureDetector, registry, _, handle) = collaborators
 
-      val reader = system.actorOf(Props(new ProtocolStateActor(
+      val reader = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = Some("abcde")),
         handle,
         ActorAssociationEventListener(testActor),
         new AkkaProtocolSettings(ConfigFactory.parseString("akka.remote.require-cookie = on").withFallback(conf)),
         codec,
-        failureDetector)))
+        failureDetector))
 
       // Send the correct cookie
       reader ! testAssociate(uid = 33, Some("abcde"))
@@ -283,14 +283,14 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
       val statusPromise: Promise[AssociationHandle] = Promise()
 
-      system.actorOf(Props(new ProtocolStateActor(
+      system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = Some("abcde")),
         remoteAddress,
         statusPromise,
         transport,
         new AkkaProtocolSettings(ConfigFactory.parseString("akka.remote.require-cookie = on").withFallback(conf)),
         codec,
-        failureDetector)))
+        failureDetector))
 
       awaitCond(lastActivityIsAssociate(registry, uid = 42, cookie = Some("abcde")))
     }
@@ -301,14 +301,14 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
       val statusPromise: Promise[AssociationHandle] = Promise()
 
-      val reader = system.actorOf(Props(new ProtocolStateActor(
+      val reader = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         remoteAddress,
         statusPromise,
         transport,
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       awaitCond(lastActivityIsAssociate(registry, uid = 42, cookie = None))
 
@@ -336,14 +336,14 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
       val statusPromise: Promise[AssociationHandle] = Promise()
 
-      val reader = system.actorOf(Props(new ProtocolStateActor(
+      val reader = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         remoteAddress,
         statusPromise,
         transport,
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       awaitCond(lastActivityIsAssociate(registry, uid = 42, cookie = None))
 
@@ -371,14 +371,14 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
       val statusPromise: Promise[AssociationHandle] = Promise()
 
-      val stateActor = system.actorOf(Props(new ProtocolStateActor(
+      val stateActor = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         remoteAddress,
         statusPromise,
         transport,
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       awaitCond(lastActivityIsAssociate(registry, uid = 42, cookie = None))
 
@@ -409,14 +409,14 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = "akka.remote.Re
 
       val statusPromise: Promise[AssociationHandle] = Promise()
 
-      val stateActor = system.actorOf(Props(new ProtocolStateActor(
+      val stateActor = system.actorOf(Props(classOf[ProtocolStateActor],
         HandshakeInfo(origin = localAddress, uid = 42, cookie = None),
         remoteAddress,
         statusPromise,
         transport,
         new AkkaProtocolSettings(conf),
         codec,
-        failureDetector)))
+        failureDetector))
 
       awaitCond(lastActivityIsAssociate(registry, uid = 42, cookie = None))
 

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -84,7 +84,7 @@ class AkkaProtocolStressTest extends AkkaSpec(configA) with ImplicitSender with 
     "guarantee at-most-once delivery and message ordering despite packet loss" taggedAs TimingTest in {
       Await.result(RARP(system).provider.transport.managementCommand(One(addressB, Drop(0.3, 0.3))), 3.seconds.dilated)
 
-      val tester = system.actorOf(Props(new SequenceVerifier(here, self))) ! "start"
+      val tester = system.actorOf(Props(classOf[SequenceVerifier], here, self)) ! "start"
 
       expectMsgPF(45.seconds) {
         case (received: Int, lost: Int) ⇒

--- a/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
@@ -117,7 +117,7 @@ abstract class SystemMessageDeliveryStressTest(msg: String, cfg: String)
   "Remoting " + msg must {
     "guaranteed delivery and message ordering despite packet loss " taggedAs TimingTest in {
       Await.result(RARP(systemB).provider.transport.managementCommand(One(address, Drop(0.3, 0.3))), 3.seconds.dilated)
-      systemB.actorOf(Props(new SystemMessageSender(MsgCount, there)))
+      systemB.actorOf(Props(classOf[SystemMessageSender], MsgCount, there))
 
       val toSend = (0 until MsgCount).toList
       val received = expectMsgAllOf(45.seconds, toSend: _*)

--- a/akka-remote/src/test/scala/akka/remote/transport/ThrottlerTransportAdapterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/ThrottlerTransportAdapterSpec.scala
@@ -84,7 +84,7 @@ class ThrottlerTransportAdapterSpec extends AkkaSpec(configA) with ImplicitSende
   "ThrottlerTransportAdapter" must {
     "maintain average message rate" taggedAs TimingTest in {
       throttle(Direction.Send, TokenBucket(200, 500, 0, 0)) must be(true)
-      val tester = system.actorOf(Props(new ThrottlingTester(here, self))) ! "start"
+      val tester = system.actorOf(Props(classOf[ThrottlingTester], here, self)) ! "start"
 
       val time = NANOSECONDS.toSeconds(expectMsgType[Long]((TotalTime + 3).seconds))
       log.warning("Total time of transmission: " + time)

--- a/akka-samples/akka-sample-camel/src/main/scala/AsyncRouteAndTransform.scala
+++ b/akka-samples/akka-sample-camel/src/main/scala/AsyncRouteAndTransform.scala
@@ -9,8 +9,8 @@ import org.apache.camel.{ Exchange }
 object AsyncRouteAndTransform extends App {
   val system = ActorSystem("rewriteAkkaToAKKA")
   val httpTransformer = system.actorOf(Props[HttpTransformer], "transformer")
-  val httpProducer = system.actorOf(Props(new HttpProducer(httpTransformer)), "producer")
-  val httpConsumer = system.actorOf(Props(new HttpConsumer(httpProducer)), "consumer")
+  val httpProducer = system.actorOf(Props(classOf[HttpProducer], httpTransformer), "producer")
+  val httpConsumer = system.actorOf(Props(classOf[HttpConsumer], httpProducer), "consumer")
 }
 
 class HttpConsumer(producer: ActorRef) extends Consumer {

--- a/akka-samples/akka-sample-camel/src/main/scala/SimpleFileConsumer.scala
+++ b/akka-samples/akka-sample-camel/src/main/scala/SimpleFileConsumer.scala
@@ -11,7 +11,7 @@ object SimpleFileConsumer extends App {
   val tmpDirUri = "file://%s/%s" format (tmpDir, subDir)
 
   val system = ActorSystem("consume-files")
-  val fileConsumer = system.actorOf(Props(new FileConsumer(tmpDirUri)), "fileConsumer")
+  val fileConsumer = system.actorOf(Props(classOf[FileConsumer], tmpDirUri), "fileConsumer")
   println(String.format("Put a text file in '%s', the consumer will pick it up!", consumeDir))
 }
 

--- a/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnBecome.scala
+++ b/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnBecome.scala
@@ -142,7 +142,7 @@ object DiningHakkers {
     //Create 5 awesome hakkers and assign them their left and right chopstick
     val hakkers = for {
       (name, i) ← List("Ghosh", "Boner", "Klang", "Krasser", "Manie").zipWithIndex
-    } yield system.actorOf(Props(new Hakker(name, chopsticks(i), chopsticks((i + 1) % 5))))
+    } yield system.actorOf(Props(classOf[Hakker], name, chopsticks(i), chopsticks((i + 1) % 5)))
 
     //Signal all hakkers that they should start thinking, and watch the show
     hakkers.foreach(_ ! Think)

--- a/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnFsm.scala
+++ b/akka-samples/akka-sample-fsm/src/main/scala/DiningHakkersOnFsm.scala
@@ -177,7 +177,7 @@ object DiningHakkersOnFsm {
     // Create 5 awesome fsm hakkers and assign them their left and right chopstick
     val hakkers = for {
       (name, i) ← List("Ghosh", "Boner", "Klang", "Krasser", "Manie").zipWithIndex
-    } yield system.actorOf(Props(new FSMHakker(name, chopsticks(i), chopsticks((i + 1) % 5))))
+    } yield system.actorOf(Props(classOf[FSMHakker], name, chopsticks(i), chopsticks((i + 1) % 5)))
 
     hakkers.foreach(_ ! Think)
   }

--- a/akka-samples/akka-sample-osgi-dining-hakkers/core/src/main/scala/akka/sample/osgi/service/DiningHakkersServiceImpl.scala
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/core/src/main/scala/akka/sample/osgi/service/DiningHakkersServiceImpl.scala
@@ -21,6 +21,6 @@ import akka.sample.osgi.internal.Hakker
 
 class DiningHakkersServiceImpl(system: ActorSystem) extends DiningHakkersService {
   def getHakker(name: String, chairNumber: Int) = {
-    system.actorOf(Props(new Hakker(name, chairNumber)))
+    system.actorOf(Props(classOf[Hakker], name, chairNumber))
   }
 }

--- a/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/HakkerStatusTest.scala
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/HakkerStatusTest.scala
@@ -93,7 +93,7 @@ java.io.EOFException
       }
     }
 
-    hakker.tell(Identify, actorSystem.actorOf(Props(new Interrogator()), "Interrogator"))
+    hakker.tell(Identify, actorSystem.actorOf(Props[Interrogator], "Interrogator"))
     val (fromHakker, busyWith) = response.poll(5, TimeUnit.SECONDS)
 
     println("---------------> %s is busy with %s.".format(fromHakker, busyWith))

--- a/akka-samples/akka-sample-remote/src/main/scala/sample/remote/calculator/CreationApplication.scala
+++ b/akka-samples/akka-sample-remote/src/main/scala/sample/remote/calculator/CreationApplication.scala
@@ -18,7 +18,7 @@ class CreationApplication extends Bootable {
     ActorSystem("RemoteCreation", ConfigFactory.load.getConfig("remotecreation"))
   val remoteActor = system.actorOf(Props[AdvancedCalculatorActor],
     name = "advancedCalculator")
-  val localActor = system.actorOf(Props(new CreationActor(remoteActor)),
+  val localActor = system.actorOf(Props(classOf[CreationActor], remoteActor),
     name = "creationActor")
 
   def doSomething(op: MathOp): Unit =

--- a/akka-samples/akka-sample-remote/src/main/scala/sample/remote/calculator/LookupApplication.scala
+++ b/akka-samples/akka-sample-remote/src/main/scala/sample/remote/calculator/LookupApplication.scala
@@ -23,7 +23,7 @@ class LookupApplication extends Bootable {
     ActorSystem("LookupApplication", ConfigFactory.load.getConfig("remotelookup"))
   val remotePath =
     "akka.tcp://CalculatorApplication@127.0.0.1:2552/user/simpleCalculator"
-  val actor = system.actorOf(Props(new LookupActor(remotePath)), "lookupActor")
+  val actor = system.actorOf(Props(classOf[LookupActor], remotePath), "lookupActor")
 
   def doSomething(op: MathOp): Unit =
     actor ! op

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -50,7 +50,7 @@ object TestActor {
   val FALSE = (x: Any) ⇒ false
 
   // make creator serializable, for VerifySerializabilitySpec
-  def props(queue: BlockingDeque[Message]): Props = Props(new TestActor(queue))
+  def props(queue: BlockingDeque[Message]): Props = Props(classOf[TestActor], queue)
 }
 
 class TestActor(queue: BlockingDeque[TestActor.Message]) extends Actor {

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -143,7 +143,7 @@ class TestActorRefSpec extends AkkaSpec("disp1.type=Dispatcher") with BeforeAndA
 
     "support reply via sender" in {
       val serverRef = TestActorRef(Props[ReplyActor])
-      val clientRef = TestActorRef(Props(new SenderActor(serverRef)))
+      val clientRef = TestActorRef(Props(classOf[SenderActor], serverRef))
 
       counter = 4
 

--- a/akka-transactor/src/test/scala/akka/transactor/CoordinatedIncrementSpec.scala
+++ b/akka-transactor/src/test/scala/akka/transactor/CoordinatedIncrementSpec.scala
@@ -72,9 +72,9 @@ class CoordinatedIncrementSpec extends AkkaSpec(CoordinatedIncrement.config) wit
   val numCounters = 4
 
   def actorOfs = {
-    def createCounter(i: Int) = system.actorOf(Props(new Counter("counter" + i)))
+    def createCounter(i: Int) = system.actorOf(Props(classOf[Counter], "counter" + i))
     val counters = (1 to numCounters) map createCounter
-    val failer = system.actorOf(Props(new Failer))
+    val failer = system.actorOf(Props[Failer])
     (counters, failer)
   }
 

--- a/akka-transactor/src/test/scala/akka/transactor/FickleFriendsSpec.scala
+++ b/akka-transactor/src/test/scala/akka/transactor/FickleFriendsSpec.scala
@@ -113,9 +113,9 @@ class FickleFriendsSpec extends AkkaSpec with BeforeAndAfterAll {
   val numCounters = 2
 
   def actorOfs = {
-    def createCounter(i: Int) = system.actorOf(Props(new FickleCounter("counter" + i)))
+    def createCounter(i: Int) = system.actorOf(Props(classOf[FickleCounter], "counter" + i))
     val counters = (1 to numCounters) map createCounter
-    val coordinator = system.actorOf(Props(new Coordinator("coordinator")))
+    val coordinator = system.actorOf(Props(classOf[Coordinator], "coordinator"))
     (counters, coordinator)
   }
 

--- a/akka-transactor/src/test/scala/akka/transactor/TransactorSpec.scala
+++ b/akka-transactor/src/test/scala/akka/transactor/TransactorSpec.scala
@@ -85,9 +85,9 @@ class TransactorSpec extends AkkaSpec {
   val numCounters = 3
 
   def createTransactors = {
-    def createCounter(i: Int) = system.actorOf(Props(new Counter("counter" + i)))
+    def createCounter(i: Int) = system.actorOf(Props(classOf[Counter], "counter" + i))
     val counters = (1 to numCounters) map createCounter
-    val failer = system.actorOf(Props(new Failer))
+    val failer = system.actorOf(Props[Failer])
     (counters, failer)
   }
 
@@ -125,7 +125,7 @@ class TransactorSpec extends AkkaSpec {
 
   "Transactor" should {
     "be usable without overriding normally" in {
-      val transactor = system.actorOf(Props(new Setter))
+      val transactor = system.actorOf(Props[Setter])
       val ref = Ref(0)
       val latch = TestLatch(1)
       transactor ! Set(ref, 5, latch)

--- a/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
@@ -68,7 +68,7 @@ class ZeroMQExtension(system: ActorSystem) extends Extension {
       case _                           ⇒ false
     }, "A socket type is required")
     val params = socketParameters.to[immutable.Seq]
-    Props(new ConcurrentSocketActor(params)).withDispatcher("akka.zeromq.socket-dispatcher")
+    Props(classOf[ConcurrentSocketActor], params).withDispatcher("akka.zeromq.socket-dispatcher")
   }
 
   /**


### PR DESCRIPTION
I replaced lots of deprecated creations of Props. Unfortunately I couldn't run the whole testsuite, because at some point in the akka-remote tests it stops with this message: 

```
Deadlocks found for monitors and ownable synchronizers:
None
```

But in the other sub projects the changes do not seem to produce additional errors in the tests.
