### PR TITLE
+str #15089 add flattening for streams: merge

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/FlattenStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/FlattenStrategy.scala
@@ -18,6 +18,8 @@ object FlattenStrategy {
    * consequence that if one of the input stream is infinite, no other streams after that will be consumed from.
    */
   def concat[T]: FlattenStrategy[Producer[T], T] = Concat[T]()
+  def merge[T](maxSimultaneousInputs: Int = 8): FlattenStrategy[Producer[T], T] = Merge[T](maxSimultaneousInputs)
 
   private[akka] case class Concat[T]() extends FlattenStrategy[Producer[T], T]
+  private[akka] case class Merge[T](maxSimultaneousInputs: Int) extends FlattenStrategy[Producer[T], T]
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -63,6 +63,10 @@ private[akka] object Ast {
     override def name = "concatFlatten"
   }
 
+  case class MergeAll(maxSimultaneousInputs: Int) extends AstNode {
+    override def name = "mergeFlatten"
+  }
+
   case class Conflate(seed: Any ⇒ Any, aggregate: (Any, Any) ⇒ Any) extends AstNode {
     override def name = "conflate"
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -38,6 +38,7 @@ private[akka] object ActorProcessor {
       case bf: Buffer        ⇒ Props(new BufferImpl(settings, bf.size, bf.overflowStrategy))
       case tt: PrefixAndTail ⇒ Props(new PrefixAndTailImpl(settings, tt.n))
       case ConcatAll         ⇒ Props(new ConcatAllImpl(settings))
+      case ma: MergeAll      ⇒ Props(new MergeAllImpl(settings, ma.maxSimultaneousInputs))
       case m: MapFuture      ⇒ Props(new MapFutureProcessorImpl(settings, m.f))
     }).withDispatcher(settings.dispatcher)
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowImpl.scala
@@ -330,6 +330,7 @@ private[akka] trait Builder[Out] {
 
   def flatten[U](strategy: FlattenStrategy[Out, U]): Thing[U] = strategy match {
     case _: FlattenStrategy.Concat[Out] ⇒ andThen(ConcatAll)
+    case m: FlattenStrategy.Merge[Out]  ⇒ andThen(MergeAll(m.maxSimultaneousInputs))
     case _                              ⇒ throw new IllegalArgumentException(s"Unsupported flattening strategy [${strategy.getClass.getSimpleName}]")
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/MergeAllImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/MergeAllImpl.scala
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl
+
+import akka.stream.MaterializerSettings
+import akka.stream.impl.MultiStreamInputProcessor.SubstreamKey
+import org.reactivestreams.api.Producer
+
+/**
+ * INTERNAL API
+ */
+private[akka] class MergeAllImpl(_settings: MaterializerSettings, maxSimultaneousInputs: Int)
+  extends MultiStreamInputProcessor(_settings) {
+  var inputs = List[SubstreamInputs]()
+
+  object InputReady extends TransferState {
+    override def isReady = primaryInputs.inputsAvailable &&
+      inputs.filterNot(_.inputsDepleted).size < maxSimultaneousInputs
+    override def isCompleted = primaryInputs.inputsDepleted
+  }
+  object SubstreamsReady extends TransferState {
+    override def isReady = inputs.exists(_.inputsAvailable)
+    override def isCompleted = !inputs.exists(!_.inputsDepleted)
+  }
+
+  val running: TransferPhase = TransferPhase(
+    primaryOutputs.NeedsDemand && (InputReady || SubstreamsReady)) { () ⇒
+      while (InputReady.isExecutable) {
+        fetchNewInputSubstream()
+      }
+      if (SubstreamsReady.isExecutable) {
+        inputs.find(_.inputsAvailable) foreach { input ⇒
+          primaryOutputs.enqueueOutputElement(input.dequeueInputElement())
+        }
+      }
+      inputs = inputs.filterNot(_.inputsDepleted)
+    }
+
+  def fetchNewInputSubstream() = {
+    val producer = primaryInputs.dequeueInputElement().asInstanceOf[Producer[Any]]
+    inputs :+= createSubstreamInputs(producer)
+  }
+
+  override def invalidateSubstream(substream: SubstreamKey, e: Throwable): Unit = {
+    fail(e)
+  }
+
+  nextPhase(running)
+}

--- a/akka-stream/src/test/scala/akka/stream/FlowMergeAllSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowMergeAllSpec.scala
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream
+
+import akka.stream.scaladsl.Flow
+import akka.stream.testkit.{ AkkaSpec, ChainSetup, StreamTestKit }
+import org.reactivestreams.api.Producer
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.control.NoStackTrace
+
+class FlowMergeAllSpec extends AkkaSpec {
+
+  val ms = MaterializerSettings(
+    initialInputBufferSize = 1,
+    maximumInputBufferSize = 1,
+    initialFanOutBufferSize = 1,
+    maxFanOutBufferSize = 1,
+    dispatcher = "akka.test.stream-dispatcher")
+  val m = FlowMaterializer(ms)
+  val testException = new Exception("test") with NoStackTrace
+  class MergeChain(maxInputs: Int = 8) extends ChainSetup[Producer[Int], Int](_.flatten(FlattenStrategy.merge(maxInputs)), ms)
+
+  "MergeAll" must {
+    "work in happy case like concatAll" in {
+      val s1 = Flow((1 to 2).iterator).toProducer(m)
+      val s2 = Flow(List.empty[Int]).toProducer(m)
+      val s3 = Flow(List(3)).toProducer(m)
+      val s4 = Flow((4 to 6).iterator).toProducer(m)
+      val s5 = Flow((7 to 10).iterator).toProducer(m)
+
+      val main: Flow[Producer[Int]] = Flow(List(s1, s2, s3, s4, s5))
+
+      val result = Await.result(main.flatten(FlattenStrategy.merge()).grouped(10).toFuture(m), 3.seconds).toSet
+      result should be(1 to 10 toSet)
+    }
+
+    "fetch messages from substreams" in {
+      new MergeChain {
+        downstreamSubscription.requestMore(5)
+        upstreamSubscription.expectRequestMore()
+        upstreamSubscription.sendNext(Flow(List(1, 2, 3)).toProducer(m))
+        downstream.expectNext(1, 2, 3)
+        downstream.expectNoMsg(200 millis)
+
+        upstreamSubscription.sendNext(Flow(List(4, 5, 6)).toProducer(m))
+        downstream.expectNext(4, 5)
+        downstream.expectNoMsg(200 millis)
+
+        downstreamSubscription.requestMore(5)
+        downstream.expectNext(6)
+        upstreamSubscription.expectRequestMore()
+
+        upstreamSubscription.sendComplete()
+        downstream.expectComplete()
+      }
+    }
+
+    "react to error in substeram and cause master stream to error" in {
+      new MergeChain {
+        downstreamSubscription.requestMore(1)
+        upstreamSubscription.expectRequestMore(1)
+        upstreamSubscription.sendNext(Flow[Int](() ⇒ throw testException).toProducer(m))
+        upstreamSubscription.expectCancellation()
+        downstream.expectError(testException)
+      }
+    }
+
+    "react to error in master stream and cause it to error" in {
+      new MergeChain {
+        downstreamSubscription.requestMore(5)
+        upstreamSubscription.expectRequestMore()
+        upstreamSubscription.sendNext(Flow(List(1, 2, 3).iterator).toProducer(m))
+        upstreamSubscription.sendError(testException)
+        downstream.expectError(testException)
+      }
+    }
+
+    "stop requesting substreams when substreams limit reached" in {
+      new MergeChain(maxInputs = 1) {
+        downstreamSubscription.requestMore(1)
+
+        val substream = StreamTestKit.producerProbe[Int]()
+        val substreamCached = StreamTestKit.producerProbe[Int]()
+        upstreamSubscription.expectRequestMore(1)
+        upstreamSubscription.sendNext(substream)
+
+        upstreamSubscription.expectRequestMore(1)
+        upstreamSubscription.sendNext(substreamCached)
+
+        val substreamSubscription = substream.expectSubscription()
+        substreamCached.expectNoMsg()
+        upstream.expectNoMsg()
+      }
+    }
+
+    "process streams one by one when max simultaneous streams is one" in {
+      val s1 = Flow((1 to 2).iterator).toProducer(m)
+      val s2 = Flow(List.empty[Int]).toProducer(m)
+      val s3 = Flow(List(3)).toProducer(m)
+      val s4 = Flow((4 to 6).iterator).toProducer(m)
+      val s5 = Flow((7 to 10).iterator).toProducer(m)
+
+      val main: Flow[Producer[Int]] = Flow(List(s1, s2, s3, s4, s5))
+
+      val result = Await.result(main.flatten(FlattenStrategy.merge(1)).grouped(10).toFuture(m), 3.seconds)
+      result should be(1 to 10)
+    }
+
+    "handle closed producers" in {
+      new MergeChain {
+        downstreamSubscription.requestMore(50)
+        val producers = 1 to 3 map { _ ⇒ StreamTestKit.producerProbe[Int] }
+        var upstreams = producers.map { _producer ⇒
+          upstreamSubscription.sendNext(_producer)
+          _producer.expectSubscription()
+        }
+        upstreamSubscription.sendComplete()
+
+        upstreams.zipWithIndex.foreach { case (us, n) ⇒ us.sendNext(n * 10) }
+        downstream.expectNext(0, 10, 20)
+
+        upstreams.last.sendComplete()
+        upstreams = upstreams.dropRight(1)
+        upstreams.zipWithIndex.foreach { case (us, n) ⇒ us.sendNext(n * 10 + 1) }
+
+        downstream.expectNext(1, 11)
+
+        upstreams.last.sendComplete()
+        upstreams = upstreams.dropRight(1)
+        upstreams.zipWithIndex.foreach { case (us, n) ⇒ us.sendNext(n * 10 + 2) }
+
+        downstream.expectNext(2)
+
+        upstreams.head.sendComplete()
+        downstream.expectComplete()
+      }
+    }
+  }
+}


### PR DESCRIPTION
I am trying to implement merge concatenation of streams described in #15089. 

This is my first PL with new functionality, so please point me to general issues need to be corrected.

What is done:
- fetching from first available substream
- simultaneous open substream limitation

What is not done:
- support of merging strategies. Now item fetched from the first available substream. Can be done after #15079

Open questions:
- when errors should be propagated?
- MergeAllImpl:19 looks ugly. Any ideas how to simplify this are welcome. 
