### PR TITLE
=act #13966 Change wrong default discardOld in UntypedActor become

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -74,7 +74,7 @@ trait ActorContext extends ActorRefFactory {
    * Changes the Actor's behavior to become the new 'Receive' (PartialFunction[Any, Unit]) handler.
    * Replaces the current behavior on the top of the behavior stack.
    */
-  def become(behavior: Actor.Receive): Unit = become(behavior, true)
+  def become(behavior: Actor.Receive): Unit = become(behavior, discardOld = true)
 
   /**
    * Changes the Actor's behavior to become the new 'Receive' (PartialFunction[Any, Unit]) handler.
@@ -528,7 +528,7 @@ private[akka] class ActorCell(
   def become(behavior: Actor.Receive, discardOld: Boolean = true): Unit =
     behaviorStack = behavior :: (if (discardOld && behaviorStack.nonEmpty) behaviorStack.tail else behaviorStack)
 
-  def become(behavior: Procedure[Any]): Unit = become(behavior, false)
+  def become(behavior: Procedure[Any]): Unit = become(behavior, discardOld = true)
 
   def become(behavior: Procedure[Any], discardOld: Boolean): Unit =
     become({ case msg ⇒ behavior.apply(msg) }: Actor.Receive, discardOld)


### PR DESCRIPTION
This might break user code that depend on the faulty behaviour, but as far as I know we are allowed to fix bugs. It is clearly documented that the default is discardOld = true.
