### PR TITLE
=rem Wrong and superfluous pattern match in EndpointWriter

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -545,13 +545,10 @@ private[remote] class EndpointWriter(
       unstashAll()
       goto(Writing)
 
-    case Event(Send(msg, senderOption, recipient, _), _) ⇒
+    case _ =>
       stash()
       stay()
 
-    case _: StopReading ⇒
-      stash()
-      stay()
   }
 
   whenUnhandled {


### PR DESCRIPTION
I distinctly remember fixing this, it seems this was lost in a rebase round somewhere. Needs to be backported to 2.2
