### PR TITLE
added protocol family argument to Bind message

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
@@ -3,17 +3,18 @@
  */
 package akka.io
 
-import java.net.InetSocketAddress
+import java.net.{ InetAddress, InetSocketAddress, ProtocolFamily, StandardProtocolFamily, NetworkInterface }
 import akka.testkit.{ TestProbe, ImplicitSender, AkkaSpec }
 import akka.util.ByteString
-import akka.actor.ActorRef
+import akka.actor.{ ActorSystem, ActorRef }
 import akka.io.Udp._
 import akka.TestUtils._
+import scala.Serializable
+import scala.collection.immutable
+import akka.io.Inet.SocketOption
+import akka.io.Inet.SO.{ ReuseAddress, JoinGroup }
 
-class UdpIntegrationSpec extends AkkaSpec("""
-    akka.loglevel = INFO
-    akka.actor.serialize-creators = on""") with ImplicitSender {
-
+trait UdpSpecHelpers { this: AkkaSpec ⇒
   val addresses = temporaryServerAddresses(3, udp = true)
 
   def bindUdp(address: InetSocketAddress, handler: ActorRef): ActorRef = {
@@ -23,12 +24,24 @@ class UdpIntegrationSpec extends AkkaSpec("""
     commander.sender()
   }
 
+  def bindUdp(family: ProtocolFamily, options: immutable.Traversable[SocketOption], address: InetSocketAddress, handler: ActorRef): TestProbe = {
+    val commander = TestProbe()
+    commander.send(IO(Udp), Bind(handler, address, options, Some(family)))
+    commander
+  }
+
   val simpleSender: ActorRef = {
     val commander = TestProbe()
     commander.send(IO(Udp), SimpleSender)
     commander.expectMsg(SimpleSenderReady)
     commander.sender()
   }
+}
+
+class UdpIntegrationSpec extends AkkaSpec("""
+    akka.loglevel = INFO
+    akka.actor.serialize-creators = on
+  """) with ImplicitSender with UdpSpecHelpers {
 
   "The UDP Fire-and-Forget implementation" must {
 
@@ -75,4 +88,36 @@ class UdpIntegrationSpec extends AkkaSpec("""
     }
   }
 
+  "The UDP Protocol Family option" must {
+
+    "be able to bind to IPv4 and IPv6 addresses" in {
+      val ipv4Address = new InetSocketAddress("127.0.0.1", 0)
+      bindUdp(StandardProtocolFamily.INET, Nil, ipv4Address, testActor).expectMsgType[Bound]
+
+      val ipv6Address = new InetSocketAddress("::1", 0)
+      bindUdp(StandardProtocolFamily.INET6, Nil, ipv6Address, testActor).expectMsgType[Bound]
+    }
+
+    "fail when the protocol family is unsupported" in {
+      val unsupported = new ProtocolFamily with Serializable { def name() = "fake protocol" }
+      val address = new InetSocketAddress("", 0)
+      bindUdp(unsupported, Nil, address, testActor).expectMsgType[CommandFailed]
+    }
+  }
+}
+
+class UdpNoSerializeIntegrationSpec extends AkkaSpec("""
+    akka.loglevel = INFO
+    akka.actor.serialize-creators = on
+    akka.actor.serialize-messages = off
+  """) with ImplicitSender with UdpSpecHelpers {
+
+  "The UDP Protocol Family option" must {
+    "be able to join an IPv4 multicast group" in {
+      val multicastAddress = new InetSocketAddress("127.0.0.1", 0)
+      val group = InetAddress.getByName("224.0.0.1")
+      val interf = NetworkInterface.getByInetAddress(InetAddress.getLocalHost)
+      bindUdp(StandardProtocolFamily.INET, List(JoinGroup(group, interf)), multicastAddress, testActor).expectMsgType[Bound]
+    }
+  }
 }

--- a/akka-actor/src/main/scala/akka/io/Inet.scala
+++ b/akka-actor/src/main/scala/akka/io/Inet.scala
@@ -3,7 +3,7 @@
  */
 package akka.io
 
-import java.net.{ DatagramSocket, Socket, ServerSocket }
+import java.net.{ DatagramSocket, Socket, ServerSocket, InetAddress, NetworkInterface }
 
 object Inet {
 
@@ -75,6 +75,16 @@ object Inet {
     final case class TrafficClass(tc: Int) extends SocketOption {
       require(0 <= tc && tc <= 255, "TrafficClass needs to be in the interval [0, 255]")
       override def afterConnect(s: Socket): Unit = s.setTrafficClass(tc)
+    }
+
+    /**
+     * [[akka.io.Inet.SocketOption]] to join a multicast group to begin
+     * receiving all datagrams sent to the group.
+     *
+     * For more information see [[java.nio.channels.MulticastChannel.join]]
+     */
+    final case class JoinGroup(group: InetAddress, interf: NetworkInterface) extends SocketOption {
+      override def beforeDatagramBind(ds: DatagramSocket): Unit = ds.getChannel.join(group, interf)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -3,8 +3,7 @@
  */
 package akka.io
 
-import java.net.DatagramSocket
-import java.net.InetSocketAddress
+import java.net.{ DatagramSocket, InetSocketAddress, ProtocolFamily }
 import com.typesafe.config.Config
 import scala.collection.immutable
 import akka.io.Inet.{ SoJavaFactories, SocketOption }
@@ -94,7 +93,8 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    */
   final case class Bind(handler: ActorRef,
                         localAddress: InetSocketAddress,
-                        options: immutable.Traversable[SocketOption] = Nil) extends Command
+                        options: immutable.Traversable[SocketOption] = Nil,
+                        family: Option[ProtocolFamily] = None) extends Command
 
   /**
    * Send this message to the listener actor that previously sent a [[Bound]]
@@ -284,6 +284,11 @@ object UdpMessage {
    * Bind without specifying options.
    */
   def bind(handler: ActorRef, endpoint: InetSocketAddress): Command = Bind(handler, endpoint, Nil)
+  /**
+   * Bind with options and protocol family.
+   */
+  def bind(handler: ActorRef, endpoint: InetSocketAddress, options: JIterable[SocketOption], family: ProtocolFamily): Command =
+    Bind(handler, endpoint, options.asScala.to, Some(family))
 
   /**
    * Send this message to the listener actor that previously sent a [[Udp.Bound]]


### PR DESCRIPTION
added new socket option to join a multicast group

This commit provides the means to specify the protocol family (e.g., IPv4 or IPv6) when an actor attempts to bind to a socket using IO(Udp). On systems that are dual stacked, the current implementation will prefer IPv6; preventing a socket from joining an IPv4 multicast group.
