### PR TITLE
Fix exiting ordering problem in ClusterSingletonManager, see #3408

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSingletonManager.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSingletonManager.scala
@@ -571,7 +571,7 @@ class ClusterSingletonManager(
         case Some(a) if a == cluster.selfAddress ⇒
           // already oldest
           stay
-        case Some(a) if removed.contains(a) ⇒
+        case Some(a) if !selfExited && removed.contains(a) ⇒
           gotoHandingOver(singleton, singletonTerminated, handOverData, None)
         case Some(a) ⇒
           // send TakeOver request in case the new oldest doesn't know previous oldest


### PR DESCRIPTION
- The problem was:
  - first is leaving, second is new oldest
  - two actors subscribe to cluster events, OldestChangedBuffer and ClusterSingletonManager
  - ClusterSingletonManager receives MemberExited(first), and then also MemberRemoved(second)
    before OldestChangedBuffer receives MemberExited(first) and delivers
    OldestChanged(first->second)
  - MemberRemoved(second) is the result of the cluster extension shutdown
  - because ClusterSingletonManager gets the MemberRemoved(second) before the OldestChanged
    it will not send the hand over data to second
  - second becomes new singleton after retry period, as designed, but without hand over data
- The solution is to check the selfExited flag in Oldest state, similar to what is done
  in WasOldest
- I considered the alternative to tunnel all member events through same subscriber,
  but that would involve more changes to the code
