### PR TITLE
=act Normalize DeathWatch Debug events' messages

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -123,7 +123,7 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
     if (watcheeSelf && !watcherSelf) {
       if (!watchedBy.contains(watcher)) maintainAddressTerminatedSubscription(watcher) {
         watchedBy += watcher
-        if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(actor), "now monitoring " + watcher))
+        if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(actor), s"now watched by $watcher"))
       }
     } else if (!watcheeSelf && watcherSelf) {
       watch(watchee)
@@ -139,7 +139,7 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
     if (watcheeSelf && !watcherSelf) {
       if (watchedBy.contains(watcher)) maintainAddressTerminatedSubscription(watcher) {
         watchedBy -= watcher
-        if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(actor), "stopped monitoring " + watcher))
+        if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(actor), s"no longer watched by $watcher"))
       }
     } else if (!watcheeSelf && watcherSelf) {
       unwatch(watchee)


### PR DESCRIPTION
If debug is enabled watching an actor produces a message saying something like
`[akka://watchee] now monitoring Actor[akka://watcher#1]` which looks confusing. Same for `unwatch`
this PR changes it to `[akka://watchee] now watched by Actor[akka://watcher#1]` form
