### PR TITLE
ClusterSharding: Expanded cluster roles support

### DIFF
--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterShardingFailureSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterShardingFailureSpec.scala
@@ -111,6 +111,7 @@ class ClusterShardingFailureSpec extends MultiNodeSpec(ClusterShardingFailureSpe
     ClusterSharding(system).start(
       typeName = "Entity",
       entryProps = Some(Props[Entity]),
+      roleOverride = None,
       rememberEntries = true,
       idExtractor = idExtractor,
       shardResolver = shardResolver)

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterShardingSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterShardingSpec.scala
@@ -501,6 +501,7 @@ class ClusterShardingSpec extends MultiNodeSpec(ClusterShardingSpec) with STMult
       val counterRegion: ActorRef = ClusterSharding(system).start(
         typeName = "Counter",
         entryProps = Some(Props[Counter]),
+        roleOverride = None,
         rememberEntries = false,
         idExtractor = idExtractor,
         shardResolver = shardResolver)
@@ -508,6 +509,7 @@ class ClusterShardingSpec extends MultiNodeSpec(ClusterShardingSpec) with STMult
       ClusterSharding(system).start(
         typeName = "AnotherCounter",
         entryProps = Some(Props[Counter]),
+        roleOverride = None,
         rememberEntries = false,
         idExtractor = idExtractor,
         shardResolver = shardResolver)
@@ -549,6 +551,7 @@ class ClusterShardingSpec extends MultiNodeSpec(ClusterShardingSpec) with STMult
       val counterRegionViaStart: ActorRef = ClusterSharding(system).start(
         typeName = "ApiTest",
         entryProps = Some(Props[Counter]),
+        roleOverride = None,
         rememberEntries = false,
         idExtractor = idExtractor,
         shardResolver = shardResolver)

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ClusterShardingTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ClusterShardingTest.java
@@ -13,6 +13,7 @@ import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.actor.ReceiveTimeout;
 import akka.japi.Procedure;
+import akka.japi.Option;
 import akka.persistence.UntypedPersistentActor;
 
 // Doc code, compile only
@@ -64,8 +65,9 @@ public class ClusterShardingTest {
     //#counter-extractor
 
     //#counter-start
+    Option<String> roleOption = Option.none();
     ActorRef startedCounterRegion = ClusterSharding.get(system).start("Counter", 
-      Props.create(Counter.class), false, messageExtractor);
+      Props.create(Counter.class), Option.java2ScalaOption(roleOption), false, messageExtractor);
     //#counter-start
 
     //#counter-usage


### PR DESCRIPTION
A fix for ClusterSharding: Expanded cluster roles support #16123

Allow a `roleOverride: Option[String]` to be used when starting `ClusterSharding` for a given entry type. This will allow role defined clusters of `ClusterSharding` for specific entry types instead of requiring the role configuration to be more or less all or nothing across all entry types.

Preserved a couple of the original `ClusterSharding.start` signatures.
