### PR TITLE
=per #13962 Close LevelDB snapshots to avoid resource leakage (Validation)

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbRecovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbRecovery.scala
@@ -87,9 +87,14 @@ private[persistence] trait LeveldbRecovery extends AsyncRecovery { this: Leveldb
   }
 
   def readHighestSequenceNr(processorId: Int) = {
-    leveldb.get(keyToBytes(counterKey(processorId)), leveldbSnapshot) match {
-      case null  ⇒ 0L
-      case bytes ⇒ counterFromBytes(bytes)
+    val ro = leveldbSnapshot()
+    try {
+      leveldb.get(keyToBytes(counterKey(processorId)), ro) match {
+        case null  ⇒ 0L
+        case bytes ⇒ counterFromBytes(bytes)
+      }
+    } finally {
+      ro.snapshot().close()
     }
   }
 }


### PR DESCRIPTION
- Cherry picked from release 2.3
- Fixes #13962
