### PR TITLE
Actor fields are cleared after Terminated is sent #3311

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -70,9 +70,13 @@ class LocalActorRefProviderSpec extends AkkaSpec(LocalActorRefProviderSpec.confi
       childProps1 must be(Props.empty)
       system stop a
       expectTerminated(a)
-      val childProps2 = child.asInstanceOf[LocalActorRef].underlying.props
-      childProps2 must not be theSameInstanceAs(childProps1)
-      childProps2 must be theSameInstanceAs ActorCell.terminatedProps
+      // the fields are cleared after the Terminated message has been sent,
+      // so we need to check for a reasonable time after we receive it
+      awaitAssert({
+        val childProps2 = child.asInstanceOf[LocalActorRef].underlying.props
+        childProps2 must not be theSameInstanceAs(childProps1)
+        childProps2 must be theSameInstanceAs ActorCell.terminatedProps
+      }, 1 second)
     }
   }
 


### PR DESCRIPTION
Race in the test where we expect a field to be cleared/set when we receive the Terminated message.
