### PR TITLE
=str #15960 Fix broken FlowGraphCompileSpec

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
@@ -315,6 +315,8 @@ class FlowGraphCompileSpec extends AkkaSpec {
         val outA = SubscriberSink(SubscriberProbe[Fruit]())
         val outB = SubscriberSink(SubscriberProbe[Fruit]())
         val merge = Merge[Fruit]
+        val unzip = Unzip[Int, String]
+        val whatever = PublisherSink[Any]
         import FlowGraphImplicits._
         FlowFrom[Fruit](() ⇒ Some(new Apple)) ~> merge
         FlowFrom[Apple](() ⇒ Some(new Apple)) ~> merge
@@ -331,6 +333,10 @@ class FlowGraphCompileSpec extends AkkaSpec {
         FlowFrom[Apple](() ⇒ Some(new Apple)) ~> Broadcast[Apple] ~> outB
         FlowFrom[Apple](() ⇒ Some(new Apple)) ~> Broadcast[Apple] ~> UndefinedSink[Fruit]
         inB ~> Broadcast[Apple] ~> merge
+
+        FlowFrom(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
+        unzip.right ~> whatever
+        unzip.left ~> UndefinedSink[Any]
 
         "UndefinedSource[Fruit] ~> FlowFrom[Apple].map(identity) ~> merge" shouldNot compile
         "UndefinedSource[Fruit] ~> Broadcast[Apple]" shouldNot compile

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowGraph.scala
@@ -27,7 +27,7 @@ sealed trait JunctionInPort[-T] {
  * Fan-in and fan-out vertices in the [[FlowGraph]] implements
  * this marker interface. Edges may start at a `JunctionOutPort`.
  */
-sealed trait JunctionOutPort[+T] {
+sealed trait JunctionOutPort[T] {
   private[akka] def port: Int = FlowGraphInternal.UnlabeledPort
   private[akka] def vertex: FlowGraphInternal.Vertex
 }


### PR DESCRIPTION
- FlowGraphCompileSpec broke when merging in the unzip on top of
  the variance adjustements
- JunctionOutPort[T] must not be defined like JunctionOutPort[+T]
  because then the NextT = Nothing doesn't work
- Do we have a reason to use JunctionOutPort[+T]? I added +T
  only for symmetry reasons with JunctionInPort[-T].

Refs #15960
