### PR TITLE
+per #15424 Added PersistentView, deprecated View

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSharding.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterSharding.scala
@@ -1188,6 +1188,8 @@ class ShardCoordinator(handOffTimeout: FiniteDuration, rebalanceInterval: Finite
   import ShardCoordinator.Internal._
   import ShardRegion.ShardId
 
+  override def persistenceId = self.path.toStringWithoutAddress
+
   var persistentState = State.empty
   var rebalanceInProgress = Set.empty[ShardId]
 

--- a/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
@@ -485,18 +485,21 @@ public class PersistenceDocTest {
 
     static Object o11 = new Object() {
         //#view
-        class MyView extends UntypedView {
-            @Override
-            public String persistenceId() {
-                return "some-persistence-id";
-            }
+        class MyView extends UntypedPersistentView {
+          @Override public String viewId() { return "some-persistence-id-view"; }
+          @Override public String persistenceId() { return "some-persistence-id"; }
 
             @Override
             public void onReceive(Object message) throws Exception {
-                if (message instanceof Persistent) {
-                    // ...
+                if (isPersistent()) {
+                    // handle message from Journal...
+                } else if (message instanceof String) {
+                    // handle message from user...
+                } else {
+                  unhandled(message);
                 }
             }
+
         }
         //#view
 

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -31,10 +31,11 @@ Changes in Akka 2.3.4
 
 In Akka 2.3.4 several of the concepts of the earlier versions were collapsed and simplified.
 In essence; ``Processor`` and ``EventsourcedProcessor`` are replaced by ``PersistentActor``. ``Channel``
-and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. See full details of the changes in the 
-:ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`. The old classes are still included, and deprecated,
-for a while to make the transition smooth. In case you need the old documentation it is located 
-`here <http://doc.akka.io/docs/akka/2.3.3/java/lambda-persistence.html#persistence-lambda-java>`_.
+and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. ``View`` is replaced by ``PersistentView``.
+
+See full details of the changes in the :ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`.
+The old classes are still included, and deprecated, for a while to make the transition smooth.
+In case you need the old documentation it is located `here <http://doc.akka.io/docs/akka/2.3.3/java/lambda-persistence.html#persistence-lambda-java>`_.
 
 Dependencies
 ============
@@ -55,7 +56,7 @@ Architecture
   When a persistent actor is started or restarted, journaled messages are replayed to that actor, so that it can
   recover internal state from these messages.
 
-* *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
+* *AbstractPersistentView*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
   persistent actor. A view itself does not journal new messages, instead, it updates internal state only from a persistent actor's
   replicated message stream.
   
@@ -270,12 +271,12 @@ to Akka persistence will allow to replay messages that have been marked as delet
 purposes, for example. To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors should call the ``deleteMessages`` method.
 
-.. _views-java-lambda:
+.. _persistent-views-java-lambda:
 
 Views
 =====
 
-Views can be implemented by extending the ``AbstractView`` abstract class, implement the ``persistenceId`` method
+Persistent views can be implemented by extending the ``AbstractView`` abstract class, implement the ``persistenceId`` method
 and setting the “initial behavior” in the constructor by calling the :meth:`receive` method.
 
 .. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#view
@@ -285,14 +286,18 @@ the referenced persistent actor is actually running. Views read messages from a 
 persistent actor is started later and begins to write new messages, the corresponding view is updated automatically, by
 default.
 
+It is possible to determine if a message was sent from the Journal or from another actor in user-land by calling the ``isPersistent``
+method. Having that said, very often you don't need this information at all and can simply apply the same logic to both cases
+(skip the ``if isPersistent`` check).
+
 Updates
 -------
 
-The default update interval of all views of an actor system is configurable:
+The default update interval of all persistent views of an actor system is configurable:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update-interval
 
-``View`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
+``AbstractPersistentView`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
 interval for a specific view class or view instance. Applications may also trigger additional updates at
 any time by sending a view an ``Update`` message.
 
@@ -303,7 +308,7 @@ incremental message replay, triggered by that update request, completed. If set 
 following the update request may interleave with the replayed message stream. Automated updates always run with
 ``await = false``.
 
-Automated updates of all views of an actor system can be turned off by configuration:
+Automated updates of all persistent views of an actor system can be turned off by configuration:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update
 
@@ -315,20 +320,20 @@ of replayed messages for manual updates can be limited with the ``replayMax`` pa
 Recovery
 --------
 
-Initial recovery of views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
+Initial recovery of persistent views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
 to self). The maximum number of replayed messages during initial recovery is determined by ``autoUpdateReplayMax``.
-Further possibilities to customize initial recovery are explained in section :ref:`recovery-java-lambda`.
+Further possibilities to customize initial recovery are explained in section :ref:`recovery-java`.
 
 .. _persistence-identifiers-java-lambda:
 
 Identifiers
 -----------
 
-A view must have an identifier that doesn't change across different actor incarnations. It defaults to the
+A persistent view must have an identifier that doesn't change across different actor incarnations. It defaults to the
 ``String`` representation of the actor path without the address part and can be obtained via the ``viewId``
 method.
 
-Applications can customize a view's id by specifying an actor name during view creation. This changes that view's
+Applications can customize a view's id by specifying an actor name during view creation. This changes that persistent view's
 name in its actor hierarchy and hence influences only part of the view id. To fully customize a view's id, the
 ``viewId`` method must be overridden. Overriding ``viewId`` is the recommended way to generate stable identifiers.
 
@@ -348,7 +353,7 @@ Snapshots
 =========
 
 Snapshots can dramatically reduce recovery times of persistent actors and views. The following discusses snapshots
-in context of persistent actors but this is also applicable to views.
+in context of persistent actors but this is also applicable to persistent views.
 
 Persistent actor can save snapshots of internal state by calling the  ``saveSnapshot`` method. If saving of a snapshot
 succeeds, the persistent actor receives a ``SaveSnapshotSuccess`` message, otherwise a ``SaveSnapshotFailure`` message

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -36,10 +36,11 @@ Changes in Akka 2.3.4
 
 In Akka 2.3.4 several of the concepts of the earlier versions were collapsed and simplified.
 In essence; ``Processor`` and ``EventsourcedProcessor`` are replaced by ``PersistentActor``. ``Channel``
-and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. See full details of the changes in the 
-:ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`. The old classes are still included, and deprecated,
-for a while to make the transition smooth. In case you need the old documentation it is located 
-`here <http://doc.akka.io/docs/akka/2.3.3/java/persistence.html>`_. 
+and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. ``View`` is replaced by ``PersistentView``.
+
+See full details of the changes in the :ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`.
+The old classes are still included, and deprecated, for a while to make the transition smooth.
+In case you need the old documentation it is located `here <http://doc.akka.io/docs/akka/2.3.3/java/persistence.html>`_.
 
 Dependencies
 ============
@@ -60,7 +61,7 @@ Architecture
   When a persistent actor is started or restarted, journaled messages are replayed to that actor, so that it can
   recover internal state from these messages.
 
-* *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
+* *UntypedPersistentView*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
   persistent actor. A view itself does not journal new messages, instead, it updates internal state only from a persistent actor's
   replicated message stream.
 
@@ -275,13 +276,13 @@ to Akka persistence will allow to replay messages that have been marked as delet
 purposes, for example. To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors should call the ``deleteMessages`` method.
 
-.. _views-java:
+.. _persistent-views-java:
 
-Views
-=====
+Persistent Views
+================
 
-Views can be implemented by extending the ``UntypedView`` trait  and implementing the ``onReceive`` and the ``persistenceId``
-methods.
+Persistent views can be implemented by extending the ``UntypedPersistentView`` trait  and implementing the ``onReceive``
+and the ``persistenceId`` methods.
 
 .. includecode:: code/docs/persistence/PersistenceDocTest.java#view
 
@@ -290,14 +291,18 @@ the referenced persistent actor is actually running. Views read messages from a 
 persistent actor is started later and begins to write new messages, the corresponding view is updated automatically, by
 default.
 
+It is possible to determine if a message was sent from the Journal or from another actor in user-land by calling the ``isPersistent``
+method. Having that said, very often you don't need this information at all and can simply apply the same logic to both cases
+(skip the ``if isPersistent`` check).
+
 Updates
 -------
 
-The default update interval of all views of an actor system is configurable:
+The default update interval of all persistent views of an actor system is configurable:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update-interval
 
-``View`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
+``UntypedPersistentView`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
 interval for a specific view class or view instance. Applications may also trigger additional updates at
 any time by sending a view an ``Update`` message.
 
@@ -308,7 +313,7 @@ incremental message replay, triggered by that update request, completed. If set 
 following the update request may interleave with the replayed message stream. Automated updates always run with
 ``await = false``.
 
-Automated updates of all views of an actor system can be turned off by configuration:
+Automated updates of all persistent views of an actor system can be turned off by configuration:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update
 
@@ -320,7 +325,7 @@ of replayed messages for manual updates can be limited with the ``replayMax`` pa
 Recovery
 --------
 
-Initial recovery of views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
+Initial recovery of persistent views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
 to self). The maximum number of replayed messages during initial recovery is determined by ``autoUpdateReplayMax``.
 Further possibilities to customize initial recovery are explained in section :ref:`recovery-java`.
 
@@ -329,11 +334,11 @@ Further possibilities to customize initial recovery are explained in section :re
 Identifiers
 -----------
 
-A view must have an identifier that doesn't change across different actor incarnations. It defaults to the
+A persistent view must have an identifier that doesn't change across different actor incarnations. It defaults to the
 ``String`` representation of the actor path without the address part and can be obtained via the ``viewId``
 method.
 
-Applications can customize a view's id by specifying an actor name during view creation. This changes that view's
+Applications can customize a view's id by specifying an actor name during view creation. This changes that persistent view's
 name in its actor hierarchy and hence influences only part of the view id. To fully customize a view's id, the
 ``viewId`` method must be overridden. Overriding ``viewId`` is the recommended way to generate stable identifiers.
 
@@ -353,7 +358,7 @@ Snapshots
 =========
 
 Snapshots can dramatically reduce recovery times of persistent actor and views. The following discusses snapshots
-in context of persistent actor but this is also applicable to views.
+in context of persistent actor but this is also applicable to persistent views.
 
 Persistent actor can save snapshots of internal state by calling the  ``saveSnapshot`` method. If saving of a snapshot
 succeeds, the persistent actor receives a ``SaveSnapshotSuccess`` message, otherwise a ``SaveSnapshotFailure`` message

--- a/akka-docs/rst/project/migration-guide-eventsourced-2.3.x.rst
+++ b/akka-docs/rst/project/migration-guide-eventsourced-2.3.x.rst
@@ -137,7 +137,7 @@ Views
 **Akka Persistence:** ``View``
 
 - Receives the message stream written by a ``PersistentActor`` by reading it directly from the
-  journal (see :ref:`views`). Alternative to using channels. Useful in situations where actors shall receive a
+  journal (see :ref:`persistent-views`). Alternative to using channels. Useful in situations where actors shall receive a
   persistent message stream in correct order without duplicates.
 - Supports :ref:`snapshots`.
 

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -4,11 +4,11 @@
 
 package docs.persistence
 
+import akka.actor.{ Actor, ActorSystem, Props }
+import akka.persistence._
+
 import scala.concurrent.duration._
 import scala.language.postfixOps
-
-import akka.actor.{ Props, Actor, ActorSystem }
-import akka.persistence._
 
 trait PersistenceDocSpec {
   val config =
@@ -29,7 +29,7 @@ trait PersistenceDocSpec {
 
   new AnyRef {
     //#definition
-    import akka.persistence.{ Persistent, PersistenceFailure, Processor }
+    import akka.persistence.{ PersistenceFailure, Persistent, Processor }
 
     class MyProcessor extends Processor {
       def receive = {
@@ -208,7 +208,7 @@ trait PersistenceDocSpec {
   new AnyRef {
     //#fsm-example
     import akka.actor.FSM
-    import akka.persistence.{ Processor, Persistent }
+    import akka.persistence.{ Persistent, Processor }
 
     class PersistentDoor extends Processor with FSM[String, Int] {
       startWith("closed", 0)
@@ -332,7 +332,6 @@ trait PersistenceDocSpec {
   }
 
   new AnyRef {
-    import akka.actor.ActorRef
 
     val processor = system.actorOf(Props[MyPersistentActor]())
 
@@ -367,7 +366,6 @@ trait PersistenceDocSpec {
     //#persist-async
   }
   new AnyRef {
-    import akka.actor.ActorRef
 
     val processor = system.actorOf(Props[MyPersistentActor]())
 
@@ -409,11 +407,15 @@ trait PersistenceDocSpec {
     import akka.actor.Props
 
     //#view
-    class MyView extends View {
+    class MyView extends PersistentView {
       override def persistenceId: String = "some-persistence-id"
+      override def viewId: String = "some-persistence-id-view"
 
       def receive: Actor.Receive = {
-        case Persistent(payload, sequenceNr) => // ...
+        case payload if isPersistent =>
+        // handle message from journal...
+        case payload                 =>
+        // handle message from user-land...
       }
     }
     //#view

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -31,10 +31,11 @@ Changes in Akka 2.3.4
 
 In Akka 2.3.4 several of the concepts of the earlier versions were collapsed and simplified.
 In essence; ``Processor`` and ``EventsourcedProcessor`` are replaced by ``PersistentActor``. ``Channel``
-and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. See full details of the changes in the 
-:ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`. The old classes are still included, and deprecated,
-for a while to make the transition smooth. In case you need the old documentation it is located 
-`here <http://doc.akka.io/docs/akka/2.3.3/scala/persistence.html>`_. 
+and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. ``View`` is replaced by ``PersistentView``.
+
+See full details of the changes in the :ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`.
+The old classes are still included, and deprecated, for a while to make the transition smooth.
+In case you need the old documentation it is located `here <http://doc.akka.io/docs/akka/2.3.3/scala/persistence.html>`_.
 
 
 Dependencies
@@ -52,7 +53,7 @@ Architecture
   When a persistent actor is started or restarted, journaled messages are replayed to that actor, so that it can
   recover internal state from these messages.
 
-* *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
+* *PersistentView*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
   persistent actor. A view itself does not journal new messages, instead, it updates internal state only from a persistent actor's
   replicated message stream.
 
@@ -274,12 +275,12 @@ persistent actors should call the ``deleteMessages`` method.
 
 
 
-.. _views:
+.. _persistent-views:
 
-Views
-=====
+Persistent Views
+================
 
-Views can be implemented by extending the ``View`` trait  and implementing the ``receive`` and the ``persistenceId``
+Persistent views can be implemented by extending the ``PersistentView`` trait  and implementing the ``receive`` and the ``persistenceId``
 methods.
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#view
@@ -289,6 +290,10 @@ the referenced persistent actor is actually running. Views read messages from a 
 persistent actor is started later and begins to write new messages, the corresponding view is updated automatically, by
 default.
 
+It is possible to determine if a message was sent from the Journal or from another actor in user-land by calling the ``isPersistent``
+method. Having that said, very often you don't need this information at all and can simply apply the same logic to both cases
+(skip the ``if isPersistent`` check).
+
 Updates
 -------
 
@@ -296,7 +301,7 @@ The default update interval of all views of an actor system is configurable:
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#auto-update-interval
 
-``View`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
+``PersistentView`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
 interval for a specific view class or view instance. Applications may also trigger additional updates at
 any time by sending a view an ``Update`` message.
 
@@ -307,7 +312,7 @@ incremental message replay, triggered by that update request, completed. If set 
 following the update request may interleave with the replayed message stream. Automated updates always run with
 ``await = false``.
 
-Automated updates of all views of an actor system can be turned off by configuration:
+Automated updates of all persistent views of an actor system can be turned off by configuration:
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#auto-update
 
@@ -319,7 +324,7 @@ of replayed messages for manual updates can be limited with the ``replayMax`` pa
 Recovery
 --------
 
-Initial recovery of views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
+Initial recovery of persistent views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
 to self). The maximum number of replayed messages during initial recovery is determined by ``autoUpdateReplayMax``.
 Further possibilities to customize initial recovery are explained in section :ref:`recovery`.
 
@@ -328,11 +333,11 @@ Further possibilities to customize initial recovery are explained in section :re
 Identifiers
 -----------
 
-A view must have an identifier that doesn't change across different actor incarnations. It defaults to the
+A persistent view must have an identifier that doesn't change across different actor incarnations. It defaults to the
 ``String`` representation of the actor path without the address part and can be obtained via the ``viewId``
 method.
 
-Applications can customize a view's id by specifying an actor name during view creation. This changes that view's
+Applications can customize a view's id by specifying an actor name during view creation. This changes that persistent view's
 name in its actor hierarchy and hence influences only part of the view id. To fully customize a view's id, the
 ``viewId`` method must be overridden. Overriding ``viewId`` is the recommended way to generate stable identifiers.
 
@@ -383,7 +388,7 @@ Snapshots
 =========
 
 Snapshots can dramatically reduce recovery times of persistent actors and views. The following discusses snapshots
-in context of persistent actors but this is also applicable to views.
+in context of persistent actors but this is also applicable to persistent views.
 
 Persistent actors can save snapshots of internal state by calling the  ``saveSnapshot`` method. If saving of a snapshot
 succeeds, the persistent actor receives a ``SaveSnapshotSuccess`` message, otherwise a ``SaveSnapshotFailure`` message

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -6,11 +6,11 @@ package akka.persistence
 
 import java.lang.{ Iterable ⇒ JIterable }
 
-import scala.collection.immutable
-
+import akka.actor.AbstractActor
 import akka.japi.{ Procedure, Util }
 import akka.persistence.JournalProtocol._
-import akka.actor.{ ActorRef, AbstractActor }
+
+import scala.collection.immutable
 
 /**
  * INTERNAL API.
@@ -550,7 +550,7 @@ abstract class UntypedEventsourcedProcessor extends UntypedProcessor with Events
    * communication with other actors). On successful validation, one or more events are
    * derived from a command and these events are then persisted by calling `persist`.
    * Commands sent to event sourced processors must not be [[Persistent]] or
-   * [[ResequenceableBatch]] messages. In this case an `UnsupportedOperationException` is
+   * [[PersistentBatch]] messages. In this case an `UnsupportedOperationException` is
    * thrown by the processor.
    */
   @throws(classOf[Exception])
@@ -563,7 +563,7 @@ abstract class UntypedEventsourcedProcessor extends UntypedProcessor with Events
  * communication with other actors). On successful validation, one or more events are
  * derived from a command and these events are then persisted by calling `persist`.
  * Commands sent to event sourced processors must not be [[Persistent]] or
- * [[ResequenceableBatch]] messages. In this case an `UnsupportedOperationException` is
+ * [[PersistentBatch]] messages. In this case an `UnsupportedOperationException` is
  * thrown by the processor.
  */
 @deprecated("AbstractEventsourcedProcessor will be removed in 2.4.x, instead extend the API equivalent `akka.persistence.PersistentProcessor`", since = "2.3.4")

--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -85,6 +85,7 @@ object Persistent {
   /**
    * [[Persistent]] extractor.
    */
+  @deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
   def unapply(persistent: Persistent): Option[(Any, Long)] =
     Some((persistent.payload, persistent.sequenceNr))
 }
@@ -113,6 +114,7 @@ object ConfirmablePersistent {
   /**
    * [[ConfirmablePersistent]] extractor.
    */
+  @deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
   def unapply(persistent: ConfirmablePersistent): Option[(Any, Long, Int)] =
     Some((persistent.payload, persistent.sequenceNr, persistent.redeliveries))
 }
@@ -328,6 +330,7 @@ private[persistence] case class PersistentImpl(
 /**
  * INTERNAL API.
  */
+@deprecated("ConfirmablePersistent will be removed, see `AtLeastOnceDelivery` instead.", since = "2.3.4")
 private[persistence] case class ConfirmablePersistentImpl(
   payload: Any,
   sequenceNr: Long,
@@ -357,6 +360,7 @@ private[persistence] case class ConfirmablePersistentImpl(
 /**
  * INTERNAL API.
  */
+@deprecated("ConfirmablePersistent will be removed, see `AtLeastOnceDelivery` instead.", since = "2.3.4")
 private[persistence] object ConfirmablePersistentImpl {
   def apply(persistent: PersistentRepr, confirmMessage: Delivered, confirmTarget: ActorRef = null): ConfirmablePersistentImpl =
     ConfirmablePersistentImpl(persistent.payload, persistent.sequenceNr, persistent.persistenceId, persistent.deleted, persistent.redeliveries, persistent.confirms, confirmMessage, confirmTarget, persistent.sender)

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentView.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentView.scala
@@ -10,14 +10,52 @@ import akka.actor._
 import akka.persistence.JournalProtocol._
 
 /**
- * A view replicates the persistent message stream of a processor. Implementation classes receive the
- * message stream as [[Persistent]] messages. These messages can be processed to update internal state
- * in order to maintain an (eventual consistent) view of the state of the corresponding processor. A
- * view can also run on a different node, provided that a replicated journal is used. Implementation
- * classes reference a processor by implementing `persistenceId`.
+ * Instructs a [[PersistentView]] to update itself. This will run a single incremental message replay with
+ * all messages from the corresponding persistent id's journal that have not yet been consumed by the view.
+ * To update a view with messages that have been written after handling this request, another `Update`
+ * request must be sent to the view.
  *
- * Views can also store snapshots of internal state by calling [[#saveSnapshot]]. The snapshots of a view
- * are independent of those of the referenced processor. During recovery, a saved snapshot is offered
+ * @param await if `true`, processing of further messages sent to the view will be delayed until the
+ *              incremental message replay, triggered by this update request, completes. If `false`,
+ *              any message sent to the view may interleave with replayed [[Persistent]] message
+ *              stream.
+ * @param replayMax maximum number of messages to replay when handling this update request. Defaults
+ *                  to `Long.MaxValue` (i.e. no limit).
+ */
+@SerialVersionUID(1L)
+case class Update(await: Boolean = false, replayMax: Long = Long.MaxValue)
+
+case object Update {
+  /**
+   * Java API.
+   */
+  def create() =
+    Update()
+
+  /**
+   * Java API.
+   */
+  def create(await: Boolean) =
+    Update(await)
+
+  /**
+   * Java API.
+   */
+  def create(await: Boolean, replayMax: Long) =
+    Update(await, replayMax)
+}
+
+/**
+ * A view replicates the persistent message stream of a [[PersistentActor]]. Implementation classes receive
+ * the message stream directly from the Journal. These messages can be processed to update internal state
+ * in order to maintain an (eventual consistent) view of the state of the corresponding processor. A
+ * persistent view can also run on a different node, provided that a replicated journal is used.
+ *
+ * Implementation classes refer to a persistent actors' message stream by implementing `persistenceId`
+ * with the corresponding (shared) identifier value.
+ *
+ * Views can also store snapshots of internal state by calling [[autoUpdate]]. The snapshots of a view
+ * are independent of those of the referenced persistent actor. During recovery, a saved snapshot is offered
  * to the view with a [[SnapshotOffer]] message, followed by replayed messages, if any, that are younger
  * than the snapshot. Default is to offer the latest saved snapshot.
  *
@@ -27,13 +65,10 @@ import akka.persistence.JournalProtocol._
  * `akka.persistence.view.auto-update-interval` configuration key. Applications may trigger additional
  * view updates by sending the view [[Update]] requests. See also methods
  *
- *  - [[#autoUpdate]] for turning automated updates on or off
- *  - [[#autoUpdateReplayMax]] for limiting the number of replayed messages per view update cycle
- *
- * Views can also use channels to communicate with destinations in the same way as processors can do.
+ *  - [[autoUpdate]] for turning automated updates on or off
+ *  - [[autoUpdateReplayMax]] for limiting the number of replayed messages per view update cycle
  */
-@deprecated("Use `akka.persistence.PersistentView` instead.", since = "2.3.4")
-trait View extends Actor with Recovery {
+trait PersistentView extends Actor with Recovery {
   import context.dispatcher
 
   /**
@@ -44,7 +79,7 @@ trait View extends Actor with Recovery {
    */
   private[persistence] override def replayStarted(await: Boolean) = new State {
     private var delegateAwaiting = await
-    private var delegate = View.super.replayStarted(await)
+    private var delegate = PersistentView.super.replayStarted(await)
 
     override def toString: String = delegate.toString
 
@@ -52,7 +87,7 @@ trait View extends Actor with Recovery {
       case Update(false, _) ⇒ // ignore
       case u @ Update(true, _) if !delegateAwaiting ⇒
         delegateAwaiting = true
-        delegate = View.super.replayStarted(await = true)
+        delegate = PersistentView.super.replayStarted(await = true)
         delegate.aroundReceive(receive, u)
       case other ⇒
         delegate.aroundReceive(receive, other)
@@ -97,15 +132,40 @@ trait View extends Actor with Recovery {
     if (await) receiverStash.unstashAll()
   }
 
-  private val _viewId = extension.persistenceId(self)
+  /**
+   * INTERNAL API
+   * WARNING: This implementation UNWRAPS PERSISTENT() before delivering to the receive block.
+   */
+  override private[persistence] def withCurrentPersistent(persistent: Persistent)(body: Persistent ⇒ Unit): Unit =
+    super.withCurrentPersistent(persistent) { p ⇒
+      receive.applyOrElse(p.payload, unhandled)
+    }
+
   private val viewSettings = extension.settings.view
 
   private var schedule: Option[Cancellable] = None
 
   /**
-   * View id. Defaults to this view's path and can be overridden.
+   * View id is used as identifier for snapshots performed by this [[PersistentView]].
+   * This allows the View to keep separate snapshots of data than the [[PersistentActor]] originating the message stream.
+   *
+   *
+   * The usual case is to have a *different* id set as `viewId` than `persistenceId`,
+   * although it is possible to share the same id with an [[PersistentActor]] - for example to decide about snapshots
+   * based on some average or sum, calculated by this view.
+   *
+   * Example:
+   * {{{
+   *    class SummingView extends PersistentView {
+   *      override def persistenceId = "count-123"
+   *      override def viewId        = "count-123-sum" // this view is performing summing,
+   *                                                   // so this view's snapshots reside under the "-sum" suffixed id
+   *
+   *      // ...
+   *    }
+   * }}}
    */
-  def viewId: String = _viewId
+  def viewId: String
 
   /**
    * Returns `viewId`.
@@ -113,9 +173,11 @@ trait View extends Actor with Recovery {
   def snapshotterId: String = viewId
 
   /**
-   * Persistence id. Defaults to this persistent-actors's path and can be overridden.
+   * If `true`, the currently processed message was persisted (is sent from the Journal).
+   * If `false`, the currently processed message comes from another actor (from "user-land").
    */
-  override def persistenceId: String = processorId
+  def isPersistent: Boolean =
+    currentPersistentMessage.isDefined
 
   /**
    * If `true`, this view automatically updates itself with an interval specified by `autoUpdateInterval`.
@@ -164,15 +226,13 @@ trait View extends Actor with Recovery {
 /**
  * Java API.
  *
- * @see [[View]]
+ * @see [[PersistentView]]
  */
-@deprecated("Use `akka.persistence.UntypedPersistentView instead.", since = "2.3.4")
-abstract class UntypedView extends UntypedActor with View
+abstract class UntypedPersistentView extends UntypedActor with PersistentView
 
 /**
  * Java API: compatible with lambda expressions (to be used with [[akka.japi.pf.ReceiveBuilder]])
  *
- * @see [[View]]
+ * @see [[PersistentView]]
  */
-@deprecated("Use `akka.persistence.AbstractPersistentView` instead.", since = "2.3.4")
-abstract class AbstractView extends AbstractActor with View
+abstract class AbstractPersistentView extends AbstractActor with PersistentView

--- a/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
@@ -76,7 +76,12 @@ trait Cleanup { this: AkkaSpec ⇒
   }
 }
 
+@deprecated("Use NamedPersistentActor instead.", since = "2.3.4")
 abstract class NamedProcessor(name: String) extends Processor {
+  override def persistenceId: String = name
+}
+
+abstract class NamedPersistentActor(name: String) extends PersistentActor {
   override def persistenceId: String = name
 }
 

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
@@ -496,15 +496,13 @@ public class LambdaPersistenceDocTest {
 
   static Object o11 = new Object() {
     //#view
-    class MyView extends AbstractView {
-      @Override
-      public String persistenceId() {
-        return "some-persistence-id";
-      }
+    class MyView extends AbstractPersistentView {
+      @Override public String persistenceId() { return "some-persistence-id"; }
+      @Override public String viewId() { return "some-persistence-id-view"; }
 
       public MyView() {
         receive(ReceiveBuilder.
-          match(Persistent.class, persistent -> {
+          match(Object.class, p -> isPersistent(),  persistent -> {
             // ...
           }).build()
         );

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ViewExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ViewExample.java
@@ -45,26 +45,21 @@ public class ViewExample {
     }
   }
 
-  public static class ExampleView extends AbstractView {
+  public static class ExampleView extends AbstractPersistentView {
 
     private int numReplicated = 0;
 
-    @Override
-    public String viewId() {
+    @Override public String persistenceId() { return "persistentActor-5"; }
+    @Override public String viewId() {
       return "view-5";
-    }
-
-    @Override
-    public String persistenceId() {
-      return "persistentActor-5";
     }
 
     public ExampleView() {
       receive(ReceiveBuilder.
-        match(Persistent.class, p -> {
+        match(Object.class, m -> isPersistent(), msg -> {
           numReplicated += 1;
           System.out.println(String.format("view received %s (num replicated = %d)",
-            p.payload(),
+            msg,
             numReplicated));
         }).
         match(SnapshotOffer.class, so -> {

--- a/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
@@ -81,7 +81,7 @@ snapshotting to reduce recovery time.
 
 <p>
 To run this example, go to the <a href="#run" class="shortcut">Run</a> tab, and run the application main class
-<b><code>sample.persistence.ViewExample</code></b>.
+<b><code>sample.persistence.PersistentViewExample</code></b>.
 </p>
 </div>
 

--- a/akka-samples/akka-sample-persistence-java/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java/tutorial/index.html
@@ -81,7 +81,7 @@ snapshotting to reduce recovery time.
 
 <p>
 To run this example, go to the <a href="#run" class="shortcut">Run</a> tab, and run the application main class
-<b><code>sample.persistence.ViewExample</code></b>.
+<b><code>sample.persistence.PersistentViewExample</code></b>.
 </p>
 </div>
 

--- a/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/ViewExample.scala
+++ b/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/ViewExample.scala
@@ -24,11 +24,10 @@ object ViewExample extends App {
     }
   }
 
-  class ExampleView extends View {
+  class ExampleView extends PersistentView {
     private var numReplicated = 0
 
     override def persistenceId: String = "persistentActor-5"
-
     override def viewId = "view-5"
 
     def receive = {
@@ -37,9 +36,11 @@ object ViewExample extends App {
       case SnapshotOffer(metadata, snapshot: Int) =>
         numReplicated = snapshot
         println(s"view received snapshot offer ${snapshot} (metadata = ${metadata})")
-      case Persistent(payload, _) =>
+      case payload if isPersistent =>
         numReplicated += 1
-        println(s"view received ${payload} (num replicated = ${numReplicated})")
+        println(s"view received persistent ${payload} (num replicated = ${numReplicated})")
+      case payload =>
+        println(s"view received not persitent ${payload}")
     }
 
   }


### PR DESCRIPTION
A PersistentView works the same way as View did previously, except:
- it requires an `peristenceId` (no default is provided)
- messages given to `receive` are NOT wrapped in Persistent()

https://github.com/akka/akka/issues/15424
