### PR TITLE
+tes #15132 Add additional overloaded expectMsg to TestKit

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -332,10 +332,20 @@ trait TestKitBase {
    */
   def expectMsg[T](max: FiniteDuration, obj: T): T = expectMsg_internal(max.dilated, obj)
 
-  private def expectMsg_internal[T](max: Duration, obj: T): T = {
+  /**
+   * Receive one message from the test actor and assert that it equals the
+   * given object. Wait time is bounded by the given duration, with an
+   * AssertionFailure being thrown in case of timeout.
+   *
+   * @return the received object
+   */
+  def expectMsg[T](max: FiniteDuration, hint: String, obj: T): T = expectMsg_internal(max.dilated, obj, Some(hint))
+
+  private def expectMsg_internal[T](max: Duration, obj: T, hint: Option[String] = None): T = {
     val o = receiveOne(max)
-    assert(o ne null, s"timeout ($max) during expectMsg while waiting for $obj")
-    assert(obj == o, s"expected $obj, found $o")
+    lazy val hintOrEmptyString = hint.map(": " + _).getOrElse("")
+    assert(o ne null, s"timeout ($max) during expectMsg while waiting for $obj" + hintOrEmptyString)
+    assert(obj == o, s"expected $obj, found $o" + hintOrEmptyString)
     o.asInstanceOf[T]
   }
 


### PR DESCRIPTION
My first idea was to implement this in terms of delegation to expectMsgPF, as @ktoso did here: https://github.com/akka/akka/pull/15122/files#diff-d7d71f733ff7a7f24858009d8fa8fc54R124

But I figured out that such solution had a couple cons:
- information about what we were expecting may be lost in case when received message didn't match and hint doesn't contain anything about expected message. (hint in expectMsgPF is used to bring some general info about what our partial function expects.. For example: we could pass "Expected response" hint in case when have PF that matches against some ACK and SYN_ACK responses).
- in case of expectMsg, we already have all necessary information (what we expected vs what we got), so the hint parameter will play the role of some additional message and IMO should be appended at the end of message passed to an AssertionError.

That's why I've decided to extend expectMsg_internal.

PS - I've signed Typesafe CLA.
