### PR TITLE
Speed up cluster gossip processing #3441

### DIFF
--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -150,7 +150,8 @@ message VectorClock {
     required int32 hashIndex = 1;
     required int64 timestamp = 2;
   }
-  required int64 timestamp = 1;
+  // the timestamp could be removed but left for test data compatibility
+  optional int64 timestamp = 1;
   repeated Version versions = 2;
 }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -9,7 +9,6 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.forkjoin.ThreadLocalRandom
 import scala.util.control.NonFatal
-import java.util.UUID
 import akka.actor.{ Actor, ActorLogging, ActorRef, Address, Cancellable, Props, PoisonPill, ReceiveTimeout, RootActorPath, Scheduler }
 import akka.actor.OneForOneStrategy
 import akka.actor.SupervisorStrategy.Stop
@@ -215,14 +214,16 @@ private[cluster] final class ClusterCoreSupervisor extends Actor with ActorLoggi
 /**
  * INTERNAL API.
  */
-private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Actor with ActorLogging
+private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with ActorLogging
   with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import InternalClusterAction._
 
   val cluster = Cluster(context.system)
-  import cluster.{ selfAddress, selfUniqueAddress, scheduler, failureDetector }
+  import cluster.{ selfAddress, scheduler, failureDetector }
   import cluster.settings._
   import cluster.InfoLogger._
+
+  protected def selfUniqueAddress = cluster.selfUniqueAddress
 
   val NumberOfGossipsBeforeShutdownWhenLeaderExits = 3
 
@@ -549,49 +550,63 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
     else if (latestGossip.members.forall(_.uniqueAddress != from))
       logInfo("Ignoring received gossip status from unknown [{}]", from)
     else {
-      (status.version tryCompareTo latestGossip.version) match {
-        case Some(0)          ⇒ // same version
-        case Some(x) if x > 0 ⇒ gossipStatusTo(from, sender) // remote is newer
-        case _                ⇒ gossipTo(from, sender) // conflicting or local is newer
+      (status.version compareTo latestGossip.version) match {
+        case VectorClock.Same  ⇒ // same version
+        case VectorClock.After ⇒ gossipStatusTo(from, sender) // remote is newer
+        case _                 ⇒ gossipTo(from, sender) // conflicting or local is newer
       }
     }
   }
 
   /**
+   * The types of gossip actions that receive gossip has performed.
+   */
+  sealed trait ReceiveGossipType
+  case object Ignored extends ReceiveGossipType
+  case object Older extends ReceiveGossipType
+  case object Newer extends ReceiveGossipType
+  case object Same extends ReceiveGossipType
+  case object Merge extends ReceiveGossipType
+
+  /**
    * Receive new gossip.
    */
-  def receiveGossip(envelope: GossipEnvelope): Unit = {
+  def receiveGossip(envelope: GossipEnvelope): ReceiveGossipType = {
     val from = envelope.from
     val remoteGossip = envelope.gossip
     val localGossip = latestGossip
 
-    if (envelope.to != selfUniqueAddress)
+    if (envelope.to != selfUniqueAddress) {
       logInfo("Ignoring received gossip intended for someone else, from [{}] to [{}]", from.address, envelope.to)
-    if (remoteGossip.overview.unreachable.exists(_.address == selfAddress))
+      Ignored
+    } else if (remoteGossip.overview.unreachable.exists(_.address == selfAddress)) {
       logInfo("Ignoring received gossip with myself as unreachable, from [{}]", from.address)
-    else if (localGossip.overview.unreachable.exists(_.uniqueAddress == from))
+      Ignored
+    } else if (localGossip.overview.unreachable.exists(_.uniqueAddress == from)) {
       logInfo("Ignoring received gossip from unreachable [{}] ", from)
-    else if (localGossip.members.forall(_.uniqueAddress != from))
+      Ignored
+    } else if (localGossip.members.forall(_.uniqueAddress != from)) {
       logInfo("Ignoring received gossip from unknown [{}]", from)
-    else if (remoteGossip.members.forall(_.uniqueAddress != selfUniqueAddress))
+      Ignored
+    } else if (remoteGossip.members.forall(_.uniqueAddress != selfUniqueAddress)) {
       logInfo("Ignoring received gossip that does not contain myself, from [{}]", from)
-    else {
+      Ignored
+    } else {
+      val comparison = remoteGossip.version compareTo localGossip.version
 
-      val comparison = remoteGossip.version tryCompareTo localGossip.version
-
-      val (winningGossip, talkback) = comparison match {
-        case None ⇒
+      val (winningGossip, talkback, gossipType) = comparison match {
+        case VectorClock.Concurrent ⇒
           // conflicting versions, merge
-          (remoteGossip merge localGossip, true)
-        case Some(0) ⇒
+          (remoteGossip merge localGossip, true, Merge)
+        case VectorClock.Same ⇒
           // same version
-          (remoteGossip mergeSeen localGossip, !remoteGossip.seenByNode(selfUniqueAddress))
-        case Some(x) if x < 0 ⇒
+          (remoteGossip mergeSeen localGossip, !remoteGossip.seenByNode(selfUniqueAddress), Same)
+        case VectorClock.Before ⇒
           // local is newer
-          (localGossip, true)
-        case _ ⇒
+          (localGossip, true, Older)
+        case VectorClock.After ⇒
           // remote is newer
-          (remoteGossip, !remoteGossip.seenByNode(selfUniqueAddress))
+          (remoteGossip, !remoteGossip.seenByNode(selfUniqueAddress), Newer)
       }
 
       latestGossip = winningGossip seen selfUniqueAddress
@@ -603,18 +618,18 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
 
       log.debug("Cluster Node [{}] - Receiving gossip from [{}]", selfAddress, from)
 
-      if (comparison.isEmpty) {
+      if (comparison == VectorClock.Concurrent) {
         log.debug(
           """Couldn't establish a causal relationship between "remote" gossip and "local" gossip - Remote[{}] - Local[{}] - merged them into [{}]""",
           remoteGossip, localGossip, winningGossip)
       }
 
       if (statsEnabled) {
-        gossipStats = comparison match {
-          case None             ⇒ gossipStats.incrementMergeCount
-          case Some(0)          ⇒ gossipStats.incrementSameCount
-          case Some(x) if x < 0 ⇒ gossipStats.incrementNewerCount
-          case _                ⇒ gossipStats.incrementOlderCount
+        gossipStats = gossipType match {
+          case Merge ⇒ gossipStats.incrementMergeCount
+          case Same  ⇒ gossipStats.incrementSameCount
+          case Newer ⇒ gossipStats.incrementNewerCount
+          case Older ⇒ gossipStats.incrementOlderCount
         }
         vclockStats = VectorClockStats(
           versionSize = latestGossip.version.versions.size,
@@ -630,6 +645,7 @@ private[cluster] final class ClusterCoreDaemon(publisher: ActorRef) extends Acto
         // older or sender had newer
         gossipTo(from, sender)
       }
+      gossipType
     }
   }
 

--- a/akka-cluster/src/test/scala/akka/cluster/VectorClockSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/VectorClockSpec.scala
@@ -199,7 +199,6 @@ class VectorClockSpec extends AkkaSpec {
     "pass blank clock incrementing" in {
       val node1 = Node("1")
       val node2 = Node("2")
-      val node3 = Node("3")
 
       val v1 = VectorClock()
       val v2 = VectorClock()
@@ -234,86 +233,6 @@ class VectorClockSpec extends AkkaSpec {
 
       (c1 > a2) must equal(true)
       (c1 > b1) must equal(true)
-    }
-  }
-
-  "An instance of Versioned" must {
-    class TestVersioned(val version: VectorClock = VectorClock()) extends Versioned[TestVersioned] {
-      def :+(node: Node): TestVersioned = new TestVersioned(version :+ node)
-    }
-
-    import Versioned.latestVersionOf
-
-    "have zero versions when created" in {
-      val versioned = new TestVersioned()
-      versioned.version.versions must be(Map())
-    }
-
-    "happen before an identical versioned with a single additional event" in {
-      val versioned1_1 = new TestVersioned()
-      val versioned2_1 = versioned1_1 :+ Node("1")
-      val versioned3_1 = versioned2_1 :+ Node("2")
-      val versioned4_1 = versioned3_1 :+ Node("1")
-
-      val versioned1_2 = new TestVersioned()
-      val versioned2_2 = versioned1_2 :+ Node("1")
-      val versioned3_2 = versioned2_2 :+ Node("2")
-      val versioned4_2 = versioned3_2 :+ Node("1")
-      val versioned5_2 = versioned4_2 :+ Node("3")
-
-      latestVersionOf[TestVersioned](versioned4_1, versioned5_2) must be(versioned5_2)
-    }
-
-    "pass misc comparison test 1" in {
-      var versioned1_1 = new TestVersioned()
-      val versioned2_1 = versioned1_1 :+ Node("1")
-
-      val versioned1_2 = new TestVersioned()
-      val versioned2_2 = versioned1_2 :+ Node("2")
-
-      latestVersionOf[TestVersioned](versioned2_1, versioned2_2) must be(versioned2_2)
-    }
-
-    "pass misc comparison test 2" in {
-      val versioned1_3 = new TestVersioned()
-      val versioned2_3 = versioned1_3 :+ Node("1")
-      val versioned3_3 = versioned2_3 :+ Node("2")
-      val versioned4_3 = versioned3_3 :+ Node("1")
-
-      val versioned1_4 = new TestVersioned()
-      val versioned2_4 = versioned1_4 :+ Node("1")
-      val versioned3_4 = versioned2_4 :+ Node("1")
-      val versioned4_4 = versioned3_4 :+ Node("3")
-
-      latestVersionOf[TestVersioned](versioned4_3, versioned4_4) must be(versioned4_4)
-    }
-
-    "pass misc comparison test 3" in {
-      val versioned1_1 = new TestVersioned()
-      val versioned2_1 = versioned1_1 :+ Node("2")
-      val versioned3_1 = versioned2_1 :+ Node("2")
-
-      val versioned1_2 = new TestVersioned()
-      val versioned2_2 = versioned1_2 :+ Node("1")
-      val versioned3_2 = versioned2_2 :+ Node("2")
-      val versioned4_2 = versioned3_2 :+ Node("2")
-      val versioned5_2 = versioned4_2 :+ Node("3")
-
-      latestVersionOf[TestVersioned](versioned3_1, versioned5_2) must be(versioned5_2)
-    }
-
-    "pass misc comparison test 4" in {
-      val versioned1_1 = new TestVersioned()
-      val versioned2_1 = versioned1_1 :+ Node("1")
-      val versioned3_1 = versioned2_1 :+ Node("2")
-      val versioned4_1 = versioned3_1 :+ Node("2")
-      val versioned5_1 = versioned4_1 :+ Node("3")
-
-      val versioned1_2 = new TestVersioned()
-      val versioned2_2 = versioned1_2 :+ Node("2")
-      val versioned3_2 = versioned2_2 :+ Node("2")
-
-      latestVersionOf[TestVersioned](versioned5_1, versioned3_2) must be(versioned3_2)
     }
   }
 }


### PR DESCRIPTION
- Check VectorClock for common case first
- Cache hashCode for VectorClock.node and UniqueAddress

I've replayed the gossip events for a couple of the nodes from the large cluster stress run
(only events where the packed version was larger than 8k) and same gossip was by far the
most common case (81%).

The culprit is the merging of the seen tables. It should probably be rewritten but this
speeds up the processing in the meantime (see t the meantime (see ticket 3442)

On my machine the average time for same gossip dropped from 20ms to 7ms, and merge gossip
from 14ms to 9ms. Both older and newer take below 1ms.
