### PR TITLE
=tes #15777 simple, but stable fix to , or . sensitivity in spec (for Validation)

### DIFF
--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/PrettyDurationSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/PrettyDurationSpec.scala
@@ -3,29 +3,42 @@
  */
 package akka.testkit.metrics.reporter
 
-import org.scalatest.{ Matchers, FlatSpec }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
 class PrettyDurationSpec extends FlatSpec with Matchers {
 
   behavior of "PrettyDuration"
 
-  import concurrent.duration._
-  import PrettyDuration._
+  import akka.testkit.metrics.reporter.PrettyDuration._
 
-  val cases =
-    95.nanos -> "95 ns" ::
-      9500.nanos -> "9.5 μs" ::
-      9500.micros -> "9.5 ms" ::
-      9500.millis -> "9.5 s" ::
-      95.seconds -> "1.6 min" ::
-      95.minutes -> "1.6 h" ::
-      95.hours -> "4.0 d" ::
+  import scala.concurrent.duration._
+
+  val cases: Seq[(Duration, String)] =
+    9.nanos -> "9.000 ns" ::
+      95.nanos -> "95.00 ns" ::
+      999.nanos -> "999.0 ns" ::
+      1000.nanos -> "1.000 μs" ::
+      9500.nanos -> "9.500 μs" ::
+      9500.micros -> "9.500 ms" ::
+      9500.millis -> "9.500 s" ::
+      95.seconds -> "1.583 min" ::
+      95.minutes -> "1.583 h" ::
+      95.hours -> "3.958 d" ::
       Nil
 
   cases foreach {
-    case (d, prettyString) ⇒
-      it should s"print $d seconds as $prettyString" in {
-        d.pretty should equal(prettyString)
+    case (d, expectedValue) ⇒
+      it should s"print $d seconds as $expectedValue" in {
+        d.pretty should fullyMatch regex expectedValue.replace(".", "[,.]")
       }
+  }
+
+  it should "work with infinity" in {
+    Duration.Inf.pretty should include("infinity")
+  }
+
+  it should "work with -infinity" in {
+    Duration.MinusInf.pretty should include("minus infinity")
   }
 }


### PR DESCRIPTION
Solves #15777

Conflicts:
    akka-testkit/src/test/scala/akka/testkit/metrics/reporter/PrettyDurationSpec.scala
