### PR TITLE
=act,rem #13946 fix handling of null parameters in Props

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/PropsCreationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/PropsCreationSpec.scala
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import akka.testkit.AkkaSpec
+
+object PropsCreationSpec {
+
+  final class A
+
+  final class B
+
+  class OneParamActor(blackhole: A) extends Actor {
+    override def receive = Actor.emptyBehavior
+  }
+
+  class TwoParamActor(blackhole1: A, blackhole2: B) extends Actor {
+    override def receive = Actor.emptyBehavior
+  }
+
+  object OneParamActorCreator extends akka.japi.Creator[Actor] {
+    override def create(): Actor = new OneParamActor(null)
+  }
+
+}
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class PropsCreationSpec extends AkkaSpec("akka.actor.serialize-creators = on") {
+
+  import akka.actor.PropsCreationSpec._
+
+  "Props" must {
+    "work with creator" in {
+      val p = Props(new OneParamActor(null))
+      system.actorOf(p)
+    }
+    "work with classOf" in {
+      val p = Props(classOf[OneParamActor], null)
+      system.actorOf(p)
+    }
+    "work with classOf + 1 `null` param" in {
+      val p = Props(classOf[OneParamActor], null)
+      system.actorOf(p)
+    }
+    "work with classOf + 2 `null` params" in {
+      val p = Props(classOf[TwoParamActor], null, null)
+      system.actorOf(p)
+    }
+  }
+
+  "Props Java API" must {
+    "work with create(creator)" in {
+      val p = Props.create(OneParamActorCreator)
+      system.actorOf(p)
+    }
+    "work with create(class, param)" in {
+      val p = Props.create(classOf[OneParamActor], null)
+      system.actorOf(p)
+    }
+  }
+
+}

--- a/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.util
+
+import org.scalatest.{ Matchers, WordSpec }
+
+import scala.collection.immutable
+
+object ReflectSpec {
+  final class A
+  final class B
+
+  class One(a: A)
+  class Two(a: A, b: B)
+
+  class MultipleOne(a: A, b: B) {
+    def this(a: A) { this(a, null) }
+    def this(b: B) { this(null, b) }
+  }
+}
+
+class ReflectSpec extends WordSpec with Matchers {
+
+  import akka.util.ReflectSpec._
+
+  "Reflect#findConstructor" must {
+
+    "deal with simple 1 matching case" in {
+      Reflect.findConstructor(classOf[One], immutable.Seq(new A))
+    }
+    "deal with 2-params 1 matching case" in {
+      Reflect.findConstructor(classOf[Two], immutable.Seq(new A, new B))
+    }
+    "deal with 2-params where one is `null` 1 matching case" in {
+      Reflect.findConstructor(classOf[Two], immutable.Seq(new A, null))
+      Reflect.findConstructor(classOf[Two], immutable.Seq(null, new B))
+    }
+    "deal with `null` in 1 matching case" in {
+      val constructor = Reflect.findConstructor(classOf[One], immutable.Seq(null))
+      constructor.newInstance(null)
+    }
+    "deal with multiple constructors" in {
+      Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(new A))
+      Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(new B))
+      Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(new A, new B))
+    }
+    "throw when multiple matching constructors" in {
+      intercept[IllegalArgumentException] {
+        Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(null))
+      }
+    }
+  }
+
+}

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -188,7 +188,8 @@ private[akka] trait Children { this: ActorCell ⇒
       try {
         val ser = SerializationExtension(cell.system)
         props.args forall (arg ⇒
-          arg.isInstanceOf[NoSerializationVerificationNeeded] ||
+          arg == null ||
+            arg.isInstanceOf[NoSerializationVerificationNeeded] ||
             ser.deserialize(ser.serialize(arg.asInstanceOf[AnyRef]).get, arg.getClass).get != null)
       } catch {
         case NonFatal(e) ⇒ throw new IllegalArgumentException(s"pre-creation serialization check failed at [${cell.self.path}/$name]", e)

--- a/akka-remote/src/test/scala/akka/remote/serialization/DaemonMsgCreateSerializerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/serialization/DaemonMsgCreateSerializerSpec.scala
@@ -16,9 +16,11 @@ import scala.concurrent.duration._
 
 object DaemonMsgCreateSerializerSpec {
   class MyActor extends Actor {
-    def receive = {
-      case _ ⇒
-    }
+    def receive = Actor.emptyBehavior
+  }
+
+  class MyActorWithParam(ignore: String) extends Actor {
+    def receive = Actor.emptyBehavior
   }
 }
 
@@ -39,6 +41,16 @@ class DaemonMsgCreateSerializerSpec extends AkkaSpec {
       verifySerialization {
         DaemonMsgCreate(
           props = Props[MyActor],
+          deploy = Deploy(),
+          path = "foo",
+          supervisor = supervisor)
+      }
+    }
+
+    "serialize and de-serialize DaemonMsgCreate with FromClassCreator, with null parameters for Props" in {
+      verifySerialization {
+        DaemonMsgCreate(
+          props = Props(classOf[MyActorWithParam], null),
           deploy = Deploy(),
           path = "foo",
           supervisor = supervisor)


### PR DESCRIPTION
- `Props` creation with `nulls` does not fail any longer
- `null` values are now serialised "properly" and can be used in remote deployments too. `"null"` marker is being used instead of class, it's theoretically redundant, but may be useful for debugging
- added tests for `Reflect.findConstructor`
- does not change wire protocol, so that's open for discussion (if we want it to be more like SerialisedMessage or not)

Resolves #13946
