### PR TITLE
Hardening of cluster member leaving path, see #3309

### DIFF
--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -54,20 +54,6 @@ message Welcome {
  * Sends an Address
  */
 
-/****************************************
- * Cluster Leader Action Messages
- ****************************************/
-
-/**
- * Exit
- * Sends a UniqueAddress
- */
-
-/**
- * Shutdown
- * Sends a UniqueAddress
- */
-
 
 /****************************************
  * Cluster Heartbeat Messages

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -146,8 +146,6 @@ object ClusterEvent {
   case class UnreachableMember(member: Member) extends ClusterDomainEvent
 
   /**
-   * INTERNAL API
-   *
    * Current snapshot of cluster node metrics. Published to subscribers.
    */
   case class ClusterMetricsChanged(nodeMetrics: Set[NodeMetrics]) extends ClusterDomainEvent {
@@ -199,13 +197,6 @@ object ClusterEvent {
       }
 
       val allNewUnreachable = newGossip.overview.unreachable -- oldGossip.overview.unreachable
-
-      val unreachableGroupedByAddress =
-        List(newGossip.overview.unreachable, oldGossip.overview.unreachable).flatten.groupBy(_.uniqueAddress)
-      val unreachableDownMembers = unreachableGroupedByAddress collect {
-        case (_, newMember :: oldMember :: Nil) if newMember.status == Down && newMember.status != oldMember.status ⇒
-          newMember
-      }
 
       val removedMembers = (oldGossip.members -- newGossip.members -- newGossip.overview.unreachable) ++
         (oldGossip.overview.unreachable -- newGossip.overview.unreachable)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -128,17 +128,33 @@ private[cluster] final class ClusterHeartbeatSender extends Actor with ActorLogg
     case UnreachableMember(m)         ⇒ removeMember(m)
     case MemberRemoved(m)             ⇒ removeMember(m)
     case s: CurrentClusterState       ⇒ reset(s)
+    case MemberExited(m)              ⇒ memberExited(m)
     case _: MemberEvent               ⇒ // not interested in other types of MemberEvent
     case HeartbeatRequest(from)       ⇒ addHeartbeatRequest(from)
     case SendHeartbeatRequest(to)     ⇒ sendHeartbeatRequest(to)
     case ExpectedFirstHeartbeat(from) ⇒ triggerFirstHeartbeat(from)
   }
 
-  def reset(snapshot: CurrentClusterState): Unit = state = state.reset(snapshot.members.map(_.address))
+  def reset(snapshot: CurrentClusterState): Unit =
+    state = state.reset(snapshot.members.map(_.address)(collection.breakOut))
 
   def addMember(m: Member): Unit = if (m.address != selfAddress) state = state addMember m.address
 
-  def removeMember(m: Member): Unit = if (m.address != selfAddress) state = state removeMember m.address
+  def removeMember(m: Member): Unit = {
+    if (m.uniqueAddress == cluster.selfUniqueAddress)
+      // This cluster node will be shutdown, but stop this actor immediately
+      // to prevent it from sending out anything more and avoid sending EndHeartbeat.
+      context stop self
+    else
+      state = state removeMember m.address
+  }
+
+  def memberExited(m: Member): Unit =
+    if (m.uniqueAddress == cluster.selfUniqueAddress) {
+      // This cluster node will be shutdown, but stop this actor immediately
+      // to prevent it from sending out anything more and avoid sending EndHeartbeat.
+      context stop self
+    }
 
   def addHeartbeatRequest(address: Address): Unit =
     if (address != selfAddress) state = state.addHeartbeatRequest(address, Deadline.now + HeartbeatRequestTimeToLive)
@@ -253,7 +269,7 @@ private[cluster] case class ClusterHeartbeatSenderState private (
 
   val active: Set[Address] = current ++ heartbeatRequest.keySet
 
-  def reset(nodes: Set[Address]): ClusterHeartbeatSenderState = {
+  def reset(nodes: immutable.HashSet[Address]): ClusterHeartbeatSenderState = {
     ClusterHeartbeatSenderState(nodes.foldLeft(this) { _ removeHeartbeatRequest _ }, ring.copy(nodes = nodes + ring.selfAddress))
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterMetricsCollector.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterMetricsCollector.scala
@@ -88,6 +88,7 @@ private[cluster] class ClusterMetricsCollector(publisher: ActorRef) extends Acto
     case state: CurrentClusterState ⇒ receiveState(state)
     case MemberUp(m)                ⇒ addMember(m)
     case MemberRemoved(m)           ⇒ removeMember(m)
+    case MemberExited(m)            ⇒ removeMember(m)
     case UnreachableMember(m)       ⇒ removeMember(m)
     case _: MemberEvent             ⇒ // not interested in other types of MemberEvent
 

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -18,7 +18,10 @@ private[cluster] object Gossip {
     if (members.isEmpty) empty else empty.copy(members = members)
 
   private val leaderMemberStatus = Set[MemberStatus](Up, Leaving)
-  private val convergenceMemberStatus = Set[MemberStatus](Up, Leaving, Exiting)
+  private val convergenceMemberStatus = Set[MemberStatus](Up, Leaving)
+  val convergenceSkipUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
+  val removeUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
+
 }
 
 /**
@@ -177,12 +180,12 @@ private[cluster] case class Gossip(
   def convergence: Boolean = {
     // First check that:
     //   1. we don't have any members that are unreachable, or
-    //   2. all unreachable members in the set have status DOWN
+    //   2. all unreachable members in the set have status DOWN or EXITING
     // Else we can't continue to check for convergence
     // When that is done we check that all members with a convergence
     // status is in the seen table and has the latest vector clock
     // version
-    overview.unreachable.forall(_.status == Down) &&
+    overview.unreachable.forall(m ⇒ Gossip.convergenceSkipUnreachableWithMemberStatus(m.status)) &&
       !members.exists(m ⇒ Gossip.convergenceMemberStatus(m.status) && !seenByNode(m.uniqueAddress))
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -33,7 +33,7 @@ class Member private[cluster] (
     case m: Member ⇒ uniqueAddress == m.uniqueAddress
     case _         ⇒ false
   }
-  override def toString = s"{Member(address = ${address}, status = ${status})"
+  override def toString = s"Member(address = ${address}, status = ${status})"
 
   def hasRole(role: String): Boolean = roles.contains(role)
 

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -38,8 +38,6 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     InternalClusterAction.InitJoin.getClass -> (_ ⇒ InternalClusterAction.InitJoin),
     classOf[InternalClusterAction.InitJoinAck] -> (bytes ⇒ InternalClusterAction.InitJoinAck(addressFromBinary(bytes))),
     classOf[InternalClusterAction.InitJoinNack] -> (bytes ⇒ InternalClusterAction.InitJoinNack(addressFromBinary(bytes))),
-    classOf[ClusterLeaderAction.Exit] -> (bytes ⇒ ClusterLeaderAction.Exit(uniqueAddressFromBinary(bytes))),
-    classOf[ClusterLeaderAction.Shutdown] -> (bytes ⇒ ClusterLeaderAction.Shutdown(uniqueAddressFromBinary(bytes))),
     classOf[ClusterHeartbeatReceiver.Heartbeat] -> (bytes ⇒ ClusterHeartbeatReceiver.Heartbeat(addressFromBinary(bytes))),
     classOf[ClusterHeartbeatReceiver.EndHeartbeat] -> (bytes ⇒ ClusterHeartbeatReceiver.EndHeartbeat(addressFromBinary(bytes))),
     classOf[ClusterHeartbeatSender.HeartbeatRequest] -> (bytes ⇒ ClusterHeartbeatSender.HeartbeatRequest(addressFromBinary(bytes))),
@@ -75,10 +73,6 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
         addressToProto(address).toByteArray
       case InternalClusterAction.InitJoinNack(address) ⇒
         addressToProto(address).toByteArray
-      case ClusterLeaderAction.Exit(node) ⇒
-        uniqueAddressToProto(node).toByteArray
-      case ClusterLeaderAction.Shutdown(node) ⇒
-        uniqueAddressToProto(node).toByteArray
       case ClusterHeartbeatReceiver.EndHeartbeat(from) ⇒
         addressToProto(from).toByteArray
       case ClusterHeartbeatSender.HeartbeatRequest(from) ⇒

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterMetricsSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterMetricsSpec.scala
@@ -50,6 +50,7 @@ abstract class ClusterMetricsSpec extends MultiNodeSpec(ClusterMetricsMultiJvmSp
       }
       enterBarrier("first-left")
       runOn(second, third, fourth, fifth) {
+        markNodeAsUnavailable(first)
         awaitAssert(clusterView.clusterMetrics.size must be(roles.size - 1))
       }
       enterBarrier("finished")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerExitingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerExitingSpec.scala
@@ -19,14 +19,7 @@ object MembershipChangeListenerExitingMultiJvmSpec extends MultiNodeConfig {
   val second = role("second")
   val third = role("third")
 
-  commonConfig(
-    debugConfig(on = false)
-      .withFallback(ConfigFactory.parseString("""
-        akka.cluster {
-          unreachable-nodes-reaper-interval = 300 s # turn "off" reaping to unreachable node set
-        }
-      """)
-        .withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet)))
+  commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet))
 }
 
 class MembershipChangeListenerExitingMultiJvmNode1 extends MembershipChangeListenerExitingSpec

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemovedSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemovedSpec.scala
@@ -15,7 +15,8 @@ object NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec extends MultiNodeConfig 
   val second = role("second")
   val third = role("third")
 
-  commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet))
+  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(
+    "akka.cluster.auto-down=on")).withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet))
 }
 
 class NodeLeavingAndExitingAndBeingRemovedMultiJvmNode1 extends NodeLeavingAndExitingAndBeingRemovedSpec
@@ -28,30 +29,35 @@ abstract class NodeLeavingAndExitingAndBeingRemovedSpec
 
   import NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec._
 
-  val reaperWaitingTime = 30.seconds.dilated
-
   "A node that is LEAVING a non-singleton cluster" must {
 
-    "eventually set to REMOVED by the reaper, and removed from membership ring and seen table" taggedAs LongRunningTest in {
+    "eventually set to REMOVED and removed from membership ring and seen table" taggedAs LongRunningTest in {
 
       awaitClusterUp(first, second, third)
 
-      runOn(first) {
-        cluster.leave(second)
-      }
-      enterBarrier("second-left")
+      within(30.seconds) {
+        runOn(first) {
+          cluster.leave(second)
+        }
+        enterBarrier("second-left")
 
-      runOn(first, third) {
-        // verify that the 'second' node is no longer part of the 'members' set
-        awaitAssert(clusterView.members.map(_.address) must not contain (address(second)), reaperWaitingTime)
+        runOn(first, third) {
+          enterBarrier("second-shutdown")
+          markNodeAsUnavailable(second)
+          // verify that the 'second' node is no longer part of the 'members'/'unreachable' set
+          awaitAssert {
+            clusterView.members.map(_.address) must not contain (address(second))
+          }
+          awaitAssert {
+            clusterView.unreachableMembers.map(_.address) must not contain (address(second))
+          }
+        }
 
-        // verify that the 'second' node is not part of the 'unreachable' set
-        awaitAssert(clusterView.unreachableMembers.map(_.address) must not contain (address(second)), reaperWaitingTime)
-      }
-
-      runOn(second) {
-        // verify that the second node is shut down
-        awaitCond(cluster.isTerminated, reaperWaitingTime)
+        runOn(second) {
+          // verify that the second node is shut down
+          awaitCond(cluster.isTerminated)
+          enterBarrier("second-shutdown")
+        }
       }
 
       enterBarrier("finished")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingSpec.scala
@@ -18,12 +18,8 @@ object NodeLeavingAndExitingMultiJvmSpec extends MultiNodeConfig {
   val second = role("second")
   val third = role("third")
 
-  commonConfig(
-    debugConfig(on = false)
-      .withFallback(ConfigFactory.parseString("""
-          # turn off unreachable reaper
-          akka.cluster.unreachable-nodes-reaper-interval = 300 s""")
-        .withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet)))
+  commonConfig(debugConfig(on = false).
+    withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet))
 }
 
 class NodeLeavingAndExitingMultiJvmNode1 extends NodeLeavingAndExitingSpec
@@ -62,9 +58,6 @@ abstract class NodeLeavingAndExitingSpec
           cluster.leave(second)
         }
         enterBarrier("second-left")
-
-        val expectedAddresses = roles.toSet map address
-        awaitAssert(clusterView.members.map(_.address) must be(expectedAddresses))
 
         // Verify that 'second' node is set to EXITING
         exitingLatch.await

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SingletonClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SingletonClusterSpec.scala
@@ -76,5 +76,13 @@ abstract class SingletonClusterSpec(multiNodeConfig: SingletonClusterMultiNodeCo
 
       enterBarrier("after-3")
     }
+
+    "leave and shutdown itself when singleton cluster" taggedAs LongRunningTest in {
+      runOn(first) {
+        cluster.leave(first)
+        awaitCond(cluster.isTerminated, 5.seconds)
+      }
+      enterBarrier("after-4")
+    }
   }
 }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -858,7 +858,7 @@ abstract class StressSpec
     }
   }
 
-  def removeOne(shutdown: Boolean): Unit = within(10.seconds + convergenceWithin(3.seconds, nbrUsedRoles - 1)) {
+  def removeOne(shutdown: Boolean): Unit = within(25.seconds + convergenceWithin(3.seconds, nbrUsedRoles - 1)) {
     val currentRoles = roles.take(nbrUsedRoles - 1)
     val title = s"${if (shutdown) "shutdown" else "remove"} one from ${nbrUsedRoles} nodes cluster"
     createResultAggregator(title, expectedResults = currentRoles.size, includeInHistory = true)
@@ -903,7 +903,7 @@ abstract class StressSpec
   }
 
   def removeSeveral(numberOfNodes: Int, shutdown: Boolean): Unit =
-    within(10.seconds + convergenceWithin(5.seconds, nbrUsedRoles - numberOfNodes)) {
+    within(25.seconds + convergenceWithin(5.seconds, nbrUsedRoles - numberOfNodes)) {
       val currentRoles = roles.take(nbrUsedRoles - numberOfNodes)
       val removeRoles = roles.slice(currentRoles.size, nbrUsedRoles)
       val title = s"${if (shutdown) "shutdown" else "leave"} ${numberOfNodes} in ${nbrUsedRoles} nodes cluster"

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterHeartbeatSenderStateSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterHeartbeatSenderStateSpec.scala
@@ -10,6 +10,7 @@ import akka.actor.Address
 import akka.routing.ConsistentHash
 import scala.concurrent.duration._
 import scala.collection.immutable
+import scala.collection.immutable.HashSet
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ClusterHeartbeatSenderStateSpec extends WordSpec with MustMatchers {
@@ -43,7 +44,7 @@ class ClusterHeartbeatSenderStateSpec extends WordSpec with MustMatchers {
     }
 
     "remove heartbeatRequest after reset" in {
-      val s = emptyState.addHeartbeatRequest(aa, Deadline.now + 30.seconds).reset(Set(aa, bb))
+      val s = emptyState.addHeartbeatRequest(aa, Deadline.now + 30.seconds).reset(HashSet(aa, bb))
       s.heartbeatRequest must be(Map.empty)
     }
 
@@ -53,13 +54,13 @@ class ClusterHeartbeatSenderStateSpec extends WordSpec with MustMatchers {
     }
 
     "remove heartbeatRequest after removeMember" in {
-      val s = emptyState.addHeartbeatRequest(aa, Deadline.now + 30.seconds).reset(Set(aa, bb)).removeMember(aa)
+      val s = emptyState.addHeartbeatRequest(aa, Deadline.now + 30.seconds).reset(HashSet(aa, bb)).removeMember(aa)
       s.heartbeatRequest must be(Map.empty)
       s.ending must be(Map(aa -> 0))
     }
 
     "remove from ending after addHeartbeatRequest" in {
-      val s = emptyState.reset(Set(aa, bb)).removeMember(aa)
+      val s = emptyState.reset(HashSet(aa, bb)).removeMember(aa)
       s.ending must be(Map(aa -> 0))
       val s2 = s.addHeartbeatRequest(aa, Deadline.now + 30.seconds)
       s2.heartbeatRequest.keySet must be(Set(aa))
@@ -67,7 +68,7 @@ class ClusterHeartbeatSenderStateSpec extends WordSpec with MustMatchers {
     }
 
     "include nodes from reset in active set" in {
-      val nodes = Set(aa, bb, cc)
+      val nodes = HashSet(aa, bb, cc)
       val s = emptyState.reset(nodes)
       s.current must be(nodes)
       s.ending must be(Map.empty)
@@ -81,8 +82,8 @@ class ClusterHeartbeatSenderStateSpec extends WordSpec with MustMatchers {
       s.addMember(ee).current.size must be(3)
     }
 
-    "move meber to ending set when removing member" in {
-      val nodes = Set(aa, bb, cc, dd, ee)
+    "move member to ending set when removing member" in {
+      val nodes = HashSet(aa, bb, cc, dd, ee)
       val s = emptyState.reset(nodes)
       s.ending must be(Map.empty)
       val included = s.current.head
@@ -95,7 +96,7 @@ class ClusterHeartbeatSenderStateSpec extends WordSpec with MustMatchers {
     }
 
     "increase ending count correctly" in {
-      val s = emptyState.reset(Set(aa)).removeMember(aa)
+      val s = emptyState.reset(HashSet(aa)).removeMember(aa)
       s.ending must be(Map(aa -> 0))
       val s2 = s.increaseEndingCount(aa).increaseEndingCount(aa)
       s2.ending must be(Map(aa -> 2))

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -42,8 +42,6 @@ class ClusterMessageSerializerSpec extends AkkaSpec {
       checkSerialization(InternalClusterAction.InitJoin)
       checkSerialization(InternalClusterAction.InitJoinAck(address))
       checkSerialization(InternalClusterAction.InitJoinNack(address))
-      checkSerialization(ClusterLeaderAction.Exit(uniqueAddress))
-      checkSerialization(ClusterLeaderAction.Shutdown(uniqueAddress))
       checkSerialization(ClusterHeartbeatReceiver.Heartbeat(address))
       checkSerialization(ClusterHeartbeatReceiver.EndHeartbeat(address))
       checkSerialization(ClusterHeartbeatSender.HeartbeatRequest(address))

--- a/akka-docs/rst/scala/cluster-usage.rst
+++ b/akka-docs/rst/scala/cluster-usage.rst
@@ -151,6 +151,26 @@ Be aware of that using auto-down implies that two separate clusters will
 automatically be formed in case of network partition. That might be
 desired by some applications but not by others.
 
+Leaving
+^^^^^^^
+
+There are two ways to remove a member from the cluster.
+
+You can just stop the actor system (or the JVM process). It will be detected
+as unreachable and removed after the automatic or manual downing as described
+above.
+
+A more graceful exit can be performed if you tell the cluster that a node shall leave.
+This can be performed using :ref:`cluster_jmx_scala` or :ref:`cluster_command_line_scala`.
+It can also be performed programatically with ``Cluster(system).leave(address)``. 
+
+Note that this command can be issued to any member in the cluster, not necessarily the
+one that is leaving. The cluster extension, but not the actor system or JVM, of the 
+leaving member will be shutdown after the leader has changed status of the member to 
+`Exiting`. Thereafter the member will be removed from the cluster. Normally this is handled 
+automatically, but in case of network failures during this process it might still be necessary
+to set the node’s status to ``Down`` in order to complete the removal.
+
 .. _cluster_subscriber_scala:
 
 Subscribe to Cluster Events
@@ -161,7 +181,15 @@ You can subscribe to change notifications of the cluster membership by using
 ``akka.cluster.ClusterEvent.CurrentClusterState``, is sent to the subscriber
 as the first event, followed by events for incremental updates.
 
-There are several types of change events, consult the API documentation
+The events to track the life-cycle of members are:
+
+* ``ClusterEvent.MemberUp`` - A new member has joined the cluster and its status has been changed to ``Up``.
+* ``ClusterEvent.MemberExited`` - A member is leaving the cluster and its status has been changed to ``Exiting``.
+  Note that the node might already have been shutdown when this event is published on another node.
+* ``ClusterEvent.MemberRemoved`` - Member completely removed from the cluster.
+* ``ClusterEvent.UnreachableMember`` - A member is considered as unreachable by the failure detector.
+
+There are more types of change events, consult the API documentation
 of classes that extends ``akka.cluster.ClusterEvent.ClusterDomainEvent``
 for details about the events.
 


### PR DESCRIPTION
- ClusterSingletonManagerSpec revealed a bug in Gossip merge, which
  caused a removed member to come back into the member set after
  a gossip merge.
- Removed leader commands for Shutdown and Exit
- Member shutdown itself  when it sees itself as Exiting
- Singleton cluster with status Exiting will shutdown itself,
  in case the Exiting gossip never arrives
- Exiting member not part convergence check
- Exiting member is removed by leader (on convergence) when the
  exiting member is in the unreachable set, i.e. sucessfully shutdown
- Reverted the change made for #3266, i.e. Exiting is
  detected as unreachable again.
