### PR TITLE
(forward port) =rem #3643 Remove warning message from normal remote system shutdown.

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -205,7 +205,7 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
     }
 
     "send warning message for wrong address" in {
-      filterEvents(EventFilter.warning(pattern = "Address is now quarantined", occurrences = 1)) {
+      filterEvents(EventFilter.warning(pattern = "Address is now gated for ", occurrences = 1)) {
         system.actorFor("akka.test://nonexistingsystem@localhost:12346/user/echo") ! "ping"
       }
     }


### PR DESCRIPTION
Conflicts:
akka-remote/src/main/scala/akka/remote/Remoting.scala
project/AkkaBuild.scala
