### PR TITLE
+con #3937 Start ShardCoordinator again after PersistenceFailure (backport)

### DIFF
--- a/akka-contrib/src/main/resources/reference.conf
+++ b/akka-contrib/src/main/resources/reference.conf
@@ -78,6 +78,9 @@ akka.contrib.cluster.sharding {
   # The extension creates a top level actor with this name in top level user scope, 
   # e.g. '/user/sharding'
   guardian-name = sharding
+  # If the coordinator can't store state changes it will be stopped
+  # and started again after this duration.
+  coordinator-failure-backoff = 10 s
   # Start the coordinator singleton manager on members tagged with this role.
   # All members are used if undefined or empty.
   # ShardRegion actor is started in proxy only mode on nodes that are not tagged

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterShardingFailureSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterShardingFailureSpec.scala
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.contrib.pattern
+
+import java.io.File
+import scala.concurrent.duration._
+import org.apache.commons.io.FileUtils
+import com.typesafe.config.ConfigFactory
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.Identify
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent._
+import akka.persistence.Persistence
+import akka.persistence.journal.leveldb.SharedLeveldbJournal
+import akka.persistence.journal.leveldb.SharedLeveldbStore
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.STMultiNodeSpec
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+
+object ClusterShardingFailureSpec extends MultiNodeConfig {
+  val controller = role("controller")
+  val first = role("first")
+  val second = role("second")
+
+  commonConfig(ConfigFactory.parseString("""
+    akka.loglevel = INFO
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.remote.log-remote-lifecycle-events = off
+    akka.cluster.auto-down-unreachable-after = 0s
+    akka.cluster.roles = ["backend"]
+    akka.persistence.journal.plugin = "akka.persistence.journal.leveldb-shared"
+    akka.persistence.journal.leveldb-shared {
+      timeout = 5s
+      store {
+        native = off
+        dir = "target/journal-ClusterShardingFailureSpec"
+      }
+    }
+    akka.persistence.snapshot-store.local.dir = "target/snapshots-ClusterShardingFailureSpec"
+    akka.contrib.cluster.sharding.coordinator-failure-backoff = 3s
+    """))
+
+  testTransport(on = true)
+
+  case class Get(id: String)
+  case class Add(id: String, i: Int)
+  case class Value(id: String, n: Int)
+
+  class Entity extends Actor {
+    var n = 0
+
+    def receive = {
+      case Get(id)    ⇒ sender() ! Value(id, n)
+      case Add(id, i) ⇒ n += i
+    }
+  }
+
+  val idExtractor: ShardRegion.IdExtractor = {
+    case m @ Get(id)    ⇒ (id, m)
+    case m @ Add(id, _) ⇒ (id, m)
+  }
+
+  val shardResolver: ShardRegion.ShardResolver = msg ⇒ msg match {
+    case Get(id)    ⇒ id.charAt(0).toString
+    case Add(id, _) ⇒ id.charAt(0).toString
+  }
+
+}
+
+class ClusterShardingFailureMultiJvmNode1 extends ClusterShardingFailureSpec
+class ClusterShardingFailureMultiJvmNode2 extends ClusterShardingFailureSpec
+class ClusterShardingFailureMultiJvmNode3 extends ClusterShardingFailureSpec
+
+class ClusterShardingFailureSpec extends MultiNodeSpec(ClusterShardingFailureSpec) with STMultiNodeSpec with ImplicitSender {
+  import ClusterShardingFailureSpec._
+
+  override def initialParticipants = roles.size
+
+  val storageLocations = List(
+    "akka.persistence.journal.leveldb.dir",
+    "akka.persistence.journal.leveldb-shared.store.dir",
+    "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
+
+  override protected def atStartup() {
+    runOn(controller) {
+      storageLocations.foreach(dir ⇒ if (dir.exists) FileUtils.deleteDirectory(dir))
+    }
+  }
+
+  override protected def afterTermination() {
+    runOn(controller) {
+      storageLocations.foreach(dir ⇒ if (dir.exists) FileUtils.deleteDirectory(dir))
+    }
+  }
+
+  def join(from: RoleName, to: RoleName): Unit = {
+    runOn(from) {
+      Cluster(system) join node(to).address
+      startSharding()
+    }
+    enterBarrier(from.name + "-joined")
+  }
+
+  def startSharding(): Unit = {
+    ClusterSharding(system).start(
+      typeName = "Entity",
+      entryProps = Some(Props[Entity]),
+      idExtractor = idExtractor,
+      shardResolver = shardResolver)
+  }
+
+  lazy val region = ClusterSharding(system).shardRegion("Entity")
+
+  "Cluster sharding with flaky journal" must {
+
+    "setup shared journal" in {
+      // start the Persistence extension
+      Persistence(system)
+      runOn(controller) {
+        system.actorOf(Props[SharedLeveldbStore], "store")
+      }
+      enterBarrier("peristence-started")
+
+      runOn(first, second) {
+        system.actorSelection(node(controller) / "user" / "store") ! Identify(None)
+        val sharedStore = expectMsgType[ActorIdentity].ref.get
+        SharedLeveldbJournal.setStore(sharedStore, system)
+      }
+
+      enterBarrier("after-1")
+    }
+
+    "join cluster" in within(20.seconds) {
+      join(first, first)
+      join(second, first)
+
+      runOn(first) {
+        region ! Add("10", 1)
+        region ! Add("20", 2)
+        region ! Get("10")
+        expectMsg(Value("10", 1))
+        region ! Get("20")
+        expectMsg(Value("20", 2))
+      }
+
+      enterBarrier("after-2")
+    }
+
+    "recover after journal failure" in within(20.seconds) {
+      runOn(controller) {
+        testConductor.blackhole(controller, first, Direction.Both).await
+        testConductor.blackhole(controller, second, Direction.Both).await
+      }
+      enterBarrier("journal-blackholed")
+
+      runOn(first) {
+        region ! Add("30", 3)
+        region ! Get("30")
+        expectMsg(Value("30", 3))
+      }
+
+      runOn(controller) {
+        testConductor.passThrough(controller, first, Direction.Both).await
+        testConductor.passThrough(controller, second, Direction.Both).await
+      }
+      enterBarrier("journal-ok")
+
+      runOn(second) {
+        region ! Add("10", 1)
+        region ! Add("20", 2)
+        region ! Add("30", 3)
+        region ! Get("10")
+        expectMsg(Value("10", 2))
+        region ! Get("20")
+        expectMsg(Value("20", 4))
+        region ! Get("30")
+        expectMsg(Value("30", 6))
+      }
+
+      enterBarrier("after-3")
+
+    }
+
+  }
+}
+

--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -84,6 +84,9 @@ akka {
 
         # Dispatcher for the plugin actor.
         plugin-dispatcher = "akka.actor.default-dispatcher"
+        
+        # timeout for async journal operations
+        timeout = 10s
 
         store {
 

--- a/akka-persistence/src/main/scala/akka/persistence/Processor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Processor.scala
@@ -91,7 +91,8 @@ trait Processor extends Actor with Recovery {
         else {
           val errorMsg = "Processor killed after persistence failure " +
             s"(processor id = [${processorId}], sequence nr = [${p.sequenceNr}], payload class = [${p.payload.getClass.getName}]). " +
-            "To avoid killing processors on persistence failure, a processor must handle PersistenceFailure messages."
+            "To avoid killing processors on persistence failure, a processor must handle PersistenceFailure messages. " +
+            "PersistenceFailure was caused by: " + cause
           throw new ActorKilledException(errorMsg)
         }
       case LoopMessageSuccess(m) ⇒ process(receive, m)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
@@ -10,6 +10,7 @@ import akka.actor._
 import akka.persistence.Persistence
 import akka.persistence.journal._
 import akka.util.Timeout
+import akka.util.Helpers.ConfigOps
 
 /**
  * INTERNAL API.
@@ -24,7 +25,8 @@ private[persistence] class LeveldbJournal extends { val configPath = "akka.persi
  * Journal backed by a [[SharedLeveldbStore]]. For testing only.
  */
 private[persistence] class SharedLeveldbJournal extends AsyncWriteProxy {
-  val timeout: Timeout = Timeout(10 seconds) // TODO: make configurable
+  val timeout: Timeout = context.system.settings.config.getMillisDuration(
+    "akka.persistence.journal.leveldb-shared.timeout")
 }
 
 object SharedLeveldbJournal {


### PR DESCRIPTION
- Add supervisor level that will start the ShardCoordinator again after
  a configurable backoff duration
- Make the timeout of SharedLeveldbJournal configurable
- Include cause of PersistenceFailure in message of ActorKilledException

(cherry picked from commit 8ebc413643c5b1e755057ecab7e660f027bfd232)
