### PR TITLE
Update books.rst (for validation)

### DIFF
--- a/akka-docs/rst/additional/books.rst
+++ b/akka-docs/rst/additional/books.rst
@@ -1,7 +1,7 @@
 Books
 =====
 
-* `Akka in Action <http://www.manning.com/roestenburg/>`_, by Raymond Roestenburg and Rob Bakker, Manning Publications Co., ISBN: 9781617291012, November 2014 (est)
+* `Akka in Action <http://typesafe.com/resources/e-book/akka-in-action>`_, by Raymond Roestenburg and Rob Bakker, Manning Publications Co., ISBN: 9781617291012, est fall 2013
 * `Developing an Akka Edge <http://bleedingedgepress.com/our-books/developing-an-akka-edge/>`_, by Thomas Lockney and Raymond Tay, Bleeding Edge Press, ISBN: 9781939902054, April 2014
 * `Effective Akka <http://shop.oreilly.com/product/0636920028789.do>`_, by Jamie Allen, O'Reilly Media, ISBN: 1449360076, August 2013
 * `Akka Concurrency <http://www.artima.com/shop/akka_concurrency>`_, by Derek Wyatt, artima developer, ISBN: 0981531660, May 2013


### PR DESCRIPTION
Per discussion with Roland and Kathleen, suggest we point users interested in the Akka in Action book to the Typesafe.com 'Akka in Action' E-Book page, so that they can obtain free sample chapters.
(cherry picked from commit b17142f368fb07b34c3bed2727eb62a77790866f)

Conflicts:
    akka-docs/rst/additional/books.rst
