### PR TITLE
=rem #3726 Fix race in RemoteWatcher for first quick watch/unwatch

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -428,6 +428,8 @@ private[akka] class RemoteActorRefProvider(
     message match {
       // Sending to local remoteWatcher relies strong delivery guarantees of local send, i.e.
       // default dispatcher must not be changed to an implementation that defeats that
+      case rew: RemoteWatcher.Rewatch ⇒
+        remoteWatcher ! RemoteWatcher.RewatchRemote(rew.watchee, rew.watcher)
       case Watch(watchee, watcher)   ⇒ remoteWatcher ! RemoteWatcher.WatchRemote(watchee, watcher)
       case Unwatch(watchee, watcher) ⇒ remoteWatcher ! RemoteWatcher.UnwatchRemote(watchee, watcher)
       case _                         ⇒


### PR DESCRIPTION
- The problem scenario was that a remote watch followed by re-watch triggered by
  first heartbeat and unwatch coming in before the extra re-watch message. That
  caused RemoteWatcher to still watch the subject even though it was intended to
  be unwatched.
- I could reproduce it with sleeps at stratgic points
- Sovled by keeping track of re-watch followed by unwatch

NOTE: I dislike adding more state to RemoteWatcher, so if you see a better solution I'm all ears.
