### PR TITLE
upgrade org.iq80.leveldb to 0.7

### DIFF
--- a/akka-samples/akka-sample-osgi-dining-hakkers/pom.xml
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/pom.xml
@@ -21,7 +21,7 @@
         <scala.dep.version>2.10</scala.dep.version>
         <scalatest.version>2.0</scalatest.version>
         <typesafe.config.version>1.2.0</typesafe.config.version>
-        <leveldb.version>0.5</leveldb.version>
+        <leveldb.version>0.7</leveldb.version>
         <leveldbjni.version>1.7</leveldbjni.version>
         <uncommons-maths.version>1.2.2</uncommons-maths.version>
     </properties>

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1100,7 +1100,7 @@ object Dependencies {
     val osgiCore      = "org.osgi"                    % "org.osgi.core"                % "4.3.1"       // ApacheV2
     val osgiCompendium= "org.osgi"                    % "org.osgi.compendium"          % "4.3.1"       // ApacheV2
     // mirrored in OSGi sample
-    val levelDB       = "org.iq80.leveldb"            % "leveldb"                      % "0.5"         // ApacheV2
+    val levelDB       = "org.iq80.leveldb"            % "leveldb"                      % "0.7"         // ApacheV2
     // mirrored in OSGi sample
     val levelDBNative = "org.fusesource.leveldbjni"   % "leveldbjni-all"               % "1.7"         // New BSD
 


### PR DESCRIPTION
Upgrade org.iq80.leveldb to the latest version 0.7 because the version 0.5 does not play nicely in a project using Guava >= 16. 

```
[ERROR] Uncaught error from thread [omnibus-akka.persistence.dispatchers.default-plugin-dispatcher-9] shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[omnibus]
[ERROR] java.lang.NoSuchMethodError: com.google.common.io.Closeables.closeQuietly(Ljava/io/Closeable;)V
[ERROR]  at org.iq80.leveldb.impl.MMapLogWriter.close(MMapLogWriter.java:83)
[ERROR]  at org.iq80.leveldb.impl.VersionSet.initializeIfNeeded(VersionSet.java:111)
[ERROR]  at org.iq80.leveldb.impl.VersionSet.<init>(VersionSet.java:91)
[ERROR]  at org.iq80.leveldb.impl.DbImpl.<init>(DbImpl.java:167)
[ERROR]  at org.iq80.leveldb.impl.Iq80DBFactory.open(Iq80DBFactory.java:59)
[ERROR]  at akka.persistence.journal.leveldb.LeveldbStore$class.preStart(LeveldbStore.scala:114)
[ERROR]  at akka.persistence.journal.leveldb.LeveldbJournal.preStart(LeveldbJournal.scala:19)
[ERROR]  at akka.actor.Actor$class.aroundPreStart(Actor.scala:470)
[ERROR]  at akka.persistence.journal.leveldb.LeveldbJournal.aroundPreStart(LeveldbJournal.scala:19)
[ERROR]  at akka.actor.ActorCell.create(ActorCell.scala:580)
[ERROR]  at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:456)
[ERROR]  at akka.actor.ActorCell.systemInvoke(ActorCell.scala:478)
[ERROR]  at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:263)
[ERROR]  at akka.dispatch.Mailbox.run(Mailbox.scala:219)
[ERROR]  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
[ERROR]  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
[ERROR]  at java.lang.Thread.run(Thread.java:724)
```

Leveldb 0.5 uses the API com.google.common.io.Closeables closeQuietly(Closeable closeable) that has been removed in Guava 16.

Version 0.7 fixes this problem and uses Guava 16.0.1. 
