### PR TITLE
fix SupervisorHierarchySpec and add more debug output, see #3312

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -406,6 +406,7 @@ object SupervisorHierarchySpec {
     }
 
     var children = Vector.empty[ActorRef]
+    var activeChildren = Vector.empty[ActorRef]
     var idleChildren = Vector.empty[ActorRef]
     var pingChildren = Set.empty[ActorRef]
 
@@ -419,8 +420,8 @@ object SupervisorHierarchySpec {
         Ping(ref)
       case x ⇒
         // fail one child
-        val pick = ((if (x >= 0.25) x - 0.25 else x) * 4 * children.size).toInt
-        Fail(children(pick), if (x > 0.25) Restart else Resume)
+        val pick = ((if (x >= 0.25) x - 0.25 else x) * 4 * activeChildren.size).toInt
+        Fail(activeChildren(pick), if (x > 0.25) Restart else Resume)
     })
 
     var hierarchy: ActorRef = _
@@ -466,8 +467,9 @@ object SupervisorHierarchySpec {
       case Init -> Stress ⇒
         self ! Work
         idleChildren = children
+        activeChildren = children
         // set timeout for completion of the whole test (i.e. including Finishing and Stopping)
-        setTimer("phase", StateTimeout, 50.seconds.dilated, false)
+        setTimer("phase", StateTimeout, 70.seconds.dilated, false)
     }
 
     val workSchedule = 50.millis
@@ -481,6 +483,7 @@ object SupervisorHierarchySpec {
       val deadGuy = path.elements
       val deadGuySize = deadGuy.size
       val isChild = (other: ActorRef) ⇒ other.path.elements.take(deadGuySize) == deadGuy
+      activeChildren = activeChildren filterNot isChild
       idleChildren = idleChildren filterNot isChild
       pingChildren = pingChildren filterNot isChild
     }
@@ -517,7 +520,9 @@ object SupervisorHierarchySpec {
       case Event(StateTimeout, todo) ⇒
         log.info("dumping state due to StateTimeout")
         log.info("children: " + children.size + " pinged: " + pingChildren.size + " idle: " + idleChildren.size + " work: " + todo)
+        pingChildren foreach println
         println(system.asInstanceOf[ActorSystemImpl].printTree)
+        pingChildren foreach getErrorsUp
         ignoreNotResumedLogs = false
         hierarchy ! Dump(2)
         goto(Failed)
@@ -673,6 +678,7 @@ object SupervisorHierarchySpec {
 
     whenUnhandled {
       case Event(Ready(ref), _) ⇒
+        activeChildren :+= ref
         children :+= ref
         idleChildren :+= ref
         stay
@@ -870,7 +876,7 @@ class SupervisorHierarchySpec extends AkkaSpec(SupervisorHierarchySpec.config) w
 
       fsm ! Init
 
-      expectMsg(70 seconds, "stressTestSuccessful")
+      expectMsg(90 seconds, "stressTestSuccessful")
       expectMsg("stressTestStopped")
     }
   }


### PR DESCRIPTION
- the children list which was used for the havoc-wreaking part was not
  the right one, leading to an exercise in necromancy
- also print outstanding pings with more detail in case of timeout
