### PR TITLE
DRAFT =act,tes #15064 Initial MetricsKit draft as well as including it in ActorPerfSpec

### DIFF
--- a/akka-testkit/src/test/java/akka/testkit/metrics/LongAdder.java
+++ b/akka-testkit/src/test/java/akka/testkit/metrics/LongAdder.java
@@ -1,0 +1,4 @@
+package akka.testkit.metrics;
+
+public class LongAdder {
+}

--- a/akka-testkit/src/test/java/akka/testkit/metrics/Striped64.java
+++ b/akka-testkit/src/test/java/akka/testkit/metrics/Striped64.java
@@ -1,0 +1,4 @@
+package akka.testkit.metrics;
+
+public class Striped64 {
+}

--- a/akka-testkit/src/test/resources/reference.conf
+++ b/akka-testkit/src/test/resources/reference.conf
@@ -1,0 +1,30 @@
+akka {
+  # Configures MetricsKit
+  test.metrics {
+
+    # Available reporters are: console, graphite
+    # In order to configure from the command line, use the alternative list syntax:
+    #     -Dakka.test.metrics.reporters.0=console -Dakka.test.metrics.reporters.1=graphite
+    reporters = [console, graphite]
+
+    reporter {
+      console {
+        # Automatically print metrics to the console at scheduled interval.
+        # To disable, set to `0`.
+        scheduled-report-interval = 0 ms
+      }
+
+      graphite {
+        prefix = ""
+        host = "54.72.154.120"
+        port = 2003
+
+        # Automatically print metrics to the console at scheduled interval.
+        # To disable, set to `0`.
+        scheduled-report-interval = 1 s
+
+        # todo filtering
+      }
+    }
+  }
+}

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/FileDescriptorMetricSet.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/FileDescriptorMetricSet.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics
+
+import java.util
+import collection.JavaConverters._
+import java.lang.management.{ OperatingSystemMXBean, ManagementFactory }
+import com.codahale.metrics.{ Gauge, Metric, MetricSet }
+import com.codahale.metrics.MetricRegistry._
+import com.codahale.metrics.jvm.FileDescriptorRatioGauge
+
+/**
+ * MetricSet exposing number of open and maximum file descriptors used by the JVM process.
+ */
+private[akka] class FileDescriptorMetricSet(os: OperatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean) extends MetricSet {
+
+  override def getMetrics: util.Map[String, Metric] = {
+    Map[String, Metric](
+
+      name("file-descriptors", "open") -> new Gauge[Long] {
+        override def getValue: Long = invoke("getOpenFileDescriptorCount")
+      },
+
+      name("file-descriptors", "max") -> new Gauge[Long] {
+        override def getValue: Long = invoke("getMaxFileDescriptorCount")
+      },
+
+      name("file-descriptors", "ratio") -> new FileDescriptorRatioGauge(os)).asJava
+  }
+
+  private def invoke(name: String): Long = {
+    val method = os.getClass.getDeclaredMethod(name)
+    method.setAccessible(true)
+    method.invoke(os).asInstanceOf[Long]
+  }
+}

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/KnownOpsInTimespanCounter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/KnownOpsInTimespanCounter.scala
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics
+
+import com.codahale.metrics._
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.TimeUnit._
+
+class KnownOpsInTimespanCounter(expectedOps: Long) extends Metric with Counting {
+
+  val startTime = System.nanoTime
+  val stopTime = new AtomicLong(0)
+
+  def stop() {
+    stopTime.compareAndSet(0, System.nanoTime)
+  }
+
+  override def getCount: Long = expectedOps
+
+  def elapsedTime: Long = stopTime.get - startTime
+
+  def avgDuration: Long = (elapsedTime.toDouble / expectedOps).toLong
+
+  def opsPerSecond: Double = expectedOps.toDouble / (elapsedTime.toDouble / NANOSECONDS.convert(1, SECONDS))
+
+}

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics
+
+import com.codahale.metrics._
+import com.codahale.metrics.graphite.{ GraphiteReporter, Graphite }
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+import com.typesafe.config.Config
+import java.util
+
+/**
+ * Allows to easily measure performance / memory / file descriptor use in tests.
+ *
+ * WARNING: This trait should not be seen as utility for micro-benchmarking,
+ * please refer to <a href="http://openjdk.java.net/projects/code-tools/jmh/">JMH</a> if that's what you're writing.
+ * This trait instead aims to give an high level overview as well as data for trend-analysis of long running tests.
+ *
+ * Reporting defaults to [[ConsoleReporter]].
+ * In order to send metrics to Graphite run sbt with the following property: `-Dakka.metrics.reporting.0=graphite`.
+ */
+private[akka] trait MetricsKit {
+
+  private var reporters: List[ScheduledReporter] = Nil
+
+  /**
+   * A configuration containing [[MetricsKitSettings]] under the key `akka.test.metrics` must be provided.
+   * This can be the ActorSystems config.
+   *
+   * The reason this is not handled by an Extension is thatwe do not want to enforce having to start an ActorSystem,
+   * since code measured using this Kit may not need one (e.g. measuring plain Queue implementations).
+   */
+  def metricsConfig: Config
+
+  private val metrics = new MetricRegistry()
+
+  initMetricReporters()
+
+  def initMetricReporters() {
+    val settings = new MetricsKitSettings(metricsConfig)
+
+    def configureConsoleReporter() {
+      if (settings.Reporters.contains("console")) {
+        val consoleReporter = ConsoleReporter.forRegistry(metrics)
+          .outputTo(System.out)
+          .convertDurationsTo(TimeUnit.MICROSECONDS)
+          .build()
+
+        if (settings.ConsoleReporter.ScheduledReportInterval > 0.millis)
+          consoleReporter.start(settings.ConsoleReporter.ScheduledReportInterval.toMillis, TimeUnit.MILLISECONDS)
+
+        reporters ::= consoleReporter
+      }
+    }
+
+    def configureGraphiteReporter() {
+      if (settings.Reporters.contains("graphite")) {
+        println(s"Will send metrics to Graphite @ ${settings.GraphiteReporter.Host}:${settings.GraphiteReporter.Port}")
+
+        val graphiteReporter = GraphiteReporter.forRegistry(metrics)
+          .convertDurationsTo(TimeUnit.MICROSECONDS)
+          .prefixedWith(settings.GraphiteReporter.Prefix)
+          .build(new Graphite(new InetSocketAddress(settings.GraphiteReporter.Host, settings.GraphiteReporter.Port)))
+
+        if (settings.GraphiteReporter.ScheduledReportInterval > 0.millis) {
+          graphiteReporter.start(settings.GraphiteReporter.ScheduledReportInterval.toMillis, TimeUnit.MILLISECONDS)
+        }
+
+        reporters ::= graphiteReporter
+      }
+    }
+
+    configureConsoleReporter()
+    configureGraphiteReporter()
+  }
+
+  /**
+   * Schedule metric reports execution iterval. Should not be used multiple times
+   */
+  def scheduleMetricReports(every: FiniteDuration) {
+    reporters foreach { _.start(every.toMillis, TimeUnit.MILLISECONDS) }
+  }
+
+  def timer(name: String) = metrics.timer(name)
+
+  /**
+   * Convinience method for measuring long running piece of code.
+   * HINT: don't use this form in loops, prefer using timer explicitly in tight loops.
+   */
+  def measureTime(name: String)(run: ⇒ Any) = {
+    val t = timer(name)
+    run
+    t.time()
+  }
+
+  /**
+   * Delegates to `System.gc()`.
+   */
+  def gc() {
+    System.gc()
+  }
+
+  def measureMemoryUse(name: String) = {
+    metrics.registerAll(new jvm.MemoryUsageGaugeSet() with MetricsPrefix { val prefix = name })
+  }
+
+  def measureGc(name: String) = {
+    metrics.registerAll(new jvm.GarbageCollectorMetricSet() with MetricsPrefix { val prefix = name })
+  }
+
+  def measureFileDescriptors(name: String) = {
+    metrics.registerAll(new FileDescriptorMetricSet() with MetricsPrefix { val prefix = name })
+  }
+
+  /**
+   * Causes immediate flush of metrics using all registered reporters.
+   *
+   * HINT: this operation can be costy, run outside of your tested code, or rely on scheduled reporting.
+   */
+  def reportAllMetrics() {
+    reporters foreach { _.report() }
+  }
+
+  /**
+   * Removes registered metrics from registry.
+   * You should call this method then you're done measuring something - usually at the end of your test case,
+   * otherwise the metrics from different tests would influence each others results (avg, min, max, ...).
+   *
+   * Please note that, if you have registered a `timer("thing")` previously, you will need to call `timer("thing")` again,
+   * in order to register a new timer.
+   */
+  def removeMetrics(matching: MetricFilter = MetricFilter.ALL) {
+    metrics.removeMatching(matching)
+  }
+
+  /**
+   * MUST be called after all tests have finished (in ``
+   */
+  def shutdownMetrics() {
+    reporters foreach { _.stop() }
+  }
+
+  private trait MetricsPrefix extends MetricSet {
+    def prefix: String
+    abstract override def getMetrics: util.Map[String, Metric] = {
+      // does not have to be fast, is only called once during registering metrics
+      import collection.JavaConverters._
+      (super.getMetrics.asScala.map { case (k, v) ⇒ (prefix + "." + k, v) }).asJava
+    }
+  }
+}
+
+private[akka] class MetricsKitSettings(config: Config) {
+
+  import akka.util.Helpers._
+
+  val Reporters = config.getStringList("akka.test.metrics.reporters")
+
+  object GraphiteReporter {
+    val Prefix = config.getString("akka.test.metrics.reporter.graphite.prefix")
+    lazy val Host = config.getString("akka.test.metrics.reporter.graphite.host").requiring(v ⇒ !v.trim.isEmpty, "akka.test.metrics.reporter.graphite.host was used but was empty!")
+    val Port = config.getInt("akka.test.metrics.reporter.graphite.port")
+
+    val ScheduledReportInterval = config.getMillisDuration("akka.test.metrics.reporter.graphite.scheduled-report-interval")
+  }
+
+  object ConsoleReporter {
+    val ScheduledReportInterval = config.getMillisDuration("akka.test.metrics.reporter.console.scheduled-report-interval")
+  }
+
+}

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/report/AkkaConsoleReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/report/AkkaConsoleReporter.scala
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics.report
+
+import java.io.PrintStream
+import java.text.DateFormat
+import java.util
+import java.util.concurrent.TimeUnit
+import com.codahale.metrics._
+import java.util.{ Locale, Date }
+import akka.testkit.metrics.{ KnownOpsInTimespanCounter, AkkaMetricRegistry, MetricsKit }
+
+class AkkaConsoleReporter(
+  registry: AkkaMetricRegistry,
+  durationUnit: TimeUnit,
+  rateUnit: TimeUnit,
+  output: PrintStream = System.out)
+  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-console-reporter", MetricsKit.KnownOpsInTimespanCounterFilter, rateUnit, durationUnit) {
+
+  private final val CONSOLE_WIDTH: Int = 80
+
+  val locale = Locale.getDefault
+  val dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM, locale)
+  val clock = Clock.defaultClock()
+
+  override def report(gauges: util.SortedMap[String, Gauge[_]], counters: util.SortedMap[String, Counter], histograms: util.SortedMap[String, Histogram], meters: util.SortedMap[String, Meter], timers: util.SortedMap[String, Timer]) {
+    val dateTime: String = dateFormat.format(new Date(clock.getTime))
+    printWithBanner(dateTime, '=')
+
+    //    printGauges(gauges)
+    //    printCounters(counters)
+    //    printHistograms(histograms)
+    //    printMeters(meters)
+    //    printTimers(timers)
+    printKnownOpsInTimespanCounters(registry.getKnownOpsInTimespanCounters)
+    output.println()
+    output.flush()
+  }
+
+  def printKnownOpsInTimespanCounters(counters: Iterable[KnownOpsInTimespanCounter]) {
+    if (!counters.isEmpty) {
+      printWithBanner("-- " + getClass.getSimpleName, '-')
+      for (entry ← counters) {
+        //        output.println(entry.getKey)
+        printKnownOpsInTimespanCounter(entry)
+      }
+      output.println()
+    }
+  }
+
+  private def printKnownOpsInTimespanCounter(counter: KnownOpsInTimespanCounter) {
+    import concurrent.duration._
+    import PrettyDuration._
+    output.print("               ops = %d%n".format(counter.getCount))
+    output.print("              time = %s%n".format(counter.elapsedTime.nanos.pretty))
+    output.print("             ops/s = %2.2f%n".format(counter.opsPerSecond))
+    output.print("               avg = %s%n".format(counter.avgDuration.nanos.pretty))
+  }
+
+  private def printWithBanner(s: String, c: Char) {
+    output.print(s)
+    output.print(' ')
+    var i: Int = 0
+    while (i < (CONSOLE_WIDTH - s.length - 1)) {
+      output.print(c)
+      i += 1
+    }
+    output.println()
+  }
+
+}
+

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/report/PrettyDuration.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/report/PrettyDuration.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics.report
+
+import java.util.concurrent.TimeUnit._
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+
+object PrettyDuration {
+
+  implicit class PrettyPrintableDuration(val d: Duration) extends AnyVal {
+
+    /** Selects most apropriate TimeUnit for given duration and formats it accordingly */
+    def pretty: String = pretty(includeNanos = false)
+
+    /** Selects most apropriate TimeUnit for given duration and formats it accordingly */
+    def pretty(includeNanos: Boolean = false): String = {
+      val nanos = d.toNanos
+
+      val unit = chooseUnit(nanos)
+      val value = nanos.toDouble / NANOSECONDS.convert(1, unit)
+
+      "%.4g %s%s".format(value, abbreviate(unit), if (includeNanos) s" ($nanos ns)" else "")
+    }
+
+    def chooseUnit(nanos: Long): TimeUnit =
+      if (DAYS.convert(nanos, NANOSECONDS) > 0) DAYS
+      else if (HOURS.convert(nanos, NANOSECONDS) > 0) HOURS
+      else if (MINUTES.convert(nanos, NANOSECONDS) > 0) MINUTES
+      else if (SECONDS.convert(nanos, NANOSECONDS) > 0) SECONDS
+      else if (MILLISECONDS.convert(nanos, NANOSECONDS) > 0) MILLISECONDS
+      else if (MICROSECONDS.convert(nanos, NANOSECONDS) > 0) MICROSECONDS
+      else NANOSECONDS
+
+    def abbreviate(unit: TimeUnit): String = unit match {
+      case NANOSECONDS  ⇒ "ns"
+      case MICROSECONDS ⇒ "\u03bcs" // μs
+      case MILLISECONDS ⇒ "ms"
+      case SECONDS      ⇒ "s"
+      case MINUTES      ⇒ "min"
+      case HOURS        ⇒ "h"
+      case DAYS         ⇒ "d"
+    }
+  }
+
+}

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1065,7 +1065,13 @@ object Dependencies {
       val karafExam    = "org.apache.karaf.tooling.exam" % "org.apache.karaf.tooling.exam.container" % "2.3.1" % "test" // ApacheV2
       // mirrored in OSGi sample
       val paxExam      = "org.ops4j.pax.exam"          % "pax-exam-junit4"              % "2.6.0"            % "test" // ApacheV2
-      val scalaXml     = "org.scala-lang.modules"      %% "scala-xml"                   % "1.0.1" % "test"
+      val scalaXml     = "org.scala-lang.modules"     %% "scala-xml"                    % "1.0.1"            % "test"
+
+      // metrics, measurements, perf testing
+      val metrics         = "com.codahale.metrics"        % "metrics-core"                 % "3.0.1"            % "test" // ApacheV2
+      val metricsJvm      = "com.codahale.metrics"        % "metrics-jvm"                  % "3.0.1"            % "test" // ApacheV2
+      val metricsGraphite = "com.codahale.metrics"        % "metrics-graphite"             % "3.0.1"            % "test" // ApacheV2
+      val metricsAll      = Seq(metrics, metricsJvm, metricsGraphite)
     }
   }
 
@@ -1075,7 +1081,7 @@ object Dependencies {
 
   val actor = Seq(config)
 
-  val testkit = Seq(Test.junit, Test.scalatest)
+  val testkit = Seq(Test.junit, Test.scalatest) ++ Test.metricsAll
 
   val actorTests = Seq(Test.junit, Test.scalatest, Test.commonsCodec, Test.commonsMath, Test.mockito, Test.scalacheck, protobuf, Test.junitIntf)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,4 +20,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 
+// stats reporting
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"


### PR DESCRIPTION
The MetricsKit lives next to the AkkaSpec, and is private[akka]

Example output:

```
actor-creation.PropsnewEmptyArgsActorsame_warmup
             count = 50000
         mean rate = 7880.37 calls/second
     1-minute rate = 10000.00 calls/second
     5-minute rate = 10000.00 calls/second
    15-minute rate = 10000.00 calls/second
               min = 1.00 microseconds
               max = 15.00 microseconds
              mean = 3.77 microseconds
            stddev = 1.72 microseconds
            median = 3.00 microseconds
              75% <= 4.75 microseconds
              95% <= 6.00 microseconds
              98% <= 9.00 microseconds
              99% <= 12.00 microseconds
            99.9% <= 14.97 microseconds
```

Example graphs in graphite:

![grafana_-_akka-actor](https://cloud.githubusercontent.com/assets/120979/2831075/5110665a-cfb5-11e3-9908-cb62c4a8c157.png)
