### PR TITLE
=clu #3683 Don't trigger extra heartbeat when not expected sender

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -148,7 +148,7 @@ akka {
         # After the heartbeat request has been sent the first failure detection
         # will start after this period, even though no heartbeat mesage has
         # been received.
-        expected-response-after = 3 s
+        expected-response-after = 5 s
 
         # Cleanup of obsolete heartbeat requests
         time-to-live = 60 s

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -145,7 +145,9 @@ private[cluster] final class ClusterHeartbeatSender extends Actor with ActorLogg
   }
 
   def reset(snapshot: CurrentClusterState): Unit =
-    state = state.reset(snapshot.members.map(_.address)(collection.breakOut))
+    state = state.reset(snapshot.members.collect {
+      case m if m.status == MemberStatus.Up ⇒ m.address
+    }(collection.breakOut))
 
   def addMember(m: Member): Unit = if (m.address != selfAddress) state = state addMember m.address
 
@@ -178,7 +180,7 @@ private[cluster] final class ClusterHeartbeatSender extends Actor with ActorLogg
     }
 
   def triggerFirstHeartbeat(address: Address): Unit =
-    if (!cluster.failureDetector.isMonitoring(address)) {
+    if (!cluster.failureDetector.isMonitoring(address) && state.ring.mySenders.contains(address)) {
       logInfo("Trigger extra expected heartbeat from [{}]", address)
       cluster.failureDetector.heartbeat(address)
     }

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
@@ -33,7 +33,7 @@ class ClusterConfigSpec extends AkkaSpec {
       HeartbeatInterval must be(1 second)
       MonitoredByNrOfMembers must be(5)
       HeartbeatRequestDelay must be(10 seconds)
-      HeartbeatExpectedResponseAfter must be(3 seconds)
+      HeartbeatExpectedResponseAfter must be(5 seconds)
       HeartbeatRequestTimeToLive must be(1 minute)
       LeaderActionsInterval must be(1 second)
       UnreachableNodesReaperInterval must be(1 second)


### PR DESCRIPTION
I had problems with this that was rather reproducible when joining 20 nodes in the cloud. Probably the membership ring is changing. With this fix it works fine.

At some point we should seriously consider to use ping-pong heartbeating instead of one-way. We don't save much, and the complexity is not worth it, in my opinion.
