### PR TITLE
=act #3725 Make FSMTimingSpec more robust.

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
@@ -70,10 +70,12 @@ class FSMTimingSpec extends AkkaSpec with ImplicitSender {
     }
 
     "resubmit single-shot timer" taggedAs TimingTest in {
-      within(2 seconds) {
-        within(500 millis, 1.5 second) {
+      within(2.5 seconds) {
+        within(500 millis, 1 second) {
           fsm ! TestSingleTimerResubmit
           expectMsg(Tick)
+        }
+        within(1 second) {
           expectMsg(Tock)
           expectMsg(Transition(fsm, TestSingleTimerResubmit, Initial))
         }


### PR DESCRIPTION
The failed timeout was after 358 millis meaning that the previous part of the test was a bit slower than "expected".
Split the timeout ranges into two and added a bit of leeway. 
