### PR TITLE
+str #15034 Add Flow javadsl

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/Support.scala
+++ b/akka-stream/src/main/scala/akka/stream/Support.scala
@@ -10,4 +10,9 @@ import scala.util.control.NoStackTrace
  * signal the end of stream (if the produced stream is not infinite). This is used for example in
  * [[akka.stream.scaladsl.Flow#apply]] (the variant which takes a closure).
  */
-case object Stop extends RuntimeException("Stop this flow") with NoStackTrace
+case object Stop extends RuntimeException("Stop this flow") with NoStackTrace {
+  /**
+   * Java API: get the singleton instance
+   */
+  def getInstance = this
+}

--- a/akka-stream/src/main/scala/akka/stream/Transformer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Transformer.scala
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream
+
+import scala.collection.immutable
+
+/**
+ * General interface for stream transformation.
+ *
+ * It is possible to keep state in the concrete [[Transformer]] instance with
+ * ordinary instance variables. The [[Transformer]] is executed by an actor and
+ * therefore you don not have to add any additional thread safety or memory
+ * visibility constructs to access the state from the callback methods.
+ *
+ * @see [[akka.stream.scaladsl.Flow#transform]]
+ * @see [[akka.stream.javadsl.Flow#transform]]
+ */
+abstract class Transformer[-T, +U] {
+  /**
+   * Invoked for each element to produce a (possibly empty) sequence of
+   * output elements.
+   */
+  def onNext(element: T): immutable.Seq[U]
+
+  /**
+   * Invoked after handing off the elements produced from one input element to the
+   * downstream consumers to determine whether to end stream processing at this point;
+   * in that case the upstream subscription is canceled.
+   */
+  def isComplete: Boolean = false
+
+  /**
+   * Invoked before signaling normal completion to the downstream consumers
+   * to produce a (possibly empty) sequence of elements in response to the
+   * end-of-stream event.
+   */
+  def onComplete(): immutable.Seq[U] = Nil
+
+  /**
+   * Invoked when failure is signaled from upstream.
+   */
+  def onError(cause: Throwable): Unit = ()
+
+  /**
+   * Invoked after normal completion or error.
+   */
+  def cleanup(): Unit = ()
+
+  /**
+   * Name of this transformation step. Used as part of the actor name.
+   * Facilitates debugging and logging.
+   */
+  def name: String = "transform"
+}
+
+/**
+ * General interface for stream transformation.
+ * @see [[akka.stream.scaladsl.Flow#transformRecover]]
+ * @see [[akka.stream.javadsl.Flow#transformRecover]]
+ * @see [[Transformer]]
+ */
+abstract class RecoveryTransformer[-T, +U] extends Transformer[T, U] {
+  /**
+   * Invoked when failure is signaled from upstream to emit an additional
+   * sequence of elements before the stream ends.
+   */
+  def onErrorRecover(cause: Throwable): immutable.Seq[U]
+
+  /**
+   * Name of this transformation step. Used as part of the actor name.
+   * Facilitates debugging and logging.
+   */
+  override def name: String = "transformRecover"
+}

--- a/akka-stream/src/main/scala/akka/stream/extra/Implicits.scala
+++ b/akka-stream/src/main/scala/akka/stream/extra/Implicits.scala
@@ -7,7 +7,8 @@ import akka.stream.scaladsl.Duct
 import akka.stream.scaladsl.Flow
 
 /**
- * Additional [[Flow]] and [[Duct]] operators.
+ * Additional [[akka.stream.scaladsl.Flow]] and [[akka.stream.scaladsl.Duct]]
+ * operators.
  */
 object Implicits {
 

--- a/akka-stream/src/main/scala/akka/stream/extra/Log.scala
+++ b/akka-stream/src/main/scala/akka/stream/extra/Log.scala
@@ -4,14 +4,14 @@
 package akka.stream.extra
 
 import scala.collection.immutable
-import akka.stream.scaladsl.Transformer
+import akka.stream.Transformer
 import akka.stream.impl.ActorBasedFlowMaterializer
 import akka.actor.ActorContext
 import akka.event.LoggingAdapter
 import akka.event.Logging
 
 /**
- * Scala API: Mix in TransformerLogging into your [[akka.stream.scaladsl.Transformer]]
+ * Scala API: Mix in TransformerLogging into your [[akka.stream.Transformer]]
  * to obtain a reference to a logger, which is available under the name [[#log]].
  */
 trait TransformerLogging { this: Transformer[_, _] ⇒

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -9,8 +9,8 @@ import org.reactivestreams.api.{ Consumer, Processor, Producer }
 import org.reactivestreams.spi.Subscriber
 import akka.actor.ActorRefFactory
 import akka.stream.{ MaterializerSettings, FlowMaterializer }
-import akka.stream.scaladsl.Transformer
-import akka.stream.scaladsl.RecoveryTransformer
+import akka.stream.Transformer
+import akka.stream.RecoveryTransformer
 import scala.util.Try
 import scala.concurrent.Future
 import scala.util.Success

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorConsumer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorConsumer.scala
@@ -11,8 +11,8 @@ import org.reactivestreams.spi.{ Subscriber, Subscription }
 import Ast.{ AstNode, Recover, Transform }
 import akka.actor.{ Actor, ActorLogging, ActorRef, Props, actorRef2Scala }
 import akka.stream.MaterializerSettings
-import akka.stream.scaladsl.Transformer
-import akka.stream.scaladsl.RecoveryTransformer
+import akka.stream.Transformer
+import akka.stream.RecoveryTransformer
 
 /**
  * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -13,8 +13,8 @@ import akka.stream.FlowMaterializer
 import akka.stream.scaladsl.Flow
 import scala.util.Success
 import scala.util.Failure
-import akka.stream.scaladsl.Transformer
-import akka.stream.scaladsl.RecoveryTransformer
+import akka.stream.Transformer
+import akka.stream.RecoveryTransformer
 import org.reactivestreams.api.Consumer
 import akka.stream.scaladsl.Duct
 

--- a/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
@@ -7,8 +7,8 @@ import scala.collection.immutable
 import scala.util.{ Failure, Success }
 import akka.actor.Props
 import akka.stream.MaterializerSettings
-import akka.stream.scaladsl.RecoveryTransformer
-import akka.stream.scaladsl.Transformer
+import akka.stream.RecoveryTransformer
+import akka.stream.Transformer
 import scala.util.control.NonFatal
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/io/StreamIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/StreamIO.scala
@@ -15,6 +15,7 @@ import akka.stream.impl.{ ActorPublisher, ExposedPublisher, ActorProcessor }
 import akka.stream.MaterializerSettings
 import akka.io.IO
 import java.net.URLEncoder
+import akka.japi.Util
 
 object StreamTcp extends ExtensionId[StreamTcpExt] with ExtensionIdProvider {
 
@@ -41,17 +42,132 @@ object StreamTcp extends ExtensionId[StreamTcpExt] with ExtensionIdProvider {
     }
   }
 
-  case class Connect(remoteAddress: InetSocketAddress,
+  /**
+   * The Connect message is sent to the StreamTcp manager actor, which is obtained via
+   * `IO(StreamTcp)`. The manager replies with a [[StreamTcp.OutgoingTcpConnection]]
+   * message.
+   *
+   * @param remoteAddress is the address to connect to
+   * @param localAddress optionally specifies a specific address to bind to
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   * @param timeout is the desired connection timeout, `null` means "no timeout"
+   */
+  case class Connect(settings: MaterializerSettings,
+                     remoteAddress: InetSocketAddress,
                      localAddress: Option[InetSocketAddress] = None,
                      options: immutable.Traversable[SocketOption] = Nil,
-                     timeout: Option[FiniteDuration] = None,
-                     settings: MaterializerSettings)
+                     timeout: Option[FiniteDuration] = None) {
 
-  case class Bind(localAddress: InetSocketAddress,
+    /**
+     * Java API
+     */
+    def withLocalAddress(localAddress: InetSocketAddress): Connect =
+      copy(localAddress = Option(localAddress))
+
+    /**
+     * Java API
+     */
+    def withSocketOptions(options: java.lang.Iterable[SocketOption]): Connect =
+      copy(options = Util.immutableSeq(options))
+
+    /**
+     * Java API
+     */
+    def withTimeout(timeout: FiniteDuration): Connect =
+      copy(timeout = Option(timeout))
+  }
+
+  /**
+   * The Bind message is send to the StreamTcp manager actor, which is obtained via
+   * `IO(StreamTcp)`, in order to bind to a listening socket. The manager
+   * replies with a [[StreamTcp.TcpServerBinding]]. If the local port is set to 0 in
+   * the Bind message, then the [[StreamTcp.TcpServerBinding]] message should be inspected to find
+   * the actual port which was bound to.
+   *
+   * @param localAddress The socket address to bind to; use port zero for
+   *                automatic assignment (i.e. an ephemeral port)
+   *
+   * @param backlog This specifies the number of unaccepted connections the O/S
+   *                kernel will hold for this port before refusing connections.
+   *
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   */
+  case class Bind(settings: MaterializerSettings,
+                  localAddress: InetSocketAddress,
                   backlog: Int = 100,
-                  options: immutable.Traversable[SocketOption] = Nil,
-                  settings: MaterializerSettings)
+                  options: immutable.Traversable[SocketOption] = Nil) {
 
+    /**
+     * Java API
+     */
+    def withBacklog(backlog: Int): Bind = copy(backlog = backlog)
+
+    /**
+     * Java API
+     */
+    def withSocketOptions(options: java.lang.Iterable[SocketOption]): Bind =
+      copy(options = Util.immutableSeq(options))
+
+  }
+
+}
+
+/**
+ * Java API: Factory methods for the messages of `StreamTcp`.
+ */
+object StreamTcpMessage {
+  /**
+   * Java API: The Connect message is sent to the StreamTcp manager actor, which is obtained via
+   * `StreamTcp.get(system).manager()`. The manager replies with a [[StreamTcp.OutgoingTcpConnection]]
+   * message.
+   *
+   * @param remoteAddress is the address to connect to
+   * @param localAddress optionally specifies a specific address to bind to
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   * @param timeout is the desired connection timeout, `null` means "no timeout"
+   */
+  def connect(
+    settings: MaterializerSettings,
+    remoteAddress: InetSocketAddress,
+    localAddress: InetSocketAddress,
+    options: java.lang.Iterable[SocketOption],
+    timeout: FiniteDuration): StreamTcp.Connect =
+    StreamTcp.Connect(settings, remoteAddress, Option(localAddress), Util.immutableSeq(options), Option(timeout))
+
+  /**
+   * Java API: Message to Connect to the given `remoteAddress` without binding to a local address and without
+   * specifying options.
+   */
+  def connect(settings: MaterializerSettings, remoteAddress: InetSocketAddress): StreamTcp.Connect =
+    StreamTcp.Connect(settings, remoteAddress)
+
+  /**
+   * Java API: The Bind message is send to the StreamTcp manager actor, which is obtained via
+   * `StreamTcp.get(system).manager()`, in order to bind to a listening socket. The manager
+   * replies with a [[StreamTcp.TcpServerBinding]]. If the local port is set to 0 in
+   * the Bind message, then the [[StreamTcp.TcpServerBinding]] message should be inspected to find
+   * the actual port which was bound to.
+   *
+   * @param localAddress The socket address to bind to; use port zero for
+   *                automatic assignment (i.e. an ephemeral port)
+   *
+   * @param backlog This specifies the number of unaccepted connections the O/S
+   *                kernel will hold for this port before refusing connections.
+   *
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   */
+  def bind(settings: MaterializerSettings,
+           localAddress: InetSocketAddress,
+           backlog: Int,
+           options: java.lang.Iterable[SocketOption]): StreamTcp.Bind =
+    StreamTcp.Bind(settings, localAddress, backlog, Util.immutableSeq(options))
+
+  /**
+   * Java API: Message to open a listening socket without specifying options.
+   */
+  def bind(settings: MaterializerSettings,
+           localAddress: InetSocketAddress): StreamTcp.Bind =
+    StreamTcp.Bind(settings, localAddress)
 }
 
 /**
@@ -81,14 +197,14 @@ private[akka] class StreamTcpManager extends Actor {
   }
 
   def receive: Receive = {
-    case StreamTcp.Connect(remoteAddress, localAddress, options, timeout, settings) ⇒
+    case StreamTcp.Connect(settings, remoteAddress, localAddress, options, timeout) ⇒
       val processorActor = context.actorOf(TcpStreamActor.outboundProps(
         Tcp.Connect(remoteAddress, localAddress, options, timeout, pullMode = true),
         requester = sender(),
         settings), name = encName("client", remoteAddress))
       processorActor ! ExposedProcessor(new ActorProcessor[ByteString, ByteString](processorActor))
 
-    case StreamTcp.Bind(localAddress, backlog, options, settings) ⇒
+    case StreamTcp.Bind(settings, localAddress, backlog, options) ⇒
       val publisherActor = context.actorOf(TcpListenStreamActor.props(
         Tcp.Bind(context.system.deadLetters, localAddress, backlog, options, pullMode = true),
         requester = sender(),

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Duct.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Duct.scala
@@ -3,13 +3,15 @@
  */
 package akka.stream.scaladsl
 
-import scala.collection.immutable
-import akka.stream.impl.DuctImpl
-import org.reactivestreams.api.Consumer
-import akka.stream.FlowMaterializer
 import scala.annotation.unchecked.uncheckedVariance
-import org.reactivestreams.api.Producer
+import scala.collection.immutable
 import scala.util.Try
+import org.reactivestreams.api.Consumer
+import org.reactivestreams.api.Producer
+import akka.stream.FlowMaterializer
+import akka.stream.RecoveryTransformer
+import akka.stream.Transformer
+import akka.stream.impl.DuctImpl
 
 object Duct {
 

--- a/akka-stream/src/test/java/akka/stream/javadsl/AkkaJUnitActorSystemResource.java
+++ b/akka-stream/src/test/java/akka/stream/javadsl/AkkaJUnitActorSystemResource.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.javadsl;
+
+import org.junit.rules.ExternalResource;
+
+import akka.actor.ActorSystem;
+import akka.stream.testkit.AkkaSpec;
+import akka.testkit.JavaTestKit;
+
+import com.typesafe.config.Config;
+
+// FIXME remove this copy, and use akka.testkit.AkkaJUnitActorSystemResource when
+//       akka-stream-experimental becomes a normal build project
+
+/**
+ * This is a resource for creating an actor system before test start and shut it
+ * down afterwards.
+ * 
+ * To use it on a class level add this to your test class:
+ * 
+ * @ClassRule public static AkkaJUnitActorSystemResource actorSystemResource =
+ *            new AkkaJUnitActorSystemResource(name, config);
+ * 
+ *            private final ActorSystem system =
+ *            actorSystemResource.getSystem();
+ * 
+ * 
+ *            To use it on a per test level add this to your test class:
+ * 
+ * @Rule public AkkaJUnitActorSystemResource actorSystemResource = new
+ *       AkkaJUnitActorSystemResource(name, config);
+ * 
+ *       private final ActorSystem system = actorSystemResource.getSystem();
+ */
+
+public class AkkaJUnitActorSystemResource extends ExternalResource {
+  private ActorSystem system = null;
+  private final String name;
+  private final Config config;
+
+  private ActorSystem createSystem(String name, Config config) {
+    try {
+      if (config == null)
+        return ActorSystem.create(name);
+      else
+        return ActorSystem.create(name, config);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  public AkkaJUnitActorSystemResource(String name, Config config) {
+    this.name = name;
+    this.config = config;
+    system = createSystem(name, config);
+  }
+
+  public AkkaJUnitActorSystemResource(String name) {
+    this(name, AkkaSpec.testConf());
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    // Sometimes the ExternalResource seems to be reused, and
+    // we don't run the constructor again, so if that's the case
+    // then create the system here
+    if (system == null) {
+      system = createSystem(name, config);
+    }
+  }
+
+  @Override
+  protected void after() {
+    JavaTestKit.shutdownActorSystem(system);
+    system = null;
+  }
+
+  public ActorSystem getSystem() {
+    return system;
+  }
+}

--- a/akka-stream/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -1,0 +1,370 @@
+package akka.stream.javadsl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.reactivestreams.api.Producer;
+
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.japi.Function;
+import akka.japi.Function2;
+import akka.japi.Procedure;
+import akka.japi.Util;
+import akka.stream.FlowMaterializer;
+import akka.stream.MaterializerSettings;
+import akka.stream.RecoveryTransformer;
+import akka.stream.Transformer;
+import akka.stream.testkit.AkkaSpec;
+import akka.testkit.JavaTestKit;
+
+public class FlowTest {
+
+  @ClassRule
+  public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource("StashJavaAPI",
+      AkkaSpec.testConf());
+
+  final ActorSystem system = actorSystemResource.getSystem();
+
+  final MaterializerSettings settings = MaterializerSettings.create();
+  final FlowMaterializer materializer = FlowMaterializer.create(settings, system);
+
+  @Test
+  public void mustBeAbleToUseSimpleOperators() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final String[] lookup = { "a", "b", "c", "d", "e", "f" };
+    final java.util.Iterator<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5).iterator();
+    Flow.create(input).drop(2).take(3).map(new Function<Integer, String>() {
+      public String apply(Integer elem) {
+        return lookup[elem];
+      }
+    }).filter(new Predicate<String>() {
+      public boolean test(String elem) {
+        return !elem.equals("c");
+      }
+    }).grouped(2).mapConcat(new Function<java.util.List<String>, java.util.List<String>>() {
+      public java.util.List<String> apply(java.util.List<String> elem) {
+        return elem;
+      }
+    }).fold("", new Function2<String, String, String>() {
+      public String apply(String acc, String elem) {
+        return acc + elem;
+      }
+    }).foreach(new Procedure<String>() {
+      public void apply(String elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }).consume(materializer);
+
+    probe.expectMsgEquals("de");
+
+  }
+
+  @Test
+  public void mustBeAbleToUseTransform() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final JavaTestKit probe2 = new JavaTestKit(system);
+    final java.lang.Iterable<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7);
+    // duplicate each element, stop after 4 elements, and emit sum to the end
+    Flow.create(input).transform(new Transformer<Integer, Integer>() {
+      int sum = 0;
+      int count = 0;
+
+      @Override
+      public scala.collection.immutable.Seq<Integer> onNext(Integer element) {
+        sum += element;
+        count += 1;
+        return Util.immutableSeq(new Integer[] { element, element });
+      }
+
+      @Override
+      public boolean isComplete() {
+        return count == 4;
+      }
+
+      @Override
+      public scala.collection.immutable.Seq<Integer> onComplete() {
+        return Util.immutableSingletonSeq(sum);
+      }
+
+      @Override
+      public void cleanup() {
+        probe2.getRef().tell("cleanup", ActorRef.noSender());
+      }
+    }).foreach(new Procedure<Integer>() {
+      public void apply(Integer elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }).consume(materializer);
+
+    probe.expectMsgEquals(0);
+    probe.expectMsgEquals(0);
+    probe.expectMsgEquals(1);
+    probe.expectMsgEquals(1);
+    probe.expectMsgEquals(2);
+    probe.expectMsgEquals(2);
+    probe.expectMsgEquals(3);
+    probe.expectMsgEquals(3);
+    probe.expectMsgEquals(6);
+    probe2.expectMsgEquals("cleanup");
+  }
+
+  @Test
+  public void mustBeAbleToUseTransformRecover() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5);
+    Flow.create(input).map(new Function<Integer, Integer>() {
+      public Integer apply(Integer elem) {
+        if (elem == 4)
+          throw new IllegalArgumentException("4 not allowed");
+        else
+          return elem + elem;
+      }
+    }).transformRecover(new RecoveryTransformer<Integer, String>() {
+
+      @Override
+      public scala.collection.immutable.Seq<String> onNext(Integer element) {
+        return Util.immutableSingletonSeq(element.toString());
+      }
+
+      @Override
+      public scala.collection.immutable.Seq<String> onErrorRecover(Throwable e) {
+        return Util.immutableSingletonSeq(e.getMessage());
+      }
+
+      @Override
+      public boolean isComplete() {
+        return false;
+      }
+
+      @Override
+      public scala.collection.immutable.Seq<String> onComplete() {
+        return Util.immutableSeq(new String[0]);
+      }
+
+      @Override
+      public void cleanup() {
+      }
+
+    }).foreach(new Procedure<String>() {
+      public void apply(String elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }).consume(materializer);
+
+    probe.expectMsgEquals("0");
+    probe.expectMsgEquals("2");
+    probe.expectMsgEquals("4");
+    probe.expectMsgEquals("6");
+    probe.expectMsgEquals("4 not allowed");
+  }
+
+  @Test
+  public void mustBeAbleToUseGroupBy() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input = Arrays.asList("Aaa", "Abb", "Bcc", "Cdd", "Cee");
+    Flow.create(input).groupBy(new Function<String, String>() {
+      public String apply(String elem) {
+        return elem.substring(0, 1);
+      }
+    }).foreach(new Procedure<Pair<String, Producer<String>>>() {
+      public void apply(final Pair<String, Producer<String>> pair) {
+        Flow.create(pair.b()).foreach(new Procedure<String>() {
+          public void apply(String elem) {
+            probe.getRef().tell(new Pair<String, String>(pair.a(), elem), ActorRef.noSender());
+          }
+        }).consume(materializer);
+      }
+    }).consume(materializer);
+
+    Map<String, List<String>> grouped = new HashMap<String, List<String>>();
+    for (Object o : probe.receiveN(5)) {
+      @SuppressWarnings("unchecked")
+      Pair<String, String> p = (Pair<String, String>) o;
+      List<String> g = grouped.get(p.a());
+      if (g == null)
+        g = new ArrayList<String>();
+      g.add(p.b());
+      grouped.put(p.a(), g);
+    }
+
+    assertEquals(Arrays.asList("Aaa", "Abb"), grouped.get("A"));
+
+  }
+
+  @Test
+  public void mustBeAbleToUseSplitWhen() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input = Arrays.asList("A", "B", "C", "\n", "D", "\n", "E", "F");
+    Flow.create(input).splitWhen(new Predicate<String>() {
+      public boolean test(String elem) {
+        return elem.equals("\n");
+      }
+    }).foreach(new Procedure<Producer<String>>() {
+      public void apply(Producer<String> subProducer) {
+        Flow.create(subProducer).filter(new Predicate<String>() {
+          public boolean test(String elem) {
+            return !elem.equals("\n");
+          }
+        }).grouped(10).foreach(new Procedure<List<String>>() {
+          public void apply(List<String> chunk) {
+            probe.getRef().tell(chunk, ActorRef.noSender());
+          }
+        }).consume(materializer);
+      }
+    }).consume(materializer);
+
+    for (Object o : probe.receiveN(3)) {
+      @SuppressWarnings("unchecked")
+      List<String> chunk = (List<String>) o;
+      if (chunk.get(0).equals("A"))
+        assertEquals(Arrays.asList("A", "B", "C"), chunk);
+      else if (chunk.get(0).equals("D"))
+        assertEquals(Arrays.asList("D"), chunk);
+      else if (chunk.get(0).equals("E"))
+        assertEquals(Arrays.asList("E", "F"), chunk);
+      else
+        assertEquals("[A, B, C] or [D] or [E, F]", chunk);
+    }
+
+  }
+
+  @Test
+  public void mustBeAbleToUseMerge() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input1 = Arrays.asList("A", "B", "C");
+    final java.lang.Iterable<String> input2 = Arrays.asList("D", "E", "F");
+    Flow.create(input1).merge(Flow.create(input2).toProducer(materializer)).foreach(new Procedure<String>() {
+      public void apply(String elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }).consume(materializer);
+
+    Set<Object> output = new HashSet<Object>(Arrays.asList(probe.receiveN(6)));
+    assertEquals(new HashSet<Object>(Arrays.asList("A", "B", "C", "D", "E", "F")), output);
+  }
+
+  @Test
+  public void mustBeAbleToUseZip() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input1 = Arrays.asList("A", "B", "C");
+    final java.lang.Iterable<Integer> input2 = Arrays.asList(1, 2, 3);
+    Flow.create(input1).zip(Flow.create(input2).toProducer(materializer))
+        .foreach(new Procedure<Pair<String, Integer>>() {
+          public void apply(Pair<String, Integer> elem) {
+            probe.getRef().tell(elem, ActorRef.noSender());
+          }
+        }).consume(materializer);
+
+    List<Object> output = Arrays.asList(probe.receiveN(3));
+    @SuppressWarnings("unchecked")
+    List<Pair<String, Integer>> expected = Arrays.asList(new Pair<String, Integer>("A", 1), new Pair<String, Integer>(
+        "B", 2), new Pair<String, Integer>("C", 3));
+    assertEquals(expected, output);
+  }
+
+  @Test
+  public void mustBeAbleToUseConcat() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input1 = Arrays.asList("A", "B", "C");
+    final java.lang.Iterable<String> input2 = Arrays.asList("D", "E", "F");
+    Flow.create(input1).concat(Flow.create(input2).toProducer(materializer)).foreach(new Procedure<String>() {
+      public void apply(String elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }).consume(materializer);
+
+    List<Object> output = Arrays.asList(probe.receiveN(6));
+    assertEquals(Arrays.asList("A", "B", "C", "D", "E", "F"), output);
+  }
+
+  @Test
+  public void mustBeAbleToUseCallableInput() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final Callable<Integer> input = new Callable<Integer>() {
+      int countdown = 5;
+
+      @Override
+      public Integer call() {
+        if (countdown == 0)
+          throw akka.stream.Stop.getInstance();
+        else {
+          countdown -= 1;
+          return countdown;
+        }
+      }
+    };
+    Flow.create(input).foreach(new Procedure<Integer>() {
+      public void apply(Integer elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }).consume(materializer);
+
+    List<Object> output = Arrays.asList(probe.receiveN(5));
+    assertEquals(Arrays.asList(4, 3, 2, 1, 0), output);
+    probe.expectNoMsg(FiniteDuration.create(500, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void mustBeAbleToUseOnCompleteSuccess() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input = Arrays.asList("A", "B", "C");
+    Flow.create(input).onComplete(materializer, new OnCompleteCallback() {
+      @Override
+      public void onComplete(Throwable e) {
+        if (e == null)
+          probe.getRef().tell("done", ActorRef.noSender());
+        else
+          probe.getRef().tell(e, ActorRef.noSender());
+      }
+    });
+
+    probe.expectMsgEquals("done");
+  }
+
+  @Test
+  public void mustBeAbleToUseOnCompleteError() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input = Arrays.asList("A", "B", "C");
+    Flow.create(input).map(new Function<String, String>() {
+      public String apply(String arg0) throws Exception {
+        throw new RuntimeException("simulated err");
+      }
+    }).onComplete(materializer, new OnCompleteCallback() {
+      @Override
+      public void onComplete(Throwable e) {
+        if (e == null)
+          probe.getRef().tell("done", ActorRef.noSender());
+        else
+          probe.getRef().tell(e, ActorRef.noSender());
+      }
+    });
+
+    probe.expectMsgEquals("simulated err");
+  }
+
+  @Test
+  public void mustBeAbleToUseToFuture() throws Exception {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final java.lang.Iterable<String> input = Arrays.asList("A", "B", "C");
+    Future<String> future = Flow.create(input).toFuture(materializer);
+    String result = Await.result(future, probe.dilated(FiniteDuration.create(3, TimeUnit.SECONDS)));
+    assertEquals("A", result);
+  }
+
+}

--- a/akka-stream/src/test/scala/akka/stream/FlowTransformRecoverSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTransformRecoverSpec.scala
@@ -11,7 +11,6 @@ import akka.testkit.EventFilter
 import scala.util.Failure
 import scala.util.control.NoStackTrace
 import akka.stream.scaladsl.Flow
-import akka.stream.scaladsl.RecoveryTransformer
 import scala.util.Try
 import scala.util.Success
 

--- a/akka-stream/src/test/scala/akka/stream/FlowTransformSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTransformSpec.scala
@@ -10,7 +10,6 @@ import akka.testkit.EventFilter
 import com.typesafe.config.ConfigFactory
 import akka.stream.scaladsl.Flow
 import akka.testkit.TestProbe
-import akka.stream.scaladsl.Transformer
 import scala.util.control.NoStackTrace
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-stream/src/test/scala/akka/stream/IdentityProcessorTest.scala
+++ b/akka-stream/src/test/scala/akka/stream/IdentityProcessorTest.scala
@@ -14,7 +14,6 @@ import akka.stream.impl.Ast
 import akka.testkit.{ TestEvent, EventFilter }
 import akka.stream.impl.ActorBasedFlowMaterializer
 import akka.stream.scaladsl.Flow
-import akka.stream.scaladsl.Transformer
 import akka.stream.testkit.AkkaSpec
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/akka-stream/src/test/scala/akka/stream/ProcessorNamingSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/ProcessorNamingSpec.scala
@@ -12,7 +12,6 @@ import akka.actor.ActorRef
 import scala.collection.immutable.TreeSet
 import scala.util.control.NonFatal
 import akka.stream.impl.ActorBasedFlowMaterializer
-import akka.stream.scaladsl.Transformer
 import akka.stream.impl.FlowNameCounter
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])

--- a/akka-stream/src/test/scala/akka/stream/io/TcpFlowSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/io/TcpFlowSpec.scala
@@ -179,7 +179,7 @@ class TcpFlowSpec extends AkkaSpec {
 
   def connect(server: Server): (Processor[ByteString, ByteString], ServerConnection) = {
     val tcpProbe = TestProbe()
-    tcpProbe.send(IO(StreamTcp), StreamTcp.Connect(server.address, settings = settings))
+    tcpProbe.send(IO(StreamTcp), StreamTcp.Connect(settings, server.address))
     val client = server.waitAccept()
     val outgoingConnection = tcpProbe.expectMsgType[StreamTcp.OutgoingTcpConnection]
 
@@ -188,13 +188,13 @@ class TcpFlowSpec extends AkkaSpec {
 
   def connect(serverAddress: InetSocketAddress): StreamTcp.OutgoingTcpConnection = {
     val connectProbe = TestProbe()
-    connectProbe.send(IO(StreamTcp), StreamTcp.Connect(serverAddress, settings = settings))
+    connectProbe.send(IO(StreamTcp), StreamTcp.Connect(settings, serverAddress))
     connectProbe.expectMsgType[StreamTcp.OutgoingTcpConnection]
   }
 
   def bind(serverAddress: InetSocketAddress = temporaryServerAddress): StreamTcp.TcpServerBinding = {
     val bindProbe = TestProbe()
-    bindProbe.send(IO(StreamTcp), StreamTcp.Bind(serverAddress, settings = settings))
+    bindProbe.send(IO(StreamTcp), StreamTcp.Bind(settings, serverAddress))
     bindProbe.expectMsgType[StreamTcp.TcpServerBinding]
   }
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -297,7 +297,7 @@ object AkkaBuild extends Build {
     id = "akka-stream-experimental",
     base = file("akka-stream"),
     settings = defaultSettings ++ formatSettings ++ scaladocSettings ++ experimentalSettings ++ javadocSettings ++ OSGi.stream ++ Seq(
-      version := "0.2-SNAPSHOT",
+      version := "0.3-SNAPSHOT",
       libraryDependencies ++= Dependencies.stream,
       // FIXME include mima when akka-stream-experimental-2.3.x has been released
       //previousArtifact := akkaPreviousArtifact("akka-stream-experimental")


### PR DESCRIPTION
- First stab for early review only

This is how it looks like:

``` scala
    final ActorSystem system = ActorSystem.create("Sys");
    final MaterializerSettings settings = MaterializerSettings.create();
    final FlowMaterializer materializer = FlowMaterializer.create(settings, system);

    final String[] lookup = { "a", "b", "c", "d", "e", "f" };
    final java.lang.Iterable<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5);
    Flow.create(input).drop(2).take(3).
      map(new Function<Integer, String>() {
        public String apply(Integer elem) {
          return lookup[elem];
        }
      }).
      filter(new Predicate<String>() {
        public boolean defined(String elem) {
          return !elem.equals("c");
        }
      }).
      grouped(2).mapConcat(new Function<java.util.List<String>, java.util.List<String>>() {
        public java.util.List<String> apply(java.util.List<String> elem) {
          return elem;
        }
      }).fold("", new Function2<String, String, String>() {
        public String apply(String acc, String elem) {
          return acc + elem;
        }
      }).foreach(new Procedure<String>() {
        public void apply(String elem) {
          System.out.println(elem);
        }
      }).consume(materializer);
```

And in Java8:

``` java
    final ActorSystem system = ActorSystem.create("Sys");
    final MaterializerSettings settings = MaterializerSettings.create();
    final FlowMaterializer materializer = FlowMaterializer.create(settings, system);

    final String[] lookup = { "a", "b", "c", "d", "e", "f" };
    final java.lang.Iterable<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5);
    Flow.create(input).drop(2).take(3).
      map(elem -> lookup[elem]).
      filter(elem -> !elem.equals("c")).
      grouped(2).
      mapConcat(elem -> elem).
      fold("", (acc, elem) -> acc + elem).
      foreach(elem -> System.out.println(elem)).
      consume(materializer);
```
