### PR TITLE
improve safety of Props.create by allowing Creator<T>, see #3377

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
@@ -1,0 +1,68 @@
+/**
+ *   Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.actor;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import akka.japi.Creator;
+
+public class ActorCreationTest {
+
+  @Test
+  public void testWrongCreator() {
+    try {
+      Props.create(new Creator<Actor>() {
+        @Override
+        public Actor create() throws Exception {
+          return null;
+        }
+      });
+      assert false;
+    } catch(IllegalArgumentException e) {
+      assertEquals("cannot use non-static local Creator to create actors; make it static or top-level", e.getMessage());
+    }
+  }
+  
+  static class C implements Creator<UntypedActor> {
+    @Override
+    public UntypedActor create() throws Exception {
+      return null;
+    }
+  }
+  
+  static class D<T> implements Creator<T> {
+    @Override
+    public T create() {
+      return null;
+    }
+  }
+  
+  static class E<T extends UntypedActor> implements Creator<T> {
+    @Override
+    public T create() {
+      return null;
+    }
+  }
+  
+  @Test
+  public void testRightCreator() {
+    final Props p = Props.create(new C());
+    assertEquals(UntypedActor.class, p.actorClass());
+  }
+  
+  @Test
+  public void testParametricCreator() {
+    final Props p = Props.create(new D<UntypedActor>());
+    assertEquals(Actor.class, p.actorClass());
+  }
+  
+  @Test
+  public void testBoundedCreator() {
+    final Props p = Props.create(new E<UntypedActor>());
+    assertEquals(UntypedActor.class, p.actorClass());
+  }
+  
+}

--- a/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/UntypedActor.scala
@@ -166,5 +166,5 @@ abstract class UntypedActor extends Actor {
 /**
  * Factory closure for an UntypedActor, to be used with 'Actors.actorOf(factory)'.
  */
-@deprecated("use Props.create(clazz, args) instead", "2.2")
+@deprecated("use Creator<T> instead", "2.2")
 trait UntypedActorFactory extends Creator[Actor] with Serializable

--- a/akka-actor/src/main/scala/akka/actor/dsl/Creators.scala
+++ b/akka-actor/src/main/scala/akka/actor/dsl/Creators.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import akka.pattern.ask
 import scala.reflect.ClassTag
-import akka.dispatch.{ UnboundedDequeBasedMailbox, RequiresMessageQueue }
 
 trait Creators { this: ActorDSL.type ⇒
 

--- a/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
+++ b/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
@@ -48,7 +48,8 @@ trait Effect {
 /**
  * A constructor/factory, takes no parameters but creates a new value of type T every call.
  */
-trait Creator[T] {
+@SerialVersionUID(1L)
+trait Creator[T] extends Serializable {
   /**
    * This method must return a different instance upon every call.
    */

--- a/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.java
@@ -49,6 +49,7 @@ import akka.actor.IndirectActorProducer;
 import akka.actor.OneForOneStrategy;
 //#import-props
 import akka.actor.Props;
+import akka.japi.Creator;
 //#import-props
 import akka.actor.SupervisorStrategy;
 import akka.actor.SupervisorStrategy.Directive;
@@ -88,14 +89,35 @@ public class UntypedActorDocTest {
 
   private final ActorSystem system = actorSystemResource.getSystem();
 
+  //#creating-props-config
+  static class MyActorC implements Creator<MyActor> {
+    @Override public MyActor create() {
+      return new MyActor("...");
+    }
+  }
+  
+  //#creating-props-config
+
   @SuppressWarnings("unused")
   @Test
   public void createProps() {
     //#creating-props-config
     Props props1 = Props.create(MyUntypedActor.class);
     Props props2 = Props.create(MyActor.class, "...");
+    Props props3 = Props.create(new MyActorC());
     //#creating-props-config
   }
+  
+  //#parametric-creator
+  static class ParametricCreator<T extends MyActor> implements Creator<T> {
+    @Override public T create() {
+      // ... fabricate actor here
+      //#parametric-creator
+      return null;
+      //#parametric-creator
+    }
+  }
+  //#parametric-creator
 
   @SuppressWarnings("deprecation")
   @Test

--- a/akka-docs/rst/java/untyped-actors.rst
+++ b/akka-docs/rst/java/untyped-actors.rst
@@ -51,11 +51,19 @@ dispatcher to use, see more below). Here are some examples of how to create a
 .. includecode:: code/docs/actor/UntypedActorDocTest.java#import-props
 .. includecode:: code/docs/actor/UntypedActorDocTest.java#creating-props-config
 
-The last line shows how to pass constructor arguments to the :class:`Actor`
+The second line shows how to pass constructor arguments to the :class:`Actor`
 being created. The presence of a matching constructor is verified during
 construction of the :class:`Props` object, resulting in an
 :class:`IllegalArgumentEception` if no or multiple matching constructors are
 found.
+
+The third line demonstrates the use of a :class:`Creator<T extends Actor>`. The
+creator class must be static, which is verified during :class:`Props`
+construction. The type parameter’s upper bound is used to determine the
+produced actor class, falling back to :class:`Actor` if fully erased. An
+example of a parametric factory could be:
+
+.. includecode:: code/docs/actor/UntypedActorDocTest.java#parametric-creator
 
 Deprecated Variants
 ^^^^^^^^^^^^^^^^^^^

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -85,18 +85,21 @@ for a migration period):
 
 .. includecode:: code/docs/actor/ActorDocSpec.scala#creating-props-deprecated
 
-The last one is deprecated because its functionality is available in full
-through :meth:`Props.apply()`.
+The first one is deprecated because the case class structure changed between
+Akka 2.1 and 2.2.
 
-The first three are deprecated because the captured closure is a local class
-which means that it implicitly carries a reference to the enclosing class. This
-can easily make the resulting :class:`Props` non-serializable, e.g. when the
-enclosing class is an :class:`Actor`. Akka advocates location transparency,
-meaning that an application written with actors should just work when it is
-deployed over multiple network nodes, and non-serializable actor factories
-would break this principle. In case indirect actor creation is needed—for
-example when using dependency injection—there is the possibility to use an
-:class:`IndirectActorProducer` as described below.
+The two variants in the middle are deprecated because :class:`Props` are
+primarily concerned with actor creation and thus the “creator” part should be
+explicitly set when creating an instance. In case you want to deploy one actor
+in the same was as another, simply use
+``Props(...).withDeploy(otherProps.deploy)``.
+
+The last one is not technically deprecated, but it is not recommended because
+it encourages to close over the enclosing scope, resulting in non-serializable
+:class:`Props` and possibly race conditions (breaking the actor encapsulation).
+We will provide a macro-based solution in a future release which allows similar
+syntax without the headaches, at which point this variant will be properly
+deprecated.
 
 There were two use-cases for these methods: passing constructor arguments to
 the actor—which is solved by the newly introduced

--- a/akka-docs/rst/scala/code/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/actor/ActorDocSpec.scala
@@ -243,19 +243,19 @@ class ActorDocSpec extends AkkaSpec(Map("akka.loglevel" -> "INFO")) {
     //#creating-props
 
     //#creating-props-deprecated
-    // DEPRECATED: encourages to close over enclosing class
+    // DEPRECATED: old case class signature
     val props4 = Props(
       creator = { () ⇒ new MyActor },
       dispatcher = "my-dispatcher")
 
-    // DEPRECATED: encourages to close over enclosing class
+    // DEPRECATED due to duplicate functionality with Props.apply()
     val props5 = props1.withCreator(new MyActor)
 
-    // DEPRECATED: encourages to close over enclosing class
-    val props6 = Props(new MyActor)
-
     // DEPRECATED due to duplicate functionality with Props.apply()
-    val props7 = props1.withCreator(classOf[MyActor])
+    val props6 = props1.withCreator(classOf[MyActor])
+
+    // NOT RECOMMENDED: encourages to close over enclosing class
+    val props7 = Props(new MyActor)
     //#creating-props-deprecated
   }
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -136,7 +136,8 @@ object AkkaBuild extends Build {
     dependencies = Seq(testkit % "compile;test->test"),
     settings = defaultSettings ++ scaladocSettings  ++ Seq(
       publishArtifact in Compile := false,
-      libraryDependencies ++= Dependencies.actorTests
+      libraryDependencies ++= Dependencies.actorTests,
+      testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
     )
   )
 
@@ -972,7 +973,7 @@ object Dependencies {
 
   val testkit = Seq(Test.junit, Test.scalatest)
 
-  val actorTests = Seq(Test.junit, Test.scalatest, Test.commonsCodec, Test.commonsMath, Test.mockito, Test.scalacheck, protobuf)
+  val actorTests = Seq(Test.junit, Test.scalatest, Test.commonsCodec, Test.commonsMath, Test.mockito, Test.scalacheck, protobuf, Test.junitIntf)
 
   val remote = Seq(netty, protobuf, uncommonsMath, Test.junit, Test.scalatest)
 


### PR DESCRIPTION
Props constructors need to be deprecated instead of being mutated
because we cannot just start throwing exceptions in people’s existing
code. Props.withCreator is deprecated for similar reasons, but also
because Props are about the creators, so replacing that after the fact
is not good style.
