### PR TITLE
=act #15102 No serialization needed for EventStreamUnsubscriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,5 @@ tm*.log
 tm.out
 worker*.log
 *-shim.sbt
+test-output
 

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -274,6 +274,19 @@ private[akka] abstract class ActorRefWithCell extends InternalActorRef { this: A
 private[akka] case object Nobody extends MinimalActorRef {
   override val path: RootActorPath = new RootActorPath(Address("akka", "all-systems"), "/Nobody")
   override def provider = throw new UnsupportedOperationException("Nobody does not provide")
+
+  private val serialized = new SerializedNobody
+
+  @throws(classOf[java.io.ObjectStreamException])
+  override protected def writeReplace(): AnyRef = serialized
+}
+
+/**
+ * INTERNAL API
+ */
+@SerialVersionUID(1L) private[akka] class SerializedNobody extends Serializable {
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): AnyRef = Nobody
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -782,6 +782,19 @@ object Logging {
     override def !(message: Any)(implicit sender: ActorRef = Actor.noSender): Unit =
       if (message == null) throw new InvalidMessageException("Message is null")
       else print(message)
+
+    @throws(classOf[java.io.ObjectStreamException])
+    override protected def writeReplace(): AnyRef = serializedStandardOutLogger
+  }
+
+  private val serializedStandardOutLogger = new SerializedStandardOutLogger
+
+  /**
+   * INTERNAL API
+   */
+  @SerialVersionUID(1L) private[akka] class SerializedStandardOutLogger extends Serializable {
+    @throws(classOf[java.io.ObjectStreamException])
+    private def readResolve(): AnyRef = Logging.StandardOutLogger
   }
 
   val StandardOutLogger = new StandardOutLogger


### PR DESCRIPTION
- The problem was that akka://all-systems/StandardOutLogger ref was
  passed during system shutdown
