### PR TITLE
!per #3717 Deletion API for snapshots and persistent messages

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -164,10 +164,11 @@ private[akka] trait StashSupport {
   }
 
   /**
-   * Prepends `others` to this stash.
+   * Prepends `others` to this stash. This method is optimized for a large stash and
+   * small `others`.
    */
   private[akka] def prepend(others: immutable.Seq[Envelope]): Unit =
-    others.reverseIterator.foreach(env ⇒ theStash = env +: theStash)
+    theStash = others.foldRight(theStash)((e, s) ⇒ e +: s)
 
   /**
    *  Prepends the oldest message in the stash to the mailbox, and then removes that

--- a/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
@@ -101,7 +101,7 @@ public class PersistenceDocTest {
             @Override
             public void preRestart(Throwable reason, Option<Object> message) {
                 if (message.isDefined() && message.get() instanceof Persistent) {
-                    deleteMessage((Persistent) message.get());
+                    deleteMessage(((Persistent) message.get()).sequenceNr());
                 }
                 super.preRestart(reason, message);
             }

--- a/akka-docs/rst/java/code/docs/persistence/PersistencePluginDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistencePluginDocTest.java
@@ -32,6 +32,10 @@ public class PersistencePluginDocTest {
         @Override
         public void doDelete(SnapshotMetadata metadata) throws Exception {
         }
+
+        @Override
+        public void doDelete(String processorId, SnapshotSelectionCriteria criteria) throws Exception {
+        }
     }
 
     class MyAsyncJournal extends AsyncWriteJournal {
@@ -51,7 +55,7 @@ public class PersistencePluginDocTest {
         }
 
         @Override
-        public Future<Void> doDeleteAsync(String processorId, long sequenceNr, boolean physical) {
+        public Future<Void> doDeleteAsync(String processorId, long fromSequenceNr, long toSequenceNr, boolean permanent) {
             return null;
         }
 

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -143,11 +143,12 @@ a replay of that message during recovery it can be deleted.
 Message deletion
 ----------------
 
-A processor can delete messages by calling the ``delete`` method with a ``Persistent`` message object or a
-sequence number as argument. An optional ``physical`` parameter specifies whether the message shall be
-physically deleted from the journal or only marked as deleted. In both cases, the message won't be replayed.
-Later extensions to Akka persistence will allow to replay messages that have been marked as deleted which can
-be useful for debugging purposes, for example.
+A processor can delete a single message by calling the ``deleteMessage`` method with the sequence number of
+that message as argument. An optional ``permanent`` parameter specifies whether the message shall be permanently
+deleted from the journal or only marked as deleted. In both cases, the message won't be replayed. Later extensions
+to Akka persistence will allow to replay messages that have been marked as deleted which can be useful for debugging
+purposes, for example. To delete all messages (journaled by a single processor) up to a specified sequence number,
+processors can call the ``deleteMessages`` method.
 
 Identifiers
 -----------
@@ -314,6 +315,13 @@ and at least one of these snapshots matches the ``SnapshotSelectionCriteria`` th
 If not specified, they default to ``SnapshotSelectionCriteria.latest()`` which selects the latest (= youngest) snapshot.
 To disable snapshot-based recovery, applications should use ``SnapshotSelectionCriteria.none()``. A recovery where no
 saved snapshot matches the specified ``SnapshotSelectionCriteria`` will replay all journaled messages.
+
+Snapshot deletion
+-----------------
+
+A processor can delete a single snapshot by calling the ``deleteSnapshot`` method with the sequence number and the
+timestamp of the snapshot as argument. To bulk-delete snapshots that match a specified ``SnapshotSelectionCriteria``
+argument, processors can call the ``deleteSnapshots`` method.
 
 .. _event-sourcing-java:
 

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -67,7 +67,7 @@ trait PersistenceDocSpec {
       //#deletion
       override def preRestart(reason: Throwable, message: Option[Any]) {
         message match {
-          case Some(p: Persistent) ⇒ deleteMessage(p)
+          case Some(p: Persistent) ⇒ deleteMessage(p.sequenceNr)
           case _                   ⇒
         }
         super.preRestart(reason, message)

--- a/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
@@ -71,7 +71,7 @@ class PersistencePluginDocSpec extends WordSpec {
 class MyJournal extends AsyncWriteJournal {
   def writeAsync(persistent: PersistentRepr): Future[Unit] = ???
   def writeBatchAsync(persistentBatch: Seq[PersistentRepr]): Future[Unit] = ???
-  def deleteAsync(processorId: String, sequenceNr: Long, physical: Boolean): Future[Unit] = ???
+  def deleteAsync(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, permanent: Boolean): Future[Unit] = ???
   def confirmAsync(processorId: String, sequenceNr: Long, channelId: String): Future[Unit] = ???
   def replayAsync(processorId: String, fromSequenceNr: Long, toSequenceNr: Long)(replayCallback: (PersistentRepr) ⇒ Unit): Future[Long] = ???
 }
@@ -79,6 +79,7 @@ class MyJournal extends AsyncWriteJournal {
 class MySnapshotStore extends SnapshotStore {
   def loadAsync(processorId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = ???
   def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = ???
-  def saved(metadata: SnapshotMetadata) {}
-  def delete(metadata: SnapshotMetadata) {}
+  def saved(metadata: SnapshotMetadata): Unit = ???
+  def delete(metadata: SnapshotMetadata): Unit = ???
+  def delete(processorId: String, criteria: SnapshotSelectionCriteria): Unit = ???
 }

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -138,11 +138,12 @@ a replay of that message during recovery it can be deleted.
 Message deletion
 ----------------
 
-A processor can delete messages by calling the ``delete`` method with a ``Persistent`` message object or a
-sequence number as argument. An optional ``physical`` parameter specifies whether the message shall be
-physically deleted from the journal or only marked as deleted. In both cases, the message won't be replayed.
-Later extensions to Akka persistence will allow to replay messages that have been marked as deleted which can
-be useful for debugging purposes, for example.
+A processor can delete a single message by calling the ``deleteMessage`` method with the sequence number of
+that message as argument. An optional ``permanent`` parameter specifies whether the message shall be permanently
+deleted from the journal or only marked as deleted. In both cases, the message won't be replayed. Later extensions
+to Akka persistence will allow to replay messages that have been marked as deleted which can be useful for debugging
+purposes, for example. To delete all messages (journaled by a single processor) up to a specified sequence number,
+processors can call the ``deleteMessages`` method.
 
 Identifiers
 -----------
@@ -325,6 +326,13 @@ and at least one of these snapshots matches the ``SnapshotSelectionCriteria`` th
 If not specified, they default to ``SnapshotSelectionCriteria.Latest`` which selects the latest (= youngest) snapshot.
 To disable snapshot-based recovery, applications should use ``SnapshotSelectionCriteria.None``. A recovery where no
 saved snapshot matches the specified ``SnapshotSelectionCriteria`` will replay all journaled messages.
+
+Snapshot deletion
+-----------------
+
+A processor can delete a single snapshot by calling the ``deleteSnapshot`` method with the sequence number and the
+timestamp of the snapshot as argument. To bulk-delete snapshots that match a specified ``SnapshotSelectionCriteria``
+argument, processors can call the ``deleteSnapshots`` method.
 
 .. _event-sourcing:
 

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncReplayPlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncReplayPlugin.java
@@ -28,7 +28,7 @@ interface AsyncReplayPlugin {
      * message must be contained in that message's `confirms` sequence.
      *
      * @param processorId processor id.
-     * @param fromSequenceNr sequence number where replay should start.
+     * @param fromSequenceNr sequence number where replay should start (inclusive).
      * @param toSequenceNr sequence number where replay should end (inclusive).
      * @param replayCallback called to replay a single message. Can be called from any
      *                       thread.

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
@@ -23,11 +23,14 @@ interface AsyncWritePlugin {
     Future<Void> doWriteBatchAsync(Iterable<PersistentRepr> persistentBatch);
 
     /**
-     * Java API, Plugin API: asynchronously deletes a persistent message. If `physical`
-     * is set to `false`, the persistent message is marked as deleted, otherwise it is
-     * physically deleted.
+     * Java API, Plugin API: asynchronously deletes all persistent messages within the
+     * range  from `fromSequenceNr` to `toSequenceNr`. If `permanent` is set to `false`,
+     * the persistent messages are marked as deleted, otherwise they are permanently
+     * deleted.
+     *
+     * @see AsyncReplayPlugin
      */
-    Future<Void> doDeleteAsync(String processorId, long sequenceNr, boolean physical);
+    Future<Void> doDeleteAsync(String processorId, long fromSequenceNr, long toSequenceNr, boolean permanent);
 
     /**
      * Java API, Plugin API: asynchronously writes a delivery confirmation to the

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/SyncWritePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/SyncWritePlugin.java
@@ -21,11 +21,14 @@ interface SyncWritePlugin {
     void doWriteBatch(Iterable<PersistentRepr> persistentBatch);
 
     /**
-     * Java API, Plugin API: synchronously deletes a persistent message. If `physical`
-     * is set to `false`, the persistent message is marked as deleted, otherwise it is
-     * physically deleted.
+     * Java API, Plugin API: synchronously deletes all persistent messages within the
+     * range  from `fromSequenceNr` to `toSequenceNr`. If `permanent` is set to `false`,
+     * the persistent messages are marked as deleted, otherwise they are permanently
+     * deleted.
+     *
+     * @see AsyncReplayPlugin
      */
-    void doDelete(String processorId, long sequenceNr, boolean physical);
+    void doDelete(String processorId, long fromSequenceNr, long toSequenceNr, boolean permanent);
 
     /**
      * Java API, Plugin API: synchronously writes a delivery confirmation to the journal.

--- a/akka-persistence/src/main/java/akka/persistence/snapshot/japi/SnapshotStorePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/snapshot/japi/SnapshotStorePlugin.java
@@ -40,5 +40,13 @@ interface SnapshotStorePlugin {
      * @param metadata snapshot metadata.
      */
     void doDelete(SnapshotMetadata metadata) throws Exception;
+
+    /**
+     * Java API, Plugin API: deletes all snapshots matching `criteria`.
+     *
+     * @param processorId processor id.
+     * @param criteria selection criteria for deleting.
+     */
+    void doDelete(String processorId, SnapshotSelectionCriteria criteria) throws Exception;
     //#snapshot-store-plugin-api
 }

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -64,11 +64,11 @@ private[persistence] trait Eventsourced extends Processor {
   private val persistingEvents: State = new State {
     def aroundReceive(receive: Receive, message: Any) = message match {
       case PersistentBatch(b) ⇒ {
-        b.foreach(p ⇒ deleteMessage(p, true))
+        b.foreach(p ⇒ deleteMessage(p.sequenceNr, true))
         throw new UnsupportedOperationException("Persistent command batches not supported")
       }
       case p: PersistentRepr ⇒ {
-        deleteMessage(p, true)
+        deleteMessage(p.sequenceNr, true)
         throw new UnsupportedOperationException("Persistent commands not supported")
       }
       case WriteSuccess(p) if identical(p.payload, persistInvocations.head._1) ⇒ {

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -13,12 +13,12 @@ import akka.actor._
  */
 private[persistence] object JournalProtocol {
   /**
-   * Instructs a journal to delete a persistent message identified by `processorId`
-   * and `sequenceNr`. If `physical` is set to `false`, the persistent message is
-   * marked as deleted in the journal, otherwise it is physically deleted from the
-   * journal.
+   * Instructs a journal to delete all persistent messages with sequence numbers in
+   * the range from `fromSequenceNr` to `toSequenceNr` (both inclusive). If `permanent`
+   * is set to `false`, the persistent messages are marked as deleted in the journal,
+   * otherwise they are permanently deleted from the journal.
    */
-  case class Delete(processorId: String, sequenceNr: Long, physical: Boolean)
+  case class Delete(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, permanent: Boolean)
 
   /**
    * Instructs a journal to persist a sequence of messages.

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncReplay.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncReplay.scala
@@ -29,7 +29,7 @@ trait AsyncReplay {
    * message must be contained in that message's `confirms` sequence.
    *
    * @param processorId processor id.
-   * @param fromSequenceNr sequence number where replay should start.
+   * @param fromSequenceNr sequence number where replay should start (inclusive).
    * @param toSequenceNr sequence number where replay should end (inclusive).
    * @param replayCallback called to replay a single message. Can be called from any
    *                       thread.

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
@@ -22,8 +22,8 @@ abstract class AsyncWriteJournal extends AsyncReplay with SAsyncWriteJournal wit
   final def writeBatchAsync(persistentBatch: immutable.Seq[PersistentRepr]) =
     doWriteBatchAsync(persistentBatch.asJava).map(Unit.unbox)
 
-  final def deleteAsync(processorId: String, sequenceNr: Long, physical: Boolean) =
-    doDeleteAsync(processorId, sequenceNr, physical).map(Unit.unbox)
+  final def deleteAsync(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, permanent: Boolean) =
+    doDeleteAsync(processorId, fromSequenceNr, toSequenceNr, permanent).map(Unit.unbox)
 
   final def confirmAsync(processorId: String, sequenceNr: Long, channelId: String) =
     doConfirmAsync(processorId, sequenceNr, channelId).map(Unit.unbox)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/SyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/SyncWriteJournal.scala
@@ -20,8 +20,8 @@ abstract class SyncWriteJournal extends AsyncReplay with SSyncWriteJournal with 
   final def writeBatch(persistentBatch: immutable.Seq[PersistentRepr]) =
     doWriteBatch(persistentBatch.asJava)
 
-  final def delete(processorId: String, sequenceNr: Long, physical: Boolean) =
-    doDelete(processorId, sequenceNr, physical)
+  final def delete(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, permanent: Boolean) =
+    doDelete(processorId, fromSequenceNr, toSequenceNr, permanent)
 
   final def confirm(processorId: String, sequenceNr: Long, channelId: String) =
     doConfirm(processorId, sequenceNr, channelId)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
@@ -45,12 +45,14 @@ private[leveldb] class LeveldbJournal extends SyncWriteJournal with LeveldbIdMap
   def writeBatch(persistentBatch: immutable.Seq[PersistentRepr]) =
     withBatch(batch ⇒ persistentBatch.foreach(persistent ⇒ addToBatch(persistent, batch)))
 
-  def delete(processorId: String, sequenceNr: Long, physical: Boolean) {
-    if (physical)
-      // TODO: delete confirmations and deletion markers, if any.
-      leveldb.delete(keyToBytes(Key(numericId(processorId), sequenceNr, 0)))
-    else
-      leveldb.put(keyToBytes(deletionKey(numericId(processorId), sequenceNr)), Array.empty[Byte])
+  def delete(processorId: String, fromSequenceNr: Long, toSequenceNr: Long, permanent: Boolean) = withBatch { batch ⇒
+    val nid = numericId(processorId)
+    if (permanent) fromSequenceNr to toSequenceNr foreach { sequenceNr ⇒
+      batch.delete(keyToBytes(Key(nid, sequenceNr, 0))) // TODO: delete confirmations and deletion markers, if any.
+    }
+    else fromSequenceNr to toSequenceNr foreach { sequenceNr ⇒
+      batch.put(keyToBytes(deletionKey(nid, sequenceNr)), Array.empty[Byte])
+    }
   }
 
   def confirm(processorId: String, sequenceNr: Long, channelId: String) {

--- a/akka-persistence/src/main/scala/akka/persistence/snapshot/japi/SnapshotStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/snapshot/japi/SnapshotStore.scala
@@ -27,4 +27,8 @@ abstract class SnapshotStore extends SSnapshotStore with SnapshotStorePlugin {
 
   final def delete(metadata: SnapshotMetadata) =
     doDelete(metadata)
+
+  final def delete(processorId: String, criteria: SnapshotSelectionCriteria) =
+    doDelete(processorId: String, criteria: SnapshotSelectionCriteria)
+
 }

--- a/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
@@ -56,6 +56,7 @@ object PersistenceSpec {
     s"""
       serialize-creators = on
       serialize-messages = on
+      akka.persistence.publish-plugin-commands = on
       akka.persistence.journal.plugin = "akka.persistence.journal.${plugin}"
       akka.persistence.journal.leveldb.dir = "target/journal-${test}-spec"
       akka.persistence.snapshot-store.local.dir = "target/snapshots-${test}-spec/"

--- a/akka-persistence/src/test/scala/akka/persistence/ProcessorStashSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/ProcessorStashSpec.scala
@@ -38,7 +38,7 @@ object ProcessorStashSpec {
   class RecoveryFailureStashingProcessor(name: String) extends StashingProcessor(name) {
     override def preRestart(reason: Throwable, message: Option[Any]) = {
       message match {
-        case Some(m: Persistent) ⇒ if (recoveryRunning) deleteMessage(m)
+        case Some(m: Persistent) ⇒ if (recoveryRunning) deleteMessage(m.sequenceNr)
         case _                   ⇒
       }
       super.preRestart(reason, message)

--- a/akka-samples/akka-sample-persistence/src/main/java/sample/persistence/japi/ProcessorFailureExample.java
+++ b/akka-samples/akka-sample-persistence/src/main/java/sample/persistence/japi/ProcessorFailureExample.java
@@ -34,7 +34,7 @@ public class ProcessorFailureExample {
         @Override
         public void preRestart(Throwable reason, Option<Object> message) {
             if (message.isDefined() && message.get() instanceof Persistent) {
-                deleteMessage((Persistent) message.get());
+                deleteMessage(((Persistent) message.get()).sequenceNr(), false);
             }
             super.preRestart(reason, message);
         }

--- a/akka-samples/akka-sample-persistence/src/main/scala/sample/persistence/ProcessorFailureExample.scala
+++ b/akka-samples/akka-sample-persistence/src/main/scala/sample/persistence/ProcessorFailureExample.scala
@@ -20,7 +20,7 @@ object ProcessorFailureExample extends App {
 
     override def preRestart(reason: Throwable, message: Option[Any]) {
       message match {
-        case Some(p: Persistent) if !recoveryRunning ⇒ deleteMessage(p) // mark failing message as deleted
+        case Some(p: Persistent) if !recoveryRunning ⇒ deleteMessage(p.sequenceNr) // mark failing message as deleted
         case _                                       ⇒ // ignore
       }
       super.preRestart(reason, message)


### PR DESCRIPTION
- single and bulk deletion of messages
- single and bulk deletion of snapshots
- run journal and snapshot store as system actors
- rename physical parameter in delete methods to permanent
- StashSupport.prepend docs and implementation enhancements
