### PR TITLE
Some more test cleanup to not create so many threads #3320

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -483,7 +483,7 @@ trait Actor {
    * Actors are automatically started asynchronously when created.
    * Empty default implementation.
    */
-  @throws(classOf[Exception]) // when changing this you MUST also change UntypedActorDocTestBase
+  @throws(classOf[Exception]) // when changing this you MUST also change UnTypedActorDocTest
   //#lifecycle-hooks
   def preStart(): Unit = ()
 
@@ -495,7 +495,7 @@ trait Actor {
    * Is called asynchronously after 'actor.stop()' is invoked.
    * Empty default implementation.
    */
-  @throws(classOf[Exception]) // when changing this you MUST also change UntypedActorDocTestBase
+  @throws(classOf[Exception]) // when changing this you MUST also change UnTypedActorDocTest
   //#lifecycle-hooks
   def postStop(): Unit = ()
 
@@ -509,7 +509,7 @@ trait Actor {
    * Is called on a crashed Actor right BEFORE it is restarted to allow clean
    * up of resources before Actor is terminated.
    */
-  @throws(classOf[Exception]) // when changing this you MUST also change UntypedActorDocTestBase
+  @throws(classOf[Exception]) // when changing this you MUST also change UnTypedActorDocTest
   //#lifecycle-hooks
   def preRestart(reason: Throwable, message: Option[Any]): Unit = {
     context.children foreach { child ⇒
@@ -527,7 +527,7 @@ trait Actor {
    * <p/>
    * Is called right AFTER restart on the newly created Actor to allow reinitialization after an Actor crash.
    */
-  @throws(classOf[Exception]) // when changing this you MUST also change UntypedActorDocTestBase
+  @throws(classOf[Exception]) // when changing this you MUST also change UnTypedActorDocTest
   //#lifecycle-hooks
   def postRestart(reason: Throwable): Unit = {
     preStart()

--- a/akka-camel/src/test/java/akka/camel/ConsumerJavaTest.java
+++ b/akka-camel/src/test/java/akka/camel/ConsumerJavaTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.*;
 
-public class ConsumerJavaTestBase {
+public class ConsumerJavaTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-camel/src/test/java/akka/camel/CustomRouteTest.java
+++ b/akka-camel/src/test/java/akka/camel/CustomRouteTest.java
@@ -19,7 +19,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 
 import java.util.concurrent.TimeUnit;
 
-public class CustomRouteTestBase {
+public class CustomRouteTest {
 
   @Rule
   public AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-camel/src/test/java/akka/camel/MessageJavaTest.java
+++ b/akka-camel/src/test/java/akka/camel/MessageJavaTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 /**
  *
  */
-public class MessageJavaTestBase {
+public class MessageJavaTest {
   private Map<String,Object> empty = new HashMap<String, Object>();
 
   @ClassRule

--- a/akka-camel/src/test/scala/akka/camel/ConsumerJavaTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConsumerJavaTest.scala
@@ -1,9 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-
-package akka.camel
-
-import org.scalatest.junit.JUnitSuite
-
-class ConsumerJavaTest extends ConsumerJavaTestBase with JUnitSuite

--- a/akka-camel/src/test/scala/akka/camel/CustomRouteTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/CustomRouteTest.scala
@@ -1,5 +1,0 @@
-package akka.camel
-
-import org.scalatest.junit.JUnitSuite
-
-class CustomRouteTest extends CustomRouteTestBase with JUnitSuite

--- a/akka-camel/src/test/scala/akka/camel/MessageJavaTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/MessageJavaTest.scala
@@ -1,9 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-
-package akka.camel
-
-import org.scalatest.junit.JUnitSuite
-
-class MessageJavaTest extends MessageJavaTestBase with JUnitSuite

--- a/akka-docs/rst/java/camel.rst
+++ b/akka-docs/rst/java/camel.rst
@@ -101,13 +101,13 @@ The ``CamelExtension`` object provides access to the `Camel`_ interface.
 The `Camel`_ interface in turn provides access to two important Apache Camel objects, the `CamelContext`_ and the `ProducerTemplate`_.
 Below you can see how you can get access to these Apache Camel objects.
 
-.. includecode:: code/docs/camel/CamelExtensionTestBase.java#CamelExtension
+.. includecode:: code/docs/camel/CamelExtensionTest.java#CamelExtension
 
 One ``CamelExtension`` is only loaded once for every one ``ActorSystem``, which makes it safe to call the ``CamelExtension`` at any point in your code to get to the
 Apache Camel objects associated with it. There is one `CamelContext`_ and one `ProducerTemplate`_ for every one ``ActorSystem`` that uses a ``CamelExtension``.
 Below an example on how to add the ActiveMQ component to the `CamelContext`_, which is required when you would like to use the ActiveMQ component.
 
-.. includecode:: code/docs/camel/CamelExtensionTestBase.java#CamelExtensionAddComponent
+.. includecode:: code/docs/camel/CamelExtensionTest.java#CamelExtensionAddComponent
 
 The `CamelContext`_ joins the lifecycle of the ``ActorSystem`` and ``CamelExtension`` it is associated with; the `CamelContext`_ is started when
 the ``CamelExtension`` is created, and it is shut down when the associated ``ActorSystem`` is shut down. The same is true for the `ProducerTemplate`_.

--- a/akka-docs/rst/java/code/docs/actor/FSMDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/FSMDocTest.java
@@ -21,7 +21,7 @@ import akka.testkit.JavaTestKit;
 import akka.testkit.TestProbe;
 import akka.testkit.AkkaSpec;
 
-public class FSMDocTestBase {
+public class FSMDocTest {
 
   static
   //#data

--- a/akka-docs/rst/java/code/docs/actor/FSMDocTest.scala
+++ b/akka-docs/rst/java/code/docs/actor/FSMDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.actor
-
-import org.scalatest.junit.JUnitSuite
-
-class FSMDocTest extends FSMDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.java
+++ b/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.java
@@ -38,7 +38,7 @@ import org.junit.BeforeClass;
 import org.junit.AfterClass;
 
 //#testkit
-public class FaultHandlingTestBase {
+public class FaultHandlingTest {
   //#testkit
   static
   //#supervisor

--- a/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.scala
+++ b/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.scala
@@ -1,7 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.actor
-import org.scalatest.junit.JUnitSuite
-
-class FaultHandlingTest extends FaultHandlingTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/actor/SchedulerDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/SchedulerDocTest.java
@@ -20,7 +20,7 @@ import akka.testkit.AkkaSpec;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import org.junit.*;
 
-public class SchedulerDocTestBase {
+public class SchedulerDocTest {
 
   @Rule
   public AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/actor/SchedulerDocTest.scala
+++ b/akka-docs/rst/java/code/docs/actor/SchedulerDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.actor
-
-import org.scalatest.junit.JUnitSuite
-
-class SchedulerDocTest extends SchedulerDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/actor/TypedActorDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/TypedActorDocTest.java
@@ -19,7 +19,7 @@ import java.lang.Exception;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
-public class TypedActorDocTestBase {
+public class TypedActorDocTest {
     Object someReference = null;
     ActorSystem system = null;
 

--- a/akka-docs/rst/java/code/docs/actor/TypedActorDocTest.scala
+++ b/akka-docs/rst/java/code/docs/actor/TypedActorDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.actor
-
-import org.scalatest.junit.JUnitSuite
-
-class TypedActorDocTest extends TypedActorDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.java
@@ -80,7 +80,7 @@ import akka.testkit.JavaTestKit;
 import akka.util.Timeout;
 //#import-ask
 
-public class UntypedActorDocTestBase {
+public class UntypedActorDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.scala
+++ b/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.actor
-
-import org.scalatest.junit.JUnitSuite
-
-class UntypedActorDocTest extends UntypedActorDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/actor/mailbox/DurableMailboxDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/mailbox/DurableMailboxDocTest.java
@@ -18,7 +18,7 @@ import com.typesafe.config.ConfigFactory;
 import akka.actor.ActorSystem;
 import akka.actor.UntypedActor;
 
-public class DurableMailboxDocTestBase {
+public class DurableMailboxDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/actor/mailbox/DurableMailboxDocTest.scala
+++ b/akka-docs/rst/java/code/docs/actor/mailbox/DurableMailboxDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.actor.mailbox
-
-import org.scalatest.junit.JUnitSuite
-
-class DurableMailboxDocTest extends DurableMailboxDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/camel/CamelExtensionDocTest.scala
+++ b/akka-docs/rst/java/code/docs/camel/CamelExtensionDocTest.scala
@@ -1,5 +1,0 @@
-package docs.camel
-
-import org.scalatest.junit.JUnitSuite
-
-class CamelExtensionDocTest extends CamelExtensionTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/camel/CamelExtensionTest.java
+++ b/akka-docs/rst/java/code/docs/camel/CamelExtensionTest.java
@@ -8,7 +8,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.junit.Test;
 
-public class CamelExtensionTestBase {
+public class CamelExtensionTest {
   @Test
   public void getCamelExtension() {
     //#CamelExtension

--- a/akka-docs/rst/java/code/docs/dispatcher/DispatcherDocTest.java
+++ b/akka-docs/rst/java/code/docs/dispatcher/DispatcherDocTest.java
@@ -47,7 +47,7 @@ import com.typesafe.config.ConfigFactory;
 import docs.actor.MyUntypedActor;
 import akka.testkit.AkkaSpec;
 
-public class DispatcherDocTestBase {
+public class DispatcherDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/dispatcher/DispatcherDocTest.scala
+++ b/akka-docs/rst/java/code/docs/dispatcher/DispatcherDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.dispatcher
-
-import org.scalatest.junit.JUnitSuite
-
-class DispatcherDocTest extends DispatcherDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/event/LoggingDocTest.java
+++ b/akka-docs/rst/java/code/docs/event/LoggingDocTest.java
@@ -30,7 +30,7 @@ import akka.actor.UntypedActor;
 import akka.actor.DeadLetter;
 //#imports-deadletter
 
-public class LoggingDocTestBase {
+public class LoggingDocTest {
   
   @Test
   public void useLoggingActor() {

--- a/akka-docs/rst/java/code/docs/event/LoggingDocTest.scala
+++ b/akka-docs/rst/java/code/docs/event/LoggingDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.event
-
-import org.scalatest.junit.JUnitSuite
-
-class LoggingDocTest extends LoggingDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/extension/ExtensionDocTest.java
+++ b/akka-docs/rst/java/code/docs/extension/ExtensionDocTest.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 
-public class ExtensionDocTestBase {
+public class ExtensionDocTest {
 
   static
   //#extension

--- a/akka-docs/rst/java/code/docs/extension/ExtensionDocTest.scala
+++ b/akka-docs/rst/java/code/docs/extension/ExtensionDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.extension
-
-import org.scalatest.junit.JUnitSuite
-
-class ExtensionDocTest extends ExtensionDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/extension/SettingsExtensionDocTest.java
+++ b/akka-docs/rst/java/code/docs/extension/SettingsExtensionDocTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 import akka.actor.UntypedActor;
 import org.junit.Test;
 
-public class SettingsExtensionDocTestBase {
+public class SettingsExtensionDocTest {
 
   static
   //#extension

--- a/akka-docs/rst/java/code/docs/extension/SettingsExtensionDocTest.scala
+++ b/akka-docs/rst/java/code/docs/extension/SettingsExtensionDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.extension
-
-import org.scalatest.junit.JUnitSuite
-
-class SettingsExtensionDocTest extends SettingsExtensionDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/future/FutureDocTest.java
+++ b/akka-docs/rst/java/code/docs/future/FutureDocTest.java
@@ -65,7 +65,7 @@ import akka.pattern.Patterns;
 
 import static org.junit.Assert.*;
 
-public class FutureDocTestBase {
+public class FutureDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/future/FutureDocTest.scala
+++ b/akka-docs/rst/java/code/docs/future/FutureDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.future
-
-import org.scalatest.junit.JUnitSuite
-
-class FutureDocTest extends FutureDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/jrouting/ConsistentHashingRouterDocTest.java
+++ b/akka-docs/rst/java/code/docs/jrouting/ConsistentHashingRouterDocTest.java
@@ -25,7 +25,7 @@ import akka.routing.ConsistentHashingRouter.ConsistentHashMapper;
 import akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope;
 //#imports2
 
-public class ConsistentHashingRouterDocTestBase {
+public class ConsistentHashingRouterDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/jrouting/ConsistentHashingRouterDocTest.scala
+++ b/akka-docs/rst/java/code/docs/jrouting/ConsistentHashingRouterDocTest.scala
@@ -1,5 +1,0 @@
-package docs.jrouting;
-
-import org.scalatest.junit.JUnitSuite
-
-class ConsistentHashingRouterDocTest extends ConsistentHashingRouterDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/jrouting/CustomRouterDocTest.java
+++ b/akka-docs/rst/java/code/docs/jrouting/CustomRouterDocTest.java
@@ -4,10 +4,10 @@
 package docs.jrouting;
 
 import static akka.pattern.Patterns.ask;
-import static docs.jrouting.CustomRouterDocTestBase.Message.DemocratCountResult;
-import static docs.jrouting.CustomRouterDocTestBase.Message.DemocratVote;
-import static docs.jrouting.CustomRouterDocTestBase.Message.RepublicanCountResult;
-import static docs.jrouting.CustomRouterDocTestBase.Message.RepublicanVote;
+import static docs.jrouting.CustomRouterDocTest.Message.DemocratCountResult;
+import static docs.jrouting.CustomRouterDocTest.Message.DemocratVote;
+import static docs.jrouting.CustomRouterDocTest.Message.RepublicanCountResult;
+import static docs.jrouting.CustomRouterDocTest.Message.RepublicanVote;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -35,7 +35,7 @@ import akka.routing.RouteeProvider;
 import akka.testkit.AkkaSpec;
 import akka.util.Timeout;
 
-public class CustomRouterDocTestBase {
+public class CustomRouterDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/jrouting/CustomRouterDocTest.scala
+++ b/akka-docs/rst/java/code/docs/jrouting/CustomRouterDocTest.scala
@@ -1,5 +1,0 @@
-package docs.jrouting;
-
-import org.scalatest.junit.JUnitSuite
-
-class CustomRouterDocTest extends CustomRouterDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramDocTest.java
+++ b/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramDocTest.java
@@ -21,7 +21,7 @@ import akka.testkit.JavaTestKit;
 import docs.jrouting.RouterViaProgramExample.ExampleActor;
 import docs.routing.RouterViaProgramDocSpec.Echo;
 
-public class RouterViaProgramDocTestBase {
+public class RouterViaProgramDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramDocTest.scala
+++ b/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramDocTest.scala
@@ -1,5 +1,0 @@
-package docs.jrouting;
-
-import org.scalatest.junit.JUnitSuite
-
-class RouterViaProgramDocTest extends RouterViaProgramDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/remoting/RemoteDeploymentDocTest.java
+++ b/akka-docs/rst/java/code/docs/remoting/RemoteDeploymentDocTest.java
@@ -21,7 +21,7 @@ import akka.remote.RemoteScope;
 
 import akka.actor.UntypedActor;
 
-public class RemoteDeploymentDocTestBase {
+public class RemoteDeploymentDocTest {
 
   public static class SampleActor extends UntypedActor {
     public void onReceive(Object message) {

--- a/akka-docs/rst/java/code/docs/remoting/RemoteDeploymentDocTest.scala
+++ b/akka-docs/rst/java/code/docs/remoting/RemoteDeploymentDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.remoting
-
-import org.scalatest.junit.JUnitSuite
-
-class RemoteDeploymentDocTest extends RemoteDeploymentDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/serialization/SerializationDocTest.java
+++ b/akka-docs/rst/java/code/docs/serialization/SerializationDocTest.java
@@ -12,7 +12,7 @@ import akka.serialization.*;
 
 //#imports
 
-public class SerializationDocTestBase {
+public class SerializationDocTest {
   static
   //#my-own-serializer
   public class MyOwnSerializer extends JSerializer {

--- a/akka-docs/rst/java/code/docs/serialization/SerializationDocTest.scala
+++ b/akka-docs/rst/java/code/docs/serialization/SerializationDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.serialization
-
-import org.scalatest.junit.JUnitSuite
-
-class SerializationDocTest extends SerializationDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/code/docs/zeromq/ZeromqDocTest.java
+++ b/akka-docs/rst/java/code/docs/zeromq/ZeromqDocTest.java
@@ -50,7 +50,7 @@ import akka.actor.ActorSystem;
 import akka.testkit.AkkaSpec;
 import akka.testkit.AkkaJUnitActorSystemResource;
 
-public class ZeromqDocTestBase {
+public class ZeromqDocTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-docs/rst/java/code/docs/zeromq/ZeromqDocTest.scala
+++ b/akka-docs/rst/java/code/docs/zeromq/ZeromqDocTest.scala
@@ -1,8 +1,0 @@
-/**
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
- */
-package docs.zeromq
-
-import org.scalatest.junit.JUnitSuite
-
-class ZeromqDocTest extends ZeromqDocTestBase with JUnitSuite

--- a/akka-docs/rst/java/dispatchers.rst
+++ b/akka-docs/rst/java/dispatchers.rst
@@ -20,7 +20,7 @@ Looking up a Dispatcher
 
 Dispatchers implement the :class:`ExecutionContext` interface and can thus be used to run :class:`Future` invocations etc.
 
-.. includecode:: code/docs/dispatcher/DispatcherDocTestBase.java#lookup
+.. includecode:: code/docs/dispatcher/DispatcherDocTest.java#lookup
 
 Setting the dispatcher for an Actor
 -----------------------------------
@@ -38,7 +38,7 @@ For more options, see the default-dispatcher section of the :ref:`configuration`
 
 Then you create the actor as usual and define the dispatcher in the deployment configuration.
 
-.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTestBase.java#defining-dispatcher-in-config
+.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTest.java#defining-dispatcher-in-config
 
 .. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala#dispatcher-deployment-config
 
@@ -46,7 +46,7 @@ An alternative to the deployment configuration is to define the dispatcher in co
 If you define the ``dispatcher`` in the deployment configuration then this value will be used instead
 of programmatically provided parameter.
 
-.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTestBase.java#defining-dispatcher-in-code
+.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTest.java#defining-dispatcher-in-code
 
 .. note::
     The dispatcher you specify in ``withDispatcher`` and the ``dispatcher`` property in the deployment 
@@ -131,7 +131,7 @@ Configuring a ``PinnedDispatcher``:
 
 And then using it:
 
-.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTestBase.java#defining-pinned-dispatcher
+.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTest.java#defining-pinned-dispatcher
 
 Note that ``thread-pool-executor`` configuration as per the above ``my-thread-pool-dispatcher`` example is
 NOT applicable. This is because every actor will have its own thread pool when using ``PinnedDispatcher``,
@@ -192,7 +192,7 @@ Mailbox configuration examples
 
 How to create a PriorityMailbox:
 
-.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTestBase.java#prio-mailbox
+.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTest.java#prio-mailbox
 
 And then add it to the configuration:
 
@@ -200,7 +200,7 @@ And then add it to the configuration:
 
 And then an example on how you would use it:
 
-.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTestBase.java#prio-dispatcher
+.. includecode:: ../java/code/docs/dispatcher/DispatcherDocTest.java#prio-dispatcher
 
 It is also possible to configure a mailbox type directly like this:
 
@@ -209,11 +209,11 @@ It is also possible to configure a mailbox type directly like this:
 
 And then use it either from deployment like this:
 
-.. includecode:: code/docs/dispatcher/DispatcherDocTestBase.java#defining-mailbox-in-config
+.. includecode:: code/docs/dispatcher/DispatcherDocTest.java#defining-mailbox-in-config
 
 Or code like this:
 
-.. includecode:: code/docs/dispatcher/DispatcherDocTestBase.java#defining-mailbox-in-code
+.. includecode:: code/docs/dispatcher/DispatcherDocTest.java#defining-mailbox-in-code
 
 
 Requiring a message queue type for an Actor
@@ -257,9 +257,9 @@ Creating your own Mailbox type
 
 An example is worth a thousand quacks:
 
-.. includecode:: code/docs/dispatcher/DispatcherDocTestBase.java#imports-custom
+.. includecode:: code/docs/dispatcher/DispatcherDocTest.java#imports-custom
 
-.. includecode:: code/docs/dispatcher/DispatcherDocTestBase.java#mailbox-implementation-example
+.. includecode:: code/docs/dispatcher/DispatcherDocTest.java#mailbox-implementation-example
 
 And then you just specify the FQCN of your MailboxType as the value of the "mailbox-type" in the dispatcher
 configuration, or the mailbox configuration.

--- a/akka-docs/rst/java/durable-mailbox.rst
+++ b/akka-docs/rst/java/durable-mailbox.rst
@@ -57,7 +57,7 @@ of the mailbox:
 
 Here is an example of how to create an actor with a durable dispatcher:
 
-.. includecode:: code/docs/actor/mailbox/DurableMailboxDocTestBase.java
+.. includecode:: code/docs/actor/mailbox/DurableMailboxDocTest.java
    :include: imports,dispatcher-config-use
 
 You can also configure and tune the file-based durable mailbox. This is done in

--- a/akka-docs/rst/java/event-bus.rst
+++ b/akka-docs/rst/java/event-bus.rst
@@ -158,12 +158,12 @@ Classification`_ which enables registering to related sets of channels (as is
 used for :class:`RemoteLifeCycleMessage`). The following example demonstrates
 how a simple subscription works. Given a simple actor:
 
-.. includecode:: code/docs/event/LoggingDocTestBase.java#imports-deadletter
-.. includecode:: code/docs/event/LoggingDocTestBase.java#deadletter-actor
+.. includecode:: code/docs/event/LoggingDocTest.java#imports-deadletter
+.. includecode:: code/docs/event/LoggingDocTest.java#deadletter-actor
 
 it can be subscribed like this:
 
-.. includecode:: code/docs/event/LoggingDocTestBase.java#deadletters
+.. includecode:: code/docs/event/LoggingDocTest.java#deadletters
 
 Default Handlers
 ----------------

--- a/akka-docs/rst/java/extending-akka.rst
+++ b/akka-docs/rst/java/extending-akka.rst
@@ -25,28 +25,28 @@ So let's create a sample extension that just lets us count the number of times s
 
 First, we define what our ``Extension`` should do:
 
-.. includecode:: code/docs/extension/ExtensionDocTestBase.java
+.. includecode:: code/docs/extension/ExtensionDocTest.java
    :include: imports
 
-.. includecode:: code/docs/extension/ExtensionDocTestBase.java
+.. includecode:: code/docs/extension/ExtensionDocTest.java
    :include: extension
 
 Then we need to create an ``ExtensionId`` for our extension so we can grab ahold of it.
 
-.. includecode:: code/docs/extension/ExtensionDocTestBase.java
+.. includecode:: code/docs/extension/ExtensionDocTest.java
    :include: imports
 
-.. includecode:: code/docs/extension/ExtensionDocTestBase.java
+.. includecode:: code/docs/extension/ExtensionDocTest.java
    :include: extensionid
 
 Wicked! Now all we need to do is to actually use it:
 
-.. includecode:: code/docs/extension/ExtensionDocTestBase.java
+.. includecode:: code/docs/extension/ExtensionDocTest.java
    :include: extension-usage
 
 Or from inside of an Akka Actor:
 
-.. includecode:: code/docs/extension/ExtensionDocTestBase.java
+.. includecode:: code/docs/extension/ExtensionDocTest.java
    :include: extension-usage-actor
 
 That's all there is to it!
@@ -60,7 +60,7 @@ in the "akka.extensions" section of the config you provide to your ``ActorSystem
 ::
 
     akka {
-      extensions = ["docs.extension.ExtensionDocTestBase.CountExtension"]
+      extensions = ["docs.extension.ExtensionDocTest.CountExtension"]
     }
 
 Applicability
@@ -83,14 +83,14 @@ Sample configuration:
 
 The ``Extension``:
 
-.. includecode:: code/docs/extension/SettingsExtensionDocTestBase.java
+.. includecode:: code/docs/extension/SettingsExtensionDocTest.java
    :include: imports
 
-.. includecode:: code/docs/extension/SettingsExtensionDocTestBase.java
+.. includecode:: code/docs/extension/SettingsExtensionDocTest.java
    :include: extension,extensionid
 
 Use it:
 
-.. includecode:: code/docs/extension/SettingsExtensionDocTestBase.java
+.. includecode:: code/docs/extension/SettingsExtensionDocTest.java
    :include: extension-usage-actor
 

--- a/akka-docs/rst/java/fault-tolerance.rst
+++ b/akka-docs/rst/java/fault-tolerance.rst
@@ -39,7 +39,7 @@ in more depth.
 
 For the sake of demonstration let us consider the following strategy:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: strategy
 
 I have chosen a few well-known exception types in order to demonstrate the
@@ -115,49 +115,49 @@ Test Application
 The following section shows the effects of the different directives in practice,
 wherefor a test setup is needed. First off, we need a suitable supervisor:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: supervisor
 
 This supervisor will be used to create a child, with which we can experiment:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: child
 
 The test is easier by using the utilities described in :ref:`akka-testkit`,
 where ``TestProbe`` provides an actor ref useful for receiving and inspecting replies.
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: testkit
 
 Let us create actors:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: create
 
 The first test shall demonstrate the ``Resume`` directive, so we try it out by
 setting some non-initial state in the actor and have it fail:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: resume
 
 As you can see the value 42 survives the fault handling directive. Now, if we
 change the failure to a more serious ``NullPointerException``, that will no
 longer be the case:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: restart
 
 And finally in case of the fatal ``IllegalArgumentException`` the child will be
 terminated by the supervisor:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: stop
 
 Up to now the supervisor was completely unaffected by the child’s failure,
 because the directives set did handle it. In case of an ``Exception``, this is not
 true anymore and the supervisor escalates the failure.
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: escalate-kill
 
 The supervisor itself is supervised by the top-level actor provided by the
@@ -170,12 +170,12 @@ child not to survive this failure.
 In case this is not desired (which depends on the use case), we need to use a
 different supervisor which overrides this behavior.
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: supervisor2
 
 With this parent, the child survives the escalated restart, as demonstrated in
 the last test:
 
-.. includecode:: code/docs/actor/FaultHandlingTestBase.java
+.. includecode:: code/docs/actor/FaultHandlingTest.java
    :include: escalate-restart
 

--- a/akka-docs/rst/java/fsm.rst
+++ b/akka-docs/rst/java/fsm.rst
@@ -35,9 +35,9 @@ using a small well-defined set of methods. One way to achieve this is to
 assemble all mutable state in a superclass which keeps it private and offers
 protected methods for mutating it.
 
-.. includecode:: code/docs/actor/FSMDocTestBase.java#imports-data
+.. includecode:: code/docs/actor/FSMDocTest.java#imports-data
 
-.. includecode:: code/docs/actor/FSMDocTestBase.java#base
+.. includecode:: code/docs/actor/FSMDocTest.java#base
 
 The benefit of this approach is that state changes can be acted upon in one
 central place, which makes it impossible to forget inserting code for reacting
@@ -50,15 +50,15 @@ The base class shown above is designed to support a similar example as for the
 Scala FSM documentation: an actor which receives and queues messages, to be
 delivered in batches to a configurable target actor. The messages involved are:
 
-.. includecode:: code/docs/actor/FSMDocTestBase.java#data
+.. includecode:: code/docs/actor/FSMDocTest.java#data
 
 This actor has only the two states ``IDLE`` and ``ACTIVE``, making their
 handling quite straight-forward in the concrete actor derived from the base
 class:
 
-.. includecode:: code/docs/actor/FSMDocTestBase.java#imports-actor
+.. includecode:: code/docs/actor/FSMDocTest.java#imports-actor
 
-.. includecode:: code/docs/actor/FSMDocTestBase.java#actor
+.. includecode:: code/docs/actor/FSMDocTest.java#actor
 
 The trick here is to factor out common functionality like :meth:`whenUnhandled`
 and :meth:`transition` in order to obtain a few well-defined points for

--- a/akka-docs/rst/java/futures.rst
+++ b/akka-docs/rst/java/futures.rst
@@ -19,10 +19,10 @@ which is very similar to a ``java.util.concurrent.Executor``. if you have an ``A
 it will use its default dispatcher as the ``ExecutionContext``, or you can use the factory methods provided
 by the ``ExecutionContexts`` class to wrap ``Executors`` and ``ExecutorServices``, or even create your own.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports1,imports7
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: diy-execution-context
 
 Use with Actors
@@ -34,10 +34,10 @@ which only works if the original sender was an ``UntypedActor``) and the second 
 Using the ``ActorRef``\'s ``ask`` method to send a message will return a ``Future``.
 To wait for and retrieve the actual result the simplest method is:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports1
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: ask-blocking
 
 This will cause the current thread to block and wait for the ``UntypedActor`` to 'complete' the ``Future`` with it's reply.
@@ -55,7 +55,7 @@ That is why the cast to ``String`` is used in the above sample.
 
 To send the result of a ``Future`` to an ``Actor``, you can use the ``pipe`` construct:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: pipe-to
 
 Use Directly
@@ -65,10 +65,10 @@ A common use case within Akka is to have some computation performed concurrently
 the extra utility of an ``UntypedActor``. If you find yourself creating a pool of ``UntypedActor``\s for the sole reason
 of performing a calculation in parallel, there is an easier (and faster) way:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports2
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: future-eval
 
 In the above code the block passed to ``future`` will be executed by the default ``Dispatcher``,
@@ -78,17 +78,17 @@ and we also avoid the overhead of managing an ``UntypedActor``.
 
 You can also create already completed Futures using the ``Futures`` class, which can be either successes:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: successful
 
 Or failures:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: failed
 
 For these examples ``PrintResult`` is defined as follows:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: print-result
 
 Functional Futures
@@ -104,10 +104,10 @@ The first method for working with ``Future`` functionally is ``map``. This metho
 some operation on the result of the ``Future``, and returning a new result.
 The return value of the ``map`` method is another ``Future`` that will contain the new result:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports2
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: map
 
 In this example we are joining two strings together within a ``Future``. Instead of waiting for f1 to complete,
@@ -121,7 +121,7 @@ Something to note when using these methods: if the ``Future`` is still being pro
 it will be the completing thread that actually does the work.
 If the ``Future`` is already complete though, it will be run in our current thread. For example:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: map2
 
 The original ``Future`` will take at least 0.1 second to execute now, which means it is still being processed at
@@ -130,7 +130,7 @@ by the dispatcher when the result is ready.
 
 If we do the opposite:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: map3
 
 Our little string has been processed long before our 0.1 second sleep has finished. Because of this,
@@ -141,7 +141,7 @@ Normally this works quite well as it means there is very little overhead to runn
 If there is a possibility of the function taking a non-trivial amount of time to process it might be better
 to have this done concurrently, and for that we use ``flatMap``:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: flat-map
 
 Now our second ``Future`` is executed concurrently as well. This technique can also be used to combine the results
@@ -149,7 +149,7 @@ of several Futures into a single calculation, which will be better explained in 
 
 If you need to do conditional propagation, you can use ``filter``:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: filter
 
 Composing Futures
@@ -158,10 +158,10 @@ Composing Futures
 It is very often desirable to be able to combine different Futures with each other,
 below are some examples on how that can be done in a non-blocking fashion.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports3
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: sequence
 
 To better explain what happened in the example, ``Future.sequence`` is taking the ``Iterable<Future<Integer>>``
@@ -171,10 +171,10 @@ and we aggregate the sum of the ``Iterable``.
 The ``traverse`` method is similar to ``sequence``, but it takes a sequence of ``A``s and applies a function from ``A`` to ``Future<B>``
 and returns a ``Future<Iterable<B>>``, enabling parallel ``map`` over the sequence, if you use ``Futures.future`` to create the ``Future``.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports4
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: traverse
 
 It's as simple as that!
@@ -185,10 +185,10 @@ and the type of the futures and returns something with the same type as the star
 and then applies the function to all elements in the sequence of futures, non-blockingly,
 the execution will be started when the last of the Futures is completed.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports5
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: fold
 
 That's all it takes!
@@ -198,10 +198,10 @@ If the sequence passed to ``fold`` is empty, it will return the start-value, in 
 In some cases you don't have a start-value and you're able to use the value of the first completing ``Future``
 in the sequence as the start-value, you can use ``reduce``, it works like this:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports6
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: reduce
 
 Same as with ``fold``, the execution will be started when the last of the Futures is completed, you can also parallelize
@@ -215,13 +215,13 @@ Callbacks
 Sometimes you just want to listen to a ``Future`` being completed, and react to that not by creating a new Future, but by side-effecting.
 For this Scala supports ``onComplete``, ``onSuccess`` and ``onFailure``, of which the latter two are specializations of the first.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: onSuccess
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: onFailure
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: onComplete
 
 Ordering
@@ -233,7 +233,7 @@ But there's a solution! And it's name is ``andThen``, and it creates a new ``Fut
 the specified callback, a ``Future`` that will have the same result as the ``Future`` it's called on,
 which allows for ordering like in the following sample:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: and-then
 
 Auxiliary methods
@@ -242,13 +242,13 @@ Auxiliary methods
 ``Future`` ``fallbackTo`` combines 2 Futures into a new ``Future``, and will hold the successful value of the second ``Future``
 if the first ``Future`` fails.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: fallback-to
 
 You can also combine two Futures into a new ``Future`` that will hold a tuple of the two Futures successful results,
 using the ``zip`` operation.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: zip
 
 Exceptions
@@ -262,7 +262,7 @@ calling ``Await.result`` will cause it to be thrown again so it can be handled p
 It is also possible to handle an ``Exception`` by returning a different result.
 This is done with the ``recover`` method. For example:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: recover
 
 In this example, if the actor replied with a ``akka.actor.Status.Failure`` containing the ``ArithmeticException``,
@@ -273,7 +273,7 @@ it will behave as if we hadn't used the ``recover`` method.
 You can also use the ``recoverWith`` method, which has the same relationship to ``recover`` as ``flatMap`` has to ``map``,
 and is use like this:
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: try-recover
 
 After
@@ -281,8 +281,8 @@ After
 
 ``akka.pattern.Patterns.after`` makes it easy to complete a ``Future`` with a value or exception after a timeout.
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: imports8
 
-.. includecode:: code/docs/future/FutureDocTestBase.java
+.. includecode:: code/docs/future/FutureDocTest.java
    :include: after

--- a/akka-docs/rst/java/logging.rst
+++ b/akka-docs/rst/java/logging.rst
@@ -17,10 +17,10 @@ How to Log
 Create a ``LoggingAdapter`` and use the ``error``, ``warning``, ``info``, or ``debug`` methods,
 as illustrated in this example:
 
-.. includecode:: code/docs/event/LoggingDocTestBase.java
+.. includecode:: code/docs/event/LoggingDocTest.java
    :include: imports
 
-.. includecode:: code/docs/event/LoggingDocTestBase.java
+.. includecode:: code/docs/event/LoggingDocTest.java
    :include: my-actor
 
 The first parameter to ``Logging.getLogger`` could also be any
@@ -42,7 +42,7 @@ placeholders results in a warning being appended to the log statement (i.e. on
 the same line with the same severity). You may pass a Java array as the only
 substitution argument to have its elements be treated individually:
 
-.. includecode:: code/docs/event/LoggingDocTestBase.java#array
+.. includecode:: code/docs/event/LoggingDocTest.java#array
 
 The Java :class:`Class` of the log source is also included in the generated
 :class:`LogEvent`. In case of a simple string this is replaced with a “marker”
@@ -218,10 +218,10 @@ logger available in the 'akka-slf4j' module.
 
 Example of creating a listener:
 
-.. includecode:: code/docs/event/LoggingDocTestBase.java
+.. includecode:: code/docs/event/LoggingDocTest.java
    :include: imports,imports-listener
 
-.. includecode:: code/docs/event/LoggingDocTestBase.java
+.. includecode:: code/docs/event/LoggingDocTest.java
    :include: my-event-listener
 
 .. _slf4j-java:

--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -100,7 +100,7 @@ which in this sample corresponds to ``sampleActorSystem@127.0.0.1:2553``.
 
 Once you have configured the properties above you would do the following in code:
 
-.. includecode:: code/docs/remoting/RemoteDeploymentDocTestBase.java#sample-actor
+.. includecode:: code/docs/remoting/RemoteDeploymentDocTest.java#sample-actor
 
 The actor class ``SampleActor`` has to be available to the runtimes using it, i.e. the classloader of the
 actor systems has to have a JAR containing the class.
@@ -133,15 +133,15 @@ precedence.
 
 With these imports:
 
-.. includecode:: code/docs/remoting/RemoteDeploymentDocTestBase.java#import
+.. includecode:: code/docs/remoting/RemoteDeploymentDocTest.java#import
 
 and a remote address like this:
 
-.. includecode:: code/docs/remoting/RemoteDeploymentDocTestBase.java#make-address
+.. includecode:: code/docs/remoting/RemoteDeploymentDocTest.java#make-address
 
 you can advise the system to create a child on that remote node like so:
 
-.. includecode:: code/docs/remoting/RemoteDeploymentDocTestBase.java#deploy
+.. includecode:: code/docs/remoting/RemoteDeploymentDocTest.java#deploy
 
 Watching Remote Actors
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -550,4 +550,4 @@ reference file for more information:
    Setting properties like the listening IP and port number programmatically is
    best done by using something like the following:
 
-   .. includecode:: code/docs/remoting/RemoteDeploymentDocTestBase.java#programmatic
+   .. includecode:: code/docs/remoting/RemoteDeploymentDocTest.java#programmatic

--- a/akka-docs/rst/java/routing.rst
+++ b/akka-docs/rst/java/routing.rst
@@ -67,7 +67,7 @@ routee actors.
 
 Routees can also be specified by providing their path strings instead of their :class:`ActorRef`\s.
 
-.. includecode:: code/docs/jrouting/RouterViaProgramDocTestBase.java#programmaticRoutingRouteePaths
+.. includecode:: code/docs/jrouting/RouterViaProgramDocTest.java#programmaticRoutingRouteePaths
 
 In addition to being able to supply looked-up remote actors as routees, you can ask the router to
 deploy its created children on a set of remote hosts. Routees will be deployed in round-robin
@@ -133,7 +133,7 @@ while still re-creating the children, will still preserve the same number of act
 
 Setting the strategy is easily done:
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java
    :include: supervision
 
 Another potentially useful approach is to give the router the same strategy as
@@ -321,16 +321,16 @@ the same time for one router. The ``withHashMapper`` is tried first.
 
 Code example:
 
-.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTestBase.java
+.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTest.java
    :include: imports1
 
-.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTestBase.java
+.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTest.java
    :include: cache-actor
 
-.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTestBase.java
+.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTest.java
    :include: imports2
 
-.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTestBase.java
+.. includecode:: code/docs/jrouting/ConsistentHashingRouterDocTest.java
    :include: consistent-hashing-router
 
 In the above example you see that the ``Get`` message implements ``ConsistentHashable`` itself,
@@ -361,7 +361,7 @@ matter how that router would normally route its messages.
 The example below shows how you would use a ``Broadcast`` message to send a very important message
 to every routee of a router.
 
-.. includecode:: code/docs/jrouting/RouterViaProgramDocTestBase.java#broadcastDavyJonesWarning
+.. includecode:: code/docs/jrouting/RouterViaProgramDocTest.java#broadcastDavyJonesWarning
 
 In this example the router receives the ``Broadcast`` message, extracts its payload
 (``"Watch out for Davy Jones' locker"``), and then sends the payload on to all of the router's
@@ -374,7 +374,7 @@ A ``PoisonPill`` message has special handling for all actors, including for rout
 receives a ``PoisonPill`` message, that actor will be stopped. See the :ref:`poison-pill-java`
 documentation for details.
 
-.. includecode:: code/docs/jrouting/RouterViaProgramDocTestBase.java#poisonPill
+.. includecode:: code/docs/jrouting/RouterViaProgramDocTest.java#poisonPill
 
 For a router, which normally passes on messages to routees, it is important to realise that
 ``PoisonPill`` messages are processed by the router only. ``PoisonPill`` messages sent to a router
@@ -392,7 +392,7 @@ router. Instead you should wrap a ``PoisonPill`` message inside a broadcast mess
 routee will the ``PoisonPill`` message directly. Note that this will stop all routees, even if the
 routees aren't children of the router, i.e. even routees programmatically provided to the router.
 
-.. includecode:: code/docs/jrouting/RouterViaProgramDocTestBase.java#broadcastPoisonPill
+.. includecode:: code/docs/jrouting/RouterViaProgramDocTest.java#broadcastPoisonPill
 
 With the code shown above, each routee will receive a ``PoisonPill`` message. Each routee will
 continue to process its messages as normal, eventually processing the ``PoisonPill``. This will
@@ -420,14 +420,14 @@ Routees that are children of the router will also be suspended, and will be affe
 supervision directive that is applied to the router. Routees that are not the routers children, i.e.
 those that were created externally to the router, will not be affected.
 
-.. includecode:: code/docs/jrouting/RouterViaProgramDocTestBase.java#kill
+.. includecode:: code/docs/jrouting/RouterViaProgramDocTest.java#kill
 
 As with the ``PoisonPill`` message, there is a distinction between killing a router, which
 indirectly kills its children (who happen to be routees), and killing routees directly (some of whom
 may not be children.) To kill routees directly the router should be sent a ``Kill`` message wrapped
 in a ``Broadcast`` message.
 
-.. includecode:: code/docs/jrouting/RouterViaProgramDocTestBase.java#broadcastKill
+.. includecode:: code/docs/jrouting/RouterViaProgramDocTest.java#broadcastKill
 
 .. _resizable-routers-java:
 
@@ -506,12 +506,12 @@ democrat related messages to the Democrat actor and all republican related messa
 
 We begin with defining the class:
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java#crRouter
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java#crRouter
    :exclude: crRoute
 
 The next step is to implement the ``createCustomRoute`` method in the class just defined:
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java#crRoute
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java#crRoute
 
 As you can see above we start off by creating the routees and put them in a collection.
 
@@ -520,12 +520,12 @@ It registers the routees internally and failing to call this method will
 cause a ``ActorInitializationException`` to be thrown when the router is used.
 Therefore always make sure to do the following in your custom router:
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java#crRegisterRoutees
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java#crRegisterRoutees
 
 The routing logic is where your magic sauce is applied. In our example it inspects the message types
 and forwards to the correct routee based on this:
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java#crRoutingLogic
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java#crRoutingLogic
 
 As you can see above what's returned in the ``CustomRoute`` function, which defines the mapping
 from incoming sender/message to a ``List`` of ``Destination(sender, routee)``.
@@ -536,11 +536,11 @@ For more information about how to alter the original sender we refer to the sour
 
 All in all the custom router looks like this:
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java#CustomRouter
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java#CustomRouter
 
 If you are interested in how to use the VoteCountRouter it looks like this:
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java#crTest
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java#crTest
 
 .. caution::
 
@@ -594,7 +594,7 @@ the actor system’s default dispatcher. All standard routers allow setting this
 property in their constructor or factory method, custom routers have to
 implement the method in a suitable way.
 
-.. includecode:: code/docs/jrouting/CustomRouterDocTestBase.java#dispatchers
+.. includecode:: code/docs/jrouting/CustomRouterDocTest.java#dispatchers
 
 .. note::
 

--- a/akka-docs/rst/java/scheduler.rst
+++ b/akka-docs/rst/java/scheduler.rst
@@ -28,23 +28,23 @@ Some examples
 
 Schedule to send the "foo"-message to the testActor after 50ms:
 
-.. includecode:: code/docs/actor/SchedulerDocTestBase.java
+.. includecode:: code/docs/actor/SchedulerDocTest.java
    :include: imports1
 
-.. includecode:: code/docs/actor/SchedulerDocTestBase.java
+.. includecode:: code/docs/actor/SchedulerDocTest.java
    :include: schedule-one-off-message
 
 Schedule a Runnable, that sends the current time to the testActor, to be executed after 50ms:
 
-.. includecode:: code/docs/actor/SchedulerDocTestBase.java
+.. includecode:: code/docs/actor/SchedulerDocTest.java
    :include: schedule-one-off-thunk
 
 Schedule to send the "Tick"-message to the ``tickActor`` after 0ms repeating every 50ms:
 
-.. includecode:: code/docs/actor/SchedulerDocTestBase.java
+.. includecode:: code/docs/actor/SchedulerDocTest.java
    :include: imports1,imports2
 
-.. includecode:: code/docs/actor/SchedulerDocTestBase.java
+.. includecode:: code/docs/actor/SchedulerDocTest.java
    :include: schedule-recurring
 
 From ``akka.actor.ActorSystem``

--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -75,10 +75,10 @@ Programmatic
 If you want to programmatically serialize/deserialize using Akka Serialization,
 here's some examples:
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: imports
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: programmatic
 
 For more information, have a look at the ``ScalaDoc`` for ``akka.serialization._``
@@ -96,10 +96,10 @@ Creating new Serializers
 First you need to create a class definition of your ``Serializer``,
 which is done by extending ``akka.serialization.JSerializer``, like this:
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: imports
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: my-own-serializer
    :exclude: ...
 
@@ -115,10 +115,10 @@ In the general case, the local address to be used depends on the type of remote
 address which shall be the recipient of the serialized information. Use
 :meth:`Serialization.serializedActorPath(actorRef)` like this:
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: imports
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: actorref-serializer
 
 This assumes that serialization happens in the context of sending a message
@@ -134,7 +134,7 @@ transport per se, which makes this question a bit more interesting. To find out
 the appropriate address to use when sending to ``remoteAddr`` you can use
 :meth:`ActorRefProvider.getExternalAddressFor(remoteAddr)` like this:
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: external-address
 
 .. note::
@@ -160,7 +160,7 @@ lenient as Akka’s RemoteActorRefProvider).
 There is also a default remote address which is the one used by cluster support
 (and typical systems have just this one); you can get it like this:
 
-.. includecode:: code/docs/serialization/SerializationDocTestBase.java
+.. includecode:: code/docs/serialization/SerializationDocTest.java
    :include: external-address-default
 
 Deep serialization of Actors

--- a/akka-docs/rst/java/typed-actors.rst
+++ b/akka-docs/rst/java/typed-actors.rst
@@ -38,7 +38,7 @@ The tools of the trade
 Before we create our first Typed Actor we should first go through the tools that we have at our disposal,
 it's located in ``akka.actor.TypedActor``.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-extension-tools
 
 .. warning::
@@ -55,42 +55,42 @@ To create a Typed Actor you need to have one or more interfaces, and one impleme
 
 The following imports are assumed:
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: imports
 
 Our example interface:
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-iface
    :exclude: typed-actor-iface-methods
 
 Our example implementation of that interface:
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-impl
    :exclude: typed-actor-impl-methods
 
 The most trivial way of creating a Typed Actor instance
 of our ``Squarer``:
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-create1
 
 First type is the type of the proxy, the second type is the type of the implementation.
 If you need to call a specific constructor you do it like this:
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-create2
 
 Since you supply a ``Props``, you can specify which dispatcher to use, what the default timeout should be used and more.
 Now, our ``Squarer`` doesn't have any methods, so we'd better add those.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-iface
 
 Alright, now we've got some methods we can call, but we need to implement those in ``SquarerImpl``.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-impl
 
 Excellent, now we have an interface and an implementation of that interface,
@@ -118,7 +118,7 @@ we *strongly* recommend that parameters passed are immutable.
 One-way message send
 ^^^^^^^^^^^^^^^^^^^^
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-call-oneway
 
 As simple as that! The method will be executed on another thread; asynchronously.
@@ -126,13 +126,13 @@ As simple as that! The method will be executed on another thread; asynchronously
 Request-reply message send
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-call-option
 
 This will block for as long as the timeout that was set in the ``Props`` of the Typed Actor,
 if needed. It will return ``None`` if a timeout occurs.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-call-strict
 
 This will block for as long as the timeout that was set in the ``Props`` of the Typed Actor,
@@ -141,7 +141,7 @@ if needed. It will throw a ``java.util.concurrent.TimeoutException`` if a timeou
 Request-reply-with-future message send
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-call-future
 
 This call is asynchronous, and the Future returned can be used for asynchronous composition.
@@ -151,12 +151,12 @@ Stopping Typed Actors
 
 Since Akka's Typed Actors are backed by Akka Actors they must be stopped when they aren't needed anymore.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-stop
 
 This asynchronously stops the Typed Actor associated with the specified proxy ASAP.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-poisonpill
 
 This asynchronously stops the Typed Actor associated with the specified proxy
@@ -168,7 +168,7 @@ Typed Actor Hierarchies
 Since you can obtain a contextual Typed Actor Extension by passing in an ``ActorContext``
 you can create child Typed Actors by invoking ``typedActorOf(..)`` on that.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java
+.. includecode:: code/docs/actor/TypedActorDocTest.java
    :include: typed-actor-hierarchy
 
 You can also create a child Typed Actor in regular Akka Actors by giving the ``UntypedActorContext``
@@ -213,4 +213,4 @@ Lookup & Remoting
 
 Since ``TypedActors`` are backed by ``Akka Actors``, you can use ``typedActorOf`` to proxy ``ActorRefs`` potentially residing on remote nodes.
 
-.. includecode:: code/docs/actor/TypedActorDocTestBase.java#typed-actor-remote
+.. includecode:: code/docs/actor/TypedActorDocTest.java#typed-actor-remote

--- a/akka-docs/rst/java/untyped-actors.rst
+++ b/akka-docs/rst/java/untyped-actors.rst
@@ -48,8 +48,8 @@ creating an actor including associated deployment information (e.g. which
 dispatcher to use, see more below). Here are some examples of how to create a
 :class:`Props` instance.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#import-props
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#creating-props-config
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#import-props
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#creating-props-config
 
 The last line shows how to pass constructor arguments to the :class:`Actor`
 being created. The presence of a matching constructor is verified during
@@ -63,8 +63,8 @@ Deprecated Variants
 Up to Akka 2.1 there were also the following possibilities (which are retained
 for a migration period):
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#import-untypedActor
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#creating-props-deprecated
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#import-untypedActor
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#creating-props-deprecated
 
 The last two are deprecated because their functionality is available in full
 through :meth:`Props.create()`.
@@ -104,7 +104,7 @@ especially when refactoring the actor’s constructor signature at a later point
 where compiler checks will allow this modification to be done with greater
 confidence than without.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#props-factory
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#props-factory
 
 Creating Actors with Props
 --------------------------
@@ -113,14 +113,14 @@ Actors are created by passing a :class:`Props` instance into the
 :meth:`actorOf` factory method which is available on :class:`ActorSystem` and
 :class:`ActorContext`.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#import-actorRef
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#system-actorOf
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#import-actorRef
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#system-actorOf
 
 Using the :class:`ActorSystem` will create top-level actors, supervised by the
 actor system’s provided guardian actor, while using an actor’s context will
 create a child actor.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#context-actorOf
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#context-actorOf
    :exclude: plus-some-behavior
 
 It is recommended to create a hierarchy of children, grand-children and so on
@@ -153,8 +153,8 @@ be part of the :class:`Props` as well, as described `above <Props>`_. But there
 are cases when a factory method must be used, for example when the actual
 constructor arguments are determined by a dependency injection framework.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#import-indirect
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#import-indirect
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: creating-indirectly
    :exclude: obtain-fresh-Actor-instance-from-DI-framework
 
@@ -226,7 +226,7 @@ In addition, it offers:
 The remaining visible methods are user-overridable life-cycle hooks which are
 described in the following:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#lifecycle-callbacks
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#lifecycle-callbacks
 
 The implementations shown above are the defaults provided by the :class:`UntypedActor`
 class.
@@ -245,8 +245,8 @@ termination (see `Stopping Actors`_). This service is provided by the
 Registering a monitor is easy (see fourth line, the rest is for demonstrating
 the whole functionality):
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#import-terminated
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#watch
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#import-terminated
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#watch
 
 It should be noted that the :class:`Terminated` message is generated
 independent of the order in which registration and termination occur.
@@ -272,7 +272,7 @@ Start Hook
 
 Right after starting the actor, its :meth:`preStart` method is invoked.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#preStart
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#preStart
 
 This method is called when the actor is first created. During restarts it is
 called by the default implementation of :meth:`postRestart`, which means that
@@ -349,7 +349,7 @@ actors may look up other actors by specifying absolute or relative
 paths—logical or physical—and receive back an :class:`ActorSelection` with the
 result:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#selection-local
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#selection-local
 
 The supplied path is parsed as a :class:`java.net.URI`, which basically means
 that it is split on ``/`` into path elements. If the path starts with ``/``, it
@@ -363,7 +363,7 @@ structure, i.e. the supervisor.
 The path elements of an actor selection may contain wildcard patterns allowing for
 broadcasting of messages to that section:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#selection-wildcard
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#selection-wildcard
 
 Messages can be sent via the :class:`ActorSelection` and the path of the
 :class:`ActorSelection` is looked up when delivering each message. If the selection
@@ -375,12 +375,12 @@ the actor. There is a built-in ``Identify`` message that all Actors will underst
 and automatically reply to with a ``ActorIdentity`` message containing the
 :class:`ActorRef`.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: import-identify,identify
 
 Remote actor addresses may also be looked up, if :ref:`remoting <remoting-java>` is enabled:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#selection-remote
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#selection-remote
 
 An example demonstrating remote actor look-up is given in :ref:`remote-lookup-sample-java`.
 
@@ -438,7 +438,7 @@ Tell: Fire-forget
 This is the preferred way of sending messages. No blocking waiting for a
 message. This gives the best concurrency and scalability characteristics.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#tell
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#tell
 
 The sender reference is passed along with the message and available within the
 receiving actor via its :meth:`getSender()` method while processing this
@@ -455,8 +455,8 @@ Ask: Send-And-Receive-Future
 The ``ask`` pattern involves actors as well as futures, hence it is offered as
 a use pattern rather than a method on :class:`ActorRef`:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#import-ask
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#ask-pipe
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#import-ask
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#ask-pipe
 
 This example demonstrates ``ask`` together with the ``pipe`` pattern on
 futures, because this is likely to be a common combination. Please note that
@@ -478,7 +478,7 @@ more below.
     To complete the future with an exception you need send a Failure message to the sender.
     This is *not done automatically* when an actor throws an exception while processing a message.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#reply-exception
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#reply-exception
 
 If the actor does not complete the future, it will expire after the timeout period,
 specified as parameter to the ``ask`` method; this will complete the
@@ -510,7 +510,7 @@ through a 'mediator'. This can be useful when writing actors that work as
 routers, load-balancers, replicators etc.
 You need to pass along your context variable as well.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#forward
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#forward
 
 Receive messages
 ================
@@ -538,7 +538,7 @@ for replying later, or passing on to other actors. If there is no sender (a
 message was sent without an actor or future context) then the sender
 defaults to a 'dead-letter' actor ref.
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#reply
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#reply
    :exclude: calculate-result
 
 Receive timeout
@@ -593,7 +593,7 @@ whole system.
 The :meth:`postStop()` hook is invoked after an actor is fully stopped. This
 enables cleaning up of resources:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#postStop
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#postStop
    :exclude: clean-up-resources-here
 
 .. note::
@@ -616,7 +616,7 @@ in the mailbox.
 
 Use it like this:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: poison-pill
 
 Graceful Stop
@@ -625,10 +625,10 @@ Graceful Stop
 :meth:`gracefulStop` is useful if you need to wait for termination or compose ordered
 termination of several actors:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: import-gracefulStop
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: gracefulStop
 
 When ``gracefulStop()`` returns successfully, the actor’s ``postStop()`` hook
@@ -663,10 +663,10 @@ at the top) and popped.
 
 To hotswap the Actor using ``getContext().become``:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: import-procedure
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: hot-swap-actor
 
 This variant of the :meth:`become` method is useful for many different things,
@@ -702,8 +702,8 @@ order as they have been received originally.
 
 Here is an example of the ``UntypedActorWithStash`` class in action:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#import-stash
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java#stash
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#import-stash
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java#stash
 
 Invoking ``stash()`` adds the current message (the message that the
 actor received last) to the actor's stash. It is typically invoked
@@ -752,7 +752,7 @@ See :ref:`supervision-directives` for more information.
 
 Use ``Kill`` like this:
 
-.. includecode:: code/docs/actor/UntypedActorDocTestBase.java
+.. includecode:: code/docs/actor/UnTypedActorDocTest.java
    :include: kill
 
 Actors and exceptions

--- a/akka-docs/rst/java/zeromq.rst
+++ b/akka-docs/rst/java/zeromq.rst
@@ -19,19 +19,19 @@ Connection
 ZeroMQ supports multiple connectivity patterns, each aimed to meet a different set of requirements. Currently, this module supports publisher-subscriber connections and connections based on dealers and routers. For connecting or accepting connections, a socket must be created.
 Sockets are always created using the ``akka.zeromq.ZeroMQExtension``, for example:
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#import-pub-socket
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#import-pub-socket
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#pub-socket
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#pub-socket
 
 Above examples will create a ZeroMQ Publisher socket that is Bound to the port 21231 on localhost.
 
 Similarly you can create a subscription socket, with a listener, that subscribes to all messages from the publisher using:
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#import-sub-socket
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#import-sub-socket
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#sub-socket
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#sub-socket
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#listener-actor
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#listener-actor
 
 The following sub-sections describe the supported connection patterns and how they can be used in an Akka environment. However, for a comprehensive discussion of connection patterns, please refer to `ZeroMQ -- The Guide <http://zguide.zeromq.org/page:all>`_.
 
@@ -47,22 +47,22 @@ When you're using zeromq pub/sub you should be aware that it needs multicast - c
 
 An actor is subscribed to a topic as follows:
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#sub-topic-socket
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#sub-topic-socket
 
 It is a prefix match so it is subscribed to all topics starting with ``foo.bar``. Note that if the given string is empty or
 ``Subscribe.all()`` is used, the actor is subscribed to all topics.
 
 To unsubscribe from a topic you do the following:
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#import-unsub-topic-socket
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#import-unsub-topic-socket
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#unsub-topic-socket
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#unsub-topic-socket
 
 To publish messages to a topic you must use two Frames with the topic in the first frame.
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#import-pub-topic
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#import-pub-topic
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#pub-topic
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#pub-topic
 
 Pub-Sub in Action
 ^^^^^^^^^^^^^^^^^
@@ -72,24 +72,24 @@ The following example illustrates one publisher with two subscribers.
 The publisher monitors current heap usage and system load and periodically publishes ``Heap`` events on the ``"health.heap"`` topic
 and ``Load`` events on the ``"health.load"`` topic.
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#import-health
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#import-health
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#health
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#health
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#health2
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#health2
 
 Let's add one subscriber that logs the information. It subscribes to all topics starting with ``"health"``, i.e. both ``Heap`` and
 ``Load`` events.
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#logger
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#logger
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#logger2
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#logger2
 
 Another subscriber keep track of used heap and warns if too much heap is used. It only subscribes to ``Heap`` events.
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#alerter
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#alerter
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#alerter2
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#alerter2
 
 Router-Dealer Connection
 ------------------------
@@ -100,7 +100,7 @@ With those socket types you can build your own reliable pub sub broker that uses
 
 To create a Router socket that has a high watermark configured, you would do:
 
-.. includecode:: code/docs/zeromq/ZeromqDocTestBase.java#high-watermark
+.. includecode:: code/docs/zeromq/ZeromqDocTest.java#high-watermark
 
 The akka-zeromq module accepts most if not all the available configuration options for a zeromq socket.
 

--- a/akka-docs/rst/scala/code/docs/dispatcher/DispatcherDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/dispatcher/DispatcherDocSpec.scala
@@ -18,7 +18,7 @@ object DispatcherDocSpec {
   val javaConfig = """
      //#prio-dispatcher-config-java
      prio-dispatcher {
-       mailbox-type = "docs.dispatcher.DispatcherDocTestBase$MyPrioMailbox"
+       mailbox-type = "docs.dispatcher.DispatcherDocTest$MyPrioMailbox"
        //Other dispatcher configuration goes here
      }
      //#prio-dispatcher-config-java

--- a/akka-docs/rst/scala/code/docs/remoting/RemoteDeploymentDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/remoting/RemoteDeploymentDocSpec.scala
@@ -20,7 +20,11 @@ object RemoteDeploymentDocSpec {
 
 class RemoteDeploymentDocSpec extends AkkaSpec("""
     akka.actor.provider = "akka.remote.RemoteActorRefProvider"
-    akka.remote.netty.tcp.port = 0
+    akka.remote.netty.tcp {
+      port = 0
+      server-socket-worker-pool.pool-size-max = 2
+      client-socket-worker-pool.pool-size-max = 2
+    }
 """) with ImplicitSender {
 
   import RemoteDeploymentDocSpec._

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -551,5 +551,5 @@ reference file for more information:
    Setting properties like the listening IP and port number programmatically is
    best done by using something like the following:
 
-   .. includecode:: ../java/code/docs/remoting/RemoteDeploymentDocTestBase.java#programmatic
+   .. includecode:: ../java/code/docs/remoting/RemoteDeploymentDocTest.java#programmatic
 

--- a/akka-remote/src/test/scala/akka/remote/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteDeathWatchSpec.scala
@@ -21,9 +21,11 @@ akka {
     remote.netty.tcp {
         hostname = "localhost"
         port = 0
+        server-socket-worker-pool.pool-size-max = 2
+        client-socket-worker-pool.pool-size-max = 2
     }
 }
-                                                                      """)) with ImplicitSender with DefaultTimeout with DeathWatchSpec {
+""")) with ImplicitSender with DefaultTimeout with DeathWatchSpec {
 
   val other = ActorSystem("other", ConfigFactory.parseString("akka.remote.netty.tcp.port=2666")
     .withFallback(system.settings.config))

--- a/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
@@ -24,6 +24,8 @@ akka {
   remote.netty.tcp {
     hostname = localhost
     port = 0
+    server-socket-worker-pool.pool-size-max = 2
+    client-socket-worker-pool.pool-size-max = 2
   }
   actor.deployment {
     /blub {

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -30,6 +30,8 @@ object AkkaProtocolStressTest {
       remote.netty.tcp {
         applied-adapters = ["gremlin"]
         port = 0
+        server-socket-worker-pool.pool-size-max = 2
+        client-socket-worker-pool.pool-size-max = 2
       }
 
     }

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -276,12 +276,13 @@ object AkkaBuild extends Build {
   )
 
   lazy val camel = Project(
-     id = "akka-camel",
-     base = file("akka-camel"),
-     dependencies = Seq(actor, slf4j, testkit % "test->test"),
-     settings = defaultSettings ++ scaladocSettings ++ javadocSettings ++ OSGi.camel ++ Seq(
-       libraryDependencies ++= Dependencies.camel
-     )
+    id = "akka-camel",
+    base = file("akka-camel"),
+    dependencies = Seq(actor, slf4j, testkit % "test->test"),
+    settings = defaultSettings ++ scaladocSettings ++ javadocSettings ++ OSGi.camel ++ Seq(
+      libraryDependencies ++= Dependencies.camel,
+      testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
+    )
   )
 
   val ActorReferenceCopyTask = TaskKey[Int]("hello", "Copy reference.conf from akka modules to akka-osgi")
@@ -992,7 +993,7 @@ object Dependencies {
 
   val kernel = Seq(Test.scalatest, Test.junit)
 
-  val camel = Seq(camelCore, Test.scalatest, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
+  val camel = Seq(camelCore, Test.scalatest, Test.junit, Test.mockito, Test.logback, Test.commonsIo, Test.junitIntf)
 
   val camelSample = Seq(camelJetty)
 


### PR DESCRIPTION
- Don't create so many threads for Netty in the remoting tests.
- Tests with JUnit `@Rule` annotations get inited once to man by ScalaTest leading to leaked ActorSystems.

Still haven't found a test that leaks an actor system with many threads though.
