### PR TITLE
=doc #3043 Adding section on testing parent-child relationships

### DIFF
--- a/akka-docs/rst/scala/code/docs/testkit/ParentChildSpec.scala
+++ b/akka-docs/rst/scala/code/docs/testkit/ParentChildSpec.scala
@@ -1,0 +1,126 @@
+package docs.testkit
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+import akka.testkit.TestKitBase
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.testkit.ImplicitSender
+import akka.testkit.TestProbe
+import akka.testkit.TestActorRef
+import akka.actor.ActorRefFactory
+
+/**
+ * Parent-Child examples
+ */
+
+//#test-example
+class Parent extends Actor {
+  val child = context.actorOf(Props[Child], "child")
+  var ponged = false
+
+  def receive = {
+    case "pingit" => child ! "ping"
+    case "pong"   => ponged = true
+  }
+}
+
+class Child extends Actor {
+  def receive = {
+    case "ping" => context.parent ! "pong"
+  }
+}
+//#test-example
+
+//#test-dependentchild
+class DependentChild(parent: ActorRef) extends Actor {
+  def receive = {
+    case "ping" => parent ! "pong"
+  }
+}
+//#test-dependentchild
+
+//#test-dependentparent
+class DependentParent(childProps: Props) extends Actor {
+  val child = context.actorOf(childProps, "child")
+  var ponged = false
+
+  def receive = {
+    case "pingit" => child ! "ping"
+    case "pong"   => ponged = true
+  }
+}
+
+class GenericDependentParent(childMaker: ActorRefFactory => ActorRef) extends Actor {
+  val child = childMaker(context)
+  var ponged = false
+
+  def receive = {
+    case "pingit" => child ! "ping"
+    case "pong"   => ponged = true
+  }
+}
+//#test-dependentparent
+
+/**
+ * Test specification
+ */
+
+class MockedChild extends Actor {
+  def receive = {
+    case "ping" => sender ! "pong"
+  }
+}
+
+class ParentChildSpec extends WordSpec with Matchers with TestKitBase {
+  implicit lazy val system = ActorSystem()
+
+  "A DependentChild" should {
+    "be tested without its parent" in {
+      val probe = TestProbe()
+      val child = system.actorOf(Props(classOf[DependentChild], probe.ref))
+      probe.send(child, "ping")
+      probe.expectMsg("pong")
+    }
+  }
+
+  "A DependentParent" should {
+    "be tested with custom props" in {
+      val probe = TestProbe()
+      val parent = TestActorRef(new DependentParent(Props[MockedChild]))
+      probe.send(parent, "pingit")
+      // test some parent state change
+      parent.underlyingActor.ponged should (be(true) or be(false))
+    }
+  }
+
+  "A GenericDependentParent" should {
+    "be tested with a child probe" in {
+      val probe = TestProbe()
+      val maker = (_: ActorRefFactory) => probe.ref
+      val parent = system.actorOf(Props(classOf[GenericDependentParent], maker))
+      probe.send(parent, "pingit")
+      probe.expectMsg("ping")
+    }
+  }
+
+  //#test-fabricated-parent
+  "A fabricated parent" should {
+    "test its child responses" in {
+      val proxy = TestProbe()
+      val parent = system.actorOf(Props(new Actor {
+        val child = context.actorOf(Props[Child], "child")
+        def receive = {
+          case x if sender == child => proxy.ref forward x
+          case x                    => child forward x
+        }
+      }))
+
+      proxy.send(parent, "ping")
+      proxy.expectMsg("pong")
+    }
+  }
+  //#test-fabricated-parent
+}

--- a/akka-docs/rst/scala/testing.rst
+++ b/akka-docs/rst/scala/testing.rst
@@ -526,6 +526,63 @@ do not react to each other's deadlines or to the deadline set in an enclosing
 
 Here, the ``expectMsg`` call will use the default timeout.
 
+Testing parent-child relationships
+----------------------------------
+
+The parent of an actor is always the actor that created it. At times this leads to
+a coupling between the two that may not be straightforward to test. 
+Broadly, there are three approaches to improve testability of parent-child 
+relationships: 
+
+1. when creating a child, pass an explicit reference to its parent 
+2. when creating a parent, tell the parent how to create its child
+3. create a fabricated parent when testing
+
+For example, the structure of the code you want to test may follow this pattern: 
+
+.. includecode:: code/docs/testkit/ParentChildSpec.scala#test-example
+
+Using dependency-injection
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The first option is to avoid use of the :meth:`context.parent` function and create 
+a child with a custom parent by passing an explicit reference to its parent instead.
+
+.. includecode:: code/docs/testkit/ParentChildSpec.scala#test-dependentchild
+
+Alternatively, you can tell the parent how to create its child. There are two ways 
+to do this: by giving it a :class:`Props` object or by giving it a partial function:
+
+.. includecode:: code/docs/testkit/ParentChildSpec.scala#test-dependentparent
+
+Creating the :class:`Props` is straightforward and the partial function may look
+like this in your test code:
+
+.. code-block:: scala
+
+   val maker = (_: ActorRefFactory) => probe.ref
+   val parent = system.actorOf(Props(classOf[GenericDependentParent], maker))
+
+And like this in your application code: 
+
+.. code-block:: scala
+
+   val maker = (f: ActorRefFactory) => f.actorOf(Props[Child])
+   system.actorOf(Props(classOf[GenericDependentParent], maker))
+
+Using a fabricated parent
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you prefer to avoid modifying the parent or child constructor you can 
+create a fabricated parent in your test. This, however, does not enable you to test
+the parent actor in isolation.
+
+.. includecode:: code/docs/testkit/ParentChildSpec.scala#test-fabricated-parent
+
+Which of these methods is the best depends on what is most important to test. The 
+most generic option is to create the parent actor by passing it the partial function, 
+but the fabricated parent is often sufficient. 
+
 .. _Scala-CallingThreadDispatcher:
 
 CallingThreadDispatcher


### PR DESCRIPTION
This adds a section to testing with testkit. Examples and docs are based on [discussions](https://www.assembla.com/spaces/akka/tickets/3043#/activity/ticket:) from akka user maillist.  
