### PR TITLE
=ben #15064 initial example akka-streams bench (map, 5 maps) 

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.stream
+
+import org.openjdk.jmh.annotations._
+import akka.actor.ActorSystem
+import akka.stream.scaladsl._
+import akka.stream.testkit._
+import com.typesafe.config.ConfigFactory
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.{Lock, Promise, duration, Await}
+import scala.concurrent.duration.Duration
+import scala.util.Success
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class FlowMapBenchmark {
+
+  val config = ConfigFactory.parseString(
+    """
+      akka {
+        log-config-on-start = off
+        log-dead-letters-during-shutdown = off
+        loglevel = "WARNING"
+
+        test {
+          timefactor =  1.0
+          filter-leeway = 3s
+          single-expect-default = 3s
+          default-timeout = 5s
+          calling-thread-dispatcher {
+            type = akka.testkit.CallingThreadDispatcherConfigurator
+          }
+        }
+      }""".stripMargin).withFallback(ConfigFactory.load())
+
+  implicit val system = ActorSystem("test", config)
+
+  var materializer: FlowMaterializer = _
+
+
+  // manual, and not via @Param, because we want @OperationsPerInvocation on our tests
+  final val data100k = (1 to 100000).toVector
+
+  final val successMarker = Success(1)
+  final val successFailure = Success(new Exception)
+
+  // safe to be benchmark scoped because the flows we construct in this bench are stateless
+  var flow: Flow[Int] = _
+
+  @Param(Array("2", "8")) // todo
+  val initialInputBufferSize = 0
+
+  @Param(Array("1", "5", "10"))
+  val numberOfMapOps = 0
+
+  @Setup
+  def setup() {
+    val settings = MaterializerSettings(
+      initialInputBufferSize = initialInputBufferSize,
+      maximumInputBufferSize = 16,
+      initialFanOutBufferSize = 1,
+      maxFanOutBufferSize = 16)
+
+    materializer = FlowMaterializer(settings)
+
+    flow = mkMaps(Flow(data100k), numberOfMapOps)(identity)
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(100000)
+  def flow_map_100k_elements() {
+    val lock = new Lock() // todo rethink what is the most lightweight way to await for a streams completion
+    lock.acquire()
+
+    flow.onComplete(materializer) { _ => lock.release() }
+
+    lock.acquire()
+  }
+
+  // flow setup
+  private def mkMaps[O](flow: Flow[O], count: Int)(op: O ⇒ O): Flow[O] = {
+    var f = flow
+    for (i ← 1 to count)
+      f = f.map(op)
+    f
+  }
+
+
+}

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -191,7 +191,7 @@ object AkkaBuild extends Build {
   lazy val benchJmh = Project(
     id = "akka-bench-jmh",
     base = file("akka-bench-jmh"),
-    dependencies = Seq(actor, stream, persistence % "compile;test->test", testkit % "compile;test->compile"),
+    dependencies = Seq(actor, stream, persistence, testkit).map(_ % "compile;compile->test"),
     settings = defaultSettings ++ Seq(
       libraryDependencies ++= Dependencies.testkit
     ) ++ settings ++ jmhSettings


### PR DESCRIPTION
This is a naive benchmark, but it already shows some order-of-magnitude behavior.

This PR also makes sure:
- `StreamTestKit` available in the benchmarks project, so adding more stream benches is easy
