### PR TITLE
Logging the NonFatal error in EndpointWrite

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -775,6 +775,7 @@ private[remote] class EndpointWriter(
     case e: EndpointException ⇒
       publishAndThrow(e, Logging.ErrorLevel)
     case NonFatal(e) ⇒
+      log.error(e, "Failed to write message to the transport")
       publishAndThrow(new EndpointException("Failed to write message to the transport", e), Logging.ErrorLevel)
   }
 


### PR DESCRIPTION
Fixing Issue #15530 [In akka-remote EndpointWriter NonFatal exception
is not logged at error level.]
