### PR TITLE
=act #3623 unsubscribe when actors terminate, instead of `isTerminated`

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -618,6 +618,7 @@ private[akka] class ActorSystemImpl(val name: String, applicationConfig: Config,
     provider.init(this)
     if (settings.LogDeadLetters > 0)
       logDeadLetterListener = Some(systemActorOf(Props[DeadLetterListener], "deadLetterListener"))
+    startEventStreamUnsubscriber(eventStream)
     registerOnTermination(stopScheduler())
     loadExtensions()
     if (LogConfigOnStart) logConfiguration()
@@ -660,6 +661,10 @@ private[akka] class ActorSystemImpl(val name: String, applicationConfig: Config,
   def abort(): Unit = {
     aborting = true
     shutdown()
+  }
+
+  def startEventStreamUnsubscriber(eventStream: EventStream) {
+    systemActorOf(Props(classOf[EventStreamUnsubscriber], eventStream, DebugEventStream), "eventStreamUnsubscriber")
   }
 
   //#create-scheduler

--- a/akka-actor/src/main/scala/akka/event/EventBus.scala
+++ b/akka-actor/src/main/scala/akka/event/EventBus.scala
@@ -175,6 +175,13 @@ trait SubchannelClassification { this: EventBus ⇒
     recv foreach (publish(event, _))
   }
 
+  /**
+   * INTERNAL API
+   * Expensive call! Avoid calling directly from event bus subscribe / unsubscribe.
+   */
+  private[akka] def hasSubscriptions(subscriber: Subscriber): Boolean =
+    cache.values exists { _ contains subscriber }
+
   private def removeFromCache(changes: immutable.Seq[(Classifier, Set[Subscriber])]): Unit =
     cache = (cache /: changes) {
       case (m, (c, cs)) ⇒ m.updated(c, m.getOrElse(c, Set.empty[Subscriber]) -- cs)
@@ -184,6 +191,7 @@ trait SubchannelClassification { this: EventBus ⇒
     cache = (cache /: changes) {
       case (m, (c, cs)) ⇒ m.updated(c, m.getOrElse(c, Set.empty[Subscriber]) ++ cs)
     }
+
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -5,9 +5,11 @@ package akka.event
 
 import language.implicitConversions
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor._
 import akka.event.Logging.simpleName
 import akka.util.Subclassification
+import java.util.concurrent.atomic.AtomicReference
+import scala.annotation.tailrec
 
 object EventStream {
   //Why is this here and why isn't there a failing test if it is removed?
@@ -28,6 +30,9 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
   type Event = AnyRef
   type Classifier = Class[_]
 
+  /** Either the list of subscribed actors, or a ref to an [[akka.event.EventStreamUnsubscriber]] */
+  private val initiallySubscribedOrUnsubscriber = new AtomicReference[Either[Set[ActorRef], ActorRef]](Left(Set.empty))
+
   protected implicit val subclassification = new Subclassification[Class[_]] {
     def isEqual(x: Class[_], y: Class[_]) = x == y
     def isSubclass(x: Class[_], y: Class[_]) = y isAssignableFrom x
@@ -36,13 +41,13 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
   protected def classify(event: AnyRef): Class[_] = event.getClass
 
   protected def publish(event: AnyRef, subscriber: ActorRef) = {
-    if (subscriber.isTerminated) unsubscribe(subscriber)
-    else subscriber ! event
+    subscriber ! event
   }
 
   override def subscribe(subscriber: ActorRef, channel: Class[_]): Boolean = {
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "subscribing " + subscriber + " to channel " + channel))
+    registerWithUnsubscriber(subscriber)
     super.subscribe(subscriber, channel)
   }
 
@@ -50,6 +55,7 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     val ret = super.unsubscribe(subscriber, channel)
     if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "unsubscribing " + subscriber + " from channel " + channel))
+    unregisterIfNoMoreSubscribedChannels(subscriber)
     ret
   }
 
@@ -57,6 +63,61 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     super.unsubscribe(subscriber)
     if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "unsubscribing " + subscriber + " from all channels"))
+    unregisterIfNoMoreSubscribedChannels(subscriber)
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def initUnsubscriber(unsubscriber: ActorRef): Boolean = {
+    initiallySubscribedOrUnsubscriber.get match {
+      case value @ Left(subscribers) ⇒
+        if (initiallySubscribedOrUnsubscriber.compareAndSet(value, Right(unsubscriber))) {
+          if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "initialized unsubscriber to: " + unsubscriber + ", registering " + subscribers.size + " initial subscribers with it"))
+          subscribers foreach registerWithUnsubscriber
+          true
+        } else {
+          // recurse, because either new subscribers have been registered since `get` (retry Left case),
+          // or another thread has succeeded in setting it's unsubscriber (end on Right case)
+          initUnsubscriber(unsubscriber)
+        }
+
+      case Right(presentUnsubscriber) ⇒
+        if (debug) publish(Logging.Debug(simpleName(this), this.getClass, s"not using unsubscriber $unsubscriber, because already initialized with $presentUnsubscriber"))
+        false
+    }
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def registerWithUnsubscriber(subscriber: ActorRef): Unit = {
+    initiallySubscribedOrUnsubscriber.get match {
+      case value @ Left(subscribers) ⇒
+        if (!initiallySubscribedOrUnsubscriber.compareAndSet(value, Left(subscribers + subscriber)))
+          registerWithUnsubscriber(subscriber)
+
+      case Right(unsubscriber) ⇒
+        unsubscriber ! EventStreamUnsubscriber.Register(subscriber)
+    }
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * The actual check if the subscriber still has subscriptions is performed by the `EventStreamUnsubscriber`,
+   * because it's an expensive operation, and we don want to block client-code for that long, the Actor will eventually
+   * catch up and perform the apropriate operation.
+   */
+  private[akka] def unregisterIfNoMoreSubscribedChannels(subscriber: ActorRef): Unit = {
+    initiallySubscribedOrUnsubscriber.get match {
+      case value @ Left(subscribers) ⇒
+        if (!initiallySubscribedOrUnsubscriber.compareAndSet(value, Left(subscribers - subscriber)))
+          unregisterIfNoMoreSubscribedChannels(subscriber)
+
+      case Right(unsubscriber) ⇒
+        unsubscriber ! EventStreamUnsubscriber.UnregisterIfNoMoreSubscribedChannels(subscriber)
+    }
   }
 
 }

--- a/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.event
+
+import akka.actor._
+import akka.event.Logging.simpleName
+
+/**
+ * Watches all actors which subscribe on the given event stream, and unsubscribes them from it when they are Terminated.
+ */
+class EventStreamUnsubscriber(eventStream: EventStream, debug: Boolean = false) extends Actor with ActorLogging {
+
+  import EventStreamUnsubscriber._
+
+  override def preStart() {
+    if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"registering unsubscriber with $eventStream"))
+    eventStream initUnsubscriber self
+  }
+
+  def receive = {
+    case Register(actor) ⇒
+      if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"watching $actor in order to unsubscribe from EventStream when it terminates"))
+      context watch actor
+
+    case UnregisterIfNoMoreSubscribedChannels(actor) if eventStream.hasSubscriptions(actor) ⇒
+      // do nothing
+      // hasSubscriptions can be slow, but it's better for this actor to take the hit than the EventStream
+
+    case UnregisterIfNoMoreSubscribedChannels(actor) ⇒
+      if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"unwatching $actor, since has no subscriptions"))
+      context unwatch actor
+
+    case Terminated(actor) ⇒
+      if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"unsubscribe $actor from $eventStream, because it was terminated"))
+      eventStream unsubscribe actor
+  }
+}
+
+object EventStreamUnsubscriber {
+  final case class Register(actor: ActorRef)
+  final case class UnregisterIfNoMoreSubscribedChannels(actor: ActorRef)
+}


### PR DESCRIPTION
Moved to removing actors proactively when they are terminated instead of checking `isTerminated` during publish.

Assumed having an `init` method on the `EventBus` is fine, as it is mutable already anyway, as @patriknw points out in the task.

Related question: should this change be documented in the docs too? I figured that it's more of an internals change so maybe not?
