### PR TITLE
15921, 16064, 16067 Import CodingDirectives + related fixes

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/HttpEntity.scala
@@ -4,8 +4,6 @@
 
 package akka.http.model
 
-import akka.http.util.FastFuture
-
 import language.implicitConversions
 import java.io.File
 import java.lang.{ Iterable ⇒ JIterable }
@@ -265,7 +263,7 @@ object HttpEntity {
               sentLastChunk = true
               Chunk(byteTransformer.onTermination(None).join) :: l :: Nil
           }
-
+          override def onError(cause: scala.Throwable): Unit = byteTransformer.onError(cause)
           override def onTermination(e: Option[Throwable]): immutable.Seq[ChunkStreamPart] = {
             val remaining =
               if (e.isEmpty && !sentLastChunk) byteTransformer.onTermination(None)
@@ -275,6 +273,8 @@ object HttpEntity {
             if (remaining.nonEmpty) Chunk(remaining.join) :: Nil
             else Nil
           }
+
+          override def cleanup(): Unit = byteTransformer.cleanup()
         })
 
       HttpEntity.Chunked(contentType, newChunks)

--- a/akka-http-core/src/main/scala/akka/http/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/util/StreamUtils.scala
@@ -4,12 +4,16 @@
 
 package akka.http.util
 
+import akka.http.model.RequestEntity
 import akka.stream.impl.ErrorPublisher
 import akka.stream.Transformer
+import akka.stream.scaladsl2.{ Source, FlowMaterializer }
 import akka.util.ByteString
 import org.reactivestreams.Publisher
 
 import scala.collection.immutable
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.control.NonFatal
 
 /**
  * INTERNAL API
@@ -46,8 +50,30 @@ private[http] object StreamUtils {
 
   def failedPublisher[T](ex: Throwable): Publisher[T] =
     ErrorPublisher(ex).asInstanceOf[Publisher[T]]
+
+  def mapErrorTransformer[T](f: Throwable ⇒ Throwable): Transformer[T, T] =
+    new Transformer[T, T] {
+      def onNext(element: T): immutable.Seq[T] = immutable.Seq(element)
+      override def onError(cause: scala.Throwable): Unit = throw f(cause)
+    }
+
+  def mapEntityError(f: Throwable ⇒ Throwable): RequestEntity ⇒ RequestEntity =
+    _.transformDataBytes(() ⇒ mapErrorTransformer(f))
 }
 
+/**
+ * INTERNAL API
+ */
 private[http] class EnhancedTransformer[T, U](val t: Transformer[T, U]) extends AnyVal {
   def map[V](f: U ⇒ V): Transformer[T, V] = StreamUtils.mapTransformer(t, f)
+}
+
+/**
+ * INTERNAL API
+ */
+private[http] class EnhancedByteStringSource(val byteStringStream: Source[ByteString]) extends AnyVal {
+  def join(implicit materializer: FlowMaterializer): Future[ByteString] =
+    byteStringStream.fold(ByteString.empty)(_ ++ _)
+  def utf8String(implicit materializer: FlowMaterializer, ec: ExecutionContext): Future[String] =
+    join.map(_.utf8String)
 }

--- a/akka-http-core/src/main/scala/akka/http/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/util/package.scala
@@ -35,6 +35,8 @@ package object util {
   private[http] implicit def enhanceRegex(regex: Regex): EnhancedRegex = new EnhancedRegex(regex)
   private[http] implicit def enhanceByteStrings(byteStrings: TraversableOnce[ByteString]): EnhancedByteStringTraversableOnce =
     new EnhancedByteStringTraversableOnce(byteStrings)
+  private[http] implicit def enhanceByteStrings(byteStrings: Source[ByteString]): EnhancedByteStringSource =
+    new EnhancedByteStringSource(byteStrings)
   private[http] implicit def enhanceTransformer[T, U](transformer: Transformer[T, U]): EnhancedTransformer[T, U] =
     new EnhancedTransformer(transformer)
 

--- a/akka-http-tests/src/test/scala/akka/http/coding/DecoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/coding/DecoderSpec.scala
@@ -35,5 +35,6 @@ class DecoderSpec extends WordSpec with CodecSpecSupport {
 
   case object DummyDecompressor extends Decompressor {
     def decompress(buffer: ByteString): ByteString = buffer ++ ByteString("compressed")
+    def finish(): ByteString = ByteString.empty
   }
 }

--- a/akka-http-tests/src/test/scala/akka/http/coding/GzipSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/coding/GzipSpec.scala
@@ -10,7 +10,7 @@ import akka.http.util._
 import HttpMethods.POST
 
 import java.io.{ InputStream, OutputStream, ByteArrayInputStream, ByteArrayOutputStream }
-import java.util.zip.{ DataFormatException, GZIPInputStream, GZIPOutputStream }
+import java.util.zip.{ ZipException, DataFormatException, GZIPInputStream, GZIPOutputStream }
 
 import akka.util.ByteString
 
@@ -50,6 +50,10 @@ class GzipSpec extends WordSpec with CodecSpecSupport {
     "throw an error on corrupt input" in {
       val ex = the[DataFormatException] thrownBy ourGunzip(corruptGzipContent)
       ex.getMessage should equal("invalid literal/length code")
+    }
+    "throw early if header is corrupt" in {
+      val ex = the[ZipException] thrownBy ourGunzip(ByteString(0, 1, 2, 3, 4))
+      ex.getMessage should equal("Not in GZIP format")
     }
     "not throw an error if a subsequent block is corrupt" in {
       pending // FIXME: should we read as long as possible and only then report an error, that seems somewhat arbitrary

--- a/akka-http-tests/src/test/scala/akka/http/coding/GzipSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/coding/GzipSpec.scala
@@ -51,6 +51,10 @@ class GzipSpec extends WordSpec with CodecSpecSupport {
       val ex = the[DataFormatException] thrownBy ourGunzip(corruptGzipContent)
       ex.getMessage should equal("invalid literal/length code")
     }
+    "throw an error on truncated input" in {
+      val ex = the[ZipException] thrownBy ourGunzip(streamGzip(smallTextBytes).dropRight(5))
+      ex.getMessage should equal("Truncated GZIP stream")
+    }
     "throw early if header is corrupt" in {
       val ex = the[ZipException] thrownBy ourGunzip(ByteString(0, 1, 2, 3, 4))
       ex.getMessage should equal("Not in GZIP format")
@@ -100,7 +104,7 @@ class GzipSpec extends WordSpec with CodecSpecSupport {
 
   def gzip(s: String) = ourGzip(ByteString(s, "UTF8"))
   def ourGzip(bytes: ByteString): ByteString = Gzip.newCompressor.compressAndFinish(bytes)
-  def ourGunzip(bytes: ByteString): ByteString = Gzip.newDecompressor.decompress(bytes)
+  def ourGunzip(bytes: ByteString): ByteString = Gzip.newDecompressor.decompressAndFinish(bytes)
 
   lazy val corruptGzipContent = {
     val content = gzip("Hello").toArray

--- a/akka-http-tests/src/test/scala/akka/http/server/directives/CodingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/server/directives/CodingDirectivesSpec.scala
@@ -67,6 +67,14 @@ class CodingDirectivesSpec extends RoutingSpec {
         responseAs[String] shouldEqual "The request's encoding is corrupt:\nNot in GZIP format"
       }
     }
+    "reject truncated gzip request content" in {
+      Post("/", helloGzipped.dropRight(2)) ~> `Content-Encoding`(gzip) ~> {
+        decodeRequest(Gzip) { echoRequestContent }
+      } ~> check {
+        status shouldEqual BadRequest
+        responseAs[String] shouldEqual "The request's encoding is corrupt:\nTruncated GZIP stream"
+      }
+    }
     "reject requests with content encoded with 'deflate'" in {
       Post("/", "Hello") ~> `Content-Encoding`(deflate) ~> {
         decodeRequest(Gzip) { completeOk }

--- a/akka-http-tests/src/test/scala/akka/http/server/directives/CodingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/server/directives/CodingDirectivesSpec.scala
@@ -1,0 +1,502 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.server
+package directives
+
+import org.scalatest.Tag
+import org.scalatest.matchers.Matcher
+
+import akka.util.ByteString
+import akka.stream.scaladsl2.Source
+
+import akka.http.util._
+
+import akka.http.model._
+import HttpEntity.{ ChunkStreamPart, Chunk }
+import headers._
+import HttpCharsets._
+import HttpEncodings._
+import MediaTypes._
+import StatusCodes._
+
+import akka.http.coding._
+
+class CodingDirectivesSpec extends RoutingSpec {
+
+  val echoRequestContent: Route = { ctx ⇒ ctx.complete(ctx.request.entity.dataBytes.utf8String) }
+
+  val yeah = complete("Yeah!")
+  lazy val yeahGzipped = compress("Yeah!", Gzip)
+  lazy val yeahDeflated = compress("Yeah!", Deflate)
+
+  lazy val helloGzipped = compress("Hello", Gzip)
+  lazy val helloDeflated = compress("Hello", Deflate)
+
+  "the NoEncoding decoder" should {
+    "decode the request content if it has encoding 'identity'" in {
+      Post("/", "yes") ~> `Content-Encoding`(identity) ~> {
+        decodeRequest(NoCoding) { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "yes" }
+    }
+    "reject requests with content encoded with 'deflate'" in {
+      Post("/", "yes") ~> `Content-Encoding`(deflate) ~> {
+        decodeRequest(NoCoding) { echoRequestContent }
+      } ~> check { rejection shouldEqual UnsupportedRequestEncodingRejection(identity) }
+    }
+    "decode the request content if no Content-Encoding header is present" in {
+      Post("/", "yes") ~> decodeRequest(NoCoding) { echoRequestContent } ~> check { responseAs[String] shouldEqual "yes" }
+    }
+    "leave request without content unchanged" in {
+      Post() ~> decodeRequest(Gzip) { completeOk } ~> check { response shouldEqual Ok }
+    }
+  }
+
+  "the Gzip decoder" should {
+    "decode the request content if it has encoding 'gzip'" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> {
+        decodeRequest(Gzip) { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "Hello" }
+    }
+    "reject the request content if it has encoding 'gzip' but is corrupt" in {
+      Post("/", fromHexDump("000102")) ~> `Content-Encoding`(gzip) ~> {
+        decodeRequest(Gzip) { echoRequestContent }
+      } ~> check {
+        status shouldEqual BadRequest
+        responseAs[String] shouldEqual "The request's encoding is corrupt:\nNot in GZIP format"
+      }
+    }
+    "reject requests with content encoded with 'deflate'" in {
+      Post("/", "Hello") ~> `Content-Encoding`(deflate) ~> {
+        decodeRequest(Gzip) { completeOk }
+      } ~> check { rejection shouldEqual UnsupportedRequestEncodingRejection(gzip) }
+    }
+    "reject requests without Content-Encoding header" in {
+      Post("/", "Hello") ~> {
+        decodeRequest(Gzip) { completeOk }
+      } ~> check { rejection shouldEqual UnsupportedRequestEncodingRejection(gzip) }
+    }
+    "leave request without content unchanged" in {
+      Post() ~> {
+        decodeRequest(Gzip) { completeOk }
+      } ~> check { response shouldEqual Ok }
+    }
+  }
+
+  "a (decodeRequest(Gzip) | decodeRequest(NoEncoding)) compound directive" should {
+    lazy val decodeWithGzipOrNoEncoding = (decodeRequest(Gzip) | decodeRequest(NoCoding))
+    "decode the request content if it has encoding 'gzip'" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> {
+        decodeWithGzipOrNoEncoding { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "Hello" }
+    }
+    "decode the request content if it has encoding 'identity'" in {
+      Post("/", "yes") ~> `Content-Encoding`(identity) ~> {
+        decodeWithGzipOrNoEncoding { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "yes" }
+    }
+    "decode the request content if no Content-Encoding header is present" in {
+      Post("/", "yes") ~> decodeWithGzipOrNoEncoding { echoRequestContent } ~> check { responseAs[String] shouldEqual "yes" }
+    }
+    "reject requests with content encoded with 'deflate'" in {
+      Post("/", "yes") ~> `Content-Encoding`(deflate) ~> {
+        decodeWithGzipOrNoEncoding { echoRequestContent }
+      } ~> check {
+        rejections shouldEqual Seq(
+          UnsupportedRequestEncodingRejection(gzip),
+          UnsupportedRequestEncodingRejection(identity))
+      }
+    }
+  }
+
+  "the Gzip encoder" should {
+    "encode the response content with GZIP if the client accepts it with a dedicated Accept-Encoding header" in {
+      Post() ~> `Accept-Encoding`(gzip) ~> {
+        encodeResponse(Gzip) { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "encode the response content with GZIP if the request has no Accept-Encoding header" in {
+      Post() ~> {
+        encodeResponse(Gzip) { yeah }
+      } ~> check { entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped) }
+    }
+    "reject the request if the client does not accept GZIP encoding" in {
+      Post() ~> `Accept-Encoding`(identity) ~> {
+        encodeResponse(Gzip) { completeOk }
+      } ~> check { rejection shouldEqual UnacceptedResponseEncodingRejection(gzip) }
+    }
+    "leave responses without content unchanged" in {
+      Post() ~> `Accept-Encoding`(gzip) ~> {
+        encodeResponse(Gzip) { completeOk }
+      } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+    "leave responses with an already set Content-Encoding header unchanged" in {
+      pending
+
+      // FIXME: when RespondWithDirectives have been imported
+      /*Post() ~> `Accept-Encoding`(gzip) ~> {
+        encodeResponse(Gzip) {
+          respondWithHeader(`Content-Encoding`(identity)) { yeah }
+        }
+      } ~> check { responseAs[String] shouldEqual "Yeah!" }*/
+    }
+    "correctly encode the chunk stream produced by a chunked response" in {
+      val text = "This is a somewhat lengthy text that is being chunked by the autochunk directive!"
+      val textChunks =
+        text.grouped(8).map { chars ⇒
+          Chunk(chars.mkString): ChunkStreamPart
+        }
+      val chunkedTextEntity = HttpEntity.Chunked(MediaTypes.`text/plain`, Source(textChunks))
+
+      Post() ~> `Accept-Encoding`(gzip) ~> {
+        encodeResponse(Gzip) {
+          complete(chunkedTextEntity)
+        }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        chunks.size shouldEqual (11 + 1) // 11 regular + the last one
+        val bytes = chunks.foldLeft(ByteString.empty)(_ ++ _.data)
+        Gzip.newDecompressor.decompress(bytes) should readAs(text)
+      }
+    }
+  }
+
+  "the encodeResponse(NoEncoding) directive" should {
+    "produce a response if no Accept-Encoding is present in the request" in {
+      Post() ~> encodeResponse(NoCoding) { completeOk } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+    "produce a response if the client explicitly accepts non-encoded responses" in {
+      Post() ~> `Accept-Encoding`(gzip, identity) ~> {
+        encodeResponse(NoCoding) { completeOk }
+      } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+    "reject the request if the client does not accept `identity` encoding" in {
+      Post() ~> `Accept-Encoding`(gzip) ~> {
+        encodeResponse(NoCoding) { completeOk }
+      } ~> check { rejection shouldEqual UnacceptedResponseEncodingRejection(identity) }
+    }
+    "reject the request if the request has an 'Accept-Encoding: identity; q=0' header" in {
+      pending
+    }
+  }
+
+  "a (encodeResponse(Gzip) | encodeResponse(NoEncoding)) compound directive" should {
+    lazy val encodeGzipOrIdentity = (encodeResponse(Gzip) | encodeResponse(NoCoding))
+    "produce a GZIP encoded response if the request has no Accept-Encoding header" in {
+      Post() ~> {
+        encodeGzipOrIdentity { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "produce a GZIP encoded response if the request has an `Accept-Encoding: deflate, gzip` header" in {
+      Post() ~> `Accept-Encoding`(deflate, gzip) ~> {
+        encodeGzipOrIdentity { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "produce a non-encoded response if the request has an `Accept-Encoding: identity` header" in {
+      Post() ~> `Accept-Encoding`(identity) ~> {
+        encodeGzipOrIdentity { completeOk }
+      } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+    "reject the request if it has an `Accept-Encoding: deflate` header" in {
+      Post() ~> `Accept-Encoding`(deflate) ~> {
+        encodeGzipOrIdentity { completeOk }
+      } ~> check {
+        rejections shouldEqual Seq(
+          UnacceptedResponseEncodingRejection(gzip),
+          UnacceptedResponseEncodingRejection(identity))
+      }
+    }
+  }
+
+  "a (encodeResponse(NoEncoding) | encodeResponse(Gzip)) compound directive" should {
+    lazy val encodeIdentityOrGzip = (encodeResponse(NoCoding) | encodeResponse(Gzip))
+    "produce a non-encoded encoded response if the request has no Accept-Encoding header" in {
+      Post() ~> {
+        encodeIdentityOrGzip { completeOk }
+      } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+    "produce a non-encoded response if the request has an `Accept-Encoding: identity` header" in {
+      Post() ~> `Accept-Encoding`(identity) ~> {
+        encodeIdentityOrGzip { completeOk }
+      } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+    "produce a GZIP encoded response if the request has an `Accept-Encoding: deflate, gzip` header" in {
+      Post() ~> `Accept-Encoding`(deflate, gzip) ~> {
+        encodeIdentityOrGzip { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "reject the request if it has an `Accept-Encoding: deflate` header" in {
+      Post() ~> `Accept-Encoding`(deflate) ~> {
+        encodeIdentityOrGzip { completeOk }
+      } ~> check {
+        rejections shouldEqual Seq(
+          UnacceptedResponseEncodingRejection(identity),
+          UnacceptedResponseEncodingRejection(gzip))
+      }
+    }
+  }
+
+  //# compressResponse-example
+  "the compressResponse directive" should {
+    "produce a GZIP compressed response if the request has no Accept-Encoding header" in {
+      Post("/") ~> {
+        compressResponse() { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "produce a GZIP compressed response if the request has an `Accept-Encoding: gzip, deflate` header" in {
+      Post("/") ~> `Accept-Encoding`(gzip, deflate) ~> {
+        compressResponse() { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "produce a Deflate compressed response if the request has an `Accept-Encoding: deflate` header" in {
+      Post("/") ~> `Accept-Encoding`(deflate) ~> {
+        compressResponse() { yeah }
+      } ~> check {
+        response should haveContentEncoding(deflate)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahDeflated)
+      }
+    }
+    "produce an uncompressed response if the request has an `Accept-Encoding: identity` header" in {
+      Post("/") ~> `Accept-Encoding`(identity) ~> {
+        compressResponse() { completeOk }
+      } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+  }
+  //#
+
+  //# compressResponseIfRequested-example
+  "the compressResponseIfRequested directive" should {
+    "produce an uncompressed response if the request has no Accept-Encoding header" in {
+      Post("/") ~> {
+        compressResponseIfRequested() { yeah }
+      } ~> check {
+        response should haveNoContentEncoding
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), "Yeah!")
+      }
+    }
+    "produce a GZIP compressed response if the request has an `Accept-Encoding: deflate, gzip` header" in {
+      Post("/") ~> `Accept-Encoding`(deflate, gzip) ~> {
+        compressResponseIfRequested() { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "produce a Deflate encoded response if the request has an `Accept-Encoding: deflate` header" in {
+      Post("/") ~> `Accept-Encoding`(deflate) ~> {
+        compressResponseIfRequested() { yeah }
+      } ~> check {
+        response should haveContentEncoding(deflate)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahDeflated)
+      }
+    }
+    "produce an uncompressed response if the request has an `Accept-Encoding: identity` header" in {
+      Post("/") ~> `Accept-Encoding`(identity) ~> {
+        compressResponseIfRequested() { completeOk }
+      } ~> check {
+        response shouldEqual Ok
+        response should haveNoContentEncoding
+      }
+    }
+  }
+  //#
+
+  //# compressResponseWith-example
+  "the compressResponseWith directive" should {
+    "produce a response compressed with the specified Encoder if the request has a matching Accept-Encoding header" in {
+      Post("/") ~> `Accept-Encoding`(gzip) ~> {
+        compressResponse(Gzip) { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "produce a response compressed with one of the specified Encoders if the request has a matching Accept-Encoding header" in {
+      Post("/") ~> `Accept-Encoding`(deflate) ~> {
+        compressResponse(Gzip, Deflate) { yeah }
+      } ~> check {
+        response should haveContentEncoding(deflate)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahDeflated)
+      }
+    }
+    "produce a response compressed with the first of the specified Encoders if the request has no Accept-Encoding header" in {
+      Post("/") ~> {
+        compressResponse(Gzip, Deflate) { yeah }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), yeahGzipped)
+      }
+    }
+    "reject the request if it has an Accept-Encoding header with an encoding that doesn't match" in {
+      Post("/") ~> `Accept-Encoding`(deflate) ~> {
+        compressResponse(Gzip) { yeah }
+      } ~> check {
+        rejection shouldEqual UnacceptedResponseEncodingRejection(gzip)
+      }
+    }
+  }
+  //#
+
+  //# decompressRequest-example
+  "the decompressRequest directive" should {
+    "decompress the request content if it has a `Content-Encoding: gzip` header and the content is gzip encoded" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> {
+        decompressRequest() { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "Hello" }
+    }
+    "decompress the request content if it has a `Content-Encoding: deflate` header and the content is deflate encoded" in {
+      Post("/", helloDeflated) ~> `Content-Encoding`(deflate) ~> {
+        decompressRequest() { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "Hello" }
+    }
+    "decompress the request content if it has a `Content-Encoding: identity` header and the content is not encoded" in {
+      Post("/", "yes") ~> `Content-Encoding`(identity) ~> {
+        decompressRequest() { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "yes" }
+    }
+    "decompress the request content using NoEncoding if no Content-Encoding header is present" in {
+      Post("/", "yes") ~> decompressRequest() { echoRequestContent } ~> check { responseAs[String] shouldEqual "yes" }
+    }
+    "reject the request if it has a `Content-Encoding: deflate` header but the request is compressed with Gzip" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(deflate) ~>
+        decompressRequest() { echoRequestContent } ~> check {
+          status shouldEqual BadRequest
+          responseAs[String] shouldEqual "The request's encoding is corrupt:\nincorrect header check"
+        }
+    }
+  }
+  //#
+
+  //# decompressRequestWith-example
+  "the decompressRequestWith directive" should {
+    "decompress the request content if its `Content-Encoding` header matches the specified encoder" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> {
+        decompressRequest(Gzip) { echoRequestContent }
+      } ~> check { responseAs[String] shouldEqual "Hello" }
+    }
+    "reject the request if its `Content-Encoding` header doesn't match the specified encoder" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(deflate) ~> {
+        decompressRequest(Gzip) { echoRequestContent }
+      } ~> check {
+        rejection shouldEqual UnsupportedRequestEncodingRejection(gzip)
+      }
+    }
+    "reject the request when decompressing with GZIP and no Content-Encoding header is present" in {
+      Post("/", "yes") ~> decompressRequest(Gzip) { echoRequestContent } ~> check {
+        rejection shouldEqual UnsupportedRequestEncodingRejection(gzip)
+      }
+    }
+  }
+  //#
+
+  //# decompress-compress-combination-example
+  "the (decompressRequest & compressResponse) compound directive" should {
+    lazy val decompressCompress = (decompressRequest() & compressResponse())
+    "decompress a GZIP compressed request and produce a GZIP compressed response if the request has no Accept-Encoding header" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> {
+        decompressCompress { echoRequestContent }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), helloGzipped)
+      }
+    }
+    "decompress a GZIP compressed request and produce a Deflate compressed response if the request has an `Accept-Encoding: deflate` header" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> `Accept-Encoding`(deflate) ~> {
+        decompressCompress { echoRequestContent }
+      } ~> check {
+        response should haveContentEncoding(deflate)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), helloDeflated)
+      }
+    }
+    "decompress an uncompressed request and produce a GZIP compressed response if the request has an `Accept-Encoding: gzip` header" in {
+      Post("/", "Hello") ~> `Accept-Encoding`(gzip) ~> {
+        decompressCompress { echoRequestContent }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), helloGzipped)
+      }
+    }
+  }
+  //#
+
+  "the (decompressRequest & compressResponseIfRequested) compound directive" should {
+    lazy val decompressCompressIfRequested = (decompressRequest() & compressResponseIfRequested())
+    "decode a GZIP encoded request and produce a non-encoded response if the request has no Accept-Encoding header" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> {
+        decompressCompressIfRequested { echoRequestContent }
+      } ~> check {
+        responseAs[String] shouldEqual "Hello"
+      }
+    }
+    "decode a GZIP encoded request and produce a Deflate encoded response if the request has an `Accept-Encoding: deflate` header" in {
+      Post("/", helloGzipped) ~> `Content-Encoding`(gzip) ~> `Accept-Encoding`(deflate) ~> {
+        decompressCompressIfRequested { echoRequestContent }
+      } ~> check {
+        response should haveContentEncoding(deflate)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), helloDeflated)
+      }
+    }
+    "decode a non-encoded request and produce a GZIP encoded response if the request has an `Accept-Encoding: gzip` header" in {
+      Post("/", "Hello") ~> `Accept-Encoding`(gzip) ~> {
+        decompressCompressIfRequested { echoRequestContent }
+      } ~> check {
+        response should haveContentEncoding(gzip)
+        entity shouldEqual HttpEntity(ContentType(`text/plain`, `UTF-8`), helloGzipped)
+      }
+    }
+  }
+
+  def compress(input: String, encoder: Encoder): ByteString = {
+    val compressor = encoder.newCompressor
+    compressor.compressAndFlush(ByteString(input)) ++ compressor.finish()
+  }
+
+  def hexDump(bytes: Array[Byte]) = bytes.map("%02x" format _).mkString
+  def fromHexDump(dump: String) = dump.grouped(2).toArray.map(chars ⇒ Integer.parseInt(new String(chars), 16).toByte)
+
+  def haveNoContentEncoding: Matcher[HttpResponse] = be(None) compose { (_: HttpResponse).header[`Content-Encoding`] }
+  def haveContentEncoding(encoding: HttpEncoding): Matcher[HttpResponse] =
+    be(Some(`Content-Encoding`(encoding))) compose { (_: HttpResponse).header[`Content-Encoding`] }
+
+  def readAs(string: String, charset: String = "UTF8") = be(string) compose { (_: ByteString).decodeString(charset) }
+}

--- a/akka-http/src/main/scala/akka/http/coding/Coder.scala
+++ b/akka-http/src/main/scala/akka/http/coding/Coder.scala
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.coding
+
+/** Marker trait for A combined Encoder and Decoder */
+trait Coder extends Encoder with Decoder

--- a/akka-http/src/main/scala/akka/http/coding/Decoder.scala
+++ b/akka-http/src/main/scala/akka/http/coding/Decoder.scala
@@ -27,7 +27,7 @@ trait Decoder {
     val decompressor = newDecompressor
 
     def decodeChunk(bytes: ByteString): ByteString = decompressor.decompress(bytes)
-    def finish(): ByteString = ByteString.empty
+    def finish(): ByteString = decompressor.finish()
 
     StreamUtils.byteStringTransformer(decodeChunk, finish)
   }
@@ -36,5 +36,11 @@ trait Decoder {
 /** A stateful object representing ongoing decompression. */
 abstract class Decompressor {
   /** Decompress the buffer and return decompressed data. */
-  def decompress(buffer: ByteString): ByteString
+  def decompress(input: ByteString): ByteString
+
+  /** Flushes potential remaining data from any internal buffers and may report on truncation errors */
+  def finish(): ByteString
+
+  /** Combines decompress and finish */
+  def decompressAndFinish(input: ByteString): ByteString = decompress(input) ++ finish()
 }

--- a/akka-http/src/main/scala/akka/http/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/coding/Deflate.scala
@@ -91,10 +91,10 @@ class DeflateCompressor extends Compressor {
 class DeflateDecompressor extends Decompressor {
   protected lazy val inflater = new Inflater()
 
-  def decompress(buffer: ByteString): ByteString =
+  def decompress(input: ByteString): ByteString =
     try {
-      inflater.setInput(buffer.toArray)
-      drain(new Array[Byte](buffer.length * 2))
+      inflater.setInput(input.toArray)
+      drain(new Array[Byte](input.length * 2))
     } catch {
       case e: DataFormatException ⇒
         throw new ZipException(e.getMessage.toOption getOrElse "Invalid ZLIB data format")
@@ -105,5 +105,10 @@ class DeflateDecompressor extends Decompressor {
     if (len > 0) drain(buffer, result ++ ByteString.fromArray(buffer, 0, len))
     else if (inflater.needsDictionary) throw new ZipException("ZLIB dictionary missing")
     else result
+  }
+
+  def finish(): ByteString = {
+    inflater.end()
+    ByteString.empty
   }
 }

--- a/akka-http/src/main/scala/akka/http/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/coding/Deflate.scala
@@ -13,7 +13,7 @@ import akka.http.util._
 import akka.http.model._
 import headers.HttpEncodings
 
-class Deflate(val messageFilter: HttpMessage ⇒ Boolean) extends Decoder with Encoder {
+class Deflate(val messageFilter: HttpMessage ⇒ Boolean) extends Coder {
   val encoding = HttpEncodings.deflate
   def newCompressor = new DeflateCompressor
   def newDecompressor = new DeflateDecompressor

--- a/akka-http/src/main/scala/akka/http/coding/Gzip.scala
+++ b/akka-http/src/main/scala/akka/http/coding/Gzip.scala
@@ -13,7 +13,7 @@ import headers.HttpEncodings
 
 import scala.util.control.{ NonFatal, NoStackTrace }
 
-class Gzip(val messageFilter: HttpMessage ⇒ Boolean) extends Decoder with Encoder {
+class Gzip(val messageFilter: HttpMessage ⇒ Boolean) extends Coder {
   val encoding = HttpEncodings.gzip
   def newCompressor = new GzipCompressor
   def newDecompressor = new GzipDecompressor

--- a/akka-http/src/main/scala/akka/http/coding/Gzip.scala
+++ b/akka-http/src/main/scala/akka/http/coding/Gzip.scala
@@ -4,7 +4,6 @@
 
 package akka.http.coding
 
-import java.io.OutputStream
 import java.util.zip.{ Inflater, CRC32, ZipException, Deflater }
 import akka.util.ByteString
 
@@ -12,7 +11,7 @@ import scala.annotation.tailrec
 import akka.http.model._
 import headers.HttpEncodings
 
-import scala.util.control.NoStackTrace
+import scala.util.control.{ NonFatal, NoStackTrace }
 
 class Gzip(val messageFilter: HttpMessage ⇒ Boolean) extends Decoder with Encoder {
   val encoding = HttpEncodings.gzip
@@ -70,9 +69,7 @@ class GzipDecompressor extends DeflateDecompressor {
     def initialState = readHeaders
 
     private def readHeaders(data: ByteString): Action =
-      // header has at least size 3
-      if (data.size < 4) SuspendAndRetryWithMoreData
-      else try {
+      try {
         val reader = new ByteReader(data)
         import reader._
 
@@ -114,7 +111,7 @@ class GzipDecompressor extends DeflateDecompressor {
         case ByteReader.NeedMoreData ⇒ SuspendAndRetryWithMoreData
       }
 
-    private def fail(msg: String) = Fail(new ZipException(msg))
+    private def fail(msg: String) = throw new ZipException(msg)
 
     private def crc16(data: ByteString) = {
       val crc = new CRC32
@@ -174,8 +171,6 @@ private[http] object GzipDecompressor {
     case class ContinueWith(nextState: State, remainingInput: ByteString) extends Action
     /** Emit some output and then proceed to the nextState and immediately run it with the remainingInput */
     case class EmitAndContinueWith(output: ByteString, nextState: State, remainingInput: ByteString) extends Action
-    /** Fail with the given exception and go into the failed state which will throw for any new data */
-    case class Fail(cause: Throwable) extends Action
 
     type State = ByteString ⇒ Action
     def initialState: State
@@ -183,26 +178,31 @@ private[http] object GzipDecompressor {
     private[this] var state: State = initialState
 
     /** Run the state machine with the current input */
-    @tailrec final def run(input: ByteString, result: ByteString = ByteString.empty): ByteString =
-      state(input) match {
-        case SuspendAndRetryWithMoreData ⇒
-          val oldState = state
-          state = { newData ⇒
-            state = oldState
-            oldState(input ++ newData)
-          }
-          result
-        case EmitAndSuspend(output) ⇒ result ++ output
-        case ContinueWith(next, remainingInput) ⇒
-          state = next
-          run(remainingInput, result)
-        case EmitAndContinueWith(output, next, remainingInput) ⇒
-          state = next
-          run(remainingInput, result ++ output)
-        case Fail(cause) ⇒
+    final def run(input: ByteString): ByteString = {
+      @tailrec def rec(input: ByteString, result: ByteString = ByteString.empty): ByteString =
+        state(input) match {
+          case SuspendAndRetryWithMoreData ⇒
+            val oldState = state
+            state = { newData ⇒
+              state = oldState
+              oldState(input ++ newData)
+            }
+            result
+          case EmitAndSuspend(output) ⇒ result ++ output
+          case ContinueWith(next, remainingInput) ⇒
+            state = next
+            rec(remainingInput, result)
+          case EmitAndContinueWith(output, next, remainingInput) ⇒
+            state = next
+            rec(remainingInput, result ++ output)
+        }
+      try rec(input)
+      catch {
+        case NonFatal(e) ⇒
           state = failState
-          throw cause
+          throw e
       }
+    }
 
     private def failState: State = _ ⇒ throw new IllegalStateException("Trying to reuse failed decompressor.")
   }

--- a/akka-http/src/main/scala/akka/http/coding/NoCoding.scala
+++ b/akka-http/src/main/scala/akka/http/coding/NoCoding.scala
@@ -35,4 +35,5 @@ object NoCodingCompressor extends Compressor {
 }
 object NoCodingDecompressor extends Decompressor {
   def decompress(input: ByteString): ByteString = input
+  def finish(): ByteString = ByteString.empty
 }

--- a/akka-http/src/main/scala/akka/http/coding/NoCoding.scala
+++ b/akka-http/src/main/scala/akka/http/coding/NoCoding.scala
@@ -11,7 +11,7 @@ import headers.HttpEncodings
 /**
  * An encoder and decoder for the HTTP 'identity' encoding.
  */
-object NoEncoding extends Decoder with Encoder {
+object NoCoding extends Coder {
   val encoding = HttpEncodings.identity
 
   override def encode[T <: HttpMessage](message: T)(implicit mapper: DataMapper[T]): T#Self = message.self
@@ -21,11 +21,11 @@ object NoEncoding extends Decoder with Encoder {
 
   val messageFilter: HttpMessage ⇒ Boolean = _ ⇒ false
 
-  def newCompressor = NoEncodingCompressor
-  def newDecompressor = NoEncodingDecompressor
+  def newCompressor = NoCodingCompressor
+  def newDecompressor = NoCodingDecompressor
 }
 
-object NoEncodingCompressor extends Compressor {
+object NoCodingCompressor extends Compressor {
   def compress(input: ByteString): ByteString = input
   def flush() = ByteString.empty
   def finish() = ByteString.empty
@@ -33,6 +33,6 @@ object NoEncodingCompressor extends Compressor {
   def compressAndFlush(input: ByteString): ByteString = input
   def compressAndFinish(input: ByteString): ByteString = input
 }
-object NoEncodingDecompressor extends Decompressor {
+object NoCodingDecompressor extends Decompressor {
   def decompress(input: ByteString): ByteString = input
 }

--- a/akka-http/src/main/scala/akka/http/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/server/Directives.scala
@@ -14,7 +14,7 @@ trait Directives extends RouteConcatenation
   //with ChunkingDirectives
   //with CookieDirectives
   //with DebuggingDirectives
-  //with EncodingDirectives
+  with CodingDirectives
   with ExecutionDirectives
   //with FileAndResourceDirectives
   //with FormFieldDirectives

--- a/akka-http/src/main/scala/akka/http/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/server/Rejection.scala
@@ -92,12 +92,6 @@ case class UnsatisfiableRangeRejection(unsatisfiableRanges: Seq[ByteRange], actu
 case class TooManyRangesRejection(maxRanges: Int) extends Rejection
 
 /**
- * Rejection created by decoding filters.
- * Signals that the request was rejected because the requests content is corrupted.
- */
-case class CorruptRequestEncodingRejection(msg: String) extends Rejection
-
-/**
  * Rejection created by unmarshallers.
  * Signals that the request was rejected because there was an error while unmarshalling the request content
  */

--- a/akka-http/src/main/scala/akka/http/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/server/RejectionHandler.scala
@@ -40,9 +40,6 @@ object RejectionHandler {
       case AuthorizationFailedRejection :: _ ⇒
       complete(Forbidden, "The supplied authentication is not authorized to access this resource")
 
-    case CorruptRequestEncodingRejection(msg) :: _ ⇒
-      complete(BadRequest, "The requests encoding is corrupt:\n" + msg)
-
     case MalformedFormFieldRejection(name, msg, _) :: _ ⇒
       complete(BadRequest, "The form field '" + name + "' was malformed:\n" + msg)
 

--- a/akka-http/src/main/scala/akka/http/server/directives/CodingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/server/directives/CodingDirectives.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.server
+package directives
+
+import akka.http.util._
+import akka.http.model._
+import headers.HttpEncoding
+import akka.http.coding._
+import scala.util.control.NonFatal
+
+trait CodingDirectives {
+  import BasicDirectives._
+  import MiscDirectives._
+  import RouteDirectives._
+  import CodingDirectives._
+
+  // encoding
+
+  /**
+   * Wraps its inner Route with encoding support using the given Encoder.
+   */
+  def encodeResponse(encoder: Encoder): Directive0 =
+    responseEncodingAccepted(encoder.encoding) &
+      mapHttpResponse(encoder.encode(_)) &
+      cancelRejections(classOf[UnacceptedResponseEncodingRejection])
+
+  /**
+   * Rejects the request with an UnacceptedResponseEncodingRejection
+   * if the given encoding is not accepted for the response.
+   */
+  def responseEncodingAccepted(encoding: HttpEncoding): Directive0 =
+    extract(_.request.isEncodingAccepted(encoding))
+      .flatMap(if (_) pass else reject(UnacceptedResponseEncodingRejection(encoding)))
+
+  /**
+   * Wraps its inner Route with response compression, using the specified
+   * encoders in the given order of preference.
+   * If no encoders are specifically given Gzip, Deflate and NoEncoding
+   * are used in this order, depending on what the client accepts.
+   */
+  def compressResponse(encoders: Encoder*): Directive0 =
+    theseOrDefault(encoders).map(encodeResponse(_)).reduce(_ | _)
+
+  /**
+   * Wraps its inner Route with response compression if and only if the client
+   * specifically requests compression with an `Accept-Encoding` header.
+   */
+  def compressResponseIfRequested(): Directive0 = compressResponse(NoCoding, Gzip, Deflate)
+
+  // decoding
+
+  /**
+   * Wraps its inner Route with decoding support using the given Decoder.
+   */
+  def decodeRequest(decoder: Decoder): Directive0 = {
+    def applyDecoder =
+      mapRequest(decoder.decode(_).mapEntity(StreamUtils.mapEntityError {
+        case NonFatal(e) ⇒
+          new IllegalRequestException(
+            StatusCodes.BadRequest,
+            ErrorInfo(s"The request's encoding is corrupt:\n${e.getMessage}"))
+      }))
+
+    requestEntityEmpty | (
+      requestEncodedWith(decoder.encoding) &
+      applyDecoder &
+      cancelRejections(classOf[UnsupportedRequestEncodingRejection]))
+  }
+
+  /**
+   * Rejects the request with an UnsupportedRequestEncodingRejection if its encoding doesn't match the given one.
+   */
+  def requestEncodedWith(encoding: HttpEncoding): Directive0 =
+    extract(_.request.encoding).flatMap {
+      case `encoding` ⇒ pass
+      case _          ⇒ reject(UnsupportedRequestEncodingRejection(encoding))
+    }
+
+  /**
+   * Decompresses the incoming request if it is encoded with one of the given
+   * encoders. If the request encoding doesn't match one of the given encoders
+   * the request is rejected with an `UnsupportedRequestEncodingRejection`.
+   */
+  def decompressRequest(decoders: Decoder*): Directive0 =
+    theseOrDefault(decoders).map(decodeRequest).reduce(_ | _)
+}
+
+object CodingDirectives extends CodingDirectives {
+  val defaultCoders: Seq[Coder] = Seq(Gzip, Deflate, NoCoding)
+  def theseOrDefault[T >: Coder](these: Seq[T]): Seq[T] =
+    if (these.isEmpty) defaultCoders
+    else these
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
@@ -47,7 +47,7 @@ object Sink {
    * A `Sink` that immediately cancels its upstream after materialization.
    */
   def cancelled[T]: Drain[T] = CancelDrain
-  
+
   private def createSinkFromBuilder[T](builder: FlowGraphBuilder, block: FlowGraphBuilder ⇒ UndefinedSource[T]): Sink[T] = {
     val in = block(builder)
     builder.partialBuild().toSink(in)


### PR DESCRIPTION
Fixes #15921, #16064, #16067 

This was actually quite some fun. Thanks to the implicit context now being carried by the RequestContext, I abandoned all of Spray's magnets in EncodingDirectives in the nearby park where they now roam trying to attract some easy prey... :rabbit: :whale: :fried_shrimp: 

/cc @sirthias
