### PR TITLE
=tes #15228 backport - metricskit fix for racy graphite client (for validation)

### DIFF
--- a/akka-testkit/src/test/resources/reference.conf
+++ b/akka-testkit/src/test/resources/reference.conf
@@ -22,9 +22,12 @@ akka {
         host = ""
         port = 2003
 
+        # turn on to print which metrics are being sent to graphite, instead of just the number how many
+        verbose = off
+
         # Automatically print metrics to the console at scheduled interval.
         # To disable, set to `0`.
-        scheduled-report-interval = 1 s
+        scheduled-report-interval = 0 s
       }
     }
   }

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/GraphiteClient.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/GraphiteClient.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics.reporter
+
+import java.util.regex.Pattern
+import java.nio.charset.Charset
+import java.io._
+import javax.net.SocketFactory
+import java.net.InetSocketAddress
+
+/**
+ * Carbon (graphite) client, which can be used to send metrics.
+ *
+ * The data is sent over a plain Socket, even though it would fit AkkaIO nicely, but this way it has no dependencies.
+ */
+class GraphiteClient(address: InetSocketAddress) extends Closeable {
+
+  private final val WHITESPACE = Pattern.compile("[\\s]+")
+  private final val charset: Charset = Charset.forName("UTF-8")
+
+  private lazy val socket = {
+    val s = SocketFactory.getDefault.createSocket(address.getAddress, address.getPort)
+    s.setKeepAlive(true)
+    s
+  }
+
+  private lazy val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream, charset))
+
+  /** Send measurement carbon server. Thread-safe. */
+  def send(name: String, value: String, timestamp: Long) {
+    val sb = new StringBuilder()
+      .append(sanitize(name)).append(' ')
+      .append(sanitize(value)).append(' ')
+      .append(timestamp.toString).append('\n')
+
+    // The write calls below handle the string in-one-go (locking);
+    // Whereas the metrics' implementation of the graphite client uses multiple `write` calls,
+    // which could become interwoven, thus producing a wrong metric-line, when called by multiple threads.
+    writer.write(sb.toString())
+    writer.flush()
+  }
+
+  /** Closes underlying connection. */
+  def close() {
+    try socket.close() finally writer.close()
+  }
+
+  protected def sanitize(s: String): String = {
+    WHITESPACE.matcher(s).replaceAll("-")
+  }
+}


### PR DESCRIPTION
Port of #15228 from master to 2.3-dev
