### PR TITLE
!scr do not remove tags (github) that are not set on an issue

### DIFF
--- a/scripts/build/github-tagging.sh
+++ b/scripts/build/github-tagging.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-# tag an github issue with the given tag, api token is taken from env ($PR_VALIDATOR_GH_TOKEN)
+# add and remove tags from an github issue, api token is taken from env ($PR_VALIDATOR_GH_TOKEN)
 # usage: ghtag ISSUE_NR OWNER REPO ADD_TAGS RM_TAGS
 #
 # ADD_TAGS should be json with tokens you want to add, as in: ["tested"]
@@ -18,10 +18,22 @@ function ghtag {
   add=$4
   remove=$5
 
+  # checking for existing tags
+  currentTagsJson=`curl -s -H "Authorization: token $PR_VALIDATOR_GH_TOKEN" https://api.github.com/repos/$owner/$repo/issues/$issue/labels`
+  currentTags=`echo "$currentTagsJson" | python -mjson.tool | grep '"name":' | awk '{ print $2 }' | sed s/\"//g | sed s/,//g`
+
+  # adding new tags - we do want to show these, always performing
   curl -s -H "Authorization: token $PR_VALIDATOR_GH_TOKEN" https://api.github.com/repos/$owner/$repo/issues/$issue/labels -X POST -d $add > /dev/null
+
+  # removing tags
   for d in $remove
   do
-    curl -s -H "Authorization: token $PR_VALIDATOR_GH_TOKEN" https://api.github.com/repos/$owner/$repo/issues/$issue/labels/$d -X DELETE > /dev/null
+    # only delete tags that actually are set on the issue, otherwise github shows these "removed tag" events,
+    # even if the tag never was previously set - which is confusing / verbose
+    if [[ $currentTags == *$d* ]]
+    then
+      curl -s -H "Authorization: token $PR_VALIDATOR_GH_TOKEN" https://api.github.com/repos/$owner/$repo/issues/$issue/labels/$d -X DELETE > /dev/null
+    fi
   done
 }
 


### PR DESCRIPTION
Since the updated github issues views, it shows all "removed tags",
events in the issue even if the removed tag was never set on the issue.
So this script would always show up as "removed validating,needs-attention"
Even if the issue never had the label needs-attention set to it,
which is confusing visually.

This change introduces that we only remove tags that actually are set on
the issue.
