### PR TITLE
Removed member higher prio than Exiting/Down, see #3309

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -824,6 +824,10 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
         } else (localGossip, false, Member.none, Member.none, Member.none, Member.none, Member.none)
 
+      // FIXME remove
+      log.info("Leader actions, convergence: [{}], changed: [{}], members: [{}], unreachable: [{}]",
+        localGossip.convergence, hasChangedState, localGossip.members, localGossip.overview.unreachable)
+
       if (hasChangedState) { // we have a change of state - version it and try to update
         // ----------------------
         // Updating the vclock version for the changes
@@ -878,6 +882,10 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
         removedUnreachableMembers foreach { member ⇒
           log.info("Cluster Node [{}] - Leader is removing unreachable node [{}]", selfAddress, member.address)
         }
+
+        // FIXME remove
+        log.info("After Leader actions, members: [{}], unreachable: [{}]",
+          latestGossip.members, latestGossip.overview.unreachable)
 
         publish(latestGossip)
       }

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -130,10 +130,16 @@ object Member {
 
   def pickHighestPriority(a: Set[Member], b: Set[Member]): Set[Member] = {
     // group all members by Address => Seq[Member]
-    val groupedByAddress = (a.toSeq ++ b.toSeq).groupBy(_.uniqueAddress)
+    val groupedByAddress = List(a, b).flatten.groupBy(_.uniqueAddress)
     // pick highest MemberStatus
     (Member.none /: groupedByAddress) {
-      case (acc, (_, members)) ⇒ acc + members.reduceLeft(highestPriorityOf)
+      case (acc, (_, members)) ⇒
+        // removed has higher priority than Down and Exiting
+        if (members.tail.isEmpty) {
+          val m = members.head
+          if (m.status == Down || m.status == Exiting) acc
+          else acc + m
+        } else acc + members.reduceLeft(highestPriorityOf)
     }
   }
 

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -47,6 +47,38 @@ class GossipSpec extends WordSpec with MustMatchers {
 
     }
 
+    "merge Removed as higher priority than Exiting" in {
+      // Removed is a bit special, since the member is actually removed from the set
+      // c3 is Down
+      val g1 = Gossip(members = SortedSet(a1, c3))
+      val g2 = Gossip(members = SortedSet(a1))
+      (g1 merge g2).members must be(SortedSet(a1))
+      (g2 merge g1).members must be(SortedSet(a1))
+    }
+
+    "merge Removed as higher priority than unreachable Down" in {
+      // Removed is a bit special, since the member is actually removed from the set
+      // e3 is Down
+      val g1 = Gossip(members = SortedSet(a1), overview = GossipOverview(unreachable = Set(b1, e3)))
+      val g2 = Gossip(members = SortedSet(a1))
+
+      val merged1 = g1 merge g2
+      merged1.members must be(SortedSet(a1))
+      merged1.overview.unreachable must be(Set(b1))
+
+      val merged2 = g2 merge g1
+      merged2.members must be(SortedSet(a1))
+      merged2.overview.unreachable must be(Set(b1))
+    }
+
+    "merge Joining as higher priority than Removed" in {
+      // e1 is Joining
+      val g1 = Gossip(members = SortedSet(a1, e1))
+      val g2 = Gossip(members = SortedSet(a1))
+      (g1 merge g2).members must be(SortedSet(a1, e1))
+      (g2 merge g1).members must be(SortedSet(a1, e1))
+    }
+
     "merge unreachable by status priority" in {
       val g1 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = Set(a1, b1, c1, d1)))
       val g2 = Gossip(members = Gossip.emptyMembers, overview = GossipOverview(unreachable = Set(a2, b2, c2, d2)))


### PR DESCRIPTION
I have not really been able to reproduce this, but this is my theory...
- ClusterSingletonManagerSpec revealed a bug in Gossip merge, which
  caused a removed member to come back into the member set after
  a gossip merge.
- Removed entry should have higher prio than Exiting, and Down in unreachable
