### PR TITLE
=clu #3536 Update doc of hostname port params in cluster jmx script

### DIFF
--- a/akka-docs/rst/java/cluster-usage.rst
+++ b/akka-docs/rst/java/cluster-usage.rst
@@ -692,7 +692,7 @@ Akka distribution.
 
 Run it without parameters to see instructions about how to use the script::
 
-  Usage: bin/akka-cluster <node-hostname:jmx-port> <command> ...
+  Usage: bin/akka-cluster <node-hostname> <jmx-port> <command> ...
 
   Supported commands are:
              join <node-url> - Sends request a JOIN node with the specified URL
@@ -710,9 +710,9 @@ Run it without parameters to see instructions about how to use the script::
   Where the <node-url> should be on the format of 
     'akka.<protocol>://<actor-system-name>@<hostname>:<port>'
 
-  Examples: bin/akka-cluster localhost:9999 is-available
-            bin/akka-cluster localhost:9999 join akka.tcp://MySystem@darkstar:2552
-            bin/akka-cluster localhost:9999 cluster-status
+  Examples: bin/akka-cluster localhost 9999 is-available
+            bin/akka-cluster localhost 9999 join akka.tcp://MySystem@darkstar:2552
+            bin/akka-cluster localhost 9999 cluster-status
 
 
 To be able to use the script you must enable remote monitoring and management when starting the JVMs of the cluster nodes,

--- a/akka-docs/rst/scala/cluster-usage.rst
+++ b/akka-docs/rst/scala/cluster-usage.rst
@@ -714,7 +714,7 @@ Akka distribution.
 
 Run it without parameters to see instructions about how to use the script::
 
-  Usage: bin/akka-cluster <node-hostname:jmx-port> <command> ...
+  Usage: bin/akka-cluster <node-hostname> <jmx-port> <command> ...
 
   Supported commands are:
              join <node-url> - Sends request a JOIN node with the specified URL
@@ -732,9 +732,9 @@ Run it without parameters to see instructions about how to use the script::
   Where the <node-url> should be on the format of 
     'akka.<protocol>://<actor-system-name>@<hostname>:<port>'
 
-  Examples: bin/akka-cluster localhost:9999 is-available
-            bin/akka-cluster localhost:9999 join akka.tcp://MySystem@darkstar:2552
-            bin/akka-cluster localhost:9999 cluster-status
+  Examples: bin/akka-cluster localhost 9999 is-available
+            bin/akka-cluster localhost 9999 join akka.tcp://MySystem@darkstar:2552
+            bin/akka-cluster localhost 9999 cluster-status
 
 
 To be able to use the script you must enable remote monitoring and management when starting the JVMs of the cluster nodes,

--- a/akka-kernel/src/main/dist/bin/akka-cluster
+++ b/akka-kernel/src/main/dist/bin/akka-cluster
@@ -45,7 +45,7 @@ case "$1" in
 
     join)
         if [ $# -ne 2 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> join <node-url-to-join>"
+            echo "Usage: $SELF <node-hostname> <jmx-port> join <node-url-to-join>"
             exit 1
         fi
 
@@ -56,7 +56,7 @@ case "$1" in
 
     leave)
         if [ $# -ne 2 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> leave <node-url-to-join>"
+            echo "Usage: $SELF <node-hostname> <jmx-port> leave <node-url-to-join>"
             exit 1
         fi
 
@@ -69,7 +69,7 @@ case "$1" in
 
     down)
         if [ $# -ne 2 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> down <node-url-to-join>"
+            echo "Usage: $SELF <node-hostname> <jmx-port> down <node-url-to-join>"
             exit 1
         fi
 
@@ -82,7 +82,7 @@ case "$1" in
 
     member-status)
         if [ $# -ne 1 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> member-status"
+            echo "Usage: $SELF <node-hostname> <jmx-port> member-status"
             exit 1
         fi
 
@@ -94,7 +94,7 @@ case "$1" in
 
     cluster-status)
         if [ $# -ne 1 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> cluster-status"
+            echo "Usage: $SELF <node-hostname> <jmx-port> cluster-status"
             exit 1
         fi
 
@@ -106,7 +106,7 @@ case "$1" in
 
     members)
         if [ $# -ne 1 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> members"
+            echo "Usage: $SELF <node-hostname> <jmx-port> members"
             exit 1
         fi
 
@@ -118,7 +118,7 @@ case "$1" in
 
     unreachable)
         if [ $# -ne 1 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> unreachable"
+            echo "Usage: $SELF <node-hostname> <jmx-port> unreachable"
             exit 1
         fi
 
@@ -130,7 +130,7 @@ case "$1" in
 
     leader)
         if [ $# -ne 1 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> leader"
+            echo "Usage: $SELF <node-hostname> <jmx-port> leader"
             exit 1
         fi
 
@@ -142,7 +142,7 @@ case "$1" in
 
     is-singleton)
         if [ $# -ne 1 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> is-singleton"
+            echo "Usage: $SELF <node-hostname> <jmx-port> is-singleton"
             exit 1
         fi
 
@@ -154,7 +154,7 @@ case "$1" in
 
     is-available)
         if [ $# -ne 1 ]; then
-            echo "Usage: $SELF <node-hostname:jmx-port> is-available"
+            echo "Usage: $SELF <node-hostname> <jmx-port> is-available"
             exit 1
         fi
 
@@ -165,7 +165,7 @@ case "$1" in
         ;;
 
     *)
-        printf "Usage: bin/$SELF <node-hostname:jmx-port> <command> ...\n"
+        printf "Usage: bin/$SELF <node-hostname> <jmx-port> <command> ...\n"
         printf "\n"
         printf "Supported commands are:\n"
         printf "%26s - %s\n" "join <node-url>"   "Sends request a JOIN node with the specified URL"
@@ -180,9 +180,9 @@ case "$1" in
         printf "%26s - %s\n" is-available        "Checks if the member node is available"
         printf "Where the <node-url> should be on the format of 'akka://actor-system-name@hostname:port'\n"
         printf "\n"
-        printf "Examples: bin/$SELF localhost:9999 is-available\n"
-        printf "          bin/$SELF localhost:9999 join akka://MySystem@darkstar:2552\n"
-        printf "          bin/$SELF localhost:9999 cluster-status\n"
+        printf "Examples: bin/$SELF localhost 9999 is-available\n"
+        printf "          bin/$SELF localhost 9999 join akka://MySystem@darkstar:2552\n"
+        printf "          bin/$SELF localhost 9999 cluster-status\n"
         exit 1
         ;;
 esac


### PR DESCRIPTION
- This was changed in the switch to jmxsh (72aa5ef), but since
  we released with space separator I updated the documentation to that
  format.
