### PR TITLE
!str #15076 Make foreach a terminal operation, returning Future[Unit]

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/http/HttpServerExampleSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/HttpServerExampleSpec.scala
@@ -32,12 +32,12 @@ class HttpServerExampleSpec
     val bindingFuture = IO(Http) ? Http.Bind(interface = "localhost", port = 8080)
     bindingFuture foreach {
       case Http.ServerBinding(localAddress, connectionStream) ⇒
-        Flow(connectionStream).foreach {
+        Flow(connectionStream).foreach({
           case Http.IncomingConnection(remoteAddress, requestProducer, responseConsumer) ⇒
             println("Accepted new connection from " + remoteAddress)
 
           // handle connection here
-        }.consume(materializer)
+        }, materializer)
     }
     //#bind-example
   }
@@ -74,12 +74,12 @@ class HttpServerExampleSpec
     // ...
     bindingFuture foreach {
       case Http.ServerBinding(localAddress, connectionStream) ⇒
-        Flow(connectionStream).foreach {
+        Flow(connectionStream).foreach({
           case Http.IncomingConnection(remoteAddress, requestProducer, responseConsumer) ⇒
             println("Accepted new connection from " + remoteAddress)
 
             Flow(requestProducer).map(requestHandler).produceTo(responseConsumer, materializer)
-        }.consume(materializer)
+        }, materializer)
     }
     //#full-server-example
   }

--- a/akka-http-core/src/test/java/akka/http/model/japi/JavaTestServer.java
+++ b/akka-http-core/src/test/java/akka/http/model/japi/JavaTestServer.java
@@ -21,42 +21,40 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 public abstract class JavaTestServer {
-    public static void main(String[] args) throws IOException, InterruptedException {
-        ActorSystem system = ActorSystem.create();
+  public static void main(String[] args) throws IOException, InterruptedException {
+    ActorSystem system = ActorSystem.create();
 
-        MaterializerSettings settings = MaterializerSettings.create();
-        final FlowMaterializer materializer = FlowMaterializer.create(settings, system);
+    MaterializerSettings settings = MaterializerSettings.create();
+    final FlowMaterializer materializer = FlowMaterializer.create(settings, system);
 
-        ActorRef httpManager = Http.get(system).manager();
-        Future<Object> binding = ask(httpManager, Http.bind("localhost", 8080), 1000);
-        binding.foreach(new Foreach<Object>() {
-            @Override
-            public void each(Object result) throws Throwable {
-                ServerBinding binding = (ServerBinding) result;
-                System.out.println("Bound to " + binding.localAddress());
+    ActorRef httpManager = Http.get(system).manager();
+    Future<Object> binding = ask(httpManager, Http.bind("localhost", 8080), 1000);
+    binding.foreach(new Foreach<Object>() {
+      @Override
+      public void each(Object result) throws Throwable {
+        ServerBinding binding = (ServerBinding) result;
+        System.out.println("Bound to " + binding.localAddress());
 
-                Flow.create(binding.getConnectionStream()).foreach(new Procedure<IncomingConnection>() {
-                    @Override
-                    public void apply(IncomingConnection conn) throws Exception {
-                        System.out.println("New incoming connection from " + conn.remoteAddress());
+        Flow.create(binding.getConnectionStream()).foreach(new Procedure<IncomingConnection>() {
+          @Override
+          public void apply(IncomingConnection conn) throws Exception {
+            System.out.println("New incoming connection from " + conn.remoteAddress());
 
-                        Flow.create(conn.getRequestPublisher())
-                                .map(new Function<HttpRequest, HttpResponse>() {
-                                    @Override
-                                    public HttpResponse apply(HttpRequest request) throws Exception {
-                                        System.out.println("Handling request to " + request.getUri());
-                                        return JavaApiTestCases.handleRequest(request);
-                                    }
-                                })
-                                .produceTo(conn.getResponseSubscriber(), materializer);
-                    }
-                }).consume(materializer);
-            }
-        }, system.dispatcher());
+            Flow.create(conn.getRequestPublisher()).map(new Function<HttpRequest, HttpResponse>() {
+              @Override
+              public HttpResponse apply(HttpRequest request) throws Exception {
+                System.out.println("Handling request to " + request.getUri());
+                return JavaApiTestCases.handleRequest(request);
+              }
+            }).produceTo(conn.getResponseSubscriber(), materializer);
+          }
+        }, materializer);
+      }
+    }, system.dispatcher());
 
-        System.out.println("Press ENTER to stop.");
-        new BufferedReader(new InputStreamReader(System.in)).readLine();
+    System.out.println("Press ENTER to stop.");
+    new BufferedReader(new InputStreamReader(System.in)).readLine();
 
-        system.shutdown();
-    }
+    system.shutdown();
+  }
 }

--- a/akka-http-core/src/test/scala/akka/http/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/TestServer.scala
@@ -36,11 +36,11 @@ object TestServer extends App {
   val bindingFuture = IO(Http) ? Http.Bind(interface = "localhost", port = 8080)
   bindingFuture foreach {
     case Http.ServerBinding(localAddress, connectionStream) ⇒
-      Flow(connectionStream).foreach {
+      Flow(connectionStream).foreach({
         case Http.IncomingConnection(remoteAddress, requestPublisher, responseSubscriber) ⇒
           println("Accepted new connection from " + remoteAddress)
           Flow(requestPublisher).map(requestHandler).produceTo(responseSubscriber, materializer)
-      }.consume(materializer)
+      }, materializer)
   }
 
   println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")

--- a/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/StreamExample.scala
+++ b/akka-samples/akka-sample-persistence-scala/src/main/scala/sample/persistence/StreamExample.scala
@@ -34,14 +34,14 @@ object StreamExample extends App {
 
   // 1 view-backed producer and 2 consumers:
   val producer1: Publisher[Persistent] = PersistentFlow.fromProcessor("p1").toPublisher(materializer)
-  Flow(producer1).foreach { p => println(s"consumer-1: ${p.payload}") }.consume(materializer)
-  Flow(producer1).foreach { p => println(s"consumer-2: ${p.payload}") }.consume(materializer)
+  Flow(producer1).foreach(p => println(s"consumer-1: ${p.payload}"), materializer)
+  Flow(producer1).foreach(p => println(s"consumer-2: ${p.payload}"), materializer)
 
   // 2 view-backed producers (merged) and 1 consumer:
   // This is an example how message/event streams from multiple processors can be merged into a single stream.
   val producer2: Publisher[Persistent] = PersistentFlow.fromProcessor("p1").toPublisher(materializer)
   val merged: Publisher[Persistent] = PersistentFlow.fromProcessor("p2").merge(producer2).toPublisher(materializer)
-  Flow(merged).foreach { p => println(s"consumer-3: ${p.payload}") }.consume(materializer)
+  Flow(merged).foreach(p => println(s"consumer-3: ${p.payload}"), materializer)
 
   while (true) {
     p1 ! Persistent("a-" + System.currentTimeMillis())

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -19,6 +19,7 @@ import akka.japi.Util.immutableSeq
 import akka.stream.{ FlattenStrategy, OverflowStrategy, FlowMaterializer, Transformer }
 import akka.stream.scaladsl.{ Flow ⇒ SFlow }
 import scala.concurrent.duration.FiniteDuration
+import akka.dispatch.ExecutionContexts
 
 /**
  * Java API
@@ -135,14 +136,6 @@ abstract class Flow[T] {
    * Use [[akka.japi.pf.PFBuilder]] to construct the `PartialFunction`.
    */
   def collect[U](pf: PartialFunction[T, U]): Flow[U]
-
-  /**
-   * Invoke the given procedure for each received element and produce a Unit value
-   * upon reaching the normal end of the stream. Please note that also in this case
-   * the flow needs to be materialized (e.g. using [[#consume]]) to initiate its
-   * execution.
-   */
-  def foreach(c: Procedure[T]): Flow[Void]
 
   /**
    * Invoke the given function for every received element, giving it its previous
@@ -390,6 +383,18 @@ abstract class Flow[T] {
    */
   def produceTo(subscriber: Subscriber[_ >: T], materializer: FlowMaterializer): Unit
 
+  /**
+   * Invoke the given procedure for each received element. Returns a [[scala.concurrent.Future]]
+   * that will be completed with `Success` when reaching the normal end of the stream, or completed
+   * with `Failure` if there is an error is signaled in the stream.
+   *
+   * *This will materialize the flow and initiate its execution.*
+   *
+   * The given FlowMaterializer decides how the flow’s logical structure is
+   * broken down into individual processing steps.
+   */
+  def foreach(c: Procedure[T], materializer: FlowMaterializer): Future[Void]
+
 }
 
 /**
@@ -415,9 +420,6 @@ private[akka] class FlowAdapter[T](delegate: SFlow[T]) extends Flow[T] {
   override def filter(p: Predicate[T]): Flow[T] = new FlowAdapter(delegate.filter(p.test))
 
   override def collect[U](pf: PartialFunction[T, U]): Flow[U] = new FlowAdapter(delegate.collect(pf))
-
-  override def foreach(c: Procedure[T]): Flow[Void] =
-    new FlowAdapter(delegate.foreach(c.apply).map(_ ⇒ null)) // FIXME optimize to one step
 
   override def fold[U](zero: U, f: Function2[U, T, U]): Flow[U] =
     new FlowAdapter(delegate.fold(zero) { case (a, b) ⇒ f.apply(a, b) })
@@ -498,5 +500,10 @@ private[akka] class FlowAdapter[T](delegate: SFlow[T]) extends Flow[T] {
 
   override def produceTo(subsriber: Subscriber[_ >: T], materializer: FlowMaterializer): Unit =
     delegate.produceTo(subsriber, materializer)
+
+  override def foreach(c: Procedure[T], materializer: FlowMaterializer): Future[Void] = {
+    implicit val ec = ExecutionContexts.sameThreadExecutionContext
+    delegate.foreach(elem ⇒ c.apply(elem), materializer).map(_ ⇒ null).mapTo[Void]
+  }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -131,14 +131,6 @@ trait Flow[+T] {
   def collect[U](pf: PartialFunction[T, U]): Flow[U]
 
   /**
-   * Invoke the given procedure for each received element and produce a Unit value
-   * upon reaching the normal end of the stream. Please note that also in this case
-   * the `Flow` needs to be materialized (e.g. using [[#consume]]) to initiate its
-   * execution.
-   */
-  def foreach(c: T ⇒ Unit): Flow[Unit]
-
-  /**
    * Invoke the given function for every received element, giving it its previous
    * output (or the given “zero” value) and the element as input. The returned stream
    * will receive the return value of the final function evaluation when the input
@@ -391,6 +383,18 @@ trait Flow[+T] {
    * broken down into individual processing steps.
    */
   def produceTo(subscriber: Subscriber[_ >: T], materializer: FlowMaterializer): Unit
+
+  /**
+   * Invoke the given procedure for each received element. Returns a [[scala.concurrent.Future]]
+   * that will be completed with `Success` when reaching the normal end of the stream, or completed
+   * with `Failure` if there is an error is signaled in the stream.
+   *
+   * *This will materialize the flow and initiate its execution.*
+   *
+   * The given FlowMaterializer decides how the flow’s logical structure is
+   * broken down into individual processing steps.
+   */
+  def foreach(c: T ⇒ Unit, materializer: FlowMaterializer): Future[Unit]
 
 }
 

--- a/akka-stream/src/test/java/akka/stream/javadsl/DuctTest.java
+++ b/akka-stream/src/test/java/akka/stream/javadsl/DuctTest.java
@@ -37,28 +37,30 @@ public class DuctTest {
     final JavaTestKit probe = new JavaTestKit(system);
     final String[] lookup = { "a", "b", "c", "d", "e", "f" };
 
-    Subscriber<Integer> inputSubscriber = Duct.create(Integer.class).drop(2).take(3).map(new Function<Integer, String>() {
-      public String apply(Integer elem) {
-        return lookup[elem];
-      }
-    }).filter(new Predicate<String>() {
-      public boolean test(String elem) {
-        return !elem.equals("c");
-      }
-    }).grouped(2).mapConcat(new Function<java.util.List<String>, java.util.List<String>>() {
-      public java.util.List<String> apply(java.util.List<String> elem) {
-        return elem;
-      }
-    }).fold("", new Function2<String, String, String>() {
-      public String apply(String acc, String elem) {
-        return acc + elem;
-      }
-    }).foreach(new Procedure<String>() {
-      public void apply(String elem) {
-        probe.getRef().tell(elem, ActorRef.noSender());
-      }
-    }).consume(materializer);
+    Pair<Subscriber<Integer>, Future<Void>> foreachPair = Duct.create(Integer.class).drop(2).take(3)
+        .map(new Function<Integer, String>() {
+          public String apply(Integer elem) {
+            return lookup[elem];
+          }
+        }).filter(new Predicate<String>() {
+          public boolean test(String elem) {
+            return !elem.equals("c");
+          }
+        }).grouped(2).mapConcat(new Function<java.util.List<String>, java.util.List<String>>() {
+          public java.util.List<String> apply(java.util.List<String> elem) {
+            return elem;
+          }
+        }).fold("", new Function2<String, String, String>() {
+          public String apply(String acc, String elem) {
+            return acc + elem;
+          }
+        }).foreach(new Procedure<String>() {
+          public void apply(String elem) {
+            probe.getRef().tell(elem, ActorRef.noSender());
+          }
+        }, materializer);
 
+    Subscriber<Integer> inputSubscriber = foreachPair.first();
     final java.util.Iterator<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5).iterator();
     Publisher<Integer> publisher = Flow.create(input).toPublisher(materializer);
 
@@ -76,7 +78,7 @@ public class DuctTest {
       public void apply(String elem) {
         probe.getRef().tell(elem, ActorRef.noSender());
       }
-    }).consume(materializer);
+    }, materializer);
     probe.expectNoMsg(FiniteDuration.create(200, TimeUnit.MILLISECONDS));
 
     Publisher<String> publisher = Flow.create(Arrays.asList("a", "b", "c")).toPublisher(materializer);
@@ -94,7 +96,7 @@ public class DuctTest {
       public void apply(String elem) {
         probe.getRef().tell(elem, ActorRef.noSender());
       }
-    }).consume(materializer);
+    }, materializer).first();
 
     Subscriber<String> inSubscriber = Duct.create(String.class).produceTo(subscriber, materializer);
 
@@ -111,13 +113,9 @@ public class DuctTest {
   public void mustBeAppendableToFlow() {
     final JavaTestKit probe = new JavaTestKit(system);
 
-    Duct<String, Void> duct = Duct.create(String.class).map(new Function<String, String>() {
+    Duct<String, String> duct = Duct.create(String.class).map(new Function<String, String>() {
       public String apply(String elem) {
         return elem.toLowerCase();
-      }
-    }).foreach(new Procedure<String>() {
-      public void apply(String elem) {
-        probe.getRef().tell(elem, ActorRef.noSender());
       }
     });
 
@@ -129,7 +127,11 @@ public class DuctTest {
       }
     });
 
-    flow.append(duct).consume(materializer);
+    flow.append(duct).foreach(new Procedure<String>() {
+      public void apply(String elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }, materializer);
 
     probe.expectMsgEquals("a");
     probe.expectMsgEquals("b");
@@ -158,7 +160,7 @@ public class DuctTest {
       public void apply(String elem) {
         probe.getRef().tell(elem, ActorRef.noSender());
       }
-    }).consume(materializer);
+    }, materializer).first();
 
     Flow.create(Arrays.asList(1, 2, 3)).produceTo(ductInSubscriber, materializer);
 
@@ -201,7 +203,7 @@ public class DuctTest {
       public void apply(String elem) {
         probe.getRef().tell(elem, ActorRef.noSender());
       }
-    }).consume(materializer);
+    }, materializer).first();
 
     final java.lang.Iterable<String> input = Arrays.asList("a", "b", "c");
     Flow.create(input).produceTo(c, materializer);

--- a/akka-stream/src/test/scala/akka/stream/DuctSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/DuctSpec.scala
@@ -103,11 +103,10 @@ class DuctSpec extends AkkaSpec {
     }
 
     "perform multiple transformation operations" in {
-      val duct = Duct[Int].map(_.toString).map("elem-" + _).foreach(testActor ! _)
-      val c = duct.consume(materializer)
+      val (in, fut) = Duct[Int].map(_.toString).map("elem-" + _).foreach(testActor ! _, materializer)
 
       val source = Flow(List(1, 2, 3)).toPublisher(materializer)
-      source.subscribe(c)
+      source.subscribe(in)
 
       expectMsg("elem-1")
       expectMsg("elem-2")

--- a/akka-stream/src/test/scala/akka/stream/FlowOnCompleteSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowOnCompleteSpec.scala
@@ -66,12 +66,13 @@ class FlowOnCompleteSpec extends AkkaSpec with ScriptedTest {
     "invoke callback after transform and foreach steps " in {
       val onCompleteProbe = TestProbe()
       val p = StreamTestKit.PublisherProbe[Int]()
+      import system.dispatcher // for the Future.onComplete
       Flow(p).map { x ⇒
         onCompleteProbe.ref ! ("map-" + x)
         x
-      }.foreach {
+      }.foreach({
         x ⇒ onCompleteProbe.ref ! ("foreach-" + x)
-      }.onComplete({ onCompleteProbe.ref ! _ }, materializer)
+      }, materializer).onComplete { onCompleteProbe.ref ! _ }
       val proc = p.expectSubscription
       proc.expectRequest()
       proc.sendNext(42)

--- a/akka-stream/src/test/scala/akka/stream/ProcessorHierarchySpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/ProcessorHierarchySpec.scala
@@ -27,8 +27,8 @@ class ProcessorHierarchySpec extends AkkaSpec("akka.actor.debug.lifecycle=off\na
         Flow(List(1)).map(x ⇒ { testActor ! self; x }).toPublisher(materializer)
       }).take(3).foreach(x ⇒ {
         testActor ! self
-        Flow(x).foreach(_ ⇒ testActor ! self).consume(materializer)
-      }).toFuture(materializer)
+        Flow(x).foreach(_ ⇒ testActor ! self, materializer)
+      }, materializer)
       Await.result(f, 3.seconds)
       val refs = receiveWhile(idle = 250.millis) {
         case r: ActorRef ⇒ r

--- a/akka-stream/src/test/scala/akka/stream/io/TcpFlowSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/io/TcpFlowSpec.scala
@@ -202,9 +202,9 @@ class TcpFlowSpec extends AkkaSpec {
   }
 
   def echoServer(serverAddress: InetSocketAddress = temporaryServerAddress): Future[Unit] =
-    Flow(bind(serverAddress).connectionStream).foreach { conn ⇒
+    Flow(bind(serverAddress).connectionStream).foreach({ conn ⇒
       conn.inputStream.subscribe(conn.outputStream)
-    }.toFuture(materializer)
+    }, materializer)
 
   "Outgoing TCP stream" must {
 


### PR DESCRIPTION
This will change with the new DSL, but it is in the right direction and something we can ship in this sprint.
Refs #15076
