### PR TITLE
=per #15937 Allow PersistentActor to be used as a stackable modification

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Recovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Recovery.scala
@@ -27,7 +27,8 @@ trait Recovery extends Actor with Snapshotter with Stash with StashFactory {
     def aroundReceive(receive: Receive, message: Any): Unit
 
     protected def process(receive: Receive, message: Any) =
-      receive.applyOrElse(message, unhandled)
+      // calls `Recovery.super.aroundReceive` to allow Processor to be used as a stackable modification
+      Recovery.super.aroundReceive(receive, message)
 
     protected def processPersistent(receive: Receive, persistent: Persistent) =
       withCurrentPersistent(persistent)(runReceive(receive))
@@ -45,7 +46,8 @@ trait Recovery extends Actor with Snapshotter with Stash with StashFactory {
    * through withCurrentPersistent().
    */
   private[persistence] def runReceive(receive: Receive)(msg: Persistent): Unit =
-    receive.applyOrElse(msg, unhandled)
+    // calls `Recovery.super.aroundReceive` to allow Processor to be used as a stackable modification
+    Recovery.super.aroundReceive(receive, msg)
 
   /**
    * INTERNAL API.


### PR DESCRIPTION
Fixes the problem reported in [#15937](http://github.com/akka/akka/issues/15937). PersistentActor now calls `super.around*` life-cycle hooks and allows to be mixed into e.g. ActorSubscriber. All current tests + new ones added by me have passed. Method preRestartDefault, lines 326-338 in Processor.scala needs closer attention as adding a call to `super.aroundPreRestart` caused some deeper refactoring - please see the comment in the source code.
