### PR TITLE
rework LARS, see #3428

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -387,6 +387,21 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
       }
     }
 
+    "properly defer jobs even when the timer thread oversleeps" in {
+      withScheduler() { (sched, driver) ⇒
+        implicit def ec = localEC
+        import driver._
+        sched.scheduleOnce(step * 3, probe.ref, "hello")
+        wakeUp(step * 5)
+        expectWait(step)
+        wakeUp(step * 2)
+        expectWait(step)
+        wakeUp(step)
+        probe.expectMsg("hello")
+        expectWait(step)
+      }
+    }
+
     "correctly wrap around wheel rounds" in {
       withScheduler(config = ConfigFactory.parseString("akka.scheduler.ticks-per-wheel=2")) { (sched, driver) ⇒
         implicit def ec = localEC

--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -32,7 +32,7 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
         settings.SerializeAllMessages must equal(false)
 
         getInt("akka.scheduler.ticks-per-wheel") must equal(512)
-        getMilliseconds("akka.scheduler.tick-duration") must equal(20)
+        getMilliseconds("akka.scheduler.tick-duration") must equal(10)
         getString("akka.scheduler.implementation") must equal("akka.actor.LightArrayRevolverScheduler")
 
         getBoolean("akka.daemonic") must be(false)

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -436,7 +436,7 @@ akka {
     # Note that it might take up to 1 tick to stop the Timer, so setting the
     # tick-duration to a high value will make shutting down the actor system
     # take longer.
-    tick-duration = 20ms
+    tick-duration = 10ms
 
     # The timer uses a circular wheel of buckets to store the timer tasks.
     # This should be set such that the majority of scheduled timeouts (for high


### PR DESCRIPTION
- tasks are still enqueued without reading the clock
- in order to be resilient against timer thread over-sleeping the tasks
  are passed to the timer thread using an AbstractNodeQueue and the
  wheel itself is now private to the timer thread
- reuse queue Nodes along the way to minimize allocation costs

The problem with the old implementation was that the timer thread could
sleep too long, then wake up and run multiple buckets in quick
succession. Tasks enqueued just before that event could then get
executed basically immediately, i.e. before their allotted time.
