### PR TITLE
=act, rem #2556 Optimize subscriptions of AddressTerminated

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -101,9 +101,9 @@ final case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
  * INTERNAL API
  *
  * Used for remote death watch. Failure detector publish this to the
- * `eventStream` when a remote node is detected to be unreachable and/or decided to
+ * [[akka.event.AddressTerminatedTopic]] when a remote node is detected to be unreachable and/or decided to
  * be removed.
- * The watcher ([[akka.actor.dungeon.DeathWatch]]) subscribes to the `eventStream`
+ * The watcher ([[akka.actor.dungeon.DeathWatch]]) subscribes to the `AddressTerminatedTopic`
  * and translates this event to [[akka.actor.Terminated]], which is sent itself.
  */
 @SerialVersionUID(1L)

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -4,11 +4,12 @@
 
 package akka.actor.dungeon
 
-import akka.actor.{ Terminated, InternalActorRef, ActorRef, ActorRefScope, ActorCell, Actor, Address, AddressTerminated }
+import akka.actor.{ Terminated, InternalActorRef, ActorRef, ActorRefScope, ActorCell, Actor, Address }
 import akka.dispatch.sysmsg.{ DeathWatchNotification, Watch, Unwatch }
 import akka.event.Logging.{ Warning, Error, Debug }
 import scala.util.control.NonFatal
 import akka.actor.MinimalActorRef
+import akka.event.AddressTerminatedTopic
 
 private[akka] trait DeathWatch { this: ActorCell ⇒
 
@@ -192,9 +193,9 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
     }
   }
 
-  private def unsubscribeAddressTerminated(): Unit = system.eventStream.unsubscribe(self, classOf[AddressTerminated])
+  private def unsubscribeAddressTerminated(): Unit = AddressTerminatedTopic(system).unsubscribe(self)
 
-  private def subscribeAddressTerminated(): Unit = system.eventStream.subscribe(self, classOf[AddressTerminated])
+  private def subscribeAddressTerminated(): Unit = AddressTerminatedTopic(system).subscribe(self)
 
 }
 

--- a/akka-actor/src/main/scala/akka/event/AddressTerminatedTopic.scala
+++ b/akka-actor/src/main/scala/akka/event/AddressTerminatedTopic.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.event
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.annotation.tailrec
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.AddressTerminated
+import akka.actor.ExtendedActorSystem
+import akka.actor.Extension
+import akka.actor.ExtensionId
+import akka.actor.ExtensionIdProvider
+
+/**
+ * INTERNAL API
+ *
+ * Watchers of remote actor references register themselves as subscribers
+ * of [[akka.actor.AddressTerminated]] notifications. Remote and cluster
+ * death watch publish `AddressTerminated` when a remote system is deemed
+ * dead.
+ */
+private[akka] object AddressTerminatedTopic extends ExtensionId[AddressTerminatedTopic] with ExtensionIdProvider {
+  override def get(system: ActorSystem): AddressTerminatedTopic = super.get(system)
+
+  override def lookup = AddressTerminatedTopic
+
+  override def createExtension(system: ExtendedActorSystem): AddressTerminatedTopic =
+    new AddressTerminatedTopic
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] final class AddressTerminatedTopic extends Extension {
+
+  private val subscribers = new AtomicReference[Set[ActorRef]](Set.empty[ActorRef])
+
+  @tailrec def subscribe(subscriber: ActorRef): Unit = {
+    val current = subscribers.get
+    if (!subscribers.compareAndSet(current, current + subscriber))
+      subscribe(subscriber) // retry
+  }
+
+  @tailrec def unsubscribe(subscriber: ActorRef): Unit = {
+    val current = subscribers.get
+    if (!subscribers.compareAndSet(current, current - subscriber))
+      unsubscribe(subscriber) // retry
+  }
+
+  def publish(msg: AddressTerminated): Unit = {
+    subscribers.get foreach { _.tell(msg, ActorRef.noSender) }
+  }
+
+}

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -20,6 +20,7 @@ import akka.actor.SelectChildPattern
 import akka.actor.Identify
 import akka.actor.ActorIdentity
 import akka.actor.EmptyLocalActorRef
+import akka.event.AddressTerminatedTopic
 
 /**
  * INTERNAL API
@@ -52,7 +53,7 @@ private[akka] class RemoteSystemDaemon(
 
   private val terminating = new Switch(false)
 
-  system.eventStream.subscribe(this, classOf[AddressTerminated])
+  AddressTerminatedTopic(system).subscribe(this)
 
   /**
    * Find the longest matching path which we know about and return that ref

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -19,6 +19,7 @@ import akka.actor.InternalActorRef
 import akka.dispatch.sysmsg.DeathWatchNotification
 import akka.dispatch.sysmsg.Watch
 import akka.actor.Deploy
+import akka.event.AddressTerminatedTopic
 
 /**
  * INTERNAL API
@@ -79,7 +80,7 @@ private[akka] object RemoteWatcher {
  * to the peer actor on the other node, which replies with [[RemoteWatcher.HeartbeatRsp]]
  * message back. The failure detector on the watching side monitors these heartbeat messages.
  * If arrival of hearbeat messages stops it will be detected and this actor will publish
- * [[akka.actor.AddressTerminated]] to the `eventStream`.
+ * [[akka.actor.AddressTerminated]] to the [[akka.event.AddressTerminatedTopic]].
  *
  * When all actors on a node have been unwatched it will stop sending heartbeat messages.
  *
@@ -171,7 +172,7 @@ private[akka] class RemoteWatcher(
     }
 
   def publishAddressTerminated(address: Address): Unit =
-    context.system.eventStream.publish(AddressTerminated(address))
+    AddressTerminatedTopic(context.system).publish(AddressTerminated(address))
 
   def quarantine(address: Address, uid: Option[Int]): Unit =
     remoteProvider.quarantine(address, uid)


### PR DESCRIPTION
- unsubscribe in eventStream is too slow when using many actors
  that are watching remote actors, and becomes a problem for example
  when shutting down such a system
- Previous eventStream solution:
  Stopping 20000 actors took 50355 ms
- This solution:
  Stopping 20000 actors took 764 ms
