### PR TITLE
Allow akka sbt plugin to be excluded from remote publishing

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -76,6 +76,7 @@ object Publish {
 
   def akkaPluginPublishTo: Initialize[Option[Resolver]] = {
     (defaultPublishTo, version) { (default, version) =>
+      pluginPublishLocally(default) orElse
       akkaPublishRepository orElse
       pluginRepo(version) orElse
       Some(Resolver.file("Default Local Repository", default))
@@ -101,6 +102,11 @@ object Publish {
 
   def akkaCredentials: Seq[Credentials] =
     Option(System.getProperty("akka.publish.credentials", null)) map (f => Credentials(new File(f))) toSeq
+
+  def pluginPublishLocally(default: File): Option[Resolver] =
+    Option(sys.props("publish.plugin.locally")) collect { case pl if pl.toLowerCase == "true" =>
+      Resolver.file("Default Local Repository", default)
+    }
 
   // timestamped versions
 

--- a/project/scripts/release
+++ b/project/scripts/release
@@ -101,7 +101,7 @@ declare release_path=${default_path}
 declare -r unzipped_dir="target/dist/unzipped"
 
 # flags
-unset run_tests dry_run no_revert
+unset run_tests dry_run no_revert no_akka_plugin
 
 # get the source location for this script; handles symlinks
 function get_script_path {
@@ -127,6 +127,7 @@ Usage: ${script_name} [options] VERSION
   -p | --path PATH       Set the path on the release server (default ${default_path})
   -n | --dry-run         Build everything but do not push the release
   -r | --no-revert       On dry-run don't revert git commits and tags
+       --no-akka-plugin  Publish the akka sbt plugin locally and not to the repositry
 EOM
 }
 
@@ -160,6 +161,7 @@ while true; do
     -p | --path ) release_path=$2; shift 2 ;;
     -n | --dry-run) dry_run=true; shift ;;
     -r | --no-revert) no_revert=true; shift ;;
+    --no-akka-plugin) no_akka_plugin=true; shift ;;
     * ) break ;;
   esac
 done
@@ -301,6 +303,9 @@ if [ ! $dry_run ]; then
   RELEASE_OPT="-Dakka.genjavadoc.enabled=true -Dpublish.maven.central=true"
 else
   RELEASE_OPT="-Dakka.genjavadoc.enabled=true"
+fi
+if [ $no_akka_plugin ]; then
+  RELEASE_OPT="${RELEASE_OPT} -Dpublish.plugin.locally=true"
 fi
 try sbt $RELEASE_OPT build-release
 echolog "Creating gzipped tar download..."


### PR DESCRIPTION
This will allow the publishing of Akka against a second Scala version to skip trying to upload the plugin again and fail.
