### PR TITLE
=con Use separate probes in ReliableProxyDocSpec

### DIFF
--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -66,24 +66,26 @@ class ReliableProxyDocSpec extends AkkaSpec with ImplicitSender {
   "A ReliableProxy" must {
 
     "show usage" in {
-      val target = testActor
-      val a = system.actorOf(Props(classOf[ProxyParent], target.path))
-      a ! "hello"
-      expectMsg("world!")
+      val probe = TestProbe()
+      val a = system.actorOf(Props(classOf[ProxyParent], probe.ref.path))
+      a.tell("hello", probe.ref)
+      probe.expectMsg("world!")
     }
 
     "show state transitions" in {
       val target = TestProbe().ref
+      val probe = TestProbe()
       val a = system.actorOf(Props(classOf[ProxyTransitionParent], target.path))
-      a ! "go"
-      expectMsg("done")
+      a.tell("go", probe.ref)
+      probe.expectMsg("done")
     }
 
     "show terminated after maxReconnects" in {
       val target = system.deadLetters
+      val probe = TestProbe()
       val a = system.actorOf(Props(classOf[WatchingProxyParent], target.path))
-      a ! "hello"
-      expectMsg("terminated")
+      a.tell("hello", probe.ref)
+      probe.expectMsg("terminated")
     }
 
   }


### PR DESCRIPTION
Failure here: https://jenkins.akka.io:8498/job/pr-validator-per-commit-jenkins/142/
