### PR TITLE
=clu #3603 Handle removed member in Gossip and Reachability merge

### DIFF
--- a/akka-actor/src/main/scala/akka/util/BoundedBlockingQueue.scala
+++ b/akka-actor/src/main/scala/akka/util/BoundedBlockingQueue.scala
@@ -104,8 +104,8 @@ class BoundedBlockingQueue[E <: AnyRef](
       @tailrec def pollElement(remainingNanos: Long): E = {
         backing.poll() match {
           case null if remainingNanos <= 0 ⇒ null.asInstanceOf[E]
-          case null ⇒ pollElement(notEmpty.awaitNanos(remainingNanos))
-          case e 	⇒ {
+          case null                        ⇒ pollElement(notEmpty.awaitNanos(remainingNanos))
+          case e ⇒ {
             notFull.signal()
             e
           }
@@ -120,7 +120,7 @@ class BoundedBlockingQueue[E <: AnyRef](
     try {
       backing.poll() match {
         case null ⇒ null.asInstanceOf[E]
-        case e    ⇒
+        case e ⇒
           notFull.signal()
           e
       }

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -127,7 +127,13 @@ object Member {
     val groupedByAddress = (a.toSeq ++ b.toSeq).groupBy(_.uniqueAddress)
     // pick highest MemberStatus
     (Member.none /: groupedByAddress) {
-      case (acc, (_, members)) ⇒ acc + members.reduceLeft(highestPriorityOf)
+      case (acc, (_, members)) ⇒
+        if (members.size == 2) acc + members.reduceLeft(highestPriorityOf)
+        else {
+          val m = members.head
+          if (Gossip.removeUnreachableWithMemberStatus(m.status)) acc // removed
+          else acc + m
+        }
     }
   }
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -287,7 +287,7 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
   def awaitMembersUp(
     numberOfMembers: Int,
     canNotBePartOfMemberRing: Set[Address] = Set.empty,
-    timeout: FiniteDuration = 20.seconds): Unit = {
+    timeout: FiniteDuration = 25.seconds): Unit = {
     within(timeout) {
       if (!canNotBePartOfMemberRing.isEmpty) // don't run this on an empty set
         awaitAssert(canNotBePartOfMemberRing foreach (a ⇒ clusterView.members.map(_.address) must not contain (a)))


### PR DESCRIPTION
- It was a regression introduced in dc9fe4f
- Two problems:
  1) Gossip merge could pop back removed member (was previously
     covered by the filter of unreachable)
  2) Reachability merge didn't handle all cases for removed member,
     i.e. when node not in allowed set
