### PR TITLE
!clu #2320 Convert the seen table into something more efficient

### DIFF
--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -112,11 +112,8 @@ message Gossip {
  * Gossip Overview
  */
 message GossipOverview {
-  message Seen {
-    required int32 addressIndex = 1;
-    required VectorClock version = 2;
-  }
-  repeated Seen seen = 1;
+  /* This is the address indexes for the nodes that have seen this gossip */
+  repeated int32 seen = 1;
   repeated Member unreachable = 2;
 }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -14,6 +14,7 @@ import akka.actor.SupervisorStrategy.Stop
 import akka.cluster.MemberStatus._
 import akka.cluster.ClusterEvent._
 import akka.dispatch.{ UnboundedMessageQueueSemantics, RequiresMessageQueue }
+import scala.collection.breakOut
 
 /**
  * Base trait for all cluster messages. All ClusterMessage's are serializable.
@@ -593,9 +594,6 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
       val comparison = remoteGossip.version compareTo localGossip.version
 
       val (winningGossip, talkback, gossipType) = comparison match {
-        case VectorClock.Concurrent ⇒
-          // conflicting versions, merge
-          (remoteGossip merge localGossip, true, Merge)
         case VectorClock.Same ⇒
           // same version
           (remoteGossip mergeSeen localGossip, !remoteGossip.seenByNode(selfUniqueAddress), Same)
@@ -605,6 +603,9 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
         case VectorClock.After ⇒
           // remote is newer
           (remoteGossip, !remoteGossip.seenByNode(selfUniqueAddress), Newer)
+        case _ ⇒
+          // conflicting versions, merge
+          (remoteGossip merge localGossip, true, Merge)
       }
 
       latestGossip = winningGossip seen selfUniqueAddress
@@ -657,15 +658,8 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
 
       val preferredGossipTargets: Vector[UniqueAddress] =
         if (ThreadLocalRandom.current.nextDouble() < GossipDifferentViewProbability) { // If it's time to try to gossip to some nodes with a different view
-          // gossip to a random alive member with preference to a member with older or newer gossip version
-          val localMemberAddressesSet = localGossip.members map { _.uniqueAddress }
-          val nodesWithDifferentView = for {
-            (node, version) ← localGossip.overview.seen
-            if localMemberAddressesSet contains node
-            if version != localGossip.version
-          } yield node
-
-          nodesWithDifferentView.toVector
+          // gossip to a random alive member with preference to a member with older gossip version
+          localGossip.members.collect { case m if !localGossip.seenByNode(m.uniqueAddress) ⇒ m.uniqueAddress }(breakOut)
         } else Vector.empty[UniqueAddress]
 
       if (preferredGossipTargets.nonEmpty) {
@@ -917,8 +911,8 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
   def updateLatestGossip(newGossip: Gossip): Unit = {
     // Updating the vclock version for the changes
     val versionedGossip = newGossip :+ vclockNode
-    // Updating the `seen` table
-    val seenVersionedGossip = versionedGossip seen selfUniqueAddress
+    // Nobody else have seen this gossip but us
+    val seenVersionedGossip = versionedGossip onlySeen (selfUniqueAddress)
     // Update the state with the new gossip
     latestGossip = seenVersionedGossip
   }

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -105,17 +105,14 @@ class GossipSpec extends WordSpec with MustMatchers {
       val g3 = (g1 copy (version = g2.version)).seen(d1.uniqueAddress)
 
       def checkMerged(merged: Gossip) {
-        val keys = merged.overview.seen.keys.toSeq
-        keys.length must be(4)
-        keys.toSet must be(Set(a1.uniqueAddress, b1.uniqueAddress, c1.uniqueAddress, d1.uniqueAddress))
+        val seen = merged.overview.seen.toSeq
+        seen.length must be(0)
 
-        merged seenByNode (a1.uniqueAddress) must be(true)
+        merged seenByNode (a1.uniqueAddress) must be(false)
         merged seenByNode (b1.uniqueAddress) must be(false)
-        merged seenByNode (c1.uniqueAddress) must be(true)
-        merged seenByNode (d1.uniqueAddress) must be(true)
+        merged seenByNode (c1.uniqueAddress) must be(false)
+        merged seenByNode (d1.uniqueAddress) must be(false)
         merged seenByNode (e1.uniqueAddress) must be(false)
-
-        merged.overview.seen(b1.uniqueAddress) must be(g1.version)
       }
 
       checkMerged(g3 merge g2)


### PR DESCRIPTION
- This is the seen table part of pull #1699 that has been broken out.
- It has the original commit and a separate commit with updates according to review comments.
- It is currently running the multi node tests on a repeat job.
