### PR TITLE
!str #15271 make transform() take a factory instead of Transformer

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/HttpEntity.scala
@@ -43,7 +43,7 @@ sealed trait HttpEntity extends japi.HttpEntity {
    */
   def toStrict(timeout: FiniteDuration, materializer: FlowMaterializer)(implicit ec: ExecutionContext): Future[HttpEntity.Strict] =
     Flow(dataBytes(materializer))
-      .transform(new TimerTransformer[ByteString, HttpEntity.Strict] {
+      .timerTransform("toStrict", () ⇒ new TimerTransformer[ByteString, HttpEntity.Strict] {
         var bytes = ByteString.newBuilder
         scheduleOnce("", timeout)
 

--- a/akka-http-core/src/main/scala/akka/http/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/rendering/HttpRequestRendererFactory.scala
@@ -106,12 +106,12 @@ private[http] class HttpRequestRendererFactory(userAgentHeader: Option[headers.`
           case HttpEntity.Default(_, contentLength, data) ⇒
             renderContentLength(contentLength)
             renderByteStrings(r,
-              Flow(data).transform(new CheckContentLengthTransformer(contentLength)).toPublisher()(materializer),
+              Flow(data).transform("checkContentLenght", () ⇒ new CheckContentLengthTransformer(contentLength)).toPublisher()(materializer),
               materializer)
 
           case HttpEntity.Chunked(_, chunks) ⇒
             r ~~ `Transfer-Encoding` ~~ ChunkedBytes ~~ CrLf ~~ CrLf
-            renderByteStrings(r, Flow(chunks).transform(new ChunkTransformer).toPublisher()(materializer), materializer)
+            renderByteStrings(r, Flow(chunks).transform("chunkTransform", () ⇒ new ChunkTransformer).toPublisher()(materializer), materializer)
         }
 
       renderRequestLine()

--- a/akka-http-core/src/main/scala/akka/http/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/rendering/HttpResponseRendererFactory.scala
@@ -132,7 +132,7 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
             renderHeaders(headers.toList)
             renderEntityContentType(r, entity)
             r ~~ `Content-Length` ~~ contentLength ~~ CrLf ~~ CrLf
-            byteStrings(Flow(data).transform(new CheckContentLengthTransformer(contentLength)).toPublisher()(materializer))
+            byteStrings(Flow(data).transform("checkContentLenght", () ⇒ new CheckContentLengthTransformer(contentLength)).toPublisher()(materializer))
 
           case HttpEntity.CloseDelimited(_, data) ⇒
             renderHeaders(headers.toList, alwaysClose = true)
@@ -149,7 +149,7 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
               if (!entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD)
                 r ~~ `Transfer-Encoding` ~~ ChunkedBytes ~~ CrLf
               r ~~ CrLf
-              byteStrings(Flow(chunks).transform(new ChunkTransformer).toPublisher()(materializer))
+              byteStrings(Flow(chunks).transform("checkContentLenght", () ⇒ new ChunkTransformer).toPublisher()(materializer))
             }
         }
 

--- a/akka-http-core/src/main/scala/akka/http/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/util/package.scala
@@ -37,8 +37,8 @@ package object util {
 
   private[http] implicit class FlowWithPrintEvent[T](val underlying: Flow[T]) {
     def printEvent(marker: String): Flow[T] =
-      underlying.transform {
-        new Transformer[T, T] {
+      underlying.transform("transform",
+        () ⇒ new Transformer[T, T] {
           def onNext(element: T) = {
             println(s"$marker: $element")
             element :: Nil
@@ -47,8 +47,7 @@ package object util {
             println(s"$marker: Terminated with error $e")
             Nil
           }
-        }
-      }
+        })
   }
 
   private[http] def errorLogger(log: LoggingAdapter, msg: String): Transformer[ByteString, ByteString] =

--- a/akka-http-core/src/test/scala/akka/http/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/parsing/RequestParserSpec.scala
@@ -354,7 +354,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
         val future =
           Flow(input.toList)
             .map(ByteString.apply)
-            .transform(parser)
+            .transform("parser", () ⇒ parser)
             .splitWhen(_.isInstanceOf[ParserOutput.MessageStart])
             .headAndTail(materializer)
             .collect {

--- a/akka-http-core/src/test/scala/akka/http/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/parsing/ResponseParserSpec.scala
@@ -213,7 +213,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
           val future =
             Flow(input.toList)
               .map(ByteString.apply)
-              .transform(newParser(requestMethod))
+              .transform("parser", () ⇒ newParser(requestMethod))
               .splitWhen(_.isInstanceOf[ParserOutput.MessageStart])
               .headAndTail(materializer)
               .collect {

--- a/akka-http/src/main/scala/akka/http/marshalling/MultipartMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/marshalling/MultipartMarshallers.scala
@@ -39,7 +39,7 @@ trait MultipartMarshallers {
     Marshaller.withOpenCharset(mediaTypeWithBoundary) { (value, charset) ⇒
       val log = actorSystem(refFactory).log
       val bodyPartRenderer = new BodyPartRenderer(boundary, charset.nioCharset, partHeadersSizeHint = 128, fm, log)
-      val chunks = Flow(value.parts).transform(bodyPartRenderer).flatten(FlattenStrategy.concat).toPublisher()(fm)
+      val chunks = Flow(value.parts).transform("bodyPartRenderer", () ⇒ bodyPartRenderer).flatten(FlattenStrategy.concat).toPublisher()(fm)
       HttpEntity.Chunked(ContentType(mediaTypeWithBoundary), chunks)
     }
   }

--- a/akka-http/src/main/scala/akka/http/unmarshalling/MultipartUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/unmarshalling/MultipartUnmarshallers.scala
@@ -40,7 +40,7 @@ trait MultipartUnmarshallers {
             case None ⇒ sys.error("Content-Type with a multipart media type must have a 'boundary' parameter")
             case Some(boundary) ⇒
               val bodyParts = Flow(entity.dataBytes(fm))
-                .transform(new BodyPartParser(defaultContentType, boundary, fm, actorSystem(refFactory).log))
+                .transform("bodyPart", () ⇒ new BodyPartParser(defaultContentType, boundary, fm, actorSystem(refFactory).log))
                 .splitWhen(_.isInstanceOf[BodyPartParser.BodyPartStart])
                 .headAndTail(fm)
                 .collect {

--- a/akka-stream/src/main/scala/akka/stream/TimerTransformer.scala
+++ b/akka-stream/src/main/scala/akka/stream/TimerTransformer.scala
@@ -3,16 +3,15 @@
  */
 package akka.stream
 
-import scala.collection.immutable
-import scala.collection.mutable
+import akka.actor.{ ActorContext, Cancellable }
+
+import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration.FiniteDuration
-import akka.actor.ActorContext
-import akka.actor.Cancellable
 
 /**
  * [[Transformer]] with support for scheduling keyed (named) timer events.
  */
-abstract class TimerTransformer[-T, +U] extends Transformer[T, U] {
+abstract class TimerTransformer[-T, +U] extends TransformerLike[T, U] {
   import TimerTransformer._
   private val timers = mutable.Map[Any, Timer]()
   private val timerIdGen = Iterator from 1

--- a/akka-stream/src/main/scala/akka/stream/Transformer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Transformer.scala
@@ -5,18 +5,7 @@ package akka.stream
 
 import scala.collection.immutable
 
-/**
- * General interface for stream transformation.
- *
- * It is possible to keep state in the concrete [[Transformer]] instance with
- * ordinary instance variables. The [[Transformer]] is executed by an actor and
- * therefore you don not have to add any additional thread safety or memory
- * visibility constructs to access the state from the callback methods.
- *
- * @see [[akka.stream.scaladsl.Flow#transform]]
- * @see [[akka.stream.javadsl.Flow#transform]]
- */
-abstract class Transformer[-T, +U] {
+abstract class TransformerLike[-T, +U] {
   /**
    * Invoked for each element to produce a (possibly empty) sequence of
    * output elements.
@@ -55,9 +44,17 @@ abstract class Transformer[-T, +U] {
    */
   def cleanup(): Unit = ()
 
-  /**
-   * Name of this transformation step. Used as part of the actor name.
-   * Facilitates debugging and logging.
-   */
-  def name: String = "transform"
 }
+
+/**
+ * General interface for stream transformation.
+ *
+ * It is possible to keep state in the concrete [[Transformer]] instance with
+ * ordinary instance variables. The [[Transformer]] is executed by an actor and
+ * therefore you don not have to add any additional thread safety or memory
+ * visibility constructs to access the state from the callback methods.
+ *
+ * @see [[akka.stream.scaladsl.Flow#transform]]
+ * @see [[akka.stream.javadsl.Flow#transform]]
+ */
+abstract class Transformer[-T, +U] extends TransformerLike[T, U]

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -19,9 +19,8 @@ private[akka] object ActorProcessor {
   import Ast._
   def props(settings: MaterializerSettings, op: AstNode): Props =
     (op match {
-      case Transform(transformer: TimerTransformer[_, _]) ⇒
-        Props(new TimerTransformerProcessorsImpl(settings, transformer))
-      case t: Transform      ⇒ Props(new TransformProcessorImpl(settings, t.transformer))
+      case t: TimerTransform ⇒ Props(new TimerTransformerProcessorsImpl(settings, t.mkTransformer()))
+      case t: Transform      ⇒ Props(new TransformProcessorImpl(settings, t.mkTransformer()))
       case s: SplitWhen      ⇒ Props(new SplitWhenProcessorImpl(settings, s.p))
       case g: GroupBy        ⇒ Props(new GroupByProcessorImpl(settings, g.f))
       case m: Merge          ⇒ Props(new MergeImpl(settings, m.other))

--- a/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SingleStreamProcessors.scala
@@ -3,17 +3,18 @@
  */
 package akka.stream.impl
 
-import scala.collection.immutable
-import scala.util.{ Failure, Success }
 import akka.actor.Props
-import akka.stream.MaterializerSettings
-import akka.stream.Transformer
+import akka.stream.{ MaterializerSettings, TransformerLike }
+
+import scala.collection.immutable
 import scala.util.control.NonFatal
 
 /**
  * INTERNAL API
  */
-private[akka] class TransformProcessorImpl(_settings: MaterializerSettings, transformer: Transformer[Any, Any]) extends ActorProcessorImpl(_settings) {
+private[akka] class TransformProcessorImpl(_settings: MaterializerSettings, transformer: TransformerLike[Any, Any])
+  extends ActorProcessorImpl(_settings) {
+
   var hasCleanupRun = false
   // TODO performance improvement: mutable buffer?
   var emits = immutable.Seq.empty[Any]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Duct.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Duct.scala
@@ -6,7 +6,7 @@ package akka.stream.scaladsl
 import scala.collection.immutable
 import scala.util.Try
 import org.reactivestreams.{ Publisher, Subscriber }
-import akka.stream.{ FlattenStrategy, OverflowStrategy, FlowMaterializer, Transformer }
+import akka.stream._
 import akka.stream.impl.DuctImpl
 import akka.stream.impl.Ast
 import scala.concurrent.duration.FiniteDuration
@@ -140,10 +140,35 @@ trait Duct[In, +Out] {
    * therefore you don not have to add any additional thread safety or memory
    * visibility constructs to access the state from the callback methods.
    *
-   * Note that you can use [[akka.stream.TimerTransformer]] if you need support
-   * for scheduled events in the transformer.
+   * Note that you can use [[#timerTransform]] if you need support for scheduled events in the transformer.
    */
-  def transform[U](transformer: Transformer[Out, U]): Duct[In, U]
+  def transform[U](name: String, transformer: () ⇒ Transformer[Out, U]): Duct[In, U]
+
+  /**
+   * Transformation of a stream, with additional support for scheduled events.
+   *
+   * For each element the [[akka.stream.Transformer#onNext]]
+   * function is invoked, expecting a (possibly empty) sequence of output elements
+   * to be produced.
+   * After handing off the elements produced from one input element to the downstream
+   * subscribers, the [[akka.stream.Transformer#isComplete]] predicate determines whether to end
+   * stream processing at this point; in that case the upstream subscription is
+   * canceled. Before signaling normal completion to the downstream subscribers,
+   * the [[akka.stream.Transformer#onComplete]] function is invoked to produce a (possibly empty)
+   * sequence of elements in response to the end-of-stream event.
+   *
+   * [[akka.stream.Transformer#onError]] is called when failure is signaled from upstream.
+   *
+   * After normal completion or error the [[akka.stream.Transformer#cleanup]] function is called.
+   *
+   * It is possible to keep state in the concrete [[akka.stream.Transformer]] instance with
+   * ordinary instance variables. The [[akka.stream.Transformer]] is executed by an actor and
+   * therefore you do not have to add any additional thread safety or memory
+   * visibility constructs to access the state from the callback methods.
+   *
+   * Note that you can use [[#transform]] if you just need to transform elements time plays no role in the transformation.
+   */
+  def timerTransform[U](name: String, mkTransformer: () ⇒ TimerTransformer[Out, U]): Duct[In, U]
 
   /**
    * Takes up to n elements from the stream and returns a pair containing a strict sequence of the taken element

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -7,7 +7,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Try
 import org.reactivestreams.{ Publisher, Subscriber }
-import akka.stream.{ FlattenStrategy, OverflowStrategy, FlowMaterializer, Transformer }
+import akka.stream._
 import akka.stream.impl.Ast.{ ExistingPublisher, IterablePublisherNode, IteratorPublisherNode, ThunkPublisherNode }
 import akka.stream.impl.Ast.FuturePublisherNode
 import akka.stream.impl.FlowImpl
@@ -209,10 +209,35 @@ trait Flow[+T] {
    * therefore you do not have to add any additional thread safety or memory
    * visibility constructs to access the state from the callback methods.
    *
-   * Note that you can use [[akka.stream.TimerTransformer]] if you need support
-   * for scheduled events in the transformer.
+   * Note that you can use [[#timerTransform]] if you need support for scheduled events in the transformer.
    */
-  def transform[U](transformer: Transformer[T, U]): Flow[U]
+  def transform[U](name: String, mkTransformer: () ⇒ Transformer[T, U]): Flow[U]
+
+  /**
+   * Transformation of a stream, with additional support for scheduled events.
+   *
+   * For each element the [[akka.stream.Transformer#onNext]]
+   * function is invoked, expecting a (possibly empty) sequence of output elements
+   * to be produced.
+   * After handing off the elements produced from one input element to the downstream
+   * subscribers, the [[akka.stream.Transformer#isComplete]] predicate determines whether to end
+   * stream processing at this point; in that case the upstream subscription is
+   * canceled. Before signaling normal completion to the downstream subscribers,
+   * the [[akka.stream.Transformer#onComplete]] function is invoked to produce a (possibly empty)
+   * sequence of elements in response to the end-of-stream event.
+   *
+   * [[akka.stream.Transformer#onError]] is called when failure is signaled from upstream.
+   *
+   * After normal completion or error the [[akka.stream.Transformer#cleanup]] function is called.
+   *
+   * It is possible to keep state in the concrete [[akka.stream.Transformer]] instance with
+   * ordinary instance variables. The [[akka.stream.Transformer]] is executed by an actor and
+   * therefore you do not have to add any additional thread safety or memory
+   * visibility constructs to access the state from the callback methods.
+   *
+   * Note that you can use [[#transform]] if you just need to transform elements time plays no role in the transformation.
+   */
+  def timerTransform[U](name: String, mkTransformer: () ⇒ TimerTransformer[T, U]): Flow[U]
 
   /**
    * Takes up to n elements from the stream and returns a pair containing a strict sequence of the taken element

--- a/akka-stream/src/test/scala/akka/stream/FlowTakeWithinSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTakeWithinSpec.scala
@@ -21,18 +21,18 @@ class FlowTakeWithinSpec extends AkkaSpec {
       val p = StreamTestKit.PublisherProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[Int]()
       Flow(p).takeWithin(1.second).produceTo(c)
-      val pSub = p.expectSubscription
-      val cSub = c.expectSubscription
+      val pSub = p.expectSubscription()
+      val cSub = c.expectSubscription()
       cSub.request(100)
-      val demand1 = pSub.expectRequest
+      val demand1 = pSub.expectRequest()
       (1 to demand1) foreach { _ ⇒ pSub.sendNext(input.next()) }
-      val demand2 = pSub.expectRequest
+      val demand2 = pSub.expectRequest()
       (1 to demand2) foreach { _ ⇒ pSub.sendNext(input.next()) }
-      val demand3 = pSub.expectRequest
+      val demand3 = pSub.expectRequest()
       val sentN = demand1 + demand2
       (1 to sentN) foreach { n ⇒ c.expectNext(n) }
       within(2.seconds) {
-        c.expectComplete
+        c.expectComplete()
       }
       (1 to demand3) foreach { _ ⇒ pSub.sendNext(input.next()) }
       c.expectNoMsg(200.millis)
@@ -41,11 +41,11 @@ class FlowTakeWithinSpec extends AkkaSpec {
     "deliver bufferd elements onComplete before the timeout" in {
       val c = StreamTestKit.SubscriberProbe[Int]()
       Flow(1 to 3).takeWithin(1.second).produceTo(c)
-      val cSub = c.expectSubscription
+      val cSub = c.expectSubscription()
       c.expectNoMsg(200.millis)
       cSub.request(100)
       (1 to 3) foreach { n ⇒ c.expectNext(n) }
-      c.expectComplete
+      c.expectComplete()
       c.expectNoMsg(200.millis)
     }
 

--- a/akka-stream/src/test/scala/akka/stream/FlowTransformRecoverSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/FlowTransformRecoverSpec.scala
@@ -42,7 +42,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "produce one-to-one transformation as expected" in {
       val p = Flow(List(1, 2, 3).iterator).toPublisher()
       val p2 = Flow(p).
-        transform(new Transformer[Int, Int] {
+        transform("transform", () ⇒ new Transformer[Int, Int] {
           var tot = 0
           override def onNext(elem: Int) = {
             tot += elem
@@ -70,7 +70,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "produce one-to-several transformation as expected" in {
       val p = Flow(List(1, 2, 3).iterator).toPublisher()
       val p2 = Flow(p).
-        transform(new Transformer[Int, Int] {
+        transform("transform", () ⇒ new Transformer[Int, Int] {
           var tot = 0
           override def onNext(elem: Int) = {
             tot += elem
@@ -101,7 +101,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "produce dropping transformation as expected" in {
       val p = Flow(List(1, 2, 3, 4).iterator).toPublisher()
       val p2 = Flow(p).
-        transform(new Transformer[Int, Int] {
+        transform("transform", () ⇒ new Transformer[Int, Int] {
           var tot = 0
           override def onNext(elem: Int) = {
             tot += elem
@@ -129,14 +129,14 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "produce multi-step transformation as expected" in {
       val p = Flow(List("a", "bc", "def").iterator).toPublisher()
       val p2 = Flow(p).
-        transform(new TryRecoveryTransformer[String, Int] {
+        transform("transform", () ⇒ new TryRecoveryTransformer[String, Int] {
           var concat = ""
           override def onNext(element: Try[String]) = {
             concat += element
             List(concat.length)
           }
         }).
-        transform(new Transformer[Int, Int] {
+        transform("transform", () ⇒ new Transformer[Int, Int] {
           var tot = 0
           override def onNext(length: Int) = {
             tot += length
@@ -173,7 +173,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "invoke onComplete when done" in {
       val p = Flow(List("a").iterator).toPublisher()
       val p2 = Flow(p).
-        transform(new TryRecoveryTransformer[String, String] {
+        transform("transform", () ⇒ new TryRecoveryTransformer[String, String] {
           var s = ""
           override def onNext(element: Try[String]) = {
             s += element
@@ -193,7 +193,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "allow cancellation using isComplete" in {
       val p = StreamTestKit.PublisherProbe[Int]()
       val p2 = Flow(p).
-        transform(new TryRecoveryTransformer[Int, Int] {
+        transform("transform", () ⇒ new TryRecoveryTransformer[Int, Int] {
           var s = ""
           override def onNext(element: Try[Int]) = {
             s += element
@@ -217,7 +217,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "call onComplete after isComplete signaled completion" in {
       val p = StreamTestKit.PublisherProbe[Int]()
       val p2 = Flow(p).
-        transform(new TryRecoveryTransformer[Int, Int] {
+        transform("transform", () ⇒ new TryRecoveryTransformer[Int, Int] {
           var s = ""
           override def onNext(element: Try[Int]) = {
             s += element
@@ -243,7 +243,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "report error when exception is thrown" in {
       val p = Flow(List(1, 2, 3).iterator).toPublisher()
       val p2 = Flow(p).
-        transform(new Transformer[Int, Int] {
+        transform("transform", () ⇒ new Transformer[Int, Int] {
           override def onNext(elem: Int) = {
             if (elem == 2) throw new IllegalArgumentException("two not allowed")
             else List(elem, elem)
@@ -272,7 +272,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
             if (elem == 2) throw new IllegalArgumentException("two not allowed")
             else (1 to 5).map(elem * 100 + _)
           }.
-          transform(new Transformer[Int, Int] {
+          transform("transform", () ⇒ new Transformer[Int, Int] {
             override def onNext(elem: Int) = List(elem)
             override def onError(e: Throwable) = ()
             override def onTermination(e: Option[Throwable]) = e match {
@@ -317,7 +317,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "transform errors in sequence with normal messages" in {
       val p = StreamTestKit.PublisherProbe[Int]()
       val p2 = Flow(p).
-        transform(new Transformer[Int, String] {
+        transform("transform", () ⇒ new Transformer[Int, String] {
           var s = ""
           override def onNext(element: Int) = {
             s += element.toString
@@ -350,7 +350,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "forward errors when received and thrown" in {
       val p = StreamTestKit.PublisherProbe[Int]()
       val p2 = Flow(p).
-        transform(new Transformer[Int, Int] {
+        transform("transform", () ⇒ new Transformer[Int, Int] {
           override def onNext(in: Int) = List(in)
           override def onError(e: Throwable) = throw e
         }).
@@ -369,7 +369,7 @@ class FlowTransformRecoverSpec extends AkkaSpec {
     "support cancel as expected" in {
       val p = Flow(List(1, 2, 3).iterator).toPublisher()
       val p2 = Flow(p).
-        transform(new Transformer[Int, Int] {
+        transform("transform", () ⇒ new Transformer[Int, Int] {
           override def onNext(elem: Int) = List(elem, elem)
           override def onError(e: Throwable) = List(-1)
         }).


### PR DESCRIPTION
- Makes reusing flows safe 
- Adds timerTransform for ops which need TimerTransformer,
  for now it was the easier way out we should rethink if we need to
  specialise a lot on it or not.

// Also, making the API more verbose. Refer to #15271 on why we want the explicit `() =>`

As discussed in the team, this is the "simple" version, no classtag magic involved (which would leak into user api).
