### PR TITLE
(backport) =act #3602 report `Connected` only when connection attempt was successful

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -139,6 +139,7 @@ class TcpConnectionSpec extends AkkaSpec("""
 
         serverSideChannel.write(ByteBuffer.wrap("immediatedata".getBytes("ASCII")))
         serverSideChannel.configureBlocking(false)
+        interestCallReceiver.expectMsg(OP_CONNECT)
 
         selector.send(connectionActor, ChannelConnectable)
         userHandler.expectMsg(Connected(serverAddress, clientSideChannel.socket.getLocalSocketAddress.asInstanceOf[InetSocketAddress]))
@@ -799,7 +800,7 @@ class TcpConnectionSpec extends AkkaSpec("""
     lazy val clientSideChannel = connectionActor.underlyingActor.channel
 
     override def run(body: ⇒ Unit): Unit = super.run {
-      registerCallReceiver.expectMsg(Registration(clientSideChannel, OP_CONNECT))
+      registerCallReceiver.expectMsg(Registration(clientSideChannel, 0))
       registerCallReceiver.sender must be(connectionActor)
       body
     }
@@ -821,6 +822,7 @@ class TcpConnectionSpec extends AkkaSpec("""
         serverSideChannel.configureBlocking(false)
         serverSideChannel must not be (null)
 
+        interestCallReceiver.expectMsg(OP_CONNECT)
         selector.send(connectionActor, ChannelConnectable)
         userHandler.expectMsg(Connected(serverAddress, clientSideChannel.socket.getLocalSocketAddress.asInstanceOf[InetSocketAddress]))
 

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
@@ -4,10 +4,12 @@
 
 package akka.io
 
-import akka.testkit.AkkaSpec
+import akka.testkit.{ TestProbe, AkkaSpec }
 import akka.util.ByteString
 import akka.TestUtils._
+import concurrent.duration._
 import Tcp._
+import java.net.InetSocketAddress
 
 class TcpIntegrationSpec extends AkkaSpec("""
     akka.loglevel = INFO
@@ -70,6 +72,13 @@ class TcpIntegrationSpec extends AkkaSpec("""
 
       override def bindOptions = List(SO.SendBufferSize(1024))
       override def connectOptions = List(SO.ReceiveBufferSize(1024))
+    }
+    "don't report Connected when endpoint isn't responding" in {
+      val connectCommander = TestProbe()
+      // a "random" endpoint hopefully unavailable
+      val endpoint = new InetSocketAddress("10.226.182.48", 23825)
+      connectCommander.send(IO(Tcp), Connect(endpoint))
+      connectCommander.expectNoMsg(1.second)
     }
   }
 


### PR DESCRIPTION
Before this change, a client connection was always instantly reported as
`Connected`, even if the endpoint would never respond at all.

The reason is a weird behavior of OP_CONNECT and SocketChannel in the JDK
(observed in Linux):
- a channel is always connectable before the connection is attempted
  (`channel.connect`). Selecting for OP_CONNECT before the `connect`
  call will instantly report connectable
- even worse: after OP_CONNECT was reported true, also `finishConnect`
  will always return true, even if the connection wasn't yet established.
  That's probably the case because `finishConnect` is internally implemented
  depending on previous epoll results (on Linux).
