### PR TITLE
rewrite mailbox selection logic, see #3342

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
@@ -47,6 +47,14 @@ public class ActorCreationTest {
     }
   }
   
+  static interface I<T> extends Creator<UntypedActor> {}
+  static class F implements I<Object> {
+    @Override
+    public UntypedActor create() {
+      return null;
+    }
+  }
+  
   @Test
   public void testRightCreator() {
     final Props p = Props.create(new C());
@@ -62,6 +70,12 @@ public class ActorCreationTest {
   @Test
   public void testBoundedCreator() {
     final Props p = Props.create(new E<UntypedActor>());
+    assertEquals(UntypedActor.class, p.actorClass());
+  }
+  
+  @Test
+  public void testSuperinterface() {
+    final Props p = Props.create(new F());
     assertEquals(UntypedActor.class, p.actorClass());
   }
   

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
@@ -9,6 +9,7 @@ import akka.testkit._
 import akka.dispatch._
 import akka.TestUtils.verifyActorTermination
 import scala.concurrent.duration.Duration
+import akka.ConfigurationException
 
 object ActorMailboxSpec {
   val mailboxConf = ConfigFactory.parseString("""
@@ -181,7 +182,7 @@ class ActorMailboxSpec extends AkkaSpec(ActorMailboxSpec.mailboxConf) with Defau
     }
 
     "fail to create actor when an unbounded dequeu message queue is configured as mailbox overriding RequestMailbox" in {
-      intercept[IllegalArgumentException](system.actorOf(Props[BoundedQueueReportingActor], "default-unbounded-deque-override-trait"))
+      intercept[ConfigurationException](system.actorOf(Props[BoundedQueueReportingActor], "default-unbounded-deque-override-trait"))
     }
 
     "get an unbounded message queue when defined in dispatcher" in {
@@ -189,7 +190,7 @@ class ActorMailboxSpec extends AkkaSpec(ActorMailboxSpec.mailboxConf) with Defau
     }
 
     "fail to create actor when an unbounded message queue is defined in dispatcher overriding RequestMailbox" in {
-      intercept[IllegalArgumentException](system.actorOf(Props[BoundedQueueReportingActor], "unbounded-default-override-trait"))
+      intercept[ConfigurationException](system.actorOf(Props[BoundedQueueReportingActor], "unbounded-default-override-trait"))
     }
 
     "get a bounded message queue when it's configured as mailbox overriding unbounded in dispatcher" in {
@@ -219,11 +220,11 @@ class ActorMailboxSpec extends AkkaSpec(ActorMailboxSpec.mailboxConf) with Defau
     }
 
     "fail with a unbounded deque-based message queue if configured and required" in {
-      intercept[IllegalArgumentException](system.actorOf(Props[StashQueueReportingActor], "bounded-deque-require-unbounded-configured"))
+      intercept[ConfigurationException](system.actorOf(Props[StashQueueReportingActor], "bounded-deque-require-unbounded-configured"))
     }
 
     "fail with a bounded deque-based message queue if not configured" in {
-      intercept[IllegalArgumentException](system.actorOf(Props[StashQueueReportingActor], "bounded-deque-require-unbounded-unconfigured"))
+      intercept[ConfigurationException](system.actorOf(Props[StashQueueReportingActor], "bounded-deque-require-unbounded-unconfigured"))
     }
 
     "get a bounded deque-based message queue if configured and required with Props" in {
@@ -236,7 +237,7 @@ class ActorMailboxSpec extends AkkaSpec(ActorMailboxSpec.mailboxConf) with Defau
     }
 
     "fail with a unbounded deque-based message queue if configured and required with Props" in {
-      intercept[IllegalArgumentException](system.actorOf(
+      intercept[ConfigurationException](system.actorOf(
         Props[StashQueueReportingActor]
           .withDispatcher("requiring-bounded-dispatcher")
           .withMailbox("akka.actor.mailbox.unbounded-deque-based"),
@@ -244,7 +245,7 @@ class ActorMailboxSpec extends AkkaSpec(ActorMailboxSpec.mailboxConf) with Defau
     }
 
     "fail with a bounded deque-based message queue if not configured with Props" in {
-      intercept[IllegalArgumentException](system.actorOf(
+      intercept[ConfigurationException](system.actorOf(
         Props[StashQueueReportingActor]
           .withDispatcher("requiring-bounded-dispatcher"),
         "bounded-deque-require-unbounded-unconfigured-props"))
@@ -259,14 +260,14 @@ class ActorMailboxSpec extends AkkaSpec(ActorMailboxSpec.mailboxConf) with Defau
     }
 
     "fail with a unbounded deque-based message queue if configured and required with Props (dispatcher)" in {
-      intercept[IllegalArgumentException](system.actorOf(
+      intercept[ConfigurationException](system.actorOf(
         Props[StashQueueReportingActor]
           .withDispatcher("requiring-bounded-dispatcher"),
         "bounded-deque-require-unbounded-configured-props-disp"))
     }
 
     "fail with a bounded deque-based message queue if not configured with Props (dispatcher)" in {
-      intercept[IllegalArgumentException](system.actorOf(
+      intercept[ConfigurationException](system.actorOf(
         Props[StashQueueReportingActor]
           .withDispatcher("requiring-bounded-dispatcher"),
         "bounded-deque-require-unbounded-unconfigured-props-disp"))
@@ -281,14 +282,14 @@ class ActorMailboxSpec extends AkkaSpec(ActorMailboxSpec.mailboxConf) with Defau
     }
 
     "fail with a unbounded deque-based message queue if configured and required with Props (mailbox)" in {
-      intercept[IllegalArgumentException](system.actorOf(
+      intercept[ConfigurationException](system.actorOf(
         Props[StashQueueReportingActor]
           .withMailbox("akka.actor.mailbox.unbounded-deque-based"),
         "bounded-deque-require-unbounded-configured-props-mail"))
     }
 
     "fail with a bounded deque-based message queue if not configured with Props (mailbox)" in {
-      intercept[IllegalArgumentException](system.actorOf(
+      intercept[ConfigurationException](system.actorOf(
         Props[StashQueueReportingActor],
         "bounded-deque-require-unbounded-unconfigured-props-mail"))
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -84,12 +84,10 @@ object ActorSystemSpec {
 
   class SlowDispatcher(_config: Config, _prerequisites: DispatcherPrerequisites) extends MessageDispatcherConfigurator(_config, _prerequisites) {
     private val instance = new Dispatcher(
-      prerequisites,
+      this,
       config.getString("id"),
       config.getInt("throughput"),
       Duration(config.getNanoseconds("throughput-deadline-time"), TimeUnit.NANOSECONDS),
-      mailboxType,
-      mailBoxTypeConfigured,
       configureExecutor(),
       Duration(config.getMilliseconds("shutdown-timeout"), TimeUnit.MILLISECONDS)) {
       val doneIt = new Switch

--- a/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/IOActor.scala
@@ -269,7 +269,7 @@ class IOActorSpec extends AkkaSpec with DefaultTimeout {
         case Failure(e) if check(n, e) ⇒
           if (delay.isDefined) {
             executor match {
-              case m: MessageDispatcher ⇒ m.prerequisites.scheduler.scheduleOnce(delay.get)(run(n + 1))
+              case m: MessageDispatcher ⇒ m.configurator.prerequisites.scheduler.scheduleOnce(delay.get)(run(n + 1))
               case _                    ⇒ // Thread.sleep, ignore, or other?
             }
           } else run(n + 1)

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -78,12 +78,10 @@ object SupervisorHierarchySpec {
     extends DispatcherConfigurator(config, prerequisites) {
 
     private val instance: MessageDispatcher =
-      new Dispatcher(prerequisites,
+      new Dispatcher(this,
         config.getString("id"),
         config.getInt("throughput"),
         Duration(config.getNanoseconds("throughput-deadline-time"), TimeUnit.NANOSECONDS),
-        mailboxType,
-        mailBoxTypeConfigured,
         configureExecutor(),
         Duration(config.getMilliseconds("shutdown-timeout"), TimeUnit.MILLISECONDS)) {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -529,12 +529,10 @@ object DispatcherModelSpec {
     extends MessageDispatcherConfigurator(config, prerequisites) {
 
     private val instance: MessageDispatcher =
-      new Dispatcher(prerequisites,
+      new Dispatcher(this,
         config.getString("id"),
         config.getInt("throughput"),
         Duration(config.getNanoseconds("throughput-deadline-time"), TimeUnit.NANOSECONDS),
-        mailboxType,
-        mailBoxTypeConfigured,
         configureExecutor(),
         Duration(config.getMilliseconds("shutdown-timeout"), TimeUnit.MILLISECONDS)) with MessageDispatcherInterceptor
 
@@ -600,20 +598,17 @@ object BalancingDispatcherModelSpec {
   }
 
   class BalancingMessageDispatcherInterceptorConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-    extends MessageDispatcherConfigurator(config, prerequisites) {
+    extends BalancingDispatcherConfigurator(config, prerequisites) {
 
-    private val instance: MessageDispatcher =
-      new BalancingDispatcher(prerequisites,
+    override protected def create(mailboxType: MailboxType): BalancingDispatcher =
+      new BalancingDispatcher(this,
         config.getString("id"),
         config.getInt("throughput"),
         Duration(config.getNanoseconds("throughput-deadline-time"), TimeUnit.NANOSECONDS),
         mailboxType,
-        mailBoxTypeConfigured,
         configureExecutor(),
         Duration(config.getMilliseconds("shutdown-timeout"), TimeUnit.MILLISECONDS),
         config.getBoolean("attempt-teamwork")) with MessageDispatcherInterceptor
-
-    override def dispatcher(): MessageDispatcher = instance
   }
 }
 

--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -63,9 +63,6 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
         {
           c.getString("type") must equal("Dispatcher")
           c.getString("executor") must equal("fork-join-executor")
-          c.getInt("mailbox-capacity") must equal(-1)
-          c.getMilliseconds("mailbox-push-timeout-time") must equal(10 * 1000)
-          c.getString("mailbox-type") must be("")
           c.getMilliseconds("shutdown-timeout") must equal(1 * 1000)
           c.getInt("throughput") must equal(5)
           c.getMilliseconds("throughput-deadline-time") must equal(0)
@@ -132,6 +129,18 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
 
           ioExtSettings.defaultBacklog must be(1000)
           io.getInt("default-backlog") must be(ioExtSettings.defaultBacklog)
+        }
+      }
+
+      {
+        val c = config.getConfig("akka.actor.default-mailbox")
+
+        // general mailbox config
+
+        {
+          c.getInt("mailbox-capacity") must equal(1000)
+          c.getMilliseconds("mailbox-push-timeout-time") must equal(10 * 1000)
+          c.getString("mailbox-type") must be("akka.dispatch.UnboundedMailbox")
         }
       }
     }

--- a/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
@@ -209,7 +209,7 @@ object CustomMailboxSpec {
     }
   }
 
-  class MyMailbox(owner: ActorRef) extends QueueBasedMessageQueue with UnboundedMessageQueueSemantics {
+  class MyMailbox(owner: ActorRef) extends UnboundedQueueBasedMessageQueue {
     final val queue = new ConcurrentLinkedQueue[Envelope]()
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/testkit/CallingThreadDispatcherModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/testkit/CallingThreadDispatcherModelSpec.scala
@@ -32,7 +32,7 @@ object CallingThreadDispatcherModelSpec {
     extends MessageDispatcherConfigurator(config, prerequisites) {
 
     private val instance: MessageDispatcher =
-      new CallingThreadDispatcher(prerequisites, UnboundedMailbox(), false) with MessageDispatcherInterceptor {
+      new CallingThreadDispatcher(this) with MessageDispatcherInterceptor {
         override def id: String = config.getString("id")
       }
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -293,7 +293,8 @@ akka {
     }
     
     default-mailbox {
-      # FQCN of the MailboxType. The Class of the FQCN must have a public constructor with
+      # FQCN of the MailboxType. The Class of the FQCN must have a public 
+      # constructor with 
       # (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
       mailbox-type = "akka.dispatch.UnboundedMailbox"
 
@@ -301,7 +302,7 @@ akka {
       # capacity. The provided value must be positive.
       # NOTICE:
       # Up to version 2.1 the mailbox type was determined based on this setting;
-      # this is no longer the case, the type must explicitly name a bounded mailbox.
+      # this is no longer the case, the type must explicitly be a bounded mailbox.
       mailbox-capacity = 1000
 
       # If the mailbox is bounded then this is the timeout for enqueueing 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -281,29 +281,33 @@ akka {
       # Throughput deadline for Dispatcher, set to 0 or negative for no deadline
       throughput-deadline-time = 0ms
 
-      # If negative (or zero) then an unbounded mailbox is used (default)
-      # If positive then a bounded mailbox is used and the capacity is set using
-      # the property
-      # NOTE: setting a mailbox to 'blocking' can be a bit dangerous, could lead
-      # to deadlock, use with care
-      # The following mailbox-push-timeout-time is only used for type=Dispatcher
-      # and only if mailbox-capacity > 0
-      mailbox-capacity = -1
-
-      # Specifies the timeout to add a new message to a mailbox that is full -
-      # negative number means infinite timeout. It is only used for type=Dispatcher
-      # and only if mailbox-capacity > 0
-      mailbox-push-timeout-time = 10s
-
-      # FQCN of the MailboxType, if not specified the default bounded or unbounded
-      # mailbox is used. The Class of the FQCN must have a public constructor with
-      # (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
-      mailbox-type = ""
-
       # For BalancingDispatcher: If the balancing dispatcher should attempt to
       # schedule idle actors using the same dispatcher when a message comes in,
       # and the dispatchers ExecutorService is not fully busy already.
       attempt-teamwork = on
+      
+      # If this dispatcher requires a specific type of mailbox, specify the 
+      # fully-qualified class name here; the actually created mailbox will 
+      # be a subtype of this type. The empty string signifies no requirement.
+      mailbox-requirement = ""
+    }
+    
+    default-mailbox {
+      # FQCN of the MailboxType. The Class of the FQCN must have a public constructor with
+      # (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
+      mailbox-type = "akka.dispatch.UnboundedMailbox"
+
+      # If the mailbox is bounded then it uses this setting to determine its
+      # capacity. The provided value must be positive.
+      # NOTICE:
+      # Up to version 2.1 the mailbox type was determined based on this setting;
+      # this is no longer the case, the type must explicitly name a bounded mailbox.
+      mailbox-capacity = 1000
+
+      # If the mailbox is bounded then this is the timeout for enqueueing 
+      # in case the mailbox is full. Negative values signify infinite
+      # timeout, which should be avoided as it bears the risk of dead-lock.
+      mailbox-push-timeout-time = 10s
 
       # For Actor with Stash: The default capacity of the stash.
       # If negative (or zero) then an unbounded stash is used (default)
@@ -322,10 +326,16 @@ akka {
       requirements {
         "akka.dispatch.UnboundedMessageQueueSemantics" =
           akka.actor.mailbox.unbounded-queue-based
-        "akka.dispatch.DequeBasedMessageQueue" =
+        "akka.dispatch.BoundedMessageQueueSemantics" =
+          akka.actor.mailbox.bounded-queue-based
+        "akka.dispatch.DequeBasedMessageQueueSemantics" =
           akka.actor.mailbox.unbounded-deque-based
         "akka.dispatch.UnboundedDequeBasedMessageQueueSemantics" =
           akka.actor.mailbox.unbounded-deque-based
+        "akka.dispatch.BoundedDequeBasedMessageQueueSemantics" =
+          akka.actor.mailbox.bounded-deque-based
+        "akka.dispatch.MultipleConsumerSemantics" =
+          akka.actor.mailbox.unbounded-queue-based
       }
 
       unbounded-queue-based {
@@ -335,11 +345,25 @@ akka {
         mailbox-type = "akka.dispatch.UnboundedMailbox"
       }
 
+      bounded-queue-based {
+        # FQCN of the MailboxType, The Class of the FQCN must have a public
+        # constructor with (akka.actor.ActorSystem.Settings,
+        # com.typesafe.config.Config) parameters.
+        mailbox-type = "akka.dispatch.BoundedMailbox"
+      }
+
       unbounded-deque-based {
         # FQCN of the MailboxType, The Class of the FQCN must have a public
         # constructor with (akka.actor.ActorSystem.Settings,
         # com.typesafe.config.Config) parameters.
         mailbox-type = "akka.dispatch.UnboundedDequeBasedMailbox"
+      }
+      
+      bounded-deque-based {
+        # FQCN of the MailboxType, The Class of the FQCN must have a public
+        # constructor with (akka.actor.ActorSystem.Settings,
+        # com.typesafe.config.Config) parameters.
+        mailbox-type = "akka.dispatch.BoundedDequeBasedMailbox"
       }
     }
 

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -16,6 +16,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
 import scala.concurrent.forkjoin.ThreadLocalRandom
 import scala.util.control.NonFatal
+import akka.dispatch.MessageDispatcher
 
 /**
  * The actor context - the view of the actor cell from the actor.
@@ -338,6 +339,7 @@ private[akka] class ActorCell(
   val system: ActorSystemImpl,
   val self: InternalActorRef,
   val props: Props,
+  val dispatcher: MessageDispatcher,
   val parent: InternalActorRef)
   extends UntypedActorContext with Cell
   with dungeon.ReceiveTimeout

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -271,6 +271,8 @@ private[akka] case object Nobody extends MinimalActorRef {
 private[akka] class LocalActorRef private[akka] (
   _system: ActorSystemImpl,
   _props: Props,
+  _dispatcher: MessageDispatcher,
+  _mailboxType: MailboxType,
   _supervisor: InternalActorRef,
   override val path: ActorPath)
   extends ActorRefWithCell with LocalRef {
@@ -285,11 +287,11 @@ private[akka] class LocalActorRef private[akka] (
    * actorCell before we call init and start, since we can start using "this"
    * object from another thread as soon as we run init.
    */
-  private val actorCell: ActorCell = newActorCell(_system, this, _props, _supervisor)
-  actorCell.init(sendSupervise = true)
+  private val actorCell: ActorCell = newActorCell(_system, this, _props, _dispatcher, _supervisor)
+  actorCell.init(sendSupervise = true, _mailboxType)
 
-  protected def newActorCell(system: ActorSystemImpl, ref: InternalActorRef, props: Props, supervisor: InternalActorRef): ActorCell =
-    new ActorCell(system, ref, props, supervisor)
+  protected def newActorCell(system: ActorSystemImpl, ref: InternalActorRef, props: Props, dispatcher: MessageDispatcher, supervisor: InternalActorRef): ActorCell =
+    new ActorCell(system, ref, props, dispatcher, supervisor)
 
   protected def actorContext: ActorContext = actorCell
 

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -760,7 +760,7 @@ private[akka] class LocalActorRefProvider private[akka] (
         } catch {
           case NonFatal(e) ⇒ throw new ConfigurationException(
             s"configuration problem while creating [$path] with router dispatcher [${routerProps.dispatcher}] and mailbox [${routerProps.mailbox}] " +
-              s" and routee dispatcher [${routeeProps.dispatcher}] and mailbox [${routeeProps.mailbox}]", e)
+              s"and routee dispatcher [${routeeProps.dispatcher}] and mailbox [${routeeProps.mailbox}]", e)
         }
     }
   }

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -559,12 +559,12 @@ private[akka] class ActorSystemImpl(val name: String, applicationConfig: Config,
     def hasSystemMessages = false
   }
 
+  val mailboxes: Mailboxes = new Mailboxes(settings, eventStream, dynamicAccess)
+
   val dispatchers: Dispatchers = new Dispatchers(settings, DefaultDispatcherPrerequisites(
-    threadFactory, eventStream, deadLetterMailbox, scheduler, dynamicAccess, settings))
+    threadFactory, eventStream, deadLetterMailbox, scheduler, dynamicAccess, settings, mailboxes))
 
   val dispatcher: ExecutionContext = dispatchers.defaultGlobalDispatcher
-
-  val mailboxes: Mailboxes = new Mailboxes(settings, eventStream, dynamicAccess)
 
   val internalCallingThreadExecutionContext: ExecutionContext =
     dynamicAccess.getObjectFor[ExecutionContext]("scala.concurrent.Future$InternalCallbackExecutor$").getOrElse(

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -29,6 +29,8 @@ import util.Try
 private[akka] class RepointableActorRef(
   val system: ActorSystemImpl,
   val props: Props,
+  val dispatcher: MessageDispatcher,
+  val mailboxType: MailboxType,
   val supervisor: InternalActorRef,
   val path: ActorPath)
   extends ActorRefWithCell with RepointableRef {
@@ -111,7 +113,7 @@ private[akka] class RepointableActorRef(
    * unstarted cell. The cell must be fully functional.
    */
   def newCell(old: UnstartedCell): Cell =
-    new ActorCell(system, this, props, supervisor).init(sendSupervise = false)
+    new ActorCell(system, this, props, dispatcher, supervisor).init(sendSupervise = false, mailboxType)
 
   def start(): Unit = ()
 

--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -3,7 +3,7 @@
  */
 package akka.actor
 
-import akka.dispatch.{ UnboundedDequeBasedMessageQueueSemantics, RequiresMessageQueue, Envelope, DequeBasedMessageQueue }
+import akka.dispatch.{ UnboundedDequeBasedMessageQueueSemantics, RequiresMessageQueue, Envelope, DequeBasedMessageQueueSemantics }
 import akka.AkkaException
 
 /**
@@ -47,7 +47,7 @@ import akka.AkkaException
  *  any trait/class that overrides the `preRestart` callback. This means it's not possible to write
  *  `Actor with MyActor with Stash` if `MyActor` overrides `preRestart`.
  */
-trait Stash extends UnrestrictedStash with RequiresMessageQueue[DequeBasedMessageQueue]
+trait Stash extends UnrestrictedStash with RequiresMessageQueue[DequeBasedMessageQueueSemantics]
 
 /**
  * The `UnboundedStash` trait is a version of `Stash` that enforces an unbounded stash for you actor.
@@ -64,16 +64,16 @@ trait UnrestrictedStash extends Actor {
    */
   private val capacity: Int = {
     val dispatcher = context.system.settings.config.getConfig(context.props.dispatcher)
-    val config = dispatcher.withFallback(context.system.settings.config.getConfig("akka.actor.default-dispatcher"))
+    val config = dispatcher.withFallback(context.system.settings.config.getConfig("akka.actor.default-mailbox"))
     config.getInt("stash-capacity")
   }
 
   /* The actor's deque-based message queue.
    * `mailbox.queue` is the underlying `Deque`.
    */
-  private val mailbox: DequeBasedMessageQueue = {
+  private val mailbox: DequeBasedMessageQueueSemantics = {
     context.asInstanceOf[ActorCell].mailbox.messageQueue match {
-      case queue: DequeBasedMessageQueue ⇒ queue
+      case queue: DequeBasedMessageQueueSemantics ⇒ queue
       case other ⇒ throw ActorInitializationException(self, s"DequeBasedMailbox required, got: ${other.getClass.getName}\n" +
         """An (unbounded) deque-based mailbox can be configured as follows:
           |  my-custom-mailbox {

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
@@ -59,7 +59,7 @@ private[akka] trait Dispatch { this: ActorCell ⇒
         val req = system.mailboxes.getRequiredType(actorClass)
         if (req isInstance mbox.messageQueue) Create(None)
         else Create(Some(ActorInitializationException(self,
-          s"Actor [$self] requires mailbox type [$req] got [${mbox.messageQueue.getClass}]")))
+          s"Actor [$self] requires mailbox type [$req] got [${mbox.messageQueue.getClass.getName}]")))
       case _ ⇒ Create(None)
     }
 

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
@@ -13,6 +13,8 @@ import akka.actor._
 import akka.serialization.SerializationExtension
 import scala.util.control.NonFatal
 import scala.util.control.Exception.Catcher
+import akka.dispatch.MailboxType
+import akka.dispatch.ProducesMessageQueue
 
 private[akka] trait Dispatch { this: ActorCell ⇒
 
@@ -30,8 +32,6 @@ private[akka] trait Dispatch { this: ActorCell ⇒
 
   final def numberOfMessages: Int = mailbox.numberOfMessages
 
-  val dispatcher: MessageDispatcher = system.dispatchers.lookup(props.dispatcher)
-
   final def isTerminated: Boolean = mailbox.isClosed
 
   /**
@@ -39,24 +39,29 @@ private[akka] trait Dispatch { this: ActorCell ⇒
    * reasonably different from the previous UID of a possible actor with the same path,
    * which can be achieved by using ThreadLocalRandom.current.nextInt().
    */
-  final def init(sendSupervise: Boolean): this.type = {
+  final def init(sendSupervise: Boolean, mailboxType: MailboxType): this.type = {
     /*
      * Create the mailbox and enqueue the Create() message to ensure that
      * this is processed before anything else.
      */
-    val mbox = dispatcher.createMailbox(this)
+    val mbox = dispatcher.createMailbox(this, mailboxType)
 
+    /*
+     * The mailboxType was calculated taking into account what the MailboxType
+     * has promised to produce. If that was more than the default, then we need
+     * to reverify here because the dispatcher may well have screwed it up.
+     */
     // we need to delay the failure to the point of actor creation so we can handle
     // it properly in the normal way
     val actorClass = props.actorClass
-    val createMessage = if (system.mailboxes.hasRequiredType(actorClass)) {
-      Create(system.mailboxes.getRequiredType(actorClass).flatMap {
-        case c if !c.isAssignableFrom(mbox.messageQueue.getClass) ⇒
-          Some(ActorInitializationException(self, s"Actor [${self}] requires mailbox type [${c}]" +
-            s" got [${mbox.messageQueue.getClass}]"))
-        case _ ⇒ None
-      })
-    } else Create(None)
+    val createMessage = mailboxType match {
+      case _: ProducesMessageQueue[_] if system.mailboxes.hasRequiredType(actorClass) ⇒
+        val req = system.mailboxes.getRequiredType(actorClass)
+        if (req isInstance mbox.messageQueue) Create(None)
+        else Create(Some(ActorInitializationException(self,
+          s"Actor [$self] requires mailbox type [$req] got [${mbox.messageQueue.getClass}]")))
+      case _ ⇒ Create(None)
+    }
 
     swapMailbox(mbox)
     mailbox.setActor(this)

--- a/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
@@ -29,16 +29,15 @@ import scala.concurrent.duration.FiniteDuration
  * @see akka.dispatch.Dispatchers
  */
 class BalancingDispatcher(
-  _prerequisites: DispatcherPrerequisites,
+  _configurator: MessageDispatcherConfigurator,
   _id: String,
   throughput: Int,
   throughputDeadlineTime: Duration,
-  mailboxType: MailboxType,
-  _mailBoxTypeConfigured: Boolean,
+  _mailboxType: MailboxType,
   _executorServiceFactoryProvider: ExecutorServiceFactoryProvider,
   _shutdownTimeout: FiniteDuration,
   attemptTeamWork: Boolean)
-  extends Dispatcher(_prerequisites, _id, throughput, throughputDeadlineTime, mailboxType, _mailBoxTypeConfigured, _executorServiceFactoryProvider, _shutdownTimeout) {
+  extends Dispatcher(_configurator, _id, throughput, throughputDeadlineTime, _executorServiceFactoryProvider, _shutdownTimeout) {
 
   /**
    * INTERNAL API
@@ -51,7 +50,7 @@ class BalancingDispatcher(
   /**
    * INTERNAL API
    */
-  private[akka] val messageQueue: MessageQueue = mailboxType.create(None, None)
+  private[akka] val messageQueue: MessageQueue = _mailboxType.create(None, None)
 
   private class SharingMailbox(val system: ActorSystemImpl, _messageQueue: MessageQueue)
     extends Mailbox(_messageQueue) with DefaultSystemMessageQueue {
@@ -69,7 +68,8 @@ class BalancingDispatcher(
     }
   }
 
-  protected[akka] override def createMailbox(actor: akka.actor.Cell): Mailbox = new SharingMailbox(actor.systemImpl, messageQueue)
+  protected[akka] override def createMailbox(actor: akka.actor.Cell, mailboxType: MailboxType): Mailbox =
+    new SharingMailbox(actor.systemImpl, messageQueue)
 
   protected[akka] override def register(actor: ActorCell): Unit = {
     super.register(actor)

--- a/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
@@ -55,7 +55,7 @@ class BalancingDispatcher(
   private class SharingMailbox(val system: ActorSystemImpl, _messageQueue: MessageQueue)
     extends Mailbox(_messageQueue) with DefaultSystemMessageQueue {
     override def cleanUp(): Unit = {
-      val dlq = system.deadLetterMailbox
+      val dlq = mailboxes.deadLetterMailbox
       //Don't call the original implementation of this since it scraps all messages, and we don't want to do that
       var messages = systemDrain(new LatestFirstSystemMessageList(NoMessage))
       while (messages.nonEmpty) {

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -19,7 +19,6 @@ import akka.actor.Deploy
 trait DispatcherPrerequisites {
   def threadFactory: ThreadFactory
   def eventStream: EventStream
-  def deadLetterMailbox: Mailbox
   def scheduler: Scheduler
   def dynamicAccess: DynamicAccess
   def settings: ActorSystem.Settings
@@ -32,7 +31,6 @@ trait DispatcherPrerequisites {
 private[akka] case class DefaultDispatcherPrerequisites(
   val threadFactory: ThreadFactory,
   val eventStream: EventStream,
-  val deadLetterMailbox: Mailbox,
   val scheduler: Scheduler,
   val dynamicAccess: DynamicAccess,
   val settings: ActorSystem.Settings,
@@ -188,11 +186,14 @@ class DispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisi
   override def dispatcher(): MessageDispatcher = instance
 }
 
-object BalancingDispatcherConfigurator {
+/**
+ * INTERNAL API
+ */
+private[akka] object BalancingDispatcherConfigurator {
   private val defaultRequirement =
     ConfigFactory.parseString("mailbox-requirement = akka.dispatch.MultipleConsumerSemantics")
   def amendConfig(config: Config): Config =
-    if (config.getString("mailbox-requirement") != "") config
+    if (config.getString("mailbox-requirement") != Mailboxes.NoMailboxRequirement) config
     else defaultRequirement.withFallback(config)
 }
 

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -347,7 +347,7 @@ trait MessageQueue {
   def cleanUp(owner: ActorRef, deadLetters: MessageQueue): Unit
 }
 
-class NodeMessageQueue extends AbstractNodeQueue[Envelope] with MessageQueue {
+class NodeMessageQueue extends AbstractNodeQueue[Envelope] with MessageQueue with UnboundedMessageQueueSemantics {
 
   final def enqueue(receiver: ActorRef, handle: Envelope): Unit = add(handle)
 
@@ -419,9 +419,15 @@ private[akka] trait DefaultSystemMessageQueue { self: Mailbox ⇒
 }
 
 /**
+ * This is a marker trait for message queues which support multiple consumers,
+ * as is required by the BalancingDispatcher.
+ */
+trait MultipleConsumerSemantics
+
+/**
  * A QueueBasedMessageQueue is a MessageQueue backed by a java.util.Queue.
  */
-trait QueueBasedMessageQueue extends MessageQueue {
+trait QueueBasedMessageQueue extends MessageQueue with MultipleConsumerSemantics {
   def queue: Queue[Envelope]
   def numberOfMessages = queue.size
   def hasMessages = !queue.isEmpty
@@ -440,7 +446,9 @@ trait QueueBasedMessageQueue extends MessageQueue {
  * UnboundedMessageQueueSemantics adds unbounded semantics to a QueueBasedMessageQueue,
  * i.e. a non-blocking enqueue and dequeue.
  */
-trait UnboundedMessageQueueSemantics extends QueueBasedMessageQueue {
+trait UnboundedMessageQueueSemantics
+
+trait UnboundedQueueBasedMessageQueue extends QueueBasedMessageQueue with UnboundedMessageQueueSemantics {
   def enqueue(receiver: ActorRef, handle: Envelope): Unit = queue add handle
   def dequeue(): Envelope = queue.poll()
 }
@@ -449,8 +457,11 @@ trait UnboundedMessageQueueSemantics extends QueueBasedMessageQueue {
  * BoundedMessageQueueSemantics adds bounded semantics to a QueueBasedMessageQueue,
  * i.e. blocking enqueue with timeout.
  */
-trait BoundedMessageQueueSemantics extends QueueBasedMessageQueue {
+trait BoundedMessageQueueSemantics {
   def pushTimeOut: Duration
+}
+
+trait BoundedQueueBasedMessageQueue extends QueueBasedMessageQueue with BoundedMessageQueueSemantics {
   override def queue: BlockingQueue[Envelope]
 
   def enqueue(receiver: ActorRef, handle: Envelope): Unit =
@@ -466,16 +477,23 @@ trait BoundedMessageQueueSemantics extends QueueBasedMessageQueue {
 /**
  * DequeBasedMessageQueue refines QueueBasedMessageQueue to be backed by a java.util.Deque.
  */
-trait DequeBasedMessageQueue extends QueueBasedMessageQueue {
-  def queue: Deque[Envelope]
+trait DequeBasedMessageQueueSemantics {
   def enqueueFirst(receiver: ActorRef, handle: Envelope): Unit
+}
+
+trait UnboundedDequeBasedMessageQueueSemantics extends DequeBasedMessageQueueSemantics with UnboundedMessageQueueSemantics
+
+trait BoundedDequeBasedMessageQueueSemantics extends DequeBasedMessageQueueSemantics with BoundedMessageQueueSemantics
+
+trait DequeBasedMessageQueue extends QueueBasedMessageQueue with DequeBasedMessageQueueSemantics {
+  def queue: Deque[Envelope]
 }
 
 /**
  * UnboundedDequeBasedMessageQueueSemantics adds unbounded semantics to a DequeBasedMessageQueue,
  * i.e. a non-blocking enqueue and dequeue.
  */
-trait UnboundedDequeBasedMessageQueueSemantics extends DequeBasedMessageQueue {
+trait UnboundedDequeBasedMessageQueue extends DequeBasedMessageQueue with UnboundedDequeBasedMessageQueueSemantics {
   def enqueue(receiver: ActorRef, handle: Envelope): Unit = queue add handle
   def enqueueFirst(receiver: ActorRef, handle: Envelope): Unit = queue addFirst handle
   def dequeue(): Envelope = queue.poll()
@@ -485,7 +503,7 @@ trait UnboundedDequeBasedMessageQueueSemantics extends DequeBasedMessageQueue {
  * BoundedMessageQueueSemantics adds bounded semantics to a DequeBasedMessageQueue,
  * i.e. blocking enqueue with timeout.
  */
-trait BoundedDequeBasedMessageQueueSemantics extends DequeBasedMessageQueue {
+trait BoundedDequeBasedMessageQueue extends DequeBasedMessageQueue with BoundedDequeBasedMessageQueueSemantics {
   def pushTimeOut: Duration
   override def queue: BlockingDeque[Envelope]
 
@@ -523,17 +541,23 @@ trait MailboxType {
   def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue
 }
 
+trait ProducesMessageQueue[T <: MessageQueue]
+
 /**
  * UnboundedMailbox is the default unbounded MailboxType used by Akka Actors.
  */
-case class UnboundedMailbox() extends MailboxType {
+case class UnboundedMailbox() extends MailboxType with ProducesMessageQueue[UnboundedMailbox.MessageQueue] {
 
   def this(settings: ActorSystem.Settings, config: Config) = this()
 
   final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
-    new ConcurrentLinkedQueue[Envelope]() with QueueBasedMessageQueue with UnboundedMessageQueueSemantics {
-      final def queue: Queue[Envelope] = this
-    }
+    new UnboundedMailbox.MessageQueue
+}
+
+object UnboundedMailbox {
+  class MessageQueue extends ConcurrentLinkedQueue[Envelope] with UnboundedQueueBasedMessageQueue {
+    final def queue: Queue[Envelope] = this
+  }
 }
 
 /**
@@ -541,17 +565,18 @@ case class UnboundedMailbox() extends MailboxType {
  * the only drawback is that you can't have multiple consumers,
  * which rules out using it with BalancingDispatcher for instance.
  */
-case class SingleConsumerOnlyUnboundedMailbox() extends MailboxType {
+case class SingleConsumerOnlyUnboundedMailbox() extends MailboxType with ProducesMessageQueue[NodeMessageQueue] {
 
   def this(settings: ActorSystem.Settings, config: Config) = this()
 
-  final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue = new NodeMessageQueue()
+  final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue = new NodeMessageQueue
 }
 
 /**
  * BoundedMailbox is the default bounded MailboxType used by Akka Actors.
  */
-case class BoundedMailbox( final val capacity: Int, final val pushTimeOut: FiniteDuration) extends MailboxType {
+case class BoundedMailbox(val capacity: Int, val pushTimeOut: FiniteDuration)
+  extends MailboxType with ProducesMessageQueue[BoundedMailbox.MessageQueue] {
 
   def this(settings: ActorSystem.Settings, config: Config) = this(config.getInt("mailbox-capacity"),
     Duration(config.getNanoseconds("mailbox-push-timeout-time"), TimeUnit.NANOSECONDS))
@@ -560,57 +585,78 @@ case class BoundedMailbox( final val capacity: Int, final val pushTimeOut: Finit
   if (pushTimeOut eq null) throw new IllegalArgumentException("The push time-out for BoundedMailbox can not be null")
 
   final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
-    new LinkedBlockingQueue[Envelope](capacity) with QueueBasedMessageQueue with BoundedMessageQueueSemantics {
-      final def queue: BlockingQueue[Envelope] = this
-      final val pushTimeOut = BoundedMailbox.this.pushTimeOut
-    }
+    new BoundedMailbox.MessageQueue(capacity, pushTimeOut)
+}
+
+object BoundedMailbox {
+  class MessageQueue(capacity: Int, final val pushTimeOut: FiniteDuration)
+    extends LinkedBlockingQueue[Envelope](capacity) with BoundedQueueBasedMessageQueue {
+    final def queue: BlockingQueue[Envelope] = this
+  }
 }
 
 /**
  * UnboundedPriorityMailbox is an unbounded mailbox that allows for prioritization of its contents.
  * Extend this class and provide the Comparator in the constructor.
  */
-class UnboundedPriorityMailbox( final val cmp: Comparator[Envelope], final val initialCapacity: Int) extends MailboxType {
+class UnboundedPriorityMailbox(val cmp: Comparator[Envelope], val initialCapacity: Int)
+  extends MailboxType with ProducesMessageQueue[UnboundedPriorityMailbox.MessageQueue] {
   def this(cmp: Comparator[Envelope]) = this(cmp, 11)
   final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
-    new PriorityBlockingQueue[Envelope](initialCapacity, cmp) with QueueBasedMessageQueue with UnboundedMessageQueueSemantics {
-      final def queue: Queue[Envelope] = this
-    }
+    new UnboundedPriorityMailbox.MessageQueue(initialCapacity, cmp)
+}
+
+object UnboundedPriorityMailbox {
+  class MessageQueue(initialCapacity: Int, cmp: Comparator[Envelope])
+    extends PriorityBlockingQueue[Envelope](initialCapacity, cmp) with UnboundedQueueBasedMessageQueue {
+    final def queue: Queue[Envelope] = this
+  }
 }
 
 /**
  * BoundedPriorityMailbox is a bounded mailbox that allows for prioritization of its contents.
  * Extend this class and provide the Comparator in the constructor.
  */
-class BoundedPriorityMailbox( final val cmp: Comparator[Envelope], final val capacity: Int, final val pushTimeOut: Duration) extends MailboxType {
+class BoundedPriorityMailbox( final val cmp: Comparator[Envelope], final val capacity: Int, final val pushTimeOut: Duration)
+  extends MailboxType with ProducesMessageQueue[BoundedPriorityMailbox.MessageQueue] {
 
   if (capacity < 0) throw new IllegalArgumentException("The capacity for BoundedMailbox can not be negative")
   if (pushTimeOut eq null) throw new IllegalArgumentException("The push time-out for BoundedMailbox can not be null")
 
   final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
-    new BoundedBlockingQueue[Envelope](capacity, new PriorityQueue[Envelope](11, cmp)) with QueueBasedMessageQueue with BoundedMessageQueueSemantics {
-      final def queue: BlockingQueue[Envelope] = this
-      final val pushTimeOut = BoundedPriorityMailbox.this.pushTimeOut
-    }
+    new BoundedPriorityMailbox.MessageQueue(capacity, cmp, pushTimeOut)
+}
+
+object BoundedPriorityMailbox {
+  class MessageQueue(capacity: Int, cmp: Comparator[Envelope], val pushTimeOut: Duration)
+    extends BoundedBlockingQueue[Envelope](capacity, new PriorityQueue[Envelope](11, cmp))
+    with BoundedQueueBasedMessageQueue {
+    final def queue: BlockingQueue[Envelope] = this
+  }
 }
 
 /**
  * UnboundedDequeBasedMailbox is an unbounded MailboxType, backed by a Deque.
  */
-case class UnboundedDequeBasedMailbox() extends MailboxType {
+case class UnboundedDequeBasedMailbox() extends MailboxType with ProducesMessageQueue[UnboundedDequeBasedMailbox.MessageQueue] {
 
   def this(settings: ActorSystem.Settings, config: Config) = this()
 
   final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
-    new LinkedBlockingDeque[Envelope]() with DequeBasedMessageQueue with UnboundedDequeBasedMessageQueueSemantics {
-      final val queue = this
-    }
+    new UnboundedDequeBasedMailbox.MessageQueue
+}
+
+object UnboundedDequeBasedMailbox {
+  class MessageQueue extends LinkedBlockingDeque[Envelope] with UnboundedDequeBasedMessageQueue {
+    final val queue = this
+  }
 }
 
 /**
  * BoundedDequeBasedMailbox is an bounded MailboxType, backed by a Deque.
  */
-case class BoundedDequeBasedMailbox( final val capacity: Int, final val pushTimeOut: FiniteDuration) extends MailboxType {
+case class BoundedDequeBasedMailbox( final val capacity: Int, final val pushTimeOut: FiniteDuration)
+  extends MailboxType with ProducesMessageQueue[BoundedDequeBasedMailbox.MessageQueue] {
 
   def this(settings: ActorSystem.Settings, config: Config) = this(config.getInt("mailbox-capacity"),
     Duration(config.getNanoseconds("mailbox-push-timeout-time"), TimeUnit.NANOSECONDS))
@@ -619,10 +665,14 @@ case class BoundedDequeBasedMailbox( final val capacity: Int, final val pushTime
   if (pushTimeOut eq null) throw new IllegalArgumentException("The push time-out for BoundedDequeBasedMailbox can not be null")
 
   final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
-    new LinkedBlockingDeque[Envelope](capacity) with DequeBasedMessageQueue with BoundedDequeBasedMessageQueueSemantics {
-      final val queue = this
-      final val pushTimeOut = BoundedDequeBasedMailbox.this.pushTimeOut
-    }
+    new BoundedDequeBasedMailbox.MessageQueue(capacity, pushTimeOut)
+}
+
+object BoundedDequeBasedMailbox {
+  class MessageQueue(capacity: Int, val pushTimeOut: FiniteDuration)
+    extends LinkedBlockingDeque[Envelope](capacity) with BoundedDequeBasedMessageQueue {
+    final val queue = this
+  }
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -147,7 +147,7 @@ private[akka] class Mailboxes(
 
   private def lookupId(queueType: Class[_]): String =
     mailboxBindings.get(queueType) match {
-      case None    ⇒ throw new IllegalArgumentException(s"Mailbox Mapping for [${queueType}] not configured")
+      case None    ⇒ throw new ConfigurationException(s"Mailbox Mapping for [${queueType}] not configured")
       case Some(s) ⇒ s
     }
 
@@ -159,10 +159,10 @@ private[akka] class Mailboxes(
           case "unbounded" ⇒ UnboundedMailbox()
           case "bounded"   ⇒ new BoundedMailbox(settings, config(id))
           case _ ⇒
-            if (!settings.config.hasPath(id)) throw new IllegalArgumentException(s"Mailbox Type [${id}] not configured")
+            if (!settings.config.hasPath(id)) throw new ConfigurationException(s"Mailbox Type [${id}] not configured")
             val conf = config(id)
             conf.getString("mailbox-type") match {
-              case "" ⇒ throw new IllegalArgumentException(s"The setting mailbox-type, defined in [$id] is empty")
+              case "" ⇒ throw new ConfigurationException(s"The setting mailbox-type, defined in [$id] is empty")
               case fqcn ⇒
                 val args = List(classOf[ActorSystem.Settings] -> settings, classOf[Config] -> conf)
                 dynamicAccess.createInstanceFor[MailboxType](fqcn, args).recover({

--- a/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
@@ -15,19 +15,15 @@ import scala.concurrent.duration.FiniteDuration
  * the `lookup` method in [[akka.dispatch.Dispatchers]].
  */
 class PinnedDispatcher(
-  _prerequisites: DispatcherPrerequisites,
+  _configurator: MessageDispatcherConfigurator,
   _actor: ActorCell,
   _id: String,
-  _mailboxType: MailboxType,
-  _mailboxTypeConfigured: Boolean,
   _shutdownTimeout: FiniteDuration,
   _threadPoolConfig: ThreadPoolConfig)
-  extends Dispatcher(_prerequisites,
+  extends Dispatcher(_configurator,
     _id,
     Int.MaxValue,
     Duration.Zero,
-    _mailboxType,
-    _mailboxTypeConfigured,
     _threadPoolConfig.copy(corePoolSize = 1, maxPoolSize = 1),
     _shutdownTimeout) {
 

--- a/akka-contrib/src/main/scala/akka/contrib/mailbox/PeekMailbox.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/mailbox/PeekMailbox.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.{ ConcurrentHashMap, ConcurrentLinkedQueue }
 import com.typesafe.config.Config
 
 import akka.actor.{ ActorContext, ActorRef, ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
-import akka.dispatch.{ Envelope, MailboxType, MessageQueue, QueueBasedMessageQueue, UnboundedMessageQueueSemantics }
+import akka.dispatch.{ Envelope, MailboxType, MessageQueue, UnboundedQueueBasedMessageQueue }
 
 object PeekMailboxExtension extends ExtensionId[PeekMailboxExtension] with ExtensionIdProvider {
   def lookup = this
@@ -53,7 +53,7 @@ class PeekMailboxType(settings: ActorSystem.Settings, config: Config) extends Ma
 }
 
 class PeekMailbox(owner: ActorRef, system: ActorSystem, maxRetries: Int)
-  extends QueueBasedMessageQueue with UnboundedMessageQueueSemantics {
+  extends UnboundedQueueBasedMessageQueue {
   final val queue = new ConcurrentLinkedQueue[Envelope]()
 
   /*

--- a/akka-docs/rst/java/mailboxes.rst
+++ b/akka-docs/rst/java/mailboxes.rst
@@ -79,8 +79,8 @@ dispatcher which will execute it. Then the mailbox is determined as follows:
 
 6. The default mailbox ``akka.actor.default-mailbox`` will be used.
 
-Which Configuration is pass to the Mailbox Type
------------------------------------------------
+Which Configuration is passed to the Mailbox Type
+-------------------------------------------------
 
 Each mailbox type is implemented by a class which extends :class:`MailboxType`
 and takes two constructor arguments: a :class:`ActorSystem.Settings` object and

--- a/akka-docs/rst/java/mailboxes.rst
+++ b/akka-docs/rst/java/mailboxes.rst
@@ -1,14 +1,96 @@
 .. _mailboxes-java:
 
 Mailboxes
-=========
+#########
 
 An Akka ``Mailbox`` holds the messages that are destined for an ``Actor``.
 Normally each ``Actor`` has its own mailbox, but with for example a ``BalancingDispatcher``
 all actors with the same ``BalancingDispatcher`` will share a single instance.
 
+Mailbox Selection
+=================
+
+Requiring a Message Queue Type for an Actor
+-------------------------------------------
+
+It is possible to require a certain type of message queue for a certain type of actor
+by having that actor implement the parameterized interface :class:`RequiresMessageQueue`. Here is
+an example:
+
+.. includecode:: code/docs/actor/MyBoundedUntypedActor.java#my-bounded-untyped-actor
+
+The type parameter to the :class:`RequiresMessageQueue` interface needs to be mapped to a mailbox in
+configuration like this:
+
+.. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala
+   :include: bounded-mailbox-config,required-mailbox-config
+
+Now every time you create an actor of type :class:`MyBoundedUntypedActor` it will try to get a bounded
+mailbox. If the actor has a different mailbox configured in deployment, either directly or via
+a dispatcher with a specified mailbox type, then that will override this mapping.
+
+.. note::
+
+  The type of the queue in the mailbox created for an actor will be checked against the required type in the
+  interface and if the queue doesn't implement the required type then actor creation will fail.
+
+Requiring a Message Queue Type for a Dispatcher
+-----------------------------------------------
+
+A dispatcher may also have a requirement for the mailbox type used by the
+actors running on it. An example is the BalancingDispatcher which requires a
+message queue that is thread-safe for multiple concurrent consumers. Such a
+requirement is formulated within the dispatcher configuration section like
+this::
+
+  my-dispatcher {
+    mailbox-requirement = org.example.MyInterface
+  }
+
+The given requirement names a class or interface which will then be ensured to
+be a supertype of the message queue’s implementation. In case of a
+conflict—e.g. if the actor requires a mailbox type which does not satisfy this
+requirement—then actor creation will fail.
+
+How the Mailbox Type is Selected
+--------------------------------
+
+When an actor is created, the :class:`ActorRefProvider` first determines the
+dispatcher which will execute it. Then the mailbox is determined as follows:
+
+1. If the actor’s deployment configuration section contains a ``mailbox`` key
+   then that names a configuration section describing the mailbox type to be
+   used.
+
+2. If the actor’s ``Props`` contains a mailbox selection—i.e. ``withMailbox``
+   was called on it—then that names a configuration section describing the
+   mailbox type to be used.
+
+3. If the dispatcher’s configuration section contains a ``mailbox-type`` key
+   the same section will be used to configure the mailbox type.
+
+4. If the actor requires a mailbox type as described above then the mapping for
+   that requirement will be used to determine the mailbox type to be used; if
+   that fails then the dispatcher’s requirement—if any—will be tried instead.
+
+5. If the dispatcher requires a mailbox type as described above then the
+   mapping for that requirement will be used to determine the mailbox type to
+   be used.
+
+6. The default mailbox ``akka.actor.default-mailbox`` will be used.
+
+Which Configuration is pass to the Mailbox Type
+-----------------------------------------------
+
+Each mailbox type is implemented by a class which extends :class:`MailboxType`
+and takes two constructor arguments: a :class:`ActorSystem.Settings` object and
+a :class:`Config` section. The latter is computed by obtaining the named
+configuration section from the actor system’s configuration, overriding its
+``id`` key with the configuration path of the mailbox type and adding a
+fall-back to the default mailbox configuration section.
+
 Builtin Mailbox Implementations
--------------------------------
+===============================
 
 Akka comes shipped with a number of default mailbox implementations:
 
@@ -47,7 +129,7 @@ Akka comes shipped with a number of default mailbox implementations:
 * Durable mailboxes, see :ref:`durable-mailboxes-java`.
 
 Mailbox configuration examples
-------------------------------
+==============================
 
 How to create a PriorityMailbox:
 
@@ -75,44 +157,8 @@ Or code like this:
 .. includecode:: code/docs/dispatcher/DispatcherDocTest.java#defining-mailbox-in-code
 
 
-Requiring a message queue type for an Actor
--------------------------------------------
-
-It is possible to require a certain type of message queue for a certain type of actor
-by having that actor implement the parameterized interface :class:`RequiresMessageQueue`. Here is
-an example:
-
-.. includecode:: code/docs/actor/MyBoundedUntypedActor.java#my-bounded-untyped-actor
-
-The type parameter to the :class:`RequiresMessageQueue` interface needs to be mapped to a mailbox in
-configuration like this:
-
-.. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala
-   :include: bounded-mailbox-config,required-mailbox-config
-
-Now every time you create an actor of type :class:`MyBoundedUntypedActor` it will try to get a bounded
-mailbox. If the actor has a different mailbox configured in deployment, either directly or via
-a dispatcher with a specified mailbox type, then that will override this mapping.
-
-.. note::
-
-  The type of the queue in the mailbox created for an actor will be checked against the required type in the
-  interface and if the queue doesn't implement the required type then actor creation will fail.
-
-
-Mailbox configuration precedence
---------------------------------
-
-The order of precedence for the mailbox type of an actor, where lower numbers override higher, is:
-
-1. Mailbox type configured in the deployment of the actor
-2. Mailbox type configured on the dispatcher of the actor
-3. Mailbox type configured on the Props of the actor
-4. Mailbox type configured via message queue requirement
-
-
 Creating your own Mailbox type
-------------------------------
+==============================
 
 An example is worth a thousand quacks:
 
@@ -135,7 +181,7 @@ configuration, or the mailbox configuration.
 
 
 Special Semantics of ``system.actorOf``
----------------------------------------
+=======================================
 
 In order to make ``system.actorOf`` both synchronous and non-blocking while
 keeping the return type :class:`ActorRef` (and the semantics that the returned

--- a/akka-docs/rst/project/migration-guide-2.1.x-2.2.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.1.x-2.2.x.rst
@@ -85,12 +85,12 @@ Search                               Replace with
 If you need to convert from Java to ``scala.collection.immutable.Seq`` or ``scala.collection.immutable.Iterable`` you should use ``akka.japi.Util.immutableSeq(…)``,
 and if you need to convert from Scala you can simply switch to using immutable collections yourself or use the ``to[immutable.<collection-type>]`` method.
 
-ActorContext & ActorRefFactory dispatcher
+ActorContext & ActorRefFactory Dispatcher
 =========================================
 
 The return type of ``ActorContext``'s and ``ActorRefFactory``'s ``dispatcher``-method now returns ``ExecutionContext`` instead of ``MessageDispatcher``.
 
-Removed fallback to default dispatcher
+Removed Fallback to Default Dispatcher
 ======================================
 
 If deploying an actor with a specific dispatcher, e.g.
@@ -105,6 +105,17 @@ Akka 2.2 introduces the possibility to add dispatcher configuration to the
 
 The fallback was removed because in many cases its application was neither
 intended nor noticed.
+
+Changed Configuration Section for Dispatcher & Mailbox
+======================================================
+
+The mailbox configuration defaults moved from ``akka.actor.default-dispatcher``
+to ``akka.actor.default-mailbox``. You will not have to change anything unless
+your configuration overrides a setting in the default dispatcher section.
+
+The ``mailbox-type`` now requires a fully-qualified class name for the mailbox
+to use. The special words ``bounded`` and ``unbounded`` are retained for a
+migration period throughout the 2.2 series.
 
 API changes to FSM and TestFSMRef
 =================================

--- a/akka-docs/rst/project/migration-guide-2.1.x-2.2.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.1.x-2.2.x.rst
@@ -348,3 +348,20 @@ message. Therefore the following is now safe::
   context.stop(target)
   context.unwatch(target)
 
+Dispatcher and Mailbox Implementation Changes
+=============================================
+
+This point is only relevant if you have implemented a custom mailbox or
+dispatcher and want to migrate that to Akka 2.2. The constructor signature of
+:class:`MessageDispatcher` has changed, it now takes a
+:class:`MessageDispatcherConfigurator` instead of
+:class:`DispatcherPrerequisites`. Its :class:`createMailbox` method now
+receives one more argument of type :class:`MailboxType`, which is the mailbox
+type determined by the :class:`ActorRefProvider` for the actor based on its
+deployment. The :class:`DispatcherPrerequisites` now include a
+:class:`Mailboxes` instance which can be used for resolving mailbox references.
+The constructor signatures of the built-in dispatcher implementation have been
+adapted accordingly.  The traits describing mailbox semantics have been
+separated from the implementation traits.
+
+

--- a/akka-docs/rst/scala/code/docs/dispatcher/DispatcherDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/dispatcher/DispatcherDocSpec.scala
@@ -203,8 +203,7 @@ object DispatcherDocSpec {
     import akka.dispatch.{
       Envelope,
       MessageQueue,
-      QueueBasedMessageQueue,
-      UnboundedMessageQueueSemantics
+      UnboundedQueueBasedMessageQueue
     }
 
     // This constructor signature must exist, it will be called by Akka
@@ -213,7 +212,7 @@ object DispatcherDocSpec {
     // The create method is called to create the MessageQueue
     final override def create(owner: Option[ActorRef],
                               system: Option[ActorSystem]): MessageQueue =
-      new QueueBasedMessageQueue with UnboundedMessageQueueSemantics {
+      new UnboundedQueueBasedMessageQueue {
         final val queue = new ConcurrentLinkedQueue[Envelope]()
       }
   }

--- a/akka-docs/rst/scala/code/docs/routing/RouterViaProgramDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/routing/RouterViaProgramDocSpec.scala
@@ -40,7 +40,7 @@ class RouterViaProgramDocSpec extends AkkaSpec with ImplicitSender {
     val actor3 = system.actorOf(Props[ExampleActor1], "actor3")
     val routees = Vector[String]("/user/actor1", "/user/actor2", "/user/actor3")
     val router = system.actorOf(
-      Props().withRouter(RoundRobinRouter(routees = routees)))
+      Props.empty.withRouter(RoundRobinRouter(routees = routees)))
     //#programmaticRoutingRouteePaths
     1 to 6 foreach { i ⇒ router ! Message1(i) }
     val received = receiveN(6, 5.seconds.dilated)

--- a/akka-docs/rst/scala/mailboxes.rst
+++ b/akka-docs/rst/scala/mailboxes.rst
@@ -79,8 +79,8 @@ dispatcher which will execute it. Then the mailbox is determined as follows:
 
 6. The default mailbox ``akka.actor.default-mailbox`` will be used.
 
-Which Configuration is pass to the Mailbox Type
------------------------------------------------
+Which Configuration is passed to the Mailbox Type
+-------------------------------------------------
 
 Each mailbox type is implemented by a class which extends :class:`MailboxType`
 and takes two constructor arguments: a :class:`ActorSystem.Settings` object and

--- a/akka-docs/rst/scala/mailboxes.rst
+++ b/akka-docs/rst/scala/mailboxes.rst
@@ -1,14 +1,96 @@
 .. _mailboxes-scala:
 
 Mailboxes
-=========
+#########
 
 An Akka ``Mailbox`` holds the messages that are destined for an ``Actor``.
 Normally each ``Actor`` has its own mailbox, but with for example a ``BalancingDispatcher``
 all actors with the same ``BalancingDispatcher`` will share a single instance.
 
+Mailbox Selection
+=================
+
+Requiring a Message Queue Type for an Actor
+-------------------------------------------
+
+It is possible to require a certain type of message queue for a certain type of actor
+by having that actor extend the parameterized trait :class:`RequiresMessageQueue`. Here is
+an example:
+
+.. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala#required-mailbox-class
+
+The type parameter to the :class:`RequiresMessageQueue` trait needs to be mapped to a mailbox in
+configuration like this:
+
+.. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala
+   :include: bounded-mailbox-config,required-mailbox-config
+
+Now every time you create an actor of type :class:`MyBoundedActor` it will try to get a bounded
+mailbox. If the actor has a different mailbox configured in deployment, either directly or via
+a dispatcher with a specified mailbox type, then that will override this mapping.
+
+.. note::
+
+  The type of the queue in the mailbox created for an actor will be checked against the required type in the
+  trait and if the queue doesn't implement the required type then actor creation will fail.
+
+Requiring a Message Queue Type for a Dispatcher
+-----------------------------------------------
+
+A dispatcher may also have a requirement for the mailbox type used by the
+actors running on it. An example is the BalancingDispatcher which requires a
+message queue that is thread-safe for multiple concurrent consumers. Such a
+requirement is formulated within the dispatcher configuration section like
+this::
+
+  my-dispatcher {
+    mailbox-requirement = org.example.MyInterface
+  }
+
+The given requirement names a class or interface which will then be ensured to
+be a supertype of the message queue’s implementation. In case of a
+conflict—e.g. if the actor requires a mailbox type which does not satisfy this
+requirement—then actor creation will fail.
+
+How the Mailbox Type is Selected
+--------------------------------
+
+When an actor is created, the :class:`ActorRefProvider` first determines the
+dispatcher which will execute it. Then the mailbox is determined as follows:
+
+1. If the actor’s deployment configuration section contains a ``mailbox`` key
+   then that names a configuration section describing the mailbox type to be
+   used.
+
+2. If the actor’s ``Props`` contains a mailbox selection—i.e. ``withMailbox``
+   was called on it—then that names a configuration section describing the
+   mailbox type to be used.
+
+3. If the dispatcher’s configuration section contains a ``mailbox-type`` key
+   the same section will be used to configure the mailbox type.
+
+4. If the actor requires a mailbox type as described above then the mapping for
+   that requirement will be used to determine the mailbox type to be used; if
+   that fails then the dispatcher’s requirement—if any—will be tried instead.
+
+5. If the dispatcher requires a mailbox type as described above then the
+   mapping for that requirement will be used to determine the mailbox type to
+   be used.
+
+6. The default mailbox ``akka.actor.default-mailbox`` will be used.
+
+Which Configuration is pass to the Mailbox Type
+-----------------------------------------------
+
+Each mailbox type is implemented by a class which extends :class:`MailboxType`
+and takes two constructor arguments: a :class:`ActorSystem.Settings` object and
+a :class:`Config` section. The latter is computed by obtaining the named
+configuration section from the actor system’s configuration, overriding its
+``id`` key with the configuration path of the mailbox type and adding a
+fall-back to the default mailbox configuration section.
+
 Builtin implementations
------------------------
+=======================
 
 Akka comes shipped with a number of default mailbox implementations:
 
@@ -47,7 +129,7 @@ Akka comes shipped with a number of default mailbox implementations:
 * Durable mailboxes, see :ref:`durable-mailboxes-scala`.
 
 Mailbox configuration examples
-------------------------------
+==============================
 
 How to create a PriorityMailbox:
 
@@ -75,44 +157,8 @@ Or code like this:
 .. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala#defining-mailbox-in-code
 
 
-Requiring a message queue type for an Actor
--------------------------------------------
-
-It is possible to require a certain type of message queue for a certain type of actor
-by having that actor extend the parameterized trait :class:`RequiresMessageQueue`. Here is
-an example:
-
-.. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala#required-mailbox-class
-
-The type parameter to the :class:`RequiresMessageQueue` trait needs to be mapped to a mailbox in
-configuration like this:
-
-.. includecode:: ../scala/code/docs/dispatcher/DispatcherDocSpec.scala
-   :include: bounded-mailbox-config,required-mailbox-config
-
-Now every time you create an actor of type :class:`MyBoundedActor` it will try to get a bounded
-mailbox. If the actor has a different mailbox configured in deployment, either directly or via
-a dispatcher with a specified mailbox type, then that will override this mapping.
-
-.. note::
-
-  The type of the queue in the mailbox created for an actor will be checked against the required type in the
-  trait and if the queue doesn't implement the required type then actor creation will fail.
-
-
-Mailbox configuration precedence
---------------------------------
-
-The order of precedence for the mailbox type of an actor, where lower numbers override higher, is:
-
-1. Mailbox type configured in the deployment of the actor
-2. Mailbox type configured on the dispatcher of the actor
-3. Mailbox type configured on the Props of the actor
-4. Mailbox type configured via message queue requirement
-
-
 Creating your own Mailbox type
-------------------------------
+==============================
 
 An example is worth a thousand quacks:
 
@@ -133,7 +179,7 @@ configuration, or the mailbox configuration.
 
 
 Special Semantics of ``system.actorOf``
----------------------------------------
+=======================================
 
 In order to make ``system.actorOf`` both synchronous and non-blocking while
 keeping the return type :class:`ActorRef` (and the semantics that the returned

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -270,14 +270,14 @@ private[akka] class RemoteActorRefProvider(
           if (hasAddress(addr)) {
             local.actorOf(system, props, supervisor, path, false, deployment.headOption, false, async)
           } else if (props.deploy.scope == LocalScope) {
-            throw new IllegalArgumentException(s"configuration requested remote deployment for local-only Props at [$path]")
+            throw new ConfigurationException(s"configuration requested remote deployment for local-only Props at [$path]")
           } else try {
             try {
               // for consistency we check configuration of dispatcher and mailbox locally
               val dispatcher = system.dispatchers.lookup(props.dispatcher)
               system.mailboxes.getMailboxType(props, dispatcher.configurator.config)
             } catch {
-              case NonFatal(e) ⇒ throw new IllegalArgumentException(
+              case NonFatal(e) ⇒ throw new ConfigurationException(
                 s"configuration problem while creating [$path] with dispatcher [${props.dispatcher}] and mailbox [${props.mailbox}]", e)
             }
             val localAddress = transport.localAddressForRemote(addr)

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -272,6 +272,14 @@ private[akka] class RemoteActorRefProvider(
           } else if (props.deploy.scope == LocalScope) {
             throw new IllegalArgumentException(s"configuration requested remote deployment for local-only Props at [$path]")
           } else try {
+            try {
+              // for consistency we check configuration of dispatcher and mailbox locally
+              val dispatcher = system.dispatchers.lookup(props.dispatcher)
+              system.mailboxes.getMailboxType(props, dispatcher.configurator.config)
+            } catch {
+              case NonFatal(e) ⇒ throw new IllegalArgumentException(
+                s"configuration problem while creating [$path] with dispatcher [${props.dispatcher}] and mailbox [${props.mailbox}]", e)
+            }
             val localAddress = transport.localAddressForRemote(addr)
             val rpath = (RootActorPath(addr) / "remote" / localAddress.protocol / localAddress.hostPort / path.elements).
               withUid(path.uid)

--- a/akka-remote/src/test/scala/akka/remote/RemoteDeployerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteDeployerSpec.scala
@@ -7,6 +7,7 @@ import akka.testkit._
 import akka.actor._
 import akka.routing._
 import com.typesafe.config._
+import akka.ConfigurationException
 
 object RemoteDeployerSpec {
   val deployerConf = ConfigFactory.parseString("""
@@ -47,7 +48,7 @@ class RemoteDeployerSpec extends AkkaSpec(RemoteDeployerSpec.deployerConf) {
     }
 
     "reject remote deployment when the source requires LocalScope" in {
-      intercept[IllegalArgumentException] {
+      intercept[ConfigurationException] {
         system.actorOf(Props.empty.withDeploy(Deploy.local), "service2")
       }.getMessage must be === "configuration requested remote deployment for local-only Props at [akka://RemoteDeployerSpec/user/service2]"
     }

--- a/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
@@ -126,18 +126,16 @@ object CallingThreadDispatcher {
  *
  * @since 1.1
  */
-class CallingThreadDispatcher(
-  _prerequisites: DispatcherPrerequisites,
-  val mailboxType: MailboxType,
-  val mailboxTypeConfigured: Boolean) extends MessageDispatcher(_prerequisites) {
+class CallingThreadDispatcher(_configurator: MessageDispatcherConfigurator) extends MessageDispatcher(_configurator) {
   import CallingThreadDispatcher._
+  import configurator.prerequisites._
 
-  val log = akka.event.Logging(prerequisites.eventStream, "CallingThreadDispatcher")
+  val log = akka.event.Logging(eventStream, "CallingThreadDispatcher")
 
   override def id: String = Id
 
-  protected[akka] override def createMailbox(actor: akka.actor.Cell) =
-    new CallingThreadMailbox(actor, getMailboxType(actor, mailboxType, mailboxTypeConfigured))
+  protected[akka] override def createMailbox(actor: akka.actor.Cell, mailboxType: MailboxType) =
+    new CallingThreadMailbox(actor, mailboxType)
 
   protected[akka] override def shutdown() {}
 
@@ -303,7 +301,7 @@ class CallingThreadDispatcher(
 class CallingThreadDispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
   extends MessageDispatcherConfigurator(config, prerequisites) {
 
-  private val instance = new CallingThreadDispatcher(prerequisites, mailboxType(), mailBoxTypeConfigured)
+  private val instance = new CallingThreadDispatcher(this)
 
   override def dispatcher(): MessageDispatcher = instance
 }

--- a/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
@@ -340,7 +340,7 @@ class CallingThreadMailbox(_receiver: akka.actor.Cell, val mailboxType: MailboxT
       val qq = queue
       CallingThreadDispatcherQueues(actor.system).gatherFromAllOtherQueues(this, qq)
       super.cleanUp()
-      qq.cleanUp(actor.self, actor.systemImpl.deadLetterMailbox.messageQueue)
+      qq.cleanUp(actor.self, actor.dispatcher.mailboxes.deadLetterMailbox.messageQueue)
       q.remove()
     }
   }

--- a/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
@@ -8,6 +8,8 @@ import akka.actor._
 import scala.concurrent.duration.Duration
 import akka.dispatch.DispatcherPrerequisites
 import scala.concurrent.duration.FiniteDuration
+import akka.dispatch.MessageDispatcher
+import akka.dispatch.MailboxType
 
 /**
  * This is a specialised form of the TestActorRef with support for querying and
@@ -35,11 +37,10 @@ import scala.concurrent.duration.FiniteDuration
  */
 class TestFSMRef[S, D, T <: Actor](
   system: ActorSystem,
-  _prerequisites: DispatcherPrerequisites,
   props: Props,
   supervisor: ActorRef,
   name: String)(implicit ev: T <:< FSM[S, D])
-  extends TestActorRef(system, _prerequisites, props, supervisor, name) {
+  extends TestActorRef(system, props, supervisor, name) {
 
   private def fsm: T = underlyingActor
 
@@ -93,11 +94,11 @@ object TestFSMRef {
 
   def apply[S, D, T <: Actor](factory: ⇒ T)(implicit ev: T <:< FSM[S, D], system: ActorSystem): TestFSMRef[S, D, T] = {
     val impl = system.asInstanceOf[ActorSystemImpl] //TODO ticket #1559
-    new TestFSMRef(impl, system.dispatchers.prerequisites, Props(creator = () ⇒ factory), impl.guardian.asInstanceOf[InternalActorRef], TestActorRef.randomName)
+    new TestFSMRef(impl, Props(creator = () ⇒ factory), impl.guardian.asInstanceOf[InternalActorRef], TestActorRef.randomName)
   }
 
   def apply[S, D, T <: Actor](factory: ⇒ T, name: String)(implicit ev: T <:< FSM[S, D], system: ActorSystem): TestFSMRef[S, D, T] = {
     val impl = system.asInstanceOf[ActorSystemImpl] //TODO ticket #1559
-    new TestFSMRef(impl, system.dispatchers.prerequisites, Props(creator = () ⇒ factory), impl.guardian.asInstanceOf[InternalActorRef], name)
+    new TestFSMRef(impl, Props(creator = () ⇒ factory), impl.guardian.asInstanceOf[InternalActorRef], name)
   }
 }


### PR DESCRIPTION
- add “mailbox-requirement” key to dispatcher section
- split out mailbox section, add akka.actor.default-mailbox
- rewrite findMarker method and use it for Props.create() and getting
  the required mailbox of an actor
- add ProducesMessageQueue trait for MailboxType so that requirements
  can be checked before trying to create the actor for real
- verify actor as well as dispatcher requirements for message queue
  before creation, even in remote-deployed case
- change MessageDispatcher constructor to take a Configurator, add that
  to migration guide
