### PR TITLE
Added optional property (skipSenderNode) to PubSub.SendToAll

### DIFF
--- a/akka-contrib/docs/distributed-pub-sub.rst
+++ b/akka-contrib/docs/distributed-pub-sub.rst
@@ -43,8 +43,8 @@ the same path, without address information, can be registered on different nodes
 On each node there can only be one such actor, since the path is unique within one
 local actor system. Typical usage of this mode is to broadcast messages to all replicas
 with the same path, e.g. 3 actors on different nodes that all perform the same actions,
-for redundancy. You can also optionally specify a property (``skipSenderNode``) deciding
-if the message should be sent to a matching path on the sender node or not.
+for redundancy. You can also optionally specify a property (``allButSelf``) deciding
+if the message should be sent to a matching path on the self node or not.
 
 **3. DistributedPubSubMediator.Publish**
 

--- a/akka-contrib/docs/distributed-pub-sub.rst
+++ b/akka-contrib/docs/distributed-pub-sub.rst
@@ -43,7 +43,8 @@ the same path, without address information, can be registered on different nodes
 On each node there can only be one such actor, since the path is unique within one
 local actor system. Typical usage of this mode is to broadcast messages to all replicas
 with the same path, e.g. 3 actors on different nodes that all perform the same actions,
-for redundancy.
+for redundancy. You can also optionally specify a property (``skipSenderNode``) deciding
+if the message should be sent to a matching path on the sender node or not.
 
 **3. DistributedPubSubMediator.Publish**
 

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
@@ -45,7 +45,7 @@ object DistributedPubSubMediatorSpec extends MultiNodeConfig {
     def receive = {
       case Whisper(path, msg)      ⇒ mediator ! Send(path, msg, localAffinity = true)
       case Talk(path, msg)         ⇒ mediator ! SendToAll(path, msg)
-      case TalkToOthers(path, msg) ⇒ mediator ! SendToAll(path, msg, skipSenderNode = true)
+      case TalkToOthers(path, msg) ⇒ mediator ! SendToAll(path, msg, allButSelf = true)
       case Shout(topic, msg)       ⇒ mediator ! Publish(topic, msg)
       case msg                     ⇒ testActor ! msg
     }

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
@@ -34,6 +34,7 @@ object DistributedPubSubMediatorSpec extends MultiNodeConfig {
   object TestChatUser {
     case class Whisper(path: String, msg: Any)
     case class Talk(path: String, msg: Any)
+    case class TalkToOthers(path: String, msg: Any)
     case class Shout(topic: String, msg: Any)
   }
 
@@ -42,10 +43,11 @@ object DistributedPubSubMediatorSpec extends MultiNodeConfig {
     import DistributedPubSubMediator._
 
     def receive = {
-      case Whisper(path, msg) ⇒ mediator ! Send(path, msg, localAffinity = true)
-      case Talk(path, msg)    ⇒ mediator ! SendToAll(path, msg)
-      case Shout(topic, msg)  ⇒ mediator ! Publish(topic, msg)
-      case msg                ⇒ testActor ! msg
+      case Whisper(path, msg)      ⇒ mediator ! Send(path, msg, localAffinity = true)
+      case Talk(path, msg)         ⇒ mediator ! SendToAll(path, msg)
+      case TalkToOthers(path, msg) ⇒ mediator ! SendToAll(path, msg, skipSenderNode = true)
+      case Shout(topic, msg)       ⇒ mediator ! Publish(topic, msg)
+      case msg                     ⇒ testActor ! msg
     }
   }
 
@@ -317,5 +319,27 @@ class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMedia
       enterBarrier("after-8")
     }
 
+    "send-all to all other nodes" in within(15 seconds) {
+      runOn(first, second, third) { // create the user on all nodes
+        val u11 = createChatUser("u11")
+        mediator ! Put(u11)
+      }
+      awaitCount(13)
+      enterBarrier("11-registered")
+
+      runOn(third) {
+        chatUser("u5") ! TalkToOthers("/user/u11", "hi") // sendToAll to all other nodes
+      }
+
+      runOn(first, second) {
+        expectMsg("hi")
+        lastSender.path.name must be("u11")
+      }
+      runOn(third) {
+        expectNoMsg(2.seconds) // sender node should not receive a message
+      }
+
+      enterBarrier("after-11")
+    }
   }
 }


### PR DESCRIPTION
Deciding if the SendToAll message should be sent to a matching path on the sender cluster node or not. +Test +Docs.

The use case for this is something I have run into lately. You start up a subscriber service on all cluster nodes (f.e. to keep data in sync). But before you publish your data through SendToAll you rather store the state directly on your local node instead of paying unnecessary bandwidth and latency of sending it through the pubsub service. Then when you broadcast you don't want to send the data to your local node once more, but only to all the other subscribers. 
