### PR TITLE
=clu #3519 Cluster router should use provided supervisor strategy (backport)

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -52,7 +52,7 @@ final case class ClusterRouterConfig(local: RouterConfig, settings: ClusterRoute
     }: Route) orElse localRoute
   }
 
-  override def createActor(): Router = new ClusterRouterActor
+  override def createActor(): Router = new ClusterRouterActor(local.supervisorStrategy)
 
   override def supervisorStrategy: SupervisorStrategy = local.supervisorStrategy
 
@@ -269,7 +269,7 @@ private[akka] class ClusterRouteeProvider(
  * INTERNAL API
  * The router actor, subscribes to cluster events.
  */
-private[akka] class ClusterRouterActor extends Router {
+private[akka] class ClusterRouterActor(override val supervisorStrategy: SupervisorStrategy) extends Router {
 
   // re-subscribe when restart
   override def preStart(): Unit = {

--- a/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster.routing
+
+import akka.testkit._
+import akka.actor._
+import akka.routing.RoundRobinRouter
+import akka.cluster.routing.ClusterRouterConfig
+import akka.actor.OneForOneStrategy
+
+object ClusterRouterSupervisorSpec {
+
+  class KillableActor(testActor: ActorRef) extends Actor {
+
+    def receive = {
+      case "go away" ⇒
+        throw new IllegalArgumentException("Goodbye then!")
+    }
+
+  }
+
+}
+
+class ClusterRouterSupervisorSpec extends AkkaSpec("""
+  akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+  akka.remote.netty.tcp.port = 0
+""") {
+
+  import ClusterRouterSupervisorSpec._
+
+  "Cluster aware routers" must {
+
+    "use provided supervisor strategy" in {
+      val router = system.actorOf(Props(classOf[KillableActor], testActor).withRouter(
+        ClusterRouterConfig(RoundRobinRouter(supervisorStrategy = OneForOneStrategy() {
+          case _ ⇒
+            testActor ! "supervised"
+            SupervisorStrategy.Stop
+        }), ClusterRouterSettings(
+          totalInstances = 1,
+          maxInstancesPerNode = 1,
+          allowLocalRoutees = true,
+          useRole = None))), name = "therouter")
+
+      router ! "go away"
+      expectMsg("supervised")
+    }
+
+  }
+
+}


### PR DESCRIPTION
(cherry picked from commit 12989a9)
