### PR TITLE
Possibility to skip mima check in release

### DIFF
--- a/project/scripts/release
+++ b/project/scripts/release
@@ -111,7 +111,7 @@ declare release_path=${default_path}
 declare -r unzipped_dir="target/dist/unzipped"
 
 # flags
-unset run_tests dry_run no_revert no_akka_plugin
+unset run_tests dry_run no_mima no_revert no_akka_plugin
 
 # get the source location for this script; handles symlinks
 function get_script_path {
@@ -136,6 +136,7 @@ Usage: ${script_name} [options] VERSION
   -s | --server SERVER   Set the release server (default ${default_server})
   -p | --path PATH       Set the path on the release server (default ${default_path})
   -n | --dry-run         Build everything but do not push the release
+  -m | --no-mima         Skip binary compatibility check in dry-run
   -r | --no-revert       On dry-run don't revert git commits and tags
        --no-akka-plugin  Publish the akka sbt plugin locally and not to the repositry
 EOM
@@ -170,6 +171,7 @@ while true; do
     -s | --server ) release_server=$2; shift 2 ;;
     -p | --path ) release_path=$2; shift 2 ;;
     -n | --dry-run) dry_run=true; shift ;;
+    -m | --no-mima) no_mima=true; shift ;;
     -r | --no-revert) no_revert=true; shift ;;
     --no-akka-plugin) no_akka_plugin=true; shift ;;
     * ) break ;;
@@ -323,7 +325,7 @@ try tar -cz -C ${unzipped_dir} -f ${release_dir}/downloads/akka-${version}.tgz a
 echolog "Successfully created local release"
 
 # check binary compatibility for dry run
-if [ $dry_run ]; then
+if [ ! $no_mima ] && [ $dry_run ]; then
   echodry "Running migration manager report..."
   sbt mima-report-binary-issues
   echodry "Finished migration manager report"


### PR DESCRIPTION
mima-report-binary-issues fails if previousArtifact is not specified
