### PR TITLE
=act #3672 fix garbling of big outgoing Tcp.Write caused by mixup of buffers

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -348,9 +348,9 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
 
         } else if (data.nonEmpty) {
           buffer.clear()
-          val copied = remainingData.copyToBuffer(buffer)
+          val copied = data.copyToBuffer(buffer)
           buffer.flip()
-          writeToChannel(remainingData drop copied)
+          writeToChannel(data drop copied)
 
         } else {
           if (!ack.isInstanceOf[NoAck]) commander ! ack


### PR DESCRIPTION
Amazing that this stayed undiscovered for so long...
