### PR TITLE
+hco #15945 Make Tcp and Http server binding closeable

### DIFF
--- a/akka-http-core/src/main/java/akka/http/model/japi/ServerBinding.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/ServerBinding.java
@@ -6,13 +6,14 @@ package akka.http.model.japi;
 
 import org.reactivestreams.Publisher;
 
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 
 /**
  * The binding of a server. Allows access to its own address and to the stream
  * of incoming connections.
  */
-public interface ServerBinding {
+public interface ServerBinding extends Closeable {
     /**
      * The local address this server is listening on.
      */

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpFlowSpec.scala
@@ -160,7 +160,8 @@ class TcpFlowSpec extends AkkaSpec with TcpHelper {
       val resultFuture = Flow(conn.inputStream).fold(ByteString.empty)((acc, in) ⇒ acc ++ in).toFuture()
 
       Await.result(resultFuture, 3.seconds) should be(expectedOutput)
-
+      server.close()
+      server.awaitTermination(3.seconds)
     }
 
     "work with a chain of echoes" in {
@@ -181,7 +182,8 @@ class TcpFlowSpec extends AkkaSpec with TcpHelper {
       val resultFuture = Flow(conn3.inputStream).fold(ByteString.empty)((acc, in) ⇒ acc ++ in).toFuture()
 
       Await.result(resultFuture, 3.seconds) should be(expectedOutput)
-
+      server.close()
+      server.awaitTermination(3.seconds)
     }
 
   }


### PR DESCRIPTION
No samples or documentation yet, since the API will change when we move to the new DSL.
Ticket #15945 should be left open.
