### PR TITLE
=pro all non-words must be replaced with _ for statsd keys

### DIFF
--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -112,7 +112,7 @@ object TestExtras {
 
       private def testTimerKey(det: Event): String = s"${det.fullyQualifiedName}.${testSelectorToId(det.selector)}"
 
-      private def testSelectorToId(sel: testing.Selector): String = sel.asInstanceOf[TestSelector].testName().replaceAll("[. ']", "_")
+      private def testSelectorToId(sel: testing.Selector): String = sel.asInstanceOf[TestSelector].testName().replaceAll("""[^\w]""", "_")
 
       private def testCounterKey(det: Event, status: Status): String = s"${det.fullyQualifiedName}.${status.toString.toLowerCase}"
 


### PR DESCRIPTION
Noticed that the replace regex was not enough - we must replace all special chars with _, otherwise statsd is unhappy with such stat key.
