### PR TITLE
=act #15217 await for both "watching" messages in eventstreamspec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventStreamSpec.scala
@@ -388,7 +388,8 @@ class EventStreamSpec extends AkkaSpec(EventStreamSpec.config) {
 
         es.subscribe(a2.ref, classOf[A])
         es.subscribe(a2.ref, classOf[T])
-        fishForDebugMessage(a1, s"watching ${a2.ref}")
+        fishForDebugMessage(a1, s"watching ${a2.ref}", 1 second)
+        fishForDebugMessage(a1, s"watching ${a2.ref}", 1 second) // the unsubscriber "starts to watch" each time, as watching is idempotent
 
         es.unsubscribe(a2.ref, classOf[A]) should equal(true)
         fishForDebugMessage(a1, s"unsubscribing ${a2.ref} from channel class akka.event.EventStreamSpec$$A")
@@ -416,8 +417,8 @@ class EventStreamSpec extends AkkaSpec(EventStreamSpec.config) {
     msg foreach (expectMsg(_))
   }
 
-  private def fishForDebugMessage(a: TestProbe, messagePrefix: String) {
-    a.fishForMessage(3 seconds, hint = "expected debug message prefix: " + messagePrefix) {
+  private def fishForDebugMessage(a: TestProbe, messagePrefix: String, max: Duration = 3 seconds) {
+    a.fishForMessage(max, hint = "expected debug message prefix: " + messagePrefix) {
       case Logging.Debug(_, _, msg: String) if msg startsWith messagePrefix ⇒ true
       case other ⇒ false
     }


### PR DESCRIPTION
We need to fish for both messages since, otherwise the test is a bit racy (as these messages are triggered by the async unsubscriber). This touches upon the racy-ness we investigated in depth during the EventStream's PR and decided this is ok (it will not cause a "wrong state").

Resolves #15217
