### PR TITLE
Mailbox configuration for routees under BalancingPool - Issue 3964 fix

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
@@ -79,7 +79,7 @@ class BalancingSpec extends AkkaSpec(
 
     "deliver messages in a balancing fashion when defined in config" in {
       val latch = TestLatch(1)
-      val pool = system.actorOf(BalancingPool(1).props(routeeProps =
+      val pool = system.actorOf(FromConfig().props(routeeProps =
         Props(classOf[Worker], latch)), name = "balancingPool-2")
       test(pool, latch)
     }

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -245,7 +245,13 @@ class BalancingDispatcherConfigurator(_config: Config, _prerequisites: Dispatche
         "BalancingDispatcher must have 'mailbox-requirement' which implements akka.dispatch.MultipleConsumerSemantics; " +
           s"dispatcher [$id] has [$requirement]")
     val mailboxType =
-      if (config.hasPath("mailbox-type")) {
+      if (config.hasPath("mailbox")) {
+        val mt = mailboxes.lookup(config.getString("mailbox"))
+        if (!requirement.isAssignableFrom(mailboxes.getProducedMessageQueueType(mt)))
+          throw new IllegalArgumentException(
+            s"BalancingDispatcher [$id] has 'mailbox' [${mt.getClass}] which is incompatible with 'mailbox-requirement' [$requirement]")
+        mt
+      } else if (config.hasPath("mailbox-type")) {
         val mt = mailboxes.lookup(id)
         if (!requirement.isAssignableFrom(mailboxes.getProducedMessageQueueType(mt)))
           throw new IllegalArgumentException(


### PR DESCRIPTION
Fix for bug described here - https://www.assembla.com/spaces/akka/tickets/3964.
- Ability to specify mailbox for routees under balancing pool in deployment configuration has been added
- Correspondent tests added too
- BalancingSpec fixed in section "deliver messages in a balancing fashion when defined in config"
