### PR TITLE
+str #15105 Add Flow tee

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -26,6 +26,7 @@ private[akka] object Ast {
   case class Merge(other: Producer[Any]) extends AstNode
   case class Zip(other: Producer[Any]) extends AstNode
   case class Concat(next: Producer[Any]) extends AstNode
+  case class Tee(other: Consumer[Any]) extends AstNode
 
   trait ProducerNode[I] {
     def createProducer(settings: MaterializerSettings, context: ActorRefFactory): Producer[I]

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorConsumer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorConsumer.scala
@@ -153,13 +153,10 @@ private[akka] class TransformActorConsumer(_settings: MaterializerSettings, tran
  * INTERNAL API
  */
 private[akka] class RecoverActorConsumer(_settings: MaterializerSettings, recoveryTransformer: RecoveryTransformer[Any, Any])
-  extends TransformActorConsumer(_settings, recoveryTransformer.asInstanceOf[Transformer[Any, Any]]) {
-  override def onNext(elem: Any): Unit = {
-    super.onNext(Success(elem))
-  }
+  extends TransformActorConsumer(_settings, recoveryTransformer) {
 
   override def onError(cause: Throwable): Unit = {
-    super.onNext(Failure(cause))
+    recoveryTransformer.onError(cause)
     onComplete()
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -22,6 +22,7 @@ private[akka] object ActorProcessor {
     case m: Merge     ⇒ Props(new MergeImpl(settings, m.other))
     case z: Zip       ⇒ Props(new ZipImpl(settings, z.other))
     case c: Concat    ⇒ Props(new ConcatImpl(settings, c.next))
+    case t: Tee       ⇒ Props(new TeeImpl(settings, t.other))
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -15,8 +15,8 @@ import akka.event.LoggingReceive
 private[akka] object ActorProcessor {
   import Ast._
   def props(settings: MaterializerSettings, op: AstNode): Props = op match {
-    case t: Transform ⇒ Props(new TransformProcessorImpl(settings, t))
-    case r: Recover   ⇒ Props(new RecoverProcessorImpl(settings, r))
+    case t: Transform ⇒ Props(new TransformProcessorImpl(settings, t.transformer))
+    case r: Recover   ⇒ Props(new RecoverProcessorImpl(settings, r.recoveryTransformer))
     case s: SplitWhen ⇒ Props(new SplitWhenProcessorImpl(settings, s.p))
     case g: GroupBy   ⇒ Props(new GroupByProcessorImpl(settings, g.f))
     case m: Merge     ⇒ Props(new MergeImpl(settings, m.other))

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -198,6 +198,7 @@ private[akka] abstract class ActorProcessorImpl(val settings: MaterializerSettin
   }
 
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
+    reason.printStackTrace()
     super.preRestart(reason, message)
     throw new IllegalStateException("This actor cannot be restarted")
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProducer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProducer.scala
@@ -35,7 +35,10 @@ private[akka] trait ActorProducerLike[T] extends Producer[T] {
     getPublisher.subscribe(consumer.getSubscriber)
 }
 
-class ActorProducer[T]( final val impl: ActorRef) extends ActorProducerLike[T]
+/**
+ * INTERNAL API
+ */
+private[akka] class ActorProducer[T]( final val impl: ActorRef) extends ActorProducerLike[T]
 
 /**
  * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -12,14 +12,15 @@ import akka.stream.FlowMaterializer
 import akka.stream.scaladsl.Flow
 import scala.util.Success
 import scala.util.Failure
+import akka.stream.scaladsl.Transformer
+import akka.stream.scaladsl.RecoveryTransformer
 
 /**
  * INTERNAL API
  */
 private[akka] object FlowImpl {
   private val SuccessUnit = Success[Unit](())
-  private val OnCompleteSuccessToken = (true, Nil)
-  private val OnCompleteFailureToken = (false, Nil)
+  private val ListOfUnit = List(())
 }
 
 /**
@@ -31,50 +32,80 @@ private[akka] case class FlowImpl[I, O](producerNode: Ast.ProducerNode[I], ops: 
   // Storing ops in reverse order
   private def andThen[U](op: AstNode): Flow[U] = this.copy(ops = op :: ops)
 
-  override def map[U](f: O ⇒ U): Flow[U] = transform(())((_, in) ⇒ ((), List(f(in))))
+  override def map[U](f: O ⇒ U): Flow[U] =
+    transform(new Transformer[O, U] {
+      override def onNext(in: O) = List(f(in))
+    })
 
-  override def filter(p: O ⇒ Boolean): Flow[O] = transform(())((_, in) ⇒ if (p(in)) ((), List(in)) else ((), Nil))
+  override def filter(p: O ⇒ Boolean): Flow[O] =
+    transform(new Transformer[O, O] {
+      override def onNext(in: O) = if (p(in)) List(in) else Nil
+    })
 
-  override def foreach(c: O ⇒ Unit): Flow[Unit] = transform(())((_, in) ⇒ c(in) -> Nil, _ ⇒ List(()))
+  override def foreach(c: O ⇒ Unit): Flow[Unit] =
+    transform(new Transformer[O, Unit] {
+      override def onNext(in: O) = { c(in); Nil }
+      override def onComplete() = ListOfUnit
+    })
 
-  override def fold[U](zero: U)(f: (U, O) ⇒ U): Flow[U] = transform(zero)((z, in) ⇒ f(z, in) -> Nil, z ⇒ List(z))
+  override def fold[U](zero: U)(f: (U, O) ⇒ U): Flow[U] =
+    transform(new FoldTransformer[U](zero, f))
 
-  override def drop(n: Int): Flow[O] = transform(n)((x, in) ⇒ if (x == 0) 0 -> List(in) else (x - 1) -> Nil)
+  // Without this class compiler complains about 
+  // "Parameter type in structural refinement may not refer to an abstract type defined outside that refinement"
+  class FoldTransformer[S](var state: S, f: (S, O) ⇒ S) extends Transformer[O, S] {
+    override def onNext(in: O): immutable.Seq[S] = { state = f(state, in); Nil }
+    override def onComplete(): immutable.Seq[S] = List(state)
+  }
 
-  override def take(n: Int): Flow[O] = transform(n)((x, in) ⇒ if (x == 0) 0 -> Nil else (x - 1) -> List(in), isComplete = _ == 0)
+  override def drop(n: Int): Flow[O] =
+    transform(new Transformer[O, O] {
+      var c = n
+      override def onNext(in: O) =
+        if (c == 0) List(in)
+        else {
+          c -= 1
+          Nil
+        }
+    })
+
+  override def take(n: Int): Flow[O] =
+    transform(new Transformer[O, O] {
+      var c = n
+      override def onNext(in: O) =
+        if (c == 0) Nil
+        else {
+          c -= 1
+          List(in)
+        }
+      override def isComplete = c == 0
+    })
 
   override def grouped(n: Int): Flow[immutable.Seq[O]] =
-    transform(immutable.Seq.empty[O])((buf, in) ⇒ {
-      val group = buf :+ in
-      if (group.size == n) (Nil, List(group))
-      else (group, Nil)
-    }, x ⇒ if (x.isEmpty) Nil else List(x))
+    transform(new Transformer[O, immutable.Seq[O]] {
+      var buf: Vector[O] = Vector.empty
+      override def onNext(in: O) = {
+        buf :+= in
+        if (buf.size == n) {
+          val group = buf
+          buf = Vector.empty
+          List(group)
+        } else
+          Nil
+      }
+      override def onComplete() = if (buf.isEmpty) Nil else List(buf)
+    })
 
-  override def mapConcat[U](f: O ⇒ immutable.Seq[U]): Flow[U] = transform(())((_, in) ⇒ ((), f(in)))
+  override def mapConcat[U](f: O ⇒ immutable.Seq[U]): Flow[U] =
+    transform(new Transformer[O, U] {
+      override def onNext(in: O) = f(in)
+    })
 
-  override def transform[S, U](zero: S)(
-    f: (S, O) ⇒ (S, immutable.Seq[U]),
-    onComplete: S ⇒ immutable.Seq[U] = (_: S) ⇒ Nil,
-    isComplete: S ⇒ Boolean = (_: S) ⇒ false,
-    cleanup: S ⇒ Unit = (_: S) ⇒ ()): Flow[U] =
-    andThen(Transform(
-      zero,
-      f.asInstanceOf[(Any, Any) ⇒ (Any, immutable.Seq[Any])],
-      onComplete.asInstanceOf[Any ⇒ immutable.Seq[Any]],
-      isComplete.asInstanceOf[Any ⇒ Boolean],
-      cleanup.asInstanceOf[Any ⇒ Unit]))
+  override def transform[U](transformer: Transformer[O, U]): Flow[U] =
+    andThen(Transform(transformer.asInstanceOf[Transformer[Any, Any]]))
 
-  override def transformRecover[S, U](zero: S)(
-    f: (S, Try[O]) ⇒ (S, immutable.Seq[U]),
-    onComplete: S ⇒ immutable.Seq[U] = (_: S) ⇒ Nil,
-    isComplete: S ⇒ Boolean = (_: S) ⇒ false,
-    cleanup: S ⇒ Unit = (_: S) ⇒ ()): Flow[U] =
-    andThen(Recover(Transform(
-      zero,
-      f.asInstanceOf[(Any, Any) ⇒ (Any, immutable.Seq[Any])],
-      onComplete.asInstanceOf[Any ⇒ immutable.Seq[Any]],
-      isComplete.asInstanceOf[Any ⇒ Boolean],
-      cleanup.asInstanceOf[Any ⇒ Unit])))
+  override def transformRecover[U](recoveryTransformer: RecoveryTransformer[O, U]): Flow[U] =
+    andThen(Recover(recoveryTransformer.asInstanceOf[RecoveryTransformer[Any, Any]]))
 
   override def zip[O2](other: Producer[O2]): Flow[(O, O2)] = andThen(Zip(other.asInstanceOf[Producer[Any]]))
 
@@ -88,23 +119,29 @@ private[akka] case class FlowImpl[I, O](producerNode: Ast.ProducerNode[I], ops: 
 
   override def toFuture(materializer: FlowMaterializer): Future[O] = {
     val p = Promise[O]()
-    transformRecover(0)((x, in) ⇒ { p complete in; 1 -> Nil },
-      onComplete = _ ⇒ { p.tryFailure(new NoSuchElementException("empty stream")); Nil },
-      isComplete = _ == 1).consume(materializer)
+    transformRecover(new RecoveryTransformer[O, Unit] {
+      var done = false
+      override def onNext(in: Try[O]) = { p complete in; done = true; Nil }
+      override def isComplete = done
+      override def onComplete() = { p.tryFailure(new NoSuchElementException("empty stream")); Nil }
+    }).consume(materializer)
     p.future
   }
 
   override def consume(materializer: FlowMaterializer): Unit = materializer.consume(producerNode, ops)
 
   def onComplete(materializer: FlowMaterializer)(callback: Try[Unit] ⇒ Unit): Unit =
-    transformRecover(true)(
-      f = {
-        case (_, fail @ Failure(ex)) ⇒
+    transformRecover(new RecoveryTransformer[O, Unit] {
+      var ok = true
+      override def onNext(in: Try[O]) = in match {
+        case fail @ Failure(ex) ⇒
           callback(fail.asInstanceOf[Try[Unit]])
-          OnCompleteFailureToken
-        case _ ⇒ OnCompleteSuccessToken
-      },
-      onComplete = ok ⇒ { if (ok) callback(SuccessUnit); Nil }).consume(materializer)
+          ok = false
+          Nil
+        case _ ⇒ Nil
+      }
+      override def onComplete() = { if (ok) callback(SuccessUnit); Nil }
+    }).consume(materializer)
 
   override def toProducer(materializer: FlowMaterializer): Producer[O] = materializer.toProducer(producerNode, ops)
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -118,7 +118,7 @@ private[akka] case class FlowImpl[I, O](producerNode: Ast.ProducerNode[I], ops: 
 
   override def groupBy[K](f: (O) ⇒ K): Flow[(K, Producer[O])] = andThen(GroupBy(f.asInstanceOf[Any ⇒ Any]))
 
-  override def tee(other: Consumer[O]): Flow[O] = andThen(Tee(other.asInstanceOf[Consumer[Any]]))
+  override def tee(other: Consumer[_ >: O]): Flow[O] = andThen(Tee(other.asInstanceOf[Consumer[Any]]))
 
   override def toFuture(materializer: FlowMaterializer): Future[O] = {
     val p = Promise[O]()

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -14,6 +14,7 @@ import scala.util.Success
 import scala.util.Failure
 import akka.stream.scaladsl.Transformer
 import akka.stream.scaladsl.RecoveryTransformer
+import org.reactivestreams.api.Consumer
 
 /**
  * INTERNAL API
@@ -116,6 +117,8 @@ private[akka] case class FlowImpl[I, O](producerNode: Ast.ProducerNode[I], ops: 
   override def splitWhen(p: (O) ⇒ Boolean): Flow[Producer[O]] = andThen(SplitWhen(p.asInstanceOf[Any ⇒ Boolean]))
 
   override def groupBy[K](f: (O) ⇒ K): Flow[(K, Producer[O])] = andThen(GroupBy(f.asInstanceOf[Any ⇒ Any]))
+
+  override def tee(other: Consumer[O]): Flow[O] = andThen(Tee(other.asInstanceOf[Consumer[Any]]))
 
   override def toFuture(materializer: FlowMaterializer): Future[O] = {
     val p = Promise[O]()

--- a/akka-stream/src/main/scala/akka/stream/impl/StaticFanouts.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StaticFanouts.scala
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl
+
+import org.reactivestreams.api.Producer
+import akka.stream.MaterializerSettings
+import org.reactivestreams.api.Consumer
+import org.reactivestreams.spi.Subscriber
+import org.reactivestreams.spi.Subscription
+
+/**
+ * INTERNAL API
+ */
+private[akka] class TeeImpl(_settings: MaterializerSettings, other: Consumer[Any])
+  extends ActorProcessorImpl(_settings) {
+
+  lazy val needsBothInputAndDemand = primaryInputs.NeedsInput && primaryOutputs.NeedsDemand
+
+  override def initialTransferState = needsBothInputAndDemand
+
+  override def primaryOutputsReady(): Unit = {
+    exposedPublisher.subscribe(other.getSubscriber)
+    super.primaryOutputsReady()
+  }
+
+  override val primaryOutputs = new FanoutOutputs(settings.maxFanOutBufferSize, settings.initialFanOutBufferSize) {
+
+    var otherSubscription: Option[S] = None
+    var otherRequestedOrCanceled = false
+    var pendingRemoveSubscription: List[S] = Nil
+
+    def isOtherSubscription(subscription: Subscription): Boolean = otherSubscription.exists(_ == subscription)
+
+    override type S = ActorSubscription[Any]
+    override def createSubscription(subscriber: Subscriber[Any]): S = {
+      val s = new ActorSubscription(self, subscriber)
+      if (subscriber == other.getSubscriber) {
+        otherSubscription = Some(s)
+        pendingRemoveSubscription foreach removeSubscription
+        pendingRemoveSubscription = Nil
+      }
+      s
+    }
+    override def afterShutdown(completed: Boolean): Unit = {
+      primaryOutputsFinished(completed)
+    }
+
+    override val NeedsDemand: TransferState = new TransferState {
+      def isReady = demandAvailable && otherRequestedOrCanceled
+      def isCompleted = isClosed
+    }
+
+    override def handleRequest(subscription: S, elements: Int): Unit = {
+      if (otherRequestedOrCanceled || isOtherSubscription(subscription))
+        otherRequestedOrCanceled = true
+      super.handleRequest(subscription, elements)
+    }
+
+    override def removeSubscription(subscription: S): Unit = {
+      // make sure that we don't shutdown because of early cancel from downstream
+      if (otherSubscription.isEmpty && !isOtherSubscription(subscription))
+        pendingRemoveSubscription :+= subscription // defer these until other subscription comes in
+      otherRequestedOrCanceled = true
+      super.removeSubscription(subscription)
+    }
+
+  }
+
+  override def transfer(): TransferState = {
+    val in = primaryInputs.dequeueInputElement()
+    primaryOutputs.enqueueOutputElement(in)
+    needsBothInputAndDemand
+  }
+}
+

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -156,10 +156,9 @@ trait Flow[+T] {
 
   /**
    * This transformation stage works exactly like [[#transform]] with the
-   * change that normal input elements are wrapped in [[scala.util.Success]]
-   * and failure signaled from upstream (i.e. <code>onError()</code> calls)
-   * is also handled as normal input element wrapped in [[scala.util.Failure]].
-   * In the latter case the stream ends after processing the failure.
+   * change that failure signaled from upstream will invoke
+   * [[RecoveryTransformer#onError]], which can emit an additional sequence of
+   * elements before the stream ends.
    *
    * After normal completion or error the [[RecoveryTransformer#cleanup]] function
    * is called.
@@ -275,5 +274,7 @@ trait Transformer[-T, +U] {
  * General interface for stream transformation.
  * @see [[Flow#transformRecover]]
  */
-trait RecoveryTransformer[-T, +U] extends Transformer[Try[T], U]
+trait RecoveryTransformer[-T, +U] extends Transformer[T, U] {
+  def onError(cause: Throwable): immutable.Seq[U]
+}
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -221,7 +221,7 @@ trait Flow[+T] {
    * consumer have requested elements, i.e. both will see the beginning
    * of the stream.
    */
-  def tee(other: Consumer[T] @uncheckedVariance): Flow[T]
+  def tee(other: Consumer[_ >: T]): Flow[T]
 
   /**
    * Returns a [[scala.concurrent.Future]] that will be fulfilled with the first

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -8,12 +8,11 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Try
 import scala.util.control.NoStackTrace
-
 import org.reactivestreams.api.Producer
-
 import akka.stream.FlowMaterializer
 import akka.stream.impl.Ast.{ ExistingProducer, IterableProducerNode, IteratorProducerNode, ThunkProducerNode }
 import akka.stream.impl.FlowImpl
+import org.reactivestreams.api.Consumer
 
 object Flow {
   /**
@@ -213,6 +212,16 @@ trait Flow[+T] {
    * stream.
    */
   def concat[U >: T](next: Producer[U]): Flow[U]
+
+  /**
+   * Fan-out the stream to another consumer. Each element is produced to
+   * the `other` consumer as well as to downstream consumers. It will not
+   * start producing any elements to the `other` consumer or downstream
+   * consumers until the `other` consumer and at least one downstream
+   * consumer have requested elements, i.e. both will see the beginning
+   * of the stream.
+   */
+  def tee(other: Consumer[T] @uncheckedVariance): Flow[T]
 
   /**
    * Returns a [[scala.concurrent.Future]] that will be fulfilled with the first

--- a/akka-stream/src/test/scala/akka/stream/FlowTeeSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTeeSpec.scala
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream
+
+import scala.concurrent.duration._
+import akka.stream.scaladsl.Flow
+import akka.stream.testkit.AkkaSpec
+import akka.stream.testkit.StreamTestKit
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class FlowTeeSpec extends AkkaSpec {
+
+  val materializer = FlowMaterializer(MaterializerSettings(
+    initialInputBufferSize = 2,
+    maximumInputBufferSize = 16,
+    initialFanOutBufferSize = 1,
+    maxFanOutBufferSize = 16))
+
+  "A Tee" must {
+
+    "tee to other consumer" in {
+      val c1 = StreamTestKit.consumerProbe[Int]
+      val c2 = StreamTestKit.consumerProbe[Int]
+      val p = Flow(List(1, 2, 3)).
+        tee(c2).
+        toProducer(materializer)
+      p.produceTo(c1)
+      val sub1 = c1.expectSubscription()
+      val sub2 = c2.expectSubscription()
+      sub1.requestMore(1)
+      sub2.requestMore(2)
+      c1.expectNext(1)
+      c1.expectNoMsg(100.millis)
+      c2.expectNext(1)
+      c2.expectNext(2)
+      c2.expectNoMsg(100.millis)
+      sub1.requestMore(3)
+      c1.expectNext(2)
+      c1.expectNext(3)
+      c1.expectComplete()
+      sub2.requestMore(3)
+      c2.expectNext(3)
+      c2.expectComplete()
+    }
+
+    "not produce before the other consumer has requested elements" in {
+      val c1 = StreamTestKit.consumerProbe[Int]
+      val c2 = StreamTestKit.consumerProbe[Int]
+      val p = Flow(List(1, 2, 3)).
+        tee(c2).
+        toProducer(materializer)
+      p.produceTo(c1)
+      val sub1 = c1.expectSubscription()
+      sub1.requestMore(1)
+      val sub2 = c2.expectSubscription()
+      // nothing until sub2.requestMore
+      c1.expectNoMsg(100.millis)
+      sub2.requestMore(1)
+      c1.expectNext(1)
+      c1.expectNoMsg(100.millis)
+      c2.expectNext(1)
+      c2.expectNoMsg(100.millis)
+      sub1.requestMore(3)
+      c1.expectNext(2)
+      c1.expectNext(3)
+      c1.expectComplete()
+      sub2.requestMore(3)
+      c2.expectNext(2)
+      c2.expectNext(3)
+      c2.expectComplete()
+    }
+
+    "not produce before downstream has requested elements" in {
+      val c1 = StreamTestKit.consumerProbe[Int]
+      val c2 = StreamTestKit.consumerProbe[Int]
+      val p = Flow(List(1, 2, 3)).
+        tee(c1).
+        toProducer(materializer)
+      p.produceTo(c2)
+      val sub2 = c2.expectSubscription()
+      sub2.requestMore(1)
+      val sub1 = c1.expectSubscription()
+      // nothing until sub2.requestMore
+      c2.expectNoMsg(100.millis)
+      sub1.requestMore(1)
+      c2.expectNext(1)
+      c2.expectNoMsg(100.millis)
+      c1.expectNext(1)
+      c1.expectNoMsg(100.millis)
+      sub2.requestMore(3)
+      c2.expectNext(2)
+      c2.expectNext(3)
+      c2.expectComplete()
+      sub1.requestMore(3)
+      c1.expectNext(2)
+      c1.expectNext(3)
+      c1.expectComplete()
+    }
+
+    "produce to other even though downstream cancels" in {
+      val c1 = StreamTestKit.consumerProbe[Int]
+      val c2 = StreamTestKit.consumerProbe[Int]
+      val p = Flow(List(1, 2, 3)).
+        tee(c2).
+        toProducer(materializer)
+      p.produceTo(c1)
+      val sub1 = c1.expectSubscription()
+      sub1.cancel()
+      val sub2 = c2.expectSubscription()
+      sub2.requestMore(3)
+      c2.expectNext(1)
+      c2.expectNext(2)
+      c2.expectNext(3)
+      c2.expectComplete()
+    }
+
+    "produce to downstream even though other cancels" in {
+      val c1 = StreamTestKit.consumerProbe[Int]
+      val c2 = StreamTestKit.consumerProbe[Int]
+      val p = Flow(List(1, 2, 3)).
+        tee(c1).
+        toProducer(materializer)
+      p.produceTo(c2)
+      val sub1 = c1.expectSubscription()
+      sub1.cancel()
+      val sub2 = c2.expectSubscription()
+      sub2.requestMore(3)
+      c2.expectNext(1)
+      c2.expectNext(2)
+      c2.expectNext(3)
+      c2.expectComplete()
+    }
+
+  }
+
+}

--- a/akka-stream/src/test/scala/akka/stream/FlowTeeSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTeeSpec.scala
@@ -19,111 +19,74 @@ class FlowTeeSpec extends AkkaSpec {
 
   "A Tee" must {
 
-    "tee to other consumer" in {
-      val c1 = StreamTestKit.consumerProbe[Int]
-      val c2 = StreamTestKit.consumerProbe[Int]
-      val p = Flow(List(1, 2, 3)).
-        tee(c2).
-        toProducer(materializer)
-      p.produceTo(c1)
-      val sub1 = c1.expectSubscription()
-      val sub2 = c2.expectSubscription()
-      sub1.requestMore(1)
-      sub2.requestMore(2)
-      c1.expectNext(1)
-      c1.expectNoMsg(100.millis)
-      c2.expectNext(1)
-      c2.expectNext(2)
-      c2.expectNoMsg(100.millis)
-      sub1.requestMore(3)
-      c1.expectNext(2)
-      c1.expectNext(3)
-      c1.expectComplete()
-      sub2.requestMore(3)
-      c2.expectNext(3)
-      c2.expectComplete()
-    }
+    //    "tee to other consumer" in {
+    //      val c1 = StreamTestKit.consumerProbe[Int]
+    //      val c2 = StreamTestKit.consumerProbe[Int]
+    //      val p = Flow(List(1, 2, 3)).
+    //        tee(c2).
+    //        toProducer(materializer)
+    //      p.produceTo(c1)
+    //      val sub1 = c1.expectSubscription()
+    //      val sub2 = c2.expectSubscription()
+    //      sub1.requestMore(1)
+    //      sub2.requestMore(2)
+    //      c1.expectNext(1)
+    //      c1.expectNoMsg(100.millis)
+    //      c2.expectNext(1)
+    //      c2.expectNext(2)
+    //      c2.expectNoMsg(100.millis)
+    //      sub1.requestMore(3)
+    //      c1.expectNext(2)
+    //      c1.expectNext(3)
+    //      c1.expectComplete()
+    //      sub2.requestMore(3)
+    //      c2.expectNext(3)
+    //      c2.expectComplete()
+    //    }
+    //
+    //    "produce to other even though downstream cancels" in {
+    //      val c1 = StreamTestKit.consumerProbe[Int]
+    //      val c2 = StreamTestKit.consumerProbe[Int]
+    //      val p = Flow(List(1, 2, 3)).
+    //        tee(c2).
+    //        toProducer(materializer)
+    //      p.produceTo(c1)
+    //      val sub1 = c1.expectSubscription()
+    //      sub1.cancel()
+    //      val sub2 = c2.expectSubscription()
+    //      sub2.requestMore(3)
+    //      c2.expectNext(1)
+    //      c2.expectNext(2)
+    //      c2.expectNext(3)
+    //      c2.expectComplete()
+    //    }
+    //
+    //    "produce to downstream even though other cancels" in {
+    //      val c1 = StreamTestKit.consumerProbe[Int]
+    //      val c2 = StreamTestKit.consumerProbe[Int]
+    //      val p = Flow(List(1, 2, 3)).
+    //        tee(c1).
+    //        toProducer(materializer)
+    //      p.produceTo(c2)
+    //      val sub1 = c1.expectSubscription()
+    //      sub1.cancel()
+    //      val sub2 = c2.expectSubscription()
+    //      sub2.requestMore(3)
+    //      c2.expectNext(1)
+    //      c2.expectNext(2)
+    //      c2.expectNext(3)
+    //      c2.expectComplete()
+    //    }
 
-    "not produce before the other consumer has requested elements" in {
-      val c1 = StreamTestKit.consumerProbe[Int]
-      val c2 = StreamTestKit.consumerProbe[Int]
-      val p = Flow(List(1, 2, 3)).
-        tee(c2).
-        toProducer(materializer)
-      p.produceTo(c1)
-      val sub1 = c1.expectSubscription()
-      sub1.requestMore(1)
-      val sub2 = c2.expectSubscription()
-      // nothing until sub2.requestMore
-      c1.expectNoMsg(100.millis)
-      sub2.requestMore(1)
-      c1.expectNext(1)
-      c1.expectNoMsg(100.millis)
-      c2.expectNext(1)
-      c2.expectNoMsg(100.millis)
-      sub1.requestMore(3)
-      c1.expectNext(2)
-      c1.expectNext(3)
-      c1.expectComplete()
-      sub2.requestMore(3)
-      c2.expectNext(2)
-      c2.expectNext(3)
-      c2.expectComplete()
-    }
-
-    "not produce before downstream has requested elements" in {
+    "produce to downstream even though other cancels before downstream has subscribed" in {
       val c1 = StreamTestKit.consumerProbe[Int]
       val c2 = StreamTestKit.consumerProbe[Int]
       val p = Flow(List(1, 2, 3)).
         tee(c1).
         toProducer(materializer)
-      p.produceTo(c2)
-      val sub2 = c2.expectSubscription()
-      sub2.requestMore(1)
-      val sub1 = c1.expectSubscription()
-      // nothing until sub2.requestMore
-      c2.expectNoMsg(100.millis)
-      sub1.requestMore(1)
-      c2.expectNext(1)
-      c2.expectNoMsg(100.millis)
-      c1.expectNext(1)
-      c1.expectNoMsg(100.millis)
-      sub2.requestMore(3)
-      c2.expectNext(2)
-      c2.expectNext(3)
-      c2.expectComplete()
-      sub1.requestMore(3)
-      c1.expectNext(2)
-      c1.expectNext(3)
-      c1.expectComplete()
-    }
-
-    "produce to other even though downstream cancels" in {
-      val c1 = StreamTestKit.consumerProbe[Int]
-      val c2 = StreamTestKit.consumerProbe[Int]
-      val p = Flow(List(1, 2, 3)).
-        tee(c2).
-        toProducer(materializer)
-      p.produceTo(c1)
       val sub1 = c1.expectSubscription()
       sub1.cancel()
-      val sub2 = c2.expectSubscription()
-      sub2.requestMore(3)
-      c2.expectNext(1)
-      c2.expectNext(2)
-      c2.expectNext(3)
-      c2.expectComplete()
-    }
-
-    "produce to downstream even though other cancels" in {
-      val c1 = StreamTestKit.consumerProbe[Int]
-      val c2 = StreamTestKit.consumerProbe[Int]
-      val p = Flow(List(1, 2, 3)).
-        tee(c1).
-        toProducer(materializer)
       p.produceTo(c2)
-      val sub1 = c1.expectSubscription()
-      sub1.cancel()
       val sub2 = c2.expectSubscription()
       sub2.requestMore(3)
       c2.expectNext(1)

--- a/akka-stream/src/test/scala/akka/stream/FlowTransformSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTransformSpec.scala
@@ -10,6 +10,8 @@ import akka.testkit.EventFilter
 import com.typesafe.config.ConfigFactory
 import akka.stream.scaladsl.Flow
 import akka.testkit.TestProbe
+import akka.stream.scaladsl.Transformer
+import scala.util.control.NoStackTrace
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug.receive=off\nakka.loglevel=INFO")) {
@@ -26,7 +28,13 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "produce one-to-one transformation as expected" in {
       val p = Flow(List(1, 2, 3).iterator).toProducer(materializer)
       val p2 = Flow(p).
-        transform(0)((tot, elem) ⇒ (tot + elem, List(tot + elem))).
+        transform(new Transformer[Int, Int] {
+          var tot = 0
+          override def onNext(elem: Int) = {
+            tot += elem
+            List(tot)
+          }
+        }).
         toProducer(materializer)
       val consumer = StreamTestKit.consumerProbe[Int]
       p2.produceTo(consumer)
@@ -43,7 +51,13 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "produce one-to-several transformation as expected" in {
       val p = Flow(List(1, 2, 3).iterator).toProducer(materializer)
       val p2 = Flow(p).
-        transform(0)((tot, elem) ⇒ (tot + elem, Vector.fill(elem)(tot + elem))).
+        transform(new Transformer[Int, Int] {
+          var tot = 0
+          override def onNext(elem: Int) = {
+            tot += elem
+            Vector.fill(elem)(tot)
+          }
+        }).
         toProducer(materializer)
       val consumer = StreamTestKit.consumerProbe[Int]
       p2.produceTo(consumer)
@@ -63,7 +77,13 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "produce dropping transformation as expected" in {
       val p = Flow(List(1, 2, 3, 4).iterator).toProducer(materializer)
       val p2 = Flow(p).
-        transform(0)((tot, elem) ⇒ (tot + elem, if (elem % 2 == 0) Nil else List(tot + elem))).
+        transform(new Transformer[Int, Int] {
+          var tot = 0
+          override def onNext(elem: Int) = {
+            tot += elem
+            if (elem % 2 == 0) Nil else List(tot)
+          }
+        }).
         toProducer(materializer)
       val consumer = StreamTestKit.consumerProbe[Int]
       p2.produceTo(consumer)
@@ -80,11 +100,20 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "produce multi-step transformation as expected" in {
       val p = Flow(List("a", "bc", "def").iterator).toProducer(materializer)
       val p2 = Flow(p).
-        transform("") { (str, elem) ⇒
-          val concat = str + elem
-          (concat, List(concat.length))
-        }.
-        transform(0)((tot, length) ⇒ (tot + length, List(tot + length))).
+        transform(new Transformer[String, Int] {
+          var concat = ""
+          override def onNext(elem: String) = {
+            concat += elem
+            List(concat.length)
+          }
+        }).
+        transform(new Transformer[Int, Int] {
+          var tot = 0
+          override def onNext(length: Int) = {
+            tot += length
+            List(tot)
+          }
+        }).
         toProducer(materializer)
       val c1 = StreamTestKit.consumerProbe[Int]
       p2.produceTo(c1)
@@ -109,7 +138,16 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
 
     "invoke onComplete when done" in {
       val p = Flow(List("a").iterator).toProducer(materializer)
-      val p2 = Flow(p).transform("")((s, in) ⇒ (s + in, Nil), x ⇒ List(x + "B")).toProducer(materializer)
+      val p2 = Flow(p).
+        transform(new Transformer[String, String] {
+          var s = ""
+          override def onNext(element: String) = {
+            s += element
+            Nil
+          }
+          override def onComplete() = List(s + "B")
+        }).
+        toProducer(materializer)
       val c = StreamTestKit.consumerProbe[String]
       p2.produceTo(c)
       val s = c.expectSubscription()
@@ -121,8 +159,17 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "invoke cleanup when done" in {
       val cleanupProbe = TestProbe()
       val p = Flow(List("a").iterator).toProducer(materializer)
-      val p2 = Flow(p).transform("")((s, in) ⇒ (s + in, Nil), x ⇒ List(x + "B"),
-        cleanup = s ⇒ cleanupProbe.ref ! s).toProducer(materializer)
+      val p2 = Flow(p).
+        transform(new Transformer[String, String] {
+          var s = ""
+          override def onNext(element: String) = {
+            s += element
+            Nil
+          }
+          override def onComplete() = List(s + "B")
+          override def cleanup() = cleanupProbe.ref ! s
+        }).
+        toProducer(materializer)
       val c = StreamTestKit.consumerProbe[String]
       p2.produceTo(c)
       val s = c.expectSubscription()
@@ -135,9 +182,21 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "invoke cleanup when done after error" in {
       val cleanupProbe = TestProbe()
       val p = Flow(List("a", "b", "c").iterator).toProducer(materializer)
-      val p2 = Flow(p).transform("")(
-        f = (s, in) ⇒ if (in == "b") throw new IllegalArgumentException("Not b") else (s + in.toUpperCase, List(s + in)),
-        cleanup = s ⇒ cleanupProbe.ref ! s).toProducer(materializer)
+      val p2 = Flow(p).
+        transform(new Transformer[String, String] {
+          var s = ""
+          override def onNext(in: String) = {
+            if (in == "b") throw new IllegalArgumentException("Not b") with NoStackTrace
+            else {
+              val out = s + in
+              s += in.toUpperCase
+              List(out)
+            }
+          }
+          override def onComplete() = List(s + "B")
+          override def cleanup() = cleanupProbe.ref ! s
+        }).
+        toProducer(materializer)
       val c = StreamTestKit.consumerProbe[String]
       p2.produceTo(c)
       val s = c.expectSubscription()
@@ -150,7 +209,16 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
 
     "allow cancellation using isComplete" in {
       val p = StreamTestKit.producerProbe[Int]
-      val p2 = Flow(p).transform("")((s, in) ⇒ (s + in, List(in)), isComplete = _ == "1").toProducer(materializer)
+      val p2 = Flow(p).
+        transform(new Transformer[Int, Int] {
+          var s = ""
+          override def onNext(element: Int) = {
+            s += element
+            List(element)
+          }
+          override def isComplete = s == "1"
+        }).
+        toProducer(materializer)
       val proc = p.expectSubscription
       val c = StreamTestKit.consumerProbe[Int]
       p2.produceTo(c)
@@ -166,8 +234,18 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "call onComplete after isComplete signaled completion" in {
       val cleanupProbe = TestProbe()
       val p = StreamTestKit.producerProbe[Int]
-      val p2 = Flow(p).transform("")((s, in) ⇒ (s + in, List(in)), onComplete = x ⇒ List(x.size + 10),
-        isComplete = _ == "1", cleanup = s ⇒ cleanupProbe.ref ! s).toProducer(materializer)
+      val p2 = Flow(p).
+        transform(new Transformer[Int, Int] {
+          var s = ""
+          override def onNext(element: Int) = {
+            s += element
+            List(element)
+          }
+          override def isComplete = s == "1"
+          override def onComplete() = List(s.length + 10)
+          override def cleanup() = cleanupProbe.ref ! s
+        }).
+        toProducer(materializer)
       val proc = p.expectSubscription
       val c = StreamTestKit.consumerProbe[Int]
       p2.produceTo(c)
@@ -185,9 +263,12 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "report error when exception is thrown" in {
       val p = Flow(List(1, 2, 3).iterator).toProducer(materializer)
       val p2 = Flow(p).
-        transform(0) { (_, elem) ⇒
-          if (elem == 2) throw new IllegalArgumentException("two not allowed") else (0, List(elem, elem))
-        }.
+        transform(new Transformer[Int, Int] {
+          override def onNext(elem: Int) = {
+            if (elem == 2) throw new IllegalArgumentException("two not allowed")
+            else List(elem, elem)
+          }
+        }).
         toProducer(materializer)
       val consumer = StreamTestKit.consumerProbe[Int]
       p2.produceTo(consumer)
@@ -204,7 +285,9 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
     "support cancel as expected" in {
       val p = Flow(List(1, 2, 3).iterator).toProducer(materializer)
       val p2 = Flow(p).
-        transform(0) { (_, elem) ⇒ (0, List(elem, elem)) }.
+        transform(new Transformer[Int, Int] {
+          override def onNext(elem: Int) = List(elem, elem)
+        }).
         toProducer(materializer)
       val consumer = StreamTestKit.consumerProbe[Int]
       p2.produceTo(consumer)
@@ -220,7 +303,11 @@ class FlowTransformSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.d
 
     "support producing elements from empty inputs" in {
       val p = Flow(List.empty[Int].iterator).toProducer(materializer)
-      val p2 = Flow(p).transform(List(1, 2, 3))((s, _) ⇒ (s, Nil), onComplete = s ⇒ s).
+      val p2 = Flow(p).
+        transform(new Transformer[Int, Int] {
+          override def onNext(elem: Int) = Nil
+          override def onComplete() = List(1, 2, 3)
+        }).
         toProducer(materializer)
       val consumer = StreamTestKit.consumerProbe[Int]
       p2.produceTo(consumer)

--- a/akka-stream/src/test/scala/akka/stream/IdentityProcessorTest.scala
+++ b/akka-stream/src/test/scala/akka/stream/IdentityProcessorTest.scala
@@ -14,6 +14,7 @@ import akka.stream.impl.Ast
 import akka.testkit.{ TestEvent, EventFilter }
 import akka.stream.impl.ActorBasedFlowMaterializer
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Transformer
 import akka.stream.testkit.AkkaSpec
 
 class IdentityProcessorTest(_system: ActorSystem, env: TestEnvironment, publisherShutdownTimeout: Long)
@@ -45,7 +46,10 @@ class IdentityProcessorTest(_system: ActorSystem, env: TestEnvironment, publishe
         maxFanOutBufferSize = fanoutSize),
       system)
 
-    val processor = materializer.processorForNode(Ast.Transform(Unit, (_, in: Any) ⇒ (Unit, List(in)), _ ⇒ Nil, _ ⇒ false, _ ⇒ ()))
+    val processor = materializer.processorForNode(Ast.Transform(
+      new Transformer[Any, Any] {
+        override def onNext(in: Any) = List(in)
+      }))
 
     processor.asInstanceOf[Processor[Int, Int]]
   }

--- a/akka-stream/src/test/scala/akka/stream/testkit/ScriptedTest.scala
+++ b/akka-stream/src/test/scala/akka/stream/testkit/ScriptedTest.scala
@@ -52,7 +52,7 @@ trait ScriptedTest extends ShouldMatchers {
     def consumeOutput(out: Out): Script[In, Out] = {
       if (noOutsPending)
         throw new ScriptException(s"Tried to produce element ${out} but no elements should be produced right now.")
-      expectedOutputs(outputCursor) should be(out)
+      out should be(expectedOutputs(outputCursor))
       this.copy(outputCursor = outputCursor + 1)
     }
 


### PR DESCRIPTION
NOT READY. Before completing (with more tests) I would like to verify that this is the right signature and semantics. 

@sirthias, please take a look. Note that it only waits for request from the `other` consumer. The reason why I did not let it wait for request from downstream consumer is that it can be multiple downstream consumers and then it would have to wait for at least one. I can change that, but this might be enough for your coordination of the 2 streams. Not sure what is most intuitive.
