### PR TITLE
[docs] fix there -> their in two places.

### DIFF
--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -401,7 +401,7 @@ An example of setting up a custom transport implementation::
 Remote Events
 -------------
 
-It is possible to listen to events that occur in Akka Remote, and to subscribe/unsubscribe to there events,
+It is possible to listen to events that occur in Akka Remote, and to subscribe/unsubscribe to these events
 you simply register as listener to the below described types in on the ``ActorSystem.eventStream``.
 
 .. note::

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -402,7 +402,7 @@ An example of setting up a custom transport implementation::
 Remote Events
 -------------
 
-It is possible to listen to events that occur in Akka Remote, and to subscribe/unsubscribe to there events,
+It is possible to listen to events that occur in Akka Remote, and to subscribe/unsubscribe to these events
 you simply register as listener to the below described types in on the ``ActorSystem.eventStream``.
 
 .. note::


### PR DESCRIPTION
Two minor grammar fixes in docs.
