### PR TITLE
=build #15103 Add Build start/finish events

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
-
 resolvers += Classpaths.typesafeResolver
+
+resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 // these comment markers are for including code into the docs
 //#sbt-multi-jvm
@@ -19,5 +20,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"


### PR DESCRIPTION
These are visible on the grafana dashboard, in order to be able to see on which commit stats have been recorded.

It's enabled via: `-Dakka.sbt.graphite=true`

Perhaps should be merged after the move to multiple build files? Does not touch much actually though.

Resolves #15103
