### PR TITLE
Do not run multi-jvm tests twice

### DIFF
--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -226,14 +226,20 @@ object TestExtras {
 
     import Keys._
 
+    private[Filter] object Params {
+      val testNamesExclude = systemPropertyAsSeq("akka.test.names.exclude").toSet
+      val testTagsExlcude = systemPropertyAsSeq("akka.test.tags.exclude").toSet
+      val testTagsOnly = systemPropertyAsSeq("akka.test.tags.only").toSet
+    }
+
     def settings = {
       Seq(
-        excludeTestNames := systemPropertyAsSeq("akka.test.names.exclude").toSet,
+        excludeTestNames := Params.testNamesExclude,
         excludeTestTags := {
-          if (onlyTestTags.value.isEmpty) systemPropertyAsSeq("akka.test.tags.exclude").toSet
+          if (onlyTestTags.value.isEmpty) Params.testTagsExlcude
           else Set.empty
         },
-        onlyTestTags := systemPropertyAsSeq("akka.test.tags.only").toSet,
+        onlyTestTags := Params.testTagsOnly,
 
         // add filters for tests excluded by name
         testOptions in Test <++= excludeTestNames map { _.toSeq.map(exclude => Tests.Filter(test => !test.contains(exclude))) },
@@ -248,6 +254,10 @@ object TestExtras {
           if (tags.isEmpty) Seq.empty else Seq(Tests.Argument("-n", tags.mkString(" ")))
         }
       )
+    }
+
+    def containsOrNotExcludesTag(tag: String) = {
+      Params.testTagsOnly.contains(tag) || !Params.testTagsExlcude(tag)
     }
 
     def systemPropertyAsSeq(name: String): Seq[String] = {


### PR DESCRIPTION
This is a fix for #15166 issue.

My only refactoring in #15113 has ended up in running multi-jvm tests twice. I am not entirely sure why it did that, but here is the revert of that refactoring. I will tackle this again, when doing general cleanup of sbt files.

I have run `akka-multi-node` job with these changes and the build time is back to 1h7m.
