### PR TITLE
FAILED: akka-publish-nightly job

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.5-RC1


### PR DESCRIPTION
akka-publish-nightly job failed with the same error two nights in a row:

```
impossible to move '/localhome/jenkinsakka/workspace/akka-publish-nightly/target/repository/com/typesafe/akka/akka/2.4-20140415-231907.part' to '/localhome/jenkinsakka/workspace/akka-publish-nightly/target/repository/com/typesafe/akka/akka/2.4-20140415-231907'
impossible to move '/localhome/jenkinsakka/workspace/akka-publish-nightly/target/repository/com/typesafe/akka/akka-samples/2.4-20140415-231907.part' to '/localhome/jenkinsakka/workspace/akka-publish-nightly/target/repository/com/typesafe/akka/akka-samples/2.4-20140415-231907'
impossible to move '/localhome/jenkinsakka/workspace/akka-publish-nightly/target/repository/com/typesafe/akka/akka-sample-osgi-dining-hakkers/2.4-20140415-231907.part' to '/localhome/jenkinsakka/workspace/akka-publish-nightly/target/repository/com/typesafe/akka/akka-sample-osgi-dining-hakkers/2.4-20140415-231907'
```

It seems that there is no such file that is tried to be moved. All of these projects are aggregates for some child projects. So most likely the parent projects should not be published at all.

The errors seems to have started after sbt upgrade to 0.13.2-RC2
