### PR TITLE
Java (Eclipse) compatibility of extensions, see #3469

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorDSL.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorDSL.scala
@@ -73,7 +73,17 @@ import java.util.concurrent.TimeUnit
  */
 object ActorDSL extends dsl.Inbox with dsl.Creators {
 
-  protected object Extension extends ExtensionKey[Extension]
+  protected object Extension extends ExtensionId[Extension] with ExtensionIdProvider {
+
+    override def lookup = Extension
+
+    override def createExtension(system: ExtendedActorSystem): Extension = new Extension(system)
+
+    /**
+     * Java API: retrieve the ActorDSL extension for the given system.
+     */
+    override def get(system: ActorSystem): Extension = super.get(system)
+  }
 
   protected class Extension(val system: ExtendedActorSystem) extends akka.actor.Extension with InboxExtension {
 

--- a/akka-actor/src/main/scala/akka/actor/Extension.scala
+++ b/akka-actor/src/main/scala/akka/actor/Extension.scala
@@ -18,8 +18,51 @@ import scala.reflect.ClassTag
  * The extension itself can be created in any way desired and has full access
  * to the ActorSystem implementation.
  *
- * This trait is only a marker interface to signify an Akka Extension, see
- * [[akka.actor.ExtensionKey]] for a concise way of formulating extensions.
+ * This trait is only a marker interface to signify an Akka Extension. This is
+ * how an extension is normally constructed.
+ *
+ * Scala API:
+ *
+ * {{{
+ * object MyExt extends ExtensionId[Ext] with ExtensionIdProvider {
+ *
+ *   override def lookup = MyExt
+ *
+ *   override def createExtension(system: ExtendedActorSystem): Ext = new Ext(system)
+ *
+ *   // Java API: retrieve the extension for the given system.
+ *   override def get(system: ActorSystem): UdpExt = super.get(system)
+ * }
+ *
+ * class Ext(system: ExtendedActorSystem) extends Extension {
+ *   ...
+ * }
+ * }}}
+ *
+ * Java API:
+ *
+ * {{{
+ * public class MyExt extends AbstractExtensionId<MyExtImpl>
+ *   implements ExtensionIdProvider {
+ *   public final static MyExt MyExtProvider = new MyExt();
+ *
+ *   private MyExt() {}
+ *
+ *   public MyExt lookup() {
+ *     return MyExt.MyExtProvider;
+ *   }
+ *
+ *   public MyExtImpl createExtension(ExtendedActorSystem system) {
+ *     return new MyExtImpl();
+ *   }
+ * }
+ *
+ * public class MyExtImpl implements Extension {
+ *    ...
+ * }
+ * }}}
+ *
+ * See also [[akka.actor.ExtensionKey]] for a concise way of formulating extensions.
  */
 trait Extension
 
@@ -90,13 +133,18 @@ trait ExtensionIdProvider {
  *
  * {{{
  * public class MyExt extends Extension {
- *   static final ExtensionKey<MyExt> key = new ExtensionKey<MyExt>(MyExt.class);
+ *   public static final ExtensionKey<MyExt> key = new ExtensionKey<MyExt>(MyExt.class);
  *
  *   public MyExt(ExtendedActorSystem system) {
  *     ...
  *   }
  * }
  * }}}
+ *
+ * Note: Don't use this class if the extension is written in Scala and consumed in
+ * Eclipse Java projects. JDT has problems resolving correct type for the
+ * `get` method.
+ *
  */
 abstract class ExtensionKey[T <: Extension](implicit m: ClassTag[T]) extends ExtensionId[T] with ExtensionIdProvider {
   def this(clazz: Class[T]) = this()(ClassTag(clazz))

--- a/akka-actor/src/main/scala/akka/io/IO.scala
+++ b/akka-actor/src/main/scala/akka/io/IO.scala
@@ -33,6 +33,6 @@ object IO {
    *
    * For the Java API please refer to the individual extensions directly.
    */
-  def apply[T <: Extension](key: ExtensionKey[T])(implicit system: ActorSystem): ActorRef = key(system).manager
+  def apply[T <: Extension](key: ExtensionId[T])(implicit system: ActorSystem): ActorRef = key(system).manager
 
 }

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -35,10 +35,14 @@ import java.lang.{ Iterable ⇒ JIterable }
  *
  * The Java API for generating TCP commands is available at [[TcpMessage]].
  */
-object Tcp extends ExtensionKey[TcpExt] {
+object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
+
+  override def lookup = Tcp
+
+  override def createExtension(system: ExtendedActorSystem): TcpExt = new TcpExt(system)
 
   /**
-   * Java API: retrieve Tcp extension for the given system.
+   * Java API: retrieve the Tcp extension for the given system.
    */
   override def get(system: ActorSystem): TcpExt = super.get(system)
 

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -30,7 +30,11 @@ import akka.actor._
  *
  * The Java API for generating UDP commands is available at [[UdpMessage]].
  */
-object Udp extends ExtensionKey[UdpExt] {
+object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
+
+  override def lookup = Udp
+
+  override def createExtension(system: ExtendedActorSystem): UdpExt = new UdpExt(system)
 
   /**
    * Java API: retrieve the Udp extension for the given system.

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -29,7 +29,12 @@ import akka.actor._
  *
  * The Java API for generating UDP commands is available at [[UdpConnectedMessage]].
  */
-object UdpConnected extends ExtensionKey[UdpConnectedExt] {
+object UdpConnected extends ExtensionId[UdpConnectedExt] with ExtensionIdProvider {
+
+  override def lookup = UdpConnected
+
+  override def createExtension(system: ExtendedActorSystem): UdpConnectedExt = new UdpConnectedExt(system)
+
   /**
    * Java API: retrieve the UdpConnected extension for the given system.
    */

--- a/akka-docs/rst/java/code/docs/extension/ExtensionDocTest.java
+++ b/akka-docs/rst/java/code/docs/extension/ExtensionDocTest.java
@@ -35,6 +35,8 @@ public class ExtensionDocTest {
     //This will be the identifier of our CountExtension
     public final static CountExtension CountExtensionProvider = new CountExtension();
 
+    private CountExtension() {}
+
     //The lookup method is required by ExtensionIdProvider,
     // so we return ourselves here, this allows us
     // to configure our extension to be loaded when

--- a/akka-docs/rst/java/code/docs/extension/SettingsExtensionDocTest.java
+++ b/akka-docs/rst/java/code/docs/extension/SettingsExtensionDocTest.java
@@ -44,6 +44,8 @@ public class SettingsExtensionDocTest {
     implements ExtensionIdProvider {
     public final static Settings SettingsProvider = new Settings();
 
+    private Settings() {}
+
     public Settings lookup() {
       return Settings.SettingsProvider;
     }

--- a/akka-docs/rst/scala/code/docs/extension/ExtensionDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/extension/ExtensionDocSpec.scala
@@ -21,6 +21,7 @@ class CountExtensionImpl extends Extension {
 //#extension
 
 //#extensionid
+import akka.actor.ActorSystem
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.actor.ExtendedActorSystem
@@ -37,6 +38,11 @@ object CountExtension
   //This method will be called by Akka
   // to instantiate our Extension
   override def createExtension(system: ExtendedActorSystem) = new CountExtensionImpl
+
+  /**
+   * Java API: retrieve the Count extension for the given system.
+   */
+  override def get(system: ActorSystem): CountExtensionImpl = super.get(system)
 }
 //#extensionid
 

--- a/akka-docs/rst/scala/code/docs/extension/SettingsExtensionDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/extension/SettingsExtensionDocSpec.scala
@@ -4,6 +4,7 @@
 package docs.extension
 
 //#imports
+import akka.actor.ActorSystem
 import akka.actor.Extension
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
@@ -33,6 +34,11 @@ object Settings extends ExtensionId[SettingsImpl] with ExtensionIdProvider {
 
   override def createExtension(system: ExtendedActorSystem) =
     new SettingsImpl(system.settings.config)
+
+  /**
+   * Java API: retrieve the Settings extension for the given system.
+   */
+  override def get(system: ActorSystem): SettingsImpl = super.get(system)
 }
 //#extensionid
 

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Extension.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Extension.scala
@@ -3,7 +3,7 @@
  */
 package akka.remote.testconductor
 
-import akka.actor.{ ExtensionKey, Extension, ExtendedActorSystem, ActorContext, ActorRef, Address, ActorSystemImpl, Props }
+import akka.actor.{ Extension, ExtensionId, ExtensionIdProvider, ExtendedActorSystem, ActorContext, ActorRef, Address, ActorSystem, Props }
 import akka.remote.RemoteActorRefProvider
 import akka.util.Timeout
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -22,7 +22,16 @@ import akka.dispatch.ThreadPoolConfig
  * tc.startClient(conductorPort)
  * }}}
  */
-object TestConductor extends ExtensionKey[TestConductorExt] {
+object TestConductor extends ExtensionId[TestConductorExt] with ExtensionIdProvider {
+
+  override def lookup = TestConductor
+
+  override def createExtension(system: ExtendedActorSystem): TestConductorExt = new TestConductorExt(system)
+
+  /**
+   * Java API: retrieve the TestConductor extension for the given system.
+   */
+  override def get(system: ActorSystem): TestConductorExt = super.get(system)
 
   def apply()(implicit ctx: ActorContext): TestConductorExt = apply(ctx.system)
 


### PR DESCRIPTION
- Eclipse JDT showed compilation error
  "The method get(ActorSystem) is ambiguous for the type..."
  for extensions defined with ExtensionKey
