### PR TITLE
=act #15165 should fix out-of-bounds in actor creation

### DIFF
--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
@@ -95,7 +95,7 @@ private[akka] trait MetricsKit extends MetricsKitOps {
    * HINT: this operation can be costy, run outside of your tested code, or rely on scheduled reporting.
    */
   def reportAndClearMetrics() {
-    reporters foreach { _.report() }
+    reportMetrics()
     clearMetrics()
   }
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitOps.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitOps.scala
@@ -43,11 +43,21 @@ private[akka] trait MetricsKitOps extends MetricKeyDSL {
    *
    * @param unitString just for human readable output, during console printing
    */
-  def histogram(key: MetricKey, highestTrackableValue: Long, numberOfSignificantValueDigits: Int, unitString: String = ""): HdrHistogram =
+  def hdrHistogram(key: MetricKey, highestTrackableValue: Long, numberOfSignificantValueDigits: Int, unitString: String = ""): HdrHistogram =
     getOrRegister((key / "hdr-histogram").toString, new HdrHistogram(highestTrackableValue, numberOfSignificantValueDigits, unitString))
+
+  /**
+   * Use when measuring for 9x'th percentiles as well as min / max / mean values.
+   *
+   * Backed by [[ExponentiallyDecayingReservoir]].
+   */
+  def histogram(key: MetricKey): Histogram = {
+    registry.histogram((key / "histogram").toString)
+  }
 
   /** Yet another delegate to `System.gc()` */
   def gc() {
+    // todo add some form of logging, to differentiate manual gc calls from "normal" ones
     System.gc()
   }
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitSpec.scala
@@ -3,11 +3,15 @@
  */
 package akka.testkit.metrics
 
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfter, MustMatchers, WordSpec }
+import org.scalatest._
 import com.typesafe.config.ConfigFactory
+import scala.util.Random
+import org.scalautils.Tolerance
 
-class MetricsKitSpec extends WordSpec with MustMatchers with BeforeAndAfter with BeforeAndAfterAll
+class MetricsKitSpec extends WordSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll
   with MetricsKit {
+
+  import scala.concurrent.duration._
 
   override def metricsConfig = ConfigFactory.load()
 
@@ -26,7 +30,7 @@ class MetricsKitSpec extends WordSpec with MustMatchers with BeforeAndAfter with
     "allow measuring file descriptor usage" in {
       measureFileDescriptors(KitKey / "file-desc")
 
-      registeredMetrics.count(_._1 contains "file-descriptor") must be > 0
+      registeredMetrics.count(_._1 contains "file-descriptor") should be > 0
     }
 
     "allow to measure time, on known number of operations" in {
@@ -43,8 +47,33 @@ class MetricsKitSpec extends WordSpec with MustMatchers with BeforeAndAfter with
       avg.add(sizes)
       avg.add(4)
 
-      avg.getValue must equal(2.5)
+      avg.getValue should equal(2.5)
     }
+
+    "measure values in histogram" in {
+      val maxMillis = 100.millis.toNanos
+      val hist = hdrHistogram(KitKey / "hist", highestTrackableValue = maxMillis, 4, "ns")
+
+      for {
+        n ← 1 to 11
+        i ← 0L to 1579331
+      } hist.update(i)
+
+      hist.update(1579331)
+      reportMetrics()
+    }
+
+    "fail with human readable error when the histogram overflowed" in {
+      val maxMillis = 100.millis.toNanos
+      val hist = hdrHistogram(KitKey / "hist", highestTrackableValue = maxMillis, 4, "ns")
+
+      val ex = intercept[IllegalArgumentException] {
+        hist.update(10.second.toNanos)
+      }
+
+      ex.getMessage should include("can not be stored in this histogram")
+    }
+
   }
 
 }

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
@@ -17,7 +17,7 @@ class AkkaConsoleReporter(
   registry: AkkaMetricRegistry,
   verbose: Boolean,
   output: PrintStream = System.out)
-  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-console-reporter", MetricsKit.KnownOpsInTimespanCounterFilter, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
+  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-console-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
 
   private final val ConsoleWidth = 80
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaGraphiteReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaGraphiteReporter.scala
@@ -19,7 +19,7 @@ class AkkaGraphiteReporter(
   registry: AkkaMetricRegistry,
   prefix: String,
   graphite: Graphite)
-  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-graphite-reporter", MetricsKit.KnownOpsInTimespanCounterFilter, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
+  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-graphite-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
 
   // todo get rid of ScheduledReporter (would mean removing codahale metrics)?
 


### PR DESCRIPTION
Should fix index out of bounds in actor creation.
- Improved actor creation tests to take into account GC pauses (coordinated omission)
- Also improved failure logging when AIOOB happens in the histogram
- Added a test which shows why the updateWithExpectedInterval method should be preferred too.

May resolve #15165, we'll need to get a failure now to get the min/max bounds and the value it failed at to set the bounds even better (histogram's max tracked value).
