### PR TITLE
New Bytes abstraction + benefits reaped by simplifying Tcp.WriteCommand hierarchy

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -20,7 +20,7 @@ import akka.io.SelectionHandler._
 import akka.io.Inet.SocketOption
 import akka.actor._
 import akka.testkit.{ AkkaSpec, EventFilter, TestActorRef, TestProbe }
-import akka.util.{ Helpers, ByteString }
+import akka.util.{ BytesUtils, Bytes, Helpers, ByteString }
 import akka.TestUtils._
 import java.util.Random
 
@@ -241,32 +241,29 @@ class TcpConnectionSpec extends AkkaSpec("""
         val size = math.min(testFile.length(), 100000000).toInt
 
         val writer = TestProbe()
-        writer.send(connectionActor, WriteFile(testFile.getAbsolutePath, 0, size, Ack))
+        writer.send(connectionActor, Write(Bytes(testFile, 0, size), Ack))
         pullFromServerSide(size, 1000000)
         writer.expectMsg(Ack)
       }
     }
 
-    "write a CompoundWrite to the network and produce correct ACKs" in new EstablishedConnectionTest() {
+    "write a CompoundBytes to the network and produce correct ACKs" in new EstablishedConnectionTest() {
       run {
-        val writer = TestProbe()
-        val compoundWrite =
-          Write(ByteString("test1"), Ack(1)) +:
-            Write(ByteString("test2")) +:
-            Write(ByteString.empty, Ack(3)) +:
-            Write(ByteString("test4"), Ack(4))
+        BytesUtils.withFileBytes("test2") { fb ⇒
+          val writer = TestProbe()
+          val compoundWrite =
+            Write((ByteString("test1"): Bytes) ++ fb ++ ByteString("test4"), Ack(1))
 
-        // reply to write commander with Ack
-        val buffer = ByteBuffer.allocate(100)
-        serverSideChannel.read(buffer) must be(0)
-        writer.send(connectionActor, compoundWrite)
+          // reply to write commander with Ack
+          val buffer = ByteBuffer.allocate(100)
+          serverSideChannel.read(buffer) must be(0)
+          writer.send(connectionActor, compoundWrite)
 
-        pullFromServerSide(remaining = 15, into = buffer)
-        buffer.flip()
-        ByteString(buffer).utf8String must be("test1test2test4")
-        writer.expectMsg(Ack(1))
-        writer.expectMsg(Ack(3))
-        writer.expectMsg(Ack(4))
+          pullFromServerSide(remaining = 15, into = buffer)
+          buffer.flip()
+          ByteString(buffer).utf8String must be("test1test2test4")
+          writer.expectMsg(Ack(1))
+        }
       }
     }
 

--- a/akka-actor-tests/src/test/scala/akka/util/BytesSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/BytesSpec.scala
@@ -1,0 +1,216 @@
+/**
+ *  Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.util
+
+import java.io.{ FileOutputStream, File }
+import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.prop.Checkers
+import org.scalacheck.{ Gen, Arbitrary }
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop
+import Prop.BooleanOperators
+
+class BytesSpec extends WordSpec with Matchers with Checkers {
+  import BytesUtils._
+
+  def genFileByte(min: Int, max: Int): Gen[Bytes.FileBytes] =
+    for {
+      n ← choose(min, max)
+    } yield BytesUtils.virtualFileBytes(n)
+  def genSimpleByteString(min: Int, max: Int) = for {
+    n ← choose(min, max)
+    b ← Gen.containerOfN[Array, Byte](n, arbitrary[Byte])
+    from ← choose(0, b.length)
+    until ← choose(from, b.length)
+  } yield ByteString(b).slice(from, until)
+
+  implicit val arbitraryBytes: Arbitrary[Bytes] = Arbitrary {
+    Gen.sized { s ⇒
+      for {
+        n ← choose(0, s)
+        element ← Gen.oneOf(genSimpleByteString(0, 1000), genFileByte(0, 1000))
+        elements ← listOfN(n, element)
+      } yield ((ByteString.empty: Bytes) /: elements)(_ ++ _)
+    }
+  }
+
+  "Bytes" must {
+    "properly support `copyToArray`" when {
+      "ByteString" in {
+        testCopyToArray(ByteString("Ken sent me!"))
+      }
+      "Bytes.FileBytes" in {
+        withFileBytes()(testCopyToArray)
+      }
+      "Bytes.CompoundBytes just with ByteStrings" in {
+        testCopyToArray(Bytes("Ken") ++ ByteString(" sent") ++ ByteString(" me") ++ ByteString("!"))
+      }
+      "Bytes.CompoundBytes containing ByteString and FileBytes" in {
+        withFileBytes(" sent")(fb ⇒ testCopyToArray(Bytes("Ken") ++ fb ++ ByteString(" me") ++ ByteString("!")))
+      }
+    }
+    "properly support `sliceBytes`" when {
+      "ByteString" in {
+        ByteString("Ken sent me!").sliceBytes(4, 3) shouldBe ByteString("sen")
+      }
+      "Bytes.FileBytes" in {
+        withFileBytes("Ken sent me!")(_.sliceBytes(4, 3) shouldBe ByteString("sen"))
+      }
+      "Bytes.CompoundBytes just with ByteStrings" in {
+        val data = ByteString("Ken") ++ ByteString(" sent ") ++ ByteString("me") ++ ByteString("!")
+        data.sliceBytes(2, 5) shouldBe ByteString("n sen")
+      }
+      "Bytes.CompoundBytes containing ByteString and FileBytes" in {
+        withFileBytes(" sent") { fb ⇒
+          val data = ByteString("Ken") ++ fb ++ ByteString("me") ++ ByteString("!")
+          data.sliceBytes(2, 5) shouldBe ByteString("n sen")
+        }
+      }
+    }
+    "properly support `slice`" when {
+      "ByteString" in {
+        ByteString("Ken sent me!").slice(4L, 3L) shouldBe ByteString("sen")
+      }
+      "Bytes.FileBytes" in {
+        val file = File.createTempFile("akka-util_BytesSpec", ".txt")
+        try {
+          writeAllText(" Ken sent me!", file)
+          Bytes(file, 1).slice(4L, 3L) shouldBe Bytes(file, 5, 3)
+        } finally file.delete
+      }
+      "Bytes.CompoundBytes just with ByteStrings" in {
+        val data = ByteString("Ken") ++ ByteString(" sent ") ++ ByteString("me") ++ ByteString("!")
+        data.slice(2L, 5L) shouldBe (Bytes("n") ++ ByteString(" sen"))
+      }
+      "Bytes.CompoundBytes containing ByteString and FileBytes" in {
+        withFileBytes(" sent ") { fb ⇒
+          val data = ByteString("Ken") ++ fb ++ ByteString("me") ++ ByteString("!")
+          data.slice(2L, 5L) shouldBe (ByteString("n") ++ fb.slice(0, 4))
+        }
+      }
+    }
+    "properly support `toChunkStream`" when {
+      "ByteString" in {
+        ByteString("Ken sent me!").toChunkStream(5) shouldBe Stream(
+          ByteString("Ken s"),
+          ByteString("ent m"),
+          ByteString("e!"))
+      }
+      "Bytes.FileBytes" in {
+        withFileBytes("Ken sent me!") { fb ⇒
+          fb.toChunkStream(5) shouldBe Stream(
+            fb.slice(0, 5),
+            fb.slice(5, 5),
+            fb.slice(10, 2))
+        }
+      }
+      "Bytes.CompoundBytes just with ByteStrings" in {
+        val data = ByteString("Ken") ++ ByteString(" sent ") ++ ByteString("me!")
+        data.toChunkStream(5) shouldBe Stream(
+          ByteString("Ken s"),
+          ByteString("ent m"),
+          ByteString("e!"))
+      }
+      "Bytes.CompoundBytes containing ByteString and FileBytes" in {
+        withFileBytes(" sent ") { fb ⇒
+          val data = ByteString("Ken") ++ fb ++ ByteString("me!")
+          data.toChunkStream(5) shouldBe Stream(
+            ByteString("Ken") ++ fb.slice(0, 2),
+            fb.slice(2, 4) ++ ByteString("m"),
+            ByteString("e!"))
+        }
+      }
+    }
+    "properly support `toByteString`" when {
+      "ByteString" in {
+        val bytes = ByteString("Ken sent me!").toByteString
+        bytes.isCompact shouldBe true
+        bytes shouldBe ByteString("Ken sent me!")
+      }
+      "Bytes.FileBytes" in {
+        val file = File.createTempFile("spray-http_BytesSpec", ".txt")
+        try {
+          writeAllText("Ken sent me!", file)
+          Bytes(file).toByteString shouldBe ByteString("Ken sent me!")
+
+        } finally file.delete
+      }
+      "Bytes.CompoundBytes just with ByteStrings" in {
+        val data = ByteString("Ken") ++ ByteString(" sent ") ++ ByteString("me") ++ ByteString("!")
+        data.toByteString shouldBe ByteString("Ken sent me!")
+      }
+      "Bytes.CompoundBytes containing ByteString and FileBytes" in {
+        withFileBytes(" sent ") { fb ⇒
+          val data = ByteString("Ken") ++ fb ++ ByteString("me") ++ ByteString("!")
+          data.toByteString shouldBe ByteString("Ken sent me!")
+        }
+      }
+    }
+    "support `++`" when {
+      "join consecutive FileBytes for ++" in {
+        val genFileBytesWithSliceOffsets =
+          for {
+            fb ← genFileByte(0, 1024)
+            l1 ← Gen.choose(0, fb.length)
+            l2 ← Gen.choose(l1, fb.length)
+          } yield (fb, l1, l2)
+
+        check {
+          Prop.forAll(genFileBytesWithSliceOffsets) {
+            case (fb: Bytes.FileBytes, l1: Long, l2: Long) ⇒
+              (fb.slice(0, l1) ++ fb.slice(l1, l2) == fb.slice(0, l1 + l2))
+          }
+        }
+      }
+
+      "size" in {
+        check { (a: Bytes, b: Bytes) ⇒
+          (a ++ b).longLength == a.longLength + b.longLength
+        }
+      }
+      "be sequential" in {
+        check { (a: Bytes, b: Bytes) ⇒
+          (b.nonEmpty) ==> ((a ++ b).slice(a.longLength) == b)
+        }
+      }
+    }
+  }
+
+  def testCopyToArray(data: Bytes): Unit = {
+    testCopyToArray(data, sourceOffset = 0, targetOffset = 0, span = 12) shouldBe "Ken sent me!xxxx"
+    testCopyToArray(data, sourceOffset = 0, targetOffset = 2, span = 12) shouldBe "xxKen sent me!xx"
+    testCopyToArray(data, sourceOffset = 0, targetOffset = 4, span = 12) shouldBe "xxxxKen sent me!"
+    testCopyToArray(data, sourceOffset = 0, targetOffset = 6, span = 12) shouldBe "xxxxxxKen sent m"
+    testCopyToArray(data, sourceOffset = 2, targetOffset = 0, span = 12) shouldBe "n sent me!xxxxxx"
+    testCopyToArray(data, sourceOffset = 8, targetOffset = 0, span = 12) shouldBe " me!xxxxxxxxxxxx"
+    testCopyToArray(data, sourceOffset = 8, targetOffset = 10, span = 2) shouldBe "xxxxxxxxxx mxxxx"
+    testCopyToArray(data, sourceOffset = 8, targetOffset = 10, span = 8) shouldBe "xxxxxxxxxx me!xx"
+  }
+
+  def testCopyToArray(data: Bytes, sourceOffset: Long, targetOffset: Int, span: Int): String = {
+    val array = "xxxxxxxxxxxxxxxx".getBytes
+    data.copyToArray(array, sourceOffset, targetOffset, span)
+    new String(array)
+  }
+}
+
+object BytesUtils {
+  def withFileBytes[T](text: String = "Ken sent me!")(f: Bytes ⇒ T): T = {
+    val file = File.createTempFile("akka-util_BytesSpec", ".txt")
+    try {
+      writeAllText(text, file)
+      f(Bytes(file))
+    } finally file.delete
+  }
+  def virtualFileBytes(length: Int): Bytes.FileBytes =
+    // using private[util] constructor, file doesn't really have to exist
+    Bytes.FileBytes("/tmp/dummy", 0, length)
+
+  def writeAllText(text: String, file: File) = {
+    val fos = new FileOutputStream(file)
+    try fos.write(text.getBytes("utf8"))
+    finally fos.close()
+  }
+}

--- a/akka-actor/src/main/scala/akka/io/Pipelines.scala
+++ b/akka-actor/src/main/scala/akka/io/Pipelines.scala
@@ -900,7 +900,7 @@ class BackpressureBuffer(lowBytes: Long, highBytes: Long, maxBytes: Long)
 
     private def buffer(w: Write, doWrite: Boolean): Iterable[Result] = {
       storage :+= w
-      stored += w.data.size
+      stored += w.data.longLength
 
       if (stored > maxBytes) {
         log.warning("aborting connection (buffer overrun)")
@@ -923,7 +923,7 @@ class BackpressureBuffer(lowBytes: Long, highBytes: Long, maxBytes: Long)
       require(seq == storageOffset, s"received ack $seq at $storageOffset")
       require(storage.nonEmpty, s"storage was empty at ack $seq")
 
-      val size = storage(0).data.size
+      val size = storage(0).data.longLength
       stored -= size
 
       storageOffset += 1

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.Config
 import scala.concurrent.duration._
 import scala.collection.immutable
 import scala.collection.JavaConverters._
-import akka.util.ByteString
+import akka.util.{ Bytes, ByteString }
 import akka.util.Helpers.Requiring
 import akka.actor._
 import java.lang.{ Iterable ⇒ JIterable }
@@ -240,87 +240,13 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    */
   object NoAck extends NoAck(null)
 
-  /**
-   * Common interface for all write commands, currently [[Write]], [[WriteFile]] and [[CompoundWrite]].
-   */
-  sealed abstract class WriteCommand extends Command {
-    /**
-     * Prepends this command with another `Write` or `WriteFile` to form
-     * a `CompoundWrite`.
-     */
-    def +:(other: SimpleWriteCommand): CompoundWrite = CompoundWrite(other, this)
-
-    /**
-     * Prepends this command with a number of other writes.
-     * The first element of the given Iterable becomes the first sub write of a potentially
-     * created `CompoundWrite`.
-     */
-    def ++:(writes: Iterable[WriteCommand]): WriteCommand =
-      writes.foldRight(this) {
-        case (a: SimpleWriteCommand, b) ⇒ a +: b
-        case (a: CompoundWrite, b)      ⇒ a ++: b
-      }
-
-    /**
-     * Java API: prepends this command with another `Write` or `WriteFile` to form
-     * a `CompoundWrite`.
-     */
-    def prepend(that: SimpleWriteCommand): CompoundWrite = that +: this
-
-    /**
-     * Java API: prepends this command with a number of other writes.
-     * The first element of the given Iterable becomes the first sub write of a potentially
-     * created `CompoundWrite`.
-     */
-    def prepend(writes: JIterable[WriteCommand]): WriteCommand = writes.asScala ++: this
-  }
-
-  object WriteCommand {
-    /**
-     * Combines the given number of write commands into one atomic `WriteCommand`.
-     */
-    def apply(writes: Iterable[WriteCommand]): WriteCommand = writes ++: Write.empty
-
-    /**
-     * Java API: combines the given number of write commands into one atomic `WriteCommand`.
-     */
-    def create(writes: JIterable[WriteCommand]): WriteCommand = apply(writes.asScala)
-  }
-
-  /**
-   * Common supertype of [[Write]] and [[WriteFile]].
-   */
-  sealed abstract class SimpleWriteCommand extends WriteCommand {
-    require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
-
-    /**
-     * The acknowledgment token associated with this write command.
-     */
-    def ack: Event
-
+  case class Write(data: Bytes, ack: Event) extends Command {
     /**
      * An acknowledgment is only sent if this write command “wants an ack”, which is
      * equivalent to the [[#ack]] token not being a of type [[NoAck]].
      */
     def wantsAck: Boolean = !ack.isInstanceOf[NoAck]
-
-    /**
-     * Java API: appends this command with another `WriteCommand` to form a `CompoundWrite`.
-     */
-    def append(that: WriteCommand): CompoundWrite = this +: that
   }
-
-  /**
-   * Write data to the TCP connection. If no ack is needed use the special
-   * `NoAck` object. The connection actor will reply with a [[CommandFailed]]
-   * message if the write could not be enqueued. If [[WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[WriteCommand#ack]]
-   * token once the write has been successfully enqueued to the O/S kernel.
-   * <b>Note that this does not in any way guarantee that the data will be
-   * or have been sent!</b> Unfortunately there is no way to determine whether
-   * a particular write has been sent by the O/S.
-   */
-  case class Write(data: ByteString, ack: Event) extends SimpleWriteCommand
   object Write {
     /**
      * The empty Write doesn't write anything and isn't acknowledged.
@@ -333,47 +259,8 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
     /**
      * Create a new unacknowledged Write command with the given data.
      */
-    def apply(data: ByteString): Write =
+    def apply(data: Bytes): Write =
       if (data.isEmpty) empty else Write(data, NoAck)
-  }
-
-  /**
-   * Write `count` bytes starting at `position` from file at `filePath` to the connection.
-   * The count must be > 0. The connection actor will reply with a [[CommandFailed]]
-   * message if the write could not be enqueued. If [[WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[WriteCommand#ack]]
-   * token once the write has been successfully enqueued to the O/S kernel.
-   * <b>Note that this does not in any way guarantee that the data will be
-   * or have been sent!</b> Unfortunately there is no way to determine whether
-   * a particular write has been sent by the O/S.
-   */
-  case class WriteFile(filePath: String, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
-    require(position >= 0, "WriteFile.position must be >= 0")
-    require(count > 0, "WriteFile.count must be > 0")
-  }
-
-  /**
-   * A write command which aggregates two other write commands. Using this construct
-   * you can chain a number of [[Write]] and/or [[WriteFile]] commands together in a way
-   * that allows them to be handled as a single write which gets written out to the
-   * network as quickly as possible.
-   * If the sub commands contain `ack` requests they will be honored as soon as the
-   * respective write has been written completely.
-   */
-  case class CompoundWrite(override val head: SimpleWriteCommand, tailCommand: WriteCommand) extends WriteCommand
-    with immutable.Iterable[SimpleWriteCommand] {
-
-    def iterator: Iterator[SimpleWriteCommand] =
-      new Iterator[SimpleWriteCommand] {
-        private[this] var current: WriteCommand = CompoundWrite.this
-        def hasNext: Boolean = current ne null
-        def next(): SimpleWriteCommand =
-          current match {
-            case null                  ⇒ Iterator.empty.next()
-            case CompoundWrite(h, t)   ⇒ { current = t; h }
-            case x: SimpleWriteCommand ⇒ { current = null; x }
-          }
-      }
   }
 
   /**
@@ -753,24 +640,11 @@ object TcpMessage {
    * or have been sent!</b> Unfortunately there is no way to determine whether
    * a particular write has been sent by the O/S.
    */
-  def write(data: ByteString, ack: Event): Command = Write(data, ack)
+  def write(data: Bytes, ack: Event): Command = Write(data, ack)
   /**
    * The same as `write(data, noAck())`.
    */
-  def write(data: ByteString): Command = Write(data)
-
-  /**
-   * Write `count` bytes starting at `position` from file at `filePath` to the connection.
-   * The count must be > 0. The connection actor will reply with a [[Tcp.CommandFailed]]
-   * message if the write could not be enqueued. If [[Tcp.WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[Tcp.WriteCommand#ack]]
-   * token once the write has been successfully enqueued to the O/S kernel.
-   * <b>Note that this does not in any way guarantee that the data will be
-   * or have been sent!</b> Unfortunately there is no way to determine whether
-   * a particular write has been sent by the O/S.
-   */
-  def writeFile(filePath: String, position: Long, count: Long, ack: Event): Command =
-    WriteFile(filePath, position, count, ack)
+  def write(data: Bytes): Command = Write(data)
 
   /**
    * When `useResumeWriting` is in effect as was indicated in the [[Tcp.Register]] message

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
 import akka.actor._
-import akka.util.ByteString
+import akka.util._
 import akka.io.Inet.SocketOption
 import akka.io.Tcp._
 import akka.io.SelectionHandler._
@@ -125,7 +125,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         }
       }
 
-    case write: WriteCommand ⇒
+    case write: Write ⇒
       if (writingSuspended) {
         if (TraceLogging) log.debug("Dropping write because writing is suspended")
         sender ! write.failureMessage
@@ -324,26 +324,41 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   override def postRestart(reason: Throwable): Unit =
     throw new IllegalStateException("Restarting not supported for connection actors.")
 
-  def PendingWrite(commander: ActorRef, write: WriteCommand): PendingWrite = {
-    @tailrec def create(head: WriteCommand, tail: WriteCommand = Write.empty): PendingWrite =
-      head match {
-        case Write.empty                         ⇒ if (tail eq Write.empty) EmptyPendingWrite else create(tail)
-        case Write(data, ack) if data.nonEmpty   ⇒ PendingBufferWrite(commander, data, ack, tail)
-        case WriteFile(path, offset, count, ack) ⇒ PendingWriteFile(commander, path, offset, count, ack, tail)
-        case CompoundWrite(h, t)                 ⇒ create(h, t)
-        case x @ Write(_, ack) ⇒ // empty write with either an ACK or a non-standard NoACK
-          if (x.wantsAck) commander ! ack
-          create(tail)
+  /** Deconstructs `Write.data` into a lazy chain of PendingWrites */
+  def PendingWrite(commander: ActorRef, write: Write): PendingWrite = {
+    // the function that sends out the ack and returns the last pending write
+    val finish: () ⇒ PendingWrite =
+      if (write.wantsAck)
+        () ⇒ {
+          commander ! write.ack
+          EmptyPendingWrite
+        }
+      else TcpConnection.FinishWithEmptyPendingWrite // pre-allocated constant function
+    def create(bytes: Bytes.SimpleBytes, continue: () ⇒ PendingWrite): PendingWrite =
+      bytes match {
+        case ByteString.empty                     ⇒ continue()
+        case data: Bytes.ByteStringBytes          ⇒ PendingBufferWrite(commander, data.toByteString, continue)
+        case Bytes.FileBytes(path, offset, count) ⇒ PendingWriteFile(commander, path, offset, count, continue)
       }
-    create(write)
+    def createCompound(parts: Vector[Bytes.SimpleBytes], offset: Int): PendingWrite = {
+      assert(parts.size > 0)
+      assert(offset < parts.size)
+      if (offset + 1 == parts.size) create(parts(offset), finish)
+      else create(parts(offset), () ⇒ createCompound(parts, offset + 1))
+    }
+
+    write.data match {
+      case compact: Bytes.SimpleBytes ⇒ create(compact, finish)
+      case Bytes.CompoundBytes(parts) ⇒ createCompound(parts, 0)
+    }
   }
 
-  def PendingBufferWrite(commander: ActorRef, data: ByteString, ack: Event, tail: WriteCommand): PendingBufferWrite = {
+  def PendingBufferWrite(commander: ActorRef, data: ByteString, continue: () ⇒ PendingWrite): PendingBufferWrite = {
     val buffer = bufferPool.acquire()
     try {
       val copied = data.copyToBuffer(buffer)
       buffer.flip()
-      new PendingBufferWrite(commander, data.drop(copied), ack, buffer, tail)
+      new PendingBufferWrite(commander, data.drop(copied), buffer, continue)
     } catch {
       case NonFatal(e) ⇒
         bufferPool.release(buffer)
@@ -354,9 +369,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   class PendingBufferWrite(
     val commander: ActorRef,
     remainingData: ByteString,
-    ack: Any,
     buffer: ByteBuffer,
-    tail: WriteCommand) extends PendingWrite {
+    continue: () ⇒ PendingWrite) extends PendingWrite {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
       @tailrec def writeToChannel(data: ByteString): PendingWrite = {
@@ -365,7 +379,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         if (buffer.hasRemaining) {
           // we weren't able to write all bytes from the buffer, so we need to try again later
           if (data eq remainingData) this
-          else new PendingBufferWrite(commander, data, ack, buffer, tail) // copy with updated remainingData
+          else new PendingBufferWrite(commander, data, buffer, continue) // copy with updated remainingData
 
         } else if (data.nonEmpty) {
           buffer.clear()
@@ -374,9 +388,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
           writeToChannel(data drop copied)
 
         } else {
-          if (!ack.isInstanceOf[NoAck]) commander ! ack
           release()
-          PendingWrite(commander, tail)
+          continue()
         }
       }
       try {
@@ -389,17 +402,15 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
     def release(): Unit = bufferPool.release(buffer)
   }
 
-  def PendingWriteFile(commander: ActorRef, filePath: String, offset: Long, count: Long, ack: Event,
-                       tail: WriteCommand): PendingWriteFile =
-    new PendingWriteFile(commander, new FileInputStream(filePath).getChannel, offset, count, ack, tail)
+  def PendingWriteFile(commander: ActorRef, filePath: String, offset: Long, count: Long, continue: () ⇒ PendingWrite): PendingWriteFile =
+    new PendingWriteFile(commander, new FileInputStream(filePath).getChannel, offset, count, continue)
 
   class PendingWriteFile(
     val commander: ActorRef,
     fileChannel: FileChannel,
     offset: Long,
     remaining: Long,
-    ack: Event,
-    tail: WriteCommand) extends PendingWrite with Runnable {
+    continue: () ⇒ PendingWrite) extends PendingWrite with Runnable {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
       tcp.fileIoDispatcher.execute(this)
@@ -414,13 +425,11 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         val written = fileChannel.transferTo(offset, toWrite, channel)
 
         if (written < remaining) {
-          val updated = new PendingWriteFile(commander, fileChannel, offset + written, remaining - written, ack, tail)
+          val updated = new PendingWriteFile(commander, fileChannel, offset + written, remaining - written, continue)
           self ! UpdatePendingWrite(updated)
-
         } else {
-          if (!ack.isInstanceOf[NoAck]) commander ! ack
           release()
-          self ! UpdatePendingWrite(PendingWrite(commander, tail))
+          self ! UpdatePendingWrite(continue()) // this sends the ack on this thread, aside from the actor
         }
       } catch {
         case e: IOException ⇒ self ! WriteFileFailed(e)
@@ -467,4 +476,5 @@ private[io] object TcpConnection {
     def doWrite(info: ConnectionInfo): PendingWrite = throw new IllegalStateException
     def release(): Unit = throw new IllegalStateException
   }
+  val FinishWithEmptyPendingWrite: () ⇒ PendingWrite = () ⇒ EmptyPendingWrite
 }

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -277,7 +277,11 @@ object ByteString {
  *
  * TODO: Add performance characteristics
  */
-sealed abstract class ByteString extends IndexedSeq[Byte] with IndexedSeqOptimized[Byte, ByteString] {
+sealed abstract class ByteString extends Bytes.ByteStringBytes with IndexedSeq[Byte] with IndexedSeqOptimized[Byte, ByteString] {
+  def toByteString: ByteString = this
+  override def isEmpty: Boolean = super.isEmpty
+  override def nonEmpty: Boolean = super.nonEmpty
+
   def apply(idx: Int): Byte
 
   override protected[this] def newBuilder: ByteStringBuilder = ByteString.newBuilder

--- a/akka-actor/src/main/scala/akka/util/Bytes.scala
+++ b/akka-actor/src/main/scala/akka/util/Bytes.scala
@@ -1,0 +1,370 @@
+/**
+ *  Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.util
+
+import java.nio.charset.Charset
+import java.io.{ File, FileInputStream }
+import scala.annotation.tailrec
+import scala.collection.immutable.VectorBuilder
+
+/**
+ *  An abstraction of bytes either from a JVM heap buffer (ByteString), or a slice
+ *  of a file on the file-system, or a combination of both.
+ *
+ *  It provides operations to combine and slice bytes efficiently and usually without
+ *  having to load bytes from files into memory or by copying data around. Operations
+ *  that actually load bytes from files are marked as such.
+ *
+ *  Bytes instances are produced by using the given constructors in the companion object and
+ *  by combining/slicing the results with the instance methods.
+ *
+ *  Bytes instances are usually consumed by pattern-matching over its structure. This way
+ *  bytes from files can be read in the most efficient way possible for the given purpose
+ *  (e.g. by using `FileChannel.transferTo` where applicable).
+ *
+ *  The complete sealed type hierarchy looks like this:
+ *
+ *  Bytes
+ *  |-- SimpleBytes
+ *  |   |-- ByteStringBytes (= ByteString)
+ *  |   |-- FileBytes
+ *  |-- CompoundBytes
+ */
+sealed abstract class Bytes {
+  def isEmpty: Boolean = longLength == 0L
+  def nonEmpty: Boolean = !isEmpty
+
+  /**
+   * Determines whether this instance is or contains data that are not
+   * already present in the JVM heap (i.e. instance of Bytes.FileBytes).
+   */
+  def hasFileBytes: Boolean
+
+  /**
+   * Returns the number of bytes contained in this instance.
+   */
+  def longLength: Long
+
+  /**
+   * Extracts `span` bytes from this instance starting at `sourceOffset` and copies
+   * them to the `xs` starting at `targetOffset`. If `span` is larger than the number
+   * of bytes available in this instance after the `sourceOffset` or if `xs` has
+   * less space available after `targetOffset` the number of bytes copied is
+   * decreased accordingly (i.e. it is not an error to specify a `span` that is
+   * too large).
+   */
+  def copyToArray(xs: Array[Byte], sourceOffset: Long = 0, targetOffset: Int = 0, span: Int = longLength.toInt): Unit
+
+  /**
+   * Returns a slice of this instance's content as a `ByteString`.
+   *
+   * CAUTION: Since this instance might point to bytes contained in an off-memory file
+   * this method might cause the loading of a large amount of data into the JVM
+   * heap (up to 2 GB!).
+   */
+  def sliceBytes(offset: Long = 0, span: Int = longLength.toInt): ByteString
+
+  /** Returns a slice of this instance as a `Bytes`. */
+  def slice(offset: Long = 0, span: Long = longLength): Bytes
+
+  /**
+   * Copies the contents of this instance into a new byte array.
+   *
+   * CAUTION: Since this instance might point to bytes contained in an off-memory file
+   * this method might cause the loading of a large amount of data into the JVM
+   * heap (up to 2 GB!).
+   * If this instance is a `FileBytes` instance containing more than 2GB of data
+   * the method will throw an `IllegalArgumentException`.
+   */
+  def toByteArray: Array[Byte]
+
+  /**
+   * Same as `toByteArray` but returning a `ByteString` instead.
+   * More efficient if this instance is a `Bytes` instance since no data will have
+   * to be copied and the `ByteString` will not have to be newly created.
+   *
+   * CAUTION: Since this instance might point to bytes contained in an off-memory file
+   * this method might cause the loading of a large amount of data into the JVM
+   * heap (up to 2 GB!).
+   * If this instance is a `FileBytes` instance containing more than 2GB of data
+   * the method will throw an `IllegalArgumentException`.
+   */
+  def toByteString: ByteString
+
+  /**
+   * Returns the contents of this instance as a `Stream[Bytes]` with each
+   * chunk not being larger than the given `maxChunkSize`.
+   */
+  def toChunkStream(maxChunkSize: Long): Stream[Bytes]
+
+  /** Appends Bytes */
+  def ++(other: Bytes): Bytes
+
+  /**
+   * Returns the contents of this instance as a string (using UTF-8 encoding).
+   *
+   * CAUTION: Since this instance might point to bytes contained in an off-memory file
+   * this method might cause the loading of a large amount of data into the JVM
+   * heap (up to 2 GB!).
+   * If this instance is a `FileBytes` instance containing more than 2GB of data
+   * the method will throw an `IllegalArgumentException`.
+   */
+  def asString: String = asString(Charset.forName("utf8"))
+
+  /**
+   * Returns the contents of this instance as a string.
+   *
+   * CAUTION: Since this instance might point to bytes contained in an off-memory file
+   * this method might cause the loading of a large amount of data into the JVM
+   * heap (up to 2 GB!).
+   * If this instance is a `FileBytes` instance containing more than 2GB of data
+   * the method will throw an `IllegalArgumentException`.
+   */
+  def asString(charset: Charset): String = new String(toByteArray, charset)
+}
+
+object Bytes {
+  private val utf8 = Charset.forName("utf8")
+  def apply(string: String): Bytes = apply(string, utf8)
+  def apply(string: String, charset: Charset): Bytes =
+    ByteString.ByteString1C(string getBytes charset)
+  def apply(bytes: Array[Byte]): Bytes = ByteString(bytes)
+
+  /**
+   * Creates a [[FileBytes]] instance if the given file exists, is readable,
+   * non-empty and the given `length` parameter is non-zero. Otherwise the method returns
+   * an empty [[ByteString]].
+   * A negative `length` value signifies that the respective number of bytes at the end of the
+   * file is to be omitted, i.e., a value of -10 will select all bytes starting at `offset`
+   * except for the last 10.
+   * If `length` is greater or equal to "file length - offset" all bytes in the file starting at
+   * `offset` are selected.
+   */
+  def apply(file: File, offset: Long = 0, length: Long = Long.MaxValue): Bytes = {
+    val fileLength = file.length
+    if (fileLength > 0) {
+      require(offset >= 0 && offset < fileLength, s"offset $offset out of range $fileLength")
+      if (file.canRead)
+        if (length > 0) new FileBytes(file.getAbsolutePath, offset, math.min(fileLength - offset, length))
+        else if (length < 0 && length > offset - fileLength) new FileBytes(file.getAbsolutePath, offset, fileLength - offset + length)
+        else Empty
+      else Empty
+    } else Empty
+  }
+
+  /**
+   * Creates a [[FileBytes]] instance if the given file exists, is readable,
+   * non-empty and the given `length` parameter is non-zero. Otherwise the method returns an
+   * empty [[ByteString]].
+   * A negative `length` value signifies that the respective number of bytes at the end of the
+   * file is to be omitted, i.e., a value of -10 will select all bytes starting at `offset`
+   * except for the last 10.
+   * If `length` is greater or equal to "file length - offset" all bytes in the file starting at
+   * `offset` are selected.
+   */
+  def fromFile(fileName: String, offset: Long = 0, length: Long = Long.MaxValue) =
+    apply(new File(fileName), offset, length)
+
+  val Empty: Bytes = ByteString.empty
+
+  /** SimpleBytes are either completely heap-based or completely file-based but no combination */
+  sealed abstract class SimpleBytes private[util] extends Bytes {
+    def toByteArray = {
+      require(longLength <= Int.MaxValue, "Cannot create a byte array greater than 2GB")
+      val array = new Array[Byte](longLength.toInt)
+      copyToArray(array)
+      array
+    }
+    def sliceBytes(offset: Long, span: Int): ByteString = slice(offset, span).toByteString
+
+    def toChunkStream(maxChunkSize: Long): Stream[Bytes] = {
+      require(maxChunkSize > 0, "chunkSize must be > 0")
+      val lastChunkStart = longLength - maxChunkSize
+      def nextChunk(ix: Long = 0): Stream[Bytes] = {
+        if (ix < lastChunkStart) Stream.cons(slice(ix, maxChunkSize), nextChunk(ix + maxChunkSize))
+        else Stream.cons(slice(ix, longLength - ix), Stream.Empty)
+      }
+      nextChunk()
+    }
+  }
+  /**
+   * A sentinel middle class to use in pattern matches instead of `ByteString` to complete the
+   * sealed type hierarchy of Bytes. Any other possible implementation of ByteStringBytes must behave
+   * like ByteString (and is discouraged by making its constructor private[akka.util]).
+   */
+  abstract class ByteStringBytes private[util] extends SimpleBytes {
+    def length: Int
+    def iterator: ByteIterator
+
+    def ++(other: Bytes): Bytes =
+      if (isEmpty) other
+      else other match {
+        case ByteString.empty                                ⇒ this
+        case bs: ByteString                                  ⇒ this.toByteString ++ bs
+        case Bytes.CompoundBytes((head: ByteString) +: tail) ⇒ Bytes.CompoundBytes((this.toByteString ++ head) +: tail)
+        case Bytes.CompoundBytes(parts)                      ⇒ Bytes.CompoundBytes(this.toByteString +: parts)
+        case o: Bytes.SimpleBytes                            ⇒ Bytes.CompoundBytes(Vector(this.toByteString, o))
+      }
+
+    def hasFileBytes: Boolean = false
+    def longLength: Long = length
+
+    def copyToArray(xs: Array[Byte], sourceOffset: Long = 0, targetOffset: Int = 0, span: Int = length.toInt) = {
+      require(sourceOffset >= 0, "sourceOffset must be >= 0 but is " + sourceOffset)
+      if (sourceOffset < length)
+        iterator.drop(sourceOffset.toInt).copyToArray(xs, targetOffset, span)
+    }
+    def slice(offset: Long, span: Long): Bytes = {
+      require(offset >= 0, "offset must be >= 0")
+      require(span >= 0, "span must be >= 0")
+
+      if (offset < length && span > 0)
+        if (offset > 0 || span < length) toByteString.slice(offset.toInt, math.min(offset + span, Int.MaxValue).toInt)
+        else this
+      else Bytes.Empty
+    }
+  }
+  /** A reference to Bytes coming from a File */
+  case class FileBytes private[util] (fileName: String, offset: Long = 0, length: Long) extends SimpleBytes {
+    def ++(other: Bytes): Bytes = other match {
+      case ByteString.empty                                    ⇒ this
+      case FileBytes(`fileName`, o, l) if o == offset + length ⇒ copy(length = length + l)
+      case CompoundBytes(parts)                                ⇒ CompoundBytes(this +: parts)
+      case o: SimpleBytes                                      ⇒ CompoundBytes(Vector(this, o))
+    }
+
+    def longLength = length
+    def copyToArray(xs: Array[Byte], sourceOffset: Long = 0, targetOffset: Int = 0, span: Int = longLength.toInt) = {
+      require(sourceOffset >= 0, "sourceOffset must be >= 0 but is " + sourceOffset)
+      if (span > 0 && xs.length > 0 && sourceOffset < longLength) {
+        require(0 <= targetOffset && targetOffset < xs.length, s"start must be >= 0 and <= ${xs.length} but is $targetOffset")
+        val input = new FileInputStream(fileName)
+        try {
+          input.skip(offset + sourceOffset)
+          val targetEnd = math.min(xs.length, targetOffset + math.min(span, (length - sourceOffset).toInt))
+          @tailrec def load(ix: Int = targetOffset): Unit =
+            if (ix < targetEnd)
+              input.read(xs, ix, targetEnd - ix) match {
+                case -1 ⇒ // file length changed since this FileBytes instance was created
+                  java.util.Arrays.fill(xs, ix, targetEnd, 0.toByte) // zero out remaining space
+                case count ⇒ load(ix + count)
+              }
+          load()
+        } finally input.close()
+      }
+    }
+    def toByteString = ByteString.ByteString1C(toByteArray)
+    def slice(offset: Long, span: Long): Bytes = {
+      require(offset >= 0, "offset must be >= 0")
+      require(span >= 0, "span must be >= 0")
+
+      if (offset < longLength && span > 0) {
+        val newOffset = this.offset + offset
+        val newLength = math.min(longLength - offset, span)
+        FileBytes(fileName, newOffset, newLength)
+      } else Bytes.Empty
+    }
+    def hasFileBytes: Boolean = true
+  }
+  /** A combination of heap-based and file-based Bytes */
+  case class CompoundBytes private[util] (parts: Vector[SimpleBytes]) extends Bytes {
+    require(parts.nonEmpty)
+    def sliceBytes(offset: Long, span: Int): ByteString = slice(offset, span).toByteString
+    def toByteArray: Array[Byte] = {
+      require(longLength <= Int.MaxValue, "Cannot create a byte array greater than 2GB")
+      val result = new Array[Byte](longLength.toInt)
+      copyToArray(result)
+      result
+    }
+    def ++(other: Bytes): Bytes = other match {
+      case ByteString.empty    ⇒ this
+      case CompoundBytes(more) ⇒ CompoundBytes(parts ++ more)
+      case c: SimpleBytes      ⇒ CompoundBytes(parts :+ c)
+    }
+
+    lazy val hasFileBytes = parts.exists(_.hasFileBytes)
+    lazy val longLength = parts.map(_.longLength).sum
+    def iterator: Iterator[SimpleBytes] = parts.iterator
+    def copyToArray(xs: Array[Byte], sourceOffset: Long = 0, targetOffset: Int = 0, span: Int = longLength.toInt): Unit = {
+      require(sourceOffset >= 0, "sourceOffset must be >= 0 but is " + sourceOffset)
+      if (span > 0 && xs.length > 0 && sourceOffset < longLength) {
+        require(0 <= targetOffset && targetOffset < xs.length, s"start must be >= 0 and <= ${xs.length} but is $targetOffset")
+        val targetEnd: Int = math.min(xs.length, targetOffset + math.min(span, (longLength - sourceOffset).toInt))
+        val iter = iterator
+        @tailrec def rec(sourceOffset: Long = sourceOffset, targetOffset: Int = targetOffset): Unit =
+          if (targetOffset < targetEnd && iter.hasNext) {
+            val current = iter.next()
+            if (sourceOffset < current.longLength) {
+              current.copyToArray(xs, sourceOffset, targetOffset, span = targetEnd - targetOffset)
+              rec(0, math.min(targetOffset + current.longLength - sourceOffset, Int.MaxValue).toInt)
+            } else rec(sourceOffset - current.longLength, targetOffset)
+          }
+        rec()
+      }
+    }
+    def slice(offset: Long, span: Long): Bytes = {
+      require(offset >= 0, "offset must be >= 0")
+      require(span >= 0, "span must be >= 0")
+      if (offset < longLength && span > 0) {
+        val iter = iterator
+        val builder = Bytes.newBuilder
+        @tailrec def rec(offset: Long = offset, span: Long = span): Bytes =
+          if (span > 0 && iter.hasNext) {
+            val current = iter.next()
+            if (offset < current.longLength) {
+              val piece = current.slice(offset, span)
+              if (piece.nonEmpty) builder += piece
+              rec(0, math.max(0, span - piece.longLength))
+            } else rec(offset - current.longLength, span)
+          } else builder.result()
+        rec()
+      } else Bytes.Empty
+    }
+    def toByteString = {
+      require(longLength <= Int.MaxValue, "Cannot create a ByteString greater than 2GB")
+      parts.foldLeft(ByteString.empty)(_ ++ _.toByteString)
+    }
+
+    // overridden to run lazily
+    override def toChunkStream(maxChunkSize: Long): Stream[Bytes] =
+      Stream.cons(slice(0, maxChunkSize), slice(maxChunkSize).toChunkStream(maxChunkSize))
+
+    override def toString = parts.map(_.toString).mkString(" ++ ")
+  }
+
+  def newBuilder: Builder = new Builder
+
+  class Builder extends scala.collection.mutable.Builder[Bytes, Bytes] {
+    private val b = new VectorBuilder[SimpleBytes]
+    private var _byteCount = 0L
+
+    def byteCount: Long = _byteCount
+
+    def +=(x: SimpleBytes): this.type = {
+      b += x
+      _byteCount += x.longLength
+      this
+    }
+
+    def +=(elem: Bytes): this.type =
+      elem match {
+        case Empty          ⇒ this
+        case x: SimpleBytes ⇒ this += x
+        case CompoundBytes(parts) ⇒
+          // TODO: optimize?
+          parts.foreach(this += _); this
+      }
+
+    def clear(): Unit = b.clear()
+
+    def result(): Bytes = {
+      val res = b.result()
+      res.size match {
+        case 0 ⇒ ByteString.empty
+        case 1 ⇒ res.head
+        case _ ⇒ CompoundBytes(res)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Here's a first proposal of the new unified Bytes abstraction as discussed [on the ML](https://groups.google.com/d/topic/akka-dev/43tW_BKXE2Q/discussion).

Some notes:

After first having put the complete `Bytes` code into `ByteString.scala` (to keep sealedness and integrate `ByteString` into the type hierarchy), I went with another approach and split the `Bytes` code into its own file with a sealed hierarchy looking like this:

```
Bytes
  |-- SimpleBytes
  |   |-- ByteStringBytes (= ByteString)
  |   |-- FileBytes
  |-- CompoundBytes
```

I left `ByteStringBytes` unsealed and derived `ByteString` from it but gave it a private constructor (leaving still a small theoretical loop-hole for custom implementations but it still seemed like the cleaner trade-off in comparison with putting anything into one file). This allows to pattern match on the complete hierarchy and still allows `ByteString` to be part of it with only minimal adaptions needed.

One potential conflict is that `Bytes` allow data with Long-range lengths. In spray's `HttpData` the signature of the length method was `def length: Long`. This isn't possible if `ByteString` should be part of the hierarchy since it already has a `def length: Int` method that is needed for inheriting from `IndexedSeq` and other standard library collections. Therefore, a `Bytes.longLength` method was introduced to support Long-range lengths where needed.

The second commit shows how the `Tcp.WriteCommand` hierarchy can be replaced by a simple `case class Tcp.Write(Bytes, ack)`.
