### PR TITLE
+act #15383 add strict japi.Option.getOrElse to simplify working with options from Java

### DIFF
--- a/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
+++ b/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
@@ -17,6 +17,7 @@ public class JavaAPITestBase {
     assertFalse(o.isEmpty());
     assertTrue(o.isDefined());
     assertEquals("abc", o.get());
+    assertEquals("abc", o.getOrElse("other"));
   }
 
   @Test
@@ -24,10 +25,12 @@ public class JavaAPITestBase {
     Option<String> o1 = Option.none();
     assertTrue(o1.isEmpty());
     assertFalse(o1.isDefined());
+    assertEquals("other", o1.getOrElse("other"));
 
     Option<Float> o2 = Option.none();
     assertTrue(o2.isEmpty());
     assertFalse(o2.isDefined());
+    assertEquals("other", o1.getOrElse("other"));
   }
 
   @Test

--- a/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
+++ b/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
@@ -130,6 +130,11 @@ abstract class JavaPartialFunction[A, B] extends AbstractPartialFunction[A, B] {
  */
 sealed abstract class Option[A] extends java.lang.Iterable[A] {
   def get: A
+  /**
+   * Returns <code>a</code> if this is <code>some(a)</code> or <code>defaultValue</code> if
+   * this is <code>none</code>.
+   */
+  def getOrElse[B >: A](defaultValue: B): B
   def isEmpty: Boolean
   def isDefined: Boolean = !isEmpty
   def asScala: scala.Option[A]
@@ -167,6 +172,7 @@ object Option {
    */
   final case class Some[A](v: A) extends Option[A] {
     def get: A = v
+    def getOrElse[B >: A](defaultValue: B): B = v
     def isEmpty: Boolean = false
     def asScala: scala.Some[A] = scala.Some(v)
   }
@@ -176,6 +182,7 @@ object Option {
    */
   private case object None extends Option[Nothing] {
     def get: Nothing = throw new NoSuchElementException("None.get")
+    def getOrElse[B](defaultValue: B): B = defaultValue
     def isEmpty: Boolean = true
     def asScala: scala.None.type = scala.None
   }


### PR DESCRIPTION
Fix for #15383. (Follow-up to #15393 rebased onto master.)
