### PR TITLE
=con #3882 Defer watch in ClusterSharding until after recovery

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSharding.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSharding.scala
@@ -1077,6 +1077,8 @@ object ShardCoordinator {
    */
   private case class RebalanceDone(shard: ShardId, ok: Boolean)
 
+  private case object AfterRecover
+
   /**
    * INTERNAL API. Rebalancing process is performed by this actor.
    * It sends [[BeginHandOff]] to all `ShardRegion` actors followed by
@@ -1136,6 +1138,9 @@ class ShardCoordinator(handOffTimeout: FiniteDuration, rebalanceInterval: Finite
   val rebalanceTask = context.system.scheduler.schedule(rebalanceInterval, rebalanceInterval, self, RebalanceTick)
   val snapshotTask = context.system.scheduler.schedule(snapshotInterval, snapshotInterval, self, SnapshotTick)
 
+  // this will be stashed and received when the recovery is completed
+  self ! AfterRecover
+
   override def postStop(): Unit = {
     super.postStop()
     rebalanceTask.cancel()
@@ -1147,13 +1152,10 @@ class ShardCoordinator(handOffTimeout: FiniteDuration, rebalanceInterval: Finite
         context.watch(region)
         persistentState = persistentState.updated(evt)
       case ShardRegionProxyRegistered(proxy) ⇒
-        context.watch(proxy)
         persistentState = persistentState.updated(evt)
       case ShardRegionTerminated(region) ⇒
-        context.unwatch(region)
         persistentState = persistentState.updated(evt)
       case ShardRegionProxyTerminated(proxy) ⇒
-        context.unwatch(proxy)
         persistentState = persistentState.updated(evt)
       case _: ShardHomeAllocated ⇒
         persistentState = persistentState.updated(evt)
@@ -1163,8 +1165,6 @@ class ShardCoordinator(handOffTimeout: FiniteDuration, rebalanceInterval: Finite
 
     case SnapshotOffer(_, state: State) ⇒
       persistentState = state
-      persistentState.regionProxies.foreach(context.watch)
-      persistentState.regions.foreach { case (a, _) ⇒ context.watch(a) }
   }
 
   override def receiveCommand: Receive = {
@@ -1245,6 +1245,10 @@ class ShardCoordinator(handOffTimeout: FiniteDuration, rebalanceInterval: Finite
 
     case SaveSnapshotFailure(_, reason) ⇒
       log.warning("Persistent snapshot failure: {}", reason.getMessage)
+
+    case AfterRecover ⇒
+      persistentState.regionProxies.foreach(context.watch)
+      persistentState.regions.foreach { case (a, _) ⇒ context.watch(a) }
 
   }
 


### PR DESCRIPTION
- To avoid unnecessary and costly watch/unwatch to non-existing systems.
- This avoids the problematic scario revealed in ticket 3879
