### PR TITLE
+str #16077 implement Zip/Unzip/Concat for javadsl

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl2/ActorBasedFlowMaterializer.scala
@@ -9,6 +9,7 @@ import akka.actor._
 import akka.pattern.ask
 import akka.stream.actor.ActorSubscriber
 import akka.stream.impl.{ ActorProcessor, ActorPublisher, BufferImpl, ConflateImpl, ExpandImpl, ExposedPublisher, MapAsyncProcessorImpl, TimerTransformerProcessorsImpl, TransformProcessorImpl }
+import akka.stream.impl2.Zip.ZipAs
 import akka.stream.scaladsl2._
 import akka.stream.{ MaterializerSettings, OverflowStrategy, TimerTransformer, Transformer }
 import org.reactivestreams.{ Processor, Publisher, Subscriber }
@@ -89,7 +90,7 @@ private[akka] object Ast {
     override def name = "balance"
   }
 
-  case object Zip extends FanInAstNode {
+  final case class Zip(as: ZipAs) extends FanInAstNode {
     override def name = "zip"
   }
 
@@ -225,8 +226,8 @@ case class ActorBasedFlowMaterializer(override val settings: MaterializerSetting
             actorOf(FairMerge.props(settings, inputCount).withDispatcher(settings.dispatcher), actorName)
           case Ast.MergePreferred ⇒
             actorOf(UnfairMerge.props(settings, inputCount).withDispatcher(settings.dispatcher), actorName)
-          case Ast.Zip ⇒
-            actorOf(Zip.props(settings).withDispatcher(settings.dispatcher), actorName)
+          case zip: Ast.Zip ⇒
+            actorOf(Zip.props(settings, zip.as).withDispatcher(settings.dispatcher), actorName)
           case Ast.Concat ⇒
             actorOf(Concat.props(settings).withDispatcher(settings.dispatcher), actorName)
           case Ast.FlexiMergeNode(merger) ⇒

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/FlowGraph.scala
@@ -3,6 +3,10 @@
  */
 package akka.stream.scaladsl2
 
+import akka.stream.impl2
+import akka.stream.impl2.Ast.FanInAstNode
+import impl2.Ast
+
 import scala.language.existentials
 import scalax.collection.edge.{ LkBase, LkDiEdge }
 import scalax.collection.mutable.Graph
@@ -240,7 +244,7 @@ object Zip {
  * by combining corresponding elements in pairs. If one of the two streams is
  * longer than the other, its remaining elements are ignored.
  */
-final class Zip[A, B](override val name: Option[String]) extends FlowGraphInternal.InternalVertex {
+private[akka] class Zip[A, B](override val name: Option[String]) extends FlowGraphInternal.InternalVertex {
   val left = new Zip.Left(this)
   val right = new Zip.Right(this)
   val out = new Zip.Out(this)
@@ -250,7 +254,7 @@ final class Zip[A, B](override val name: Option[String]) extends FlowGraphIntern
   override def minimumOutputCount: Int = 1
   override def maximumOutputCount: Int = 1
 
-  override private[akka] def astNode = Ast.Zip
+  override private[akka] def astNode: FanInAstNode = Ast.Zip(impl2.Zip.AsScalaTuple2)
 
   final override private[scaladsl2] def newInstance() = new Zip[A, B](name = None)
 }


### PR DESCRIPTION
This PR will contain more commits - for now it's just the Zip operation but wanted to show/get-early feedback on the method I used to not duplicate the implementation while being able to emit java Pairs or Tuple2s.  

Refs #16077
