### PR TITLE
Remove hardcoded port in RemoteRouterSpec, see #3369

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
@@ -19,207 +19,213 @@ object RemoteRouterSpec {
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class RemoteRouterSpec extends AkkaSpec("""
-akka {
-  actor.provider = "akka.remote.RemoteActorRefProvider"
-  remote.netty.tcp {
-    hostname = localhost
-    port = 0
-  }
-  actor.deployment {
-    /blub {
-      router = round-robin
-      nr-of-instances = 2
-      target.nodes = ["akka.tcp://remote-sys@localhost:12347"]
+    akka.actor.provider = "akka.remote.RemoteActorRefProvider"
+    akka.remote.netty.tcp {
+      hostname = localhost
+      port = 0
     }
-    /elastic-blub {
-      router = round-robin
-      resizer {
-        lower-bound = 2
-        upper-bound = 3
+    akka.actor.deployment {
+      /remote-override {
+        router = round-robin
+        nr-of-instances = 4
       }
-      target.nodes = ["akka.tcp://remote-sys@localhost:12347"]
-    }
-    /remote-blub {
-      remote = "akka.tcp://remote-sys@localhost:12347"
-      router = round-robin
-      nr-of-instances = 2
-    }
-    /local-blub {
-      remote = "akka://RemoteRouterSpec"
-      router = round-robin
-      nr-of-instances = 2
-      target.nodes = ["akka.tcp://remote-sys@localhost:12347"]
-    }
-    /local-blub2 {
-      router = round-robin
-      nr-of-instances = 4
-      target.nodes = ["akka.tcp://remote-sys@localhost:12347"]
-    }
-  }
-}
-""") with ImplicitSender {
+    }""") {
 
   import RemoteRouterSpec._
 
-  val conf = ConfigFactory.parseString("""akka.remote.netty.tcp.port=12347
-akka.actor.deployment {
-  /remote-override {
-    router = round-robin
-    nr-of-instances = 4
-  }
-}""").withFallback(system.settings.config)
-  val otherSystem = ActorSystem("remote-sys", conf)
+  val port = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.port.get
+  val sysName = system.name
+  val conf = ConfigFactory.parseString(
+    s"""
+    akka {
+      actor.deployment {
+        /blub {
+          router = round-robin
+          nr-of-instances = 2
+          target.nodes = ["akka.tcp://${sysName}@localhost:${port}"]
+        }
+        /elastic-blub {
+          router = round-robin
+          resizer {
+            lower-bound = 2
+            upper-bound = 3
+          }
+          target.nodes = ["akka.tcp://${sysName}@localhost:${port}"]
+        }
+        /remote-blub {
+          remote = "akka.tcp://${sysName}@localhost:${port}"
+          router = round-robin
+          nr-of-instances = 2
+        }
+        /local-blub {
+          remote = "akka://MasterRemoteRouterSpec"
+          router = round-robin
+          nr-of-instances = 2
+          target.nodes = ["akka.tcp://${sysName}@localhost:${port}"]
+        }
+        /local-blub2 {
+          router = round-robin
+          nr-of-instances = 4
+          target.nodes = ["akka.tcp://${sysName}@localhost:${port}"]
+        }
+      }
+    }""").withFallback(system.settings.config)
+  val masterSystem = ActorSystem("Master" + sysName, conf)
 
   override def afterTermination() {
-    shutdown(otherSystem)
+    shutdown(masterSystem)
   }
 
   "A Remote Router" must {
 
     "deploy its children on remote host driven by configuration" in {
-      val router = system.actorOf(Props[Echo].withRouter(RoundRobinRouter(2)), "blub")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(RoundRobinRouter(2)), "blub")
       val replies = for (i ← 1 to 5) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children must have size 2
       children.map(_.parent) must have size 1
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "deploy its children on remote host driven by programatic definition" in {
-      val router = system.actorOf(Props[Echo].withRouter(new RemoteRouterConfig(RoundRobinRouter(2),
-        Seq(Address("akka.tcp", "remote-sys", "localhost", 12347)))), "blub2")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(new RemoteRouterConfig(RoundRobinRouter(2),
+        Seq(Address("akka.tcp", sysName, "localhost", port)))), "blub2")
       val replies = for (i ← 1 to 5) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children must have size 2
       children.map(_.parent) must have size 1
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "deploy dynamic resizable number of children on remote host driven by configuration" in {
-      val router = system.actorOf(Props[Echo].withRouter(FromConfig), "elastic-blub")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(FromConfig), "elastic-blub")
       val replies = for (i ← 1 to 5000) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children.size must be >= 2
       children.map(_.parent) must have size 1
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "deploy remote routers based on configuration" in {
-      val router = system.actorOf(Props[Echo].withRouter(FromConfig), "remote-blub")
-      router.path.address.toString must be("akka.tcp://remote-sys@localhost:12347")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(FromConfig), "remote-blub")
+      router.path.address.toString must be(s"akka.tcp://${sysName}@localhost:${port}")
       val replies = for (i ← 1 to 5) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children must have size 2
       val parents = children.map(_.parent)
       parents must have size 1
       parents.head must be(router.path)
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "deploy remote routers based on explicit deployment" in {
-      val router = system.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
-        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString("akka.tcp://remote-sys@localhost:12347")))), "remote-blub2")
-      router.path.address.toString must be("akka.tcp://remote-sys@localhost:12347")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"akka.tcp://${sysName}@localhost:${port}")))), "remote-blub2")
+      router.path.address.toString must be(s"akka.tcp://${sysName}@localhost:${port}")
       val replies = for (i ← 1 to 5) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children must have size 2
       val parents = children.map(_.parent)
       parents must have size 1
       parents.head must be(router.path)
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "let remote deployment be overridden by local configuration" in {
-      val router = system.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
-        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString("akka.tcp://remote-sys@localhost:12347")))), "local-blub")
-      router.path.address.toString must be("akka://RemoteRouterSpec")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"akka.tcp://${sysName}@localhost:${port}")))), "local-blub")
+      router.path.address.toString must be("akka://MasterRemoteRouterSpec")
       val replies = for (i ← 1 to 5) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children must have size 2
       val parents = children.map(_.parent)
       parents must have size 1
-      parents.head.address must be(Address("akka.tcp", "remote-sys", "localhost", 12347))
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      parents.head.address must be(Address("akka.tcp", sysName, "localhost", port))
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "let remote deployment router be overridden by local configuration" in {
-      val router = system.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
-        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString("akka.tcp://remote-sys@localhost:12347")))), "local-blub2")
-      router.path.address.toString must be("akka.tcp://remote-sys@localhost:12347")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"akka.tcp://${sysName}@localhost:${port}")))), "local-blub2")
+      router.path.address.toString must be(s"akka.tcp://${sysName}@localhost:${port}")
       val replies = for (i ← 1 to 5) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children must have size 4
       val parents = children.map(_.parent)
       parents must have size 1
       parents.head must be(router.path)
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "let remote deployment be overridden by remote configuration" in {
-      val router = system.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
-        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString("akka.tcp://remote-sys@localhost:12347")))), "remote-override")
-      router.path.address.toString must be("akka.tcp://remote-sys@localhost:12347")
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(Props[Echo].withRouter(RoundRobinRouter(2))
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"akka.tcp://${sysName}@localhost:${port}")))), "remote-override")
+      router.path.address.toString must be(s"akka.tcp://${sysName}@localhost:${port}")
       val replies = for (i ← 1 to 5) yield {
-        router ! ""
-        expectMsgType[ActorRef].path
+        router.tell("", probe.ref)
+        probe.expectMsgType[ActorRef].path
       }
       val children = replies.toSet
       children must have size 4
       val parents = children.map(_.parent)
       parents must have size 1
       parents.head must be(router.path)
-      children foreach (_.address.toString must be === "akka.tcp://remote-sys@localhost:12347")
-      system.stop(router)
+      children foreach (_.address.toString must be === s"akka.tcp://${sysName}@localhost:${port}")
+      masterSystem.stop(router)
     }
 
     "set supplied supervisorStrategy" in {
+      val probe = TestProbe()(masterSystem)
       val escalator = OneForOneStrategy() {
-        case e ⇒ testActor ! e; SupervisorStrategy.Escalate
+        case e ⇒ probe.ref ! e; SupervisorStrategy.Escalate
       }
-      val router = system.actorOf(Props.empty.withRouter(new RemoteRouterConfig(
+      val router = masterSystem.actorOf(Props.empty.withRouter(new RemoteRouterConfig(
         RoundRobinRouter(1, supervisorStrategy = escalator),
-        Seq(Address("akka.tcp", "remote-sys", "localhost", 12347)))), "blub3")
+        Seq(Address("akka.tcp", sysName, "localhost", port)))), "blub3")
 
-      router ! CurrentRoutees
-      EventFilter[ActorKilledException](occurrences = 1) intercept {
-        expectMsgType[RouterRoutees].routees.head ! Kill
-      }
-      expectMsgType[ActorKilledException]
+      router.tell(CurrentRoutees, probe.ref)
+      EventFilter[ActorKilledException](occurrences = 1).intercept {
+        probe.expectMsgType[RouterRoutees].routees.head ! Kill
+      }(masterSystem)
+      probe.expectMsgType[ActorKilledException]
     }
 
-  }
-
-  override def beforeTermination() {
-    system.eventStream.publish(TestEvent.Mute(
-      EventFilter.warning(pattern = "received dead letter.*Disassociate")))
   }
 
 }


### PR DESCRIPTION
I'm not sure this is the reason for the failure, but it should be cleaned up anyway.
