### PR TITLE
+tes Added system as default param to TestKit.shutdown

### DIFF
--- a/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
@@ -31,7 +31,7 @@ class ProducerFeatureTest extends TestKit(ActorSystem("test", AkkaSpec.testConf)
 
   override protected def afterAll() {
     super.afterAll()
-    shutdown(system)
+    shutdown()
   }
 
   val camelContext = camel.context

--- a/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/ActivationTrackerTest.scala
@@ -11,7 +11,7 @@ import akka.camel.internal.ActivationProtocol._
 
 class ActivationTrackerTest extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with GivenWhenThen {
 
-  override protected def afterAll() { shutdown(system) }
+  override protected def afterAll() { shutdown() }
 
   var actor: TestProbe = _
   var awaiting: Awaiting = _

--- a/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
@@ -379,7 +379,7 @@ private[camel] trait ActorProducerFixture extends MockitoSugar with BeforeAndAft
   }
 
   override protected def afterAll() {
-    shutdown(system)
+    shutdown()
   }
 
   def msg(s: String) = CamelMessage(s, Map.empty)

--- a/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
@@ -46,7 +46,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
   import TimerBasedThrottlerSpec._
 
   override def afterAll {
-    shutdown(system)
+    shutdown()
   }
 
   "A throttler" must {

--- a/akka-docs/rst/scala/code/docs/testkit/TestKitUsageSpec.scala
+++ b/akka-docs/rst/scala/code/docs/testkit/TestKitUsageSpec.scala
@@ -45,7 +45,7 @@ class TestKitUsageSpec
     system.actorOf(Props(classOf[SequencingActor], testActor, headList, tailList))
 
   override def afterAll {
-    shutdown(system)
+    shutdown()
   }
 
   "An EchoActor" should {

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -656,7 +656,7 @@ trait TestKitBase {
    *
    * If verifySystemShutdown is true, then an exception will be thrown on failure.
    */
-  def shutdown(actorSystem: ActorSystem,
+  def shutdown(actorSystem: ActorSystem = system,
                duration: Duration = 5.seconds.dilated.min(10.seconds),
                verifySystemShutdown: Boolean = false) {
     TestKit.shutdownActorSystem(actorSystem, duration, verifySystemShutdown)

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -72,7 +72,7 @@ abstract class AkkaSpec(_system: ActorSystem)
 
   final override def afterAll {
     beforeTermination()
-    shutdown(system)
+    shutdown()
     afterTermination()
     stopCoroner()
   }


### PR DESCRIPTION
This PR adds `system` as default for the first parameter of the `shutdown` method on TestKit. Every occurrence of `shutdown(system)`, where `system` is the `ActorSystem` associated with the `TestKit` instance has been replaced by `shutdown()`.
