### PR TITLE
=tes #15165 MetricsKit should not nullpointer on racy graphite usage

### DIFF
--- a/akka-testkit/src/test/resources/reference.conf
+++ b/akka-testkit/src/test/resources/reference.conf
@@ -22,9 +22,12 @@ akka {
         host = ""
         port = 2003
 
+        # turn on to print which metrics are being sent to graphite, instead of just the number how many
+        verbose = off
+
         # Automatically print metrics to the console at scheduled interval.
         # To disable, set to `0`.
-        scheduled-report-interval = 1 s
+        scheduled-report-interval = 0 s
       }
     }
   }

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaGraphiteReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaGraphiteReporter.scala
@@ -3,14 +3,13 @@
  */
 package akka.testkit.metrics.reporter
 
-import java.io.IOException
 import java.text.DateFormat
 import java.util
 import java.util.concurrent.TimeUnit
 import com.codahale.metrics._
 import java.util.{ Locale, Date }
 import akka.testkit.metrics._
-import com.codahale.metrics.graphite.Graphite
+import scala.concurrent.duration._
 
 /**
  * Used to report [[Metric]] types that the original [[com.codahale.metrics.graphite.GraphiteReporter]] is unaware of (cannot re-use directly because of private constructor).
@@ -18,7 +17,8 @@ import com.codahale.metrics.graphite.Graphite
 class AkkaGraphiteReporter(
   registry: AkkaMetricRegistry,
   prefix: String,
-  graphite: Graphite)
+  graphite: GraphiteClient,
+  verbose: Boolean = false)
   extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-graphite-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
 
   // todo get rid of ScheduledReporter (would mean removing codahale metrics)?
@@ -41,10 +41,8 @@ class AkkaGraphiteReporter(
     sendWithBanner("== AkkaGraphiteReporter @ " + dateTime + " == (" + metricsCount + " metrics)", '=')
 
     try {
-      graphite.connect()
-
       // graphite takes timestamps in seconds
-      val now = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis)
+      val now = System.currentTimeMillis.millis.toSeconds
 
       // default Metrics types
       import collection.JavaConverters._
@@ -58,19 +56,15 @@ class AkkaGraphiteReporter(
       sendMetrics(now, hdrHistograms, sendHdrHistogram)
       sendMetrics(now, averagingGauges, sendAveragingGauge)
 
-    } finally {
-      try {
-        graphite.close()
-      } catch {
-        case ex: IOException ⇒
-          System.err.println(s"Unable to close connection to graphite!")
-      }
+    } catch {
+      case ex: Exception ⇒ throw new RuntimeException("Unable to send metrics to Graphite!", ex)
     }
   }
 
   def sendMetrics[T <: Metric](now: Long, metrics: Iterable[(String, T)], send: (Long, String, T) ⇒ Unit) {
     for ((key, metric) ← metrics) {
-      println("  " + key)
+      if (verbose)
+        println("  " + key)
       send(now, key, metric)
     }
   }
@@ -171,7 +165,7 @@ class AkkaGraphiteReporter(
   }
 
   private def send(key: String, value: Long, now: Long) {
-    if (value >= 0) //
+    if (value >= 0)
       graphite.send(s"$prefix.$key", value.toString, now)
   }
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/GraphiteClient.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/GraphiteClient.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics.reporter
+
+import java.util.regex.Pattern
+import java.nio.charset.Charset
+import java.io._
+import javax.net.SocketFactory
+import java.net.InetSocketAddress
+
+/**
+ * Carbon (graphite) client, which can be used to send metrics.
+ *
+ * The data is sent over a plain Socket, even though it would fit AkkaIO nicely, but this way it has no dependencies.
+ */
+class GraphiteClient(address: InetSocketAddress) extends Closeable {
+
+  private final val WHITESPACE = Pattern.compile("[\\s]+")
+  private final val charset: Charset = Charset.forName("UTF-8")
+
+  private lazy val socket = {
+    val s = SocketFactory.getDefault.createSocket(address.getAddress, address.getPort)
+    s.setKeepAlive(true)
+    s
+  }
+
+  private lazy val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream, charset))
+
+  /** Send measurement carbon server. Thread-safe. */
+  def send(name: String, value: String, timestamp: Long) {
+    val sb = new StringBuilder()
+      .append(sanitize(name)).append(' ')
+      .append(sanitize(value)).append(' ')
+      .append(timestamp.toString).append('\n')
+
+    // The write calls below handle the string in-one-go (locking);
+    // Whereas the metrics' implementation of the graphite client uses multiple `write` calls,
+    // which could become interwoven, thus producing a wrong metric-line, when called by multiple threads.
+    writer.write(sb.toString())
+    writer.flush()
+  }
+
+  /** Closes underlying connection. */
+  def close() {
+    try socket.close() finally writer.close()
+  }
+
+  protected def sanitize(s: String): String = {
+    WHITESPACE.matcher(s).replaceAll("-")
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,10 +74,9 @@ object Dependencies {
       // metrics, measurements, perf testing
       val metrics         = "com.codahale.metrics"        % "metrics-core"                 % "3.0.1"            % "test" // ApacheV2
       val metricsJvm      = "com.codahale.metrics"        % "metrics-jvm"                  % "3.0.1"            % "test" // ApacheV2
-      val metricsGraphite = "com.codahale.metrics"        % "metrics-graphite"             % "3.0.1"            % "test" // ApacheV2
       val latencyUtils    = "org.latencyutils"            % "LatencyUtils"                 % "1.0.3"            % "test" // Free BSD
       val hdrHistogram    = "org.hdrhistogram"            % "HdrHistogram"                 % "1.1.4"            % "test" // CC0
-      val metricsAll      = Seq(metrics, metricsJvm, metricsGraphite, latencyUtils, hdrHistogram)
+      val metricsAll      = Seq(metrics, metricsJvm, latencyUtils, hdrHistogram)
     }
   }
 


### PR DESCRIPTION
The report() call can come from multiple threads in our code,
yet it was opening/closing a shared graphite client instance in this
method. With the scheduled reporting + manual triggering races could
happen (close/open socket connection, which nulled fields too (inside metric's code).

Graphite's internal socket is now reused among writers; The
graphite.send must be synchronised due to this. Implementing a client by
hand seems more tempting again...

Resolves #15165
