### PR TITLE
=15648 ker Use wildcard in microkernel classpath

### DIFF
--- a/akka-kernel/src/main/dist/bin/akka
+++ b/akka-kernel/src/main/dist/bin/akka
@@ -19,6 +19,6 @@ declare AKKA_HOME="$(cd "$(cd "$(dirname "$0")"; pwd -P)"/..; pwd)"
 
 [ -n "$JAVA_OPTS" ] || JAVA_OPTS="-Xms1024M -Xmx1024M -Xss1M -XX:MaxPermSize=256M -XX:+UseParallelGC"
 
-[ -n "$AKKA_CLASSPATH" ] || AKKA_CLASSPATH="$AKKA_HOME/lib/scala-library.jar:$AKKA_HOME/config:$AKKA_HOME/lib/akka/*"
+[ -n "$AKKA_CLASSPATH" ] || AKKA_CLASSPATH="$AKKA_HOME/lib/*:$AKKA_HOME/config:$AKKA_HOME/lib/akka/*"
 
 java $JAVA_OPTS -cp "$AKKA_CLASSPATH" -Dakka.home="$AKKA_HOME" -Dakka.kernel.quiet=$quiet akka.kernel.Main "$@"

--- a/akka-kernel/src/main/dist/bin/akka.bat
+++ b/akka-kernel/src/main/dist/bin/akka.bat
@@ -2,6 +2,6 @@
 
 set AKKA_HOME=%~dp0..
 set JAVA_OPTS=-Xmx1024M -Xms1024M -Xss1M -XX:MaxPermSize=256M -XX:+UseParallelGC
-set AKKA_CLASSPATH=%AKKA_HOME%\lib\scala-library.jar;%AKKA_HOME%\config;%AKKA_HOME%\lib\akka\*
+set AKKA_CLASSPATH=%AKKA_HOME%\lib\*;%AKKA_HOME%\config;%AKKA_HOME%\lib\akka\*
 
 java %JAVA_OPTS% -cp "%AKKA_CLASSPATH%" -Dakka.home="%AKKA_HOME%" akka.kernel.Main %*


### PR DESCRIPTION
- scala-library.jar had changed name to scala-library-2.10.4.jar
- use wildcard to avoid same problem when scala-library version is changed
- the wilcard will only include jar files in the lib directory, and not the
  lib/akka directory, see 'Understanding class path wildcards'
  http://docs.oracle.com/javase/6/docs/technotes/tools/windows/classpath.html
