### PR TITLE
Fixing minor issues I found while building Akka on Windows

### DIFF
--- a/akka-docs/rst/dev/building-akka.rst
+++ b/akka-docs/rst/dev/building-akka.rst
@@ -103,12 +103,6 @@ to use from an sbt project) use the ``publish-local`` command::
 
    sbt publish-local
 
-.. note::
-
-   Akka generates class diagrams for the API documentation using ScalaDoc. This needs the ``dot`` command from
-   the Graphviz software package to be installed to avoid errors. You can disable the diagram generation by
-   adding the flag ``-Dakka.scaladoc.diagrams=false``
-
 
 sbt Interactive Mode
 --------------------
@@ -154,9 +148,8 @@ dependencies.
 Scaladoc Dependencies
 =====================
 
-The Scaladoc may generate Content (Type) Hierarchy diagrams. For this, you may
-be required to download and install Graphviz (http://www.graphviz.org/).
-The installed toolset has to be added to the PATH.
-
-Without Graphviz, the project will be completely built but with error messages
-regarding the absence of the diagram tool cumulated at the end.
+Akka generates class diagrams for the API documentation using ScalaDoc. This 
+needs the ``dot`` command from the Graphviz software package to be installed to
+avoid errors. You can disable the diagram generation by adding the flag
+``-Dakka.scaladoc.diagrams=false``. After installing Graphviz, make sure you add
+the toolset to the PATH (definitely on Windows).

--- a/akka-docs/rst/dev/building-akka.rst
+++ b/akka-docs/rst/dev/building-akka.rst
@@ -150,3 +150,13 @@ You can look at the Ivy dependency resolution information that is created on
 the resolution information for the akka-remote module compile dependencies. If
 you open this file in a web browser you will get an easy to navigate view of
 dependencies.
+
+Scaladoc Dependencies
+=====================
+
+The Scaladoc may generate Content (Type) Hierarchy diagrams. For this, you may
+be required to download and install Graphviz (http://www.graphviz.org/).
+The installed toolset has to be added to the PATH.
+
+Without Graphviz, the project will be completely built but with error messages
+regarding the absence of the diagram tool cumulated at the end.

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -896,7 +896,7 @@ object AkkaBuild extends Build {
           val name = f.getName
           if (name.endsWith(".html") && !name.startsWith("index-") &&
             !(name.compare("index.html") == 0) && !(name.compare("package.html") == 0)) {
-            val source = scala.io.Source.fromFile(f)
+            val source = scala.io.Source.fromFile(f)("utf-8")
             val hd = source.getLines().exists(_.contains("<div class=\"toggleContainer block diagram-container\" id=\"inheritance-diagram-container\">"))
             source.close()
             hd


### PR DESCRIPTION
Fixes #13983

Two changes have been made:
- In AkkaBuild, forced using UTF-8 to verify HTML files containing
  diagrams
- In the documentation chapter Building Akka, added a section clarifying
  the Graphviz dependency of generating Scaladoc Content Hierarchies

These fixes eliminates the issues I faced while building Akka on Windows
with NetBeans. The first issue is a Windows specific issue where the
default charset cannot be UTF-8. The second is Windows related in the
sense that Graphviz, the optional dependency of Scaladoc, had to be
manually resolved.
