### PR TITLE
+str #15904 Ported Tcp IO to new Stream DSL

### DIFF
--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestDefaultMailbox.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestDefaultMailbox.scala
@@ -26,7 +26,7 @@ private[akka] case class StreamTestDefaultMailbox() extends MailboxType with Pro
         val actorClass = r.underlying.props.actorClass
         assert(actorClass != classOf[Actor], s"Don't use anonymous actor classes, actor class for $r was [${actorClass.getName}]")
         // StreamTcpManager is allowed to use another dispatcher
-        assert(!actorClass.getName.startsWith("akka.stream.") || actorClass == classOf[StreamTcpManager],
+        assert(!actorClass.getName.startsWith("akka.stream.") || actorClass == classOf[StreamTcpManager] || actorClass == classOf[akka.stream.io2.StreamTcpManager],
           s"$r with actor class [${actorClass.getName}] must not run on default dispatcher in tests. " +
             "Did you forget to define `props.withDispatcher` when creating the actor? " +
             "Or did you forget to configure the `akka.stream.materializer` setting accordingly or force the " +

--- a/akka-stream-tests/src/test/scala/akka/stream/io2/TcpFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io2/TcpFlowSpec.scala
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io2
+
+import akka.stream.scaladsl2._
+import akka.stream.testkit.AkkaSpec
+import akka.util.ByteString
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+class TcpFlowSpec extends AkkaSpec with TcpHelper {
+  import akka.stream.io2.TcpHelper._
+  var demand = 0L
+
+  "Outgoing TCP stream" must {
+
+    "work in the happy case" in {
+      val testData = ByteString(1, 2, 3, 4, 5)
+
+      val server = new Server()
+
+      val (tcpSubscriber, tcpPublisher, serverConnection) = connect(server)
+
+      val tcpReadProbe = new TcpReadProbe(tcpPublisher)
+      val tcpWriteProbe = new TcpWriteProbe(tcpSubscriber)
+
+      serverConnection.write(testData)
+      serverConnection.read(5)
+      tcpReadProbe.read(5) should be(testData)
+      tcpWriteProbe.write(testData)
+      serverConnection.waitRead() should be(testData)
+
+      tcpWriteProbe.close()
+      tcpReadProbe.close()
+
+      //client.read() should be(ByteString.empty)
+      server.close()
+    }
+
+    "be able to write a sequence of ByteStrings" in {
+      val server = new Server()
+      val (tcpSubscriber, tcpPublisher, serverConnection) = connect(server)
+
+      val testInput = Iterator.range(0, 256).map(ByteString(_))
+      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+
+      serverConnection.read(256)
+      Source(tcpPublisher).connect(BlackholeDrain).run()
+
+      Source(testInput).connect(SubscriberDrain(tcpSubscriber)).run()
+      serverConnection.waitRead() should be(expectedOutput)
+
+      server.close()
+    }
+
+    "be able to read a sequence of ByteStrings" in {
+      val server = new Server()
+      val (tcpSubscriber, tcpPublisher, serverConnection) = connect(server)
+
+      val testInput = Iterator.range(0, 256).map(ByteString(_))
+      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+
+      for (in ← testInput) serverConnection.write(in)
+      new TcpWriteProbe(tcpSubscriber) // Just register an idle upstream
+
+      val resultFuture = Source(tcpPublisher).fold(ByteString.empty) { case (res, elem) ⇒ res ++ elem }
+
+      serverConnection.confirmedClose()
+      Await.result(resultFuture, 3.seconds) should be(expectedOutput)
+      server.close()
+    }
+
+    "half close the connection when output stream is closed" in {
+      val testData = ByteString(1, 2, 3, 4, 5)
+      val server = new Server()
+      val (tcpSubscriber, tcpPublisher, serverConnection) = connect(server)
+
+      val tcpReadProbe = new TcpReadProbe(tcpPublisher)
+      val tcpWriteProbe = new TcpWriteProbe(tcpSubscriber)
+
+      tcpWriteProbe.close()
+      // FIXME: expect PeerClosed on server
+      serverConnection.write(testData)
+      tcpReadProbe.read(5) should be(testData)
+      serverConnection.confirmedClose()
+      tcpReadProbe.subscriberProbe.expectComplete()
+      server.close()
+    }
+
+    "stop reading when the input stream is cancelled" in {
+      val testData = ByteString(1, 2, 3, 4, 5)
+      val server = new Server()
+      val (tcpSubscriber, tcpPublisher, serverConnection) = connect(server)
+
+      val tcpReadProbe = new TcpReadProbe(tcpPublisher)
+      val tcpWriteProbe = new TcpWriteProbe(tcpSubscriber)
+
+      tcpReadProbe.close()
+      // FIXME: expect PeerClosed on server
+      serverConnection.write(testData)
+      tcpReadProbe.subscriberProbe.expectNoMsg(1.second)
+      serverConnection.read(5)
+      tcpWriteProbe.write(testData)
+      serverConnection.waitRead() should be(testData)
+      tcpWriteProbe.close()
+      server.close()
+    }
+
+    "keep write side open when remote half-closes" in {
+      val testData = ByteString(1, 2, 3, 4, 5)
+      val server = new Server()
+      val (tcpSubscriber, tcpPublisher, serverConnection) = connect(server)
+
+      val tcpReadProbe = new TcpReadProbe(tcpPublisher)
+      val tcpWriteProbe = new TcpWriteProbe(tcpSubscriber)
+
+      // FIXME: here (and above tests) add a chitChat() method ensuring this works even after prior communication
+      // there should be a chitchat and non-chitchat version
+
+      serverConnection.confirmedClose()
+      tcpReadProbe.subscriberProbe.expectComplete()
+
+      serverConnection.read(5)
+      tcpWriteProbe.write(testData)
+      serverConnection.waitRead() should be(testData)
+
+      tcpWriteProbe.close()
+      // FIXME: expect closed event
+      server.close()
+    }
+
+    "shut down both streams when connection is completely closed" in {
+      // Client gets a PeerClosed event and does not know that the write side is also closed
+      val testData = ByteString(1, 2, 3, 4, 5)
+      val server = new Server()
+      val (tcpSubscriber, tcpPublisher, serverConnection) = connect(server)
+
+      val tcpReadProbe = new TcpReadProbe(tcpPublisher)
+      val tcpWriteProbe = new TcpWriteProbe(tcpSubscriber)
+
+      serverConnection.abort()
+      tcpReadProbe.subscriberProbe.expectError()
+      tcpWriteProbe.tcpWriteSubscription.expectCancellation()
+    }
+
+    "close the connection when input stream and oputput streams are closed" in {
+      pending
+    }
+
+  }
+
+  "TCP listen stream" must {
+
+    "be able to implement echo" in {
+      val serverAddress = temporaryServerAddress
+      val server = echoServer(serverAddress)
+      val (tcpSubscriber, tcpPublisher) = connect(serverAddress)
+
+      val testInput = Iterator.range(0, 256).map(ByteString(_))
+      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+
+      Source(testInput).connect(SubscriberDrain(tcpSubscriber)).run()
+      val resultFuture = Source(tcpPublisher).fold(ByteString.empty) { case (res, elem) ⇒ res ++ elem }
+
+      Await.result(resultFuture, 3.seconds) should be(expectedOutput)
+      server.close()
+      server.awaitTermination(3.seconds)
+    }
+
+    "work with a chain of echoes" in {
+      val serverAddress = temporaryServerAddress
+      val server = echoServer(serverAddress)
+
+      val (tcpSubscriber1, tcpPublisher1) = connect(serverAddress)
+      val (tcpSubscriber2, tcpPublisher2) = connect(serverAddress)
+      val (tcpSubscriber3, tcpPublisher3) = connect(serverAddress)
+
+      val testInput = Iterator.range(0, 256).map(ByteString(_))
+      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+
+      Source(testInput).connect(SubscriberDrain(tcpSubscriber1)).run()
+      tcpPublisher1.subscribe(tcpSubscriber2)
+      tcpPublisher2.subscribe(tcpSubscriber3)
+      val resultFuture = Source(tcpPublisher3).fold(ByteString.empty) { case (res, elem) ⇒ res ++ elem }
+
+      Await.result(resultFuture, 3.seconds) should be(expectedOutput)
+      server.close()
+      server.awaitTermination(3.seconds)
+    }
+
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/io2/TcpHelper.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io2/TcpHelper.scala
@@ -1,0 +1,227 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io2
+
+import java.io.Closeable
+
+import akka.actor.{ Actor, ActorRef, Props }
+import akka.io.{ IO, Tcp }
+import akka.stream.io2.StreamTcp.IncomingTcpConnection
+import akka.stream.scaladsl2._
+import akka.stream.testkit.StreamTestKit
+import akka.stream.MaterializerSettings
+import akka.testkit.{ TestKitBase, TestProbe }
+import akka.util.ByteString
+import java.net.InetSocketAddress
+import java.nio.channels.ServerSocketChannel
+import org.reactivestreams.{ Subscriber, Publisher }
+import scala.collection.immutable.Queue
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+object TcpHelper {
+  case class ClientWrite(bytes: ByteString)
+  case class ClientRead(count: Int, readTo: ActorRef)
+  case class ClientClose(cmd: Tcp.CloseCommand)
+
+  case object WriteAck extends Tcp.Event
+
+  def testClientProps(connection: ActorRef): Props =
+    Props(new TestClient(connection)).withDispatcher("akka.test.stream-dispatcher")
+  def testServerProps(address: InetSocketAddress, probe: ActorRef): Props =
+    Props(new TestServer(address, probe)).withDispatcher("akka.test.stream-dispatcher")
+
+  class TestClient(connection: ActorRef) extends Actor {
+    connection ! Tcp.Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
+
+    var queuedWrites = Queue.empty[ByteString]
+    var writePending = false
+
+    var toRead = 0
+    var readBuffer = ByteString.empty
+    var readTo: ActorRef = context.system.deadLetters
+
+    var closeAfterWrite: Option[Tcp.CloseCommand] = None
+
+    // FIXME: various close scenarios
+    def receive = {
+      case ClientWrite(bytes) if !writePending ⇒
+        writePending = true
+        connection ! Tcp.Write(bytes, WriteAck)
+      case ClientWrite(bytes) ⇒
+        queuedWrites = queuedWrites.enqueue(bytes)
+      case WriteAck if queuedWrites.nonEmpty ⇒
+        val (next, remaining) = queuedWrites.dequeue
+        queuedWrites = remaining
+        connection ! Tcp.Write(next, WriteAck)
+      case WriteAck ⇒
+        writePending = false
+        closeAfterWrite match {
+          case Some(cmd) ⇒ connection ! cmd
+          case None      ⇒
+        }
+      case ClientRead(count, requester) ⇒
+        readTo = requester
+        toRead = count
+        connection ! Tcp.ResumeReading
+      case Tcp.Received(bytes) ⇒
+        readBuffer ++= bytes
+        if (readBuffer.size >= toRead) {
+          readTo ! readBuffer
+          readBuffer = ByteString.empty
+          toRead = 0
+          readTo = context.system.deadLetters
+        } else connection ! Tcp.ResumeReading
+
+      case ClientClose(cmd) ⇒
+        if (!writePending) connection ! cmd
+        else closeAfterWrite = Some(cmd)
+    }
+
+  }
+
+  case object ServerClose
+
+  class TestServer(serverAddress: InetSocketAddress, probe: ActorRef) extends Actor {
+    import context.system
+    IO(Tcp) ! Tcp.Bind(self, serverAddress, pullMode = true)
+    var listener: ActorRef = _
+
+    def receive = {
+      case b @ Tcp.Bound(_) ⇒
+        listener = sender()
+        listener ! Tcp.ResumeAccepting(1)
+        probe ! b
+      case Tcp.Connected(_, _) ⇒
+        val handler = context.actorOf(testClientProps(sender()))
+        listener ! Tcp.ResumeAccepting(1)
+        probe ! handler
+      case ServerClose ⇒
+        listener ! Tcp.Unbind
+        context.stop(self)
+    }
+
+  }
+
+  // FIXME: get it from TestUtil
+  def temporaryServerAddress: InetSocketAddress = {
+    val serverSocket = ServerSocketChannel.open().socket()
+    serverSocket.bind(new InetSocketAddress("127.0.0.1", 0))
+    val address = new InetSocketAddress("127.0.0.1", serverSocket.getLocalPort)
+    serverSocket.close()
+    address
+  }
+
+  def concurrently[O1, O2](block1: ⇒ O1, block2: ⇒ O2): (O1, O2) = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val list = Await.result(Future.sequence(List(Future(block1), Future(block2))), 5.seconds)
+    (list(0).asInstanceOf[O1], list(1).asInstanceOf[O2])
+  }
+}
+
+trait TcpHelper { this: TestKitBase ⇒
+  import TcpHelper._
+
+  val settings = MaterializerSettings(system)
+    .withInputBuffer(initialSize = 4, maxSize = 4)
+    .withFanOutBuffer(initialSize = 2, maxSize = 2)
+
+  implicit val materializer = FlowMaterializer(settings)
+
+  class Server(val address: InetSocketAddress = temporaryServerAddress) {
+    val serverProbe = TestProbe()
+    val serverRef = system.actorOf(testServerProps(address, serverProbe.ref))
+    serverProbe.expectMsgType[Tcp.Bound]
+
+    def waitAccept(): ServerConnection = new ServerConnection(serverProbe.expectMsgType[ActorRef])
+    def close(): Unit = serverRef ! ServerClose
+  }
+
+  class ServerConnection(val connectionActor: ActorRef) {
+    val connectionProbe = TestProbe()
+    def write(bytes: ByteString): Unit = connectionActor ! ClientWrite(bytes)
+
+    def read(count: Int): Unit = connectionActor ! ClientRead(count, connectionProbe.ref)
+
+    def waitRead(): ByteString = connectionProbe.expectMsgType[ByteString]
+    def confirmedClose(): Unit = connectionActor ! ClientClose(Tcp.ConfirmedClose)
+    def close(): Unit = connectionActor ! ClientClose(Tcp.Close)
+    def abort(): Unit = connectionActor ! ClientClose(Tcp.Abort)
+  }
+
+  class TcpReadProbe(tcpPublisher: Publisher[ByteString]) {
+    val subscriberProbe = StreamTestKit.SubscriberProbe[ByteString]()
+    tcpPublisher.subscribe(subscriberProbe)
+    val tcpReadSubscription = subscriberProbe.expectSubscription()
+
+    def read(count: Int): ByteString = {
+      var result = ByteString.empty
+      while (result.size < count) {
+        tcpReadSubscription.request(1)
+        result ++= subscriberProbe.expectNext()
+      }
+      result
+    }
+
+    def close(): Unit = tcpReadSubscription.cancel()
+  }
+
+  class TcpWriteProbe(tcpSubscriber: Subscriber[ByteString]) {
+    val publisherProbe = StreamTestKit.PublisherProbe[ByteString]()
+    publisherProbe.subscribe(tcpSubscriber)
+    val tcpWriteSubscription = publisherProbe.expectSubscription()
+    var demand = 0L
+
+    def write(bytes: ByteString): Unit = {
+      if (demand == 0) demand += tcpWriteSubscription.expectRequest()
+      tcpWriteSubscription.sendNext(bytes)
+      demand -= 1
+    }
+
+    def close(): Unit = tcpWriteSubscription.sendComplete()
+  }
+
+  class EchoServer(termination: Future[Unit], closeable: Closeable) extends Closeable {
+    def close(): Unit = {
+      closeable.close()
+    }
+
+    def awaitTermination(atMost: Duration): Unit = {
+      Await.result(termination, atMost)
+    }
+
+    def terminationFuture: Future[Unit] = termination
+  }
+
+  def connect(server: Server): (Subscriber[ByteString], Publisher[ByteString], ServerConnection) = {
+    val (client, (subscriber, publisher)) = concurrently(server.waitAccept(), connect(server.address))
+    (subscriber, publisher, client)
+  }
+
+  def connect(serverAddress: InetSocketAddress): (Subscriber[ByteString], Publisher[ByteString]) = {
+    val tcpProbe = TestProbe()
+    val outbound = SubscriberTap[ByteString]
+    val inbound = PublisherDrain[ByteString]
+    tcpProbe.send(IO(StreamTcp), StreamTcp.Connect(outbound, inbound, serverAddress))
+
+    val outgoingConnection = tcpProbe.expectMsgType[StreamTcp.OutgoingTcpConnection]
+
+    (outgoingConnection.outbound.materializedTap(outbound), outgoingConnection.inbound.materializedDrain(inbound))
+  }
+
+  def bind(connectionHandler: Sink[StreamTcp.IncomingTcpConnection],
+           serverAddress: InetSocketAddress = temporaryServerAddress): StreamTcp.TcpServerBinding = {
+    val bindProbe = TestProbe()
+    bindProbe.send(IO(StreamTcp), StreamTcp.Bind(connectionHandler, serverAddress))
+    bindProbe.expectMsgType[StreamTcp.TcpServerBinding]
+  }
+
+  def echoServer(serverAddress: InetSocketAddress = temporaryServerAddress): EchoServer = {
+    val foreachDrain = ForeachDrain[IncomingTcpConnection] { conn ⇒
+      conn.inbound.connect(conn.outbound).run()
+    }
+    val binding = bind(Flow[IncomingTcpConnection].connect(foreachDrain), serverAddress)
+    new EchoServer(binding.connection.materializedDrain(foreachDrain), binding)
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/io2/StreamTcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/io2/StreamTcp.scala
@@ -1,0 +1,247 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io2
+
+import akka.actor._
+import akka.actor.SupervisorStrategy.Stop
+import akka.io.Inet.SocketOption
+import akka.io.{ Tcp, IO }
+import akka.japi.Util
+import akka.stream.MaterializerSettings
+import akka.stream.scaladsl2._
+import akka.util.ByteString
+import java.io.Closeable
+import java.net.InetSocketAddress
+import java.net.URLEncoder
+import scala.collection._
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+
+object StreamTcp extends ExtensionId[StreamTcpExt] with ExtensionIdProvider {
+
+  override def lookup = StreamTcp
+  override def createExtension(system: ExtendedActorSystem): StreamTcpExt = new StreamTcpExt(system)
+  override def get(system: ActorSystem): StreamTcpExt = super.get(system)
+
+  final case class OutgoingTcpConnection(remoteAddress: InetSocketAddress, localAddress: InetSocketAddress)(val outbound: MaterializedMap, val inbound: MaterializedMap)
+
+  final case class TcpServerBinding(localAddress: InetSocketAddress)(val connection: MaterializedMap, closeable: Option[Closeable]) extends Closeable {
+    def close(): Unit = closeable.foreach(_.close())
+  }
+
+  final case class IncomingTcpConnection(remoteAddress: InetSocketAddress,
+                                         outbound: Sink[ByteString],
+                                         inbound: Source[ByteString])
+
+  /**
+   * The Connect message is sent to the StreamTcp manager actor, which is obtained via
+   * `IO(StreamTcp)`. The manager replies with a [[StreamTcp.OutgoingTcpConnection]]
+   * message.
+   *
+   * @param outbound the outbound [[Source]] that will be connected over TCP
+   * @param inbound the inbound [[Sink]] that will be connected over TCP
+   * @param remoteAddress the address to connect to
+   * @param localAddress optionally specifies a specific address to bind to
+   * @param materializer if Some the passed in [[FlowMaterializer]] will be used during stream actor
+   *                     creation, otherwise the ActorSystem's default settings will be used
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   * @param connectTimeout the desired timeout for connection establishment, infinite means "no timeout"
+   * @param idleTimeout the desired idle timeout on the connection, infinite means "no timeout"
+   */
+  final case class Connect(outbound: Source[ByteString],
+                           inbound: Sink[ByteString],
+                           remoteAddress: InetSocketAddress,
+                           localAddress: Option[InetSocketAddress] = None,
+                           materializer: Option[FlowMaterializer] = None,
+                           options: immutable.Traversable[SocketOption] = Nil,
+                           connectTimeout: Duration = Duration.Inf,
+                           idleTimeout: Duration = Duration.Inf) {
+    /**
+     * Java API
+     */
+    def withMaterializer(materializer: FlowMaterializer): Connect =
+      copy(materializer = Option(materializer))
+
+    /**
+     * Java API
+     */
+    def withLocalAddress(localAddress: InetSocketAddress): Connect =
+      copy(localAddress = Option(localAddress))
+
+    /**
+     * Java API
+     */
+    def withSocketOptions(options: java.lang.Iterable[SocketOption]): Connect =
+      copy(options = Util.immutableSeq(options))
+
+    /**
+     * Java API
+     */
+    def withConnectTimeout(connectTimeout: Duration): Connect =
+      copy(connectTimeout = connectTimeout)
+
+    /**
+     * Java API
+     */
+    def withIdleTimeout(idleTimeout: Duration): Connect =
+      copy(idleTimeout = idleTimeout)
+  }
+
+  /**
+   * The Bind message is sent to the StreamTcp manager actor, which is obtained via
+   * `IO(StreamTcp)`, in order to bind to a listening socket. The manager
+   * replies with a [[StreamTcp.TcpServerBinding]]. If the local port is set to 0 in
+   * the Bind message, then the [[StreamTcp.TcpServerBinding]] message should be inspected to find
+   * the actual port which was bound to.
+   *
+   * @param connectionHandler the flow that will handle the incoming connections
+   * @param localAddress the socket address to bind to; use port zero for automatic assignment (i.e. an ephemeral port)
+   * @param materializer if Some the passed in [[FlowMaterializer]] will be used during stream actor
+   *                     creation, otherwise the ActorSystem's default settings will be used
+   * @param backlog the number of unaccepted connections the O/S
+   *                kernel will hold for this port before refusing connections.
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   * @param idleTimeout the desired idle timeout on the accepted connections, infinite means "no timeout"
+   */
+  final case class Bind(connectionHandler: Sink[IncomingTcpConnection],
+                        localAddress: InetSocketAddress,
+                        materializer: Option[FlowMaterializer] = None,
+                        backlog: Int = 100,
+                        options: immutable.Traversable[SocketOption] = Nil,
+                        idleTimeout: Duration = Duration.Inf) {
+
+    /**
+     * Java API
+     */
+    def withBacklog(backlog: Int): Bind = copy(backlog = backlog)
+
+    /**
+     * Java API
+     */
+    def withSocketOptions(options: java.lang.Iterable[SocketOption]): Bind =
+      copy(options = Util.immutableSeq(options))
+
+    /**
+     * Java API
+     */
+    def withIdleTimeout(idleTimeout: Duration): Bind =
+      copy(idleTimeout = idleTimeout)
+  }
+
+}
+
+/**
+ * Java API: Factory methods for the messages of `StreamTcp`.
+ */
+object StreamTcpMessage {
+  import StreamTcp.{ Connect, Bind, IncomingTcpConnection }
+  /**
+   * Java API: The Connect message is sent to the StreamTcp manager actor, which is obtained via
+   * `StreamTcp.get(system).manager()`. The manager replies with a [[StreamTcp.OutgoingTcpConnection]]
+   * message.
+   *
+   * @param outbound the outbound [[Source]] that will be connected over TCP
+   * @param inbound the inbound [[Sink]] that will be connected over TCP
+   * @param materializer the materializer that will be used during stream actor creation
+   * @param remoteAddress is the address to connect to
+   * @param localAddress optionally specifies a specific address to bind to
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   * @param connectTimeout the desired timeout for connection establishment, infinite means "no timeout"
+   * @param idleTimeout the desired idle timeout on the connection, infinite means "no timeout"
+   */
+  def connect(
+    outbound: Source[ByteString],
+    inbound: Sink[ByteString],
+    materializer: FlowMaterializer,
+    remoteAddress: InetSocketAddress,
+    localAddress: InetSocketAddress,
+    options: java.lang.Iterable[SocketOption],
+    connectTimeout: Duration,
+    idleTimeout: Duration): Connect =
+    Connect(outbound, inbound, remoteAddress, Option(localAddress), Option(materializer), Util.immutableSeq(options), connectTimeout, idleTimeout)
+
+  /**
+   * Java API: Message to Connect to the given `remoteAddress` without binding to a local address and without
+   * specifying options.
+   */
+  def connect(outbound: Source[ByteString],
+              inbound: Sink[ByteString],
+              materailizer: FlowMaterializer,
+              remoteAddress: InetSocketAddress): Connect =
+    Connect(outbound, inbound, remoteAddress, materializer = Option(materailizer))
+
+  /**
+   * Java API: The Bind message is sent to the StreamTcp manager actor, which is obtained via
+   * `StreamTcp.get(system).manager()`, in order to bind to a listening socket. The manager
+   * replies with a [[StreamTcp.TcpServerBinding]]. If the local port is set to 0 in
+   * the Bind message, then the [[StreamTcp.TcpServerBinding]] message should be inspected to find
+   * the actual port which was bound to.
+   *
+   * @param localAddress the socket address to bind to; use port zero for automatic assignment (i.e. an ephemeral port)
+   * @param backlog the number of unaccepted connections the O/S
+   *                kernel will hold for this port before refusing connections.
+   * @param options Please refer to [[akka.io.TcpSO]] for a list of all supported options.
+   * @param idleTimeout the desired idle timeout on the accepted connections, infinite means "no timeout"
+   */
+  def bind(connectionHandler: Sink[IncomingTcpConnection],
+           localAddress: InetSocketAddress,
+           materializer: FlowMaterializer,
+           backlog: Int,
+           options: java.lang.Iterable[SocketOption],
+           idleTimeout: Duration): StreamTcp.Bind =
+    Bind(connectionHandler, localAddress, Some(materializer), backlog, Util.immutableSeq(options), idleTimeout)
+
+  /**
+   * Java API: Message to open a listening socket without specifying options.
+   */
+  def bind(connectionHandler: Sink[IncomingTcpConnection], localAddress: InetSocketAddress): StreamTcp.Bind =
+    Bind(connectionHandler, localAddress)
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class StreamTcpExt(system: ExtendedActorSystem) extends IO.Extension {
+  val manager = system.systemActorOf(Props[StreamTcpManager], name = "IO-TCP-STREAM2")
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class StreamTcpManager extends Actor {
+
+  override val supervisorStrategy = OneForOneStrategy(maxNrOfRetries = 0) {
+    case _ ⇒ Stop
+  }
+
+  var nameCounter = 0
+  def encName(prefix: String, address: InetSocketAddress) = {
+    nameCounter += 1
+    s"$prefix-$nameCounter-${URLEncoder.encode(address.toString, "utf-8")}"
+  }
+
+  def receive: Receive = {
+    case c @ StreamTcp.Connect(outbound, inbound, remoteAddress, localAddress, maybeMaterializer, options, connectTimeout, idleTimeout) ⇒
+      val connTimeout = connectTimeout match {
+        case x: FiniteDuration ⇒ Some(x)
+        case _                 ⇒ None
+      }
+      val materializer = maybeMaterializer getOrElse FlowMaterializer(MaterializerSettings(context.system))
+
+      context.actorOf(TcpStreamActor.outboundProps(
+        Tcp.Connect(remoteAddress, localAddress, options, connTimeout, pullMode = true),
+        requester = sender(),
+        outbound = outbound,
+        inbound = inbound,
+        materializer = materializer), name = encName("client", remoteAddress))
+
+    case StreamTcp.Bind(connectionHandler, localAddress, maybeMaterializer, backlog, options, idleTimeout) ⇒
+      val materializer = maybeMaterializer getOrElse FlowMaterializer(MaterializerSettings(context.system))
+
+      val publisherActor = context.actorOf(TcpListenStreamActor.props(
+        Tcp.Bind(context.system.deadLetters, localAddress, backlog, options, pullMode = true),
+        requester = sender(),
+        connectionHandler = connectionHandler,
+        materializer = materializer), name = encName("server", localAddress))
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/io2/TcpConnectionStream.scala
+++ b/akka-stream/src/main/scala/akka/stream/io2/TcpConnectionStream.scala
@@ -1,0 +1,220 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io2
+
+import akka.io.{ IO, Tcp }
+import akka.stream.scaladsl2._
+import scala.util.control.NoStackTrace
+import akka.actor._
+import akka.stream.impl._
+import akka.util.ByteString
+import akka.io.Tcp._
+import akka.stream.MaterializerSettings
+import org.reactivestreams.Processor
+
+/**
+ * INTERNAL API
+ */
+private[akka] object TcpStreamActor {
+  case object WriteAck extends Tcp.Event
+  class TcpStreamException(msg: String) extends RuntimeException(msg) with NoStackTrace
+
+  def outboundProps(connectCmd: Connect, requester: ActorRef, outbound: Source[ByteString],
+                    inbound: Sink[ByteString], materializer: FlowMaterializer): Props =
+    Props(new OutboundTcpStreamActor(connectCmd, requester, outbound, inbound, materializer)).withDispatcher(materializer.settings.dispatcher)
+  def inboundProps(connection: ActorRef, materializer: FlowMaterializer): Props =
+    Props(new InboundTcpStreamActor(connection, materializer)).withDispatcher(materializer.settings.dispatcher)
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] abstract class TcpStreamActor(implicit val materializer: FlowMaterializer) extends Actor with Stash {
+
+  import TcpStreamActor._
+
+  val primaryInputs: Inputs = new BatchingInputBuffer(materializer.settings.initialInputBufferSize, writePump) {
+    override def inputOnError(e: Throwable): Unit = fail(e)
+  }
+
+  val primaryOutputs: Outputs = new SimpleOutputs(self, readPump)
+
+  object tcpInputs extends DefaultInputTransferStates {
+    private var closed: Boolean = false
+    private var pendingElement: ByteString = null
+    private var connection: ActorRef = _
+
+    val subreceive = new SubReceive(Actor.emptyBehavior)
+
+    def setConnection(c: ActorRef): Unit = {
+      connection = c
+      // Prefetch
+      c ! ResumeReading
+      subreceive.become(handleRead)
+      readPump.pump()
+    }
+
+    def handleRead: Receive = {
+      case Received(data) ⇒
+        pendingElement = data
+        readPump.pump()
+      case Closed ⇒
+        closed = true
+        tcpOutputs.complete()
+        writePump.pump()
+        readPump.pump()
+      case ConfirmedClosed ⇒
+        closed = true
+        readPump.pump()
+      case PeerClosed ⇒
+        closed = true
+        readPump.pump()
+      case ErrorClosed(cause) ⇒ fail(new TcpStreamException(s"The connection closed with error $cause"))
+      case CommandFailed(cmd) ⇒ fail(new TcpStreamException(s"Tcp command [$cmd] failed"))
+      case Aborted            ⇒ fail(new TcpStreamException("The connection has been aborted"))
+    }
+
+    override def inputsAvailable: Boolean = pendingElement ne null
+    override def inputsDepleted: Boolean = closed && !inputsAvailable
+    override def isClosed: Boolean = closed
+
+    override def cancel(): Unit = {
+      closed = true
+      pendingElement = null
+    }
+
+    override def dequeueInputElement(): Any = {
+      val elem = pendingElement
+      pendingElement = null
+      connection ! ResumeReading
+      elem
+    }
+
+  }
+
+  object tcpOutputs extends DefaultOutputTransferStates {
+    private var closed: Boolean = false
+    private var pendingDemand = true
+    private var connection: ActorRef = _
+
+    private def initialized: Boolean = connection ne null
+
+    def setConnection(c: ActorRef): Unit = {
+      connection = c
+      writePump.pump()
+      subreceive.become(handleWrite)
+    }
+
+    val subreceive = new SubReceive(Actor.emptyBehavior)
+
+    def handleWrite: Receive = {
+      case WriteAck ⇒
+        pendingDemand = true
+        writePump.pump()
+    }
+
+    override def isClosed: Boolean = closed
+    override def cancel(e: Throwable): Unit = {
+      if (!closed && initialized) connection ! Abort
+      closed = true
+    }
+    override def complete(): Unit = {
+      if (!closed && initialized) connection ! ConfirmedClose
+      closed = true
+    }
+    override def enqueueOutputElement(elem: Any): Unit = {
+      connection ! Write(elem.asInstanceOf[ByteString], WriteAck)
+      pendingDemand = false
+    }
+
+    override def demandAvailable: Boolean = pendingDemand
+  }
+
+  object writePump extends Pump {
+
+    def running = TransferPhase(primaryInputs.NeedsInput && tcpOutputs.NeedsDemand) { () ⇒
+      var batch = ByteString.empty
+      while (primaryInputs.inputsAvailable) batch ++= primaryInputs.dequeueInputElement().asInstanceOf[ByteString]
+      tcpOutputs.enqueueOutputElement(batch)
+    }
+
+    override protected def pumpFinished(): Unit = {
+      tcpOutputs.complete()
+      tryShutdown()
+    }
+    override protected def pumpFailed(e: Throwable): Unit = fail(e)
+  }
+
+  object readPump extends Pump {
+
+    def running = TransferPhase(tcpInputs.NeedsInput && primaryOutputs.NeedsDemand) { () ⇒
+      primaryOutputs.enqueueOutputElement(tcpInputs.dequeueInputElement())
+    }
+
+    override protected def pumpFinished(): Unit = {
+      tcpInputs.cancel()
+      primaryOutputs.complete()
+      tryShutdown()
+    }
+    override protected def pumpFailed(e: Throwable): Unit = fail(e)
+  }
+
+  override def receive =
+    primaryInputs.subreceive orElse primaryOutputs.subreceive orElse tcpInputs.subreceive orElse tcpOutputs.subreceive
+
+  readPump.nextPhase(readPump.running)
+  writePump.nextPhase(writePump.running)
+
+  def fail(e: Throwable): Unit = {
+    tcpInputs.cancel()
+    tcpOutputs.cancel(e)
+    primaryInputs.cancel()
+    primaryOutputs.cancel(e)
+  }
+
+  def tryShutdown(): Unit = if (primaryInputs.isClosed && tcpInputs.isClosed && tcpOutputs.isClosed) context.stop(self)
+
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class InboundTcpStreamActor(
+  val connection: ActorRef, _materializer: FlowMaterializer)
+  extends TcpStreamActor()(_materializer) {
+
+  connection ! Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
+  tcpInputs.setConnection(connection)
+  tcpOutputs.setConnection(connection)
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class OutboundTcpStreamActor(val connectCmd: Connect, val requester: ActorRef, outbound: Source[ByteString],
+                                           inbound: Sink[ByteString], _materializer: FlowMaterializer)
+  extends TcpStreamActor()(_materializer) {
+  import TcpStreamActor._
+  import context.system
+
+  IO(Tcp) ! connectCmd
+
+  override def receive = {
+    case c @ Connected(remoteAddress, localAddress) ⇒
+      val connection = sender()
+      val processor = new ActorProcessor[ByteString, ByteString](self)
+      self ! ExposedPublisher(processor.asInstanceOf[ActorPublisher[Any]])
+      connection ! Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
+      tcpOutputs.setConnection(connection)
+      tcpInputs.setConnection(connection)
+      val obmf = outbound.connect(Sink(processor)).run()
+      val ibmf = Source(processor).connect(inbound).run()
+      requester ! StreamTcp.OutgoingTcpConnection(remoteAddress, localAddress)(obmf, ibmf)
+      context.become(super.receive)
+    case f: CommandFailed ⇒
+      val ex = new TcpStreamException("Connection failed.")
+      requester ! Status.Failure(ex)
+      fail(ex)
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/io2/TcpListenStreamActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/io2/TcpListenStreamActor.scala
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io2
+
+import java.io.Closeable
+import java.net.{ URLEncoder, InetSocketAddress }
+import akka.actor._
+import akka.io.Tcp._
+import akka.io.{ IO, Tcp }
+import akka.stream.impl._
+import akka.stream.impl2.ActorBasedFlowMaterializer
+import akka.stream.io2.StreamTcp.IncomingTcpConnection
+import akka.stream.io2.TcpListenStreamActor.TCPSinkSource
+import akka.stream.scaladsl2._
+import akka.util.ByteString
+import org.reactivestreams.{ Subscriber, Publisher }
+import scala.util.control.NoStackTrace
+
+/**
+ * INTERNAL API
+ */
+private[akka] object TcpListenStreamActor {
+  class TcpListenStreamException(msg: String) extends RuntimeException(msg) with NoStackTrace
+
+  def props(bindCmd: Tcp.Bind,
+            requester: ActorRef,
+            connectionHandler: Sink[IncomingTcpConnection],
+            materializer: FlowMaterializer): Props = {
+    Props(new TcpListenStreamActor(bindCmd, requester, connectionHandler)(materializer))
+  }
+
+  final class TCPSinkSource(propser: (FlowMaterializer) ⇒ Props, name: String) {
+    private var _processor: ActorProcessor[ByteString, ByteString] = null
+    private def processor(materializer: ActorBasedFlowMaterializer, flowName: String): ActorProcessor[ByteString, ByteString] = this.synchronized {
+      if (_processor ne null)
+        _processor
+      else {
+        _processor = ActorProcessor(materializer.actorOf(propser(materializer), s"$flowName-$name"))
+        _processor
+      }
+    }
+
+    val sink = new SimpleDrain[ByteString] {
+      override def attach(flowPublisher: Publisher[ByteString], materializer: ActorBasedFlowMaterializer, flowName: String): Unit = {
+        val p = processor(materializer, flowName)
+        flowPublisher.subscribe(p)
+      }
+
+      override def create(materializer: ActorBasedFlowMaterializer, flowName: String): Subscriber[ByteString] =
+        processor(materializer, flowName)
+
+      override def isActive: Boolean = true
+    }
+
+    val source = new SimpleTap[ByteString] {
+      override def attach(flowSubscriber: Subscriber[ByteString], materializer: ActorBasedFlowMaterializer, flowName: String): Unit = {
+        val p = processor(materializer, flowName)
+        p.subscribe(flowSubscriber)
+      }
+
+      override def create(materializer: ActorBasedFlowMaterializer, flowName: String): Publisher[ByteString] =
+        processor(materializer, flowName)
+
+      override def isActive = true
+    }
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class TcpListenStreamActor(bindCmd: Tcp.Bind,
+                                         requester: ActorRef,
+                                         connectionHandler: Sink[IncomingTcpConnection])(implicit val materializer: FlowMaterializer) extends Actor
+  with Pump with Stash {
+  import akka.stream.io.TcpListenStreamActor._
+  import context.system
+
+  IO(Tcp) ! bindCmd.copy(handler = self)
+
+  val primaryOutputs = new SimpleOutputs(self, pump = this)
+
+  private var finished = false
+  override protected def pumpFinished(): Unit = {
+    if (!finished) {
+      finished = true
+      incomingConnections.cancel()
+      primaryOutputs.complete()
+      context.stop(self)
+    }
+  }
+
+  override protected def pumpFailed(e: Throwable): Unit = fail(e)
+
+  val incomingConnections: Inputs = new DefaultInputTransferStates {
+    var listener: ActorRef = _
+    private var closed: Boolean = false
+    private var pendingConnection: (Connected, ActorRef) = null
+
+    def waitBound: Receive = {
+      case Bound(localAddress) ⇒
+        listener = sender()
+        nextPhase(runningPhase)
+        listener ! ResumeAccepting(1)
+        val publisher = ActorPublisher[IncomingTcpConnection](self)
+        val mf = Source(publisher).connect(connectionHandler).run()
+        val target = self
+        requester ! StreamTcp.TcpServerBinding(localAddress)(mf, Some(new Closeable {
+          override def close() = target ! Unbind
+        }))
+        subreceive.become(running)
+      case f: CommandFailed ⇒
+        val ex = new TcpListenStreamException("Bind failed")
+        requester ! Status.Failure(ex)
+        fail(ex)
+    }
+
+    def running: Receive = {
+      case c: Connected ⇒
+        pendingConnection = (c, sender())
+        pump()
+      case f: CommandFailed ⇒
+        fail(new TcpListenStreamException(s"Command [${f.cmd}] failed"))
+        pump()
+      case Unbind ⇒
+        cancel()
+        pump()
+      case Unbound ⇒ // If we're unbound then just shut down
+        closed = true
+        pump()
+    }
+
+    override val subreceive = new SubReceive(waitBound)
+
+    override def inputsAvailable: Boolean = pendingConnection ne null
+    override def inputsDepleted: Boolean = closed && !inputsAvailable
+    override def isClosed: Boolean = closed
+    override def cancel(): Unit = {
+      if (!closed && listener != null) listener ! Unbind
+      closed = true
+      pendingConnection = null
+    }
+    override def dequeueInputElement(): Any = {
+      val elem = pendingConnection
+      pendingConnection = null
+      listener ! ResumeAccepting(1)
+      elem
+    }
+
+  }
+
+  final override def receive = incomingConnections.subreceive orElse primaryOutputs.subreceive
+
+  var nameCounter: Long = 0
+  def encName(localAddress: InetSocketAddress, remoteAddress: InetSocketAddress) = {
+    nameCounter += 1
+    s"$nameCounter-${URLEncoder.encode(localAddress.toString, "utf-8")}-${URLEncoder.encode(remoteAddress.toString, "utf-8")}"
+  }
+
+  def runningPhase = TransferPhase(primaryOutputs.NeedsDemand && incomingConnections.NeedsInput) { () ⇒
+    val (connected: Connected, connection: ActorRef) = incomingConnections.dequeueInputElement()
+    val tcpStreamActorCreator = (materializer: FlowMaterializer) ⇒ {
+      TcpStreamActor.inboundProps(connection, materializer)
+    }
+
+    val tcpSinkSource = new TCPSinkSource(tcpStreamActorCreator, encName(connected.localAddress, connected.remoteAddress))
+    primaryOutputs.enqueueOutputElement(StreamTcp.IncomingTcpConnection(connected.remoteAddress, tcpSinkSource.sink, tcpSinkSource.source))
+  }
+
+  def fail(e: Throwable): Unit = {
+    incomingConnections.cancel()
+    primaryOutputs.cancel(e)
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
@@ -5,6 +5,7 @@ package akka.stream.scaladsl2
 
 import org.reactivestreams.Subscriber
 
+import scala.concurrent.Future
 import scala.language.implicitConversions
 import scala.annotation.unchecked.uncheckedVariance
 
@@ -18,4 +19,11 @@ trait Sink[-In] {
    * of the `Tap`, e.g. the `Subscriber` of a [[SubscriberTap]].
    */
   def runWith(tap: TapWithKey[In])(implicit materializer: FlowMaterializer): tap.MaterializedType
+}
+
+object Sink {
+  /**
+   * Helper to create [[Sink]] from `Subscriber`.
+   */
+  def apply[T](subscriber: Subscriber[T]): Drain[T] = SubscriberDrain(subscriber)
 }


### PR DESCRIPTION
- Port of Tcp IO to the new Stream DSL
- ~~Ordered shutdown of the server is to be discussed (was missing in the old one as well)~~
- ~~This PR also includes the broadcast fixes for #15948 which can be ignored (will be removed)~~

Fixes #15904
