### PR TITLE
+act #3529 Add convenience helper for looking up an actor by identity

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -146,6 +146,8 @@ object Patterns {
    * Register an onComplete callback on this [[scala.concurrent.Future]] to send
    * the result to the given [[akka.actor.ActorRef]] or [[akka.actor.ActorSelection]].
    * Returns the original Future to allow method chaining.
+   * If the future was completed with failure it is sent as a [[akka.actor.Status.Failure]]
+   * to the recipient.
    *
    * <b>Recommended usage example:</b>
    *

--- a/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
@@ -51,6 +51,9 @@ trait PipeToSupport {
    * pipe(someFuture) to nextActor
    *
    * }}}
+   *
+   * The successful result of the future is sent as a message to the recipient, or
+   * the failure is sent in a [[akka.actor.Status.Failure]] to the recipient.
    */
   implicit def pipe[T](future: Future[T])(implicit executionContext: ExecutionContext): PipeableFuture[T] = new PipeableFuture(future)
 }

--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -71,6 +71,8 @@ To acquire an :class:`ActorRef` for an :class:`ActorSelection` you need to
 send a message to the selection and use the ``getSender`` reference of the reply from
 the actor. There is a built-in ``Identify`` message that all Actors will understand
 and automatically reply to with a ``ActorIdentity`` message containing the
+:class:`ActorRef`. This can also be done with the ``resolveOne`` method of
+the :class:`ActorSelection`, which returns a ``Future`` of the matching
 :class:`ActorRef`.
 
 .. note::

--- a/akka-docs/rst/java/untyped-actors.rst
+++ b/akka-docs/rst/java/untyped-actors.rst
@@ -274,7 +274,9 @@ occupying it. ``ActorSelection`` cannot be watched for this reason. It is
 possible to resolve the current incarnation's ``ActorRef`` living under the
 path by sending an ``Identify`` message to the ``ActorSelection`` which
 will be replied to with an ``ActorIdentity`` containing the correct reference
-(see :ref:`actorSelection-java`).
+(see :ref:`actorSelection-java`). This can also be done with the ``resolveOne`` 
+method of the :class:`ActorSelection`, which returns a ``Future`` of the matching
+:class:`ActorRef`.
 
 .. _deathwatch-java:
 
@@ -426,6 +428,12 @@ of that reply is guaranteed, it still is a normal message.
 
 .. includecode:: code/docs/actor/UntypedActorDocTest.java
    :include: import-identify,identify
+
+You can also acquire an :class:`ActorRef` for an :class:`ActorSelection` with
+the ``resolveOne`` method of the :class:`ActorSelection`. It returns a ``Future`` 
+of the matching :class:`ActorRef` if such an actor exists. It is completed with 
+failure [[akka.actor.ActorNotFound]] if no such actor exists or the identification
+didn't complete within the supplied `timeout`.
 
 Remote actor addresses may also be looked up, if :ref:`remoting <remoting-java>` is enabled:
 

--- a/akka-docs/rst/project/migration-guide-2.1.x-2.2.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.1.x-2.2.x.rst
@@ -262,6 +262,12 @@ the actor. There is a built-in ``Identify`` message that all Actors will underst
 and automatically reply to with a ``ActorIdentity`` message containing the
 :class:`ActorRef`.
 
+You can also acquire an :class:`ActorRef` for an :class:`ActorSelection` with
+the ``resolveOne`` method of the :class:`ActorSelection`. It returns a ``Future`` 
+of the matching :class:`ActorRef` if such an actor exists. It is completed with 
+failure [[akka.actor.ActorNotFound]] if no such actor exists or the identification
+didn't complete within the supplied `timeout`.
+
 Read more about ``actorSelection`` in :ref:`docs for Java <actorSelection-java>` or
 :ref:`docs for Scala <actorSelection-scala>`.
 

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -363,7 +363,9 @@ occupying it. ``ActorSelection`` cannot be watched for this reason. It is
 possible to resolve the current incarnation's ``ActorRef`` living under the
 path by sending an ``Identify`` message to the ``ActorSelection`` which
 will be replied to with an ``ActorIdentity`` containing the correct reference
-(see :ref:`actorSelection-scala`).
+(see :ref:`actorSelection-scala`). This can also be done with the ``resolveOne`` 
+method of the :class:`ActorSelection`, which returns a ``Future`` of the matching
+:class:`ActorRef`.
 
 .. _deathwatch-scala:
 
@@ -509,6 +511,12 @@ negative result is generated. Please note that this does not mean that delivery
 of that reply is guaranteed, it still is a normal message.
 
 .. includecode:: code/docs/actor/ActorDocSpec.scala#identify
+
+You can also acquire an :class:`ActorRef` for an :class:`ActorSelection` with
+the ``resolveOne`` method of the :class:`ActorSelection`. It returns a ``Future`` 
+of the matching :class:`ActorRef` if such an actor exists. It is completed with 
+failure [[akka.actor.ActorNotFound]] if no such actor exists or the identification
+didn't complete within the supplied `timeout`.
 
 Remote actor addresses may also be looked up, if :ref:`remoting <remoting-scala>` is enabled:
 

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -78,6 +78,8 @@ To acquire an :class:`ActorRef` for an :class:`ActorSelection` you need to
 send a message to the selection and use the ``sender`` reference of the reply from
 the actor. There is a built-in ``Identify`` message that all Actors will understand
 and automatically reply to with a ``ActorIdentity`` message containing the
+:class:`ActorRef`. This can also be done with the ``resolveOne`` method of
+the :class:`ActorSelection`, which returns a ``Future`` of the matching
 :class:`ActorRef`.
 
 .. note::


### PR DESCRIPTION
- ActorSelection.resolveOne

Should be backported to 2.2.x
