### PR TITLE
!tes #3638 ImplicitSender and DefaultTimeout requires TestKitBase

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -803,11 +803,11 @@ object TestProbe {
   def apply()(implicit system: ActorSystem) = new TestProbe(system)
 }
 
-trait ImplicitSender { this: TestKit ⇒
+trait ImplicitSender { this: TestKitBase ⇒
   implicit def self = testActor
 }
 
-trait DefaultTimeout { this: TestKit ⇒
+trait DefaultTimeout { this: TestKitBase ⇒
   implicit val timeout: Timeout = testKitSettings.DefaultTimeout
 }
 

--- a/akka-testkit/src/test/scala/akka/testkit/DefaultTimeoutSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/DefaultTimeoutSpec.scala
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2013-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit
+
+import org.scalatest.{ WordSpec, BeforeAndAfterAll }
+import org.scalatest.Matchers
+import akka.actor.ActorSystem
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class DefaultTimeoutSpec
+  extends WordSpec with Matchers with BeforeAndAfterAll with TestKitBase with DefaultTimeout {
+
+  implicit lazy val system = ActorSystem("AkkaCustomSpec")
+
+  override def afterAll = system.shutdown
+
+  "A spec with DefaultTimeout" should {
+    "use timeout from settings" in {
+      timeout should be(testKitSettings.DefaultTimeout)
+    }
+  }
+}

--- a/akka-testkit/src/test/scala/akka/testkit/ImplicitSenderSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/ImplicitSenderSpec.scala
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2013-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit
+
+import org.scalatest.{ WordSpec, BeforeAndAfterAll }
+import org.scalatest.Matchers
+import akka.actor.ActorSystem
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class ImplicitSenderSpec
+  extends WordSpec with Matchers with BeforeAndAfterAll with TestKitBase with ImplicitSender {
+
+  implicit lazy val system = ActorSystem("AkkaCustomSpec")
+
+  override def afterAll = system.shutdown
+
+  "An ImplicitSender" should {
+    "have testActor as its self" in {
+      self should be(testActor)
+    }
+  }
+}


### PR DESCRIPTION
The ImplicitSenderSpec tests the behaviour of ImplicitSender but not that it must inherit TestKitBase. The latter is kind of guaranteed by the ImplicitSenderSpec itself as it would result in a compile error if changed. 
