### PR TITLE
!str #15950 Add runWith and remove toX 

### DIFF
--- a/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -62,7 +62,7 @@ class HttpModelIntegrationSpec extends WordSpec with Matchers with BeforeAndAfte
         entity = HttpEntity.Default(
           contentType = ContentTypes.`application/json`,
           contentLength = 5,
-          Source(List(ByteString("hello"))).toPublisher()))
+          Source(List(ByteString("hello"))).runWith(PublisherDrain())))
 
       // Our library uses a simple model of headers: a Seq[(String, String)].
       // The body is represented as an Array[Byte]. To get the headers in
@@ -141,7 +141,7 @@ class HttpModelIntegrationSpec extends WordSpec with Matchers with BeforeAndAfte
       // convert the body into a Publisher[ByteString].
 
       val byteStringBody = ByteString(byteArrayBody)
-      val publisherBody = Source(List(byteStringBody)).toPublisher()
+      val publisherBody = Source(List(byteStringBody)).runWith(PublisherDrain())
 
       // Finally we can create our HttpResponse.
 

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit2/ScriptedTest.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit2/ScriptedTest.scala
@@ -9,17 +9,17 @@ import akka.stream.scaladsl2.{ FlowMaterializer, Source, Flow }
 import akka.stream.testkit.StreamTestKit._
 import org.reactivestreams.Publisher
 import org.scalatest.Matchers
-
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.concurrent.forkjoin.ThreadLocalRandom
+import akka.stream.scaladsl2.PublisherDrain
 
 trait ScriptedTest extends Matchers {
 
   class ScriptException(msg: String) extends RuntimeException(msg)
 
   def toPublisher[In, Out]: (Source[Out], FlowMaterializer) ⇒ Publisher[Out] =
-    (f, m) ⇒ f.toPublisher()(m)
+    (f, m) ⇒ f.runWith(PublisherDrain())(m)
 
   object Script {
     def apply[In, Out](phases: (Seq[In], Seq[Out])*): Script[In, Out] = {

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit2/TwoStreamsSetup.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit2/TwoStreamsSetup.scala
@@ -41,7 +41,7 @@ abstract class TwoStreamsSetup extends AkkaSpec {
 
   def completedPublisher[T]: Publisher[T] = StreamTestKit.emptyPublisher[T]
 
-  def nonemptyPublisher[T](elems: Iterator[T]): Publisher[T] = Source(elems).toPublisher()
+  def nonemptyPublisher[T](elems: Iterator[T]): Publisher[T] = Source(elems).runWith(PublisherDrain())
 
   def soonToFailPublisher[T]: Publisher[T] = StreamTestKit.lazyErrorPublisher[T](TestException)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowAppendSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowAppendSpec.scala
@@ -17,7 +17,7 @@ class FlowAppendSpec extends AkkaSpec with River {
   "Flow" should {
     "append Flow" in riverOf[String] { subscriber ⇒
       val flow = Flow[Int].connect(otherFlow)
-      Source(elements).connect(flow).publishTo(subscriber)
+      Source(elements).connect(flow).connect(SubscriberDrain(subscriber)).run()
     }
 
     "append Sink" in riverOf[String] { subscriber ⇒
@@ -30,7 +30,7 @@ class FlowAppendSpec extends AkkaSpec with River {
     "append Flow" in riverOf[String] { subscriber ⇒
       Source(elements)
         .connect(otherFlow)
-        .publishTo(subscriber)
+        .connect(SubscriberDrain(subscriber)).run()
     }
 
     "append Sink" in riverOf[String] { subscriber ⇒

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConcatAllSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConcatAllSpec.scala
@@ -32,7 +32,7 @@ class FlowConcatAllSpec extends AkkaSpec {
       val main = Source(List(s1, s2, s3, s4, s5))
 
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
-      main.flatten(FlattenStrategy.concat).publishTo(subscriber)
+      main.flatten(FlattenStrategy.concat).connect(SubscriberDrain(subscriber)).run()
       val subscription = subscriber.expectSubscription()
       subscription.request(10)
       subscriber.probe.receiveN(10) should be((1 to 10).map(StreamTestKit.OnNext(_)))
@@ -42,7 +42,7 @@ class FlowConcatAllSpec extends AkkaSpec {
 
     "work together with SplitWhen" in {
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
-      Source((1 to 10).iterator).splitWhen(_ % 2 == 0).flatten(FlattenStrategy.concat).publishTo(subscriber)
+      Source((1 to 10).iterator).splitWhen(_ % 2 == 0).flatten(FlattenStrategy.concat).connect(SubscriberDrain(subscriber)).run()
       val subscription = subscriber.expectSubscription()
       subscription.request(10)
       subscriber.probe.receiveN(10) should be((1 to 10).map(StreamTestKit.OnNext(_)))
@@ -53,7 +53,7 @@ class FlowConcatAllSpec extends AkkaSpec {
     "on onError on master stream cancel the current open substream and signal error" in {
       val publisher = StreamTestKit.PublisherProbe[Source[Int]]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
-      Source(publisher).flatten(FlattenStrategy.concat).publishTo(subscriber)
+      Source(publisher).flatten(FlattenStrategy.concat).connect(SubscriberDrain(subscriber)).run()
 
       val upstream = publisher.expectSubscription()
       val downstream = subscriber.expectSubscription()
@@ -73,7 +73,7 @@ class FlowConcatAllSpec extends AkkaSpec {
     "on onError on open substream, cancel the master stream and signal error " in {
       val publisher = StreamTestKit.PublisherProbe[Source[Int]]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
-      Source(publisher).flatten(FlattenStrategy.concat).publishTo(subscriber)
+      Source(publisher).flatten(FlattenStrategy.concat).connect(SubscriberDrain(subscriber)).run()
 
       val upstream = publisher.expectSubscription()
       val downstream = subscriber.expectSubscription()
@@ -93,7 +93,7 @@ class FlowConcatAllSpec extends AkkaSpec {
     "on cancellation cancel the current open substream and the master stream" in {
       val publisher = StreamTestKit.PublisherProbe[Source[Int]]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
-      Source(publisher).flatten(FlattenStrategy.concat).publishTo(subscriber)
+      Source(publisher).flatten(FlattenStrategy.concat).connect(SubscriberDrain(subscriber)).run()
 
       val upstream = publisher.expectSubscription()
       val downstream = subscriber.expectSubscription()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConflateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConflateSpec.scala
@@ -56,11 +56,10 @@ class FlowConflateSpec extends AkkaSpec {
     }
 
     "work on a variable rate chain" in {
-      val foldDrain = FoldDrain[Int, Int](0)(_ + _)
       val future = Source((1 to 1000).iterator)
         .conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i)
         .map { i ⇒ if (ThreadLocalRandom.current().nextBoolean()) Thread.sleep(10); i }
-        .runWith(FoldDrain[Int, Int](0)(_ + _))
+        .fold(0)(_ + _)
       Await.result(future, 10.seconds) should be(500500)
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConflateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowConflateSpec.scala
@@ -23,7 +23,7 @@ class FlowConflateSpec extends AkkaSpec {
       val publisher = StreamTestKit.PublisherProbe[Int]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
 
-      Source(publisher).conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i).publishTo(subscriber)
+      Source(publisher).conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i).connect(SubscriberDrain(subscriber)).run()
 
       val autoPublisher = new StreamTestKit.AutoPublisher(publisher)
       val sub = subscriber.expectSubscription()
@@ -41,7 +41,7 @@ class FlowConflateSpec extends AkkaSpec {
       val publisher = StreamTestKit.PublisherProbe[Int]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
 
-      Source(publisher).conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i).publishTo(subscriber)
+      Source(publisher).conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i).connect(SubscriberDrain(subscriber)).run()
 
       val autoPublisher = new StreamTestKit.AutoPublisher(publisher)
       val sub = subscriber.expectSubscription()
@@ -57,12 +57,10 @@ class FlowConflateSpec extends AkkaSpec {
 
     "work on a variable rate chain" in {
       val foldDrain = FoldDrain[Int, Int](0)(_ + _)
-      val mf = Source((1 to 1000).iterator)
+      val future = Source((1 to 1000).iterator)
         .conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i)
         .map { i ⇒ if (ThreadLocalRandom.current().nextBoolean()) Thread.sleep(10); i }
-        .connect(foldDrain)
-        .run()
-      val future = foldDrain.future(mf)
+        .runWith(FoldDrain[Int, Int](0)(_ + _))
       Await.result(future, 10.seconds) should be(500500)
     }
 
@@ -70,7 +68,7 @@ class FlowConflateSpec extends AkkaSpec {
       val publisher = StreamTestKit.PublisherProbe[Int]()
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
 
-      Source(publisher).conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i).publishTo(subscriber)
+      Source(publisher).conflate[Int](seed = i ⇒ i, aggregate = (sum, i) ⇒ sum + i).connect(SubscriberDrain(subscriber)).run()
 
       val autoPublisher = new StreamTestKit.AutoPublisher(publisher)
       val sub = subscriber.expectSubscription()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowDispatcherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowDispatcherSpec.scala
@@ -16,7 +16,7 @@ class FlowDispatcherSpec extends AkkaSpec {
       val probe = TestProbe()
       val p = Source(List(1, 2, 3)).map(i ⇒
         { probe.ref ! Thread.currentThread().getName(); i }).
-        consume()
+        connect(BlackholeDrain).run()
       probe.receiveN(3) foreach {
         case s: String ⇒ s should startWith(system.name + "-akka.test.stream-dispatcher")
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowDropSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowDropSpec.scala
@@ -29,7 +29,7 @@ class FlowDropSpec extends AkkaSpec with ScriptedTest {
 
     "not drop anything for negative n" in {
       val probe = StreamTestKit.SubscriberProbe[Int]()
-      Source(List(1, 2, 3)).drop(-1).publishTo(probe)
+      Source(List(1, 2, 3)).drop(-1).connect(SubscriberDrain(probe)).run()
       probe.expectSubscription().request(10)
       probe.expectNext(1)
       probe.expectNext(2)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowDropWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowDropWithinSpec.scala
@@ -18,7 +18,7 @@ class FlowDropWithinSpec extends AkkaSpec {
       val input = Iterator.from(1)
       val p = StreamTestKit.PublisherProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[Int]()
-      Source(p).dropWithin(1.second).publishTo(c)
+      Source(p).dropWithin(1.second).connect(SubscriberDrain(c)).run()
       val pSub = p.expectSubscription
       val cSub = c.expectSubscription
       cSub.request(100)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowExpandSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowExpandSpec.scala
@@ -67,7 +67,7 @@ class FlowExpandSpec extends AkkaSpec {
       val future = Source((1 to 100).iterator)
         .map { i ⇒ if (ThreadLocalRandom.current().nextBoolean()) Thread.sleep(10); i }
         .expand[Int, Int](seed = i ⇒ i, extrapolate = i ⇒ (i, i))
-        .runWith(FoldDrain[Set[Int], Int](Set.empty[Int])(_ + _))
+        .fold(Set.empty[Int])(_ + _)
 
       Await.result(future, 10.seconds) should be(Set.empty[Int] ++ (1 to 100))
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFilterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFilterSpec.scala
@@ -30,7 +30,7 @@ class FlowFilterSpec extends AkkaSpec with ScriptedTest {
 
       val probe = StreamTestKit.SubscriberProbe[Int]()
       Source(Iterator.fill(1000)(0) ++ List(1)).filter(_ != 0).
-        toPublisher().subscribe(probe)
+        connect(SubscriberDrain(probe)).run()
 
       val subscription = probe.expectSubscription()
       for (_ ← 1 to 10000) {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFoldSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFoldSpec.scala
@@ -15,14 +15,14 @@ class FlowFoldSpec extends AkkaSpec with DefaultTimeout {
 
     "fold" in {
       val input = 1 to 100
-      val future = Source(input).runWith(FoldDrain[Int, Int](0)(_ + _))
+      val future = Source(input).fold(0)(_ + _)
       val expected = input.fold(0)(_ + _)
       Await.result(future, timeout.duration) should be(expected)
     }
 
     "propagate an error" in {
       val error = new Exception with NoStackTrace
-      val future = Source[Unit](() ⇒ throw error).runWith(FoldDrain[Unit, Unit](())((_, _) ⇒ ()))
+      val future = Source[Unit](() ⇒ throw error).fold(())((_, _) ⇒ ())
       the[Exception] thrownBy Await.result(future, timeout.duration) should be(error)
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFoldSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFoldSpec.scala
@@ -15,18 +15,14 @@ class FlowFoldSpec extends AkkaSpec with DefaultTimeout {
 
     "fold" in {
       val input = 1 to 100
-      val foldDrain = FoldDrain[Int, Int](0)(_ + _)
-      val mf = Source(input).connect(foldDrain).run()
-      val future = foldDrain.future(mf)
+      val future = Source(input).runWith(FoldDrain[Int, Int](0)(_ + _))
       val expected = input.fold(0)(_ + _)
       Await.result(future, timeout.duration) should be(expected)
     }
 
     "propagate an error" in {
       val error = new Exception with NoStackTrace
-      val foldSink = FoldDrain[Unit, Unit](())((_, _) ⇒ ())
-      val mf = Source[Unit](() ⇒ throw error).connect(foldSink).run()
-      val future = foldSink.future(mf)
+      val future = Source[Unit](() ⇒ throw error).runWith(FoldDrain[Unit, Unit](())((_, _) ⇒ ()))
       the[Exception] thrownBy Await.result(future, timeout.duration) should be(error)
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowForeachSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowForeachSpec.scala
@@ -16,9 +16,7 @@ class FlowForeachSpec extends AkkaSpec {
   "A Foreach" must {
 
     "call the procedure for each element" in {
-      val foreachDrain = ForeachDrain[Int](testActor ! _)
-      val mf = Source(1 to 3).connect(foreachDrain).run()
-      foreachDrain.future(mf).onSuccess {
+      Source(1 to 3).runWith(ForeachDrain[Int](testActor ! _)) onSuccess {
         case _ ⇒ testActor ! "done"
       }
       expectMsg(1)
@@ -29,8 +27,7 @@ class FlowForeachSpec extends AkkaSpec {
 
     "complete the future for an empty stream" in {
       val foreachDrain = ForeachDrain[Int](testActor ! _)
-      val mf = Source(Nil).connect(foreachDrain).run()
-      foreachDrain.future(mf).onSuccess {
+      val mf = Source(Nil).runWith(ForeachDrain[Int](testActor ! _)) onSuccess {
         case _ ⇒ testActor ! "done"
       }
       expectMsg("done")
@@ -39,8 +36,7 @@ class FlowForeachSpec extends AkkaSpec {
     "yield the first error" in {
       val p = StreamTestKit.PublisherProbe[Int]()
       val foreachDrain = ForeachDrain[Int](testActor ! _)
-      val mf = Source(p).connect(foreachDrain).run()
-      foreachDrain.future(mf).onFailure {
+      val mf = Source(p).runWith(ForeachDrain[Int](testActor ! _)) onFailure {
         case ex ⇒ testActor ! ex
       }
       val proc = p.expectSubscription

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowForeachSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowForeachSpec.scala
@@ -16,7 +16,7 @@ class FlowForeachSpec extends AkkaSpec {
   "A Foreach" must {
 
     "call the procedure for each element" in {
-      Source(1 to 3).runWith(ForeachDrain[Int](testActor ! _)) onSuccess {
+      Source(1 to 3).foreach(testActor ! _) onSuccess {
         case _ ⇒ testActor ! "done"
       }
       expectMsg(1)
@@ -26,8 +26,7 @@ class FlowForeachSpec extends AkkaSpec {
     }
 
     "complete the future for an empty stream" in {
-      val foreachDrain = ForeachDrain[Int](testActor ! _)
-      val mf = Source(Nil).runWith(ForeachDrain[Int](testActor ! _)) onSuccess {
+      val mf = Source(Nil).foreach(testActor ! _) onSuccess {
         case _ ⇒ testActor ! "done"
       }
       expectMsg("done")
@@ -35,8 +34,7 @@ class FlowForeachSpec extends AkkaSpec {
 
     "yield the first error" in {
       val p = StreamTestKit.PublisherProbe[Int]()
-      val foreachDrain = ForeachDrain[Int](testActor ! _)
-      val mf = Source(p).runWith(ForeachDrain[Int](testActor ! _)) onFailure {
+      val mf = Source(p).foreach(testActor ! _) onFailure {
         case ex ⇒ testActor ! ex
       }
       val proc = p.expectSubscription

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFromFutureSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowFromFutureSpec.scala
@@ -17,7 +17,7 @@ class FlowFromFutureSpec extends AkkaSpec {
 
   "A Flow based on a Future" must {
     "produce one element from already successful Future" in {
-      val p = Source(Future.successful(1)).toPublisher()
+      val p = Source(Future.successful(1)).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -29,7 +29,7 @@ class FlowFromFutureSpec extends AkkaSpec {
 
     "produce error from already failed Future" in {
       val ex = new RuntimeException("test") with NoStackTrace
-      val p = Source(Future.failed[Int](ex)).toPublisher()
+      val p = Source(Future.failed[Int](ex)).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       c.expectError(ex)
@@ -37,7 +37,7 @@ class FlowFromFutureSpec extends AkkaSpec {
 
     "produce one element when Future is completed" in {
       val promise = Promise[Int]()
-      val p = Source(promise.future).toPublisher()
+      val p = Source(promise.future).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -51,7 +51,7 @@ class FlowFromFutureSpec extends AkkaSpec {
 
     "produce one element when Future is completed but not before request" in {
       val promise = Promise[Int]()
-      val p = Source(promise.future).toPublisher()
+      val p = Source(promise.future).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -64,7 +64,7 @@ class FlowFromFutureSpec extends AkkaSpec {
 
     "produce elements with multiple subscribers" in {
       val promise = Promise[Int]()
-      val p = Source(promise.future).toPublisher()
+      val p = Source(promise.future).runWith(PublisherDrain())
       val c1 = StreamTestKit.SubscriberProbe[Int]()
       val c2 = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c1)
@@ -82,7 +82,7 @@ class FlowFromFutureSpec extends AkkaSpec {
 
     "produce elements to later subscriber" in {
       val promise = Promise[Int]()
-      val p = Source(promise.future).toPublisher()
+      val p = Source(promise.future).runWith(PublisherDrain())
       val keepAlive = StreamTestKit.SubscriberProbe[Int]()
       val c1 = StreamTestKit.SubscriberProbe[Int]()
       val c2 = StreamTestKit.SubscriberProbe[Int]()
@@ -103,7 +103,7 @@ class FlowFromFutureSpec extends AkkaSpec {
 
     "allow cancel before receiving element" in {
       val promise = Promise[Int]()
-      val p = Source(promise.future).toPublisher()
+      val p = Source(promise.future).runWith(PublisherDrain())
       val keepAlive = StreamTestKit.SubscriberProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(keepAlive)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGraphCompileSpec.scala
@@ -190,7 +190,7 @@ class FlowGraphCompileSpec extends AkkaSpec {
         b.attachSink(undefinedSink1, out1)
 
       }.run()
-      out1.publisher(mg) should not be (null)
+      mg.materializedDrain(out1) should not be (null)
     }
 
     "build partial flow graphs" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGroupedWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowGroupedWithinSpec.scala
@@ -24,7 +24,7 @@ class FlowGroupedWithinSpec extends AkkaSpec with ScriptedTest {
       val input = Iterator.from(1)
       val p = StreamTestKit.PublisherProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[immutable.Seq[Int]]()
-      Source(p).groupedWithin(1000, 1.second).publishTo(c)
+      Source(p).groupedWithin(1000, 1.second).connect(SubscriberDrain(c)).run()
       val pSub = p.expectSubscription
       val cSub = c.expectSubscription
       cSub.request(100)
@@ -49,7 +49,7 @@ class FlowGroupedWithinSpec extends AkkaSpec with ScriptedTest {
 
     "deliver bufferd elements onComplete before the timeout" in {
       val c = StreamTestKit.SubscriberProbe[immutable.Seq[Int]]()
-      Source(1 to 3).groupedWithin(1000, 10.second).publishTo(c)
+      Source(1 to 3).groupedWithin(1000, 10.second).connect(SubscriberDrain(c)).run()
       val cSub = c.expectSubscription
       cSub.request(100)
       c.expectNext((1 to 3).toList)
@@ -61,7 +61,7 @@ class FlowGroupedWithinSpec extends AkkaSpec with ScriptedTest {
       val input = Iterator.from(1)
       val p = StreamTestKit.PublisherProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[immutable.Seq[Int]]()
-      Source(p).groupedWithin(1000, 1.second).publishTo(c)
+      Source(p).groupedWithin(1000, 1.second).connect(SubscriberDrain(c)).run()
       val pSub = p.expectSubscription
       val cSub = c.expectSubscription
       cSub.request(1)
@@ -81,7 +81,7 @@ class FlowGroupedWithinSpec extends AkkaSpec with ScriptedTest {
     "drop empty groups" in {
       val p = StreamTestKit.PublisherProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[immutable.Seq[Int]]()
-      Source(p).groupedWithin(1000, 500.millis).publishTo(c)
+      Source(p).groupedWithin(1000, 500.millis).connect(SubscriberDrain(c)).run()
       val pSub = p.expectSubscription
       val cSub = c.expectSubscription
       cSub.request(2)
@@ -103,7 +103,7 @@ class FlowGroupedWithinSpec extends AkkaSpec with ScriptedTest {
       val input = Iterator.from(1)
       val p = StreamTestKit.PublisherProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[immutable.Seq[Int]]()
-      Source(p).groupedWithin(3, 2.second).publishTo(c)
+      Source(p).groupedWithin(3, 2.second).connect(SubscriberDrain(c)).run()
       val pSub = p.expectSubscription
       val cSub = c.expectSubscription
       cSub.request(4)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowIterableSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowIterableSpec.scala
@@ -18,7 +18,7 @@ class FlowIterableSpec extends AkkaSpec {
 
   "A Flow based on an iterable" must {
     "produce elements" in {
-      val p = Source(List(1, 2, 3)).toPublisher()
+      val p = Source(List(1, 2, 3)).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -32,7 +32,7 @@ class FlowIterableSpec extends AkkaSpec {
     }
 
     "complete empty" in {
-      val p = Source(List.empty[Int]).toPublisher()
+      val p = Source(List.empty[Int]).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       c.expectComplete()
@@ -44,7 +44,7 @@ class FlowIterableSpec extends AkkaSpec {
     }
 
     "produce elements with multiple subscribers" in {
-      val p = Source(List(1, 2, 3)).toPublisher()
+      val p = Source(List(1, 2, 3)).runWith(PublisherDrain())
       val c1 = StreamTestKit.SubscriberProbe[Int]()
       val c2 = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c1)
@@ -68,7 +68,7 @@ class FlowIterableSpec extends AkkaSpec {
     }
 
     "produce elements to later subscriber" in {
-      val p = Source(List(1, 2, 3)).toPublisher()
+      val p = Source(List(1, 2, 3)).runWith(PublisherDrain())
       val c1 = StreamTestKit.SubscriberProbe[Int]()
       val c2 = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c1)
@@ -94,7 +94,7 @@ class FlowIterableSpec extends AkkaSpec {
     }
 
     "produce elements with one transformation step" in {
-      val p = Source(List(1, 2, 3)).map(_ * 2).toPublisher()
+      val p = Source(List(1, 2, 3)).map(_ * 2).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -106,7 +106,7 @@ class FlowIterableSpec extends AkkaSpec {
     }
 
     "produce elements with two transformation steps" in {
-      val p = Source(List(1, 2, 3, 4)).filter(_ % 2 == 0).map(_ * 2).toPublisher()
+      val p = Source(List(1, 2, 3, 4)).filter(_ % 2 == 0).map(_ * 2).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -118,7 +118,7 @@ class FlowIterableSpec extends AkkaSpec {
 
     "allow cancel before receiving all elements" in {
       val count = 100000
-      val p = Source(1 to count).toPublisher()
+      val p = Source(1 to count).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -134,19 +134,19 @@ class FlowIterableSpec extends AkkaSpec {
     }
 
     "have value equality of publisher" in {
-      val p1 = Source(List(1, 2, 3)).toPublisher()
-      val p2 = Source(List(1, 2, 3)).toPublisher()
+      val p1 = Source(List(1, 2, 3)).runWith(PublisherDrain())
+      val p2 = Source(List(1, 2, 3)).runWith(PublisherDrain())
       p1 should be(p2)
       p2 should be(p1)
-      val p3 = Source(List(1, 2, 3, 4)).toPublisher()
+      val p3 = Source(List(1, 2, 3, 4)).runWith(PublisherDrain())
       p1 should not be (p3)
       p3 should not be (p1)
-      val p4 = Source(Vector.empty[String]).toPublisher()
-      val p5 = Source(Set.empty[String]).toPublisher()
+      val p4 = Source(Vector.empty[String]).runWith(PublisherDrain())
+      val p5 = Source(Set.empty[String]).runWith(PublisherDrain())
       p1 should not be (p4)
       p4 should be(p5)
       p5 should be(p4)
-      val p6 = Source(List(1, 2, 3).iterator).toPublisher()
+      val p6 = Source(List(1, 2, 3).iterator).runWith(PublisherDrain())
       p1 should not be (p6)
       p6 should not be (p1)
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowIteratorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowIteratorSpec.scala
@@ -22,7 +22,7 @@ class FlowIteratorSpec extends AkkaSpec {
 
   "A Flow based on an iterator" must {
     "produce elements" in {
-      val p = Source(List(1, 2, 3).iterator).toPublisher()
+      val p = Source(List(1, 2, 3).iterator).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -36,7 +36,7 @@ class FlowIteratorSpec extends AkkaSpec {
     }
 
     "complete empty" in {
-      val p = Source(List.empty[Int].iterator).toPublisher()
+      val p = Source(List.empty[Int].iterator).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       c.expectComplete()
@@ -48,7 +48,7 @@ class FlowIteratorSpec extends AkkaSpec {
     }
 
     "produce elements with multiple subscribers" in {
-      val p = Source(List(1, 2, 3).iterator).toPublisher()
+      val p = Source(List(1, 2, 3).iterator).runWith(PublisherDrain())
       val c1 = StreamTestKit.SubscriberProbe[Int]()
       val c2 = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c1)
@@ -72,7 +72,7 @@ class FlowIteratorSpec extends AkkaSpec {
     }
 
     "produce elements to later subscriber" in {
-      val p = Source(List(1, 2, 3).iterator).toPublisher()
+      val p = Source(List(1, 2, 3).iterator).runWith(PublisherDrain())
       val c1 = StreamTestKit.SubscriberProbe[Int]()
       val c2 = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c1)
@@ -95,7 +95,7 @@ class FlowIteratorSpec extends AkkaSpec {
     }
 
     "produce elements with one transformation step" in {
-      val p = Source(List(1, 2, 3).iterator).map(_ * 2).toPublisher()
+      val p = Source(List(1, 2, 3).iterator).map(_ * 2).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -107,7 +107,7 @@ class FlowIteratorSpec extends AkkaSpec {
     }
 
     "produce elements with two transformation steps" in {
-      val p = Source(List(1, 2, 3, 4).iterator).filter(_ % 2 == 0).map(_ * 2).toPublisher()
+      val p = Source(List(1, 2, 3, 4).iterator).filter(_ % 2 == 0).map(_ * 2).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -119,7 +119,7 @@ class FlowIteratorSpec extends AkkaSpec {
 
     "allow cancel before receiving all elements" in {
       val count = 100000
-      val p = Source((1 to count).iterator).toPublisher()
+      val p = Source((1 to count).iterator).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapAsyncSpec.scala
@@ -23,7 +23,7 @@ class FlowMapAsyncSpec extends AkkaSpec {
     "produce future elements" in {
       val c = StreamTestKit.SubscriberProbe[Int]()
       implicit val ec = system.dispatcher
-      val p = Source(1 to 3).mapAsync(n ⇒ Future(n)).publishTo(c)
+      val p = Source(1 to 3).mapAsync(n ⇒ Future(n)).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(2)
       c.expectNext(1)
@@ -40,7 +40,7 @@ class FlowMapAsyncSpec extends AkkaSpec {
       val p = Source(1 to 50).mapAsync(n ⇒ Future {
         Thread.sleep(ThreadLocalRandom.current().nextInt(1, 10))
         n
-      }).publishTo(c)
+      }).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(1000)
       for (n ← 1 to 50) c.expectNext(n)
@@ -54,7 +54,7 @@ class FlowMapAsyncSpec extends AkkaSpec {
       val p = Source(1 to 20).mapAsync(n ⇒ Future {
         probe.ref ! n
         n
-      }).publishTo(c)
+      }).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       // nothing before requested
       probe.expectNoMsg(500.millis)
@@ -82,7 +82,7 @@ class FlowMapAsyncSpec extends AkkaSpec {
           Await.ready(latch, 10.seconds)
           n
         }
-      }).publishTo(c)
+      }).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(10)
       c.expectError.getMessage should be("err1")
@@ -101,7 +101,7 @@ class FlowMapAsyncSpec extends AkkaSpec {
             n
           }
         }).
-        publishTo(c)
+        connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(10)
       c.expectError.getMessage should be("err2")

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapAsyncUnorderedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapAsyncUnorderedSpec.scala
@@ -26,7 +26,7 @@ class FlowMapAsyncUnorderedSpec extends AkkaSpec {
       val p = Source(1 to 4).mapAsyncUnordered(n ⇒ Future {
         Await.ready(latch(n), 5.seconds)
         n
-      }).publishTo(c)
+      }).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(5)
       latch(2).countDown()
@@ -47,7 +47,7 @@ class FlowMapAsyncUnorderedSpec extends AkkaSpec {
       val p = Source(1 to 20).mapAsyncUnordered(n ⇒ Future {
         probe.ref ! n
         n
-      }).publishTo(c)
+      }).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       // nothing before requested
       probe.expectNoMsg(500.millis)
@@ -76,7 +76,7 @@ class FlowMapAsyncUnorderedSpec extends AkkaSpec {
           Await.ready(latch, 10.seconds)
           n
         }
-      }).publishTo(c)
+      }).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(10)
       c.expectError.getMessage should be("err1")
@@ -95,7 +95,7 @@ class FlowMapAsyncUnorderedSpec extends AkkaSpec {
             n
           }
         }).
-        publishTo(c)
+        connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(10)
       c.expectError.getMessage should be("err2")

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowMapSpec.scala
@@ -28,7 +28,7 @@ class FlowMapSpec extends AkkaSpec with ScriptedTest {
       val probe = StreamTestKit.SubscriberProbe[Int]()
       Source(List(1).iterator).
         map(_ + 1).map(_ + 1).map(_ + 1).map(_ + 1).map(_ + 1).
-        toPublisher().subscribe(probe)
+        runWith(PublisherDrain()).subscribe(probe)
 
       val subscription = probe.expectSubscription()
       for (_ ← 1 to 10000) {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowOnCompleteSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowOnCompleteSpec.scala
@@ -66,11 +66,11 @@ class FlowOnCompleteSpec extends AkkaSpec with ScriptedTest {
       val foreachDrain = ForeachDrain[Int] {
         x ⇒ onCompleteProbe.ref ! ("foreach-" + x)
       }
-      val mf = Source(p).map { x ⇒
+      val future = Source(p).map { x ⇒
         onCompleteProbe.ref ! ("map-" + x)
         x
-      }.connect(foreachDrain).run()
-      foreachDrain.future(mf) onComplete { onCompleteProbe.ref ! _ }
+      }.runWith(foreachDrain)
+      future onComplete { onCompleteProbe.ref ! _ }
       val proc = p.expectSubscription
       proc.expectRequest()
       proc.sendNext(42)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowSplitWhenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowSplitWhenSpec.scala
@@ -32,7 +32,7 @@ class FlowSplitWhenSpec extends AkkaSpec {
 
   class SubstreamsSupport(splitWhen: Int = 3, elementCount: Int = 6) {
     val tap = Source((1 to elementCount).iterator)
-    val groupStream = tap.splitWhen(_ == splitWhen).toPublisher()
+    val groupStream = tap.splitWhen(_ == splitWhen).runWith(PublisherDrain())
     val masterSubscriber = StreamTestKit.SubscriberProbe[Source[Int]]()
 
     groupStream.subscribe(masterSubscriber)
@@ -53,7 +53,7 @@ class FlowSplitWhenSpec extends AkkaSpec {
   "splitWhen" must {
 
     "work in the happy case" in new SubstreamsSupport(elementCount = 4) {
-      val s1 = StreamPuppet(getSubFlow().toPublisher())
+      val s1 = StreamPuppet(getSubFlow().runWith(PublisherDrain()))
       masterSubscriber.expectNoMsg(100.millis)
 
       s1.request(2)
@@ -62,7 +62,7 @@ class FlowSplitWhenSpec extends AkkaSpec {
       s1.request(1)
       s1.expectComplete()
 
-      val s2 = StreamPuppet(getSubFlow().toPublisher())
+      val s2 = StreamPuppet(getSubFlow().runWith(PublisherDrain()))
 
       s2.request(1)
       s2.expectNext(3)
@@ -77,9 +77,9 @@ class FlowSplitWhenSpec extends AkkaSpec {
     }
 
     "support cancelling substreams" in new SubstreamsSupport(splitWhen = 5, elementCount = 8) {
-      val s1 = StreamPuppet(getSubFlow().toPublisher())
+      val s1 = StreamPuppet(getSubFlow().runWith(PublisherDrain()))
       s1.cancel()
-      val s2 = StreamPuppet(getSubFlow().toPublisher())
+      val s2 = StreamPuppet(getSubFlow().runWith(PublisherDrain()))
 
       s2.request(4)
       s2.expectNext(5)
@@ -94,7 +94,7 @@ class FlowSplitWhenSpec extends AkkaSpec {
     }
 
     "support cancelling the master stream" in new SubstreamsSupport(splitWhen = 5, elementCount = 8) {
-      val s1 = StreamPuppet(getSubFlow().toPublisher())
+      val s1 = StreamPuppet(getSubFlow().runWith(PublisherDrain()))
       masterSubscription.cancel()
       s1.request(4)
       s1.expectNext(1)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowTakeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowTakeSpec.scala
@@ -34,7 +34,7 @@ class FlowTakeSpec extends AkkaSpec with ScriptedTest {
 
     "not take anything for negative n" in {
       val probe = StreamTestKit.SubscriberProbe[Int]()
-      Source(List(1, 2, 3)).take(-1).publishTo(probe)
+      Source(List(1, 2, 3)).take(-1).connect(SubscriberDrain(probe)).run()
       probe.expectSubscription().request(10)
       probe.expectComplete()
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowTakeWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowTakeWithinSpec.scala
@@ -18,7 +18,7 @@ class FlowTakeWithinSpec extends AkkaSpec {
       val input = Iterator.from(1)
       val p = StreamTestKit.PublisherProbe[Int]()
       val c = StreamTestKit.SubscriberProbe[Int]()
-      Source(p).takeWithin(1.second).publishTo(c)
+      Source(p).takeWithin(1.second).connect(SubscriberDrain(c)).run()
       val pSub = p.expectSubscription()
       val cSub = c.expectSubscription()
       cSub.request(100)
@@ -38,7 +38,7 @@ class FlowTakeWithinSpec extends AkkaSpec {
 
     "deliver bufferd elements onComplete before the timeout" in {
       val c = StreamTestKit.SubscriberProbe[Int]()
-      Source(1 to 3).takeWithin(1.second).publishTo(c)
+      Source(1 to 3).takeWithin(1.second).connect(SubscriberDrain(c)).run()
       val cSub = c.expectSubscription()
       c.expectNoMsg(200.millis)
       cSub.request(100)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowThunkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowThunkSpec.scala
@@ -18,7 +18,7 @@ class FlowThunkSpec extends AkkaSpec {
     "produce elements" in {
 
       val iter = List(1, 2, 3).iterator
-      val p = Source(() ⇒ if (iter.hasNext) Some(iter.next()) else None).map(_ + 10).toPublisher()
+      val p = Source(() ⇒ if (iter.hasNext) Some(iter.next()) else None).map(_ + 10).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -32,7 +32,7 @@ class FlowThunkSpec extends AkkaSpec {
     }
 
     "complete empty" in {
-      val p = Source(() ⇒ None).toPublisher()
+      val p = Source(() ⇒ None).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()
@@ -44,7 +44,7 @@ class FlowThunkSpec extends AkkaSpec {
     "allow cancel before receiving all elements" in {
       val count = 100000
       val iter = (1 to count).iterator
-      val p = Source(() ⇒ if (iter.hasNext) Some(iter.next()) else None).toPublisher()
+      val p = Source(() ⇒ if (iter.hasNext) Some(iter.next()) else None).runWith(PublisherDrain())
       val c = StreamTestKit.SubscriberProbe[Int]()
       p.subscribe(c)
       val sub = c.expectSubscription()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowTimerTransformerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FlowTimerTransformerSpec.scala
@@ -28,7 +28,7 @@ class FlowTimerTransformerSpec extends AkkaSpec {
           }
           override def isComplete: Boolean = !isTimerActive("tick")
         }).
-        toPublisher()
+        runWith(PublisherDrain())
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
       p2.subscribe(subscriber)
       val subscription = subscriber.expectSubscription()
@@ -54,7 +54,7 @@ class FlowTimerTransformerSpec extends AkkaSpec {
           }
           override def isComplete: Boolean = !isTimerActive("tick")
         }).
-        consume()
+        connect(BlackholeDrain).run()
       val pSub = p.expectSubscription()
       expectMsg("tick-1")
       expectMsg("tick-2")
@@ -72,7 +72,7 @@ class FlowTimerTransformerSpec extends AkkaSpec {
           def onNext(element: Int) = Nil
           override def onTimer(timerKey: Any) =
             throw exception
-        }).toPublisher()
+        }).runWith(PublisherDrain())
 
       val subscriber = StreamTestKit.SubscriberProbe[Int]()
       p2.subscribe(subscriber)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphBalanceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphBalanceSpec.scala
@@ -59,7 +59,7 @@ class GraphBalanceSpec extends AkkaSpec {
         balance ~> Flow[Int].grouped(15) ~> f5
       }.run()
 
-      Set(f1, f2, f3, f4, f5) flatMap (sink ⇒ Await.result(sink.future(g), 3.seconds)) should be((0 to 14).toSet)
+      Set(f1, f2, f3, f4, f5) flatMap (sink ⇒ Await.result(g.materializedDrain(sink), 3.seconds)) should be((0 to 14).toSet)
     }
 
     "fairly balance between three outputs" in {
@@ -73,7 +73,7 @@ class GraphBalanceSpec extends AkkaSpec {
       }.run()
 
       Seq(f1, f2, f3) map { sink ⇒
-        Await.result(sink.future(g), 3.seconds) should be(numElementsForSink +- 1000)
+        Await.result(g.materializedDrain(sink), 3.seconds) should be(numElementsForSink +- 1000)
       }
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphBroadcastSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphBroadcastSpec.scala
@@ -62,11 +62,11 @@ class GraphBroadcastSpec extends AkkaSpec {
         bcast ~> Flow[Int].grouped(5) ~> f5
       }.run()
 
-      Await.result(g.getDrainFor(f1), 3.seconds) should be(List(1, 2, 3))
-      Await.result(g.getDrainFor(f2), 3.seconds) should be(List(1, 2, 3))
-      Await.result(g.getDrainFor(f3), 3.seconds) should be(List(1, 2, 3))
-      Await.result(g.getDrainFor(f4), 3.seconds) should be(List(1, 2, 3))
-      Await.result(g.getDrainFor(f5), 3.seconds) should be(List(1, 2, 3))
+      Await.result(g.materializedDrain(f1), 3.seconds) should be(List(1, 2, 3))
+      Await.result(g.materializedDrain(f2), 3.seconds) should be(List(1, 2, 3))
+      Await.result(g.materializedDrain(f3), 3.seconds) should be(List(1, 2, 3))
+      Await.result(g.materializedDrain(f4), 3.seconds) should be(List(1, 2, 3))
+      Await.result(g.materializedDrain(f5), 3.seconds) should be(List(1, 2, 3))
     }
 
     "produce to other even though downstream cancels" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/ImplicitFlowMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/ImplicitFlowMaterializerSpec.scala
@@ -23,7 +23,7 @@ object ImplicitFlowMaterializerSpec {
         // run takes an implicit FlowMaterializer parameter, which is provided by ImplicitFlowMaterializer
         import context.dispatcher
         val foldDrain = FoldDrain[String, String]("")(_ + _)
-        flow.runWith(foldDrain) pipeTo sender()
+        flow.fold("")(_ + _) pipeTo sender()
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/ImplicitFlowMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/ImplicitFlowMaterializerSpec.scala
@@ -23,8 +23,7 @@ object ImplicitFlowMaterializerSpec {
         // run takes an implicit FlowMaterializer parameter, which is provided by ImplicitFlowMaterializer
         import context.dispatcher
         val foldDrain = FoldDrain[String, String]("")(_ + _)
-        val mf = flow.connect(foldDrain).run()
-        foldDrain.future(mf) pipeTo sender()
+        flow.runWith(foldDrain) pipeTo sender()
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/TickPublisherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/TickPublisherSpec.scala
@@ -17,7 +17,7 @@ class TickPublisherSpec extends AkkaSpec {
     "produce ticks" in {
       val tickGen = Iterator from 1
       val c = StreamTestKit.SubscriberProbe[String]()
-      Source(1.second, 500.millis, () ⇒ "tick-" + tickGen.next()).publishTo(c)
+      Source(1.second, 500.millis, () ⇒ "tick-" + tickGen.next()).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(3)
       c.expectNoMsg(600.millis)
@@ -33,7 +33,7 @@ class TickPublisherSpec extends AkkaSpec {
     "drop ticks when not requested" in {
       val tickGen = Iterator from 1
       val c = StreamTestKit.SubscriberProbe[String]()
-      Source(1.second, 1.second, () ⇒ "tick-" + tickGen.next()).publishTo(c)
+      Source(1.second, 1.second, () ⇒ "tick-" + tickGen.next()).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(2)
       c.expectNext("tick-1")
@@ -50,7 +50,7 @@ class TickPublisherSpec extends AkkaSpec {
 
     "produce ticks with multiple subscribers" in {
       val tickGen = Iterator from 1
-      val p = Source(1.second, 1.second, () ⇒ "tick-" + tickGen.next()).toPublisher()
+      val p = Source(1.second, 1.second, () ⇒ "tick-" + tickGen.next()).runWith(PublisherDrain())
       val c1 = StreamTestKit.SubscriberProbe[String]()
       val c2 = StreamTestKit.SubscriberProbe[String]()
       p.subscribe(c1)
@@ -74,7 +74,7 @@ class TickPublisherSpec extends AkkaSpec {
 
     "signal onError when tick closure throws" in {
       val c = StreamTestKit.SubscriberProbe[String]()
-      Source[String](1.second, 1.second, () ⇒ throw new RuntimeException("tick err") with NoStackTrace).publishTo(c)
+      Source[String](1.second, 1.second, () ⇒ throw new RuntimeException("tick err") with NoStackTrace).connect(SubscriberDrain(c)).run()
       val sub = c.expectSubscription()
       sub.request(3)
       c.expectError.getMessage should be("tick err")
@@ -83,8 +83,8 @@ class TickPublisherSpec extends AkkaSpec {
     // FIXME enable this test again when zip is back
     "be usable with zip for a simple form of rate limiting" ignore {
       //      val c = StreamTestKit.SubscriberProbe[Int]()
-      //      val rate = Source(1.second, 1.second, () ⇒ "tick").toPublisher()
-      //      Source(1 to 100).zip(rate).map { case (n, _) ⇒ n }.publishTo(c)
+      //      val rate = Source(1.second, 1.second, () ⇒ "tick").runWith(PublisherDrain())
+      //      Source(1 to 100).zip(rate).map { case (n, _) ⇒ n }.connect(SubscriberDrain(c)).run()
       //      val sub = c.expectSubscription()
       //      sub.request(1000)
       //      c.expectNext(1)

--- a/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
@@ -136,36 +136,36 @@ case class ActorBasedFlowMaterializer(override val settings: MaterializerSetting
   }
 
   // Ops come in reverse order
-  override def materialize[In, Out](tap: Tap[In], drain: Drain[Out], ops: List[Ast.AstNode]): MaterializedPipe = {
+  override def materialize[In, Out](tap: Tap[In], drain: Drain[Out], ops: List[Ast.AstNode]): MaterializedMap = {
     val flowName = createFlowName()
 
     def attachDrain(pub: Publisher[Out]) = drain match {
-      case s: SimpleDrain[Out]     ⇒ s.attach(pub, this, flowName)
-      case s: DrainWithKey[Out, _] ⇒ s.attach(pub, this, flowName)
-      case _                       ⇒ throw new MaterializationException("unknown Drain type " + drain.getClass)
+      case s: SimpleDrain[Out]  ⇒ s.attach(pub, this, flowName)
+      case s: DrainWithKey[Out] ⇒ s.attach(pub, this, flowName)
+      case _                    ⇒ throw new MaterializationException("unknown Drain type " + drain.getClass)
     }
     def attachTap(sub: Subscriber[In]) = tap match {
-      case s: SimpleTap[In]     ⇒ s.attach(sub, this, flowName)
-      case s: TapWithKey[In, _] ⇒ s.attach(sub, this, flowName)
-      case _                    ⇒ throw new MaterializationException("unknown Tap type " + drain.getClass)
+      case s: SimpleTap[In]  ⇒ s.attach(sub, this, flowName)
+      case s: TapWithKey[In] ⇒ s.attach(sub, this, flowName)
+      case _                 ⇒ throw new MaterializationException("unknown Tap type " + drain.getClass)
     }
     def createDrain() = drain.asInstanceOf[Drain[In]] match {
-      case s: SimpleDrain[In]     ⇒ s.create(this, flowName) -> (())
-      case s: DrainWithKey[In, _] ⇒ s.create(this, flowName)
-      case _                      ⇒ throw new MaterializationException("unknown Drain type " + drain.getClass)
+      case s: SimpleDrain[In]  ⇒ s.create(this, flowName) -> (())
+      case s: DrainWithKey[In] ⇒ s.create(this, flowName)
+      case _                   ⇒ throw new MaterializationException("unknown Drain type " + drain.getClass)
     }
     def createTap() = tap.asInstanceOf[Tap[Out]] match {
-      case s: SimpleTap[Out]     ⇒ s.create(this, flowName) -> (())
-      case s: TapWithKey[Out, _] ⇒ s.create(this, flowName)
-      case _                     ⇒ throw new MaterializationException("unknown Tap type " + drain.getClass)
+      case s: SimpleTap[Out]  ⇒ s.create(this, flowName) -> (())
+      case s: TapWithKey[Out] ⇒ s.create(this, flowName)
+      case _                  ⇒ throw new MaterializationException("unknown Tap type " + drain.getClass)
     }
     def isActive(s: AnyRef) = s match {
-      case tap: SimpleTap[_]         ⇒ tap.isActive
-      case tap: TapWithKey[_, _]     ⇒ tap.isActive
-      case drain: SimpleDrain[_]     ⇒ drain.isActive
-      case drain: DrainWithKey[_, _] ⇒ drain.isActive
-      case _: Tap[_]                 ⇒ throw new MaterializationException("unknown Tap type " + drain.getClass)
-      case _: Drain[_]               ⇒ throw new MaterializationException("unknown Drain type " + drain.getClass)
+      case tap: SimpleTap[_]      ⇒ tap.isActive
+      case tap: TapWithKey[_]     ⇒ tap.isActive
+      case drain: SimpleDrain[_]  ⇒ drain.isActive
+      case drain: DrainWithKey[_] ⇒ drain.isActive
+      case _: Tap[_]              ⇒ throw new MaterializationException("unknown Tap type " + drain.getClass)
+      case _: Drain[_]            ⇒ throw new MaterializationException("unknown Drain type " + drain.getClass)
     }
 
     val (tapValue, drainValue) =

--- a/akka-stream/src/main/scala/akka/stream/impl2/ConcatAllImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/ConcatAllImpl.scala
@@ -7,6 +7,7 @@ import akka.stream.impl.TransferPhase
 import akka.stream.impl.MultiStreamInputProcessor
 import akka.stream.scaladsl2.Source
 import akka.stream.scaladsl2.FlowMaterializer
+import akka.stream.scaladsl2.PublisherDrain
 
 /**
  * INTERNAL API
@@ -17,8 +18,8 @@ private[akka] class ConcatAllImpl(materializer: FlowMaterializer)
   import MultiStreamInputProcessor._
 
   val takeNextSubstream = TransferPhase(primaryInputs.NeedsInput && primaryOutputs.NeedsDemand) { () ⇒
-    val flow = primaryInputs.dequeueInputElement().asInstanceOf[Source[Any]]
-    val publisher = flow.toPublisher()(materializer)
+    val source = primaryInputs.dequeueInputElement().asInstanceOf[Source[Any]]
+    val publisher = source.runWith(PublisherDrain())(materializer)
     // FIXME we can pass the flow to createSubstreamInput (but avoiding copy impl now)
     val inputs = createAndSubscribeSubstreamInput(publisher)
     nextPhase(streamSubstream(inputs))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Flow.scala
@@ -27,6 +27,14 @@ trait Flow[-In, +Out] extends FlowOps[Out] {
    * Connect this flow to a sink, concatenating the processing steps of both.
    */
   def connect(sink: Sink[Out]): Sink[In]
+
+  /**
+   *
+   * Connect the `Tap` to this `Flow` and then connect it to the `Drain` and run it. The returned tuple contains
+   * the materialized values of the `Tap` and `Drain`, e.g. the `Subscriber` of a [[SubscriberTap]] and
+   * and `Publisher` of a [[PublisherDrain]].
+   */
+  def runWith(tap: TapWithKey[In], drain: DrainWithKey[Out])(implicit materializer: FlowMaterializer): (tap.MaterializedType, drain.MaterializedType)
 }
 
 object Flow {
@@ -41,15 +49,8 @@ object Flow {
  * Flow with attached input and output, can be executed.
  */
 trait RunnableFlow {
-  def run()(implicit materializer: FlowMaterializer): MaterializedFlow
+  def run()(implicit materializer: FlowMaterializer): MaterializedMap
 }
-
-/**
- * Returned by [[RunnableFlow#run]] and can be used as parameter to the
- * accessor method to retrieve the materialized `Tap` or `Drain`, e.g.
- * [[SubscriberTap#subscriber]] or [[PublisherDrain#publisher]].
- */
-trait MaterializedFlow extends MaterializedTap with MaterializedDrain
 
 /**
  * Scala API: Operations offered by Flows and Sources with a free output side: the DSL flows left-to-right only.
@@ -434,3 +435,4 @@ private[scaladsl2] object FlowOps {
     override def onNext(elem: Any) = List(elem)
   }
 }
+

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowMaterializer.scala
@@ -138,7 +138,7 @@ abstract class FlowMaterializer(val settings: MaterializerSettings) {
    * stream. The result can be highly implementation specific, ranging from
    * local actor chains to remote-deployed processing networks.
    */
-  def materialize[In, Out](tap: Tap[In], drain: Drain[Out], ops: List[Ast.AstNode]): MaterializedPipe
+  def materialize[In, Out](tap: Tap[In], drain: Drain[Out], ops: List[Ast.AstNode]): MaterializedMap
 
   /**
    * Create publishers and subscribers for fan-in and fan-out operations.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/MaterializedMap.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/MaterializedMap.scala
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl2
+
+/**
+ * Returned by [[RunnableFlow#run]] and [[FlowGraph#run]] and can be used to retrieve the materialized
+ * `Tap` inputs or `Drain` outputs, e.g. [[SubscriberTap]] or [[PublisherDrain]].
+ */
+trait MaterializedMap {
+
+  /**
+   * Retrieve a materialized `Tap`, e.g. the `Subscriber` of a [[SubscriberTap]].
+   */
+  def materializedTap(key: TapWithKey[_]): key.MaterializedType
+
+  /**
+   * Retrieve a materialized `Drain`, e.g. the `Publisher` of a [[PublisherDrain]].
+   */
+  def materializedDrain(key: DrainWithKey[_]): key.MaterializedType
+
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
@@ -13,6 +13,9 @@ import scala.annotation.unchecked.uncheckedVariance
  * Can be used as a `Subscriber`
  */
 trait Sink[-In] {
-  def toSubscriber()(implicit materializer: FlowMaterializer): Subscriber[In @uncheckedVariance] =
-    Flow[In].connect(this).toSubscriber()
+  /**
+   * Connect this `Sink` to a `Tap` and run it. The returned value is the materialized value
+   * of the `Tap`, e.g. the `Subscriber` of a [[SubscriberTap]].
+   */
+  def runWith(tap: TapWithKey[In])(implicit materializer: FlowMaterializer): tap.MaterializedType
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Source.scala
@@ -36,6 +36,27 @@ trait Source[+Out] extends FlowOps[Out] {
    */
   def runWith(drain: DrainWithKey[Out])(implicit materializer: FlowMaterializer): drain.MaterializedType
 
+  /**
+   * Shortcut for running this `Source` with a fold function.
+   * The given function is invoked for every received element, giving it its previous
+   * output (or the given `zero` value) and the element as input.
+   * The returned [[scala.concurrent.Future]] will be completed with value of the final
+   * function evaluation when the input stream ends, or completed with `Failure`
+   * if there is an error is signaled in the stream.
+   */
+  def fold[U](zero: U)(f: (U, Out) ⇒ U)(implicit materializer: FlowMaterializer): Future[U] =
+    runWith(FoldDrain(zero)(f))
+
+  /**
+   * Shortcut for running this `Source` with a foreach procedure. The given procedure is invoked
+   * for each received element.
+   * The returned [[scala.concurrent.Future]] will be completed with `Success` when reaching the
+   * normal end of the stream, or completed with `Failure` if there is an error is signaled in
+   * the stream.
+   */
+  def foreach(f: Out ⇒ Unit)(implicit materializer: FlowMaterializer): Future[Unit] =
+    runWith(ForeachDrain(f))
+
 }
 
 object Source {


### PR DESCRIPTION
This should cover most things and is ready for review, but I will check if I have covered everything on monday (and add some docs).
- runWith(drainWithKey) and runWith(tapWithKey) returning the
  materialized drain/tap
- remove toPublisher, toSubscriber, and friends, in favor of using
  runWith
- MaterializedMap is the return type for both flow and graph
