### PR TITLE
=doc #15772 Make IPv6 multicast tests work on OS X

### DIFF
--- a/akka-samples/akka-docs-udp-multicast/src/test/java/docs/io/JavaUdpMulticastTest.java
+++ b/akka-samples/akka-docs-udp-multicast/src/test/java/docs/io/JavaUdpMulticastTest.java
@@ -7,6 +7,7 @@ package docs.io;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
+import akka.io.Udp;
 import akka.testkit.JavaTestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -16,6 +17,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
+import java.util.Random;
 
 public class JavaUdpMulticastTest {
 
@@ -40,14 +42,23 @@ public class JavaUdpMulticastTest {
                 }
             }
 
-            final String group = "FF33::1200";
+            // host assigned link local multicast address http://tools.ietf.org/html/rfc3307#section-4.3.2
+            // generate a random 32 bit multicast address with the high order bit set
+            final String randomAddress = Long.toHexString(((long) Math.abs(new Random().nextInt())) | (1L << 31)).toUpperCase();
+            final StringBuilder groupBuilder = new StringBuilder("FF02:");
+            for (int i = 0; i < 2; i += 1) {
+                groupBuilder.append(":");
+                groupBuilder.append(randomAddress.subSequence(i * 4, i * 4 + 4));
+            }
+            final String group = groupBuilder.toString();
             final Integer port = TestUtils.temporaryUdpIpv6Port(ipv6Iface);
             final String msg = "ohi";
             final ActorRef sink = getRef();
+            final String iface = ipv6Iface.getName();
 
-            final ActorRef listener = system.actorOf(Props.create(Listener.class, ipv6Iface.getName(), group, port, sink));
-            final ActorRef sender = system.actorOf(Props.create(Sender.class, group, port, msg));
-
+            final ActorRef listener = system.actorOf(Props.create(JavaUdpMulticast.Listener.class, iface, group, port, sink));
+            expectMsgClass(Udp.Bound.class);
+            final ActorRef sender = system.actorOf(Props.create(JavaUdpMulticast.Sender.class, iface, group, port, msg));
             expectMsgEquals(msg);
 
             // unbind


### PR DESCRIPTION
- Fixed a small race by waiting for the listenert to be bound
- Changed the Java test to test the Java code (imported the wrong class)
- Changed to a known link local multicas address (the old one just gave me a no route to host)
