### PR TITLE
=tcp #15766: Workaround for Windows to detect TCP abort

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -592,6 +592,15 @@ akka {
       # OP_CONNECT. Retries are needed if the OP_CONNECT notification doesn't imply that
       # `finishConnect` will succeed, which is the case on Android.
       finish-connect-retries = 5
+
+      # On Windows connection aborts are not reliably detected unless an OP_READ is
+      # registered on the selector _after_ the connection has been reset. This
+      # workaround enables an OP_CONNECT which forces the abort to be visible on Windows.
+      # Enabling this setting on other platforms than Windows will cause various failures
+      # and undefined behavior.
+      # Possible values of this key are on, off and auto where auto will enable the
+      # workaround if Windows is detected automatically.
+      windows-connection-abort-workaround-enabled = auto
     }
 
     udp {

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -6,12 +6,13 @@ package akka.io
 
 import java.net.InetSocketAddress
 import java.net.Socket
+import akka.ConfigurationException
 import akka.io.Inet._
 import com.typesafe.config.Config
 import scala.concurrent.duration._
 import scala.collection.immutable
 import scala.collection.JavaConverters._
-import akka.util.ByteString
+import akka.util.{ Helpers, ByteString }
 import akka.util.Helpers.Requiring
 import akka.actor._
 import java.lang.{ Iterable ⇒ JIterable }
@@ -543,6 +544,11 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
     val MaxChannelsPerSelector: Int = if (MaxChannels == -1) -1 else math.max(MaxChannels / NrOfSelectors, 1)
     val FinishConnectRetries: Int = getInt("finish-connect-retries") requiring (_ > 0,
       "finish-connect-retries must be > 0")
+
+    val WindowsConnectionAbortWorkaroundEnabled: Boolean = getString("windows-connection-abort-workaround-enabled") match {
+      case "auto" ⇒ Helpers.isWindows
+      case _ => getBoolean("windows-connection-abort-workaround-enabled")
+    }
 
     private[this] def getIntBytes(path: String): Int = {
       val size = getBytes(path)


### PR DESCRIPTION
Nasty workaround that makes Windows report connection aborts without needing to register an OP_READ _after_ the abort (which basically implies that OP_READ needs to be provided peridodically)
- [X] Allow this behavior to be overridable (i.e. settings on | off | auto)
- [X] Test on Windows 8
- [X] Test on Windows 7
- [X] Test on Build server
- [X] Test on Java 6
- [x] Test on OSX
