### PR TITLE
New Bytes abstraction V2

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -20,7 +20,7 @@ import akka.io.SelectionHandler._
 import akka.io.Inet.SocketOption
 import akka.actor._
 import akka.testkit.{ AkkaSpec, EventFilter, TestActorRef, TestProbe }
-import akka.util.{ Helpers, ByteString }
+import akka.util.{ Bytes, Helpers, ByteString }
 import akka.TestUtils._
 import java.util.Random
 
@@ -241,7 +241,7 @@ class TcpConnectionSpec extends AkkaSpec("""
         val size = math.min(testFile.length(), 100000000).toInt
 
         val writer = TestProbe()
-        writer.send(connectionActor, WriteFile(testFile.getAbsolutePath, 0, size, Ack))
+        writer.send(connectionActor, Write(Bytes.fromFile(testFile.getAbsolutePath, 0, size), Ack))
         pullFromServerSide(size, 1000000)
         writer.expectMsg(Ack)
       }

--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -247,29 +247,6 @@ class TcpConnectionSpec extends AkkaSpec("""
       }
     }
 
-    "write a CompoundWrite to the network and produce correct ACKs" in new EstablishedConnectionTest() {
-      run {
-        val writer = TestProbe()
-        val compoundWrite =
-          Write(ByteString("test1"), Ack(1)) +:
-            Write(ByteString("test2")) +:
-            Write(ByteString.empty, Ack(3)) +:
-            Write(ByteString("test4"), Ack(4))
-
-        // reply to write commander with Ack
-        val buffer = ByteBuffer.allocate(100)
-        serverSideChannel.read(buffer) should be(0)
-        writer.send(connectionActor, compoundWrite)
-
-        pullFromServerSide(remaining = 15, into = buffer)
-        buffer.flip()
-        ByteString(buffer).utf8String should be("test1test2test4")
-        writer.expectMsg(Ack(1))
-        writer.expectMsg(Ack(3))
-        writer.expectMsg(Ack(4))
-      }
-    }
-
     /*
      * Disabled on Windows: http://support.microsoft.com/kb/214397
      *

--- a/akka-actor-tests/src/test/scala/akka/util/BytesSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/BytesSpec.scala
@@ -1,0 +1,72 @@
+/**
+ *  Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.util
+
+import java.io.{ FileOutputStream, File }
+import org.scalatest.{ Matchers, WordSpec }
+
+class BytesSpec extends WordSpec with Matchers {
+  import BytesUtils._
+
+  "Bytes" must {
+    "properly support `slice`" when {
+      "ByteString" in {
+        ByteString("Ken sent me!").slice(4L, 3L) shouldBe ByteString("sen")
+      }
+      "FileBytes" in {
+        val file = File.createTempFile("akka-util_BytesSpec", ".txt")
+        try {
+          writeAllText(" Ken sent me!", file)
+          Bytes(file, 1).slice(4L, 3L) shouldBe Bytes(file, 5, 3)
+        } finally file.delete
+      }
+      "ByteStrings.slice" in {
+        val data = ByteString("Ken") ++ ByteString(" sent ") ++ ByteString("me") ++ ByteString("!")
+        data.slice(2L, 5L) shouldBe ByteString("n sen")
+      }
+    }
+    "properly support `chunk`" when {
+      "ByteString" in {
+        ByteString("Ken sent me!").chunk(5) shouldBe Stream(
+          ByteString("Ken s"),
+          ByteString("ent m"),
+          ByteString("e!"))
+      }
+      "FileBytes" in {
+        withFileBytes("Ken sent me!") { fb ⇒
+          fb.chunk(5) shouldBe Stream(
+            fb.slice(0, 5),
+            fb.slice(5, 5),
+            fb.slice(10, 2))
+        }
+      }
+      "ByteStrings.chunk" in {
+        val data = ByteString("Ken") ++ ByteString(" sent ") ++ ByteString("me!")
+        data.chunk(5) shouldBe Stream(
+          ByteString("Ken s"),
+          ByteString("ent m"),
+          ByteString("e!"))
+      }
+    }
+  }
+}
+
+object BytesUtils {
+  def withFileBytes[T](text: String = "Ken sent me!")(f: Bytes ⇒ T): T = {
+    val file = File.createTempFile("akka-util_BytesSpec", ".txt")
+    try {
+      writeAllText(text, file)
+      f(Bytes(file))
+    } finally file.delete
+  }
+  def virtualFileBytes(length: Int): FileBytes =
+    // using private[util] constructor, file doesn't really have to exist
+    FileBytes("/tmp/dummy", 0, length)
+
+  def writeAllText(text: String, file: File) = {
+    val fos = new FileOutputStream(file)
+    try fos.write(text.getBytes("utf8"))
+    finally fos.close()
+  }
+}

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -223,8 +223,8 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
   }
 
   /**
-   * Each [[WriteCommand]] can optionally request a positive acknowledgment to be sent
-   * to the commanding actor. If such notification is not desired the [[WriteCommand#ack]]
+   * Each [[Write]] can optionally request a positive acknowledgment to be sent
+   * to the commanding actor. If such notification is not desired the [[Write#ack]]
    * must be set to an instance of this class. The token contained within can be used
    * to recognize which write failed when receiving a [[CommandFailed]] message.
    */
@@ -236,82 +236,18 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    */
   object NoAck extends NoAck(null)
 
-  /**
-   * Common interface for all write commands, currently [[Write]], and [[CompoundWrite]].
-   */
-  sealed abstract class WriteCommand extends Command {
-    /**
-     * Prepends this command with another `Write` or `WriteFile` to form
-     * a `CompoundWrite`.
-     */
-    def +:(other: Write): CompoundWrite = CompoundWrite(other, this)
-
-    /**
-     * Prepends this command with a number of other writes.
-     * The first element of the given Iterable becomes the first sub write of a potentially
-     * created `CompoundWrite`.
-     */
-    def ++:(writes: Iterable[WriteCommand]): WriteCommand =
-      writes.foldRight(this) {
-        case (a: Write, b)         ⇒ a +: b
-        case (a: CompoundWrite, b) ⇒ a ++: b
-      }
-
-    /**
-     * Java API: prepends this command with another `Write` or `WriteFile` to form
-     * a `CompoundWrite`.
-     */
-    def prepend(that: Write): CompoundWrite = that +: this
-
-    /**
-     * Java API: prepends this command with a number of other writes.
-     * The first element of the given Iterable becomes the first sub write of a potentially
-     * created `CompoundWrite`.
-     */
-    def prepend(writes: JIterable[WriteCommand]): WriteCommand = writes.asScala ++: this
-  }
-
-  object WriteCommand {
-    /**
-     * Combines the given number of write commands into one atomic `WriteCommand`.
-     */
-    def apply(writes: Iterable[WriteCommand]): WriteCommand = writes ++: Write.empty
-
-    /**
-     * Java API: combines the given number of write commands into one atomic `WriteCommand`.
-     */
-    def create(writes: JIterable[WriteCommand]): WriteCommand = apply(writes.asScala)
-  }
-
-  /**
-   * Write data to the TCP connection. If no ack is needed use the special
-   * `NoAck` object. The connection actor will reply with a [[CommandFailed]]
-   * message if the write could not be enqueued. If [[WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[WriteCommand#ack]]
-   * token once the write has been successfully enqueued to the O/S kernel.
-   * <b>Note that this does not in any way guarantee that the data will be
-   * or have been sent!</b> Unfortunately there is no way to determine whether
-   * a particular write has been sent by the O/S.
-   */
-  final case class Write(data: Bytes, ack: Event) extends WriteCommand {
-    require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
-
+  final case class Write(data: Bytes, ack: Event) extends Command {
     /**
      * An acknowledgment is only sent if this write command “wants an ack”, which is
      * equivalent to the [[#ack]] token not being a of type [[NoAck]].
      */
     def wantsAck: Boolean = !ack.isInstanceOf[NoAck]
-
-    /**
-     * Java API: appends this command with another `WriteCommand` to form a `CompoundWrite`.
-     */
-    def append(that: WriteCommand): CompoundWrite = this +: that
   }
   object Write {
     /**
      * The empty Write doesn't write anything and isn't acknowledged.
      * It will, however, be denied and sent back with `CommandFailed` if the
-     * connection isn't currently ready to send any data (because another WriteCommand
+     * connection isn't currently ready to send any data (because another Write
      * is still pending).
      */
     val empty: Write = Write(ByteString.empty, NoAck)
@@ -319,38 +255,14 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
     /**
      * Create a new unacknowledged Write command with the given data.
      */
-    def apply(data: ByteString): Write =
+    def apply(data: Bytes): Write =
       if (data.isEmpty) empty else Write(data, NoAck)
-  }
-
-  /**
-   * A write command which aggregates two other write commands. Using this construct
-   * you can chain a number of [[Write]] commands together in a way
-   * that allows them to be handled as a single write which gets written out to the
-   * network as quickly as possible.
-   * If the sub commands contain `ack` requests they will be honored as soon as the
-   * respective write has been written completely.
-   */
-  final case class CompoundWrite(override val head: Write, tailCommand: WriteCommand) extends WriteCommand
-    with immutable.Iterable[Write] {
-
-    def iterator: Iterator[Write] =
-      new Iterator[Write] {
-        private[this] var current: WriteCommand = CompoundWrite.this
-        def hasNext: Boolean = current ne null
-        def next(): Write =
-          current match {
-            case null                ⇒ Iterator.empty.next()
-            case CompoundWrite(h, t) ⇒ { current = t; h }
-            case x: Write            ⇒ { current = null; x }
-          }
-      }
   }
 
   /**
    * When `useResumeWriting` is in effect as was indicated in the [[Register]] message
    * then this command needs to be sent to the connection actor in order to re-enable
-   * writing after a [[CommandFailed]] event. All [[WriteCommand]] processed by the
+   * writing after a [[CommandFailed]] event. All Writes processed by the
    * connection actor between the first [[CommandFailed]] and subsequent reception of
    * this message will also be rejected with [[CommandFailed]].
    */
@@ -698,8 +610,8 @@ object TcpMessage {
   def abort: Command = Abort
 
   /**
-   * Each [[Tcp.WriteCommand]] can optionally request a positive acknowledgment to be sent
-   * to the commanding actor. If such notification is not desired the [[Tcp.WriteCommand#ack]]
+   * Each [[Tcp.Write]] can optionally request a positive acknowledgment to be sent
+   * to the commanding actor. If such notification is not desired the [[Tcp.Write#ack]]
    * must be set to an instance of this class. The token contained within can be used
    * to recognize which write failed when receiving a [[Tcp.CommandFailed]] message.
    */
@@ -713,37 +625,23 @@ object TcpMessage {
   /**
    * Write data to the TCP connection. If no ack is needed use the special
    * `NoAck` object. The connection actor will reply with a [[Tcp.CommandFailed]]
-   * message if the write could not be enqueued. If [[Tcp.WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[Tcp.WriteCommand#ack]]
+   * message if the write could not be enqueued. If [[Tcp.Write#wantsAck]]
+   * returns true, the connection actor will reply with the supplied [[Tcp.Write#ack]]
    * token once the write has been successfully enqueued to the O/S kernel.
    * <b>Note that this does not in any way guarantee that the data will be
    * or have been sent!</b> Unfortunately there is no way to determine whether
    * a particular write has been sent by the O/S.
    */
-  def write(data: ByteString, ack: Event): Command = Write(data, ack)
+  def write(data: Bytes, ack: Event): Command = Write(data, ack)
   /**
    * The same as `write(data, noAck())`.
    */
-  def write(data: ByteString): Command = Write(data)
-
-  /**
-   * Write `count` bytes starting at `position` from file at `filePath` to the connection.
-   * The count must be > 0. The connection actor will reply with a [[Tcp.CommandFailed]]
-   * message if the write could not be enqueued. If [[Tcp.WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[Tcp.WriteCommand#ack]]
-   * token once the write has been successfully enqueued to the O/S kernel.
-   * <b>Note that this does not in any way guarantee that the data will be
-   * or have been sent!</b> Unfortunately there is no way to determine whether
-   * a particular write has been sent by the O/S.
-   */
-  @deprecated("Use Bytes.fromFile instead", "2.4.0")
-  def writeFile(filePath: String, position: Long, count: Long, ack: Event): Command =
-    Write(Bytes.fromFile(filePath, position, count), ack)
+  def write(data: Bytes): Command = Write(data)
 
   /**
    * When `useResumeWriting` is in effect as was indicated in the [[Tcp.Register]] message
    * then this command needs to be sent to the connection actor in order to re-enable
-   * writing after a [[Tcp.CommandFailed]] event. All [[Tcp.WriteCommand]] processed by the
+   * writing after a [[Tcp.CommandFailed]] event. All [[Tcp.Write]] processed by the
    * connection actor between the first [[Tcp.CommandFailed]] and subsequent reception of
    * this message will also be rejected with [[Tcp.CommandFailed]].
    */

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -125,7 +125,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         }
       }
 
-    case write: WriteCommand ⇒
+    case write: Write ⇒
       if (writingSuspended) {
         if (TraceLogging) log.debug("Dropping write because writing is suspended")
         sender() ! write.failureMessage
@@ -326,26 +326,27 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   override def postRestart(reason: Throwable): Unit =
     throw new IllegalStateException("Restarting not supported for connection actors.")
 
-  def PendingWrite(commander: ActorRef, write: WriteCommand): PendingWrite = {
-    @tailrec def create(head: WriteCommand, tail: WriteCommand = Write.empty): PendingWrite =
-      head match {
-        case Write.empty                                   ⇒ if (tail eq Write.empty) EmptyPendingWrite else create(tail)
-        case Write(data: ByteString, ack) if data.nonEmpty ⇒ PendingBufferWrite(commander, data, ack, tail)
-        case Write(FileBytes(path, offset, count), ack)    ⇒ PendingWriteFile(commander, path, offset, count, ack, tail)
-        case CompoundWrite(h, t)                           ⇒ create(h, t)
-        case x @ Write(_, ack) ⇒ // empty write with either an ACK or a non-standard NoACK
-          if (x.wantsAck) commander ! ack
-          create(tail)
-      }
-    create(write)
+  /** Creates a pending write dependening on the subtype of `Write.data` */
+  def PendingWrite(commander: ActorRef, write: Write): PendingWrite =
+    write.data match {
+      case ByteString.empty ⇒
+        handleCompletedWrite(commander, write.ack)
+        EmptyPendingWrite
+      case data: ByteString               ⇒ PendingBufferWrite(commander, data, write.ack)
+      case FileBytes(path, offset, count) ⇒ PendingWriteFile(commander, path, offset, count, write.ack)
+    }
+
+  def handleCompletedWrite(commander: ActorRef, ack: Event): PendingWrite = {
+    if (!ack.isInstanceOf[NoAck]) commander ! ack
+    EmptyPendingWrite
   }
 
-  def PendingBufferWrite(commander: ActorRef, data: ByteString, ack: Event, tail: WriteCommand): PendingBufferWrite = {
+  def PendingBufferWrite(commander: ActorRef, data: ByteString, ack: Event): PendingBufferWrite = {
     val buffer = bufferPool.acquire()
     try {
       val copied = data.copyToBuffer(buffer)
       buffer.flip()
-      new PendingBufferWrite(commander, data.drop(copied), ack, buffer, tail)
+      new PendingBufferWrite(commander, data.drop(copied), buffer, ack)
     } catch {
       case NonFatal(e) ⇒
         bufferPool.release(buffer)
@@ -356,9 +357,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   class PendingBufferWrite(
     val commander: ActorRef,
     remainingData: ByteString,
-    ack: Any,
     buffer: ByteBuffer,
-    tail: WriteCommand) extends PendingWrite {
+    ack: Event) extends PendingWrite {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
       @tailrec def writeToChannel(data: ByteString): PendingWrite = {
@@ -367,7 +367,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         if (buffer.hasRemaining) {
           // we weren't able to write all bytes from the buffer, so we need to try again later
           if (data eq remainingData) this
-          else new PendingBufferWrite(commander, data, ack, buffer, tail) // copy with updated remainingData
+          else new PendingBufferWrite(commander, data, buffer, ack) // copy with updated remainingData
 
         } else if (data.nonEmpty) {
           buffer.clear()
@@ -376,9 +376,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
           writeToChannel(data drop copied)
 
         } else {
-          if (!ack.isInstanceOf[NoAck]) commander ! ack
           release()
-          PendingWrite(commander, tail)
+          handleCompletedWrite(commander, ack)
         }
       }
       try {
@@ -391,17 +390,15 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
     def release(): Unit = bufferPool.release(buffer)
   }
 
-  def PendingWriteFile(commander: ActorRef, filePath: String, offset: Long, count: Long, ack: Event,
-                       tail: WriteCommand): PendingWriteFile =
-    new PendingWriteFile(commander, new FileInputStream(filePath).getChannel, offset, count, ack, tail)
+  def PendingWriteFile(commander: ActorRef, filePath: String, offset: Long, count: Long, ack: Event): PendingWriteFile =
+    new PendingWriteFile(commander, new FileInputStream(filePath).getChannel, offset, count, ack)
 
   class PendingWriteFile(
     val commander: ActorRef,
     fileChannel: FileChannel,
     offset: Long,
     remaining: Long,
-    ack: Event,
-    tail: WriteCommand) extends PendingWrite with Runnable {
+    ack: Event) extends PendingWrite with Runnable {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
       tcp.fileIoDispatcher.execute(this)
@@ -415,18 +412,18 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         val toWrite = math.min(remaining, tcp.Settings.TransferToLimit)
         val written = fileChannel.transferTo(offset, toWrite, channel)
 
-        if (written < remaining) {
-          val updated = new PendingWriteFile(commander, fileChannel, offset + written, remaining - written, ack, tail)
-          self ! UpdatePendingWrite(updated)
-
-        } else {
-          if (!ack.isInstanceOf[NoAck]) commander ! ack
+        if (written < remaining)
+          self ! UpdatePendingWrite(advanceCursorBy(written))
+        else {
           release()
-          self ! UpdatePendingWrite(PendingWrite(commander, tail))
+          self ! UpdatePendingWrite(handleCompletedWrite(commander, ack)) // this sends the ack on this thread, aside from the actor
         }
       } catch {
         case e: IOException ⇒ self ! WriteFileFailed(e)
       }
+
+    def advanceCursorBy(bytes: Long): PendingWriteFile =
+      new PendingWriteFile(commander, fileChannel, offset + bytes, remaining - bytes, ack)
   }
 }
 


### PR DESCRIPTION
As discussed in #1900, the proposal was much simplified by getting rid of any kind of `CompoundBytes` (in favor of a future stream based solution).

The first commit introduces the new abstraction as a superclass of ByteString. The second commit unifies `Tcp.WriteFile` and `Tcp.Write` into a single `Tcp.Write` with a `data: Bytes` parameter. The third commit goes one step further and also removes `Tcp.CompoundWrite`.

While the first two commits preserve all functionality under a changed API, the third commit basically reverts the `TcpConnection` back to a state without CompoundWrites (i.e. before #1709). The consensus seemed to be that compounding wasn't a strict necessity for users of TcpConnection before (although they simplified things e.g. in spray), and won't be needed once there's a stream based solution which would take care of any backpressure/buffering issues.
