### PR TITLE
useRole ignored on local, because routers unaware of roles locally

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/Balancing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Balancing.scala
@@ -66,14 +66,13 @@ private[akka] final class BalancingRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class BalancingPool(
-  override val nrOfInstances: Int,
+  nrOfInstances: Int,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
   extends Pool {
 
   def this(config: Config) =
-    this(
-      nrOfInstances = config.getInt("nr-of-instances"))
+    this(nrOfInstances = config.getInt("nr-of-instances"))
 
   /**
    * Java API
@@ -93,6 +92,8 @@ final case class BalancingPool(
    * supervision, death watch and router management messages.
    */
   def withDispatcher(dispatcherId: String): BalancingPool = copy(routerDispatcher = dispatcherId)
+
+  def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * INTERNAL API

--- a/akka-actor/src/main/scala/akka/routing/Broadcast.scala
+++ b/akka-actor/src/main/scala/akka/routing/Broadcast.scala
@@ -58,7 +58,7 @@ final class BroadcastRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class BroadcastPool(
-  override val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
+  nrOfInstances: Int, override val resizer: Option[Resizer] = None,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
@@ -77,6 +77,8 @@ final case class BroadcastPool(
   def this(nr: Int) = this(nrOfInstances = nr)
 
   override def createRouter(system: ActorSystem): Router = new Router(BroadcastRoutingLogic())
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * Setting the supervisor strategy to be used for the “head” Router actor.

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -260,7 +260,8 @@ final case class ConsistentHashingRoutingLogic(
  */
 @SerialVersionUID(1L)
 final case class ConsistentHashingPool(
-  override val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
+  val nrOfInstances: Int,
+  override val resizer: Option[Resizer] = None,
   val virtualNodesFactor: Int = 0,
   val hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
@@ -282,6 +283,8 @@ final case class ConsistentHashingPool(
 
   override def createRouter(system: ActorSystem): Router =
     new Router(ConsistentHashingRoutingLogic(system, virtualNodesFactor, hashMapping))
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * Setting the supervisor strategy to be used for the “head” Router actor.

--- a/akka-actor/src/main/scala/akka/routing/Random.scala
+++ b/akka-actor/src/main/scala/akka/routing/Random.scala
@@ -59,7 +59,7 @@ final class RandomRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class RandomPool(
-  override val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
+  val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
@@ -78,6 +78,8 @@ final case class RandomPool(
   def this(nr: Int) = this(nrOfInstances = nr)
 
   override def createRouter(system: ActorSystem): Router = new Router(RandomRoutingLogic())
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * Setting the supervisor strategy to be used for the “head” Router actor.

--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -64,7 +64,7 @@ final class RoundRobinRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class RoundRobinPool(
-  override val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
+  val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
@@ -82,6 +82,8 @@ final case class RoundRobinPool(
   def this(nr: Int) = this(nrOfInstances = nr)
 
   override def createRouter(system: ActorSystem): Router = new Router(RoundRobinRoutingLogic())
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * Setting the supervisor strategy to be used for the “head” Router actor.

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -176,10 +176,11 @@ abstract class PoolBase extends Pool
  * them from the router if they terminate.
  */
 trait Pool extends RouterConfig {
+
   /**
    * Initial number of routee instances
    */
-  def nrOfInstances: Int
+  def nrOfInstances(sys: ActorSystem): Int
 
   /**
    * Use a dedicated dispatcher for the routees of the pool.
@@ -315,7 +316,7 @@ class FromConfig(override val resizer: Option[Resizer],
   def withDispatcher(dispatcherId: String): FromConfig =
     new FromConfig(resizer, supervisorStrategy, dispatcherId)
 
-  override val nrOfInstances: Int = 0
+  override def nrOfInstances(sys: ActorSystem): Int = 0
 
   /**
    * [[akka.actor.Props]] for a group router based on the settings defined by

--- a/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
+++ b/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
@@ -93,7 +93,7 @@ private[akka] final case class ScatterGatherFirstCompletedRoutees(
  */
 @SerialVersionUID(1L)
 final case class ScatterGatherFirstCompletedPool(
-  override val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
+  val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
   within: FiniteDuration,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
@@ -116,6 +116,8 @@ final case class ScatterGatherFirstCompletedPool(
   def this(nr: Int, within: FiniteDuration) = this(nrOfInstances = nr, within = within)
 
   override def createRouter(system: ActorSystem): Router = new Router(ScatterGatherFirstCompletedRoutingLogic(within))
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * Setting the supervisor strategy to be used for the “head” Router actor.

--- a/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
+++ b/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
@@ -174,7 +174,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class SmallestMailboxPool(
-  override val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
+  val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
@@ -193,6 +193,8 @@ final case class SmallestMailboxPool(
   def this(nr: Int) = this(nrOfInstances = nr)
 
   override def createRouter(system: ActorSystem): Router = new Router(SmallestMailboxRoutingLogic())
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * Setting the supervisor strategy to be used for the “head” Router actor.

--- a/akka-actor/src/main/scala/akka/routing/TailChopping.scala
+++ b/akka-actor/src/main/scala/akka/routing/TailChopping.scala
@@ -120,7 +120,7 @@ private[akka] final case class TailChoppingRoutees(
  */
 @SerialVersionUID(1L)
 final case class TailChoppingPool(
-  override val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
+  val nrOfInstances: Int, override val resizer: Option[Resizer] = None,
   within: FiniteDuration,
   interval: FiniteDuration,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
@@ -149,6 +149,8 @@ final case class TailChoppingPool(
   override def createRouter(system: ActorSystem): Router =
     new Router(TailChoppingRoutingLogic(system.scheduler, within,
       interval, system.dispatchers.lookup(routerDispatcher)))
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   /**
    * Setting the supervisor strategy to be used for the “head” Router actor.

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -3,40 +3,14 @@
  */
 package akka.cluster
 
-import com.typesafe.config.Config
 import akka.ConfigurationException
-import akka.actor.ActorSystem
-import akka.actor.ActorSystemImpl
-import akka.actor.Deploy
-import akka.actor.DynamicAccess
-import akka.actor.InternalActorRef
-import akka.actor.NoScopeGiven
-import akka.actor.Scheduler
-import akka.actor.Scope
-import akka.actor.Terminated
-import akka.dispatch.sysmsg.DeathWatchNotification
+import akka.actor.{ ActorRef, ActorSystem, ActorSystemImpl, Deploy, DynamicAccess, NoScopeGiven, Scope }
+import akka.cluster.routing.{ ClusterRouterGroup, ClusterRouterGroupSettings, ClusterRouterPool, ClusterRouterPoolSettings }
 import akka.event.EventStream
-import akka.japi.Util.immutableSeq
-import akka.remote.RemoteActorRefProvider
-import akka.remote.RemoteDeployer
+import akka.remote.{ RemoteActorRefProvider, RemoteDeployer }
 import akka.remote.routing.RemoteRouterConfig
-import akka.routing.RouterConfig
-import akka.routing.DefaultResizer
-import akka.cluster.routing.MixMetricsSelector
-import akka.cluster.routing.HeapMetricsSelector
-import akka.cluster.routing.SystemLoadAverageMetricsSelector
-import akka.cluster.routing.CpuMetricsSelector
-import akka.cluster.routing.MetricsSelector
-import akka.dispatch.sysmsg.SystemMessage
-import akka.actor.ActorRef
-import akka.actor.Props
-import akka.routing.Pool
-import akka.routing.Group
-import akka.cluster.routing.ClusterRouterPool
-import akka.cluster.routing.ClusterRouterGroup
-import com.typesafe.config.ConfigFactory
-import akka.cluster.routing.ClusterRouterPoolSettings
-import akka.cluster.routing.ClusterRouterGroupSettings
+import akka.routing.{ Group, Pool }
+import com.typesafe.config.Config
 
 /**
  * INTERNAL API

--- a/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
@@ -128,7 +128,7 @@ final case class AdaptiveLoadBalancingRoutingLogic(system: ActorSystem, metricsS
 @SerialVersionUID(1L)
 final case class AdaptiveLoadBalancingPool(
   metricsSelector: MetricsSelector = MixMetricsSelector,
-  override val nrOfInstances: Int = 0,
+  val nrOfInstances: Int = 0,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
@@ -148,6 +148,8 @@ final case class AdaptiveLoadBalancingPool(
   def this(metricsSelector: MetricsSelector, nr: Int) = this(nrOfInstances = nr)
 
   override def resizer: Option[Resizer] = None
+
+  override def nrOfInstances(sys: ActorSystem) = this.nrOfInstances
 
   override def createRouter(system: ActorSystem): Router =
     new Router(AdaptiveLoadBalancingRoutingLogic(system, metricsSelector))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
@@ -1,0 +1,210 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster.routing
+
+import akka.actor._
+import akka.cluster.MultiNodeClusterSpec
+import akka.pattern.ask
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.routing.GetRoutees
+import akka.routing.RoundRobinPool
+import akka.routing.Routees
+import akka.testkit.DefaultTimeout
+import akka.testkit.ImplicitSender
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object UseRoleIgnoredMultiJvmSpec extends MultiNodeConfig {
+
+  class SomeActor(routeeType: RouteeType) extends Actor with ActorLogging {
+    log.info("Starting on {}", self.path.address)
+
+    def this() = this(PoolRoutee)
+
+    def receive = {
+      case msg ⇒
+        log.info("msg = {}", msg)
+        sender() ! Reply(routeeType, self)
+    }
+  }
+
+  final case class Reply(routeeType: RouteeType, ref: ActorRef)
+
+  sealed trait RouteeType extends Serializable
+  object PoolRoutee extends RouteeType
+  object GroupRoutee extends RouteeType
+
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false).
+    withFallback(MultiNodeClusterSpec.clusterConfig))
+
+  nodeConfig(first)(ConfigFactory.parseString("""akka.cluster.roles =["a", "c"]"""))
+  nodeConfig(second, third)(ConfigFactory.parseString("""akka.cluster.roles =["b", "c"]"""))
+
+}
+
+class UseRoleIgnoredMultiJvmNode1 extends UseRoleIgnoredSpec
+class UseRoleIgnoredMultiJvmNode2 extends UseRoleIgnoredSpec
+class UseRoleIgnoredMultiJvmNode3 extends UseRoleIgnoredSpec
+
+abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSpec)
+  with MultiNodeClusterSpec
+  with ImplicitSender with DefaultTimeout {
+  import akka.cluster.routing.UseRoleIgnoredMultiJvmSpec._
+
+  def receiveReplies(routeeType: RouteeType, expectedReplies: Int): Map[Address, Int] = {
+    val zero = Map.empty[Address, Int] ++ roles.map(address(_) -> 0)
+    (receiveWhile(5 seconds, messages = expectedReplies) {
+      case Reply(`routeeType`, ref) ⇒ fullAddress(ref)
+    }).foldLeft(zero) {
+      case (replyMap, address) ⇒ replyMap + (address -> (replyMap(address) + 1))
+    }
+  }
+
+  /**
+   * Fills in self address for local ActorRef
+   */
+  private def fullAddress(actorRef: ActorRef): Address = actorRef.path.address match {
+    case Address(_, _, None, None) ⇒ cluster.selfAddress
+    case a                         ⇒ a
+  }
+
+  def currentRoutees(router: ActorRef) =
+    Await.result(router ? GetRoutees, timeout.duration).asInstanceOf[Routees].routees
+
+  "A cluster" must {
+    "start cluster" taggedAs LongRunningTest in {
+      awaitClusterUp(first, second, third)
+      runOn(first) { info("first, roles: " + cluster.selfRoles) }
+      runOn(second) { info("second, roles: " + cluster.selfRoles) }
+      runOn(third) { info("third, roles: " + cluster.selfRoles) }
+      enterBarrier("after-1")
+    }
+
+    "local: off, roles: off, 6 => 0,2,2" taggedAs LongRunningTest in {
+
+      runOn(first) {
+        val role = Some("b")
+
+        val router = system.actorOf(ClusterRouterPool(
+          RoundRobinPool(nrOfInstances = 6),
+          ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = false, useRole = role)).
+          props(Props[SomeActor]),
+          "router-2")
+
+        awaitAssert(currentRoutees(router).size should be(4))
+
+        val iterationCount = 10
+        for (i ← 0 until iterationCount) {
+          router ! s"hit-$i"
+        }
+
+        val replies = receiveReplies(PoolRoutee, iterationCount)
+
+        replies(first) should be(0) // should not be deployed locally, does not have required role
+        replies(second) should be > 0
+        replies(third) should be > 0
+        replies.values.sum should be(iterationCount)
+      }
+
+      enterBarrier("after-2")
+    }
+
+    "local: on, role: b, 6 => 0,2,2" taggedAs LongRunningTest in {
+
+      runOn(first) {
+        val role = Some("b")
+
+        val router = system.actorOf(ClusterRouterPool(
+          RoundRobinPool(nrOfInstances = 6),
+          ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRole = role)).
+          props(Props[SomeActor]),
+          "router-3")
+
+        awaitAssert(currentRoutees(router).size should be(4))
+
+        val iterationCount = 10
+        for (i ← 0 until iterationCount) {
+          router ! s"hit-$i"
+        }
+
+        val replies = receiveReplies(PoolRoutee, iterationCount)
+
+        replies(first) should be(0) // should not be deployed locally, does not have required role
+        replies(second) should be > 0
+        replies(third) should be > 0
+        replies.values.sum should be(iterationCount)
+      }
+
+      enterBarrier("after-3")
+    }
+
+    "local: on, role: a, 6 => 2,0,0" taggedAs LongRunningTest in {
+
+      runOn(first) {
+        val role = Some("a")
+
+        val router = system.actorOf(ClusterRouterPool(
+          RoundRobinPool(nrOfInstances = 6),
+          ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRole = role)).
+          props(Props[SomeActor]),
+          "router-4")
+
+        awaitAssert(currentRoutees(router).size should be(2))
+
+        val iterationCount = 10
+        for (i ← 0 until iterationCount) {
+          router ! s"hit-$i"
+        }
+
+        val replies = receiveReplies(PoolRoutee, iterationCount)
+
+        replies(first) should be > 0
+        replies(second) should be(0)
+        replies(third) should be(0)
+        replies.values.sum should be(iterationCount)
+      }
+
+      enterBarrier("after-4")
+    }
+
+    "local: on, role: c, 6 => 2,2,2" taggedAs LongRunningTest in {
+
+      runOn(first) {
+        val role = Some("c")
+
+        val router = system.actorOf(ClusterRouterPool(
+          RoundRobinPool(nrOfInstances = 6),
+          ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRole = role)).
+          props(Props[SomeActor]),
+          "router-5")
+
+        awaitAssert(currentRoutees(router).size should be(6))
+
+        val iterationCount = 10
+        for (i ← 0 until iterationCount) {
+          router ! s"hit-$i"
+        }
+
+        val replies = receiveReplies(PoolRoutee, iterationCount)
+
+        replies(first) should be > 0
+        replies(second) should be > 0
+        replies(third) should be > 0
+        replies.values.sum should be(iterationCount)
+      }
+
+      enterBarrier("after-5")
+    }
+
+  }
+}

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -115,3 +115,12 @@ If you use ``Slf4jLogger`` you should add the following configuration::
 
 It will filter the log events using the backend configuration (e.g. logback.xml) before
 they are published to the event bus.
+
+Pool routers nrOfInstances method now takes ActorSystem
+=======================================================
+
+In order to make cluster routers smarter about when they can start local routees,
+``nrOfInstances`` defined on ``Pool`` now takes ``ActorSystem`` as an argument.
+In case you have implemented a custom Pool you will have to update the method's signature,
+however the implementation can remain the same if you don't need to rely on an ActorSystem in your logic.
+

--- a/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
@@ -3,25 +3,25 @@
  */
 package akka.remote.routing
 
-import akka.routing.Router
-import akka.actor.Props
-import akka.actor.ActorContext
-import akka.routing.Routee
 import java.util.concurrent.atomic.AtomicInteger
-import akka.actor.Address
+
 import akka.actor.ActorCell
-import akka.actor.Deploy
-import com.typesafe.config.ConfigFactory
-import akka.routing.ActorRefRoutee
-import akka.remote.RemoteScope
-import akka.actor.Actor
-import akka.actor.SupervisorStrategy
-import akka.routing.Resizer
-import akka.routing.RouterConfig
-import akka.routing.Pool
+import akka.actor.ActorContext
 import akka.actor.ActorSystem
-import akka.routing.RouterActor
+import akka.actor.Address
+import akka.actor.Deploy
+import akka.actor.Props
+import akka.actor.SupervisorStrategy
 import akka.japi.Util.immutableSeq
+import akka.remote.RemoteScope
+import akka.routing.ActorRefRoutee
+import akka.routing.Pool
+import akka.routing.Resizer
+import akka.routing.Routee
+import akka.routing.Router
+import akka.routing.RouterActor
+import akka.routing.RouterConfig
+import com.typesafe.config.ConfigFactory
 
 /**
  * [[akka.routing.RouterConfig]] implementation for remote deployment on defined
@@ -44,7 +44,7 @@ final case class RemoteRouterConfig(local: Pool, nodes: Iterable[Address]) exten
 
   override def createRouter(system: ActorSystem): Router = local.createRouter(system)
 
-  override def nrOfInstances: Int = local.nrOfInstances
+  override def nrOfInstances(sys: ActorSystem): Int = local.nrOfInstances(sys)
 
   override def newRoutee(routeeProps: Props, context: ActorContext): Routee = {
     val name = "c" + childNameCounter.incrementAndGet


### PR DESCRIPTION
FOR DISCUSSION, see discussion in related topic: https://github.com/akka/akka/issues/15042

In general the question is

1) if we want to make cluster routers take an actor system / cluster or not. There's also a broader question, as this issue is somewhat related to https://github.com/akka/akka/issues/13802 (`nr-of-instances` being confusing), which may point to that cluster routers should become more specialised?

2) The issue itself can be "solved" easily by returning `0` from the `nrOfInstances`, but that makes it possible to deadLetter some initial messages sent to the router if normally (when using `allowLocal`), that would not be the case. This safety though is a bit accidental, and maybe that's fine for fixing this issue?

If we don't want to break APIs, this could still be solved, but by setting the actor system "later" from "the inside", but's going to endup pretty ugly I think...

May eventually resolve https://github.com/akka/akka/issues/15042
