### PR TITLE
=con #3865 Fix race in pub-sub when nodes are removed

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/DistributedPubSubMediator.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/DistributedPubSubMediator.scala
@@ -337,11 +337,15 @@ class DistributedPubSubMediator(
     case Delta(buckets) ⇒
       // reply from Status message in the gossip chat
       // the Delta contains potential updates (newer versions) from the other node
-      if (nodes.contains(sender().path.address)) {
+      // only accept deltas/buckets from known nodes, otherwise there is a risk of
+      // adding back entries when nodes are removed
+      if (nodes(sender().path.address)) {
         buckets foreach { b ⇒
-          val myBucket = registry(b.owner)
-          if (b.version > myBucket.version) {
-            registry += (b.owner -> myBucket.copy(version = b.version, content = myBucket.content ++ b.content))
+          if (nodes(b.owner)) {
+            val myBucket = registry(b.owner)
+            if (b.version > myBucket.version) {
+              registry += (b.owner -> myBucket.copy(version = b.version, content = myBucket.content ++ b.content))
+            }
           }
         }
       }


### PR DESCRIPTION
- The race can happen if the MemberRemoved event is received followed by a Delta update from
  a node that has not yet got the MemberRemoved. That will make the bucket for the removed
  node to be added back in the registry.
