### PR TITLE
=doc #16134 read file as binary stream, because StreamReader expects binary

### DIFF
--- a/akka-docs/_sphinx/exts/includecode.py
+++ b/akka-docs/_sphinx/exts/includecode.py
@@ -53,7 +53,7 @@ class IncludeCode(Directive):
         encoding = self.options.get('encoding', env.config.source_encoding)
         codec_info = codecs.lookup(encoding)
         try:
-            f = codecs.StreamReaderWriter(open(fn, 'U'),
+            f = codecs.StreamReaderWriter(codecs.open(fn, 'Ub'),
                     codec_info[2], codec_info[3], 'strict')
             lines = f.readlines()
             f.close()


### PR DESCRIPTION
Also use `codecs.open` because [it is](https://docs.python.org/3/howto/pyporting.html#text-files) recommended for backwards compatibility.

Fixes #16134
