### PR TITLE
=doc #3792 Fixed broken tex/pdf config

### DIFF
--- a/akka-docs/rst/conf.py
+++ b/akka-docs/rst/conf.py
@@ -65,7 +65,7 @@ epub_cover = ("../_sphinx/static/akka.png", "")
 
 def setup(app):
   from sphinx.util.texescape import tex_replacements
-  tex_replacements.append((u'=>', ur'\(\Rightarrow\)'))
+  tex_replacements.append((u'⇒', ur'\(\Rightarrow\)'))
 
 latex_paper_size = 'a4'
 latex_font_size = '10pt'


### PR DESCRIPTION
Simply put "=>" is not a single character.
