### PR TITLE
(Forward Port Validation) +act,sam,doc #3940 Added receive setter for Java Lambda actors

### DIFF
--- a/akka-actor/src/main/java/akka/japi/pf/ReceiveBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/ReceiveBuilder.java
@@ -14,8 +14,8 @@ package akka.japi.pf;
  * Example:
  * <pre>
  * @Override
- * public PartialFunction<Object, BoxedUnit> receive() {
- *   return ReceiveBuilder.
+ * public Actor() {
+ *   receive(ReceiveBuilder.
  *     match(Double.class, d -> {
  *       sender().tell(d.isNaN() ? 0 : d, self());
  *     }).
@@ -24,7 +24,8 @@ package akka.japi.pf;
  *     }).
  *     match(String.class, s -> s.startsWith("foo"), s -> {
  *       sender().tell(s.toUpperCase(), self());
- *     }).build();
+ *     }).build()
+ *   );
  * }
  * </pre>
  *

--- a/akka-docs/rst/java/lambda-actors.rst
+++ b/akka-docs/rst/java/lambda-actors.rst
@@ -38,11 +38,13 @@ Creating Actors
 Defining an Actor class
 -----------------------
 
-Actor classes are implemented by extending the :class:`AbstractActor` class and implementing
-the :meth:`receive` method. The :meth:`receive` method should define a series of match
-statements (which has the type ``PartialFunction<Object, BoxedUnit>``) that defines
-which messages your Actor can handle, along with the implementation of how the
-messages should be processed.
+Actor classes are implemented by extending the :class:`AbstractActor` class and setting
+the “initial behavior” in the constructor by calling the :meth:`receive` method in
+the :class:`AbstractActor`.
+
+The argument to the :meth:`receive` method is a ``PartialFunction<Object,BoxedUnit>``
+that defines which messages your Actor can handle, along with the implementation of
+how the messages should be processed.
 
 Don't let the type signature scare you. To allow you to easily build up a partial
 function there is a builder named ``ReceiveBuilder`` that you can use.
@@ -64,7 +66,7 @@ Note further that the return type of the behavior defined above is ``Unit``; if
 the actor shall reply to the received message then this must be done explicitly
 as explained below.
 
-The result of the :meth:`receive` method is a partial function object, which is
+The argument to the :meth:`receive` method is a partial function object, which is
 stored within the actor as its “initial behavior”, see `Become/Unbecome`_ for
 further information on changing the behavior of an actor after its
 construction.
@@ -218,8 +220,8 @@ last line.  Watching an actor is quite simple as well:
 Actor API
 =========
 
-The :class:`AbstractActor` class defines only one abstract method, the above mentioned
-:meth:`receive`, which implements the behavior of the actor.
+The :class:`AbstractActor` class defines a method called :meth:`receive`,
+that is used to set the “initial behavior” of the actor.
 
 If the current actor behavior does not match a received message,
 :meth:`unhandled` is called, which by default publishes an
@@ -592,13 +594,21 @@ routers, load-balancers, replicators etc.
 Receive messages
 ================
 
-An Actor has to implement the ``receive`` method to receive messages:
+An Actor either has to set its initial receive behavior in the constructor by
+calling the :meth:`receive` method in the :class:`AbstractActor`:
+
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/ActorDocTest.java
+   :include: receive-constructor
+   :exclude: and-some-behavior
+
+or by implementing the :meth:`receive` method in the :class:`Actor` interface:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/ActorDocTest.java#receive
 
-The :meth:`receive` method should define a series of match statements (which has the type
-``PartialFunction<Object, BoxedUnit>``) that defines which messages your Actor can handle,
-along with the implementation of how the messages should be processed.
+Both the argument to the :class:`AbstractActor` :meth:`receive` method and the return
+type of the :class:`Actor` :meth:`receive` method is a ``PartialFunction<Object, BoxedUnit>``
+that defines which messages your Actor can handle, along with the implementation of how the messages
+should be processed.
 
 Don't let the type signature scare you. To allow you to easily build up a partial
 function there is a builder named ``ReceiveBuilder`` that you can use.
@@ -764,9 +774,6 @@ behavior is not the default).
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/ActorDocTest.java#swapper
 
-
-Stash
-=====
 
 Stash
 =====

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -41,7 +41,7 @@ Architecture
 ============
 
 * *Processor*: A processor is a persistent, stateful actor. Messages sent to a processor are written to a journal
-  before its ``receive`` method is called. When a processor is started or restarted, journaled messages are replayed
+  before its behavior is called. When a processor is started or restarted, journaled messages are replayed
   to that processor, so that it can recover internal state from these messages.
 
 * *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
@@ -71,13 +71,13 @@ Architecture
 Processors
 ==========
 
-A processor can be implemented by extending ``AbstractProcessor`` class and implementing the
-``receive`` method.
+A processor can be implemented by extending ``AbstractProcessor`` class and setting
+the “initial behavior” in the constructor by calling the :meth:`receive` method
 
 .. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#definition
 
 Processors only write messages of type ``Persistent`` to the journal, others are received without being persisted.
-When a processor's ``receive`` method is called with a ``Persistent`` message it can safely assume that this message
+When a processor's behavior is called with a ``Persistent`` message it can safely assume that this message
 has been successfully written to the journal. If a journal fails to write a ``Persistent`` message then the processor
 is stopped, by default. If a processor should continue running on persistence failures it must handle
 ``PersistenceFailure`` messages. In this case, a processor may want to inform the sender about the failure,
@@ -164,9 +164,8 @@ Overriding ``processorId`` is the recommended way to generate stable identifiers
 Views
 =====
 
-Views can be implemented by extending the ``AbstractView`` abstract class and implementing the ``receive`` and the
-``processorId``
-methods.
+Views can be implemented by extending the ``AbstractView`` abstract class, implement the ``processorId`` method
+and setting the “initial behavior” in the constructor by calling the :meth:`receive` method.
 
 .. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#view
 

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -222,7 +222,7 @@ private[persistence] trait Eventsourced extends Processor {
  * An event sourced processor.
  */
 trait EventsourcedProcessor extends Processor with Eventsourced {
-  final def receive = receiveCommand
+  def receive = receiveCommand
 }
 
 /**
@@ -344,4 +344,10 @@ abstract class AbstractEventsourcedProcessor extends AbstractActor with Eventsou
    */
   final def persist[A](events: JIterable[A], handler: Procedure[A]): Unit =
     persist(Util.immutableSeq(events))(event ⇒ handler(event))
+
+  override def receive = super[EventsourcedProcessor].receive
+
+  override def receive(receive: Receive): Unit = {
+    throw new IllegalArgumentException("Define the behavior by overriding receiveRecover and receiveCommand")
+  }
 }

--- a/akka-persistence/src/main/scala/akka/persistence/Processor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Processor.scala
@@ -388,28 +388,23 @@ final case class RecoveryException(message: String, cause: Throwable) extends Ak
 abstract class UntypedProcessor extends UntypedActor with Processor
 
 /**
- * Java API: compatible with lambda expressions (to be used with [[akka.japi.pf.ReceiveBuilder]]).
+ * Java API: compatible with lambda expressions
+ *
  * An actor that persists (journals) messages of type [[Persistent]]. Messages of other types
  * are not persisted.
- *
- * {{{
- * import akka.persistence.AbstractProcessor;
- * import akka.persistence.Persistent;
- * import akka.actor.ActorRef;
- * import akka.actor.Props;
- * import akka.japi.pf.ReceiveBuilder;
- * import scala.PartialFunction;
- * import scala.runtime.BoxedUnit;
- *
+ * <p/>
+ * Example:
+ * <pre>
  * class MyProcessor extends AbstractProcessor {
- *     public PartialFunction<Object, BoxedUnit> receive() {
- *         return ReceiveBuilder.
- *             match(Persistent.class, p -> {
- *                 Object payload = p.payload();
- *                 Long sequenceNr = p.sequenceNr();
+ *   public MyProcessor() {
+ *     receive(ReceiveBuilder.
+ *       match(Persistent.class, p -> {
+ *         Object payload = p.payload();
+ *         Long sequenceNr = p.sequenceNr();
  *                 // ...
- *             }).build();
- *     }
+ *       }).build()
+ *     );
+ *   }
  * }
  *
  * // ...
@@ -418,7 +413,7 @@ abstract class UntypedProcessor extends UntypedActor with Processor
  *
  * processor.tell(Persistent.create("foo"), null);
  * processor.tell("bar", null);
- * }}}
+ * </pre>
  *
  * During start and restart, persistent messages are replayed to a processor so that it can recover internal
  * state from these messages. New messages sent to a processor during recovery do not interfere with replayed

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/FaultHandlingTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/FaultHandlingTest.java
@@ -64,12 +64,12 @@ public class FaultHandlingTest {
 
     //#strategy
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return ReceiveBuilder.
+    public Supervisor() {
+      receive(ReceiveBuilder.
         match(Props.class, props -> {
           sender().tell(context().actorOf(props), self());
-        }).build();
+        }).build()
+      );
     }
   }
 
@@ -94,12 +94,12 @@ public class FaultHandlingTest {
 
     //#strategy2
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return ReceiveBuilder.
+    public Supervisor2() {
+      receive(ReceiveBuilder.
         match(Props.class, props -> {
           sender().tell(context().actorOf(props), self());
-        }).build();
+        }).build()
+      );
     }
 
     @Override
@@ -115,12 +115,12 @@ public class FaultHandlingTest {
   public class Child extends AbstractActor {
     int state = 0;
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return ReceiveBuilder.
+    public Child() {
+      receive(ReceiveBuilder.
         match(Exception.class, exception -> { throw exception; }).
         match(Integer.class, i -> state = i).
-        matchEquals("get", s -> sender().tell(state, self())).build();
+        matchEquals("get", s -> sender().tell(state, self())).build()
+      );
     }
   }
 

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/InitializationDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/InitializationDocTest.java
@@ -32,21 +32,21 @@ public class InitializationDocTest {
   }
 
   public static class MessageInitExample extends AbstractActor {
-    //#messageInit
     private String initializeMe = null;
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return ReceiveBuilder.
+    public MessageInitExample() {
+      //#messageInit
+      receive(ReceiveBuilder.
         matchEquals("init", m1 -> {
           initializeMe = "Up and running";
           context().become(ReceiveBuilder.
             matchEquals("U OK?", m2 -> {
               sender().tell(initializeMe, self());
             }).build());
-        }).build();
+        }).build()
+      //#messageInit
+      );
     }
-    //#messageInit
   }
 
   @Test

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/MyActor.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/MyActor.java
@@ -9,8 +9,6 @@ import akka.actor.AbstractActor;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import akka.japi.pf.ReceiveBuilder;
-import scala.PartialFunction;
-import scala.runtime.BoxedUnit;
 
 //#imports
 
@@ -18,9 +16,8 @@ import scala.runtime.BoxedUnit;
 public class MyActor extends AbstractActor {
   private final LoggingAdapter log = Logging.getLogger(context().system(), this);
 
-  @Override
-  public PartialFunction<Object, BoxedUnit> receive() {
-    return ReceiveBuilder.
+  public MyActor() {
+    receive(ReceiveBuilder.
       match(String.class, s -> {
         log.info("Received String message: {}", s);
         //#my-actor
@@ -29,7 +26,8 @@ public class MyActor extends AbstractActor {
         //#reply
         //#my-actor
       }).
-      matchAny(o -> log.info("received unknown message")).build();
+      matchAny(o -> log.info("received unknown message")).build()
+    );
   }
 }
 //#my-actor

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/SampleActor.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/SampleActor.java
@@ -18,9 +18,8 @@ public class SampleActor extends AbstractActor {
       context().unbecome();
     }).build();
 
-  @Override
-  public PartialFunction<Object, BoxedUnit> receive() {
-    return ReceiveBuilder.
+  public SampleActor() {
+    receive(ReceiveBuilder.
       match(Double.class, d -> {
         sender().tell(d.isNaN() ? 0 : d, self());
       }).
@@ -30,7 +29,8 @@ public class SampleActor extends AbstractActor {
       match(String.class, s -> s.startsWith("guard"), s -> {
         sender().tell("startsWith(guard): " + s.toUpperCase(), self());
         context().become(guarded, false);
-      }).build();
+      }).build()
+    );
   }
 }
 //#sample-actor

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/japi/FaultHandlingDocSample.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/actor/japi/FaultHandlingDocSample.java
@@ -73,9 +73,8 @@ public class FaultHandlingDocSample {
       context().setReceiveTimeout(Duration.create("15 seconds"));
     }
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return LoggingReceive.create(ReceiveBuilder.
+    public Listener() {
+      receive(LoggingReceive.create(ReceiveBuilder.
         match(Progress.class, progress -> {
           log().info("Current progress: {} %", progress.percent);
           if (progress.percent >= 100.0) {
@@ -87,7 +86,8 @@ public class FaultHandlingDocSample {
           // No progress within 15 seconds, ServiceUnavailable
           log().error("Shutting down due to unavailable service");
           context().system().shutdown();
-        }).build(), context());
+        }).build(), context()
+      ));
     }
   }
 
@@ -137,9 +137,8 @@ public class FaultHandlingDocSample {
       return strategy;
     }
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return LoggingReceive.create(ReceiveBuilder.
+    public Worker() {
+      receive(LoggingReceive.create(ReceiveBuilder.
         matchEquals(Start, x -> progressListener == null, x -> {
           progressListener = sender();
           context().system().scheduler().schedule(
@@ -160,7 +159,8 @@ public class FaultHandlingDocSample {
               }
             }, context().dispatcher()), context().dispatcher())
             .to(progressListener);
-        }).build(), context());
+        }).build(), context())
+      );
     }
   }
 
@@ -266,9 +266,8 @@ public class FaultHandlingDocSample {
       storage.tell(new Get(key), self());
     }
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return LoggingReceive.create(ReceiveBuilder.
+    public CounterService() {
+      receive(LoggingReceive.create(ReceiveBuilder.
         match(Entry.class, entry -> entry.key.equals(key) && counter == null, entry -> {
           // Reply from Storage of the initial value, now we can create the Counter
           final long value = entry.value;
@@ -301,7 +300,8 @@ public class FaultHandlingDocSample {
         matchEquals(Reconnect, o -> {
           // Re-establish storage after the scheduled delay
           initStorage();
-        }).build(), context());
+        }).build(), context())
+      );
     }
 
     void forwardOrPlaceInBacklog(Object msg) {
@@ -348,11 +348,8 @@ public class FaultHandlingDocSample {
     public Counter(String key, long initialValue) {
       this.key = key;
       this.count = initialValue;
-    }
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return LoggingReceive.create(ReceiveBuilder.
+      receive(LoggingReceive.create(ReceiveBuilder.
         match(UseStorage.class, useStorage -> {
           storage = useStorage.storage;
           storeCount();
@@ -363,7 +360,8 @@ public class FaultHandlingDocSample {
         }).
         matchEquals(GetCurrentCount, gcc -> {
           sender().tell(new CurrentCount(key, count), self());
-        }).build(), context());
+        }).build(), context())
+      );
     }
 
     void storeCount() {
@@ -435,9 +433,8 @@ public class FaultHandlingDocSample {
 
     final DummyDB db = DummyDB.instance;
 
-    @Override
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return LoggingReceive.create(ReceiveBuilder.
+    public Storage() {
+      receive(LoggingReceive.create(ReceiveBuilder.
         match(Store.class, store -> {
           db.save(store.entry.key, store.entry.value);
         }).
@@ -445,7 +442,8 @@ public class FaultHandlingDocSample {
           Long value = db.load(get.key);
           sender().tell(new Entry(get.key, value == null ?
             Long.valueOf(0L) : value), self());
-        }).build(), context());
+        }).build(), context())
+      );
     }
   }
 

--- a/akka-samples/akka-sample-fsm-java-lambda/src/main/java/sample/become/DiningHakkersOnBecome.java
+++ b/akka-samples/akka-sample-fsm-java-lambda/src/main/java/sample/become/DiningHakkersOnBecome.java
@@ -43,8 +43,8 @@ public class DiningHakkersOnBecome {
       }).build();
 
     //A Chopstick begins its existence as available
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return available;
+    public Chopstick() {
+      receive(available);
     }
   }
 
@@ -125,11 +125,11 @@ public class DiningHakkersOnBecome {
       }).build();
 
     //All hakkers start in a non-eating state
-    public PartialFunction<Object, BoxedUnit> receive() {
-      return ReceiveBuilder.matchEquals(Think, m -> {
+    public Hakker() {
+      receive(ReceiveBuilder.matchEquals(Think, m -> {
         System.out.println(String.format("%s starts to think", name));
         startThinking(Duration.create(5, SECONDS));
-      }).build();
+      }).build());
     }
 
     private void startThinking(FiniteDuration duration) {

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistencePluginDocTest.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistencePluginDocTest.java
@@ -37,16 +37,17 @@ public class LambdaPersistencePluginDocTest {
         selection.tell(new Identify(1), self());
       }
 
-      @Override public PartialFunction<Object, BoxedUnit> receive() {
-        return ReceiveBuilder.
-            match(ActorIdentity.class, ai -> {
-              if (ai.correlationId().equals(1)) {
-                ActorRef store = ai.getRef();
-                if (store != null) {
-                  SharedLeveldbJournal.setStore(store, context().system());
-                }
+      public SharedStorageUsage() {
+        receive(ReceiveBuilder.
+          match(ActorIdentity.class, ai -> {
+            if (ai.correlationId().equals(1)) {
+              ActorRef store = ai.getRef();
+              if (store != null) {
+                SharedLeveldbJournal.setStore(store, context().system());
               }
-            }).build();
+            }
+          }).build()
+        );
       }
     }
     //#shared-store-usage

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ConversationRecoveryExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ConversationRecoveryExample.java
@@ -13,62 +13,64 @@ import scala.PartialFunction;
 import scala.runtime.BoxedUnit;
 
 public class ConversationRecoveryExample {
-    public static String PING = "PING";
-    public static String PONG = "PONG";
+  public static String PING = "PING";
+  public static String PONG = "PONG";
 
-    public static class Ping extends AbstractProcessor {
-        final ActorRef pongChannel = context().actorOf(Channel.props(), "pongChannel");
-        int counter = 0;
+  public static class Ping extends AbstractProcessor {
+    final ActorRef pongChannel = context().actorOf(Channel.props(), "pongChannel");
+    int counter = 0;
 
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(ConfirmablePersistent.class, cp -> cp.payload().equals(PING), cp -> {
-                    counter += 1;
-                    System.out.println(String.format("received ping %d times", counter));
-                    cp.confirm();
-                    if (!recoveryRunning()) {
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                    pongChannel.tell(Deliver.create(cp.withPayload(PONG), sender().path()), self());
-                }).
-                match(String.class,
-                      s -> s.equals("init"),
-                      s -> pongChannel.tell(Deliver.create(Persistent.create(PONG), sender().path()), self())).build();
-        }
+    public Ping() {
+      receive(ReceiveBuilder.
+          match(ConfirmablePersistent.class, cp -> cp.payload().equals(PING), cp -> {
+            counter += 1;
+            System.out.println(String.format("received ping %d times", counter));
+            cp.confirm();
+            if (!recoveryRunning()) {
+              try {
+                Thread.sleep(1000);
+              } catch (InterruptedException e) {
+                e.printStackTrace();
+              }
+            }
+            pongChannel.tell(Deliver.create(cp.withPayload(PONG), sender().path()), self());
+          }).
+          match(String.class,
+            s -> s.equals("init"),
+            s -> pongChannel.tell(Deliver.create(Persistent.create(PONG), sender().path()), self())).build()
+      );
     }
+  }
 
-    public static class Pong extends AbstractProcessor {
-        private final ActorRef pingChannel = context().actorOf(Channel.props(), "pingChannel");
-        private       int      counter     = 0;
+  public static class Pong extends AbstractProcessor {
+    private final ActorRef pingChannel = context().actorOf(Channel.props(), "pingChannel");
+    private       int      counter     = 0;
 
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(ConfirmablePersistent.class, cp -> cp.payload().equals(PONG), cp -> {
-                    counter += 1;
-                    System.out.println(String.format("received pong %d times", counter));
-                    cp.confirm();
-                    if (!recoveryRunning()) {
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                    pingChannel.tell(Deliver.create(cp.withPayload(PING), sender().path()), self());
-                }).build();
-        }
+    public Pong() {
+      receive(ReceiveBuilder.
+        match(ConfirmablePersistent.class, cp -> cp.payload().equals(PONG), cp -> {
+          counter += 1;
+          System.out.println(String.format("received pong %d times", counter));
+          cp.confirm();
+          if (!recoveryRunning()) {
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              e.printStackTrace();
+            }
+          }
+          pingChannel.tell(Deliver.create(cp.withPayload(PING), sender().path()), self());
+        }).build()
+      );
     }
+  }
 
-    public static void main(String... args) throws Exception {
-        final ActorSystem system = ActorSystem.create("example");
+  public static void main(String... args) throws Exception {
+    final ActorSystem system = ActorSystem.create("example");
 
-        final ActorRef ping = system.actorOf(Props.create(Ping.class), "ping");
-        final ActorRef pong = system.actorOf(Props.create(Pong.class), "pong");
+    final ActorRef ping = system.actorOf(Props.create(Ping.class), "ping");
+    final ActorRef pong = system.actorOf(Props.create(Pong.class), "pong");
 
-        ping.tell("init", pong);
-    }
+    ping.tell("init", pong);
+  }
 }

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/EventsourcedExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/EventsourcedExample.java
@@ -80,13 +80,15 @@ class ExampleProcessor extends AbstractEventsourcedProcessor {
         return state.size();
     }
 
-    @Override public PartialFunction<Object, BoxedUnit> receiveRecover() {
+  @Override
+  public PartialFunction<Object, BoxedUnit> receiveRecover() {
         return ReceiveBuilder.
             match(Evt.class, state::update).
             match(SnapshotOffer.class, ss -> state = (ExampleState) ss.snapshot()).build();
     }
 
-    @Override public PartialFunction<Object, BoxedUnit> receiveCommand() {
+  @Override
+  public PartialFunction<Object, BoxedUnit> receiveCommand() {
         return ReceiveBuilder.match(Cmd.class, c -> {
             final String data = c.getData();
             final Evt evt1 = new Evt(data + "-" + getNumEvents());

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ProcessorChannelExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ProcessorChannelExample.java
@@ -14,45 +14,45 @@ import scala.PartialFunction;
 import scala.runtime.BoxedUnit;
 
 public class ProcessorChannelExample {
-    public static class ExampleProcessor extends AbstractProcessor {
-        private ActorRef destination;
-        private ActorRef channel;
+  public static class ExampleProcessor extends AbstractProcessor {
+    private ActorRef destination;
+    private ActorRef channel;
 
-        public ExampleProcessor(ActorRef destination) {
-            this.destination = destination;
-            this.channel = context().actorOf(Channel.props(), "channel");
-        }
+    public ExampleProcessor(ActorRef destination) {
+      this.destination = destination;
+      this.channel = context().actorOf(Channel.props(), "channel");
 
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(Persistent.class, p -> {
-                    System.out.println("processed " + p.payload());
-                    channel.tell(Deliver.create(p.withPayload("processed " + p.payload()), destination.path()), self());
-                }).
-                match(String.class, s -> System.out.println("reply = " + s)).build();
-        }
+      receive(ReceiveBuilder.
+        match(Persistent.class, p -> {
+          System.out.println("processed " + p.payload());
+          channel.tell(Deliver.create(p.withPayload("processed " + p.payload()), destination.path()), self());
+        }).
+        match(String.class, s -> System.out.println("reply = " + s)).build()
+      );
     }
+  }
 
-    public static class ExampleDestination extends AbstractActor {
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(ConfirmablePersistent.class, cp -> {
-                    System.out.println("received " + cp.payload());
-                    sender().tell(String.format("re: %s (%d)", cp.payload(), cp.sequenceNr()), null);
-                    cp.confirm();
-                }).build();
-        }
+  public static class ExampleDestination extends AbstractActor {
+    public ExampleDestination() {
+      receive(ReceiveBuilder.
+        match(ConfirmablePersistent.class, cp -> {
+          System.out.println("received " + cp.payload());
+          sender().tell(String.format("re: %s (%d)", cp.payload(), cp.sequenceNr()), null);
+          cp.confirm();
+        }).build()
+      );
     }
+  }
 
-    public static void main(String... args) throws Exception {
-        final ActorSystem system = ActorSystem.create("example");
-        final ActorRef destination = system.actorOf(Props.create(ExampleDestination.class));
-        final ActorRef processor = system.actorOf(Props.create(ExampleProcessor.class, destination), "processor-1");
+  public static void main(String... args) throws Exception {
+    final ActorSystem system = ActorSystem.create("example");
+    final ActorRef destination = system.actorOf(Props.create(ExampleDestination.class));
+    final ActorRef processor = system.actorOf(Props.create(ExampleProcessor.class, destination), "processor-1");
 
-        processor.tell(Persistent.create("a"), null);
-        processor.tell(Persistent.create("b"), null);
+    processor.tell(Persistent.create("a"), null);
+    processor.tell(Persistent.create("b"), null);
 
-        Thread.sleep(1000);
-        system.shutdown();
-    }
+    Thread.sleep(1000);
+    system.shutdown();
+  }
 }

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ProcessorFailureExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ProcessorFailureExample.java
@@ -17,56 +17,57 @@ import scala.runtime.BoxedUnit;
 import java.util.ArrayList;
 
 public class ProcessorFailureExample {
-    public static class ExampleProcessor extends AbstractProcessor {
-        private ArrayList<Object> received = new ArrayList<Object>();
+  public static class ExampleProcessor extends AbstractProcessor {
+    private ArrayList<Object> received = new ArrayList<Object>();
 
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(Persistent.class, p -> p.payload().equals("boom"), p -> {throw new RuntimeException("boom");}).
-                match(Persistent.class, p -> !p.payload().equals("boom"), p -> received.add(p.payload())).
-                match(String.class, s -> s.equals("boom"), s -> {throw new RuntimeException("boom");}).
-                match(String.class, s -> s.equals("print"), s -> System.out.println("received " + received)).build();
-        }
-
-        @Override
-        public void preRestart(Throwable reason, Option<Object> message) {
-            if (message.isDefined() && message.get() instanceof Persistent) {
-                deleteMessage(((Persistent) message.get()).sequenceNr(), false);
-            }
-            super.preRestart(reason, message);
-        }
+    public ExampleProcessor() {
+      receive(ReceiveBuilder.
+        match(Persistent.class, p -> p.payload().equals("boom"), p -> {throw new RuntimeException("boom");}).
+        match(Persistent.class, p -> !p.payload().equals("boom"), p -> received.add(p.payload())).
+        match(String.class, s -> s.equals("boom"), s -> {throw new RuntimeException("boom");}).
+        match(String.class, s -> s.equals("print"), s -> System.out.println("received " + received)).build()
+      );
     }
 
-    public static void main(String... args) throws Exception {
-        final ActorSystem system = ActorSystem.create("example");
-        final ActorRef processor = system.actorOf(Props.create(ExampleProcessor.class), "processor-2");
-
-        processor.tell(Persistent.create("a"), null);
-        processor.tell("print", null);
-        processor.tell("boom", null);
-        processor.tell("print", null);
-        processor.tell(Persistent.create("b"), null);
-        processor.tell("print", null);
-        processor.tell(Persistent.create("boom"), null);
-        processor.tell("print", null);
-        processor.tell(Persistent.create("c"), null);
-        processor.tell("print", null);
-
-        // Will print in a first run (i.e. with empty journal):
-
-        // received [a]
-        // received [a, b]
-        // received [a, b, c]
-
-        // Will print in a second run:
-
-        // received [a, b, c, a]
-        // received [a, b, c, a, b]
-        // received [a, b, c, a, b, c]
-
-        // etc ...
-
-        Thread.sleep(1000);
-        system.shutdown();
+    @Override
+    public void preRestart(Throwable reason, Option<Object> message) {
+      if (message.isDefined() && message.get() instanceof Persistent) {
+        deleteMessage(((Persistent) message.get()).sequenceNr(), false);
+      }
+      super.preRestart(reason, message);
     }
+  }
+
+  public static void main(String... args) throws Exception {
+    final ActorSystem system = ActorSystem.create("example");
+    final ActorRef processor = system.actorOf(Props.create(ExampleProcessor.class), "processor-2");
+
+    processor.tell(Persistent.create("a"), null);
+    processor.tell("print", null);
+    processor.tell("boom", null);
+    processor.tell("print", null);
+    processor.tell(Persistent.create("b"), null);
+    processor.tell("print", null);
+    processor.tell(Persistent.create("boom"), null);
+    processor.tell("print", null);
+    processor.tell(Persistent.create("c"), null);
+    processor.tell("print", null);
+
+    // Will print in a first run (i.e. with empty journal):
+
+    // received [a]
+    // received [a, b]
+    // received [a, b, c]
+
+    // Will print in a second run:
+
+    // received [a, b, c, a]
+    // received [a, b, c, a, b]
+    // received [a, b, c, a, b, c]
+
+    // etc ...
+
+    Thread.sleep(1000);
+    system.shutdown();
+  }
 }

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ViewExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ViewExample.java
@@ -17,84 +17,87 @@ import scala.runtime.BoxedUnit;
 import java.util.concurrent.TimeUnit;
 
 public class ViewExample {
-    public static class ExampleProcessor extends AbstractProcessor {
-        @Override
-        public String processorId() {
-            return "processor-5";
-        }
-
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(Persistent.class,
-                      p -> System.out.println(String.format("processor received %s (sequence nr = %d)",
-                                                            p.payload(),
-                                                            p.sequenceNr()))).build();
-        }
+  public static class ExampleProcessor extends AbstractProcessor {
+    @Override
+    public String processorId() {
+      return "processor-5";
     }
 
-    public static class ExampleView extends AbstractView {
-        private final ActorRef destination = context().actorOf(Props.create(ExampleDestination.class));
-        private final ActorRef channel     = context().actorOf(Channel.props("channel"));
+    public ExampleProcessor() {
+      receive(ReceiveBuilder.
+        match(Persistent.class,
+          p -> System.out.println(String.format("processor received %s (sequence nr = %d)",
+            p.payload(),
+            p.sequenceNr()))).build()
+      );
+    }
+  }
 
-        private int numReplicated = 0;
+  public static class ExampleView extends AbstractView {
+    private final ActorRef destination = context().actorOf(Props.create(ExampleDestination.class));
+    private final ActorRef channel     = context().actorOf(Channel.props("channel"));
 
-        @Override
-        public String viewId() {
-            return "view-5";
-        }
+    private int numReplicated = 0;
 
-        @Override
-        public String processorId() {
-            return "processor-5";
-        }
-
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(Persistent.class, p -> {
-                    numReplicated += 1;
-                    System.out.println(String.format("view received %s (sequence nr = %d, num replicated = %d)",
-                                                     p.payload(),
-                                                     p.sequenceNr(),
-                                                     numReplicated));
-                    channel.tell(Deliver.create(p.withPayload("replicated-" + p.payload()), destination.path()),
-                                 self());
-                }).
-                match(SnapshotOffer.class, so -> {
-                    numReplicated = (Integer) so.snapshot();
-                    System.out.println(String.format("view received snapshot offer %s (metadata = %s)",
-                                                     numReplicated,
-                                                     so.metadata()));
-                }).
-                match(String.class, s -> s.equals("snap"), s -> saveSnapshot(numReplicated)).build();
-        }
+    @Override
+    public String viewId() {
+      return "view-5";
     }
 
-    public static class ExampleDestination extends AbstractActor {
-
-        @Override public PartialFunction<Object, BoxedUnit> receive() {
-            return ReceiveBuilder.
-                match(ConfirmablePersistent.class, cp -> {
-                    System.out.println(String.format("destination received %s (sequence nr = %s)",
-                                                     cp.payload(),
-                                                     cp.sequenceNr()));
-                    cp.confirm();
-                }).build();
-        }
+    @Override
+    public String processorId() {
+      return "processor-5";
     }
 
-    public static void main(String... args) throws Exception {
-        final ActorSystem system = ActorSystem.create("example");
-        final ActorRef processor = system.actorOf(Props.create(ExampleProcessor.class));
-        final ActorRef view = system.actorOf(Props.create(ExampleView.class));
-
-        system.scheduler()
-            .schedule(Duration.Zero(),
-                      Duration.create(2, TimeUnit.SECONDS),
-                      processor,
-                      Persistent.create("scheduled"),
-                      system.dispatcher(),
-                      null);
-        system.scheduler()
-            .schedule(Duration.Zero(), Duration.create(5, TimeUnit.SECONDS), view, "snap", system.dispatcher(), null);
+    public ExampleView() {
+      receive(ReceiveBuilder.
+        match(Persistent.class, p -> {
+          numReplicated += 1;
+          System.out.println(String.format("view received %s (sequence nr = %d, num replicated = %d)",
+            p.payload(),
+            p.sequenceNr(),
+            numReplicated));
+          channel.tell(Deliver.create(p.withPayload("replicated-" + p.payload()), destination.path()),
+            self());
+        }).
+        match(SnapshotOffer.class, so -> {
+          numReplicated = (Integer) so.snapshot();
+          System.out.println(String.format("view received snapshot offer %s (metadata = %s)",
+            numReplicated,
+            so.metadata()));
+        }).
+        match(String.class, s -> s.equals("snap"), s -> saveSnapshot(numReplicated)).build()
+      );
     }
+  }
+
+  public static class ExampleDestination extends AbstractActor {
+
+    public ExampleDestination() {
+      receive(ReceiveBuilder.
+        match(ConfirmablePersistent.class, cp -> {
+          System.out.println(String.format("destination received %s (sequence nr = %s)",
+            cp.payload(),
+            cp.sequenceNr()));
+          cp.confirm();
+        }).build()
+      );
+    }
+  }
+
+  public static void main(String... args) throws Exception {
+    final ActorSystem system = ActorSystem.create("example");
+    final ActorRef processor = system.actorOf(Props.create(ExampleProcessor.class));
+    final ActorRef view = system.actorOf(Props.create(ExampleView.class));
+
+    system.scheduler()
+      .schedule(Duration.Zero(),
+        Duration.create(2, TimeUnit.SECONDS),
+        processor,
+        Persistent.create("scheduled"),
+        system.dispatcher(),
+        null);
+    system.scheduler()
+      .schedule(Duration.Zero(), Duration.create(5, TimeUnit.SECONDS), view, "snap", system.dispatcher(), null);
+  }
 }

--- a/akka-samples/akka-sample-supervision-java-lambda/src/main/java/supervision/ArithmeticService.java
+++ b/akka-samples/akka-sample-supervision-java-lambda/src/main/java/supervision/ArithmeticService.java
@@ -61,15 +61,15 @@ class ArithmeticService extends AbstractLoggingActor {
     }
   }
 
-  @Override
-  public PartialFunction<Object, BoxedUnit> receive() {
-    return ReceiveBuilder.
+  ArithmeticService() {
+    receive(ReceiveBuilder.
       match(Expression.class, expr -> {
         // We delegate the dangerous task of calculation to a worker, passing the
         // expression as a constructor argument to the actor.
         ActorRef worker = context().actorOf(FlakyExpressionCalculator.props(expr, Left));
         pendingWorkers.put(worker, sender());
       }).
-      match(Result.class, r -> notifyConsumerSuccess(sender(), r.getValue())).build();
+      match(Result.class, r -> notifyConsumerSuccess(sender(), r.getValue())).build()
+    );
   }
 }

--- a/akka-samples/akka-sample-supervision-java-lambda/src/main/java/supervision/FlakyExpressionCalculator.java
+++ b/akka-samples/akka-sample-supervision-java-lambda/src/main/java/supervision/FlakyExpressionCalculator.java
@@ -67,11 +67,6 @@ public class FlakyExpressionCalculator extends AbstractLoggingActor {
   private final Expression expr;
   private final Position myPosition;
 
-  public FlakyExpressionCalculator(Expression expr, Position myPosition) {
-    this.expr = expr;
-    this.myPosition = myPosition;
-  }
-
   private Expression getExpr() {
     return expr;
   }
@@ -107,9 +102,11 @@ public class FlakyExpressionCalculator extends AbstractLoggingActor {
     }
   }
 
-  @Override
-  public PartialFunction<Object, BoxedUnit> receive() {
-    return ReceiveBuilder.
+  public FlakyExpressionCalculator(Expression expr, Position myPosition) {
+    this.expr = expr;
+    this.myPosition = myPosition;
+
+    receive(ReceiveBuilder.
       match(Result.class, r -> expected.contains(r.getPosition()), r -> {
         expected.remove(r.getPosition());
         results.put(r.getPosition(), r.getValue());
@@ -126,7 +123,7 @@ public class FlakyExpressionCalculator extends AbstractLoggingActor {
       throw new IllegalStateException("Expected results for positions " +
         expected.stream().map(Object::toString).collect(Collectors.joining(", ")) +
         " but got position " + r.getPosition());
-    }).build();
+    }).build());
   }
 
   private Integer evaluate(Expression expr, Integer left, Integer right) {


### PR DESCRIPTION
Only for PR validation
- Added a setter for Java lambda actors to "hide" the not so nice looking type
  signature of the "receive" method.
- Updated docs to reflect the changes.
- Converted samples to use the new setter.
