### PR TITLE
=str #16095 make Actor{Publisher,Subscriber} as {Source,Sink}

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl2/Sink.scala
@@ -3,6 +3,7 @@
  */
 package akka.stream.scaladsl2
 
+import akka.actor.Props
 import org.reactivestreams.Subscriber
 import scala.util.Try
 
@@ -50,6 +51,13 @@ object Sink {
     val in = block(builder)
     builder.partialBuild().toSink(in)
   }
+
+  /**
+   * Creates a `Sink` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor
+   * created according to the passed in [[akka.actor.Props]]. Actor created by the `props` should
+   * be [[akka.stream.actor.ActorSubscriber]].
+   */
+  def apply[T](props: Props): PropsSink[T] = PropsSink[T](props)
 
   /**
    * A `Sink` that immediately cancels its upstream after materialization.


### PR DESCRIPTION
- Props{Source,Sink} creates an actor from props as a child
  of StreamSupervisor actor and wraps it into {Publisher,Subscriber}
- ActorRef{Source,Sink} wraps a given ActorRef into {Publisher,Subscriber}
- In both cases user actor should one of akka.stream.actor.Actor{Publisher,Subscriber}

Fixes #16095
