### PR TITLE
+act NO_ISSUE Added support for asynchronous file handling

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/FileHandlerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/FileHandlerSpec.scala
@@ -1,0 +1,113 @@
+package akka.io
+
+import akka.testkit.{ ImplicitSender, TestActorRef, AkkaSpec }
+import java.nio.channels.{ OverlappingFileLockException, AsynchronousFileChannel }
+import java.nio.file.{ StandardOpenOption, Paths }
+import akka.actor.Props
+import akka.io.File._
+import akka.util.ByteString
+import java.nio.ByteBuffer
+
+class FileHandlerSpec extends AkkaSpec with ImplicitSender {
+  "A FileHandler" must {
+    "be able to write to a file" in new TestSetup {
+      ref ! Write(ByteString(testString), 0)
+
+      expectMsg(Written(testString.size))
+
+      val dst = ByteBuffer.allocate(4)
+      fileChannel.read(dst, 0).get() should be(4)
+
+      dst.rewind()
+
+      dst.array() should be(testString)
+    }
+
+    "be able to read from a file" in new TestSetup {
+      fileChannel.write(ByteBuffer.wrap(testString), 0).get() should be(4)
+
+      ref ! Read("test".getBytes.size, 0)
+
+      expectMsg(ReadResult(ByteString(testString), testString.size))
+    }
+
+    "be able to read from a specific position in a file" in new TestSetup {
+      fileChannel.write(ByteBuffer.wrap(testString ++ "foo".getBytes), 0).get()
+
+      ref ! Read(3, testString.size)
+
+      expectMsg(ReadResult(ByteString("foo"), 3))
+    }
+
+    "be able to get the size of a file" in new TestSetup {
+      fileChannel.write(ByteBuffer.wrap(testString), 0).get()
+
+      ref ! GetSize
+
+      expectMsg(Size(4))
+    }
+
+    "be able to force write to disk" in new TestSetup {
+      fileChannel.write(ByteBuffer.wrap(testString), 0).get()
+
+      ref ! Force(true)
+
+      expectMsg(Forced)
+    }
+
+    "be able to truncate a file" in new TestSetup {
+      fileChannel.write(ByteBuffer.wrap(testString), 0).get()
+
+      ref ! Truncate(2)
+
+      expectMsg(Truncated)
+
+      ref ! GetSize
+
+      expectMsg(Size(2))
+    }
+
+    "be able to lock a file" in new TestSetup {
+      ref ! Lock
+
+      expectMsg(Locked)
+
+      ref.underlyingActor.lock.isDefined should be(true)
+
+      intercept[OverlappingFileLockException] {
+        fileChannel.lock().get()
+      }
+    }
+
+    "be able to unlock a file" in new TestSetup {
+      val lock = fileChannel.lock().get()
+      ref.underlyingActor.lock = Some(lock)
+
+      ref ! Unlock
+
+      expectMsg(Unlocked)
+
+      ref.underlyingActor.lock should be(None)
+
+      lock.isValid should be(false)
+    }
+
+    "be able to close a file" in new TestSetup {
+      ref ! Close
+
+      watch(ref)
+
+      expectMsg(Closed)
+
+      expectTerminated(ref)
+
+      fileChannel.isOpen should be(false)
+    }
+  }
+
+  class TestSetup {
+    val testString = "test".getBytes
+    val fileChannel = AsynchronousFileChannel.open(Paths.get("/tmp", "akka-test-file.txt"), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.DELETE_ON_CLOSE)
+    val ref = TestActorRef[FileHandler](Props(classOf[FileHandler], fileChannel))
+  }
+}

--- a/akka-actor/src/main/scala/akka/io/File.scala
+++ b/akka-actor/src/main/scala/akka/io/File.scala
@@ -1,0 +1,168 @@
+package akka.io
+
+import akka.actor._
+import java.nio.file.{ OpenOption, Path }
+import java.nio.file.attribute.FileAttribute
+import com.typesafe.config.Config
+import java.nio.channels.{ FileLock, CompletionHandler, AsynchronousFileChannel }
+import akka.util.ByteString
+import java.io.IOException
+import java.nio.ByteBuffer
+
+object File extends ExtensionId[FileExt] with ExtensionIdProvider {
+
+  override def lookup() = File
+
+  override def createExtension(system: ExtendedActorSystem): FileExt = new FileExt(system)
+
+  // commands
+  trait Command
+
+  case class Open(file: Path, openOptions: Seq[_ <: OpenOption] = Nil, fileAttributes: Seq[FileAttribute[_]] = Nil) extends Command
+
+  case class Write(bytes: ByteString, position: Long) extends Command
+
+  case class Read(size: Int, position: Long) extends Command
+
+  case object GetSize extends Command
+
+  case class Force(metaData: Boolean) extends Command
+
+  case class Truncate(size: Long) extends Command
+
+  case object Lock extends Command
+
+  case object Unlock extends Command
+
+  case object Close extends Command
+
+  // events
+  trait Event
+
+  case class Opened(handler: ActorRef) extends Event
+
+  case class Size(size: Long) extends Event
+
+  case class Written(bytesWritten: Int) extends Event
+
+  case class ReadResult(bytes: ByteString, bytesRead: Int) extends Event
+
+  case class CommandFailed(cmd: Command, cause: Throwable) extends Event
+
+  case object Forced extends Event
+
+  case object Truncated extends Event
+
+  case object Locked extends Event
+
+  case object Unlocked extends Event
+
+  case object Closed extends Event
+}
+
+class FileExt(system: ExtendedActorSystem) extends IO.Extension {
+  val manager: ActorRef = {
+    system.asInstanceOf[ActorSystemImpl].systemActorOf(
+      props = Props(classOf[FileManager], this).withDeploy(Deploy.local),
+      name = "IO-FILE")
+  }
+}
+
+class FileManager extends Actor {
+  import File._
+  import scala.collection.JavaConverters._
+
+  override def receive = {
+    case cmd @ Open(file, openOptions, fileAttributes) ⇒
+      try {
+        val channel = AsynchronousFileChannel.open(file, openOptions.toSet.asJava, null, fileAttributes: _*)
+        val ref = context.actorOf(Props(classOf[FileHandler], channel))
+        sender() ! Opened(ref)
+      } catch {
+        case e: Exception ⇒ sender() ! CommandFailed(cmd, e)
+      }
+  }
+}
+
+class FileHandler(channel: AsynchronousFileChannel) extends Actor {
+  import File._
+  import FileHandler._
+
+  var lock: Option[FileLock] = None
+
+  override def receive = {
+    case cmd @ Write(bytes, position) ⇒
+      channel.write[AnyRef](bytes.asByteBuffer, position, null, new WriteCompletionHandler(sender(), cmd))
+
+    case cmd @ Read(size, position) ⇒
+      val dst = ByteBuffer.allocate(size)
+      channel.read[AnyRef](dst, position, null, new ReadCompletionHandler(sender(), dst, cmd))
+
+    case GetSize ⇒
+      try {
+        sender() ! Size(channel.size())
+      } catch {
+        case e: Exception ⇒ sender() ! CommandFailed(GetSize, e)
+      }
+
+    case cmd @ Force(metaData) ⇒
+      try {
+        channel.force(metaData)
+        sender() ! Forced
+      } catch {
+        case e: Exception ⇒ sender ! CommandFailed(cmd, e)
+      }
+
+    case cmd @ Truncate(size) ⇒
+      try {
+        channel.truncate(size)
+        sender() ! Truncated
+      } catch {
+        case e: Exception ⇒ sender() ! CommandFailed(cmd, e)
+      }
+
+    case Lock ⇒ channel.lock[AnyRef](null, new LockCompletionHandler(self, sender(), Lock))
+
+    case Unlock ⇒
+      lock.foreach(_.release())
+      lock = None
+      sender() ! Unlocked
+
+    case FileLockAcquired(_lock) ⇒ lock = Some(_lock)
+
+    case Close ⇒
+      context.stop(self)
+      sender ! Closed
+  }
+
+  override def postStop = channel.close()
+
+  private[this] sealed trait BasicCompletionHandler[A, B] extends CompletionHandler[A, B] {
+    def receiver: ActorRef
+    def cmd: Command
+
+    override def failed(exc: Throwable, attachment: B): Unit = receiver ! CommandFailed(cmd, exc)
+  }
+
+  private[this] class WriteCompletionHandler(val receiver: ActorRef, val cmd: Command) extends BasicCompletionHandler[Integer, AnyRef] {
+    override def completed(result: Integer, attachment: AnyRef): Unit = receiver ! Written(result.intValue())
+  }
+
+  private[this] class ReadCompletionHandler(val receiver: ActorRef, dst: ByteBuffer, val cmd: Command) extends BasicCompletionHandler[Integer, AnyRef] {
+    override def completed(result: Integer, attachment: AnyRef): Unit = {
+      dst.rewind()
+      receiver ! ReadResult(ByteString(dst), result.intValue())
+    }
+  }
+
+  private[this] class LockCompletionHandler(fileHandler: ActorRef, val receiver: ActorRef, val cmd: Command) extends BasicCompletionHandler[FileLock, AnyRef] {
+    override def completed(result: FileLock, attachment: AnyRef): Unit = {
+      fileHandler ! FileLockAcquired(result)
+      receiver ! Locked
+    }
+  }
+}
+
+object FileHandler {
+  private[FileHandler] case class FileLockAcquired(lock: FileLock) extends NoSerializationVerificationNeeded
+}


### PR DESCRIPTION
This PR adds support for asynchronous file handling to the `akka.io` package. As it uses `AsynchronousFileChannel`, it is not Java 6 compatible.
