### PR TITLE
=doc #3596 Add paragraph about Agent locality

### DIFF
--- a/akka-docs/rst/scala/agents.rst
+++ b/akka-docs/rst/scala/agents.rst
@@ -29,7 +29,13 @@ that transaction. Agents are integrated with Scala STM - any dispatches made in
 a transaction are held until that transaction commits, and are discarded if it
 is retried or aborted.
 
+.. note::
 
+  Agents are local to the node on which they are created. This implies that you
+  should generally not include them in messages that may be passed to remote Actors
+  or as constructor parameters for remote Actors; those remote Actors will not be able to
+  read or update the Agent.
+ 
 Creating Agents
 ============================
 


### PR DESCRIPTION
- Based on discussion on akka-user, Sept 6-9 2013. It seems appropriate
  to mention that Agents are not remoteable, so that naive users (like me)
  know to design for that.
- This change has not been locally built with Sphinx, but seems to be
  small and safe.
