### PR TITLE
+str Various cleanups of internal streams architecture

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/extra/Log.scala
+++ b/akka-stream/src/main/scala/akka/stream/extra/Log.scala
@@ -76,7 +76,7 @@ class Log[T](override val name: String = "log") extends Transformer[T, T] with T
     log.info("OnNext: [{}]", element)
   }
 
-  final override def onComplete(): immutable.Seq[T] = {
+  final override def onTermination(e: Option[Throwable]): immutable.Seq[T] = {
     logOnComplete()
     Nil
   }
@@ -85,7 +85,10 @@ class Log[T](override val name: String = "log") extends Transformer[T, T] with T
     log.info("OnComplete")
   }
 
-  final override def onError(cause: Throwable): Unit = logOnError(cause)
+  final override def onError(cause: Throwable): Unit = {
+    logOnError(cause)
+    throw cause
+  }
 
   def logOnError(cause: Throwable): Unit = {
     log.error(cause, "OnError")

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -10,7 +10,6 @@ import org.reactivestreams.spi.Subscriber
 import akka.actor.ActorRefFactory
 import akka.stream.{ MaterializerSettings, FlowMaterializer }
 import akka.stream.Transformer
-import akka.stream.RecoveryTransformer
 import scala.util.Try
 import scala.concurrent.Future
 import scala.util.Success
@@ -33,9 +32,6 @@ private[akka] object Ast {
 
   case class Transform(transformer: Transformer[Any, Any]) extends AstNode {
     override def name = transformer.name
-  }
-  case class Recover(recoveryTransformer: RecoveryTransformer[Any, Any]) extends AstNode {
-    override def name = recoveryTransformer.name
   }
   case class GroupBy(f: Any ⇒ Any) extends AstNode {
     override def name = "groupBy"

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -8,13 +8,12 @@ import scala.concurrent.{ Future, Promise }
 import scala.util.Try
 import org.reactivestreams.api.Consumer
 import org.reactivestreams.api.Producer
-import Ast.{ AstNode, Recover, Transform }
+import Ast.{ AstNode, Transform }
 import akka.stream.FlowMaterializer
 import akka.stream.scaladsl.Flow
 import scala.util.Success
 import scala.util.Failure
 import akka.stream.Transformer
-import akka.stream.RecoveryTransformer
 import org.reactivestreams.api.Consumer
 import akka.stream.scaladsl.Duct
 
@@ -32,12 +31,12 @@ private[akka] case class FlowImpl[I, O](producerNode: Ast.ProducerNode[I], ops: 
 
   override def toFuture(materializer: FlowMaterializer): Future[O] = {
     val p = Promise[O]()
-    transformRecover(new RecoveryTransformer[O, Unit] {
+    transform(new Transformer[O, Unit] {
       var done = false
       override def onNext(in: O) = { p success in; done = true; Nil }
-      override def onErrorRecover(e: Throwable) = { p failure e; Nil }
+      override def onError(e: Throwable) = { p failure e }
       override def isComplete = done
-      override def onComplete() = { p.tryFailure(new NoSuchElementException("empty stream")); Nil }
+      override def onTermination(e: Option[Throwable]) = { p.tryFailure(new NoSuchElementException("empty stream")); Nil }
     }).consume(materializer)
     p.future
   }
@@ -45,15 +44,16 @@ private[akka] case class FlowImpl[I, O](producerNode: Ast.ProducerNode[I], ops: 
   override def consume(materializer: FlowMaterializer): Unit = materializer.consume(producerNode, ops)
 
   override def onComplete(materializer: FlowMaterializer)(callback: Try[Unit] ⇒ Unit): Unit =
-    transformRecover(new RecoveryTransformer[O, Unit] {
-      var ok = true
+    transform(new Transformer[O, Unit] {
       override def onNext(in: O) = Nil
-      override def onErrorRecover(e: Throwable) = {
+      override def onError(e: Throwable) = {
         callback(Failure(e))
-        ok = false
+        throw e
+      }
+      override def onTermination(e: Option[Throwable]) = {
+        callback(Builder.SuccessUnit)
         Nil
       }
-      override def onComplete() = { if (ok) callback(Builder.SuccessUnit); Nil }
     }).consume(materializer)
 
   override def toProducer(materializer: FlowMaterializer): Producer[O] = materializer.toProducer(producerNode, ops)
@@ -79,15 +79,16 @@ private[akka] case class DuctImpl[In, Out](ops: List[Ast.AstNode]) extends Duct[
     materializer.ductConsume(ops)
 
   override def onComplete(materializer: FlowMaterializer)(callback: Try[Unit] ⇒ Unit): Consumer[In] =
-    transformRecover(new RecoveryTransformer[Out, Unit] {
-      var ok = true
+    transform(new Transformer[Out, Unit] {
       override def onNext(in: Out) = Nil
-      override def onErrorRecover(e: Throwable) = {
+      override def onError(e: Throwable) = {
         callback(Failure(e))
-        ok = false
+        throw e
+      }
+      override def onTermination(e: Option[Throwable]) = {
+        callback(Builder.SuccessUnit)
         Nil
       }
-      override def onComplete() = { if (ok) callback(Builder.SuccessUnit); Nil }
     }).consume(materializer)
 
   override def build(materializer: FlowMaterializer): (Consumer[In], Producer[Out]) =
@@ -145,7 +146,7 @@ private[akka] trait Builder[Out] {
   def foreach(c: Out ⇒ Unit): Thing[Unit] =
     transform(new Transformer[Out, Unit] {
       override def onNext(in: Out) = { c(in); Nil }
-      override def onComplete() = ListOfUnit
+      override def onTermination(e: Option[Throwable]) = ListOfUnit
       override def name = "foreach"
     })
 
@@ -156,7 +157,7 @@ private[akka] trait Builder[Out] {
   // "Parameter type in structural refinement may not refer to an abstract type defined outside that refinement"
   class FoldTransformer[S](var state: S, f: (S, Out) ⇒ S) extends Transformer[Out, S] {
     override def onNext(in: Out): immutable.Seq[S] = { state = f(state, in); Nil }
-    override def onComplete(): immutable.Seq[S] = List(state)
+    override def onTermination(e: Option[Throwable]): immutable.Seq[S] = List(state)
     override def name = "fold"
   }
 
@@ -209,7 +210,7 @@ private[akka] trait Builder[Out] {
         } else
           Nil
       }
-      override def onComplete() = if (buf.isEmpty) Nil else List(buf)
+      override def onTermination(e: Option[Throwable]) = if (buf.isEmpty) Nil else List(buf)
       override def name = "grouped"
     })
 
@@ -221,9 +222,6 @@ private[akka] trait Builder[Out] {
 
   def transform[U](transformer: Transformer[Out, U]): Thing[U] =
     andThen(Transform(transformer.asInstanceOf[Transformer[Any, Any]]))
-
-  def transformRecover[U](recoveryTransformer: RecoveryTransformer[Out, U]): Thing[U] =
-    andThen(Recover(recoveryTransformer.asInstanceOf[RecoveryTransformer[Any, Any]]))
 
   def zip[O2](other: Producer[O2]): Thing[(Out, O2)] = andThen(Zip(other.asInstanceOf[Producer[Any]]))
 

--- a/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
@@ -3,74 +3,63 @@
  */
 package akka.stream.impl
 
-import org.reactivestreams.spi.Subscription
 import akka.actor.{ Terminated, Props, ActorRef }
 import akka.stream.MaterializerSettings
-import akka.stream.impl._
-
-/**
- * INTERNAL API
- */
-private[akka] object GroupByProcessorImpl {
-
-  sealed trait SubstreamElementState
-  case object NoPending extends SubstreamElementState
-  case class PendingElement(elem: Any, key: Any) extends SubstreamElementState
-  case class PendingElementForNewStream(elem: Any, key: Any) extends SubstreamElementState
-}
 
 /**
  * INTERNAL API
  */
 private[akka] class GroupByProcessorImpl(settings: MaterializerSettings, val keyFor: Any ⇒ Any) extends MultiStreamOutputProcessor(settings) {
-  import GroupByProcessorImpl._
-
   var keyToSubstreamOutputs = collection.mutable.Map.empty[Any, SubstreamOutputs]
-  var substreamPendingState: SubstreamElementState = NoPending
 
-  override def initialTransferState = needsPrimaryInputAndDemand
+  var pendingSubstreamOutputs: SubstreamOutputs = _
 
-  override def transfer(): TransferState = {
-    substreamPendingState match {
-      case PendingElementForNewStream(elem, key) ⇒
-        if (primaryOutputs.isClosed) {
-          substreamPendingState = NoPending
-          // Just drop, we do not open any more substreams
-        } else {
-          val substreamOutput = newSubstream()
-          primaryOutputs.enqueueOutputElement((key, substreamOutput.processor))
-          keyToSubstreamOutputs(key) = substreamOutput
-          substreamPendingState = PendingElement(elem, key)
-        }
+  // No substream is open yet. If downstream cancels now, we are complete
+  val waitFirst = TransferPhase(primaryInputs.NeedsInput && primaryOutputs.NeedsDemand) { () ⇒
+    val elem = primaryInputs.dequeueInputElement()
+    val key = keyFor(elem)
+    nextPhase(openSubstream(elem, key))
+  }
 
-      case PendingElement(elem, key) ⇒
-        if (keyToSubstreamOutputs(key).isOpen) keyToSubstreamOutputs(key).enqueueOutputElement(elem)
-        substreamPendingState = NoPending
+  // some substreams are open now. If downstream cancels, we still continue until the substreams are closed
+  val waitNext = TransferPhase(primaryInputs.NeedsInput) { () ⇒
+    val elem = primaryInputs.dequeueInputElement()
+    val key = keyFor(elem)
 
-      case NoPending ⇒
-        val elem = primaryInputs.dequeueInputElement()
-        val key = keyFor(elem)
-
-        substreamPendingState = keyToSubstreamOutputs.get(key) match {
-          case Some(substream) if substream.isOpen ⇒ PendingElement(elem, key)
-          case None if primaryOutputs.isOpen       ⇒ PendingElementForNewStream(elem, key)
-          case _                                   ⇒ NoPending
-        }
-    }
-
-    substreamPendingState match {
-      case NoPending                        ⇒ primaryInputs.NeedsInput
-      case PendingElement(_, key)           ⇒ keyToSubstreamOutputs(key).NeedsDemand
-      case PendingElementForNewStream(_, _) ⇒ primaryOutputs.NeedsDemand
+    keyToSubstreamOutputs.get(key) match {
+      case Some(substream) if substream.isOpen ⇒ nextPhase(dispatchToSubstream(elem, keyToSubstreamOutputs(key)))
+      case None if primaryOutputs.isOpen       ⇒ nextPhase(openSubstream(elem, key))
+      case _                                   ⇒ // stay
     }
   }
 
+  def openSubstream(elem: Any, key: Any): TransferPhase = TransferPhase(primaryOutputs.NeedsDemand) { () ⇒
+    if (primaryOutputs.isClosed) {
+      // Just drop, we do not open any more substreams
+      nextPhase(waitNext)
+    } else {
+      val substreamOutput = newSubstream()
+      primaryOutputs.enqueueOutputElement((key, substreamOutput.processor))
+      keyToSubstreamOutputs(key) = substreamOutput
+      nextPhase(dispatchToSubstream(elem, substreamOutput))
+    }
+  }
+
+  def dispatchToSubstream(elem: Any, substream: SubstreamOutputs): TransferPhase = {
+    pendingSubstreamOutputs = substream
+    TransferPhase(substream.NeedsDemand) { () ⇒
+      if (substream.isOpen) substream.enqueueOutputElement(elem)
+      pendingSubstreamOutputs = null
+      nextPhase(waitNext)
+    }
+  }
+
+  nextPhase(waitFirst)
+
   override def invalidateSubstream(substream: ActorRef): Unit = {
-    substreamPendingState match {
-      case PendingElement(_, key) if keyToSubstreamOutputs(key).substream == substream ⇒
-        setTransferState(primaryInputs.NeedsInput)
-        substreamPendingState = NoPending
-      case _ ⇒
+    if ((pendingSubstreamOutputs ne null) && substream == pendingSubstreamOutputs.substream) {
+      pendingSubstreamOutputs = null
+      nextPhase(waitNext)
     }
     super.invalidateSubstream(substream)
   }

--- a/akka-stream/src/main/scala/akka/stream/io/TcpConnectionStream.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/TcpConnectionStream.scala
@@ -28,39 +28,95 @@ private[akka] object TcpStreamActor {
 /**
  * INTERNAL API
  */
-private[akka] abstract class TcpStreamActor(val settings: MaterializerSettings) extends Actor
-  with PrimaryInputs
-  with PrimaryOutputs {
+private[akka] abstract class TcpStreamActor(val settings: MaterializerSettings) extends Actor {
 
   import TcpStreamActor._
-  def connection: ActorRef
 
-  val tcpInputs = new DefaultInputTransferStates {
+  val primaryInputs: Inputs = new BatchingInputBuffer(settings.initialInputBufferSize, writePump) {
+    override def inputOnError(e: Throwable): Unit = fail(e)
+  }
+
+  val primaryOutputs: Outputs =
+    new FanoutOutputs(settings.maxFanOutBufferSize, settings.initialFanOutBufferSize, self, readPump) {
+      override def afterShutdown(): Unit = {
+        tcpInputs.cancel()
+        TcpStreamActor.this.tryShutdown()
+      }
+    }
+
+  object tcpInputs extends DefaultInputTransferStates {
     private var closed: Boolean = false
     private var pendingElement: ByteString = null
+    private var connection: ActorRef = _
+
+    val subreceive = new SubReceive(Actor.emptyBehavior)
+
+    def setConnection(c: ActorRef): Unit = {
+      connection = c
+      // Prefetch
+      c ! ResumeReading
+      subreceive.become(handleRead)
+      readPump.pump()
+    }
+
+    def handleRead: Receive = {
+      case Received(data) ⇒
+        pendingElement = data
+        readPump.pump()
+      case Closed ⇒
+        closed = true
+        tcpOutputs.complete()
+        writePump.pump()
+        readPump.pump()
+      case ConfirmedClosed ⇒
+        closed = true
+        readPump.pump()
+      case PeerClosed ⇒
+        closed = true
+        readPump.pump()
+      case ErrorClosed(cause) ⇒ fail(new TcpStreamException(s"The connection closed with error $cause"))
+      case CommandFailed(cmd) ⇒ fail(new TcpStreamException(s"Tcp command [$cmd] failed"))
+      case Aborted            ⇒ fail(new TcpStreamException("The connection has been aborted"))
+    }
 
     override def inputsAvailable: Boolean = pendingElement ne null
     override def inputsDepleted: Boolean = closed && !inputsAvailable
-    override def prefetch(): Unit = connection ! ResumeReading
     override def isClosed: Boolean = closed
-    override def complete(): Unit = closed = true
+
     override def cancel(): Unit = {
       closed = true
       pendingElement = null
     }
+
     override def dequeueInputElement(): Any = {
       val elem = pendingElement
       pendingElement = null
       connection ! ResumeReading
       elem
     }
-    override def enqueueInputElement(elem: Any): Unit = pendingElement = elem.asInstanceOf[ByteString]
 
   }
 
   object tcpOutputs extends DefaultOutputTransferStates {
     private var closed: Boolean = false
     private var pendingDemand = true
+    private var connection: ActorRef = _
+
+    def setConnection(c: ActorRef): Unit = {
+      connection = c
+      writePump.pump()
+      receive.become(handleWrite)
+    }
+
+    val receive = new SubReceive(Actor.emptyBehavior)
+
+    def handleWrite: Receive = {
+      case WriteAck ⇒
+        pendingDemand = true
+        writePump.pump()
+
+    }
+
     override def isClosed: Boolean = closed
     override def cancel(e: Throwable): Unit = {
       if (!closed) connection ! Abort
@@ -74,90 +130,54 @@ private[akka] abstract class TcpStreamActor(val settings: MaterializerSettings) 
       connection ! Write(elem.asInstanceOf[ByteString], WriteAck)
       pendingDemand = false
     }
-    def enqueueDemand(): Unit = pendingDemand = true
 
     override def demandAvailable: Boolean = pendingDemand
   }
 
   object writePump extends Pump {
-    lazy val NeedsInputAndDemand = primaryInputs.NeedsInput && tcpOutputs.NeedsDemand
-    override protected def transfer(): TransferState = {
+
+    def running = TransferPhase(primaryInputs.NeedsInput && tcpOutputs.NeedsDemand) { () ⇒
       var batch = ByteString.empty
       while (primaryInputs.inputsAvailable) batch ++= primaryInputs.dequeueInputElement().asInstanceOf[ByteString]
       tcpOutputs.enqueueOutputElement(batch)
-      NeedsInputAndDemand
     }
-    override protected def pumpFinished(): Unit = tcpOutputs.complete()
+
+    override protected def pumpFinished(): Unit = {
+      tcpOutputs.complete()
+      tryShutdown()
+    }
     override protected def pumpFailed(e: Throwable): Unit = fail(e)
     override protected def pumpContext: ActorRefFactory = context
   }
 
   object readPump extends Pump {
-    lazy val NeedsInputAndDemand = tcpInputs.NeedsInput && primaryOutputs.NeedsDemand
-    override protected def transfer(): TransferState = {
+
+    def running = TransferPhase(tcpInputs.NeedsInput && primaryOutputs.NeedsDemand) { () ⇒
       primaryOutputs.enqueueOutputElement(tcpInputs.dequeueInputElement())
-      NeedsInputAndDemand
     }
-    override protected def pumpFinished(): Unit = primaryOutputs.complete()
+
+    override protected def pumpFinished(): Unit = {
+      primaryOutputs.complete()
+      tryShutdown()
+    }
     override protected def pumpFailed(e: Throwable): Unit = fail(e)
     override protected def pumpContext: ActorRefFactory = context
   }
 
-  override def pumpInputs(): Unit = writePump.pump()
-  override def pumpOutputs(): Unit = readPump.pump()
+  override def receive =
+    primaryInputs.subreceive orElse primaryOutputs.receive orElse tcpInputs.subreceive orElse tcpOutputs.receive
 
-  override def receive = waitingExposedPublisher
-
-  override def primaryInputOnError(e: Throwable): Unit = fail(e)
-  override def primaryInputOnComplete(): Unit = shutdown()
-  override def primaryInputsReady(): Unit = {
-    connection ! Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
-    readPump.setTransferState(readPump.NeedsInputAndDemand)
-    writePump.setTransferState(writePump.NeedsInputAndDemand)
-    tcpInputs.prefetch()
-    context.become(running)
-  }
-
-  override def primaryOutputsReady(): Unit = context.become(downstreamManagement orElse waitingForUpstream)
-  override def primaryOutputsFinished(completed: Boolean): Unit = shutdown()
-
-  val running: Receive = upstreamManagement orElse downstreamManagement orElse {
-    case WriteAck ⇒
-      tcpOutputs.enqueueDemand()
-      pumpInputs()
-    case Received(data) ⇒
-      tcpInputs.enqueueInputElement(data)
-      pumpOutputs()
-    case Closed ⇒
-      tcpInputs.complete()
-      tcpOutputs.complete()
-      writePump.pump()
-      readPump.pump()
-    case ConfirmedClosed ⇒
-      tcpInputs.complete()
-      pumpOutputs()
-    case PeerClosed ⇒
-      tcpInputs.complete()
-      pumpOutputs()
-    case ErrorClosed(cause) ⇒ fail(new TcpStreamException(s"The connection closed with error $cause"))
-    case CommandFailed(cmd) ⇒ fail(new TcpStreamException(s"Tcp command [$cmd] failed"))
-    case Aborted            ⇒ fail(new TcpStreamException("The connection has been aborted"))
-  }
+  readPump.nextPhase(readPump.running)
+  writePump.nextPhase(writePump.running)
 
   def fail(e: Throwable): Unit = {
     tcpInputs.cancel()
     tcpOutputs.cancel(e)
-    if (primaryInputs ne null) primaryInputs.cancel()
+    primaryInputs.cancel()
     primaryOutputs.cancel(e)
-    exposedPublisher.shutdown(Some(e))
   }
 
-  def shutdown(): Unit = {
-    if (tcpOutputs.isClosed && primaryOutputs.isClosed) {
-      context.stop(self)
-      exposedPublisher.shutdown(None)
-    }
-  }
+  def tryShutdown(): Unit = if (primaryInputs.isClosed && tcpInputs.isClosed && tcpOutputs.isClosed) context.stop(self)
 
 }
 
@@ -168,6 +188,9 @@ private[akka] class InboundTcpStreamActor(
   val connection: ActorRef, _settings: MaterializerSettings)
   extends TcpStreamActor(_settings) {
 
+  connection ! Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
+  tcpInputs.setConnection(connection)
+  tcpOutputs.setConnection(connection)
 }
 
 /**
@@ -176,23 +199,26 @@ private[akka] class InboundTcpStreamActor(
 private[akka] class OutboundTcpStreamActor(val connectCmd: Connect, val requester: ActorRef, _settings: MaterializerSettings)
   extends TcpStreamActor(_settings) {
   import TcpStreamActor._
-  var connection: ActorRef = _
   import context.system
 
-  override def primaryOutputsReady(): Unit = context.become(waitingExposedProcessor)
+  val initSteps = new SubReceive(waitingExposedProcessor)
 
-  val waitingExposedProcessor: Receive = {
+  override def receive = initSteps orElse super.receive
+
+  def waitingExposedProcessor: Receive = {
     case StreamTcpManager.ExposedProcessor(processor) ⇒
       IO(Tcp) ! connectCmd
-      context.become(waitConnection(processor))
-    case _ ⇒ throw new IllegalStateException("The second message must be ExposedProcessor")
+      initSteps.become(waitConnection(processor))
   }
 
   def waitConnection(exposedProcessor: Processor[ByteString, ByteString]): Receive = {
     case Connected(remoteAddress, localAddress) ⇒
-      connection = sender()
+      val connection = sender()
+      connection ! Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
+      tcpOutputs.setConnection(connection)
+      tcpInputs.setConnection(connection)
       requester ! StreamTcp.OutgoingTcpConnection(remoteAddress, localAddress, exposedProcessor)
-      context.become(downstreamManagement orElse waitingForUpstream)
+      initSteps.become(Actor.emptyBehavior)
     case f: CommandFailed ⇒
       val ex = new TcpStreamException("Connection failed.")
       requester ! Status.Failure(ex)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Duct.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Duct.scala
@@ -9,7 +9,6 @@ import scala.util.Try
 import org.reactivestreams.api.Consumer
 import org.reactivestreams.api.Producer
 import akka.stream.FlowMaterializer
-import akka.stream.RecoveryTransformer
 import akka.stream.Transformer
 import akka.stream.impl.DuctImpl
 
@@ -115,17 +114,6 @@ trait Duct[In, +Out] {
    * visibility constructs to access the state from the callback methods.
    */
   def transform[U](transformer: Transformer[Out, U]): Duct[In, U]
-
-  /**
-   * This transformation stage works exactly like [[#transform]] with the
-   * change that failure signaled from upstream will invoke
-   * [[RecoveryTransformer#onError]], which can emit an additional sequence of
-   * elements before the stream ends.
-   *
-   * After normal completion or error the [[RecoveryTransformer#cleanup]] function
-   * is called.
-   */
-  def transformRecover[U](recoveryTransformer: RecoveryTransformer[Out, U]): Duct[In, U]
 
   /**
    * This operation demultiplexes the incoming stream into separate output

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -10,7 +10,6 @@ import scala.util.Try
 import org.reactivestreams.api.Consumer
 import org.reactivestreams.api.Producer
 import akka.stream.FlowMaterializer
-import akka.stream.RecoveryTransformer
 import akka.stream.Transformer
 import akka.stream.impl.Ast.{ ExistingProducer, IterableProducerNode, IteratorProducerNode, ThunkProducerNode }
 import akka.stream.impl.Ast.FutureProducerNode
@@ -174,16 +173,6 @@ trait Flow[+T] {
    * visibility constructs to access the state from the callback methods.
    */
   def transform[U](transformer: Transformer[T, U]): Flow[U]
-
-  /**
-   * This transformation stage works exactly like [[#transform]] with the
-   * change that failure signaled from upstream will invoke
-   * [[akka.stream.RecoveryTransformer#onErrorRecover]], which can emit an additional sequence of
-   * elements before the stream ends.
-   *
-   * [[akka.stream.Transformer#onError]] is not called when failure is signaled from upstream.
-   */
-  def transformRecover[U](recoveryTransformer: RecoveryTransformer[T, U]): Flow[U]
 
   /**
    * This operation demultiplexes the incoming stream into separate output

--- a/akka-stream/src/test/java/akka/stream/javadsl/DuctTest.java
+++ b/akka-stream/src/test/java/akka/stream/javadsl/DuctTest.java
@@ -29,7 +29,6 @@ import akka.japi.Procedure;
 import akka.japi.Util;
 import akka.stream.FlowMaterializer;
 import akka.stream.MaterializerSettings;
-import akka.stream.RecoveryTransformer;
 import akka.stream.Transformer;
 import akka.stream.testkit.AkkaSpec;
 import akka.testkit.JavaTestKit;

--- a/akka-stream/src/test/scala/akka/stream/FlowConcatSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowConcatSpec.scala
@@ -81,18 +81,14 @@ class FlowConcatSpec extends TwoStreamsSetup {
       consumer1.expectErrorOrSubscriptionFollowedByError(TestException)
 
       val consumer2 = setup(nonemptyPublisher((1 to 4).iterator), failedPublisher)
-      val subscription2 = consumer2.expectSubscription()
-      subscription2.requestMore(5)
       consumer2.expectErrorOrSubscriptionFollowedByError(TestException)
     }
 
     "work with one delayed failed and one nonempty producer" in {
       val consumer1 = setup(soonToFailPublisher, nonemptyPublisher((1 to 4).iterator))
-      val subscription1 = consumer1.expectSubscription()
       consumer1.expectErrorOrSubscriptionFollowedByError(TestException)
 
       val consumer2 = setup(nonemptyPublisher((1 to 4).iterator), soonToFailPublisher)
-      val subscription2 = consumer2.expectSubscription()
       consumer2.expectErrorOrSubscriptionFollowedByError(TestException)
     }
 

--- a/akka-stream/src/test/scala/akka/stream/FlowGroupBySpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowGroupBySpec.scala
@@ -204,9 +204,7 @@ class FlowGroupBySpec extends AkkaSpec {
       val consumer = StreamTestKit.consumerProbe[(Int, Producer[Int])]
       producer.produceTo(consumer)
 
-      val subscription = consumer.expectSubscription()
-      subscription.requestMore(100)
-      consumer.expectComplete()
+      consumer.expectCompletedOrSubscriptionFollowedByComplete()
     }
 
     "abort on onError from upstream" in {

--- a/akka-stream/src/test/scala/akka/stream/FlowZipSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowZipSpec.scala
@@ -43,26 +43,18 @@ class FlowZipSpec extends TwoStreamsSetup {
 
     "work with one immediately completed and one nonempty producer" in {
       val consumer1 = setup(completedPublisher, nonemptyPublisher((1 to 4).iterator))
-      val subscription1 = consumer1.expectSubscription()
-      subscription1.requestMore(4)
-      consumer1.expectComplete()
+      consumer1.expectCompletedOrSubscriptionFollowedByComplete()
 
       val consumer2 = setup(nonemptyPublisher((1 to 4).iterator), completedPublisher)
-      val subscription2 = consumer2.expectSubscription()
-      subscription2.requestMore(4)
-      consumer2.expectComplete()
+      consumer2.expectCompletedOrSubscriptionFollowedByComplete()
     }
 
     "work with one delayed completed and one nonempty producer" in {
       val consumer1 = setup(soonToCompletePublisher, nonemptyPublisher((1 to 4).iterator))
-      val subscription1 = consumer1.expectSubscription()
-      subscription1.requestMore(4)
-      consumer1.expectComplete()
+      consumer1.expectCompletedOrSubscriptionFollowedByComplete()
 
       val consumer2 = setup(nonemptyPublisher((1 to 4).iterator), soonToCompletePublisher)
-      val subscription2 = consumer2.expectSubscription()
-      subscription2.requestMore(4)
-      consumer2.expectComplete()
+      consumer2.expectCompletedOrSubscriptionFollowedByComplete()
     }
 
     "work with one immediately failed and one nonempty producer" in {
@@ -70,14 +62,11 @@ class FlowZipSpec extends TwoStreamsSetup {
       consumer1.expectErrorOrSubscriptionFollowedByError(TestException)
 
       val consumer2 = setup(nonemptyPublisher((1 to 4).iterator), failedPublisher)
-      val subscription2 = consumer2.expectSubscription()
-      subscription2.requestMore(4)
       consumer2.expectErrorOrSubscriptionFollowedByError(TestException)
     }
 
     "work with one delayed failed and one nonempty producer" in {
       val consumer1 = setup(soonToFailPublisher, nonemptyPublisher((1 to 4).iterator))
-      val subscription1 = consumer1.expectSubscription()
       consumer1.expectErrorOrSubscriptionFollowedByError(TestException)
 
       val consumer2 = setup(nonemptyPublisher((1 to 4).iterator), soonToFailPublisher)

--- a/akka-stream/src/test/scala/akka/stream/TwoStreamsSetup.scala
+++ b/akka-stream/src/test/scala/akka/stream/TwoStreamsSetup.scala
@@ -75,23 +75,17 @@ abstract class TwoStreamsSetup extends AkkaSpec {
   def commonTests() = {
     "work with two immediately completed producers" in {
       val consumer = setup(completedPublisher, completedPublisher)
-      val subscription = consumer.expectSubscription()
-      subscription.requestMore(1)
-      consumer.expectComplete()
+      consumer.expectCompletedOrSubscriptionFollowedByComplete()
     }
 
     "work with two delayed completed producers" in {
       val consumer = setup(soonToCompletePublisher, soonToCompletePublisher)
-      val subscription = consumer.expectSubscription()
-      subscription.requestMore(1)
-      consumer.expectComplete()
+      consumer.expectCompletedOrSubscriptionFollowedByComplete()
     }
 
     "work with one immediately completed and one delayed completed producer" in {
       val consumer = setup(completedPublisher, soonToCompletePublisher)
-      val subscription = consumer.expectSubscription()
-      subscription.requestMore(1)
-      consumer.expectComplete()
+      consumer.expectCompletedOrSubscriptionFollowedByComplete()
     }
 
     "work with two immediately failed producers" in {

--- a/akka-stream/src/test/scala/akka/stream/testkit/ConsumerProbe.scala
+++ b/akka-stream/src/test/scala/akka/stream/testkit/ConsumerProbe.scala
@@ -23,6 +23,7 @@ trait ConsumerProbe[I] extends Consumer[I] {
   def expectError(): Throwable
   def expectErrorOrSubscriptionFollowedByError(cause: Throwable): Unit
   def expectErrorOrSubscriptionFollowedByError(): Throwable
+  def expectCompletedOrSubscriptionFollowedByComplete()
   def expectComplete(): Unit
 
   def expectNoMsg(): Unit

--- a/akka-stream/src/test/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream/src/test/scala/akka/stream/testkit/StreamTestKit.scala
@@ -42,6 +42,15 @@ object StreamTestKit {
           case OnError(cause) ⇒ cause
         }
 
+      def expectCompletedOrSubscriptionFollowedByComplete(): Unit = {
+        probe.expectMsgPF() {
+          case s: OnSubscribe ⇒
+            s.subscription.requestMore(1)
+            expectComplete()
+          case OnComplete ⇒
+        }
+      }
+
       def expectNoMsg(): Unit = probe.expectNoMsg()
       def expectNoMsg(max: FiniteDuration): Unit = probe.expectNoMsg(max)
 


### PR DESCRIPTION
Round 1:
- Factored out input and output receive blocks using a switchable PartialFunction
- reduced surface of ActorProcessorImpl
- removed lazy vals of TransferStates
- somewhat cleaner shutdown process
- robustified some of the tests
