### PR TITLE
add ActorRef.noSender() for the Java API, see #3429

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -13,6 +13,16 @@ import scala.annotation.tailrec
 import java.util.concurrent.ConcurrentHashMap
 import akka.event.LoggingAdapter
 
+object ActorRef {
+
+  /**
+   * Use this value as an argument to [[#tell]] if there is not actor to
+   * reply to (e.g. when sending from non-actor code).
+   */
+  final val noSender: ActorRef = Actor.noSender
+
+}
+
 /**
  * Immutable and serializable handle to an actor, which may or may not reside
  * on the local host or inside the same [[akka.actor.ActorSystem]]. An ActorRef

--- a/akka-docs/rst/java/code/docs/actor/FSMDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/FSMDocTest.java
@@ -189,11 +189,11 @@ public class FSMDocTest {
   public void mustBunch() {
     final ActorRef buncher = system.actorOf(Props.create(MyFSM.class));
     final TestProbe probe = new TestProbe(system);
-    buncher.tell(new SetTarget(probe.ref()), null);
-    buncher.tell(new Queue(1), null);
-    buncher.tell(new Queue(2), null);
-    buncher.tell(flush, null);
-    buncher.tell(new Queue(3), null);
+    buncher.tell(new SetTarget(probe.ref()), ActorRef.noSender());
+    buncher.tell(new Queue(1), ActorRef.noSender());
+    buncher.tell(new Queue(2), ActorRef.noSender());
+    buncher.tell(flush, ActorRef.noSender());
+    buncher.tell(new Queue(3), ActorRef.noSender());
     final Batch b = probe.expectMsgClass(Batch.class);
     assert b.objects.size() == 2;
     assert b.objects.contains(1);

--- a/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.java
+++ b/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.java
@@ -179,21 +179,21 @@ public class FaultHandlingTest {
     //#create
 
     //#resume
-    child.tell(42, null);
+    child.tell(42, ActorRef.noSender());
     assert Await.result(ask(child, "get", 5000), timeout).equals(42);
-    child.tell(new ArithmeticException(), null);
+    child.tell(new ArithmeticException(), ActorRef.noSender());
     assert Await.result(ask(child, "get", 5000), timeout).equals(42);
     //#resume
 
     //#restart
-    child.tell(new NullPointerException(), null);
+    child.tell(new NullPointerException(), ActorRef.noSender());
     assert Await.result(ask(child, "get", 5000), timeout).equals(0);
     //#restart
 
     //#stop
     final TestProbe probe = new TestProbe(system);
     probe.watch(child);
-    child.tell(new IllegalArgumentException(), null);
+    child.tell(new IllegalArgumentException(), ActorRef.noSender());
     probe.expectMsgClass(Terminated.class);
     //#stop
 
@@ -202,7 +202,7 @@ public class FaultHandlingTest {
       Props.create(Child.class), 5000), timeout);
     probe.watch(child);
     assert Await.result(ask(child, "get", 5000), timeout).equals(0);
-    child.tell(new Exception(), null);
+    child.tell(new Exception(), ActorRef.noSender());
     probe.expectMsgClass(Terminated.class);
     //#escalate-kill
 
@@ -211,9 +211,9 @@ public class FaultHandlingTest {
     supervisor = system.actorOf(superprops);
     child = (ActorRef) Await.result(ask(supervisor,
       Props.create(Child.class), 5000), timeout);
-    child.tell(23, null);
+    child.tell(23, ActorRef.noSender());
     assert Await.result(ask(child, "get", 5000), timeout).equals(23);
-    child.tell(new Exception(), null);
+    child.tell(new Exception(), ActorRef.noSender());
     assert Await.result(ask(child, "get", 5000), timeout).equals(0);
     //#escalate-restart
     //#testkit

--- a/akka-docs/rst/java/code/docs/actor/FirstUntypedActor.java
+++ b/akka-docs/rst/java/code/docs/actor/FirstUntypedActor.java
@@ -16,6 +16,6 @@ public class FirstUntypedActor extends UntypedActor {
 
   public void onReceive(Object message) {
     myActor.forward(message, getContext());
-    myActor.tell(PoisonPill.getInstance(), null);
+    myActor.tell(PoisonPill.getInstance(), ActorRef.noSender());
   }
 }

--- a/akka-docs/rst/java/code/docs/actor/InboxDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/InboxDocTest.java
@@ -49,7 +49,7 @@ public class InboxDocTest {
     //#watch
     final Inbox inbox = Inbox.create(system);
     inbox.watch(target);
-    target.tell(PoisonPill.getInstance(), null);
+    target.tell(PoisonPill.getInstance(), ActorRef.noSender());
     assert inbox.receive(Duration.create(1, TimeUnit.SECONDS)) instanceof Terminated;
     //#watch
   }

--- a/akka-docs/rst/java/code/docs/actor/SchedulerDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/SchedulerDocTest.java
@@ -41,7 +41,7 @@ public class SchedulerDocTest {
       new Runnable() {
         @Override
         public void run() {
-          testActor.tell(System.currentTimeMillis(), null);
+          testActor.tell(System.currentTimeMillis(), ActorRef.noSender());
         }
     }, system.dispatcher());
     //#schedule-one-off-thunk

--- a/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/UntypedActorDocTest.java
@@ -370,7 +370,7 @@ public class UntypedActorDocTest {
         master.tell("", getRef());
         final ActorRef victim = expectMsgClass(ActorRef.class);
         //#kill
-        victim.tell(akka.actor.Kill.getInstance(), null);
+        victim.tell(akka.actor.Kill.getInstance(), ActorRef.noSender());
         //#kill
         expectMsgEquals("killed");
         expectMsgEquals("stopped");

--- a/akka-docs/rst/java/code/docs/actor/UntypedActorSwapper.java
+++ b/akka-docs/rst/java/code/docs/actor/UntypedActorSwapper.java
@@ -44,12 +44,12 @@ public class UntypedActorSwapper {
   public static void main(String... args) {
     ActorSystem system = ActorSystem.create("MySystem");
     ActorRef swap = system.actorOf(Props.create(Swapper.class));
-    swap.tell(SWAP, null); // logs Hi
-    swap.tell(SWAP, null); // logs Ho
-    swap.tell(SWAP, null); // logs Hi
-    swap.tell(SWAP, null); // logs Ho
-    swap.tell(SWAP, null); // logs Hi
-    swap.tell(SWAP, null); // logs Ho
+    swap.tell(SWAP, ActorRef.noSender()); // logs Hi
+    swap.tell(SWAP, ActorRef.noSender()); // logs Ho
+    swap.tell(SWAP, ActorRef.noSender()); // logs Hi
+    swap.tell(SWAP, ActorRef.noSender()); // logs Ho
+    swap.tell(SWAP, ActorRef.noSender()); // logs Hi
+    swap.tell(SWAP, ActorRef.noSender()); // logs Ho
   }
 
 }

--- a/akka-docs/rst/java/code/docs/actor/mailbox/DurableMailboxDocTest.java
+++ b/akka-docs/rst/java/code/docs/actor/mailbox/DurableMailboxDocTest.java
@@ -33,7 +33,7 @@ public class DurableMailboxDocTest {
     ActorRef myActor = system.actorOf(Props.create(MyUntypedActor.class).
         withDispatcher("my-dispatcher"), "myactor");
     //#dispatcher-config-use
-    myActor.tell("test", null);
+    myActor.tell("test", ActorRef.noSender());
   }
 
   public static class MyUntypedActor extends UntypedActor {

--- a/akka-docs/rst/java/code/docs/camel/OnRouteResponseTestBase.java
+++ b/akka-docs/rst/java/code/docs/camel/OnRouteResponseTestBase.java
@@ -14,7 +14,7 @@ public class OnRouteResponseTestBase {
         Forwarder.class, "http://localhost:8080/news/akka", receiver));
     // the Forwarder sends out a request to the web page and forwards the response to
     // the ResponseReceiver
-    forwardResponse.tell("some request", null);
+    forwardResponse.tell("some request", ActorRef.noSender());
     //#RouteResponse
     system.stop(receiver);
     system.stop(forwardResponse);

--- a/akka-docs/rst/java/code/docs/camel/ProducerTestBase.java
+++ b/akka-docs/rst/java/code/docs/camel/ProducerTestBase.java
@@ -17,7 +17,8 @@ public class ProducerTestBase {
     ActorSystem system = ActorSystem.create("some-system");
     Props props = Props.create(Orders.class);
     ActorRef producer = system.actorOf(props, "jmsproducer");
-    producer.tell("<order amount=\"100\" currency=\"PLN\" itemId=\"12345\"/>", null);
+    producer.tell("<order amount=\"100\" currency=\"PLN\" itemId=\"12345\"/>",
+        ActorRef.noSender());
     //#TellProducer
     JavaTestKit.shutdownActorSystem(system);
   }
@@ -42,7 +43,7 @@ public class ProducerTestBase {
     Map<String,Object> headers = new HashMap<String, Object>();
     headers.put(CamelMessage.MessageExchangeId(),"123");
     producer.tell(new CamelMessage("<order amount=\"100\" currency=\"PLN\" " +
-      "itemId=\"12345\"/>",headers), null);
+      "itemId=\"12345\"/>",headers), ActorRef.noSender());
     //#Correlate
     system.stop(producer);
     JavaTestKit.shutdownActorSystem(system);

--- a/akka-docs/rst/java/code/docs/event/LoggingDocTest.java
+++ b/akka-docs/rst/java/code/docs/event/LoggingDocTest.java
@@ -36,7 +36,7 @@ public class LoggingDocTest {
   public void useLoggingActor() {
     ActorSystem system = ActorSystem.create("MySystem");
     ActorRef myActor = system.actorOf(Props.create(MyActor.class, this));
-    myActor.tell("test", null);
+    myActor.tell("test", ActorRef.noSender());
     JavaTestKit.shutdownActorSystem(system);
   }
 

--- a/akka-docs/rst/java/code/docs/io/japi/EchoServer.java
+++ b/akka-docs/rst/java/code/docs/io/japi/EchoServer.java
@@ -24,8 +24,8 @@ public class EchoServer {
       final ActorRef watcher = system.actorOf(Props.create(Watcher.class, latch), "watcher");
       final ActorRef nackServer = system.actorOf(Props.create(EchoManager.class, EchoHandler.class), "nack");
       final ActorRef ackServer = system.actorOf(Props.create(EchoManager.class, SimpleEchoHandler.class), "ack");
-      watcher.tell(nackServer, null);
-      watcher.tell(ackServer, null);
+      watcher.tell(nackServer, ActorRef.noSender());
+      watcher.tell(ackServer, ActorRef.noSender());
       latch.await(10, TimeUnit.MINUTES);
     } finally {
       system.shutdown();

--- a/akka-docs/rst/java/code/docs/io/japi/MessageStage.java
+++ b/akka-docs/rst/java/code/docs/io/japi/MessageStage.java
@@ -95,7 +95,7 @@ public class MessageStage extends
             if (cmd instanceof PipelineTest.SetTarget) {
               target = ((PipelineTest.SetTarget) cmd).getRef();
             } else if (cmd instanceof TickGenerator.Tick && target != null) {
-              target.tell(cmd, null);
+              target.tell(cmd, ActorRef.noSender());
             }
             //#omitted
             if (cmd instanceof TickGenerator.Tick) {

--- a/akka-docs/rst/java/code/docs/io/japi/PipelineTest.java
+++ b/akka-docs/rst/java/code/docs/io/japi/PipelineTest.java
@@ -72,12 +72,12 @@ public class PipelineTest {
 
           @Override
           public void onCommand(ByteString cmd) throws Throwable {
-            commandHandler.tell(cmd, null);
+            commandHandler.tell(cmd, ActorRef.noSender());
           }
 
           @Override
           public void onEvent(Message evt) throws Throwable {
-            eventHandler.tell(evt, null);
+            eventHandler.tell(evt, ActorRef.noSender());
           }
         };
         
@@ -127,9 +127,9 @@ public class PipelineTest {
         final ActorRef proc = system.actorOf(Props.create(
             P.class, this, getRef(), getRef()), "processor");
         expectMsgClass(TickGenerator.Tick.class);
-        proc.tell(msg, null);
+        proc.tell(msg, ActorRef.noSender());
         final ByteString encoded = expectMsgClass(ByteString.class);
-        proc.tell(encoded, null);
+        proc.tell(encoded, ActorRef.noSender());
         final Message decoded = expectMsgClass(Message.class);
         assert msg == decoded;
 
@@ -140,13 +140,13 @@ public class PipelineTest {
             expectMsgClass(TickGenerator.Tick.class);
           }
         };
-        proc.tell("fail!", null);
+        proc.tell("fail!", ActorRef.noSender());
         new Within(Duration.create(1700, TimeUnit.MILLISECONDS),
             Duration.create(3, TimeUnit.SECONDS)) {
           protected void run() {
             expectMsgClass(TickGenerator.Tick.class);
             expectMsgClass(TickGenerator.Tick.class);
-            proc.tell(PoisonPill.getInstance(), null);
+            proc.tell(PoisonPill.getInstance(), ActorRef.noSender());
             expectNoMsg();
           }
         };

--- a/akka-docs/rst/java/code/docs/io/japi/TickGenerator.java
+++ b/akka-docs/rst/java/code/docs/io/japi/TickGenerator.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 import scala.util.Either;
+import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.io.AbstractPipePair;
 import akka.io.PipePair;
@@ -74,7 +75,8 @@ public class TickGenerator<Cmd, Evt> extends
           @Override
           public Iterable<Either<Evt, Cmd>> onManagementCommand(Object cmd) {
             if (cmd == trigger) {
-              ctx.getContext().self().tell(new Tick(Deadline.now().time()), null);
+              ctx.getContext().self().tell(new Tick(Deadline.now().time()),
+                  ActorRef.noSender());
               schedule();
             }
             return Collections.emptyList();

--- a/akka-docs/rst/java/code/docs/jrouting/CustomRouterDocTest.java
+++ b/akka-docs/rst/java/code/docs/jrouting/CustomRouterDocTest.java
@@ -77,11 +77,11 @@ public class CustomRouterDocTest {
   public void countVotesAsIntendedNotAsInFlorida() throws Exception {
     ActorRef routedActor = system.actorOf(
       Props.empty().withRouter(new VoteCountRouter()));
-    routedActor.tell(DemocratVote, null);
-    routedActor.tell(DemocratVote, null);
-    routedActor.tell(RepublicanVote, null);
-    routedActor.tell(DemocratVote, null);
-    routedActor.tell(RepublicanVote, null);
+    routedActor.tell(DemocratVote, ActorRef.noSender());
+    routedActor.tell(DemocratVote, ActorRef.noSender());
+    routedActor.tell(RepublicanVote, ActorRef.noSender());
+    routedActor.tell(DemocratVote, ActorRef.noSender());
+    routedActor.tell(RepublicanVote, ActorRef.noSender());
     Timeout timeout = new Timeout(Duration.create(1, "seconds"));
     Future<Object> democratsResult =
       ask(routedActor, DemocratCountResult, timeout);

--- a/akka-docs/rst/java/code/docs/jrouting/RouterViaConfigExample.java
+++ b/akka-docs/rst/java/code/docs/jrouting/RouterViaConfigExample.java
@@ -47,7 +47,7 @@ public class RouterViaConfigExample {
       Props.create(ExampleActor.class).withRouter(new FromConfig()), "myrouter1");
     //#configurableRouting
     for (int i = 1; i <= 10; i++) {
-      router.tell(new ExampleActor.Message(i), null);
+      router.tell(new ExampleActor.Message(i), ActorRef.noSender());
     }
 
     //#configurableRoutingWithResizer
@@ -55,7 +55,7 @@ public class RouterViaConfigExample {
       Props.create(ExampleActor.class).withRouter(new FromConfig()), "myrouter2");
     //#configurableRoutingWithResizer
     for (int i = 1; i <= 10; i++) {
-      router2.tell(new ExampleActor.Message(i), null);
+      router2.tell(new ExampleActor.Message(i), ActorRef.noSender());
     }
   }
 }

--- a/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramDocTest.java
+++ b/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramDocTest.java
@@ -55,7 +55,7 @@ public class RouterViaProgramDocTest {
         Props.empty().withRouter(new RoundRobinRouter(routees)));
       //#programmaticRoutingRouteePaths
       for (int i = 1; i <= 6; i++) {
-        router.tell(new ExampleActor.Message(i), null);
+        router.tell(new ExampleActor.Message(i), ActorRef.noSender());
       }
     }};
   }

--- a/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramExample.java
+++ b/akka-docs/rst/java/code/docs/jrouting/RouterViaProgramExample.java
@@ -50,7 +50,7 @@ public class RouterViaProgramExample {
       Props.create(ExampleActor.class).withRouter(new RoundRobinRouter(nrOfInstances)));
     //#programmaticRoutingNrOfInstances
     for (int i = 1; i <= 6; i++) {
-      router1.tell(new ExampleActor.Message(i), null);
+      router1.tell(new ExampleActor.Message(i), ActorRef.noSender());
     }
 
     //#programmaticRoutingRoutees
@@ -63,7 +63,7 @@ public class RouterViaProgramExample {
       Props.empty().withRouter(RoundRobinRouter.create(routees)));
     //#programmaticRoutingRoutees
     for (int i = 1; i <= 6; i++) {
-      router2.tell(new ExampleActor.Message(i), null);
+      router2.tell(new ExampleActor.Message(i), ActorRef.noSender());
     }
 
     //#programmaticRoutingWithResizer
@@ -74,7 +74,7 @@ public class RouterViaProgramExample {
       Props.create(ExampleActor.class).withRouter(new RoundRobinRouter(resizer)));
     //#programmaticRoutingWithResizer
     for (int i = 1; i <= 6; i++) {
-      router3.tell(new ExampleActor.Message(i), null);
+      router3.tell(new ExampleActor.Message(i), ActorRef.noSender());
     }
     
     //#remoteRoutees

--- a/akka-docs/rst/java/code/docs/remoting/RemoteDeploymentDocTest.java
+++ b/akka-docs/rst/java/code/docs/remoting/RemoteDeploymentDocTest.java
@@ -53,7 +53,7 @@ public class RemoteDeploymentDocTest {
     //#sample-actor
 
     ActorRef actor = system.actorOf(Props.create(SampleActor.class), "sampleActor");
-    actor.tell("Pretty slick", null);
+    actor.tell("Pretty slick", ActorRef.noSender());
     //#sample-actor
   }
   

--- a/akka-docs/rst/java/code/docs/testkit/TestKitDocTest.java
+++ b/akka-docs/rst/java/code/docs/testkit/TestKitDocTest.java
@@ -84,7 +84,7 @@ public class TestKitDocTest {
   public void demonstrateWithin() {
     //#test-within
     new JavaTestKit(system) {{
-      getRef().tell(42, null);
+      getRef().tell(42, ActorRef.noSender());
       new Within(Duration.Zero(), Duration.create(1, "second")) {
         // do not put code outside this method, will run afterwards
         public void run() {
@@ -99,7 +99,7 @@ public class TestKitDocTest {
   public void demonstrateExpectMsg() {
     //#test-expectmsg
     new JavaTestKit(system) {{
-      getRef().tell(42, null);
+      getRef().tell(42, ActorRef.noSender());
       final String out = new ExpectMsg<String>("match hint") {
           // do not put code outside this method, will run afterwards
           protected String match(Object in) {
@@ -119,9 +119,9 @@ public class TestKitDocTest {
   public void demonstrateReceiveWhile() {
     //#test-receivewhile
     new JavaTestKit(system) {{
-      getRef().tell(42, null);
-      getRef().tell(43, null);
-      getRef().tell("hello", null);
+      getRef().tell(42, ActorRef.noSender());
+      getRef().tell(43, ActorRef.noSender());
+      getRef().tell("hello", ActorRef.noSender());
       final String[] out =
         new ReceiveWhile<String>(String.class, duration("1 second")) {
           // do not put code outside this method, will run afterwards
@@ -159,7 +159,7 @@ public class TestKitDocTest {
   public void demonstrateAwaitCond() {
     //#test-awaitCond
     new JavaTestKit(system) {{
-      getRef().tell(42, null);
+      getRef().tell(42, ActorRef.noSender());
       new AwaitCond(
             duration("1 second"),  // maximum wait time
             duration("100 millis") // interval at which to check the condition
@@ -178,7 +178,7 @@ public class TestKitDocTest {
   public void demonstrateAwaitAssert() {
     //#test-awaitAssert
     new JavaTestKit(system) {{
-      getRef().tell(42, null);
+      getRef().tell(42, ActorRef.noSender());
       new AwaitAssert(
             duration("1 second"),  // maximum wait time
             duration("100 millis") // interval at which to check the condition
@@ -196,12 +196,12 @@ public class TestKitDocTest {
   @SuppressWarnings({ "unchecked", "unused" }) // due to generic varargs
   public void demonstrateExpect() {
     new JavaTestKit(system) {{
-      getRef().tell("hello", null);
-      getRef().tell("hello", null);
-      getRef().tell("hello", null);
-      getRef().tell("world", null);
-      getRef().tell(42, null);
-      getRef().tell(42, null);
+      getRef().tell("hello", ActorRef.noSender());
+      getRef().tell("hello", ActorRef.noSender());
+      getRef().tell("hello", ActorRef.noSender());
+      getRef().tell("world", ActorRef.noSender());
+      getRef().tell(42, ActorRef.noSender());
+      getRef().tell(42, ActorRef.noSender());
       //#test-expect
       final String hello = expectMsgEquals("hello");
       final Object   any = expectMsgAnyOf("hello", "world");
@@ -210,8 +210,8 @@ public class TestKitDocTest {
       final Number j     = expectMsgAnyClassOf(Integer.class, Long.class);
       expectNoMsg();
       //#test-expect
-      getRef().tell("receveN-1", null);
-      getRef().tell("receveN-2", null);
+      getRef().tell("receveN-1", ActorRef.noSender());
+      getRef().tell("receveN-2", ActorRef.noSender());
       //#test-expect
       final Object[] two = receiveN(2);
       //#test-expect
@@ -233,12 +233,12 @@ public class TestKitDocTest {
           return msg instanceof String;
         }
       };
-      getRef().tell("hello", null);
-      getRef().tell(42, null);
+      getRef().tell("hello", ActorRef.noSender());
+      getRef().tell(42, ActorRef.noSender());
       expectMsgEquals(42);
       // remove message filter
       ignoreNoMsg();
-      getRef().tell("hello", null);
+      getRef().tell("hello", ActorRef.noSender());
       expectMsgEquals("hello");
     }};
     //#test-ignoreMsg
@@ -300,7 +300,7 @@ public class TestKitDocTest {
       }
 
       final MyProbe probe = new MyProbe();
-      probe.getRef().tell("hello", null);
+      probe.getRef().tell("hello", ActorRef.noSender());
       probe.assertHello();
     }};
     //#test-special-probe
@@ -313,7 +313,7 @@ public class TestKitDocTest {
     new JavaTestKit(system) {{
       final JavaTestKit probe = new JavaTestKit(system);
       probe.watch(target);
-      target.tell(PoisonPill.getInstance(), null);
+      target.tell(PoisonPill.getInstance(), ActorRef.noSender());
       final Terminated msg = probe.expectMsgClass(Terminated.class);
       assertEquals(msg.getActor(), target);
     }};
@@ -374,7 +374,7 @@ public class TestKitDocTest {
       // install auto-pilot
       probe.setAutoPilot(new TestActor.AutoPilot() {
         public AutoPilot run(ActorRef sender, Object msg) {
-          sender.tell(msg, null);
+          sender.tell(msg, ActorRef.noSender());
           return noAutoPilot();
         }
       });
@@ -406,7 +406,7 @@ public class TestKitDocTest {
 
       final int result = new EventFilter<Integer>(ActorKilledException.class) {
         protected Integer run() {
-          victim.tell(Kill.getInstance(), null);
+          victim.tell(Kill.getInstance(), ActorRef.noSender());
           return 42;
         }
       }.from("akka://TestKitDocTest/user/victim").occurrences(1).exec();

--- a/akka-docs/rst/java/code/docs/transactor/TransactorDocTest.java
+++ b/akka-docs/rst/java/code/docs/transactor/TransactorDocTest.java
@@ -30,7 +30,7 @@ public class TransactorDocTest {
 
     Timeout timeout = new Timeout(5, SECONDS);
 
-    counter1.tell(new Coordinated(new Increment(counter2), timeout), null);
+    counter1.tell(new Coordinated(new Increment(counter2), timeout), ActorRef.noSender());
 
     Integer count = (Integer) Await.result(
       ask(counter1, "GetCount", timeout), timeout.duration());
@@ -52,11 +52,11 @@ public class TransactorDocTest {
     ActorRef actor = system.actorOf(Props.create(Coordinator.class));
 
     //#send-coordinated
-    actor.tell(new Coordinated(new Message(), timeout), null);
+    actor.tell(new Coordinated(new Message(), timeout), ActorRef.noSender());
     //#send-coordinated
 
     //#include-coordinated
-    actor.tell(coordinated.coordinate(new Message()), null);
+    actor.tell(coordinated.coordinate(new Message()), ActorRef.noSender());
     //#include-coordinated
 
     coordinated.await();
@@ -71,7 +71,7 @@ public class TransactorDocTest {
 
     Timeout timeout = new Timeout(5, SECONDS);
     Coordinated coordinated = new Coordinated(timeout);
-    counter.tell(coordinated.coordinate(new Increment()), null);
+    counter.tell(coordinated.coordinate(new Increment()), ActorRef.noSender());
     coordinated.await();
 
     Integer count = (Integer) Await.result(ask(counter, "GetCount", timeout), timeout.duration());
@@ -88,7 +88,7 @@ public class TransactorDocTest {
 
     Timeout timeout = new Timeout(5, SECONDS);
     Coordinated coordinated = new Coordinated(timeout);
-    friendlyCounter.tell(coordinated.coordinate(new Increment(friend)), null);
+    friendlyCounter.tell(coordinated.coordinate(new Increment(friend)), ActorRef.noSender());
     coordinated.await();
 
     Integer count1 = (Integer) Await.result(ask(friendlyCounter, "GetCount", timeout), timeout.duration());

--- a/akka-docs/rst/java/code/docs/zeromq/ZeromqDocTest.java
+++ b/akka-docs/rst/java/code/docs/zeromq/ZeromqDocTest.java
@@ -83,13 +83,13 @@ public class ZeromqDocTest {
     //#sub-topic-socket
 
     //#unsub-topic-socket
-    subTopicSocket.tell(new Unsubscribe("foo.bar"), null);
+    subTopicSocket.tell(new Unsubscribe("foo.bar"), ActorRef.noSender());
     //#unsub-topic-socket
 
     byte[] payload = new byte[0];
     //#pub-topic
     pubSocket.tell(ZMQMessage.withFrames(ByteString.fromString("foo.bar"), 
-      ByteString.fromArray(payload)), null);
+      ByteString.fromArray(payload)), ActorRef.noSender());
     //#pub-topic
 
     system.stop(subSocket);
@@ -193,7 +193,7 @@ public class ZeromqDocTest {
     public void preStart() {
       getContext().system().scheduler()
           .schedule(Duration.create(1, "second"), Duration.create(1, "second"),
-            getSelf(), TICK, getContext().dispatcher(), null);
+            getSelf(), TICK, getContext().dispatcher(), ActorRef.noSender());
     }
 
     @Override


### PR DESCRIPTION
- Actor.noSender is not accessible from Java, but it was in 2.1 so don’t
  remove
- replaced all “null” in doc tests with ActorRef.noSender()
