### PR TITLE
Increase timeout for akka.camel.ConcurrentActivationTest #3269

### DIFF
--- a/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
@@ -25,7 +25,7 @@ class ConcurrentActivationTest extends WordSpec with MustMatchers with NonShared
 
   "Activation" must {
     "support concurrent registrations and de-registrations" in {
-      implicit val timeout = Timeout((5 seconds).dilated)
+      implicit val timeout = Timeout((10 seconds).dilated)
       val timeoutDuration = timeout.duration
       implicit val ec = system.dispatcher
       val number = 10


### PR DESCRIPTION
The GC is likely to kick in during this test since it is creating and holding on to a lot of objects so the timeout has been increased to avoid false positives.
