### PR TITLE
+tes #15132 Add additional overloaded expectMsg to TestKit (for validation)

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -323,10 +323,20 @@ trait TestKitBase {
    */
   def expectMsg[T](max: FiniteDuration, obj: T): T = expectMsg_internal(max.dilated, obj)
 
-  private def expectMsg_internal[T](max: Duration, obj: T): T = {
+  /**
+   * Receive one message from the test actor and assert that it equals the
+   * given object. Wait time is bounded by the given duration, with an
+   * AssertionFailure being thrown in case of timeout.
+   *
+   * @return the received object
+   */
+  def expectMsg[T](max: FiniteDuration, hint: String, obj: T): T = expectMsg_internal(max.dilated, obj, Some(hint))
+
+  private def expectMsg_internal[T](max: Duration, obj: T, hint: Option[String] = None): T = {
     val o = receiveOne(max)
-    assert(o ne null, "timeout (" + max + ") during expectMsg while waiting for " + obj)
-    assert(obj == o, "expected " + obj + ", found " + o)
+    lazy val hintOrEmptyString = hint.map(": " + _).getOrElse("")
+    assert(o ne null, s"timeout ($max) during expectMsg while waiting for $obj" + hintOrEmptyString)
+    assert(obj == o, s"expected $obj, found $o" + hintOrEmptyString)
     o.asInstanceOf[T]
   }
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1057,7 +1057,10 @@ object AkkaBuild extends Build {
       FilterAnyProblem("akka.actor.ActorSelectionMessage$"),
       FilterAnyProblem("akka.actor.ActorSelectionMessage"),
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ContainerFormats#SelectionEnvelopeOrBuilder.hasWildcardFanOut"),
-      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ContainerFormats#SelectionEnvelopeOrBuilder.getWildcardFanOut")
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ContainerFormats#SelectionEnvelopeOrBuilder.getWildcardFanOut"),
+
+      // Adding expectMsg overload to testkit #15425
+      ProblemFilters.exclude[MissingMethodProblem]("akka.testkit.TestKitBase.expectMsg")
     )
   }
 


### PR DESCRIPTION
Backport from `master`. Adds `expectMsg(max, hint, o)`.
