### PR TITLE
=pro do not push releasing* branch

### DIFF
--- a/project/scripts/release
+++ b/project/scripts/release
@@ -360,10 +360,8 @@ trap arrgh_interrupt SIGHUP SIGINT SIGTERM
 echolog "Pushing to git origin..."
 if [ $dry_run ]; then
   echodry "Not actually pushing to git origin. Commands:"
-  echodry "  git push origin ${release_branch}"
   echodry "  git push origin --tags"
 else
-  important git push origin ${release_branch}
   important git push origin --tags
 fi
 


### PR DESCRIPTION
Tag is more than plenty.

Will backport to release-2.3 and release-2.3-dev.
