### PR TITLE
Tweaked AkkaProtocolStressSpec drop policies

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -70,7 +70,9 @@ class AkkaProtocolStressTest extends AkkaSpec(configA) with ImplicitSender with 
 
   val systemB = ActorSystem(
     "systemB",
-    ConfigFactory.parseString("akka.remote.maximum-retries-in-window = 10").withFallback(system.settings.config))
+    // Retry limit for system B should be high enough that it does not trigger during this test. Otherwise
+    // too much messages can be dropped causing the test to fail sporadically.
+    ConfigFactory.parseString("akka.remote.maximum-retries-in-window = 20").withFallback(system.settings.config))
   val remote = systemB.actorOf(Props(new Actor {
     def receive = {
       case seq: Int ⇒ sender ! seq

--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -68,7 +68,9 @@ object AkkaProtocolStressTest {
 
 class AkkaProtocolStressTest extends AkkaSpec(configA) with ImplicitSender with DefaultTimeout {
 
-  val systemB = ActorSystem("systemB", system.settings.config)
+  val systemB = ActorSystem(
+    "systemB",
+    ConfigFactory.parseString("akka.remote.maximum-retries-in-window = 10").withFallback(system.settings.config))
   val remote = systemB.actorOf(Props(new Actor {
     def receive = {
       case seq: Int ⇒ sender ! seq


### PR DESCRIPTION
Basically the probability of dropping the last batches of messages was higher than I expected, since I forgot that I have set the retry limit to 3 on _both_ systems, and not just one.

Since the expected number of attempts for successful association is ~2.78 this was sometimes triggered on both sides to drop messages too often because of the retry limit of 3 (plus there is a 30% drop probability in both directions already). Now only one of the systems has an aggressive dropping policy, making the test more reliable.

NB: The SystemMessageDelivery\* tests are not affected, since they resend messages, while this test just fire-and-forget.
