### PR TITLE
Per abstract persistence id ktoso

### DIFF
--- a/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
@@ -133,6 +133,9 @@ public class PersistenceDocTest {
         }
         
         class MyProcessor5 extends UntypedPersistentActor {
+            @Override
+            public String persistenceId() { return "persistence-id"; }
+
             //#recovery-completed
           
             @Override
@@ -356,6 +359,9 @@ public class PersistenceDocTest {
     static Object o8 = new Object() {
         //#reliable-event-delivery
         class MyPersistentActor extends UntypedPersistentActor {
+            @Override
+            public String persistenceId() { return "some-persistence-id"; }
+
             private ActorRef destination;
             private ActorRef channel;
 
@@ -394,6 +400,8 @@ public class PersistenceDocTest {
     static Object o9 = new Object() {
         //#persist-async
         class MyPersistentActor extends UntypedPersistentActor {
+            @Override
+            public String persistenceId() { return "some-persistence-id"; }
 
             @Override
             public void onReceiveRecover(Object msg) {
@@ -441,6 +449,8 @@ public class PersistenceDocTest {
     static Object o10 = new Object() {
         //#defer
         class MyPersistentActor extends UntypedPersistentActor {
+            @Override
+            public String persistenceId() { return "some-persistence-id"; }
 
             @Override
             public void onReceiveRecover(Object msg) {
@@ -487,9 +497,7 @@ public class PersistenceDocTest {
         //#view
         class MyView extends UntypedPersistentView {
             @Override
-            public String persistenceId() {
-                return "some-persistence-id";
-            }
+            public String persistenceId() { return "some-persistence-id"; }
 
             @Override
             public void onReceive(Object message) throws Exception {

--- a/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
@@ -485,7 +485,7 @@ public class PersistenceDocTest {
 
     static Object o11 = new Object() {
         //#view
-        class MyView extends UntypedView {
+        class MyView extends UntypedPersistentView {
             @Override
             public String persistenceId() {
                 return "some-persistence-id";
@@ -493,8 +493,12 @@ public class PersistenceDocTest {
 
             @Override
             public void onReceive(Object message) throws Exception {
-                if (message instanceof Persistent) {
-                    // ...
+                if (isPersistent()) {
+                    // handle message from Journal...
+                } else if (message instanceof String) {
+                    // handle message from user...
+                } else {
+                  unhandled(message);
                 }
             }
         }

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -31,10 +31,11 @@ Changes in Akka 2.3.4
 
 In Akka 2.3.4 several of the concepts of the earlier versions were collapsed and simplified.
 In essence; ``Processor`` and ``EventsourcedProcessor`` are replaced by ``PersistentActor``. ``Channel``
-and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. See full details of the changes in the 
-:ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`. The old classes are still included, and deprecated,
-for a while to make the transition smooth. In case you need the old documentation it is located 
-`here <http://doc.akka.io/docs/akka/2.3.3/java/lambda-persistence.html#persistence-lambda-java>`_.
+and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. ``View`` is replaced by ``PersistentView``.
+
+See full details of the changes in the :ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`.
+The old classes are still included, and deprecated, for a while to make the transition smooth.
+In case you need the old documentation it is located `here <http://doc.akka.io/docs/akka/2.3.3/java/lambda-persistence.html#persistence-lambda-java>`_.
 
 Dependencies
 ============
@@ -55,7 +56,7 @@ Architecture
   When a persistent actor is started or restarted, journaled messages are replayed to that actor, so that it can
   recover internal state from these messages.
 
-* *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
+* *AbstractPersistentView*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
   persistent actor. A view itself does not journal new messages, instead, it updates internal state only from a persistent actor's
   replicated message stream.
   
@@ -270,12 +271,12 @@ to Akka persistence will allow to replay messages that have been marked as delet
 purposes, for example. To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors should call the ``deleteMessages`` method.
 
-.. _views-java-lambda:
+.. _persistent-views-java-lambda:
 
 Views
 =====
 
-Views can be implemented by extending the ``AbstractView`` abstract class, implement the ``persistenceId`` method
+Persistent views can be implemented by extending the ``AbstractView`` abstract class, implement the ``persistenceId`` method
 and setting the “initial behavior” in the constructor by calling the :meth:`receive` method.
 
 .. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#view
@@ -285,14 +286,18 @@ the referenced persistent actor is actually running. Views read messages from a 
 persistent actor is started later and begins to write new messages, the corresponding view is updated automatically, by
 default.
 
+It is possible to determine if a message was sent from the Journal or from another actor in user-land by calling the ``isPersistent``
+method. Having that said, very often you need this information at all and can simply apply the same logic to both cases
+(skip the ``if isPersistent`` check).
+
 Updates
 -------
 
-The default update interval of all views of an actor system is configurable:
+The default update interval of all persistent views of an actor system is configurable:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update-interval
 
-``View`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
+``AbstractPersistentView`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
 interval for a specific view class or view instance. Applications may also trigger additional updates at
 any time by sending a view an ``Update`` message.
 
@@ -303,7 +308,7 @@ incremental message replay, triggered by that update request, completed. If set 
 following the update request may interleave with the replayed message stream. Automated updates always run with
 ``await = false``.
 
-Automated updates of all views of an actor system can be turned off by configuration:
+Automated updates of all persistent views of an actor system can be turned off by configuration:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update
 
@@ -315,20 +320,20 @@ of replayed messages for manual updates can be limited with the ``replayMax`` pa
 Recovery
 --------
 
-Initial recovery of views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
+Initial recovery of persistent views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
 to self). The maximum number of replayed messages during initial recovery is determined by ``autoUpdateReplayMax``.
-Further possibilities to customize initial recovery are explained in section :ref:`recovery-java-lambda`.
+Further possibilities to customize initial recovery are explained in section :ref:`recovery-java`.
 
 .. _persistence-identifiers-java-lambda:
 
 Identifiers
 -----------
 
-A view must have an identifier that doesn't change across different actor incarnations. It defaults to the
+A persistent view must have an identifier that doesn't change across different actor incarnations. It defaults to the
 ``String`` representation of the actor path without the address part and can be obtained via the ``viewId``
 method.
 
-Applications can customize a view's id by specifying an actor name during view creation. This changes that view's
+Applications can customize a view's id by specifying an actor name during view creation. This changes that persistent view's
 name in its actor hierarchy and hence influences only part of the view id. To fully customize a view's id, the
 ``viewId`` method must be overridden. Overriding ``viewId`` is the recommended way to generate stable identifiers.
 
@@ -348,7 +353,7 @@ Snapshots
 =========
 
 Snapshots can dramatically reduce recovery times of persistent actors and views. The following discusses snapshots
-in context of persistent actors but this is also applicable to views.
+in context of persistent actors but this is also applicable to persistent views.
 
 Persistent actor can save snapshots of internal state by calling the  ``saveSnapshot`` method. If saving of a snapshot
 succeeds, the persistent actor receives a ``SaveSnapshotSuccess`` message, otherwise a ``SaveSnapshotFailure`` message

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -36,10 +36,11 @@ Changes in Akka 2.3.4
 
 In Akka 2.3.4 several of the concepts of the earlier versions were collapsed and simplified.
 In essence; ``Processor`` and ``EventsourcedProcessor`` are replaced by ``PersistentActor``. ``Channel``
-and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. See full details of the changes in the 
-:ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`. The old classes are still included, and deprecated,
-for a while to make the transition smooth. In case you need the old documentation it is located 
-`here <http://doc.akka.io/docs/akka/2.3.3/java/persistence.html>`_. 
+and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. ``View`` is replaced by ``PersistentView``.
+
+See full details of the changes in the :ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`.
+The old classes are still included, and deprecated, for a while to make the transition smooth.
+In case you need the old documentation it is located `here <http://doc.akka.io/docs/akka/2.3.3/java/persistence.html>`_.
 
 Dependencies
 ============
@@ -60,7 +61,7 @@ Architecture
   When a persistent actor is started or restarted, journaled messages are replayed to that actor, so that it can
   recover internal state from these messages.
 
-* *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
+* *UntypedPersistentView*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
   persistent actor. A view itself does not journal new messages, instead, it updates internal state only from a persistent actor's
   replicated message stream.
 
@@ -275,13 +276,13 @@ to Akka persistence will allow to replay messages that have been marked as delet
 purposes, for example. To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors should call the ``deleteMessages`` method.
 
-.. _views-java:
+.. _persistent-views-java:
 
-Views
-=====
+Persistent Views
+================
 
-Views can be implemented by extending the ``UntypedView`` trait  and implementing the ``onReceive`` and the ``persistenceId``
-methods.
+Persistent views can be implemented by extending the ``UntypedPersistentView`` trait  and implementing the ``onReceive``
+and the ``persistenceId`` methods.
 
 .. includecode:: code/docs/persistence/PersistenceDocTest.java#view
 
@@ -290,14 +291,18 @@ the referenced persistent actor is actually running. Views read messages from a 
 persistent actor is started later and begins to write new messages, the corresponding view is updated automatically, by
 default.
 
+It is possible to determine if a message was sent from the Journal or from another actor in user-land by calling the ``isPersistent``
+method. Having that said, very often you need this information at all and can simply apply the same logic to both cases
+(skip the ``if isPersistent`` check).
+
 Updates
 -------
 
-The default update interval of all views of an actor system is configurable:
+The default update interval of all persistent views of an actor system is configurable:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update-interval
 
-``View`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
+``UntypedPersistentView`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
 interval for a specific view class or view instance. Applications may also trigger additional updates at
 any time by sending a view an ``Update`` message.
 
@@ -308,7 +313,7 @@ incremental message replay, triggered by that update request, completed. If set 
 following the update request may interleave with the replayed message stream. Automated updates always run with
 ``await = false``.
 
-Automated updates of all views of an actor system can be turned off by configuration:
+Automated updates of all persistent views of an actor system can be turned off by configuration:
 
 .. includecode:: ../scala/code/docs/persistence/PersistenceDocSpec.scala#auto-update
 
@@ -320,7 +325,7 @@ of replayed messages for manual updates can be limited with the ``replayMax`` pa
 Recovery
 --------
 
-Initial recovery of views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
+Initial recovery of persistent views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
 to self). The maximum number of replayed messages during initial recovery is determined by ``autoUpdateReplayMax``.
 Further possibilities to customize initial recovery are explained in section :ref:`recovery-java`.
 
@@ -329,11 +334,11 @@ Further possibilities to customize initial recovery are explained in section :re
 Identifiers
 -----------
 
-A view must have an identifier that doesn't change across different actor incarnations. It defaults to the
+A persistent view must have an identifier that doesn't change across different actor incarnations. It defaults to the
 ``String`` representation of the actor path without the address part and can be obtained via the ``viewId``
 method.
 
-Applications can customize a view's id by specifying an actor name during view creation. This changes that view's
+Applications can customize a view's id by specifying an actor name during view creation. This changes that persistent view's
 name in its actor hierarchy and hence influences only part of the view id. To fully customize a view's id, the
 ``viewId`` method must be overridden. Overriding ``viewId`` is the recommended way to generate stable identifiers.
 
@@ -353,7 +358,7 @@ Snapshots
 =========
 
 Snapshots can dramatically reduce recovery times of persistent actor and views. The following discusses snapshots
-in context of persistent actor but this is also applicable to views.
+in context of persistent actor but this is also applicable to persistent views.
 
 Persistent actor can save snapshots of internal state by calling the  ``saveSnapshot`` method. If saving of a snapshot
 succeeds, the persistent actor receives a ``SaveSnapshotSuccess`` message, otherwise a ``SaveSnapshotFailure`` message

--- a/akka-docs/rst/project/migration-guide-eventsourced-2.3.x.rst
+++ b/akka-docs/rst/project/migration-guide-eventsourced-2.3.x.rst
@@ -137,7 +137,7 @@ Views
 **Akka Persistence:** ``View``
 
 - Receives the message stream written by a ``PersistentActor`` by reading it directly from the
-  journal (see :ref:`views`). Alternative to using channels. Useful in situations where actors shall receive a
+  journal (see :ref:`persistent-views`). Alternative to using channels. Useful in situations where actors shall receive a
   persistent message stream in correct order without duplicates.
 - Supports :ref:`snapshots`.
 

--- a/akka-docs/rst/project/migration-guide-persistence-experimental-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-persistence-experimental-2.3.x-2.4.x.rst
@@ -15,22 +15,34 @@ Migrating to ``2.4.x`` is as simple as changing all your classes to extending  `
 
 Replace all classes like::
 
-    class DeprecatedProcessor extends EventsourcedProcessor { /*...*/ }
+    class DeprecatedProcessor extends EventsourcedProcessor {
+      def processorId = "id"
+      /*...*/
+    }
 
 To extend ``PersistentActor``::
 
-    class NewPersistentProcessor extends PersistentActor { /*...*/ }
+    class NewPersistentProcessor extends PersistentActor {
+      def persistenceId = "id"
+      /*...*/
+    }
 
 
-Renamed processorId to persistenceId
-====================================
+Changed processorId to (abstract) persistenceId
+===============================================
 In Akka Persistence ``2.3.3`` and previously, the main building block of applications were Processors.
 Persistent messages, as well as processors implemented the ``processorId`` method to identify which persistent entity a message belonged to.
 
 This concept remains the same in Akka ``2.3.4``, yet we rename ``processorId`` to ``persistenceId`` because Processors will be removed,
 and persistent messages can be used from different classes not only ``PersistentActor`` (Views, directly from Journals etc).
 
-We provided the renamed method also on already deprecated classes (Channels), so you can simply apply a global rename of ``processorId`` to ``persistenceId``.
+Please note that ``processorId`` is **abstract** in the new API classes (``PersistentActor`` and ``PersistentView``),
+and we do **not** provide a default (actor-path derrived) value for it like we did for ``processorId``.
+The rationale behind this change being stricter de-coupling of your Actor hierarchy and the logical "which persistent entity this actor represents".
+A longer discussion on this subject can be found on `issue #15436 <https://github.com/akka/akka/issues/15436>`_ on github.
+
+We provided the renamed method also on already deprecated classes (Channels),
+so you can simply apply a global rename of ``processorId`` to ``persistenceId``.
 
 Plugin APIs: Renamed PersistentId to PersistenceId
 ==================================================
@@ -76,6 +88,8 @@ the throughput
 Now deprecated code using Processor::
 
     class OldProcessor extends Processor {
+      override def processorId = "user-wallet-1337"
+
       def receive = {
         case Persistent(cmd) => sender() ! cmd
       }
@@ -84,6 +98,8 @@ Now deprecated code using Processor::
 Replacement code, with the same semantics, using PersistentActor::
 
     class NewProcessor extends PersistentActor {
+      override def persistenceId = "user-wallet-1337"
+
       def receiveCommand = {
         case cmd =>
           persistAsync(cmd) { e => sender() ! e }
@@ -100,3 +116,42 @@ any of the problems Futures have when closing over the sender reference.
 Using the``PersistentActor`` instead of ``Processor`` also shifts the responsibility of deciding if a message should be persisted
 to the receiver instead of the sender of the message. Previously, using ``Processor``, clients would have to wrap messages as ``Persistent(cmd)``
 manually, as well as have to be aware of the receiver being a ``Processor``, which didn't play well with transparency of the ActorRefs in general.
+
+Renamed View to PersistentView, which receives plain messages (Persistent() wrapper is gone)
+============================================================================================
+Views used to receive messages wrapped as ``Persistent(payload, seqNr)``, this is no longer the case and views receive
+the ``payload`` as message from the ``Journal`` directly. The rationale here is that the wrapper aproach was inconsistent
+with the other Akka Persistence APIs and also is not easily "discoverable" (you have to *know* you will be getting this Persistent wrapper).
+
+Instead, since ``2.3.4``, views get plain messages, and can use additional methods provided by the ``View`` to identify if a message
+was sent from the Journal (had been played back to the view). So if you had code like this::
+
+    class AverageView extends View {
+      override def processorId = "average-view"
+
+      def receive = {
+        case Persistent(msg, seqNr) =>
+          // from Journal
+
+        case msg =>
+          // from user-land
+    }
+
+You should update it to extend ``PersistentView`` instead::
+
+    class AverageView extends PersistentView {
+      override def persistenceId = "average-view"
+
+      def receive = {
+        case msg if isPersistent =>
+          // from Journal
+          val seqNr = lastSequenceNr // in case you require the sequence number
+
+        case msg =>
+          // from user-land
+      }
+    }
+
+In case you need to obtain the current sequence number the view is looking at, you can use the ``lastSequenceNr`` method.
+It is equivalent to "current sequence number", when ``isPersistent`` returns true, otherwise it yields the sequence number
+of the last persistent message that this view was updated with.

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -31,10 +31,11 @@ Changes in Akka 2.3.4
 
 In Akka 2.3.4 several of the concepts of the earlier versions were collapsed and simplified.
 In essence; ``Processor`` and ``EventsourcedProcessor`` are replaced by ``PersistentActor``. ``Channel``
-and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. See full details of the changes in the 
-:ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`. The old classes are still included, and deprecated,
-for a while to make the transition smooth. In case you need the old documentation it is located 
-`here <http://doc.akka.io/docs/akka/2.3.3/scala/persistence.html>`_. 
+and ``PersistentChannel`` are replaced by ``AtLeastOnceDelivery``. ``View`` is replaced by ``PersistentView``.
+
+See full details of the changes in the :ref:`migration-guide-persistence-experimental-2.3.x-2.4.x`.
+The old classes are still included, and deprecated, for a while to make the transition smooth.
+In case you need the old documentation it is located `here <http://doc.akka.io/docs/akka/2.3.3/scala/persistence.html>`_.
 
 
 Dependencies
@@ -52,7 +53,7 @@ Architecture
   When a persistent actor is started or restarted, journaled messages are replayed to that actor, so that it can
   recover internal state from these messages.
 
-* *View*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
+* *PersistentView*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
   persistent actor. A view itself does not journal new messages, instead, it updates internal state only from a persistent actor's
   replicated message stream.
 
@@ -274,12 +275,12 @@ persistent actors should call the ``deleteMessages`` method.
 
 
 
-.. _views:
+.. _persistent-views:
 
-Views
-=====
+Persistent Views
+================
 
-Views can be implemented by extending the ``View`` trait  and implementing the ``receive`` and the ``persistenceId``
+Persistent views can be implemented by extending the ``PersistentView`` trait  and implementing the ``receive`` and the ``persistenceId``
 methods.
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#view
@@ -289,6 +290,10 @@ the referenced persistent actor is actually running. Views read messages from a 
 persistent actor is started later and begins to write new messages, the corresponding view is updated automatically, by
 default.
 
+It is possible to determine if a message was sent from the Journal or from another actor in user-land by calling the ``isPersistent``
+method. Having that said, very often you need this information at all and can simply apply the same logic to both cases
+(skip the ``if isPersistent`` check).
+
 Updates
 -------
 
@@ -296,7 +301,7 @@ The default update interval of all views of an actor system is configurable:
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#auto-update-interval
 
-``View`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
+``PersistentView`` implementation classes may also override the ``autoUpdateInterval`` method to return a custom update
 interval for a specific view class or view instance. Applications may also trigger additional updates at
 any time by sending a view an ``Update`` message.
 
@@ -307,7 +312,7 @@ incremental message replay, triggered by that update request, completed. If set 
 following the update request may interleave with the replayed message stream. Automated updates always run with
 ``await = false``.
 
-Automated updates of all views of an actor system can be turned off by configuration:
+Automated updates of all persistent views of an actor system can be turned off by configuration:
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#auto-update
 
@@ -319,7 +324,7 @@ of replayed messages for manual updates can be limited with the ``replayMax`` pa
 Recovery
 --------
 
-Initial recovery of views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
+Initial recovery of persistent views works in the very same way as for a persistent actor (i.e. by sending a ``Recover`` message
 to self). The maximum number of replayed messages during initial recovery is determined by ``autoUpdateReplayMax``.
 Further possibilities to customize initial recovery are explained in section :ref:`recovery`.
 
@@ -328,11 +333,11 @@ Further possibilities to customize initial recovery are explained in section :re
 Identifiers
 -----------
 
-A view must have an identifier that doesn't change across different actor incarnations. It defaults to the
+A persistent view must have an identifier that doesn't change across different actor incarnations. It defaults to the
 ``String`` representation of the actor path without the address part and can be obtained via the ``viewId``
 method.
 
-Applications can customize a view's id by specifying an actor name during view creation. This changes that view's
+Applications can customize a view's id by specifying an actor name during view creation. This changes that persistent view's
 name in its actor hierarchy and hence influences only part of the view id. To fully customize a view's id, the
 ``viewId`` method must be overridden. Overriding ``viewId`` is the recommended way to generate stable identifiers.
 
@@ -383,7 +388,7 @@ Snapshots
 =========
 
 Snapshots can dramatically reduce recovery times of persistent actors and views. The following discusses snapshots
-in context of persistent actors but this is also applicable to views.
+in context of persistent actors but this is also applicable to persistent views.
 
 Persistent actors can save snapshots of internal state by calling the  ``saveSnapshot`` method. If saving of a snapshot
 succeeds, the persistent actor receives a ``SaveSnapshotSuccess`` message, otherwise a ``SaveSnapshotFailure`` message

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -6,11 +6,11 @@ package akka.persistence
 
 import java.lang.{ Iterable ⇒ JIterable }
 
-import scala.collection.immutable
-
+import akka.actor.{ AbstractActor, UntypedActor }
 import akka.japi.{ Procedure, Util }
 import akka.persistence.JournalProtocol._
-import akka.actor.{ Actor, ActorRef, AbstractActor }
+
+import scala.collection.immutable
 
 /**
  * INTERNAL API.
@@ -388,7 +388,6 @@ trait EventsourcedProcessor extends Processor with Eventsourced {
 /**
  * An persistent Actor - can be used to implement command or event sourcing.
  */
-// TODO remove EventsourcedProcessor / Processor #15230
 trait PersistentActor extends ProcessorImpl with Eventsourced {
   def receive = receiveCommand
 }
@@ -396,7 +395,8 @@ trait PersistentActor extends ProcessorImpl with Eventsourced {
 /**
  * Java API: an persistent actor - can be used to implement command or event sourcing.
  */
-abstract class UntypedPersistentActor extends PersistentActor with Eventsourced {
+abstract class UntypedPersistentActor extends UntypedActor with ProcessorImpl with Eventsourced {
+
   final def onReceive(message: Any) = onReceiveCommand(message)
 
   final def receiveRecover: Receive = {
@@ -542,7 +542,7 @@ abstract class UntypedPersistentActor extends PersistentActor with Eventsourced 
    * communication with other actors). On successful validation, one or more events are
    * derived from a command and these events are then persisted by calling `persist`.
    * Commands sent to event sourced processors must not be [[Persistent]] or
-   * [[ResequenceableBatch]] messages. In this case an `UnsupportedOperationException` is
+   * [[PersistentBatch]] messages. In this case an `UnsupportedOperationException` is
    * thrown by the processor.
    */
   @throws(classOf[Exception])
@@ -552,7 +552,7 @@ abstract class UntypedPersistentActor extends PersistentActor with Eventsourced 
 /**
  * Java API: an persistent actor - can be used to implement command or event sourcing.
  */
-abstract class AbstractPersistentActor extends PersistentActor with Eventsourced {
+abstract class AbstractPersistentActor extends AbstractActor with PersistentActor with Eventsourced {
 
   /**
    * Java API: asynchronously persists `event`. On successful persistence, `handler` is called with the
@@ -680,7 +680,7 @@ abstract class UntypedEventsourcedProcessor extends UntypedPersistentActor {
  * communication with other actors). On successful validation, one or more events are
  * derived from a command and these events are then persisted by calling `persist`.
  * Commands sent to event sourced processors must not be [[Persistent]] or
- * [[ResequenceableBatch]] messages. In this case an `UnsupportedOperationException` is
+ * [[PersistentBatch]] messages. In this case an `UnsupportedOperationException` is
  * thrown by the processor.
  */
 @deprecated("AbstractEventsourcedProcessor will be removed in 2.4.x, instead extend the API equivalent `akka.persistence.PersistentProcessor`", since = "2.3.4")

--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -85,6 +85,7 @@ object Persistent {
   /**
    * [[Persistent]] extractor.
    */
+  @deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
   def unapply(persistent: Persistent): Option[(Any, Long)] =
     Some((persistent.payload, persistent.sequenceNr))
 }
@@ -113,6 +114,7 @@ object ConfirmablePersistent {
   /**
    * [[ConfirmablePersistent]] extractor.
    */
+  @deprecated("Use akka.persistence.PersistentActor instead", since = "2.3.4")
   def unapply(persistent: ConfirmablePersistent): Option[(Any, Long, Int)] =
     Some((persistent.payload, persistent.sequenceNr, persistent.redeliveries))
 }
@@ -328,6 +330,7 @@ private[persistence] case class PersistentImpl(
 /**
  * INTERNAL API.
  */
+@deprecated("ConfirmablePersistent will be removed, see `AtLeastOnceDelivery` instead.", since = "2.3.4")
 private[persistence] case class ConfirmablePersistentImpl(
   payload: Any,
   sequenceNr: Long,
@@ -357,6 +360,7 @@ private[persistence] case class ConfirmablePersistentImpl(
 /**
  * INTERNAL API.
  */
+@deprecated("ConfirmablePersistent will be removed, see `AtLeastOnceDelivery` instead.", since = "2.3.4")
 private[persistence] object ConfirmablePersistentImpl {
   def apply(persistent: PersistentRepr, confirmMessage: Delivered, confirmTarget: ActorRef = null): ConfirmablePersistentImpl =
     ConfirmablePersistentImpl(persistent.payload, persistent.sequenceNr, persistent.persistenceId, persistent.deleted, persistent.redeliveries, persistent.confirms, confirmMessage, confirmTarget, persistent.sender)

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentView.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentView.scala
@@ -10,14 +10,52 @@ import akka.actor._
 import akka.persistence.JournalProtocol._
 
 /**
- * A view replicates the persistent message stream of a processor. Implementation classes receive the
- * message stream as [[Persistent]] messages. These messages can be processed to update internal state
+ * Instructs a [[PersistentView]] to update itself. This will run a single incremental message replay with
+ * all messages from the corresponding persistent id's journal that have not yet been consumed by the view.
+ * To update a view with messages that have been written after handling this request, another `Update`
+ * request must be sent to the view.
+ *
+ * @param await if `true`, processing of further messages sent to the view will be delayed until the
+ *              incremental message replay, triggered by this update request, completes. If `false`,
+ *              any message sent to the view may interleave with replayed [[Persistent]] message
+ *              stream.
+ * @param replayMax maximum number of messages to replay when handling this update request. Defaults
+ *                  to `Long.MaxValue` (i.e. no limit).
+ */
+@SerialVersionUID(1L)
+case class Update(await: Boolean = false, replayMax: Long = Long.MaxValue)
+
+case object Update {
+  /**
+   * Java API.
+   */
+  def create() =
+    Update()
+
+  /**
+   * Java API.
+   */
+  def create(await: Boolean) =
+    Update(await)
+
+  /**
+   * Java API.
+   */
+  def create(await: Boolean, replayMax: Long) =
+    Update(await, replayMax)
+}
+
+/**
+ * A view replicates the persistent message stream of a [[PersistentActor]]. Implementation classes receive
+ * the message stream directly from the Journal. These messages can be processed to update internal state
  * in order to maintain an (eventual consistent) view of the state of the corresponding processor. A
- * view can also run on a different node, provided that a replicated journal is used. Implementation
- * classes reference a processor by implementing `persistenceId`.
+ * persistent view can also run on a different node, provided that a replicated journal is used.
+ *
+ * Implementation classes refer to a persistent actors' message stream by implementing `persistenceId`
+ * with the corresponding (shared) identifier value.
  *
  * Views can also store snapshots of internal state by calling [[#saveSnapshot]]. The snapshots of a view
- * are independent of those of the referenced processor. During recovery, a saved snapshot is offered
+ * are independent of those of the referenced persistent actor. During recovery, a saved snapshot is offered
  * to the view with a [[SnapshotOffer]] message, followed by replayed messages, if any, that are younger
  * than the snapshot. Default is to offer the latest saved snapshot.
  *
@@ -29,11 +67,8 @@ import akka.persistence.JournalProtocol._
  *
  *  - [[#autoUpdate]] for turning automated updates on or off
  *  - [[#autoUpdateReplayMax]] for limiting the number of replayed messages per view update cycle
- *
- * Views can also use channels to communicate with destinations in the same way as processors can do.
  */
-@deprecated("Use `akka.persistence.PersistentView` instead.", since = "2.3.4")
-trait View extends Actor with Recovery {
+trait PersistentView extends Actor with Recovery {
   import context.dispatcher
 
   /**
@@ -44,7 +79,7 @@ trait View extends Actor with Recovery {
    */
   private[persistence] override def replayStarted(await: Boolean) = new State {
     private var delegateAwaiting = await
-    private var delegate = View.super.replayStarted(await)
+    private var delegate = PersistentView.super.replayStarted(await)
 
     override def toString: String = delegate.toString
 
@@ -52,8 +87,11 @@ trait View extends Actor with Recovery {
       case Update(false, _) ⇒ // ignore
       case u @ Update(true, _) if !delegateAwaiting ⇒
         delegateAwaiting = true
-        delegate = View.super.replayStarted(await = true)
+        delegate = PersistentView.super.replayStarted(await = true)
         delegate.aroundReceive(receive, u)
+      case other: ReplayedMessage ⇒
+        _atSeqNr = other.persistent.sequenceNr
+        delegate.aroundReceive(receive, other)
       case other ⇒
         delegate.aroundReceive(receive, other)
     }
@@ -97,6 +135,15 @@ trait View extends Actor with Recovery {
     if (await) receiverStash.unstashAll()
   }
 
+  /**
+   * INTERNAL API
+   * WARNING: This implementation UNWRAPS PERSISTENT() before delivering to the receive block.
+   */
+  override private[persistence] def withCurrentPersistent(persistent: Persistent)(body: Persistent ⇒ Unit): Unit =
+    super.withCurrentPersistent(persistent) { p ⇒
+      receive.applyOrElse(p.payload, unhandled)
+    }
+
   private val _viewId = extension.persistenceId(self)
   private val viewSettings = extension.settings.view
 
@@ -112,10 +159,12 @@ trait View extends Actor with Recovery {
    */
   def snapshotterId: String = viewId
 
-  /**
-   * Persistence id. Defaults to this persistent-actors's path and can be overridden.
-   */
-  override def persistenceId: String = processorId
+  private var _atSeqNr: Long = 0L
+
+  def atSeqNr = _atSeqNr
+
+  def isPersistent: Boolean =
+    currentPersistentMessage.isDefined
 
   /**
    * If `true`, this view automatically updates itself with an interval specified by `autoUpdateInterval`.
@@ -164,15 +213,13 @@ trait View extends Actor with Recovery {
 /**
  * Java API.
  *
- * @see [[View]]
+ * @see [[PersistentView]]
  */
-@deprecated("Use `akka.persistence.UntypedPersistentView instead.", since = "2.3.4")
-abstract class UntypedView extends UntypedActor with View
+abstract class UntypedPersistentView extends UntypedActor with PersistentView
 
 /**
  * Java API: compatible with lambda expressions (to be used with [[akka.japi.pf.ReceiveBuilder]])
  *
- * @see [[View]]
+ * @see [[PersistentView]]
  */
-@deprecated("Use `akka.persistence.AbstractPersistentView` instead.", since = "2.3.4")
-abstract class AbstractView extends AbstractActor with View
+abstract class AbstractPersistentView extends AbstractActor with PersistentView

--- a/akka-persistence/src/main/scala/akka/persistence/Processor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Processor.scala
@@ -52,7 +52,15 @@ import akka.dispatch._
  * @see [[PersistentBatch]]
  */
 @deprecated("Processor will be removed. Instead extend `akka.persistence.PersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
-trait Processor extends Actor with Recovery {
+trait Processor extends ProcessorImpl {
+  /**
+   * Persistence id. Defaults to this persistent-actors's path and can be overridden.
+   */
+  override def persistenceId: String = processorId
+}
+
+@deprecated("Processor will be removed. Instead extend `akka.persistence.PersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
+trait ProcessorImpl extends Actor with Recovery {
   // todo remove Processor in favor of PersistentActor #15230
 
   import JournalProtocol._
@@ -166,11 +174,6 @@ trait Processor extends Actor with Recovery {
    */
   @deprecated("Override `persistenceId: String` instead. Processor will be removed.", since = "2.3.4")
   override def processorId: String = _persistenceId // TODO: remove processorId
-
-  /**
-   * Persistence id. Defaults to this persistent-actors's path and can be overridden.
-   */
-  override def persistenceId: String = processorId
 
   /**
    * Returns `persistenceId`.
@@ -412,7 +415,7 @@ case object RecoveryCompleted extends RecoveryCompleted {
  * @see [[PersistentBatch]]
  */
 @deprecated("UntypedProcessor will be removed. Instead extend `akka.persistence.UntypedPersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
-abstract class UntypedProcessor extends UntypedActor with Processor
+abstract class UntypedProcessor extends UntypedActor with ProcessorImpl
 
 /**
  * Java API: compatible with lambda expressions
@@ -467,4 +470,4 @@ abstract class UntypedProcessor extends UntypedActor with Processor
  * @see [[PersistentBatch]]
  */
 @deprecated("AbstractProcessor will be removed. Instead extend `akka.persistence.AbstractPersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
-abstract class AbstractProcessor extends AbstractActor with Processor
+abstract class AbstractProcessor extends AbstractActor with ProcessorImpl

--- a/akka-persistence/src/main/scala/akka/persistence/Processor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Processor.scala
@@ -59,9 +59,10 @@ trait Processor extends ProcessorImpl {
   override def persistenceId: String = processorId
 }
 
+/** INTERNAL API */
 @deprecated("Processor will be removed. Instead extend `akka.persistence.PersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
-trait ProcessorImpl extends Actor with Recovery {
-  // todo remove Processor in favor of PersistentActor #15230
+private[akka] trait ProcessorImpl extends Actor with Recovery {
+  // TODO: remove Processor in favor of PersistentActor #15230
 
   import JournalProtocol._
 
@@ -415,7 +416,7 @@ case object RecoveryCompleted extends RecoveryCompleted {
  * @see [[PersistentBatch]]
  */
 @deprecated("UntypedProcessor will be removed. Instead extend `akka.persistence.UntypedPersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
-abstract class UntypedProcessor extends UntypedActor with ProcessorImpl
+abstract class UntypedProcessor extends UntypedActor with Processor
 
 /**
  * Java API: compatible with lambda expressions
@@ -470,4 +471,4 @@ abstract class UntypedProcessor extends UntypedActor with ProcessorImpl
  * @see [[PersistentBatch]]
  */
 @deprecated("AbstractProcessor will be removed. Instead extend `akka.persistence.AbstractPersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
-abstract class AbstractProcessor extends AbstractActor with ProcessorImpl
+abstract class AbstractProcessor extends AbstractActor with Processor

--- a/akka-persistence/src/main/scala/akka/persistence/Recovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Recovery.scala
@@ -30,19 +30,6 @@ trait Recovery extends Actor with Snapshotter with Stash with StashFactory {
     protected def processPersistent(receive: Receive, persistent: Persistent) =
       withCurrentPersistent(persistent)(receive.applyOrElse(_, unhandled))
 
-    protected def updateLastSequenceNr(persistent: Persistent): Unit =
-      if (persistent.sequenceNr > _lastSequenceNr) _lastSequenceNr = persistent.sequenceNr
-
-    def updateLastSequenceNr(value: Long): Unit =
-      _lastSequenceNr = value
-
-    /** INTERNAL API */
-    private[akka] def withCurrentPersistent(persistent: Persistent)(body: Persistent ⇒ Unit): Unit = try {
-      _currentPersistent = persistent
-      updateLastSequenceNr(persistent)
-      body(persistent)
-    } finally _currentPersistent = null
-
     protected def recordFailure(cause: Throwable): Unit = {
       _recoveryFailureCause = cause
       _recoveryFailureMessage = context.asInstanceOf[ActorCell].currentMessage
@@ -108,11 +95,12 @@ trait Recovery extends Actor with Snapshotter with Stash with StashFactory {
 
     def aroundReceive(receive: Receive, message: Any) = message match {
       case r: Recover ⇒ // ignore
-      case ReplayedMessage(p) ⇒ try { processPersistent(receive, p) } catch {
-        case t: Throwable ⇒
-          _currentState = replayFailed // delay throwing exception to prepareRestart
-          recordFailure(t)
-      }
+      case ReplayedMessage(p) ⇒
+        try processPersistent(receive, p) catch {
+          case t: Throwable ⇒
+            _currentState = replayFailed // delay throwing exception to prepareRestart
+            recordFailure(t)
+        }
       case ReplayMessagesSuccess        ⇒ onReplaySuccess(receive, await)
       case ReplayMessagesFailure(cause) ⇒ onReplayFailure(receive, await, cause)
       case other ⇒
@@ -174,7 +162,25 @@ trait Recovery extends Actor with Snapshotter with Stash with StashFactory {
   @deprecated("Override `persistenceId` instead. Processor will be removed.", since = "2.3.4")
   def processorId: String = extension.persistenceId(self) // TODO: remove processorId
 
-  def persistenceId: String = processorId
+  /**
+   * Id of the persistent entity for which messages should be replayed.
+   */
+  def persistenceId: String
+
+  /** INTERNAL API */
+  private[persistence] def withCurrentPersistent(persistent: Persistent)(body: Persistent ⇒ Unit): Unit = try {
+    _currentPersistent = persistent
+    updateLastSequenceNr(persistent)
+    body(persistent)
+  } finally _currentPersistent = null
+
+  /** INTERNAL API. */
+  private[persistence] def updateLastSequenceNr(persistent: Persistent): Unit =
+    if (persistent.sequenceNr > _lastSequenceNr) _lastSequenceNr = persistent.sequenceNr
+
+  /** INTERNAL API. */
+  private[persistence] def updateLastSequenceNr(value: Long): Unit =
+    _lastSequenceNr = value
 
   /**
    * Returns the current persistent message if there is any.

--- a/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
@@ -76,7 +76,12 @@ trait Cleanup { this: AkkaSpec ⇒
   }
 }
 
+@deprecated("Use NamedPersistentActor instead.", since = "2.3.4")
 abstract class NamedProcessor(name: String) extends Processor {
+  override def persistenceId: String = name
+}
+
+abstract class NamedPersistentActor(name: String) extends PersistentActor {
   override def persistenceId: String = name
 }
 

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentViewSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentViewSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
  */
 package akka.persistence
 
@@ -10,7 +10,8 @@ import com.typesafe.config.Config
 
 import scala.concurrent.duration._
 
-object ViewSpec {
+object PersistentViewSpec {
+
   private class TestPersistentActor(name: String, probe: ActorRef) extends NamedPersistentActor(name) {
     def receiveCommand = {
       case msg ⇒
@@ -18,11 +19,11 @@ object ViewSpec {
     }
 
     override def receiveRecover: Receive = {
-      case _ ⇒
+      case _ ⇒ // do nothing...
     }
   }
 
-  private class TestView(name: String, probe: ActorRef, interval: FiniteDuration, var failAt: Option[String]) extends View {
+  private class TestPersistentView(name: String, probe: ActorRef, interval: FiniteDuration, var failAt: Option[String]) extends PersistentView {
     def this(name: String, probe: ActorRef, interval: FiniteDuration) =
       this(name, probe, interval, None)
 
@@ -30,7 +31,7 @@ object ViewSpec {
       this(name, probe, 100.milliseconds)
 
     override def autoUpdateInterval: FiniteDuration = interval.dilated(context.system)
-    override val processorId: String = name
+    override val persistenceId: String = name
 
     var last: String = _
 
@@ -39,10 +40,12 @@ object ViewSpec {
         probe ! last
       case "boom" ⇒
         throw new TestException("boom")
-      case Persistent(payload, _) if Some(payload) == failAt ⇒
+
+      case payload if isPersistent && shouldFailOn(payload) ⇒
         throw new TestException("boom")
-      case Persistent(payload, sequenceNr) ⇒
-        last = s"replicated-${payload}-${sequenceNr}"
+
+      case payload if isPersistent ⇒
+        last = s"replicated-${payload}-${lastSequenceNr}"
         probe ! last
     }
 
@@ -50,9 +53,12 @@ object ViewSpec {
       super.postRestart(reason)
       failAt = None
     }
+
+    def shouldFailOn(m: Any): Boolean =
+      failAt.foldLeft(false) { (a, f) ⇒ a || (m == f) }
   }
 
-  private class PassiveTestView(name: String, probe: ActorRef, var failAt: Option[String]) extends View {
+  private class PassiveTestPersistentView(name: String, probe: ActorRef, var failAt: Option[String]) extends PersistentView {
     override val persistenceId: String = name
 
     override def autoUpdate: Boolean = false
@@ -63,10 +69,10 @@ object ViewSpec {
     def receive = {
       case "get" ⇒
         probe ! last
-      case Persistent(payload, _) if Some(payload) == failAt ⇒
+      case payload if isPersistent && shouldFailOn(payload) ⇒
         throw new TestException("boom")
-      case Persistent(payload, sequenceNr) ⇒
-        last = s"replicated-${payload}-${sequenceNr}"
+      case payload ⇒
+        last = s"replicated-${payload}-${lastSequenceNr}"
     }
 
     override def postRestart(reason: Throwable): Unit = {
@@ -74,42 +80,32 @@ object ViewSpec {
       failAt = None
     }
 
+    def shouldFailOn(m: Any): Boolean =
+      failAt.foldLeft(false) { (a, f) ⇒ a || (m == f) }
+
   }
 
-  private class ActiveTestView(name: String, probe: ActorRef) extends View {
+  private class ActiveTestPersistentView(name: String, probe: ActorRef) extends PersistentView {
     override val persistenceId: String = name
     override def autoUpdateInterval: FiniteDuration = 50.millis
     override def autoUpdateReplayMax: Long = 2
 
     def receive = {
-      case Persistent(payload, sequenceNr) ⇒
-        probe ! s"replicated-${payload}-${sequenceNr}"
+      case payload ⇒
+        probe ! s"replicated-${payload}-${lastSequenceNr}"
     }
   }
 
-  private class TestDestination(probe: ActorRef) extends Actor {
-    def receive = {
-      case cp @ ConfirmablePersistent(payload, sequenceNr, _) ⇒
-        cp.confirm()
-        probe ! s"${payload}-${sequenceNr}"
-    }
-  }
-
-  private class EmittingView(name: String, destination: ActorRef) extends View {
+  private class PersistentOrNotTestPersistentView(name: String, probe: ActorRef) extends PersistentView {
     override val persistenceId: String = name
-    override def autoUpdateInterval: FiniteDuration = 100.milliseconds.dilated(context.system)
-
-    val channel = context.actorOf(Channel.props(s"${name}-channel"))
 
     def receive = {
-      case "restart" ⇒
-        throw new TestException("restart requested")
-      case Persistent(payload, sequenceNr) ⇒
-        channel ! Deliver(Persistent(s"emitted-${payload}"), destination.path)
+      case payload if isPersistent ⇒ probe ! s"replicated-${payload}-${lastSequenceNr}"
+      case payload                 ⇒ probe ! s"normal-${payload}-${lastSequenceNr}"
     }
   }
 
-  private class SnapshottingView(name: String, probe: ActorRef) extends View {
+  private class SnapshottingPersistentView(name: String, probe: ActorRef) extends PersistentView {
     override val persistenceId: String = name
     override val viewId: String = s"${name}-replicator"
 
@@ -129,38 +125,38 @@ object ViewSpec {
       case SnapshotOffer(metadata, snapshot: String) ⇒
         last = snapshot
         probe ! last
-      case Persistent(payload, sequenceNr) ⇒
-        last = s"replicated-${payload}-${sequenceNr}"
+      case payload ⇒
+        last = s"replicated-${payload}-${lastSequenceNr}"
         probe ! last
     }
   }
 }
 
-abstract class ViewSpec(config: Config) extends AkkaSpec(config) with PersistenceSpec with ImplicitSender {
-  import akka.persistence.ViewSpec._
+abstract class PersistentViewSpec(config: Config) extends AkkaSpec(config) with PersistenceSpec with ImplicitSender {
+  import akka.persistence.PersistentViewSpec._
 
-  var persistor: ActorRef = _
+  var persistentActor: ActorRef = _
   var view: ActorRef = _
 
-  var processorProbe: TestProbe = _
+  var persistentActorProbe: TestProbe = _
   var viewProbe: TestProbe = _
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
 
-    processorProbe = TestProbe()
+    persistentActorProbe = TestProbe()
     viewProbe = TestProbe()
 
-    persistor = system.actorOf(Props(classOf[TestPersistentActor], name, processorProbe.ref))
-    persistor ! "a"
-    persistor ! "b"
+    persistentActor = system.actorOf(Props(classOf[TestPersistentActor], name, persistentActorProbe.ref))
+    persistentActor ! "a"
+    persistentActor ! "b"
 
-    processorProbe.expectMsg("a-1")
-    processorProbe.expectMsg("b-2")
+    persistentActorProbe.expectMsg("a-1")
+    persistentActorProbe.expectMsg("b-2")
   }
 
   override protected def afterEach(): Unit = {
-    system.stop(persistor)
+    system.stop(persistentActor)
     system.stop(view)
     super.afterEach()
   }
@@ -174,50 +170,50 @@ abstract class ViewSpec(config: Config) extends AkkaSpec(config) with Persistenc
   def subscribeToReplay(probe: TestProbe): Unit =
     system.eventStream.subscribe(probe.ref, classOf[ReplayMessages])
 
-  "A view" must {
+  "A persistent view" must {
     "receive past updates from a processor" in {
-      view = system.actorOf(Props(classOf[TestView], name, viewProbe.ref))
+      view = system.actorOf(Props(classOf[TestPersistentView], name, viewProbe.ref))
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
     }
     "receive live updates from a processor" in {
-      view = system.actorOf(Props(classOf[TestView], name, viewProbe.ref))
+      view = system.actorOf(Props(classOf[TestPersistentView], name, viewProbe.ref))
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
-      persistor ! "c"
+      persistentActor ! "c"
       viewProbe.expectMsg("replicated-c-3")
     }
     "run updates at specified interval" in {
-      view = system.actorOf(Props(classOf[TestView], name, viewProbe.ref, 2.seconds))
+      view = system.actorOf(Props(classOf[TestPersistentView], name, viewProbe.ref, 2.seconds))
       // initial update is done on start
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
       // live updates takes 5 seconds to replicate
-      persistor ! "c"
+      persistentActor ! "c"
       viewProbe.expectNoMsg(1.second)
       viewProbe.expectMsg("replicated-c-3")
     }
     "run updates on user request" in {
-      view = system.actorOf(Props(classOf[TestView], name, viewProbe.ref, 5.seconds))
+      view = system.actorOf(Props(classOf[TestPersistentView], name, viewProbe.ref, 5.seconds))
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
-      persistor ! "c"
-      processorProbe.expectMsg("c-3")
+      persistentActor ! "c"
+      persistentActorProbe.expectMsg("c-3")
       view ! Update(await = false)
       viewProbe.expectMsg("replicated-c-3")
     }
     "run updates on user request and await update" in {
-      view = system.actorOf(Props(classOf[TestView], name, viewProbe.ref, 5.seconds))
+      view = system.actorOf(Props(classOf[TestPersistentView], name, viewProbe.ref, 5.seconds))
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
-      persistor ! "c"
-      processorProbe.expectMsg("c-3")
+      persistentActor ! "c"
+      persistentActorProbe.expectMsg("c-3")
       view ! Update(await = true)
       view ! "get"
       viewProbe.expectMsg("replicated-c-3")
     }
     "run updates again on failure outside an update cycle" in {
-      view = system.actorOf(Props(classOf[TestView], name, viewProbe.ref, 5.seconds))
+      view = system.actorOf(Props(classOf[TestPersistentView], name, viewProbe.ref, 5.seconds))
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
       view ! "boom"
@@ -225,26 +221,26 @@ abstract class ViewSpec(config: Config) extends AkkaSpec(config) with Persistenc
       viewProbe.expectMsg("replicated-b-2")
     }
     "run updates again on failure during an update cycle" in {
-      persistor ! "c"
-      processorProbe.expectMsg("c-3")
-      view = system.actorOf(Props(classOf[TestView], name, viewProbe.ref, 5.seconds, Some("b")))
+      persistentActor ! "c"
+      persistentActorProbe.expectMsg("c-3")
+      view = system.actorOf(Props(classOf[TestPersistentView], name, viewProbe.ref, 5.seconds, Some("b")))
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
       viewProbe.expectMsg("replicated-c-3")
     }
     "run size-limited updates on user request" in {
-      persistor ! "c"
-      persistor ! "d"
-      persistor ! "e"
-      persistor ! "f"
+      persistentActor ! "c"
+      persistentActor ! "d"
+      persistentActor ! "e"
+      persistentActor ! "f"
 
-      processorProbe.expectMsg("c-3")
-      processorProbe.expectMsg("d-4")
-      processorProbe.expectMsg("e-5")
-      processorProbe.expectMsg("f-6")
+      persistentActorProbe.expectMsg("c-3")
+      persistentActorProbe.expectMsg("d-4")
+      persistentActorProbe.expectMsg("e-5")
+      persistentActorProbe.expectMsg("f-6")
 
-      view = system.actorOf(Props(classOf[PassiveTestView], name, viewProbe.ref, None))
+      view = system.actorOf(Props(classOf[PassiveTestPersistentView], name, viewProbe.ref, None))
 
       view ! Update(await = true, replayMax = 2)
       view ! "get"
@@ -261,15 +257,15 @@ abstract class ViewSpec(config: Config) extends AkkaSpec(config) with Persistenc
     "run size-limited updates automatically" in {
       val replayProbe = TestProbe()
 
-      persistor ! "c"
-      persistor ! "d"
+      persistentActor ! "c"
+      persistentActor ! "d"
 
-      processorProbe.expectMsg("c-3")
-      processorProbe.expectMsg("d-4")
+      persistentActorProbe.expectMsg("c-3")
+      persistentActorProbe.expectMsg("d-4")
 
       subscribeToReplay(replayProbe)
 
-      view = system.actorOf(Props(classOf[ActiveTestView], name, viewProbe.ref))
+      view = system.actorOf(Props(classOf[ActiveTestPersistentView], name, viewProbe.ref))
 
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
@@ -280,42 +276,39 @@ abstract class ViewSpec(config: Config) extends AkkaSpec(config) with Persistenc
       replayProbe.expectMsgPF() { case ReplayMessages(3L, _, 2L, _, _, _) ⇒ }
       replayProbe.expectMsgPF() { case ReplayMessages(5L, _, 2L, _, _, _) ⇒ }
     }
-  }
+    "check if an incoming message is persistent" in {
+      persistentActor ! "c"
 
-  "A view" can {
-    "use channels" in {
-      val confirmProbe = TestProbe()
-      val destinationProbe = TestProbe()
-      val destination = system.actorOf(Props(classOf[TestDestination], destinationProbe.ref))
+      persistentActorProbe.expectMsg("c-3")
 
-      subscribeToConfirmation(confirmProbe)
+      view = system.actorOf(Props(classOf[PersistentOrNotTestPersistentView], name, viewProbe.ref))
 
-      view = system.actorOf(Props(classOf[EmittingView], name, destination))
-      destinationProbe.expectMsg("emitted-a-1")
-      destinationProbe.expectMsg("emitted-b-2")
-      awaitConfirmation(confirmProbe)
-      awaitConfirmation(confirmProbe)
+      view ! "d"
+      view ! "e"
 
-      view ! "restart"
-      persistor ! "c"
+      viewProbe.expectMsg("replicated-a-1")
+      viewProbe.expectMsg("replicated-b-2")
+      viewProbe.expectMsg("replicated-c-3")
+      viewProbe.expectMsg("normal-d-3")
+      viewProbe.expectMsg("normal-e-3")
 
-      destinationProbe.expectMsg("emitted-c-3")
-      awaitConfirmation(confirmProbe)
+      persistentActor ! "f"
+      viewProbe.expectMsg("replicated-f-4")
     }
     "take snapshots" in {
-      view = system.actorOf(Props(classOf[SnapshottingView], name, viewProbe.ref))
+      view = system.actorOf(Props(classOf[SnapshottingPersistentView], name, viewProbe.ref))
       viewProbe.expectMsg("replicated-a-1")
       viewProbe.expectMsg("replicated-b-2")
       view ! "snap"
       viewProbe.expectMsg("snapped")
       view ! "restart"
-      persistor ! "c"
+      persistentActor ! "c"
       viewProbe.expectMsg("replicated-b-2")
       viewProbe.expectMsg("replicated-c-3")
     }
   }
 }
 
-class LeveldbViewSpec extends ViewSpec(PersistenceSpec.config("leveldb", "LeveldbViewSpec"))
-class InmemViewSpec extends ViewSpec(PersistenceSpec.config("inmem", "InmemViewSpec"))
+class LeveldbPersistentViewSpec extends PersistentViewSpec(PersistenceSpec.config("leveldb", "LeveldbPersistentViewSpec"))
+class InmemPersistentViewSpec extends PersistentViewSpec(PersistenceSpec.config("inmem", "InmemPersistentViewSpec"))
 

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
@@ -498,9 +498,7 @@ public class LambdaPersistenceDocTest {
     //#view
     class MyView extends AbstractPersistentView {
       @Override
-      public String persistenceId() {
-        return "some-persistence-id";
-      }
+      public String persistenceId() { return "some-persistence-id"; }
 
       public MyView() {
         receive(ReceiveBuilder.

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
@@ -496,7 +496,7 @@ public class LambdaPersistenceDocTest {
 
   static Object o11 = new Object() {
     //#view
-    class MyView extends AbstractView {
+    class MyView extends AbstractPersistentView {
       @Override
       public String persistenceId() {
         return "some-persistence-id";
@@ -504,7 +504,7 @@ public class LambdaPersistenceDocTest {
 
       public MyView() {
         receive(ReceiveBuilder.
-          match(Persistent.class, persistent -> {
+          match(Object.class, p -> isPersistent(),  persistent -> {
             // ...
           }).build()
         );

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ViewExample.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/sample/persistence/ViewExample.java
@@ -45,7 +45,7 @@ public class ViewExample {
     }
   }
 
-  public static class ExampleView extends AbstractView {
+  public static class ExampleView extends AbstractPersistentView {
 
     private int numReplicated = 0;
 
@@ -61,10 +61,10 @@ public class ViewExample {
 
     public ExampleView() {
       receive(ReceiveBuilder.
-        match(Persistent.class, p -> {
+        match(Object.class, m -> isPersistent(), msg -> {
           numReplicated += 1;
           System.out.println(String.format("view received %s (num replicated = %d)",
-            p.payload(),
+            msg,
             numReplicated));
         }).
         match(SnapshotOffer.class, so -> {

--- a/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
@@ -81,7 +81,7 @@ snapshotting to reduce recovery time.
 
 <p>
 To run this example, go to the <a href="#run" class="shortcut">Run</a> tab, and run the application main class
-<b><code>sample.persistence.ViewExample</code></b>.
+<b><code>sample.persistence.PersistentViewExample</code></b>.
 </p>
 </div>
 

--- a/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentActorExample.java
+++ b/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentActorExample.java
@@ -66,6 +66,9 @@ class ExampleState implements Serializable {
 }
 
 class ExamplePersistentActor extends UntypedPersistentActor {
+    @Override
+    public String persistenceId() { return "persistence-id"; }
+
     private ExampleState state = new ExampleState();
 
     public int getNumEvents() {

--- a/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentActorFailureExample.java
+++ b/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentActorFailureExample.java
@@ -1,12 +1,18 @@
 package sample.persistence;
 
-import java.util.ArrayList;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
 import akka.japi.Procedure;
-import akka.actor.*;
-import akka.persistence.*;
+import akka.persistence.UntypedPersistentActor;
+
+import java.util.ArrayList;
 
 public class PersistentActorFailureExample {
   public static class ExamplePersistentActor extends UntypedPersistentActor {
+    @Override
+    public String persistenceId() { return "persistence-id"; }
+
     private ArrayList<Object> received = new ArrayList<Object>();
 
     @Override
@@ -35,7 +41,6 @@ public class PersistentActorFailureExample {
         unhandled(message);
       }
     }
-
   }
 
   public static void main(String... args) throws Exception {

--- a/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentViewExample.java
+++ b/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentViewExample.java
@@ -1,13 +1,17 @@
 package sample.persistence;
 
-import java.util.concurrent.TimeUnit;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.japi.Procedure;
+import akka.persistence.SnapshotOffer;
+import akka.persistence.UntypedPersistentActor;
+import akka.persistence.UntypedPersistentView;
 import scala.concurrent.duration.Duration;
 
-import akka.actor.*;
-import akka.persistence.*;
-import akka.japi.Procedure;
+import java.util.concurrent.TimeUnit;
 
-public class ViewExample {
+public class PersistentViewExample {
     public static class ExamplePersistentActor extends UntypedPersistentActor {
         private int count = 1;
       
@@ -41,7 +45,7 @@ public class ViewExample {
         }
     }
 
-    public static class ExampleView extends UntypedView {
+    public static class ExampleView extends UntypedPersistentView {
 
         private int numReplicated = 0;
 
@@ -57,16 +61,17 @@ public class ViewExample {
 
         @Override
         public void onReceive(Object message) throws Exception {
-            if (message instanceof Persistent) {
-                Persistent p = (Persistent)message;
+            if (isPersistent()) {
                 numReplicated += 1;
-                System.out.println(String.format("view received %s (num replicated = %d)", p.payload(), numReplicated));
+                System.out.println(String.format("view received %s (num replicated = %d)", message, numReplicated));
             } else if (message instanceof SnapshotOffer) {
                 SnapshotOffer so = (SnapshotOffer)message;
                 numReplicated = (Integer)so.snapshot();
                 System.out.println(String.format("view received snapshot offer %s (metadata = %s)", numReplicated, so.metadata()));
             } else if (message.equals("snap")) {
                 saveSnapshot(numReplicated);
+            } else {
+              unhandled(message);
             }
         }
     }

--- a/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentViewExample.java
+++ b/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentViewExample.java
@@ -13,13 +13,11 @@ import java.util.concurrent.TimeUnit;
 
 public class PersistentViewExample {
     public static class ExamplePersistentActor extends UntypedPersistentActor {
-        private int count = 1;
-      
         @Override
-        public String persistenceId() {
-            return "persistentActor-5";
-        }
-        
+        public String persistenceId() { return "persistentActor-5"; }
+
+        private int count = 1;
+
         @Override
         public void onReceiveRecover(Object message) {
           if (message instanceof String) {

--- a/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/SnapshotExample.java
+++ b/akka-samples/akka-sample-persistence-java/src/main/java/sample/persistence/SnapshotExample.java
@@ -1,11 +1,16 @@
 package sample.persistence;
 
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.japi.Procedure;
+import akka.persistence.SaveSnapshotFailure;
+import akka.persistence.SaveSnapshotSuccess;
+import akka.persistence.SnapshotOffer;
+import akka.persistence.UntypedPersistentActor;
+
 import java.io.Serializable;
 import java.util.ArrayList;
-
-import akka.actor.*;
-import akka.persistence.*;
-import akka.japi.Procedure;
 
 public class SnapshotExample {
     public static class ExampleState implements Serializable {
@@ -34,6 +39,9 @@ public class SnapshotExample {
     }
 
     public static class ExamplePersistentActor extends UntypedPersistentActor {
+        @Override
+        public String persistenceId() { return "persistence-id"; }
+
         private ExampleState state = new ExampleState();
 
         @Override
@@ -72,6 +80,7 @@ public class SnapshotExample {
             unhandled(message);
           }
         }
+
     }
 
     public static void main(String... args) throws Exception {

--- a/akka-samples/akka-sample-persistence-java/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java/tutorial/index.html
@@ -81,7 +81,7 @@ snapshotting to reduce recovery time.
 
 <p>
 To run this example, go to the <a href="#run" class="shortcut">Run</a> tab, and run the application main class
-<b><code>sample.persistence.ViewExample</code></b>.
+<b><code>sample.persistence.PersistentViewExample</code></b>.
 </p>
 </div>
 

--- a/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/PersistentActorExample.scala
+++ b/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/PersistentActorExample.scala
@@ -14,6 +14,8 @@ case class ExampleState(events: List[String] = Nil) {
 }
 
 class ExamplePersistentActor extends PersistentActor {
+  override def persistenceId = "persistence-id"
+
   var state = ExampleState()
 
   def updateState(event: Evt): Unit =

--- a/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/PersistentActorFailureExample.scala
+++ b/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/PersistentActorFailureExample.scala
@@ -5,6 +5,8 @@ import akka.persistence._
 
 object PersistentActorFailureExample extends App {
   class ExamplePersistentActor extends PersistentActor {
+    override def persistenceId = "persistence-id"
+
     var received: List[String] = Nil // state
 
     def receiveCommand: Actor.Receive = {

--- a/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/SnapshotExample.scala
+++ b/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/SnapshotExample.scala
@@ -10,6 +10,8 @@ object SnapshotExample extends App {
   }
 
   class ExamplePersistentActor extends PersistentActor {
+    def persistenceId: String = "persistence-id"
+
     var state = ExampleState()
 
     def receiveCommand: Actor.Receive = {
@@ -28,6 +30,7 @@ object SnapshotExample extends App {
       case evt: String =>
         state = state.updated(evt)
     }
+
   }
 
   val system = ActorSystem("example")

--- a/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/ViewExample.scala
+++ b/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/ViewExample.scala
@@ -24,7 +24,7 @@ object ViewExample extends App {
     }
   }
 
-  class ExampleView extends View {
+  class ExampleView extends PersistentView {
     private var numReplicated = 0
 
     override def persistenceId: String = "persistentActor-5"
@@ -37,9 +37,11 @@ object ViewExample extends App {
       case SnapshotOffer(metadata, snapshot: Int) =>
         numReplicated = snapshot
         println(s"view received snapshot offer ${snapshot} (metadata = ${metadata})")
-      case Persistent(payload, _) =>
+      case payload if isPersistent =>
         numReplicated += 1
-        println(s"view received ${payload} (num replicated = ${numReplicated})")
+        println(s"view received persistent ${payload} (num replicated = ${numReplicated})")
+      case payload =>
+        println(s"view received not persitent ${payload}")
     }
 
   }


### PR DESCRIPTION
Makes `persistenceId` abstract in the new classes (PersistentActor, PersistentView, and all their java versions).

Depends on adding `PersistentView`, after that please rebase.

Resolves half of https://github.com/akka/akka/issues/15436
