### PR TITLE
Use a dilated timeout for ConcurrentActivationTest #3269

### DIFF
--- a/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
@@ -25,7 +25,7 @@ class ConcurrentActivationTest extends WordSpec with MustMatchers with NonShared
 
   "Activation" must {
     "support concurrent registrations and de-registrations" in {
-      implicit val timeout = Timeout(10 seconds)
+      implicit val timeout = Timeout((5 seconds).dilated)
       val timeoutDuration = timeout.duration
       implicit val ec = system.dispatcher
       val number = 10


### PR DESCRIPTION
- This test also exercise DeathWatch since the router watches all routees, so it's failure is related to #1441.
- It didn't have a dilated timeout.
