### PR TITLE
Send extra DeathWatchNotification from RemoteWatcher, see #3368

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteDeploymentWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDeploymentWatcher.scala
@@ -35,7 +35,8 @@ private[akka] class RemoteDeploymentWatcher extends Actor with RequiresMessageQu
 
     case t @ Terminated(a) if supervisors isDefinedAt a ⇒
       // send extra DeathWatchNotification to the supervisor so that it will remove the child
-      supervisors(a).sendSystemMessage(DeathWatchNotification(a, existenceConfirmed = false, addressTerminated = true))
+      supervisors(a).sendSystemMessage(DeathWatchNotification(a, existenceConfirmed = t.existenceConfirmed,
+        addressTerminated = t.addressTerminated))
       supervisors -= a
 
     case _: Terminated ⇒


### PR DESCRIPTION
This one part of the solution for ticket 3368. The other part is to properly flush and shutdown the remoting when the actor system is shutdown.
