### PR TITLE
+per defer for PersistentActor

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/persistence/Common.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/Common.scala
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence
+
+import akka.actor.Actor
+
+/** only as a "the best we could possibly get" baseline, does not persist anything */
+class BaselineActor(respondAfter: Int) extends Actor {
+  override def receive = {
+    case n: Int => if (n == respondAfter) sender() ! n
+  }
+}
+
+final case class Evt(i: Int)

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh._
+import com.typesafe.config.ConfigFactory
+import akka.actor._
+import akka.testkit.TestProbe
+import java.io.File
+import org.apache.commons.io.FileUtils
+import org.openjdk.jmh.annotations.Scope
+
+/*
+  # OS:   OSX 10.9.3
+  # CPU:  Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
+  # Date: Mon Jun  9 13:22:42 CEST 2014
+
+  [info] Benchmark                                                                            Mode   Samples         Mean   Mean error    Units
+  [info] a.p.PersistentActorDeferBenchmark.tell_persistAsync_defer_persistAsync_reply        thrpt        10        6.858        0.515   ops/ms
+  [info] a.p.PersistentActorDeferBenchmark.tell_persistAsync_defer_persistAsync_replyASAP    thrpt        10       20.256        2.941   ops/ms
+  [info] a.p.PersistentActorDeferBenchmark.tell_processor_Persistent_reply                   thrpt        10        6.531        0.114   ops/ms
+  [info] a.p.PersistentActorDeferBenchmark.tell_processor_Persistent_replyASAP               thrpt        10       26.000        0.694   ops/ms
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class PersistentActorDeferBenchmark {
+
+  val config = PersistenceSpec.config("leveldb", "benchmark")
+
+  lazy val storageLocations = List(
+    "akka.persistence.journal.leveldb.dir",
+    "akka.persistence.journal.leveldb-shared.store.dir",
+    "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
+
+  var system: ActorSystem = _
+
+  var probe: TestProbe = _
+  var processor: ActorRef = _
+  var processor_replyASAP: ActorRef = _
+  var persistAsync_defer: ActorRef = _
+  var persistAsync_defer_replyASAP: ActorRef = _
+
+  val data10k = (1 to 10000).toArray
+
+  @Setup
+  def setup() {
+    system = ActorSystem("test", config)
+
+    probe = TestProbe()(system)
+
+    storageLocations.foreach(FileUtils.deleteDirectory)
+    processor                    = system.actorOf(Props(classOf[`processor, forward Persistent, like defer`], data10k.last), "p-1")
+    processor_replyASAP          = system.actorOf(Props(classOf[`processor, forward Persistent, reply ASAP`], data10k.last), "p-2")
+    persistAsync_defer           = system.actorOf(Props(classOf[`persistAsync, defer`], data10k.last), "a-1")
+    persistAsync_defer_replyASAP = system.actorOf(Props(classOf[`persistAsync, defer, respond ASAP`], data10k.last), "a-2")
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+
+    storageLocations.foreach(FileUtils.deleteDirectory)
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(10000)
+  def tell_processor_Persistent_reply() {
+    for (i <- data10k) processor.tell(i, probe.ref)
+
+    probe.expectMsg(data10k.last)
+  }
+  
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(10000)
+  def tell_processor_Persistent_replyASAP() {
+    for (i <- data10k) processor_replyASAP.tell(i, probe.ref)
+
+    probe.expectMsg(data10k.last)
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(10000)
+  def tell_persistAsync_defer_persistAsync_reply() {
+    for (i <- data10k) persistAsync_defer.tell(i, probe.ref)
+
+    probe.expectMsg(data10k.last)
+  }
+
+  @GenerateMicroBenchmark
+  @OperationsPerInvocation(10000)
+  def tell_persistAsync_defer_persistAsync_replyASAP() {
+    for (i <- data10k) persistAsync_defer_replyASAP.tell(i, probe.ref)
+
+    probe.expectMsg(data10k.last)
+  }
+
+}
+
+class `processor, forward Persistent, like defer`(respondAfter: Int) extends Processor {
+  def receive = {
+    case n: Int =>
+      self forward Persistent(Evt(n))
+      self forward Evt(n)
+    case Persistent(p) => // ignore
+    case Evt(n) if n == respondAfter => sender() ! respondAfter
+  }
+}
+class `processor, forward Persistent, reply ASAP`(respondAfter: Int) extends Processor {
+  def receive = {
+    case n: Int =>
+      self forward Persistent(Evt(n))
+      if (n == respondAfter) sender() ! respondAfter
+    case _ => // ignore
+  }
+}
+
+class `persistAsync, defer`(respondAfter: Int) extends PersistentActor {
+  override def receiveCommand  = {
+    case n: Int  =>
+      persistAsync(Evt(n)) { e => }
+      defer(Evt(n)) { e => if (e.i == respondAfter) sender() ! e.i }
+  }
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+}
+class `persistAsync, defer, respond ASAP`(respondAfter: Int) extends PersistentActor {
+  override def receiveCommand  = {
+    case n: Int  =>
+      persistAsync(Evt(n)) { e => }
+      defer(Evt(n)) { e => }
+      if (n == respondAfter) sender() ! n 
+  }
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
@@ -61,7 +61,7 @@ class PersistentActorThroughputBenchmark {
   def tell_normalActor_reply_baseline() {
     for (i <- data10k) actor.tell(i, probe.ref)
 
-    probe.expectMsg(Evt(data10k.last))
+    probe.expectMsg(data10k.last)
   }
 
   @GenerateMicroBenchmark
@@ -95,9 +95,9 @@ class PersistentActorThroughputBenchmark {
 
     probe.expectMsg(Evt(data10k.last))
   }
+
 }
 
-final case class Evt(i: Int)
 
 class Persist1EventPersistentActor(respondAfter: Int) extends PersistentActor {
   override def receiveCommand  = {
@@ -133,12 +133,5 @@ class PersistAsync1EventQuickReplyPersistentActor(respondAfter: Int) extends Per
   }
   override def receiveRecover = {
     case _ => // do nothing
-  }
-}
-
-/** only as a "the best we could possibly get" baseline, does not persist anything */
-class BaselineActor(respondAfter: Int) extends Actor {
-  override def receive = {
-    case n: Int => if (n == respondAfter) sender() ! Evt(n)
   }
 }

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -40,9 +40,14 @@ Akka persistence is a separate jar file. Make sure that you have the following d
 Architecture
 ============
 
-* *Processor*: A processor is a persistent, stateful actor. Messages sent to a processor are written to a journal
-  before its behavior is called. When a processor is started or restarted, journaled messages are replayed
-  to that processor, so that it can recover internal state from these messages.
+* *Processor* (deprecated, use *PersistentActor* instead): A processor is a persistent, stateful actor. Messages sent
+  to a processor are written to a journal before its ``onReceive`` method is called. When a processor is started or
+  restarted, journaled messages are replayed to that processor, so that it can recover internal state from these messages.
+
+* *PersistentActor*: Is a persistent, stateful actor. It is able to persist events to a journal and can react to
+  them in a thread-safe manner. It can be used to implement both *command* as well as *event sourced* actors.
+  When a persistent actor is started or restarted, journaled messages are replayed to that actor, so that it can
+  recover internal state from these messages.
 
 * *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
   processor. A view itself does not journal new messages, instead, it updates internal state only from a processor's
@@ -427,6 +432,11 @@ use the ``deleteSnapshots`` method.
 Event sourcing
 ==============
 
+.. note::
+  The ``PersistentActor`` introduced in this section was previously known as ``EventsourcedProcessor``,
+  which was a subset of the ``PersistentActor``. Migrating your code to use persistent actors instead is
+  very simple and is explained in the :ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`.
+
 In all the examples so far, messages that change a processor's state have been sent as ``Persistent`` messages
 by an application, so that they can be replayed during recovery. From this point of view, the journal acts as
 a write-ahead-log for whatever ``Persistent`` messages a processor receives. This is also known as *command
@@ -484,6 +494,50 @@ It contains instructions on how to run the ``PersistentActorExample``.
   recovery you need to take special care to perform the same state transitions with ``become`` and
   ``unbecome`` in the ``receiveRecover`` method as you would have done in the command handler.
 
+Relaxed local consistency requirements and high throughput use-cases
+--------------------------------------------------------------------
+
+If faced with Relaxed local consistency requirements and high throughput demands sometimes ``PersistentActor`` and it's
+``persist`` may not be enough in terms of consuming incoming Commands at a high rate, because it has to wait until all
+Events related to a given Command are processed in order to start processing the next Command. While this abstraction is
+very useful for most cases, sometimes you may be faced with relaxed requirements about consistency – for example you may
+want to process commands as fast as you can, assuming that Event will eventually be persisted and handled properly in
+the background and retroactively reacting to persistence failures if needed.
+
+The ``persistAsync`` method provides a tool for implementing high-throughput processors. It will *not*
+stash incoming Commands while the Journal is still working on persisting and/or user code is executing event callbacks.
+
+In the below example, the event callbacks may be called "at any time", even after the next Command has been processed.
+The ordering between events is still guaranteed ("evt-b-1" will be sent after "evt-a-2", which will be sent after "evt-a-1" etc.).
+
+.. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#persist-async
+
+Notice that the client does not have to wrap any messages in the `Persistent` class in order to obtain "command sourcing like"
+semantics. It's up to the processor to decide about persisting (or not) of messages, unlike ``Processor`` where the sender had to be aware of this decision.
+
+.. note::
+  In order to implement the pattern known as "*command sourcing*" simply ``persistAsync`` all incoming events right away,
+  and handle them in the callback.
+
+.. _defer-java-lambda:
+
+Deferring actions until preceeding persist handlers have executed
+-----------------------------------------------------------------
+
+Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
+''happens-after the previous ``persistAsync`` handlers have been invoked''. ``PersistentActor`` provides an utility method
+called ``defer``, which works similarily to ``persistAsync`` yet does not persist the passed in event. It is recommended to
+use it for *read* operations, and actions which do not have corresponding events in your domain model.
+
+Using this method is very similar to the persist family of methods, yet it does **not** persist the passed in event.
+It will be kept in memory and used when invoking the handler.
+
+.. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#defer
+
+Notice that the ``sender()`` is **safe** to access in the handler callback, and will be pointing to the original sender
+of the command for which this ``defer`` handler was called.
+
+.. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#defer-caller
 
 Reliable event delivery
 -----------------------

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -558,9 +558,33 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 
 .. includecode:: code/docs/persistence/PersistenceDocTest.java#persist-async
 
+Notice that the client does not have to wrap any messages in the `Persistent` class in order to obtain "command sourcing like"
+semantics. It's up to the processor to decide about persisting (or not) of messages, unlike ``Processor`` where the sender had to be aware of this decision.
+
 .. note::
   In order to implement the pattern known as "*command sourcing*" simply ``persistAsync`` all incoming events right away,
   and handle them in the callback.
+
+.. _defer-java:
+
+Deferring actions until preceeding persist handlers have executed
+-----------------------------------------------------------------
+
+Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
+''happens-after the previous ``persistAsync`` handlers have been invoked''. ``PersistentActor`` provides an utility method
+called ``defer``, which works similarily to ``persistAsync`` yet does not persist the passed in event. It is recommended to
+use it for *read* operations, and actions which do not have corresponding events in your domain model.
+
+Using this method is very similar to the persist family of methods, yet it does **not** persist the passed in event.
+It will be kept in memory and used when invoking the handler.
+
+.. includecode:: code/docs/persistence/PersistenceDocTest.java#defer
+
+Notice that the ``sender()`` is **safe** to access in the handler callback, and will be pointing to the original sender
+of the command for which this ``defer`` handler was called.
+
+.. includecode:: code/docs/persistence/PersistenceDocTest.java#defer-caller
+
 
 Reliable event delivery
 -----------------------

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -303,7 +303,7 @@ request  instructs a channel to send a ``Persistent`` message to a destination. 
 preserved by a channel, therefore, a destination can reply to the sender of a ``Deliver`` request.
 
 .. note::
-  
+
   Sending via a channel has at-least-once delivery semantics—by virtue of either
   the sending actor or the channel being persistent—which means that the
   semantics do not match those of a normal :class:`ActorRef` send operation:
@@ -601,13 +601,33 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#persist-async
 
 Notice that the client does not have to wrap any messages in the `Persistent` class in order to obtain "command sourcing like"
-semantics. It's up to the processor to decide about persisting (or not) of messages, unlike ``Processor`` where this decision
-was made by the sender.
-
+semantics. It's up to the processor to decide about persisting (or not) of messages, unlike ``Processor`` where the sender had to be aware of this decision.
 
 .. note::
   In order to implement the "*command sourcing*" simply call ``persistAsync(cmd)(...)`` right away on all incomming
   messages right away, and handle them in the callback.
+
+.. _defer-scala:
+
+Deferring actions until preceeding persist handlers have executed
+-----------------------------------------------------------------
+
+Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
+''happens-after the previous ``persistAsync`` handlers have been invoked''. ``PersistentActor`` provides an utility method
+called ``defer``, which works similarily to ``persistAsync`` yet does not persist the passed in event. It is recommended to
+use it for *read* operations, and actions which do not have corresponding events in your domain model.
+
+Using this method is very similar to the persist family of methods, yet it does **not** persist the passed in event.
+It will be kept in memory and used when invoking the handler.
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#defer
+
+Notice that the ``sender()`` is **safe** to access in the handler callback, and will be pointing to the original sender
+of the command for which this ``defer`` handler was called.
+
+The calling side will get the responses in this (guaranteed) order:
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#defer-caller
 
 Reliable event delivery
 -----------------------

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -8,8 +8,6 @@ import scala.collection.immutable
 
 import akka.actor._
 
-import akka.persistence.serialization.Message
-
 /**
  * INTERNAL API.
  *
@@ -60,7 +58,7 @@ private[persistence] object JournalProtocol {
    * @param messages messages to be written.
    * @param processor write requestor.
    */
-  case class WriteMessages(messages: immutable.Seq[PersistentRepr], processor: ActorRef)
+  case class WriteMessages(messages: immutable.Seq[Resequenceable], processor: ActorRef)
 
   /**
    * Reply message to a successful [[WriteMessages]] request. This reply is sent to the requestor

--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -15,12 +15,21 @@ import akka.pattern.PromiseActorRef
 import akka.persistence.serialization.Message
 
 /**
- * Persistent message.
+ * Marks messages which can be resequenced by the [[akka.persistence.journal.AsyncWriteJournal]].
+ *
+ * In essence it is either an [[NonPersistentRepr]] or [[Persistent]].
  */
-@deprecated("Messages wrapped in Persistent were only required by Processor and Command Sourcing, " +
-  "which is now deprecated. Use `akka.persistence.PersistentActor` and Event Sourcing instead.",
-  since = "2.3.4")
-sealed abstract class Persistent {
+sealed trait Resequenceable {
+  def payload: Any
+  def sender: ActorRef
+}
+
+/** Message which can be resequenced by the Journal, but will not be persisted. */
+final case class NonPersistentRepr(payload: Any, sender: ActorRef) extends Resequenceable
+
+/** Persistent message. */
+@deprecated("Use akka.persistence.PersistentActor instead.", since = "2.3.4")
+sealed abstract class Persistent extends Resequenceable {
   /**
    * This persistent message's payload.
    */
@@ -41,9 +50,7 @@ sealed abstract class Persistent {
   def withPayload(payload: Any): Persistent
 }
 
-@deprecated("Messages wrapped in Persistent were only required by Processor and Command Sourcing, " +
-  "which is now deprecated. Use `akka.persistence.PersistentActor` and Event Sourcing instead.",
-  since = "2.3.4")
+@deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
 object Persistent {
   /**
    * Java API: creates a new persistent message. Must only be used outside processors.
@@ -71,9 +78,7 @@ object Persistent {
    * @param payload payload of the new persistent message.
    * @param currentPersistentMessage optional current persistent message, defaults to `None`.
    */
-  @deprecated("Messages wrapped in Persistent were only required by Processor and Command Sourcing, " +
-    "which is now deprecated. Use `akka.persistence.PersistentActor` and Event Sourcing instead.",
-    since = "2.3.4")
+  @deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
   def apply(payload: Any)(implicit currentPersistentMessage: Option[Persistent] = None): Persistent =
     currentPersistentMessage.map(_.withPayload(payload)).getOrElse(PersistentRepr(payload))
 
@@ -88,9 +93,7 @@ object Persistent {
  * Persistent message that has been delivered by a [[Channel]] or [[PersistentChannel]]. Channel
  * destinations that receive messages of this type can confirm their receipt by calling [[confirm]].
  */
-@deprecated("Messages wrapped in Persistent were only required by Processor and Command Sourcing, " +
-  "which is now deprecated. Use `akka.persistence.PersistentActor` and Event Sourcing instead.",
-  since = "2.3.4")
+@deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
 sealed abstract class ConfirmablePersistent extends Persistent {
   /**
    * Called by [[Channel]] and [[PersistentChannel]] destinations to confirm the receipt of a
@@ -105,9 +108,7 @@ sealed abstract class ConfirmablePersistent extends Persistent {
   def redeliveries: Int
 }
 
-@deprecated("Messages wrapped in Persistent were only required by Processor and Command Sourcing, " +
-  "which is now deprecated. Use `akka.persistence.PersistentActor` and Event Sourcing instead.",
-  since = "2.3.4")
+@deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
 object ConfirmablePersistent {
   /**
    * [[ConfirmablePersistent]] extractor.
@@ -121,18 +122,7 @@ object ConfirmablePersistent {
  * journal. The processor receives the written messages individually as [[Persistent]] messages.
  * During recovery, they are also replayed individually.
  */
-@deprecated("Messages wrapped in Persistent were only required by Processor and Command Sourcing, " +
-  "which is now deprecated. Use `akka.persistence.PersistentActor` and Event Sourcing instead.",
-  since = "2.3.4")
-case class PersistentBatch(persistentBatch: immutable.Seq[Persistent]) extends Message {
-  // todo while we want to remove Persistent() from user-land, the batch may (probably?) become private[akka] to remain for journal internals #15230
-
-  /**
-   * INTERNAL API.
-   */
-  private[persistence] def persistentReprList: List[PersistentRepr] =
-    persistentBatch.toList.asInstanceOf[List[PersistentRepr]]
-}
+case class PersistentBatch(batch: immutable.Seq[Resequenceable]) extends Message
 
 /**
  * Plugin API: confirmation entry written by journal plugins.
@@ -170,7 +160,7 @@ private[persistence] case class PersistentIdImpl(processorId: String, sequenceNr
  * @see [[journal.AsyncWriteJournal]]
  * @see [[journal.AsyncRecovery]]
  */
-trait PersistentRepr extends Persistent with PersistentId with Message {
+trait PersistentRepr extends Persistent with Resequenceable with PersistentId with Message {
   // todo we want to get rid of the Persistent() wrapper from user land; PersistentRepr is here to stay. #15230
 
   import scala.collection.JavaConverters._

--- a/akka-persistence/src/main/scala/akka/persistence/journal/WriteJournalBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/WriteJournalBase.scala
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.persistence.journal
+
+import akka.persistence.{ PersistentRepr, Resequenceable }
+import akka.actor.Actor
+import scala.collection.immutable
+
+private[akka] trait WriteJournalBase {
+  this: Actor ⇒
+
+  protected def preparePersistentBatch(rb: immutable.Seq[Resequenceable]): immutable.Seq[PersistentRepr] =
+    rb.filter(persistentPrepareWrite).asInstanceOf[immutable.Seq[PersistentRepr]] // filter instead of flatMap to avoid Some allocations
+
+  private def persistentPrepareWrite(r: Resequenceable): Boolean = r match {
+    case p: PersistentRepr ⇒
+      p.prepareWrite(); true
+    case _ ⇒
+      false
+  }
+
+}

--- a/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
@@ -86,7 +86,9 @@ class MessageSerializer(val system: ExtendedActorSystem) extends Serializer {
 
   private def persistentMessageBatchBuilder(persistentBatch: PersistentBatch) = {
     val builder = PersistentMessageBatch.newBuilder
-    persistentBatch.persistentReprList.foreach(p ⇒ builder.addBatch(persistentMessageBuilder(p)))
+    persistentBatch.batch.
+      filter(_.isInstanceOf[PersistentRepr]).
+      foreach(p ⇒ builder.addBatch(persistentMessageBuilder(p.asInstanceOf[PersistentRepr])))
     builder
   }
 

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
@@ -18,7 +18,7 @@ object PersistentActorSpec {
   case class Cmd(data: Any)
   case class Evt(data: Any)
 
-  abstract class ExampleProcessor(name: String) extends NamedProcessor(name) with PersistentActor {
+  abstract class ExamplePersistentActor(name: String) extends NamedProcessor(name) with PersistentActor {
     var events: List[Any] = Nil
 
     val updateState: Receive = {
@@ -33,14 +33,14 @@ object PersistentActorSpec {
     def receiveRecover = updateState
   }
 
-  class Behavior1Processor(name: String) extends ExampleProcessor(name) {
+  class Behavior1Processor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior orElse {
       case Cmd(data) ⇒
         persist(Seq(Evt(s"${data}-1"), Evt(s"${data}-2")))(updateState)
     }
   }
 
-  class Behavior2Processor(name: String) extends ExampleProcessor(name) {
+  class Behavior2Processor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior orElse {
       case Cmd(data) ⇒
         persist(Seq(Evt(s"${data}-1"), Evt(s"${data}-2")))(updateState)
@@ -48,7 +48,7 @@ object PersistentActorSpec {
     }
   }
 
-  class Behavior3Processor(name: String) extends ExampleProcessor(name) {
+  class Behavior3Processor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior orElse {
       case Cmd(data) ⇒
         persist(Seq(Evt(s"${data}-11"), Evt(s"${data}-12")))(updateState)
@@ -56,7 +56,7 @@ object PersistentActorSpec {
     }
   }
 
-  class ChangeBehaviorInLastEventHandlerProcessor(name: String) extends ExampleProcessor(name) {
+  class ChangeBehaviorInLastEventHandlerProcessor(name: String) extends ExamplePersistentActor(name) {
     val newBehavior: Receive = {
       case Cmd(data) ⇒
         persist(Evt(s"${data}-21"))(updateState)
@@ -75,7 +75,7 @@ object PersistentActorSpec {
     }
   }
 
-  class ChangeBehaviorInFirstEventHandlerProcessor(name: String) extends ExampleProcessor(name) {
+  class ChangeBehaviorInFirstEventHandlerProcessor(name: String) extends ExamplePersistentActor(name) {
     val newBehavior: Receive = {
       case Cmd(data) ⇒
         persist(Evt(s"${data}-21")) { event ⇒
@@ -94,7 +94,7 @@ object PersistentActorSpec {
     }
   }
 
-  class ChangeBehaviorInCommandHandlerFirstProcessor(name: String) extends ExampleProcessor(name) {
+  class ChangeBehaviorInCommandHandlerFirstProcessor(name: String) extends ExamplePersistentActor(name) {
     val newBehavior: Receive = {
       case Cmd(data) ⇒
         context.unbecome()
@@ -109,7 +109,7 @@ object PersistentActorSpec {
     }
   }
 
-  class ChangeBehaviorInCommandHandlerLastProcessor(name: String) extends ExampleProcessor(name) {
+  class ChangeBehaviorInCommandHandlerLastProcessor(name: String) extends ExamplePersistentActor(name) {
     val newBehavior: Receive = {
       case Cmd(data) ⇒
         persist(Seq(Evt(s"${data}-31"), Evt(s"${data}-32")))(updateState)
@@ -124,7 +124,7 @@ object PersistentActorSpec {
     }
   }
 
-  class SnapshottingPersistentActor(name: String, probe: ActorRef) extends ExampleProcessor(name) {
+  class SnapshottingPersistentActor(name: String, probe: ActorRef) extends ExamplePersistentActor(name) {
     override def receiveRecover = super.receiveRecover orElse {
       case SnapshotOffer(_, events: List[_]) ⇒
         probe ! "offered"
@@ -160,14 +160,14 @@ object PersistentActorSpec {
     }
   }
 
-  class ReplyInEventHandlerProcessor(name: String) extends ExampleProcessor(name) {
+  class ReplyInEventHandlerProcessor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = {
       case Cmd("a")      ⇒ persist(Evt("a"))(evt ⇒ sender() ! evt.data)
       case p: Persistent ⇒ sender() ! p // not expected
     }
   }
 
-  class UserStashProcessor(name: String) extends ExampleProcessor(name) {
+  class UserStashProcessor(name: String) extends ExamplePersistentActor(name) {
     var stashed = false
     val receiveCommand: Receive = {
       case Cmd("a") ⇒ if (!stashed) { stash(); stashed = true } else sender() ! "a"
@@ -176,7 +176,7 @@ object PersistentActorSpec {
     }
   }
 
-  class UserStashManyProcessor(name: String) extends ExampleProcessor(name) {
+  class UserStashManyProcessor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior orElse {
       case Cmd("a") ⇒ persist(Evt("a")) { evt ⇒
         updateState(evt)
@@ -196,7 +196,7 @@ object PersistentActorSpec {
       case other ⇒ stash()
     }
   }
-  class AsyncPersistProcessor(name: String) extends ExampleProcessor(name) {
+  class AsyncPersistProcessor(name: String) extends ExamplePersistentActor(name) {
     var counter = 0
 
     val receiveCommand: Receive = commonBehavior orElse {
@@ -212,7 +212,7 @@ object PersistentActorSpec {
       counter
     }
   }
-  class AsyncPersistThreeTimesProcessor(name: String) extends ExampleProcessor(name) {
+  class AsyncPersistThreeTimesProcessor(name: String) extends ExamplePersistentActor(name) {
     var counter = 0
 
     val receiveCommand: Receive = commonBehavior orElse {
@@ -231,7 +231,7 @@ object PersistentActorSpec {
       counter
     }
   }
-  class AsyncPersistSameEventTwiceProcessor(name: String) extends ExampleProcessor(name) {
+  class AsyncPersistSameEventTwiceProcessor(name: String) extends ExamplePersistentActor(name) {
 
     // atomic because used from inside the *async* callbacks
     val sendMsgCounter = new AtomicInteger()
@@ -249,7 +249,7 @@ object PersistentActorSpec {
         persistAsync(event) { evt ⇒ sender() ! s"${evt.data}-b-${sendMsgCounter.incrementAndGet()}" }
     }
   }
-  class AsyncPersistAndPersistMixedSyncAsyncSyncProcessor(name: String) extends ExampleProcessor(name) {
+  class AsyncPersistAndPersistMixedSyncAsyncSyncProcessor(name: String) extends ExamplePersistentActor(name) {
 
     var counter = 0
 
@@ -276,12 +276,10 @@ object PersistentActorSpec {
       counter
     }
   }
-  class AsyncPersistAndPersistMixedSyncAsyncProcessor(name: String) extends ExampleProcessor(name) {
+  class AsyncPersistAndPersistMixedSyncAsyncProcessor(name: String) extends ExamplePersistentActor(name) {
 
     var sendMsgCounter = 0
 
-    val start = System.currentTimeMillis()
-    def time = s" ${System.currentTimeMillis() - start}ms"
     val receiveCommand: Receive = commonBehavior orElse {
       case Cmd(data) ⇒
         sender() ! data
@@ -301,7 +299,7 @@ object PersistentActorSpec {
     }
   }
 
-  class UserStashFailureProcessor(name: String) extends ExampleProcessor(name) {
+  class UserStashFailureProcessor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior orElse {
       case Cmd(data) ⇒
         if (data == "b-2") throw new TestException("boom")
@@ -322,9 +320,47 @@ object PersistentActorSpec {
     }
   }
 
-  class AnyValEventProcessor(name: String) extends ExampleProcessor(name) {
+  class AnyValEventProcessor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = {
       case Cmd("a") ⇒ persist(5)(evt ⇒ sender() ! evt)
+    }
+  }
+
+  class DeferringWithPersistActor(name: String) extends ExamplePersistentActor(name) {
+    val receiveCommand: Receive = {
+      case Cmd(data) ⇒
+        defer("d-1") { sender() ! _ }
+        persist(s"$data-2") { sender() ! _ }
+        defer("d-3") { sender() ! _ }
+        defer("d-4") { sender() ! _ }
+    }
+  }
+  class DeferringWithAsyncPersistActor(name: String) extends ExamplePersistentActor(name) {
+    val receiveCommand: Receive = {
+      case Cmd(data) ⇒
+        defer(s"d-$data-1") { sender() ! _ }
+        persistAsync(s"pa-$data-2") { sender() ! _ }
+        defer(s"d-$data-3") { sender() ! _ }
+        defer(s"d-$data-4") { sender() ! _ }
+    }
+  }
+  class DeferringMixedCallsPPADDPADPersistActor(name: String) extends ExamplePersistentActor(name) {
+    val receiveCommand: Receive = {
+      case Cmd(data) ⇒
+        persist(s"p-$data-1") { sender() ! _ }
+        persistAsync(s"pa-$data-2") { sender() ! _ }
+        defer(s"d-$data-3") { sender() ! _ }
+        defer(s"d-$data-4") { sender() ! _ }
+        persistAsync(s"pa-$data-5") { sender() ! _ }
+        defer(s"d-$data-6") { sender() ! _ }
+    }
+  }
+  class DeferringWithNoPersistCallsPersistActor(name: String) extends ExamplePersistentActor(name) {
+    val receiveCommand: Receive = {
+      case Cmd(data) ⇒
+        defer("d-1") { sender() ! _ }
+        defer("d-2") { sender() ! _ }
+        defer("d-3") { sender() ! _ }
     }
   }
 
@@ -623,6 +659,71 @@ abstract class PersistentActorSpec(config: Config) extends AkkaSpec(config) with
       expectMsg("c-e1-5")
       expectMsg("c-ea2-6")
 
+      expectNoMsg(100.millis)
+    }
+    "allow deferring handlers in order to provide ordered processing in respect to persist handlers" in {
+      val processor = namedProcessor[DeferringWithPersistActor]
+      processor ! Cmd("a")
+      expectMsg("d-1")
+      expectMsg("a-2")
+      expectMsg("d-3")
+      expectMsg("d-4")
+      expectNoMsg(100.millis)
+    }
+    "allow deferring handlers in order to provide ordered processing in respect to asyncPersist handlers" in {
+      val processor = namedProcessor[DeferringWithAsyncPersistActor]
+      processor ! Cmd("a")
+      expectMsg("d-a-1")
+      expectMsg("pa-a-2")
+      expectMsg("d-a-3")
+      expectMsg("d-a-4")
+      expectNoMsg(100.millis)
+    }
+    "invoke deferred handlers, in presence of mixed a long series persist / persistAsync calls" in {
+      val processor = namedProcessor[DeferringMixedCallsPPADDPADPersistActor]
+      val p1, p2 = TestProbe()
+
+      processor.tell(Cmd("a"), p1.ref)
+      processor.tell(Cmd("b"), p2.ref)
+      p1.expectMsg("p-a-1")
+      p1.expectMsg("pa-a-2")
+      p1.expectMsg("d-a-3")
+      p1.expectMsg("d-a-4")
+      p1.expectMsg("pa-a-5")
+      p1.expectMsg("d-a-6")
+
+      p2.expectMsg("p-b-1")
+      p2.expectMsg("pa-b-2")
+      p2.expectMsg("d-b-3")
+      p2.expectMsg("d-b-4")
+      p2.expectMsg("pa-b-5")
+      p2.expectMsg("d-b-6")
+
+      expectNoMsg(100.millis)
+    }
+    "invoke deferred handlers right away, if there are no pending persist handlers registered" in {
+      val processor = namedProcessor[DeferringWithNoPersistCallsPersistActor]
+      processor ! Cmd("a")
+      expectMsg("d-1")
+      expectMsg("d-2")
+      expectMsg("d-3")
+      expectNoMsg(100.millis)
+    }
+    "invoke deferred handlers, perserving the original sender references" in {
+      val processor = namedProcessor[DeferringWithAsyncPersistActor]
+      val p1, p2 = TestProbe()
+
+      processor.tell(Cmd("a"), p1.ref)
+      processor.tell(Cmd("b"), p2.ref)
+      p1.expectMsg("d-a-1")
+      p1.expectMsg("pa-a-2")
+      p1.expectMsg("d-a-3")
+      p1.expectMsg("d-a-4")
+
+      p2.expectMsg("d-b-1")
+      p2.expectMsg("pa-b-2")
+      p2.expectMsg("d-b-3")
+      p2.expectMsg("d-b-4")
       expectNoMsg(100.millis)
     }
     "receive RecoveryFinished if it is handled after all events have been replayed" in {

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/PersistentActorExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/PersistentActorExample.java
@@ -48,7 +48,7 @@ class ExampleState implements Serializable {
     private final ArrayList<String> events;
 
     public ExampleState() {
-        this(new ArrayList<String>());
+        this(new ArrayList<>());
     }
 
     public ExampleState(ArrayList<String> events) {
@@ -56,7 +56,7 @@ class ExampleState implements Serializable {
     }
 
     public ExampleState copy() {
-        return new ExampleState(new ArrayList<String>(events));
+        return new ExampleState(new ArrayList<>(events));
     }
 
     public void update(Evt evt) {

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1030,8 +1030,10 @@ object AkkaBuild extends Build {
       // Change of private method to protected by #15212
       ProblemFilters.exclude[MissingMethodProblem]("akka.persistence.snapshot.local.LocalSnapshotStore.akka$persistence$snapshot$local$LocalSnapshotStore$$save"),
 
-      // Changes in akka-persistence-experimental - still source compatible (2.3.3 -> 2.3.4)
-      // Adding `Eventsourced.persistAsync`
+      // Changes in akka-stream-experimental - still source compatible (2.3.3 -> 2.3.4)
+      // Adding `PersistentActor.persistAsync`
+      // Adding `PersistentActor.defer`
+      FilterAnyProblem("akka.persistence.Recovery"),
       FilterAnyProblem("akka.persistence.Eventsourced"),
       FilterAnyProblem("akka.persistence.UntypedEventsourcedProcessor"),
       FilterAnyProblem("akka.persistence.AbstractEventsourcedProcessor"),


### PR DESCRIPTION
note: defer does not persist anything (does not even hit the journal). I think this is enough, as if someone wants to persist stuff (get replayable stuff), they can just use persist methods.

Refs https://github.com/akka/akka/issues/15230
Depends on #15227

TODO: 
- [x] try to implement using same mechanisms as `persistAsync`, remove the 3rd state, make the Journal not persist `LoopStuff` wrapped messages.
- [x] update the persistence lambda docs
