### PR TITLE
=act 3684 prevent usage of WriteCommands other than Tcp.Write with SslTlsSupport

### DIFF
--- a/akka-actor/src/main/scala/akka/io/SslTlsSupport.scala
+++ b/akka-actor/src/main/scala/akka/io/SslTlsSupport.scala
@@ -94,6 +94,10 @@ class SslTlsSupport(engine: SSLEngine) extends PipelineStage[HasLogging, Command
           // to shutdown the connection when getting CLOSED in encrypt
           closeEngine()
 
+        case x: Tcp.WriteCommand =>
+          throw new IllegalArgumentException(
+            "SslTlsSupport doesn't support Tcp.WriteCommands of type " + x.getClass.getSimpleName)
+
         case cmd ⇒ ctx.singleCommand(cmd)
       }
 


### PR DESCRIPTION
Brute-force, but maybe that's what needed until we fix it properly.
