### PR TITLE
Race in creating new remote child, see #3423

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -83,7 +83,7 @@ private[akka] class RemoteSystemDaemon(
   override def sendSystemMessage(message: SystemMessage): Unit = message match {
     case DeathWatchNotification(child: ActorRefWithCell with ActorRefScope, _, _) if child.isLocal ⇒
       terminating.locked {
-        removeChild(child.path.elements.drop(1).mkString("/"))
+        removeChild(child.path.elements.drop(1).mkString("/"), child)
         terminationHookDoneWhenNoChildren()
       }
     case _ ⇒ super.sendSystemMessage(message)


### PR DESCRIPTION
- RemoteSystemDaemon removes its child when sendSystemMessage
  DeathWatchNotification is called from tellWatchersWeDied.
  That can happen after Terminated is delivered to other watcher,
  which create a new child with same name, and then the new child
  can then be removed instead of the old one.
- RemoteSystemDaemon must only remove child with exact match of
  full ActorRef
