### PR TITLE
+act,slf #11715 Add configurable LoggingFilter

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -12,6 +12,7 @@ import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.event.Logging.DefaultLogger
 import java.util.concurrent.TimeUnit
+import akka.event.DefaultLoggingFilter
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.findClassLoader())) {
@@ -57,6 +58,8 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
 
         getDuration("akka.logger-startup-timeout", TimeUnit.MILLISECONDS) should be(5.seconds.toMillis)
         settings.LoggerStartTimeout.duration should be(5.seconds)
+
+        getString("akka.logging-filter") should be(classOf[DefaultLoggingFilter].getName)
 
         getInt("akka.log-dead-letters") should be(10)
         settings.LogDeadLetters should be(10)

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -15,6 +15,15 @@ akka {
   # Loggers to register at boot time (akka.event.Logging$DefaultLogger logs
   # to STDOUT)
   loggers = ["akka.event.Logging$DefaultLogger"]
+  
+  # Filter of log events that is used by the LoggingAdapter before 
+  # publishing log events to the eventStream. It can perform
+  # fine grained filtering based on the log source. The default
+  # implementation filters on the `loglevel`.
+  # FQCN of the LoggingFilter. The Class of the FQCN must implement 
+  # akka.event.LoggingFilter and have a public constructor with
+  # (akka.actor.ActorSystem.Settings, akka.event.EventStream) parameters.
+  logging-filter = "akka.event.DefaultLoggingFilter"
 
   # Loggers are created and registered synchronously during ActorSystem
   # start-up, and since they are actors, this timeout is used to bound the

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -8,7 +8,7 @@ import java.util.concurrent._
 import akka.event.Logging.{ Debug, Error, LogEventException }
 import akka.actor._
 import akka.dispatch.sysmsg._
-import akka.event.{ BusLogging, EventStream }
+import akka.event.EventStream
 import com.typesafe.config.{ ConfigFactory, Config }
 import akka.util.{ Unsafe, Index }
 import scala.annotation.tailrec

--- a/akka-docs/rst/general/configuration.rst
+++ b/akka-docs/rst/general/configuration.rst
@@ -147,6 +147,10 @@ A custom ``application.conf`` might look like this::
     # This logger prints the log messages to stdout (System.out).
     # Options: OFF, ERROR, WARNING, INFO, DEBUG
     stdout-loglevel = "DEBUG"
+    
+    # Filter of log events that is used by the LoggingAdapter before 
+    # publishing log events to the eventStream.
+    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
     actor {
       provider = "akka.cluster.ClusterActorRefProvider"

--- a/akka-docs/rst/java/logging.rst
+++ b/akka-docs/rst/java/logging.rst
@@ -222,7 +222,9 @@ and it will receive the log events in the same order as they were emitted.
 
 You can configure which event handlers are created at system start-up and listen to logging events. That is done using the 
 ``loggers`` element in the :ref:`configuration`.
-Here you can also define the log level.
+Here you can also define the log level. More fine grained filtering based on the log source 
+can be implemented in a custom ``LoggingFilter``, which can be defined in the ``logging-filter`` 
+configuration property. 
 
 .. code-block:: ruby
 
@@ -245,8 +247,6 @@ Example of creating a listener:
 .. includecode:: code/docs/event/LoggingDocTest.java
    :include: my-event-listener
 
-.. _slf4j-java:
-
 Logging to stdout during startup and shutdown
 =============================================
 
@@ -254,6 +254,8 @@ While the actor system is starting up and shutting down the configured ``loggers
 Instead log messages are printed to stdout (System.out). The default log level for this
 stdout logger is ``WARNING`` and it can be silenced completely by setting 
 ``akka.stdout-loglevel=OFF``.
+
+.. _slf4j-java:
 
 SLF4J
 =====
@@ -269,16 +271,19 @@ It has one single dependency; the slf4j-api jar. In runtime you also need a SLF4
        <version>1.0.13</version>
      </dependency>
 
-You need to enable the Slf4jLogger in the 'loggers' element in
+You need to enable the Slf4jLogger in the ``loggers`` element in
 the :ref:`configuration`. Here you can also define the log level of the event bus.
 More fine grained log levels can be defined in the configuration of the SLF4J backend
-(e.g. logback.xml).
+(e.g. logback.xml). You should also define ``akka.event.slf4j.Slf4jLoggingFilter`` in
+the ``logging-filter`` configuration property. It will filter the log events using the backend
+configuration (e.g. logback.xml) before they are published to the event bus.
 
 .. code-block:: ruby
 
   akka {
     loggers = ["akka.event.slf4j.Slf4jLogger"]
     loglevel = "DEBUG"
+    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   }
   
 One gotcha is that the timestamp is attributed in the event handler, not when actually doing the logging.

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -94,3 +94,12 @@ The following, previously deprecated, features have been removed:
 
 * Java API TestKit.dilated, moved to JavaTestKit.dilated
 
+Slf4j logging filter
+====================
+
+If you use ``Slf4jLogger`` you should add the following configuration::
+
+    akka.logging-filter = "akka.event.slf4j.Slf4jLoggingFilter" 
+
+It will filter the log events using the backend configuration (e.g. logback.xml) before
+they are published to the event bus.

--- a/akka-docs/rst/scala/logging.rst
+++ b/akka-docs/rst/scala/logging.rst
@@ -263,7 +263,9 @@ and it will receive the log events in the same order as they were emitted.
 
 You can configure which event handlers are created at system start-up and listen to logging events. That is done using the 
 ``loggers`` element in the :ref:`configuration`.
-Here you can also define the log level.
+Here you can also define the log level. More fine grained filtering based on the log source 
+can be implemented in a custom ``LoggingFilter``, which can be defined in the ``logging-filter`` 
+configuration property.
 
 .. code-block:: ruby
 
@@ -284,8 +286,6 @@ Example of creating a listener:
 .. includecode:: code/docs/event/LoggingDocSpec.scala
    :include: my-event-listener
 
-.. _slf4j-scala:
-
 Logging to stdout during startup and shutdown
 =============================================
 
@@ -293,6 +293,8 @@ When the actor system is starting up and shutting down the configured ``loggers`
 Instead log messages are printed to stdout (System.out). The default log level for this
 stdout logger is ``WARNING`` and it can be silenced completely by setting 
 ``akka.stdout-loglevel=OFF``.
+
+.. _slf4j-scala:
 
 SLF4J
 =====
@@ -302,19 +304,22 @@ It has one single dependency; the slf4j-api jar. In runtime you also need a SLF4
 
   .. code-block:: scala
 
-     lazy val logback = "ch.qos.logback" % "logback-classic" % "1.0.13"
+     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.0.13"
 
 
-You need to enable the Slf4jLogger in the 'loggers' element in
+You need to enable the Slf4jLogger in the ``loggers`` element in
 the :ref:`configuration`. Here you can also define the log level of the event bus.
 More fine grained log levels can be defined in the configuration of the SLF4J backend
-(e.g. logback.xml).
+(e.g. logback.xml). You should also define ``akka.event.slf4j.Slf4jLoggingFilter`` in
+the ``logging-filter`` configuration property. It will filter the log events using the backend
+configuration (e.g. logback.xml) before they are published to the event bus.
 
 .. code-block:: ruby
 
   akka {
     loggers = ["akka.event.slf4j.Slf4jLogger"]
     loglevel = "DEBUG"
+    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   }
 
 One gotcha is that the timestamp is attributed in the event handler, not when actually doing the logging.

--- a/akka-samples/akka-sample-osgi-dining-hakkers/core/src/main/resources/application.conf
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/core/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 akka {
 
     loggers = ["akka.event.slf4j.Slf4jLogger", "akka.event.Logging$DefaultLogger"]
+    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
     actor {
         provider = "akka.cluster.ClusterActorRefProvider"

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -10,6 +10,8 @@ import akka.event.Logging._
 import akka.actor._
 import akka.event.DummyClassForStringSources
 import akka.util.Helpers
+import akka.event.LoggingFilter
+import akka.event.EventStream
 
 /**
  * Base trait for all classes that wants to be able use the SLF4J logging infrastructure.
@@ -104,3 +106,18 @@ class Slf4jLogger extends Actor with SLF4JLogging {
     Helpers.currentTimeMillisToUTCString(timestamp)
 }
 
+/**
+ * [[akka.event.LoggingFilter]] that uses the log level defined in in the SLF4J
+ * backend configuration (e.g. logback.xml) to filter log events before publishing
+ * the log events to the `eventStream`.
+ */
+class Slf4jLoggingFilter(settings: ActorSystem.Settings, eventStream: EventStream) extends LoggingFilter {
+  def isErrorEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= ErrorLevel) && Logger(logClass, logSource).isErrorEnabled
+  def isWarningEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= WarningLevel) && Logger(logClass, logSource).isWarnEnabled
+  def isInfoEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= InfoLevel) && Logger(logClass, logSource).isInfoEnabled
+  def isDebugEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= DebugLevel) && Logger(logClass, logSource).isDebugEnabled
+}

--- a/akka-slf4j/src/test/resources/logback-test.xml
+++ b/akka-slf4j/src/test/resources/logback-test.xml
@@ -1,26 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <configuration>
-
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-		<encoder>
-			<pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
-		</encoder>
-	</appender>
-
-	<appender name="TEST"
-		class="akka.event.slf4j.Slf4jLoggerSpec$TestAppender">
-		<encoder>
-			<pattern>%date{ISO8601} level=[%level] logger=[%logger] akkaSource=[%X{akkaSource}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc}] - msg=[%msg]%n----%n</pattern>
-		</encoder>
-	</appender>
-
-	<logger name="akka.event.slf4j.Slf4jLoggerSpec" level="info" additivity="false">
-		<appender-ref ref="TEST" />
-	</logger>
-
-	<root level="info">
-		<appender-ref ref="STDOUT" />
-	</root>
-
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="TEST" class="akka.event.slf4j.Slf4jLoggerSpec$TestAppender">
+    <encoder>
+      <pattern>%date{ISO8601} level=[%level] logger=[%logger] akkaSource=[%X{akkaSource}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc}] - msg=[%msg]%n----%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="akka.event.slf4j.Slf4jLoggingFilterSpec$DebugLevelProducer"
+    level="debug" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <logger name="akka.event.slf4j.Slf4jLoggingFilterSpec$WarningLevelProducer"
+    level="warn" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <logger name="akka.event.slf4j.Slf4jLoggerSpec" level="info"
+    additivity="false">
+    <appender-ref ref="TEST" />
+  </logger>
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggingFilterSpec.scala
+++ b/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggingFilterSpec.scala
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.event.slf4j
+
+import language.postfixOps
+import akka.testkit.AkkaSpec
+import akka.actor.{ DiagnosticActorLogging, Actor, ActorLogging, Props }
+import scala.concurrent.duration._
+import akka.event.Logging
+import ch.qos.logback.core.OutputStreamAppender
+import java.io.StringWriter
+import java.io.ByteArrayOutputStream
+import org.scalatest.BeforeAndAfterEach
+import akka.actor.ActorRef
+import akka.event.Logging.InitializeLogger
+import akka.event.Logging.LoggerInitialized
+import akka.event.Logging.LogEvent
+import akka.testkit.TestProbe
+import akka.event.Logging.Warning
+import akka.event.Logging.Info
+import akka.event.Logging.Debug
+import akka.event.LoggingAdapter
+import akka.event.LogSource
+
+object Slf4jLoggingFilterSpec {
+
+  // This test depends on logback configuration in src/test/resources/logback-test.xml
+
+  val config = """
+    akka {
+      loglevel = DEBUG
+      loggers = ["akka.event.slf4j.Slf4jLoggingFilterSpec$TestLogger"]
+      logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+    }
+    """
+
+  final case class SetTarget(ref: ActorRef)
+
+  class TestLogger extends Actor {
+    var target: Option[ActorRef] = None
+    override def receive: Receive = {
+      case InitializeLogger(bus) ⇒
+        bus.subscribe(context.self, classOf[SetTarget])
+        sender() ! LoggerInitialized
+      case SetTarget(ref) ⇒
+        target = Some(ref)
+        ref ! ("OK")
+      case event: LogEvent ⇒
+        println("# event: " + event)
+        target foreach { _ ! event }
+    }
+  }
+
+  class DebugLevelProducer extends Actor with ActorLogging {
+    def receive = {
+      case s: String ⇒
+        log.warning(s)
+        log.info(s)
+        println("# DebugLevelProducer: " + log.isDebugEnabled)
+        log.debug(s)
+    }
+  }
+
+  class WarningLevelProducer extends Actor with ActorLogging {
+    def receive = {
+      case s: String ⇒
+        log.warning(s)
+        log.info(s)
+        log.debug(s)
+    }
+  }
+
+}
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class Slf4jLoggingFilterSpec extends AkkaSpec(Slf4jLoggingFilterSpec.config) with BeforeAndAfterEach {
+  import Slf4jLoggingFilterSpec._
+
+  "Slf4jLoggingFilter" must {
+
+    "use configured LoggingFilter at debug log level in logback conf" in {
+      import LogSource.fromClass
+      val log1 = Logging(system, classOf[DebugLevelProducer])
+      log1.isDebugEnabled should be(true)
+      log1.isInfoEnabled should be(true)
+      log1.isWarningEnabled should be(true)
+      log1.isErrorEnabled should be(true)
+    }
+
+    "use configured LoggingFilter at warning log level in logback conf" in {
+      import LogSource.fromClass
+      val log1 = Logging(system, classOf[WarningLevelProducer])
+      log1.isDebugEnabled should be(false)
+      log1.isInfoEnabled should be(false)
+      log1.isWarningEnabled should be(true)
+      log1.isErrorEnabled should be(true)
+    }
+
+    "filter ActorLogging at debug log level with logback conf" in {
+      val probe = TestProbe()
+      system.eventStream.publish(SetTarget(probe.ref))
+      probe.expectMsg("OK")
+      val debugLevelProducer = system.actorOf(Props[DebugLevelProducer], name = "debugLevelProducer")
+      debugLevelProducer ! "test1"
+      probe.expectMsgType[Warning].message should be("test1")
+      probe.expectMsgType[Info].message should be("test1")
+      probe.expectMsgType[Debug].message should be("test1")
+    }
+
+    "filter ActorLogging at warning log level with logback conf" in {
+      val probe = TestProbe()
+      system.eventStream.publish(SetTarget(probe.ref))
+      probe.expectMsg("OK")
+      val debugLevelProducer = system.actorOf(Props[WarningLevelProducer], name = "warningLevelProducer")
+      debugLevelProducer ! "test2"
+      probe.expectMsgType[Warning].message should be("test2")
+      probe.expectNoMsg(500.millis)
+    }
+  }
+
+}


### PR DESCRIPTION
- The filter is used by the LoggingAdapter before publishing
  to the event bus
- Slf4jLoggingFilter uses backend log level configuration
  (e.g. logback.xml)
