### PR TITLE
!act #3526 Make SupervisorStrategy.logFailure public

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -325,7 +325,7 @@ abstract class SupervisorStrategy {
    * `Resume` failures are logged at `Warning` level.
    * `Stop` and `Restart` failures are logged at `Error` level.
    */
-  protected def logFailure(context: ActorContext, child: ActorRef, cause: Throwable, decision: Directive): Unit =
+  def logFailure(context: ActorContext, child: ActorRef, cause: Throwable, decision: Directive): Unit =
     if (loggingEnabled) {
       val logMessage = cause match {
         case e: ActorInitializationException if e.getCause ne null ⇒ e.getCause.getMessage

--- a/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
+++ b/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
@@ -93,8 +93,8 @@ private[io] object SelectionHandler {
    */
   private[io] final val connectionSupervisorStrategy: SupervisorStrategy =
     new OneForOneStrategy()(SupervisorStrategy.stoppingStrategy.decider) {
-      override protected def logFailure(context: ActorContext, child: ActorRef, cause: Throwable,
-                                        decision: SupervisorStrategy.Directive): Unit =
+      override def logFailure(context: ActorContext, child: ActorRef, cause: Throwable,
+                              decision: SupervisorStrategy.Directive): Unit =
         if (cause.isInstanceOf[DeathPactException]) {
           try context.system.eventStream.publish {
             Logging.Debug(child.path.toString, getClass, "Closed after handler termination")
@@ -252,8 +252,8 @@ private[io] class SelectionHandler(settings: SelectionHandlerSettings) extends A
       case _: Exception ⇒ SupervisorStrategy.Stop
     }
     new OneForOneStrategy()(stoppingDecider) {
-      override protected def logFailure(context: ActorContext, child: ActorRef, cause: Throwable,
-                                        decision: SupervisorStrategy.Directive): Unit =
+      override def logFailure(context: ActorContext, child: ActorRef, cause: Throwable,
+                              decision: SupervisorStrategy.Directive): Unit =
         try {
           val logMessage = cause match {
             case e: ActorInitializationException if e.getCause ne null ⇒ e.getCause.getMessage


### PR DESCRIPTION
- This change is not source compatible since anyone that has
  overridden logFailure will have compilation error
  "has weaker access privileges; it should be public"

CANNOT BE BACKPORTED TO 2.2.x
