### PR TITLE
=act #15409 Fix race in ActorDSL

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -372,7 +372,7 @@ class NodeMessageQueue extends AbstractNodeQueue[Envelope] with MessageQueue wit
 
 //Discards overflowing messages into DeadLetters
 class BoundedNodeMessageQueue(capacity: Int) extends AbstractBoundedNodeQueue[Envelope](capacity)
-with MessageQueue with BoundedMessageQueueSemantics with MultipleConsumerSemantics {
+  with MessageQueue with BoundedMessageQueueSemantics with MultipleConsumerSemantics {
   final def pushTimeOut: Duration = Duration.Undefined
 
   final def enqueue(receiver: ActorRef, handle: Envelope): Unit =


### PR DESCRIPTION
- The reason it didn't work is that messages are delivered before the cell is swapped
  as can be seen in RepointableActorRef.replaceWith (L195)
- Use ask until the RepointableActorRef is started, then use attachChild
