### PR TITLE
=act #3857 Ensure that only relevant test messages go to dead letters

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
@@ -343,6 +343,8 @@ class ActorSelectionSpec extends AkkaSpec("akka.loglevel=DEBUG") with DefaultTim
     }
 
     "send ActorSelection wildcard targeted to missing actor to deadLetters" in {
+      val creator = TestProbe()
+      implicit def self = creator.ref
       val top = system.actorOf(p, "top")
       top ! Create("child1")
       top ! Create("child2")


### PR DESCRIPTION
-   Since there was no sender for the `Create` message in the test, the
  created `ActorRef` was also sent to dead letters, creating a race
  where the test could start to subscribe _too early_ and receive the
  `ActorRef` instead of the expected string.
