### PR TITLE
=str #15355 Fix race in Tee causing a RequestMore overtaking ExposedPublisher

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -197,7 +197,7 @@ private[akka] abstract class FanoutOutputs(val maxBufferSize: Int, val initialBu
   override protected def requestFromUpstream(elements: Int): Unit = downstreamBufferSpace += elements
 
   private def subscribePending(): Unit =
-    exposedPublisher.takePendingSubscribers() foreach super.registerSubscriber
+    exposedPublisher.takePendingSubscribers() foreach registerSubscriber
 
   override protected def shutdown(completed: Boolean): Unit = {
     if (exposedPublisher ne null) {

--- a/akka-stream/src/test/scala/akka/stream/FlowTeeSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTeeSpec.scala
@@ -79,23 +79,6 @@ class FlowTeeSpec extends AkkaSpec {
       c2.expectComplete()
     }
 
-    "produce to downstream even though other cancels before downstream has subscribed" in {
-      val c1 = StreamTestKit.consumerProbe[Int]
-      val c2 = StreamTestKit.consumerProbe[Int]
-      val p = Flow(List(1, 2, 3)).
-        tee(c1).
-        toProducer(materializer)
-      val sub1 = c1.expectSubscription()
-      sub1.cancel()
-      p.produceTo(c2)
-      val sub2 = c2.expectSubscription()
-      sub2.requestMore(3)
-      c2.expectNext(1)
-      c2.expectNext(2)
-      c2.expectNext(3)
-      c2.expectComplete()
-    }
-
   }
 
 }


### PR DESCRIPTION
This also makes the secondary subscription lazy, which leaves more wiggling room for #15086. It might be possible to restore the eager behavior, but currently I see less complications with this approach.

Fixes #15355
