### PR TITLE
+clu #3627 Cluster router group  with multiple paths per node

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -151,8 +151,8 @@ akka {
         # In case of routing, the actors to be routed to can be specified
         # in several ways:
         # - nr-of-instances: will create that many children
-        # - routees.paths: will look the paths up using actorFor and route to
-        #   them, i.e. will not create children
+        # - routees.paths: will route messages to these paths using ActorSelection,
+        #   i.e. will not create children
         # - resizer: dynamically resizable number of routees as specified in
         #   resizer below
         router = "from-code"

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -216,11 +216,7 @@ akka {
     # Useful for master-worker scenario where all routees are remote.
     allow-local-routees = on
 
-    # Actor path of the routees to lookup with actorFor on the member
-    # nodes in the cluster. E.g. "/user/myservice". If this isn't defined
-    # the routees will be deployed instead of looked up.
-    # max-nr-of-instances-per-node should not be configured (default value is 1)
-    # when routees-path is defined.
+    # Deprecated in 2.3, use routees.paths instead
     routees-path = ""
 
     # Use members with specified role, or all members if undefined or empty.

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -90,8 +90,7 @@ private[akka] class ClusterActorRefProvider(
 private[akka] class ClusterDeployer(_settings: ActorSystem.Settings, _pm: DynamicAccess) extends RemoteDeployer(_settings, _pm) {
   override def parseConfig(path: String, config: Config): Option[Deploy] = {
 
-    // For backwards compatibility we must add this fake routees.paths so that the deployer creates a Group
-    // even though routees.paths is not defined. This will be cleaned up by ticket #3627
+    // For backwards compatibility we must transform 'cluster.routees-path' to 'routees.paths'
     val config2 =
       if (config.hasPath("cluster.routees-path"))
         config.withFallback(ConfigFactory.parseString(s"""routees.paths=["${config.getString("cluster.routees-path")}"]"""))

--- a/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
@@ -219,11 +219,11 @@ final case class AdaptiveLoadBalancingGroup(
    * Java API
    * @param metricsSelector decides what probability to use for selecting a routee, based
    *   on remaining capacity as indicated by the node metrics
-   * @param routeePaths string representation of the actor paths of the routees, messages are
+   * @param routeesPaths string representation of the actor paths of the routees, messages are
    *   sent with [[akka.actor.ActorSelection]] to these paths
    */
   def this(metricsSelector: MetricsSelector,
-           routeePaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeePaths))
+           routeesPaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeesPaths))
 
   override def createRouter(system: ActorSystem): Router =
     new Router(AdaptiveLoadBalancingRoutingLogic(system, metricsSelector))
@@ -566,11 +566,11 @@ case class AdaptiveLoadBalancingRouter(
    * Java API: Constructor that sets the routees to be used.
    *
    * @param selector the selector is responsible for producing weighted mix of routees from the node metrics
-   * @param routeePaths string representation of the actor paths of the routees that will be looked up
+   * @param routeesPaths string representation of the actor paths of the routees that will be looked up
    *   using `actorFor` in [[akka.actor.ActorRefProvider]]
    */
-  def this(selector: MetricsSelector, routeePaths: java.lang.Iterable[String]) =
-    this(metricsSelector = selector, routees = immutableSeq(routeePaths))
+  def this(selector: MetricsSelector, routeesPaths: java.lang.Iterable[String]) =
+    this(metricsSelector = selector, routees = immutableSeq(routeesPaths))
 
   /**
    * Java API: Constructor that sets the resizer to be used.

--- a/akka-cluster/src/main/scala/akka/cluster/routing/DeprecatedClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/DeprecatedClusterRouterConfig.scala
@@ -149,7 +149,7 @@ final case class ClusterRouterConfig(local: DeprecatedRouterConfig, settings: Cl
       new ClusterRouterPoolActor(local.supervisorStrategy, ClusterRouterPoolSettings(settings.totalInstances,
         settings.maxInstancesPerNode, settings.allowLocalRoutees, settings.useRole))
     else
-      new ClusterRouterGroupActor(ClusterRouterGroupSettings(settings.totalInstances, settings.routeesPath,
+      new ClusterRouterGroupActor(ClusterRouterGroupSettings(settings.totalInstances, List(settings.routeesPath),
         settings.allowLocalRoutees, settings.useRole))
 
   override def supervisorStrategy: SupervisorStrategy = local.supervisorStrategy

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -147,9 +147,9 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       /master-node-2/workers {
         router = round-robin-group
         nr-of-instances = 100
+        routees.paths = ["/user/worker"]
         cluster {
           enabled = on
-          routees-path = "/user/worker"
           allow-local-routees = on
         }
       }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/AdaptiveLoadBalancingRouterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/AdaptiveLoadBalancingRouterSpec.scala
@@ -25,7 +25,7 @@ import akka.routing.Routees
 
 object AdaptiveLoadBalancingRouterMultiJvmSpec extends MultiNodeConfig {
 
-  class Routee extends Actor {
+  class Echo extends Actor {
     def receive = {
       case _ ⇒ sender ! Reply(Cluster(context.system).selfAddress)
     }
@@ -117,7 +117,7 @@ abstract class AdaptiveLoadBalancingRouterSpec extends MultiNodeSpec(AdaptiveLoa
     val router = system.actorOf(ClusterRouterPool(
       local = AdaptiveLoadBalancingPool(HeapMetricsSelector),
       settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRole = None)).
-      props(Props[Routee]),
+      props(Props[Echo]),
       name)
     // it may take some time until router receives cluster member events
     awaitAssert { currentRoutees(router).size must be(roles.size) }

--- a/akka-docs/rst/java/cluster-usage.rst
+++ b/akka-docs/rst/java/cluster-usage.rst
@@ -457,14 +457,12 @@ That is not done by the router. The configuration for a group looks like this:
   available at that point it will be removed from the router and it will only re-try when the 
   cluster members are changed.
 
-It is the relative actor path defined in ``routees-path`` that identify what actor to lookup. 
+It is the relative actor paths defined in ``routees.paths`` that identify what actor to lookup. 
 It is possible to limit the lookup of routees to member nodes tagged with a certain role by
 specifying ``use-role``.
 
-``nr-of-instances`` defines total number of routees in the cluster, but there will not be
-more than one per node. That routee actor could easily fan out to local children if more parallelism 
-is needed. Setting ``nr-of-instances`` to a high value will result in new routees
-added to the router when nodes join the cluster.
+``nr-of-instances`` defines total number of routees in the cluster. Setting ``nr-of-instances`` 
+to a high value will result in new routees added to the router when nodes join the cluster.
 
 The same type of router could also have been defined in code:
 
@@ -506,7 +504,7 @@ The service that receives text from users and splits it up into words, delegates
 Note, nothing cluster specific so far, just plain actors.
 
 All nodes start ``StatsService`` and ``StatsWorker`` actors. Remember, routees are the workers in this case.
-The router is configured with ``routees-path``:
+The router is configured with ``routees.paths``:
 
 .. includecode:: ../../../akka-samples/akka-sample-cluster/src/main/resources/application.conf#config-router-lookup
 

--- a/akka-docs/rst/project/migration-guide-2.2.x-2.3.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.2.x-2.3.x.rst
@@ -73,10 +73,22 @@ Example in Java::
     getContext().actorOf(new RoundRobinPool(5).props(Props.create(Worker.class)), 
         "router2");
 
+To support multiple routee paths for a cluster aware router sending to paths the deployment configuration
+property ``cluster.routees-path`` has been changed to string list ``routees.paths`` property.
+The old ``cluster.routees-path`` is deprecated, but still working during the deprecation phase.
+
+Example::
+
+    /router4 {
+      router = round-robin
+      nr-of-instances = 10
+      routees.paths = ["/user/myserviceA", "/user/myserviceB"]
+      cluster.enabled = on
+    }
+
 The API for creating custom routers and resizers have changed without keeping the old API as deprecated. 
 That should be a an API used by only a few users and they should be able to migrate to the new API
 without much trouble.
 
 Read more about the new routers in the :ref:`documentation for Scala <routing-scala>` and 
 :ref:`documentation for Java <routing-java>`.
- 

--- a/akka-docs/rst/scala/cluster-usage.rst
+++ b/akka-docs/rst/scala/cluster-usage.rst
@@ -448,14 +448,12 @@ That is not done by the router. The configuration for a group looks like this:
   available at that point it will be removed from the router and it will only re-try when the 
   cluster members are changed.
 
-It is the relative actor path defined in ``routees-path`` that identify what actor to lookup. 
+It is the relative actor paths defined in ``routees.paths`` that identify what actor to lookup. 
 It is possible to limit the lookup of routees to member nodes tagged with a certain role by
 specifying ``use-role``.
 
-``nr-of-instances`` defines total number of routees in the cluster, but there will not be
-more than one per node. That routee actor could easily fan out to local children if more parallelism 
-is needed. Setting ``nr-of-instances`` to a high value will result in new routees
-added to the router when nodes join the cluster.
+``nr-of-instances`` defines total number of routees in the cluster. Setting ``nr-of-instances`` 
+to a high value will result in new routees added to the router when nodes join the cluster.
 
 The same type of router could also have been defined in code:
 
@@ -495,7 +493,7 @@ The service that receives text from users and splits it up into words, delegates
 Note, nothing cluster specific so far, just plain actors.
 
 All nodes start ``StatsService`` and ``StatsWorker`` actors. Remember, routees are the workers in this case.
-The router is configured with ``routees-path``:
+The router is configured with ``routees.paths``:
 
 .. includecode:: ../../../akka-samples/akka-sample-cluster/src/main/resources/application.conf#config-router-lookup
 

--- a/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsService.java
+++ b/akka-samples/akka-sample-cluster/src/main/java/sample/cluster/stats/japi/StatsService.java
@@ -3,6 +3,7 @@ package sample.cluster.stats.japi;
 import java.util.Collections;
 
 import sample.cluster.stats.japi.StatsMessages.StatsJob;
+
 //#imports
 import akka.actor.ActorRef;
 import akka.actor.Props;
@@ -60,13 +61,13 @@ public class StatsService extends UntypedActor {
 abstract class StatsService2 extends UntypedActor {
   //#router-lookup-in-code
   int totalInstances = 100;
-  String routeesPath = "/user/statsWorker";
+  Iterable<String> routeesPaths = Collections.singletonList("/user/statsWorker");
   boolean allowLocalRoutees = true;
   String useRole = "compute";
   ActorRef workerRouter = getContext().actorOf(
       new ClusterRouterGroup(
-          new ConsistentHashingGroup(Collections.<String>emptyList()), new ClusterRouterGroupSettings(
-              totalInstances, routeesPath, allowLocalRoutees, useRole)).props(),
+          new ConsistentHashingGroup(routeesPaths), new ClusterRouterGroupSettings(
+              totalInstances, routeesPaths, allowLocalRoutees, useRole)).props(),
       "workerRouter2");
   //#router-lookup-in-code
 }

--- a/akka-samples/akka-sample-cluster/src/main/resources/application.conf
+++ b/akka-samples/akka-sample-cluster/src/main/resources/application.conf
@@ -26,9 +26,9 @@ akka.actor.deployment {
   /statsService/workerRouter {
     router = consistent-hashing-group
     nr-of-instances = 100
+    routees.paths = ["/user/statsWorker"]
     cluster {
       enabled = on
-      routees-path = "/user/statsWorker"
       allow-local-routees = on
       use-role = compute
     }
@@ -60,9 +60,9 @@ akka.actor.deployment {
     # metrics-selector = cpu
     metrics-selector = mix
     nr-of-instances = 100
+    routees.paths = ["/user/factorialBackend"]
     cluster {
       enabled = on
-      routees-path = "/user/factorialBackend"
       use-role = backend
       allow-local-routees = off
     }

--- a/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/factorial/FactorialSample.scala
+++ b/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/factorial/FactorialSample.scala
@@ -149,7 +149,7 @@ abstract class FactorialFrontend2 extends Actor {
   val backend = context.actorOf(
     ClusterRouterGroup(AdaptiveLoadBalancingGroup(HeapMetricsSelector),
       ClusterRouterGroupSettings(
-        totalInstances = 100, routeesPath = "/user/factorialBackend",
+        totalInstances = 100, routeesPaths = List("/user/factorialBackend"),
         allowLocalRoutees = true, useRole = Some("backend"))).props(),
     name = "factorialBackendRouter2")
   //#router-lookup-in-code

--- a/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
+++ b/akka-samples/akka-sample-cluster/src/main/scala/sample/cluster/stats/StatsSample.scala
@@ -230,7 +230,7 @@ abstract class StatsService2 extends Actor {
 
   val workerRouter = context.actorOf(
     ClusterRouterGroup(ConsistentHashingGroup(Nil), ClusterRouterGroupSettings(
-      totalInstances = 100, routeesPath = "/user/statsWorker",
+      totalInstances = 100, routeesPaths = List("/user/statsWorker"),
       allowLocalRoutees = true, useRole = Some("compute"))).props(),
     name = "workerRouter2")
   //#router-lookup-in-code

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -34,9 +34,9 @@ object StatsSampleSpecConfig extends MultiNodeConfig {
       /statsService/workerRouter {
           router = consistent-hashing-group
           nr-of-instances = 100
+          routees.paths = ["/user/statsWorker"]
           cluster {
             enabled = on
-            routees-path = "/user/statsWorker"
             allow-local-routees = on
             use-role = compute
           }

--- a/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
+++ b/akka-samples/akka-sample-cluster/src/multi-jvm/scala/sample/cluster/stats/japi/StatsSampleJapiSpec.scala
@@ -37,9 +37,9 @@ object StatsSampleJapiSpecConfig extends MultiNodeConfig {
       /statsService/workerRouter {
           router = consistent-hashing-group
           nr-of-instances = 100
+          routees.paths = ["/user/statsWorker"]
           cluster {
             enabled = on
-            routees-path = "/user/statsWorker"
             allow-local-routees = on
             use-role = compute
           }


### PR DESCRIPTION
- Use the ordinary routees.paths config property instead of
  cluster.routees-path
- Backwards compatible in deprecation phase
