### PR TITLE
=str #16085 PublisherSink is no longer a singleton

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FutureSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/FutureSinkSpec.scala
@@ -12,7 +12,7 @@ import scala.util.Failure
 import akka.stream.MaterializerSettings
 import scala.concurrent.Future
 
-class FlowToFutureSpec extends AkkaSpec with ScriptedTest {
+class FutureSinkSpec extends AkkaSpec with ScriptedTest {
 
   val settings = MaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/PublisherSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/PublisherSinkSpec.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl2
+
+import akka.stream.testkit.AkkaSpec
+import org.scalatest.concurrent.ScalaFutures._
+
+class PublisherSinkSpec extends AkkaSpec {
+
+  implicit val materializer = FlowMaterializer()
+
+  "A PublisherSink" must {
+
+    "be unique when created twice" in {
+      val p1 = Sink.publisher[Int]
+      val p2 = Sink.publisher[Int]
+
+      val m = FlowGraph { implicit b ⇒
+        import FlowGraphImplicits._
+
+        val bcast = Broadcast[Int]
+
+        Source(0 to 5) ~> bcast
+        bcast ~> Flow[Int].map(_ * 2) ~> p1
+        bcast ~> p2
+      }.run()
+
+      Seq(p1, p2) map { sink ⇒
+        Source(m.get(sink)).map(identity).fold(0)(_ + _)
+      } zip Seq(30, 15) foreach {
+        case (future, result) ⇒ whenReady(future)(_ shouldBe result)
+      }
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/SubscriberSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl2/SubscriberSinkSpec.scala
@@ -7,7 +7,7 @@ import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 import akka.stream.MaterializerSettings
 
-class FlowPublishToSubscriberSpec extends AkkaSpec {
+class SubscriberSinkSpec extends AkkaSpec {
 
   val settings = MaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
@@ -15,7 +15,7 @@ class FlowPublishToSubscriberSpec extends AkkaSpec {
 
   implicit val materializer = FlowMaterializer(settings)
 
-  "A Flow with Sink" must {
+  "A Flow with SubscriberSink" must {
 
     "publish elements to the subscriber" in {
       val c = StreamTestKit.SubscriberProbe[Int]()

--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/ActorFlowSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/ActorFlowSink.scala
@@ -64,19 +64,18 @@ trait SimpleActorFlowSink[-In] extends ActorFlowSink[In] {
  */
 trait KeyedActorFlowSink[-In] extends ActorFlowSink[In] with KeyedSink[In]
 
+private[scaladsl2] object PublisherSink {
+  def apply[T](): PublisherSink[T] = new PublisherSink[T]
+  def withFanout[T](initialBufferSize: Int, maximumBufferSize: Int): FanoutPublisherSink[T] =
+    new FanoutPublisherSink[T](initialBufferSize, maximumBufferSize)
+}
+
 /**
  * Holds the downstream-most [[org.reactivestreams.Publisher]] interface of the materialized flow.
  * The stream will not have any subscribers attached at this point, which means that after prefetching
  * elements to fill the internal buffers it will assert back-pressure until
  * a subscriber connects and creates demand for elements to be emitted.
  */
-private[scaladsl2] object PublisherSink {
-  private val instance = new PublisherSink[Nothing]
-  def apply[T](): PublisherSink[T] = instance.asInstanceOf[PublisherSink[T]]
-  def withFanout[T](initialBufferSize: Int, maximumBufferSize: Int): FanoutPublisherSink[T] =
-    new FanoutPublisherSink[T](initialBufferSize, maximumBufferSize)
-}
-
 private[scaladsl2] class PublisherSink[In] extends KeyedActorFlowSink[In] {
   type MaterializedType = Publisher[In]
 


### PR DESCRIPTION
- PublisherSink is no longer a singleton
- rename existing Source/Sink tests to the latest names
- uncomment TickSource test with Zip

Fixes #16085
