### PR TITLE
=rem #3643 Remove warning message from normal remote system shutdown.

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -205,7 +205,7 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
     }
 
     "send warning message for wrong address" in {
-      filterEvents(EventFilter.warning(pattern = "Address is now quarantined", occurrences = 1)) {
+      filterEvents(EventFilter.warning(pattern = "Address is now gated for ", occurrences = 1)) {
         system.actorFor("akka.test://nonexistingsystem@localhost:12346/user/echo") ! "ping"
       }
     }

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -930,6 +930,7 @@ object AkkaBuild extends Build {
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.EndpointWriter.akka$remote$EndpointWriter$$publishAndThrow"),
       ProblemFilters.exclude[MissingClassProblem]("akka.remote.transport.ThrottlerManager$OriginResolved$"),
       ProblemFilters.exclude[MissingClassProblem]("akka.remote.transport.ThrottlerManager$OriginResolved"),
+      ProblemFilters.exclude[MissingClassProblem]("akka.remote.QuarantinedUidException"),
 
       // inside package akka.camel.internal marked as private[camel] and INTERNAL API (and also inside actor)
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.camel.internal.Registry.supervisorStrategy")


### PR DESCRIPTION
It has now been turned into a debug level message with a slightly better wording.
