### PR TITLE
=rem #3566 Fix failing RemoteNodeRestartDeathWatchSpec

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Props.scala
+++ b/akka-actor/src/main/scala/akka/actor/Props.scala
@@ -78,7 +78,7 @@ object Props {
    * {{{
    * 'Props(new Actor with Stash { ... })
    * }}}
-   * Instead you must create a named class that mixin the trait, 
+   * Instead you must create a named class that mixin the trait,
    * e.g. `class MyActor extends Actor with Stash`.
    */
   def apply[T <: Actor: ClassTag](creator: ⇒ T): Props =

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeRestartDeathWatchSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeRestartDeathWatchSpec.scala
@@ -82,8 +82,13 @@ abstract class RemoteNodeRestartDeathWatchSpec
 
         expectTerminated(subject, 15.seconds)
 
-        system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! "shutdown"
-        expectMsg("shutdown-ack")
+        within(5.seconds) {
+          // retry because the Subject actor might not be started yet
+          awaitAssert {
+            system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! "shutdown"
+            expectMsg(1.second, "shutdown-ack")
+          }
+        }
       }
 
       runOn(second) {


### PR DESCRIPTION
I'm not completely sure that I have nailed it, but I will run this branch in a repeat job.
First I suspected that the "shutdown-ack" was never delivered, but from the logs I can see that the system is not shutdown. No trace of "Shutting down remote daemon". That means that it is the "shutdown" message that is not delivered, and therefore this retry-until-successful.
