### PR TITLE
=doc clean up what-is-akka.rst and switch to www.typesafe.com

### DIFF
--- a/akka-contrib/docs/cluster-client.rst
+++ b/akka-contrib/docs/cluster-client.rst
@@ -83,9 +83,9 @@ The ``initialContacts`` parameter is a ``Set[ActorSelection]``, which can be cre
 
 You will probably define the address information of the initial contact points in configuration or system property.
 
-A more comprehensive sample is available in the `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Distributed workers with Akka and Scala! <http://typesafe.com/activator/template/akka-distributed-workers>`_
-and `Distributed workers with Akka and Java! <http://typesafe.com/activator/template/akka-distributed-workers-java>`_.
+A more comprehensive sample is available in the `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Distributed workers with Akka and Scala! <http://www.typesafe.com/activator/template/akka-distributed-workers>`_
+and `Distributed workers with Akka and Java! <http://www.typesafe.com/activator/template/akka-distributed-workers-java>`_.
 
 ClusterReceptionistExtension
 ----------------------------

--- a/akka-contrib/docs/cluster-sharding.rst
+++ b/akka-contrib/docs/cluster-sharding.rst
@@ -110,8 +110,8 @@ first message for a specific entry is delivered.
 
 .. includecode:: @contribSrc@/src/multi-jvm/scala/akka/contrib/pattern/ClusterShardingSpec.scala#counter-usage
 
-A more comprehensive sample is available in the `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Akka Cluster Sharding with Scala! <http://typesafe.com/activator/template/akka-cluster-sharding-scala>`_.
+A more comprehensive sample is available in the `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Akka Cluster Sharding with Scala! <http://www.typesafe.com/activator/template/akka-cluster-sharding-scala>`_.
 
 How it works
 ------------

--- a/akka-contrib/docs/cluster-singleton.rst
+++ b/akka-contrib/docs/cluster-singleton.rst
@@ -105,8 +105,8 @@ A nice alternative to the above proxy is to use :ref:`distributed-pub-sub`. Let 
 actor register itself to the mediator with ``DistributedPubSubMediator.Put`` message when it is
 started. Send messages to the singleton actor via the mediator with ``DistributedPubSubMediator.SendToAll``.
 
-A more comprehensive sample is available in the `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Distributed workers with Akka and Scala! <http://typesafe.com/activator/template/akka-distributed-workers>`_
-and `Distributed workers with Akka and Java! <http://typesafe.com/activator/template/akka-distributed-workers-java>`_.
+A more comprehensive sample is available in the `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Distributed workers with Akka and Scala! <http://www.typesafe.com/activator/template/akka-distributed-workers>`_
+and `Distributed workers with Akka and Java! <http://www.typesafe.com/activator/template/akka-distributed-workers-java>`_.
 
 

--- a/akka-contrib/docs/distributed-pub-sub.rst
+++ b/akka-contrib/docs/distributed-pub-sub.rst
@@ -108,8 +108,8 @@ It can publish messages to the topic from anywhere in the cluster:
 
 .. includecode:: @contribSrc@/src/multi-jvm/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala#publish-message
 
-A more comprehensive sample is available in the `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Akka Clustered PubSub with Scala! <http://typesafe.com/activator/template/akka-clustering>`_.
+A more comprehensive sample is available in the `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Akka Clustered PubSub with Scala! <http://www.typesafe.com/activator/template/akka-clustering>`_.
 
 DistributedPubSubExtension
 --------------------------

--- a/akka-docs/_sphinx/themes/akka/layout.html
+++ b/akka-docs/_sphinx/themes/akka/layout.html
@@ -49,10 +49,10 @@
         <ul class="nav">
           <li><a href="http://akka.io/docs">Documentation</a></li>
           <li><a href="http://akka.io/faq">FAQ</a></li>
-          <li><a href="http://typesafe.com/stack/downloads/akka">Download</a></li>
+          <li><a href="http://akka.io/downloads">Download</a></li>
           <li><a href="http://groups.google.com/group/akka-user">Mailing List</a></li>
           <li><a href="http://github.com/akka/akka">Code</a></li>           
-          <li><a href="http://typesafe.com/products/typesafe-subscription">Commercial Support</a></li>
+          <li><a href="http://www.typesafe.com/how/subscription">Commercial Support</a></li>
         </ul>
       </div>
     </div>
@@ -119,7 +119,7 @@
       <li><h5>Akka</h5></li>
       <li><a href="http://akka.io/docs">Documentation</a></li>
       <li><a href="http://akka.io/faq">FAQ</a></li>
-      <li><a href="http://typesafe.com/stack/downloads/akka">Downloads</a></li>
+      <li><a href="http://akka.io/downloads">Downloads</a></li>
       <li><a href="http://akka.io/news">News</a></li>
       <li><a href="http://letitcrash.com">Blog</a></li>
     </ul>
@@ -132,7 +132,7 @@
     </ul>
     <ul>
       <li><h5>Company</h5></li>
-      <li><a href="http://typesafe.com/products/typesafe-subscription">Commercial Support</a></li>
+      <li><a href="http://www.typesafe.com/how/subscription">Commercial Support</a></li>
       <li><a href="http://akka.io/team">Team</a></li>
       <li><a href="mailto:info@typesafe.com">Contact</a></li>
     </ul>
@@ -142,7 +142,7 @@
   </div>
   <div class="container copyright">
     <p style="float: left;">
-      © 2014 <a href="http://typesafe.com/">Typesafe Inc.</a> <span class="license">Akka is Open Source and available under the Apache 2 License.</span>
+      © 2014 <a href="http://www.typesafe.com/">Typesafe Inc.</a> <span class="license">Akka is Open Source and available under the Apache 2 License.</span>
     </p>
     <p style="float: right; font-size: 12px;">
       Last updated: {{ last_updated }}

--- a/akka-docs/rst/dev/multi-node-testing.rst
+++ b/akka-docs/rst/dev/multi-node-testing.rst
@@ -199,8 +199,8 @@ message send/receive.
 .. includecode:: ../../../akka-samples/akka-sample-multi-node-scala/src/multi-jvm/scala/sample/multinode/MultiNodeSample.scala
   :include: package,spec
 
-The easiest way to run this example yourself is to download `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-and open the tutorial named `Akka Multi-Node Testing Sample with Scala <http://typesafe.com/activator/template/akka-sample-multi-node-scala>`_.
+The easiest way to run this example yourself is to download `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+and open the tutorial named `Akka Multi-Node Testing Sample with Scala <http://www.typesafe.com/activator/template/akka-sample-multi-node-scala>`_.
 
 Things to Keep in Mind
 ======================

--- a/akka-docs/rst/intro/getting-started.rst
+++ b/akka-docs/rst/intro/getting-started.rst
@@ -10,7 +10,7 @@ later installed on you machine.
 Getting Started Guides and Template Projects
 --------------------------------------------
 
-The best way to start learning Akka is to download `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
+The best way to start learning Akka is to download `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
 and try out one of Akka Template Projects.
 
 Download
@@ -69,7 +69,7 @@ How to see the JARs dependencies of each Akka module is described in the
 Using a release distribution
 ----------------------------
 
-Download the release you need from http://typesafe.com/stack/downloads/akka and unzip it.
+Download the release you need from http://akka.io/downloads and unzip it.
 
 Using a snapshot version
 ------------------------
@@ -117,8 +117,8 @@ Using Akka with Maven
 ---------------------
 
 The simplest way to get started with Akka and Maven is to check out the
-`Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Akka Main in Java <http://typesafe.com/activator/template/akka-sample-main-java>`_.
+`Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Akka Main in Java <http://www.typesafe.com/activator/template/akka-sample-main-java>`_.
 
 Since Akka is published to Maven Central (for versions since 2.1-M2), is it
 enough to add the Akka dependencies to the POM. For example, here is the
@@ -139,7 +139,7 @@ Using Akka with SBT
 -------------------
 
 The simplest way to get started with Akka and SBT is to check out the
-`Akka/SBT template <http://typesafe.com/resources/getting-started/typesafe-stack/downloading-installing.html#template-projects-for-scala-akka-and-play>`_
+`Akka/SBT template <http://www.typesafe.com/resources/getting-started/typesafe-stack/downloading-installing.html#template-projects-for-scala-akka-and-play>`_
 project.
 
 Summary of the essential parts for using Akka with SBT:
@@ -237,7 +237,7 @@ Need help?
 
 If you have questions you can get help on the `Akka Mailing List <http://groups.google.com/group/akka-user>`_.
 
-You can also ask for `commercial support <http://typesafe.com>`_.
+You can also ask for `commercial support <http://www.typesafe.com>`_.
 
 Thanks for being a part of the Akka community.
 

--- a/akka-docs/rst/intro/what-is-akka.rst
+++ b/akka-docs/rst/intro/what-is-akka.rst
@@ -8,20 +8,22 @@
 
 We believe that writing correct concurrent, fault-tolerant and scalable
 applications is too hard. Most of the time it's because we are using the wrong
-tools and the wrong level of abstraction. Akka is here to change that. Using the
-Actor Model we raise the abstraction level and provide a better platform to build
-correct, concurrent, and scalable applications. For fault-tolerance we adopt the
-"Let it crash" model which the telecom industry has used with great success to
-build applications that self-heal and systems that never stop. Actors also provide
-the abstraction for transparent distribution and the basis for truly scalable and
-fault-tolerant applications.
+tools and the wrong level of abstraction. Akka is here to change that. Using
+the Actor Model we raise the abstraction level and provide a better platform to
+build scalable, resilient and responsive applications—see the `Reactive
+Manifesto <http://reactivemanifesto.org/>`_ for more details. For
+fault-tolerance we adopt the "let it crash" model which the telecom industry
+has used with great success to build applications that self-heal and systems
+that never stop. Actors also provide the abstraction for transparent
+distribution and the basis for truly scalable and fault-tolerant applications.
 
 Akka is Open Source and available under the Apache 2 License.
 
-Download from http://typesafe.com/stack/downloads/akka/
+Download from http://akka.io/downloads.
 
 Please note that all code samples compile, so if you want direct access to the sources, have a look
-over at the `Akka Docs Project <@github@/akka-docs/rst>`_.
+over at the Akka Docs subproject on github: for `Java <@github@/akka-docs/rst/java/code/docs>`_ 
+and `Scala <@github@/akka-docs/rst/scala/code/docs>`_.
 
 
 Akka implements a unique hybrid
@@ -32,27 +34,28 @@ Actors
 
 Actors give you:
 
-  - Simple and high-level abstractions for concurrency and parallelism.
-  - Asynchronous, non-blocking and highly performant event-driven programming model.
-  - Very lightweight event-driven processes (approximately 2.7 million actors per GB RAM).
+- Simple and high-level abstractions for concurrency and parallelism.
+- Asynchronous, non-blocking and highly performant event-driven programming model.
+- Very lightweight event-driven processes (several million actors per GB of heap memory).
 
-See :ref:`Actors (Scala) <actors-scala>` and :ref:`Untyped Actors (Java) <untyped-actors-java>`
+See the chapter for :ref:`Scala <actors-scala>` or :ref:`Java <untyped-actors-java>`.
 
 Fault Tolerance
 ---------------
 
-  - Supervisor hierarchies with "let-it-crash" semantics.
-  - Supervisor hierarchies can span over multiple JVMs to provide truly fault-tolerant systems.
-  - Excellent for writing highly fault-tolerant systems that self-heal and never stop.
+- Supervisor hierarchies with "let-it-crash" semantics.
+- Supervisor hierarchies can span over multiple JVMs to provide truly fault-tolerant systems.
+- Excellent for writing highly fault-tolerant systems that self-heal and never stop.
 
-See :ref:`Fault Tolerance (Scala) <fault-tolerance-scala>` and :ref:`Fault Tolerance (Java) <fault-tolerance-java>`
+See :ref:`Fault Tolerance (Scala) <fault-tolerance-scala>` and :ref:`Fault Tolerance (Java) <fault-tolerance-java>`.
 
 Location Transparency
 ---------------------
 Everything in Akka is designed to work in a distributed environment: all
 interactions of actors use pure message passing and everything is asynchronous.
 
-For an overview of the remoting see :ref:`remoting`
+For an overview of the cluster support see the :ref:`Java <cluster_usage_java>`
+and :ref:`Scala <cluster_usage_scala>` documentation chapters.
 
 Persistence
 -----------
@@ -60,6 +63,8 @@ Persistence
 Messages received by an actor can optionally be persisted and replayed when the actor is started or
 restarted. This allows actors to recover their state, even after JVM crashes or when being migrated
 to another node.
+
+You can find more details in the respective chapter for :ref:`Java <persistence-java>` or :ref:`Scala <persistence-scala>`.
 
 Scala and Java APIs
 ===================
@@ -77,45 +82,10 @@ Akka can be used in two different ways
 
 See the :ref:`deployment-scenarios` for details.
 
-What happened to Cloudy Akka?
-=============================
+Commercial Support
+==================
 
-The commercial offering was earlier referred to as Cloudy Akka. This offering 
-consisted of two things:
+Akka is available from Typesafe Inc. under a commercial license which includes
+development or production support, read more `here
+<http://www.typesafe.com/how/subscription>`_.
 
-- Cluster support for Akka
-- Monitoring & Management (formerly called Atmos)
-
-Cloudy Akka has been discontinued and the Cluster support is now being moved into the
-Open Source version of Akka (the upcoming Akka 2.1), while Monitoring & Management
-(Atmos) has been re-branded as the Typesafe Console, which is now part of the commercial
-subscription for the Typesafe Stack (see below for details).
-
-Typesafe Stack
-==============
-
-Akka is now also part of the `Typesafe Stack <http://typesafe.com/stack>`_.
-
-The Typesafe Stack is a modern software platform that makes it easy for developers
-to build scalable software applications. It combines the Scala programming language,
-Akka, the Play! web framework and robust developer tools in a simple package that
-integrates seamlessly with existing Java infrastructure.
-
-The Typesafe Stack is all fully open source.
-
-Typesafe Console
-================
-
-On top of the Typesafe Stack we also have a commercial product called Typesafe
-Console which provides the following features:
-
-#. Slick Web UI with real-time view into the system
-#. Management through Dashboard, JMX and REST
-#. Dapper-style tracing of messages across components and remote nodes
-#. Real-time statistics
-#. Very low overhead monitoring agents (should always be on in production)
-#. Consolidation of statistics and logging information to a single node
-#. Storage of statistics data for later processing
-#. Provisioning and rolling upgrades
-
-Read more `here <http://typesafe.com/products/typesafe-subscription>`_.

--- a/akka-docs/rst/java/camel.rst
+++ b/akka-docs/rst/java/camel.rst
@@ -469,8 +469,8 @@ __ https://svn.apache.org/repos/asf/camel/tags/camel-2.8.0/camel-core/src/main/j
 Examples
 ========
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Akka Camel Samples with Java <http://typesafe.com/activator/template/akka-sample-camel-java>`_
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Akka Camel Samples with Java <http://www.typesafe.com/activator/template/akka-sample-camel-java>`_
 contains 3 samples:
 
  * Asynchronous routing and transformation - This example demonstrates how to implement consumer and 

--- a/akka-docs/rst/java/cluster-usage.rst
+++ b/akka-docs/rst/java/cluster-usage.rst
@@ -47,8 +47,8 @@ An actor that uses the cluster extension may look like this:
 The actor registers itself as subscriber of certain cluster events. It receives events corresponding to the current state
 of the cluster when the subscription starts and then it receives events for changes that happen in the cluster.
 
-The easiest way to run this example yourself is to download `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-and open the tutorial named `Akka Cluster Samples with Java <http://typesafe.com/activator/template/akka-sample-cluster-java>`_.
+The easiest way to run this example yourself is to download `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+and open the tutorial named `Akka Cluster Samples with Java <http://www.typesafe.com/activator/template/akka-sample-cluster-java>`_.
 It contains instructions of how to run the ``SimpleClusterApp``.
 
 Joining to Seed Nodes
@@ -241,8 +241,8 @@ network failures and JVM crashes, in addition to graceful termination of watched
 actor. Death watch generates the ``Terminated`` message to the watching actor when the 
 unreachable cluster node has been downed and removed.
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Java <http://typesafe.com/activator/template/akka-sample-cluster-java>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Java <http://www.typesafe.com/activator/template/akka-sample-cluster-java>`_.
 contains the full source code and instructions of how to run the **Worker Dial-in Example**.
 
 Node Roles
@@ -483,8 +483,8 @@ The router is configured with ``routees.paths``:
 This means that user requests can be sent to ``StatsService`` on any node and it will use
 ``StatsWorker`` on all nodes.
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Java <http://typesafe.com/activator/template/akka-sample-cluster-java>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Java <http://www.typesafe.com/activator/template/akka-sample-cluster-java>`_.
 contains the full source code and instructions of how to run the **Router Example with Group of Routees**.
 
 Router with Pool of Remote Deployed Routees
@@ -530,8 +530,8 @@ All nodes start ``StatsFacade`` and the ``ClusterSingletonManager``. The router 
 
 .. includecode:: ../../../akka-samples/akka-sample-cluster-java/src/main/resources/stats2.conf#config-router-deploy
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Java <http://typesafe.com/activator/template/akka-sample-cluster-java>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Java <http://www.typesafe.com/activator/template/akka-sample-cluster-java>`_.
 contains the full source code and instructions of how to run the **Router Example with Pool of Remote Deployed Routees**.
 
 Cluster Metrics
@@ -595,8 +595,8 @@ The same type of router could also have been defined in code:
 
 .. includecode:: ../../../akka-samples/akka-sample-cluster-java/src/main/java/sample/cluster/factorial/Extra.java#router-deploy-in-code
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Java <http://typesafe.com/activator/template/akka-sample-cluster-java>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Java <http://www.typesafe.com/activator/template/akka-sample-cluster-java>`_.
 contains the full source code and instructions of how to run the **Adaptive Load Balancing** sample.
 
 Subscribe to Metrics Events

--- a/akka-docs/rst/java/hello-world.rst
+++ b/akka-docs/rst/java/hello-world.rst
@@ -3,8 +3,8 @@ The Obligatory Hello World
 ##########################
 
 The actor based version of the tough problem of printing a
-well-known greeting to the console is introduced in a `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Akka Main in Java <http://typesafe.com/activator/template/akka-sample-main-java>`_.
+well-known greeting to the console is introduced in a `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Akka Main in Java <http://www.typesafe.com/activator/template/akka-sample-main-java>`_.
 
 The tutorial illustrates the generic launcher class :class:`akka.Main` which expects only
 one command line argument: the class name of the application’s main actor. This
@@ -12,7 +12,7 @@ main method will then create the infrastructure needed for running the actors,
 start the given main actor and arrange for the whole application to shut down
 once the main actor terminates.
 
-There is also another `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial in the same problem domain that is named `Hello Akka! <http://typesafe.com/activator/template/hello-akka>`_.
+There is also another `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial in the same problem domain that is named `Hello Akka! <http://www.typesafe.com/activator/template/hello-akka>`_.
 It describes the basics of Akka in more depth. 
 

--- a/akka-docs/rst/java/lambda-actors.rst
+++ b/akka-docs/rst/java/lambda-actors.rst
@@ -195,7 +195,7 @@ __ Props_
 Techniques for dependency injection and integration with dependency injection frameworks
 are described in more depth in the
 `Using Akka with Dependency Injection <http://letitcrash.com/post/55958814293/akka-dependency-injection>`_
-guideline and the `Akka Java Spring <http://typesafe.com/activator/template/akka-java-spring>`_ tutorial
+guideline and the `Akka Java Spring <http://www.typesafe.com/activator/template/akka-java-spring>`_ tutorial
 in Typesafe Activator.
 
 The Inbox
@@ -754,7 +754,7 @@ Hakkers`_). It will replace the current behavior (i.e. the top of the behavior
 stack), which means that you do not use :meth:`unbecome`, instead always the
 next behavior is explicitly installed.
 
-.. _Dining Hakkers: http://typesafe.com/activator/template/akka-sample-fsm-java-lambda
+.. _Dining Hakkers: http://www.typesafe.com/activator/template/akka-sample-fsm-java-lambda
 
 The other way of using :meth:`become` does not replace but add to the top of
 the behavior stack. In this case care must be taken to ensure that the number

--- a/akka-docs/rst/java/lambda-fsm.rst
+++ b/akka-docs/rst/java/lambda-fsm.rst
@@ -460,5 +460,5 @@ Examples
 ========
 
 A bigger FSM example contrasted with Actor's :meth:`become`/:meth:`unbecome` can be found in
-the `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ template named 
-`Akka FSM in Scala <http://typesafe.com/activator/template/akka-sample-fsm-java-lambda>`_
+the `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ template named 
+`Akka FSM in Scala <http://www.typesafe.com/activator/template/akka-sample-fsm-java-lambda>`_

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -465,8 +465,8 @@ the ``persist`` call and the execution(s) of the associated event handler. This 
 calls in context of a single command. The example also shows how to switch between command different command handlers
 with ``context().become()`` and ``context().unbecome()``.
 
-The easiest way to run this example yourself is to download `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-and open the tutorial named `Akka Persistence Samples with Java <http://typesafe.com/activator/template/akka-sample-persistence-java8>`_.
+The easiest way to run this example yourself is to download `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+and open the tutorial named `Akka Persistence Samples with Java <http://www.typesafe.com/activator/template/akka-sample-persistence-java8>`_.
 It contains instructions on how to run the ``EventsourcedExample``.
 
 Reliable event delivery

--- a/akka-docs/rst/java/microkernel.rst
+++ b/akka-docs/rst/java/microkernel.rst
@@ -10,7 +10,7 @@ having to create a launcher script.
 
 The Akka Microkernel is included in the Akka download found at `downloads`_.
 
-.. _downloads: http://typesafe.com/stack/downloads/akka
+.. _downloads: http://akka.io/downloads
 
 To run an application with the microkernel you need to create a Bootable class
 that handles the startup and shutdown the application. An example is included below.

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -490,8 +490,8 @@ the ``persist`` call and the execution(s) of the associated event handler. This 
 calls in context of a single command. The example also shows how to switch between command different command handlers
 with ``getContext().become()`` and ``getContext().unbecome()``.
 
-The easiest way to run this example yourself is to download `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-and open the tutorial named `Akka Persistence Samples with Java <http://typesafe.com/activator/template/akka-sample-persistence-java>`_.
+The easiest way to run this example yourself is to download `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+and open the tutorial named `Akka Persistence Samples with Java <http://www.typesafe.com/activator/template/akka-sample-persistence-java>`_.
 It contains instructions on how to run the ``EventsourcedExample``.
 
 Reliable event delivery

--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -279,8 +279,8 @@ That is not done by the router.
 Remoting Sample
 ^^^^^^^^^^^^^^^
 
-There is a more extensive remote example that comes with `Typesafe Activator <http://typesafe.com/platform/getstarted>`_.
-The tutorial named `Akka Remote Samples with Java <http://typesafe.com/activator/template/akka-sample-remote-java>`_
+There is a more extensive remote example that comes with `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_.
+The tutorial named `Akka Remote Samples with Java <http://www.typesafe.com/activator/template/akka-sample-remote-java>`_
 demonstrates both remote deployment and look-up of remote actors.
 
 Pluggable transport support

--- a/akka-docs/rst/java/untyped-actors.rst
+++ b/akka-docs/rst/java/untyped-actors.rst
@@ -151,7 +151,7 @@ __ Props_
 Techniques for dependency injection and integration with dependency injection frameworks
 are described in more depth in the
 `Using Akka with Dependency Injection <http://letitcrash.com/post/55958814293/akka-dependency-injection>`_
-guideline and the `Akka Java Spring <http://typesafe.com/activator/template/akka-java-spring>`_ tutorial
+guideline and the `Akka Java Spring <http://www.typesafe.com/activator/template/akka-java-spring>`_ tutorial
 in Typesafe Activator.
 
 The Inbox

--- a/akka-docs/rst/project/links.rst
+++ b/akka-docs/rst/project/links.rst
@@ -7,8 +7,8 @@
 Commercial Support
 ^^^^^^^^^^^^^^^^^^
 
-Commercial support is provided by `Typesafe <http://typesafe.com>`_.
-Akka is now part of the `Typesafe Stack <http://typesafe.com/stack>`_.
+Commercial support is provided by `Typesafe <http://www.typesafe.com>`_.
+Akka is part of the `Typesafe Reactive Platform <http://www.typesafe.com/platform>`_.
 
 Mailing List
 ^^^^^^^^^^^^
@@ -21,7 +21,7 @@ Mailing List
 Downloads
 ^^^^^^^^^
 
-`<http://typesafe.com/stack/downloads/akka/>`_
+`<http://akka.io/downloads>`_
 
 
 Source Code

--- a/akka-docs/rst/project/sponsors.rst
+++ b/akka-docs/rst/project/sponsors.rst
@@ -10,7 +10,7 @@ Typesafe is the company behind the Akka Project, Scala Programming Language,
 Play Web Framework, Scala IDE, Simple Build Tool and many other open source
 projects. It also provides the Typesafe Stack, a full-featured development
 stack consisting of AKka, Play and Scala. Learn more at
-`typesafe.com <http://typesafe.com>`_.
+`typesafe.com <http://www.typesafe.com>`_.
 
 YourKit
 -------

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -183,7 +183,7 @@ __ Props_
 Techniques for dependency injection and integration with dependency injection frameworks
 are described in more depth in the 
 `Using Akka with Dependency Injection <http://letitcrash.com/post/55958814293/akka-dependency-injection>`_ 
-guideline and the `Akka Java Spring <http://typesafe.com/activator/template/akka-java-spring>`_ tutorial
+guideline and the `Akka Java Spring <http://www.typesafe.com/activator/template/akka-java-spring>`_ tutorial
 in Typesafe Activator.
 
 The Inbox
@@ -756,7 +756,7 @@ Hakkers`_). It will replace the current behavior (i.e. the top of the behavior
 stack), which means that you do not use :meth:`unbecome`, instead always the
 next behavior is explicitly installed.
 
-.. _Dining Hakkers: http://typesafe.com/activator/template/akka-sample-fsm-scala
+.. _Dining Hakkers: http://www.typesafe.com/activator/template/akka-sample-fsm-scala
 
 The other way of using :meth:`become` does not replace but add to the top of
 the behavior stack. In this case care must be taken to ensure that the number

--- a/akka-docs/rst/scala/camel.rst
+++ b/akka-docs/rst/scala/camel.rst
@@ -463,8 +463,8 @@ __ https://svn.apache.org/repos/asf/camel/tags/camel-2.8.0/camel-core/src/main/j
 Examples
 ========
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Akka Camel Samples with Scala <http://typesafe.com/activator/template/akka-sample-camel-scala>`_
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Akka Camel Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-camel-scala>`_
 contains 3 samples:
 
  * Asynchronous routing and transformation - This example demonstrates how to implement consumer and 

--- a/akka-docs/rst/scala/cluster-usage.rst
+++ b/akka-docs/rst/scala/cluster-usage.rst
@@ -41,8 +41,8 @@ An actor that uses the cluster extension may look like this:
 The actor registers itself as subscriber of certain cluster events. It receives events corresponding to the current state
 of the cluster when the subscription starts and then it receives events for changes that happen in the cluster.
 
-The easiest way to run this example yourself is to download `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-and open the tutorial named `Akka Cluster Samples with Scala <http://typesafe.com/activator/template/akka-sample-cluster-scala>`_.
+The easiest way to run this example yourself is to download `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+and open the tutorial named `Akka Cluster Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-cluster-scala>`_.
 It contains instructions of how to run the ``SimpleClusterApp``.
 
 Joining to Seed Nodes
@@ -235,8 +235,8 @@ network failures and JVM crashes, in addition to graceful termination of watched
 actor. Death watch generates the ``Terminated`` message to the watching actor when the 
 unreachable cluster node has been downed and removed.
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Scala <http://typesafe.com/activator/template/akka-sample-cluster-scala>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-cluster-scala>`_.
 contains the full source code and instructions of how to run the **Worker Dial-in Example**.
 
 Node Roles
@@ -478,8 +478,8 @@ The router is configured with ``routees.paths``:
 This means that user requests can be sent to ``StatsService`` on any node and it will use
 ``StatsWorker`` on all nodes.
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Scala <http://typesafe.com/activator/template/akka-sample-cluster-scala>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-cluster-scala>`_.
 contains the full source code and instructions of how to run the **Router Example with Group of Routees**.
 
 Router with Pool of Remote Deployed Routees
@@ -525,8 +525,8 @@ All nodes start ``StatsFacade`` and the ``ClusterSingletonManager``. The router 
 
 .. includecode:: ../../../akka-samples/akka-sample-cluster-scala/src/main/resources/stats2.conf#config-router-deploy
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Scala <http://typesafe.com/activator/template/akka-sample-cluster-scala>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-cluster-scala>`_.
 contains the full source code and instructions of how to run the **Router Example with Pool of Remote Deployed Routees**.
 
 Cluster Metrics
@@ -586,8 +586,8 @@ The same type of router could also have been defined in code:
 
 .. includecode:: ../../../akka-samples/akka-sample-cluster-scala/src/main/scala/sample/cluster/factorial/Extra.scala#router-deploy-in-code
 
-The `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ tutorial named 
-`Akka Cluster Samples with Scala <http://typesafe.com/activator/template/akka-sample-cluster-scala>`_.
+The `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ tutorial named 
+`Akka Cluster Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-cluster-scala>`_.
 contains the full source code and instructions of how to run the **Adaptive Load Balancing** sample.
 
 Subscribe to Metrics Events

--- a/akka-docs/rst/scala/fsm.rst
+++ b/akka-docs/rst/scala/fsm.rst
@@ -480,5 +480,5 @@ Examples
 ========
 
 A bigger FSM example contrasted with Actor's :meth:`become`/:meth:`unbecome` can be found in
-the `Typesafe Activator <http://typesafe.com/platform/getstarted>`_ template named 
-`Akka FSM in Scala <http://typesafe.com/activator/template/akka-sample-fsm-scala>`_
+the `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_ template named 
+`Akka FSM in Scala <http://www.typesafe.com/activator/template/akka-sample-fsm-scala>`_

--- a/akka-docs/rst/scala/hello-world.rst
+++ b/akka-docs/rst/scala/hello-world.rst
@@ -3,8 +3,8 @@ The Obligatory Hello World
 ##########################
 
 The actor based version of the tough problem of printing a
-well-known greeting to the console is introduced in a `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial named `Akka Main in Scala <http://typesafe.com/activator/template/akka-sample-main-scala>`_.
+well-known greeting to the console is introduced in a `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial named `Akka Main in Scala <http://www.typesafe.com/activator/template/akka-sample-main-scala>`_.
 
 The tutorial illustrates the generic launcher class :class:`akka.Main` which expects only
 one command line argument: the class name of the application’s main actor. This
@@ -12,7 +12,7 @@ main method will then create the infrastructure needed for running the actors,
 start the given main actor and arrange for the whole application to shut down
 once the main actor terminates.
 
-There is also another `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-tutorial in the same problem domain that is named `Hello Akka! <http://typesafe.com/activator/template/hello-akka>`_.
+There is also another `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+tutorial in the same problem domain that is named `Hello Akka! <http://www.typesafe.com/activator/template/hello-akka>`_.
 It describes the basics of Akka in more depth. 
 

--- a/akka-docs/rst/scala/microkernel.rst
+++ b/akka-docs/rst/scala/microkernel.rst
@@ -10,7 +10,7 @@ having to create a launcher script.
 
 The Akka Microkernel is included in the Akka download found at `downloads`_.
 
-.. _downloads: http://typesafe.com/stack/downloads/akka
+.. _downloads: http://akka.io/downloads
 
 To run an application with the microkernel you need to create a Bootable class
 that handles the startup and shutdown the application. An example is included below.

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -500,8 +500,8 @@ the ``persist`` call and the execution(s) of the associated event handler. This 
 calls in context of a single command. The example also shows how to switch between command different command handlers
 with ``context.become()`` and ``context.unbecome()``.
 
-The easiest way to run this example yourself is to download `Typesafe Activator <http://typesafe.com/platform/getstarted>`_
-and open the tutorial named `Akka Persistence Samples with Scala <http://typesafe.com/activator/template/akka-sample-persistence-scala>`_.
+The easiest way to run this example yourself is to download `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
+and open the tutorial named `Akka Persistence Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-persistence-scala>`_.
 It contains instructions on how to run the ``EventsourcedExample``.
 
 Reliable event delivery

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -286,8 +286,8 @@ That is not done by the router.
 Remoting Sample
 ^^^^^^^^^^^^^^^
 
-There is a more extensive remote example that comes with `Typesafe Activator <http://typesafe.com/platform/getstarted>`_.
-The tutorial named `Akka Remote Samples with Scala <http://typesafe.com/activator/template/akka-sample-remote-scala>`_
+There is a more extensive remote example that comes with `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_.
+The tutorial named `Akka Remote Samples with Scala <http://www.typesafe.com/activator/template/akka-sample-remote-scala>`_
 demonstrates both remote deployment and look-up of remote actors.
 
 Pluggable transport support


### PR DESCRIPTION
the latter is necessary because of broken DNS requirements which make
apex domains brittle (since they must resolve to an A record with a
single IP)

_will need back-port to release-2.3_
