### PR TITLE
!str #15971 get rid of extra type parameters of RunnableFlow, FlowWithSink, and FlowWithSource

### DIFF
--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit2/ChainSetup.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit2/ChainSetup.scala
@@ -12,12 +12,12 @@ class ChainSetup[In, Out](
   stream: ProcessorFlow[In, In] ⇒ ProcessorFlow[In, Out],
   val settings: MaterializerSettings,
   materializer: FlowMaterializer,
-  toPublisher: (FlowWithSource[In, Out], FlowMaterializer) ⇒ Publisher[Out])(implicit val system: ActorSystem) {
+  toPublisher: (FlowWithSource[Out], FlowMaterializer) ⇒ Publisher[Out])(implicit val system: ActorSystem) {
 
-  def this(stream: ProcessorFlow[In, In] ⇒ ProcessorFlow[In, Out], settings: MaterializerSettings, toPublisher: (FlowWithSource[In, Out], FlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
+  def this(stream: ProcessorFlow[In, In] ⇒ ProcessorFlow[In, Out], settings: MaterializerSettings, toPublisher: (FlowWithSource[Out], FlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
     this(stream, settings, FlowMaterializer(settings)(system), toPublisher)(system)
 
-  def this(stream: ProcessorFlow[In, In] ⇒ ProcessorFlow[In, Out], settings: MaterializerSettings, materializerCreator: (MaterializerSettings, ActorRefFactory) ⇒ FlowMaterializer, toPublisher: (FlowWithSource[In, Out], FlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
+  def this(stream: ProcessorFlow[In, In] ⇒ ProcessorFlow[In, Out], settings: MaterializerSettings, materializerCreator: (MaterializerSettings, ActorRefFactory) ⇒ FlowMaterializer, toPublisher: (FlowWithSource[Out], FlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
     this(stream, settings, materializerCreator(settings, system), toPublisher)(system)
 
   val upstream = StreamTestKit.PublisherProbe[In]()

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit2/ScriptedTest.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit2/ScriptedTest.scala
@@ -18,7 +18,7 @@ trait ScriptedTest extends Matchers {
 
   class ScriptException(msg: String) extends RuntimeException(msg)
 
-  def toPublisher[In, Out]: (FlowWithSource[In, Out], FlowMaterializer) ⇒ Publisher[Out] =
+  def toPublisher[In, Out]: (FlowWithSource[Out], FlowMaterializer) ⇒ Publisher[Out] =
     (f, m) ⇒ f.toPublisher()(m)
 
   object Script {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConcatAllSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConcatAllSpec.scala
@@ -51,7 +51,7 @@ class FlowConcatAllSpec extends AkkaSpec {
     }
 
     "on onError on master stream cancel the current open substream and signal error" in {
-      val publisher = StreamTestKit.PublisherProbe[FlowWithSource[Int, Int]]()
+      val publisher = StreamTestKit.PublisherProbe[FlowWithSource[Int]]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
       FlowFrom(publisher).flatten(FlattenStrategy.concat).publishTo(subscriber)
 
@@ -71,7 +71,7 @@ class FlowConcatAllSpec extends AkkaSpec {
     }
 
     "on onError on open substream, cancel the master stream and signal error " in {
-      val publisher = StreamTestKit.PublisherProbe[FlowWithSource[Int, Int]]()
+      val publisher = StreamTestKit.PublisherProbe[FlowWithSource[Int]]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
       FlowFrom(publisher).flatten(FlattenStrategy.concat).publishTo(subscriber)
 
@@ -91,7 +91,7 @@ class FlowConcatAllSpec extends AkkaSpec {
     }
 
     "on cancellation cancel the current open substream and the master stream" in {
-      val publisher = StreamTestKit.PublisherProbe[FlowWithSource[Int, Int]]()
+      val publisher = StreamTestKit.PublisherProbe[FlowWithSource[Int]]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
       FlowFrom(publisher).flatten(FlattenStrategy.concat).publishTo(subscriber)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGroupBySpec.scala
@@ -34,17 +34,17 @@ class FlowGroupBySpec extends AkkaSpec {
   class SubstreamsSupport(groupCount: Int = 2, elementCount: Int = 6) {
     val source = FlowFrom((1 to elementCount).iterator).toPublisher()
     val groupStream = FlowFrom(source).groupBy(_ % groupCount).toPublisher()
-    val masterSubscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int, Int])]()
+    val masterSubscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int])]()
 
     groupStream.subscribe(masterSubscriber)
     val masterSubscription = masterSubscriber.expectSubscription()
 
-    def getSubFlow(expectedKey: Int): FlowWithSource[Int, Int] = {
+    def getSubFlow(expectedKey: Int): FlowWithSource[Int] = {
       masterSubscription.request(1)
       expectSubFlow(expectedKey: Int)
     }
 
-    def expectSubFlow(expectedKey: Int): FlowWithSource[Int, Int] = {
+    def expectSubFlow(expectedKey: Int): FlowWithSource[Int] = {
       val (key, substream) = masterSubscriber.expectNext()
       key should be(expectedKey)
       substream
@@ -111,7 +111,7 @@ class FlowGroupBySpec extends AkkaSpec {
     "accept cancellation of master stream when not consumed anything" in {
       val publisherProbeProbe = StreamTestKit.PublisherProbe[Int]()
       val publisher = FlowFrom(publisherProbeProbe).groupBy(_ % 2).toPublisher()
-      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int])]()
       publisher.subscribe(subscriber)
 
       val upstreamSubscription = publisherProbeProbe.expectSubscription()
@@ -142,7 +142,7 @@ class FlowGroupBySpec extends AkkaSpec {
 
     "work with empty input stream" in {
       val publisher = FlowFrom(List.empty[Int]).groupBy(_ % 2).toPublisher()
-      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int])]()
       publisher.subscribe(subscriber)
 
       subscriber.expectCompletedOrSubscriptionFollowedByComplete()
@@ -151,7 +151,7 @@ class FlowGroupBySpec extends AkkaSpec {
     "abort on onError from upstream" in {
       val publisherProbeProbe = StreamTestKit.PublisherProbe[Int]()
       val publisher = FlowFrom(publisherProbeProbe).groupBy(_ % 2).toPublisher()
-      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int])]()
       publisher.subscribe(subscriber)
 
       val upstreamSubscription = publisherProbeProbe.expectSubscription()
@@ -168,7 +168,7 @@ class FlowGroupBySpec extends AkkaSpec {
     "abort on onError from upstream when substreams are running" in {
       val publisherProbeProbe = StreamTestKit.PublisherProbe[Int]()
       val publisher = FlowFrom(publisherProbeProbe).groupBy(_ % 2).toPublisher()
-      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(Int, FlowWithSource[Int])]()
       publisher.subscribe(subscriber)
 
       val upstreamSubscription = publisherProbeProbe.expectSubscription()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowPrefixAndTailSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowPrefixAndTailSpec.scala
@@ -25,7 +25,7 @@ class FlowPrefixAndTailSpec extends AkkaSpec {
 
     val testException = new Exception("test") with NoStackTrace
 
-    def newFutureSink = FutureSink[(immutable.Seq[Int], FlowWithSource[Int, Int])]
+    def newFutureSink = FutureSink[(immutable.Seq[Int], FlowWithSource[Int])]
 
     "work on empty input" in {
       val futureSink = newFutureSink
@@ -102,7 +102,7 @@ class FlowPrefixAndTailSpec extends AkkaSpec {
 
     "handle onError when no substream open" in {
       val publisher = StreamTestKit.PublisherProbe[Int]()
-      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int])]()
 
       FlowFrom(publisher).prefixAndTail(3).publishTo(subscriber)
 
@@ -120,7 +120,7 @@ class FlowPrefixAndTailSpec extends AkkaSpec {
 
     "handle onError when substream is open" in {
       val publisher = StreamTestKit.PublisherProbe[Int]()
-      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int])]()
 
       FlowFrom(publisher).prefixAndTail(1).publishTo(subscriber)
 
@@ -147,7 +147,7 @@ class FlowPrefixAndTailSpec extends AkkaSpec {
 
     "handle master stream cancellation" in {
       val publisher = StreamTestKit.PublisherProbe[Int]()
-      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int])]()
 
       FlowFrom(publisher).prefixAndTail(3).publishTo(subscriber)
 
@@ -165,7 +165,7 @@ class FlowPrefixAndTailSpec extends AkkaSpec {
 
     "handle substream cancellation" in {
       val publisher = StreamTestKit.PublisherProbe[Int]()
-      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int, Int])]()
+      val subscriber = StreamTestKit.SubscriberProbe[(immutable.Seq[Int], FlowWithSource[Int])]()
 
       FlowFrom(publisher).prefixAndTail(1).publishTo(subscriber)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowSplitWhenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowSplitWhenSpec.scala
@@ -33,17 +33,17 @@ class FlowSplitWhenSpec extends AkkaSpec {
   class SubstreamsSupport(splitWhen: Int = 3, elementCount: Int = 6) {
     val source = FlowFrom((1 to elementCount).iterator)
     val groupStream = source.splitWhen(_ == splitWhen).toPublisher()
-    val masterSubscriber = StreamTestKit.SubscriberProbe[FlowWithSource[Int, Int]]()
+    val masterSubscriber = StreamTestKit.SubscriberProbe[FlowWithSource[Int]]()
 
     groupStream.subscribe(masterSubscriber)
     val masterSubscription = masterSubscriber.expectSubscription()
 
-    def getSubFlow(): FlowWithSource[Int, Int] = {
+    def getSubFlow(): FlowWithSource[Int] = {
       masterSubscription.request(1)
       expectSubPublisher()
     }
 
-    def expectSubPublisher(): FlowWithSource[Int, Int] = {
+    def expectSubPublisher(): FlowWithSource[Int] = {
       val substream = masterSubscriber.expectNext()
       substream
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/TickPublisherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/TickPublisherSpec.scala
@@ -74,7 +74,7 @@ class TickPublisherSpec extends AkkaSpec {
 
     "signal onError when tick closure throws" in {
       val c = StreamTestKit.SubscriberProbe[String]()
-      FlowFrom(1.second, 1.second, () ⇒ throw new RuntimeException("tick err") with NoStackTrace).publishTo(c)
+      FlowFrom[String](1.second, 1.second, () ⇒ throw new RuntimeException("tick err") with NoStackTrace).publishTo(c)
       val sub = c.expectSubscription()
       sub.request(3)
       c.expectError.getMessage should be("tick err")

--- a/akka-stream/src/main/scala/akka/stream/impl2/ConcatAllImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/ConcatAllImpl.scala
@@ -17,7 +17,7 @@ private[akka] class ConcatAllImpl(materializer: FlowMaterializer)
   import MultiStreamInputProcessor._
 
   val takeNextSubstream = TransferPhase(primaryInputs.NeedsInput && primaryOutputs.NeedsDemand) { () ⇒
-    val flow = primaryInputs.dequeueInputElement().asInstanceOf[FlowWithSource[Any, Any]]
+    val flow = primaryInputs.dequeueInputElement().asInstanceOf[FlowWithSource[Any]]
     val publisher = flow.toPublisher()(materializer)
     // FIXME we can pass the flow to createSubstreamInput (but avoiding copy impl now)
     val inputs = createAndSubscribeSubstreamInput(publisher)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/FlattenStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/FlattenStrategy.scala
@@ -17,7 +17,7 @@ object FlattenStrategy {
    * emitting its elements directly to the output until it completes and then taking the next stream. This has the
    * consequence that if one of the input stream is infinite, no other streams after that will be consumed from.
    */
-  def concat[T]: FlattenStrategy[FlowWithSource[_, T], T] = Concat[T]()
+  def concat[T]: FlattenStrategy[FlowWithSource[T], T] = Concat[T]()
 
-  private[akka] case class Concat[T]() extends FlattenStrategy[FlowWithSource[_, T], T]
+  private[akka] case class Concat[T]() extends FlattenStrategy[FlowWithSource[T], T]
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Source.scala
@@ -29,7 +29,7 @@ object FlowFrom {
    * that mediate the flow of elements downstream and the propagation of
    * back-pressure upstream.
    */
-  def apply[T](publisher: Publisher[T]): FlowWithSource[T, T] = FlowFrom[T].withSource(PublisherSource(publisher))
+  def apply[T](publisher: Publisher[T]): FlowWithSource[T] = FlowFrom[T].withSource(PublisherSource(publisher))
 
   /**
    * Helper to create `Flow` with [[Source]] from `Iterator`.
@@ -41,7 +41,7 @@ object FlowFrom {
    * in accordance with the demand coming from the downstream transformation
    * steps.
    */
-  def apply[T](iterator: Iterator[T]): FlowWithSource[T, T] = FlowFrom[T].withSource(IteratorSource(iterator))
+  def apply[T](iterator: Iterator[T]): FlowWithSource[T] = FlowFrom[T].withSource(IteratorSource(iterator))
 
   /**
    * Helper to create `Flow` with [[Source]] from `Iterable`.
@@ -52,14 +52,14 @@ object FlowFrom {
    * stream will see an individual flow of elements (always starting from the
    * beginning) regardless of when they subscribed.
    */
-  def apply[T](iterable: immutable.Iterable[T]): FlowWithSource[T, T] = FlowFrom[T].withSource(IterableSource(iterable))
+  def apply[T](iterable: immutable.Iterable[T]): FlowWithSource[T] = FlowFrom[T].withSource(IterableSource(iterable))
 
   /**
    * Define the sequence of elements to be produced by the given closure.
    * The stream ends normally when evaluation of the closure returns a `None`.
    * The stream ends exceptionally when an exception is thrown from the closure.
    */
-  def apply[T](f: () ⇒ Option[T]): FlowWithSource[T, T] = FlowFrom[T].withSource(ThunkSource(f))
+  def apply[T](f: () ⇒ Option[T]): FlowWithSource[T] = FlowFrom[T].withSource(ThunkSource(f))
 
   /**
    * Start a new `Flow` from the given `Future`. The stream will consist of
@@ -67,7 +67,7 @@ object FlowFrom {
    * may happen before or after materializing the `Flow`.
    * The stream terminates with an error if the `Future` is completed with a failure.
    */
-  def apply[T](future: Future[T]): FlowWithSource[T, T] = FlowFrom[T].withSource(FutureSource(future))
+  def apply[T](future: Future[T]): FlowWithSource[T] = FlowFrom[T].withSource(FutureSource(future))
 
   /**
    * Elements are produced from the tick closure periodically with the specified interval.
@@ -76,7 +76,7 @@ object FlowFrom {
    * element is produced it will not receive that tick element later. It will
    * receive new tick elements as soon as it has requested more elements.
    */
-  def apply[T](initialDelay: FiniteDuration, interval: FiniteDuration, tick: () ⇒ T): FlowWithSource[T, T] =
+  def apply[T](initialDelay: FiniteDuration, interval: FiniteDuration, tick: () ⇒ T): FlowWithSource[T] =
     FlowFrom[T].withSource(TickSource(initialDelay, interval, tick))
 
 }


### PR DESCRIPTION
This is an concrete proposal for improving the situation Mathias started to discuss in #15971.

Here all the extra type parameters are removed at the expense of also removing the `withoutX` methods which aren't particularly useful compared to the cognitive cost they add.

This also fixes #15973. It could also make sense to hide all the parameters of the case classes as well. This isn't strictly necessary for correctness but would e.g. prevent people using the plain AstNodes as API.

I had to add one remaining suspect instance of `@uncheckedVariance`, not sure if this is the compiler being too strict or if there's really an unsoundness here.

/cc @sirthias 
