### PR TITLE
=act #15488 Removed guard around _logLevel (for validation)

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -39,7 +39,7 @@ trait LoggingBus extends ActorEventBus {
   /**
    * Query currently set log level. See object Logging for more information.
    */
-  def logLevel = guard.withGuard { _logLevel }
+  def logLevel = _logLevel
 
   /**
    * Change log level: default loggers (i.e. from configuration file) are


### PR DESCRIPTION
backport of https://github.com/akka/akka/pull/15481
