### PR TITLE
!con #3597 Remove hand over data message in cluster singleton

### DIFF
--- a/akka-contrib/docs/cluster-singleton.rst
+++ b/akka-contrib/docs/cluster-singleton.rst
@@ -28,9 +28,8 @@ supplied ``Props``. ``ClusterSingletonManager`` makes sure that at most one sing
 is running at any point in time.
 
 The singleton actor is always running on the oldest member, which can be determined by
-``Member#isOlderThan``. This can change when removing members. A graceful hand over can normally
-be performed when current oldest node is leaving the cluster. Be aware that there is a short
-time period when there is no active singleton during the hand-over process.
+``Member#isOlderThan``. This can change when removing that member from the cluster. Be aware
+that there is a short time period when there is no active singleton during the hand-over process.
 
 The cluster failure detector will notice when oldest node becomes unreachable due to
 things like JVM crash, hard shut down, or network failure. Then a new oldest node will

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterSingletonManagerChaosSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterSingletonManagerChaosSpec.scala
@@ -78,7 +78,7 @@ class ClusterSingletonManagerChaosSpec extends MultiNodeSpec(ClusterSingletonMan
 
   def createSingleton(): ActorRef = {
     system.actorOf(ClusterSingletonManager.props(
-      singletonProps = handOverData ⇒ Props(classOf[Echo], testActor),
+      singletonProps = Props(classOf[Echo], testActor),
       singletonName = "echo",
       terminationMessage = PoisonPill,
       role = None),

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ClusterSingletonManagerTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ClusterSingletonManagerTest.java
@@ -31,13 +31,9 @@ public class ClusterSingletonManagerTest {
 
     //#create-singleton-manager
     system.actorOf(
-      ClusterSingletonManager.defaultProps("consumer", new End(), "worker",
-        new ClusterSingletonPropsFactory() {
-          @Override
-          public Props create(Object handOverData) {
-            return Props.create(Consumer.class, handOverData, queue, testActor);
-          }
-        }), "singleton");
+      ClusterSingletonManager.defaultProps(
+          Props.create(Consumer.class, queue, testActor), "consumer", 
+          new End(), "worker"), "singleton");
     //#create-singleton-manager
   }
 

--- a/akka-docs/rst/project/migration-guide-2.0.x-2.1.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.0.x-2.1.x.rst
@@ -5,4 +5,4 @@
 ################################
 
 Migration from 2.0.x to 2.1.x is described in the 
-`documentation of 2.1 <http://doc.akka.io/docs/akka/2.1.2/project/migration-guide-2.0.x-2.1.x.html>`_.
+`documentation of 2.1 <http://doc.akka.io/docs/akka/2.1.4/project/migration-guide-2.0.x-2.1.x.html>`_.

--- a/akka-docs/rst/project/migration-guide-2.2.x-2.3.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.2.x-2.3.x.rst
@@ -1,0 +1,21 @@
+.. _migration-2.3:
+
+################################
+ Migration Guide 2.2.x to 2.3.x
+################################
+
+The 2.2 release contains some structural changes that require some
+simple, mechanical source-level changes in client code.
+
+When migrating from earlier versions you should first follow the instructions for
+migrating :ref:`1.3.x to 2.0.x <migration-2.0>` and then :ref:`2.0.x to 2.1.x <migration-2.1>`
+and then :ref:`2.1.x to 2.2.x <migration-2.2>`.
+
+Removed hand over data in cluster singleton
+===========================================
+
+The support for passing data from previous singleton instance to new instance
+in a graceful leaving scenario has been removed. Valuable state should be persisted
+in durable storage instead, e.g. using akka-persistence. The constructor/props parameters
+of ``ClusterSingletonManager`` has been changed to ordinary ``Props`` parameter for the
+singleton actor instead of the factory parameter.

--- a/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsSampleOneMasterMain.java
+++ b/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsSampleOneMasterMain.java
@@ -6,7 +6,6 @@ import akka.actor.ActorSystem;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.contrib.pattern.ClusterSingletonManager;
-import akka.contrib.pattern.ClusterSingletonPropsFactory;
 
 public class StatsSampleOneMasterMain {
 
@@ -23,13 +22,9 @@ public class StatsSampleOneMasterMain {
 
     //#create-singleton-manager
     system.actorOf(ClusterSingletonManager.defaultProps(
-      "statsService", PoisonPill.getInstance(), "compute",
-      new ClusterSingletonPropsFactory() {
-        @Override
-        public Props create(Object handOverData) {
-          return Props.create(StatsService.class);
-        }
-      }), "singleton");
+      Props.create(StatsService.class),  
+      "statsService", PoisonPill.getInstance(), "compute"), 
+      "singleton");
     //#create-singleton-manager
 
     system.actorOf(Props.create(StatsFacade.class), "statsFacade");

--- a/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
+++ b/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
@@ -155,7 +155,7 @@ object StatsSampleOneMaster {
 
     //#create-singleton-manager
     system.actorOf(ClusterSingletonManager.props(
-      singletonProps = _ ⇒ Props[StatsService], singletonName = "statsService",
+      singletonProps = Props[StatsService], singletonName = "statsService",
       terminationMessage = PoisonPill, role = Some("compute")),
       name = "singleton")
     //#create-singleton-manager

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -85,7 +85,7 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
       Cluster(system).unsubscribe(testActor)
 
       system.actorOf(ClusterSingletonManager.props(
-        singletonProps = _ ⇒ Props[StatsService], singletonName = "statsService",
+        singletonProps = Props[StatsService], singletonName = "statsService",
         terminationMessage = PoisonPill, role = Some("compute")), name = "singleton")
 
       system.actorOf(Props[StatsFacade], "statsFacade")

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleSingleMasterJapiSpec.scala
@@ -19,7 +19,6 @@ import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
 import akka.testkit.ImplicitSender
 import sample.cluster.stats.japi.StatsMessages._
-import akka.contrib.pattern.ClusterSingletonPropsFactory
 
 object StatsSampleSingleMasterJapiSpecConfig extends MultiNodeConfig {
   // register the named roles (nodes) of the test
@@ -85,12 +84,10 @@ abstract class StatsSampleSingleMasterJapiSpec extends MultiNodeSpec(StatsSample
       Cluster(system).unsubscribe(testActor)
 
       system.actorOf(ClusterSingletonManager.defaultProps(
+        Props[StatsService],  
         singletonName = "statsService",
         terminationMessage = PoisonPill,
-        role = null,
-        singletonPropsFactory = new ClusterSingletonPropsFactory {
-          def create(handOverData: Any) = Props[StatsService]
-        }), name = "singleton")
+        role = null), name = "singleton")
 
       system.actorOf(Props[StatsFacade], "statsFacade")
 


### PR DESCRIPTION
The initial version of the cluster singleton was running the singleton actor on the leader node, which could easily change, and therefore it made sense to be able to pass over state when switching singleton.
Then it was changed to run on the oldest member, and then this hand over feature doesn't add much value any more.
It is only used when leaving the oldest member gracefully, and the crash scenario must anyway be handled.
The implementation will be simplified by removing this feature.
