### PR TITLE
=doc #15491 java circuit breaker doc update

### DIFF
--- a/akka-docs/rst/common/code/docs/circuitbreaker/DangerousJavaActor.java
+++ b/akka-docs/rst/common/code/docs/circuitbreaker/DangerousJavaActor.java
@@ -51,17 +51,15 @@ public class DangerousJavaActor extends UntypedActor {
     if (message instanceof String) {
       String m = (String) message;
       if ("is my middle name".equals(m)) {
-        final Future<String> f = future(
-          new Callable<String>() {
-            public String call() {
-              return dangerousCall();
-            }
-          }, getContext().dispatcher());
-
         pipe(breaker.callWithCircuitBreaker(
           new Callable<Future<String>>() {
             public Future<String> call() throws Exception {
-              return f;
+              return future(
+                      new Callable<String>() {
+                          public String call() {
+                            return dangerousCall();
+                          }
+                        }, getContext().dispatcher());
             }
           }), getContext().dispatcher()).to(getSender());
       }


### PR DESCRIPTION
Quick fix to avoid f to start executing even if circuit is open. Unsure whether to use getContext().dispatcher() inside Callable or do final ExecutionContext ec = getContext().dispatcher() outside instead.

I somehow managed to screw up the first commit, ignore that. 
