### PR TITLE
Added paragraph about Agent locality

### DIFF
--- a/akka-docs/rst/scala/agents.rst
+++ b/akka-docs/rst/scala/agents.rst
@@ -29,6 +29,11 @@ that transaction. Agents are integrated with Scala STM - any dispatches made in
 a transaction are held until that transaction commits, and are discarded if it
 is retried or aborted.
 
+Agents are local to the node on which they are created. This implies that you
+should generally not include them in messages that may be passed to remote Actors
+or as constructor parameters for remote Actors; those remote Actors will not be able to
+read or update the Agent.
+
 
 Creating Agents
 ============================

--- a/akka-docs/rst/scala/agents.rst
+++ b/akka-docs/rst/scala/agents.rst
@@ -29,7 +29,7 @@ that transaction. Agents are integrated with Scala STM - any dispatches made in
 a transaction are held until that transaction commits, and are discarded if it
 is retried or aborted.
 
-Agents are local to the node on which they are created. This implies that you
+.. note::Agents are local to the node on which they are created. This implies that you
 should generally not include them in messages that may be passed to remote Actors
 or as constructor parameters for remote Actors; those remote Actors will not be able to
 read or update the Agent.

--- a/akka-docs/rst/scala/agents.rst
+++ b/akka-docs/rst/scala/agents.rst
@@ -29,10 +29,12 @@ that transaction. Agents are integrated with Scala STM - any dispatches made in
 a transaction are held until that transaction commits, and are discarded if it
 is retried or aborted.
 
-.. note::Agents are local to the node on which they are created. This implies that you
-should generally not include them in messages that may be passed to remote Actors
-or as constructor parameters for remote Actors; those remote Actors will not be able to
-read or update the Agent.
+.. note::
+
+  Agents are local to the node on which they are created. This implies that you
+  should generally not include them in messages that may be passed to remote Actors
+  or as constructor parameters for remote Actors; those remote Actors will not be able to
+  read or update the Agent.
 
 
 Creating Agents


### PR DESCRIPTION
Based on discussion on akka-user, Sept 6-9 2013. It seems appropriate to mention that Agents are not remoteable, so that naive users (like me) know to design for that.

(I haven't done a local build of the document, but since it's just adding a vanilla paragraph, it seems safe.)
