### PR TITLE
Update AbstractNodeQueue.java to avoid redundant reads of head in peekNode

### DIFF
--- a/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
@@ -33,7 +33,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         Node<T> next = tail.next();
         if (next == null && get() != tail) {
             // if tail != head this is not going to change until consumer makes progress
-            // we can avoid reading the head and just spin on next until it shows the f**k up
+            // we can avoid reading the head and just spin on next until it shows up
             do {
                 next = tail.next();
             } while (next == null);

--- a/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
@@ -57,12 +57,12 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
     }
 
     public final boolean isEmpty() {
-        return peek() == null;
+        return Unsafe.instance.getObjectVolatile(this, tailOffset)) == get();
     }
 
     public final int count() {
         int count = 0;
-        for(Node<T> n = peekNode();n != null; n = n.next())
+        for(Node<T> n = peekNode();n != null && count < Integer.MAX_VALUE; n = n.next())
           ++count;
         return count;
     }

--- a/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
@@ -24,7 +24,9 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
        set(n);
     }
 
-    /*
+    /**
+     * Use this method only from the consumer thread!
+     * 
      * !!! There is a copy of this code in pollNode() !!!
      */
     @SuppressWarnings("unchecked")
@@ -40,7 +42,9 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         }
         return next;
     }
-
+    /**
+     * Use this method only from the consumer thread!
+     */
     public final T peek() {
         final Node<T> n = peekNode();
         return (n != null) ? n.value : null;
@@ -67,7 +71,9 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         return count;
     }
 
-    /*
+    /**
+     * Use this method only from the consumer thread!
+     * 
      * !!! There is a copy of this code in pollNode() !!!
      */
     public final T poll() {
@@ -81,6 +87,9 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         }
     }
     
+    /**
+     * Use this method only from the consumer thread!
+     */
     @SuppressWarnings("unchecked")
     public final Node<T> pollNode() {
       Node<T> tail;

--- a/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
@@ -61,7 +61,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
     }
 
     public final boolean isEmpty() {
-        return Unsafe.instance.getObjectVolatile(this, tailOffset)) == get();
+        return Unsafe.instance.getObjectVolatile(this, tailOffset) == get();
     }
 
     public final int count() {

--- a/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
@@ -24,7 +24,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
        set(n);
     }
 
-    /**
+    /*
      * Use this method only from the consumer thread!
      * 
      * !!! There is a copy of this code in pollNode() !!!
@@ -42,7 +42,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         }
         return next;
     }
-    /**
+    /*
      * Use this method only from the consumer thread!
      */
     public final T peek() {
@@ -71,7 +71,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         return count;
     }
 
-    /**
+    /*
      * Use this method only from the consumer thread!
      * 
      * !!! There is a copy of this code in pollNode() !!!
@@ -87,7 +87,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         }
     }
     
-    /**
+    /*
      * Use this method only from the consumer thread!
      */
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Avoid spinning on head when a peek/poll observes a null next but the queue is not empty.
