### PR TITLE
=doc Typed actors chapter improvement

### DIFF
--- a/akka-docs/rst/java/typed-actors.rst
+++ b/akka-docs/rst/java/typed-actors.rst
@@ -103,8 +103,8 @@ Methods returning:
 
   * ``void`` will be dispatched with ``fire-and-forget`` semantics, exactly like ``ActorRef.tell``
   * ``scala.concurrent.Future<?>`` will use ``send-request-reply`` semantics, exactly like ``ActorRef.ask``
-  * ``scala.Option<?>`` or ``akka.japi.Option<?>`` will use ``send-request-reply`` semantics, but *will* block to wait for an answer,
-    and return None if no answer was produced within the timeout, or scala.Some/akka.japi.Some containing the result otherwise.
+  * ``akka.japi.Option<?>`` will use ``send-request-reply`` semantics, but *will* block to wait for an answer,
+    and return ``akka.japi.Option.None`` if no answer was produced within the timeout, or ``akka.japi.Option.Some<?>`` containing the result otherwise.
     Any exception that was thrown during this call will be rethrown.
   * Any other type of value will use ``send-request-reply`` semantics, but *will* block to wait for an answer,
     throwing ``java.util.concurrent.TimeoutException`` if there was a timeout or rethrow any exception that was thrown during this call.

--- a/akka-docs/rst/scala/typed-actors.rst
+++ b/akka-docs/rst/scala/typed-actors.rst
@@ -90,8 +90,8 @@ Methods returning:
 
   * ``Unit`` will be dispatched with ``fire-and-forget`` semantics, exactly like ``ActorRef.tell``
   * ``scala.concurrent.Future[_]`` will use ``send-request-reply`` semantics, exactly like ``ActorRef.ask``
-  * ``scala.Option[_]`` or ``akka.japi.Option<?>`` will use ``send-request-reply`` semantics, but *will* block to wait for an answer,
-    and return None if no answer was produced within the timeout, or scala.Some/akka.japi.Some containing the result otherwise.
+  * ``scala.Option[_]`` will use ``send-request-reply`` semantics, but *will* block to wait for an answer,
+    and return ``scala.None`` if no answer was produced within the timeout, or ``scala.Some[_]`` containing the result otherwise.
     Any exception that was thrown during this call will be rethrown.
   * Any other type of value will use ``send-request-reply`` semantics, but *will* block to wait for an answer,
     throwing ``java.util.concurrent.TimeoutException`` if there was a timeout or rethrow any exception that was thrown during this call.


### PR DESCRIPTION
*Scala version:
Added package tag `` around scala.None and .Some[_];
Added "[_]" after scala.Some statement;
Removed japi part, because its a Scala documentation version;

*Java version
Fixed wrong path to japi.Option.Some and None
Added package tag ``
Removed scala packages (i know about implicit conversion, but i think it mght be beter)
