### PR TITLE
Implement transparent HEAD support

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpResponseRendererFactory.scala
@@ -134,7 +134,7 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
             byteStrings(Flow(data).transform("checkContentLength", () ⇒ new CheckContentLengthTransformer(contentLength)).toPublisher())
 
           case HttpEntity.CloseDelimited(_, data) ⇒
-            renderHeaders(headers.toList, alwaysClose = true)
+            renderHeaders(headers.toList, alwaysClose = ctx.requestMethod != HttpMethods.HEAD)
             renderEntityContentType(r, entity)
             r ~~ CrLf
             byteStrings(data)

--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/RenderSupport.scala
@@ -4,7 +4,7 @@
 
 package akka.http.engine.rendering
 
-import org.reactivestreams.Publisher
+import org.reactivestreams.{ Subscription, Subscriber, Publisher }
 import akka.parboiled2.CharUtils
 import akka.util.ByteString
 import akka.event.LoggingAdapter
@@ -39,7 +39,11 @@ private object RenderSupport {
     val messageStart = SynchronousPublisherFromIterable(r.get :: Nil)
     val messageBytes =
       if (!skipEntity) Flow(messageStart).concat(entityBytes).toPublisher()
-      else messageStart
+      else {
+        // FIXME: This should be fixed by a CancelledSink once #15903 is done. Currently this is needed for the tests
+        entityBytes.subscribe(cancelledSusbcriber)
+        messageStart
+      }
     messageBytes :: Nil
   }
 

--- a/akka-http-core/src/main/scala/akka/http/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/util/package.scala
@@ -7,7 +7,7 @@ package akka.http
 import language.implicitConversions
 import java.nio.charset.Charset
 import com.typesafe.config.Config
-import org.reactivestreams.Publisher
+import org.reactivestreams.{Subscription, Subscriber, Publisher}
 import scala.util.matching.Regex
 import akka.event.LoggingAdapter
 import akka.util.ByteString
@@ -51,6 +51,14 @@ package object util {
             Nil
           }
         })
+  }
+
+  // FIXME: This should be fixed by a CancelledSink once #15903 is done. Currently this is needed for the tests
+  private[http] def cancelledSusbcriber[T]: Subscriber[T] = new Subscriber[T] {
+    override def onSubscribe(s: Subscription): Unit = s.cancel()
+    override def onError(t: Throwable): Unit = ()
+    override def onComplete(): Unit = ()
+    override def onNext(t: T): Unit = ()
   }
 
   private[http] def errorLogger(log: LoggingAdapter, msg: String): Transformer[ByteString, ByteString] =


### PR DESCRIPTION
and don't close on HEAD request when sending CloseDelimited
