### PR TITLE
fix some FIXMEs, see #3192

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
@@ -132,16 +132,16 @@ class EventStreamSpec extends AkkaSpec(EventStreamSpec.config) {
       val c = new C
       val bus = new EventStream(false)
       within(2 seconds) {
-        bus.subscribe(testActor, classOf[B2]) === true
+        bus.subscribe(testActor, classOf[B2]) must be === true
         bus.publish(c)
         bus.publish(b2)
         expectMsg(b2)
-        bus.subscribe(testActor, classOf[A]) === true
+        bus.subscribe(testActor, classOf[A]) must be === true
         bus.publish(c)
         expectMsg(c)
         bus.publish(b1)
         expectMsg(b1)
-        bus.unsubscribe(testActor, classOf[B1]) === true
+        bus.unsubscribe(testActor, classOf[B1]) must be === true
         bus.publish(c)
         bus.publish(b2)
         bus.publish(a)

--- a/akka-actor-tests/src/test/scala/akka/io/BackpressureSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/BackpressureSpec.scala
@@ -166,15 +166,15 @@ class BackpressureSpec extends AkkaSpec with ImplicitSender {
         send ! StartSending(N)
         val hash = expectMsgType[Done].hash
         implicit val t = Timeout(100.millis)
-        awaitAssert(Await.result(recv ? GetProgress, t.duration) === N)
+        awaitAssert(Await.result(recv ? GetProgress, t.duration) must be === Progress(N))
         recv ! GetHash
-        expectMsgType[Hash].hash === hash
+        expectMsgType[Hash].hash must be === hash
       }
       send ! Close
       val terminated = receiveWhile(1.second, messages = 2) {
         case Terminated(t) ⇒ t
       }
-      terminated === Set(send, recv)
+      terminated.toSet must be === Set(send, recv)
     }
 
     "transmit the right bytes with hiccups" in {
@@ -187,15 +187,15 @@ class BackpressureSpec extends AkkaSpec with ImplicitSender {
         send ! StartSending(N)
         val hash = expectMsgType[Done].hash
         implicit val t = Timeout(100.millis)
-        awaitAssert(Await.result(recv ? GetProgress, t.duration) === N)
+        awaitAssert(Await.result(recv ? GetProgress, t.duration) must be === Progress(N))
         recv ! GetHash
-        expectMsgType[Hash].hash === hash
+        expectMsgType[Hash].hash must be === hash
       }
       send ! Close
       val terminated = receiveWhile(1.second, messages = 2) {
         case Terminated(t) ⇒ t
       }
-      terminated === Set(send, recv)
+      terminated.toSet must be === Set(send, recv)
     }
 
   }

--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
@@ -45,10 +45,7 @@ class UdpConnectedIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with 
 
       server ! Udp.Send(data2, clientAddress)
 
-      // FIXME: Currently this line fails
-      expectMsgPF() {
-        case UdpConnected.Received(d) ⇒ d must be === data2
-      }
+      expectMsgType[UdpConnected.Received].data must be === data2
     }
 
     "be able to send and receive with binding" in {
@@ -67,10 +64,7 @@ class UdpConnectedIntegrationSpec extends AkkaSpec("akka.loglevel = INFO") with 
 
       server ! Udp.Send(data2, clientAddress)
 
-      // FIXME: Currently this line fails
-      expectMsgPF() {
-        case UdpConnected.Received(d) ⇒ d must be === data2
-      }
+      expectMsgType[UdpConnected.Received].data must be === data2
     }
 
   }

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -156,7 +156,6 @@ trait ActorRefProvider {
    */
   def terminationFuture: Future[Unit]
 
-  //FIXME I PROPOSE TO REMOVE THIS IN 2.1 - √
   /**
    * Obtain the address which is to be used within sender references when
    * sending to the given other address or none if the other address cannot be

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -544,7 +544,6 @@ private[akka] class ActorSystemImpl(val name: String, applicationConfig: Config,
 
   def deadLetters: ActorRef = provider.deadLetters
 
-  //FIXME Why do we need this at all?
   val deadLetterMailbox: Mailbox = new Mailbox(new MessageQueue {
     def enqueue(receiver: ActorRef, envelope: Envelope): Unit =
       deadLetters.tell(DeadLetter(envelope.message, envelope.sender, receiver), envelope.sender)

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -220,36 +220,32 @@ private[akka] class UnstartedCell(val systemImpl: ActorSystemImpl,
     }
   }
 
-  // FIXME: once we have guaranteed delivery of system messages, hook this in!
-  def sendSystemMessage(msg: SystemMessage): Unit =
-    if (lock.tryLock(timeout.length, timeout.unit)) {
-      try {
-        val cell = self.underlying
-        if (cellIsReady(cell)) {
-          cell.sendSystemMessage(msg)
-        } else {
-          // systemMessages that are sent during replace need to jump to just after the last system message in the queue, so it's processed before other messages
-          val wasEnqueued = if ((self.lookup ne this) && (self.underlying eq this) && !queue.isEmpty()) {
-            @tailrec def tryEnqueue(i: JListIterator[Any] = queue.listIterator(), insertIntoIndex: Int = -1): Boolean =
-              if (i.hasNext())
-                tryEnqueue(i,
-                  if (i.next().isInstanceOf[SystemMessage]) i.nextIndex() // update last sysmsg seen so far
-                  else insertIntoIndex) // or just keep the last seen one
-              else if (insertIntoIndex == -1) queue.offer(msg)
-              else Try(queue.add(insertIntoIndex, msg)).isSuccess
-            tryEnqueue()
-          } else queue.offer(msg)
+  def sendSystemMessage(msg: SystemMessage): Unit = {
+    lock.lock // we cannot lose system messages, ever, and we cannot throw an Error from here as well
+    try {
+      val cell = self.underlying
+      if (cellIsReady(cell)) {
+        cell.sendSystemMessage(msg)
+      } else {
+        // systemMessages that are sent during replace need to jump to just after the last system message in the queue, so it's processed before other messages
+        val wasEnqueued = if ((self.lookup ne this) && (self.underlying eq this) && !queue.isEmpty()) {
+          @tailrec def tryEnqueue(i: JListIterator[Any] = queue.listIterator(), insertIntoIndex: Int = -1): Boolean =
+            if (i.hasNext())
+              tryEnqueue(i,
+                if (i.next().isInstanceOf[SystemMessage]) i.nextIndex() // update last sysmsg seen so far
+                else insertIntoIndex) // or just keep the last seen one
+            else if (insertIntoIndex == -1) queue.offer(msg)
+            else Try(queue.add(insertIntoIndex, msg)).isSuccess
+          tryEnqueue()
+        } else queue.offer(msg)
 
-          if (!wasEnqueued) {
-            system.eventStream.publish(Warning(self.path.toString, getClass, "dropping system message " + msg + " due to enqueue failure"))
-            system.deadLetters ! DeadLetter(msg, self, self)
-          } else if (Mailbox.debug) println(s"$self temp queueing system $msg")
-        }
-      } finally lock.unlock()
-    } else {
-      system.eventStream.publish(Warning(self.path.toString, getClass, "dropping system message " + msg + " due to lock timeout"))
-      system.deadLetters ! DeadLetter(msg, self, self)
-    }
+        if (!wasEnqueued) {
+          system.eventStream.publish(Warning(self.path.toString, getClass, "dropping system message " + msg + " due to enqueue failure"))
+          system.deadLetters ! DeadLetter(msg, self, self)
+        } else if (Mailbox.debug) println(s"$self temp queueing system $msg")
+      }
+    } finally lock.unlock()
+  }
 
   def isLocal = true
 

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -109,7 +109,7 @@ abstract class MessageDispatcher(val prerequisites: DispatcherPrerequisites) ext
   /**
    *  Creates and returns a mailbox for the given actor.
    */
-  protected[akka] def createMailbox(actor: Cell): Mailbox //FIXME should this really be private[akka]?
+  protected[akka] def createMailbox(actor: Cell): Mailbox
 
   /**
    * Finds out the mailbox type for an actor based on configuration, props and requirements.

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -359,6 +359,16 @@ akka {
 
       # Sets the size of the connection backlog
       backlog = 4096
+      
+      # Enables the TCP_NODELAY flag, i.e. disables Nagle’s algorithm
+      tcp-nodelay = on
+      
+      # Enables TCP Keepalive, subject to the O/S kernel’s configuration
+      tcp-keepalive = on
+      
+      # Enables SO_REUSEADDR, which determines when an ActorSystem can open
+      # the specified listen port (the meaning differs between *nix and Windows)
+      tcp-reuse-addr = on
 
       # Used to configure the number of I/O worker threads on server sockets
       server-socket-worker-pool {

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettySSLSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettySSLSupport.scala
@@ -38,7 +38,6 @@ private[akka] class SSLSettings(config: Config) {
 
   val SSLRandomNumberGenerator = emptyIsNone(getString("random-number-generator"))
 
-  // FIXME: Change messages to reflect new configuration
   if (SSLProtocol.isEmpty) throw new ConfigurationException(
     "Configuration option 'akka.remote.netty.ssl.enable-ssl is turned on but no protocol is defined in 'akka.remote.netty.ssl.security.protocol'.")
   if (SSLKeyStore.isEmpty && SSLTrustStore.isEmpty) throw new ConfigurationException(

--- a/akka-remote/src/test/scala/akka/io/ssl/SslTlsSupportSpec.scala
+++ b/akka-remote/src/test/scala/akka/io/ssl/SslTlsSupportSpec.scala
@@ -236,9 +236,9 @@ class SslTlsSupportSpec extends AkkaSpec {
 
     def run() {
       write("1+2")
-      readLine() === "3"
+      readLine() must be === "3"
       write("12+24")
-      readLine() === "36"
+      readLine() must be === "36"
     }
 
     def write(string: String) {

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.ExtendedActorSystem
 import scala.concurrent.duration._
 import akka.remote.transport.AkkaProtocolSettings
 import akka.util.{ Timeout, Helpers }
-import akka.remote.transport.netty.SSLSettings
+import akka.remote.transport.netty.{ NettyTransportSettings, SSLSettings }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class RemoteConfigSpec extends AkkaSpec(
@@ -79,9 +79,22 @@ class RemoteConfigSpec extends AkkaSpec(
 
     "contain correct netty.tcp values in reference.conf" in {
       val c = RARP(system).provider.remoteSettings.config.getConfig("akka.remote.netty.tcp")
+      val s = new NettyTransportSettings(c)
+      import s._
 
-      c.getBytes("maximum-frame-size") must be(128000)
-      c.getMilliseconds("connection-timeout") must be(15000)
+      ConnectionTimeout must be === 15.seconds
+      WriteBufferHighWaterMark must be === None
+      WriteBufferLowWaterMark must be === None
+      SendBufferSize must be === Some(256000)
+      ReceiveBufferSize must be === Some(256000)
+      MaxFrameSize must be === 128000
+      Backlog must be === 4096
+      TcpNodelay must be(true)
+      TcpKeepalive must be(true)
+      TcpReuseAddr must be(true)
+      c.getString("hostname") must be === ""
+      ServerSocketWorkerPoolSize must be === 2
+      ClientSocketWorkerPoolSize must be === 2
     }
 
     "contain correct socket worker pool configuration values in reference.conf" in {


### PR DESCRIPTION
- remove some outdated ones (which were already fixed but not removed)
- make socket options fully configurable in NettyTransport
- also apply socket options to outbound connections, not only the listen
  socket
- remove timeout from taking the lock in RepointableActorRef, because we
  cannot afford to lose system messages anymore, so we should rather
  block the sender
