### PR TITLE
tcp-reuse-addr off on windows, see #3450

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -369,7 +369,10 @@ akka {
 
       # Enables SO_REUSEADDR, which determines when an ActorSystem can open
       # the specified listen port (the meaning differs between *nix and Windows)
-      tcp-reuse-addr = on
+      # Valid values are "on", "off" and "off-for-windows"
+      # due to the following Windows bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4476378
+      # "off-for-windows" of course means that it's "on" for all other platforms
+      tcp-reuse-addr = off-for-windows
 
       # Used to configure the number of I/O worker threads on server sockets
       server-socket-worker-pool {

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -27,6 +27,7 @@ import scala.concurrent.{ ExecutionContext, Promise, Future, blocking }
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.{ NoStackTrace, NonFatal }
 import akka.util.Helpers.Requiring
+import akka.util.Helpers
 
 object NettyTransportSettings {
   sealed trait Mode
@@ -110,7 +111,10 @@ class NettyTransportSettings(config: Config) {
 
   val TcpKeepalive: Boolean = getBoolean("tcp-keepalive")
 
-  val TcpReuseAddr: Boolean = getBoolean("tcp-reuse-addr")
+  val TcpReuseAddr: Boolean = getString("tcp-reuse-addr") match {
+    case "off-for-windows" ⇒ !Helpers.isWindows
+    case _                 ⇒ getBoolean("tcp-reuse-addr")
+  }
 
   val Hostname: String = getString("hostname") match {
     case ""    ⇒ InetAddress.getLocalHost.getHostAddress

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -91,7 +91,7 @@ class RemoteConfigSpec extends AkkaSpec(
       Backlog must be === 4096
       TcpNodelay must be(true)
       TcpKeepalive must be(true)
-      TcpReuseAddr must be(true)
+      TcpReuseAddr must be(!Helpers.isWindows)
       c.getString("hostname") must be === ""
       ServerSocketWorkerPoolSize must be === 2
       ClientSocketWorkerPoolSize must be === 2


### PR DESCRIPTION
- Pretty much a forward port of corresponding setting in Akka 2.1
