### PR TITLE
=pro,ben update sbt-jmh to 0.1.4 (provides JMH 0.9 (latest))

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
@@ -65,7 +65,7 @@ class PersistentActorDeferBenchmark {
     storageLocations.foreach(FileUtils.deleteDirectory)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_processor_Persistent_reply() {
     for (i <- data10k) processor.tell(i, probe.ref)
@@ -73,7 +73,7 @@ class PersistentActorDeferBenchmark {
     probe.expectMsg(data10k.last)
   }
   
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_processor_Persistent_replyASAP() {
     for (i <- data10k) processor_replyASAP.tell(i, probe.ref)
@@ -81,7 +81,7 @@ class PersistentActorDeferBenchmark {
     probe.expectMsg(data10k.last)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_persistAsync_defer_persistAsync_reply() {
     for (i <- data10k) persistAsync_defer.tell(i, probe.ref)
@@ -89,7 +89,7 @@ class PersistentActorDeferBenchmark {
     probe.expectMsg(data10k.last)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_persistAsync_defer_persistAsync_replyASAP() {
     for (i <- data10k) persistAsync_defer_replyASAP.tell(i, probe.ref)

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
@@ -56,7 +56,7 @@ class PersistentActorThroughputBenchmark {
     storageLocations.foreach(FileUtils.deleteDirectory)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_normalActor_reply_baseline() {
     for (i <- data10k) actor.tell(i, probe.ref)
@@ -64,7 +64,7 @@ class PersistentActorThroughputBenchmark {
     probe.expectMsg(data10k.last)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_persist_reply() {
     for (i <- data10k) persist1EventProcessor.tell(i, probe.ref)
@@ -72,7 +72,7 @@ class PersistentActorThroughputBenchmark {
     probe.expectMsg(Evt(data10k.last))
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_commandPersist_reply() {
     for (i <- data10k) persist1CommandProcessor.tell(i, probe.ref)
@@ -80,7 +80,7 @@ class PersistentActorThroughputBenchmark {
     probe.expectMsg(Evt(data10k.last))
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_persistAsync_reply() {
     for (i <- data10k) persistAsync1EventProcessor.tell(i, probe.ref)
@@ -88,7 +88,7 @@ class PersistentActorThroughputBenchmark {
     probe.expectMsg(Evt(data10k.last))
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(10000)
   def tell_persistAsync_replyRightOnCommandReceive() {
     for (i <- data10k) persistAsync1QuickReplyEventProcessor.tell(i, probe.ref)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,6 +18,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.4")
 
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"


### PR DESCRIPTION
Updates JMH to latest version; 
Mostly internal cleanups, but also changed default bytecode generator (reflection, instead of asm) - should handle edgy cases better.

Changelog: http://hg.openjdk.java.net/code-tools/jmh/

TODO: 
- [ ] port to master
- [ ] port to  2.3-dev

(didn't forget, it's coming)
