### PR TITLE
!act Marked StashWhen* marker traits as internal API (backport)

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/sysmsg/SystemMessage.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/sysmsg/SystemMessage.scala
@@ -193,9 +193,15 @@ private[akka] sealed trait SystemMessage extends PossiblyHarmful with Serializab
   def unlinked: Boolean = next eq null
 }
 
-trait StashWhenWaitingForChildren
+/**
+ * INTERNAL API
+ */
+private[akka] trait StashWhenWaitingForChildren
 
-trait StashWhenFailed
+/**
+ * INTERNAL API
+ */
+private[akka] trait StashWhenFailed
 
 /**
  * INTERNAL API


### PR DESCRIPTION
(cherry picked from commit 8f57f12)
