### PR TITLE
=act:3478 don’t fail constructor at end of hierarchy stress

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -113,13 +113,14 @@ object SupervisorHierarchySpec {
    */
   case class HierarchyState(log: Vector[Event], kids: Map[ActorPath, Int], failConstr: Failure)
   val stateCache = new ConcurrentHashMap[ActorPath, HierarchyState]()
+  @volatile var ignoreFailConstr = false
 
   class Hierarchy(size: Int, breadth: Int, listener: ActorRef, myLevel: Int) extends Actor {
 
     var log = Vector.empty[Event]
 
     stateCache.get(self.path) match {
-      case hs @ HierarchyState(l: Vector[Event], _, f: Failure) if f.failConstr > 0 ⇒
+      case hs @ HierarchyState(l: Vector[Event], _, f: Failure) if f.failConstr > 0 && !ignoreFailConstr ⇒
         val log = l :+ Event("Failed in constructor", identityHashCode(this))
         stateCache.put(self.path, hs.copy(log = log, failConstr = f.copy(failConstr = f.failConstr - 1)))
         throw f
@@ -467,7 +468,7 @@ object SupervisorHierarchySpec {
         idleChildren = children
         activeChildren = children
         // set timeout for completion of the whole test (i.e. including Finishing and Stopping)
-        setTimer("phase", StateTimeout, 70.seconds.dilated, false)
+        setTimer("phase", StateTimeout, 90.seconds.dilated, false)
     }
 
     val workSchedule = 50.millis
@@ -524,6 +525,10 @@ object SupervisorHierarchySpec {
         ignoreNotResumedLogs = false
         hierarchy ! Dump(2)
         goto(Failed)
+    }
+
+    onTransition {
+      case Stress -> Finishing ⇒ ignoreFailConstr = true
     }
 
     when(Finishing) {
@@ -876,7 +881,7 @@ class SupervisorHierarchySpec extends AkkaSpec(SupervisorHierarchySpec.config) w
 
       fsm ! Init
 
-      expectMsg(90 seconds, "stressTestSuccessful")
+      expectMsg(110 seconds, "stressTestSuccessful")
       expectMsg("stressTestStopped")
     }
   }


### PR DESCRIPTION
This is what’s causing it:
- some Failures are dispensed which specify failConstr > 0, meaning that they will be put into the stateCache for later (re)starts
- immediately thereafter the Finishing state is entered and a large hierarchy reboot happens (failure of the “head”)
- last pings are handled by the few currently “known active” actors and state Stopping is soon entered
- the PingOfDeath is sent down the hierarchy to do the final checks and clean up
- meanwhile the tree rebuild reaches the actor which still has a constructor failure queued up from step 1
- this failure will be answered with Resume, no matter what it originally specified, because we are terminating after all
- if the failure originally was a Restart, then the actor will be confused in its postStop() checks
- BOOOM
