### PR TITLE
=con #3616 Fix failing ClusterClientSpec

### DIFF
--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterClientSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterClientSpec.scala
@@ -130,7 +130,7 @@ class ClusterClientSpec extends MultiNodeSpec(ClusterClientSpec) with STMultiNod
       }
       //#server
 
-      runOn(host1, host2, host3) {
+      runOn(host1, host2, host3, fourth) {
         awaitCount(4)
       }
       enterBarrier("services-replicated")


### PR DESCRIPTION
- client connected to fourth node, but the replication check didn't
  include that node
