### PR TITLE
ReliableProxy handling when tunnel goes away

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -126,8 +126,8 @@ import ReliableProxy._
  * '''''maxRetries''''' is the maximum number of retries (0 means no maximum).
  * After the maxRetries has been reached the actor will stop itself and send a
  * ProxyTerminated message to its parent.
- */
-class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int = 0)
+ */ // TODO - default args on Actor constructors no longer supported?
+class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int)
   extends Actor with FSM[State, Vector[Message]] {
 
   val tunnel = context.actorOf(receiver(target).withDeploy(Deploy(scope = RemoteScope(target.path.address))), "tunnel")
@@ -245,8 +245,8 @@ case class Unsent(private val queue: Vector[Message])
  * after receiving a ProxyTerminated message).  Note this setting does not prevent
  * this actor from recreating its ReliableProxy after it has propagated
  * ProxyTerminated to its parent.
- */
-class ReliableProxySuper(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int = 0, maxSuperRetries: Int = 0)
+ */ // TODO - default args on Actor constructors no longer supported?
+class ReliableProxySuper(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int, maxSuperRetries: Int)
   extends Actor with ActorLogging {
 
   var numRetries = 0

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -101,6 +101,9 @@ import ReliableProxy._
  * transition into [[ReliableProxy.Active]] state when ACKs are outstanding and
  * return to the [[ReliableProxy.Idle]] state when every message send so far
  * has been confirmed by the peer end-point.
+ * If a Unsent message is sent while the proxy is in ReliableProxy.Idle state the
+ * contained messages will be relayed through the tunnel to the target.  See the
+ * docs for Unsent for more details.
  * Any other message type sent to this actor will be delivered via a remote-deployed
  * child actor to the designated target. Message types declared in the companion
  * object are for internal use only and not to be sent from the outside.
@@ -118,12 +121,19 @@ import ReliableProxy._
  * ref points to.
  *
  * '''''retryAfter''''' is the ACK timeout after which all outstanding messages
- * will be resent. There is not limit on the queue size or the number of retries.
+ * will be resent. There is no limit on the queue size.
+ *
+ * '''''maxRetries''''' is the maximum number of retries (0 means no maximum).
+ * After the maxRetries has been reached the actor will stop itself and send a
+ * ProxyTerminated message to its parent.
  */
-class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration) extends Actor with FSM[State, Vector[Message]] {
+class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int = 0)
+  extends Actor with FSM[State, Vector[Message]] {
 
   val tunnel = context.actorOf(receiver(target).withDeploy(Deploy(scope = RemoteScope(target.path.address))), "tunnel")
   context.watch(tunnel)
+
+  var numRetries = 0
 
   override def supervisorStrategy = OneForOneStrategy() {
     case _ ⇒ SupervisorStrategy.Escalate
@@ -132,9 +142,10 @@ class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration) extends Actor 
   startWith(Idle, Vector.empty)
 
   when(Idle) {
-    case Event(Terminated(`tunnel`), _) ⇒ stop
-    case Event(Ack(_), _)               ⇒ stay
-    case Event(msg, _)                  ⇒ goto(Active) using Vector(send(msg))
+    case Event(Terminated(`tunnel`), _) ⇒ stop()
+    case Event(Ack(_), _)               ⇒ stay()
+    case Event(Unsent(queue), _)        ⇒ goto(Active) using resend(queue)
+    case Event(msg, _)                  ⇒ goto(Active) using Vector(send(msg, sender))
   }
 
   onTransition {
@@ -143,27 +154,140 @@ class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration) extends Actor 
   }
 
   when(Active) {
-    case Event(Terminated(`tunnel`), _) ⇒ stop
+    case Event(Terminated(`tunnel`), _) ⇒ stop()
     case Event(Ack(serial), queue) ⇒
       val q = queue dropWhile (m ⇒ compare(m.serial, serial) <= 0)
       scheduleTick()
+      numRetries = 0
       if (q.isEmpty) goto(Idle) using Vector.empty
       else stay using q
     case Event(Tick, queue) ⇒
-      queue foreach (tunnel ! _)
-      scheduleTick()
-      stay
-    case Event(msg, queue) ⇒ stay using (queue :+ send(msg))
+      if (maxRetries > 0 && numRetries >= maxRetries) {
+        log.warning("Stopping proxy after " + numRetries + " retries. Proxy=" + self)
+        context.parent ! ProxyTerminated(self, Unsent(queue))
+        stop()
+      } else {
+        log.warning("Resending " + queue.size + " messages through tunnel. Proxy=" + self)
+        queue foreach (tunnel ! _)
+        scheduleTick()
+        numRetries += 1
+        stay()
+      }
+    case Event(msg, queue) ⇒ stay using (queue :+ send(msg, sender))
   }
 
-  def scheduleTick(): Unit = setTimer("resend", Tick, retryAfter, false)
+  def scheduleTick(): Unit = setTimer("resend", Tick, retryAfter, repeat = false)
 
   var nextSerial = 1
-  def send(msg: Any): Message = {
+  def send(msg: Any, sender: ActorRef): Message = {
     val m = Message(msg, sender, nextSerial)
     nextSerial += 1
     tunnel ! m
     m
   }
 
+  def resend(q: Vector[Message]): Vector[Message] =
+    q map { case Message(msg, sender, _) ⇒ send(msg, sender) }
+}
+
+/**
+ * If the JVM running the tunnel (Receiver) crashes or is killed then DeathWatch
+ * will not send Terminated messages when the ReliableProxy is stopped
+ * (because it is unable to stop its child tunnel).
+ *
+ * In addition, if the JVM that was running the tunnel is then restarted,
+ * the tunnel will not exist in the new instance of the JVM.
+ *
+ * To mitigate these problems the ReliableProxy will send a ProxyTerminated
+ * message to its parent during postStop() to alert the parent of its death.
+ * It includes the unsent messages in case the parent wants to recreate the
+ * proxy (and tunnel) and resend the unsent messages (in this case, send the
+ * Unsent object itself).
+ */
+case class ProxyTerminated(actor: ActorRef, outstanding: Unsent)
+
+/**
+ * Sent to a ReliableProxy's parent as part of a ProxyTerminated message
+ * or directly to a ReliableProxySuper's parent when its underlying ReliableProxy
+ * has terminated.
+ *
+ * If this is sent back to the ReliableProxy/ReliableProxySuper the messages
+ * contained in it will be resent through the new tunnel.  Note: this has
+ * to be sent back to ReliableProxy/ReliableProxySuper before any other message.
+ *
+ * Note: the contained ``queue`` is for internal use only.
+ */
+case class Unsent(queue: Vector[Message])
+
+/**
+ * ReliableProxySuper is an actor that both proxies the ReliableProxy and
+ * supervises it, creating new ReliableProxy actors when they are terminated.
+ *
+ * When a ReliableProxy is terminated it sends a ProxyTerminated message to its
+ * parent including the unsent messages.  If ``maxSuperRetries`` has not been
+ * reached this actor will create a new ReliableProxy and send it the unsent
+ * messages.
+ *
+ * If a ProxyTerminated message is received and ``maxSuperRetries`` has been
+ * reached then this actor will send the Unsent messages to its parent and will
+ * reset its internal ReliableProxy reference.  The next time this actor receives
+ * a message it will create a new ReliableProxy.
+ *
+ * Note: Clients that want to take advantage of ReliableProxySuper should create
+ * and send messages to ReliableProxySuper instead of creating and sending
+ * messages to ReliableProxy.
+ *
+ * == Arguments ==
+ *
+ * This class takes the same arguments as ReliableProxy with one addition:
+ *
+ * ''''maxSuperRetries'''' is the number of times this actor will try to recreate
+ * a ReliableProxy and send it outstanding messages after receiving a
+ * ProxyTerminated message (0 means never recreate a ReliableProxy immediately
+ * after receiving a ProxyTerminated message).  Note this setting does not prevent
+ * this actor from recreating its ReliableProxy after it has propagated
+ * ProxyTerminated to its parent.
+ */
+class ReliableProxySuper(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int = 0, maxSuperRetries: Int = 0)
+  extends Actor with ActorLogging {
+
+  var numRetries = 0
+  var proxyCount = 0
+  var proxy: Option[ActorRef] = Some(createProxy())
+
+  override def supervisorStrategy = OneForOneStrategy() {
+    case _ ⇒ SupervisorStrategy.Escalate
+  }
+
+  def receive = {
+    case ProxyTerminated(actor, unsent) if (proxy exists (_ == actor)) ⇒
+      log.warning("ProxyTerminated: " + actor)
+      if (maxSuperRetries >= 0 && numRetries >= maxSuperRetries) {
+        proxy = None
+        numRetries = 0
+        context.parent ! unsent
+      } else {
+        val p = createProxy()
+        proxy = Some(p)
+        numRetries += 1
+        p ! unsent
+      }
+
+    case msg ⇒
+      if (proxy.isEmpty) proxy = Some(createProxy())
+      proxy foreach (_.forward(msg))
+  }
+
+  def createProxy(): ActorRef = {
+    val proxy = context.actorOf(Props(classOf[ReliableProxy], target, retryAfter, maxRetries), proxyName(target))
+    log.info("Proxying " + target + " with " + proxy)
+    proxy
+  }
+
+  def proxyName(ref: ActorRef): String = {
+    val rpa = ref.path.address
+    proxyCount += 1
+    rpa.host.getOrElse(sys.error(ref + " is not a RemoteActorRef")) +
+      "-" + rpa.port.getOrElse(0) + "-" + ref.path.name + "-" + proxyCount
+  }
 }

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -7,10 +7,19 @@ package akka.contrib.pattern
 import akka.actor._
 import akka.remote.RemoteScope
 import scala.concurrent.duration._
+import scala.util.Try
 
 object ReliableProxy {
+  def props(target: ActorRef, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration,
+            maxReconnects: Option[Int]): Props = {
+    Props(classOf[ReliableProxy], target, retryAfter, reconnectAfter, maxReconnects)
+  }
 
-  class Receiver(target: ActorRef) extends Actor with ActorLogging {
+  def props(target: ActorRef, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration): Props = {
+    props(target, retryAfter, reconnectAfter, None)
+  }
+
+  class Receiver(target: ActorRef) extends Actor with DebugLogging {
     var lastSerial = 0
 
     context.watch(target)
@@ -24,36 +33,68 @@ object ReliableProxy {
         } else if (compare(serial, lastSerial) <= 0) {
           sender ! Ack(serial)
         } else {
-          log.debug("received msg of {} from {} with wrong serial", msg.asInstanceOf[AnyRef].getClass, snd)
+          logDebug(s"Received message from $snd with wrong serial: $msg")
         }
-      //TODO use exact match of target when all actor references have uid, i.e. actorFor has been removed
-      case Terminated(a) if a.path == target.path ⇒ context stop self
+      case Terminated(`target`) ⇒ context stop self
     }
   }
 
   /**
-   * Wrap-around aware comparison of integers: differences limited to 2^31-1
+   * Wrap-around aware comparison of integers: differences limited to 2**31-1
    * in magnitude will work correctly.
    */
-  def compare(a: Int, b: Int): Int = (a - b) match {
-    case x if x < 0  ⇒ -1
-    case x if x == 0 ⇒ 0
-    case x if x > 0  ⇒ 1
+  def compare(a: Int, b: Int): Int = {
+    val c = a - b
+    c match {
+      case x if x < 0  ⇒ -1
+      case x if x == 0 ⇒ 0
+      case x if x > 0  ⇒ 1
+    }
   }
 
+  // Internal messages
   case class Message(msg: Any, sender: ActorRef, serial: Int)
   case class Ack(serial: Int)
   case object Tick
+  case object ReconnectTick
+
+  /**
+   *  Wrap a message in NoRetry to have the proxy send the message directly to the target
+   *  (not through the tunnel) without retrying.  This is useful if you need to send unreliable
+   *  messages to the target but don't want to track changing target ActorRefs in your actor.
+   */
+  case class NoRetry(msg: Any)
+
+  /**
+   * TargetChanged is sent to transition subscribers when the target ActorRef has changed
+   * (for example, the target system crashed and has been restarted).
+   */
+  case class TargetChanged(ref: ActorRef)
+
+  /**
+   * ProxyTerminated is sent to transition subscribers during postStop.  Any outstanding unsent
+   * messages are contained the Unsent object.
+   */
+  case class ProxyTerminated(actor: ActorRef, outstanding: Unsent)
+  case class Unsent(queue: Vector[Message])
 
   def receiver(target: ActorRef): Props = Props(classOf[Receiver], target)
 
   sealed trait State
   case object Idle extends State
   case object Active extends State
+  case object Reconnect extends State
 
   // Java API
   val idle = Idle
   val active = Active
+  val reconnect = Reconnect
+
+  trait DebugLogging extends ActorLogging { this: Actor ⇒
+    val debug = Try(context.system.settings.config.getBoolean("akka.actor.debug.reliable-proxy")) getOrElse false
+
+    def logDebug(s: String) = if (debug) log.debug(s"$s [$self]")
+  }
 }
 
 import ReliableProxy._
@@ -62,8 +103,8 @@ import ReliableProxy._
  * A ReliableProxy is a means to wrap a remote actor reference in order to
  * obtain certain improved delivery guarantees:
  *
- *  - as long as none of the JVMs crashes and the proxy and its remote-deployed
- *    peer are not forcefully terminated or restarted, no messages will be lost
+ *  - as long as the proxy is not terminated before it sends all of its queued
+ *    messages then no messages will be lost
  *  - messages re-sent due to the first point will not be delivered out-of-order,
  *    message ordering is preserved
  *
@@ -74,17 +115,16 @@ import ReliableProxy._
  * situations or other VM errors).
  *
  * You can create a reliable connection like this:
- *
- * In Scala:
- *
  * {{{
- * val proxy = context.actorOf(Props(classOf[ReliableProxy], target))
+ * val proxy = context.actorOf(Props(new ReliableProxy(target)))
  * }}}
- *
- * In Java:
- *
+ * or in Java:
  * {{{
- * final ActorRef proxy = getContext().actorOf(Props.create(ReliableProxy.class target));
+ * final ActorRef proxy = getContext().actorOf(new Props(new UntypedActorFactory() {
+ *   public Actor create() {
+ *     return new ReliableProxy(target);
+ *   }
+ * }));
  * }}}
  *
  * '''''Please note:''''' the tunnel is uni-directional, and original sender
@@ -94,19 +134,36 @@ import ReliableProxy._
  *
  * ==Message Types==
  *
- * This actor is an [[akka.actor.FSM]], hence it offers the service of
+ * This actor is an akka.actor.FSM, hence it offers the service of
  * transition callbacks to those actors which subscribe using the
  * ``SubscribeTransitionCallBack`` and ``UnsubscribeTransitionCallBack``
- * messages; see [[akka.actor.FSM]] for more documentation. The proxy will
- * transition into [[ReliableProxy.Active]] state when ACKs are outstanding and
- * return to the [[ReliableProxy.Idle]] state when every message send so far
+ * messages; see akka.actor.FSM for more documentation. The proxy will
+ * transition into ReliableProxy.Active state when ACKs are outstanding and
+ * return to the ReliableProxy.Idle state when every message send so far
  * has been confirmed by the peer end-point.
- * If a Unsent message is sent while the proxy is in ReliableProxy.Idle state the
- * contained messages will be relayed through the tunnel to the target.  See the
- * docs for Unsent for more details.
+ *
+ * If a communication failure causes the tunnel to terminate via Remote Deathwatch
+ * the proxy will transition into ReliableProxy.Reconnect state. In this state the
+ * proxy will repeatedly send Identify messages to ActorSelection(target.path) in
+ * order to obtain a new ActorRef for the target.  When an ActorIdentity for the
+ * target is received a new tunnel will be created and the proxy will transition to
+ * either Active or Idle, depending if there are any outstanding messages.  If the
+ * target ActorRef has changed a TargetChanged message will be sent to the proxy's
+ * transition subscribers.
+ *
+ * If the proxy is stopped and it still has outstanding messages a ProxyTerminated
+ * message will be sent to the transition subscribers.  It contains an Unsent object
+ * with the outstanding messages.
+ *
+ * If an Unsent message is sent to this actor the messages contained within it will
+ * be relayed through the tunnel to the target.
+ *
+ * If a NoRetry message is sent the message it wraps will be forwarded to the target
+ * directly (ie, not through the tunnel).  NoRetry messages have no delivery guarantees.
+ *
  * Any other message type sent to this actor will be delivered via a remote-deployed
- * child actor to the designated target. Message types declared in the companion
- * object are for internal use only and not to be sent from the outside.
+ * child actor to the designated target. All other message types declared in the
+ * companion object are for internal use only and not to be sent from the outside.
  *
  * ==Failure Cases==
  *
@@ -115,177 +172,169 @@ import ReliableProxy._
  *
  * ==Arguments==
  *
- * '''''target''''' is the [[akka.actor.ActorRef]] to which all messages will be
+ * '''''target''''' is the akka.actor.ActorRef to which all messages will be
  * forwarded which are sent to this actor. It can be any type of actor reference,
  * but the “remote” tunnel endpoint will be deployed on the node where the target
  * ref points to.
  *
  * '''''retryAfter''''' is the ACK timeout after which all outstanding messages
- * will be resent. There is no limit on the queue size.
+ * will be resent. There is no limit on the queue size or the number of retries.
  *
- * '''''maxRetries''''' is the maximum number of retries (0 means no maximum).
- * After the maxRetries has been reached the actor will stop itself and send a
- * ProxyTerminated message to its parent.
- */ // TODO - default args on Actor constructors no longer supported?
-class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int)
-  extends Actor with FSM[State, Vector[Message]] {
+ * '''''reconnectAfter''''' is the interval between reconnection attempts after the tunnel
+ * is terminated.  The minimum recommended value for this is the sum of the properties
+ * akka.remote.gate-invalid-addresses-for and akka.remote.quarantine-systems-for.
+ *
+ * '''''maxReconnects''''' is an optional maximum number of reconnection attempts for each
+ * tunnel. Use None for unlimited.
+ */
+class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration,
+                    maxReconnects: Option[Int])
+  extends Actor with LoggingFSM[State, Vector[Message]] with DebugLogging {
 
-  val tunnel = context.actorOf(receiver(target).withDeploy(Deploy(scope = RemoteScope(target.path.address))), "tunnel")
-  context.watch(tunnel)
+  var currentSerial: Int = _
+  var currentTarget: ActorRef = _
+  var attemptedReconnects: Int = _
 
-  var numRetries = 0
+  def createTunnel(target: ActorRef): ActorRef = {
+    logDebug(s"Creating new tunnel for $target")
+    val t = context.actorOf(receiver(target).withDeploy(Deploy(scope = RemoteScope(target.path.address))), "tunnel")
+
+    context.watch(t)
+    currentSerial = 0 // New tunnel expects first message to start with 1
+    currentTarget = target
+    attemptedReconnects = 0
+    resetBackoff()
+    t
+  }
+
+  if (target.path.address.host.isEmpty && self.path.address == target.path.address) {
+    logDebug(s"Unnecessary to use ReliableProxy for local target: $target")
+  }
+  var tunnel = createTunnel(target)
+
+  val resendTimer = "resend"
+  val reconnectTimer = "reconnect"
 
   override def supervisorStrategy = OneForOneStrategy() {
     case _ ⇒ SupervisorStrategy.Escalate
+  }
+
+  override def postStop() {
+    logDebug(s"Stopping proxy and sending ${stateData.size} messages to parent in Unsent")
+    gossip(ProxyTerminated(self, Unsent(stateData)))
+    super.postStop()
   }
 
   startWith(Idle, Vector.empty)
 
   when(Idle) {
-    case Event(Terminated(`tunnel`), _) ⇒ stop()
-    case Event(Ack(_), _)               ⇒ stay()
-    case Event(Unsent(queue), _)        ⇒ goto(Active) using resend(queue)
-    case Event(msg, _)                  ⇒ goto(Active) using Vector(send(msg, sender))
+    case Event(Terminated(_), _) ⇒ terminated()
+    case Event(Ack(_), _)        ⇒ stay()
+    case Event(Unsent(msgs), _)  ⇒ goto(Active) using resend(msgs)
+    case Event(NoRetry(msg), _)  ⇒ currentTarget forward msg; stay()
+    case Event(msg, _)           ⇒ goto(Active) using Vector(send(msg, sender))
   }
 
   onTransition {
-    case Idle -> Active ⇒ scheduleTick()
-    case Active -> Idle ⇒ cancelTimer("resend")
+    case _ -> Active    ⇒ scheduleTick()
+    case Active -> Idle ⇒ cancelTimer(resendTimer)
+    case _ -> Reconnect ⇒ scheduleReconnectTick()
   }
 
   when(Active) {
-    case Event(Terminated(`tunnel`), _) ⇒ stop()
+    case Event(Terminated(_), _) ⇒
+      terminated()
     case Event(Ack(serial), queue) ⇒
       val q = queue dropWhile (m ⇒ compare(m.serial, serial) <= 0)
       scheduleTick()
-      numRetries = 0
       if (q.isEmpty) goto(Idle) using Vector.empty
       else stay using q
     case Event(Tick, queue) ⇒
-      if (maxRetries > 0 && numRetries >= maxRetries) {
-        log.warning("Stopping proxy after " + numRetries + " retries. Proxy=" + self)
-        context.parent ! ProxyTerminated(self, Unsent(queue))
-        stop()
-      } else {
-        log.warning("Resending " + queue.size + " messages through tunnel. Proxy=" + self)
-        queue foreach (tunnel ! _)
-        scheduleTick()
-        numRetries += 1
-        stay()
-      }
-    case Event(msg, queue) ⇒ stay using (queue :+ send(msg, sender))
+      logResend(queue.size)
+      queue foreach { tunnel ! _ }
+      scheduleTick()
+      stay()
+    case Event(Unsent(msgs), _) ⇒
+      stay using resend(msgs)
+    case Event(NoRetry(msg), _) ⇒
+      currentTarget forward msg
+      stay()
+    case Event(msg, queue) ⇒
+      stay using (queue :+ send(msg, sender))
   }
 
-  def scheduleTick(): Unit = setTimer("resend", Tick, retryAfter, repeat = false)
+  when(Reconnect) {
+    case Event(Terminated(_), _) ⇒
+      stay()
+    case Event(ActorIdentity(_, Some(actor)), queue) ⇒
+      val curr = currentTarget
+      cancelTimer(reconnectTimer)
+      tunnel = createTunnel(actor)
+      if (currentTarget != curr) gossip(TargetChanged(currentTarget))
+      if (queue.isEmpty) goto(Idle) else goto(Active) using resend(queue)
+    case Event(ActorIdentity(_, None), _) ⇒
+      stay()
+    case Event(ReconnectTick, _) ⇒
+      if (maxReconnects exists (_ == attemptedReconnects)) {
+        logDebug(s"Failed to reconnect after $attemptedReconnects")
+        stop()
+      } else {
+        logDebug(s"${context.actorSelection(target.path)} ! ${Identify(target.path)}")
+        context.actorSelection(target.path) ! Identify(target.path)
+        scheduleReconnectTick()
+        attemptedReconnects += 1
+        stay()
+      }
+    case Event(NoRetry(msg), _) ⇒ // Drop msg
+      stay()
+    case Event(Unsent(msgs), queue) ⇒
+      stay using queue ++ msgs
+    case Event(msg, queue) ⇒
+      stay using (queue :+ Message(msg, sender, nextSerial()))
+  }
 
-  var nextSerial = 1
+  def scheduleTick(): Unit = setTimer(resendTimer, Tick, retryAfter, repeat = false)
+
+  def nextSerial(): Int = {
+    currentSerial += 1
+    currentSerial
+  }
+
   def send(msg: Any, sender: ActorRef): Message = {
-    val m = Message(msg, sender, nextSerial)
-    nextSerial += 1
+    val m = Message(msg, sender, nextSerial())
     tunnel ! m
     m
   }
 
-  def resend(q: Vector[Message]): Vector[Message] =
+  // Send q messages with new serial #s
+  def resend(q: Vector[Message]): Vector[Message] = {
+    logResend(q.size)
     q map { case Message(msg, sender, _) ⇒ send(msg, sender) }
-}
-
-/**
- * If the JVM running the tunnel (Receiver) crashes or is killed then DeathWatch
- * will not send Terminated messages when the ReliableProxy is stopped
- * (because it is unable to stop its child tunnel).
- *
- * In addition, if the JVM that was running the tunnel is then restarted,
- * the tunnel will not exist in the new instance of the JVM.
- *
- * To mitigate these problems the ReliableProxy will send a ProxyTerminated
- * message to its parent during postStop() to alert the parent of its death.
- * It includes the unsent messages in case the parent wants to recreate the
- * proxy (and tunnel) and resend the unsent messages (in this case, send the
- * Unsent object itself).
- */
-case class ProxyTerminated(actor: ActorRef, outstanding: Unsent)
-
-/**
- * Sent to a ReliableProxy's parent as part of a ProxyTerminated message
- * or directly to a ReliableProxySuper's parent when its underlying ReliableProxy
- * has terminated.
- *
- * If this is sent back to the ReliableProxy/ReliableProxySuper the messages
- * contained in it will be resent through the new tunnel.  Note: this has
- * to be sent back to ReliableProxy/ReliableProxySuper before any other message.
- */
-case class Unsent(private val queue: Vector[Message])
-
-/**
- * ReliableProxySuper is an actor that both proxies the ReliableProxy and
- * supervises it, creating new ReliableProxy actors when they are terminated.
- *
- * When a ReliableProxy is terminated it sends a ProxyTerminated message to its
- * parent including the unsent messages.  If ``maxSuperRetries`` has not been
- * reached this actor will create a new ReliableProxy and send it the unsent
- * messages.
- *
- * If a ProxyTerminated message is received and ``maxSuperRetries`` has been
- * reached then this actor will send the Unsent messages to its parent and will
- * reset its internal ReliableProxy reference.  The next time this actor receives
- * a message it will create a new ReliableProxy.
- *
- * Note: Clients that want to take advantage of ReliableProxySuper should create
- * and send messages to ReliableProxySuper instead of creating and sending
- * messages to ReliableProxy.
- *
- * == Arguments ==
- *
- * This class takes the same arguments as ReliableProxy with one addition:
- *
- * ''''maxSuperRetries'''' is the number of times this actor will try to recreate
- * a ReliableProxy and send it outstanding messages after receiving a
- * ProxyTerminated message (0 means never recreate a ReliableProxy immediately
- * after receiving a ProxyTerminated message).  Note this setting does not prevent
- * this actor from recreating its ReliableProxy after it has propagated
- * ProxyTerminated to its parent.
- */ // TODO - default args on Actor constructors no longer supported?
-class ReliableProxySuper(target: ActorRef, retryAfter: FiniteDuration, maxRetries: Int, maxSuperRetries: Int)
-  extends Actor with ActorLogging {
-
-  var numRetries = 0
-  var proxyCount = 0
-  var proxy: Option[ActorRef] = Some(createProxy())
-
-  override def supervisorStrategy = OneForOneStrategy() {
-    case _ ⇒ SupervisorStrategy.Escalate
   }
 
-  def receive = {
-    case ProxyTerminated(actor, unsent) if (proxy exists (_ == actor)) ⇒
-      log.warning("ProxyTerminated: " + actor)
-      if (maxSuperRetries >= 0 && numRetries >= maxSuperRetries) {
-        proxy = None
-        numRetries = 0
-        context.parent ! unsent
-      } else {
-        val p = createProxy()
-        proxy = Some(p)
-        numRetries += 1
-        p ! unsent
-      }
+  def logResend(size: Int): Unit =
+    logDebug(s"Resending $size messages through tunnel")
 
-    case msg ⇒
-      if (proxy.isEmpty) proxy = Some(createProxy())
-      proxy foreach (_.forward(msg))
+  def terminated(): State = {
+    logDebug(s"Terminated: $target")
+    goto(Reconnect)
   }
 
-  def createProxy(): ActorRef = {
-    val proxy = context.actorOf(Props(classOf[ReliableProxy], target, retryAfter, maxRetries), proxyName(target))
-    log.info("Proxying " + target + " with " + proxy)
-    proxy
+  def scheduleReconnectTick(): Unit = {
+    val delay = nextBackoff()
+    logDebug(s"Will attempt to reconnect to ${target.path} in $delay")
+    setTimer(reconnectTimer, ReconnectTick, delay, repeat = false)
   }
 
-  def proxyName(ref: ActorRef): String = {
-    val rpa = ref.path.address
-    proxyCount += 1
-    rpa.host.getOrElse(sys.error(ref + " is not a RemoteActorRef")) +
-      "-" + rpa.port.getOrElse(0) + "-" + ref.path.name + "-" + proxyCount
-  }
+  /**
+   * Reset backoff interval.
+   *
+   * This and nextBackoff are meant to be implemented by subclasses.
+   */
+  def resetBackoff() {}
+
+  /**
+   * Returns the next retry interval duration.  By default each interval is the same, reconnectAfter.
+   */
+  def nextBackoff(): FiniteDuration = reconnectAfter
 }

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -214,10 +214,8 @@ case class ProxyTerminated(actor: ActorRef, outstanding: Unsent)
  * If this is sent back to the ReliableProxy/ReliableProxySuper the messages
  * contained in it will be resent through the new tunnel.  Note: this has
  * to be sent back to ReliableProxy/ReliableProxySuper before any other message.
- *
- * Note: the contained ``queue`` is for internal use only.
  */
-case class Unsent(queue: Vector[Message])
+case class Unsent(private val queue: Vector[Message])
 
 /**
  * ReliableProxySuper is an actor that both proxies the ReliableProxy and

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -71,7 +71,7 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
 
         system.actorSelection(node(remote) / "user" / "echo") ! Identify("echo")
         target = expectMsgType[ActorIdentity].ref.get
-        proxy = system.actorOf(Props(classOf[ReliableProxy], target, 100.millis, 0), "proxy")
+        proxy = system.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds), "proxy")
         //#demo
         proxy ! FSM.SubscribeTransitionCallBack(testActor)
         expectState(Idle)

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -71,7 +71,7 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
 
         system.actorSelection(node(remote) / "user" / "echo") ! Identify("echo")
         target = expectMsgType[ActorIdentity].ref.get
-        proxy = system.actorOf(Props(classOf[ReliableProxy], target, 100.millis), "proxy")
+        proxy = system.actorOf(Props(classOf[ReliableProxy], target, 100.millis, 0), "proxy")
         //#demo
         proxy ! FSM.SubscribeTransitionCallBack(testActor)
         expectState(Idle)

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
@@ -9,7 +9,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import scala.concurrent.duration.Duration;
-import scala.concurrent.duration.FiniteDuration;
 import akka.actor.Actor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -43,7 +42,7 @@ public class ReliableProxyTest {
 
           //#demo-proxy
           final ActorRef proxy = getContext().actorOf(
-              Props.create(ReliableProxy.class, target, Duration.create(100, "millis"), 0));
+              ReliableProxy.props(target, Duration.create(100, "millis"), Duration.create(120, "seconds")));
 
           public void onReceive(Object msg) {
             if ("hello".equals(msg)) {
@@ -68,7 +67,8 @@ public class ReliableProxyTest {
         return new UntypedActor() {
 
           //#demo-transition
-          final ActorRef proxy = getContext().actorOf(Props.create(ReliableProxy.class, target, Duration.create(100, "millis"), 0));
+          final ActorRef proxy = getContext().actorOf(
+                  ReliableProxy.props(target, Duration.create(100, "millis"), Duration.create(120, "seconds")));
           ActorRef client = null;
           {
             proxy.tell(new FSM.SubscribeTransitionCallBack(getSelf()), getSelf());

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
@@ -43,7 +43,7 @@ public class ReliableProxyTest {
 
           //#demo-proxy
           final ActorRef proxy = getContext().actorOf(
-              Props.create(ReliableProxy.class, target, Duration.create(100, "millis")));
+              Props.create(ReliableProxy.class, target, Duration.create(100, "millis"), 0));
 
           public void onReceive(Object msg) {
             if ("hello".equals(msg)) {
@@ -68,7 +68,7 @@ public class ReliableProxyTest {
         return new UntypedActor() {
 
           //#demo-transition
-          final ActorRef proxy = getContext().actorOf(Props.create(ReliableProxy.class, target, Duration.create(100, "millis")));
+          final ActorRef proxy = getContext().actorOf(Props.create(ReliableProxy.class, target, Duration.create(100, "millis"), 0));
           ActorRef client = null;
           {
             proxy.tell(new FSM.SubscribeTransitionCallBack(getSelf()), getSelf());

--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -20,7 +20,7 @@ class ReliableProxyDocSpec extends AkkaSpec with ImplicitSender {
       val target = system.deadLetters
       val a = system.actorOf(Props(new Actor {
         //#demo-transition
-        val proxy = context.actorOf(Props(classOf[ReliableProxy], target, 100.millis))
+        val proxy = context.actorOf(Props(classOf[ReliableProxy], target, 100.millis, 0))
         proxy ! FSM.SubscribeTransitionCallBack(self)
 
         var client: ActorRef = _

--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -20,7 +20,7 @@ class ReliableProxyDocSpec extends AkkaSpec with ImplicitSender {
       val target = system.deadLetters
       val a = system.actorOf(Props(new Actor {
         //#demo-transition
-        val proxy = context.actorOf(Props(classOf[ReliableProxy], target, 100.millis, 0))
+        val proxy = context.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds))
         proxy ! FSM.SubscribeTransitionCallBack(self)
 
         var client: ActorRef = _

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -183,7 +183,7 @@ object AkkaBuild extends Build {
     dependencies = Seq(remote, remoteTests % "test->test" , testkit % "test->test"),
     settings = defaultSettings ++ scaladocSettings ++ javadocSettings ++ multiJvmSettings ++ OSGi.cluster ++ experimentalSettings ++
       scalabuffSettings ++ Seq(
-      scalabuffVersion in ScalaBuff := "1.2.0-SNAPSHOT",
+      scalabuffVersion in ScalaBuff := "1.2.0",
       libraryDependencies ++= Dependencies.cluster,
       // disable parallel tests
       parallelExecution in Test := false,


### PR DESCRIPTION
ReliableProxy handling when tunnel goes away.  Fixes #2731
- Add ReliableProxyProxy to proxy and manage lifecycle of ReliableProxy
- Enhancements to ReliableProxy to support ReliableProxyProxy (also works without ReliableProxyProxy).

This is the initial checkin for this enhancement to get feedback.   This is my first contribution to Akka so I'm sure there's a ton of stuff that I'm missing/need to fix.

To do 
- Remote Deathwatch support (code/comments based on Akka 2.1)
- Decide if API should change, default actor constructor params no longer supported
- Tests
- Reference docs
- Feedback
