### PR TITLE
Class name typo in the testing documentation

### DIFF
--- a/akka-docs/rst/scala/testing.rst
+++ b/akka-docs/rst/scala/testing.rst
@@ -466,7 +466,7 @@ above; just use the power!
 Watching Other Actors from Probes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A :class:`TestKit` can register itself for DeathWatch of any other actor:
+A :class:`TestProbe` can register itself for DeathWatch of any other actor:
 
 .. includecode:: code/docs/testkit/TestkitDocSpec.scala
    :include: test-probe-watch


### PR DESCRIPTION
The section Watching ... from Probes references class TestKit where TestProbe should be used.
