### PR TITLE
=rem #3902: Reduce disassociate errors in remote stress-test

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/AkkaProtocolStressTest.scala
@@ -104,7 +104,7 @@ class AkkaProtocolStressTest extends AkkaSpec(configA) with ImplicitSender with 
     "guarantee at-most-once delivery and message ordering despite packet loss" taggedAs TimingTest in {
       system.eventStream.publish(TestEvent.Mute(DeadLettersFilter[Any]))
       systemB.eventStream.publish(TestEvent.Mute(DeadLettersFilter[Any]))
-      Await.result(RARP(system).provider.transport.managementCommand(One(addressB, Drop(0.3, 0.3))), 3.seconds.dilated)
+      Await.result(RARP(system).provider.transport.managementCommand(One(addressB, Drop(0.1, 0.1))), 3.seconds.dilated)
 
       val tester = system.actorOf(Props(classOf[SequenceVerifier], here, self)) ! "start"
 


### PR DESCRIPTION
The drop probability influences how often the gremlin generates transport-level connection failures:
- 1-(1-0.3)*(1-0.3) = 0.51 meaning at least every second attempt will fail

And on top of that it still have the probability of 0.3 to drop the akka-protocol level messages in both directions (the above formula is for the lower layer attempt failures). Since this test (unlike the system message tests) does not have redelivery capabilities, this can lead to a long series of failed association attempts causing a long burst of loss. The timeout can be reproduced by increasing the drop probability and I have seen close-to-fail scenarios with the original settings as well.

I reduced the dropping probabilities for now.
