### PR TITLE
=per #15457 Correlate persistAsync handlers with journal messages

### DIFF
--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -214,9 +214,13 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
   In order to implement the pattern known as "*command sourcing*" simply ``persistAsync`` all incoming events right away,
   and handle them in the callback.
 
+.. warning::
+  The callback will not be invoked if the actor is restarted (or stopped) in between the call to
+  ``persistAsync`` and the journal has confirmed the write.
+
 .. _defer-java-lambda:
 
-Deferring actions until preceeding persist handlers have executed
+Deferring actions until preceding persist handlers have executed
 -----------------------------------------------------------------
 
 Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
@@ -233,6 +237,10 @@ Notice that the ``sender()`` is **safe** to access in the handler callback, and 
 of the command for which this ``defer`` handler was called.
 
 .. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#defer-caller
+
+.. warning::
+  The callback will not be invoked if the actor is restarted (or stopped) in between the call to
+  ``defer`` and the journal has processed and confirmed all preceding writes.
 
 Batch writes
 ------------

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -218,10 +218,14 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 .. note::
   In order to implement the pattern known as "*command sourcing*" simply ``persistAsync`` all incoming events right away,
   and handle them in the callback.
+  
+.. warning::
+  The callback will not be invoked if the actor is restarted (or stopped) in between the call to
+  ``persistAsync`` and the journal has confirmed the write.  
 
 .. _defer-java:
 
-Deferring actions until preceeding persist handlers have executed
+Deferring actions until preceding persist handlers have executed
 -----------------------------------------------------------------
 
 Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
@@ -238,6 +242,10 @@ Notice that the ``sender()`` is **safe** to access in the handler callback, and 
 of the command for which this ``defer`` handler was called.
 
 .. includecode:: code/docs/persistence/PersistenceDocTest.java#defer-caller
+
+.. warning::
+  The callback will not be invoked if the actor is restarted (or stopped) in between the call to
+  ``defer`` and the journal has processed and confirmed all preceding writes.
 
 Batch writes
 ------------

--- a/akka-docs/rst/java/routing.rst
+++ b/akka-docs/rst/java/routing.rst
@@ -536,7 +536,7 @@ Managagement Messages
 These management messages may be handled after other messages, so if you send ``AddRoutee`` immediately followed
 an ordinary message you are not guaranteed that the routees have been changed when the ordinary message
 is routed. If you need to know when the change has been applied you can send ``AddRoutee`` followed by ``GetRoutees``
-and when you receive the ``Routees`` reply you know that the preceeding change has been applied.
+and when you receive the ``Routees`` reply you know that the preceding change has been applied.
 
 .. _resizable-routers-java:
 

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -210,10 +210,14 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 .. note::
   In order to implement the pattern known as "*command sourcing*" simply call ``persistAsync(cmd)(...)`` right away on all incomming
   messages right away, and handle them in the callback.
+  
+.. warning::
+  The callback will not be invoked if the actor is restarted (or stopped) in between the call to
+  ``persistAsync`` and the journal has confirmed the write.
 
 .. _defer-scala:
 
-Deferring actions until preceeding persist handlers have executed
+Deferring actions until preceding persist handlers have executed
 -----------------------------------------------------------------
 
 Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
@@ -233,6 +237,9 @@ The calling side will get the responses in this (guaranteed) order:
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#defer-caller
 
+.. warning::
+  The callback will not be invoked if the actor is restarted (or stopped) in between the call to
+  ``defer`` and the journal has processed and confirmed all preceding writes.
 
 .. _batch-writes:
 

--- a/akka-docs/rst/scala/routing.rst
+++ b/akka-docs/rst/scala/routing.rst
@@ -535,7 +535,7 @@ Managagement Messages
 These management messages may be handled after other messages, so if you send ``AddRoutee`` immediately followed
 an ordinary message you are not guaranteed that the routees have been changed when the ordinary message
 is routed. If you need to know when the change has been applied you can send ``AddRoutee`` followed by ``GetRoutees``
-and when you receive the ``Routees`` reply you know that the preceeding change has been applied.
+and when you receive the ``Routees`` reply you know that the preceding change has been applied.
 
 .. _resizable-routers-scala:
 

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -58,7 +58,7 @@ private[persistence] object JournalProtocol {
    * @param messages messages to be written.
    * @param persistentActor write requestor.
    */
-  case class WriteMessages(messages: immutable.Seq[Resequenceable], persistentActor: ActorRef)
+  case class WriteMessages(messages: immutable.Seq[Resequenceable], persistentActor: ActorRef, actorInstanceId: Int)
 
   /**
    * Reply message to a successful [[WriteMessages]] request. This reply is sent to the requestor
@@ -80,7 +80,7 @@ private[persistence] object JournalProtocol {
    *
    * @param persistent successfully written message.
    */
-  case class WriteMessageSuccess(persistent: PersistentRepr)
+  case class WriteMessageSuccess(persistent: PersistentRepr, actorInstanceId: Int)
 
   /**
    * Reply message to a failed [[WriteMessages]] request. For each contained [[PersistentRepr]] message
@@ -89,7 +89,7 @@ private[persistence] object JournalProtocol {
    * @param message message failed to be written.
    * @param cause failure cause.
    */
-  case class WriteMessageFailure(message: PersistentRepr, cause: Throwable)
+  case class WriteMessageFailure(message: PersistentRepr, cause: Throwable, actorInstanceId: Int)
 
   /**
    * Request to loop a `message` back to `persistent actor`, without persisting the message. Looping of messages
@@ -98,14 +98,14 @@ private[persistence] object JournalProtocol {
    * @param message message to be looped through the journal.
    * @param persistentActor loop requestor.
    */
-  case class LoopMessage(message: Any, persistentActor: ActorRef)
+  case class LoopMessage(message: Any, persistentActor: ActorRef, actorInstanceId: Int)
 
   /**
    * Reply message to a [[LoopMessage]] request.
    *
    * @param message looped message.
    */
-  case class LoopMessageSuccess(message: Any)
+  case class LoopMessageSuccess(message: Any, actorInstanceId: Int)
 
   /**
    * Request to replay messages to `persistentActor`.

--- a/akka-persistence/src/main/scala/akka/persistence/Processor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Processor.scala
@@ -7,6 +7,7 @@ package akka.persistence
 import akka.AkkaException
 import akka.actor._
 import akka.dispatch._
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * An actor that persists (journals) messages of type [[Persistent]]. Messages of other types are not persisted.
@@ -59,12 +60,22 @@ trait Processor extends ProcessorImpl {
   override def persistenceId: String = processorId
 }
 
+/**
+ * INTERNAL API
+ */
+private[akka] object ProcessorImpl {
+  // ok to wrap around (2*Int.MaxValue restarts will not happen within a journal roundtrip)
+  private val instanceIdCounter = new AtomicInteger
+}
+
 /** INTERNAL API */
 @deprecated("Processor will be removed. Instead extend `akka.persistence.PersistentActor` and use it's `persistAsync(command)(callback)` method to get equivalent semantics.", since = "2.3.4")
 private[akka] trait ProcessorImpl extends Actor with Recovery {
   // TODO: remove Processor in favor of PersistentActor #15230
 
   import JournalProtocol._
+
+  private[persistence] val instanceId: Int = ProcessorImpl.instanceIdCounter.incrementAndGet()
 
   /**
    * Processes the highest stored sequence number response from the journal and then switches
@@ -95,12 +106,12 @@ private[akka] trait ProcessorImpl extends Actor with Recovery {
     private var batching = false
 
     def aroundReceive(receive: Receive, message: Any) = message match {
-      case r: Recover                             ⇒ // ignore
-      case ReplayedMessage(p)                     ⇒ processPersistent(receive, p) // can occur after unstash from user stash
-      case WriteMessageSuccess(p: PersistentRepr) ⇒ processPersistent(receive, p)
-      case WriteMessageSuccess(r: Resequenceable) ⇒ process(receive, r)
-      case WriteMessageFailure(p, cause)          ⇒ process(receive, PersistenceFailure(p.payload, p.sequenceNr, cause))
-      case LoopMessageSuccess(m)                  ⇒ process(receive, m)
+      case r: Recover                                ⇒ // ignore
+      case ReplayedMessage(p)                        ⇒ processPersistent(receive, p) // can occur after unstash from user stash
+      case WriteMessageSuccess(p: PersistentRepr, _) ⇒ processPersistent(receive, p)
+      case WriteMessageSuccess(r: Resequenceable, _) ⇒ process(receive, r)
+      case WriteMessageFailure(p, cause, _)          ⇒ process(receive, PersistenceFailure(p.payload, p.sequenceNr, cause))
+      case LoopMessageSuccess(m, _)                  ⇒ process(receive, m)
       case WriteMessagesSuccessful | WriteMessagesFailed(_) ⇒
         if (processorBatch.isEmpty) batching = false else journalBatch()
       case p: PersistentRepr ⇒
@@ -117,7 +128,7 @@ private[akka] trait ProcessorImpl extends Actor with Recovery {
       case m ⇒
         // submit all batched messages before looping this message
         if (processorBatch.isEmpty) batching = false else journalBatch()
-        journal forward LoopMessage(m, self)
+        journal forward LoopMessage(m, self, instanceId)
     }
 
     def addToBatch(p: Resequenceable): Unit = p match {
@@ -134,7 +145,7 @@ private[akka] trait ProcessorImpl extends Actor with Recovery {
       processorBatch.length >= extension.settings.journal.maxMessageBatchSize
 
     def journalBatch(): Unit = {
-      journal ! WriteMessages(processorBatch, self)
+      journal ! WriteMessages(processorBatch, self, instanceId)
       processorBatch = Vector.empty
       batching = true
     }
@@ -270,10 +281,10 @@ private[akka] trait ProcessorImpl extends Actor with Recovery {
       unstashAll(unstashFilterPredicate)
     } finally {
       message match {
-        case Some(WriteMessageSuccess(m)) ⇒ preRestartDefault(reason, Some(m))
-        case Some(LoopMessageSuccess(m))  ⇒ preRestartDefault(reason, Some(m))
-        case Some(ReplayedMessage(m))     ⇒ preRestartDefault(reason, Some(m))
-        case mo                           ⇒ preRestartDefault(reason, None)
+        case Some(WriteMessageSuccess(m, _)) ⇒ preRestartDefault(reason, Some(m))
+        case Some(LoopMessageSuccess(m, _))  ⇒ preRestartDefault(reason, Some(m))
+        case Some(ReplayedMessage(m))        ⇒ preRestartDefault(reason, Some(m))
+        case mo                              ⇒ preRestartDefault(reason, None)
       }
     }
   }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -28,19 +28,19 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
   private var resequencerCounter = 1L
 
   def receive = {
-    case WriteMessages(resequenceables, processor) ⇒
+    case WriteMessages(resequenceables, processor, actorInstanceId) ⇒
       val cctr = resequencerCounter
       def resequence(f: PersistentRepr ⇒ Any) = resequenceables.zipWithIndex.foreach {
         case (p: PersistentRepr, i) ⇒ resequencer ! Desequenced(f(p), cctr + i + 1, processor, p.sender)
-        case (r, i)                 ⇒ resequencer ! Desequenced(LoopMessageSuccess(r.payload), cctr + i + 1, processor, r.sender)
+        case (r, i)                 ⇒ resequencer ! Desequenced(LoopMessageSuccess(r.payload, actorInstanceId), cctr + i + 1, processor, r.sender)
       }
       asyncWriteMessages(preparePersistentBatch(resequenceables)) onComplete {
         case Success(_) ⇒
           resequencer ! Desequenced(WriteMessagesSuccessful, cctr, processor, self)
-          resequence(WriteMessageSuccess(_))
+          resequence(WriteMessageSuccess(_, actorInstanceId))
         case Failure(e) ⇒
           resequencer ! Desequenced(WriteMessagesFailed(e), cctr, processor, self)
-          resequence(WriteMessageFailure(_, e))
+          resequence(WriteMessageFailure(_, e, actorInstanceId))
       }
       resequencerCounter += resequenceables.length + 1
     case r @ ReplayMessages(fromSequenceNr, toSequenceNr, max, persistenceId, processor, replayDeleted) ⇒
@@ -80,8 +80,8 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
         case Success(_) ⇒ if (publish) context.system.eventStream.publish(d)
         case Failure(e) ⇒
       }
-    case LoopMessage(message, processor) ⇒
-      resequencer ! Desequenced(LoopMessageSuccess(message), resequencerCounter, processor, sender)
+    case LoopMessage(message, processor, actorInstanceId) ⇒
+      resequencer ! Desequenced(LoopMessageSuccess(message, actorInstanceId), resequencerCounter, processor, sender)
       resequencerCounter += 1
   }
 


### PR DESCRIPTION
We have assumed that the handlers can be popped when replies come back from journal, but if messages to journal are in flight when the actor is restarted the handlers does not match up with journal replies.

This solution ignores journal replies that were emitted by an old PersistentActor instance
by passing an uid with the journal messages. This means that the handler will not be
invoked for such messages. That is expected for persistAsync (I think). More suprising
might be that deferred messages are not handled?
