### PR TITLE
#3159 - ReliableProxy with reconnection

### DIFF
--- a/akka-contrib/docs/reliable-proxy.rst
+++ b/akka-contrib/docs/reliable-proxy.rst
@@ -80,13 +80,13 @@ How to use it
 -------------
 
 Since this implementation does not offer much in the way of configuration,
-simply instantiate a proxy wrapping some target reference. From Java it looks
-like this:
+simply instantiate a proxy wrapping a target ``ActorRef`` or ``ActorPath``. From Java it looks
+like this (using an ``ActorPath``):
 
 .. includecode:: @contribSrc@/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
    :include: import,demo-proxy
 
-And from Scala like this:
+And from Scala like this (using an ``ActorRef``):
 
 .. includecode:: @contribSrc@/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala#demo
 
@@ -103,6 +103,16 @@ From Scala it would look like so:
 
 .. includecode:: @contribSrc@/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala#demo-transition
 
+Configuration
+^^^^^^^^^^^^^
+
+* Set ``akka.reliable-proxy.debug`` to ``on`` to turn on extra debug logging for your
+  :class:`ReliableProxy` actors.
+* ``akka.reliable-proxy.default-connect-interval`` is used only if you create a :class:`ReliableProxy`
+  using the *Props taking ActorPath with no reconnections* (that is, ``reconnectAfter == None``).
+  The default value is ``500 ms``.  In this case the :class:`ReliableProxy` will send an ``Identify`` message
+  to the *target* every 500 milliseconds to try to resolve the :class:`ActorPath` to an :class:`ActorRef` so
+  that messages can be sent to the *target*.
 
 The Actor Contract
 ------------------

--- a/akka-contrib/docs/reliable-proxy.rst
+++ b/akka-contrib/docs/reliable-proxy.rst
@@ -61,12 +61,12 @@ actor system) must be considered as one when evaluating the reliability of this
 communication channel. The benefit is that the network in-between is taken out
 of that equation.
 
-Reconnecting to the target
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Connecting to the target
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the ``target`` terminates the ``proxy`` will optionally try to reconnect to
-it using mechanism outlined in :ref:`actorSelection-scala`.  If the maximum
-number of reconnection attempts is reached the ``proxy`` will terminate.
+The ``proxy`` tries to connect to the ``target`` using the mechanism outlined in
+:ref:`actorSelection-scala`.  Once connected, if the ``tunnel`` terminates the ``proxy``
+will optionally try to reconnect to the target using using the same process.
 
 Note that during the reconnection process there is a possibility that a message
 could be delivered to the ``target`` more than once.  Consider the case where a message
@@ -109,10 +109,9 @@ Configuration
 * Set ``akka.reliable-proxy.debug`` to ``on`` to turn on extra debug logging for your
   :class:`ReliableProxy` actors.
 * ``akka.reliable-proxy.default-connect-interval`` is used only if you create a :class:`ReliableProxy`
-  using the *Props taking ActorPath with no reconnections* (that is, ``reconnectAfter == None``).
-  The default value is ``500 ms``.  In this case the :class:`ReliableProxy` will send an ``Identify`` message
-  to the *target* every 500 milliseconds to try to resolve the :class:`ActorPath` to an :class:`ActorRef` so
-  that messages can be sent to the *target*.
+  with no reconnections (that is, ``reconnectAfter == None``). The default value is ``500 ms``.  In this
+  case the :class:`ReliableProxy` will send an ``Identify`` message to the *target* every 500 milliseconds
+  to try to resolve the :class:`ActorPath` to an :class:`ActorRef` so that messages can be sent to the *target*.
 
 The Actor Contract
 ------------------
@@ -145,6 +144,7 @@ Arguments it Takes
   messages, ``B`` in the above illustration.
 * *retryAfter* is the timeout for receiving ACK messages from the remote
   end-point; once it fires, all outstanding message sends will be retried.
-* *reconnectAfter* is an optional interval between reconnection attempts after
-  the target is terminated.
-* *maxReconnects* is an optional maximum number of attempts to reconnect to the target.
+* *reconnectAfter* is an optional interval between connection attempts. It is also used as the interval
+  between receiving a ``Terminated`` for the tunnel and attempting to reconnect to the target actor.
+* *maxConnectAttempts* is an optional maximum number of attempts to connect to the target while in
+  the ``Connecting`` state.

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -21,12 +21,12 @@ object ReliableProxy {
   }
 
   def props(targetRef: ActorRef, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration,
-            maxReconnects: Int): Props = {
+            maxReconnects: Int): Props = {     // Java compatibility
     props(targetRef, retryAfter, reconnectAfter, if (maxReconnects > 0) Some(maxReconnects) else None)
   }
 
   def props(targetPath: ActorPath, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration,
-            maxReconnects: Int): Props = {
+            maxReconnects: Int): Props = {     // Java compatibility
     props(targetPath, retryAfter, reconnectAfter, if (maxReconnects > 0) Some(maxReconnects) else None)
   }
 
@@ -127,8 +127,11 @@ import ReliableProxy._
  *    message ordering is preserved
  *
  * These guarantees are valid for the communication between the two end-points
- * of the reliable “tunnel”, which usually spans an unreliable network. Delivery
- * from the remote end-point to the target actor is still subject to in-JVM
+ * of the reliable “tunnel”, which usually spans an unreliable network.
+ *
+ * Note that the ReliableProxy guarantees at-least-once, not exactly-once, delivery.
+ *
+ * Delivery from the remote end-point to the target actor is still subject to in-JVM
  * delivery semantics (i.e. not strictly guaranteed due to possible OutOfMemory
  * situations or other VM errors).
  *
@@ -151,7 +154,7 @@ import ReliableProxy._
  *
  * ==Message Types==
  *
- * This actor is an [[akka.actor.FSM]], hence it offers the service o
+ * This actor is an [[akka.actor.FSM]], hence it offers the service of
  * transition callbacks to those actors which subscribe using the
  * ``SubscribeTransitionCallBack`` and ``UnsubscribeTransitionCallBack``
  * messages; see [[akka.actor.FSM]] for more documentation. The proxy will

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -270,7 +270,7 @@ class ReliableProxy(targetPath: ActorPath, retryAfter: FiniteDuration,
     case Event(Terminated(_), _) ⇒ terminated()
     case Event(Ack(_), _)        ⇒ stay()
     case Event(Unsent(msgs), _)  ⇒ goto(Active) using resend(updateSerial(msgs))
-    case Event(msg, _)           ⇒ goto(Active) using Vector(send(msg, sender))
+    case Event(msg, _)           ⇒ goto(Active) using Vector(send(msg, sender()))
   }
 
   onTransition {
@@ -296,7 +296,7 @@ class ReliableProxy(targetPath: ActorPath, retryAfter: FiniteDuration,
     case Event(Unsent(msgs), queue) ⇒
       stay using queue ++ resend(updateSerial(msgs))
     case Event(msg, queue) ⇒
-      stay using (queue :+ send(msg, sender))
+      stay using (queue :+ send(msg, sender()))
   }
 
   when(Connecting) {
@@ -324,7 +324,7 @@ class ReliableProxy(targetPath: ActorPath, retryAfter: FiniteDuration,
     case Event(Unsent(msgs), queue) ⇒
       stay using queue ++ updateSerial(msgs)
     case Event(msg, queue) ⇒
-      stay using (queue :+ Message(msg, sender, nextSerial()))
+      stay using (queue :+ Message(msg, sender(), nextSerial()))
   }
 
   def scheduleTick(): Unit = setTimer(resendTimer, Tick, retryAfter, repeat = false)

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -206,7 +206,7 @@ import ReliableProxy._
  * state when every message send so far has been confirmed by the peer end-point.
  *
  * If a communication failure causes the tunnel to terminate via Remote Deathwatch
- * the proxy will transition into [[ReliableProxy.Reconnect]]
+ * the proxy will transition into [[ReliableProxy.Reconnecting]]
  * state. In this state the proxy will repeatedly send [[akka.actor.Identify]] messages
  * to ActorSelection(target.path) in order to obtain a new ActorRef for the target.
  * When an [[akka.actor.ActorIdentity]] for the target is received a new tunnel will
@@ -240,7 +240,7 @@ import ReliableProxy._
  *
  * @param target is the actor to which all messages will be forwarded which are sent to
  *   this actor. It is either an `ActorRef` or an `ActorPath`.  In the case of an
- *   `ActorPath` this actor will start in the `Reconnect` state and will attempt to
+ *   `ActorPath` this actor will start in the `Reconnecting` state and will attempt to
  *   connect to the remote actor as described above. ``target`` can be a local or remote
  *   actor, but the “remote” tunnel endpoint will be deployed on the node where the
  *   target actor lives.

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -7,10 +7,19 @@ package akka.contrib.pattern
 import akka.actor._
 import akka.remote.RemoteScope
 import scala.concurrent.duration._
+import scala.util.Try
 
 object ReliableProxy {
+  def props(target: ActorRef, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration,
+            maxReconnects: Option[Int]): Props = {
+    Props(classOf[ReliableProxy], target, retryAfter, reconnectAfter, maxReconnects)
+  }
 
-  class Receiver(target: ActorRef) extends Actor with ActorLogging {
+  def props(target: ActorRef, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration): Props = {
+    props(target, retryAfter, reconnectAfter, None)
+  }
+
+  class Receiver(target: ActorRef) extends Actor with DebugLogging {
     var lastSerial = 0
 
     context.watch(target)
@@ -24,36 +33,68 @@ object ReliableProxy {
         } else if (compare(serial, lastSerial) <= 0) {
           sender() ! Ack(serial)
         } else {
-          log.debug("received msg of {} from {} with wrong serial", msg.asInstanceOf[AnyRef].getClass, snd)
+          logDebug(s"Received message from $snd with wrong serial: $msg")
         }
-      //TODO use exact match of target when all actor references have uid, i.e. actorFor has been removed
-      case Terminated(a) if a.path == target.path ⇒ context stop self
+      case Terminated(`target`) ⇒ context stop self
     }
   }
 
   /**
-   * Wrap-around aware comparison of integers: differences limited to 2^31-1
+   * Wrap-around aware comparison of integers: differences limited to 2**31-1
    * in magnitude will work correctly.
    */
-  def compare(a: Int, b: Int): Int = (a - b) match {
-    case x if x < 0  ⇒ -1
-    case x if x == 0 ⇒ 0
-    case x if x > 0  ⇒ 1
+  def compare(a: Int, b: Int): Int = {
+    val c = a - b
+    c match {
+      case x if x < 0  ⇒ -1
+      case x if x == 0 ⇒ 0
+      case x if x > 0  ⇒ 1
+    }
   }
 
+  // Internal messages
   case class Message(msg: Any, sender: ActorRef, serial: Int)
   case class Ack(serial: Int)
   case object Tick
+  case object ReconnectTick
+
+  /**
+   *  Wrap a message in NoRetry to have the proxy send the message directly to the target
+   *  (not through the tunnel) without retrying.  This is useful if you need to send unreliable
+   *  messages to the target but don't want to track changing target ActorRefs in your actor.
+   */
+  case class NoRetry(msg: Any)
+
+  /**
+   * TargetChanged is sent to transition subscribers when the target ActorRef has changed
+   * (for example, the target system crashed and has been restarted).
+   */
+  case class TargetChanged(ref: ActorRef)
+
+  /**
+   * ProxyTerminated is sent to transition subscribers during postStop.  Any outstanding unsent
+   * messages are contained the Unsent object.
+   */
+  case class ProxyTerminated(actor: ActorRef, outstanding: Unsent)
+  case class Unsent(queue: Vector[Message])
 
   def receiver(target: ActorRef): Props = Props(classOf[Receiver], target)
 
   sealed trait State
   case object Idle extends State
   case object Active extends State
+  case object Reconnect extends State
 
   // Java API
   val idle = Idle
   val active = Active
+  val reconnect = Reconnect
+
+  trait DebugLogging extends ActorLogging { this: Actor ⇒
+    val debug = Try(context.system.settings.config.getBoolean("akka.actor.debug.reliable-proxy")) getOrElse false
+
+    def logDebug(s: String) = if (debug) log.debug(s"$s [$self]")
+  }
 }
 
 import ReliableProxy._
@@ -62,8 +103,8 @@ import ReliableProxy._
  * A ReliableProxy is a means to wrap a remote actor reference in order to
  * obtain certain improved delivery guarantees:
  *
- *  - as long as none of the JVMs crashes and the proxy and its remote-deployed
- *    peer are not forcefully terminated or restarted, no messages will be lost
+ *  - as long as the proxy is not terminated before it sends all of its queued
+ *    messages then no messages will be lost
  *  - messages re-sent due to the first point will not be delivered out-of-order,
  *    message ordering is preserved
  *
@@ -74,17 +115,13 @@ import ReliableProxy._
  * situations or other VM errors).
  *
  * You can create a reliable connection like this:
- *
- * In Scala:
- *
  * {{{
- * val proxy = context.actorOf(Props(classOf[ReliableProxy], target))
+ * val proxy = context.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds)
  * }}}
- *
- * In Java:
- *
+ * or in Java:
  * {{{
- * final ActorRef proxy = getContext().actorOf(Props.create(ReliableProxy.class target));
+ * final ActorRef proxy = getContext().actorOf(ReliableProxy.props(
+ *   target, Duration.create(100, "millis"), Duration.create(120, "seconds")));
  * }}}
  *
  * '''''Please note:''''' the tunnel is uni-directional, and original sender
@@ -94,16 +131,36 @@ import ReliableProxy._
  *
  * ==Message Types==
  *
- * This actor is an [[akka.actor.FSM]], hence it offers the service of
+ * This actor is an akka.actor.FSM, hence it offers the service of
  * transition callbacks to those actors which subscribe using the
  * ``SubscribeTransitionCallBack`` and ``UnsubscribeTransitionCallBack``
- * messages; see [[akka.actor.FSM]] for more documentation. The proxy will
- * transition into [[ReliableProxy.Active]] state when ACKs are outstanding and
- * return to the [[ReliableProxy.Idle]] state when every message send so far
+ * messages; see akka.actor.FSM for more documentation. The proxy will
+ * transition into ReliableProxy.Active state when ACKs are outstanding and
+ * return to the ReliableProxy.Idle state when every message send so far
  * has been confirmed by the peer end-point.
+ *
+ * If a communication failure causes the tunnel to terminate via Remote Deathwatch
+ * the proxy will transition into ReliableProxy.Reconnect state. In this state the
+ * proxy will repeatedly send Identify messages to ActorSelection(target.path) in
+ * order to obtain a new ActorRef for the target.  When an ActorIdentity for the
+ * target is received a new tunnel will be created and the proxy will transition to
+ * either Active or Idle, depending if there are any outstanding messages.  If the
+ * target ActorRef has changed a TargetChanged message will be sent to the proxy's
+ * transition subscribers.
+ *
+ * If the proxy is stopped and it still has outstanding messages a ProxyTerminated
+ * message will be sent to the transition subscribers.  It contains an Unsent object
+ * with the outstanding messages.
+ *
+ * If an Unsent message is sent to this actor the messages contained within it will
+ * be relayed through the tunnel to the target.
+ *
+ * If a NoRetry message is sent the message it wraps will be forwarded to the target
+ * directly (ie, not through the tunnel).  NoRetry messages have no delivery guarantees.
+ *
  * Any other message type sent to this actor will be delivered via a remote-deployed
- * child actor to the designated target. Message types declared in the companion
- * object are for internal use only and not to be sent from the outside.
+ * child actor to the designated target. All other message types declared in the
+ * companion object are for internal use only and not to be sent from the outside.
  *
  * ==Failure Cases==
  *
@@ -112,58 +169,170 @@ import ReliableProxy._
  *
  * ==Arguments==
  *
- * '''''target''''' is the [[akka.actor.ActorRef]] to which all messages will be
+ * '''''target''''' is the akka.actor.ActorRef to which all messages will be
  * forwarded which are sent to this actor. It can be any type of actor reference,
  * but the “remote” tunnel endpoint will be deployed on the node where the target
  * ref points to.
  *
  * '''''retryAfter''''' is the ACK timeout after which all outstanding messages
- * will be resent. There is not limit on the queue size or the number of retries.
+ * will be resent. There is no limit on the queue size or the number of retries.
+ *
+ * '''''reconnectAfter''''' is the interval between reconnection attempts after the tunnel
+ * is terminated.  The minimum recommended value for this is the sum of the properties
+ * akka.remote.gate-invalid-addresses-for and akka.remote.quarantine-systems-for.
+ *
+ * '''''maxReconnects''''' is an optional maximum number of reconnection attempts for each
+ * tunnel. Use None for unlimited.
  */
-class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration) extends Actor with FSM[State, Vector[Message]] {
+class ReliableProxy(target: ActorRef, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration,
+                    maxReconnects: Option[Int])
+  extends Actor with LoggingFSM[State, Vector[Message]] with DebugLogging {
 
-  val tunnel = context.actorOf(receiver(target).withDeploy(Deploy(scope = RemoteScope(target.path.address))), "tunnel")
-  context.watch(tunnel)
+  var currentSerial: Int = _
+  var currentTarget: ActorRef = _
+  var attemptedReconnects: Int = _
+
+  def createTunnel(target: ActorRef): ActorRef = {
+    logDebug(s"Creating new tunnel for $target")
+    val t = context.actorOf(receiver(target).withDeploy(Deploy(scope = RemoteScope(target.path.address))), "tunnel")
+
+    context.watch(t)
+    currentSerial = 0 // New tunnel expects first message to start with 1
+    currentTarget = target
+    attemptedReconnects = 0
+    resetBackoff()
+    t
+  }
+
+  if (target.path.address.host.isEmpty && self.path.address == target.path.address) {
+    logDebug(s"Unnecessary to use ReliableProxy for local target: $target")
+  }
+  var tunnel = createTunnel(target)
+
+  val resendTimer = "resend"
+  val reconnectTimer = "reconnect"
 
   override def supervisorStrategy = OneForOneStrategy() {
     case _ ⇒ SupervisorStrategy.Escalate
   }
 
+  override def postStop() {
+    logDebug(s"Stopping proxy and sending ${stateData.size} messages to parent in Unsent")
+    gossip(ProxyTerminated(self, Unsent(stateData)))
+    super.postStop()
+  }
+
   startWith(Idle, Vector.empty)
 
   when(Idle) {
-    case Event(Terminated(`tunnel`), _) ⇒ stop
-    case Event(Ack(_), _)               ⇒ stay
-    case Event(msg, _)                  ⇒ goto(Active) using Vector(send(msg))
+    case Event(Terminated(_), _) ⇒ terminated()
+    case Event(Ack(_), _)        ⇒ stay()
+    case Event(Unsent(msgs), _)  ⇒ goto(Active) using resend(msgs)
+    case Event(NoRetry(msg), _)  ⇒
+      currentTarget forward msg; stay()
+    case Event(msg, _)           ⇒ goto(Active) using Vector(send(msg, sender))
   }
 
   onTransition {
-    case Idle -> Active ⇒ scheduleTick()
-    case Active -> Idle ⇒ cancelTimer("resend")
+    case _ -> Active    ⇒ scheduleTick()
+    case Active -> Idle ⇒ cancelTimer(resendTimer)
+    case _ -> Reconnect ⇒ scheduleReconnectTick()
   }
 
   when(Active) {
-    case Event(Terminated(`tunnel`), _) ⇒ stop
+    case Event(Terminated(_), _) ⇒
+      terminated()
     case Event(Ack(serial), queue) ⇒
       val q = queue dropWhile (m ⇒ compare(m.serial, serial) <= 0)
       scheduleTick()
       if (q.isEmpty) goto(Idle) using Vector.empty
       else stay using q
     case Event(Tick, queue) ⇒
-      queue foreach (tunnel ! _)
+      logResend(queue.size)
+      queue foreach { tunnel ! _ }
       scheduleTick()
-      stay
-    case Event(msg, queue) ⇒ stay using (queue :+ send(msg))
+      stay()
+    case Event(Unsent(msgs), _) ⇒
+      stay using resend(msgs)
+    case Event(NoRetry(msg), _) ⇒
+      currentTarget forward msg
+      stay()
+    case Event(msg, queue) ⇒
+      stay using (queue :+ send(msg, sender))
   }
 
-  def scheduleTick(): Unit = setTimer("resend", Tick, retryAfter, false)
+  when(Reconnect) {
+    case Event(Terminated(_), _) ⇒
+      stay()
+    case Event(ActorIdentity(_, Some(actor)), queue) ⇒
+      val curr = currentTarget
+      cancelTimer(reconnectTimer)
+      tunnel = createTunnel(actor)
+      if (currentTarget != curr) gossip(TargetChanged(currentTarget))
+      if (queue.isEmpty) goto(Idle) else goto(Active) using resend(queue)
+    case Event(ActorIdentity(_, None), _) ⇒
+      stay()
+    case Event(ReconnectTick, _) ⇒
+      if (maxReconnects exists (_ == attemptedReconnects)) {
+        logDebug(s"Failed to reconnect after $attemptedReconnects")
+        stop()
+      } else {
+        logDebug(s"${context.actorSelection(target.path)} ! ${Identify(target.path)}")
+        context.actorSelection(target.path) ! Identify(target.path)
+        scheduleReconnectTick()
+        attemptedReconnects += 1
+        stay()
+      }
+    case Event(NoRetry(msg), _) ⇒ // Drop msg
+      stay()
+    case Event(Unsent(msgs), queue) ⇒
+      stay using queue ++ msgs
+    case Event(msg, queue) ⇒
+      stay using (queue :+ Message(msg, sender, nextSerial()))
+  }
 
-  var nextSerial = 1
-  def send(msg: Any): Message = {
-    val m = Message(msg, sender(), nextSerial)
-    nextSerial += 1
+  def scheduleTick(): Unit = setTimer(resendTimer, Tick, retryAfter, repeat = false)
+
+  def nextSerial(): Int = {
+    currentSerial += 1
+    currentSerial
+  }
+
+  def send(msg: Any, snd: ActorRef): Message = {
+    val m = Message(msg, snd, nextSerial())
     tunnel ! m
     m
   }
 
+  // Send q messages with new serial #s
+  def resend(q: Vector[Message]): Vector[Message] = {
+    logResend(q.size)
+    q map { case Message(msg, sender, _) ⇒ send(msg, sender) }
+  }
+
+  def logResend(size: Int): Unit =
+    logDebug(s"Resending $size messages through tunnel")
+
+  def terminated(): State = {
+    logDebug(s"Terminated: $target")
+    goto(Reconnect)
+  }
+
+  def scheduleReconnectTick(): Unit = {
+    val delay = nextBackoff()
+    logDebug(s"Will attempt to reconnect to ${target.path} in $delay")
+    setTimer(reconnectTimer, ReconnectTick, delay, repeat = false)
+  }
+
+  /**
+   * Reset backoff interval.
+   *
+   * This and nextBackoff are meant to be implemented by subclasses.
+   */
+  def resetBackoff() {}
+
+  /**
+   * Returns the next retry interval duration.  By default each interval is the same, reconnectAfter.
+   */
+  def nextBackoff(): FiniteDuration = reconnectAfter
 }

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -13,13 +13,9 @@ import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.actor._
 import akka.testkit.ImplicitSender
 import scala.concurrent.duration._
-<<<<<<< HEAD
 import akka.actor.FSM
 import akka.actor.ActorRef
 import akka.testkit.TestKitExtension
-import akka.testkit.TestProbe
-=======
->>>>>>> 0f7c5e9... Add tests covering Reconnection, ActorPath, maxReconnects, no reconnects, ProxyTerminated/Unsent, TargetChanged.   Use Option(reconnectAfter) instead of Some(reconnectAfter) in Java props.   Add a new config property to handle Props variation with ActorPath but reconnectAfter = None (defaultConnectInterval).  Ref doc updates show ActorPath usage and discuss config properties.
 import akka.actor.ActorIdentity
 import akka.actor.Identify
 
@@ -144,15 +140,8 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
       runOn(local) {
         testConductor.blackhole(local, remote, Direction.Send).await
         sendN(100)
-<<<<<<< HEAD
         expectTransition(1 second, Idle, Active)
         expectNoMsg(expectNoMsgTimeout)
-=======
-        within(1 second) {
-          expectTransition(Idle, Active)
-          expectNoMsg()
-        }
->>>>>>> 0f7c5e9... Add tests covering Reconnection, ActorPath, maxReconnects, no reconnects, ProxyTerminated/Unsent, TargetChanged.   Use Option(reconnectAfter) instead of Some(reconnectAfter) in Java props.   Add a new config property to handle Props variation with ActorPath but reconnectAfter = None (defaultConnectInterval).  Ref doc updates show ActorPath usage and discuss config properties.
       }
 
       enterBarrier("test2a")
@@ -180,15 +169,8 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
       runOn(local) {
         testConductor.blackhole(local, remote, Direction.Receive).await
         sendN(100)
-<<<<<<< HEAD
         expectTransition(1 second, Idle, Active)
         expectNoMsg(expectNoMsgTimeout)
-=======
-        within(1 second) {
-          expectTransition(Idle, Active)
-          expectNoMsg()
-        }
->>>>>>> 0f7c5e9... Add tests covering Reconnection, ActorPath, maxReconnects, no reconnects, ProxyTerminated/Unsent, TargetChanged.   Use Option(reconnectAfter) instead of Some(reconnectAfter) in Java props.   Add a new config property to handle Props variation with ActorPath but reconnectAfter = None (defaultConnectInterval).  Ref doc updates show ActorPath usage and discuss config properties.
       }
       runOn(remote) {
         within(1 second) {

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -80,7 +80,7 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
 
         system.actorSelection(node(remote) / "user" / "echo") ! Identify("echo")
         target = expectMsgType[ActorIdentity].ref.get
-        proxy = system.actorOf(Props(classOf[ReliableProxy], target, 100.millis), "proxy")
+        proxy = system.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds), "proxy")
         proxy ! FSM.SubscribeTransitionCallBack(testActor)
         expectState(Idle)
         proxy ! "hello"

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -376,7 +376,7 @@ class ReliableProxySpec extends MultiNodeSpec(ReliableProxySpec) with STMultiNod
           val proxyTerm = expectMsgType[ProxyTerminated]
           // Validate that the unsent messages are 50 ints
           val unsentInts = proxyTerm.outstanding.queue collect { case Message(i: Int, _, _) if i > 0 && i <= 50 ⇒ i }
-          unsentInts must have size 50
+          unsentInts should have size 50
           expectMsgType[Terminated]
         }
       }

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
@@ -38,8 +38,9 @@ public class ReliableProxyTest {
 
     public ProxyParent(ActorRef target) {
       proxy = getContext().actorOf(
-          Props.create(ReliableProxy.class, target,
-              Duration.create(100, TimeUnit.MILLISECONDS)));
+          ReliableProxy.props(target,
+              Duration.create(100, TimeUnit.MILLISECONDS),
+              Duration.create(120, TimeUnit.SECONDS)));
     }
 
     public void onReceive(Object msg) {
@@ -58,8 +59,9 @@ public class ReliableProxyTest {
 
     public ProxyTransitionParent(ActorRef target) {
       proxy = getContext().actorOf(
-          Props.create(ReliableProxy.class, target,
-              Duration.create(100, TimeUnit.MILLISECONDS)));
+          ReliableProxy.props(target,
+              Duration.create(100, TimeUnit.MILLISECONDS),
+              Duration.create(120, TimeUnit.SECONDS)));
       proxy.tell(new FSM.SubscribeTransitionCallBack(getSelf()), getSelf());
     }
 

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
@@ -39,8 +39,7 @@ public class ReliableProxyTest {
     public ProxyParent(ActorRef target) {
       proxy = getContext().actorOf(
           ReliableProxy.props(target,
-              Duration.create(100, TimeUnit.MILLISECONDS),
-              Duration.create(120, TimeUnit.SECONDS)));
+              Duration.create(100, TimeUnit.MILLISECONDS)));
     }
 
     public void onReceive(Object msg) {
@@ -60,8 +59,7 @@ public class ReliableProxyTest {
     public ProxyTransitionParent(ActorRef target) {
       proxy = getContext().actorOf(
           ReliableProxy.props(target,
-              Duration.create(100, TimeUnit.MILLISECONDS),
-              Duration.create(120, TimeUnit.SECONDS)));
+              Duration.create(100, TimeUnit.MILLISECONDS)));
       proxy.tell(new FSM.SubscribeTransitionCallBack(getSelf()), getSelf());
     }
 

--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -19,7 +19,7 @@ object ReliableProxyDocSpec {
   import akka.contrib.pattern.ReliableProxy
 
   class ProxyParent(target: ActorRef) extends Actor {
-    val proxy = context.actorOf(Props(classOf[ReliableProxy], target, 100.millis))
+    val proxy = context.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds))
 
     def receive = {
       case "hello" ⇒ proxy ! "world!"
@@ -29,7 +29,7 @@ object ReliableProxyDocSpec {
 
   //#demo-transition
   class ProxyTransitionParent(target: ActorRef) extends Actor {
-    val proxy = context.actorOf(Props(classOf[ReliableProxy], target, 100.millis))
+    val proxy = context.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds))
     proxy ! FSM.SubscribeTransitionCallBack(self)
 
     var client: ActorRef = _

--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -24,8 +24,8 @@ object ReliableProxyDocSpec {
   //#demo
 
   //#demo-transition
-  class ProxyTransitionParent(targetRef: ActorRef) extends Actor {
-    val proxy = context.actorOf(ReliableProxy.props(targetRef, 100.millis))
+  class ProxyTransitionParent(targetPath: ActorPath) extends Actor {
+    val proxy = context.actorOf(ReliableProxy.props(targetPath, 100.millis))
     proxy ! FSM.SubscribeTransitionCallBack(self)
 
     var client: ActorRef = _
@@ -58,7 +58,7 @@ class ReliableProxyDocSpec extends AkkaSpec with ImplicitSender {
 
     "show state transitions" in {
       val target = system.deadLetters
-      val a = system.actorOf(Props(classOf[ProxyTransitionParent], target))
+      val a = system.actorOf(Props(classOf[ProxyTransitionParent], target.path))
       a ! "go"
       expectMsg("done")
     }

--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -5,21 +5,17 @@
 package akka.contrib.pattern
 
 import akka.testkit.AkkaSpec
-import akka.actor.Props
-import akka.actor.Actor
+import akka.actor._
 import akka.testkit.ImplicitSender
 import scala.concurrent.duration._
-import akka.actor.FSM
-import akka.actor.ActorRef
-import akka.testkit.TestProbe
 
 object ReliableProxyDocSpec {
 
   //#demo
   import akka.contrib.pattern.ReliableProxy
 
-  class ProxyParent(target: ActorRef) extends Actor {
-    val proxy = context.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds))
+  class ProxyParent(targetPath: ActorPath) extends Actor {
+    val proxy = context.actorOf(ReliableProxy.props(targetPath, 100.millis))
 
     def receive = {
       case "hello" ⇒ proxy ! "world!"
@@ -28,8 +24,8 @@ object ReliableProxyDocSpec {
   //#demo
 
   //#demo-transition
-  class ProxyTransitionParent(target: ActorRef) extends Actor {
-    val proxy = context.actorOf(ReliableProxy.props(target, 100.millis, 120.seconds))
+  class ProxyTransitionParent(targetRef: ActorRef) extends Actor {
+    val proxy = context.actorOf(ReliableProxy.props(targetRef, 100.millis))
     proxy ! FSM.SubscribeTransitionCallBack(self)
 
     var client: ActorRef = _
@@ -55,7 +51,7 @@ class ReliableProxyDocSpec extends AkkaSpec with ImplicitSender {
 
     "show usage" in {
       val target = testActor
-      val a = system.actorOf(Props(classOf[ProxyParent], target))
+      val a = system.actorOf(Props(classOf[ProxyParent], target.path))
       a ! "hello"
       expectMsg("world!")
     }

--- a/akka-docs/rst/java/testing.rst
+++ b/akka-docs/rst/java/testing.rst
@@ -121,7 +121,7 @@ The Way In-Between: Expecting Exceptions
 If you want to test the actor behavior, including hotswapping, but without
 involving a dispatcher and without having the :class:`TestActorRef` swallow
 any thrown exceptions, then there is another mode available for you: just use
-the :meth:`receive` method :class:`TestActorRef`, which will be forwarded to the
+the :meth:`receive` method on :class:`TestActorRef`, which will be forwarded to the
 underlying actor:
 
 .. includecode:: code/docs/testkit/TestKitDocTest.java#test-expecting-exceptions

--- a/akka-docs/rst/scala/testing.rst
+++ b/akka-docs/rst/scala/testing.rst
@@ -130,7 +130,7 @@ The Way In-Between: Expecting Exceptions
 If you want to test the actor behavior, including hotswapping, but without
 involving a dispatcher and without having the :class:`TestActorRef` swallow
 any thrown exceptions, then there is another mode available for you: just use
-the :meth:`receive` method :class:`TestActorRef`, which will be forwarded to the
+the :meth:`receive` method on :class:`TestActorRef`, which will be forwarded to the
 underlying actor:
 
 .. includecode:: code/docs/testkit/TestkitDocSpec.scala#test-expecting-exceptions


### PR DESCRIPTION
ReliableProxy with reconnection.  Fixes #3159
- When the proxy receives `Terminated` for the tunnel it goes into a `Reconnecting` state which uses `Identify`/`ActorIdentity` to obtain a new `ActorRef`.
- Adds option to use `ActorPath` instead of `ActorRef` for _target_ in constructor.  If `ActorPath` used it the `ReliableProxy` will resolve it to an `ActorRef` before proxying messages to the target.
- Adds new constructor parameters `reconnectAfter` and `maxReconnectAttempts` (see Scaladoc).
- Adds new messages `ProxyTerminated`, `Unsent`, `TargetChanged` (See Scaladoc).
- Additional unit tests for new behavior. 
