### PR TITLE
!str #15289 Java API for ActorPublisher and ActorSubscriber

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -6,7 +6,8 @@ package akka.stream.impl
 import org.reactivestreams.{ Publisher, Subscriber, Subscription, Processor }
 import akka.actor._
 import akka.stream.MaterializerSettings
-import akka.stream.actor.ActorSubscriber.{ OnSubscribe, OnNext, OnComplete, OnError }
+import akka.stream.actor.ActorSubscriber.OnSubscribe
+import akka.stream.actor.ActorSubscriberMessage.{ OnNext, OnComplete, OnError }
 import java.util.Arrays
 import akka.stream.TimerTransformer
 

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
@@ -6,7 +6,8 @@ package akka.stream.impl
 import akka.stream.MaterializerSettings
 import akka.actor.{ Actor, Terminated, ActorRef }
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
-import akka.stream.actor.ActorSubscriber.{ OnNext, OnError, OnComplete, OnSubscribe }
+import akka.stream.actor.ActorSubscriber.OnSubscribe
+import akka.stream.actor.ActorSubscriberMessage.{ OnNext, OnError, OnComplete }
 import akka.actor.Stash
 
 /**

--- a/akka-stream/src/test/java/akka/stream/actor/ActorPublisherTest.java
+++ b/akka-stream/src/test/java/akka/stream/actor/ActorPublisherTest.java
@@ -1,0 +1,61 @@
+package akka.stream.actor;
+
+import org.reactivestreams.Publisher;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.stream.FlowMaterializer;
+import akka.stream.MaterializerSettings;
+import akka.stream.javadsl.AkkaJUnitActorSystemResource;
+import akka.stream.javadsl.Flow;
+import akka.stream.testkit.AkkaSpec;
+import akka.testkit.JavaTestKit;
+import akka.japi.Procedure;
+
+import static akka.stream.actor.ActorPublisherMessage.Request;
+
+public class ActorPublisherTest {
+
+  @ClassRule
+  public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource("FlowTest",
+      AkkaSpec.testConf());
+
+  public static class TestPublisher extends UntypedActorPublisher<Integer> {
+
+    @Override
+    public void onReceive(Object msg) {
+      if (msg instanceof Request) {
+        onNext(1);
+        onComplete();
+      } else if (msg == ActorPublisherMessage.cancelInstance()) {
+        getContext().stop(getSelf());
+      } else {
+        unhandled(msg);
+      }
+    }
+
+  }
+
+  final ActorSystem system = actorSystemResource.getSystem();
+
+  final MaterializerSettings settings = MaterializerSettings.create().withDispatcher("akka.test.stream-dispatcher");
+  final FlowMaterializer materializer = FlowMaterializer.create(settings, system);
+
+  @Test
+  public void mustHaveJavaAPI() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final ActorRef ref = system
+        .actorOf(Props.create(TestPublisher.class).withDispatcher("akka.test.stream-dispatcher"));
+    final Publisher<Integer> publisher = UntypedActorPublisher.create(ref);
+    Flow.create(publisher).foreach(new Procedure<Integer>() {
+      public void apply(Integer elem) {
+        probe.getRef().tell(elem, ActorRef.noSender());
+      }
+    }, materializer);
+    probe.expectMsgEquals(1);
+  }
+
+}

--- a/akka-stream/src/test/java/akka/stream/actor/ActorSubscriberTest.java
+++ b/akka-stream/src/test/java/akka/stream/actor/ActorSubscriberTest.java
@@ -1,0 +1,79 @@
+package akka.stream.actor;
+
+import org.reactivestreams.Subscriber;
+import org.junit.ClassRule;
+import org.junit.Test;
+import java.util.Arrays;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.stream.FlowMaterializer;
+import akka.stream.MaterializerSettings;
+import akka.stream.javadsl.AkkaJUnitActorSystemResource;
+import akka.stream.javadsl.Flow;
+import akka.stream.testkit.AkkaSpec;
+import akka.testkit.JavaTestKit;
+import akka.japi.Procedure;
+
+import static akka.stream.actor.ActorSubscriberMessage.OnNext;
+import static akka.stream.actor.ActorSubscriberMessage.OnError;
+
+public class ActorSubscriberTest {
+
+  @ClassRule
+  public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource("FlowTest",
+      AkkaSpec.testConf());
+
+  public static class TestSubscriber extends UntypedActorSubscriber {
+
+    final ActorRef probe;
+
+    public TestSubscriber(ActorRef probe) {
+      this.probe = probe;
+    }
+
+    @Override
+    public RequestStrategy requestStrategy() {
+      return ZeroRequestStrategy.getInstance();
+    }
+
+    @Override
+    public void onReceive(Object msg) {
+      if (msg.equals("run")) {
+        request(4);
+      } else if (msg instanceof OnNext) {
+        probe.tell(((OnNext) msg).element(), getSelf());
+      } else if (msg == ActorSubscriberMessage.onCompleteInstance()) {
+        probe.tell("done", getSelf());
+        getContext().stop(getSelf());
+      } else if (msg instanceof OnError) {
+        probe.tell("err", getSelf());
+        getContext().stop(getSelf());
+      } else {
+        unhandled(msg);
+      }
+    }
+  }
+
+  final ActorSystem system = actorSystemResource.getSystem();
+
+  final MaterializerSettings settings = MaterializerSettings.create().withDispatcher("akka.test.stream-dispatcher");
+  final FlowMaterializer materializer = FlowMaterializer.create(settings, system);
+
+  @Test
+  public void mustHaveJavaAPI() {
+    final JavaTestKit probe = new JavaTestKit(system);
+    final ActorRef ref = system.actorOf(Props.create(TestSubscriber.class, probe.getRef()).withDispatcher(
+        "akka.test.stream-dispatcher"));
+    final Subscriber<Integer> subscriber = UntypedActorSubscriber.create(ref);
+    final java.util.Iterator<Integer> input = Arrays.asList(1, 2, 3).iterator();
+    Flow.create(input).produceTo(subscriber, materializer);
+    ref.tell("run", null);
+    probe.expectMsgEquals(1);
+    probe.expectMsgEquals(2);
+    probe.expectMsgEquals(3);
+    probe.expectMsgEquals("done");
+  }
+
+}

--- a/akka-stream/src/test/scala/akka/stream/FlowTakeSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTakeSpec.scala
@@ -6,7 +6,7 @@ package akka.stream
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.ScriptedTest
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
-import akka.stream.actor.ActorSubscriber.{ OnNext, OnComplete }
+import akka.stream.actor.ActorSubscriberMessage.{ OnNext, OnComplete }
 import akka.stream.impl.RequestMore
 
 class FlowTakeSpec extends AkkaSpec with ScriptedTest {

--- a/akka-stream/src/test/scala/akka/stream/actor/ActorPublisherSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/actor/ActorPublisherSpec.scala
@@ -10,7 +10,6 @@ import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.stream.FlowMaterializer
 import akka.stream.MaterializerSettings
-import akka.stream.actor.ActorSubscriber.WatermarkRequestStrategy
 import akka.stream.scaladsl.Flow
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
@@ -32,6 +31,7 @@ object ActorPublisherSpec {
 
   class TestPublisher(probe: ActorRef) extends ActorPublisher[String] {
     import ActorPublisher._
+    import ActorPublisherMessage._
 
     def receive = {
       case Request(element) ⇒ probe ! TotalDemand(totalDemand)
@@ -45,8 +45,7 @@ object ActorPublisherSpec {
   def senderProps: Props = Props[Sender].withDispatcher("akka.test.stream-dispatcher")
 
   class Sender extends ActorPublisher[Int] {
-    import ActorPublisher.Cancel
-    import ActorPublisher.Request
+    import ActorPublisherMessage._
 
     var buf = Vector.empty[Int]
 
@@ -76,7 +75,7 @@ object ActorPublisherSpec {
     Props(new Receiver(probe)).withDispatcher("akka.test.stream-dispatcher")
 
   class Receiver(probe: ActorRef) extends ActorSubscriber {
-    import ActorSubscriber._
+    import ActorSubscriberMessage._
 
     override val requestStrategy = WatermarkRequestStrategy(10)
 

--- a/akka-stream/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala
@@ -10,7 +10,6 @@ import akka.stream.FlowMaterializer
 import akka.stream.MaterializerSettings
 import akka.stream.scaladsl.Flow
 import akka.stream.testkit.AkkaSpec
-import akka.stream.actor.ActorSubscriber.RequestStrategy
 import akka.actor.Actor
 import akka.routing.ActorRefRoutee
 import akka.routing.Router
@@ -24,7 +23,7 @@ object ActorSubscriberSpec {
     Props(new ManualSubscriber(probe)).withDispatcher("akka.test.stream-dispatcher")
 
   class ManualSubscriber(probe: ActorRef) extends ActorSubscriber {
-    import ActorSubscriber._
+    import ActorSubscriberMessage._
 
     override val requestStrategy = ZeroRequestStrategy
 
@@ -42,7 +41,7 @@ object ActorSubscriberSpec {
     Props(new RequestStrategySubscriber(probe, strat)).withDispatcher("akka.test.stream-dispatcher")
 
   class RequestStrategySubscriber(probe: ActorRef, strat: RequestStrategy) extends ActorSubscriber {
-    import ActorSubscriber._
+    import ActorSubscriberMessage._
 
     override val requestStrategy = strat
 
@@ -61,7 +60,7 @@ object ActorSubscriberSpec {
     Props(new Streamer).withDispatcher("akka.test.stream-dispatcher")
 
   class Streamer extends ActorSubscriber {
-    import ActorSubscriber._
+    import ActorSubscriberMessage._
     var queue = Map.empty[Int, ActorRef]
 
     val router = {
@@ -98,7 +97,7 @@ object ActorSubscriberSpec {
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ActorSubscriberSpec extends AkkaSpec with ImplicitSender {
   import ActorSubscriberSpec._
-  import ActorSubscriber._
+  import ActorSubscriberMessage._
 
   implicit val materializer = FlowMaterializer(MaterializerSettings(dispatcher = "akka.test.stream-dispatcher"))
 


### PR DESCRIPTION
- had to change api because of trait+object not useable from java
- ActorSubscriber.RequestStrategy and its implementations moved to
  top level
- messages moved to ActorSubscriberMessage and ActorPublisherMessage
  object

Refs #15289
