### PR TITLE
=per #15472 Flush instead of unstash when PersistentActor restarts

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -370,6 +370,16 @@ private[persistence] trait Eventsourced extends ProcessorImpl {
   }
 
   /**
+   * INTERNAL API.
+   */
+  override protected[akka] def aroundPreRestart(reason: Throwable, message: Option[Any]): Unit = {
+    // flushJournalBatch will send outstanding persistAsync and defer events to the journal
+    // and also prevent those to be unstashed in Processor.aroundPreRestart
+    flushJournalBatch()
+    super.aroundPreRestart(reason, message)
+  }
+
+  /**
    * Calls `super.preRestart` then unstashes all messages from the internal stash.
    */
   override def preRestart(reason: Throwable, message: Option[Any]) {

--- a/akka-persistence/src/main/scala/akka/persistence/Processor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Processor.scala
@@ -145,8 +145,7 @@ private[akka] trait ProcessorImpl extends Actor with Recovery {
       processorBatch.length >= extension.settings.journal.maxMessageBatchSize
 
     def journalBatch(): Unit = {
-      journal ! WriteMessages(processorBatch, self, instanceId)
-      processorBatch = Vector.empty
+      flushJournalBatch()
       batching = true
     }
   }
@@ -255,6 +254,14 @@ private[akka] trait ProcessorImpl extends Actor with Recovery {
    */
   def deleteMessages(toSequenceNr: Long, permanent: Boolean): Unit = {
     journal ! DeleteMessagesTo(persistenceId, toSequenceNr, permanent)
+  }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def flushJournalBatch(): Unit = {
+    journal ! WriteMessages(processorBatch, self, instanceId)
+    processorBatch = Vector.empty
   }
 
   /**


### PR DESCRIPTION
- When using the Processor batching buffer for persistAsync and defer
  the events were unstashed by Processor.aroundPreRestart and
  thereby were received as commands after restart
- Instead we must flush this buffer when using PersistentActor
