### PR TITLE
!act #3581 Add Tcp.CompoundWrite, some cleanup

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -32,13 +32,13 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   import tcp.bufferPool
   import TcpConnection._
 
-  private[this] var pendingWrite: PendingWrite = _
+  private[this] var pendingWrite: PendingWrite = EmptyPendingWrite
   private[this] var peerClosed = false
   private[this] var writingSuspended = false
   private[this] var interestedInResume: Option[ActorRef] = None
   var closedMessage: CloseInformation = _ // for ConnectionClosed message in postStop
 
-  def writePending = pendingWrite ne null
+  def writePending = pendingWrite ne EmptyPendingWrite
 
   // STATES
 
@@ -95,11 +95,15 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
       doWrite(info)
       if (!writePending) // writing is now finished
         handleClose(info, closeCommander, closedEvent)
-    case SendBufferFull(remaining) ⇒ { pendingWrite = remaining; info.registration.enableInterest(OP_WRITE) }
-    case WriteFileFinished         ⇒ { pendingWrite = null; handleClose(info, closeCommander, closedEvent) }
-    case WriteFileFailed(e)        ⇒ handleError(info.handler, e) // rethrow exception from dispatcher task
 
-    case Abort                     ⇒ handleClose(info, Some(sender), Aborted)
+    case UpdatePendingWrite(remaining) ⇒
+      pendingWrite = remaining
+      if (writePending) info.registration.enableInterest(OP_WRITE)
+      else handleClose(info, closeCommander, closedEvent)
+
+    case WriteFileFailed(e) ⇒ handleError(info.handler, e) // rethrow exception from dispatcher task
+
+    case Abort              ⇒ handleClose(info, Some(sender), Aborted)
   }
 
   /** connection is closed on our side and we're waiting from confirmation from the other side */
@@ -130,13 +134,9 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         sender ! write.failureMessage
         if (info.useResumeWriting) writingSuspended = true
 
-      } else write match {
-        case Write(data, ack) if data.isEmpty ⇒
-          if (write.wantsAck) sender ! ack
-
-        case _ ⇒
-          pendingWrite = createWrite(write)
-          doWrite(info)
+      } else {
+        pendingWrite = PendingWrite(sender, write)
+        if (writePending) doWrite(info)
       }
 
     case ResumeWriting ⇒
@@ -156,9 +156,11 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         else sender ! CommandFailed(ResumeWriting)
       } else sender ! WritingResumed
 
-    case SendBufferFull(remaining) ⇒ { pendingWrite = remaining; info.registration.enableInterest(OP_WRITE) }
-    case WriteFileFinished         ⇒ pendingWrite = null
-    case WriteFileFailed(e)        ⇒ handleError(info.handler, e) // rethrow exception from dispatcher task
+    case UpdatePendingWrite(remaining) ⇒
+      pendingWrite = remaining
+      if (writePending) info.registration.enableInterest(OP_WRITE)
+
+    case WriteFileFailed(e) ⇒ handleError(info.handler, e) // rethrow exception from dispatcher task
   }
 
   // AUXILIARIES and IMPLEMENTATION
@@ -301,114 +303,108 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   override def postRestart(reason: Throwable): Unit =
     throw new IllegalStateException("Restarting not supported for connection actors.")
 
-  /** Create a pending write from a WriteCommand */
-  private[io] def createWrite(write: WriteCommand): PendingWrite = write match {
-    case write: Write ⇒
-      val buffer = bufferPool.acquire()
-
-      try {
-        val copied = write.data.copyToBuffer(buffer)
-        buffer.flip()
-
-        PendingBufferWrite(sender, write.ack, write.data.drop(copied), buffer)
-      } catch {
-        case NonFatal(e) ⇒
-          bufferPool.release(buffer)
-          throw e
+  def PendingWrite(commander: ActorRef, write: WriteCommand): PendingWrite = {
+    @tailrec def create(head: WriteCommand, tail: WriteCommand = Write.empty): PendingWrite =
+      head match {
+        case Write.empty                         ⇒ if (tail eq Write.empty) EmptyPendingWrite else create(tail)
+        case Write(data, ack) if data.nonEmpty   ⇒ PendingBufferWrite(commander, data, ack, tail)
+        case WriteFile(path, offset, count, ack) ⇒ PendingWriteFile(commander, path, offset, count, ack, tail)
+        case CompoundWrite(h, t)                 ⇒ create(h, t)
+        case x @ Write(_, ack) ⇒ // empty write with either an ACK or a non-standard NoACK
+          if (x.wantsAck) commander ! ack
+          create(tail)
       }
-    case write: WriteFile ⇒
-      PendingWriteFile(sender, write, new FileInputStream(write.filePath).getChannel, 0L)
+    create(write)
   }
 
-  private[io] case class PendingBufferWrite(
-    commander: ActorRef,
-    ack: Any,
-    remainingData: ByteString,
-    buffer: ByteBuffer) extends PendingWrite {
+  def PendingBufferWrite(commander: ActorRef, data: ByteString, ack: Event, tail: WriteCommand): PendingBufferWrite = {
+    val buffer = bufferPool.acquire()
+    try {
+      val copied = data.copyToBuffer(buffer)
+      buffer.flip()
+      new PendingBufferWrite(commander, data.drop(copied), ack, buffer, tail)
+    } catch {
+      case NonFatal(e) ⇒
+        bufferPool.release(buffer)
+        throw e
+    }
+  }
 
-    def release(): Unit = bufferPool.release(buffer)
+  class PendingBufferWrite(
+    val commander: ActorRef,
+    remainingData: ByteString,
+    ack: Any,
+    buffer: ByteBuffer,
+    tail: WriteCommand) extends PendingWrite {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
-      @tailrec def innerWrite(pendingWrite: PendingBufferWrite): PendingWrite = {
-        val toWrite = pendingWrite.buffer.remaining()
-        require(toWrite != 0)
-        val writtenBytes = channel.write(pendingWrite.buffer)
+      @tailrec def writeToChannel(data: ByteString): PendingWrite = {
+        val writtenBytes = channel.write(buffer) // at first we try to drain the remaining bytes from the buffer
         if (TraceLogging) log.debug("Wrote [{}] bytes to channel", writtenBytes)
+        if (buffer.hasRemaining) {
+          // we weren't able to write all bytes from the buffer, so we need to try again later
+          if (data eq remainingData) this
+          else new PendingBufferWrite(commander, data, ack, buffer, tail) // copy with updated remainingData
 
-        val nextWrite = pendingWrite.consume(writtenBytes)
+        } else if (data.nonEmpty) {
+          buffer.clear()
+          val copied = remainingData.copyToBuffer(buffer)
+          buffer.flip()
+          writeToChannel(remainingData drop copied)
 
-        if (pendingWrite.hasData)
-          if (writtenBytes == toWrite) innerWrite(nextWrite) // wrote complete buffer, try again now
-          else {
-            info.registration.enableInterest(OP_WRITE)
-            nextWrite
-          } // try again later
-        else { // everything written
-          if (pendingWrite.wantsAck)
-            pendingWrite.commander ! pendingWrite.ack
-
-          pendingWrite.release()
-          null
+        } else {
+          if (!ack.isInstanceOf[NoAck]) commander ! ack
+          release()
+          PendingWrite(commander, tail)
         }
       }
-
-      try innerWrite(this)
-      catch { case e: IOException ⇒ handleError(info.handler, e); this }
+      try {
+        val next = writeToChannel(remainingData)
+        if (next ne EmptyPendingWrite) info.registration.enableInterest(OP_WRITE)
+        next
+      } catch { case e: IOException ⇒ handleError(info.handler, e); this }
     }
-    def hasData = buffer.hasRemaining || remainingData.nonEmpty
-    def consume(writtenBytes: Int): PendingBufferWrite =
-      if (buffer.hasRemaining) this
-      else {
-        buffer.clear()
-        val copied = remainingData.copyToBuffer(buffer)
-        buffer.flip()
-        copy(remainingData = remainingData.drop(copied))
-      }
+
+    def release(): Unit = bufferPool.release(buffer)
   }
 
-  private[io] case class PendingWriteFile(
-    commander: ActorRef,
-    write: WriteFile,
+  def PendingWriteFile(commander: ActorRef, filePath: String, offset: Long, count: Long, ack: Event,
+                       tail: WriteCommand): PendingWriteFile =
+    new PendingWriteFile(commander, new FileInputStream(filePath).getChannel, offset, count, ack, tail)
+
+  class PendingWriteFile(
+    val commander: ActorRef,
     fileChannel: FileChannel,
-    alreadyWritten: Long) extends PendingWrite {
+    offset: Long,
+    remaining: Long,
+    ack: Event,
+    tail: WriteCommand) extends PendingWrite with Runnable {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
-      tcp.fileIoDispatcher.execute(writeFileRunnable(this))
+      tcp.fileIoDispatcher.execute(this)
       this
     }
 
-    def ack: Any = write.ack
+    def release(): Unit = fileChannel.close()
 
-    /** Release any open resources */
-    def release() { fileChannel.close() }
+    def run(): Unit =
+      try {
+        val toWrite = math.min(remaining, tcp.Settings.TransferToLimit)
+        val written = fileChannel.transferTo(offset, toWrite, channel)
 
-    def updatedWrite(nowWritten: Long): PendingWriteFile = {
-      require(nowWritten < write.count)
-      copy(alreadyWritten = nowWritten)
-    }
+        if (written < remaining) {
+          val updated = new PendingWriteFile(commander, fileChannel, offset + written, remaining - written, ack, tail)
+          self ! UpdatePendingWrite(updated)
 
-    def remainingBytes = write.count - alreadyWritten
-    def currentPosition = write.position + alreadyWritten
-  }
-
-  private[io] def writeFileRunnable(pendingWrite: PendingWriteFile): Runnable =
-    new Runnable {
-      def run(): Unit = try {
-        import pendingWrite._
-        val toWrite = math.min(remainingBytes, tcp.Settings.TransferToLimit)
-        val writtenBytes = fileChannel.transferTo(currentPosition, toWrite, channel)
-
-        if (writtenBytes < remainingBytes) self ! SendBufferFull(pendingWrite.updatedWrite(alreadyWritten + writtenBytes))
-        else { // finished
-          if (wantsAck) commander ! write.ack
-          self ! WriteFileFinished
-
-          pendingWrite.release()
+        } else {
+          if (!ack.isInstanceOf[NoAck]) commander ! ack
+          release()
+          self ! UpdatePendingWrite(PendingWrite(commander, tail))
         }
       } catch {
         case e: IOException ⇒ self ! WriteFileFailed(e)
       }
-    }
+  }
 }
 
 /**
@@ -436,22 +432,18 @@ private[io] object TcpConnection {
 
   // INTERNAL MESSAGES
 
-  /** Informs actor that no writing was possible but there is still work remaining */
-  case class SendBufferFull(remainingWrite: PendingWrite) extends NoSerializationVerificationNeeded
-  /** Informs actor that a pending file write has finished */
-  case object WriteFileFinished
-  /** Informs actor that a pending WriteFile failed */
+  case class UpdatePendingWrite(remainingWrite: PendingWrite) extends NoSerializationVerificationNeeded
   case class WriteFileFailed(e: IOException)
 
-  /** Abstraction over pending writes */
-  trait PendingWrite {
+  sealed abstract class PendingWrite {
     def commander: ActorRef
-    def ack: Any
-
-    def wantsAck = !ack.isInstanceOf[NoAck]
     def doWrite(info: ConnectionInfo): PendingWrite
+    def release(): Unit // free any occupied resources
+  }
 
-    /** Release any open resources */
-    def release(): Unit
+  object EmptyPendingWrite extends PendingWrite {
+    def commander: ActorRef = throw new IllegalStateException
+    def doWrite(info: ConnectionInfo): PendingWrite = throw new IllegalStateException
+    def release(): Unit = throw new IllegalStateException
   }
 }

--- a/akka-docs/rst/java/io.rst
+++ b/akka-docs/rst/java/io.rst
@@ -85,6 +85,8 @@ nacked messages it may need to keep a buffer of pending messages.
   the I/O driver has successfully processed the write. The Ack/Nack protocol described here is a means of flow control
   not error handling. In other words, data may still be lost, even if every write is acknowledged.
 
+.. _ByteString:
+
 ByteString
 ^^^^^^^^^^
 

--- a/akka-docs/rst/scala/io-tcp.rst
+++ b/akka-docs/rst/scala/io-tcp.rst
@@ -126,6 +126,43 @@ it receives one of the above close commands.
 All close notifications are sub-types of ``ConnectionClosed`` so listeners who do not need fine-grained close events
 may handle all close events in the same way.
 
+Writing to a connection
+-----------------------
+
+Once a connection has been established data can be sent to it from any actor in the form of a ``Tcp.WriteCommand``.
+``Tcp.WriteCommand`` is an abstract class with three concrete implementations:
+
+Tcp.Write
+  The simplest ``WriteCommand`` implementation which wraps a ``ByteString`` instance and an "ack" event.
+  A ``ByteString`` (as explained in :ref:`this section <ByteString>`) models one or more chunks of immutable
+  in-memory data with a maximum (total) size of 2 GB (2^31 bytes).
+
+Tcp.WriteFile
+  If you want to send "raw" data from a file you can do so efficiently with the ``Tcp.WriteFile`` command.
+  This allows you do designate a (contiguous) chunk of on-disk bytes for sending across the connection without
+  the need to first load them into the JVM memory. As such ``Tcp.WriteFile`` can "hold" more than 2GB of data and
+  an "ack" event if required.
+
+Tcp.CompoundWrite
+  Sometimes you might want to group (or interleave) several ``Tcp.Write`` and/or ``Tcp.WriteFile`` commands into
+  one atomic write command which gets written to the connection in one go. The ``Tcp.CompoundWrite`` allows you
+  to do just that and offers three benefits:
+
+  1. As explained in the following section the TCP connection actor can only handle one single write command at a time.
+     By combining several writes into one ``CompoundWrite`` you can have them be sent across the connection with
+     minimum overhead and without the need to spoon feed them to the connection actor via an *ACK-based* message
+     protocol.
+
+  2. Because a ``WriteCommand`` is atomic you can be sure that no other actor can "inject" other writes into your
+     series of writes if you combine them into one single ``CompoundWrite``. In scenarios where several actors write
+     to the same connection this can be an important feature which can be somewhat hard to achieve otherwise.
+
+  3. The "sub writes" of a ``CompoundWrite`` are regular ``Write`` or ``WriteFile`` commands that themselves can request
+     "ack" events. These ACKs are sent out as soon as the respective "sub write" has been completed. This allows you to
+     attach more than one ACK to a ``Write`` or ``WriteFile`` (by combining it with an empty write that itself requests
+     an ACK) or to have the connection actor acknowledge the progress of transmitting the ``CompoundWrite`` by sending
+     out intermediate ACKs at arbitrary points.
+
 Throttling Reads and Writes
 ---------------------------
 

--- a/akka-docs/rst/scala/io.rst
+++ b/akka-docs/rst/scala/io.rst
@@ -90,6 +90,8 @@ nacked messages it may need to keep a buffer of pending messages.
   the I/O driver has successfully processed the write. The Ack/Nack protocol described here is a means of flow control
   not error handling. In other words, data may still be lost, even if every write is acknowledged.
 
+.. _ByteString:
+
 ByteString
 ^^^^^^^^^^
 


### PR DESCRIPTION
Even though most of this patch changes stuff "under the hood" there is one breaking change:

The `def ack: Event` and `def wantsAck: Boolean` methods from the `Tcp.WriteCommand` type are moved down to the newly introduced `Tcp.CompactWriteCommand`, which can break existing code.

However, since this is an important feature for spray it'd be great if there was a way to bring `Tcp.CompoundWrite` support back to Akka 2.2. Either we accept the breaking change in the next minor update to Akka 2.2.2 (and point to  the "experimental" state of akka-io) or we backport in a way that doesn't break existing code by leaving the two methods in `Tcp.WriteCommand` and implementing them with a hard `def ack = NoAck` and `def wantsAck = false` in `Tcp.CompoundWrite`.
