### PR TITLE
RecoveryCompleted handled by receiveRecover

### DIFF
--- a/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
@@ -143,14 +143,15 @@ public class PersistenceDocTest {
           
             @Override
             public void onReceiveRecover(Object message) {
+	      if (message instanceof RecoveryCompleted) {
+	          recoveryCompleted();
+	      }
               // ...
             }
             
             @Override
             public void onReceiveCommand(Object message) throws Exception {
-                if (message instanceof RecoveryCompleted) {
-                    recoveryCompleted();
-                } else if (message instanceof String) {
+                if (message instanceof String) {
                   // ...
                 } else {
                     unhandled(message);

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -92,11 +92,11 @@ trait PersistenceDocSpec {
       //#recovery-completed
 
       def receiveRecover: Receive = {
+        case RecoveryCompleted => recoveryCompleted()
         case evt => //...
       }
 
       def receiveCommand: Receive = {
-        case RecoveryCompleted => recoveryCompleted()
         case msg               => //...
       }
 

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
@@ -146,14 +146,14 @@ public class LambdaPersistenceDocTest {
 
       @Override public PartialFunction<Object, BoxedUnit> receiveRecover() {
         return ReceiveBuilder.
+          match(RecoveryCompleted.class, r -> {
+            recoveryCompleted();
+          }).
           match(String.class, this::handleEvent).build();
       }
 
       @Override public PartialFunction<Object, BoxedUnit> receiveCommand() {
         return ReceiveBuilder.
-          match(RecoveryCompleted.class, r -> {
-            recoveryCompleted();
-          }).
           match(String.class, s -> s.equals("cmd"),
             s -> persist("evt", this::handleEvent)).build();
       }      


### PR DESCRIPTION
There is a little mistake in docs: RecoveryComplete is handled by receiveRecover, not by receiveCommand

```
class RecoveryTest extends PersistentActor with AtLeastOnceDelivery {
  val log = Logging(context.system, this)
  def receiveCommand = {
      case RecoveryCompleted => log.info("Recovery completed in receiveCommand")
   }
  def receiveRecover = {
      case RecoveryCompleted => log.info("Recovery completed in receiveRecover")
   }
}
```

Prints:

```
[info] [INFO] [07/03/2014 04:05:35.170] [default-akka.actor.default-dispatcher-3] [akka://default/user/$a] Recovery complete in receiveRecover
```
