### PR TITLE
=rem #3555: Wrong and superfluous match in EndpointWriter (backport)

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -545,13 +545,10 @@ private[remote] class EndpointWriter(
       unstashAll()
       goto(Writing)
 
-    case Event(Send(msg, senderOption, recipient, _), _) ⇒
+    case _ =>
       stash()
       stay()
 
-    case _: StopReading ⇒
-      stash()
-      stay()
   }
 
   whenUnhandled {


### PR DESCRIPTION
(cherry picked from commit 89a3454)
