### PR TITLE
=per #15064 persistence perf spec is now MetricsKit enabled

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorCreationPerfSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorCreationPerfSpec.scala
@@ -101,11 +101,10 @@ object ActorCreationPerfSpec {
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ActorCreationPerfSpec extends AkkaSpec("akka.actor.serialize-messages = off") with ImplicitSender
-  with MetricsKit with BeforeAndAfterAll {
+  with AkkaMetricsKit with BeforeAndAfterAll {
 
   import ActorCreationPerfSpec._
 
-  def metricsConfig = system.settings.config
   val ActorCreationKey = MetricKey.fromString("actor-creation")
   val BlockingTimeKey = ActorCreationKey / "synchronous-part"
   val TotalTimeKey = ActorCreationKey / "total"

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/AkkaMetricsKit.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/AkkaMetricsKit.scala
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.testkit.metrics
+
+import akka.testkit.AkkaSpec
+
+/**
+ * Convinience trait for using [[MetricsKit]] in [[akka.testkit.AkkaSpec]] backed tests.
+ * Metrics configuration is used from the AkkaSpecs' actor systems' configuration.
+ *
+ * The reason MetricsKit does not require AkkaSpec (or an actor system) out of the box,
+ * is in order to allow using metrics in code that does not depend on actors (plain queues etc).
+ */
+trait AkkaMetricsKit extends MetricsKit {
+  this: AkkaSpec ⇒
+
+  override def metricsConfig = system.settings.config
+}

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
@@ -12,8 +12,8 @@ import com.typesafe.config.Config
 import java.util
 import scala.util.matching.Regex
 import scala.collection.mutable
-import akka.testkit.metrics.reporter.{ GraphiteClient, AkkaGraphiteReporter, AkkaConsoleReporter }
-import org.scalatest.Notifying
+import akka.testkit.metrics.reporter.{GraphiteClient, AkkaGraphiteReporter, AkkaConsoleReporter}
+import org.scalatest.{ Informing, Notifying }
 import scala.reflect.ClassTag
 
 /**
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
  * In order to send registry to Graphite run sbt with the following property: `-Dakka.registry.reporting.0=graphite`.
  */
 private[akka] trait MetricsKit extends MetricsKitOps {
-  this: Notifying ⇒
+  this: Notifying with Informing ⇒
 
   import MetricsKit._
   import collection.JavaConverters._
@@ -50,34 +50,37 @@ private[akka] trait MetricsKit extends MetricsKitOps {
   def initMetricReporters() {
     val settings = new MetricsKitSettings(metricsConfig)
 
-    def configureConsoleReporter() {
-      if (settings.Reporters.contains("console")) {
-        val akkaConsoleReporter = new AkkaConsoleReporter(registry, settings.ConsoleReporter.Verbose)
+    reporters :::= configureConsoleReporter(settings)
+    reporters :::= configureGraphiteReporter(settings)
+  }
 
-        if (settings.ConsoleReporter.ScheduledReportInterval > Duration.Zero)
-          akkaConsoleReporter.start(settings.ConsoleReporter.ScheduledReportInterval.toMillis, TimeUnit.MILLISECONDS)
+  protected def configureConsoleReporter(settings: MetricsKitSettings): List[ScheduledReporter] = {
+    if (settings.Reporters.contains("console")) {
+      val akkaConsoleReporter = new AkkaConsoleReporter(registry, settings.ConsoleReporter.Verbose, l ⇒ if (!l.matches("""\W+""")) info(l))
 
-        reporters ::= akkaConsoleReporter
-      }
+      if (settings.ConsoleReporter.ScheduledReportInterval > Duration.Zero)
+        akkaConsoleReporter.start(settings.ConsoleReporter.ScheduledReportInterval.toMillis, TimeUnit.MILLISECONDS)
+
+      List(akkaConsoleReporter)
+    } else {
+      Nil
     }
+  }
 
-    def configureGraphiteReporter() {
-      if (settings.Reporters.contains("graphite")) {
-        note(s"MetricsKit: Graphite reporter enabled, sending metrics to: ${settings.GraphiteReporter.Host}:${settings.GraphiteReporter.Port}")
-        val address = new InetSocketAddress(settings.GraphiteReporter.Host, settings.GraphiteReporter.Port)
-        val graphite = new GraphiteClient(address)
-        val akkaGraphiteReporter = new AkkaGraphiteReporter(registry, settings.GraphiteReporter.Prefix, graphite, settings.GraphiteReporter.Verbose)
+  protected def configureGraphiteReporter(settings: MetricsKitSettings): List[ScheduledReporter] = {
+    if (settings.Reporters.contains("graphite")) {
+      note(s"MetricsKit: Graphite reporter enabled, sending metrics to: ${settings.GraphiteReporter.Host}:${settings.GraphiteReporter.Port}")
+      val graphite = new GraphiteClient(new InetSocketAddress(settings.GraphiteReporter.Host, settings.GraphiteReporter.Port))
+      val akkaGraphiteReporter = new AkkaGraphiteReporter(registry, settings.GraphiteReporter.Prefix, graphite)
 
-        if (settings.GraphiteReporter.ScheduledReportInterval > Duration.Zero) {
-          akkaGraphiteReporter.start(settings.GraphiteReporter.ScheduledReportInterval.toMillis, TimeUnit.MILLISECONDS)
-        }
-
-        reporters ::= akkaGraphiteReporter
+      if (settings.GraphiteReporter.ScheduledReportInterval > Duration.Zero) {
+        akkaGraphiteReporter.start(settings.GraphiteReporter.ScheduledReportInterval.toMillis, TimeUnit.MILLISECONDS)
       }
-    }
 
-    configureConsoleReporter()
-    configureGraphiteReporter()
+      List(akkaGraphiteReporter)
+    } else {
+      Nil
+    }
   }
 
   /**

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.Config
 import java.util
 import scala.util.matching.Regex
 import scala.collection.mutable
-import akka.testkit.metrics.reporter.{GraphiteClient, AkkaGraphiteReporter, AkkaConsoleReporter}
+import akka.testkit.metrics.reporter.{ GraphiteClient, AkkaGraphiteReporter, AkkaConsoleReporter }
 import org.scalatest.{ Informing, Notifying }
 import scala.reflect.ClassTag
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
@@ -35,9 +35,6 @@ class AkkaConsoleReporter(
     printMetrics(registry.getKnownOpsInTimespanCounters, printKnownOpsInTimespanCounter)
     printMetrics(registry.getHdrHistograms, printHdrHistogram)
     printMetrics(registry.getAveragingGauges, printAveragingGauge)
-
-    output.println()
-    output.flush()
   }
 
   def printMetrics[T <: Metric](metrics: Iterable[(String, T)], printer: T ⇒ Unit)(implicit clazz: ClassTag[T]) {

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
@@ -16,8 +16,8 @@ import scala.reflect.ClassTag
 class AkkaConsoleReporter(
   registry: AkkaMetricRegistry,
   verbose: Boolean,
-  output: PrintStream = System.out)
-  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-console-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
+  print: String ⇒ Unit = s ⇒ System.out.print(s))
+  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-console-reporter", MetricsKit.KnownOpsInTimespanCounterFilter, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
 
   private final val ConsoleWidth = 80
 
@@ -42,104 +42,99 @@ class AkkaConsoleReporter(
 
   def printMetrics[T <: Metric](metrics: Iterable[(String, T)], printer: T ⇒ Unit)(implicit clazz: ClassTag[T]) {
     if (!metrics.isEmpty) {
-      printWithBanner(s"-- ${simpleName(metrics.head._2.getClass)}", '-')
+      printWithBanner(s"  ${simpleName(metrics.head._2.getClass)}", '-')
       for ((key, metric) ← metrics) {
-        output.println("  " + key)
+        print(s"""  $key""".stripMargin)
         printer(metric)
       }
-      output.println()
     }
   }
 
   private def printMeter(meter: Meter) {
-    output.print("             count = %d%n".format(meter.getCount))
-    output.print("         mean rate = %2.2f events/%s%n".format(convertRate(meter.getMeanRate), getRateUnit))
-    output.print("     1-minute rate = %2.2f events/%s%n".format(convertRate(meter.getOneMinuteRate), getRateUnit))
-    output.print("     5-minute rate = %2.2f events/%s%n".format(convertRate(meter.getFiveMinuteRate), getRateUnit))
-    output.print("    15-minute rate = %2.2f events/%s%n".format(convertRate(meter.getFifteenMinuteRate), getRateUnit))
+    print("             count = %d".format(meter.getCount))
+    print("         mean rate = %2.2f events/%s".format(convertRate(meter.getMeanRate), getRateUnit))
+    print("     1-minute rate = %2.2f events/%s".format(convertRate(meter.getOneMinuteRate), getRateUnit))
+    print("     5-minute rate = %2.2f events/%s".format(convertRate(meter.getFiveMinuteRate), getRateUnit))
+    print("    15-minute rate = %2.2f events/%s".format(convertRate(meter.getFifteenMinuteRate), getRateUnit))
   }
 
   private def printCounter(entry: Counter) {
-    output.print("             count = %d%n".format(entry.getCount))
+    print("             count = %d".format(entry.getCount))
   }
 
   private def printGauge(entry: Gauge[_]) {
-    output.print("             value = %s%n".format(entry.getValue))
+    print("             value = %s".format(entry.getValue))
   }
 
   private def printHistogram(histogram: Histogram) {
     val snapshot = histogram.getSnapshot
-    output.print("             count = %d%n".format(histogram.getCount))
-    output.print("               min = %d%n".format(snapshot.getMin))
-    output.print("               max = %d%n".format(snapshot.getMax))
-    output.print("              mean = %2.2f%n".format(snapshot.getMean))
-    output.print("            stddev = %2.2f%n".format(snapshot.getStdDev))
-    output.print("            median = %2.2f%n".format(snapshot.getMedian))
-    output.print("              75%% <= %2.2f%n".format(snapshot.get75thPercentile))
-    output.print("              95%% <= %2.2f%n".format(snapshot.get95thPercentile))
-    output.print("              98%% <= %2.2f%n".format(snapshot.get98thPercentile))
-    output.print("              99%% <= %2.2f%n".format(snapshot.get99thPercentile))
-    output.print("            99.9%% <= %2.2f%n".format(snapshot.get999thPercentile))
+    print("             count = %d".format(histogram.getCount))
+    print("               min = %d".format(snapshot.getMin))
+    print("               max = %d".format(snapshot.getMax))
+    print("              mean = %2.2f".format(snapshot.getMean))
+    print("            stddev = %2.2f".format(snapshot.getStdDev))
+    print("            median = %2.2f".format(snapshot.getMedian))
+    print("              75%% <= %2.2f".format(snapshot.get75thPercentile))
+    print("              95%% <= %2.2f".format(snapshot.get95thPercentile))
+    print("              98%% <= %2.2f".format(snapshot.get98thPercentile))
+    print("              99%% <= %2.2f".format(snapshot.get99thPercentile))
+    print("            99.9%% <= %2.2f".format(snapshot.get999thPercentile))
   }
 
   private def printTimer(timer: Timer) {
     val snapshot = timer.getSnapshot
-    output.print("             count = %d%n".format(timer.getCount))
-    output.print("         mean rate = %2.2f calls/%s%n".format(convertRate(timer.getMeanRate), getRateUnit))
-    output.print("     1-minute rate = %2.2f calls/%s%n".format(convertRate(timer.getOneMinuteRate), getRateUnit))
-    output.print("     5-minute rate = %2.2f calls/%s%n".format(convertRate(timer.getFiveMinuteRate), getRateUnit))
-    output.print("    15-minute rate = %2.2f calls/%s%n".format(convertRate(timer.getFifteenMinuteRate), getRateUnit))
-    output.print("               min = %2.2f %s%n".format(convertDuration(snapshot.getMin), getDurationUnit))
-    output.print("               max = %2.2f %s%n".format(convertDuration(snapshot.getMax), getDurationUnit))
-    output.print("              mean = %2.2f %s%n".format(convertDuration(snapshot.getMean), getDurationUnit))
-    output.print("            stddev = %2.2f %s%n".format(convertDuration(snapshot.getStdDev), getDurationUnit))
-    output.print("            median = %2.2f %s%n".format(convertDuration(snapshot.getMedian), getDurationUnit))
-    output.print("              75%% <= %2.2f %s%n".format(convertDuration(snapshot.get75thPercentile), getDurationUnit))
-    output.print("              95%% <= %2.2f %s%n".format(convertDuration(snapshot.get95thPercentile), getDurationUnit))
-    output.print("              98%% <= %2.2f %s%n".format(convertDuration(snapshot.get98thPercentile), getDurationUnit))
-    output.print("              99%% <= %2.2f %s%n".format(convertDuration(snapshot.get99thPercentile), getDurationUnit))
-    output.print("            99.9%% <= %2.2f %s%n".format(convertDuration(snapshot.get999thPercentile), getDurationUnit))
+    print("             count = %d".format(timer.getCount))
+    print("         mean rate = %2.2f calls/%s".format(convertRate(timer.getMeanRate), getRateUnit))
+    print("     1-minute rate = %2.2f calls/%s".format(convertRate(timer.getOneMinuteRate), getRateUnit))
+    print("     5-minute rate = %2.2f calls/%s".format(convertRate(timer.getFiveMinuteRate), getRateUnit))
+    print("    15-minute rate = %2.2f calls/%s".format(convertRate(timer.getFifteenMinuteRate), getRateUnit))
+    print("               min = %2.2f %s".format(convertDuration(snapshot.getMin), getDurationUnit))
+    print("               max = %2.2f %s".format(convertDuration(snapshot.getMax), getDurationUnit))
+    print("              mean = %2.2f %s".format(convertDuration(snapshot.getMean), getDurationUnit))
+    print("            stddev = %2.2f %s".format(convertDuration(snapshot.getStdDev), getDurationUnit))
+    print("            median = %2.2f %s".format(convertDuration(snapshot.getMedian), getDurationUnit))
+    print("              75%% <= %2.2f %s".format(convertDuration(snapshot.get75thPercentile), getDurationUnit))
+    print("              95%% <= %2.2f %s".format(convertDuration(snapshot.get95thPercentile), getDurationUnit))
+    print("              98%% <= %2.2f %s".format(convertDuration(snapshot.get98thPercentile), getDurationUnit))
+    print("              99%% <= %2.2f %s".format(convertDuration(snapshot.get99thPercentile), getDurationUnit))
+    print("            99.9%% <= %2.2f %s".format(convertDuration(snapshot.get999thPercentile), getDurationUnit))
   }
 
   private def printKnownOpsInTimespanCounter(counter: KnownOpsInTimespanTimer) {
     import concurrent.duration._
     import PrettyDuration._
-    output.print("               ops = %d%n".format(counter.getCount))
-    output.print("              time = %s%n".format(counter.elapsedTime.nanos.pretty))
-    output.print("             ops/s = %2.2f%n".format(counter.opsPerSecond))
-    output.print("               avg = %s%n".format(counter.avgDuration.nanos.pretty))
+    print("               ops = %d".format(counter.getCount))
+    print("              time = %s".format(counter.elapsedTime.nanos.pretty))
+    print("             ops/s = %2.2f".format(counter.opsPerSecond))
+    print("               avg = %s".format(counter.avgDuration.nanos.pretty))
   }
 
   private def printHdrHistogram(hist: HdrHistogram) {
     val data = hist.getData
     val unit = hist.unit
-    output.print("               min = %d %s%n".format(data.getMinValue, unit))
-    output.print("               max = %d %s%n".format(data.getMaxValue, unit))
-    output.print("              mean = %2.2f %s%n".format(data.getMean, unit))
-    output.print("            stddev = %2.2f%n".format(data.getStdDeviation))
-    output.print("              75%% <= %d %s%n".format(data.getValueAtPercentile(75.0), unit))
-    output.print("              95%% <= %d %s%n".format(data.getValueAtPercentile(95.0), unit))
-    output.print("              98%% <= %d %s%n".format(data.getValueAtPercentile(98.0), unit))
-    output.print("              99%% <= %d %s%n".format(data.getValueAtPercentile(99.0), unit))
-    output.print("            99.9%% <= %d %s%n".format(data.getValueAtPercentile(99.9), unit))
-
-    if (verbose)
-      data.outputPercentileDistribution(output, 1)
+    print("               min = %d %s".format(data.getMinValue, unit))
+    print("               max = %d %s".format(data.getMaxValue, unit))
+    print("              mean = %2.2f %s".format(data.getMean, unit))
+    print("            stddev = %2.2f".format(data.getStdDeviation))
+    print("              75%% <= %d %s".format(data.getValueAtPercentile(75.0), unit))
+    print("              95%% <= %d %s".format(data.getValueAtPercentile(95.0), unit))
+    print("              98%% <= %d %s".format(data.getValueAtPercentile(98.0), unit))
+    print("              99%% <= %d %s".format(data.getValueAtPercentile(99.0), unit))
+    print("            99.9%% <= %d %s".format(data.getValueAtPercentile(99.9), unit))
   }
 
   private def printAveragingGauge(gauge: AveragingGauge) {
-    output.print("                avg = %2.2f%n".format(gauge.getValue))
+    print("                avg = %2.2f".format(gauge.getValue))
   }
 
   private def printWithBanner(s: String, c: Char) {
-    output.print(s)
-    output.print(' ')
+    val sb = new StringBuilder(s + " ")
     var i: Int = 0
     while (i < (ConsoleWidth - s.length - 1)) {
-      output.print(c)
+      sb.append(c.toString)
       i += 1
     }
-    output.println()
+    print(sb.toString())
   }
 
   /** Required for getting simple names of refined instances */


### PR DESCRIPTION
- `PerformanceSpec` in akka persistence will now report metrics when run on jenkins.
- Small updates in MetricsKit (better console printing - metrics come after the test name, not before it = thanks to using info instead of println)

Useful to have before tackling https://github.com/akka/akka/issues/15227 in order to see a perf diff after the changes needed for that (though I'd suggest a specific JMH bench for eventsourced processor - will come soon).

Refs #15064
