### PR TITLE
=per #3898 Increase expect timeout for SharedLeveldbJournalSpec

### DIFF
--- a/akka-persistence/src/test/scala/akka/persistence/journal/leveldb/SharedLeveldbJournalSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/journal/leveldb/SharedLeveldbJournalSpec.scala
@@ -35,6 +35,7 @@ object SharedLeveldbJournalSpec {
         loglevel = ERROR
         log-dead-letters = 0
         log-dead-letters-during-shutdown = off
+        test.single-expect-default = 10s
       }
     """
 


### PR DESCRIPTION
This was the only persistence tests where we forgot to set a non-default timeout of 10s.
