### PR TITLE
=con #15285 wrap message in RouterEnvelope before routing (for validation)

### DIFF
--- a/akka-contrib/src/main/resources/reference.conf
+++ b/akka-contrib/src/main/resources/reference.conf
@@ -14,9 +14,9 @@ akka.contrib.cluster.pub-sub {
   # Start the mediator on members tagged with this role.
   # All members are used if undefined or empty.
   role = ""
-  
+
   # The routing logic to use for 'Send'
-  # Possible values: random, round-robin, consistent-hashing, broadcast
+  # Possible values: random, round-robin, broadcast
   routing-logic = random
 
   # How often the DistributedPubSubMediator should send out gossip information
@@ -24,11 +24,11 @@ akka.contrib.cluster.pub-sub {
 
   # Removed entries are pruned after this duration
   removed-time-to-live = 120s
-  
+
   # Maximum number of elements to transfer in one message when synchronizing the registries.
-  # Next chunk will be transferred in next round of gossip. 
+  # Next chunk will be transferred in next round of gossip.
   max-delta-elements = 3000
-  
+
 }
 # //#pub-sub-ext-config
 
@@ -75,7 +75,7 @@ akka.contrib.cluster.client {
 # //#sharding-ext-config
 # Settings for the ClusterShardingExtension
 akka.contrib.cluster.sharding {
-  # The extension creates a top level actor with this name in top level user scope, 
+  # The extension creates a top level actor with this name in top level user scope,
   # e.g. '/user/sharding'
   guardian-name = sharding
   # If the coordinator can't store state changes it will be stopped
@@ -84,9 +84,9 @@ akka.contrib.cluster.sharding {
   # Start the coordinator singleton manager on members tagged with this role.
   # All members are used if undefined or empty.
   # ShardRegion actor is started in proxy only mode on nodes that are not tagged
-  # with this role. 
+  # with this role.
   role = ""
-  # The ShardRegion retries registration and shard location requests to the 
+  # The ShardRegion retries registration and shard location requests to the
   # ShardCoordinator with this interval if it does not reply.
   retry-interval = 2 s
   # Maximum number of messages that are buffered by a ShardRegion actor.

--- a/akka-contrib/src/test/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/DistributedPubSubMediatorSpec.scala
@@ -1,0 +1,120 @@
+package akka.contrib.pattern
+
+import akka.testkit._
+import akka.routing.{ ConsistentHashingRoutingLogic, RouterEnvelope }
+import org.scalatest.WordSpecLike
+import akka.actor.{ ActorInitializationException, ActorRef }
+
+case class WrappedMessage(msg: String) extends RouterEnvelope {
+  override def message = msg
+}
+
+case class UnwrappedMessage(msg: String)
+
+object DistributedPubSubMediatorSpec {
+  def config(routingLogic: String) = s"""
+    akka.loglevel = INFO
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.remote.log-remote-lifecycle-events = off
+    akka.contrib.cluster.pub-sub.routing-logic = $routingLogic
+  """
+}
+
+trait DistributedPubSubMediatorSpec { this: WordSpecLike with TestKit with ImplicitSender ⇒
+  def nonUnwrappingPubSub(mediator: ActorRef, testActor: ActorRef, msg: Any) {
+
+    val path = testActor.path.toStringWithoutAddress
+
+    "keep the RouterEnvelope when sending to a local logical path" in {
+
+      mediator ! DistributedPubSubMediator.Put(testActor)
+
+      mediator ! DistributedPubSubMediator.Send(path, msg, localAffinity = true)
+      expectMsg(msg)
+
+      mediator ! DistributedPubSubMediator.Remove(path)
+    }
+
+    "keep the RouterEnvelope when sending to a logical path" in {
+
+      mediator ! DistributedPubSubMediator.Put(testActor)
+
+      mediator ! DistributedPubSubMediator.Send(path, msg, localAffinity = false)
+      expectMsg(msg)
+
+      mediator ! DistributedPubSubMediator.Remove(path)
+    }
+
+    "keep the RouterEnvelope when sending to all actors on a logical path" in {
+
+      mediator ! DistributedPubSubMediator.Put(testActor)
+
+      mediator ! DistributedPubSubMediator.SendToAll(path, msg)
+      expectMsg(msg) // SendToAll does not use provided RoutingLogic
+
+      mediator ! DistributedPubSubMediator.Remove(path)
+    }
+
+    "keep the RouterEnvelope when sending to a topic" in {
+
+      mediator ! DistributedPubSubMediator.Subscribe("topic", testActor)
+      expectMsgClass(classOf[DistributedPubSubMediator.SubscribeAck])
+
+      mediator ! DistributedPubSubMediator.Publish("topic", msg)
+      expectMsg(msg) // Publish(... sendOneMessageToEachGroup = false) does not use provided RoutingLogic
+
+      mediator ! DistributedPubSubMediator.Unsubscribe("topic", testActor)
+      expectMsgClass(classOf[DistributedPubSubMediator.UnsubscribeAck])
+    }
+
+    "keep the RouterEnvelope when sending to a topic for a group" in {
+
+      mediator ! DistributedPubSubMediator.Subscribe("topic", Some("group"), testActor)
+      expectMsgClass(classOf[DistributedPubSubMediator.SubscribeAck])
+
+      mediator ! DistributedPubSubMediator.Publish("topic", msg, sendOneMessageToEachGroup = true)
+      expectMsg(msg)
+
+      mediator ! DistributedPubSubMediator.Unsubscribe("topic", testActor)
+      expectMsgClass(classOf[DistributedPubSubMediator.UnsubscribeAck])
+    }
+  }
+}
+
+class DistributedPubSubMediatorWithRandomRouterSpec
+  extends AkkaSpec(DistributedPubSubMediatorSpec.config("random"))
+  with DistributedPubSubMediatorSpec with DefaultTimeout with ImplicitSender {
+
+  val mediator = DistributedPubSubExtension(system).mediator
+
+  "DistributedPubSubMediator when sending wrapped message" must {
+    val msg = WrappedMessage("hello")
+    behave like nonUnwrappingPubSub(mediator, testActor, msg)
+  }
+
+  "DistributedPubSubMediator when sending unwrapped message" must {
+    val msg = UnwrappedMessage("hello")
+    behave like nonUnwrappingPubSub(mediator, testActor, msg)
+  }
+}
+
+class DistributedPubSubMediatorWithHashRouterSpec
+  extends AkkaSpec(DistributedPubSubMediatorSpec.config("consistent-hashing"))
+  with DistributedPubSubMediatorSpec with DefaultTimeout with ImplicitSender {
+
+  "DistributedPubSubMediator with Consistent Hash router" must {
+    "not be allowed" when {
+      "constructed by extension" in {
+        intercept[IllegalArgumentException] {
+          DistributedPubSubExtension(system).mediator
+        }
+      }
+      "constructed by props" in {
+        EventFilter[ActorInitializationException](occurrences = 1) intercept {
+          system.actorOf(
+            DistributedPubSubMediator.props(None, routingLogic = ConsistentHashingRoutingLogic(system)))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
PubSubMediator uses router which always unwraps RouterEnvelope messages.
However unwrapping is undesirable if user sends message in
ConsistentHashableEnvelope. Thus PubSubMediator should always wrap user
messages in RouterEnvelope which will be unwrapped by the router, leaving
user message unchanged.

Also disallow consistent hashing routing logic in pub-sub mediator.

Fixes #15285
