### PR TITLE
Change defaults for Netty pools, see #3346

### DIFF
--- a/akka-docs/rst/scala/code/docs/remoting/RemoteDeploymentDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/remoting/RemoteDeploymentDocSpec.scala
@@ -22,8 +22,6 @@ class RemoteDeploymentDocSpec extends AkkaSpec("""
     akka.actor.provider = "akka.remote.RemoteActorRefProvider"
     akka.remote.netty.tcp {
       port = 0
-      server-socket-worker-pool.pool-size-max = 2
-      client-socket-worker-pool.pool-size-max = 2
     }
 """) with ImplicitSender {
 

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -370,7 +370,7 @@ akka {
         pool-size-factor = 1.0
 
         # Max number of threads to cap factor-based number to
-        pool-size-max = 8
+        pool-size-max = 2
       }
 
       # Used to configure the number of I/O worker threads on client sockets
@@ -385,7 +385,7 @@ akka {
         pool-size-factor = 1.0
 
         # Max number of threads to cap factor-based number to
-        pool-size-max = 8
+        pool-size-max = 2
       }
 
 

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -93,7 +93,7 @@ class RemoteConfigSpec extends AkkaSpec(
         pool.getInt("pool-size-min") must equal(2)
 
         pool.getDouble("pool-size-factor") must equal(1.0)
-        pool.getInt("pool-size-max") must equal(8)
+        pool.getInt("pool-size-max") must equal(2)
       }
 
       // client-socket-worker-pool
@@ -101,7 +101,7 @@ class RemoteConfigSpec extends AkkaSpec(
         val pool = c.getConfig("client-socket-worker-pool")
         pool.getInt("pool-size-min") must equal(2)
         pool.getDouble("pool-size-factor") must equal(1.0)
-        pool.getInt("pool-size-max") must equal(8)
+        pool.getInt("pool-size-max") must equal(2)
       }
 
     }

--- a/akka-remote/src/test/scala/akka/remote/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteDeathWatchSpec.scala
@@ -21,8 +21,6 @@ akka {
     remote.netty.tcp {
         hostname = "localhost"
         port = 0
-        server-socket-worker-pool.pool-size-max = 2
-        client-socket-worker-pool.pool-size-max = 2
     }
 }
 """)) with ImplicitSender with DefaultTimeout with DeathWatchSpec {

--- a/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
@@ -24,8 +24,6 @@ akka {
   remote.netty.tcp {
     hostname = localhost
     port = 0
-    server-socket-worker-pool.pool-size-max = 2
-    client-socket-worker-pool.pool-size-max = 2
   }
   actor.deployment {
     /blub {

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -72,8 +72,6 @@ object RemotingSpec {
     common-netty-settings {
       port = 0
       hostname = "localhost"
-      server-socket-worker-pool.pool-size-max = 2
-      client-socket-worker-pool.pool-size-max = 2
     }
 
     akka {

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -30,8 +30,6 @@ object AkkaProtocolStressTest {
       remote.netty.tcp {
         applied-adapters = ["gremlin"]
         port = 0
-        server-socket-worker-pool.pool-size-max = 2
-        client-socket-worker-pool.pool-size-max = 2
       }
 
     }


### PR DESCRIPTION
server-socket-worker-pool.pool-size-max = 2
client-socket-worker-pool.pool-size-max = 2
