### PR TITLE
=tes #15808 force the locale in pretty duration, its only a helper

### DIFF
--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/PrettyDuration.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/PrettyDuration.scala
@@ -3,6 +3,8 @@
  */
 package akka.testkit.metrics.reporter
 
+import java.util.Locale
+
 import scala.concurrent.duration._
 
 object PrettyDuration {
@@ -21,10 +23,11 @@ object PrettyDuration {
           val unit = chooseUnit(nanos)
           val value = nanos.toDouble / NANOSECONDS.convert(1, unit)
 
-          s"%.${precision}g %s%s".format(value, abbreviate(unit), if (includeNanos) s" ($nanos ns)" else "")
+          s"%.${precision}g %s%s".formatLocal(Locale.ROOT, value, abbreviate(unit), if (includeNanos) s" ($nanos ns)" else "")
 
-        case d: Duration.Infinite if d == Duration.MinusInf ⇒ s" -∞ (minus infinity)"
-        case d ⇒ s"∞ (infinity)"
+        case Duration.MinusInf ⇒ s"-∞ (minus infinity)"
+        case Duration.Inf      ⇒ s"∞ (infinity)"
+        case _                 ⇒ "undefined"
       }
     }
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/PrettyDurationSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/PrettyDurationSpec.scala
@@ -29,8 +29,8 @@ class PrettyDurationSpec extends FlatSpec with Matchers {
 
   cases foreach {
     case (d, expectedValue) ⇒
-      it should s"print $d seconds as $expectedValue" in {
-        d.pretty should fullyMatch regex expectedValue.replace(".", "[,.]")
+      it should s"print $d nanos as $expectedValue" in {
+        d.pretty should be(expectedValue)
       }
   }
 
@@ -40,5 +40,9 @@ class PrettyDurationSpec extends FlatSpec with Matchers {
 
   it should "work with -infinity" in {
     Duration.MinusInf.pretty should include("minus infinity")
+  }
+
+  it should "work with undefined" in {
+    Duration.Undefined.pretty should include("undefined")
   }
 }


### PR DESCRIPTION
Fixing the locale so we always get a `.`, does not really need to be locale sensitive, since it's only printing in tests etc.
