### PR TITLE
+proj porting akka-bench-jmh to release-2.3

### DIFF
--- a/akka-bench-jmh/README.md
+++ b/akka-bench-jmh/README.md
@@ -1,0 +1,29 @@
+Akka JMH Benchmarks
+===================
+This project should depend on tested projects, and allows to benchmark them using the JMH library.
+
+For good results consider running the benchmarks at least for 10 iterations (both warmup and measuring).
+
+Usage
+-----
+Simply run a specified benchmark (parameters are 1:1 like in JMH):
+
+```
+run                             // all benchmarks, on default settings
+run -i 3 -wi 3 -f 1 .*actor.*   // all actor benchmarks, 3 warmups, 3 iterations, 1 fork
+run -h                          // shows JMH help
+```
+
+The internal workings of the code generation process are as follows:
+
+```
+compile: scala -> bytecode_1
+generate: bytecode_1 -> java benchmarks source code
+compile: java benchmarks -. bytecode_2
+```
+
+Examples
+--------
+There are a lot of good examples here (in java): http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples
+
+

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -17,6 +17,8 @@ import com.typesafe.tools.mima.plugin.MimaKeys.reportBinaryIssues
 import com.typesafe.tools.mima.plugin.MimaKeys.binaryIssueFilters
 import com.typesafe.sbt.SbtSite.site
 import com.typesafe.sbt.site.SphinxSupport
+import pl.project13.scala.sbt.SbtJmh._
+import pl.project13.scala.sbt.SbtJmh.JmhKeys._
 import com.typesafe.sbt.site.SphinxSupport.{ enableOutput, generatePdf, generatedPdf, generateEpub, generatedEpub, sphinxInputs, sphinxPackages, Sphinx }
 import com.typesafe.sbt.preprocess.Preprocess.{ preprocess, preprocessExts, preprocessVars, simplePreprocess }
 import java.lang.Boolean.getBoolean
@@ -184,6 +186,17 @@ object AkkaBuild extends Build {
       libraryDependencies ++= Dependencies.testkit,
       initialCommands += "import akka.testkit._",
       previousArtifact := akkaPreviousArtifact("akka-testkit")
+    )
+  )
+
+  lazy val benchJmh = Project(
+    id = "akka-bench-jmh",
+    base = file("akka-bench-jmh"),
+    dependencies = Seq(actor, stream, persistence, testkit).map(_ % "compile;compile->test"),
+    settings = defaultSettings ++ Seq(
+      libraryDependencies ++= Dependencies.testkit
+    ) ++ settings ++ jmhSettings ++ Seq(
+      outputTarget in Jmh := target.value
     )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,4 +18,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.3")
+
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"


### PR DESCRIPTION
Backport from `release-2.3-dev` branch, in order to have benchmarks for akka persistence.
