### PR TITLE
Optimize the gossip processing

### DIFF
--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -112,11 +112,8 @@ message Gossip {
  * Gossip Overview
  */
 message GossipOverview {
-  message Seen {
-    required int32 addressIndex = 1;
-    required VectorClock version = 2;
-  }
-  repeated Seen seen = 1;
+  /* This is the address indexes for the nodes that have seen this gossip */
+  repeated int32 seen = 1;
   repeated Member unreachable = 2;
 }
 

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -5,7 +5,6 @@
 package akka.cluster
 
 import scala.collection.immutable
-import scala.collection.immutable.TreeMap
 import MemberStatus._
 
 /**
@@ -80,11 +79,10 @@ private[cluster] case class Gossip(
         format (allowedLiveMemberStatus.mkString(", "),
           (members filter hasNotAllowedLiveMemberStatus).mkString(", ")))
 
-    val seenButNotMember = overview.seen.keySet -- members.map(_.uniqueAddress) -- overview.unreachable.map(_.uniqueAddress)
+    val seenButNotMember = overview.seen -- members.map(_.uniqueAddress) -- overview.unreachable.map(_.uniqueAddress)
     if (seenButNotMember.nonEmpty)
       throw new IllegalArgumentException("Nodes not part of cluster have marked the Gossip as seen, got [%s]"
         format seenButNotMember.mkString(", "))
-
   }
 
   /**
@@ -102,53 +100,34 @@ private[cluster] case class Gossip(
 
   /**
    * Marks the gossip as seen by this node (address) by updating the address entry in the 'gossip.overview.seen'
-   * Map with the VectorClock (version) for the new gossip.
    */
   def seen(node: UniqueAddress): Gossip = {
     if (seenByNode(node)) this
-    else this copy (overview = overview copy (seen = overview.seen + (node -> version)))
+    else this copy (overview = overview copy (seen = overview.seen + node))
+  }
+
+  /**
+   * Marks the gossip as seen by only this node (address) by replacing the 'gossip.overview.seen'
+   */
+  def onlySeen(node: UniqueAddress): Gossip = {
+    this copy (overview = overview copy (seen = Set(node)))
   }
 
   /**
    * The nodes that have seen current version of the Gossip.
    */
-  def seenBy: Set[UniqueAddress] = {
-    overview.seen.collect {
-      case (node, vclock) if vclock == version ⇒ node
-    }.toSet
-  }
+  def seenBy: Set[UniqueAddress] = overview.seen
 
   /**
    * Has this Gossip been seen by this node.
    */
-  def seenByNode(node: UniqueAddress): Boolean = {
-    overview.seen.get(node).exists(_ == version)
-  }
-
-  private def mergeSeenTables(allowed: immutable.SortedSet[Member],
-                              one: TreeMap[UniqueAddress, VectorClock],
-                              another: TreeMap[UniqueAddress, VectorClock]): TreeMap[UniqueAddress, VectorClock] =
-    (TreeMap.empty[UniqueAddress, VectorClock] /: allowed) {
-      (merged, member) ⇒
-        val node = member.uniqueAddress
-        (one.get(node), another.get(node)) match {
-          case (None, None)     ⇒ merged
-          case (Some(v1), None) ⇒ merged.updated(node, v1)
-          case (None, Some(v2)) ⇒ merged.updated(node, v2)
-          case (Some(v1), Some(v2)) ⇒
-            v1 compareTo v2 match {
-              case VectorClock.Same | VectorClock.After ⇒ merged.updated(node, v1)
-              case VectorClock.Before                   ⇒ merged.updated(node, v2)
-              case VectorClock.Concurrent               ⇒ merged
-            }
-        }
-    }
+  def seenByNode(node: UniqueAddress): Boolean = overview.seen(node)
 
   /**
    * Merges the seen table of two Gossip instances.
    */
   def mergeSeen(that: Gossip): Gossip =
-    this copy (overview = overview copy (seen = mergeSeenTables(members, overview.seen, that.overview.seen)))
+    this copy (overview = overview copy (seen = overview.seen ++ that.overview.seen))
 
   /**
    * Merges two Gossip instances including membership tables, and the VectorClock histories.
@@ -166,8 +145,8 @@ private[cluster] case class Gossip(
     //    and exclude unreachable
     val mergedMembers = Gossip.emptyMembers ++ Member.pickHighestPriority(this.members, that.members).filterNot(mergedUnreachable.contains)
 
-    // 4. merge seen table
-    val mergedSeen = mergeSeenTables(mergedMembers, overview.seen, that.overview.seen)
+    // 4. Nobody can have seen this new gossip yet
+    val mergedSeen = Set.empty[UniqueAddress]
 
     Gossip(mergedMembers, GossipOverview(mergedSeen, mergedUnreachable), mergedVClock)
   }
@@ -237,7 +216,7 @@ private[cluster] case class Gossip(
  */
 @SerialVersionUID(1L)
 private[cluster] case class GossipOverview(
-  seen: TreeMap[UniqueAddress, VectorClock] = TreeMap.empty,
+  seen: Set[UniqueAddress] = Set.empty,
   unreachable: Set[Member] = Set.empty) {
 
   override def toString =

--- a/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
@@ -10,6 +10,7 @@ import System.{ currentTimeMillis ⇒ newTimestamp }
 import java.security.MessageDigest
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.immutable.TreeMap
+import scala.annotation.tailrec
 
 /**
  * VectorClock module with helper classes and methods.
@@ -98,22 +99,84 @@ case class VectorClock(
   /**
    * Returns true if <code>this</code> and <code>that</code> are concurrent else false.
    */
-  def <>(that: VectorClock): Boolean = compareTo(that) == Concurrent
+  def <>(that: VectorClock): Boolean = compareTo(that) eq Concurrent
 
   /**
    * Returns true if <code>this</code> is before <code>that</code> else false.
    */
-  def <(that: VectorClock): Boolean = compareTo(that) == Before
+  def <(that: VectorClock): Boolean = compareOnlyTo(that, Before) eq Before
 
   /**
    * Returns true if <code>this</code> is after <code>that</code> else false.
    */
-  def >(that: VectorClock): Boolean = compareTo(that) == After
+  def >(that: VectorClock): Boolean = compareOnlyTo(that, After) eq After
 
   /**
    * Returns true if this VectorClock has the same history as the 'that' VectorClock else false.
    */
-  def ==(that: VectorClock): Boolean = versions == that.versions
+  def ==(that: VectorClock): Boolean = compareOnlyTo(that, Same) eq Same
+
+  /**
+   * Marker to ensure that we do a full order comparison instead of bailing out early.
+   */
+  private case object FullOrder extends Ordering
+
+  /**
+   * Marker to signal that we have reached the end of a vector clock.
+   */
+  private val cmpEndMarker = (VectorClock.Node("endmarker"), Timestamp(Int.MinValue))
+
+  /**
+   * Vector clock comparison according to the semantics described by compareTo, with the ability to bail
+   * out early if the we can't reach the Ordering that we are looking for.
+   *
+   * If you send in the ordering FullOrder, you will get a full comparison.
+   */
+  private final def compareOnlyTo(that: VectorClock, ordering: Ordering): Ordering = {
+    def nextOrElse[T](iter: Iterator[T], default: T): T = if (iter.hasNext) iter.next() else default
+
+    def compare(i1: Iterator[(Node, Timestamp)], i2: Iterator[(Node, Timestamp)]): Ordering = {
+      @tailrec
+      def compareNext(nt1: (Node, Timestamp), nt2: (Node, Timestamp), order: Ordering): Ordering =
+        if ((ordering ne FullOrder) && (order ne Same) && (order ne ordering)) order
+        else if ((nt1 eq cmpEndMarker) && (nt2 eq cmpEndMarker)) order
+        // i1 is empty but i2 is not, so i1 can only be Before
+        else if (nt1 eq cmpEndMarker) { if (order eq After) Concurrent else Before }
+        // i2 is empty but i1 is not, so i1 can only be After
+        else if (nt2 eq cmpEndMarker) { if (order eq Before) Concurrent else After }
+        else {
+          val nc = nt1._1 compareTo nt2._1
+          if (nc == 0) {
+            // both nodes exist compare them
+            val tc = nt1._2 compareTo nt2._2
+            // same timestamp so just continue with the next nodes
+            if (tc == 0) compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), order)
+            else if (tc < 0) {
+              // t1 is less than t2, so i1 can only be Before
+              if (order == After) Concurrent
+              else compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), Before)
+            } else {
+              // t2 is less than t1, so i1 can only be After
+              if (order == Before) Concurrent
+              compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), After)
+            }
+          } else if (nc < 0) {
+            // this node only exists in i1 so i1 can only be After
+            if (order eq Before) Concurrent
+            else compareNext(nextOrElse(i1, cmpEndMarker), nt2, After)
+          } else {
+            // this node only exists in i2 so i1 can only be Before
+            if (order eq After) Concurrent
+            else compareNext(nt1, nextOrElse(i2, cmpEndMarker), Before)
+          }
+        }
+
+      compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), Same)
+    }
+
+    if ((this eq that) || (this.versions eq that.versions)) Same
+    else compare(this.versions.iterator, that.versions.iterator)
+  }
 
   /**
    * Compare two vector clocks. The outcome will be one of the following:
@@ -126,14 +189,7 @@ case class VectorClock(
    * }}}
    */
   def compareTo(that: VectorClock): Ordering = {
-    def olderOrSameIn(version: Pair[Node, Timestamp], versions: Map[Node, Timestamp]): Boolean = {
-      version match { case (n, t) ⇒ t <= versions(n) }
-    }
-
-    if (versions == that.versions) Same
-    else if (versions.forall(olderOrSameIn(_, that.versions.withDefaultValue(Timestamp.zero)))) Before
-    else if (that.versions.forall(olderOrSameIn(_, versions.withDefaultValue(Timestamp.zero)))) After
-    else Concurrent
+    compareOnlyTo(that, FullOrder)
   }
 
   /**

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -144,8 +144,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     val addressMapping = allAddresses.zipWithIndex.toMap
     val allRoles = allMembers.foldLeft(Set.empty[String])((acc, m) ⇒ acc ++ m.roles).to[Vector]
     val roleMapping = allRoles.zipWithIndex.toMap
-    val allHashes = gossip.overview.seen.values.foldLeft(gossip.version.versions.keys.toSet)(
-      { case (s, VectorClock(v)) ⇒ s ++ v.keys }).to[Vector]
+    val allHashes = gossip.version.versions.keys.to[Vector]
     val hashMapping = allHashes.zipWithIndex.toMap
 
     def mapUniqueAddress(uniqueAddress: UniqueAddress) = mapWithErrorMessage(addressMapping, uniqueAddress, "address")
@@ -155,14 +154,13 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
       msg.Member(mapUniqueAddress(member.uniqueAddress), member.upNumber,
         msg.MemberStatus.valueOf(memberStatusToInt(member.status)), member.roles.map(mapRole)(breakOut))
 
-    def seenToProto(seen: (UniqueAddress, VectorClock)) = {
-      val (address, version) = seen
-      msg.GossipOverview.Seen(mapUniqueAddress(address), vectorClockToProto(version, hashMapping))
+    def seenToProto(address: UniqueAddress) = {
+      mapUniqueAddress(address)
     }
 
     val unreachable: Vector[msg.Member] = gossip.overview.unreachable.map(memberToProto)(breakOut)
     val members: Vector[msg.Member] = gossip.members.map(memberToProto)(breakOut)
-    val seen: Vector[msg.GossipOverview.Seen] = gossip.overview.seen.map(seenToProto)(breakOut)
+    val seen: Vector[Int] = gossip.overview.seen.map(seenToProto)(breakOut)
 
     val overview = msg.GossipOverview(seen, unreachable)
 
@@ -202,12 +200,11 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
       new Member(addressMapping(member.addressIndex), member.upNumber, memberStatusFromInt(member.status.id),
         member.rolesIndexes.map(roleMapping)(breakOut))
 
-    def seenFromProto(seen: msg.GossipOverview.Seen) =
-      (addressMapping(seen.addressIndex), vectorClockFromProto(seen.version, hashMapping))
+    def seenFromProto(seen: Int) = addressMapping(seen)
 
     val members: immutable.SortedSet[Member] = gossip.members.map(memberFromProto)(breakOut)
     val unreachable: immutable.Set[Member] = gossip.overview.unreachable.map(memberFromProto)(breakOut)
-    val seen: immutable.TreeMap[UniqueAddress, VectorClock] = gossip.overview.seen.map(seenFromProto)(breakOut)
+    val seen: Set[UniqueAddress] = gossip.overview.seen.map(seenFromProto)(breakOut)
     val overview = GossipOverview(seen, unreachable)
 
     Gossip(members, overview, vectorClockFromProto(gossip.version, hashMapping))

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -105,17 +105,14 @@ class GossipSpec extends WordSpec with MustMatchers {
       val g3 = (g1 copy (version = g2.version)).seen(d1.uniqueAddress)
 
       def checkMerged(merged: Gossip) {
-        val keys = merged.overview.seen.keys.toSeq
-        keys.length must be(4)
-        keys.toSet must be(Set(a1.uniqueAddress, b1.uniqueAddress, c1.uniqueAddress, d1.uniqueAddress))
+        val seen = merged.overview.seen.toSeq
+        seen.length must be(0)
 
-        merged seenByNode (a1.uniqueAddress) must be(true)
+        merged seenByNode (a1.uniqueAddress) must be(false)
         merged seenByNode (b1.uniqueAddress) must be(false)
-        merged seenByNode (c1.uniqueAddress) must be(true)
-        merged seenByNode (d1.uniqueAddress) must be(true)
+        merged seenByNode (c1.uniqueAddress) must be(false)
+        merged seenByNode (d1.uniqueAddress) must be(false)
         merged seenByNode (e1.uniqueAddress) must be(false)
-
-        merged.overview.seen(b1.uniqueAddress) must be(g1.version)
       }
 
       checkMerged(g3 merge g2)

--- a/akka-cluster/src/test/scala/akka/cluster/VectorClockPerfSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/VectorClockPerfSpec.scala
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.cluster
+
+import akka.testkit.AkkaSpec
+import scala.collection.immutable.{ TreeMap, SortedSet }
+import org.scalatest.WordSpec
+import org.scalatest.matchers.ShouldMatchers
+
+object VectorClockPerfSpec {
+  import VectorClock._
+
+  def createVectorClockOfSize(size: Int): (VectorClock, SortedSet[Node]) =
+    ((VectorClock(), SortedSet.empty[Node]) /: (1 to size)) {
+      case ((vc, nodes), i) ⇒
+        val node = Node(i.toString)
+        (vc :+ node, nodes + node)
+    }
+
+  def copyVectorClock(vc: VectorClock): VectorClock = {
+    val versions = (TreeMap.empty[Node, Timestamp] /: vc.versions) {
+      case (versions, (n, t)) ⇒ versions.updated(Node.fromHash(n), Timestamp(t.time))
+    }
+    vc.copy(versions = versions)
+  }
+
+}
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class VectorClockPerfSpec extends WordSpec with ShouldMatchers {
+  import VectorClock._
+  import VectorClockPerfSpec._
+
+  val clockSize = sys.props.get("akka.cluster.VectorClockPerfSpec.clockSize").getOrElse("1000").toInt
+  val iterations = sys.props.get("akka.cluster.VectorClockPerfSpec.iterations").getOrElse("10000").toInt
+
+  val (vcBefore, nodes) = createVectorClockOfSize(clockSize)
+  val firstNode = nodes.head
+  val lastNode = nodes.last
+  val middleNode = nodes.drop(clockSize / 2).head
+  val vcBaseLast = vcBefore :+ lastNode
+  val vcAfterLast = vcBaseLast :+ firstNode
+  val vcConcurrentLast = vcBefore :+ lastNode
+  val vcBaseMiddle = vcBefore :+ middleNode
+  val vcAfterMiddle = vcBaseMiddle :+ firstNode
+  val vcConcurrentMiddle = vcBefore :+ middleNode
+
+  def checkThunkFor(vc1: VectorClock, vc2: VectorClock, thunk: (VectorClock, VectorClock) ⇒ Unit, times: Int): Unit = {
+    val vcc1 = copyVectorClock(vc1)
+    val vcc2 = copyVectorClock(vc2)
+    for (i ← 1 to times) {
+      thunk(vcc1, vcc2)
+    }
+  }
+
+  def compareTo(order: Ordering)(vc1: VectorClock, vc2: VectorClock): Unit = {
+    vc1 compareTo vc2 should be(order)
+  }
+
+  def !==(vc1: VectorClock, vc2: VectorClock): Unit = {
+    vc1 == vc2 should be(false)
+  }
+
+  s"VectorClock comparisons of size $clockSize" must {
+
+    s"do a warm up run $iterations times" in {
+      checkThunkFor(vcBaseLast, vcBaseLast, compareTo(Same), iterations)
+    }
+
+    s"compare Same a $iterations times" in {
+      checkThunkFor(vcBaseLast, vcBaseLast, compareTo(Same), iterations)
+    }
+
+    s"compare Before (last) $iterations times" in {
+      checkThunkFor(vcBefore, vcBaseLast, compareTo(Before), iterations)
+    }
+
+    s"compare After (last) $iterations times" in {
+      checkThunkFor(vcAfterLast, vcBaseLast, compareTo(After), iterations)
+    }
+
+    s"compare Concurrent (last) $iterations times" in {
+      checkThunkFor(vcAfterLast, vcConcurrentLast, compareTo(Concurrent), iterations)
+    }
+
+    s"compare Before (middle) $iterations times" in {
+      checkThunkFor(vcBefore, vcBaseMiddle, compareTo(Before), iterations)
+    }
+
+    s"compare After (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcBaseMiddle, compareTo(After), iterations)
+    }
+
+    s"compare Concurrent (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcConcurrentMiddle, compareTo(Concurrent), iterations)
+    }
+
+    s"compare !== Before (middle) $iterations times" in {
+      checkThunkFor(vcBefore, vcBaseMiddle, !==, iterations)
+    }
+
+    s"compare !== After (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcBaseMiddle, !==, iterations)
+    }
+
+    s"compare !== Concurrent (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcConcurrentMiddle, !==, iterations)
+    }
+
+  }
+}


### PR DESCRIPTION
This pull contains two commits
- =clu Optimize the vector clock comparison
- !clu Convert the seen table into something more efficient

The first one cuts the normal vector clock comparison time roughly in half
(it's backwards compatible).

The second exploits the fact that we only care about who has seen this exact
gossip version and does away with the mapping between nodes and the gossip version
that they have seen for a set of nodes which have seen this exact gossip version.
The gossip processing for the normal case (same gossip) drops from ~7ms to sub ms for
a 100 node cluster. The only thing that takes any time now is the merging of vector clocks
when you have a gossip conflict(which is rare), but that's still in the 2ms range for a
100 node cluster.
