### PR TITLE
Wip 15101 stream framing drewhk

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/io/Codecs.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/Codecs.scala
@@ -1,0 +1,214 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io
+
+import akka.util.ByteString
+import java.nio.ByteOrder
+import akka.stream.io.Codecs._
+import scala.annotation.tailrec
+
+trait FieldDecoder[T] {
+  import Decoder._
+  def context: DecodeContext
+  def andThen: T ⇒ DecodeStep
+  def decode: DecodeStep
+}
+
+trait DecodeContext {
+  import Decoder._
+  def read(count: ⇒ Int)(andThen: ReadAction): DecodeStep
+  def read(atLeast: ⇒ Int, atMost: ⇒ Int)(andThen: ReadAction): DecodeStep
+  def pushBack(count: ⇒ Int): Unit
+  def decode[T](decoder: FieldDecoder[T]): DecodeStep
+}
+
+object Decoder {
+  type ReadAction = (ByteString, Int, Int) ⇒ DecodeStep
+
+  // TODO: try to make it private
+  case class DecodeStep(preamble: () ⇒ Unit, step: ReadAction)
+}
+
+abstract class Decoder[Out] extends DecodeContext {
+  import Decoder._
+
+  private var buffer = ByteString.empty
+  private var readIdx = 0
+  private var readTarget = 0
+  private var minimumReadTarget = 0
+  // TODO: make it pull based
+  private var results: List[Out] = Nil
+  private var compactionMarker = 0
+  def start: DecodeStep
+
+  private var currentStep: DecodeStep = _
+
+  implicit protected def context: DecodeContext = this
+
+  final def parseFragment(fragment: ByteString): List[Out] = {
+    // Lazily initialize the first step
+    if (currentStep eq null) {
+      currentStep = start
+      currentStep.preamble()
+    }
+    if (results.nonEmpty) results = Nil
+    buffer ++= fragment
+
+    while (buffer.size >= minimumReadTarget) {
+      readTarget = math.min(readTarget, buffer.size)
+      minimumReadTarget = readTarget
+      currentStep = currentStep.step(buffer, readIdx, readTarget)
+      currentStep.preamble()
+    }
+
+    results.reverse
+  }
+
+  final private def nextStep(atLeastBytes: ⇒ Int, atMostBytes: ⇒ Int, step: ReadAction): DecodeStep = {
+    DecodeStep(
+      () ⇒ {
+        val available = readTarget
+        readTarget = available + atMostBytes
+        minimumReadTarget = available + atLeastBytes
+      },
+      (buf, start, end) ⇒ {
+        val next = step(buf, start, end)
+        readIdx = math.min(readTarget, buffer.size)
+        readTarget = readIdx
+        minimumReadTarget = readIdx
+        next
+      })
+  }
+
+  final override def read(count: ⇒ Int)(andThen: ReadAction): DecodeStep = nextStep(count, count, andThen)
+  final override def read(atLeast: ⇒ Int, atMost: ⇒ Int)(andThen: ReadAction): DecodeStep = nextStep(atLeast, atMost, andThen)
+
+  final override def pushBack(count: ⇒ Int): Unit = {
+    val pb = count
+    if (pb > readTarget)
+      throw new IllegalArgumentException("Cannot push back more bytes than was read from the previous step. " +
+        s"Attempted to push back [$pb] while only [$readTarget] is avalaible.")
+    readTarget -= pb
+    minimumReadTarget -= pb
+    readIdx = math.min(readTarget, buffer.size) - pb
+  }
+
+  final override def decode[T](decoder: FieldDecoder[T]): DecodeStep = decoder.decode
+
+  final protected def emit(out: Out): DecodeStep = {
+    emitIntermediate(out)
+    start
+  }
+
+  final protected def emitIntermediate(out: Out): Unit = {
+    results = out :: results
+    slideAndCompact()
+    readTarget = 0
+    minimumReadTarget = 0
+    readIdx = 0
+  }
+
+  private def slideAndCompact(): Unit = {
+    buffer = buffer.drop(readTarget)
+    compactionMarker -= readTarget
+    if (compactionMarker < 0) {
+      buffer = buffer.compact
+      compactionMarker = buffer.size
+    }
+  }
+}
+
+object Codecs {
+  import Decoder.DecodeStep
+
+  // TODO: endian support
+  case class IntField(andThen: Int ⇒ DecodeStep)(implicit val context: DecodeContext) extends FieldDecoder[Int] {
+    val decode: DecodeStep = context.read(4) { (buf, start, end) ⇒
+      andThen(buf.slice(start, end).iterator.getInt(ByteOrder.BIG_ENDIAN))
+    }
+    override def toString = "[32 bit Integer field]"
+  }
+
+  case class VarintField(andThen: Int ⇒ DecodeStep)(implicit val context: DecodeContext) extends FieldDecoder[Int] {
+    private def unpackFirst(first: Byte): Int = first.toInt & 0x3f
+    private def unpack(prev: Int, next: Byte): Int = (prev << 8) + (next.toInt & 0xff)
+
+    val decode = context.read(1) { (buf, start, end) ⇒
+      buf(start) & 0xc0 match {
+        case 0x00 ⇒
+          andThen(unpackFirst(buf(start)))
+        case 0x40 ⇒
+          context.pushBack(1)
+          decode2Bytes
+        case 0x80 ⇒
+          context.pushBack(1)
+          decode3Bytes
+        case 0xc0 ⇒
+          context.pushBack(1)
+          decode4Bytes
+      }
+    }
+
+    private val decode2Bytes = context.read(2) {
+      (buf, start, end) ⇒ andThen(unpack(unpackFirst(buf(start)), buf(start + 1)))
+    }
+
+    private val decode3Bytes = context.read(3) {
+      (buf, start, end) ⇒ andThen(unpack(unpack(unpackFirst(buf(start)), buf(start + 1)), buf(start + 2)))
+    }
+
+    private val decode4Bytes = context.read(4) {
+      (buf, start, end) ⇒ andThen(unpack(unpack(unpack(unpackFirst(buf(start)), buf(start + 1)), buf(start + 2)), buf(start + 3)))
+    }
+
+    override def toString = "[Variable length encoded Integer field]"
+  }
+
+  case class DelimiterEncodedField(delimiter: ByteString, lookAhead: Int = 1024)(val andThen: ByteString ⇒ DecodeStep)(implicit val context: DecodeContext) extends FieldDecoder[ByteString] {
+    require(delimiter.size > 0, "Delmiter must be at least one byte long, but it was empty")
+
+    private val delimiterSize = delimiter.size
+    private val delimiterFirstByte = delimiter(0)
+    private var nextPossibleMatch = -1
+    private var frameStart = -1
+
+    @tailrec
+    private def scan(buf: ByteString): Int = {
+      if (nextPossibleMatch >= buf.size - delimiterSize) -1
+      else {
+        val possibleMatch = buf.indexOf(delimiterFirstByte, nextPossibleMatch)
+        if (possibleMatch >= 0) {
+          if (buf.slice(possibleMatch, possibleMatch + delimiterSize) == delimiter) possibleMatch
+          else {
+            nextPossibleMatch += 1
+            scan(buf)
+          }
+        } else -1
+      }
+    }
+
+    lazy val decode: DecodeStep =
+      context.read(atLeast = 1, atMost = lookAhead) { (buf, start, end) ⇒
+        if (nextPossibleMatch == -1) {
+          nextPossibleMatch = start
+          frameStart = start
+        }
+
+        if (end < nextPossibleMatch + delimiterSize)
+          decode
+        else {
+          val delimiterPos = scan(buf)
+          if (delimiterPos >= 0) {
+            val frameEnd = delimiterPos + delimiterSize
+            val currentFrameStart = frameStart
+            nextPossibleMatch = -1
+            frameStart = -1
+            context.pushBack(end - frameEnd)
+            andThen(buf.slice(currentFrameStart, frameEnd))
+          } else decode
+        }
+      }
+
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -189,7 +189,7 @@ trait Flow[+T] {
    * the current element if the given predicate returns true for it. This means
    * that for the following series of predicate values, three substreams will
    * be produced with lengths 1, 2, and 3:
-   * 
+   *
    * {{{
    * false,             // element goes into first substream
    * true, false,       // elements go into second substream

--- a/akka-stream/src/test/scala/akka/stream/io/CodecSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/io/CodecSpec.scala
@@ -1,0 +1,259 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io
+
+import akka.stream.testkit.AkkaSpec
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
+import scala.concurrent.forkjoin.ThreadLocalRandom
+import scala.collection.immutable
+import akka.stream.impl.ActorBasedFlowMaterializer
+import akka.stream.MaterializerSettings
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import akka.stream.io.Codecs._
+import akka.stream.io.Decoder.DecodeStep
+
+class CodecSpec extends AkkaSpec {
+
+  val materializer = new ActorBasedFlowMaterializer(MaterializerSettings(
+    initialInputBufferSize = 2,
+    maximumInputBufferSize = 2,
+    initialFanOutBufferSize = 2,
+    maxFanOutBufferSize = 2), system)
+
+  def chunkUp(data: ByteString): (ByteString, immutable.Seq[ByteString]) = {
+    if (data.isEmpty) {
+      if (ThreadLocalRandom.current().nextBoolean()) (ByteString.empty, List(ByteString.empty))
+      else (data, Nil)
+    } else {
+      if (ThreadLocalRandom.current().nextBoolean()) (ByteString.empty, List(data))
+      else {
+        val splitIdx = ThreadLocalRandom.current().nextInt(data.size)
+        (data.drop(splitIdx), List(data.slice(0, splitIdx)))
+      }
+    }
+  }
+
+  def rechunk(flow: Flow[ByteString]): Flow[ByteString] = {
+    flow.transform(ByteString.empty)(
+      f = (aggregated, incoming) ⇒ chunkUp(aggregated ++ incoming),
+      onComplete = (aggregated) ⇒ List(aggregated))
+
+  }
+
+  def decodingTransform[Out](flow: Flow[ByteString], decoder: Decoder[Out]): Flow[Out] =
+    flow.transform(decoder)(
+      f = (builder, fragment) ⇒ (decoder, decoder.parseFragment(fragment)))
+
+  abstract class TestSetup[T] {
+    def testSequence: immutable.Seq[T]
+    def encode(in: T): ByteString
+    def decoder: Decoder[T]
+
+    val decoded = decodingTransform(rechunk(Flow(testSequence) map encode), decoder)
+      .fold(Vector.empty[T])((acc, in) ⇒ acc :+ in).toFuture(materializer)
+
+    Await.result(decoded, 3.seconds) should be(testSequence)
+  }
+
+  "Codec support" must {
+
+    "be able to decode a stream of integers with fixed size" in new TestSetup[Int] {
+      def encode(i: Int) = ByteString((i >>> 24).toByte, (i >>> 16).toByte, (i >>> 8).toByte, i.toByte)
+      def testSequence = List(1, 2, 3, Int.MaxValue, 0, Int.MinValue)
+      def decoder = new Decoder[Int] {
+        val start = decode(IntField(emit))
+      }
+    }
+
+    "be able to decode a stream of integers with variable size" in new TestSetup[Int] {
+      def encode(i: Int) =
+        if (i < 64) ByteString(i.toByte)
+        else if (i < 16384) ByteString(((i >> 8) | 0x40).toByte, i.toByte)
+        else if (i < 4194304) ByteString(((i >> 16) | 0x80).toByte, (i >> 8).toByte, i.toByte)
+        else if (i < 1073741824) ByteString(((i >> 24) | 0xc0).toByte, (i >> 16).toByte, (i >> 8).toByte, i.toByte)
+        else throw new IllegalArgumentException(s"Only nonnegative integers up to 2^30 may be represented. Input was: $i")
+
+      def testSequence = List(1, 2, 3, 16384, 4194304, 1073741823, 4, 3, 22, 2048, 65537)
+
+      def decoder = new Decoder[Int] {
+        val start = decode(VarintField(emit))
+      }
+    }
+
+    "be able to decode a stream of strings with a length header" in new TestSetup[String] {
+      def encode(s: String) = {
+        ByteString((s.length >>> 24).toByte, (s.length >>> 16).toByte, (s.length >>> 8).toByte, s.length.toByte) ++
+          ByteString(s, "UTF-8")
+      }
+
+      def testSequence = List("test1", "", "longertest", "\n", "\r", "another string", "", "")
+
+      def decoder = new Decoder[String] {
+        var frameLength = 0
+
+        val start = decode(IntField { length ⇒ frameLength = length; decodeBody })
+        val decodeBody = read(frameLength) { (buf, start, end) ⇒ emit(buf.slice(start, end).utf8String) }
+      }
+    }
+
+    "be able to decode a stream of frames containing sequences" in new TestSetup[List[Int]] {
+      override def encode(in: List[Int]): ByteString = {
+        var header = ByteString((in.size >>> 24).toByte, (in.size >>> 16).toByte, (in.size >>> 8).toByte, in.size.toByte)
+        for (i ← in) header ++= ByteString((i >>> 24).toByte, (i >>> 16).toByte, (i >>> 8).toByte, i.toByte)
+        header
+      }
+
+      override def testSequence: scala.collection.immutable.Seq[List[Int]] = List(
+        List(1),
+        List(3, 4, 16384, Int.MaxValue),
+        Nil)
+
+      override def decoder: Decoder[List[Int]] = new Decoder[List[Int]] {
+        var remaining = 0
+        var acc: List[Int] = Nil
+
+        val start = decode(IntField { size ⇒
+          if (size == 0) emit(Nil)
+          else {
+            remaining = size
+            acc = Nil
+            decodeElements
+          }
+        })
+
+        lazy val decodeElements: DecodeStep = decode(IntField { elem ⇒
+          remaining -= 1
+          acc ::= elem
+          if (remaining > 0) decodeElements
+          else emit(acc.reverse)
+        })
+      }
+    }
+
+    "be able to decode a stream of frames containing sequences, streaming the elements" in {
+      def encode(in: List[Int]): ByteString = {
+        var header = ByteString((in.size >>> 24).toByte, (in.size >>> 16).toByte, (in.size >>> 8).toByte, in.size.toByte)
+        for (i ← in) header ++= ByteString((i >>> 24).toByte, (i >>> 16).toByte, (i >>> 8).toByte, i.toByte)
+        header
+      }
+
+      val testSequence: scala.collection.immutable.Seq[List[Int]] = Vector(
+        List(1),
+        List(3, 4, 16384, Int.MaxValue),
+        Nil)
+
+      val decoder: Decoder[Int] = new Decoder[Int] {
+        var remaining = 0
+        var acc: List[Int] = Nil
+
+        lazy val start: DecodeStep = decode(IntField { size ⇒
+          if (size == 0) start
+          else {
+            remaining = size
+            decodeElements
+          }
+        })
+
+        lazy val decodeElements: DecodeStep = decode(IntField { elem ⇒
+          remaining -= 1
+          emitIntermediate(elem)
+          if (remaining > 0) decodeElements
+          else start
+        })
+      }
+
+      val decoded = decodingTransform(rechunk(Flow(testSequence) map encode), decoder)
+        .fold(Vector.empty[Int])((acc, in) ⇒ acc :+ in).toFuture(materializer)
+
+      Await.result(decoded, 3.seconds) should be(testSequence.flatten)
+    }
+
+    "be able to decode a stream of delimiter bounded elements" in new TestSetup[String] {
+      override def encode(in: String): ByteString = ByteString(in + "\r\n")
+      override def testSequence: scala.collection.immutable.Seq[String] = List(
+        "", "hello", "world", "\r", "\n", "", "still living")
+      override def decoder: Decoder[String] = new Decoder[String] {
+        val start: DecodeStep = decode(DelimiterEncodedField(ByteString("\r\n")) { bytes ⇒
+          emit(bytes.utf8String.stripSuffix("\r\n"))
+        })
+      }
+    }
+
+    "be able to decode a string length header, then a stream of bytes" in {
+      def encode(in: ByteString): ByteString = {
+        val header = ByteString(s"${in.size}\r\n")
+        header ++ in
+      }
+
+      val testSequence: scala.collection.immutable.Seq[ByteString] = Vector(
+        ByteString("Hello"),
+        ByteString(" "),
+        ByteString(""),
+        ByteString(""),
+        ByteString("world"),
+        ByteString("!"))
+
+      val decoder: Decoder[ByteString] = new Decoder[ByteString] {
+        var remaining = 0
+
+        val start: DecodeStep = decode(DelimiterEncodedField(ByteString("\r\n")) { header ⇒
+          remaining = Integer.parseInt(header.utf8String.stripSuffix("\r\n"))
+          readBody
+        })
+
+        lazy val readBody: DecodeStep = read(atLeast = 1, atMost = remaining) { (buf, start, end) ⇒
+          remaining -= end - start
+          if (remaining == 0) emit(buf.slice(start, end))
+          else {
+            emitIntermediate(buf.slice(start, end))
+            readBody
+          }
+        }
+
+      }
+
+      val decoded = decodingTransform(rechunk(Flow(testSequence) map encode), decoder)
+        .fold(Vector.empty[ByteString])((acc, in) ⇒ acc :+ in).toFuture(materializer)
+
+      Await.result(decoded, 3.seconds).reduceLeft(_ ++ _).utf8String should be("Hello world!")
+    }
+
+    sealed trait MyVariantType
+    case class MyNumber(i: Int) extends MyVariantType
+    case class MyString(s: String) extends MyVariantType
+
+    "be able to decode a sequence of variant type fields" in new TestSetup[MyVariantType] {
+      override def encode(in: MyVariantType): ByteString = in match {
+        case MyNumber(i) ⇒
+          ByteString(0) ++ ByteString((i >>> 24).toByte, (i >>> 16).toByte, (i >>> 8).toByte, i.toByte)
+        case MyString(s) ⇒
+          ByteString(1) ++ ByteString(s + "\r\n")
+      }
+      override def testSequence = Vector(
+        MyNumber(Int.MaxValue), MyNumber(0), MyString(""), MyNumber(-1), MyString("boo"), MyString("\n"),
+        MyString("\r"), MyNumber(42))
+      override def decoder: Decoder[MyVariantType] = new Decoder[MyVariantType] {
+        val start = read(1) { (buf, start, end) ⇒
+          buf(start) match {
+            case 0 ⇒ decodeInt
+            case 1 ⇒ decodeString
+          }
+        }
+
+        val decodeInt = decode(IntField { i ⇒
+          emit(MyNumber(i))
+        })
+
+        val decodeString = decode(DelimiterEncodedField(ByteString("\r\n")) { s ⇒
+          emit(MyString(s.utf8String.stripSuffix("\r\n")))
+        })
+
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
NOT READY YET

Initial implementation for flexible decoding a stream of ByteStrings. The design goal was to be able to control allocations as much as possible (after constructing the decoder itself) while allowing to fully exploit the streaming possibilities and remaining readable. This is a low-level tool, ordinary framing elements similar to the pipelines we had in the past will be provided for convenience.

Unfortunately the current implementation is not Java friendly. 
