### PR TITLE
+str #15977 add SourceFlow/SinkFlow

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
@@ -226,6 +226,23 @@ class FlowGraphCompileSpec extends AkkaSpec {
       }.run()
     }
 
+    "allow attaching SourceFlow and SinkFlow" in {
+      FlowGraph { implicit b ⇒
+        import FlowGraphImplicits._
+        val undefinedSrc = UndefinedSource[String]
+        val undefinedSink = UndefinedSink[String]
+        val bcast = Broadcast[String]
+        undefinedSrc ~> bcast ~> undefinedSink
+        bcast ~> BlackholeSink
+
+        "b.attachSource(undefinedSrc, FlowFrom[String])" shouldNot compile
+        "b.attachSink(undefinedSink, FlowFrom[String])" shouldNot compile
+
+        b.attachSource(undefinedSrc, FlowFrom(List("hello", "world")))
+        b.attachSink(undefinedSink, FlowFrom[String].withSink(BlackholeSink))
+      }.run()
+    }
+
     "chain input and output ports" in {
       FlowGraph { implicit b ⇒
         val zip = Zip[Int, String]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Flow.scala
@@ -22,22 +22,7 @@ import akka.stream.OverflowStrategy
  * operations are presented because the concrete type of Flow (i.e. whether
  * it has a [[Source]] or a [[Sink]]) determines what is available.
  */
-sealed trait Flow
-
-protected[scaladsl2] object FlowOps {
-  private case object TakeWithinTimerKey
-  private case object DropWithinTimerKey
-  private case object GroupedWithinTimerKey
-
-  private val takeCompletedTransformer: Transformer[Any, Any] = new Transformer[Any, Any] {
-    override def onNext(elem: Any) = Nil
-    override def isComplete = true
-  }
-
-  private val identityTransformer: Transformer[Any, Any] = new Transformer[Any, Any] {
-    override def onNext(elem: Any) = List(elem)
-  }
-}
+sealed abstract class Flow
 
 /**
  * This type describes a flow that can be used as a source. In contrast to
@@ -45,7 +30,7 @@ protected[scaladsl2] object FlowOps {
  * into a ProcessorFlow. This restriction allows the omission of the input
  * type parameter.
  */
-sealed trait SourceFlow[+T] extends FlowOps[Nothing, T] with Flow {
+sealed trait SourceFlow[+T] extends Flow with FlowOps[Nothing, T] {
   type Repr[-I, +O] <: SourceFlow[O]
 
   /**
@@ -101,6 +86,21 @@ sealed trait SinkFlow[-T] extends Flow {
    * useful when writing a [[FlowMaterializer]].
    */
   def ops: List[AstNode]
+}
+
+protected[scaladsl2] object FlowOps {
+  private case object TakeWithinTimerKey
+  private case object DropWithinTimerKey
+  private case object GroupedWithinTimerKey
+
+  private val takeCompletedTransformer: Transformer[Any, Any] = new Transformer[Any, Any] {
+    override def onNext(elem: Any) = Nil
+    override def isComplete = true
+  }
+
+  private val identityTransformer: Transformer[Any, Any] = new Transformer[Any, Any] {
+    override def onNext(elem: Any) = List(elem)
+  }
 }
 
 /**


### PR DESCRIPTION
- sources must really be sources (the same for sinks), hence
  ProcessorFlow cannot implement either of these
- therefore they are just other names for FlowWithSource/Sink
- also fixed type-safety of FlowGraph’s edge labels
