### PR TITLE
Stream perf tuning 2

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -48,7 +48,7 @@ class FlowMapBenchmark {
   // safe to be benchmark scoped because the flows we construct in this bench are stateless
   var flow: Flow[Int] = _
 
-  @Param(Array("1", "3", "5")) // "10", "15"
+  @Param(Array("1", "3", "5", "10", "15"))
   val numberOfMapOps = 3
 
   @Param(Array("16", "32")) // "8", "16", "32"

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -48,10 +48,10 @@ class FlowMapBenchmark {
   // safe to be benchmark scoped because the flows we construct in this bench are stateless
   var flow: Flow[Int] = _
 
-  @Param(Array("1", "3", "5", "10", "15"))
+  @Param(Array("1", "3", "5")) // "10", "15"
   val numberOfMapOps = 3
 
-  @Param(Array("8", "16", "32"))
+  @Param(Array("16", "32")) // "8", "16", "32"
   val inputBufferSize = 16
 
   @Param(Array("4"))

--- a/akka-stream/src/main/scala/akka/stream/Transformer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Transformer.scala
@@ -61,3 +61,49 @@ abstract class Transformer[-T, +U] {
    */
   def name: String = "transform"
 }
+
+abstract class Transformer2[-T, +U] {
+  /**
+   * Invoked for each element to produce a (possibly empty) sequence of
+   * output elements.
+   */
+  def onNext(element: T): Iterator[U]
+
+  /**
+   * Invoked after handing off the elements produced from one input element to the
+   * downstream consumers to determine whether to end stream processing at this point;
+   * in that case the upstream subscription is canceled.
+   */
+  def isComplete: Boolean = false
+
+  /**
+   * Invoked before the Transformer terminates (either normal completion or after an onError)
+   * to produce a (possibly empty) sequence of elements in response to the
+   * end-of-stream event.
+   *
+   * This method is only called if [[Transformer#onError]] does not throw an exception. The default implementation
+   * of [[Transformer#onError]] throws the received cause forcing the error to propagate downstream immediately.
+   *
+   * @param e Contains a non-empty option with the error causing the termination or an empty option
+   *          if the Transformer was completed normally
+   */
+  def onTermination(e: Option[Throwable]): Iterator[U] = Iterator.empty
+
+  /**
+   * Invoked when failure is signaled from upstream. If this method throws an exception, then onError is immediately
+   * propagated downstream. If this method completes normally then [[Transformer#onTermination]] is invoked as a final
+   * step, passing the original cause.
+   */
+  def onError(cause: Throwable): Unit = throw cause
+
+  /**
+   * Invoked after normal completion or error.
+   */
+  def cleanup(): Unit = ()
+
+  /**
+   * Name of this transformation step. Used as part of the actor name.
+   * Facilitates debugging and logging.
+   */
+  def name: String = "transform"
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -21,6 +21,7 @@ import akka.actor.ExtendedActorSystem
 import akka.actor.ActorSystem
 import akka.actor.Extension
 import akka.stream.actor.ActorConsumer
+import akka.stream.Transformer2
 
 /**
  * INTERNAL API
@@ -31,6 +32,9 @@ private[akka] object Ast {
   }
 
   case class Transform(transformer: Transformer[Any, Any]) extends AstNode {
+    override def name = transformer.name
+  }
+  case class Transform2(transformer: Transformer2[Any, Any]) extends AstNode {
     override def name = transformer.name
   }
   case class GroupBy(f: Any ⇒ Any) extends AstNode {

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -174,7 +174,47 @@ private[akka] class ActorBasedFlowMaterializer(
 
   private def createFlowName(): String = s"$namePrefix-${nextFlowNameCount()}"
 
-  @tailrec private def processorChain(topConsumer: Consumer[_], ops: immutable.Seq[AstNode],
+  private def meld(ops: List[AstNode]): List[AstNode] = {
+    def meldTwo(op1: AstNode, op2: AstNode): Option[AstNode] =
+      (op1, op2) match {
+        case (Transform2(t1), Transform2(t2)) ⇒
+          val t = new Transformer2[Any, Any] {
+            override def onNext(element: Any) = {
+              val i2 = t2.onNext(element)
+              new Iterator[Any] {
+                var i1: Iterator[Any] = Iterator.empty
+                override def hasNext: Boolean = i2.hasNext || i1.hasNext
+                override def next(): Any = {
+                  if (i1.isEmpty) {
+                    i1 = t1.onNext(i2.next())
+                    i1.next() // FIXME not correct if i1 is empty, but trying this for map only now
+                  } else i1.next()
+                }
+              }
+            }
+
+            // FIXME override other methods, incl name
+          }
+          Some(Transform2(t))
+        case _ ⇒ None
+      }
+
+    @tailrec def doMeld(remaining: List[AstNode], acc: List[AstNode]): List[AstNode] =
+      remaining match {
+        case Nil       ⇒ acc.reverse
+        case op :: Nil ⇒ doMeld(Nil, op :: acc)
+        case op1 :: op2 :: tail ⇒
+          meldTwo(op1, op2) match {
+            case Some(op) ⇒ doMeld(op :: tail, acc)
+            case None     ⇒ doMeld(op2 :: tail, op1 :: acc)
+          }
+      }
+
+    if (ops.isEmpty || ops.tail.isEmpty) ops
+    else doMeld(ops, Nil)
+  }
+
+  @tailrec private def processorChain(topConsumer: Consumer[_], ops: List[AstNode],
                                       flowName: String, n: Int): Consumer[_] = {
     ops match {
       case op :: tail ⇒
@@ -190,9 +230,10 @@ private[akka] class ActorBasedFlowMaterializer(
     val flowName = createFlowName()
     if (ops.isEmpty) producerNode.createProducer(this, flowName).asInstanceOf[Producer[O]]
     else {
-      val opsSize = ops.size
-      val opProcessor = processorForNode(ops.head, flowName, opsSize)
-      val topConsumer = processorChain(opProcessor, ops.tail, flowName, opsSize - 1)
+      val meldedOps = meld(ops)
+      val opsSize = meldedOps.size
+      val opProcessor = processorForNode(meldedOps.head, flowName, opsSize)
+      val topConsumer = processorChain(opProcessor, meldedOps.tail, flowName, opsSize - 1)
       producerNode.createProducer(this, flowName).produceTo(topConsumer.asInstanceOf[Consumer[I]])
       opProcessor.asInstanceOf[Producer[O]]
     }
@@ -212,8 +253,10 @@ private[akka] class ActorBasedFlowMaterializer(
     new ActorProcessor(context.actorOf(ActorProcessor.props(settings, op),
       name = s"$flowName-$n-${op.name}"))
 
-  override def ductProduceTo[In, Out](consumer: Consumer[Out], ops: List[Ast.AstNode]): Consumer[In] =
-    processorChain(consumer, ops, createFlowName(), ops.size).asInstanceOf[Consumer[In]]
+  override def ductProduceTo[In, Out](consumer: Consumer[Out], ops: List[Ast.AstNode]): Consumer[In] = {
+    val meldedOps = meld(ops)
+    processorChain(consumer, meldedOps, createFlowName(), meldedOps.size).asInstanceOf[Consumer[In]]
+  }
 
   override def ductBuild[In, Out](ops: List[Ast.AstNode]): (Consumer[In], Producer[Out]) = {
     val flowName = createFlowName()
@@ -221,9 +264,10 @@ private[akka] class ActorBasedFlowMaterializer(
       val identityProcessor: Processor[In, Out] = processorForNode(identityTransform, flowName, 1).asInstanceOf[Processor[In, Out]]
       (identityProcessor, identityProcessor)
     } else {
-      val opsSize = ops.size
-      val outProcessor = processorForNode(ops.head, flowName, opsSize).asInstanceOf[Processor[In, Out]]
-      val topConsumer = processorChain(outProcessor, ops.tail, flowName, opsSize - 1).asInstanceOf[Processor[In, Out]]
+      val meldedOps = meld(ops)
+      val opsSize = meldedOps.size
+      val outProcessor = processorForNode(meldedOps.head, flowName, opsSize).asInstanceOf[Processor[In, Out]]
+      val topConsumer = processorChain(outProcessor, meldedOps.tail, flowName, opsSize - 1).asInstanceOf[Processor[In, Out]]
       (topConsumer, outProcessor)
     }
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -23,6 +23,7 @@ private[akka] object ActorProcessor {
   import Ast._
   def props(settings: MaterializerSettings, op: AstNode): Props =
     (op match {
+      case t: Transform2     ⇒ Props(new Transform2ProcessorImpl(settings, t.transformer))
       case t: Transform      ⇒ Props(new TransformProcessorImpl(settings, t.transformer))
       case s: SplitWhen      ⇒ Props(new SplitWhenProcessorImpl(settings, s.p))
       case g: GroupBy        ⇒ Props(new GroupByProcessorImpl(settings, g.f))

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -16,6 +16,7 @@ import scala.util.Success
 import scala.util.Failure
 import org.reactivestreams.api.Consumer
 import akka.stream.scaladsl.Duct
+import akka.stream.Transformer2
 
 /**
  * INTERNAL API
@@ -140,8 +141,8 @@ private[akka] trait Builder[Out] {
   protected def andThen[U](op: Ast.AstNode): Thing[U]
 
   def map[U](f: Out ⇒ U): Thing[U] =
-    transform(new Transformer[Out, U] {
-      override def onNext(in: Out) = List(f(in))
+    transform2(new Transformer2[Out, U] {
+      override def onNext(in: Out) = Iterator.single(f(in))
       override def name = "map"
     })
 
@@ -237,6 +238,9 @@ private[akka] trait Builder[Out] {
 
   def transform[U](transformer: Transformer[Out, U]): Thing[U] =
     andThen(Transform(transformer.asInstanceOf[Transformer[Any, Any]]))
+
+  def transform2[U](transformer: Transformer2[Out, U]): Thing[U] =
+    andThen(Transform2(transformer.asInstanceOf[Transformer2[Any, Any]]))
 
   def zip[O2](other: Producer[O2]): Thing[(Out, O2)] = andThen(Zip(other.asInstanceOf[Producer[Any]]))
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Transform2ProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Transform2ProcessorImpl.scala
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl
+
+import scala.collection.immutable
+import akka.stream.MaterializerSettings
+import scala.util.control.NonFatal
+import akka.stream.Transformer2
+
+/**
+ * INTERNAL API
+ */
+private[akka] class Transform2ProcessorImpl(_settings: MaterializerSettings, transformer: Transformer2[Any, Any]) extends ActorProcessorImpl(_settings) {
+  var hasCleanupRun = false
+  // TODO performance improvement: mutable buffer?
+  var emits: Iterator[Any] = Iterator.empty
+  var errorEvent: Option[Throwable] = None
+
+  override def onError(e: Throwable): Unit = {
+    try {
+      transformer.onError(e)
+      errorEvent = Some(e)
+      pump()
+    } catch { case NonFatal(ex) ⇒ fail(ex) }
+  }
+
+  object NeedsInputAndDemandOrCompletion extends TransferState {
+    def isReady = (primaryInputs.inputsAvailable && primaryOutputs.demandAvailable) || primaryInputs.inputsDepleted
+    def isCompleted = false
+  }
+
+  val running: TransferPhase = TransferPhase(NeedsInputAndDemandOrCompletion) { () ⇒
+    if (primaryInputs.inputsDepleted) nextPhase(terminate)
+    else {
+      emits = transformer.onNext(primaryInputs.dequeueInputElement())
+      if (transformer.isComplete) emitAndThen(terminate)
+      else emitAndThen(running)
+    }
+  }
+
+  val terminate = TransferPhase(Always) { () ⇒
+    emits = transformer.onTermination(errorEvent)
+    emitAndThen(completedPhase)
+  }
+
+  // Save previous phase we should return to in a var to avoid allocation
+  var phaseAfterFlush: TransferPhase = _
+
+  // Enters flushing phase if there are emits pending
+  def emitAndThen(andThen: TransferPhase): Unit =
+    if (emits.nonEmpty) {
+      phaseAfterFlush = andThen
+      nextPhase(emitting)
+    } else nextPhase(andThen)
+
+  // Emits all pending elements, then returns to savedPhase
+  val emitting = TransferPhase(primaryOutputs.NeedsDemand) { () ⇒
+    primaryOutputs.enqueueOutputElement(emits.next())
+    if (emits.isEmpty) nextPhase(phaseAfterFlush)
+  }
+
+  nextPhase(running)
+
+  override def toString: String = s"Transformer(emits=$emits, transformer=$transformer)"
+
+  override def softShutdown(): Unit = {
+    transformer.cleanup()
+    hasCleanupRun = true // for postStop
+    super.softShutdown()
+  }
+
+  override def postStop(): Unit = {
+    try super.postStop() finally if (!hasCleanupRun) transformer.cleanup()
+  }
+}


### PR DESCRIPTION
Exploring iterator based transformer, in two steps. First only changing to Iterator, then adding melding of operators. Not covering everything, just an early indication.

These results can be compared with #15305
Running on MacBook Pro, 2,3 GHz Intel Core i7, with java 1.7.0_45
akka-bench-jmh > jmh:run -o result9-iterator-meld.txt -r 3 -i 5 -wi 3 -f 3 -prof gc,stack -jvmArgs "-Xms1024m -Xms1024m -XX:+UseCompressedOops" akka.stream.FlowMapBenchmark.*

baseline before Transform with Iterator

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15     1334.722       45.950   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15     1183.999       35.057   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15     1032.527       44.215   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15     1387.664       37.349   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15     1306.621       31.856   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15     1107.189       40.113   ops/ms
```

258f653 Transform with Iterator

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15     1673.165       79.986   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15     1355.013       31.576   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15     1114.652       31.779   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15     1751.866       43.758   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15     1404.107       27.075   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15     1181.734       61.098   ops/ms
```

c382935 meld transform iterators

```
Benchmark                                     (dispatcherPoolSize) (inputBufferSize) (numberOfMapOps)   Mode   Samples         Mean   Mean error    Units
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                1  thrpt        15     1717.114       33.623   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                3  thrpt        15     1243.303       24.122   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16                5  thrpt        15     1153.754        8.026   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               10  thrpt        15      980.477       13.273   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                16               15  thrpt        15      788.748       27.032   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                1  thrpt        15     1781.289       29.267   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                3  thrpt        15     1281.246       23.206   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32                5  thrpt        15     1144.894       16.271   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               10  thrpt        15      920.991       14.080   ops/ms
a.s.FlowMapBenchmark.flow_map_500k_elements                      4                32               15  thrpt        15      779.691       12.619   ops/ms
```
