### PR TITLE
16087, 16088 fix RouteResult handling support in routing infrastructure

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/util/FastFutureSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/util/FastFutureSpec.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.util
+
+import org.scalatest.{ FreeSpec, Matchers }
+
+import scala.concurrent.{ Await, Promise, Future }
+import scala.concurrent.duration._
+import scala.util.{ Try, Failure, Success }
+import akka.http.util.FastFuture._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.control.NoStackTrace
+
+class FastFutureSpec extends FreeSpec with Matchers {
+  object TheException extends RuntimeException("Expected exception") with NoStackTrace
+
+  "FastFuture should implement" - {
+    "transformWith(Try => Future)" - {
+      "Success -> Success" in {
+        test(Success(23), _.transformWith(t ⇒ FastFuture(t.map(_ + 19)))) {
+          _ shouldEqual Success(42)
+        }
+      }
+      "Success -> Failure" in {
+        test(Success(23), _.transformWith(_ ⇒ FastFuture.failed(TheException))) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "Failure -> Success" in {
+        test(Failure(TheException), _.transformWith(t ⇒ FastFuture.successful(23))) {
+          _ shouldEqual Success(23)
+        }
+      }
+      "Failure -> Failure" in {
+        test(Failure(TheException), _.transformWith(_ ⇒ FastFuture.failed(TheException))) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "Success -> user-function failed" in {
+        test(Success(23), _.transformWith(failF)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "Failure -> user-function failed" in {
+        test(Failure(TheException), _.transformWith(failF)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+    }
+    "transformWith(A => Future[B], Throwable => Future[B])" - {
+      "Success -> Success" in {
+        test(Success(23), _.transformWith(t ⇒ FastFuture.successful(t + 19), neverCalled)) {
+          _ shouldEqual Success(42)
+        }
+      }
+      "Success -> Failure" in {
+        test(Success(23), _.transformWith(_ ⇒ FastFuture.failed(TheException), neverCalled)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "Failure -> Success" in {
+        test(Failure(TheException), _.transformWith(neverCalled, t ⇒ FastFuture.successful(23))) {
+          _ shouldEqual Success(23)
+        }
+      }
+      "Failure -> Failure" in {
+        test(Failure(TheException), _.transformWith(neverCalled, _ ⇒ FastFuture.failed(TheException))) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "Success -> user-function failed" in {
+        test(Success(23), _.transformWith(failF, neverCalled)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "Failure -> user-function failed" in {
+        test(Failure(TheException), _.transformWith(neverCalled, failF)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+    }
+    "map" - {
+      "map success" in {
+        test(Success(23), _.map(_ + 19)) {
+          _ shouldEqual Success(42)
+        }
+      }
+      "report exceptions from user function" in {
+        test(Success(23), _.map(failF)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "propagate errors" in {
+        test(Failure(TheException), _.map(neverCalled)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+    }
+    "flatMap" - {
+      "both success" in {
+        test(Success(23), _.flatMap(i ⇒ FastFuture.successful(i + 19))) {
+          _ shouldEqual Success(42)
+        }
+      }
+      "outer failure" in {
+        test(Failure(TheException), _.flatMap(neverCalled)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "inner failure" in {
+        test(Success(23), _.flatMap(i ⇒ FastFuture.failed(TheException))) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "user-func failure" in {
+        test(Success(23), _.flatMap(failF)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+    }
+    "recoverWith" - {
+      "Success" in {
+        test(Success(23), _.recoverWith(neverCalled)) {
+          _ shouldEqual Success(23)
+        }
+      }
+      "Failure -> Success" in {
+        test(Failure(UnexpectedException), _.recoverWith { case _ ⇒ FastFuture.successful(23) }) {
+          _ shouldEqual Success(23)
+        }
+      }
+      "Failure -> Failure" in {
+        test(Failure(UnexpectedException), _.recoverWith { case _ ⇒ FastFuture.failed(TheException) }) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+      "user-function failed" in {
+        test(Failure(UnexpectedException), _.recoverWith(failF)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+    }
+    "recover" - {
+      "Success" in {
+        test(Success(23), _.recover(neverCalled)) {
+          _ shouldEqual Success(23)
+        }
+      }
+      "Failure -> Success" in {
+        test(Failure(UnexpectedException), _.recover { case _ ⇒ 23 }) {
+          _ shouldEqual Success(23)
+        }
+      }
+      "user-function failed" in {
+        test(Failure(UnexpectedException), _.recoverWith(failF)) {
+          _ shouldEqual Failure(TheException)
+        }
+      }
+    }
+  }
+
+  def test(result: Try[Int], op: FastFuture[Int] ⇒ Future[Int])(check: Try[Int] ⇒ Unit): Unit = {
+    def testStrictly(): Unit = {
+      val f = FastFuture(result)
+      check(op(f.fast).value.get)
+    }
+    def testLazily(): Unit = {
+      val p = Promise[Int]
+      val opped = op(p.future.fast)
+      p.complete(result)
+      Await.ready(opped, 100.millis)
+      check(opped.value.get)
+    }
+    testStrictly()
+    testLazily()
+  }
+
+  def failF: PartialFunction[Any, Nothing] = PartialFunction(_ ⇒ throw TheException)
+  class UnexpectedException extends RuntimeException("Unexpected exception - should never happen")
+  object UnexpectedException extends UnexpectedException with NoStackTrace
+  def neverCalled: PartialFunction[Any, Nothing] = PartialFunction(_ ⇒ throw new UnexpectedException)
+}

--- a/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTest.scala
@@ -83,7 +83,7 @@ trait RouteTest extends RequestBuilding with RouteTestResultComponent {
     case _                                      ⇒ Nil
   }
 
-  def rejections: List[Rejection] = result.rejections
+  def rejections: immutable.Seq[Rejection] = result.rejections
   def rejection: Rejection = {
     val r = rejections
     if (r.size == 1) r.head else failTest("Expected a single rejection but got %s (%s)".format(r.size, r))

--- a/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTestResultComponent.scala
@@ -21,12 +21,12 @@ trait RouteTestResultComponent {
    * A receptacle for the response or rejections created by a route.
    */
   class RouteTestResult(timeout: FiniteDuration)(implicit fm: FlowMaterializer) {
-    private[this] var result: Option[Either[List[Rejection], HttpResponse]] = None
+    private[this] var result: Option[Either[immutable.Seq[Rejection], HttpResponse]] = None
     private[this] val latch = new CountDownLatch(1)
 
     def handled: Boolean = synchronized { result.isDefined && result.get.isRight }
 
-    def rejections: List[Rejection] = synchronized {
+    def rejections: immutable.Seq[Rejection] = synchronized {
       result match {
         case Some(Left(rejections)) ⇒ rejections
         case Some(Right(response))  ⇒ failTest("Request was not rejected, response was " + response)

--- a/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTestResultComponent.scala
@@ -63,7 +63,6 @@ trait RouteTestResultComponent {
           result = rr match {
             case RouteResult.Complete(response)   ⇒ Some(Right(response))
             case RouteResult.Rejected(rejections) ⇒ Some(Left(RejectionHandler.applyTransformations(rejections)))
-            case RouteResult.Failure(error)       ⇒ sys.error("Route produced exception: " + error)
           }
           latch.countDown()
         } else failTest("Route completed/rejected more than once")

--- a/akka-http-testkit/src/test/scala/akka/http/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/testkit/ScalatestRouteTestSpec.scala
@@ -77,5 +77,5 @@ class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteT
 
   // TODO: remove once RespondWithDirectives have been ported
   def respondWithHeader(responseHeader: HttpHeader): Directive0 =
-    mapHttpResponseHeaders(responseHeader +: _)
+    mapResponseHeaders(responseHeader +: _)
 }

--- a/akka-http-tests/src/test/scala/akka/http/server/BasicRouteSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/server/BasicRouteSpecs.scala
@@ -4,7 +4,9 @@
 
 package akka.http.server
 
-import akka.http.model.HttpMethods._
+import akka.http.model
+import model.HttpMethods._
+import model.StatusCodes
 import akka.http.server.PathMatchers.{ Segment, IntNumber }
 
 class BasicRouteSpecs extends RoutingSpec {
@@ -72,6 +74,23 @@ class BasicRouteSpecs extends RoutingSpec {
           complete(s"$str ${i + i2} $str2")
         }
       } ~> check { responseAs[String] shouldEqual "The cat 84 The cat" }
+    }
+  }
+  "Route disjunction" should {
+    "work" in {
+      val route = sealRoute((path("abc") | path("def")) {
+        completeOk
+      })
+
+      Get("/abc") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+      Get("/def") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+      Get("/ghi") ~> route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
     }
   }
   "Case class extraction with Directive.as" should {

--- a/akka-http/src/main/scala/akka/http/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/server/Rejection.scala
@@ -7,6 +7,8 @@ package akka.http.server
 import akka.http.model._
 import akka.http.model.headers.{ ByteRange, HttpEncoding }
 
+import scala.collection.immutable
+
 /**
  * A rejection encapsulates a specific reason why a Route was not able to handle a request. Rejections are gathered
  * up over the course of a Route evaluation and finally converted to [[spray.http.HttpResponse]]s by the
@@ -179,7 +181,7 @@ case class ValidationRejection(message: String, cause: Option[Throwable] = None)
  * MethodRejection added by the ``get`` directive is cancelled by the ``put`` directive (since the HTTP method
  * did indeed match eventually).
  */
-case class TransformationRejection(transform: List[Rejection] ⇒ List[Rejection]) extends Rejection
+case class TransformationRejection(transform: immutable.Seq[Rejection] ⇒ immutable.Seq[Rejection]) extends Rejection
 
 /**
  * A Throwable wrapping a Rejection.

--- a/akka-http/src/main/scala/akka/http/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/server/RejectionHandler.scala
@@ -4,6 +4,7 @@
 
 package akka.http.server
 
+import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import akka.http.model._
 import StatusCodes._
@@ -16,102 +17,102 @@ trait RejectionHandler extends RejectionHandler.PF {
 }
 
 object RejectionHandler {
-  type PF = PartialFunction[List[Rejection], Route]
+  type PF = PartialFunction[immutable.Seq[Rejection], Route]
 
   implicit def apply(pf: PF): RejectionHandler = apply(default = false)(pf)
 
   private def apply(default: Boolean)(pf: PF): RejectionHandler =
     new RejectionHandler {
       def isDefault = default
-      def isDefinedAt(rejections: List[Rejection]) = pf.isDefinedAt(rejections)
-      def apply(rejections: List[Rejection]) = pf(rejections)
+      def isDefinedAt(rejections: immutable.Seq[Rejection]) = pf.isDefinedAt(rejections)
+      def apply(rejections: immutable.Seq[Rejection]) = pf(rejections)
     }
 
   def default(implicit ec: ExecutionContext) = apply(default = true) {
     case Nil ⇒ complete(NotFound, "The requested resource could not be found.")
 
-    case AuthenticationFailedRejection(cause, challengeHeaders) :: _ ⇒
+    case AuthenticationFailedRejection(cause, challengeHeaders) +: _ ⇒
       val rejectionMessage = cause match {
         case CredentialsMissing  ⇒ "The resource requires authentication, which was not supplied with the request"
         case CredentialsRejected ⇒ "The supplied authentication is invalid"
       }
       ctx ⇒ ctx.complete(Unauthorized, challengeHeaders, rejectionMessage)
 
-      case AuthorizationFailedRejection :: _ ⇒
+      case AuthorizationFailedRejection +: _ ⇒
       complete(Forbidden, "The supplied authentication is not authorized to access this resource")
 
-    case MalformedFormFieldRejection(name, msg, _) :: _ ⇒
+    case MalformedFormFieldRejection(name, msg, _) +: _ ⇒
       complete(BadRequest, "The form field '" + name + "' was malformed:\n" + msg)
 
-    case MalformedHeaderRejection(headerName, msg, _) :: _ ⇒
+    case MalformedHeaderRejection(headerName, msg, _) +: _ ⇒
       complete(BadRequest, s"The value of HTTP header '$headerName' was malformed:\n" + msg)
 
-    case MalformedQueryParamRejection(name, msg, _) :: _ ⇒
+    case MalformedQueryParamRejection(name, msg, _) +: _ ⇒
       complete(BadRequest, "The query parameter '" + name + "' was malformed:\n" + msg)
 
-    case MalformedRequestContentRejection(msg, _) :: _ ⇒
+    case MalformedRequestContentRejection(msg, _) +: _ ⇒
       complete(BadRequest, "The request content was malformed:\n" + msg)
 
-    case rejections @ (MethodRejection(_) :: _) ⇒
+    case rejections @ (MethodRejection(_) +: _) ⇒
       val methods = rejections.collect { case MethodRejection(method) ⇒ method }
       complete(MethodNotAllowed, List(Allow(methods)), "HTTP method not allowed, supported methods: " + methods.mkString(", "))
 
-    case rejections @ (SchemeRejection(_) :: _) ⇒
+    case rejections @ (SchemeRejection(_) +: _) ⇒
       val schemes = rejections.collect { case SchemeRejection(scheme) ⇒ scheme }
       complete(BadRequest, "Uri scheme not allowed, supported schemes: " + schemes.mkString(", "))
 
-    case MissingCookieRejection(cookieName) :: _ ⇒
+    case MissingCookieRejection(cookieName) +: _ ⇒
       complete(BadRequest, "Request is missing required cookie '" + cookieName + '\'')
 
-    case MissingFormFieldRejection(fieldName) :: _ ⇒
+    case MissingFormFieldRejection(fieldName) +: _ ⇒
       complete(BadRequest, "Request is missing required form field '" + fieldName + '\'')
 
-    case MissingHeaderRejection(headerName) :: _ ⇒
+    case MissingHeaderRejection(headerName) +: _ ⇒
       complete(BadRequest, "Request is missing required HTTP header '" + headerName + '\'')
 
-    case MissingQueryParamRejection(paramName) :: _ ⇒
+    case MissingQueryParamRejection(paramName) +: _ ⇒
       complete(NotFound, "Request is missing required query parameter '" + paramName + '\'')
 
-    case RequestEntityExpectedRejection :: _ ⇒
+    case RequestEntityExpectedRejection +: _ ⇒
       complete(BadRequest, "Request entity expected but not supplied")
 
-    case TooManyRangesRejection(_) :: _ ⇒
+    case TooManyRangesRejection(_) +: _ ⇒
       complete(RequestedRangeNotSatisfiable, "Request contains too many ranges.")
 
-    case UnsatisfiableRangeRejection(unsatisfiableRanges, actualEntityLength) :: _ ⇒
+    case UnsatisfiableRangeRejection(unsatisfiableRanges, actualEntityLength) +: _ ⇒
       complete(RequestedRangeNotSatisfiable, List(`Content-Range`(ContentRange.Unsatisfiable(actualEntityLength))),
         unsatisfiableRanges.mkString("None of the following requested Ranges were satisfiable:\n", "\n", ""))
 
-    case rejections @ (UnacceptedResponseContentTypeRejection(_) :: _) ⇒
+    case rejections @ (UnacceptedResponseContentTypeRejection(_) +: _) ⇒
       val supported = rejections.flatMap {
         case UnacceptedResponseContentTypeRejection(supported) ⇒ supported
         case _ ⇒ Nil
       }
       complete(NotAcceptable, "Resource representation is only available with these Content-Types:\n" + supported.map(_.value).mkString("\n"))
 
-    case rejections @ (UnacceptedResponseEncodingRejection(_) :: _) ⇒
+    case rejections @ (UnacceptedResponseEncodingRejection(_) +: _) ⇒
       val supported = rejections.collect { case UnacceptedResponseEncodingRejection(supported) ⇒ supported }
       complete(NotAcceptable, "Resource representation is only available with these Content-Encodings:\n" + supported.map(_.value).mkString("\n"))
 
-    case rejections @ (UnsupportedRequestContentTypeRejection(_) :: _) ⇒
+    case rejections @ (UnsupportedRequestContentTypeRejection(_) +: _) ⇒
       val supported = rejections.collect { case UnsupportedRequestContentTypeRejection(supported) ⇒ supported }
       complete(UnsupportedMediaType, "There was a problem with the requests Content-Type:\n" + supported.mkString(" or "))
 
-    case rejections @ (UnsupportedRequestEncodingRejection(_) :: _) ⇒
+    case rejections @ (UnsupportedRequestEncodingRejection(_) +: _) ⇒
       val supported = rejections.collect { case UnsupportedRequestEncodingRejection(supported) ⇒ supported }
       complete(BadRequest, "The requests Content-Encoding must be one the following:\n" + supported.map(_.value).mkString("\n"))
 
-    case ValidationRejection(msg, _) :: _ ⇒
+    case ValidationRejection(msg, _) +: _ ⇒
       complete(BadRequest, msg)
 
-    case x :: _ ⇒ sys.error("Unhandled rejection: " + x)
+    case x +: _ ⇒ sys.error("Unhandled rejection: " + x)
   }
 
   /**
    * Filters out all TransformationRejections from the given sequence and applies them (in order) to the
    * remaining rejections.
    */
-  def applyTransformations(rejections: List[Rejection]): List[Rejection] = {
+  def applyTransformations(rejections: immutable.Seq[Rejection]): immutable.Seq[Rejection] = {
     val (transformations, rest) = rejections.partition(_.isInstanceOf[TransformationRejection])
     (rest.distinct /: transformations.asInstanceOf[Seq[TransformationRejection]]) {
       case (remaining, transformation) ⇒ transformation.transform(remaining)

--- a/akka-http/src/main/scala/akka/http/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/server/RequestContext.scala
@@ -107,12 +107,12 @@ trait RequestContext {
   /**
    * Returns a copy of this context with the given rejection transformation function chained into the response chain.
    */
-  def withRejectionsMapped(f: List[Rejection] ⇒ List[Rejection]): RequestContext
+  def withRejectionsMapped(f: immutable.Seq[Rejection] ⇒ immutable.Seq[Rejection]): RequestContext
 
   /**
    * Returns a copy of this context with the given rejection handling function chained into the response chain.
    */
-  def withRejectionHandling(f: List[Rejection] ⇒ Future[RouteResult]): RequestContext
+  def withRejectionHandling(f: immutable.Seq[Rejection] ⇒ Future[RouteResult]): RequestContext
 
   /**
    * Returns a copy of this context with the given exception handling function chained into the response chain.

--- a/akka-http/src/main/scala/akka/http/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/server/RequestContext.scala
@@ -4,7 +4,6 @@
 
 package akka.http.server
 
-import scala.collection.immutable
 import scala.concurrent.{ Future, ExecutionContext }
 import akka.event.LoggingAdapter
 import akka.http.marshalling.ToResponseMarshallable
@@ -73,56 +72,6 @@ trait RequestContext {
    * Returns a copy of this context with the unmatchedPath transformed by the given function.
    */
   def withUnmatchedPathMapped(f: Uri.Path ⇒ Uri.Path): RequestContext
-
-  /**
-   * Returns a copy of this context with the given response transformation function chained into the response chain.
-   */
-  def withRouteResponseMapped(f: RouteResult ⇒ RouteResult): RequestContext
-
-  /**
-   * Returns a copy of this context with the given response transformation function chained into the response chain.
-   */
-  def withRouteResponseMappedPF(f: PartialFunction[RouteResult, RouteResult]): RequestContext
-
-  /**
-   * Returns a copy of this context with the given response transformation function chained into the response chain.
-   */
-  def withRouteResponseFlatMapped(f: RouteResult ⇒ Future[RouteResult]): RequestContext
-
-  /**
-   * Returns a copy of this context with the given response transformation function chained into the response chain.
-   */
-  def withHttpResponseMapped(f: HttpResponse ⇒ HttpResponse): RequestContext
-
-  /**
-   * Returns a copy of this context with the given response transformation function chained into the response chain.
-   */
-  def withHttpResponseEntityMapped(f: ResponseEntity ⇒ ResponseEntity): RequestContext
-
-  /**
-   * Returns a copy of this context with the given response transformation function chained into the response chain.
-   */
-  def withHttpResponseHeadersMapped(f: immutable.Seq[HttpHeader] ⇒ immutable.Seq[HttpHeader]): RequestContext
-
-  /**
-   * Returns a copy of this context with the given rejection transformation function chained into the response chain.
-   */
-  def withRejectionsMapped(f: immutable.Seq[Rejection] ⇒ immutable.Seq[Rejection]): RequestContext
-
-  /**
-   * Returns a copy of this context with the given rejection handling function chained into the response chain.
-   */
-  def withRejectionHandling(f: immutable.Seq[Rejection] ⇒ Future[RouteResult]): RequestContext
-
-  /**
-   * Returns a copy of this context with the given exception handling function chained into the response chain.
-   */
-  def withExceptionHandling(pf: PartialFunction[Throwable, Future[RouteResult]]): RequestContext
-
-  /**
-   * Returns a copy of this context with the given function handling a part of the response space.
-   */
-  def withRouteResponseHandling(pf: PartialFunction[RouteResult, Future[RouteResult]]): RequestContext
 
   /**
    * Removes a potentially existing Accept header from the request headers.

--- a/akka-http/src/main/scala/akka/http/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/server/RequestContextImpl.scala
@@ -38,7 +38,7 @@ private[http] class RequestContextImpl(
       .fast.flatMap(finish)(executionContext)
 
   override def reject(rejections: Rejection*): Future[RouteResult] =
-    finish(RouteResult.rejected(rejections.toList))
+    finish(RouteResult.rejected(rejections.toVector))
 
   override def fail(error: Throwable): Future[RouteResult] =
     finish(RouteResult.failure(error))
@@ -75,12 +75,12 @@ private[http] class RequestContextImpl(
   override def withHttpResponseHeadersMapped(f: immutable.Seq[HttpHeader] ⇒ immutable.Seq[HttpHeader]): RequestContext =
     withHttpResponseMapped(_ mapHeaders f)
 
-  override def withRejectionsMapped(f: List[Rejection] ⇒ List[Rejection]): RequestContext =
+  override def withRejectionsMapped(f: immutable.Seq[Rejection] ⇒ immutable.Seq[Rejection]): RequestContext =
     withRouteResponseMappedPF {
       case RouteResult.Rejected(rejs) ⇒ RouteResult.rejected(f(rejs))
     }
 
-  override def withRejectionHandling(f: List[Rejection] ⇒ Future[RouteResult]): RequestContext =
+  override def withRejectionHandling(f: immutable.Seq[Rejection] ⇒ Future[RouteResult]): RequestContext =
     withRouteResponseHandling {
       case RouteResult.Rejected(rejs) ⇒
         // `finish` is *not* chained in here, because the user already applied it when creating the result of f

--- a/akka-http/src/main/scala/akka/http/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/server/RequestContextImpl.scala
@@ -4,11 +4,10 @@
 
 package akka.http.server
 
-import scala.collection.immutable
 import scala.concurrent.{ Future, ExecutionContext }
 import akka.event.LoggingAdapter
 import akka.http.marshalling.ToResponseMarshallable
-import akka.http.util.{ FastFuture, identityFunc }
+import akka.http.util.FastFuture
 import akka.http.model._
 import FastFuture._
 
@@ -19,8 +18,7 @@ private[http] class RequestContextImpl(
   val request: HttpRequest,
   val unmatchedPath: Uri.Path,
   val executionContext: ExecutionContext,
-  val log: LoggingAdapter,
-  finish: RouteResult ⇒ Future[RouteResult] = FastFuture.successful) extends RequestContext {
+  val log: LoggingAdapter) extends RequestContext {
 
   def this(request: HttpRequest, log: LoggingAdapter)(implicit ec: ExecutionContext) =
     this(request, request.uri.path, ec, log)
@@ -33,15 +31,13 @@ private[http] class RequestContextImpl(
       .fast.map(res ⇒ RouteResult.complete(res))(executionContext)
       .fast.recover {
         case RejectionError(rej) ⇒ RouteResult.rejected(rej :: Nil)
-        case error               ⇒ RouteResult.failure(error)
       }(executionContext)
-      .fast.flatMap(finish)(executionContext)
 
   override def reject(rejections: Rejection*): Future[RouteResult] =
-    finish(RouteResult.rejected(rejections.toVector))
+    FastFuture.successful(RouteResult.rejected(rejections.toVector))
 
   override def fail(error: Throwable): Future[RouteResult] =
-    finish(RouteResult.failure(error))
+    FastFuture.failed(error)
 
   override def withRequest(req: HttpRequest): RequestContext =
     copy(request = req)
@@ -55,55 +51,12 @@ private[http] class RequestContextImpl(
   override def withUnmatchedPathMapped(f: Uri.Path ⇒ Uri.Path): RequestContext =
     copy(unmatchedPath = f(unmatchedPath))
 
-  override def withRouteResponseMapped(f: RouteResult ⇒ RouteResult): RequestContext =
-    copy(finish = f andThen finish)
-
-  override def withRouteResponseMappedPF(pf: PartialFunction[RouteResult, RouteResult]): RequestContext =
-    withRouteResponseMapped(pf.applyOrElse(_, identityFunc[RouteResult]))
-
-  override def withRouteResponseFlatMapped(f: RouteResult ⇒ Future[RouteResult]): RequestContext =
-    copy(finish = rr ⇒ f(rr).fast.flatMap(finish)(executionContext))
-
-  override def withHttpResponseMapped(f: HttpResponse ⇒ HttpResponse): RequestContext =
-    withRouteResponseMappedPF {
-      case RouteResult.Complete(response) ⇒ RouteResult.complete(f(response))
-    }
-
-  override def withHttpResponseEntityMapped(f: ResponseEntity ⇒ ResponseEntity): RequestContext =
-    withHttpResponseMapped(_ mapEntity f)
-
-  override def withHttpResponseHeadersMapped(f: immutable.Seq[HttpHeader] ⇒ immutable.Seq[HttpHeader]): RequestContext =
-    withHttpResponseMapped(_ mapHeaders f)
-
-  override def withRejectionsMapped(f: immutable.Seq[Rejection] ⇒ immutable.Seq[Rejection]): RequestContext =
-    withRouteResponseMappedPF {
-      case RouteResult.Rejected(rejs) ⇒ RouteResult.rejected(f(rejs))
-    }
-
-  override def withRejectionHandling(f: immutable.Seq[Rejection] ⇒ Future[RouteResult]): RequestContext =
-    withRouteResponseHandling {
-      case RouteResult.Rejected(rejs) ⇒
-        // `finish` is *not* chained in here, because the user already applied it when creating the result of f
-        f(rejs)
-    }
-
-  override def withExceptionHandling(pf: PartialFunction[Throwable, Future[RouteResult]]): RequestContext =
-    withRouteResponseHandling {
-      case RouteResult.Failure(error) if pf isDefinedAt error ⇒
-        // `finish` is *not* chained in here, because the user already applied it when creating the result of pf
-        pf(error)
-    }
-
-  def withRouteResponseHandling(pf: PartialFunction[RouteResult, Future[RouteResult]]): RequestContext =
-    copy(finish = pf.applyOrElse(_, finish))
-
   override def withContentNegotiationDisabled: RequestContext =
     copy(request = request.withHeaders(request.headers filterNot (_.isInstanceOf[headers.Accept])))
 
   private def copy(request: HttpRequest = request,
                    unmatchedPath: Uri.Path = unmatchedPath,
                    executionContext: ExecutionContext = executionContext,
-                   log: LoggingAdapter = log,
-                   finish: RouteResult ⇒ Future[RouteResult] = finish) =
-    new RequestContextImpl(request, unmatchedPath, executionContext, log, finish)
+                   log: LoggingAdapter = log) =
+    new RequestContextImpl(request, unmatchedPath, executionContext, log)
 }

--- a/akka-http/src/main/scala/akka/http/server/RouteConcatenation.scala
+++ b/akka-http/src/main/scala/akka/http/server/RouteConcatenation.scala
@@ -9,18 +9,14 @@ trait RouteConcatenation {
   implicit def enhanceRouteWithConcatenation(route: Route) = new RouteConcatenation(route: Route)
 
   class RouteConcatenation(route: Route) {
-
     /**
      * Returns a Route that chains two Routes. If the first Route rejects the request the second route is given a
      * chance to act upon the request.
      */
-    def ~(other: Route): Route = { ctx ⇒
-      route {
-        ctx.withRejectionHandling { rejections ⇒
-          other(ctx.withRejectionsMapped(rejections ++ _))
-        }
-      }
-    }
+    def ~(other: Route): Route = ctx ⇒
+      route(ctx).recoverRejectionsWith(outerRejections ⇒
+        other(ctx).recoverRejections(innerRejections ⇒
+          RouteResult.rejected(outerRejections ++ innerRejections))(ctx.executionContext))(ctx.executionContext)
   }
 
 }

--- a/akka-http/src/main/scala/akka/http/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/server/RouteResult.scala
@@ -4,6 +4,8 @@
 
 package akka.http.server
 
+import scala.collection.immutable
+
 import akka.http.model.HttpResponse
 
 /**
@@ -17,8 +19,8 @@ sealed trait RouteResult
 object RouteResult {
   final case class Complete private[RouteResult] (response: HttpResponse) extends RouteResult
   final case class Failure private[RouteResult] (exception: Throwable) extends RouteResult
-  final case class Rejected private[RouteResult] (rejections: List[Rejection]) extends RouteResult
+  final case class Rejected private[RouteResult] (rejections: immutable.Seq[Rejection]) extends RouteResult
   private[http] def complete(response: HttpResponse) = Complete(response)
   private[http] def failure(exception: Throwable) = Failure(exception)
-  private[http] def rejected(rejections: List[Rejection]) = Rejected(rejections)
+  private[http] def rejected(rejections: immutable.Seq[Rejection]) = Rejected(rejections)
 }

--- a/akka-http/src/main/scala/akka/http/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/server/RouteResult.scala
@@ -18,9 +18,7 @@ sealed trait RouteResult
 
 object RouteResult {
   final case class Complete private[RouteResult] (response: HttpResponse) extends RouteResult
-  final case class Failure private[RouteResult] (exception: Throwable) extends RouteResult
   final case class Rejected private[RouteResult] (rejections: immutable.Seq[Rejection]) extends RouteResult
   private[http] def complete(response: HttpResponse) = Complete(response)
-  private[http] def failure(exception: Throwable) = Failure(exception)
   private[http] def rejected(rejections: immutable.Seq[Rejection]) = Rejected(rejections)
 }

--- a/akka-http/src/main/scala/akka/http/server/ScalaRoutingDSL.scala
+++ b/akka-http/src/main/scala/akka/http/server/ScalaRoutingDSL.scala
@@ -67,7 +67,6 @@ trait ScalaRoutingDSL extends Directives {
       sealedRoute(new RequestContextImpl(request, routingLog.requestLog(request))).fast.map {
         case RouteResult.Complete(response) ⇒ response
         case RouteResult.Rejected(rejected) ⇒ throw new IllegalStateException(s"Unhandled rejections '$rejected', unsealed RejectionHandler?!")
-        case RouteResult.Failure(error)     ⇒ throw new IllegalStateException(s"Unhandled error '$error', unsealed ExceptionHandler?!")
       }
   }
 

--- a/akka-http/src/main/scala/akka/http/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/server/directives/BasicDirectives.scala
@@ -27,7 +27,7 @@ trait BasicDirectives {
   def mapRouteResponsePF(f: PartialFunction[RouteResult, RouteResult]): Directive0 =
     mapRequestContext(_ withRouteResponseMappedPF f)
 
-  def mapRejections(f: List[Rejection] ⇒ List[Rejection]): Directive0 =
+  def mapRejections(f: immutable.Seq[Rejection] ⇒ immutable.Seq[Rejection]): Directive0 =
     mapRequestContext(_ withRejectionsMapped f)
 
   def mapHttpResponse(f: HttpResponse ⇒ HttpResponse): Directive0 =

--- a/akka-http/src/main/scala/akka/http/server/directives/CodingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/server/directives/CodingDirectives.scala
@@ -24,7 +24,7 @@ trait CodingDirectives {
    */
   def encodeResponse(encoder: Encoder): Directive0 =
     responseEncodingAccepted(encoder.encoding) &
-      mapHttpResponse(encoder.encode(_)) &
+      mapResponse(encoder.encode(_)) &
       cancelRejections(classOf[UnacceptedResponseEncodingRejection])
 
   /**

--- a/akka-http/src/main/scala/akka/http/server/directives/MiscDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/server/directives/MiscDirectives.scala
@@ -70,7 +70,7 @@ object MiscDirectives extends MiscDirectives {
     extract(_.request.entity.isKnownEmpty).flatMap(if (_) reject else pass)
 
   private val _rejectEmptyResponse: Directive0 =
-    mapRouteResponse {
+    mapRouteResult {
       case Complete(response) if response.entity.isKnownEmpty ⇒ rejected(Nil)
       case x ⇒ x
     }


### PR DESCRIPTION
This contains a pretty important change that fixes a long-standing oddity about which part of the routing infrastructure should deal with continuations (see #16088). "Continuations" are used in the routing DSL to support that directives which enclose other routes are able to manipulate the result of the inner route. Previously, this support was built into RequestContext. spray used mapped UnregisteredActorRefs to support this feature, and in akka-http we used `RequestContextImpl.finish` for that purpose. We figured that `RequestContext` isn't the right place to deal with result side data transformation. Instead, it belongs very naturally into `Directive` which is the place which actually allows the nesting DSL in spray/akka-http and, therefore, should also deal with the continuation.

We need a bit more infrastructure in FastFuture for this purpose which another commit provides.

Fixes #16087, #16088.

/cc @sirthias 
