### PR TITLE
=act #3798 Increase coroner timeout in ConsistencySpec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ConsistencySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ConsistencySpec.scala
@@ -50,6 +50,9 @@ object ConsistencySpec {
 
 class ConsistencySpec extends AkkaSpec(ConsistencySpec.config) {
   import ConsistencySpec._
+
+  override def expectedTestDuration: FiniteDuration = 3.minutes
+
   "The Akka actor model implementation" must {
     "provide memory consistency" in {
       val noOfActors = 7


### PR DESCRIPTION
I checked a few builds, and it takes slightly more than 2 minutes.
