### PR TITLE
!per #3681 Performance and consistency improvements

### DIFF
--- a/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
@@ -9,6 +9,8 @@ import scala.Option;
 import akka.actor.*;
 import akka.persistence.*;
 
+import static java.util.Arrays.asList;
+
 public class PersistenceDocTest {
 
     public interface ProcessorMethods {
@@ -236,5 +238,32 @@ public class PersistenceDocTest {
                 //#snapshot-criteria
             }
         }
+    };
+
+    static Object o6 = new Object() {
+        //#batch-write
+        class MyProcessor extends UntypedProcessor {
+            public void onReceive(Object message) throws Exception {
+                if (message instanceof Persistent) {
+                    Persistent p = (Persistent)message;
+                    if (p.payload().equals("a")) { /* ... */ }
+                    if (p.payload().equals("b")) { /* ... */ }
+                }
+            }
+        }
+
+        class Example {
+            final ActorSystem system = ActorSystem.create("example");
+            final ActorRef processor = system.actorOf(Props.create(MyProcessor.class));
+
+            public void batchWrite() {
+                processor.tell(PersistentBatch.create(asList(
+                        Persistent.create("a"),
+                        Persistent.create("b"))), null);
+            }
+
+            // ...
+        }
+        //#batch-write
     };
 }

--- a/akka-docs/rst/java/code/docs/persistence/PersistencePluginDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistencePluginDocTest.java
@@ -46,6 +46,11 @@ public class PersistencePluginDocTest {
         }
 
         @Override
+        public Future<Void> doWriteBatchAsync(Iterable<PersistentImpl> persistentBatch) {
+            return null;
+        }
+
+        @Override
         public Future<Void> doDeleteAsync(PersistentImpl persistent) {
             return null;
         }

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -265,6 +265,8 @@ If not specified, they default to ``SnapshotSelectionCriteria.latest()`` which s
 To disable snapshot-based recovery, applications should use ``SnapshotSelectionCriteria.none()``. A recovery where no
 saved snapshot matches the specified ``SnapshotSelectionCriteria`` will replay all journaled messages.
 
+.. _event-sourcing-java:
+
 Event sourcing
 ==============
 
@@ -317,6 +319,20 @@ calls in context of a single command.
 The example also demonstrates how to change the processor's default behavior, defined by ``onReceiveCommand``, to
 another behavior, defined by ``otherCommandHandler``, and back using ``getContext().become()`` and
 ``getContext().unbecome()``. See also the API docs of ``persist`` for further details.
+
+Batch writes
+============
+
+Applications may also send a batch of ``Persistent`` messages to a processor via a ``PersistentBatch`` message.
+
+.. includecode:: code/docs/persistence/PersistenceDocTest.java#batch-write
+
+``Persistent`` messages contained in a ``PersistentBatch`` message are written to the journal atomically but are
+received  by the processor separately (as ``Persistent`` messages). They are also replayed separately. Batch writes
+can not only increase the throughput of a processor but may also be necessary for consistency reasons. For example,
+in :ref:`event-sourcing-java`, all events that are generated and persisted by a single command are batch-written to
+the journal. The recovery of an ``UntypedEventsourcedProcessor`` will therefore never be done partially i.e. with
+only a subset of events persisted by a single command.
 
 Storage plugins
 ===============

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -225,4 +225,22 @@ trait PersistenceDocSpec {
       maxTimestamp = System.currentTimeMillis))
     //#snapshot-criteria
   }
+
+  new AnyRef {
+    import akka.actor.Props
+    //#batch-write
+    class MyProcessor extends Processor {
+      def receive = {
+        case Persistent("a", _) ⇒ // ...
+        case Persistent("b", _) ⇒ // ...
+      }
+    }
+
+    val system = ActorSystem("example")
+    val processor = system.actorOf(Props[MyProcessor])
+
+    processor ! PersistentBatch(Vector(Persistent("a"), Persistent("b")))
+    //#batch-write
+    system.shutdown()
+  }
 }

--- a/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
@@ -6,6 +6,7 @@ package docs.persistence
 
 //#plugin-imports
 import scala.concurrent.Future
+import scala.collection.immutable.Seq
 //#plugin-imports
 
 import com.typesafe.config._
@@ -69,6 +70,7 @@ class PersistencePluginDocSpec extends WordSpec {
 
 class MyJournal extends AsyncWriteJournal {
   def writeAsync(persistent: PersistentImpl): Future[Unit] = ???
+  def writeBatchAsync(persistentBatch: Seq[PersistentImpl]): Future[Unit] = ???
   def deleteAsync(persistent: PersistentImpl): Future[Unit] = ???
   def confirmAsync(processorId: String, sequenceNr: Long, channelId: String): Future[Unit] = ???
   def replayAsync(processorId: String, fromSequenceNr: Long, toSequenceNr: Long)(replayCallback: (PersistentImpl) ⇒ Unit): Future[Long] = ???

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -331,6 +331,20 @@ The example also demonstrates how to change the processor's default behavior, de
 another behavior, defined by ``otherCommandHandler``, and back using ``context.become()`` and ``context.unbecome()``.
 See also the API docs of ``persist`` for further details.
 
+Batch writes
+============
+
+Applications may also send a batch of ``Persistent`` messages to a processor via a ``PersistentBatch`` message.
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#batch-write
+
+``Persistent`` messages contained in a ``PersistentBatch`` message are written to the journal atomically but are
+received  by the processor separately (as ``Persistent`` messages). They are also replayed separately. Batch writes
+can not only increase the throughput of a processor but may also be necessary for consistency reasons. For example,
+in :ref:`event-sourcing`, all events that are generated and persisted by a single command are batch-written to the
+journal. The recovery of an ``EventsourcedProcessor`` will therefore never be done partially i.e. with only a subset
+of events persisted by a single command.
+
 Storage plugins
 ===============
 

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
@@ -20,6 +20,14 @@ interface AsyncWritePlugin {
     /**
      * Plugin Java API.
      *
+     * Asynchronously writes a batch of persistent messages to the journal. The batch write
+     * must be atomic i.e. either all persistent messages in the batch are written or none.
+     */
+    Future<Void> doWriteBatchAsync(Iterable<PersistentImpl> persistentBatch);
+
+    /**
+     * Plugin Java API.
+     *
      * Asynchronously marks a `persistent` message as deleted.
      */
     Future<Void> doDeleteAsync(PersistentImpl persistent);

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/SyncWritePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/SyncWritePlugin.java
@@ -18,6 +18,14 @@ interface SyncWritePlugin {
     /**
      * Plugin Java API.
      *
+     * Synchronously writes a batch of persistent messages to the journal. The batch write
+     * must be atomic i.e. either all persistent messages in the batch are written or none.
+     */
+    void doWriteBatch(Iterable<PersistentImpl> persistentBatch);
+
+    /**
+     * Plugin Java API.
+     *
      * Synchronously marks a `persistent` message as deleted.
      */
     void doDelete(PersistentImpl persistent) throws Exception;

--- a/akka-persistence/src/main/java/akka/persistence/serialization/MessageFormats.java
+++ b/akka-persistence/src/main/java/akka/persistence/serialization/MessageFormats.java
@@ -8,6 +8,692 @@ public final class MessageFormats {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
+  public interface PersistentMessageBatchOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // repeated .PersistentMessage batch = 1;
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    java.util.List<akka.persistence.serialization.MessageFormats.PersistentMessage> 
+        getBatchList();
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    akka.persistence.serialization.MessageFormats.PersistentMessage getBatch(int index);
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    int getBatchCount();
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    java.util.List<? extends akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
+        getBatchOrBuilderList();
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder getBatchOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code PersistentMessageBatch}
+   */
+  public static final class PersistentMessageBatch extends
+      com.google.protobuf.GeneratedMessage
+      implements PersistentMessageBatchOrBuilder {
+    // Use PersistentMessageBatch.newBuilder() to construct.
+    private PersistentMessageBatch(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private PersistentMessageBatch(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final PersistentMessageBatch defaultInstance;
+    public static PersistentMessageBatch getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public PersistentMessageBatch getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private PersistentMessageBatch(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                batch_ = new java.util.ArrayList<akka.persistence.serialization.MessageFormats.PersistentMessage>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              batch_.add(input.readMessage(akka.persistence.serialization.MessageFormats.PersistentMessage.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          batch_ = java.util.Collections.unmodifiableList(batch_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return akka.persistence.serialization.MessageFormats.internal_static_PersistentMessageBatch_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return akka.persistence.serialization.MessageFormats.internal_static_PersistentMessageBatch_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              akka.persistence.serialization.MessageFormats.PersistentMessageBatch.class, akka.persistence.serialization.MessageFormats.PersistentMessageBatch.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<PersistentMessageBatch> PARSER =
+        new com.google.protobuf.AbstractParser<PersistentMessageBatch>() {
+      public PersistentMessageBatch parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new PersistentMessageBatch(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<PersistentMessageBatch> getParserForType() {
+      return PARSER;
+    }
+
+    // repeated .PersistentMessage batch = 1;
+    public static final int BATCH_FIELD_NUMBER = 1;
+    private java.util.List<akka.persistence.serialization.MessageFormats.PersistentMessage> batch_;
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    public java.util.List<akka.persistence.serialization.MessageFormats.PersistentMessage> getBatchList() {
+      return batch_;
+    }
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    public java.util.List<? extends akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
+        getBatchOrBuilderList() {
+      return batch_;
+    }
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    public int getBatchCount() {
+      return batch_.size();
+    }
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    public akka.persistence.serialization.MessageFormats.PersistentMessage getBatch(int index) {
+      return batch_.get(index);
+    }
+    /**
+     * <code>repeated .PersistentMessage batch = 1;</code>
+     */
+    public akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder getBatchOrBuilder(
+        int index) {
+      return batch_.get(index);
+    }
+
+    private void initFields() {
+      batch_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      for (int i = 0; i < getBatchCount(); i++) {
+        if (!getBatch(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < batch_.size(); i++) {
+        output.writeMessage(1, batch_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < batch_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, batch_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.persistence.serialization.MessageFormats.PersistentMessageBatch parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(akka.persistence.serialization.MessageFormats.PersistentMessageBatch prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code PersistentMessageBatch}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements akka.persistence.serialization.MessageFormats.PersistentMessageBatchOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.persistence.serialization.MessageFormats.internal_static_PersistentMessageBatch_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.persistence.serialization.MessageFormats.internal_static_PersistentMessageBatch_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.persistence.serialization.MessageFormats.PersistentMessageBatch.class, akka.persistence.serialization.MessageFormats.PersistentMessageBatch.Builder.class);
+      }
+
+      // Construct using akka.persistence.serialization.MessageFormats.PersistentMessageBatch.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getBatchFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        if (batchBuilder_ == null) {
+          batch_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          batchBuilder_.clear();
+        }
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return akka.persistence.serialization.MessageFormats.internal_static_PersistentMessageBatch_descriptor;
+      }
+
+      public akka.persistence.serialization.MessageFormats.PersistentMessageBatch getDefaultInstanceForType() {
+        return akka.persistence.serialization.MessageFormats.PersistentMessageBatch.getDefaultInstance();
+      }
+
+      public akka.persistence.serialization.MessageFormats.PersistentMessageBatch build() {
+        akka.persistence.serialization.MessageFormats.PersistentMessageBatch result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public akka.persistence.serialization.MessageFormats.PersistentMessageBatch buildPartial() {
+        akka.persistence.serialization.MessageFormats.PersistentMessageBatch result = new akka.persistence.serialization.MessageFormats.PersistentMessageBatch(this);
+        int from_bitField0_ = bitField0_;
+        if (batchBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            batch_ = java.util.Collections.unmodifiableList(batch_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.batch_ = batch_;
+        } else {
+          result.batch_ = batchBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof akka.persistence.serialization.MessageFormats.PersistentMessageBatch) {
+          return mergeFrom((akka.persistence.serialization.MessageFormats.PersistentMessageBatch)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(akka.persistence.serialization.MessageFormats.PersistentMessageBatch other) {
+        if (other == akka.persistence.serialization.MessageFormats.PersistentMessageBatch.getDefaultInstance()) return this;
+        if (batchBuilder_ == null) {
+          if (!other.batch_.isEmpty()) {
+            if (batch_.isEmpty()) {
+              batch_ = other.batch_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureBatchIsMutable();
+              batch_.addAll(other.batch_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.batch_.isEmpty()) {
+            if (batchBuilder_.isEmpty()) {
+              batchBuilder_.dispose();
+              batchBuilder_ = null;
+              batch_ = other.batch_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              batchBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getBatchFieldBuilder() : null;
+            } else {
+              batchBuilder_.addAllMessages(other.batch_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        for (int i = 0; i < getBatchCount(); i++) {
+          if (!getBatch(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        akka.persistence.serialization.MessageFormats.PersistentMessageBatch parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (akka.persistence.serialization.MessageFormats.PersistentMessageBatch) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated .PersistentMessage batch = 1;
+      private java.util.List<akka.persistence.serialization.MessageFormats.PersistentMessage> batch_ =
+        java.util.Collections.emptyList();
+      private void ensureBatchIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          batch_ = new java.util.ArrayList<akka.persistence.serialization.MessageFormats.PersistentMessage>(batch_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          akka.persistence.serialization.MessageFormats.PersistentMessage, akka.persistence.serialization.MessageFormats.PersistentMessage.Builder, akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> batchBuilder_;
+
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public java.util.List<akka.persistence.serialization.MessageFormats.PersistentMessage> getBatchList() {
+        if (batchBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(batch_);
+        } else {
+          return batchBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public int getBatchCount() {
+        if (batchBuilder_ == null) {
+          return batch_.size();
+        } else {
+          return batchBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public akka.persistence.serialization.MessageFormats.PersistentMessage getBatch(int index) {
+        if (batchBuilder_ == null) {
+          return batch_.get(index);
+        } else {
+          return batchBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder setBatch(
+          int index, akka.persistence.serialization.MessageFormats.PersistentMessage value) {
+        if (batchBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureBatchIsMutable();
+          batch_.set(index, value);
+          onChanged();
+        } else {
+          batchBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder setBatch(
+          int index, akka.persistence.serialization.MessageFormats.PersistentMessage.Builder builderForValue) {
+        if (batchBuilder_ == null) {
+          ensureBatchIsMutable();
+          batch_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          batchBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder addBatch(akka.persistence.serialization.MessageFormats.PersistentMessage value) {
+        if (batchBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureBatchIsMutable();
+          batch_.add(value);
+          onChanged();
+        } else {
+          batchBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder addBatch(
+          int index, akka.persistence.serialization.MessageFormats.PersistentMessage value) {
+        if (batchBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureBatchIsMutable();
+          batch_.add(index, value);
+          onChanged();
+        } else {
+          batchBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder addBatch(
+          akka.persistence.serialization.MessageFormats.PersistentMessage.Builder builderForValue) {
+        if (batchBuilder_ == null) {
+          ensureBatchIsMutable();
+          batch_.add(builderForValue.build());
+          onChanged();
+        } else {
+          batchBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder addBatch(
+          int index, akka.persistence.serialization.MessageFormats.PersistentMessage.Builder builderForValue) {
+        if (batchBuilder_ == null) {
+          ensureBatchIsMutable();
+          batch_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          batchBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder addAllBatch(
+          java.lang.Iterable<? extends akka.persistence.serialization.MessageFormats.PersistentMessage> values) {
+        if (batchBuilder_ == null) {
+          ensureBatchIsMutable();
+          super.addAll(values, batch_);
+          onChanged();
+        } else {
+          batchBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder clearBatch() {
+        if (batchBuilder_ == null) {
+          batch_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          batchBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public Builder removeBatch(int index) {
+        if (batchBuilder_ == null) {
+          ensureBatchIsMutable();
+          batch_.remove(index);
+          onChanged();
+        } else {
+          batchBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public akka.persistence.serialization.MessageFormats.PersistentMessage.Builder getBatchBuilder(
+          int index) {
+        return getBatchFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder getBatchOrBuilder(
+          int index) {
+        if (batchBuilder_ == null) {
+          return batch_.get(index);  } else {
+          return batchBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public java.util.List<? extends akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
+           getBatchOrBuilderList() {
+        if (batchBuilder_ != null) {
+          return batchBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(batch_);
+        }
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public akka.persistence.serialization.MessageFormats.PersistentMessage.Builder addBatchBuilder() {
+        return getBatchFieldBuilder().addBuilder(
+            akka.persistence.serialization.MessageFormats.PersistentMessage.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public akka.persistence.serialization.MessageFormats.PersistentMessage.Builder addBatchBuilder(
+          int index) {
+        return getBatchFieldBuilder().addBuilder(
+            index, akka.persistence.serialization.MessageFormats.PersistentMessage.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .PersistentMessage batch = 1;</code>
+       */
+      public java.util.List<akka.persistence.serialization.MessageFormats.PersistentMessage.Builder> 
+           getBatchBuilderList() {
+        return getBatchFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          akka.persistence.serialization.MessageFormats.PersistentMessage, akka.persistence.serialization.MessageFormats.PersistentMessage.Builder, akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder> 
+          getBatchFieldBuilder() {
+        if (batchBuilder_ == null) {
+          batchBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              akka.persistence.serialization.MessageFormats.PersistentMessage, akka.persistence.serialization.MessageFormats.PersistentMessage.Builder, akka.persistence.serialization.MessageFormats.PersistentMessageOrBuilder>(
+                  batch_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          batch_ = null;
+        }
+        return batchBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:PersistentMessageBatch)
+    }
+
+    static {
+      defaultInstance = new PersistentMessageBatch(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:PersistentMessageBatch)
+  }
+
   public interface PersistentMessageOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -3060,6 +3746,11 @@ public final class MessageFormats {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_PersistentMessageBatch_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_PersistentMessageBatch_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_PersistentMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -3083,38 +3774,46 @@ public final class MessageFormats {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\024MessageFormats.proto\"\371\001\n\021PersistentMes" +
-      "sage\022#\n\007payload\030\001 \001(\0132\022.PersistentPayloa" +
-      "d\022\022\n\nsequenceNr\030\002 \001(\003\022\023\n\013processorId\030\003 \001" +
-      "(\t\022\021\n\tchannelId\030\004 \001(\t\022\017\n\007deleted\030\005 \001(\010\022\020" +
-      "\n\010resolved\030\006 \001(\010\022\020\n\010confirms\030\010 \003(\t\022\'\n\016co" +
-      "nfirmMessage\030\n \001(\0132\017.ConfirmMessage\022\025\n\rc" +
-      "onfirmTarget\030\t \001(\t\022\016\n\006sender\030\007 \001(\t\"S\n\021Pe" +
-      "rsistentPayload\022\024\n\014serializerId\030\001 \002(\005\022\017\n" +
-      "\007payload\030\002 \002(\014\022\027\n\017payloadManifest\030\003 \001(\014\"" +
-      "L\n\016ConfirmMessage\022\023\n\013processorId\030\001 \001(\t\022\022",
-      "\n\nsequenceNr\030\002 \001(\003\022\021\n\tchannelId\030\003 \001(\tB\"\n" +
-      "\036akka.persistence.serializationH\001"
+      "\n\024MessageFormats.proto\";\n\026PersistentMess" +
+      "ageBatch\022!\n\005batch\030\001 \003(\0132\022.PersistentMess" +
+      "age\"\371\001\n\021PersistentMessage\022#\n\007payload\030\001 \001" +
+      "(\0132\022.PersistentPayload\022\022\n\nsequenceNr\030\002 \001" +
+      "(\003\022\023\n\013processorId\030\003 \001(\t\022\021\n\tchannelId\030\004 \001" +
+      "(\t\022\017\n\007deleted\030\005 \001(\010\022\020\n\010resolved\030\006 \001(\010\022\020\n" +
+      "\010confirms\030\010 \003(\t\022\'\n\016confirmMessage\030\n \001(\0132" +
+      "\017.ConfirmMessage\022\025\n\rconfirmTarget\030\t \001(\t\022" +
+      "\016\n\006sender\030\007 \001(\t\"S\n\021PersistentPayload\022\024\n\014" +
+      "serializerId\030\001 \002(\005\022\017\n\007payload\030\002 \002(\014\022\027\n\017p",
+      "ayloadManifest\030\003 \001(\014\"L\n\016ConfirmMessage\022\023" +
+      "\n\013processorId\030\001 \001(\t\022\022\n\nsequenceNr\030\002 \001(\003\022" +
+      "\021\n\tchannelId\030\003 \001(\tB\"\n\036akka.persistence.s" +
+      "erializationH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
         public com.google.protobuf.ExtensionRegistry assignDescriptors(
             com.google.protobuf.Descriptors.FileDescriptor root) {
           descriptor = root;
-          internal_static_PersistentMessage_descriptor =
+          internal_static_PersistentMessageBatch_descriptor =
             getDescriptor().getMessageTypes().get(0);
+          internal_static_PersistentMessageBatch_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_PersistentMessageBatch_descriptor,
+              new java.lang.String[] { "Batch", });
+          internal_static_PersistentMessage_descriptor =
+            getDescriptor().getMessageTypes().get(1);
           internal_static_PersistentMessage_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_PersistentMessage_descriptor,
               new java.lang.String[] { "Payload", "SequenceNr", "ProcessorId", "ChannelId", "Deleted", "Resolved", "Confirms", "ConfirmMessage", "ConfirmTarget", "Sender", });
           internal_static_PersistentPayload_descriptor =
-            getDescriptor().getMessageTypes().get(1);
+            getDescriptor().getMessageTypes().get(2);
           internal_static_PersistentPayload_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_PersistentPayload_descriptor,
               new java.lang.String[] { "SerializerId", "Payload", "PayloadManifest", });
           internal_static_ConfirmMessage_descriptor =
-            getDescriptor().getMessageTypes().get(2);
+            getDescriptor().getMessageTypes().get(3);
           internal_static_ConfirmMessage_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ConfirmMessage_descriptor,

--- a/akka-persistence/src/main/protobuf/MessageFormats.proto
+++ b/akka-persistence/src/main/protobuf/MessageFormats.proto
@@ -5,6 +5,10 @@
 option java_package = "akka.persistence.serialization";
 option optimize_for = SPEED;
 
+message PersistentMessageBatch {
+  repeated PersistentMessage batch = 1;
+}
+
 message PersistentMessage {
   optional PersistentPayload payload = 1;
   optional int64 sequenceNr = 2;

--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -18,6 +18,7 @@ akka {
     serialization-bindings {
 
       "akka.persistence.serialization.Snapshot" = akka-persistence-snapshot
+      "akka.persistence.PersistentBatch" = akka-persistence-message
       "akka.persistence.PersistentImpl" = akka-persistence-message
       "akka.persistence.Confirm" = akka-persistence-message
     }

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -4,6 +4,8 @@
 
 package akka.persistence
 
+import scala.collection.immutable
+
 import akka.actor._
 
 /**
@@ -17,6 +19,14 @@ private[persistence] object JournalProtocol {
    * @param persistent persistent message.
    */
   case class Delete(persistent: Persistent)
+
+  /**
+   * Instructs a journal to persist a sequence of messages.
+   *
+   * @param persistentBatch batch of messages to be persisted.
+   * @param processor requesting processor.
+   */
+  case class WriteBatch(persistentBatch: immutable.Seq[PersistentImpl], processor: ActorRef)
 
   /**
    * Instructs a journal to persist a message.

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
@@ -4,7 +4,8 @@
 
 package akka.persistence.journal.japi
 
-import scala.concurrent.Future
+import scala.collection.immutable
+import scala.collection.JavaConverters._
 
 import akka.persistence.journal.{ AsyncWriteJournal ⇒ SAsyncWriteJournal }
 import akka.persistence.PersistentImpl
@@ -19,6 +20,9 @@ abstract class AsyncWriteJournal extends AsyncReplay with SAsyncWriteJournal wit
 
   final def writeAsync(persistent: PersistentImpl) =
     doWriteAsync(persistent).map(Unit.unbox)
+
+  final def writeBatchAsync(persistentBatch: immutable.Seq[PersistentImpl]) =
+    doWriteBatchAsync(persistentBatch.asJava).map(Unit.unbox)
 
   final def deleteAsync(persistent: PersistentImpl) =
     doDeleteAsync(persistent).map(Unit.unbox)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/SyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/SyncWriteJournal.scala
@@ -4,6 +4,9 @@
 
 package akka.persistence.journal.japi
 
+import scala.collection.immutable
+import scala.collection.JavaConverters._
+
 import akka.persistence.journal.{ SyncWriteJournal ⇒ SSyncWriteJournal }
 import akka.persistence.PersistentImpl
 
@@ -15,6 +18,9 @@ import akka.persistence.PersistentImpl
 abstract class SyncWriteJournal extends AsyncReplay with SSyncWriteJournal with SyncWritePlugin {
   final def write(persistent: PersistentImpl) =
     doWrite(persistent)
+
+  final def writeBatch(persistentBatch: immutable.Seq[PersistentImpl]) =
+    doWriteBatch(persistentBatch.asJava)
 
   final def delete(persistent: PersistentImpl) =
     doDelete(persistent)

--- a/akka-persistence/src/test/scala/akka/persistence/PerformanceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PerformanceSpec.scala
@@ -1,0 +1,163 @@
+package akka.persistence
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import com.typesafe.config.ConfigFactory
+
+import akka.actor._
+import akka.testkit._
+
+object PerformanceSpec {
+  // multiply cycles with 100 for more
+  // accurate throughput measurements
+  val config =
+    """
+      akka.persistence.performance.cycles.warmup = 300
+      akka.persistence.performance.cycles.load = 1000
+    """
+
+  case object StartMeasure
+  case object StopMeasure
+  case class FailAt(sequenceNr: Long)
+
+  abstract class PerformanceTestProcessor(name: String) extends NamedProcessor(name) {
+    val NanoToSecond = 1000.0 * 1000 * 1000
+
+    var startTime: Long = 0L
+    var stopTime: Long = 0L
+
+    var startSequenceNr = 0L;
+    var stopSequenceNr = 0L;
+
+    var failAt: Long = -1
+
+    val controlBehavior: Receive = {
+      case StartMeasure ⇒ {
+        startSequenceNr = lastSequenceNr
+        startTime = System.nanoTime
+      }
+      case StopMeasure ⇒ {
+        stopSequenceNr = lastSequenceNr
+        stopTime = System.nanoTime
+        sender ! (NanoToSecond * (stopSequenceNr - startSequenceNr) / (stopTime - startTime))
+      }
+      case FailAt(sequenceNr) ⇒ failAt = sequenceNr
+    }
+
+    override def postRestart(reason: Throwable) {
+      super.postRestart(reason)
+      receive(StartMeasure)
+    }
+  }
+
+  class CommandsourcedTestProcessor(name: String) extends PerformanceTestProcessor(name) {
+    def receive = controlBehavior orElse {
+      case p: Persistent ⇒ {
+        if (lastSequenceNr % 1000 == 0) if (recoveryRunning) print("r") else print(".")
+        if (lastSequenceNr == failAt) throw new TestException("boom")
+      }
+    }
+  }
+
+  class EventsourcedTestProcessor(name: String) extends PerformanceTestProcessor(name) with EventsourcedProcessor {
+    val receiveReplay: Receive = {
+      case _ ⇒ if (lastSequenceNr % 1000 == 0) print("r")
+    }
+
+    val receiveCommand: Receive = controlBehavior orElse {
+      case cmd ⇒ persist(cmd) { _ ⇒
+        if (lastSequenceNr % 1000 == 0) print(".")
+        if (lastSequenceNr == failAt) throw new TestException("boom")
+      }
+    }
+  }
+
+  class StashingEventsourcedTestProcessor(name: String) extends PerformanceTestProcessor(name) with EventsourcedProcessor {
+    val receiveReplay: Receive = {
+      case _ ⇒ if (lastSequenceNr % 1000 == 0) print("r")
+    }
+
+    val printProgress: PartialFunction[Any, Any] = {
+      case m ⇒ if (lastSequenceNr % 1000 == 0) print("."); m
+    }
+
+    val receiveCommand: Receive = printProgress andThen (controlBehavior orElse {
+      case "a" ⇒ persist("a")(_ ⇒ context.become(processC))
+      case "b" ⇒ persist("b")(_ ⇒ ())
+    })
+
+    val processC: Receive = printProgress andThen {
+      case "c" ⇒ {
+        persist("c")(_ ⇒ context.unbecome())
+        unstashAll()
+      }
+      case other ⇒ stash()
+    }
+  }
+}
+
+class PerformanceSpec extends AkkaSpec(PersistenceSpec.config("leveldb", "performance").withFallback(ConfigFactory.parseString(PerformanceSpec.config))) with PersistenceSpec with ImplicitSender {
+  import PerformanceSpec._
+
+  val warmupClycles = system.settings.config.getInt("akka.persistence.performance.cycles.warmup")
+  val loadCycles = system.settings.config.getInt("akka.persistence.performance.cycles.load")
+
+  def stressCommandsourcedProcessor(failAt: Option[Long]): Unit = {
+    val processor = namedProcessor[CommandsourcedTestProcessor]
+    failAt foreach { processor ! FailAt(_) }
+    1 to warmupClycles foreach { i ⇒ processor ! Persistent(s"msg${i}") }
+    processor ! StartMeasure
+    1 to loadCycles foreach { i ⇒ processor ! Persistent(s"msg${i}") }
+    processor ! StopMeasure
+    expectMsgPF(100 seconds) {
+      case throughput: Double ⇒ println(f"\nthroughput = $throughput%.2f persistent commands per second")
+    }
+  }
+
+  def stressEventsourcedProcessor(failAt: Option[Long]): Unit = {
+    val processor = namedProcessor[EventsourcedTestProcessor]
+    failAt foreach { processor ! FailAt(_) }
+    1 to warmupClycles foreach { i ⇒ processor ! s"msg${i}" }
+    processor ! StartMeasure
+    1 to loadCycles foreach { i ⇒ processor ! s"msg${i}" }
+    processor ! StopMeasure
+    expectMsgPF(100 seconds) {
+      case throughput: Double ⇒ println(f"\nthroughput = $throughput%.2f persistent events per second")
+    }
+  }
+
+  def stressStashingEventsourcedProcessor(): Unit = {
+    val processor = namedProcessor[StashingEventsourcedTestProcessor]
+    1 to warmupClycles foreach { i ⇒ processor ! "b" }
+    processor ! StartMeasure
+    val cmds = 1 to (loadCycles / 3) flatMap (_ ⇒ List("a", "b", "c"))
+    processor ! StartMeasure
+    cmds foreach (processor ! _)
+    processor ! StopMeasure
+    expectMsgPF(100 seconds) {
+      case throughput: Double ⇒ println(f"\nthroughput = $throughput%.2f persistent events per second")
+    }
+  }
+
+  "A command sourced processor" should {
+    "have some reasonable throughput" in {
+      stressCommandsourcedProcessor(None)
+    }
+    "have some reasonable throughput under failure conditions" in {
+      stressCommandsourcedProcessor(Some(warmupClycles + loadCycles / 10))
+    }
+  }
+
+  "An event sourced processor" should {
+    "have some reasonable throughput" in {
+      stressEventsourcedProcessor(None)
+    }
+    "have some reasonable throughput under failure conditions" in {
+      stressEventsourcedProcessor(Some(warmupClycles + loadCycles / 10))
+    }
+    "have some reasonable throughput with stashing and unstashing every 3rd command" in {
+      stressStashingEventsourcedProcessor()
+    }
+  }
+}

--- a/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
@@ -8,6 +8,7 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.reflect.ClassTag
+import scala.util.control.NoStackTrace
 
 import com.typesafe.config.ConfigFactory
 
@@ -53,12 +54,12 @@ trait PersistenceSpec extends BeforeAndAfterEach { this: AkkaSpec ⇒
 object PersistenceSpec {
   def config(plugin: String, test: String) = ConfigFactory.parseString(
     s"""
-      |serialize-creators = on
-      |serialize-messages = on
-      |akka.persistence.journal.plugin = "akka.persistence.journal.${plugin}"
-      |akka.persistence.journal.leveldb.dir = "target/journal-${test}-spec"
-      |akka.persistence.snapshot-store.local.dir = "target/snapshots-${test}-spec/"
-    """.stripMargin)
+      serialize-creators = on
+      serialize-messages = on
+      akka.persistence.journal.plugin = "akka.persistence.journal.${plugin}"
+      akka.persistence.journal.leveldb.dir = "target/journal-${test}-spec"
+      akka.persistence.snapshot-store.local.dir = "target/snapshots-${test}-spec/"
+    """)
 }
 
 abstract class NamedProcessor(name: String) extends Processor {
@@ -68,5 +69,7 @@ abstract class NamedProcessor(name: String) extends Processor {
 trait TurnOffRecoverOnStart { this: Processor ⇒
   override def preStart(): Unit = ()
 }
+
+class TestException(msg: String) extends Exception(msg) with NoStackTrace
 
 case object GetState

--- a/akka-persistence/src/test/scala/akka/persistence/ProcessorStashSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/ProcessorStashSpec.scala
@@ -18,8 +18,8 @@ object ProcessorStashSpec {
       case Persistent("b", snr)  ⇒ update("b", snr)
       case Persistent("c", snr)  ⇒ update("c", snr); unstashAll()
       case "x"                   ⇒ update("x")
-      case "boom"                ⇒ throw new Exception("boom")
-      case Persistent("boom", _) ⇒ throw new Exception("boom")
+      case "boom"                ⇒ throw new TestException("boom")
+      case Persistent("boom", _) ⇒ throw new TestException("boom")
       case GetState              ⇒ sender ! state.reverse
     }
 


### PR DESCRIPTION
- batch-write of persistent messages (user API)
- batch-write of events (in EventsourcedProcessor)
- replace stash with command buffer actor for event sourcing
  - fixes denial of service (stash/unstash/receive overhead) under high load
  - throughput of event sourcing is now approx. 50% of command sourcing
- initial performance tests (disabled)
  - command sourcing
  - event sourcing
  - event sourcing with user stash operations
- suppress stack traces in tests
