### PR TITLE
Fixes unsubscribe of DistributedPubSubMediator to actually receive the UnsubscribeAck

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/DistributedPubSubMediator.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/DistributedPubSubMediator.scala
@@ -326,7 +326,7 @@ class DistributedPubSubMediator(
 
     case msg @ Unsubscribe(topic, _) ⇒
       context.child(URLEncoder.encode(topic, "utf-8")) match {
-        case Some(g) ⇒ g ! msg
+        case Some(g) ⇒ g forward msg
         case None    ⇒ // no such topic here
       }
 

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
@@ -405,6 +405,20 @@ class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMedia
 
       enterBarrier("after-13")
     }
+
+    "receive proper unsubscribeAck message" in within(15 seconds) {
+      runOn(first) {
+        val user = createChatUser("u111")
+        val topic = "sample-topic1"
+        val s1 = Subscribe(topic, user)
+        mediator ! s1
+        expectMsg(SubscribeAck(s1))
+        val uns = Unsubscribe(topic, user)
+        mediator ! uns
+        expectMsg(UnsubscribeAck(uns))
+      }
+      enterBarrier("after-14")
+    }
   }
 
 }


### PR DESCRIPTION
Unsubscribe of DistributedPubSubMediator never responded with UnsubscribeAck as documented. There was a bug (tell instead of forward). This also adds a test case for that.
