### PR TITLE
=str #15844 Use key labeled edges to support multiple edges between same vertices

### DIFF
--- a/akka-stream/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
+++ b/akka-stream/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
@@ -121,12 +121,7 @@ class FlowGraphCompileSpec extends AkkaSpec {
         val merge = Merge[String]
         import FlowGraphImplicits._
         in1 ~> f1 ~> bcast ~> f2 ~> merge ~> f3 ~> out1
-        bcast ~> f4 ~> bcast2 ~> f5 ~> merge
-        bcast2 ~> f6 ~> out2
-
-        // FIXME the following is doesn't work because of edge equality
-        //        in1 ~> f1 ~> bcast ~> f2 ~> merge ~> f3 ~> out1
-        //        bcast ~> f4 ~> merge
+        bcast ~> f4 ~> merge
       }.run()
     }
 


### PR DESCRIPTION
@rkuhn @drewhk The whole purpose of [key-labeled](http://www.scala-graph.org/guides/core-initializing.html) edges is this, of course. Sorry that I didn't realize immediately.

When using `LkDiEdge` the edge label (equals/hashCode) will part of the edge identity.
