### PR TITLE
Removed guard around _logLevel

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -39,7 +39,7 @@ trait LoggingBus extends ActorEventBus {
   /**
    * Query currently set log level. See object Logging for more information.
    */
-  def logLevel = guard.withGuard { _logLevel }
+  def logLevel = _logLevel
 
   /**
    * Change log level: default loggers (i.e. from configuration file) are


### PR DESCRIPTION
This patch removes a lock around the getter of _logLevel. The setter is
still guarded for consistency. Note that out of thin-air reads, while
not excluded under the current JMM, are forbidden by current hardware.

We needed to read the log level for some additional logging requirements, and the lock was proving to be a bottleneck.
