### PR TITLE
=act #3738 Fix memory leaks in tests

### DIFF
--- a/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ProducerFeatureTest.scala
@@ -24,7 +24,7 @@ import akka.actor.Status.Failure
 /**
  * Tests the features of the Camel Producer.
  */
-class ProducerFeatureTest extends TestKit(ActorSystem("test", AkkaSpec.testConf)) with WordSpecLike with BeforeAndAfterAll with BeforeAndAfterEach with Matchers {
+class ProducerFeatureTest extends TestKit(ActorSystem("ProducerFeatureTest", AkkaSpec.testConf)) with WordSpecLike with BeforeAndAfterAll with BeforeAndAfterEach with Matchers {
 
   import ProducerFeatureTest._
   implicit def camel = CamelExtension(system)

--- a/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
@@ -10,8 +10,9 @@ import scala.collection.immutable.Seq
 //#plugin-imports
 
 import com.typesafe.config._
-
 import org.scalatest.WordSpec
+import scala.concurrent.duration._
+import akka.testkit.TestKit
 
 import akka.actor.ActorSystem
 //#plugin-imports
@@ -69,8 +70,12 @@ class PersistencePluginDocSpec extends WordSpec {
         //#snapshot-store-plugin-config
       """
 
-    val system = ActorSystem("doc", ConfigFactory.parseString(providerConfig).withFallback(ConfigFactory.parseString(PersistencePluginDocSpec.config)))
-    val extension = Persistence(system)
+    val system = ActorSystem("PersistencePluginDocSpec", ConfigFactory.parseString(providerConfig).withFallback(ConfigFactory.parseString(PersistencePluginDocSpec.config)))
+    try {
+      Persistence(system)
+    } finally {
+      TestKit.shutdownActorSystem(system, 10.seconds, false)
+    }
   }
 }
 

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceSerializerDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceSerializerDocSpec.scala
@@ -5,11 +5,11 @@
 package docs.persistence
 
 import com.typesafe.config._
-
+import scala.concurrent.duration._
 import org.scalatest.WordSpec
-
 import akka.actor.ActorSystem
 import akka.serialization.{ Serializer, SerializationExtension }
+import akka.testkit.TestKit
 
 class PersistenceSerializerDocSpec extends WordSpec {
 
@@ -29,7 +29,12 @@ class PersistenceSerializerDocSpec extends WordSpec {
       //#custom-serializer-config
     """.stripMargin
 
-  SerializationExtension(ActorSystem("doc", ConfigFactory.parseString(customSerializerConfig)))
+  val system = ActorSystem("PersistenceSerializerDocSpec", ConfigFactory.parseString(customSerializerConfig))
+  try {
+    SerializationExtension(system)
+  } finally {
+    TestKit.shutdownActorSystem(system, 10.seconds, false)
+  }
 }
 
 class MyPayload

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
@@ -160,8 +160,8 @@ abstract class Ticket1978CommunicationSpec(val cipherConfig: CipherConfig) exten
       }
 
     } else {
-      "not be run when the cipher is not supported by the platform this test is currently being executed on" ignore {
-
+      "not be run when the cipher is not supported by the platform this test is currently being executed on" in {
+        pending
       }
     }
 

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -65,6 +65,8 @@ abstract class AkkaSpec(_system: ActorSystem)
 
   val log: LoggingAdapter = Logging(system, this.getClass)
 
+  override val invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
+
   final override def beforeAll {
     startCoroner
     atStartup()


### PR DESCRIPTION
- afterAll not called when all tests marked as ignore,
  invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
  should solve that, but changed to pending in Ticket1978 anyway
- Try to shutdown when ActorSystem init fails. It is difficult
  to cover all scenarios, but this should improve the situation.
  This was the reason why DeployerSpec leaked.
- missing shutdown in some tests
