### PR TITLE
=act #3645 Make TcpOutgoingConnection actor handle UnresolvedAddressExceptions

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -4,9 +4,8 @@
 
 package akka.io
 
-import java.io.IOException
 import java.nio.channels.{ SelectionKey, SocketChannel }
-import java.net.ConnectException
+import scala.util.control.NonFatal
 import scala.collection.immutable
 import scala.concurrent.duration._
 import akka.actor.{ ReceiveTimeout, ActorRef }
@@ -42,7 +41,7 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
     try {
       thunk
     } catch {
-      case e: IOException ⇒
+      case NonFatal(e) ⇒
         log.debug("Could not establish connection to [{}] due to {}", remoteAddress, e)
         stop()
     }


### PR DESCRIPTION
Simple fix.

We'd also need a backport onto release-2.2 please.
