### PR TITLE
Resolves high contention on unsubscribeAddresssTermination #3547

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -101,14 +101,15 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
 
   protected def unwatchWatchedActors(actor: Actor): Unit =
     if (!watching.isEmpty) {
-      try {
-        watching foreach { // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-          case watchee: InternalActorRef ⇒ watchee.sendSystemMessage(Unwatch(watchee, self))
+      maintainAddressTerminatedSubscription() {
+        try {
+          watching foreach { // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
+            case watchee: InternalActorRef ⇒ watchee.sendSystemMessage(Unwatch(watchee, self))
+          }
+        } finally {
+          watching = ActorCell.emptyActorRefSet
+          terminatedQueued = ActorCell.emptyActorRefSet
         }
-      } finally {
-        watching = ActorCell.emptyActorRefSet
-        terminatedQueued = ActorCell.emptyActorRefSet
-        unsubscribeAddressTerminated()
       }
     }
 


### PR DESCRIPTION
Looks like we can reuse existing function, which does exactly what we need: checks are there any nonlocal watches exist in given actor, and iff they are - call unsubscribeAddressTermination.
