### PR TITLE
Stream perf tuning

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -171,7 +171,35 @@ private[akka] class ActorBasedFlowMaterializer(
 
   private def createFlowName(): String = s"$namePrefix-${nextFlowNameCount()}"
 
-  @tailrec private def processorChain(topConsumer: Consumer[_], ops: immutable.Seq[AstNode],
+  private def meld(ops: List[AstNode]): List[AstNode] = {
+    def meldTwo(op1: AstNode, op2: AstNode): Option[AstNode] =
+      (op1, op2) match {
+        case (SingleElement(f1, name1), SingleElement(f2, name2)) ⇒
+          val f = (in: Any) ⇒ {
+            val r2 = f2(in)
+            if (r2 == null) null
+            else f1(r2)
+          }
+          Some(SingleElement(f, name2 + "-" + name1))
+        case _ ⇒ None
+      }
+
+    @tailrec def doMeld(remaining: List[AstNode], acc: List[AstNode]): List[AstNode] =
+      remaining match {
+        case Nil       ⇒ acc.reverse
+        case op :: Nil ⇒ doMeld(Nil, op :: acc)
+        case op1 :: op2 :: tail ⇒
+          meldTwo(op1, op2) match {
+            case Some(op) ⇒ doMeld(op :: tail, acc)
+            case None     ⇒ doMeld(op2 :: tail, op1 :: acc)
+          }
+      }
+
+    if (ops.isEmpty || ops.tail.isEmpty) ops
+    else doMeld(ops, Nil)
+  }
+
+  @tailrec private def processorChain(topConsumer: Consumer[_], ops: List[AstNode],
                                       flowName: String, n: Int): Consumer[_] = {
     ops match {
       case op :: tail ⇒
@@ -187,9 +215,10 @@ private[akka] class ActorBasedFlowMaterializer(
     val flowName = createFlowName()
     if (ops.isEmpty) producerNode.createProducer(this, flowName).asInstanceOf[Producer[O]]
     else {
-      val opsSize = ops.size
-      val opProcessor = processorForNode(ops.head, flowName, opsSize)
-      val topConsumer = processorChain(opProcessor, ops.tail, flowName, opsSize - 1)
+      val meldedOps = meld(ops)
+      val opsSize = meldedOps.size
+      val opProcessor = processorForNode(meldedOps.head, flowName, opsSize)
+      val topConsumer = processorChain(opProcessor, meldedOps.tail, flowName, opsSize - 1)
       producerNode.createProducer(this, flowName).produceTo(topConsumer.asInstanceOf[Consumer[I]])
       opProcessor.asInstanceOf[Producer[O]]
     }
@@ -209,8 +238,10 @@ private[akka] class ActorBasedFlowMaterializer(
     new ActorProcessor(context.actorOf(ActorProcessor.props(settings, op),
       name = s"$flowName-$n-${op.name}"))
 
-  override def ductProduceTo[In, Out](consumer: Consumer[Out], ops: List[Ast.AstNode]): Consumer[In] =
-    processorChain(consumer, ops, createFlowName(), ops.size).asInstanceOf[Consumer[In]]
+  override def ductProduceTo[In, Out](consumer: Consumer[Out], ops: List[Ast.AstNode]): Consumer[In] = {
+    val meldedOps = meld(ops)
+    processorChain(consumer, meldedOps, createFlowName(), meldedOps.size).asInstanceOf[Consumer[In]]
+  }
 
   override def ductBuild[In, Out](ops: List[Ast.AstNode]): (Consumer[In], Producer[Out]) = {
     val flowName = createFlowName()
@@ -218,9 +249,10 @@ private[akka] class ActorBasedFlowMaterializer(
       val identityProcessor: Processor[In, Out] = processorForNode(identityTransform, flowName, 1).asInstanceOf[Processor[In, Out]]
       (identityProcessor, identityProcessor)
     } else {
-      val opsSize = ops.size
-      val outProcessor = processorForNode(ops.head, flowName, opsSize).asInstanceOf[Processor[In, Out]]
-      val topConsumer = processorChain(outProcessor, ops.tail, flowName, opsSize - 1).asInstanceOf[Processor[In, Out]]
+      val meldedOps = meld(ops)
+      val opsSize = meldedOps.size
+      val outProcessor = processorForNode(meldedOps.head, flowName, opsSize).asInstanceOf[Processor[In, Out]]
+      val topConsumer = processorChain(outProcessor, meldedOps.tail, flowName, opsSize - 1).asInstanceOf[Processor[In, Out]]
       (topConsumer, outProcessor)
     }
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -33,6 +33,7 @@ private[akka] object Ast {
   case class Transform(transformer: Transformer[Any, Any]) extends AstNode {
     override def name = transformer.name
   }
+  case class SingleElement(f: Any ⇒ Any, name: String) extends AstNode
   case class GroupBy(f: Any ⇒ Any) extends AstNode {
     override def name = "groupBy"
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -24,6 +24,7 @@ private[akka] object ActorProcessor {
   def props(settings: MaterializerSettings, op: AstNode): Props =
     (op match {
       case t: Transform      ⇒ Props(new TransformProcessorImpl(settings, t.transformer))
+      case s: SingleElement  ⇒ Props(new SingleElementProcessorImpl(settings, s.f))
       case s: SplitWhen      ⇒ Props(new SplitWhenProcessorImpl(settings, s.p))
       case g: GroupBy        ⇒ Props(new GroupByProcessorImpl(settings, g.f))
       case m: Merge          ⇒ Props(new MergeImpl(settings, m.other))

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -140,21 +140,17 @@ private[akka] trait Builder[Out] {
   protected def andThen[U](op: Ast.AstNode): Thing[U]
 
   def map[U](f: Out ⇒ U): Thing[U] =
-    transform(new Transformer[Out, U] {
-      override def onNext(in: Out) = List(f(in))
-      override def name = "map"
-    })
+    andThen(SingleElement(f.asInstanceOf[Any ⇒ Any], "map"))
 
-  def filter(p: Out ⇒ Boolean): Thing[Out] =
-    transform(new Transformer[Out, Out] {
-      override def onNext(in: Out) = if (p(in)) List(in) else Nil
-      override def name = "filter"
-    })
+  def filter(p: Out ⇒ Boolean): Thing[Out] = {
+    val f = (in: Out) ⇒ if (p(in)) in else null
+    andThen(SingleElement(f.asInstanceOf[Any ⇒ Any], "filter"))
+  }
 
-  def collect[U](pf: PartialFunction[Out, U]): Thing[U] =
-    transform(new Transformer[Out, U] {
-      override def onNext(in: Out) = if (pf.isDefinedAt(in)) List(pf(in)) else Nil
-    })
+  def collect[U](pf: PartialFunction[Out, U]): Thing[U] = {
+    val f = (in: Out) ⇒ if (pf.isDefinedAt(in)) pf(in) else null
+    andThen(SingleElement(f.asInstanceOf[Any ⇒ Any], "collect"))
+  }
 
   def foreach(c: Out ⇒ Unit): Thing[Unit] =
     transform(new Transformer[Out, Unit] {
@@ -174,23 +170,21 @@ private[akka] trait Builder[Out] {
     override def name = "fold"
   }
 
-  def drop(n: Int): Thing[Out] =
-    transform(new Transformer[Out, Out] {
-      var delegate: Transformer[Out, Out] =
-        if (n == 0) identityTransformer.asInstanceOf[Transformer[Out, Out]]
-        else new Transformer[Out, Out] {
-          var c = n
-          override def onNext(in: Out) = {
+  def drop(n: Int): Thing[Out] = {
+    val f: Any ⇒ Any =
+      if (n == 0) identity
+      else {
+        var c = n
+        (in: Any) ⇒ {
+          if (c == 0) in
+          else {
             c -= 1
-            if (c == 0)
-              delegate = identityTransformer.asInstanceOf[Transformer[Out, Out]]
-            Nil
+            null
           }
         }
-
-      override def onNext(in: Out) = delegate.onNext(in)
-      override def name = "drop"
-    })
+      }
+    andThen(SingleElement(f, "drop"))
+  }
 
   def take(n: Int): Thing[Out] =
     transform(new Transformer[Out, Out] {

--- a/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
@@ -81,6 +81,28 @@ private[akka] class TransformProcessorImpl(_settings: MaterializerSettings, tran
 /**
  * INTERNAL API
  */
+private[akka] class SingleElementProcessorImpl(_settings: MaterializerSettings, f: Any ⇒ Any) extends ActorProcessorImpl(_settings) {
+
+  object NeedsInputAndDemandOrCompletion extends TransferState {
+    def isReady = (primaryInputs.inputsAvailable && primaryOutputs.demandAvailable) || primaryInputs.inputsDepleted
+    def isCompleted = false
+  }
+
+  val running: TransferPhase = TransferPhase(NeedsInputAndDemandOrCompletion) { () ⇒
+    if (primaryInputs.inputsDepleted) nextPhase(completedPhase)
+    else {
+      val emit = f(primaryInputs.dequeueInputElement())
+      if (emit != null) primaryOutputs.enqueueOutputElement(emit)
+    }
+  }
+
+  nextPhase(running)
+
+}
+
+/**
+ * INTERNAL API
+ */
 private[akka] object IdentityProcessorImpl {
   def props(settings: MaterializerSettings): Props = Props(new IdentityProcessorImpl(settings))
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
@@ -97,7 +97,6 @@ private[akka] class SingleElementProcessorImpl(_settings: MaterializerSettings, 
   }
 
   nextPhase(running)
-
 }
 
 /**

--- a/akka-stream/src/test/scala/akka/stream/FlowMeldSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowMeldSpec.scala
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream
+
+import akka.stream.testkit.AkkaSpec
+import akka.stream.testkit.{ StreamTestKit, ScriptedTest }
+import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
+import akka.stream.scaladsl.Flow
+import akka.stream.impl.ActorBasedFlowMaterializer
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class FlowMeldSpec extends AkkaSpec with ScriptedTest {
+
+  val m = FlowMaterializer(MaterializerSettings(
+    dispatcher = "akka.test.stream-dispatcher"))
+
+  "A Flow with meldable operations" must {
+
+    "work with zero operations" in {
+      val c = StreamTestKit.consumerProbe[Int]
+      Flow(1 to 3).produceTo(m, c)
+      val sub = c.expectSubscription()
+      sub.requestMore(10)
+      c.expectNext(1)
+      c.expectNext(2)
+      c.expectNext(3)
+      c.expectComplete()
+    }
+
+    "work with one operation" in {
+      val c = StreamTestKit.consumerProbe[String]
+      Flow(1 to 3).map(n ⇒ "elem-" + n).produceTo(m, c)
+      val sub = c.expectSubscription()
+      sub.requestMore(10)
+      c.expectNext("elem-1")
+      c.expectNext("elem-2")
+      c.expectNext("elem-3")
+      c.expectComplete()
+    }
+
+    "meld two operations" in {
+      val c = StreamTestKit.consumerProbe[String]
+      Flow(1 to 5).
+        filter(_ % 2 == 0).
+        map(n ⇒ "elem-" + n).
+        produceTo(m, c)
+      val sub = c.expectSubscription()
+      sub.requestMore(10)
+      c.expectNext("elem-2")
+      c.expectNext("elem-4")
+      c.expectComplete()
+    }
+
+    "meld three operations" in {
+      val c = StreamTestKit.consumerProbe[String]
+      Flow(1 to 10).
+        filter(_ % 2 == 0).
+        collect {
+          case n if n <= 4 ⇒ n * 2
+        }.
+        map(n ⇒ "elem-" + n).
+        produceTo(m, c)
+      val sub = c.expectSubscription()
+      sub.requestMore(10)
+      c.expectNext("elem-4")
+      c.expectNext("elem-8")
+      c.expectComplete()
+    }
+
+    "meld many operations" in {
+      val c = StreamTestKit.consumerProbe[String]
+      Flow(-1 to 5).
+        drop(2).
+        filter(_ % 2 == 0).
+        map(_.toString).
+        map(_.toInt).
+        map(n ⇒ "elem-" + n).
+        map(_.toUpperCase).
+        produceTo(m, c)
+      val sub = c.expectSubscription()
+      sub.requestMore(10)
+      c.expectNext("ELEM-2")
+      c.expectNext("ELEM-4")
+      c.expectComplete()
+    }
+
+    "work with combinations of meldable and not meldable operators" in {
+      val c = StreamTestKit.consumerProbe[String]
+      Flow(1 to 5).
+        filter(_ % 2 == 0).
+        mapConcat(n ⇒ List(n, n)).
+        map(n ⇒ "elem-" + n).
+        map(_.toUpperCase).
+        drop(1).
+        take(2).
+        map(_.toLowerCase).
+        produceTo(m, c)
+      val sub = c.expectSubscription()
+      sub.requestMore(10)
+      c.expectNext("elem-2")
+      c.expectNext("elem-4")
+      c.expectComplete()
+    }
+
+  }
+
+}


### PR DESCRIPTION
Some early benchmarks, and exploring a few optimization ideas.

I have run the JMH benchmark [FlowMapBenchmark](https://github.com/akka/akka/blob/10b305f0e4462f3dbdc1bb5003e029483cdf35e9/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala) on my MacBook Pro and on a0 server for each of the commits in this PR.
#### MacBook Pro, 2,3 GHz Intel Core i7

akka-bench-jmh > jmh:run -o result4.txt -r 3 -i 5 -wi 3 -f 3 -prof gc,stack -jvmArgs "-Xms1024m -Xms1024m" akka.stream.FlowMapBenchmark.*

9083147 baseline-1:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15     1372.621       16.821   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15     1083.655       20.590   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15      881.340       27.921   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15      502.314       12.562   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15      355.213        8.703   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15     1314.737       47.114   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15     1175.235       38.830   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15     1016.799       27.944   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      578.903       22.684   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15      398.284        7.564   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15     1348.605       33.749   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15     1288.192       18.258   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15     1111.043       47.815   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      626.880       23.312   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      426.780       27.654   ops/ms
```

877d217 inline withCtx to avoid allocations:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15     1352.759       24.729   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15     1058.239       45.667   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15      867.613       23.226   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15      494.316       12.477   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15      345.340       19.637   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15     1300.565       43.169   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15     1194.002       18.677   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15     1051.464       49.493   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      562.280       19.097   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15      394.728       16.800   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15     1311.480       33.852   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15     1280.198       31.515   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15     1145.833       59.118   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      643.246       39.715   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      434.573       14.903   ops/ms
```

175f680 Specialized processor for single element transform:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15     1554.854       48.597   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15     1333.449       27.429   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15     1043.226       22.191   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15      617.836       11.572   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15      417.560       12.261   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15     1971.960       27.653   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15     1533.039       22.923   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15     1266.102       18.008   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      703.862       41.133   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15      450.350       52.939   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15     2096.001       24.710   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15     1626.579       20.110   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15     1392.384       18.343   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      787.450       24.344   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      564.587       10.508   ops/ms
```

10b305f meld operators:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15     1579.800       45.954   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15     1521.992       38.840   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15     1537.341       12.879   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15     1398.995       23.391   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15     1296.101       20.733   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15     1942.903       34.342   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15     1874.584       28.136   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15     1793.426       29.125   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15     1346.030       17.245   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15     1225.767       30.770   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15     2134.254       26.655   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15     1965.900       32.709   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15     1875.211       10.410   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15     1480.152       39.391   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15     1295.409       28.295   ops/ms
```
#### a0, 48 core AMD Opteron (4 dual-socket with 6 core AMD® Opteron™ 6172 2.1 GHz)

akka-bench-jmh > jmh:run -o result4.txt -r 3 -i 5 -wi 3 -f 3 -prof gc,stack -jvm /usr/lib/jvm/java-7-openjdk-amd64/bin/java -jvmArgs "-Xms1024m -Xms1024m -XX:+UseNUMA" akka.stream.FlowMapBenchmark.*

9083147 baseline-1:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15      228.736        6.202   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15      224.559        8.841   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15      197.587        3.530   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15      114.896        2.833   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15       76.601        4.117   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15      326.009       13.201   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15      250.947       12.681   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15      231.585       13.320   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      126.862        5.935   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15       95.104        5.523   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15      390.745        8.496   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15      271.565        8.752   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15      263.098       10.530   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      144.422        6.150   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      109.571        6.937   ops/ms
```

877d217 inline withCtx to avoid allocations:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15      226.603        6.944   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15      233.485       12.055   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15      201.555        9.228   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15      112.002        5.080   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15       81.224        4.186   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15      325.441       17.759   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15      259.571       10.327   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15      246.767        9.014   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      136.002       10.276   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15       90.844        2.425   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15      386.583       14.325   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15      271.218       12.498   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15      271.416       11.126   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      144.660        9.232   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      100.049        8.259   ops/ms
```

175f680 Specialized processor for single element transform:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15      280.784       10.442   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15      272.778       10.489   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15      232.369        8.761   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15      136.433        5.329   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15       93.526        4.938   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15      421.266        9.573   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15      317.528       15.786   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15      279.191       13.236   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      163.453       10.892   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15      114.252        5.298   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15      483.136       10.805   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15      368.681       10.607   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15      306.408       15.914   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      187.567        7.903   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      126.177        7.202   ops/ms
```

10b305f meld operators:

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                1  thrpt        15      298.659        9.351   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                3  thrpt        15      278.120       11.799   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8                5  thrpt        15      271.391       12.608   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               10  thrpt        15      240.467        9.467   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                 8               15  thrpt        15      232.587       10.871   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15      420.818       13.944   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15      403.725       10.936   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15      386.976       16.776   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      341.098       15.246   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15      322.719       26.228   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15      501.471       17.499   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15      474.063       15.032   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15      451.945       31.671   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      421.512       22.594   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      379.978       35.200   ops/ms
```
