### PR TITLE
!act #13490 Changed the callback to SocketOption to accept a channel instead of a Socket, this allows for using the nio features.

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -5,7 +5,7 @@
 package akka.io
 
 import java.net.InetSocketAddress
-import java.net.Socket
+import java.nio.channels.SocketChannel
 import akka.io.Inet._
 import com.typesafe.config.Config
 import scala.concurrent.duration._
@@ -56,7 +56,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
      * For more information see [[java.net.Socket.setKeepAlive]]
      */
     final case class KeepAlive(on: Boolean) extends SocketOption {
-      override def afterConnect(s: Socket): Unit = s.setKeepAlive(on)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setKeepAlive(on)
     }
 
     /**
@@ -67,7 +67,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
      * For more information see [[java.net.Socket.setOOBInline]]
      */
     final case class OOBInline(on: Boolean) extends SocketOption {
-      override def afterConnect(s: Socket): Unit = s.setOOBInline(on)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setOOBInline(on)
     }
 
     // SO_LINGER is handled by the Close code
@@ -81,7 +81,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
      * For more information see [[java.net.Socket.setTcpNoDelay]]
      */
     final case class TcpNoDelay(on: Boolean) extends SocketOption {
-      override def afterConnect(s: Socket): Unit = s.setTcpNoDelay(on)
+      override def afterConnect(c: SocketChannel): Unit = c.socket.setTcpNoDelay(on)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -179,7 +179,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
                       options: immutable.Traversable[SocketOption]): Unit = {
     // Turn off Nagle's algorithm by default
     channel.socket.setTcpNoDelay(true)
-    options.foreach(_.afterConnect(channel.socket))
+    options.foreach(_.afterConnect(channel))
 
     commander ! Connected(
       channel.socket.getRemoteSocketAddress.asInstanceOf[InetSocketAddress],

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -49,7 +49,7 @@ private[io] class TcpListener(selectorRouter: ActorRef,
   val localAddress =
     try {
       val socket = channel.socket
-      bind.options.foreach(_.beforeServerSocketBind(socket))
+      bind.options.foreach(_.beforeBind(channel))
       socket.bind(bind.localAddress, bind.backlog)
       val ret = socket.getLocalSocketAddress match {
         case isa: InetSocketAddress ⇒ isa
@@ -57,6 +57,7 @@ private[io] class TcpListener(selectorRouter: ActorRef,
       }
       channelRegistry.register(channel, if (bind.pullMode) 0 else SelectionKey.OP_ACCEPT)
       log.debug("Successfully bound to {}", ret)
+      bind.options.foreach(_.afterConnect(channel))
       ret
     } catch {
       case NonFatal(e) ⇒

--- a/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -30,7 +30,7 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
 
   context.watch(commander) // sign death pact
 
-  options.foreach(_.beforeConnect(channel.socket))
+  options.foreach(_.beforeBind(channel))
   localAddress.foreach(channel.socket.bind)
   channelRegistry.register(channel, 0)
   timeout foreach context.setReceiveTimeout //Initiate connection timeout if supplied

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -3,8 +3,8 @@
  */
 package akka.io
 
-import java.net.DatagramSocket
 import java.net.InetSocketAddress
+import java.nio.channels.DatagramChannel
 import com.typesafe.config.Config
 import scala.collection.immutable
 import akka.io.Inet.{ SoJavaFactories, SocketOption }
@@ -180,7 +180,7 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
      * For more information see [[java.net.DatagramSocket#setBroadcast]]
      */
     final case class Broadcast(on: Boolean) extends SocketOption {
-      override def beforeDatagramBind(s: DatagramSocket): Unit = s.setBroadcast(on)
+      override def beforeBind(c: DatagramChannel): Unit = c.socket.setBroadcast(on)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -35,7 +35,7 @@ private[io] class UdpConnection(udpConn: UdpConnectedExt,
     val datagramChannel = DatagramChannel.open
     datagramChannel.configureBlocking(false)
     val socket = datagramChannel.socket
-    options.foreach(_.beforeDatagramBind(socket))
+    options.foreach(_.beforeBind(datagramChannel))
     try {
       localAddress foreach socket.bind
       datagramChannel.connect(remoteAddress)
@@ -53,6 +53,7 @@ private[io] class UdpConnection(udpConn: UdpConnectedExt,
 
   def receive = {
     case registration: ChannelRegistration ⇒
+      options.foreach(_.afterConnect(channel))
       commander ! Connected
       context.become(connected(registration), discardOld = true)
   }

--- a/akka-actor/src/main/scala/akka/io/UdpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpListener.scala
@@ -37,7 +37,7 @@ private[io] class UdpListener(val udp: UdpExt,
   val localAddress =
     try {
       val socket = channel.socket
-      bind.options.foreach(_.beforeDatagramBind(socket))
+      bind.options.foreach(_.beforeBind(channel))
       socket.bind(bind.localAddress)
       val ret = socket.getLocalSocketAddress match {
         case isa: InetSocketAddress ⇒ isa
@@ -45,6 +45,7 @@ private[io] class UdpListener(val udp: UdpExt,
       }
       channelRegistry.register(channel, OP_READ)
       log.debug("Successfully bound to [{}]", ret)
+      bind.options.foreach(_.afterConnect(channel))
       ret
     } catch {
       case NonFatal(e) ⇒

--- a/akka-actor/src/main/scala/akka/io/UdpSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpSender.scala
@@ -23,9 +23,7 @@ private[io] class UdpSender(val udp: UdpExt,
   val channel = {
     val datagramChannel = DatagramChannel.open
     datagramChannel.configureBlocking(false)
-    val socket = datagramChannel.socket
-
-    options foreach { _.beforeDatagramBind(socket) }
+    options foreach { _.beforeBind(datagramChannel) }
 
     datagramChannel
   }
@@ -33,6 +31,7 @@ private[io] class UdpSender(val udp: UdpExt,
 
   def receive: Receive = {
     case registration: ChannelRegistration ⇒
+      options.foreach(_.afterConnect(channel))
       commander ! SimpleSenderReady
       context.become(sendHandlers(registration))
   }

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -51,6 +51,21 @@ Which turns out to be useful in many systems where same-state transitions actual
 
 In case you do *not* want to trigger a state transition event when effectively performing an ``X->X`` transition, use ``stay()`` instead.
 
+SocketOption's method signature changed to access channel
+=========================================================
+Server Socket Methods have been changed to take a channel instead of a socket.  The channel's socket can be retrieved by calling ``channel.socket``.  This allows for accessing new NIO features in Java 7.
+
+========================================  =====================================
+                 2.3                                      2.4
+========================================  =====================================
+``beforeDatagramBind(DatagramSocket)``    ``beforeBind(DatagramChannel)``
+``beforeServerSocketBind(ServerSocket)``  ``beforeBind(ServerSocketChannel)``
+``beforeConnect(Socket)``                 ``beforeBind(SocketChannel)``
+\                                         ``afterConnect(DatagramChannel)``
+\                                         ``afterConnect(ServerSocketChannel)``
+``afterConnect(Socket)``                  ``afterConnect(SocketChannel)``
+========================================  =====================================
+
 Removed Deprecated Features
 ===========================
 


### PR DESCRIPTION
Changed the callback to SocketOption to accept a channel instead of a Socket, this allows for using the nio features.

For example in Java 7 you can now join a multicast group:

``` scala
case class JoinGroup(group: InetAddress, networkInterface: NetworkInterface) extends SocketOption {

  override def afterConnect(c: DatagramChannel): Unit = {
    c.join(group, networkInterface)
  }
}

  IO(Udp) ! Udp.Bind(self, new InetSocketAddress(MulticastListener.port),
    options=List(ReuseAddress(true),
      JoinGroup(MulticastListener.group, MulticastListener.interf)))
```
