### PR TITLE
io: tone down error logging a bit more

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/BackpressureSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/BackpressureSpec.scala
@@ -9,13 +9,13 @@ import java.security.MessageDigest
 import scala.concurrent.Await
 import scala.concurrent.duration.{ Duration, DurationInt }
 import scala.concurrent.forkjoin.ThreadLocalRandom
-import akka.actor.{ Actor, ActorContext, ActorLogging, ActorRef, Props, ReceiveTimeout, Stash, Terminated }
+import scala.util.control.NonFatal
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props, ReceiveTimeout, Stash, Terminated }
 import akka.io.TcpPipelineHandler.{ Init, Management, WithinActorContext }
 import akka.pattern.ask
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 import akka.util.{ ByteString, Timeout }
 import akka.actor.Deploy
-import scala.util.control.NonFatal
 
 object BackpressureSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
@@ -5,9 +5,8 @@
 package akka.io
 
 import akka.testkit.{ TestProbe, AkkaSpec }
+import akka.TestUtils._
 import Tcp._
-import akka.TestUtils
-import TestUtils._
 
 class CapacityLimitSpec extends AkkaSpec("""
     akka.loglevel = ERROR

--- a/akka-actor-tests/src/test/scala/akka/io/DelimiterFramingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/DelimiterFramingSpec.scala
@@ -6,7 +6,7 @@ package akka.io
 import akka.testkit.{ TestProbe, AkkaSpec }
 import java.net.InetSocketAddress
 import akka.util.ByteString
-import akka.actor.{ Props, ActorLogging, Actor, ActorContext }
+import akka.actor.{ Props, ActorLogging, Actor }
 import akka.TestUtils
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration._

--- a/akka-actor-tests/src/test/scala/akka/io/PipelineSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/PipelineSpec.scala
@@ -4,13 +4,11 @@
 
 package akka.io
 
+import scala.annotation.tailrec
+import scala.concurrent.forkjoin.ThreadLocalRandom
+import scala.util.Success
 import akka.testkit.AkkaSpec
 import akka.util.ByteString
-import scala.annotation.tailrec
-import java.nio.ByteOrder
-import scala.concurrent.forkjoin.ThreadLocalRandom
-import scala.util.Try
-import scala.util.Success
 
 class PipelineSpec extends AkkaSpec("akka.actor.serialize-creators = on") {
 

--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -457,12 +457,11 @@ class TcpConnectionSpec extends AkkaSpec("""
 
     "report when peer aborted the connection" in new EstablishedConnectionTest() {
       run {
-        EventFilter[IOException](occurrences = 1) intercept {
-          abortClose(serverSideChannel)
-          selector.send(connectionActor, ChannelReadable)
-          val err = connectionHandler.expectMsgType[ErrorClosed]
-          err.cause must be(ConnectionResetByPeerMessage)
-        }
+        abortClose(serverSideChannel)
+        selector.send(connectionActor, ChannelReadable)
+        val err = connectionHandler.expectMsgType[ErrorClosed]
+        err.cause must be(ConnectionResetByPeerMessage)
+
         // wait a while
         connectionHandler.expectNoMsg(200.millis)
 
@@ -475,11 +474,9 @@ class TcpConnectionSpec extends AkkaSpec("""
         val writer = TestProbe()
 
         abortClose(serverSideChannel)
-        EventFilter[IOException](occurrences = 1) intercept {
-          writer.send(connectionActor, Write(ByteString("testdata")))
-          // bother writer and handler should get the message
-          writer.expectMsgType[ErrorClosed]
-        }
+        writer.send(connectionActor, Write(ByteString("testdata")))
+        // bother writer and handler should get the message
+        writer.expectMsgType[ErrorClosed]
         connectionHandler.expectMsgType[ErrorClosed]
 
         assertThisConnectionActorTerminated()
@@ -501,10 +498,8 @@ class TcpConnectionSpec extends AkkaSpec("""
             key.isConnectable must be(true)
             val forceThisLazyVal = connectionActor.toString
             Thread.sleep(300)
-            EventFilter[ConnectException](occurrences = 1) intercept {
-              selector.send(connectionActor, ChannelConnectable)
-              userHandler.expectMsg(CommandFailed(Connect(UnboundAddress)))
-            }
+            selector.send(connectionActor, ChannelConnectable)
+            userHandler.expectMsg(CommandFailed(Connect(UnboundAddress)))
 
             verifyActorTermination(connectionActor)
           } finally sel.close()
@@ -516,9 +511,7 @@ class TcpConnectionSpec extends AkkaSpec("""
         override lazy val connectionActor = createConnectionActor(serverAddress = UnboundAddress, timeout = Option(100.millis))
         run {
           connectionActor.toString must not be ("")
-          EventFilter[SocketTimeoutException](occurrences = 1) intercept {
-            userHandler.expectMsg(CommandFailed(Connect(UnboundAddress, timeout = Option(100.millis))))
-          }
+          userHandler.expectMsg(CommandFailed(Connect(UnboundAddress, timeout = Option(100.millis))))
           verifyActorTermination(connectionActor)
         }
       }

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
@@ -4,14 +4,10 @@
 
 package akka.io
 
-import scala.concurrent.duration._
 import akka.testkit.AkkaSpec
 import akka.util.ByteString
+import akka.TestUtils._
 import Tcp._
-import akka.TestUtils
-import TestUtils._
-import akka.testkit.EventFilter
-import java.io.IOException
 
 class TcpIntegrationSpec extends AkkaSpec("""
     akka.loglevel = INFO

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
@@ -5,13 +5,12 @@
 package akka.io
 
 import scala.annotation.tailrec
+import scala.collection.immutable
 import akka.testkit.{ AkkaSpec, TestProbe }
 import akka.actor.ActorRef
-import scala.collection.immutable
 import akka.io.Inet.SocketOption
+import akka.TestUtils._
 import Tcp._
-import akka.TestUtils
-import TestUtils._
 
 trait TcpIntegrationSpecSupport { _: AkkaSpec ⇒
 

--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
@@ -3,12 +3,11 @@
  */
 package akka.io
 
-import akka.testkit.{ TestProbe, ImplicitSender, AkkaSpec }
-import akka.TestUtils
-import TestUtils._
-import akka.util.ByteString
 import java.net.InetSocketAddress
+import akka.testkit.{ TestProbe, ImplicitSender, AkkaSpec }
+import akka.util.ByteString
 import akka.actor.ActorRef
+import akka.TestUtils._
 
 class UdpConnectedIntegrationSpec extends AkkaSpec("""
     akka.loglevel = INFO

--- a/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
@@ -3,12 +3,12 @@
  */
 package akka.io
 
+import java.net.InetSocketAddress
 import akka.testkit.{ TestProbe, ImplicitSender, AkkaSpec }
+import akka.util.ByteString
+import akka.actor.ActorRef
 import akka.io.Udp._
 import akka.TestUtils._
-import akka.util.ByteString
-import java.net.InetSocketAddress
-import akka.actor.ActorRef
 
 class UdpIntegrationSpec extends AkkaSpec("""
     akka.loglevel = INFO


### PR DESCRIPTION
We are seeing quite bit of error messages like this in our spray-can server logs:

```
06/14 14:19:03 ERROR[t-dispatcher-29] a.i.TcpIncomingConnection - Connection reset by peer
java.io.IOException: Connection reset by peer
  at sun.nio.ch.FileDispatcher.read0(Native Method) ~[na:1.6.0_26]
  at sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:21) ~[na:1.6.0_26]
  at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:202) ~[na:1.6.0_26]
  at sun.nio.ch.IOUtil.read(IOUtil.java:169) ~[na:1.6.0_26]
  at sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:243) ~[na:1.6.0_26]
  at akka.io.TcpConnection.innerRead$1(TcpConnection.scala:198) ~[site.jar:na]
  at akka.io.TcpConnection.doRead(TcpConnection.scala:214) ~[site.jar:na]
  at akka.io.TcpConnection$$anonfun$connected$1.applyOrElse(TcpConnection.scala:76) ~[site.jar:na]
  at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:166) ~[site.jar:na]
  at akka.actor.ActorCell.receiveMessage(ActorCell.scala:425) [site.jar:na]
  at akka.actor.ActorCell.invoke(ActorCell.scala:386) [site.jar:na]
  at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:230) [site.jar:na]
  at akka.dispatch.Mailbox.run(Mailbox.scala:212) [site.jar:na]
  at akka.dispatch.ForkJoinExecutorConfigurator$MailboxExecutionTask.exec(AbstractDispatcher.scala:506) [site.jar:na]
  at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260) [site.jar:na]
  at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339) [site.jar:na]
  at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979) [site.jar:na]
  at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107) [site.jar:na]
```

While these entries themselves are certainly helpful the stack traces are not. This patch introduces a new config setting for the TCP side of akka-io enabling the suppression of these stack traces.

(Initially I only wanted to suppress the stack trace for "Connection reset by peer" errors, but since these cannot be easily and reliably distinguished from other IOExceptions this patch treats all IOExceptions the same.)
