### PR TITLE
!act #3490 Changed the callback to SocketOption to accept a channel inst...

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
@@ -77,21 +77,6 @@ class UdpIntegrationSpec extends AkkaSpec("""
     }
 
     "call options" in {
-      case class AssertCall() extends SocketOption {
-        var beforeCalled = 0
-        var afterCalled = 0
-
-        override def beforeBind(c: DatagramChannel): Unit = {
-          assert(c.socket.isBound === false)
-          beforeCalled += 1
-        }
-
-        override def afterConnect(c: DatagramChannel): Unit = {
-          assert(c.socket.isBound === true)
-          afterCalled += 1
-        }
-      }
-
       val commander = TestProbe()
       val assertOption = AssertCall()
       commander.send(IO(Udp), Bind(testActor, addresses(3), options = List(assertOption)))
@@ -101,4 +86,19 @@ class UdpIntegrationSpec extends AkkaSpec("""
     }
   }
 
+}
+
+case class AssertCall() extends SocketOption {
+  var beforeCalled = 0
+  var afterCalled = 0
+
+  override def beforeBind(c: DatagramChannel): Unit = {
+    assert(!c.socket.isBound)
+    beforeCalled += 1
+  }
+
+  override def afterConnect(c: DatagramChannel): Unit = {
+    assert(c.socket.isBound)
+    afterCalled += 1
+  }
 }

--- a/akka-actor/src/main/scala/akka/io/Inet.scala
+++ b/akka-actor/src/main/scala/akka/io/Inet.scala
@@ -3,7 +3,7 @@
  */
 package akka.io
 
-import java.net.{ DatagramSocket, Socket, ServerSocket }
+import java.nio.channels.{ DatagramChannel, SocketChannel, ServerSocketChannel }
 
 object Inet {
 
@@ -13,19 +13,38 @@ object Inet {
    */
   trait SocketOption {
 
-    def beforeDatagramBind(ds: DatagramSocket): Unit = ()
-
-    def beforeServerSocketBind(ss: ServerSocket): Unit = ()
+    /**
+     * Action to be taken for this option before bind is called()
+     */
+    def beforeBind(ds: DatagramChannel): Unit = ()
 
     /**
-     * Action to be taken for this option before calling connect()
+     * Action to be taken for this option before bind is called()
      */
-    def beforeConnect(s: Socket): Unit = ()
+    def beforeBind(ss: ServerSocketChannel): Unit = ()
+
+    /**
+     * Action to be taken for this option before bind is called()
+     */
+    def beforeBind(s: SocketChannel): Unit = ()
+
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterConnect(s: Socket): Unit = ()
+    def afterConnect(c: DatagramChannel): Unit = ()
+
+    /**
+     * Action to be taken for this option after connect returned (i.e. on
+     * the slave socket for servers).
+     */
+    def afterConnect(c: ServerSocketChannel): Unit = ()
+
+    /**
+     * Action to be taken for this option after connect returned (i.e. on
+     * the slave socket for servers).
+     */
+    def afterConnect(c: SocketChannel): Unit = ()
   }
 
   object SO {
@@ -37,9 +56,9 @@ object Inet {
      */
     case class ReceiveBufferSize(size: Int) extends SocketOption {
       require(size > 0, "ReceiveBufferSize must be > 0")
-      override def beforeServerSocketBind(s: ServerSocket): Unit = s.setReceiveBufferSize(size)
-      override def beforeDatagramBind(s: DatagramSocket): Unit = s.setReceiveBufferSize(size)
-      override def beforeConnect(s: Socket): Unit = s.setReceiveBufferSize(size)
+      override def beforeBind(c: ServerSocketChannel): Unit = c.socket.setReceiveBufferSize(size)
+      override def beforeBind(c: DatagramChannel): Unit = c.socket.setReceiveBufferSize(size)
+      override def beforeBind(c: SocketChannel): Unit = c.socket.setReceiveBufferSize(size)
     }
 
     // server socket options
@@ -50,9 +69,9 @@ object Inet {
      * For more information see [[java.net.Socket.setReuseAddress]]
      */
     case class ReuseAddress(on: Boolean) extends SocketOption {
-      override def beforeServerSocketBind(s: ServerSocket): Unit = s.setReuseAddress(on)
-      override def beforeDatagramBind(s: DatagramSocket): Unit = s.setReuseAddress(on)
-      override def beforeConnect(s: Socket): Unit = s.setReuseAddress(on)
+      override def beforeBind(c: ServerSocketChannel): Unit = c.socket.setReuseAddress(on)
+      override def beforeBind(c: DatagramChannel): Unit = c.socket.setReuseAddress(on)
+      override def beforeBind(c: SocketChannel): Unit = c.socket.setReuseAddress(on)
     }
 
     /**
@@ -62,7 +81,8 @@ object Inet {
      */
     case class SendBufferSize(size: Int) extends SocketOption {
       require(size > 0, "SendBufferSize must be > 0")
-      override def afterConnect(s: Socket): Unit = s.setSendBufferSize(size)
+      override def afterConnect(c: DatagramChannel): Unit = c.socket.setSendBufferSize(size)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setSendBufferSize(size)
     }
 
     /**
@@ -74,7 +94,8 @@ object Inet {
      */
     case class TrafficClass(tc: Int) extends SocketOption {
       require(0 <= tc && tc <= 255, "TrafficClass needs to be in the interval [0, 255]")
-      override def afterConnect(s: Socket): Unit = s.setTrafficClass(tc)
+      override def afterConnect(c: DatagramChannel): Unit = c.socket.setTrafficClass(tc)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setTrafficClass(tc)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -5,7 +5,7 @@
 package akka.io
 
 import java.net.InetSocketAddress
-import java.net.Socket
+import java.nio.channels.SocketChannel
 import akka.io.Inet._
 import com.typesafe.config.Config
 import scala.concurrent.duration._
@@ -62,7 +62,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
      * For more information see [[java.net.Socket.setKeepAlive]]
      */
     case class KeepAlive(on: Boolean) extends SocketOption {
-      override def afterConnect(s: Socket): Unit = s.setKeepAlive(on)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setKeepAlive(on)
     }
 
     /**
@@ -73,7 +73,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
      * For more information see [[java.net.Socket.setOOBInline]]
      */
     case class OOBInline(on: Boolean) extends SocketOption {
-      override def afterConnect(s: Socket): Unit = s.setOOBInline(on)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setOOBInline(on)
     }
 
     // SO_LINGER is handled by the Close code
@@ -87,7 +87,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
      * For more information see [[java.net.Socket.setTcpNoDelay]]
      */
     case class TcpNoDelay(on: Boolean) extends SocketOption {
-      override def afterConnect(s: Socket): Unit = s.setTcpNoDelay(on)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setTcpNoDelay(on)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -171,7 +171,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
                       options: immutable.Traversable[SocketOption]): Unit = {
     // Turn off Nagle's algorithm by default
     channel.socket.setTcpNoDelay(true)
-    options.foreach(_.afterConnect(channel.socket))
+    options.foreach(_.afterConnect(channel))
 
     commander ! Connected(
       channel.socket.getRemoteSocketAddress.asInstanceOf[InetSocketAddress],

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -47,7 +47,7 @@ private[io] class TcpListener(selectorRouter: ActorRef,
   val localAddress =
     try {
       val socket = channel.socket
-      bind.options.foreach(_.beforeServerSocketBind(socket))
+      bind.options.foreach(_.beforeBind(channel))
       socket.bind(bind.localAddress, bind.backlog)
       val ret = socket.getLocalSocketAddress match {
         case isa: InetSocketAddress ⇒ isa
@@ -55,6 +55,7 @@ private[io] class TcpListener(selectorRouter: ActorRef,
       }
       channelRegistry.register(channel, SelectionKey.OP_ACCEPT)
       log.debug("Successfully bound to {}", ret)
+      bind.options.foreach(_.afterConnect(channel))
       ret
     } catch {
       case NonFatal(e) ⇒

--- a/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -30,7 +30,7 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
 
   context.watch(commander) // sign death pact
 
-  options.foreach(_.beforeConnect(channel.socket))
+  options.foreach(_.beforeBind(channel))
   localAddress.foreach(channel.socket.bind)
   channelRegistry.register(channel, 0)
   timeout foreach context.setReceiveTimeout //Initiate connection timeout if supplied

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -3,8 +3,8 @@
  */
 package akka.io
 
-import java.net.DatagramSocket
 import java.net.InetSocketAddress
+import java.nio.channels.DatagramChannel
 import com.typesafe.config.Config
 import scala.collection.immutable
 import akka.io.Inet.{ SoJavaFactories, SocketOption }
@@ -186,7 +186,7 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
      * For more information see [[java.net.DatagramSocket#setBroadcast]]
      */
     case class Broadcast(on: Boolean) extends SocketOption {
-      override def beforeDatagramBind(s: DatagramSocket): Unit = s.setBroadcast(on)
+      override def beforeBind(c: DatagramChannel): Unit = c.socket.setBroadcast(on)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -35,7 +35,7 @@ private[io] class UdpConnection(udpConn: UdpConnectedExt,
     val datagramChannel = DatagramChannel.open
     datagramChannel.configureBlocking(false)
     val socket = datagramChannel.socket
-    options.foreach(_.beforeDatagramBind(socket))
+    options.foreach(_.beforeBind(datagramChannel))
     try {
       localAddress foreach socket.bind
       datagramChannel.connect(remoteAddress)
@@ -53,6 +53,7 @@ private[io] class UdpConnection(udpConn: UdpConnectedExt,
 
   def receive = {
     case registration: ChannelRegistration ⇒
+      options.foreach(_.afterConnect(channel))
       commander ! Connected
       context.become(connected(registration), discardOld = true)
   }

--- a/akka-actor/src/main/scala/akka/io/UdpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpListener.scala
@@ -37,7 +37,7 @@ private[io] class UdpListener(val udp: UdpExt,
   val localAddress =
     try {
       val socket = channel.socket
-      bind.options.foreach(_.beforeDatagramBind(socket))
+      bind.options.foreach(_.beforeBind(channel))
       socket.bind(bind.localAddress)
       val ret = socket.getLocalSocketAddress match {
         case isa: InetSocketAddress ⇒ isa
@@ -45,6 +45,7 @@ private[io] class UdpListener(val udp: UdpExt,
       }
       channelRegistry.register(channel, OP_READ)
       log.debug("Successfully bound to [{}]", ret)
+      bind.options.foreach(_.afterConnect(channel))
       ret
     } catch {
       case NonFatal(e) ⇒

--- a/akka-actor/src/main/scala/akka/io/UdpSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpSender.scala
@@ -23,9 +23,7 @@ private[io] class UdpSender(val udp: UdpExt,
   val channel = {
     val datagramChannel = DatagramChannel.open
     datagramChannel.configureBlocking(false)
-    val socket = datagramChannel.socket
-
-    options foreach { _.beforeDatagramBind(socket) }
+    options foreach { _.beforeBind(datagramChannel) }
 
     datagramChannel
   }
@@ -33,6 +31,7 @@ private[io] class UdpSender(val udp: UdpExt,
 
   def receive: Receive = {
     case registration: ChannelRegistration ⇒
+      options.foreach(_.afterConnect(channel))
       commander ! SimpleSenderReady
       context.become(sendHandlers(registration))
   }


### PR DESCRIPTION
...ead of a Socket, this allows for using the nio features.

For example in Java 7 you can now join a multicast group:

``` scala
case class JoinGroup(group: InetAddress, networkInterface: NetworkInterface) extends SocketOption {

  override def afterConnect(c: DatagramChannel): Unit = {
    c.join(group, networkInterface)
  }
}

  IO(Udp) ! Udp.Bind(self, new InetSocketAddress(MulticastListener.port),
    options=List(ReuseAddress(true),
      JoinGroup(MulticastListener.group, MulticastListener.interf)))
```

Other minor changes:
- changed all methods in SocketOption to take a Channel instead of a Socket.  The socket can be gotten from the Channel but not the reverse.
- all methods that are called before the bind are now called beforeBind for consistency.
- All network connections now call the beforeBind and afterConnect.
