### PR TITLE
=per #15022 Persistent channel had an 1-off error

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/PersistentChannel.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentChannel.scala
@@ -320,7 +320,7 @@ private class RequestReader(channelId: String, channelSettings: PersistentChanne
     case d: Delivered ⇒
       delivery forward d
       numPending = math.max(numPending - 1L, 0L)
-      if (numPending == pendingConfirmationsMin) onReadRequest()
+      if (numPending <= pendingConfirmationsMin) onReadRequest()
     case d @ RedeliverFailure(ms) ⇒
       val numPendingPrev = numPending
       numPending = math.max(numPending - ms.length, 0L)


### PR DESCRIPTION
Pulling in fix suggested by Michael Pisula.
Recovery should start already when < minPending, not == minPending
