### PR TITLE
!act,doc #3893 Removed isTerminated checks from ActorClassification

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
@@ -10,9 +10,11 @@ import org.scalatest.BeforeAndAfterEach
 import akka.testkit._
 import scala.concurrent.duration._
 import java.util.concurrent.atomic._
-import akka.actor.{ Props, Actor, ActorRef, ActorSystem }
-import java.util.Comparator
+
+import akka.actor.{ Props, Actor, ActorRef, ActorSystem, PoisonPill, RootActorPath }
 import akka.japi.{ Procedure, Function }
+import com.typesafe.config.{ Config, ConfigFactory }
+import scala.concurrent.Await
 
 object EventBusSpec {
   class TestActorWrapperActor(testActor: ActorRef) extends Actor {
@@ -23,7 +25,7 @@ object EventBusSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-abstract class EventBusSpec(busName: String) extends AkkaSpec with BeforeAndAfterEach {
+abstract class EventBusSpec(busName: String, conf: Config = AkkaSpec.testConf) extends AkkaSpec(conf) with BeforeAndAfterEach {
   import EventBusSpec._
   type BusType <: EventBus
 
@@ -37,13 +39,13 @@ abstract class EventBusSpec(busName: String) extends AkkaSpec with BeforeAndAfte
 
   def disposeSubscriber(system: ActorSystem, subscriber: BusType#Subscriber): Unit
 
-  busName must {
+  lazy val bus = createNewEventBus()
 
+  busName must {
     def createNewSubscriber() = createSubscriber(testActor).asInstanceOf[bus.Subscriber]
     def getClassifierFor(event: BusType#Event) = classifierFor(event).asInstanceOf[bus.Classifier]
     def createNewEvents(numberOfEvents: Int): Iterable[bus.Event] = createEvents(numberOfEvents).asInstanceOf[Iterable[bus.Event]]
 
-    val bus = createNewEventBus()
     val events = createNewEvents(100)
     val event = events.head
     val classifier = getClassifierFor(event)
@@ -144,30 +146,137 @@ abstract class EventBusSpec(busName: String) extends AkkaSpec with BeforeAndAfte
 }
 
 object ActorEventBusSpec {
-  class ComposedActorEventBus extends ActorEventBus with LookupClassification {
-    type Event = Int
-    type Classifier = String
+  class MyActorEventBus(protected val system: ActorSystem) extends ActorEventBus
+    with ActorClassification with ActorClassifier {
 
-    def classify(event: Event) = event.toString
+    type Event = Notification
+
+    def classify(event: Event) = event.ref
     protected def mapSize = 32
     def publish(event: Event, subscriber: Subscriber) = subscriber ! event
   }
+
+  case class Notification(ref: ActorRef, payload: Int)
 }
 
-class ActorEventBusSpec extends EventBusSpec("ActorEventBus") {
+class ActorEventBusSpec(conf: Config) extends EventBusSpec("ActorEventBus", conf) {
   import akka.event.ActorEventBusSpec._
   import EventBusSpec.TestActorWrapperActor
 
-  type BusType = ComposedActorEventBus
-  def createNewEventBus(): BusType = new ComposedActorEventBus
+  def this() {
+    this(ConfigFactory.parseString("akka.actor.debug.event-stream = on").withFallback(AkkaSpec.testConf))
+  }
 
-  def createEvents(numberOfEvents: Int) = (0 until numberOfEvents)
+  type BusType = MyActorEventBus
+  def createNewEventBus(): BusType = new MyActorEventBus(system)
+
+  // different actor in each event because we want each event to have a different classifier (see EventBusSpec tests)
+  def createEvents(numberOfEvents: Int) = (0 until numberOfEvents).map(Notification(TestProbe().ref, _)).toSeq
 
   def createSubscriber(pipeTo: ActorRef) = system.actorOf(Props(new TestActorWrapperActor(pipeTo)))
 
-  def classifierFor(event: BusType#Event) = event.toString
+  def classifierFor(event: BusType#Event) = event.ref
 
   def disposeSubscriber(system: ActorSystem, subscriber: BusType#Subscriber): Unit = system.stop(subscriber)
+
+  // ActorClassification specific tests
+
+  "must unsubscribe subscriber when it terminates" in {
+    val a1 = createSubscriber(system.deadLetters)
+    val subs = createSubscriber(testActor)
+    def m(i: Int) = Notification(a1, i)
+    val p = TestProbe()
+    system.eventStream.subscribe(p.ref, classOf[Logging.Debug])
+
+    bus.subscribe(subs, a1)
+    bus.publish(m(1))
+    expectMsg(m(1))
+
+    watch(subs)
+    subs ! PoisonPill // when a1 dies, subs has nothing subscribed
+    expectTerminated(subs)
+    expectUnsubscribedByUnsubscriber(p, subs)
+
+    bus.publish(m(2))
+    expectNoMsg(1 second)
+
+    disposeSubscriber(system, subs)
+    disposeSubscriber(system, a1)
+  }
+
+  "must keep subscriber even if it's subscription-actors have died" in {
+    // Deaths of monitored actors should not influence the subscription.
+    // For example: one might still want to monitor messages classified to A
+    // even though it died, and handle these in some way.
+    val a1 = createSubscriber(system.deadLetters)
+    val subs = createSubscriber(testActor)
+    def m(i: Int) = Notification(a1, i)
+
+    bus.subscribe(subs, a1) should equal(true)
+
+    bus.publish(m(1))
+    expectMsg(m(1))
+
+    watch(a1)
+    a1 ! PoisonPill
+    expectTerminated(a1)
+
+    bus.publish(m(2)) // even though a1 has terminated, classification still applies
+    expectMsg(m(2))
+
+    disposeSubscriber(system, subs)
+    disposeSubscriber(system, a1)
+  }
+
+  "must unregister subscriber only after it unsubscribes from all of it's subscriptions" in {
+    val a1, a2 = createSubscriber(system.deadLetters)
+    val subs = createSubscriber(testActor)
+    def m1(i: Int) = Notification(a1, i)
+    def m2(i: Int) = Notification(a2, i)
+
+    val p = TestProbe()
+    system.eventStream.subscribe(p.ref, classOf[Logging.Debug])
+
+    bus.subscribe(subs, a1) should equal(true)
+    bus.subscribe(subs, a2) should equal(true)
+
+    bus.publish(m1(1))
+    bus.publish(m2(1))
+    expectMsg(m1(1))
+    expectMsg(m2(1))
+
+    bus.unsubscribe(subs, a1)
+    bus.publish(m1(2))
+    expectNoMsg(1 second)
+    bus.publish(m2(2))
+    expectMsg(m2(2))
+
+    bus.unsubscribe(subs, a2)
+    expectUnregisterFromUnsubscriber(p, subs)
+    bus.publish(m1(3))
+    bus.publish(m2(3))
+    expectNoMsg(1 second)
+
+    disposeSubscriber(system, subs)
+    disposeSubscriber(system, a1)
+    disposeSubscriber(system, a2)
+  }
+
+  private def expectUnsubscribedByUnsubscriber(p: TestProbe, a: ActorRef) {
+    val expectedMsg = s"actor $a has terminated, unsubscribing it from $bus"
+    p.fishForMessage(1 second, hint = expectedMsg) {
+      case Logging.Debug(_, _, msg) if msg equals expectedMsg ⇒ true
+      case other ⇒ false
+    }
+  }
+
+  private def expectUnregisterFromUnsubscriber(p: TestProbe, a: ActorRef) {
+    val expectedMsg = s"unregistered watch of $a in $bus"
+    p.fishForMessage(1 second, hint = expectedMsg) {
+      case Logging.Debug(_, _, msg) if msg equals expectedMsg ⇒ true
+      case other ⇒ false
+    }
+  }
 }
 
 object ScanningEventBusSpec {

--- a/akka-actor/src/main/scala/akka/event/EventBus.scala
+++ b/akka-actor/src/main/scala/akka/event/EventBus.scala
@@ -4,13 +4,14 @@
 
 package akka.event
 
-import akka.actor.ActorRef
+import akka.actor.{ ActorSystem, ActorRef }
 import akka.util.Index
 import java.util.concurrent.ConcurrentSkipListSet
 import java.util.Comparator
 import akka.util.{ Subclassification, SubclassifiedIndex }
 import scala.collection.immutable.TreeSet
-import scala.collection.immutable
+import scala.collection._
+import java.util.concurrent.atomic.{ AtomicReference, AtomicInteger }
 
 /**
  * Represents the base type for EventBuses
@@ -175,6 +176,12 @@ trait SubchannelClassification { this: EventBus ⇒
     recv foreach (publish(event, _))
   }
 
+  /**
+   * INTERNAL API
+   */
+  private[akka] def hasSubscriptions(subscriber: Subscriber): Boolean =
+    cache.values exists { _ contains subscriber }
+
   private def removeFromCache(changes: immutable.Seq[(Classifier, Set[Subscriber])]): Unit =
     cache = (cache /: changes) {
       case (m, (c, cs)) ⇒ m.updated(c, m.getOrElse(c, Set.empty[Subscriber]) -- cs)
@@ -184,6 +191,7 @@ trait SubchannelClassification { this: EventBus ⇒
     cache = (cache /: changes) {
       case (m, (c, cs)) ⇒ m.updated(c, m.getOrElse(c, Set.empty[Subscriber]) ++ cs)
     }
+
 }
 
 /**
@@ -243,60 +251,88 @@ trait ScanningClassification { self: EventBus ⇒
 }
 
 /**
- * Maps ActorRefs to ActorRefs to form an EventBus where ActorRefs can listen to other ActorRefs
+ * Maps ActorRefs to ActorRefs to form an EventBus where ActorRefs can listen to other ActorRefs.
+ *
+ * All subscribers will be watched by an [[akka.event.ActorClassificationUnsubscriber]] and unsubscribed when they terminate.
+ * The unsubscriber actor will not be stopped automatically, and if you want to stop using the bus you should stop it yourself.
  */
 trait ActorClassification { this: ActorEventBus with ActorClassifier ⇒
-  import java.util.concurrent.ConcurrentHashMap
   import scala.annotation.tailrec
+
+  protected val system: ActorSystem
+
+  case class ActorClassificationMappings(seqNr: Int, backing: Map[ActorRef, TreeSet[ActorRef]]) {
+
+    @inline def get(monitored: ActorRef): TreeSet[ActorRef] = backing.getOrElse(monitored, empty)
+
+    @inline def add(monitored: ActorRef, monitor: ActorRef) = {
+      val watchers = backing.get(monitored).getOrElse(empty) + monitor
+      new ActorClassificationMappings(seqNr + 1, backing.updated(monitored, watchers))
+    }
+
+    @inline def remove(monitored: ActorRef, monitor: ActorRef) = {
+      val monitors = backing.get(monitored).getOrElse(empty) - monitor
+      new ActorClassificationMappings(seqNr + 1, backing.updated(monitored, monitors))
+    }
+
+    @inline def remove(monitored: ActorRef) = {
+      val v = backing - monitored
+      new ActorClassificationMappings(seqNr + 1, v)
+    }
+  }
+
+  private val mappings = new AtomicReference[ActorClassificationMappings](
+    new ActorClassificationMappings(0, Map.empty[ActorRef, TreeSet[ActorRef]]))
   private val empty = TreeSet.empty[ActorRef]
-  private val mappings = new ConcurrentHashMap[ActorRef, TreeSet[ActorRef]](mapSize)
+
+  /** The unsubscriber takes care of unsubscribing actors, which have terminated. */
+  protected val unsubscriber = ActorClassificationUnsubscriber.start(system, this)
 
   @tailrec
   protected final def associate(monitored: ActorRef, monitor: ActorRef): Boolean = {
-    val current = mappings get monitored
-    current match {
-      case null ⇒
-        if (monitored.isTerminated) false
+    val current = mappings.get
+
+    current.backing.get(monitored) match {
+      case None ⇒
+        val added = current.add(monitored, monitor)
+
+        if (mappings.compareAndSet(current, added)) registerWithUnsubscriber(monitor, added.seqNr)
+        else associate(monitored, monitor)
+
+      case Some(monitors) ⇒
+        if (monitors.contains(monitored)) false
         else {
-          if (mappings.putIfAbsent(monitored, empty + monitor) ne null) associate(monitored, monitor)
-          else if (monitored.isTerminated) !dissociate(monitored, monitor) else true
-        }
-      case raw: TreeSet[_] ⇒
-        val v = raw.asInstanceOf[TreeSet[ActorRef]]
-        if (monitored.isTerminated) false
-        if (v.contains(monitor)) true
-        else {
-          val added = v + monitor
-          if (!mappings.replace(monitored, v, added)) associate(monitored, monitor)
-          else if (monitored.isTerminated) !dissociate(monitored, monitor) else true
+          val added = current.add(monitored, monitor)
+          val noChange = current.backing == added.backing
+
+          if (noChange) false
+          else if (mappings.compareAndSet(current, added)) registerWithUnsubscriber(monitor, added.seqNr)
+          else associate(monitored, monitor)
         }
     }
   }
 
-  protected final def dissociate(monitored: ActorRef): immutable.Iterable[ActorRef] = {
+  protected final def dissociate(monitored: ActorRef): Unit = {
     @tailrec
-    def dissociateAsMonitored(monitored: ActorRef): immutable.Iterable[ActorRef] = {
-      val current = mappings get monitored
-      current match {
-        case null ⇒ empty
-        case raw: TreeSet[_] ⇒
-          val v = raw.asInstanceOf[TreeSet[ActorRef]]
-          if (!mappings.remove(monitored, v)) dissociateAsMonitored(monitored)
-          else v
+    def dissociateAsMonitored(monitored: ActorRef): Unit = {
+      val current = mappings.get
+      if (current.backing.contains(monitored)) {
+        val removed = current.remove(monitored)
+        if (!mappings.compareAndSet(current, removed))
+          dissociateAsMonitored(monitored)
       }
     }
 
-    def dissociateAsMonitor(monitor: ActorRef): Unit = {
-      val i = mappings.entrySet.iterator
-      while (i.hasNext()) {
-        val entry = i.next()
-        val v = entry.getValue
-        v match {
-          case raw: TreeSet[_] ⇒
-            val monitors = raw.asInstanceOf[TreeSet[ActorRef]]
-            if (monitors.contains(monitor))
-              dissociate(entry.getKey, monitor)
-          case _ ⇒ //Dun care
+    def dissociateAsMonitor(monitored: ActorRef): Unit = {
+      val current = mappings.get
+      val i = current.backing.iterator
+      while (i.hasNext) {
+        val (key, value) = i.next()
+        value match {
+          case null ⇒
+          case monitors ⇒
+            if (monitors.contains(monitored))
+              dissociate(key, monitored)
         }
       }
     }
@@ -306,17 +342,19 @@ trait ActorClassification { this: ActorEventBus with ActorClassifier ⇒
 
   @tailrec
   protected final def dissociate(monitored: ActorRef, monitor: ActorRef): Boolean = {
-    val current = mappings get monitored
-    current match {
-      case null ⇒ false
-      case raw: TreeSet[_] ⇒
-        val v = raw.asInstanceOf[TreeSet[ActorRef]]
-        val removed = v - monitor
-        if (removed eq raw) false
-        else if (removed.isEmpty) {
-          if (!mappings.remove(monitored, v)) dissociate(monitored, monitor) else true
+    val current = mappings.get
+
+    current.backing.get(monitored) match {
+      case None ⇒ false
+      case Some(monitors) ⇒
+        val removed = current.remove(monitored, monitor)
+        val removedMonitors = removed.get(monitored)
+
+        if (monitors.isEmpty || monitors == removedMonitors) {
+          false
         } else {
-          if (!mappings.replace(monitored, v, removed)) dissociate(monitored, monitor) else true
+          if (mappings.compareAndSet(current, removed)) unregisterFromUnsubscriber(monitor, removed.seqNr)
+          else dissociate(monitored, monitor)
         }
     }
   }
@@ -331,9 +369,11 @@ trait ActorClassification { this: ActorEventBus with ActorClassifier ⇒
    */
   protected def mapSize: Int
 
-  def publish(event: Event): Unit = mappings.get(classify(event)) match {
-    case null ⇒ ()
-    case some ⇒ some foreach { _ ! event }
+  def publish(event: Event): Unit = {
+    mappings.get.backing.get(classify(event)) match {
+      case None       ⇒ ()
+      case Some(refs) ⇒ refs.foreach { _ ! event }
+    }
   }
 
   def subscribe(subscriber: Subscriber, to: Classifier): Boolean =
@@ -349,4 +389,20 @@ trait ActorClassification { this: ActorEventBus with ActorClassifier ⇒
   def unsubscribe(subscriber: Subscriber): Unit =
     if (subscriber eq null) throw new IllegalArgumentException("Subscriber is null")
     else dissociate(subscriber)
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def registerWithUnsubscriber(subscriber: ActorRef, seqNr: Int): Boolean = {
+    unsubscriber ! ActorClassificationUnsubscriber.Register(subscriber, seqNr)
+    true
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def unregisterFromUnsubscriber(subscriber: ActorRef, seqNr: Int): Boolean = {
+    unsubscriber ! ActorClassificationUnsubscriber.Unregister(subscriber, seqNr)
+    true
+  }
 }

--- a/akka-actor/src/main/scala/akka/event/EventBusUnsubscribers.scala
+++ b/akka-actor/src/main/scala/akka/event/EventBusUnsubscribers.scala
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.event
+
+import akka.actor._
+import akka.event.Logging.simpleName
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Watches all actors which subscribe on the given event stream, and unsubscribes them from it when they are Terminated.
+ */
+class EventStreamUnsubscriber(eventStream: EventStream, debug: Boolean) extends Actor {
+
+  import EventStreamUnsubscriber._
+
+  override def preStart() {
+    super.preStart()
+    if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"registering unsubscriber with $eventStream"))
+    eventStream initUnsubscriber self
+  }
+
+  def receive = {
+    case Register(actor) ⇒
+      if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"watching $actor in order to unsubscribe from EventStream when it terminates"))
+      context watch actor
+
+    case Unregister(actor) ⇒
+      if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"unwatching $actor"))
+      context unwatch actor
+
+    case Terminated(actor) ⇒
+      if (debug) eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"unsubscribe $actor from $eventStream, because it was terminated"))
+
+      eventStream unsubscribe actor
+  }
+}
+
+object EventStreamUnsubscriber {
+
+  final case class Register(actor: ActorRef)
+  final case class Unregister(actor: ActorRef)
+
+  def props(eventStream: EventStream, debug: Boolean = false) =
+    Props(classOf[EventStreamUnsubscriber], eventStream, debug)
+
+}
+
+/**
+ * Watches all actors which subscribe on the given event stream, and unsubscribes them from it when they are Terminated.
+ */
+private[akka] class ActorClassificationUnsubscriber(bus: ActorClassification, debug: Boolean) extends Actor with Stash {
+
+  import ActorClassificationUnsubscriber._
+
+  private var atSeq = 0
+  private def nextSeq = atSeq + 1
+
+  override def preStart() {
+    super.preStart()
+    if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"will monitor $bus"))
+  }
+
+  def receive = {
+    case Register(actor, seq) if seq == nextSeq ⇒
+      if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"registered watch for $actor in $bus"))
+      context watch actor
+      atSeq = nextSeq
+      unstashAll()
+
+    case reg: Register ⇒
+      stash()
+
+    case Unregister(actor, seq) if seq == nextSeq ⇒
+      if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"unregistered watch of $actor in $bus"))
+      context unwatch actor
+      atSeq = nextSeq
+      unstashAll()
+
+    case unreg: Unregister ⇒
+      stash()
+
+    case Terminated(actor) ⇒
+      if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"actor $actor has terminated, unsubscribing it from $bus"))
+      // the `unsubscribe` will trigger another `Unregister(actor, _)` message to this unsubscriber;
+      // but since that actor is terminated, there cannot be any harm in processing an Unregister for it.
+      bus unsubscribe actor
+  }
+
+}
+
+/**
+ * Extension providing factory for [[akka.event.ActorClassificationUnsubscriber]] actors with unique names.
+ */
+private[akka] object ActorClassificationUnsubscriber {
+
+  private val unsubscribersCount = new AtomicInteger(0)
+
+  final case class Register(actor: ActorRef, seq: Int)
+  final case class Unregister(actor: ActorRef, seq: Int)
+
+  def start(system: ActorSystem, bus: ActorClassification) = {
+    val debug = system.settings.config.getBoolean("akka.actor.debug.event-stream")
+    system.asInstanceOf[ExtendedActorSystem]
+      .systemActorOf(props(bus, debug), "actorClassificationUnsubscriber-" + unsubscribersCount.incrementAndGet())
+  }
+
+  private def props(eventBus: ActorClassification, debug: Boolean) = Props(classOf[ActorClassificationUnsubscriber], eventBus, debug)
+
+}
+

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -8,6 +8,7 @@ import language.implicitConversions
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.event.Logging.simpleName
 import akka.util.Subclassification
+import java.util.concurrent.atomic.AtomicReference
 
 object EventStream {
   //Why is this here and why isn't there a failing test if it is removed?
@@ -28,6 +29,9 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
   type Event = AnyRef
   type Classifier = Class[_]
 
+  /** Either the list of subscribed actors, or a ref to an [[akka.event.EventStreamUnsubscriber]] */
+  private val initiallySubscribedOrUnsubscriber = new AtomicReference[Either[Set[ActorRef], ActorRef]](Left(Set.empty))
+
   protected implicit val subclassification = new Subclassification[Class[_]] {
     def isEqual(x: Class[_], y: Class[_]) = x == y
     def isSubclass(x: Class[_], y: Class[_]) = y isAssignableFrom x
@@ -43,12 +47,14 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
   override def subscribe(subscriber: ActorRef, channel: Class[_]): Boolean = {
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "subscribing " + subscriber + " to channel " + channel))
+    registerWithUnsubscriber(subscriber)
     super.subscribe(subscriber, channel)
   }
 
   override def unsubscribe(subscriber: ActorRef, channel: Class[_]): Boolean = {
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     val ret = super.unsubscribe(subscriber, channel)
+    unregisterIfNoMoreSubscribedChannels(ret, subscriber, channel)
     if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "unsubscribing " + subscriber + " from channel " + channel))
     ret
   }
@@ -56,7 +62,68 @@ class EventStream(private val debug: Boolean = false) extends LoggingBus with Su
   override def unsubscribe(subscriber: ActorRef) {
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     super.unsubscribe(subscriber)
+    unregisterFromUnsubscriber(subscriber)
     if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "unsubscribing " + subscriber + " from all channels"))
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def initUnsubscriber(unsubscriber: ActorRef): Boolean = {
+    initiallySubscribedOrUnsubscriber.get match {
+      case value @ Left(subscribers) ⇒
+        if (initiallySubscribedOrUnsubscriber.compareAndSet(value, Right(unsubscriber))) {
+          if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "initialized unsubscriber to: " + unsubscriber + ", registering " + subscribers.size + " initial subscribers with it"))
+          subscribers foreach registerWithUnsubscriber
+          true
+        } else {
+          // recurse, because either new subscribers have been registered since `get` (retry Left case),
+          // or another thread has succeeded in setting it's unsubscriber (end on Right case)
+          initUnsubscriber(unsubscriber)
+        }
+
+      case Right(presentUnsubscriber) ⇒
+        if (debug) publish(Logging.Debug(simpleName(this), this.getClass, s"not using unsubscriber $unsubscriber, because already initialized with $presentUnsubscriber"))
+        false
+    }
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def registerWithUnsubscriber(subscriber: ActorRef): Unit = {
+    initiallySubscribedOrUnsubscriber.get match {
+      case value @ Left(subscribers) ⇒
+        if (!initiallySubscribedOrUnsubscriber.compareAndSet(value, Left(subscribers + subscriber)))
+          registerWithUnsubscriber(subscriber)
+
+      case Right(unsubscriber) ⇒
+        unsubscriber ! EventStreamUnsubscriber.Register(subscriber)
+    }
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def unregisterFromUnsubscriber(subscriber: ActorRef): Unit = {
+    initiallySubscribedOrUnsubscriber.get match {
+      case value @ Left(subscribers) ⇒
+        if (!initiallySubscribedOrUnsubscriber.compareAndSet(value, Left(subscribers - subscriber)))
+          unregisterFromUnsubscriber(subscriber)
+
+      case Right(unsubscriber) ⇒
+        unsubscriber ! EventStreamUnsubscriber.Unregister(subscriber)
+    }
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def unregisterIfNoMoreSubscribedChannels(unsubscribeHadDiff: Boolean, subscriber: ActorRef, channel: Class[_]) {
+    if (!unsubscribeHadDiff || !hasSubscriptions(subscriber)) {
+      if (debug) publish(Logging.Debug(simpleName(this), this.getClass, "subscriber " + subscriber + " has now 0 channel subscriptions, after unsubscribing from channel" + channel))
+      unregisterFromUnsubscriber(subscriber)
+    }
   }
 
 }

--- a/akka-actor/src/main/scala/akka/event/japi/EventBusJavaAPI.scala
+++ b/akka-actor/src/main/scala/akka/event/japi/EventBusJavaAPI.scala
@@ -4,7 +4,7 @@
 package akka.event.japi
 
 import akka.util.Subclassification
-import akka.actor.ActorRef
+import akka.actor.{ ActorSystem, ActorRef }
 
 /**
  * Java API: See documentation for [[akka.event.EventBus]]
@@ -89,12 +89,11 @@ abstract class LookupEventBus[E, S, C] extends EventBus[E, S, C] {
 }
 
 /**
- * See documentation for [[akka.event.SubchannelClassification]]
+ * Java API: See documentation for [[akka.event.SubchannelClassification]]
  * E is the Event type
  * S is the Subscriber type
  * C is the Classifier type
  */
-
 abstract class SubchannelEventBus[E, S, C] extends EventBus[E, S, C] {
   private val bus = new akka.event.EventBus with akka.event.SubchannelClassification {
     type Event = E
@@ -134,7 +133,7 @@ abstract class SubchannelEventBus[E, S, C] extends EventBus[E, S, C] {
 }
 
 /**
- * See documentation for [[akka.event.ScanningClassification]]
+ * Java API: See documentation for [[akka.event.ScanningClassification]]
  * E is the Event type
  * S is the Subscriber type
  * C is the Classifier type
@@ -185,14 +184,16 @@ abstract class ScanningEventBus[E, S, C] extends EventBus[E, S, C] {
 }
 
 /**
- * See documentation for [[akka.event.ActorClassification]]
+ * Java API: See documentation for [[akka.event.ActorClassification]]
  * An EventBus where the Subscribers are ActorRefs and the Classifier is ActorRef
  * Means that ActorRefs "listen" to other ActorRefs
  * E is the Event type
  */
-abstract class ActorEventBus[E] extends EventBus[E, ActorRef, ActorRef] {
+abstract class ActorEventBus[E](system: ActorSystem) extends EventBus[E, ActorRef, ActorRef] {
   private val bus = new akka.event.ActorEventBus with akka.event.ActorClassification with akka.event.ActorClassifier {
     type Event = E
+
+    override val system = ActorEventBus.this.system
 
     override protected def mapSize: Int = ActorEventBus.this.mapSize
 

--- a/akka-docs/rst/java/code/docs/event/EventBusDocTest.java
+++ b/akka-docs/rst/java/code/docs/event/EventBusDocTest.java
@@ -3,36 +3,25 @@
  */
 package docs.event;
 
-import java.util.concurrent.TimeUnit;
-
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import scala.concurrent.duration.FiniteDuration;
-import akka.actor.ActorSystem;
 import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.event.japi.*;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.testkit.JavaTestKit;
-import akka.event.japi.EventBus;
-
-//#lookup-bus
-import akka.event.japi.LookupEventBus;
-
-//#lookup-bus
-
-//#subchannel-bus
-import akka.event.japi.SubchannelEventBus;
 import akka.util.Subclassification;
+import org.junit.ClassRule;
+import org.junit.Test;
+import scala.concurrent.duration.FiniteDuration;
 
+import java.util.concurrent.TimeUnit;
+
+//#lookup-bus
+//#lookup-bus
 //#subchannel-bus
-
+//#subchannel-bus
 //#scanning-bus
-import akka.event.japi.ScanningEventBus;
-
 //#scanning-bus
-
 //#actor-bus
-import akka.event.japi.ActorEventBus;
 
 //#actor-bus
 
@@ -226,6 +215,12 @@ public class EventBusDocTest {
   static
   //#actor-bus
   public class ActorBusImpl extends ActorEventBus<Notification> {
+
+    // the ActorSystem will be used for book-keeping operations, such as subscribers terminating
+    public ActorBusImpl(ActorSystem system) {
+      super(system);
+    }
+
     // is used for extracting the classifier from the incoming events
     @Override public ActorRef classify(Notification event) {
       return event.ref;
@@ -299,7 +294,7 @@ public class EventBusDocTest {
       JavaTestKit probe2 = new JavaTestKit(system);
       ActorRef subscriber1 = probe1.getRef();
       ActorRef subscriber2 = probe2.getRef();
-      ActorBusImpl actorBus = new ActorBusImpl();
+      ActorBusImpl actorBus = new ActorBusImpl(system);
       actorBus.subscribe(subscriber1, observer1);
       actorBus.subscribe(subscriber2, observer1);
       actorBus.subscribe(subscriber2, observer2);

--- a/akka-docs/rst/java/event-bus.rst
+++ b/akka-docs/rst/java/event-bus.rst
@@ -111,6 +111,11 @@ This classification was originally developed specifically for implementing
 :ref:`DeathWatch <deathwatch-java>`: subscribers as well as classifiers are of
 type :class:`ActorRef`.
 
+This classification requires an :class:`ActorSystem` in order to perform book-keeping
+operations related to the subscribers being Actors, which can terminate without first
+unsubscribing from the EventBus. ActorClassification maitains a system Actor which
+takes care of unsubscribing terminated actors automatically.
+
 The necessary methods to be implemented are illustrated with the following example:
 
 .. includecode:: code/docs/event/EventBusDocTest.java#actor-bus
@@ -140,6 +145,8 @@ how a simple subscription works. Given a simple actor:
 it can be subscribed like this:
 
 .. includecode:: code/docs/event/LoggingDocTest.java#deadletters
+
+Similarily to `Actor Classification`_, :class:`EventStream` will automatically remove subscibers when they terminate.
 
 Default Handlers
 ----------------

--- a/akka-docs/rst/scala/code/docs/event/EventBusDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/event/EventBusDocSpec.scala
@@ -5,7 +5,7 @@ package docs.event
 
 import scala.concurrent.duration._
 import akka.testkit.AkkaSpec
-import akka.actor.ActorRef
+import akka.actor.{ ActorSystem, ActorRef }
 import akka.testkit.TestProbe
 
 object EventBusDocSpec {
@@ -126,7 +126,7 @@ object EventBusDocSpec {
 
   final case class Notification(ref: ActorRef, id: Int)
 
-  class ActorBusImpl extends ActorEventBus with ActorClassifier with ActorClassification {
+  class ActorBusImpl(val system: ActorSystem) extends ActorEventBus with ActorClassifier with ActorClassification {
     type Event = Notification
 
     // is used for extracting the classifier from the incoming events
@@ -187,7 +187,7 @@ class EventBusDocSpec extends AkkaSpec {
     val probe2 = TestProbe()
     val subscriber1 = probe1.ref
     val subscriber2 = probe2.ref
-    val actorBus = new ActorBusImpl
+    val actorBus = new ActorBusImpl(system)
     actorBus.subscribe(subscriber1, observer1)
     actorBus.subscribe(subscriber2, observer1)
     actorBus.subscribe(subscriber2, observer2)

--- a/akka-docs/rst/scala/event-bus.rst
+++ b/akka-docs/rst/scala/event-bus.rst
@@ -111,6 +111,11 @@ This classification was originally developed specifically for implementing
 :ref:`DeathWatch <deathwatch-scala>`: subscribers as well as classifiers are of
 type :class:`ActorRef`.
 
+This classification requires an :class:`ActorSystem` in order to perform book-keeping
+operations related to the subscribers being Actors, which can terminate without first
+unsubscribing from the EventBus. ActorClassification maitains a system Actor which
+takes care of unsubscribing terminated actors automatically.
+
 The necessary methods to be implemented are illustrated with the following example:
 
 .. includecode:: code/docs/event/EventBusDocSpec.scala#actor-bus
@@ -135,6 +140,8 @@ used for :class:`RemotingLifecycleEvent`). The following example demonstrates
 how a simple subscription works:
 
 .. includecode:: code/docs/event/LoggingDocSpec.scala#deadletters
+
+Similarily to `Actor Classification`_, :class:`EventStream` will automatically remove subscibers when they terminate.
 
 Default Handlers
 ----------------


### PR DESCRIPTION
Instead of `isTerminated` we now use death watch on subscribers in `ActorClassification`

This PR is a follow up from https://github.com/akka/akka/pull/2011#issuecomment-35864011 where `isTerminated` has been replaced with death watching actors.

Was suggested to be pulled in for **2.4**, since it's breaking API (`ActorClassification` now requires an ActorSystem, and it's required to stop the system actor ("unwatcher"), when done using such an event bus).
Or can be rewritten to use init method based approach instead.
