### PR TITLE
=act Fix typo in scheduler error message (backport)

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -193,7 +193,7 @@ class LightArrayRevolverScheduler(config: Config,
   val TickDuration =
     Duration(config.getMilliseconds("akka.scheduler.tick-duration"), MILLISECONDS)
       .requiring(_ >= 10.millis || !Helpers.isWindows, "minimum supported akka.scheduler.tick-duration on Windows is 10ms")
-      .requiring(_ >= 1.millis, "minimum supported akka.scheduler.tick-duration is ms")
+      .requiring(_ >= 1.millis, "minimum supported akka.scheduler.tick-duration is 1ms")
   val ShutdownTimeout = Duration(config.getMilliseconds("akka.scheduler.shutdown-timeout"), MILLISECONDS)
 
   import LightArrayRevolverScheduler._


### PR DESCRIPTION
(cherry picked from commit 7dc2e052285938e452258e1a0e70a70ca26552d3)
