### PR TITLE
=rem #3870 Stop re-delivery of system messages when watching non-existing sys

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -89,7 +89,7 @@ private[cluster] class ClusterRemoteWatcher(
       if (m.address != selfAddress) {
         clusterNodes -= m.address
         if (previousStatus == MemberStatus.Down) {
-          quarantine(m.address, m.uniqueAddress.uid)
+          quarantine(m.address, Some(m.uniqueAddress.uid))
         }
         publishAddressTerminated(m.address)
       }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteQuarantinePiercingSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteQuarantinePiercingSpec.scala
@@ -67,7 +67,7 @@ abstract class RemoteQuarantinePiercingSpec extends MultiNodeSpec(RemoteQuaranti
         enterBarrier("actor-identified")
 
         // Manually Quarantine the other system
-        RARP(system).provider.transport.quarantine(node(second).address, uidFirst)
+        RARP(system).provider.transport.quarantine(node(second).address, Some(uidFirst))
 
         // Quarantine is up -- Cannot communicate with remote system any more
         system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! "identify"

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -417,9 +417,10 @@ private[akka] class RemoteActorRefProvider(
   /**
    * Marks a remote system as out of sync and prevents reconnects until the quarantine timeout elapses.
    * @param address Address of the remote system to be quarantined
-   * @param uid UID of the remote system
+   * @param uid UID of the remote system, if the uid is not defined it will not be a strong quarantine but
+   *   the current endpoint writer will be stopped (dropping system messages) and the address will be gated
    */
-  def quarantine(address: Address, uid: Int): Unit = transport.quarantine(address: Address, uid: Int)
+  def quarantine(address: Address, uid: Option[Int]): Unit = transport.quarantine(address, uid)
 
   /**
    * INTERNAL API

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -85,9 +85,10 @@ private[akka] abstract class RemoteTransport(val system: ExtendedActorSystem, va
   /**
    * Marks a remote system as out of sync and prevents reconnects until the quarantine timeout elapses.
    * @param address Address of the remote system to be quarantined
-   * @param uid UID of the remote system
+   * @param uid UID of the remote system, if the uid is not defined it will not be a strong quarantine but
+   *   the current endpoint writer will be stopped (dropping system messages) and the address will be gated
    */
-  def quarantine(address: Address, uid: Int): Unit
+  def quarantine(address: Address, uid: Option[Int]): Unit
 
   /**
    * When this method returns true, some functionality will be turned off for security purposes.

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -164,7 +164,7 @@ private[akka] class RemoteWatcher(
     watchingNodes foreach { a ⇒
       if (!unreachable(a) && !failureDetector.isAvailable(a)) {
         log.warning("Detected unreachable: [{}]", a)
-        addressUids.get(a) foreach { uid ⇒ quarantine(a, uid) }
+        quarantine(a, addressUids.get(a))
         publishAddressTerminated(a)
         unreachable += a
       }
@@ -173,7 +173,7 @@ private[akka] class RemoteWatcher(
   def publishAddressTerminated(address: Address): Unit =
     context.system.eventStream.publish(AddressTerminated(address))
 
-  def quarantine(address: Address, uid: Int): Unit =
+  def quarantine(address: Address, uid: Option[Int]): Unit =
     remoteProvider.quarantine(address, uid)
 
   def rewatchRemote(watchee: ActorRef, watcher: ActorRef): Unit =

--- a/akka-remote/src/test/scala/akka/remote/RemoteConsistentHashingRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConsistentHashingRouterSpec.scala
@@ -27,8 +27,8 @@ class RemoteConsistentHashingRouterSpec extends AkkaSpec("""
       val consistentHash1 = ConsistentHash(nodes1, 10)
       val consistentHash2 = ConsistentHash(nodes2, 10)
       val keys = List("A", "B", "C", "D", "E", "F", "G")
-      val result1 = keys collect { case k => consistentHash1.nodeFor(k).routee }
-      val result2 = keys collect { case k => consistentHash2.nodeFor(k).routee }
+      val result1 = keys collect { case k ⇒ consistentHash1.nodeFor(k).routee }
+      val result2 = keys collect { case k ⇒ consistentHash2.nodeFor(k).routee }
       result1 should be(result2)
     }
 


### PR DESCRIPTION
- We don't know the UID so we can't quarantine, but we can stop the endpoint
  writer and drop outstanding system messages
