### PR TITLE
Don't rely on Scala 2.10 compiler bug with inheritance, privates

### DIFF
--- a/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
+++ b/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
@@ -72,7 +72,7 @@ private[akka] object SubclassifiedIndex {
  * cache, e.g. HashMap, is faster than tree traversal which must use linear
  * scan at each level. Therefore, no value traversals are published.
  */
-private[akka] class SubclassifiedIndex[K, V] private (private var values: Set[V])(implicit sc: Subclassification[K]) {
+private[akka] class SubclassifiedIndex[K, V] private (protected var values: Set[V])(implicit sc: Subclassification[K]) {
 
   import SubclassifiedIndex._
 


### PR DESCRIPTION
A subclass should not inherit private members of its parents.
In Scala 2.10, enforcement of this rule was conflated with the
notion of access: a private member of `class C` may be accessed
from its companion.

I brought the compiler into line with the Spec recently in
SI-7575 / https://github.com/scala/scala/pull/3440.

Two remedies exist: loosen access, or upcast to the parent
type before selecting the private member. I've chosen the former
here.

This is a touch counterintuitive ("why should upcasting ever make
new members visible?"). I double checked this change yesterday
with @odersky, and he answered:

> Yes, the fix matches the spec exactly, as far as I can tell.
> I just verified that javac behaves the same. In
> 
> class C {
>     private void foo() {}
>     void test(D d) { d.foo(); }
> }
> 
> class D extends C {}
> 
> You get "cannot find symbol" on line 3.

This patch brought to you courtesy of dbuild! A backport to the
last stable release branch of Akka might be worthwhile, but I'll
leave that decision to you.
