### PR TITLE
=con #15577 Harden ReliableProxyDocSpec

### DIFF
--- a/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/pattern/ReliableProxyDocSpec.scala
@@ -80,7 +80,7 @@ class ReliableProxyDocSpec extends AkkaSpec {
       probe.expectMsg("done")
     }
 
-    "show terminated after maxReconnects" in {
+    "show terminated after maxReconnects" in within(5.seconds) {
       val target = system.deadLetters
       val probe = TestProbe()
       val a = system.actorOf(Props(classOf[WatchingProxyParent], target.path))


### PR DESCRIPTION
- I couldn't find anything wrong
- Increasing the test timeout, it takes 1.5 s for the reconnects,
  so the previous total of 3 s might not have been enough
  (for that run)
