### PR TITLE
=tes #3563: Mark internal Testkit messages as NoSerializationVerificationNeeded (backport)

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -37,10 +37,10 @@ object TestActor {
     def run(sender: ActorRef, msg: Any): AutoPilot = sys.error("must not call")
   }
 
-  case class SetIgnore(i: Ignore)
-  case class Watch(ref: ActorRef)
-  case class UnWatch(ref: ActorRef)
-  case class SetAutoPilot(ap: AutoPilot)
+  case class SetIgnore(i: Ignore) extends NoSerializationVerificationNeeded
+  case class Watch(ref: ActorRef) extends NoSerializationVerificationNeeded
+  case class UnWatch(ref: ActorRef) extends NoSerializationVerificationNeeded
+  case class SetAutoPilot(ap: AutoPilot) extends NoSerializationVerificationNeeded
 
   trait Message {
     def msg: AnyRef


### PR DESCRIPTION
(cherry picked from commit c1928da)
