### PR TITLE
 #3371 - using a new port for each of the TcpConnectionSpec tests to avo...

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -24,8 +24,6 @@ import akka.util.{ Helpers, ByteString }
 import akka.TestUtils._
 
 class TcpConnectionSpec extends AkkaSpec("akka.io.tcp.register-timeout = 500ms") {
-  val serverAddress = temporaryServerAddress()
-
   // Helper to avoid Windows localization specific differences
   def ignoreIfWindows(): Unit =
     if (Helpers.isWindows) {
@@ -705,6 +703,7 @@ class TcpConnectionSpec extends AkkaSpec("akka.io.tcp.register-timeout = 500ms")
   }
 
   abstract class LocalServerTest extends ChannelRegistry {
+    val serverAddress = temporaryServerAddress()
     val localServerChannel = ServerSocketChannel.open()
     val userHandler = TestProbe()
     val selector = TestProbe()


### PR DESCRIPTION
...id races with reuse of port numbers
