### PR TITLE
adapt SchedulerSpec rate test to 10ms time slices, see #3391

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -236,12 +236,12 @@ trait SchedulerSpec extends BeforeAndAfterEach with DefaultTimeout with Implicit
 
     "adjust for scheduler inaccuracy" taggedAs TimingTest in {
       val startTime = System.nanoTime
-      val n = 33
+      val n = 333
       val latch = new TestLatch(n)
-      system.scheduler.schedule(150.millis, 150.millis) { latch.countDown() }
+      system.scheduler.schedule(15.millis, 15.millis) { latch.countDown() }
       Await.ready(latch, 6.seconds)
       // Rate
-      n * 1000.0 / (System.nanoTime - startTime).nanos.toMillis must be(6.66 plusOrMinus 0.4)
+      n * 1000.0 / (System.nanoTime - startTime).nanos.toMillis must be(66.6 plusOrMinus 4)
     }
 
     "not be affected by long running task" taggedAs TimingTest in {


### PR DESCRIPTION
using a larger sample will also make the spread of the resulting
calculated rate smaller; the referenced ticket is about a deviation from
the target rate which was slightly out of bounds
