### PR TITLE
only create the routees once they can be looked-up, see #3406

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/RouteeCreationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RouteeCreationSpec.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.routing
+
+import akka.testkit.AkkaSpec
+import akka.actor.Props
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.LocalActorRef
+import scala.concurrent.duration._
+
+class RouteeCreationSpec extends AkkaSpec {
+
+  "Creating Routees" must {
+
+    "result in visible routees" in {
+      val N = 100
+      system.actorOf(Props(new Actor {
+        testActor ! system.actorFor(self.path)
+        def receive = Actor.emptyBehavior
+      }).withRouter(RoundRobinRouter(N)))
+      for (i ← 1 to N) {
+        expectMsgType[ActorRef] match {
+          case _: LocalActorRef ⇒ // fine
+          case x                ⇒ fail(s"routee $i was a ${x.getClass}")
+        }
+      }
+    }
+
+    "allow sending to context.parent" in {
+      val N = 100
+      system.actorOf(Props(new Actor {
+        context.parent ! "one"
+        def receive = {
+          case "one" ⇒ testActor forward "two"
+        }
+      }).withRouter(RoundRobinRouter(N)))
+      val gotit = receiveWhile(messages = N) {
+        case "two" ⇒ lastSender.toString
+      }
+      expectNoMsg(100.millis)
+      if (gotit.size != N) {
+        fail(s"got only ${gotit.size} from \n${gotit mkString "\n"}")
+      }
+    }
+
+  }
+
+}

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
@@ -74,7 +74,7 @@ private[akka] trait Dispatch { this: ActorCell ⇒
   /**
    * Start this cell, i.e. attach it to the dispatcher.
    */
-  final def start(): this.type = {
+  def start(): this.type = {
     // This call is expected to start off the actor by scheduling its mailbox.
     dispatcher.attach(this)
     this


### PR DESCRIPTION
- move the creation of the RoutedActorCell’s route into
  ActorCell.start(); it used to be done in the constructor
- this requires “val route” to turn into a volatile private var
