### PR TITLE
Switch akka-zeromq to use the pure java JeroMQ implementation.

### DIFF
--- a/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
+++ b/akka-zeromq/src/main/scala/akka/zeromq/ZeroMQExtension.scala
@@ -251,8 +251,8 @@ class ZeroMQExtension(system: ActorSystem) extends Extension {
       }
 
       private def nonfatal(ex: ZMQException) = ex.getErrorCode match {
-        case org.zeromq.ZeroMQ.EFSM | 45 /* ENOTSUP */ ⇒ true
-        case _                                         ⇒ false
+        case zmq.ZError.EFSM | zmq.ZError.ENOTSUP ⇒ true
+        case _                                    ⇒ false
       }
 
       def receive = { case p: Props ⇒ sender() ! context.actorOf(p) }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   object Versions {
     val scalaVersion = sys.props.get("akka.scalaVersion").getOrElse("2.10.4")
     val scalaStmVersion  = sys.props.get("akka.build.scalaStmVersion").getOrElse("0.7")
-    val scalaZeroMQVersion = sys.props.get("akka.build.scalaZeroMQVersion").getOrElse("0.0.7")
+    val scalaJeroMQVersion = sys.props.get("akka.build.scalaJeroMQVersion").getOrElse("0.3.4")
     val scalaTestVersion = sys.props.get("akka.build.scalaTestVersion").getOrElse("2.1.3")
     val scalaCheckVersion = sys.props.get("akka.build.scalaCheckVersion").getOrElse("1.11.3")
   }
@@ -30,7 +30,7 @@ object Dependencies {
     val scalaStm      = "org.scala-stm"              %% "scala-stm"                    % scalaStmVersion // Modified BSD (Scala)
 
     val slf4jApi      = "org.slf4j"                   % "slf4j-api"                    % "1.7.5"       // MIT
-    val zeroMQClient  = "org.zeromq"                 %% "zeromq-scala-binding"         % scalaZeroMQVersion // ApacheV2
+    val zeroMQClient  = "org.zeromq"                  % "jeromq"                       % scalaJeroMQVersion // LGPL
     // mirrored in OSGi sample
     val uncommonsMath = "org.uncommons.maths"         % "uncommons-maths"              % "1.2.2a" exclude("jfree", "jcommon") exclude("jfree", "jfreechart")      // ApacheV2
     // mirrored in OSGi sample


### PR DESCRIPTION
I understand from https://github.com/akka/akka/issues/13856 that this
change may or may not be desired.  However @chrisdinn asked for a PR.  Here ya go...  We have been using this change with the current 'stable' JeroMQ 0.3.4 on a production server with success.  All Akka unit tests pass with this change.

Thanks for the great work!
