### PR TITLE
3748 actorselection helpers

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
@@ -332,6 +332,14 @@ class ActorSelectionSpec extends AkkaSpec("akka.loglevel=DEBUG") with DefaultTim
         s"ActorSelection[Anchor(akka://ActorSelectionSpec/user/c2/c21#${c21.path.uid}), Path(/../*/hello)]")
     }
 
+    "have a stringly serializable path" in {
+      system.actorSelection(system / "c2").toSerializationFormat should be("akka://ActorSelectionSpec/user/c2")
+      system.actorSelection(system / "c2" / "c21").toSerializationFormat should be("akka://ActorSelectionSpec/user/c2/c21")
+      ActorSelection(c2, "/").toSerializationFormat should be("akka://ActorSelectionSpec/user/c2")
+      ActorSelection(c2, "../*/hello").toSerializationFormat should be("akka://ActorSelectionSpec/user/c2/../*/hello")
+      ActorSelection(c2, "/../*/hello").toSerializationFormat should be("akka://ActorSelectionSpec/user/c2/../*/hello")
+    }
+
     "send ActorSelection targeted to missing actor to deadLetters" in {
       val p = TestProbe()
       system.eventStream.subscribe(p.ref, classOf[DeadLetter])

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -99,6 +99,27 @@ abstract class ActorSelection extends Serializable {
    */
   def pathString: String = path.mkString("/", "/", "")
 
+  /**
+   * String representation of the actor selection suitable for storage and recreation.
+   * The output is similar to the URI fragment returned by [[akka.actor.ActorPath.toSerializationFormat]].
+   * @return URI fragment
+   */
+  def toSerializationFormat: String = {
+    val anchorPath = anchor match {
+      case a: ActorRefWithCell ⇒ anchor.path.toStringWithAddress(a.provider.getDefaultAddress)
+      case _                   ⇒ anchor.path.toString
+    }
+
+    val builder = new java.lang.StringBuilder()
+    builder.append(anchorPath)
+    val lastChar = builder.charAt(builder.length - 1)
+    if (path.nonEmpty && lastChar != '/')
+      builder.append(path.mkString("/", "/", ""))
+    else if (path.nonEmpty)
+      builder.append(path.mkString("/"))
+    builder.toString
+  }
+
   override def equals(obj: Any): Boolean = obj match {
     case s: ActorSelection ⇒ this.anchor == s.anchor && this.path == s.path
     case _                 ⇒ false

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -416,6 +416,10 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
       system.actorSelection(child.path / "*" / "grandgrandchild") ! Identify("idReq13")
       expectMsg(ActorIdentity("idReq13", Some(grandgrandchild)))
 
+      val sel1 = system.actorSelection("/user/looker2/child/grandchild/grandgrandchild")
+      system.actorSelection(sel1.toSerializationFormat) ! Identify("idReq18")
+      expectMsg(ActorIdentity("idReq18", Some(grandgrandchild)))
+
       child ! Identify("idReq14")
       expectMsg(ActorIdentity("idReq14", Some(child)))
       watch(child)


### PR DESCRIPTION
Adds a serialization format in the style of ActorPath#toSerializationFormat. Also added more direct access to the anchor and path parts of an actor selection.

ticket is here: https://www.assembla.com/spaces/akka/simple_planner#/ticket:3748
discussion is here: https://groups.google.com/d/msg/akka-user/4whh2m6ttD4/dyty7EAnxXEJww

My personal use case was around stringifying actor selection so I'm not sure the API exposing the anchor & path are the best.

An alternative would be to move the protected pieces to a different name and allow the anchor & path to be the public API.

So, 

``` scala
protected[akka] val anchor:ActorRef
protected val path: immutable.IndexedSeq[SelectionPathElement]
```

becomes

``` scala
protected[akka] val _anchor:ActorRef
protected val _path: immutable.IndexedSeq[SelectionPathElement]

val anchor:ActorPath = _anchor.path
val path: String = _path.mkString("/","/","")
```
