### PR TITLE
add pipeToSelection support, see #3430

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -79,8 +79,8 @@ object Patterns {
 
   /**
    * Register an onComplete callback on this [[scala.concurrent.Future]] to send
-   * the result to the given actor reference. Returns the original Future to
-   * allow method chaining.
+   * the result to the given [[akka.actor.ActorRef]] or [[akka.actor.ActorSelection]].
+   * Returns the original Future to allow method chaining.
    *
    * <b>Recommended usage example:</b>
    *

--- a/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
@@ -4,10 +4,10 @@
 package akka.pattern
 
 import language.implicitConversions
-
 import scala.concurrent.{ Future, ExecutionContext }
 import scala.util.{ Failure, Success }
 import akka.actor.{ Status, ActorRef, Actor }
+import akka.actor.ActorSelection
 
 trait PipeToSupport {
 
@@ -19,9 +19,21 @@ trait PipeToSupport {
       }
       future
     }
+    def pipeToSelection(recipient: ActorSelection)(implicit sender: ActorRef = Actor.noSender): Future[T] = {
+      future onComplete {
+        case Success(r) ⇒ recipient ! r
+        case Failure(f) ⇒ recipient ! Status.Failure(f)
+      }
+      future
+    }
     def to(recipient: ActorRef): PipeableFuture[T] = to(recipient, Actor.noSender)
     def to(recipient: ActorRef, sender: ActorRef): PipeableFuture[T] = {
       pipeTo(recipient)(sender)
+      this
+    }
+    def to(recipient: ActorSelection): PipeableFuture[T] = to(recipient, Actor.noSender)
+    def to(recipient: ActorSelection, sender: ActorRef): PipeableFuture[T] = {
+      pipeToSelection(recipient)(sender)
       this
     }
   }

--- a/akka-actor/src/main/scala/akka/pattern/package.scala
+++ b/akka-actor/src/main/scala/akka/pattern/package.scala
@@ -17,7 +17,9 @@ import akka.actor._
  * <li><b>ask:</b> create a temporary one-off actor for receiving a reply to a
  * message and complete a [[scala.concurrent.Future]] with it; returns said
  * Future.</li>
- * <li><b>pipeTo:</b> feed eventually computed value of a future to an actor as
+ * <li><b>pipeTo:</b> feed eventually computed value of a future to an [[akka.actor.ActorRef]] as
+ * a message.</li>
+ * <li><b>pipeToSelection:</b> feed eventually computed value of a future to an [[akka.actor.ActorSelection]] as
  * a message.</li>
  * </ul>
  *

--- a/akka-docs/rst/java/untyped-actors.rst
+++ b/akka-docs/rst/java/untyped-actors.rst
@@ -379,11 +379,15 @@ Messages can be sent via the :class:`ActorSelection` and the path of the
 :class:`ActorSelection` is looked up when delivering each message. If the selection
 does not match any actors the message will be dropped.
 
-To acquire an :class:`ActorRef` for an :class:`ActorSelection` you need to
-send a message to the selection and use the ``getSender`` reference of the reply from
-the actor. There is a built-in ``Identify`` message that all Actors will understand
-and automatically reply to with a ``ActorIdentity`` message containing the
-:class:`ActorRef`.
+To acquire an :class:`ActorRef` for an :class:`ActorSelection` you need to send
+a message to the selection and use the ``getSender`` reference of the reply
+from the actor. There is a built-in ``Identify`` message that all Actors will
+understand and automatically reply to with a ``ActorIdentity`` message
+containing the :class:`ActorRef`. This message is handled specially by the
+actors which are traversed in the sense that if a concrete name lookup fails
+(i.e. a non-wildcard path element does not correspond to a live actor) then a
+negative result is generated. Please note that this does not mean that delivery
+of that reply is guaranteed, it still is a normal message.
 
 .. includecode:: code/docs/actor/UntypedActorDocTest.java
    :include: import-identify,identify

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -463,11 +463,15 @@ Messages can be sent via the :class:`ActorSelection` and the path of the
 :class:`ActorSelection` is looked up when delivering each message. If the selection
 does not match any actors the message will be dropped.
 
-To acquire an :class:`ActorRef` for an :class:`ActorSelection` you need to
-send a message to the selection and use the ``sender`` reference of the reply from
-the actor. There is a built-in ``Identify`` message that all Actors will understand
-and automatically reply to with a ``ActorIdentity`` message containing the
-:class:`ActorRef`.
+To acquire an :class:`ActorRef` for an :class:`ActorSelection` you need to send
+a message to the selection and use the ``sender`` reference of the reply from
+the actor. There is a built-in ``Identify`` message that all Actors will
+understand and automatically reply to with a ``ActorIdentity`` message
+containing the :class:`ActorRef`. This message is handled specially by the
+actors which are traversed in the sense that if a concrete name lookup fails
+(i.e. a non-wildcard path element does not correspond to a live actor) then a
+negative result is generated. Please note that this does not mean that delivery
+of that reply is guaranteed, it still is a normal message.
 
 .. includecode:: code/docs/actor/ActorDocSpec.scala#identify
 


### PR DESCRIPTION
also add explanation to docs about what happens when Identify message
hits a non-existing path element
