### PR TITLE
Do not publish aggregator projects, see #3481

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -597,7 +597,7 @@ object AkkaBuild extends Build {
   lazy val baseSettings = Defaults.defaultSettings ++ Publish.settings
 
   lazy val parentSettings = baseSettings ++ Seq(
-    publishArtifact in Compile := false
+    publishArtifact := false
   )
 
   lazy val sampleSettings = defaultSettings ++ Seq(


### PR DESCRIPTION
With this change the only file that is generated for the parent projects is ivy.xml, e.g.
.ivy2/local/com.typesafe.akka/akka-samples/2.2-SNAPSHOT/ivys/ivy.xml
I assume that is all fine. I can't see it on maven central: http://mirrors.ibiblio.org/maven2/com/typesafe/akka/akka-samples/2.2.0-RC2/
