### PR TITLE
=str fix typo in scaladoc

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -173,7 +173,7 @@ abstract class Flow[T] {
    *
    * It is possible to keep state in the concrete [[akka.stream.Transformer]] instance with
    * ordinary instance variables. The [[akka.stream.Transformer]] is executed by an actor and
-   * therefore you don not have to add any additional thread safety or memory
+   * therefore you do not have to add any additional thread safety or memory
    * visibility constructs to access the state from the callback methods.
    */
   def transform[U](transformer: Transformer[T, U]): Flow[U]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -170,7 +170,7 @@ trait Flow[+T] {
    *
    * It is possible to keep state in the concrete [[akka.stream.Transformer]] instance with
    * ordinary instance variables. The [[akka.stream.Transformer]] is executed by an actor and
-   * therefore you don not have to add any additional thread safety or memory
+   * therefore you do not have to add any additional thread safety or memory
    * visibility constructs to access the state from the callback methods.
    */
   def transform[U](transformer: Transformer[T, U]): Flow[U]


### PR DESCRIPTION
Just to make sure, is it correct to prefix it with `=str` instead of `=doc`?
