### PR TITLE
+str #15079 Add flexible merge

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphFlexiMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphFlexiMergeSpec.scala
@@ -1,0 +1,132 @@
+package akka.stream.scaladsl2
+
+import akka.stream.testkit.AkkaSpec
+import FlowGraphImplicits._
+
+class GraphFlexiMergeSpec extends AkkaSpec {
+
+  val in1 = IterableTap(List("a", "b", "c"))
+  val in2 = IterableTap(List("d", "e", "f"))
+
+  val out1 = PublisherDrain[String]
+
+  "FlexiMerge" must {
+
+    "build simple merge" in {
+      FlowGraph { implicit b ⇒
+        val merge = new Fair[String]
+        in1 ~> merge.input1
+        in2 -> merge.input2
+        merge.out ~> out1
+      }
+
+      FlowGraph { implicit b ⇒
+        val merge = new Fair[String]
+        in1 ~> merge.input1
+        in2 -> merge.input2
+        merge.input1.next ~> out1
+      }
+    }
+
+  }
+
+  class Fair[T] extends FlexiMerge[T]("fairMerge") {
+    import FlexiMerge._
+    val input1 = input[T]()
+    val input2 = input[T]()
+
+    def createMergeLogic = new MergeLogic[T] {
+      become {
+        State(ReadAny(input1, input2)) {
+          in ⇒ emit(in)
+        }
+      }
+    }
+  }
+
+  class RoundRobin[T] extends FlexiMerge[T]("roundRobinMerge") {
+    import FlexiMerge._
+    val input1 = input[T]()
+    val input2 = input[T]()
+
+    def createMergeLogic = new MergeLogic[T] {
+
+      def read1: State[T] = State(Read(input1)) { in ⇒
+        emit(in)
+        become(read2)
+      }
+
+      def read2 = State(Read(input2)) { in ⇒
+        emit(in)
+        become(read1)
+      }
+
+      become(read1)
+    }
+  }
+
+  class Zip[A, B] extends FlexiMerge[(A, B)]("zip") {
+    import FlexiMerge._
+    val input1 = input[A]()
+    val input2 = input[B]()
+
+    def createMergeLogic = new MergeLogic[(A, B)] {
+      var lastInA: A = _
+
+      def readA: State[A] = State(Read(input1)) { in ⇒
+        lastInA
+        become(readB)
+      }
+
+      def readB = State(Read(input2)) { in ⇒
+        emit((lastInA, in))
+        become(readA)
+      }
+
+      become(readA, eagerClose)
+    }
+  }
+
+  class OrderedMerge extends FlexiMerge[Int] {
+    import FlexiMerge._
+    val input1 = input[Int]()
+    val input2 = input[Int]()
+
+    def createMergeLogic = new MergeLogic[Int] {
+      private var reference = 0
+      
+      val emitOtherOnClose = CompletionHandling(
+        onComplete = {
+          case input: Input[Int] ⇒
+            emit(reference)
+            become(readRemaining(other(input)), defaultCompletionHandling)
+        },
+        onError = (_, cause) ⇒ error(cause)
+      )
+
+      def other(input: Input[Int]): Input[Int] = if (input eq input1) input2 else input1
+
+      def getFirstElement = State(ReadAnyWithInput(input1, input2)) {
+        case (in, input) ⇒
+          reference = in
+          become(readUntilLarger(other(input)), emitOtherOnClose)
+      }
+
+      def readUntilLarger(input: Input[Int]): State[Int] = State(Read(input)) { in ⇒
+        if (in <= reference) emit(in)
+        else {
+          emit(reference)
+          reference = in
+          become(readUntilLarger(other(input)))
+        }
+      }
+
+      def readRemaining(input: Input[Int]) = State(Read(input)) {
+        in ⇒ emit(in)
+      }
+
+      become(getFirstElement)
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphFlexiMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/GraphFlexiMergeSpec.scala
@@ -2,131 +2,502 @@ package akka.stream.scaladsl2
 
 import akka.stream.testkit.AkkaSpec
 import FlowGraphImplicits._
+import akka.stream.testkit.StreamTestKit.SubscriberProbe
+import akka.stream.testkit.StreamTestKit.OnNext
+import akka.stream.testkit.StreamTestKit.PublisherProbe
+import akka.stream.testkit.StreamTestKit.AutoPublisher
+import scala.util.control.NoStackTrace
 
-class GraphFlexiMergeSpec extends AkkaSpec {
+object GraphFlexiMergeSpec {
 
-  val in1 = IterableTap(List("a", "b", "c"))
-  val in2 = IterableTap(List("d", "e", "f"))
-
-  val out1 = PublisherDrain[String]
-
-  "FlexiMerge" must {
-
-    "build simple merge" in {
-      FlowGraph { implicit b ⇒
-        val merge = new Fair[String]
-        in1 ~> merge.input1
-        in2 -> merge.input2
-        merge.out ~> out1
-      }
-
-      FlowGraph { implicit b ⇒
-        val merge = new Fair[String]
-        in1 ~> merge.input1
-        in2 -> merge.input2
-        merge.input1.next ~> out1
-      }
-    }
-
-  }
-
+  /**
+   * This is fair in that sense that after dequeueing from an input it yields to other inputs if
+   * they are available. Or in other words, if all inputs have elements available at the same
+   * time then in finite steps all those elements are dequeued from them.
+   */
   class Fair[T] extends FlexiMerge[T]("fairMerge") {
     import FlexiMerge._
-    val input1 = input[T]()
-    val input2 = input[T]()
+    val input1 = createInputPort[T]()
+    val input2 = createInputPort[T]()
 
-    def createMergeLogic = new MergeLogic[T] {
-      become {
-        State(ReadAny(input1, input2)) {
-          in ⇒ emit(in)
-        }
+    def createMergeLogic: MergeLogic[T] = new MergeLogic[T] {
+      override def inputHandles(inputCount: Int) = Vector(input1, input2)
+      override def initialState = State[T](ReadAny(input1, input2)) { (ctx, input, element) ⇒
+        ctx.emit(element)
+        SameState
       }
     }
   }
 
-  class RoundRobin[T] extends FlexiMerge[T]("roundRobinMerge") {
+  /**
+   * It never skips an input while cycling but waits on it instead (closed inputs are skipped though).
+   * The fair merge above is a non-strict round-robin (skips currently unavailable inputs).
+   */
+  class StrictRoundRobin[T] extends FlexiMerge[T]("roundRobinMerge") {
     import FlexiMerge._
-    val input1 = input[T]()
-    val input2 = input[T]()
+    val input1 = createInputPort[T]()
+    val input2 = createInputPort[T]()
 
     def createMergeLogic = new MergeLogic[T] {
 
-      def read1: State[T] = State(Read(input1)) { in ⇒
-        emit(in)
-        become(read2)
+      override def inputHandles(inputCount: Int) = Vector(input1, input2)
+
+      val emitOtherOnClose = CompletionHandling(
+        onComplete = { (ctx, input) ⇒
+          ctx.changeCompletionHandling(defaultCompletionHandling)
+          readRemaining(other(input))
+        },
+        onError = { (ctx, _, cause) ⇒
+          ctx.error(cause)
+          SameState
+        })
+
+      def other(input: InputHandle): InputHandle = if (input eq input1) input2 else input1
+
+      val read1: State[T] = State[T](Read(input1)) { (ctx, input, element) ⇒
+        ctx.emit(element)
+        read2
       }
 
-      def read2 = State(Read(input2)) { in ⇒
-        emit(in)
-        become(read1)
+      val read2 = State[T](Read(input2)) { (ctx, input, element) ⇒
+        ctx.emit(element)
+        read1
       }
 
-      become(read1)
+      def readRemaining(input: InputHandle) = State[T](Read(input)) { (ctx, input, element) ⇒
+        ctx.emit(element)
+        SameState
+      }
+
+      override def initialState = read1
+
+      override def initialCompletionHandling = emitOtherOnClose
     }
   }
 
   class Zip[A, B] extends FlexiMerge[(A, B)]("zip") {
     import FlexiMerge._
-    val input1 = input[A]()
-    val input2 = input[B]()
+    val input1 = createInputPort[A]()
+    val input2 = createInputPort[B]()
 
     def createMergeLogic = new MergeLogic[(A, B)] {
       var lastInA: A = _
 
-      def readA: State[A] = State(Read(input1)) { in ⇒
-        lastInA
-        become(readB)
+      override def inputHandles(inputCount: Int) = {
+        require(inputCount == 2, s"Zip must have two connected inputs, was $inputCount")
+        Vector(input1, input2)
       }
 
-      def readB = State(Read(input2)) { in ⇒
-        emit((lastInA, in))
-        become(readA)
+      val readA: State[A] = State[A](Read(input1)) { (ctx, input, element) ⇒
+        lastInA = element
+        readB
       }
 
-      become(readA, eagerClose)
+      val readB: State[B] = State[B](Read(input2)) { (ctx, input, element) ⇒
+        ctx.emit((lastInA, element))
+        readA
+      }
+
+      override def initialState = readA
+
+      override def initialCompletionHandling = eagerClose
     }
   }
 
   class OrderedMerge extends FlexiMerge[Int] {
     import FlexiMerge._
-    val input1 = input[Int]()
-    val input2 = input[Int]()
+    val input1 = createInputPort[Int]()
+    val input2 = createInputPort[Int]()
 
     def createMergeLogic = new MergeLogic[Int] {
       private var reference = 0
-      
+
+      override def inputHandles(inputCount: Int) = Vector(input1, input2)
+
       val emitOtherOnClose = CompletionHandling(
-        onComplete = {
-          case input: Input[Int] ⇒
-            emit(reference)
-            become(readRemaining(other(input)), defaultCompletionHandling)
+        onComplete = { (ctx, input) ⇒
+          ctx.changeCompletionHandling(emitLast)
+          readRemaining(other(input))
         },
-        onError = (_, cause) ⇒ error(cause)
-      )
+        onError = { (ctx, input, cause) ⇒
+          ctx.error(cause)
+          SameState
+        })
 
-      def other(input: Input[Int]): Input[Int] = if (input eq input1) input2 else input1
+      def other(input: InputHandle): InputHandle = if (input eq input1) input2 else input1
 
-      def getFirstElement = State(ReadAnyWithInput(input1, input2)) {
-        case (in, input) ⇒
-          reference = in
-          become(readUntilLarger(other(input)), emitOtherOnClose)
+      def getFirstElement = State[Int](ReadAny(input1, input2)) { (ctx, input, element) ⇒
+        reference = element
+        ctx.changeCompletionHandling(emitOtherOnClose)
+        readUntilLarger(other(input))
       }
 
-      def readUntilLarger(input: Input[Int]): State[Int] = State(Read(input)) { in ⇒
-        if (in <= reference) emit(in)
-        else {
-          emit(reference)
-          reference = in
-          become(readUntilLarger(other(input)))
-        }
+      def readUntilLarger(input: InputHandle): State[Int] = State[Int](Read(input)) {
+        (ctx, input, element) ⇒
+          if (element <= reference) {
+            ctx.emit(element)
+            SameState
+          } else {
+            ctx.emit(reference)
+            reference = element
+            readUntilLarger(other(input))
+          }
       }
 
-      def readRemaining(input: Input[Int]) = State(Read(input)) {
-        in ⇒ emit(in)
+      def readRemaining(input: InputHandle) = State[Int](Read(input)) {
+        (ctx, input, element) ⇒
+          if (element <= reference)
+            ctx.emit(element)
+          else {
+            ctx.emit(reference)
+            reference = element
+          }
+          SameState
       }
 
-      become(getFirstElement)
+      val emitLast = CompletionHandling(
+        onComplete = { (ctx, input) ⇒
+          if (ctx.isDemandAvailable)
+            ctx.emit(reference)
+          SameState
+        },
+        onError = { (ctx, input, cause) ⇒
+          ctx.error(cause)
+          SameState
+        })
+
+      override def initialState = getFirstElement
     }
   }
 
+  class TestMerge extends FlexiMerge[String]("testMerge") {
+    import FlexiMerge._
+    val input1 = createInputPort[String]()
+    val input2 = createInputPort[String]()
+    val input3 = createInputPort[String]()
+
+    def createMergeLogic: MergeLogic[String] = new MergeLogic[String] {
+      val handles = Vector(input1, input2, input3)
+      override def inputHandles(inputCount: Int) = handles
+
+      override def initialState = State[String](ReadAny(handles)) {
+        (ctx, input, element) ⇒
+          if (element == "cancel")
+            ctx.cancel(input)
+          else if (element == "err")
+            ctx.error(new RuntimeException("err") with NoStackTrace)
+          else if (element == "complete")
+            ctx.complete()
+          else
+            ctx.emit("onInput: " + element)
+
+          SameState
+      }
+
+      override def initialCompletionHandling = CompletionHandling(
+        onComplete = { (ctx, input) ⇒
+          if (ctx.isDemandAvailable)
+            ctx.emit("onComplete: " + input.portIndex)
+          SameState
+        },
+        onError = { (ctx, input, cause) ⇒
+          cause match {
+            case _: IllegalArgumentException ⇒ // swallow
+            case _                           ⇒ ctx.error(cause)
+          }
+          SameState
+        })
+    }
+  }
 }
+
+class GraphFlexiMergeSpec extends AkkaSpec {
+  import GraphFlexiMergeSpec._
+
+  implicit val materializer = FlowMaterializer()
+
+  val in1 = Source(List("a", "b", "c", "d"))
+  val in2 = Source(List("e", "f"))
+
+  val out1 = PublisherDrain[String]
+
+  "FlexiMerge" must {
+
+    "build simple fair merge" in {
+      val m = FlowGraph { implicit b ⇒
+        val merge = new Fair[String]
+        in1 ~> merge.input1 ~> out1
+        in2 ~> merge.input2
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(10)
+      (s.probe.receiveN(6).map { case OnNext(elem) ⇒ elem }).toSet should be(
+        Set("a", "b", "c", "d", "e", "f"))
+      s.expectComplete()
+    }
+
+    "build simple round robin merge" in {
+      val m = FlowGraph { implicit b ⇒
+        val merge = new StrictRoundRobin[String]
+        in1 ~> merge.input1
+        in2 ~> merge.input2
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(10)
+      s.expectNext("a")
+      s.expectNext("e")
+      s.expectNext("b")
+      s.expectNext("f")
+      s.expectNext("c")
+      s.expectNext("d")
+      s.expectComplete()
+    }
+
+    "build simple zip merge" in {
+      val output = PublisherDrain[(Int, String)]
+      val m = FlowGraph { implicit b ⇒
+        val merge = new Zip[Int, String]
+        Source(List(1, 2, 3, 4)) ~> merge.input1
+        Source(List("a", "b", "c")) ~> merge.input2
+        merge.out ~> output
+      }.run()
+
+      val s = SubscriberProbe[(Int, String)]
+      val p = m.materializedDrain(output)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(10)
+      s.expectNext(1 -> "a")
+      s.expectNext(2 -> "b")
+      s.expectNext(3 -> "c")
+      s.expectComplete()
+    }
+
+    "build simple ordered merge 1" in {
+      val output = PublisherDrain[Int]
+      val m = FlowGraph { implicit b ⇒
+        val merge = new OrderedMerge
+        Source(List(3, 5, 6, 7, 8)) ~> merge.input1
+        Source(List(1, 2, 4, 9)) ~> merge.input2
+        merge.out ~> output
+      }.run()
+
+      val s = SubscriberProbe[Int]
+      val p = m.materializedDrain(output)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(100)
+      for (n ← 1 to 9)
+        s.expectNext(n)
+      s.expectComplete()
+    }
+
+    "build simple ordered merge 2" in {
+      val output = PublisherDrain[Int]
+      val m = FlowGraph { implicit b ⇒
+        val merge = new OrderedMerge
+        Source(List(3, 5, 6, 7, 8)) ~> merge.input1
+        Source(List(3, 5, 6, 7, 8, 10)) ~> merge.input2
+        merge.out ~> output
+      }.run()
+
+      val s = SubscriberProbe[Int]
+      val p = m.materializedDrain(output)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(100)
+      s.expectNext(3)
+      s.expectNext(3)
+      s.expectNext(5)
+      s.expectNext(5)
+      s.expectNext(6)
+      s.expectNext(6)
+      s.expectNext(7)
+      s.expectNext(7)
+      s.expectNext(8)
+      s.expectNext(8)
+      s.expectNext(10)
+      s.expectComplete()
+    }
+
+    "support cancel of input" in {
+      val publisher = PublisherProbe[String]
+      val m = FlowGraph { implicit b ⇒
+        val merge = new TestMerge
+        Source(publisher) ~> merge.input1
+        Source(List("b", "c", "d")) ~> merge.input2
+        Source(List("e", "f")) ~> merge.input3
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+
+      val autoPublisher = new AutoPublisher(publisher)
+      autoPublisher.sendNext("a")
+      autoPublisher.sendNext("cancel")
+
+      val sub = s.expectSubscription()
+      sub.request(10)
+      s.expectNext("onInput: a")
+      s.expectNext("onInput: b")
+      s.expectNext("onInput: e")
+      s.expectNext("onInput: c")
+      s.expectNext("onInput: f")
+      s.expectNext("onComplete: 2")
+      s.expectNext("onInput: d")
+      s.expectNext("onComplete: 1")
+
+      autoPublisher.sendNext("x")
+
+      s.expectComplete()
+    }
+
+    "complete when all inputs cancelled" in {
+      val publisher1 = PublisherProbe[String]
+      val publisher2 = PublisherProbe[String]
+      val publisher3 = PublisherProbe[String]
+      val m = FlowGraph { implicit b ⇒
+        val merge = new TestMerge
+        Source(publisher1) ~> merge.input1
+        Source(publisher2) ~> merge.input2
+        Source(publisher3) ~> merge.input3
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+
+      val autoPublisher1 = new AutoPublisher(publisher1)
+      autoPublisher1.sendNext("a")
+      autoPublisher1.sendNext("cancel")
+
+      val autoPublisher2 = new AutoPublisher(publisher2)
+      autoPublisher2.sendNext("b")
+      autoPublisher2.sendNext("cancel")
+
+      val autoPublisher3 = new AutoPublisher(publisher3)
+      autoPublisher3.sendNext("c")
+      autoPublisher3.sendNext("cancel")
+
+      val sub = s.expectSubscription()
+      sub.request(10)
+      s.expectNext("onInput: a")
+      s.expectNext("onInput: b")
+      s.expectNext("onInput: c")
+      s.expectComplete()
+    }
+
+    "handle error" in {
+      val m = FlowGraph { implicit b ⇒
+        val merge = new TestMerge
+        Source.failed[String](new IllegalArgumentException("ERROR") with NoStackTrace) ~> merge.input1
+        Source(List("a", "b")) ~> merge.input2
+        Source(List("c")) ~> merge.input3
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(10)
+      // IllegalArgumentException is swallowed by the CompletionHandler
+      s.expectNext("onInput: a")
+      s.expectNext("onInput: c")
+      s.expectNext("onComplete: 2")
+      s.expectNext("onInput: b")
+      s.expectNext("onComplete: 1")
+      s.expectComplete()
+    }
+
+    "propagate error" in {
+      val publisher = PublisherProbe[String]
+      val m = FlowGraph { implicit b ⇒
+        val merge = new TestMerge
+        Source(publisher) ~> merge.input1
+        Source.failed[String](new IllegalStateException("ERROR") with NoStackTrace) ~> merge.input2
+        Source.empty[String] ~> merge.input3
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+      s.expectErrorOrSubscriptionFollowedByError().getMessage should be("ERROR")
+    }
+
+    "emit error" in {
+      val m = FlowGraph { implicit b ⇒
+        val merge = new TestMerge
+        Source(List("a", "err")) ~> merge.input1
+        Source(List("b", "c")) ~> merge.input2
+        Source.empty[String] ~> merge.input3
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(10)
+      s.expectNext("onInput: a")
+      s.expectNext("onInput: b")
+      s.expectError().getMessage should be("err")
+    }
+
+    "support complete from onInput" in {
+      val m = FlowGraph { implicit b ⇒
+        val merge = new TestMerge
+        Source(List("a", "complete")) ~> merge.input1
+        Source(List("b", "c")) ~> merge.input2
+        Source.empty[String] ~> merge.input3
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(10)
+      s.expectNext("onInput: a")
+      s.expectNext("onInput: b")
+      s.expectComplete()
+    }
+
+    "support unconnected inputs" in {
+      val m = FlowGraph { implicit b ⇒
+        val merge = new TestMerge
+        Source(List("a")) ~> merge.input1
+        Source(List("b", "c")) ~> merge.input2
+        // input3 not connected
+        merge.out ~> out1
+      }.run()
+
+      val s = SubscriberProbe[String]
+      val p = m.materializedDrain(out1)
+      p.subscribe(s)
+      val sub = s.expectSubscription()
+      sub.request(10)
+      s.expectNext("onInput: a")
+      s.expectNext("onComplete: 0")
+      s.expectNext("onInput: b")
+      s.expectNext("onInput: c")
+      s.expectNext("onComplete: 1")
+      s.expectComplete()
+    }
+
+  }
+}
+

--- a/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
@@ -109,6 +109,10 @@ private[akka] object Ast {
     override def name = "concat"
   }
 
+  case class FlexiMergeNode(merger: FlexiMerge[Any]) extends FanInAstNode {
+    override def name = merger.name.getOrElse("")
+  }
+
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
@@ -240,6 +240,9 @@ case class ActorBasedFlowMaterializer(override val settings: MaterializerSetting
             actorOf(Zip.props(settings).withDispatcher(settings.dispatcher), actorName)
           case Ast.Concat ⇒
             actorOf(Concat.props(settings).withDispatcher(settings.dispatcher), actorName)
+          case Ast.FlexiMergeNode(merger) ⇒
+            actorOf(FlexiMergeImpl.props(settings, inputCount, merger.createMergeLogic()).
+              withDispatcher(settings.dispatcher), actorName)
         }
 
         val publisher = new ActorPublisher[Out](impl, equalityValue = None)

--- a/akka-stream/src/main/scala/akka/stream/impl2/FlexiMergeImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/FlexiMergeImpl.scala
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl2
+
+import scala.collection.breakOut
+import akka.stream.impl.TransferPhase
+import akka.stream.scaladsl2.FlexiMerge
+import akka.stream.MaterializerSettings
+import akka.stream.impl.TransferState
+import akka.actor.Props
+
+/**
+ * INTERNAL API
+ */
+private[akka] object FlexiMergeImpl {
+  def props(settings: MaterializerSettings, inputCount: Int, mergeLogic: FlexiMerge.MergeLogic[Any]): Props =
+    Props(new FlexiMergeImpl(settings, inputCount, mergeLogic))
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class FlexiMergeImpl(_settings: MaterializerSettings,
+                                   inputCount: Int,
+                                   mergeLogic: FlexiMerge.MergeLogic[Any])
+  extends FanIn(_settings, inputCount) {
+
+  import FlexiMerge._
+
+  val inputMapping: Map[Int, InputHandle] =
+    mergeLogic.inputHandles(inputCount).take(inputCount).zipWithIndex.map(_.swap)(breakOut)
+
+  private type StateT = mergeLogic.State[Any]
+  private type CompletionT = mergeLogic.CompletionHandling
+
+  private var behavior: StateT = _
+  private var completion: CompletionT = _
+
+  override protected val inputBunch = new FanIn.InputBunch(inputPorts, settings.maxInputBufferSize, this) {
+    override def onError(input: Int, e: Throwable): Unit = {
+      changeBehavior(completion.onError(ctx, inputMapping(input), e))
+      cancel(input)
+    }
+
+    override def onDepleted(input: Int): Unit =
+      changeBehavior(completion.onComplete(ctx, inputMapping(input)))
+  }
+
+  private val ctx: mergeLogic.MergeLogicContext = new mergeLogic.MergeLogicContext {
+    override def isDemandAvailable: Boolean = primaryOutputs.demandAvailable
+
+    override def emit(elem: Any): Unit = {
+      require(primaryOutputs.demandAvailable, "emit not allowed when no demand available")
+      primaryOutputs.enqueueOutputElement(elem)
+    }
+
+    override def complete(): Unit = {
+      inputBunch.cancel()
+      primaryOutputs.complete()
+      context.stop(self)
+    }
+
+    override def error(cause: Throwable): Unit = fail(cause)
+
+    override def cancel(input: InputHandle): Unit = inputBunch.cancel(input.portIndex)
+
+    override def changeCompletionHandling(newCompletion: CompletionT): Unit =
+      FlexiMergeImpl.this.changeCompletionHandling(newCompletion)
+
+  }
+
+  private def markInputs(inputs: Array[InputHandle]): Unit = {
+    inputBunch.unmarkAllInputs()
+    var i = 0
+    while (i < inputs.length) {
+      val id = inputs(i).portIndex
+      if (inputMapping.contains(id) && !inputBunch.isCancelled(id) && !inputBunch.isDepleted(id))
+        inputBunch.markInput(id)
+      i += 1
+    }
+  }
+
+  private def precondition: TransferState = {
+    behavior.condition match {
+      case _: ReadAny | _: Read ⇒ inputBunch.AnyOfMarkedInputs && primaryOutputs.NeedsDemand
+    }
+  }
+
+  private def changeCompletionHandling(newCompletion: CompletionT): Unit =
+    completion = newCompletion.asInstanceOf[CompletionT]
+
+  private def changeBehavior[A](newBehavior: mergeLogic.State[A]): Unit =
+    if (newBehavior != mergeLogic.SameState && (newBehavior ne behavior)) {
+      behavior = newBehavior.asInstanceOf[StateT]
+      behavior.condition match {
+        case read: ReadAny ⇒
+          markInputs(read.inputs.toArray)
+        case Read(input) ⇒
+          require(inputMapping.contains(input.portIndex), s"Unknown input handle $input")
+          require(!inputBunch.isCancelled(input.portIndex), s"Read not allowed from cancelled $input")
+          require(!inputBunch.isDepleted(input.portIndex), s"Read not allowed from depleted $input")
+          inputBunch.unmarkAllInputs()
+          inputBunch.markInput(input.portIndex)
+      }
+    }
+
+  changeBehavior(mergeLogic.initialState)
+  changeCompletionHandling(mergeLogic.initialCompletionHandling)
+
+  nextPhase(TransferPhase(precondition) { () ⇒
+    behavior.condition match {
+      case read: ReadAny ⇒
+        val id = inputBunch.idToDequeue()
+        val elem = inputBunch.dequeueAndYield(id)
+        val inputHandle = inputMapping(id)
+        changeBehavior(behavior.onInput(ctx, inputHandle, elem))
+        triggerCompletionAfterRead(inputHandle)
+
+      case Read(inputHandle) ⇒
+        val elem = inputBunch.dequeue(inputHandle.portIndex)
+        changeBehavior(behavior.onInput(ctx, inputHandle, elem))
+        triggerCompletionAfterRead(inputHandle)
+
+    }
+
+  })
+
+  private def triggerCompletionAfterRead(inputHandle: InputHandle): Unit =
+    if (inputBunch.isDepleted(inputHandle.portIndex))
+      changeBehavior(completion.onComplete(ctx, inputHandle))
+
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -52,8 +52,8 @@ object Flow {
    */
   def apply[T](f: () ⇒ Option[T]): Flow[T] =
     FlowImpl(ThunkPublisherNode(() ⇒ f() match {
-      case Some(t) => t
-      case _ => throw Stop
+      case Some(t) ⇒ t
+      case _       ⇒ throw Stop
     }), Nil)
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/FlexiMerge.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/FlexiMerge.scala
@@ -1,88 +1,245 @@
 /**
  * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
  */
-
 package akka.stream.scaladsl2
 
+import scala.collection.immutable
 import akka.stream.impl2.Ast
 
 object FlexiMerge {
 
-  sealed trait Input[T] extends JunctionInPort[T]
-
-  sealed trait ReadCondition[T]
-  final case class Read[T](input: Input[T]) extends ReadCondition[T]
-  final case class ReadAnyWithInput[T](inputs: Input[T]*) extends ReadCondition[(T, Input[T])]
-  final case class ReadAny[T](inputs: Input[T]*) extends ReadCondition[T]
-
-  sealed case class State[T](condition: ReadCondition[T])(onInput: T ⇒ Unit)
-  sealed case class CompletionHandling(onComplete: Input[_] ⇒ Unit, onError: (Input[_], Throwable) ⇒ Unit)
-
-  abstract class MergeLogic[Out] {
-
-    // Will continue to operate until a read becomes unsatisfiable, then it completes
-    // Errors are immediately propagated
-    val defaultCompletionHandling = CompletionHandling(
-      onError = (_, cause) ⇒ error(cause),
-      onComplete = _ ⇒ ())
-
-    // Completes as soon as any input completes
-    // Errors are immediately propagated
-    val eagerClose = CompletionHandling(
-      onError = (_, cause) ⇒ error(cause),
-      onComplete = _ ⇒ complete())
-
-    // FIXME: Check for empty behavior in the corresponding FanIn
-    private var currentBehavior: State[_] = null
-    private var currentCompletionHandling: CompletionHandling = defaultCompletionHandling
-
-    protected def become(nextBehavior: State[_]): Unit = currentBehavior = nextBehavior
-    protected def become(nextBehavior: State[_], completionHandling: CompletionHandling): Unit = {
-      currentBehavior = nextBehavior
-      currentCompletionHandling = completionHandling
-    }
-
-    protected def emit(elem: Out): Unit = ???
-    protected def complete(): Unit = ???
-    protected def error(cause: Throwable): Unit = ???
-    protected def cancel(input: Input[_]): Unit = ???
+  /**
+   * @see [[InputPort]]
+   */
+  sealed trait InputHandle {
+    private[akka] def portIndex: Int
   }
 
-  private[akka] class FlexiInput[T, Out](override val port: Int, parent: FlexiMerge[Out]) extends Input[T] {
-    override type NextT = Out
+  /**
+   * An `InputPort` can be connected to a [[Source]] with the [[FlowGraphBuilder]].
+   * The `InputPort` is also an [[InputHandle]], which is passed as parameter
+   * to [[MergeLogic#State]] `onInput` when an input element has been read so that you
+   * can know exactly from which input the element was read.
+   */
+  class InputPort[In, Out] private[akka] (override private[akka] val port: Int, parent: FlexiMerge[Out])
+    extends JunctionInPort[In] with InputHandle {
+    type NextT = Out
     override private[akka] def next = parent.out
     override private[akka] def vertex = parent.vertex
+
+    override private[akka] def portIndex: Int = port
+
+    override def toString: String = s"InputPort($port)"
+  }
+
+  sealed trait ReadCondition
+  /**
+   * Read condition for the [[MergeLogic#State]] that will is
+   * fulfilled when there are elements for one specfic upstream
+   * input.
+   *
+   * It is not allowed to use a handle that has been cancelled or
+   * has been completed. `IllegalArgumentException` is thrown if
+   * that is not obeyed.
+   */
+  final case class Read(input: InputHandle) extends ReadCondition
+
+  object ReadAny {
+    def apply(inputs: immutable.Seq[InputHandle]): ReadAny = new ReadAny(inputs: _*)
+  }
+  /**
+   * Read condition for the [[MergeLogic#State]] that will is
+   * fulfilled when there are elements for any of the given upstream
+   * inputs.
+   *
+   * Cancelled and completed inputs are not used, i.e. it is allowed
+   * to specify them in the list of `inputs`.
+   */
+  final case class ReadAny(inputs: InputHandle*) extends ReadCondition
+
+  /**
+   * The possibly stateful logic that reads from input via the defined [[State]] and
+   * handles completion and error via the defined [[CompletionHandling]].
+   *
+   * Concrete instance is supposed to be created by implementing [[FlexiMerge#createMergeLogic]].
+   */
+  abstract class MergeLogic[Out] {
+    def inputHandles(inputCount: Int): immutable.IndexedSeq[InputHandle]
+    def initialState: State[_]
+    def initialCompletionHandling: CompletionHandling = defaultCompletionHandling
+
+    /**
+     * Context that is passed to the methods of [[State]] and [[CompletionHandling]].
+     * The context provides means for performing side effects, such as emitting elements
+     * downstream.
+     */
+    trait MergeLogicContext {
+      /**
+       * @return `true` if at least one element has been requested by downstream (output).
+       */
+      def isDemandAvailable: Boolean
+
+      /**
+       * Emit one element downstream. It is only allowed to `emit` when
+       * [[#isDemandAvailable]] is `true`, otherwise `IllegalArgumentException`
+       * is thrown.
+       */
+      def emit(elem: Out): Unit
+
+      /**
+       * Complete this stream succesfully. Upstream subscriptions will be cancelled.
+       */
+      def complete(): Unit
+
+      /**
+       * Complete this stream with failure. Upstream subscriptions will be cancelled.
+       */
+      def error(cause: Throwable): Unit
+
+      /**
+       * Cancel a specific upstream input stream.
+       */
+      def cancel(input: InputHandle): Unit
+
+      /**
+       * Replace current [[CompletionHandling]].
+       */
+      def changeCompletionHandling(completion: CompletionHandling): Unit
+    }
+
+    /**
+     * Definition of which inputs to read from and how to act on the read elements.
+     * When an element has been read [[#onInput]] is called and then it is ensured
+     * that downstream has requested at least one element, i.e. it is allowed to
+     * emit at least one element downstream with [[MergeLogicContext#emit]].
+     *
+     * The `onInput` function is called when an `element` was read from the `input`.
+     * The function returns next behavior or [[#SameState]] to keep current behavior.
+     */
+    sealed case class State[In](val condition: ReadCondition)(
+      val onInput: (MergeLogicContext, InputHandle, In) ⇒ State[_])
+
+    /**
+     * Return this from [[State]] `onInput` to use same state for next element.
+     */
+    def SameState[In]: State[In] = sameStateInstance.asInstanceOf[State[In]]
+
+    private val sameStateInstance = new State[Any](ReadAny(Nil))((_, _, _) ⇒
+      throw new UnsupportedOperationException("SameState.onInput should not be called")) {
+
+      // unique instance, don't use case class
+      override def equals(other: Any): Boolean = super.equals(other)
+      override def hashCode: Int = super.hashCode
+      override def toString: String = "SameState"
+    }
+
+    /**
+     * How to handle completion or error from upstream input.
+     *
+     * The `onComplete` function is called when an upstream input was completed sucessfully.
+     * It returns next behavior or [[#SameState]] to keep current behavior.
+     * A completion can be propagated downstream with [[MergeLogicContext#complete]],
+     * or it can be swallowed to continue with remaining inputs.
+     *
+     * The `onError` function is called when an upstream input was completed sucessfully.
+     * It returns next behavior or [[#SameState]] to keep current behavior.
+     * An error can be propagated downstream with [[MergeLogicContext#error]],
+     * or it can be swallowed to continue with remaining inputs.
+     */
+    sealed case class CompletionHandling(
+      onComplete: (MergeLogicContext, InputHandle) ⇒ State[_],
+      onError: (MergeLogicContext, InputHandle, Throwable) ⇒ State[_])
+
+    /**
+     * Will continue to operate until a read becomes unsatisfiable, then it completes.
+     * Errors are immediately propagated.
+     */
+    val defaultCompletionHandling: CompletionHandling = CompletionHandling(
+      onComplete = (_, _) ⇒ SameState,
+      onError = (ctx, _, cause) ⇒ { ctx.error(cause); SameState })
+
+    /**
+     * Completes as soon as any input completes.
+     * Errors are immediately propagated.
+     */
+    def eagerClose: CompletionHandling = CompletionHandling(
+      onComplete = (ctx, _) ⇒ { ctx.complete(); SameState },
+      onError = (ctx, _, cause) ⇒ { ctx.error(cause); SameState })
   }
 
 }
 
+/**
+ * Base class for implementing custom merge junctions.
+ * Such a junction always has one [[#out]] port and one or more input ports.
+ * The input ports are to be defined in the concrete subclass and are created with
+ * [[#createInputPort]].
+ *
+ * The concrete subclass must implement [[#createMergeLogic]] to define the [[FlexiMerge#MergeLogic]]
+ * that will be used when reading input elements and emitting output elements.
+ * The [[FlexiMerge#MergeLogic]] instance may be stateful, but the ``FlexiMerge`` instance
+ * must not hold mutable state, since it may be shared across several materialized ``FlowGraph``
+ * instances.
+ *
+ * Note that a `FlexiMerge` with a specific name can only be used at one place (one vertex)
+ * in the `FlowGraph`. If the `name` is not specified the `FlexiMerge` instance can only
+ * be used at one place (one vertex) in the `FlowGraph`.
+ *
+ * @param name optional name of the junction in the [[FlowGraph]],
+ */
 abstract class FlexiMerge[Out](val name: Option[String]) {
+  import FlexiMerge._
 
   def this(name: String) = this(Some(name))
   def this() = this(None)
 
-  import FlexiMerge._
   private var inputCount = 0
 
-  private val vertex = new FlowGraphInternal.InternalVertex {
+  // hide the internal vertex things from subclass, and make it possible to create new instance
+  private class FlexiMergeVertex(vertexName: Option[String]) extends FlowGraphInternal.InternalVertex {
     override def minimumInputCount = 2
     override def maximumInputCount = inputCount
     override def minimumOutputCount = 1
     override def maximumOutputCount = 1
 
-    override private[akka] val astNode = Ast.FlexiMergeNode(this.asInstanceOf[FlexiMerge[Any]])
-    override val name = FlexiMerge.this.name
+    override private[akka] val astNode = Ast.FlexiMergeNode(FlexiMerge.this.asInstanceOf[FlexiMerge[Any]])
+    override def name = vertexName
+
+    final override private[scaladsl2] def newInstance() = new FlexiMergeVertex(None)
   }
 
-  val out = new JunctionOutPort[Out] {
+  private[scaladsl2] val vertex: FlowGraphInternal.InternalVertex = new FlexiMergeVertex(name)
+
+  /**
+   * Output port of the `FlexiMerge` junction. A [[Sink]] can be connected to this output
+   * with the [[FlowGraphBuilder]].
+   */
+  val out: JunctionOutPort[Out] = new JunctionOutPort[Out] {
     override private[akka] def vertex = FlexiMerge.this.vertex
   }
 
-  def input[T](): Input[T] { type NextT = Out } = {
+  /**
+   * Concrete subclass is supposed to define one or more input ports and
+   * they are created by calling this method. Each [[FlexiMerge.InputPort]] can be
+   * connected to a [[Source]] with the [[FlowGraphBuilder]].
+   * The `InputPort` is also an [[FlexiMerge.InputHandle]], which is passed as parameter
+   * to [[FlexiMerge#MergeLogic#State]] `onInput` when an input element has been read so that you
+   * can know exactly from which input the element was read.
+   */
+  protected final def createInputPort[T](): InputPort[T, Out] = {
     val port = inputCount
     inputCount += 1
-    new FlexiInput(port, parent = this)
+    new InputPort(port, parent = this)
   }
 
-  def createMergeLogic: MergeLogic[Out]
+  /**
+   * Create the stateful logic that will be used when reading input elements
+   * and emitting output elements. Create a new instance every time.
+   */
+  def createMergeLogic(): MergeLogic[Out]
+
+  override def toString = name match {
+    case Some(n) ⇒ n
+    case None    ⇒ getClass.getSimpleName + "@" + Integer.toHexString(super.hashCode())
+  }
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/FlexiMerge.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/FlexiMerge.scala
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.stream.scaladsl2
+
+import akka.stream.impl2.Ast
+
+object FlexiMerge {
+
+  sealed trait Input[T] extends JunctionInPort[T]
+
+  sealed trait ReadCondition[T]
+  final case class Read[T](input: Input[T]) extends ReadCondition[T]
+  final case class ReadAnyWithInput[T](inputs: Input[T]*) extends ReadCondition[(T, Input[T])]
+  final case class ReadAny[T](inputs: Input[T]*) extends ReadCondition[T]
+
+  sealed case class State[T](condition: ReadCondition[T])(onInput: T ⇒ Unit)
+  sealed case class CompletionHandling(onComplete: Input[_] ⇒ Unit, onError: (Input[_], Throwable) ⇒ Unit)
+
+  abstract class MergeLogic[Out] {
+
+    // Will continue to operate until a read becomes unsatisfiable, then it completes
+    // Errors are immediately propagated
+    val defaultCompletionHandling = CompletionHandling(
+      onError = (_, cause) ⇒ error(cause),
+      onComplete = _ ⇒ ())
+
+    // Completes as soon as any input completes
+    // Errors are immediately propagated
+    val eagerClose = CompletionHandling(
+      onError = (_, cause) ⇒ error(cause),
+      onComplete = _ ⇒ complete())
+
+    // FIXME: Check for empty behavior in the corresponding FanIn
+    private var currentBehavior: State[_] = null
+    private var currentCompletionHandling: CompletionHandling = defaultCompletionHandling
+
+    protected def become(nextBehavior: State[_]): Unit = currentBehavior = nextBehavior
+    protected def become(nextBehavior: State[_], completionHandling: CompletionHandling): Unit = {
+      currentBehavior = nextBehavior
+      currentCompletionHandling = completionHandling
+    }
+
+    protected def emit(elem: Out): Unit = ???
+    protected def complete(): Unit = ???
+    protected def error(cause: Throwable): Unit = ???
+    protected def cancel(input: Input[_]): Unit = ???
+  }
+
+  private[akka] class FlexiInput[T, Out](override val port: Int, parent: FlexiMerge[Out]) extends Input[T] {
+    override type NextT = Out
+    override private[akka] def next = parent.out
+    override private[akka] def vertex = parent.vertex
+  }
+
+}
+
+abstract class FlexiMerge[Out](val name: Option[String]) {
+
+  def this(name: String) = this(Some(name))
+  def this() = this(None)
+
+  import FlexiMerge._
+  private var inputCount = 0
+
+  private val vertex = new FlowGraphInternal.InternalVertex {
+    override def minimumInputCount = 2
+    override def maximumInputCount = inputCount
+    override def minimumOutputCount = 1
+    override def maximumOutputCount = 1
+
+    override private[akka] val astNode = Ast.FlexiMergeNode(this.asInstanceOf[FlexiMerge[Any]])
+    override val name = FlexiMerge.this.name
+  }
+
+  val out = new JunctionOutPort[Out] {
+    override private[akka] def vertex = FlexiMerge.this.vertex
+  }
+
+  def input[T](): Input[T] { type NextT = Out } = {
+    val port = inputCount
+    inputCount += 1
+    new FlexiInput(port, parent = this)
+  }
+
+  def createMergeLogic: MergeLogic[Out]
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowGraph.scala
@@ -15,7 +15,7 @@ import akka.stream.impl2.Ast
  * Fan-in and fan-out vertices in the [[FlowGraph]] implements
  * this marker interface. Edges may end at a `JunctionInPort`.
  */
-sealed trait JunctionInPort[-T] {
+trait JunctionInPort[-T] {
   private[akka] def port: Int = FlowGraphInternal.UnlabeledPort
   private[akka] def vertex: FlowGraphInternal.Vertex
   type NextT
@@ -26,7 +26,7 @@ sealed trait JunctionInPort[-T] {
  * Fan-in and fan-out vertices in the [[FlowGraph]] implements
  * this marker interface. Edges may start at a `JunctionOutPort`.
  */
-sealed trait JunctionOutPort[T] {
+trait JunctionOutPort[T] {
   private[akka] def port: Int = FlowGraphInternal.UnlabeledPort
   private[akka] def vertex: FlowGraphInternal.Vertex
 }
@@ -450,7 +450,7 @@ private[akka] object FlowGraphInternal {
     final override private[scaladsl2] def newInstance() = this.copy()
   }
 
-  sealed trait InternalVertex extends Vertex {
+  trait InternalVertex extends Vertex {
     def name: Option[String]
 
     def minimumInputCount: Int

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Tap.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Tap.scala
@@ -185,8 +185,8 @@ final case class ThunkTap[Out](f: () ⇒ Option[Out]) extends SimpleTap[Out] {
   override def create(materializer: ActorBasedFlowMaterializer, flowName: String): Publisher[Out] =
     ActorPublisher[Out](materializer.actorOf(SimpleCallbackPublisher.props(materializer.settings,
       () ⇒ f() match {
-        case Some(out) => out
-        case _ => throw Stop
+        case Some(out) ⇒ out
+        case _         ⇒ throw Stop
       }), name = s"$flowName-0-thunk"))
 }
 


### PR DESCRIPTION
Still only a prototype, but would be great with a round of feedback for tomorrow's work.

I tried the "return next behavior" approach (see savepoint1 if you are interested), but that was a dead end. We want to allow return of behavior with new input and output types, e.g. Zip, and I couldn't get that to work without explosion of types. Reverted back to become.

// cc @drewhk @sirthias 
