### PR TITLE
=ben #update PersistentActor and friends benchmark 

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
@@ -110,9 +110,14 @@ class Persist1EventPersistentActor(respondAfter: Int) extends PersistentActor {
   }
 
 }
-class Persist1CommandProcessor(respondAfter: Int) extends Processor {
-  override def receive = {
+class Persist1CommandProcessor(respondAfter: Int) extends PersistentActor {
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
     case n: Int => if (n == respondAfter) sender() ! Evt(n)
+  }
+  override def receiveRecover = {
+    case _ => // do nothing
   }
 }
 


### PR DESCRIPTION
sorry for my previous PR https://github.com/akka/akka/pull/15517 not that right,I corrected this via this one.
now the Persist1CommandProcessor extends the PersistentActor and not `persist`message.
