### PR TITLE
=act #3825 Fix bug in BalancingSpec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
@@ -32,7 +32,7 @@ class BalancingSpec extends AkkaSpec(
     akka.actor.deployment {
       /balancingPool-2 {
         router = balancing-pool
-        nr-of-instances = 10
+        nr-of-instances = 5
         pool-dispatcher {
           attempt-teamwork = on
         }
@@ -41,7 +41,7 @@ class BalancingSpec extends AkkaSpec(
     """) with ImplicitSender with BeforeAndAfterEach {
   import BalancingSpec._
 
-  val poolSize = 10
+  val poolSize = 5 // must be less than fork-join parallelism-min, which is 8 in AkkaSpec
 
   override def beforeEach(): Unit = {
     counter.set(1)


### PR DESCRIPTION
- The problem was that the pool had 10 routees and
  depend on blocking to verify balancing scheduling
  to unblocked routee, but the thread pool size was 8
  and therefore routee 8 and 9 was never scheduled
  (blocked) as expected.
