### PR TITLE
improve logging in {Tcp,Udp}Listener, see #3305

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -40,7 +40,7 @@ object Udp extends ExtensionKey[UdpExt] {
   }
 
   case class Bind(handler: ActorRef,
-                  endpoint: InetSocketAddress,
+                  localAddress: InetSocketAddress,
                   options: immutable.Traversable[SocketOption] = Nil) extends Command
   case object Unbind extends Command
 

--- a/akka-actor/src/main/scala/akka/io/UdpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpListener.scala
@@ -22,32 +22,34 @@ private[io] class UdpListener(val udp: UdpExt,
                               val bind: Bind)
   extends Actor with ActorLogging with WithUdpSend {
 
-  import bind._
   import udp.bufferPool
   import udp.settings._
 
   def selector: ActorRef = context.parent
 
-  context.watch(handler) // sign death pact
-  val channel = {
-    val datagramChannel = DatagramChannel.open
-    datagramChannel.configureBlocking(false)
-    val socket = datagramChannel.socket
-    options.foreach(_.beforeDatagramBind(socket))
+  context.watch(bind.handler) // sign death pact
+
+  val channel = DatagramChannel.open
+  channel.configureBlocking(false)
+
+  val localAddress =
     try {
-      socket.bind(endpoint)
-      require(socket.getLocalSocketAddress.isInstanceOf[InetSocketAddress],
-        s"bound to unknown SocketAddress [${socket.getLocalSocketAddress}]")
+      val socket = channel.socket
+      bind.options.foreach(_.beforeDatagramBind(socket))
+      socket.bind(bind.localAddress)
+      val ret = socket.getLocalSocketAddress match {
+        case isa: InetSocketAddress ⇒ isa
+        case x                      ⇒ throw new IllegalArgumentException(s"bound to unknown SocketAddress [$x]")
+      }
+      context.parent ! RegisterChannel(channel, OP_READ)
+      log.debug("Successfully bound to [{}]", ret)
+      ret
     } catch {
       case NonFatal(e) ⇒
         bindCommander ! CommandFailed(bind)
-        log.error(e, "Failed to bind UDP channel to endpoint [{}]", endpoint)
+        log.error(e, "Failed to bind UDP channel to endpoint [{}]", bind.localAddress)
         context.stop(self)
     }
-    datagramChannel
-  }
-  context.parent ! RegisterChannel(channel, OP_READ)
-  log.debug("Successfully bound to [{}]", endpoint)
 
   def receive: Receive = {
     case ChannelRegistered ⇒
@@ -58,14 +60,14 @@ private[io] class UdpListener(val udp: UdpExt,
   def readHandlers: Receive = {
     case StopReading     ⇒ selector ! DisableReadInterest
     case ResumeReading   ⇒ selector ! ReadInterest
-    case ChannelReadable ⇒ doReceive(handler)
+    case ChannelReadable ⇒ doReceive(bind.handler)
 
     case Unbind ⇒
-      log.debug("Unbinding endpoint [{}]", endpoint)
+      log.debug("Unbinding endpoint [{}]", bind.localAddress)
       try {
         channel.close()
         sender ! Unbound
-        log.debug("Unbound endpoint [{}], stopping listener", endpoint)
+        log.debug("Unbound endpoint [{}], stopping listener", bind.localAddress)
       } finally context.stop(self)
   }
 


### PR DESCRIPTION
- do not log success message when bind fails
- use real port (and not zero if that was given) in further logging
