### PR TITLE
=pro #3552 Upgrade ScalaTest to 1.9.2-SNAP2 for dbuild

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -5,7 +5,7 @@ package akka.actor
 
 import language.postfixOps
 import akka.testkit._
-import org.scalatest.junit.JUnitSuite
+import org.scalatest.junit.JUnitSuiteLike
 import com.typesafe.config.ConfigFactory
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -19,7 +19,7 @@ import com.typesafe.config.Config
 import java.util.concurrent.{ LinkedBlockingQueue, BlockingQueue, TimeUnit }
 import akka.util.Switch
 
-class JavaExtensionSpec extends JavaExtension with JUnitSuite
+class JavaExtensionSpec extends JavaExtension with JUnitSuiteLike
 
 object TestExtension extends ExtensionId[TestExtension] with ExtensionIdProvider {
   def lookup = this

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -13,7 +13,7 @@ import akka.pattern.ask
 import scala.concurrent.duration._
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.junit.JUnitSuite
+import org.scalatest.junit.JUnitSuiteLike
 
 object ActorWithStashSpec {
 
@@ -79,7 +79,7 @@ object ActorWithStashSpec {
 
 }
 
-class JavaActorWithStashSpec extends StashJavaAPI with JUnitSuite
+class JavaActorWithStashSpec extends StashJavaAPI with JUnitSuiteLike
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ActorWithStashSpec extends AkkaSpec(ActorWithStashSpec.testConf) with DefaultTimeout with BeforeAndAfterEach {

--- a/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
@@ -3,6 +3,6 @@
  */
 package akka.actor
 
-import org.scalatest.junit.JUnitSuite
+import org.scalatest.junit.JUnitSuiteLike
 
-class JavaAPISpec extends JavaAPI with JUnitSuite
+class JavaAPISpec extends JavaAPI with JUnitSuiteLike

--- a/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/FutureSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ Await, Awaitable, Future, Promise, ExecutionContext }
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
-import org.scalatest.junit.JUnitSuite
+import org.scalatest.junit.JUnitSuiteLike
 import scala.runtime.NonLocalReturnControl
 import akka.pattern.ask
 import java.lang.{ IllegalStateException, ArithmeticException }
@@ -51,7 +51,7 @@ object FutureSpec {
   }
 }
 
-class JavaFutureSpec extends JavaFutureTests with JUnitSuite
+class JavaFutureSpec extends JavaFutureTests with JUnitSuiteLike
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class FutureSpec extends AkkaSpec with Checkers with BeforeAndAfterAll with DefaultTimeout {

--- a/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
+++ b/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
@@ -1,5 +1,5 @@
 package akka.japi
 
-import org.scalatest.junit.JUnitSuite
+import org.scalatest.junit.JUnitSuiteLike
 
-class JavaAPITest extends JavaAPITestBase with JUnitSuite
+class JavaAPITest extends JavaAPITestBase with JUnitSuiteLike

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -231,7 +231,7 @@ class ByteStringSpec extends WordSpec with MustMatchers with Checkers {
     for (i ← 0 until data.length) builder.putLongPart(data(i), nBytes)(byteOrder)
 
     reference.zipWithIndex.collect({ // Since there is no partial put on LongBuffer, we need to collect only the interesting bytes
-      case (r, i) if byteOrder == ByteOrder.LITTLE_ENDIAN && i % elemSize < nBytes     ⇒ r
+      case (r, i) if byteOrder == ByteOrder.LITTLE_ENDIAN && i % elemSize < nBytes            ⇒ r
       case (r, i) if byteOrder == ByteOrder.BIG_ENDIAN && i % elemSize >= (elemSize - nBytes) ⇒ r
     }).toSeq == builder.result
   }

--- a/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
@@ -3,6 +3,6 @@
  */
 package akka.util
 
-import org.scalatest.junit.JUnitSuite
+import org.scalatest.junit.JUnitSuiteLike
 
-class JavaDurationSpec extends JavaDuration with JUnitSuite
+class JavaDurationSpec extends JavaDuration with JUnitSuiteLike

--- a/akka-camel/src/test/scala/akka/camel/CamelMessageTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/CamelMessageTest.scala
@@ -7,10 +7,10 @@ package akka.camel
 import org.apache.camel.impl.{ DefaultExchange, DefaultMessage }
 import akka.camel.TestSupport.SharedCamelSystem
 import org.scalatest.matchers.MustMatchers
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 
 //TODO merge it with MessageScalaTest
-class CamelMessageTest extends MustMatchers with WordSpec with SharedCamelSystem {
+class CamelMessageTest extends MustMatchers with WordSpecLike with SharedCamelSystem {
 
   "CamelMessage" must {
 

--- a/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
@@ -12,7 +12,7 @@ import org.apache.camel.component.mock.MockEndpoint
 import scala.concurrent.Await
 import akka.camel.TestSupport.SharedCamelSystem
 import akka.actor.SupervisorStrategy.Stop
-import org.scalatest.{ BeforeAndAfterEach, BeforeAndAfterAll, WordSpec }
+import org.scalatest.{ BeforeAndAfterEach, BeforeAndAfterAll, WordSpecLike }
 import akka.actor._
 import akka.pattern._
 import scala.concurrent.duration._
@@ -24,7 +24,7 @@ import akka.actor.Status.Failure
 /**
  * Tests the features of the Camel Producer.
  */
-class ProducerFeatureTest extends TestKit(ActorSystem("test", AkkaSpec.testConf)) with WordSpec with BeforeAndAfterAll with BeforeAndAfterEach with MustMatchers {
+class ProducerFeatureTest extends TestKit(ActorSystem("test", AkkaSpec.testConf)) with WordSpecLike with BeforeAndAfterAll with BeforeAndAfterEach with MustMatchers {
 
   import ProducerFeatureTest._
   implicit def camel = CamelExtension(system)

--- a/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
@@ -3,13 +3,13 @@ package akka.camel.internal
 import language.postfixOps
 import org.scalatest.matchers.MustMatchers
 import scala.concurrent.duration._
-import org.scalatest.{ GivenWhenThen, BeforeAndAfterEach, BeforeAndAfterAll, WordSpec }
+import org.scalatest.{ GivenWhenThen, BeforeAndAfterEach, BeforeAndAfterAll, WordSpecLike }
 import akka.actor.{ Props, ActorSystem }
 import akka.camel._
 import akka.testkit.{ TimingTest, TestProbe, TestKit }
 import akka.camel.internal.ActivationProtocol._
 
-class ActivationTrackerTest extends TestKit(ActorSystem("test")) with WordSpec with MustMatchers with BeforeAndAfterAll with BeforeAndAfterEach with GivenWhenThen {
+class ActivationTrackerTest extends TestKit(ActorSystem("test")) with WordSpecLike with MustMatchers with BeforeAndAfterAll with BeforeAndAfterEach with GivenWhenThen {
 
   override protected def afterAll() { shutdown(system) }
 

--- a/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 import java.lang.String
 import akka.camel._
 import internal.{ DefaultCamel, CamelExchangeAdapter }
-import org.scalatest.{ Suite, WordSpec, BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.{ Suite, WordSpecLike, BeforeAndAfterAll, BeforeAndAfterEach }
 import akka.camel.TestSupport._
 import java.util.concurrent.{ TimeoutException, CountDownLatch, TimeUnit }
 import org.mockito.{ ArgumentMatcher, Matchers, Mockito }
@@ -30,7 +30,7 @@ import akka.util.Timeout
 import akka.actor._
 import akka.testkit._
 
-class ActorProducerTest extends TestKit(ActorSystem("test")) with WordSpec with MustMatchers with ActorProducerFixture {
+class ActorProducerTest extends TestKit(ActorSystem("test")) with WordSpecLike with MustMatchers with ActorProducerFixture {
   implicit val timeout = Timeout(10 seconds)
 
   "ActorProducer" when {

--- a/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
@@ -14,7 +14,7 @@ import akka.testkit.ImplicitSender
 import akka.contrib.throttle.Throttler._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.BeforeAndAfterAll
 import akka.testkit._
@@ -29,7 +29,7 @@ object TimerBasedThrottlerSpec {
 
 @RunWith(classOf[JUnitRunner])
 class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSpec")) with ImplicitSender
-  with WordSpec with MustMatchers with BeforeAndAfterAll {
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll {
 
   override def afterAll {
     shutdown(system)

--- a/akka-docs/rst/dev/multi-jvm-testing.rst
+++ b/akka-docs/rst/dev/multi-jvm-testing.rst
@@ -72,8 +72,8 @@ Here is an example Build.scala file that uses the MultiJvm plugin:
            "test" @crossString@,
          "com.typesafe.akka" %% "akka-multi-node-testkit" % "@version@" %
            "test" @crossString@,
-         "org.scalatest"     %% "scalatest" % "1.9.1" % "test",
-         "junit"              % "junit" % "4.5" % "test"
+         "org.scalatest"     %% "scalatest" % "1.9.2-SNAP2" % "test",
+         "junit"              % "junit" % "4.10" % "test"
        )
      }
    }

--- a/akka-docs/rst/scala/code/docs/testkit/PlainWordSpec.scala
+++ b/akka-docs/rst/scala/code/docs/testkit/PlainWordSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.actor.Actor
 import akka.actor.Props
 import akka.testkit.TestKit
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.BeforeAndAfterAll
 import akka.testkit.ImplicitSender
@@ -23,7 +23,7 @@ object MySpec {
 
 //#implicit-sender
 class MySpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with WordSpec with MustMatchers with BeforeAndAfterAll {
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll {
   //#implicit-sender
 
   def this() = this(ActorSystem("MySpec"))

--- a/akka-docs/rst/scala/code/docs/testkit/TestKitUsageSpec.scala
+++ b/akka-docs/rst/scala/code/docs/testkit/TestKitUsageSpec.scala
@@ -9,7 +9,7 @@ import language.postfixOps
 import scala.util.Random
 
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.ShouldMatchers
 
 import com.typesafe.config.ConfigFactory
@@ -31,7 +31,7 @@ class TestKitUsageSpec
   extends TestKit(ActorSystem("TestKitUsageSpec",
     ConfigFactory.parseString(TestKitUsageSpec.config)))
   with DefaultTimeout with ImplicitSender
-  with WordSpec with ShouldMatchers with BeforeAndAfterAll {
+  with WordSpecLike with ShouldMatchers with BeforeAndAfterAll {
   import TestKitUsageSpec._
 
   val echoRef = system.actorOf(Props[EchoActor])

--- a/akka-durable-mailboxes/akka-mailboxes-common/src/test/scala/akka/actor/mailbox/DurableMailboxSpec.scala
+++ b/akka-durable-mailboxes/akka-mailboxes-common/src/test/scala/akka/actor/mailbox/DurableMailboxSpec.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
 
-import org.scalatest.{ WordSpec, BeforeAndAfterAll }
+import org.scalatest.{ WordSpecLike, BeforeAndAfterAll }
 import org.scalatest.matchers.MustMatchers
 
 import com.typesafe.config.{ ConfigFactory, Config }
@@ -55,7 +55,7 @@ object DurableMailboxSpec {
  * The id of the dispatcher must be the same as the `<backendName>-dispatcher`.
  */
 abstract class DurableMailboxSpec(system: ActorSystem, val backendName: String)
-  extends TestKit(system) with WordSpec with MustMatchers with BeforeAndAfterAll {
+  extends TestKit(system) with WordSpecLike with MustMatchers with BeforeAndAfterAll {
 
   import DurableMailboxSpecActorFactory._
 

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -431,7 +431,7 @@ abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles:
  * Example trait for MultiNodeSpec with ScalaTest
  *
  * {{{
- * trait STMultiNodeSpec extends MultiNodeSpecCallbacks with WordSpec with MustMatchers with BeforeAndAfterAll {
+ * trait STMultiNodeSpec extends MultiNodeSpecCallbacks with WordSpecLike with MustMatchers with BeforeAndAfterAll {
  *   override def beforeAll() = multiNodeSpecBeforeAll()
  *   override def afterAll() = multiNodeSpecAfterAll()
  * }

--- a/akka-remote-tests/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
@@ -4,13 +4,13 @@
 
 package akka.remote.testkit
 
-import org.scalatest.{ BeforeAndAfterAll, WordSpec }
+import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
 import org.scalatest.matchers.MustMatchers
 
 /**
  * Hooks up MultiNodeSpec with ScalaTest
  */
-trait STMultiNodeSpec extends MultiNodeSpecCallbacks with WordSpec with MustMatchers with BeforeAndAfterAll {
+trait STMultiNodeSpec extends MultiNodeSpecCallbacks with WordSpecLike with MustMatchers with BeforeAndAfterAll {
 
   override def beforeAll() = multiNodeSpecBeforeAll()
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -4,7 +4,7 @@ import language.postfixOps
 import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 import akka.actor.PoisonPill
 import akka.actor.Props
@@ -58,7 +58,7 @@ class StatsSampleSingleMasterSpecMultiJvmNode2 extends StatsSampleSingleMasterSp
 class StatsSampleSingleMasterSpecMultiJvmNode3 extends StatsSampleSingleMasterSpec
 
 abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSingleMasterSpecConfig)
-  with WordSpec with MustMatchers with BeforeAndAfterAll with ImplicitSender {
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll with ImplicitSender {
 
   import StatsSampleSingleMasterSpecConfig._
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -57,13 +57,13 @@ class StatsSampleSpecMultiJvmNode3 extends StatsSampleSpec
 
 //#abstract-test
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 import akka.remote.testkit.MultiNodeSpec
 import akka.testkit.ImplicitSender
 
 abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
-  with WordSpec with MustMatchers with BeforeAndAfterAll
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll
   with ImplicitSender {
 
   import StatsSampleSpecConfig._

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
@@ -14,7 +14,7 @@ import sample.cluster.stats.japi.StatsMessages._
 import akka.remote.testkit.MultiNodeConfig
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 import akka.remote.testkit.MultiNodeSpec
 import akka.testkit.ImplicitSender
@@ -55,7 +55,7 @@ class StatsSampleJapiSpecMultiJvmNode2 extends StatsSampleJapiSpec
 class StatsSampleJapiSpecMultiJvmNode3 extends StatsSampleJapiSpec
 
 abstract class StatsSampleJapiSpec extends MultiNodeSpec(StatsSampleJapiSpecConfig)
-  with WordSpec with MustMatchers with BeforeAndAfterAll
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll
   with ImplicitSender {
 
   import StatsSampleJapiSpecConfig._

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
@@ -4,7 +4,7 @@ import language.postfixOps
 import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 import akka.actor.PoisonPill
 import akka.actor.Props
@@ -58,7 +58,7 @@ class StatsSampleSingleMasterJapiSpecMultiJvmNode2 extends StatsSampleSingleMast
 class StatsSampleSingleMasterJapiSpecMultiJvmNode3 extends StatsSampleSingleMasterJapiSpec
 
 abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSampleSingleMasterJapiSpecConfig)
-  with WordSpec with MustMatchers with BeforeAndAfterAll with ImplicitSender {
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll with ImplicitSender {
 
   import StatsSampleSingleMasterJapiSpecConfig._
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 
 import akka.actor.Props
@@ -47,7 +47,7 @@ class TransformationSampleSpecMultiJvmNode4 extends TransformationSampleSpec
 class TransformationSampleSpecMultiJvmNode5 extends TransformationSampleSpec
 
 abstract class TransformationSampleSpec extends MultiNodeSpec(TransformationSampleSpecConfig)
-  with WordSpec with MustMatchers with BeforeAndAfterAll with ImplicitSender {
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll with ImplicitSender {
 
   import TransformationSampleSpecConfig._
 

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/transformation/japi/TransformationSampleJapiSpec.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.WordSpec
+import org.scalatest.WordSpecLike
 import org.scalatest.matchers.MustMatchers
 
 import akka.actor.Props
@@ -49,7 +49,7 @@ class TransformationSampleJapiSpecMultiJvmNode4 extends TransformationSampleJapi
 class TransformationSampleJapiSpecMultiJvmNode5 extends TransformationSampleJapiSpec
 
 abstract class TransformationSampleJapiSpec extends MultiNodeSpec(TransformationSampleJapiSpecConfig)
-  with WordSpec with MustMatchers with BeforeAndAfterAll with ImplicitSender {
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll with ImplicitSender {
 
   import TransformationSampleJapiSpecConfig._
 

--- a/akka-samples/akka-sample-multi-node/src/test/scala/sample/multinode/STMultiNodeSpec.scala
+++ b/akka-samples/akka-sample-multi-node/src/test/scala/sample/multinode/STMultiNodeSpec.scala
@@ -5,7 +5,7 @@
 package sample.multinode
 
 //#imports
-import org.scalatest.{ BeforeAndAfterAll, WordSpec }
+import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
 import org.scalatest.matchers.MustMatchers
 import akka.remote.testkit.MultiNodeSpecCallbacks
 //#imports
@@ -15,7 +15,7 @@ import akka.remote.testkit.MultiNodeSpecCallbacks
  * Hooks up MultiNodeSpec with ScalaTest
  */
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
-  with WordSpec with MustMatchers with BeforeAndAfterAll {
+  with WordSpecLike with MustMatchers with BeforeAndAfterAll {
 
   override def beforeAll() = multiNodeSpecBeforeAll()
 

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -5,7 +5,7 @@ package akka.testkit
 
 import language.{ postfixOps, reflectiveCalls }
 
-import org.scalatest.{ WordSpec, BeforeAndAfterAll, Tag }
+import org.scalatest.{ WordSpecLike, BeforeAndAfterAll, Tag }
 import org.scalatest.matchers.MustMatchers
 import akka.actor.{ Actor, Props, ActorSystem, PoisonPill, DeadLetter, ActorSystemImpl }
 import akka.event.{ Logging, LoggingAdapter }
@@ -54,7 +54,7 @@ object AkkaSpec {
 }
 
 abstract class AkkaSpec(_system: ActorSystem)
-  extends TestKit(_system) with WordSpec with MustMatchers with BeforeAndAfterAll with WatchedByCoroner {
+  extends TestKit(_system) with WordSpecLike with MustMatchers with BeforeAndAfterAll with WatchedByCoroner {
 
   def this(config: Config) = this(ActorSystem(AkkaSpec.getCallerName(getClass),
     ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1035,7 +1035,7 @@ object Dependencies {
       val logback      = "ch.qos.logback"              % "logback-classic"              % "1.0.7"            % "test" // EPL 1.0 / LGPL 2.1
       val mockito      = "org.mockito"                 % "mockito-all"                  % "1.8.1"            % "test" // MIT
       // changing the scalatest dependency must be reflected in akka-docs/rst/dev/multi-jvm-testing.rst
-      val scalatest    = "org.scalatest"              %% "scalatest"                    % "1.9.1"            % "test" // ApacheV2
+      val scalatest    = "org.scalatest"              %% "scalatest"                    % "1.9.2-SNAP2"      % "test" // ApacheV2
       val scalacheck   = "org.scalacheck"             %% "scalacheck"                   % "1.10.0"           % "test" // New BSD
       val ariesProxy   = "org.apache.aries.proxy"      % "org.apache.aries.proxy.impl"  % "0.3"              % "test" // ApacheV2
       val pojosr       = "com.googlecode.pojosr"       % "de.kalpatec.pojosr.framework" % "0.1.4"            % "test" // ApacheV2


### PR DESCRIPTION
- This can't go into 2.2.x since ScalaTest 1.9.2-SNAP2 has source incompatible
  changes and the dependecy in akka-multi-node-node-testkit would force people
  to upgrade.
