### PR TITLE
Let the application specify custom MDC values

### DIFF
--- a/akka-actor-tests/src/test/java/akka/event/ActorWithMDC.java
+++ b/akka-actor-tests/src/test/java/akka/event/ActorWithMDC.java
@@ -1,0 +1,61 @@
+package akka.event;
+
+import akka.actor.UntypedActor;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ActorWithMDC extends UntypedActor {
+
+    private final DiagnosticLoggingAdapter logger = Logging.getLogger(this);
+
+    @Override
+    public void onReceive(Object message) throws Exception {
+        Log log = (Log) message;
+
+        Map<String, Object> mdc;
+        if(log.message.startsWith("No MDC")) {
+            mdc = Collections.emptyMap();
+        } else if(log.message.equals("Null MDC")) {
+            mdc = null;
+        } else {
+            mdc = new LinkedHashMap<String, Object>();
+            mdc.put("messageLength", log.message.length());
+        }
+        logger.setMDC(mdc);
+
+        switch (log.level()) {
+            case 1:
+                logger.error(log.message);
+                break;
+            case 2:
+                logger.warning(log.message);
+                break;
+            case 3:
+                logger.info(log.message);
+                break;
+            default:
+                logger.debug(log.message);
+                break;
+        }
+
+        logger.clearMDC();
+    }
+
+    public static class Log {
+        private final Object level;
+        public final String message;
+
+        public Log(Object level, String message) {
+            this.level = level;
+            this.message = message;
+        }
+
+        public int level() {
+            return (Integer) this.level;
+        }
+    }
+
+
+}

--- a/akka-actor-tests/src/test/java/akka/event/LoggingAdapterTest.java
+++ b/akka-actor-tests/src/test/java/akka/event/LoggingAdapterTest.java
@@ -1,0 +1,142 @@
+package akka.event;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.testkit.JavaTestKit;
+import akka.event.Logging.Error;
+import akka.event.ActorWithMDC.Log;
+import static akka.event.Logging.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+import scala.concurrent.duration.Duration;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+
+public class LoggingAdapterTest {
+
+    private static final Config config = ConfigFactory.parseString(
+            "akka.loglevel = DEBUG\n" +
+            "akka.actor.serialize-messages = off"
+    );
+
+    @Test
+    public void mustFormatMessage() {
+        final ActorSystem system = ActorSystem.create("test-system", config);
+        final LoggingAdapter log = Logging.getLogger(system, this);
+        new LogJavaTestKit(system) {{
+            system.eventStream().subscribe(getRef(), LogEvent.class);
+            log.error("One arg message: {}", "the arg");
+            expectLog(ErrorLevel(), "One arg message: the arg");
+
+            Throwable cause = new IllegalStateException("This state is illegal");
+            log.error(cause, "Two args message: {}, {}", "an arg", "another arg");
+            expectLog(ErrorLevel(), "Two args message: an arg, another arg", cause);
+
+            int[] primitiveArgs = {10, 20, 30};
+            log.warning("Args as array of primitives: {}, {}, {}", primitiveArgs);
+            expectLog(WarningLevel(), "Args as array of primitives: 10, 20, 30");
+
+            Date now = new Date();
+            UUID uuid = UUID.randomUUID();
+            Object[] objArgs = {"A String", now, uuid};
+            log.info("Args as array of objects: {}, {}, {}", objArgs);
+            expectLog(InfoLevel(), "Args as array of objects: A String, " + now.toString() + ", " + uuid.toString());
+
+            log.debug("Four args message: {}, {}, {}, {}", 1, 2, 3, 4);
+            expectLog(DebugLevel(), "Four args message: 1, 2, 3, 4");
+
+        }};
+    }
+
+    @Test
+    public void mustCallMdcForEveryLog() throws Exception {
+        final ActorSystem system = ActorSystem.create("test-system", config);
+        new LogJavaTestKit(system) {{
+            system.eventStream().subscribe(getRef(), LogEvent.class);
+            ActorRef ref = system.actorOf(Props.create(ActorWithMDC.class));
+
+            ref.tell(new Log(ErrorLevel(), "An Error"), system.deadLetters());
+            expectLog(ErrorLevel(), "An Error", "Map(messageLength -> 8)");
+            ref.tell(new Log(WarningLevel(), "A Warning"), system.deadLetters());
+            expectLog(WarningLevel(), "A Warning", "Map(messageLength -> 9)");
+            ref.tell(new Log(InfoLevel(), "Some Info"), system.deadLetters());
+            expectLog(InfoLevel(), "Some Info", "Map(messageLength -> 9)");
+            ref.tell(new Log(DebugLevel(), "No MDC for 4th call"), system.deadLetters());
+            expectLog(DebugLevel(), "No MDC for 4th call");
+            ref.tell(new Log(Logging.DebugLevel(), "And now yes, a debug with MDC"), system.deadLetters());
+            expectLog(DebugLevel(), "And now yes, a debug with MDC", "Map(messageLength -> 29)");
+        }};
+    }
+
+    @Test
+    public void mustSupportMdcNull() throws Exception {
+        final ActorSystem system = ActorSystem.create("test-system", config);
+        new LogJavaTestKit(system) {{
+            system.eventStream().subscribe(getRef(), LogEvent.class);
+            ActorRef ref = system.actorOf(Props.create(ActorWithMDC.class));
+
+            ref.tell(new Log(InfoLevel(), "Null MDC"), system.deadLetters());
+            expectLog(InfoLevel(), "Null MDC", "Map()");
+        }};
+    }
+
+    /*
+     * #3671: Let the application specify custom MDC values
+     * Java backward compatibility check
+     */
+    @Test
+    public void mustBeAbleToCreateLogEventsWithOldConstructor() throws Exception {
+        assertNotNull(new Error(new Exception(), "logSource", this.getClass(), "The message"));
+        assertNotNull(new Error("logSource", this.getClass(), "The message"));
+        assertNotNull(new Warning("logSource", this.getClass(), "The message"));
+        assertNotNull(new Info("logSource", this.getClass(), "The message"));
+        assertNotNull(new Debug("logSource", this.getClass(), "The message"));
+    }
+
+    private static class LogJavaTestKit extends JavaTestKit {
+
+        private static final String emptyMDC = "Map()";
+
+        public LogJavaTestKit(ActorSystem system) {
+            super(system);
+        }
+
+        void expectLog(Object level, String message) {
+            expectLog(level, message, null, emptyMDC);
+        }
+
+        void expectLog(Object level, String message, Throwable cause) {
+            expectLog(level, message, cause, emptyMDC);
+        }
+
+        void expectLog(Object level, String message, String mdc) {
+            expectLog(level, message, null, mdc);
+        }
+
+        void expectLog(final Object level, final String message, final Throwable cause, final String mdc) {
+            new ExpectMsg<Void>(Duration.create(3, TimeUnit.SECONDS), "LogEvent") {
+                protected Void match(Object event) {
+                    LogEvent log = (LogEvent) event;
+                    assertEquals(message, log.message());
+                    assertEquals(level, log.level());
+                    assertEquals(mdc, log.mdc().toString());
+                    if(cause != null) {
+                        Error error = (Error) log;
+                        assertSame(cause, error.cause());
+                    }
+                    return null;
+                }
+            };
+        }
+    }
+}
+

--- a/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
@@ -6,13 +6,16 @@ package akka.event
 import akka.testkit._
 import scala.concurrent.duration._
 import com.typesafe.config.{ Config, ConfigFactory }
-import akka.actor.{ ActorRef, Actor, ActorSystem }
+import akka.actor._
 import java.util.{ Date, GregorianCalendar, TimeZone, Calendar }
 import org.scalatest.WordSpec
 import org.scalatest.matchers.MustMatchers
 import akka.serialization.SerializationExtension
-import akka.event.Logging.{ Warning, LogEvent, LoggerInitialized, InitializeLogger }
+import akka.event.Logging._
 import akka.util.Helpers
+import akka.event.Logging.InitializeLogger
+import scala.Some
+import akka.event.Logging.Warning
 
 object LoggerSpec {
 
@@ -55,6 +58,17 @@ object LoggerSpec {
       }
     """).withFallback(AkkaSpec.testConf)
 
+  val ticket3671Config = ConfigFactory.parseString("""
+      akka {
+        stdout-loglevel = "WARNING"
+        loglevel = "WARNING"
+        loggers = ["akka.event.LoggerSpec$TestLogger1"]
+        actor {
+          serialize-messages = off
+        }
+      }
+    """).withFallback(AkkaSpec.testConf)
+
   case class SetTarget(ref: ActorRef, qualifier: Int)
 
   class TestLogger1 extends TestLogger(1)
@@ -68,11 +82,33 @@ object LoggerSpec {
       case SetTarget(ref, `qualifier`) ⇒
         target = Some(ref)
         ref ! ("OK")
+      case event: LogEvent if !event.mdc.isEmpty ⇒
+        print(event)
+        target foreach { _ ! event }
       case event: LogEvent ⇒
         print(event)
         target foreach { _ ! event.message }
     }
   }
+
+  class ActorWithMDC extends Actor with DiagnosticActorLogging {
+    var reqId = 0
+
+    override def mdc(currentMessage: Any): MDC = {
+      reqId += 1
+      val always = Map("requestId" -> reqId)
+      val perMessage = currentMessage match {
+        case cm @ "Current Message in MDC" ⇒ Map("currentMsg" -> cm, "currentMsgLength" -> cm.length)
+        case _                             ⇒ Map()
+      }
+      always ++ perMessage
+    }
+
+    def receive: Receive = {
+      case m: String ⇒ log.warning(m)
+    }
+  }
+
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
@@ -142,6 +178,47 @@ class LoggerSpec extends WordSpec with MustMatchers {
         }
       }
     }
+  }
+
+  "Ticket 3671" must {
+
+    "log message with given MDC values" in {
+      implicit val system = ActorSystem("ticket-3671", ticket3671Config)
+      try {
+        val probe = TestProbe()
+        system.eventStream.publish(SetTarget(probe.ref, qualifier = 1))
+        probe.expectMsg("OK")
+
+        val ref = system.actorOf(Props[ActorWithMDC])
+
+        ref ! "Processing new Request"
+        probe.expectMsgPF(max = 3.seconds) {
+          case w @ Warning(_, _, "Processing new Request") if w.mdc.size == 1 && w.mdc("requestId") == 1 ⇒
+        }
+
+        ref ! "Processing another Request"
+        probe.expectMsgPF(max = 3.seconds) {
+          case w @ Warning(_, _, "Processing another Request") if w.mdc.size == 1 && w.mdc("requestId") == 2 ⇒
+        }
+
+        ref ! "Current Message in MDC"
+        probe.expectMsgPF(max = 3.seconds) {
+          case w @ Warning(_, _, "Current Message in MDC") if w.mdc.size == 3 &&
+            w.mdc("requestId") == 3 &&
+            w.mdc("currentMsg") == "Current Message in MDC" &&
+            w.mdc("currentMsgLength") == 22 ⇒
+        }
+
+        ref ! "Current Message removed from MDC"
+        probe.expectMsgPF(max = 3.seconds) {
+          case w @ Warning(_, _, "Current Message removed from MDC") if w.mdc.size == 1 && w.mdc("requestId") == 4 ⇒
+        }
+
+      } finally {
+        TestKit.shutdownActorSystem(system)
+      }
+    }
+
   }
 
   "Ticket 3080" must {

--- a/akka-docs/rst/java/logging.rst
+++ b/akka-docs/rst/java/logging.rst
@@ -335,3 +335,43 @@ If you want to more accurately output the timestamp, use the MDC attribute ``akk
       <pattern>%X{akkaTimestamp} %-5level %logger{36} %X{akkaSource} - %msg%n</pattern>
     </encoder>
   </appender>
+
+
+MDC values defined by the application
+-------------------------------------
+
+One useful feature available in Slf4j is `MDC <http://logback.qos.ch/manual/mdc.html>`_,
+Akka has a way for let the application specify custom values, you just need to get a
+specialized :class:`LoggingAdapter`, the :class:`DiagnosticLoggingAdapter`. In order to
+get it you will use the factory receiving an UntypedActor as logSource:
+
+.. code-block:: scala
+
+    // Within your UntypedActor
+    final DiagnosticLoggingAdapter log = Logging.getLogger(this);
+
+Once you have the logger, you just need to add the custom values before you log something.
+This way, the values will be put in the SLF4J MDC right before appending the log and removed after.
+
+.. note::
+
+  The cleanup (removal) should be done in the actor at the end,
+  otherwise, next message will log with same mdc values,
+  if it is not set to a new map. Use ``log.clearMDC()``.
+
+.. includecode:: code/docs/event/LoggingDocTest.java
+    :include: imports-mdc
+
+.. includecode:: code/docs/event/LoggingDocTest.java
+    :include: mdc-actor
+
+Now, the values will be available in the MDC, so you can use them in the layout pattern::
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>
+        %-5level %logger{36} [req: %X{requestId}, visitor: %X{visitorId}] - %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+

--- a/akka-docs/rst/scala/logging.rst
+++ b/akka-docs/rst/scala/logging.rst
@@ -374,3 +374,45 @@ If you want to more accurately output the timestamp, use the MDC attribute ``akk
       <pattern>%X{akkaTimestamp} %-5level %logger{36} %X{akkaSource} - %msg%n</pattern>
     </encoder>
   </appender>
+
+MDC values defined by the application
+-------------------------------------
+
+One useful feature available in Slf4j is `MDC <http://logback.qos.ch/manual/mdc.html>`_,
+Akka has a way for let the application specify custom values, you just need to get a
+specialized :class:`LoggingAdapter`, the :class:`DiagnosticLoggingAdapter`. In order to
+get it you will use the factory receiving an Actor as logSource:
+
+.. code-block:: scala
+
+    // Within your Actor
+    val log: DiagnosticLoggingAdapter = Logging(this);
+
+Once you have the logger, you just need to add the custom values before you log something.
+This way, the values will be put in the SLF4J MDC right before appending the log and removed after.
+
+.. note::
+
+  The cleanup (removal) should be done in the actor at the end,
+  otherwise, next message will log with same mdc values,
+  if it is not set to a new map. Use ``log.clearMDC()``.
+
+.. includecode:: code/docs/event/LoggingDocSpec.scala#mdc
+
+For convenience you can mixin the ``log`` member into actors, instead of defining it as above.
+This trait also lets you override ``def mdc(msg: Any): MDC`` for specifying MDC values
+depending on current message and lets you forget about the cleanup as well, since it already does it for you.
+
+.. includecode:: code/docs/event/LoggingDocSpec.scala
+    :include: mdc-actor
+
+Now, the values will be available in the MDC, so you can use them in the layout pattern::
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>
+        %-5level %logger{36} [req: %X{requestId}, visitor: %X{visitorId}] - %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -63,7 +63,7 @@ class Slf4jLogger extends Actor with SLF4JLogging {
       withMdc(logSource, event) {
         cause match {
           case Error.NoCause | null ⇒ Logger(logClass, logSource).error(if (message != null) message.toString else null)
-          case cause                ⇒ Logger(logClass, logSource).error(if (message != null) message.toString else cause.getLocalizedMessage, cause)
+          case _                    ⇒ Logger(logClass, logSource).error(if (message != null) message.toString else cause.getLocalizedMessage, cause)
         }
       }
 
@@ -86,10 +86,12 @@ class Slf4jLogger extends Actor with SLF4JLogging {
     MDC.put(mdcAkkaSourceAttributeName, logSource)
     MDC.put(mdcThreadAttributeName, logEvent.thread.getName)
     MDC.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
+    logEvent.mdc foreach { case (k, v) ⇒ MDC.put(k, String.valueOf(v)) }
     try logStatement finally {
       MDC.remove(mdcAkkaSourceAttributeName)
       MDC.remove(mdcThreadAttributeName)
       MDC.remove(mdcAkkaTimestamp)
+      logEvent.mdc.keys.foreach(k ⇒ MDC.remove(k))
     }
   }
 

--- a/akka-slf4j/src/test/resources/logback-test.xml
+++ b/akka-slf4j/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
 	<appender name="TEST"
 		class="akka.event.slf4j.Slf4jLoggerSpec$TestAppender">
 		<encoder>
-			<pattern>%date{ISO8601} level=[%level] logger=[%logger] akkaSource=[%X{akkaSource}] sourceThread=[%X{sourceThread}] - msg=[%msg]%n----%n</pattern>
+			<pattern>%date{ISO8601} level=[%level] logger=[%logger] akkaSource=[%X{akkaSource}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc}] - msg=[%msg]%n----%n</pattern>
 		</encoder>
 	</appender>
 


### PR DESCRIPTION
Hi guys,

With some modifications to LoggingAdapter, BusLogging and Slf4jLogger I was able to let the application specify custom MDC values when logging any message.
This new feature is hard to use as it is, but combined together with an Akka pattern I'm developing ( https://github.com/ktonga/akka-contextual-actors ) the experience of being using a transparent MDC solution gets a little bit more real.

Let me know if you need some further modifications!
Thanks.
