### PR TITLE
=clu #3442 Optimize the vector clock comparison

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
@@ -10,6 +10,7 @@ import System.{ currentTimeMillis ⇒ newTimestamp }
 import java.security.MessageDigest
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.immutable.TreeMap
+import scala.annotation.tailrec
 
 /**
  * VectorClock module with helper classes and methods.
@@ -72,6 +73,16 @@ private[cluster] object VectorClock {
   case object Before extends Ordering
   case object Same extends Ordering
   case object Concurrent extends Ordering
+  /**
+   * Marker to ensure that we do a full order comparison instead of bailing out early.
+   */
+  private case object FullOrder extends Ordering
+
+  /**
+   * Marker to signal that we have reached the end of a vector clock.
+   */
+  private val cmpEndMarker = (VectorClock.Node("endmarker"), Timestamp(Int.MinValue))
+
 }
 
 /**
@@ -98,22 +109,80 @@ case class VectorClock(
   /**
    * Returns true if <code>this</code> and <code>that</code> are concurrent else false.
    */
-  def <>(that: VectorClock): Boolean = compareTo(that) == Concurrent
+  def <>(that: VectorClock): Boolean = compareOnlyTo(that, Concurrent) eq Concurrent
 
   /**
    * Returns true if <code>this</code> is before <code>that</code> else false.
    */
-  def <(that: VectorClock): Boolean = compareTo(that) == Before
+  def <(that: VectorClock): Boolean = compareOnlyTo(that, Before) eq Before
 
   /**
    * Returns true if <code>this</code> is after <code>that</code> else false.
    */
-  def >(that: VectorClock): Boolean = compareTo(that) == After
+  def >(that: VectorClock): Boolean = compareOnlyTo(that, After) eq After
 
   /**
    * Returns true if this VectorClock has the same history as the 'that' VectorClock else false.
    */
-  def ==(that: VectorClock): Boolean = versions == that.versions
+  def ==(that: VectorClock): Boolean = compareOnlyTo(that, Same) eq Same
+
+  /**
+   * Vector clock comparison according to the semantics described by compareTo, with the ability to bail
+   * out early if the we can't reach the Ordering that we are looking for.
+   *
+   * The ordering always starts with Same and can then go to Same, Before or After
+   * If we're on After we can only go to After or Concurrent
+   * If we're on Before we can only go to Before or Concurrent
+   * If we go to Concurrent we exit the loop immediately
+   *
+   * If you send in the ordering FullOrder, you will get a full comparison.
+   */
+  private final def compareOnlyTo(that: VectorClock, order: Ordering): Ordering = {
+    def nextOrElse[T](iter: Iterator[T], default: T): T = if (iter.hasNext) iter.next() else default
+
+    def compare(i1: Iterator[(Node, Timestamp)], i2: Iterator[(Node, Timestamp)], requestedOrder: Ordering): Ordering = {
+      @tailrec
+      def compareNext(nt1: (Node, Timestamp), nt2: (Node, Timestamp), currentOrder: Ordering): Ordering =
+        if ((requestedOrder ne FullOrder) && (currentOrder ne Same) && (currentOrder ne requestedOrder)) currentOrder
+        else if ((nt1 eq cmpEndMarker) && (nt2 eq cmpEndMarker)) currentOrder
+        // i1 is empty but i2 is not, so i1 can only be Before
+        else if (nt1 eq cmpEndMarker) { if (currentOrder eq After) Concurrent else Before }
+        // i2 is empty but i1 is not, so i1 can only be After
+        else if (nt2 eq cmpEndMarker) { if (currentOrder eq Before) Concurrent else After }
+        else {
+          // compare the nodes
+          val nc = nt1._1 compareTo nt2._1
+          if (nc == 0) {
+            // both nodes exist compare the timestamps
+            val tc = nt1._2 compareTo nt2._2
+            // same timestamp so just continue with the next nodes
+            if (tc == 0) compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), currentOrder)
+            else if (tc < 0) {
+              // t1 is less than t2, so i1 can only be Before
+              if (currentOrder eq After) Concurrent
+              else compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), Before)
+            } else {
+              // t2 is less than t1, so i1 can only be After
+              if (currentOrder eq Before) Concurrent
+              else compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), After)
+            }
+          } else if (nc < 0) {
+            // this node only exists in i1 so i1 can only be After
+            if (currentOrder eq Before) Concurrent
+            else compareNext(nextOrElse(i1, cmpEndMarker), nt2, After)
+          } else {
+            // this node only exists in i2 so i1 can only be Before
+            if (currentOrder eq After) Concurrent
+            else compareNext(nt1, nextOrElse(i2, cmpEndMarker), Before)
+          }
+        }
+
+      compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), Same)
+    }
+
+    if ((this eq that) || (this.versions eq that.versions)) Same
+    else compare(this.versions.iterator, that.versions.iterator, if (order eq Concurrent) FullOrder else order)
+  }
 
   /**
    * Compare two vector clocks. The outcome will be one of the following:
@@ -126,14 +195,7 @@ case class VectorClock(
    * }}}
    */
   def compareTo(that: VectorClock): Ordering = {
-    def olderOrSameIn(version: Pair[Node, Timestamp], versions: Map[Node, Timestamp]): Boolean = {
-      version match { case (n, t) ⇒ t <= versions(n) }
-    }
-
-    if (versions == that.versions) Same
-    else if (versions.forall(olderOrSameIn(_, that.versions.withDefaultValue(Timestamp.zero)))) Before
-    else if (that.versions.forall(olderOrSameIn(_, versions.withDefaultValue(Timestamp.zero)))) After
-    else Concurrent
+    compareOnlyTo(that, FullOrder)
   }
 
   /**

--- a/akka-cluster/src/test/scala/akka/cluster/VectorClockPerfSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/VectorClockPerfSpec.scala
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.cluster
+
+import akka.testkit.AkkaSpec
+import scala.collection.immutable.{ TreeMap, SortedSet }
+import org.scalatest.WordSpec
+import org.scalatest.matchers.ShouldMatchers
+
+object VectorClockPerfSpec {
+  import VectorClock._
+
+  def createVectorClockOfSize(size: Int): (VectorClock, SortedSet[Node]) =
+    ((VectorClock(), SortedSet.empty[Node]) /: (1 to size)) {
+      case ((vc, nodes), i) ⇒
+        val node = Node(i.toString)
+        (vc :+ node, nodes + node)
+    }
+
+  def copyVectorClock(vc: VectorClock): VectorClock = {
+    val versions = (TreeMap.empty[Node, Timestamp] /: vc.versions) {
+      case (versions, (n, t)) ⇒ versions.updated(Node.fromHash(n), Timestamp(t.time))
+    }
+    vc.copy(versions = versions)
+  }
+
+}
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class VectorClockPerfSpec extends WordSpec with ShouldMatchers {
+  import VectorClock._
+  import VectorClockPerfSpec._
+
+  val clockSize = sys.props.get("akka.cluster.VectorClockPerfSpec.clockSize").getOrElse("1000").toInt
+  val iterations = sys.props.get("akka.cluster.VectorClockPerfSpec.iterations").getOrElse("10000").toInt
+
+  val (vcBefore, nodes) = createVectorClockOfSize(clockSize)
+  val firstNode = nodes.head
+  val lastNode = nodes.last
+  val middleNode = nodes.drop(clockSize / 2).head
+  val vcBaseLast = vcBefore :+ lastNode
+  val vcAfterLast = vcBaseLast :+ firstNode
+  val vcConcurrentLast = vcBefore :+ lastNode
+  val vcBaseMiddle = vcBefore :+ middleNode
+  val vcAfterMiddle = vcBaseMiddle :+ firstNode
+  val vcConcurrentMiddle = vcBefore :+ middleNode
+
+  def checkThunkFor(vc1: VectorClock, vc2: VectorClock, thunk: (VectorClock, VectorClock) ⇒ Unit, times: Int): Unit = {
+    val vcc1 = copyVectorClock(vc1)
+    val vcc2 = copyVectorClock(vc2)
+    for (i ← 1 to times) {
+      thunk(vcc1, vcc2)
+    }
+  }
+
+  def compareTo(order: Ordering)(vc1: VectorClock, vc2: VectorClock): Unit = {
+    vc1 compareTo vc2 should be(order)
+  }
+
+  def !==(vc1: VectorClock, vc2: VectorClock): Unit = {
+    vc1 == vc2 should be(false)
+  }
+
+  s"VectorClock comparisons of size $clockSize" must {
+
+    s"do a warm up run $iterations times" in {
+      checkThunkFor(vcBaseLast, vcBaseLast, compareTo(Same), iterations)
+    }
+
+    s"compare Same a $iterations times" in {
+      checkThunkFor(vcBaseLast, vcBaseLast, compareTo(Same), iterations)
+    }
+
+    s"compare Before (last) $iterations times" in {
+      checkThunkFor(vcBefore, vcBaseLast, compareTo(Before), iterations)
+    }
+
+    s"compare After (last) $iterations times" in {
+      checkThunkFor(vcAfterLast, vcBaseLast, compareTo(After), iterations)
+    }
+
+    s"compare Concurrent (last) $iterations times" in {
+      checkThunkFor(vcAfterLast, vcConcurrentLast, compareTo(Concurrent), iterations)
+    }
+
+    s"compare Before (middle) $iterations times" in {
+      checkThunkFor(vcBefore, vcBaseMiddle, compareTo(Before), iterations)
+    }
+
+    s"compare After (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcBaseMiddle, compareTo(After), iterations)
+    }
+
+    s"compare Concurrent (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcConcurrentMiddle, compareTo(Concurrent), iterations)
+    }
+
+    s"compare !== Before (middle) $iterations times" in {
+      checkThunkFor(vcBefore, vcBaseMiddle, !==, iterations)
+    }
+
+    s"compare !== After (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcBaseMiddle, !==, iterations)
+    }
+
+    s"compare !== Concurrent (middle) $iterations times" in {
+      checkThunkFor(vcAfterMiddle, vcConcurrentMiddle, !==, iterations)
+    }
+
+  }
+}

--- a/akka-cluster/src/test/scala/akka/cluster/VectorClockSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/VectorClockSpec.scala
@@ -4,9 +4,7 @@
 
 package akka.cluster
 
-import java.net.InetSocketAddress
 import akka.testkit.AkkaSpec
-import akka.actor.ActorSystem
 
 class VectorClockSpec extends AkkaSpec {
   import VectorClock._
@@ -119,6 +117,19 @@ class VectorClockSpec extends AkkaSpec {
 
       clock5_1 <> clock3_2 must be(true)
       clock3_2 <> clock5_1 must be(true)
+    }
+
+    "pass misc comparison test 8" in {
+      val clock1_1 = VectorClock()
+      val clock2_1 = clock1_1 :+ Node.fromHash("1")
+      val clock3_1 = clock2_1 :+ Node.fromHash("3")
+
+      val clock1_2 = clock3_1 :+ Node.fromHash("2")
+
+      val clock4_1 = clock3_1 :+ Node.fromHash("3")
+
+      clock4_1 <> clock1_2 must be(true)
+      clock1_2 <> clock4_1 must be(true)
     }
 
     "correctly merge two clocks" in {


### PR DESCRIPTION
- This is the vector clock part of pull #1699 that has been broken out.
- It has the original commit and aseparate commit with updates according to review comments including the fix for the bug I found while updating.
- It has successfully run the multinode tests with assertion comparisons against the old code since yesterday (16 runs).
