### PR TITLE
Changed design of RemoteWatcher due to cleanup race, see #3265

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -65,8 +65,7 @@ private[akka] class ClusterActorRefProvider(
       failureDetector,
       heartbeatInterval = WatchHeartBeatInterval,
       unreachableReaperInterval = WatchUnreachableReaperInterval,
-      heartbeatExpectedResponseAfter = WatchHeartbeatExpectedResponseAfter,
-      numberOfEndHeartbeatRequests = WatchNumberOfEndHeartbeatRequests), "remote-watcher")
+      heartbeatExpectedResponseAfter = WatchHeartbeatExpectedResponseAfter), "remote-watcher")
   }
 
   /**

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -26,10 +26,9 @@ private[cluster] object ClusterRemoteWatcher {
     failureDetector: FailureDetectorRegistry[Address],
     heartbeatInterval: FiniteDuration,
     unreachableReaperInterval: FiniteDuration,
-    heartbeatExpectedResponseAfter: FiniteDuration,
-    numberOfEndHeartbeatRequests: Int): Props =
+    heartbeatExpectedResponseAfter: FiniteDuration): Props =
     Props(classOf[ClusterRemoteWatcher], failureDetector, heartbeatInterval, unreachableReaperInterval,
-      heartbeatExpectedResponseAfter, numberOfEndHeartbeatRequests)
+      heartbeatExpectedResponseAfter)
 }
 
 /**
@@ -47,14 +46,12 @@ private[cluster] class ClusterRemoteWatcher(
   failureDetector: FailureDetectorRegistry[Address],
   heartbeatInterval: FiniteDuration,
   unreachableReaperInterval: FiniteDuration,
-  heartbeatExpectedResponseAfter: FiniteDuration,
-  numberOfEndHeartbeatRequests: Int)
+  heartbeatExpectedResponseAfter: FiniteDuration)
   extends RemoteWatcher(
     failureDetector,
     heartbeatInterval,
     unreachableReaperInterval,
-    heartbeatExpectedResponseAfter,
-    numberOfEndHeartbeatRequests) {
+    heartbeatExpectedResponseAfter) {
 
   import RemoteWatcher._
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeDeathWatchSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeDeathWatchSpec.scala
@@ -86,6 +86,8 @@ abstract class RemoteNodeDeathWatchSpec
 
   override def initialParticipants = roles.size
 
+  muteDeadLetters(Heartbeat.getClass)()
+
   lazy val remoteWatcher: ActorRef = {
     system.actorSelection("/system/remote-watcher") ! Identify(None)
     expectMsgType[ActorIdentity].ref.get

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -209,11 +209,6 @@ akka {
       # been received.
       expected-response-after = 3 s
 
-      # When a node unwatch another node it will end that
-      # with this number of EndHeartbeatRequest messages, which will stop the
-      # heartbeating from the other side
-      nr-of-end-heartbeats = 8
-
     }
 
     # After failed to establish an outbound connection, the remoting will mark the

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -191,8 +191,7 @@ private[akka] class RemoteActorRefProvider(
       failureDetector,
       heartbeatInterval = WatchHeartBeatInterval,
       unreachableReaperInterval = WatchUnreachableReaperInterval,
-      heartbeatExpectedResponseAfter = WatchHeartbeatExpectedResponseAfter,
-      numberOfEndHeartbeatRequests = WatchNumberOfEndHeartbeatRequests), "remote-watcher")
+      heartbeatExpectedResponseAfter = WatchHeartbeatExpectedResponseAfter), "remote-watcher")
   }
 
   protected def createRemoteWatcherFailureDetector(system: ExtendedActorSystem): FailureDetectorRegistry[Address] = {

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -87,9 +87,6 @@ class RemoteSettings(val config: Config) {
   val WatchUnreachableReaperInterval: FiniteDuration = {
     Duration(WatchFailureDetectorConfig.getMilliseconds("unreachable-nodes-reaper-interval"), MILLISECONDS)
   } requiring (_ > Duration.Zero, "watch-failure-detector.unreachable-nodes-reaper-interval must be > 0")
-  val WatchNumberOfEndHeartbeatRequests: Int = {
-    WatchFailureDetectorConfig.getInt("nr-of-end-heartbeats")
-  } requiring (_ > 0, "watch-failure-detector.nr-of-end-heartbeats must be > 0")
   val WatchHeartbeatExpectedResponseAfter: FiniteDuration = {
     Duration(WatchFailureDetectorConfig.getMilliseconds("expected-response-after"), MILLISECONDS)
   } requiring (_ > Duration.Zero, "watch-failure-detector.expected-response-after > 0")

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -51,7 +51,6 @@ class RemoteConfigSpec extends AkkaSpec(
 
       WatchFailureDetectorImplementationClass must be(classOf[PhiAccrualFailureDetector].getName)
       WatchHeartBeatInterval must be(1 seconds)
-      WatchNumberOfEndHeartbeatRequests must be(8)
       WatchHeartbeatExpectedResponseAfter must be(3 seconds)
       WatchUnreachableReaperInterval must be(1 second)
       WatchFailureDetectorConfig.getDouble("threshold") must be(10.0 plusOrMinus 0.0001)

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -247,7 +247,7 @@ trait TestKitBase {
       val failed =
         try { a; false } catch {
           case NonFatal(e) ⇒
-            if (now >= stop) throw e
+            if ((now + t) >= stop) throw e
             true
         }
       if (failed) {


### PR DESCRIPTION
- The problem was a race caused by HeartbeatReq sent out, and
  the watchee terminated immediately. That caused the RemoteWatcher
  peers watching each other without any other watch registered.
  It is racy.
- Instead of one-way heartbeats from the side beeing watched I
  changed to ping-pong style. That makes the problem go away
  and simplifies a lot of things in RemoteWatcher.
