### PR TITLE
=sam #15028 Change reference from java file to scala file

### DIFF
--- a/akka-samples/akka-sample-cluster-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-cluster-scala/tutorial/index.html
@@ -48,7 +48,7 @@ Open <a href="#code/src/main/scala/sample/cluster/simple/SimpleClusterApp.scala"
 The small program together with its configuration starts an ActorSystem with the Cluster enabled.
 It joins the cluster and starts an actor that logs some membership events.
 Take a look at the 
-<a href="#code/src/main/java/sample/cluster/simple/SimpleClusterListener.java" class="shortcut">SimpleClusterListener.java</a>
+<a href="#code/src/main/scala/sample/cluster/simple/SimpleClusterListener.scala" class="shortcut">SimpleClusterListener.scala</a>
 actor. 
 </p>
 


### PR DESCRIPTION
Fixes #15028.

Just changes a link reference in the akka-sample-cluster-scala tutorial from a nonexistent java file to the correct scala file.
