### PR TITLE
+act #2075 Added possibility to pass an ExecutionContext to an ActorSystem.

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -72,11 +72,17 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
 
         {
           c.getString("type") should equal("Dispatcher")
-          c.getString("executor") should equal("fork-join-executor")
+          c.getString("executor") should equal("default-executor")
           c.getDuration("shutdown-timeout", TimeUnit.MILLISECONDS) should equal(1 * 1000)
           c.getInt("throughput") should equal(5)
           c.getDuration("throughput-deadline-time", TimeUnit.MILLISECONDS) should equal(0)
           c.getBoolean("attempt-teamwork") should equal(true)
+        }
+
+        //Default executor config
+        {
+          val pool = c.getConfig("default-executor")
+          pool.getString("fallback") should equal("fork-join-executor")
         }
 
         //Fork join executor config

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -238,10 +238,23 @@ akka {
 
       # Which kind of ExecutorService to use for this dispatcher
       # Valid options:
+      #  - "default-executor" requires a "default-executor" section
       #  - "fork-join-executor" requires a "fork-join-executor" section
       #  - "thread-pool-executor" requires a "thread-pool-executor" section
       #  - A FQCN of a class extending ExecutorServiceConfigurator
-      executor = "fork-join-executor"
+      executor = "default-executor"
+
+      # This will be used if you have set "executor = "default-executor"".
+      # If an ActorSystem is created with a given ExecutionContext, this
+      # ExecutionContext will be used as the default executor for all
+      # dispatchers in the ActorSystem configured with
+      # executor = "default-executor". Note that "default-executor"
+      # is the default value for executor, and therefore used if not
+      # specified otherwise. If no ExecutionContext is given,
+      # the executor configured in "fallback" will be used.
+      default-executor {
+        fallback = "fork-join-executor"
+      }
 
       # This will be used if you have set "executor = "fork-join-executor""
       fork-join-executor {

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration.Duration
 import akka.ConfigurationException
 import akka.actor.Deploy
 import akka.util.Helpers.ConfigOps
+import scala.concurrent.ExecutionContext
 
 /**
  * DispatcherPrerequisites represents useful contextual pieces when constructing a MessageDispatcher
@@ -24,6 +25,7 @@ trait DispatcherPrerequisites {
   def dynamicAccess: DynamicAccess
   def settings: ActorSystem.Settings
   def mailboxes: Mailboxes
+  def defaultExecutionContext: Option[ExecutionContext]
 }
 
 /**
@@ -35,7 +37,8 @@ private[akka] case class DefaultDispatcherPrerequisites(
   val scheduler: Scheduler,
   val dynamicAccess: DynamicAccess,
   val settings: ActorSystem.Settings,
-  val mailboxes: Mailboxes) extends DispatcherPrerequisites
+  val mailboxes: Mailboxes,
+  val defaultExecutionContext: Option[ExecutionContext]) extends DispatcherPrerequisites
 
 object Dispatchers {
   /**

--- a/akka-docs/rst/java/dispatchers.rst
+++ b/akka-docs/rst/java/dispatchers.rst
@@ -11,7 +11,11 @@ Default dispatcher
 ------------------
 
 Every ``ActorSystem`` will have a default dispatcher that will be used in case nothing else is configured for an ``Actor``.
-The default dispatcher can be configured, and is by default a ``Dispatcher`` with a "fork-join-executor", which gives excellent performance in most cases.
+The default dispatcher can be configured, and is by default a ``Dispatcher`` with the specified ``default-executor``.
+If an ActorSystem is created with an ExecutionContext passed in, this ExecutionContext will be used as the default executor for all
+dispatchers in this ActorSystem. If no ExecutionContext is given, it will fallback to the executor specified in
+``akka.actor.default-dispatcher.default-executor.fallback``. By default this is a "fork-join-executor", which
+gives excellent performance in most cases.
 
 .. _dispatcher-lookup-java:
 

--- a/akka-docs/rst/scala/dispatchers.rst
+++ b/akka-docs/rst/scala/dispatchers.rst
@@ -11,7 +11,11 @@ Default dispatcher
 ------------------
 
 Every ``ActorSystem`` will have a default dispatcher that will be used in case nothing else is configured for an ``Actor``.
-The default dispatcher can be configured, and is by default a ``Dispatcher`` with a "fork-join-executor", which gives excellent performance in most cases.
+The default dispatcher can be configured, and is by default a ``Dispatcher`` with the specified ``default-executor``.
+If an ActorSystem is created with an ExecutionContext passed in, this ExecutionContext will be used as the default executor for all
+dispatchers in this ActorSystem. If no ExecutionContext is given, it will fallback to the executor specified in
+``akka.actor.default-dispatcher.default-executor.fallback``. By default this is a "fork-join-executor", which
+gives excellent performance in most cases.
 
 .. _dispatcher-lookup-scala:
 


### PR DESCRIPTION
This PR adds the possibility to pass an ExecutionContext to an ActorSystem. This ExecutionContext will be used in the default dispatcher, unless the executor of the default-dispatcher is being overridden in the application.conf. If no ExecutionContext is given, it falls back to 'akka.actor.default-dispatcher.default-executor.fallback'.
