### PR TITLE
+str #15996 Add unorderedMapAsync

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapAsyncSpec.scala
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl2
+
+import scala.concurrent.duration._
+import scala.concurrent.forkjoin.ThreadLocalRandom
+import scala.util.control.NoStackTrace
+import akka.stream.testkit.AkkaSpec
+import akka.stream.testkit.StreamTestKit
+import akka.testkit.TestProbe
+import akka.testkit.TestLatch
+import scala.concurrent.Await
+import scala.concurrent.Future
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class FlowMapAsyncSpec extends AkkaSpec {
+
+  implicit val materializer = FlowMaterializer()
+
+  "A Flow with mapAsync" must {
+
+    "produce future elements" in {
+      val c = StreamTestKit.SubscriberProbe[Int]()
+      implicit val ec = system.dispatcher
+      val p = FlowFrom(1 to 3).mapAsync(n ⇒ Future(n)).publishTo(c)
+      val sub = c.expectSubscription()
+      sub.request(2)
+      c.expectNext(1)
+      c.expectNext(2)
+      c.expectNoMsg(200.millis)
+      sub.request(2)
+      c.expectNext(3)
+      c.expectComplete()
+    }
+
+    "produce future elements in order" in {
+      val c = StreamTestKit.SubscriberProbe[Int]()
+      implicit val ec = system.dispatcher
+      val p = FlowFrom(1 to 50).mapAsync(n ⇒ Future {
+        Thread.sleep(ThreadLocalRandom.current().nextInt(1, 10))
+        n
+      }).publishTo(c)
+      val sub = c.expectSubscription()
+      sub.request(1000)
+      for (n ← 1 to 50) c.expectNext(n)
+      c.expectComplete()
+    }
+
+    "not run more futures than requested elements" in {
+      val probe = TestProbe()
+      val c = StreamTestKit.SubscriberProbe[Int]()
+      implicit val ec = system.dispatcher
+      val p = FlowFrom(1 to 20).mapAsync(n ⇒ Future {
+        probe.ref ! n
+        n
+      }).publishTo(c)
+      val sub = c.expectSubscription()
+      // nothing before requested
+      probe.expectNoMsg(500.millis)
+      sub.request(1)
+      probe.expectMsg(1)
+      probe.expectNoMsg(500.millis)
+      sub.request(2)
+      probe.receiveN(2).toSet should be(Set(2, 3))
+      probe.expectNoMsg(500.millis)
+      sub.request(10)
+      probe.receiveN(10).toSet should be((4 to 13).toSet)
+      probe.expectNoMsg(200.millis)
+
+      for (n ← 1 to 13) c.expectNext(n)
+      c.expectNoMsg(200.millis)
+    }
+
+    "signal future failure" in {
+      val latch = TestLatch(1)
+      val c = StreamTestKit.SubscriberProbe[Int]()
+      implicit val ec = system.dispatcher
+      val p = FlowFrom(1 to 5).mapAsync(n ⇒ Future {
+        if (n == 3) throw new RuntimeException("err1") with NoStackTrace
+        else {
+          Await.ready(latch, 10.seconds)
+          n
+        }
+      }).publishTo(c)
+      val sub = c.expectSubscription()
+      sub.request(10)
+      c.expectError.getMessage should be("err1")
+      latch.countDown()
+    }
+
+    "signal error from mapAsync" in {
+      val latch = TestLatch(1)
+      val c = StreamTestKit.SubscriberProbe[Int]()
+      implicit val ec = system.dispatcher
+      val p = FlowFrom(1 to 5).mapAsync(n ⇒
+        if (n == 3) throw new RuntimeException("err2") with NoStackTrace
+        else {
+          Future {
+            Await.ready(latch, 10.seconds)
+            n
+          }
+        }).
+        publishTo(c)
+      val sub = c.expectSubscription()
+      sub.request(10)
+      c.expectError.getMessage should be("err2")
+      latch.countDown()
+    }
+
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -32,7 +32,7 @@ private[akka] object ActorProcessor {
       case bf: Buffer        ⇒ Props(new BufferImpl(settings, bf.size, bf.overflowStrategy))
       case tt: PrefixAndTail ⇒ Props(new PrefixAndTailImpl(settings, tt.n))
       case ConcatAll         ⇒ Props(new ConcatAllImpl(settings))
-      case m: MapFuture      ⇒ Props(new MapFutureProcessorImpl(settings, m.f))
+      case m: MapFuture      ⇒ Props(new MapAsyncProcessorImpl(settings, m.f))
     }).withDispatcher(settings.dispatcher)
 
   def apply[I, O](impl: ActorRef): ActorProcessor[I, O] = {

--- a/akka-stream/src/main/scala/akka/stream/impl/Emit.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Emit.scala
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl
+
+import scala.collection.immutable
+
+/**
+ * INTERNAL API
+ */
+private[akka] trait Emit { this: ActorProcessorImpl with Pump ⇒
+
+  // TODO performance improvement: mutable buffer?
+  var emits = immutable.Seq.empty[Any]
+
+  // Save previous phase we should return to in a var to avoid allocation
+  private var phaseAfterFlush: TransferPhase = _
+
+  // Enters flushing phase if there are emits pending
+  def emitAndThen(andThen: TransferPhase): Unit =
+    if (emits.nonEmpty) {
+      phaseAfterFlush = andThen
+      nextPhase(emitting)
+    } else nextPhase(andThen)
+
+  // Emits all pending elements, then returns to savedPhase
+  private val emitting = TransferPhase(primaryOutputs.NeedsDemand) { () ⇒
+    primaryOutputs.enqueueOutputElement(emits.head)
+    emits = emits.tail
+    if (emits.isEmpty) nextPhase(phaseAfterFlush)
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl2/MapAsyncUnorderedProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/MapAsyncUnorderedProcessorImpl.scala
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl2
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+import akka.stream.MaterializerSettings
+import akka.stream.impl.ActorProcessorImpl
+import akka.stream.impl.Emit
+import akka.stream.impl.TransferPhase
+import akka.stream.impl.TransferState
+import akka.pattern.pipe
+
+/**
+ * INTERNAL API
+ */
+private[akka] object MapAsyncUnorderedProcessorImpl {
+  case class FutureElement(element: Any)
+  case class FutureFailure(cause: Throwable)
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class MapAsyncUnorderedProcessorImpl(_settings: MaterializerSettings, f: Any ⇒ Future[Any])
+  extends ActorProcessorImpl(_settings) with Emit {
+  import MapAsyncUnorderedProcessorImpl._
+
+  // Execution context for pipeTo and friends
+  import context.dispatcher
+
+  var inProgressCount = 0
+
+  override def activeReceive = futureReceive orElse super.activeReceive
+
+  def futureReceive: Receive = {
+    case FutureElement(element) ⇒
+      inProgressCount -= 1
+      emits = List(element)
+      emitAndThen(running)
+      pump()
+
+    case FutureFailure(cause) ⇒
+      fail(cause)
+  }
+
+  override def onError(e: Throwable): Unit = {
+    // propagate upstream error immediately
+    fail(e)
+  }
+
+  object RunningPhaseCondition extends TransferState {
+    def isReady = (primaryInputs.inputsAvailable && primaryOutputs.demandCount - inProgressCount > 0) ||
+      (primaryInputs.inputsDepleted && inProgressCount == 0)
+    def isCompleted = false
+  }
+
+  val running: TransferPhase = TransferPhase(RunningPhaseCondition) { () ⇒
+    if (primaryInputs.inputsDepleted) {
+      emitAndThen(completedPhase)
+    } else if (primaryInputs.inputsAvailable && primaryOutputs.demandCount - inProgressCount > 0) {
+      val elem = primaryInputs.dequeueInputElement()
+      inProgressCount += 1
+      try {
+        f(elem).map(FutureElement.apply).recover {
+          case err ⇒ FutureFailure(err)
+        }.pipeTo(self)
+      } catch {
+        case NonFatal(err) ⇒
+          // f threw, propagate error immediately
+          fail(err)
+      }
+      emitAndThen(running)
+    }
+  }
+
+  nextPhase(running)
+
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Flow.scala
@@ -73,9 +73,24 @@ trait FlowOps[-In, +Out] {
    * element that will be emitted downstream. As many futures as requested elements by
    * downstream may run in parallel and may complete in any order, but the elements that
    * are emitted downstream are in the same order as from upstream.
+   *
+   * @see [[#mapAsyncUnordered]]
    */
-  def mapFuture[T](f: Out ⇒ Future[T]): Repr[In, T] =
-    andThen(MapFuture(f.asInstanceOf[Any ⇒ Future[Any]]))
+  def mapAsync[T](f: Out ⇒ Future[T]): Repr[In, T] =
+    andThen(MapAsync(f.asInstanceOf[Any ⇒ Future[Any]]))
+
+  /**
+   * Transform this stream by applying the given function to each of the elements
+   * as they pass through this processing step. The function returns a `Future` of the
+   * element that will be emitted downstream. As many futures as requested elements by
+   * downstream may run in parallel and each processed element will be emitted dowstream
+   * as soon as it is ready, i.e. it is possible that the elements are not emitted downstream
+   * in the same order as from upstream.
+   *
+   * @see [[#mapAsync]]
+   */
+  def mapAsyncUnordered[T](f: Out ⇒ Future[T]): Repr[In, T] =
+    andThen(MapAsyncUnordered(f.asInstanceOf[Any ⇒ Future[Any]]))
 
   /**
    * Only pass on those elements that satisfy the given predicate.


### PR DESCRIPTION
- rename mapFuture to mapAsync
- add unorderedMapAsync
- extract common things for emits to a trait

I'm not sure about the name `unorderedMapAsync`. Any better suggestions?

Refs #15996
