### PR TITLE
=con #15574 impr TimerBasedThrottlerSpec stability

### DIFF
--- a/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottlerSpec.scala
@@ -87,7 +87,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
       expectNoMsg(1 second)
       throttler ! SetTarget(Some(echo))
       4 to 7 foreach { throttler ! _ }
-      within(0.5 seconds, 1.5 seconds) {
+      within(1.5 seconds) {
         4 to 7 foreach { expectMsg(_) }
       }
     }
@@ -104,7 +104,7 @@ class TimerBasedThrottlerSpec extends TestKit(ActorSystem("TimerBasedThrottlerSp
       }
       expectNoMsg(1 second)
       throttler ! SetTarget(Some(echo))
-      within(0.5 seconds, 1.5 seconds) {
+      within(1.5 seconds) {
         4 to 7 foreach { expectMsg(_) }
       }
     }


### PR DESCRIPTION
- the lower bound was rather racy, depends on "where in it's Tick"
  time the throtteler currently was. In general the upper bound is also
  not exact, but "good enough" because the `.5` is an estimation of "the
  throtteler must finish it's previous tick, and then it sends the data"

Resolves #15574
