### PR TITLE
=rem #13960 #13989 #13742 #13985  Optimize EndpointWriter (for validation)

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -10,6 +10,7 @@ import akka.actor.{ ActorLogging, ActorRef, ActorSelection, Address, Actor, Root
 import akka.cluster.ClusterEvent._
 import akka.routing.MurmurHash
 import akka.remote.FailureDetectorRegistry
+import akka.remote.PriorityMessage
 
 /**
  * INTERNAL API.
@@ -34,12 +35,12 @@ private[cluster] object ClusterHeartbeatSender {
   /**
    * Sent at regular intervals for failure detection.
    */
-  case class Heartbeat(from: Address) extends ClusterMessage
+  case class Heartbeat(from: Address) extends ClusterMessage with PriorityMessage
 
   /**
    * Sent as reply to [[Heartbeat]] messages.
    */
-  case class HeartbeatRsp(from: UniqueAddress) extends ClusterMessage
+  case class HeartbeatRsp(from: UniqueAddress) extends ClusterMessage with PriorityMessage
 
   // sent to self only
   case object HeartbeatTick

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -80,7 +80,7 @@ akka {
 
     # Controls the backoff interval after a refused write is reattempted.
     # (Transports may refuse writes if their internal buffer is full)
-    backoff-interval = 0.01 s
+    backoff-interval = 5 ms
 
     # Acknowledgment timeout of management commands sent to the transport stack.
     command-ack-timeout = 30 s
@@ -142,46 +142,33 @@ akka {
     # a value in bytes, such as 1000b. Note that for all messages larger than this
     # limit there will be extra performance and scalability cost.
     log-frame-size-exceeding = off
+    
+    # Log warning if the number of messages in the backoff buffer in the endpoint
+    # writer exceeds this limit. It can be disabled by setting the value to off.
+    log-buffer-size-exceeding = 50000
 
     ### Failure detection and recovery
 
-    # Settings for the Phi accrual failure detector (http://ddg.jaist.ac.jp/pub/HDY+04.pdf
-    # [Hayashibara et al]) used by the remoting subsystem to detect failed
-    # connections.
+    # Settings for the failure detector to monitor connections.
+    # For TCP it is not important to have fast failure detection, since
+    # most connection failures are captured by TCP itself. 
     transport-failure-detector {
 
       # FQCN of the failure detector implementation.
       # It must implement akka.remote.FailureDetector and have
       # a public constructor with a com.typesafe.config.Config and
       # akka.actor.EventStream parameter.
-      implementation-class = "akka.remote.PhiAccrualFailureDetector"
+      implementation-class = "akka.remote.DeadlineFailureDetector"
 
       # How often keep-alive heartbeat messages should be sent to each connection.
       heartbeat-interval = 4 s
 
-      # Defines the failure detector threshold.
-      # A low threshold is prone to generate many wrong suspicions but ensures
-      # a quick detection in the event of a real crash. Conversely, a high
-      # threshold generates fewer mistakes but needs more time to detect
-      # actual crashes.
-      threshold = 7.0
-
-      # Number of the samples of inter-heartbeat arrival times to adaptively
-      # calculate the failure timeout for connections.
-      max-sample-size = 100
-
-      # Minimum standard deviation to use for the normal distribution in
-      # AccrualFailureDetector. Too low standard deviation might result in
-      # too much sensitivity for sudden, but normal, deviations in heartbeat
-      # inter arrival times.
-      min-std-deviation = 100 ms
-
       # Number of potentially lost/delayed heartbeats that will be
       # accepted before considering it to be an anomaly.
-      # This margin is important to be able to survive sudden, occasional,
-      # pauses in heartbeat arrivals, due to for example garbage collect or
+      # A margin to the `heartbeat-interval` is important to be able to survive sudden,
+      # occasional, pauses in heartbeat arrivals, due to for example garbage collect or
       # network drop.
-      acceptable-heartbeat-pause = 10 s
+      acceptable-heartbeat-pause = 20 s
     }
 
     # Settings for the Phi accrual failure detector (http://ddg.jaist.ac.jp/pub/HDY+04.pdf
@@ -485,6 +472,16 @@ akka {
     ### Default dispatcher for the remoting subsystem
 
     default-remote-dispatcher {
+      type = Dispatcher
+      executor = "fork-join-executor"
+      fork-join-executor {
+        # Min number of threads to cap factor-based parallelism number to
+        parallelism-min = 2
+        parallelism-max = 2
+      }
+    }
+    
+    backoff-remote-dispatcher {
       type = Dispatcher
       executor = "fork-join-executor"
       fork-join-executor {

--- a/akka-remote/src/main/scala/akka/remote/DeadlineFailureDetector.scala
+++ b/akka-remote/src/main/scala/akka/remote/DeadlineFailureDetector.scala
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.remote
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+import com.typesafe.config.Config
+import akka.event.EventStream
+import akka.remote.FailureDetector.Clock
+import akka.util.Helpers.ConfigOps
+
+/**
+ * Implementation of failure detector using an absolute timeout of missing heartbeats
+ * to trigger unavailability.
+ *
+ * @param acceptableHeartbeatPause Duration corresponding to number of potentially lost/delayed
+ *   heartbeats that will be accepted before considering it to be an anomaly.
+ *
+ * @param clock The clock, returning current time in milliseconds, but can be faked for testing
+ *   purposes. It is only used for measuring intervals (duration).
+ */
+class DeadlineFailureDetector(
+  val acceptableHeartbeatPause: FiniteDuration)(
+    implicit clock: Clock) extends FailureDetector {
+
+  /**
+   * Constructor that reads parameters from config.
+   * Expecting config properties named `acceptable-heartbeat-pause`.
+   */
+  def this(config: Config, ev: EventStream) =
+    this(acceptableHeartbeatPause = config.getMillisDuration("acceptable-heartbeat-pause"))
+
+  require(acceptableHeartbeatPause >= Duration.Zero, "failure-detector.acceptable-heartbeat-pause must be >= 0")
+
+  private val acceptableHeartbeatPauseMillis = acceptableHeartbeatPause.toMillis
+  @volatile private var heartbeatTimestamp = 0L //not used until active (first heartbeat)
+  @volatile private var active = false
+
+  override def isAvailable: Boolean = isAvailable(clock())
+
+  private def isAvailable(timestamp: Long): Boolean =
+    if (active) (heartbeatTimestamp + acceptableHeartbeatPauseMillis) > timestamp
+    else true // treat unmanaged connections, e.g. with zero heartbeats, as healthy connections
+
+  override def isMonitoring: Boolean = active
+
+  final override def heartbeat(): Unit = {
+    heartbeatTimestamp = clock()
+    active = true
+  }
+
+}
+

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -25,6 +25,9 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.tailrec
 import scala.concurrent.duration.{ Duration, Deadline }
 import scala.util.control.NonFatal
+import java.util.concurrent.locks.LockSupport
+import scala.concurrent.Future
+import scala.concurrent.blocking
 
 /**
  * INTERNAL API
@@ -315,7 +318,8 @@ private[remote] class ReliableDeliverySupervisor(
       uid = Some(receivedUid)
       resendAll()
 
-    case s: EndpointWriter.StopReading ⇒ writer forward s
+    case s: EndpointWriter.StopReading ⇒
+      writer forward s
   }
 
   def gated: Receive = {
@@ -338,8 +342,9 @@ private[remote] class ReliableDeliverySupervisor(
     case s @ Send(msg: SystemMessage, _, _, _) ⇒ tryBuffer(s.copy(seqOpt = Some(nextSeq())))
     case s: Send                               ⇒ context.system.deadLetters ! s
     case EndpointWriter.FlushAndStop           ⇒ context.stop(self)
-    case EndpointWriter.StopReading(w)         ⇒ sender() ! EndpointWriter.StoppedReading(w)
-    case _                                     ⇒ // Ignore
+    case EndpointWriter.StopReading(w, replyTo) ⇒
+      replyTo ! EndpointWriter.StoppedReading(w)
+      sender() ! EndpointWriter.StoppedReading(w)
   }
 
   def idle: Receive = {
@@ -352,8 +357,9 @@ private[remote] class ReliableDeliverySupervisor(
       writer = createWriter()
       // Resending will be triggered by the incoming GotUid message after the connection finished
       context.become(receive)
-    case EndpointWriter.FlushAndStop   ⇒ context.stop(self)
-    case EndpointWriter.StopReading(w) ⇒ sender() ! EndpointWriter.StoppedReading(w)
+    case EndpointWriter.FlushAndStop ⇒ context.stop(self)
+    case EndpointWriter.StopReading(w, replyTo) ⇒
+      replyTo ! EndpointWriter.StoppedReading(w)
   }
 
   def flushWait: Receive = {
@@ -452,25 +458,26 @@ private[remote] object EndpointWriter {
    * used instead.
    * @param handle Handle of the new inbound association.
    */
-  case class TakeOver(handle: AkkaProtocolHandle) extends NoSerializationVerificationNeeded
+  case class TakeOver(handle: AkkaProtocolHandle, replyTo: ActorRef) extends NoSerializationVerificationNeeded
   case class TookOver(writer: ActorRef, handle: AkkaProtocolHandle) extends NoSerializationVerificationNeeded
   case object BackoffTimer
   case object FlushAndStop
+  private case object FlushAndStopTimeout
   case object AckIdleCheckTimer
-  case class StopReading(writer: ActorRef)
+  case class StopReading(writer: ActorRef, replyTo: ActorRef)
   case class StoppedReading(writer: ActorRef)
 
   case class Handle(handle: AkkaProtocolHandle) extends NoSerializationVerificationNeeded
 
   case class OutboundAck(ack: Ack)
 
-  sealed trait State
-  case object Initializing extends State
-  case object Buffering extends State
-  case object Writing extends State
-  case object Handoff extends State
+  // These settings are not configurable because wrong configuration will break the auto-tuning 
+  private val SendBufferBatchSize = 5
+  private val MinAdaptiveBackoffNanos = 300000L // 0.3 ms
+  private val MaxAdaptiveBackoffNanos = 2000000L // 2 ms
+  private val LogBufferSizeInterval = 5000000000L // 5 s, in nanoseconds
+  private val MaxWriteCount = 50
 
-  val AckIdleTimerName = "AckIdleTimer"
 }
 
 /**
@@ -486,17 +493,17 @@ private[remote] class EndpointWriter(
   codec: AkkaPduCodec,
   val receiveBuffers: ConcurrentHashMap[Link, ResendState],
   val reliableDeliverySupervisor: Option[ActorRef])
-  extends EndpointActor(localAddress, remoteAddress, transport, settings, codec) with UnboundedStash
-  with FSM[EndpointWriter.State, Unit] {
+  extends EndpointActor(localAddress, remoteAddress, transport, settings, codec) {
 
   import EndpointWriter._
   import context.dispatcher
 
   val extendedSystem: ExtendedActorSystem = context.system.asInstanceOf[ExtendedActorSystem]
   val remoteMetrics = RemoteMetricsExtension(extendedSystem)
+  val backoffDispatcher = context.system.dispatchers.lookup("akka.remote.backoff-remote-dispatcher")
 
   var reader: Option[ActorRef] = None
-  var handle: Option[AkkaProtocolHandle] = handleOrActive // FIXME: refactor into state data
+  var handle: Option[AkkaProtocolHandle] = handleOrActive
   val readerId = Iterator from 0
 
   def newAckDeadline: Deadline = Deadline.now + settings.SysMsgAckTimeout
@@ -511,8 +518,15 @@ private[remote] class EndpointWriter(
   val provider = RARP(extendedSystem).provider
   val msgDispatch = new DefaultMessageDispatcher(extendedSystem, provider, log)
 
-  var inbound = handle.isDefined
+  val inbound = handle.isDefined
   var stopReason: DisassociateInfo = AssociationHandle.Unknown
+
+  // Use an internal buffer instead of Stash for efficiency
+  // stash/unstashAll is slow when many messages are stashed
+  // IMPORTANT: sender is not stored, so sender() and forward must not be used in EndpointWriter
+  val buffer = new java.util.LinkedList[AnyRef]
+  val prioBuffer = new java.util.LinkedList[Send]
+  var largeBufferLogTimestamp = System.nanoTime()
 
   private def publishAndThrow(reason: Throwable, logLevel: Logging.LogLevel): Nothing = {
     reason match {
@@ -522,180 +536,298 @@ private[remote] class EndpointWriter(
     throw reason
   }
 
-  private def logAndStay(reason: Throwable): State = {
-    log.error(reason, "Transient association error (association remains live)")
-    stay()
-  }
-
-  override def postRestart(reason: Throwable): Unit = {
-    handle = None // Wipe out the possibly injected handle
-    inbound = false
-    preStart()
+  val ackIdleTimer = {
+    val interval = settings.SysMsgAckTimeout / 2
+    context.system.scheduler.schedule(interval, interval, self, AckIdleCheckTimer)
   }
 
   override def preStart(): Unit = {
-
-    setTimer(AckIdleTimerName, AckIdleCheckTimer, settings.SysMsgAckTimeout / 2, repeat = true)
-
-    startWith(
-      handle match {
-        case Some(h) ⇒
-          reader = startReadEndpoint(h)
-          Writing
-        case None ⇒
-          transport.associate(remoteAddress, refuseUid).map(Handle(_)) pipeTo self
-          Initializing
-      },
-      stateData = ())
+    handle match {
+      case Some(h) ⇒
+        reader = startReadEndpoint(h)
+      case None ⇒
+        transport.associate(remoteAddress, refuseUid).map(Handle(_)) pipeTo self
+    }
   }
 
-  when(Initializing) {
-    case Event(Send(msg, senderOption, recipient, _), _) ⇒
-      stash()
-      stay()
-    case Event(Status.Failure(e: InvalidAssociationException), _) ⇒
+  override def postRestart(reason: Throwable): Unit =
+    throw new IllegalStateException("EndpointWriter must not be restarted")
+
+  override def postStop(): Unit = {
+    ackIdleTimer.cancel()
+    while (!prioBuffer.isEmpty)
+      extendedSystem.deadLetters ! prioBuffer.poll
+    while (!buffer.isEmpty)
+      extendedSystem.deadLetters ! buffer.poll
+    handle foreach { _.disassociate(stopReason) }
+    eventPublisher.notifyListeners(DisassociatedEvent(localAddress, remoteAddress, inbound))
+  }
+
+  def receive = if (handle.isEmpty) initializing else writing
+
+  def initializing: Receive = {
+    case s: Send ⇒
+      enqueueInBuffer(s)
+    case Status.Failure(e: InvalidAssociationException) ⇒
       publishAndThrow(new InvalidAssociation(localAddress, remoteAddress, e), Logging.WarningLevel)
-    case Event(Status.Failure(e), _) ⇒
+    case Status.Failure(e) ⇒
       publishAndThrow(new EndpointAssociationException(s"Association failed with [$remoteAddress]", e), Logging.DebugLevel)
-    case Event(Handle(inboundHandle), _) ⇒
+    case Handle(inboundHandle) ⇒
       // Assert handle == None?
       context.parent ! ReliableDeliverySupervisor.GotUid(inboundHandle.handshakeInfo.uid)
       handle = Some(inboundHandle)
       reader = startReadEndpoint(inboundHandle)
-      goto(Writing)
+      eventPublisher.notifyListeners(AssociatedEvent(localAddress, remoteAddress, inbound))
+      becomeWritingOrSendBufferedMessages()
+  }
+
+  def enqueueInBuffer(msg: AnyRef): Unit = msg match {
+    case s @ Send(_: PriorityMessage, _, _, _) ⇒ prioBuffer offer s
+    case s @ Send(ActorSelectionMessage(_: PriorityMessage, _), _, _, _) ⇒ prioBuffer offer s
+    case _ ⇒ buffer offer msg
+  }
+
+  val buffering: Receive = {
+    case s: Send      ⇒ enqueueInBuffer(s)
+    case BackoffTimer ⇒ sendBufferedMessages()
+    case FlushAndStop ⇒
+      // Flushing is postponed after the pending writes
+      buffer offer FlushAndStop
+      context.system.scheduler.scheduleOnce(settings.FlushWait, self, FlushAndStopTimeout)
+    case FlushAndStopTimeout ⇒
+      // enough
+      flushAndStop()
+  }
+
+  def becomeWritingOrSendBufferedMessages(): Unit =
+    if (buffer.isEmpty)
+      context.become(writing)
+    else {
+      context.become(buffering)
+      sendBufferedMessages()
+    }
+
+  var writeCount = 0
+  var maxWriteCount = MaxWriteCount
+  var adaptiveBackoffNanos = 1000000L // 1 ms
+  var fullBackoff = false
+
+  // FIXME remove these counters when tuning/testing is completed
+  var fullBackoffCount = 1
+  var smallBackoffCount = 0
+  var noBackoffCount = 0
+
+  def adjustAdaptiveBackup(): Unit = {
+    maxWriteCount = math.max(writeCount, maxWriteCount)
+    if (writeCount <= SendBufferBatchSize) {
+      fullBackoff = true
+      adaptiveBackoffNanos = math.min((adaptiveBackoffNanos * 1.2).toLong, MaxAdaptiveBackoffNanos)
+    } else if (writeCount >= maxWriteCount * 0.6)
+      adaptiveBackoffNanos = math.max((adaptiveBackoffNanos * 0.9).toLong, MinAdaptiveBackoffNanos)
+    else if (writeCount <= maxWriteCount * 0.2)
+      adaptiveBackoffNanos = math.min((adaptiveBackoffNanos * 1.1).toLong, MaxAdaptiveBackoffNanos)
+
+    writeCount = 0
+  }
+
+  def sendBufferedMessages(): Unit = {
+
+    def delegate(msg: Any): Boolean = msg match {
+      case s: Send ⇒
+        writeSend(s)
+      case FlushAndStop ⇒
+        flushAndStop()
+        false
+      case s @ StopReading(_, replyTo) ⇒
+        reader.foreach(_.tell(s, replyTo))
+        true
+    }
+
+    @tailrec def writeLoop(count: Int): Boolean =
+      if (count > 0 && !buffer.isEmpty)
+        if (delegate(buffer.peek)) {
+          buffer.removeFirst()
+          writeCount += 1
+          writeLoop(count - 1)
+        } else false
+      else true
+
+    @tailrec def writePrioLoop(): Boolean =
+      if (prioBuffer.isEmpty) true
+      else writeSend(prioBuffer.peek) && { prioBuffer.removeFirst(); writePrioLoop() }
+
+    val size = buffer.size
+
+    val ok = writePrioLoop() && writeLoop(SendBufferBatchSize)
+    if (buffer.isEmpty && prioBuffer.isEmpty) {
+      // FIXME remove this when testing/tuning is completed
+      if (log.isDebugEnabled)
+        log.debug(s"Drained buffer with maxWriteCount: $maxWriteCount, fullBackoffCount: $fullBackoffCount" +
+          s", smallBackoffCount: $smallBackoffCount, noBackoffCount: $noBackoffCount " +
+          s", adaptiveBackoff: ${adaptiveBackoffNanos / 1000}")
+      fullBackoffCount = 1
+      smallBackoffCount = 0
+      noBackoffCount = 0
+
+      writeCount = 0
+      maxWriteCount = MaxWriteCount
+      context.become(writing)
+    } else if (ok) {
+      noBackoffCount += 1
+      self ! BackoffTimer
+    } else {
+
+      if (size > settings.LogBufferSizeExceeding) {
+        val now = System.nanoTime()
+        if (now - largeBufferLogTimestamp >= LogBufferSizeInterval) {
+          log.warning("[{}] buffered messages in EndpointWriter for [{}]. " +
+            "You should probably implement flow control to avoid flooding the remote connection.",
+            size, remoteAddress)
+          largeBufferLogTimestamp = now
+        }
+      }
+
+      adjustAdaptiveBackup()
+      scheduleBackoffTimer()
+    }
 
   }
 
-  when(Buffering) {
-    case Event(_: Send, _) ⇒
-      stash()
-      stay()
-
-    case Event(BackoffTimer, _) ⇒ goto(Writing)
-
-    case Event(FlushAndStop, _) ⇒
-      stash() // Flushing is postponed after the pending writes
-      stay()
+  def scheduleBackoffTimer(): Unit = {
+    if (fullBackoff) {
+      fullBackoffCount += 1
+      fullBackoff = false
+      context.system.scheduler.scheduleOnce(settings.BackoffPeriod, self, BackoffTimer)
+    } else {
+      smallBackoffCount += 1
+      val s = self
+      val backoffDeadlinelineNanoTime = System.nanoTime + adaptiveBackoffNanos
+      Future {
+        @tailrec def backoff(): Unit = {
+          val backoffNanos = backoffDeadlinelineNanoTime - System.nanoTime
+          if (backoffNanos > 0) {
+            LockSupport.parkNanos(backoffNanos)
+            // parkNanos allows for spurious wakeup, check again
+            backoff()
+          }
+        }
+        backoff()
+        s.tell(BackoffTimer, ActorRef.noSender)
+      }(backoffDispatcher)
+    }
   }
 
-  when(Writing) {
-    case Event(s @ Send(msg, senderOption, recipient, seqOption), _) ⇒
-      try {
-        handle match {
-          case Some(h) ⇒
-            if (provider.remoteSettings.LogSend) {
-              def msgLog = s"RemoteMessage: [$msg] to [$recipient]<+[${recipient.path}] from [${senderOption.getOrElse(extendedSystem.deadLetters)}]"
-              log.debug("sending message {}", msgLog)
-            }
+  val writing: Receive = {
+    case s: Send ⇒
+      if (!writeSend(s)) {
+        if (s.seqOpt.isEmpty) enqueueInBuffer(s)
+        scheduleBackoffTimer()
+        context.become(buffering)
+      }
 
-            val pdu = codec.constructMessage(
-              recipient.localAddressToUse,
-              recipient,
-              serializeMessage(msg),
-              senderOption,
-              seqOption = seqOption,
-              ackOption = lastAck)
+    // We are in Writing state, so buffer is empty, safe to stop here
+    case FlushAndStop ⇒
+      flushAndStop()
 
+    case AckIdleCheckTimer if ackDeadline.isOverdue() ⇒
+      trySendPureAck()
+  }
+
+  def writeSend(s: Send): Boolean = try {
+    handle match {
+      case Some(h) ⇒
+        if (provider.remoteSettings.LogSend) {
+          def msgLog = s"RemoteMessage: [${s.message}] to [${s.recipient}]<+[${s.recipient.path}] from [${s.senderOption.getOrElse(extendedSystem.deadLetters)}]"
+          log.debug("sending message {}", msgLog)
+        }
+
+        val pdu = codec.constructMessage(
+          s.recipient.localAddressToUse,
+          s.recipient,
+          serializeMessage(s.message),
+          s.senderOption,
+          seqOption = s.seqOpt,
+          ackOption = lastAck)
+
+        val pduSize = pdu.size
+        remoteMetrics.logPayloadBytes(s.message, pduSize)
+
+        if (pduSize > transport.maximumPayloadBytes) {
+          val reason = new OversizedPayloadException(s"Discarding oversized payload sent to ${s.recipient}: max allowed size ${transport.maximumPayloadBytes} bytes, actual size of encoded ${s.message.getClass} was ${pdu.size} bytes.")
+          log.error(reason, "Transient association error (association remains live)")
+          true
+        } else {
+          val ok = h.write(pdu)
+          if (ok) {
             ackDeadline = newAckDeadline
             lastAck = None
-
-            val pduSize = pdu.size
-            remoteMetrics.logPayloadBytes(msg, pduSize)
-
-            if (pduSize > transport.maximumPayloadBytes) {
-              logAndStay(new OversizedPayloadException(s"Discarding oversized payload sent to ${recipient}: max allowed size ${transport.maximumPayloadBytes} bytes, actual size of encoded ${msg.getClass} was ${pdu.size} bytes."))
-            } else if (h.write(pdu)) {
-              stay()
-            } else {
-              if (seqOption.isEmpty) stash()
-              goto(Buffering)
-            }
-          case None ⇒
-            throw new EndpointException("Internal error: Endpoint is in state Writing, but no association handle is present.")
+          }
+          ok
         }
-      } catch {
-        case e: NotSerializableException ⇒
-          logAndStay(e)
-        case e: EndpointException ⇒
-          publishAndThrow(e, Logging.ErrorLevel)
-        case NonFatal(e) ⇒
-          publishAndThrow(new EndpointException("Failed to write message to the transport", e), Logging.ErrorLevel)
-      }
 
-    // We are in Writing state, so stash is empty, safe to stop here
-    case Event(FlushAndStop, _) ⇒
-      // Try to send a last Ack message
-      trySendPureAck()
-      stopReason = AssociationHandle.Shutdown
-      stop()
-
-    case Event(AckIdleCheckTimer, _) if ackDeadline.isOverdue() ⇒
-      trySendPureAck()
-      stay()
+      case None ⇒
+        throw new EndpointException("Internal error: Endpoint is in state Writing, but no association handle is present.")
+    }
+  } catch {
+    case e: NotSerializableException ⇒
+      log.error(e, "Transient association error (association remains live)")
+      true
+    case e: EndpointException ⇒
+      publishAndThrow(e, Logging.ErrorLevel)
+    case NonFatal(e) ⇒
+      publishAndThrow(new EndpointException("Failed to write message to the transport", e), Logging.ErrorLevel)
   }
 
-  when(Handoff) {
-    case Event(Terminated(_), _) ⇒
+  def handoff: Receive = {
+    case Terminated(_) ⇒
       reader = startReadEndpoint(handle.get)
-      unstashAll()
-      goto(Writing)
+      becomeWritingOrSendBufferedMessages()
 
-    case _ ⇒
-      stash()
-      stay()
-
+    case s: Send ⇒
+      enqueueInBuffer(s)
   }
 
-  whenUnhandled {
-    case Event(Terminated(r), _) if r == reader.orNull ⇒
+  override def unhandled(message: Any): Unit = message match {
+    case Terminated(r) if r == reader.orNull ⇒
       publishAndThrow(new EndpointDisassociatedException("Disassociated"), Logging.DebugLevel)
-    case Event(s: StopReading, _) ⇒
+    case s @ StopReading(_, replyTo) ⇒
       reader match {
-        case Some(r) ⇒ r forward s
-        case None    ⇒ stash()
+        case Some(r) ⇒
+          r.tell(s, replyTo)
+        case None ⇒
+          // initalizing, buffer and take care of it later when buffer is sent
+          enqueueInBuffer(s)
       }
-      stay()
-    case Event(TakeOver(newHandle), _) ⇒
+    case TakeOver(newHandle, replyTo) ⇒
       // Shutdown old reader
       handle foreach { _.disassociate() }
       handle = Some(newHandle)
-      sender() ! TookOver(self, newHandle)
-      goto(Handoff)
-    case Event(FlushAndStop, _) ⇒
+      replyTo ! TookOver(self, newHandle)
+      context.become(handoff)
+    case FlushAndStop ⇒
       stopReason = AssociationHandle.Shutdown
-      stop()
-    case Event(OutboundAck(ack), _) ⇒
+      context.stop(self)
+    case OutboundAck(ack) ⇒
       lastAck = Some(ack)
-      stay()
-    case Event(AckIdleCheckTimer, _) ⇒ stay() // Ignore
+    case AckIdleCheckTimer   ⇒ // Ignore
+    case FlushAndStopTimeout ⇒ // ignore
+    case BackoffTimer        ⇒ // ignore
+    case other               ⇒ super.unhandled(other)
   }
 
-  onTransition {
-    case Initializing -> Writing ⇒
-      unstashAll()
-      eventPublisher.notifyListeners(AssociatedEvent(localAddress, remoteAddress, inbound))
-    case Writing -> Buffering ⇒
-      setTimer("backoff-timer", BackoffTimer, settings.BackoffPeriod, repeat = false)
-    case Buffering -> Writing ⇒
-      unstashAll()
-      cancelTimer("backoff-timer")
+  def flushAndStop(): Unit = {
+    // Try to send a last Ack message
+    trySendPureAck()
+    stopReason = AssociationHandle.Shutdown
+    context.stop(self)
   }
 
-  onTermination {
-    case StopEvent(_, _, _) ⇒
-      cancelTimer(AckIdleTimerName)
-      // It is important to call unstashAll() for the stash to work properly and maintain messages during restart.
-      // As the FSM trait does not call super.postStop(), this call is needed
-      unstashAll()
-      handle foreach { _.disassociate(stopReason) }
-      eventPublisher.notifyListeners(DisassociatedEvent(localAddress, remoteAddress, inbound))
-  }
-
-  private def trySendPureAck(): Unit = for (h ← handle; ack ← lastAck)
-    if (h.write(codec.constructPureAck(ack))) {
-      ackDeadline = newAckDeadline
-      lastAck = None
-    }
+  private def trySendPureAck(): Unit =
+    for (h ← handle; ack ← lastAck)
+      if (h.write(codec.constructPureAck(ack))) {
+        ackDeadline = newAckDeadline
+        lastAck = None
+      }
 
   private def startReadEndpoint(handle: AkkaProtocolHandle): Some[ActorRef] = {
     val newReader =
@@ -812,18 +944,18 @@ private[remote] class EndpointReader(
         s"max allowed size [${transport.maximumPayloadBytes}] bytes, actual size [${oversized.size}] bytes."),
         "Transient error while reading from association (association remains live)")
 
-    case StopReading(writer) ⇒
+    case StopReading(writer, replyTo) ⇒
       saveState()
       context.become(notReading)
-      sender() ! StoppedReading(writer)
+      replyTo ! StoppedReading(writer)
 
   }
 
   def notReading: Receive = {
     case Disassociated(info) ⇒ handleDisassociated(info)
 
-    case StopReading(writer) ⇒
-      sender() ! StoppedReading(writer)
+    case StopReading(writer, replyTo) ⇒
+      replyTo ! StoppedReading(writer)
 
     case InboundPayload(p) ⇒
       val (ackOption, _) = tryDecodeMessageAndAck(p)

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -66,6 +66,14 @@ final class RemoteSettings(val config: Config) {
     config.getMillisDuration("akka.remote.backoff-interval")
   } requiring (_ > Duration.Zero, "backoff-interval must be > 0")
 
+  val LogBufferSizeExceeding: Int = {
+    val key = "akka.remote.log-buffer-size-exceeding"
+    config.getString(key).toLowerCase match {
+      case "off" | "false" ⇒ Int.MaxValue
+      case _               ⇒ config.getInt(key)
+    }
+  }
+
   val SysMsgAckTimeout: FiniteDuration = {
     config.getMillisDuration("akka.remote.system-message-ack-piggyback-timeout")
   } requiring (_ > Duration.Zero, "system-message-ack-piggyback-timeout must be > 0")

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -43,8 +43,8 @@ private[akka] object RemoteWatcher {
   @SerialVersionUID(1L)
   class Rewatch(watchee: InternalActorRef, watcher: InternalActorRef) extends Watch(watchee, watcher)
 
-  @SerialVersionUID(1L) case object Heartbeat
-  @SerialVersionUID(1L) case class HeartbeatRsp(addressUid: Int)
+  @SerialVersionUID(1L) case object Heartbeat extends PriorityMessage
+  @SerialVersionUID(1L) case class HeartbeatRsp(addressUid: Int) extends PriorityMessage
 
   // sent to self only
   case object HeartbeatTick

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -240,7 +240,7 @@ private[transport] object ProtocolStateActor {
   case class ListenerReady(listener: HandleEventListener, wrappedHandle: AssociationHandle)
     extends ProtocolStateData
 
-  case object TimeoutReason
+  case class TimeoutReason(errorMessage: String)
   case object ForbiddenUidReason
 
   private[remote] def outboundProps(
@@ -414,18 +414,22 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
           stop(FSM.Failure(info))
 
         case Heartbeat ⇒
-          failureDetector.heartbeat(); stay()
+          failureDetector.heartbeat()
+          stay()
 
-        case Payload(payload) ⇒ stateData match {
-          case AssociatedWaitHandler(handlerFuture, wrappedHandle, queue) ⇒
-            // Queue message until handler is registered
-            stay() using AssociatedWaitHandler(handlerFuture, wrappedHandle, queue :+ payload)
-          case ListenerReady(listener, _) ⇒
-            listener notify InboundPayload(payload)
-            stay()
-          case msg ⇒
-            throw new AkkaProtocolException(s"unhandled message in state Open(InboundPayload) with type [${safeClassName(msg)}]")
-        }
+        case Payload(payload) ⇒
+          // use incoming ordinary message as alive sign
+          failureDetector.heartbeat()
+          stateData match {
+            case AssociatedWaitHandler(handlerFuture, wrappedHandle, queue) ⇒
+              // Queue message until handler is registered
+              stay() using AssociatedWaitHandler(handlerFuture, wrappedHandle, queue :+ payload)
+            case ListenerReady(listener, _) ⇒
+              listener notify InboundPayload(payload)
+              stay()
+            case msg ⇒
+              throw new AkkaProtocolException(s"unhandled message in state Open(InboundPayload) with type [${safeClassName(msg)}]")
+          }
 
         case _ ⇒ stay()
       }
@@ -459,7 +463,7 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
     } else {
       // send disassociate just to be sure
       sendDisassociate(wrappedHandle, Unknown)
-      stop(FSM.Failure(TimeoutReason))
+      stop(FSM.Failure(TimeoutReason("No response from remote. Handshake timed out or transport failure detector triggered.")))
     }
   }
 
@@ -482,8 +486,8 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
 
     case StopEvent(reason, _, OutboundUnderlyingAssociated(statusPromise, wrappedHandle)) ⇒
       statusPromise.tryFailure(reason match {
-        case FSM.Failure(TimeoutReason) ⇒
-          new AkkaProtocolException("No response from remote. Handshake timed out")
+        case FSM.Failure(TimeoutReason(errorMessage)) ⇒
+          new AkkaProtocolException(errorMessage)
         case FSM.Failure(info: DisassociateInfo) ⇒
           disassociateException(info)
         case FSM.Failure(ForbiddenUidReason) ⇒
@@ -526,10 +530,11 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
   }
 
   override protected def logTermination(reason: FSM.Reason): Unit = reason match {
-    case FSM.Failure(TimeoutReason)       ⇒ // no logging
     case FSM.Failure(_: DisassociateInfo) ⇒ // no logging
     case FSM.Failure(ForbiddenUidReason)  ⇒ // no logging
-    case other                            ⇒ super.logTermination(reason)
+    case FSM.Failure(TimeoutReason(errorMessage)) ⇒
+      log.info(errorMessage)
+    case other ⇒ super.logTermination(reason)
   }
 
   private def listenForListenerRegistration(readHandlerPromise: Promise[HandleEventListener]): Unit =
@@ -578,7 +583,7 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
   // Neither heartbeats neither disassociate cares about backing off if write fails:
   //  - Missing heartbeats are not critical
   //  - Disassociate messages are not guaranteed anyway
-  private def sendHeartbeat(wrappedHandle: AssociationHandle): Unit = try wrappedHandle.write(codec.constructHeartbeat) catch {
+  private def sendHeartbeat(wrappedHandle: AssociationHandle): Boolean = try wrappedHandle.write(codec.constructHeartbeat) catch {
     case NonFatal(e) ⇒ throw new AkkaProtocolException("Error writing HEARTBEAT to transport", e)
   }
 

--- a/akka-remote/src/test/scala/akka/remote/DeadlineFailureDetectorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/DeadlineFailureDetectorSpec.scala
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.remote
+
+import akka.testkit.AkkaSpec
+import scala.collection.immutable.TreeMap
+import scala.concurrent.duration._
+import akka.remote.FailureDetector.Clock
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class DeadlineFailureDetectorSpec extends AkkaSpec {
+
+  "A DeadlineFailureDetector" must {
+
+    def fakeTimeGenerator(timeIntervals: Seq[Long]): Clock = new Clock {
+      @volatile var times = timeIntervals.tail.foldLeft(List[Long](timeIntervals.head))((acc, c) ⇒ acc ::: List[Long](acc.last + c))
+      override def apply(): Long = {
+        val currentTime = times.head
+        times = times.tail
+        currentTime
+      }
+    }
+
+    def createFailureDetector(
+      acceptableLostDuration: FiniteDuration,
+      clock: Clock = FailureDetector.defaultClock) =
+      new DeadlineFailureDetector(acceptableLostDuration)(clock = clock)
+
+    "mark node as monitored after a series of successful heartbeats" in {
+      val timeInterval = List[Long](0, 1000, 100, 100)
+      val fd = createFailureDetector(acceptableLostDuration = 5.seconds, clock = fakeTimeGenerator(timeInterval))
+      fd.isMonitoring should be(false)
+
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.heartbeat()
+
+      fd.isMonitoring should be(true)
+      fd.isAvailable should be(true)
+    }
+
+    "mark node as dead if heartbeat are missed" in {
+      val timeInterval = List[Long](0, 1000, 100, 100, 7000)
+      val fd = createFailureDetector(acceptableLostDuration = 5.seconds, clock = fakeTimeGenerator(timeInterval))
+
+      fd.heartbeat() //0
+      fd.heartbeat() //1000
+      fd.heartbeat() //1100
+
+      fd.isAvailable should be(true) //1200
+      fd.isAvailable should be(false) //8200
+    }
+
+    "mark node as available if it starts heartbeat again after being marked dead due to detection of failure" in {
+      // 1000 regular intervals, 5 minute pause, and then a short pause again that should trigger unreachable again
+      val regularIntervals = 0L +: Vector.fill(999)(1000L)
+      val timeIntervals = regularIntervals :+ (5 * 60 * 1000L) :+ 100L :+ 900L :+ 100L :+ 7000L :+ 100L :+ 900L :+ 100L :+ 900L
+      val fd = createFailureDetector(acceptableLostDuration = 7.seconds, clock = fakeTimeGenerator(timeIntervals))
+
+      for (_ ← 0 until 1000) fd.heartbeat()
+      fd.isAvailable should be(false) // after the long pause
+      fd.heartbeat()
+      fd.isAvailable should be(true)
+      fd.heartbeat()
+      fd.isAvailable should be(false) // after the 7 seconds pause
+      fd.heartbeat()
+      fd.isAvailable should be(true)
+      fd.heartbeat()
+      fd.isAvailable should be(true)
+    }
+
+    "accept some configured missing heartbeats" in {
+      val timeInterval = List[Long](0, 1000, 1000, 1000, 4000, 1000, 1000)
+      val fd = createFailureDetector(acceptableLostDuration = 5.seconds, clock = fakeTimeGenerator(timeInterval))
+
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.isAvailable should be(true)
+      fd.heartbeat()
+      fd.isAvailable should be(true)
+    }
+
+    "fail after configured acceptable missing heartbeats" in {
+      val timeInterval = List[Long](0, 1000, 1000, 1000, 1000, 1000, 500, 500, 5000)
+      val fd = createFailureDetector(acceptableLostDuration = 5.seconds, clock = fakeTimeGenerator(timeInterval))
+
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.heartbeat()
+      fd.isAvailable should be(true)
+      fd.heartbeat()
+      fd.isAvailable should be(false)
+    }
+
+  }
+
+}

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -36,7 +36,8 @@ class RemoteConfigSpec extends AkkaSpec(
       RetryGateClosedFor should be(5 seconds)
       Dispatcher should be("akka.remote.default-remote-dispatcher")
       UsePassiveConnections should be(true)
-      BackoffPeriod should be(10 millis)
+      BackoffPeriod should be(5 millis)
+      LogBufferSizeExceeding should be(50000)
       SysMsgAckTimeout should be(0.3 seconds)
       SysResendTimeout should be(2 seconds)
       SysMsgBufferSize should be(1000)
@@ -69,12 +70,9 @@ class RemoteConfigSpec extends AkkaSpec(
       RequireCookie should be(false)
       SecureCookie should be(None)
 
-      TransportFailureDetectorImplementationClass should be(classOf[PhiAccrualFailureDetector].getName)
+      TransportFailureDetectorImplementationClass should be(classOf[DeadlineFailureDetector].getName)
       TransportHeartBeatInterval should be(4.seconds)
-      TransportFailureDetectorConfig.getDouble("threshold") should be(7.0 +- 0.0001)
-      TransportFailureDetectorConfig.getInt("max-sample-size") should be(100)
-      TransportFailureDetectorConfig.getMillisDuration("acceptable-heartbeat-pause") should be(10 seconds)
-      TransportFailureDetectorConfig.getMillisDuration("min-std-deviation") should be(100 millis)
+      TransportFailureDetectorConfig.getMillisDuration("acceptable-heartbeat-pause") should be(20 seconds)
 
     }
 

--- a/akka-samples/akka-sample-remote-scala/src/main/scala/sample/remote/benchmark/Receiver.scala
+++ b/akka-samples/akka-sample-remote-scala/src/main/scala/sample/remote/benchmark/Receiver.scala
@@ -1,0 +1,24 @@
+package sample.remote.benchmark
+
+import akka.actor.Actor
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+import akka.actor.Props
+
+object Receiver {
+  def main(args: Array[String]): Unit = {
+    val system = ActorSystem("Sys", ConfigFactory.load("remotelookup"))
+    system.actorOf(Props[Receiver], "rcv")
+  }
+}
+
+class Receiver extends Actor {
+  import Sender._
+
+  def receive = {
+    case m: Echo  => sender() ! m
+    case Shutdown => context.system.shutdown()
+    case _        =>
+  }
+}
+

--- a/akka-samples/akka-sample-remote-scala/src/main/scala/sample/remote/benchmark/Sender.scala
+++ b/akka-samples/akka-sample-remote-scala/src/main/scala/sample/remote/benchmark/Sender.scala
@@ -1,0 +1,120 @@
+package sample.remote.benchmark
+
+import scala.concurrent.duration._
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.Identify
+import akka.actor.ReceiveTimeout
+import akka.actor.Terminated
+import akka.actor.Props
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+
+object Sender {
+  def main(args: Array[String]): Unit = {
+    val system = ActorSystem("Sys", ConfigFactory.load("calculator"))
+
+    val remoteHostPort = if (args.length >= 1) args(0) else "127.0.0.1:2553"
+    val remotePath = s"akka.tcp://Sys@$remoteHostPort/user/rcv"
+    val totalMessages = if (args.length >= 2) args(1).toInt else 500000
+    val burstSize = if (args.length >= 3) args(2).toInt else 5000
+    val payloadSize = if (args.length >= 4) args(3).toInt else 100
+
+    system.actorOf(Sender.props(remotePath, totalMessages, burstSize, payloadSize), "snd")
+  }
+
+  def props(path: String, totalMessages: Int, burstSize: Int, payloadSize: Int): Props =
+    Props(new Sender(path, totalMessages, burstSize, payloadSize))
+
+  private case object Warmup
+  case object Shutdown
+  sealed trait Echo
+  case object Start extends Echo
+  case object Done extends Echo
+  case class Continue(remaining: Int, startTime: Long, burstStartTime: Long, n: Int)
+    extends Echo
+}
+
+class Sender(path: String, totalMessages: Int, burstSize: Int, payloadSize: Int) extends Actor {
+  import Sender._
+
+  val payload: Array[Byte] = Vector.fill(payloadSize)("a").mkString.getBytes
+  var startTime = 0L
+  var maxRoundTripMillis = 0L
+
+  context.setReceiveTimeout(3.seconds)
+  sendIdentifyRequest()
+
+  def sendIdentifyRequest(): Unit =
+    context.actorSelection(path) ! Identify(path)
+
+  def receive = identifying
+
+  def identifying: Receive = {
+    case ActorIdentity(`path`, Some(actor)) =>
+      context.watch(actor)
+      context.become(active(actor))
+      context.setReceiveTimeout(Duration.Undefined)
+      self ! Warmup
+    case ActorIdentity(`path`, None) => println(s"Remote actor not available: $path")
+    case ReceiveTimeout              => sendIdentifyRequest()
+  }
+
+  def active(actor: ActorRef): Receive = {
+    case Warmup =>
+      sendBatch(actor, burstSize)
+      actor ! Start
+
+    case Start =>
+      println(s"Starting benchmark of $totalMessages messages with burst size $burstSize and payload size $payloadSize")
+      startTime = System.nanoTime
+      val remaining = sendBatch(actor, totalMessages)
+      if (remaining == 0)
+        actor ! Done
+      else
+        actor ! Continue(remaining, startTime, startTime, burstSize)
+
+    case c @ Continue(remaining, t0, t1, n) =>
+      val now = System.nanoTime()
+      val duration = (now - t0).nanos.toMillis
+      val roundTripMillis = (now - t1).nanos.toMillis
+      maxRoundTripMillis = math.max(maxRoundTripMillis, roundTripMillis)
+      if (duration >= 500) {
+        val throughtput = (n * 1000.0 / duration).toInt
+        println(s"It took $duration ms to deliver $n messages, throughtput $throughtput msg/s, " +
+          s"latest round-trip $roundTripMillis ms, remaining $remaining of $totalMessages")
+      }
+
+      val nextRemaining = sendBatch(actor, remaining)
+      if (nextRemaining == 0)
+        actor ! Done
+      else if (duration >= 500)
+        actor ! Continue(nextRemaining, now, now, burstSize)
+      else
+        actor ! c.copy(remaining = nextRemaining, burstStartTime = now, n = n + burstSize)
+
+    case Done =>
+      val took = (System.nanoTime - startTime).nanos.toMillis
+      val throughtput = (totalMessages * 1000.0 / took).toInt
+      println(s"== It took $took ms to deliver $totalMessages messages, throughtput $throughtput msg/s, " +
+        s"max round-trip $maxRoundTripMillis ms, burst size $burstSize, " +
+        s"payload size $payloadSize")
+      actor ! Shutdown
+
+    case Terminated(`actor`) =>
+      println("Receiver terminated")
+      context.system.shutdown()
+
+  }
+
+  /**
+   * @return remaining messages after sending the batch
+   */
+  def sendBatch(actor: ActorRef, remaining: Int): Int = {
+    val batchSize = math.min(remaining, burstSize)
+    (1 to batchSize) foreach { x => actor ! payload }
+    remaining - batchSize
+  }
+}
+

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1002,7 +1002,11 @@ object AkkaBuild extends Build {
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.testconductor.Conductor.shutdown"),
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.testkit.MultiNodeSpec.akka$remote$testkit$MultiNodeSpec$$deployer"),
       FilterAnyProblem("akka.remote.EndpointManager$Pass"),
-      FilterAnyProblem("akka.remote.EndpointManager$EndpointRegistry")
+      FilterAnyProblem("akka.remote.EndpointManager$EndpointRegistry"),
+      FilterAnyProblem("akka.remote.EndpointWriter"),
+      FilterAnyProblem("akka.remote.EndpointWriter$StopReading"),
+      FilterAnyProblem("akka.remote.EndpointWriter$State"),
+      FilterAnyProblem("akka.remote.EndpointWriter$TakeOver")
     )
   }
 


### PR DESCRIPTION
- Replace stash with internal bufferi, j.u.LinkedList
- Replace FSM with become
- Adaptive backoff, important to backoff, but not for too long,
  depends on environment and use case
- Prioritize heartbeat messages from remote watcher and cluster
  failure detector
- Use payload messages as heartbeats for transport failure detector,
  change transport failure detector to be based on absolute timeout,
  see ticket #13989 and #13742
- Log remote disassociate from transport failure detector,
  see ticket #13985
- Add benchmark sample in akka-sample-remote-scala

(cherry picked from commit a97de7db90818ae1febf85b903a225ab202749c8)
