### PR TITLE
Add the ability to use an external camel context

### DIFF
--- a/akka-camel/src/main/resources/reference.conf
+++ b/akka-camel/src/main/resources/reference.conf
@@ -7,6 +7,11 @@
 
 akka {
   camel {
+    # FQCN of the ContextProvider to be used to create or locate a CamelContext
+    # it must implement akka.camel.ContextProvider and have a no-arg constructor
+    # the built-in default create a fresh DefaultCamelContext
+    context-provider = akka.camel.DefaultContextProvider
+
     # Whether JMX should be enabled or disabled for the Camel Context
     jmx = off
     # enable/disable streaming cache on the Camel Context

--- a/akka-camel/src/main/scala/akka/camel/ContextProvider.scala
+++ b/akka-camel/src/main/scala/akka/camel/ContextProvider.scala
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.camel
+
+import akka.actor.ExtendedActorSystem
+import org.apache.camel.impl.DefaultCamelContext
+
+/**
+ * Implement this interface in order to inject a specific CamelContext in a system
+ * An instance of this class must be instantiable using a no-arg constructor.
+ */
+trait ContextProvider {
+  /**
+   * Retrieve or create a Camel Context for the given actor system
+   * Called once per actor system
+   */
+  def getContext(system: ExtendedActorSystem): DefaultCamelContext
+}
+
+/**
+ * Default implementation of [[akka.camel.ContextProvider]]
+ * Provides a new DefaultCamelContext per actor system
+ */
+final class DefaultContextProvider extends ContextProvider {
+  override def getContext(system: ExtendedActorSystem) = new DefaultCamelContext
+}

--- a/akka-camel/src/main/scala/akka/camel/internal/DefaultCamel.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/DefaultCamel.scala
@@ -15,9 +15,7 @@ import org.apache.camel.ProducerTemplate
 import scala.concurrent.{ Future, ExecutionContext }
 import akka.util.Timeout
 import akka.pattern.ask
-import java.io.InputStream
-import org.apache.camel.model.RouteDefinition
-import akka.actor.{ ExtendedActorSystem, ActorRef, Props, ActorSystem }
+import akka.actor.{ ExtendedActorSystem, ActorRef, Props }
 
 /**
  * INTERNAL API
@@ -33,7 +31,7 @@ private[camel] class DefaultCamel(val system: ExtendedActorSystem) extends Camel
   private[camel] implicit val log = Logging(system, "Camel")
 
   lazy val context: DefaultCamelContext = {
-    val ctx = new DefaultCamelContext
+    val ctx = settings.ContextProvider.getContext(system)
     if (!settings.JmxStatistics) ctx.disableJMX()
     ctx.setName(system.name)
     ctx.setStreamCaching(settings.StreamingCache)

--- a/akka-camel/src/test/scala/akka/camel/CamelConfigSpec.scala
+++ b/akka-camel/src/test/scala/akka/camel/CamelConfigSpec.scala
@@ -46,6 +46,10 @@ class CamelConfigSpec extends WordSpec with Matchers {
       conversions.getString("file") should be("java.io.InputStream")
       conversions.entrySet.size should be(1)
     }
+
+    "have correct Context Provider" in {
+      settings.ContextProvider.isInstanceOf[DefaultContextProvider] should be(true)
+    }
   }
 }
 

--- a/akka-docs/rst/java/camel.rst
+++ b/akka-docs/rst/java/camel.rst
@@ -89,6 +89,12 @@ Below you can see how you can get access to these Apache Camel objects.
 
 One ``CamelExtension`` is only loaded once for every one ``ActorSystem``, which makes it safe to call the ``CamelExtension`` at any point in your code to get to the
 Apache Camel objects associated with it. There is one `CamelContext`_ and one `ProducerTemplate`_ for every one ``ActorSystem`` that uses a ``CamelExtension``.
+By Default, a new `CamelContext`_ is created when the ``CamelExtension`` starts. If you want to inject your own context instead,
+you can implement the `ContextProvider`_ interface and add the FQCN of your implementation in the config, as the value of the "akka.camel.context-provider".
+This interface define a single method ``getContext()`` used to load the `CamelContext`_.
+
+.. _ContextProvider: @github@/akka-camel/src/main/scala/akka/camel/ContextProvider.scala
+
 Below an example on how to add the ActiveMQ component to the `CamelContext`_, which is required when you would like to use the ActiveMQ component.
 
 .. includecode:: code/docs/camel/CamelExtensionTest.java#CamelExtensionAddComponent

--- a/akka-docs/rst/scala/camel.rst
+++ b/akka-docs/rst/scala/camel.rst
@@ -88,6 +88,12 @@ Below you can see how you can get access to these Apache Camel objects.
 
 One ``CamelExtension`` is only loaded once for every one ``ActorSystem``, which makes it safe to call the ``CamelExtension`` at any point in your code to get to the
 Apache Camel objects associated with it. There is one `CamelContext`_ and one `ProducerTemplate`_ for every one ``ActorSystem`` that uses a ``CamelExtension``.
+By Default, a new `CamelContext`_ is created when the ``CamelExtension`` starts. If you want to inject your own context instead,
+you can extend the `ContextProvider`_ trait and add the FQCN of your implementation in the config, as the value of the "akka.camel.context-provider".
+This interface define a single method ``getContext`` used to load the `CamelContext`_.
+
+.. _ContextProvider: @github@/akka-camel/src/main/scala/akka/camel/ContextProvider.scala
+
 Below an example on how to add the ActiveMQ component to the `CamelContext`_, which is required when you would like to use the ActiveMQ component.
 
 .. includecode:: code/docs/camel/Introduction.scala#CamelExtensionAddComponent


### PR DESCRIPTION
This allows to specify a ContextProvider class in the config, which will be reponsible to provide the camel context.

I tested it succesfully with a camel context created with spring. 
To achieve this, I have a classic SpringExtension that holds the application context.
This create a dependency between the CamelExtension and the SpringExtension (as we need the application context to find the camel context). 
It does not seam to cause an issue in practice, but I enforce in the code that SpringExtension is loaded before.

Thanks for reviewing. I propose to add some documentation about it if you are ok with the code.
