### PR TITLE
+pro,ben #15180 add akka-bench-jmh, enable running jmh benchmarks form sbt

### DIFF
--- a/akka-bench-jmh/README.md
+++ b/akka-bench-jmh/README.md
@@ -1,0 +1,29 @@
+Akka JMH Benchmarks
+===================
+This project should depend on tested projects, and allows to benchmark them using the JMH library.
+
+For good results consider running the benchmarks at least for 10 iterations (both warmup and measuring).
+
+Usage
+-----
+Simply run a specified benchmark (parameters are 1:1 like in JMH):
+
+```
+run                             // all benchmarks, on default settings
+run -i 3 -wi 3 -f 1 .*actor.*   // all actor benchmarks, 3 warmups, 3 iterations, 1 fork
+run -h                          // shows JMH help
+```
+
+The internal workings of the code generation process are as follows:
+
+```
+compile: scala -> bytecode_1
+generate: bytecode_1 -> java benchmarks source code
+compile: java benchmarks -. bytecode_2
+```
+
+Examples
+--------
+There are a lot of good examples here (in java): http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples
+
+

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.actor
+
+import org.openjdk.jmh.annotations._
+import com.typesafe.config.ConfigFactory
+import akka.testkit.TestProbe
+import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class ActorCreationBenchmark {
+
+  val config = ConfigFactory.parseString(
+    """
+      akka {
+        log-config-on-start = off
+        log-dead-letters-during-shutdown = off
+        loglevel = "WARNING"
+
+        test {
+          timefactor =  1.0
+          filter-leeway = 3s
+          single-expect-default = 3s
+          default-timeout = 5s
+          calling-thread-dispatcher {
+            type = akka.testkit.CallingThreadDispatcherConfigurator
+          }
+        }
+      }""".stripMargin).withFallback(ConfigFactory.load())
+
+  implicit val system = ActorSystem("test", config)
+
+  val probe = TestProbe()
+  implicit val testActor = probe.ref
+
+
+//  @Param(Array("100000"))
+  val numberOfActors = 100000
+
+  @Setup
+  def setup() {
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  import ActorCreationPerfSpec._
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(100000)
+  def actor_creation_time_for_actorOf_Props_EmptyActor__each_time_new__100k_actors() {
+    val propsCreator = () => Props[EmptyActor]
+
+    test(propsCreator)
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(100000)
+  def actor_creation_time_for_actorOf_Props_EmptyActor__each_time_same__100k_actors() {
+    val p = Props[EmptyActor]
+    val propsCreator = () => p
+
+    test(propsCreator)
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(100000)
+  def actor_creation_time_for_actorOf_Props_new_EmptyActor__each_time_new__100k_actors() {
+    val propsCreator = () => { Props(new EmptyActor) }
+
+    test(propsCreator)
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(100000)
+  def actor_creation_time_for_actorOf_Props_new_EmptyActor__each_time_same__100k_actors() {
+    val p = Props(new EmptyActor)
+    val propsCreator = () => p
+
+    test(propsCreator)
+  }
+
+  @OperationsPerInvocation(100000)
+  def actor_creation_time_for_actorOf_Props_classOf_EmptyArgsActor__each_time_new__100k_actors() {
+    val propsCreator = () => Props(classOf[EmptyArgsActor], 4711, 1729)
+
+    test(propsCreator)
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(100000)
+  def actor_creation_time_for_actorOf_Props_classOf_EmptyArgsActor__each_time_same__100k_actors() {
+    val p = Props(classOf[EmptyArgsActor], 4711, 1729)
+    val propsCreator = () => p
+
+    test(propsCreator)
+  }
+
+  @inline def test(propsCreator: () => Props) {
+    val driver = system.actorOf(Props(classOf[Driver]), "driver-1")
+    probe.watch(driver)
+
+    driver ! IsAlive
+    probe.expectMsg(Alive)
+
+    driver ! Create(numberOfActors, propsCreator)
+    probe.expectMsgPF(15 seconds, s"waiting for Created") { case Created => }
+
+    driver ! WaitForChildren
+    probe.expectMsgPF(15 seconds, s"waiting for Waited") { case Waited => }
+
+    driver ! PoisonPill
+    probe.expectTerminated(driver, 15 seconds)
+  }
+
+}
+
+object ActorCreationPerfSpec {
+
+  final case class Create(numberOfActors: Int, props: () => Props)
+  case object Created
+  case object IsAlive
+  case object Alive
+  case object WaitForChildren
+  case object Waited
+
+  class EmptyActor extends Actor {
+    def receive = {
+      case IsAlive => sender() ! Alive
+    }
+  }
+
+  class EmptyArgsActor(val foo: Int, val bar: Int) extends Actor {
+    def receive = {
+      case IsAlive => sender() ! Alive
+    }
+  }
+
+  class Driver extends Actor {
+
+    def receive = {
+      case IsAlive =>
+        sender() ! Alive
+      case Create(numberOfActors, propsCreator) =>
+        for (i ← 1 to numberOfActors) {
+          context.actorOf(propsCreator.apply())
+        }
+        sender() ! Created
+      case WaitForChildren =>
+        context.children.foreach(_ ! IsAlive)
+        context.become(waiting(context.children.size, sender()), discardOld = false)
+    }
+
+    def waiting(number: Int, replyTo: ActorRef): Receive = {
+      var current = number
+
+      {
+        case Alive =>
+          current -= 1
+          if (current == 0) {
+            replyTo ! Waited
+            context.unbecome()
+          }
+      }
+    }
+  }
+}
+

--- a/akka-bench-jmh/src/main/scala/akka/actor/TellPingPongBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/TellPingPongBenchmark.scala
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.actor
+
+import org.openjdk.jmh.annotations._
+import com.typesafe.config.ConfigFactory
+import akka.testkit.TestProbe
+import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+class TellPingPongBenchmark {
+
+  val config = ConfigFactory.parseString("""
+       akka {
+         log-config-on-start = off
+         log-dead-letters-during-shutdown = off
+         loglevel = "WARNING"
+
+         test {
+           timefactor =  1.0
+           filter-leeway = 3s
+           single-expect-default = 3s
+           default-timeout = 5s
+           calling-thread-dispatcher {
+             type = akka.testkit.CallingThreadDispatcherConfigurator
+           }
+         }
+       }""".stripMargin).withFallback(ConfigFactory.load())
+
+  implicit val system = ActorSystem("test", config)
+
+  val probe = TestProbe()
+  implicit val testActor = probe.ref
+
+  var worker: ActorRef = _
+  var waiter: ActorRef = _
+
+  @Setup
+  def setup() {
+    worker = system.actorOf(Props[Worker], "worker")
+    waiter = system.actorOf(Props(classOf[Waiter], probe.ref), "waiter")
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OperationsPerInvocation(200000) // twice as much messages are sent, because ping<->pong
+  @GenerateMicroBenchmark
+  def tell_100000_msgs_a() {
+    waiter ! AwaitUntil(100000)
+    worker.tell("ping", waiter)
+
+    probe.expectMsg(60.seconds, GotLast)
+  }
+
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.SampleTime))
+  @OperationsPerInvocation(200000) // twice as much messages are sent, because ping<->pong
+  @GenerateMicroBenchmark
+  def tell_100000_msgs_b() {
+    waiter ! AwaitUntil(100000)
+    worker.tell("ping", waiter)
+
+    probe.expectMsg(60.seconds, GotLast)
+  }
+
+}
+
+final case class AwaitUntil(n: Long)
+case object GotLast
+
+class Worker extends Actor {
+  def receive = {
+    case _ => sender() ! "ping"
+  }
+}
+
+class Waiter(notifyWhenDone: ActorRef) extends Actor {
+  var until = 1L
+
+  def receive = {
+    case AwaitUntil(n) =>
+      until = n
+      context.become(waiting(n))
+  }
+
+  def waiting(n: Long): Actor.Receive = {
+    case _ if until <= 0 =>
+      notifyWhenDone ! GotLast
+
+    case _ =>
+      until -= 1
+      sender() ! "pong"
+  }
+}
+
+

--- a/akka-bench-jmh/src/main/scala/akka/event/EventStreamPublishingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/event/EventStreamPublishingBenchmark.scala
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.event
+
+import org.openjdk.jmh.annotations._
+import com.typesafe.config.ConfigFactory
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.TestProbe
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class EventStreamPublishingBenchmark {
+
+  val config = ConfigFactory.parseString( """
+      akka {
+        log-config-on-start = off
+        log-dead-letters-during-shutdown = off
+        loglevel = "WARNING"
+
+        test {
+          timefactor =  1.0
+          filter-leeway = 3s
+          single-expect-default = 3s
+          default-timeout = 5s
+          calling-thread-dispatcher {
+            type = akka.testkit.CallingThreadDispatcherConfigurator
+          }
+        }
+      }""".stripMargin).withFallback(ConfigFactory.load())
+
+  var system: ActorSystem = _
+  var eventStream: EventStream = _
+
+  class A
+  class B
+  class C
+
+  final val channelA = classOf[A]
+  final val channelB = classOf[B]
+  final val channelC = classOf[C]
+
+  final val a = new A
+  final val b = new B
+  final val c = new C
+
+  @Param(Array("1", "100", "1000"))
+  var subscribersOfA = 0
+
+  @Param(Array("0", "1", "100"))
+  var subscribersOfB = 0
+
+  @Setup(Level.Iteration)
+  def setup() {
+    system = ActorSystem("test", config)
+    eventStream = system.eventStream
+
+    1 to subscribersOfA foreach { i => eventStream.subscribe(TestProbe()(system).ref, channelA) }
+    1 to subscribersOfB foreach { i => eventStream.subscribe(TestProbe()(system).ref, channelB) }
+  }
+
+  @TearDown(Level.Iteration)
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @Threads(1)
+  @GenerateMicroBenchmark
+  def publish_matching_events_to_event_stream_1_thread() {
+    eventStream.publish(a)
+  }
+
+  @Threads(8)
+  @GenerateMicroBenchmark
+  def publish_matching_events_to_event_stream_8_threads() {
+    eventStream.publish(a)
+  }
+
+  @Threads(1)
+  @GenerateMicroBenchmark
+  def publish_notMatching_events_to_event_stream_1_threads() {
+    eventStream.publish(c)
+  }
+
+  @Threads(8)
+  @GenerateMicroBenchmark
+  def publish_notMatching_events_to_event_stream_8_threads() {
+    eventStream.publish(c)
+  }
+
+}
+

--- a/akka-bench-jmh/src/main/scala/akka/event/EventStreamSubscriptionsBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/event/EventStreamSubscriptionsBenchmark.scala
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.event
+
+import org.openjdk.jmh.annotations._
+import com.typesafe.config.ConfigFactory
+import akka.testkit.TestProbe
+import akka.actor.{ActorRef, ActorSystem}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class EventStreamSubscriptionsBenchmark {
+
+  val config = ConfigFactory.parseString("""
+     akka {
+       log-config-on-start = off
+       log-dead-letters-during-shutdown = off
+       loglevel = "WARNING"
+
+       test {
+         timefactor =  1.0
+         filter-leeway = 3s
+         single-expect-default = 3s
+         default-timeout = 5s
+         calling-thread-dispatcher {
+           type = akka.testkit.CallingThreadDispatcherConfigurator
+         }
+       }
+     }""".stripMargin).withFallback(ConfigFactory.load())
+
+  var system: ActorSystem = _
+  var eventStream: EventStream = _
+
+  var subsProbe: TestProbe = _
+  var subs: ActorRef = _
+
+  trait A
+  trait B
+  trait AB extends A with B
+
+  final val channelA = classOf[A]
+  final val channelB = classOf[B]
+  final val channelAB = classOf[AB]
+
+  @Setup(Level.Iteration)
+  def setup() {
+    system = ActorSystem("test", config)
+
+    eventStream = system.eventStream
+    subsProbe = TestProbe()(system)
+    subs = subsProbe.ref
+  }
+
+  @TearDown(Level.Iteration)
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @Threads(1)
+  @GenerateMicroBenchmark
+  def subscribe_unsubscribe_same_actor_1_thread() {
+    eventStream.subscribe(subs, channelA)
+    eventStream.unsubscribe(subs)
+  }
+
+  @Threads(8)
+  @GenerateMicroBenchmark
+  def subscribe_unsubscribe_same_actor_8_threads() {
+    eventStream.subscribe(subs, channelA)
+    eventStream.unsubscribe(subs)
+  }
+
+  @Group("subscribe_vs_unsubscribe")
+  @GenerateMicroBenchmark
+  def subscribing_in_group_vs_unsubscribing() {
+    eventStream.subscribe(subs, channelA)
+  }
+
+  @Group("subscribe_vs_unsubscribe")
+  @GenerateMicroBenchmark
+  def unsubscribing_in_group_vs_subscribing() {
+    eventStream.unsubscribe(subs)
+  }
+
+}
+
+
+

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -17,6 +17,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.reportBinaryIssues
 import com.typesafe.tools.mima.plugin.MimaKeys.binaryIssueFilters
 import com.typesafe.sbt.SbtSite.site
 import com.typesafe.sbt.site.SphinxSupport
+import pl.project13.scala.sbt.SbtJmh._
 import com.typesafe.sbt.site.SphinxSupport.{ enableOutput, generatePdf, generatedPdf, generateEpub, generatedEpub, sphinxInputs, sphinxPackages, Sphinx }
 import com.typesafe.sbt.preprocess.Preprocess.{ preprocess, preprocessExts, preprocessVars, simplePreprocess }
 import java.lang.Boolean.getBoolean
@@ -185,6 +186,15 @@ object AkkaBuild extends Build {
       initialCommands += "import akka.testkit._",
       previousArtifact := akkaPreviousArtifact("akka-testkit")
     )
+  )
+
+  lazy val benchJmh = Project(
+    id = "akka-bench-jmh",
+    base = file("akka-bench-jmh"),
+    dependencies = Seq(actor, stream, persistence % "compile;test->test", testkit % "compile;test->compile"),
+    settings = defaultSettings ++ Seq(
+      libraryDependencies ++= Dependencies.testkit
+    ) ++ settings ++ jmhSettings
   )
 
   lazy val actorTests = Project(
@@ -1169,7 +1179,7 @@ object Dependencies {
     val camelJetty  = "org.apache.camel"              % "camel-jetty"                  % camelCore.revision // ApacheV2
 
     // Cluster Sample
-    val sigar       = "org.fusesource"                   % "sigar"                        % "1.6.4"            // ApacheV2
+    val sigar       = "org.fusesource"                % "sigar"                        % "1.6.4"            // ApacheV2
 
     // Compiler plugins
     val genjavadoc    = compilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % genJavaDocVersion cross CrossVersion.full) // ApacheV2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,5 +18,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
-// stats reporting
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.1")
+
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"
+


### PR DESCRIPTION
Working integration with JMH.

Details in commits - it's now runnable by just going to the `akka-bench-jmh` (better name ideas?) project and running `run [any jmh options]`. Example: `run -i 3 -wi 3 -f 1 .*actor.*`, for understanding the options simply pass in `-h`.

// btw "why not a loop but JMH": http://hg.openjdk.java.net/code-tools/jmh/file/f2e982b7c51b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_11_Loops.java

Eventually will resolve #15180
