### PR TITLE
=doc,osg Effort to get OSGi integration tests running again

### DIFF
--- a/akka-docs/rst/dev/documentation.rst
+++ b/akka-docs/rst/dev/documentation.rst
@@ -129,7 +129,7 @@ Add texlive bin to $PATH:
 
 ::
 
-  /usr/local/texlive/2012basic/bin/universal-darwin
+  /usr/local/texlive/2013basic/bin/universal-darwin
 
 Add missing tex packages:
 

--- a/akka-samples/akka-sample-osgi-dining-hakkers/assembly-features/src/main/resources/features.xml
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/assembly-features/src/main/resources/features.xml
@@ -15,7 +15,7 @@
     </feature>
 
     <feature name='protobuf' description='Protobuf feature' version='${protobuf.version}' resolver='(obr)'>
-        <bundle start-level="20">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.protobuf-java/${protobuf.version}_1</bundle>
+        <bundle start-level="20">mvn:com.google.protobuf/protobuf-java/${protobuf.version}</bundle>
     </feature>
 
     <feature name='netty' description='Netty feature' version='${netty.version}' resolver='(obr)'>

--- a/akka-samples/akka-sample-osgi-dining-hakkers/pom.xml
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/pom.xml
@@ -17,7 +17,7 @@
         <paxexam.version>2.6.0</paxexam.version>
         <paxswissbox.version>1.6.0</paxswissbox.version>
         <protobuf.version>2.5.0</protobuf.version>
-        <scala.version>2.10.1</scala.version>
+        <scala.version>2.10.2</scala.version>
         <scala.dep.version>2.10</scala.dep.version>
         <scalatest.version>1.9.1</scalatest.version>
         <typesafe.config.version>1.0.2</typesafe.config.version>

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1026,7 +1026,7 @@ object AkkaBuild extends Build {
       OsgiKeys.exportPackage := packages
     )
     def defaultImports = Seq("!sun.misc", akkaImport(), configImport(), scalaImport(), "*")
-    def akkaImport(packageName: String = "akka.*") = "%s;version=\"[2.2,2.3)\"".format(packageName)
+    def akkaImport(packageName: String = "akka.*") = "%s;version=\"[2.3,2.4)\"".format(packageName)
     def configImport(packageName: String = "com.typesafe.config.*") = "%s;version=\"[0.4.1,1.1.0)\"".format(packageName)
     def protobufImport(packageName: String = "com.google.protobuf.*") = "%s;version=\"[2.5.0,2.6.0)\"".format(packageName)
     def scalaImport(packageName: String = "scala.*") = "%s;version=\"[2.10,2.11)\"".format(packageName)


### PR DESCRIPTION
Discussion at https://groups.google.com/forum/#!topic/akka-dev/VdZz8d5LJEs
- Update protobuf dependency so mvn clean install runs again
- Bump OSGi version range in AkkaBuild to include current 2.3 for generated manifests
- Update path in dev documentation to correct TexBasic folder

Review by @patriknw

btw I signed the CLA
