### PR TITLE
Fix 3 dead links to a paper. (More docs fixes)

### DIFF
--- a/akka-docs/rst/general/remoting.rst
+++ b/akka-docs/rst/general/remoting.rst
@@ -18,8 +18,8 @@ available equally when running within a single JVM or on a cluster of hundreds
 of machines. The key for enabling this is to go from remote to local by way of
 optimization instead of trying to go from local to remote by way of
 generalization. See `this classic paper
-<http://labs.oracle.com/techrep/1994/abstract-29.html>`_ for a detailed
-discussion on why the second approach is bound to fail.
+<http://doc.akka.io/docs/misc/smli_tr-94-29.pdf>`_
+for a detailed discussion on why the second approach is bound to fail.
 
 Ways in which Transparency is Broken
 ------------------------------------

--- a/akka-docs/rst/java/typed-actors.rst
+++ b/akka-docs/rst/java/typed-actors.rst
@@ -27,10 +27,10 @@ blog post <http://letitcrash.com/post/19074284309/when-to-use-typedactors>`_.
 
 A bit more background: TypedActors can very easily be abused as RPC, and that
 is an abstraction which is `well-known
-<http://labs.oracle.com/techrep/1994/abstract-29.html>`_ to be leaky. Hence
-TypedActors are not what we think of first when we talk about making highly
-scalable concurrent software easier to write correctly. They have their niche,
-use them sparingly.
+<http://doc.akka.io/docs/misc/smli_tr-94-29.pdf>`_
+to be leaky. Hence TypedActors are not what we think of first when we talk
+about making highly scalable concurrent software easier to write correctly.
+They have their niche, use them sparingly.
 
 The tools of the trade
 ----------------------

--- a/akka-docs/rst/scala/typed-actors.rst
+++ b/akka-docs/rst/scala/typed-actors.rst
@@ -30,10 +30,10 @@ blog post <http://letitcrash.com/post/19074284309/when-to-use-typedactors>`_.
 
 A bit more background: TypedActors can very easily be abused as RPC, and that
 is an abstraction which is `well-known
-<http://labs.oracle.com/techrep/1994/abstract-29.html>`_ to be leaky. Hence
-TypedActors are not what we think of first when we talk about making highly
-scalable concurrent software easier to write correctly. They have their niche,
-use them sparingly.
+<http://doc.akka.io/docs/misc/smli_tr-94-29.pdf>`_
+to be leaky. Hence TypedActors are not what we think of first when we talk
+about making highly scalable concurrent software easier to write correctly.
+They have their niche, use them sparingly.
 
 The tools of the trade
 ----------------------


### PR DESCRIPTION
I fixed this by finding a mirror of the paper, but there's nothing saying this
mirror is going to last. It might be worth mirroring this paper elsewhere and
linking to it from an Akka project mirror or something.
