### PR TITLE
Cluster member age, and usage in singleton, see #3195

### DIFF
--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -139,8 +139,9 @@ message GossipOverview {
  */
 message Member {
   required int32 addressIndex = 1;
-  required MemberStatus status = 2;
-  repeated int32 rolesIndexes = 3 [packed = true];
+  required int32 upNumber = 2;
+  required MemberStatus status = 3;
+  repeated int32 rolesIndexes = 4 [packed = true];
 }
 
 /**

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -748,16 +748,29 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
           // transform the node member ring
           val newMembers = localMembers collect {
-            // Move JOINING => UP (once all nodes have seen that this node is JOINING, i.e. we have a convergence)
-            // and minimum number of nodes have joined the cluster
-            case member if isJoiningToUp(member) ⇒ member copy (status = Up)
-            // Move LEAVING => EXITING (once we have a convergence on LEAVING
-            // *and* if we have a successful partition handoff)
-            case member if member.status == Leaving && hasPartionHandoffCompletedSuccessfully ⇒
-              member copy (status = Exiting)
-            // Everyone else that is not Exiting stays as they are
-            case member if member.status != Exiting && member.status != Down ⇒ member
-            // Move EXITING => REMOVED, DOWN => REMOVED - i.e. remove the nodes from the `members` set/node ring and seen table
+            var upNumber = 0
+
+            {
+              // Move JOINING => UP (once all nodes have seen that this node is JOINING, i.e. we have a convergence)
+              // and minimum number of nodes have joined the cluster
+              case member if isJoiningToUp(member) ⇒
+                if (upNumber == 0) {
+                  // It is alright to use same upNumber as already used by a removed member, since the upNumber
+                  // is only used for comparing age of current cluster members (Member.isOlderThan)
+                  val youngest = localGossip.youngestMember
+                  upNumber = 1 + (if (youngest.upNumber == Int.MaxValue) 0 else youngest.upNumber)
+                } else {
+                  upNumber += 1
+                }
+                member.copyUp(upNumber)
+              // Move LEAVING => EXITING (once we have a convergence on LEAVING
+              // *and* if we have a successful partition handoff)
+              case member if member.status == Leaving && hasPartionHandoffCompletedSuccessfully ⇒
+                member copy (status = Exiting)
+              // Everyone else that is not Exiting stays as they are
+              case member if member.status != Exiting && member.status != Down ⇒ member
+              // Move EXITING => REMOVED, DOWN => REMOVED - i.e. remove the nodes from the `members` set/node ring and seen table
+            }
           }
 
           // ----------------------

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -213,6 +213,16 @@ private[cluster] case class Gossip(
       getOrElse(Member.removed(node)) // placeholder for removed member
   }
 
+  def youngestMember: Member = {
+    require(members.nonEmpty, "No youngest when no members")
+    def maxByUpNumber(mbrs: Iterable[Member]): Member =
+      mbrs.maxBy(m ⇒ if (m.upNumber == Int.MaxValue) 0 else m.upNumber)
+    if (overview.unreachable.isEmpty)
+      maxByUpNumber(members)
+    else
+      maxByUpNumber(members ++ overview.unreachable)
+  }
+
   override def toString =
     s"Gossip(members = [${members.mkString(", ")}], overview = ${overview}, version = ${version})"
 }

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -21,6 +21,8 @@ import MemberStatus._
 class Member private[cluster] (
   /** INTERNAL API **/
   private[cluster] val uniqueAddress: UniqueAddress,
+  /** INTERNAL API **/
+  private[cluster] val upNumber: Int,
   val status: MemberStatus,
   val roles: Set[String]) extends Serializable {
 
@@ -41,14 +43,26 @@ class Member private[cluster] (
   def getRoles: java.util.Set[String] =
     scala.collection.JavaConverters.setAsJavaSetConverter(roles).asJava
 
+  /**
+   * Is this member older, has been part of cluster longer, than another
+   * member. It is only correct when comparing two existing members in a
+   * cluster. A member that joined after removal of another member may be
+   * considered older than the removed member.
+   */
+  def isOlderThan(other: Member): Boolean = upNumber < other.upNumber
+
   def copy(status: MemberStatus): Member = {
     val oldStatus = this.status
     if (status == oldStatus) this
     else {
       require(allowedTransitions(oldStatus)(status),
         s"Invalid member status transition [ ${this} -> ${status}]")
-      new Member(uniqueAddress, status, roles)
+      new Member(uniqueAddress, upNumber, status, roles)
     }
+  }
+
+  def copyUp(upNumber: Int): Member = {
+    new Member(uniqueAddress, upNumber, status, roles).copy(Up)
   }
 }
 
@@ -64,12 +78,12 @@ object Member {
    * Create a new member with status Joining.
    */
   private[cluster] def apply(uniqueAddress: UniqueAddress, roles: Set[String]): Member =
-    new Member(uniqueAddress, Joining, roles)
+    new Member(uniqueAddress, Int.MaxValue, Joining, roles)
 
   /**
    * INTERNAL API
    */
-  private[cluster] def removed(node: UniqueAddress): Member = new Member(node, Removed, Set.empty)
+  private[cluster] def removed(node: UniqueAddress): Member = new Member(node, Int.MaxValue, Removed, Set.empty)
 
   /**
    * `Address` ordering type class, sorts addresses by host and port.

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -145,7 +145,8 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     def mapRole(role: String) = mapWithErrorMessage(roleMapping, role, "role")
 
     def memberToProto(member: Member) = {
-      msg.Member(mapUniqueAddress(member.uniqueAddress), msg.MemberStatus.valueOf(memberStatusToInt(member.status)), member.roles.map(mapRole).to[Vector])
+      msg.Member(mapUniqueAddress(member.uniqueAddress), member.upNumber,
+        msg.MemberStatus.valueOf(memberStatusToInt(member.status)), member.roles.map(mapRole).to[Vector])
     }
 
     def seenToProto(seen: (UniqueAddress, VectorClock)) = seen match {
@@ -194,7 +195,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     val hashMapping = gossip.allHashes
 
     def memberFromProto(member: msg.Member) = {
-      new Member(addressMapping(member.addressIndex), memberStatusFromInt(member.status.id),
+      new Member(addressMapping(member.addressIndex), member.upNumber, memberStatusFromInt(member.status.id),
         member.rolesIndexes.map(roleMapping).to[Set])
     }
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeMembershipSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeMembershipSpec.scala
@@ -58,5 +58,18 @@ abstract class NodeMembershipSpec
 
       enterBarrier("after-2")
     }
+
+    "correct member age" taggedAs LongRunningTest in {
+      val firstMember = clusterView.members.find(_.address == address(first)).get
+      val secondMember = clusterView.members.find(_.address == address(second)).get
+      val thirdMember = clusterView.members.find(_.address == address(third)).get
+      firstMember.isOlderThan(thirdMember) must be(true)
+      thirdMember.isOlderThan(firstMember) must be(false)
+      secondMember.isOlderThan(thirdMember) must be(true)
+      thirdMember.isOlderThan(secondMember) must be(false)
+
+      enterBarrier("after-3")
+
+    }
   }
 }

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -121,5 +121,15 @@ class GossipSpec extends WordSpec with MustMatchers {
       checkMerged(g3 merge g2)
       checkMerged(g2 merge g3)
     }
+
+    "know who is youngest" in {
+      // a2 and e1 is Joining
+      val g1 = Gossip(members = SortedSet(a2, b1.copyUp(3)), overview = GossipOverview(unreachable = Set(e1)))
+      g1.youngestMember must be(b1)
+      val g2 = Gossip(members = SortedSet(a2), overview = GossipOverview(unreachable = Set(b1.copyUp(3), e1)))
+      g2.youngestMember must be(b1)
+      val g3 = Gossip(members = SortedSet(a2, b1.copyUp(3), e2.copyUp(4)))
+      g3.youngestMember must be(e2)
+    }
   }
 }

--- a/akka-cluster/src/test/scala/akka/cluster/TestMember.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/TestMember.scala
@@ -10,5 +10,5 @@ object TestMember {
     apply(address, status, Set.empty)
 
   def apply(address: Address, status: MemberStatus, roles: Set[String]): Member =
-    new Member(UniqueAddress(address, 0), status, roles)
+    new Member(UniqueAddress(address, 0), Int.MaxValue, status, roles)
 }

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ClusterSingletonManagerTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ClusterSingletonManagerTest.java
@@ -1,0 +1,119 @@
+/**
+ *  Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.contrib.pattern;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import akka.actor.ActorSystem;
+import akka.actor.ActorRef;
+import akka.actor.ActorSelection;
+import akka.actor.Props;
+import akka.actor.UntypedActor;
+import akka.cluster.Cluster;
+import akka.cluster.Member;
+import akka.cluster.ClusterEvent.CurrentClusterState;
+import akka.cluster.ClusterEvent.MemberEvent;
+import akka.cluster.ClusterEvent.MemberUp;
+import akka.cluster.ClusterEvent.MemberRemoved;
+
+public class ClusterSingletonManagerTest {
+
+  public void demo() {
+    final ActorSystem system = null;
+    final ActorRef queue = null;
+    final ActorRef testActor = null;
+
+    //#create-singleton-manager
+    system.actorOf(
+      ClusterSingletonManager.defaultProps("consumer", new End(), "worker",
+        new ClusterSingletonPropsFactory() {
+          @Override
+          public Props create(Object handOverData) {
+            return Props.create(Consumer.class, handOverData, queue, testActor);
+          }
+        }), "singleton");
+    //#create-singleton-manager
+  }
+
+  static//documentation of how to keep track of the oldest member in user land
+  //#singleton-proxy
+  public class ConsumerProxy extends UntypedActor {
+
+    final Cluster cluster = Cluster.get(getContext().system());
+
+    final Comparator<Member> ageComparator = new Comparator<Member>() {
+      public int compare(Member a, Member b) {
+        if (a.isOlderThan(b))
+          return -1;
+        else if (b.isOlderThan(a))
+          return 1;
+        else
+          return 0;
+      }
+    };
+    final SortedSet<Member> membersByAge = new TreeSet<Member>(ageComparator);
+
+    final String role = "worker";
+
+    //subscribe to cluster changes
+    @Override
+    public void preStart() {
+      cluster.subscribe(getSelf(), MemberEvent.class);
+    }
+
+    //re-subscribe when restart
+    @Override
+    public void postStop() {
+      cluster.unsubscribe(getSelf());
+    }
+
+    @Override
+    public void onReceive(Object message) {
+      if (message instanceof CurrentClusterState) {
+        CurrentClusterState state = (CurrentClusterState) message;
+        List<Member> members = new ArrayList<Member>();
+        for (Member m : state.getMembers()) {
+          if (m.hasRole(role))
+            members.add(m);
+        }
+        membersByAge.clear();
+        membersByAge.addAll(members);
+
+      } else if (message instanceof MemberUp) {
+        Member m = ((MemberUp) message).member();
+        if (m.hasRole(role))
+          membersByAge.add(m);
+
+      } else if (message instanceof MemberRemoved) {
+        Member m = ((MemberUp) message).member();
+        if (m.hasRole(role))
+          membersByAge.remove(m);
+
+      } else if (message instanceof MemberEvent) {
+        // not interesting
+
+      } else if (!membersByAge.isEmpty()) {
+        currentMaster().tell(message, getSender());
+
+      }
+    }
+
+    ActorSelection currentMaster() {
+      return getContext().actorSelection(membersByAge.first().address() +
+          "/user/singleton/statsService");
+    }
+
+  }
+  //#singleton-proxy
+
+
+  public static class End {}
+
+  public static class Consumer {}
+}

--- a/akka-docs/rst/java/cluster-usage.rst
+++ b/akka-docs/rst/java/cluster-usage.rst
@@ -275,10 +275,10 @@ Cluster Singleton Pattern
 For some use cases it is convenient and sometimes also mandatory to ensure that
 you have exactly one actor of a certain type running somewhere in the cluster.
 
-This can be implemented by subscribing to ``LeaderChanged`` or ``RoleLeaderChanged``
-events, but there are several corner cases to consider. Therefore, this specific use 
-case is made easily accessible by the :ref:`cluster-singleton` in the contrib module.
-You can use it as is, or adjust to fit your specific needs. 
+This can be implemented by subscribing to member events, but there are several corner 
+cases to consider. Therefore, this specific use case is made easily accessible by the 
+:ref:`cluster-singleton` in the contrib module. You can use it as is, or adjust to fit
+your specific needs. 
 
 Distributed Publish Subscribe Pattern
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -473,9 +473,7 @@ delegates jobs to the ``StatsService``.
 .. includecode:: ../../../akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsFacade.java#facade
 
 The ``StatsFacade`` receives text from users and delegates to the current ``StatsService``, the single
-master. It listens to cluster events to lookup the ``StatsService`` on the leader node. The master runs 
-on the same node as the leader of the cluster members, which is nothing more than the address currently 
-sorted first in the member ring, i.e. it can change when new nodes join or when current leader leaves.
+master. It listens to cluster events to lookup the ``StatsService`` on the oldest node.
 
 All nodes start ``StatsFacade`` and the ``ClusterSingletonManager``. The router is now configured like this:
 

--- a/akka-docs/rst/scala/cluster-usage.rst
+++ b/akka-docs/rst/scala/cluster-usage.rst
@@ -263,10 +263,10 @@ Cluster Singleton Pattern
 For some use cases it is convenient and sometimes also mandatory to ensure that
 you have exactly one actor of a certain type running somewhere in the cluster.
 
-This can be implemented by subscribing to ``LeaderChanged`` or ``RoleLeaderChanged``
-events, but there are several corner cases to consider. Therefore, this specific use 
-case is made easily accessible by the :ref:`cluster-singleton` in the contrib module.
-You can use it as is, or adjust to fit your specific needs. 
+This can be implemented by subscribing to member events, but there are several corner 
+cases to consider. Therefore, this specific use case is made easily accessible by the 
+:ref:`cluster-singleton` in the contrib module. You can use it as is, or adjust to fit
+your specific needs. 
 
 Distributed Publish Subscribe Pattern
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -456,9 +456,7 @@ delegates jobs to the ``StatsService``.
 .. includecode:: ../../../akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala#facade
 
 The ``StatsFacade`` receives text from users and delegates to the current ``StatsService``, the single
-master. It listens to cluster events to lookup the ``StatsService`` on the leader node. The master runs 
-on the same node as the leader of the cluster members, which is nothing more than the address currently 
-sorted first in the member ring, i.e. it can change when new nodes join or when current leader leaves.
+master. It listens to cluster events to lookup the ``StatsService`` on the oldest node.
 
 All nodes start ``StatsFacade`` and the ``ClusterSingletonManager``. The router is now configured like this:
 

--- a/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsFacade.java
+++ b/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsFacade.java
@@ -1,13 +1,21 @@
 package sample.cluster.stats.japi;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
 import sample.cluster.stats.japi.StatsMessages.JobFailed;
 import sample.cluster.stats.japi.StatsMessages.StatsJob;
 import akka.actor.ActorSelection;
-import akka.actor.Address;
 import akka.actor.UntypedActor;
 import akka.cluster.Cluster;
 import akka.cluster.ClusterEvent.CurrentClusterState;
-import akka.cluster.ClusterEvent.RoleLeaderChanged;
+import akka.cluster.ClusterEvent.MemberEvent;
+import akka.cluster.ClusterEvent.MemberUp;
+import akka.cluster.ClusterEvent.MemberRemoved;
+import akka.cluster.Member;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
 
@@ -15,15 +23,23 @@ import akka.event.LoggingAdapter;
 //#facade
 public class StatsFacade extends UntypedActor {
 
-  LoggingAdapter log = Logging.getLogger(getContext().system(), this);
-  Cluster cluster = Cluster.get(getContext().system());
+  final LoggingAdapter log = Logging.getLogger(getContext().system(), this);
+  final Cluster cluster = Cluster.get(getContext().system());
 
-  ActorSelection currentMaster = null;
+  final Comparator<Member> ageComparator = new Comparator<Member>() {
+    public int compare(Member a, Member b) {
+      if (a.isOlderThan(b)) return -1;
+      else if (b.isOlderThan(a)) return 1;
+      else return 0;
+    }
+  };
+  final SortedSet<Member> membersByAge = new TreeSet<Member>(ageComparator);
 
-  //subscribe to cluster changes, RoleLeaderChanged
+
+  //subscribe to cluster changes
   @Override
   public void preStart() {
-    cluster.subscribe(getSelf(), RoleLeaderChanged.class);
+    cluster.subscribe(getSelf(), MemberEvent.class);
   }
 
   //re-subscribe when restart
@@ -34,33 +50,41 @@ public class StatsFacade extends UntypedActor {
 
   @Override
   public void onReceive(Object message) {
-    if (message instanceof StatsJob && currentMaster == null) {
+    if (message instanceof StatsJob && membersByAge.isEmpty()) {
       getSender().tell(new JobFailed("Service unavailable, try again later"),
           getSelf());
 
     } else if (message instanceof StatsJob) {
-      currentMaster.tell(message, getSender());
+      currentMaster().tell(message, getSender());
 
     } else if (message instanceof CurrentClusterState) {
       CurrentClusterState state = (CurrentClusterState) message;
-      setCurrentMaster(state.getRoleLeader("compute"));
+      List<Member> members = new ArrayList<Member>();
+      for (Member m : state.getMembers()) {
+        if (m.hasRole("compute")) members.add(m);
+      }
+      membersByAge.clear();
+      membersByAge.addAll(members);
 
-    } else if (message instanceof RoleLeaderChanged) {
-      RoleLeaderChanged leaderChanged = (RoleLeaderChanged) message;
-      if (leaderChanged.role().equals("compute"))
-        setCurrentMaster(leaderChanged.getLeader());
+    } else if (message instanceof MemberUp) {
+      Member m = ((MemberUp) message).member();
+      if (m.hasRole("compute")) membersByAge.add(m);
+
+    } else if (message instanceof MemberRemoved) {
+      Member m = ((MemberUp) message).member();
+      if (m.hasRole("compute")) membersByAge.remove(m);
+
+    } else if (message instanceof MemberEvent) {
+      // not interesting
 
     } else {
       unhandled(message);
     }
   }
 
-  void setCurrentMaster(Address address) {
-    if (address == null)
-      currentMaster = null;
-    else
-      currentMaster = getContext().actorSelection(address +
-          "/user/singleton/statsService");
+  ActorSelection currentMaster() {
+    return getContext().actorSelection(membersByAge.first().address() +
+        "/user/singleton/statsService");
   }
 
 }


### PR DESCRIPTION
- Assign internal upNumber when member is moved to Up
- Public API Member.isOlder
- Change cluster singleton to use oldest member instead of leader
- Update samples and docs
