### PR TITLE
!str #16069 disallows using one Keyed sink/source ambiguously (many times)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphInitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphInitSpec.scala
@@ -3,12 +3,12 @@
  */
 package akka.stream.scaladsl
 
+import akka.stream.FlowMaterializer
+import akka.stream.testkit.AkkaSpec
+
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
-import akka.stream.FlowMaterializer
-import akka.stream.testkit.AkkaSpec
 
 class FlowGraphInitSpec extends AkkaSpec {
 
@@ -39,6 +39,87 @@ class FlowGraphInitSpec extends AkkaSpec {
 
       val graphs = Vector.fill(5)(Future(create()))
       val result = Await.result(Future.sequence(graphs), 5.seconds).flatten.size should be(5)
+    }
+
+    "fail when the same `KeyedSink` is used in it multiple times" in {
+      val s = Source(1 to 5)
+      val b = Broadcast[Int]
+
+      val sink: KeyedSink[Int] = Sink.foreach[Int](i ⇒ i)
+      val otherSink: KeyedSink[Int] = Sink.foreach[Int](i ⇒ 2 * i)
+
+      FlowGraph { implicit builder ⇒
+        import FlowGraphImplicits._
+        // format: OFF
+        s ~> b ~> sink
+             b ~> otherSink // this is fine
+        // format: ON
+      }
+
+      val ex1 = intercept[IllegalArgumentException] {
+        FlowGraph { implicit builder ⇒
+          import FlowGraphImplicits._
+          // format: OFF
+          s ~> b ~> sink
+               b ~> sink // this is not fine
+          // format: ON
+        }
+      }
+      ex1.getMessage should include(sink.getClass.getSimpleName)
+
+      val ex2 = intercept[IllegalArgumentException] {
+        FlowGraph { implicit builder ⇒
+          import FlowGraphImplicits._
+          // format: OFF
+          s ~> b ~> sink
+               b ~> otherSink // this is fine
+               b ~> sink // this is not fine
+          // format: ON
+        }
+      }
+      ex2.getMessage should include(sink.getClass.getSimpleName)
+    }
+
+    "fail when the same `KeyedSource` is used in it multiple times" in {
+      val s = Sink.ignore
+      val m = Merge[Int]
+
+      val source1: KeyedSource[Int] = Source.subscriber
+      val source2: KeyedSource[Int] = Source.subscriber
+
+      FlowGraph { implicit builder ⇒
+        import FlowGraphImplicits._
+        // KeyedSources of same type should be fine to be mixed
+        // format: OFF
+        source1 ~> m
+                   m ~> s
+        source2 ~> m
+        // format: ON
+      }
+
+      val ex1 = intercept[IllegalArgumentException] {
+        FlowGraph { implicit builder ⇒
+          import FlowGraphImplicits._
+          // format: OFF
+          source1 ~> m
+                     m ~> s
+          source1 ~> m // whoops
+          // format: ON
+        }
+      }
+      ex1.getMessage should include(source1.getClass.getSimpleName)
+
+      val ex2 = intercept[IllegalArgumentException] {
+        FlowGraph { implicit builder ⇒
+          import FlowGraphImplicits._
+          // format: OFF
+          source1 ~> m
+          source2 ~> m ~> s
+          source1 ~> m // this is not fine
+          // format: ON
+        }
+      }
+      ex2.getMessage should include(source1.getClass.getSimpleName)
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlowSpec.scala
@@ -202,7 +202,12 @@ class GraphFlowSpec extends AkkaSpec {
         val out = UndefinedSink[Int]
         val probe = StreamTestKit.SubscriberProbe[Int]()
 
-        val source = Source[Int]() { implicit b ⇒
+        val source1 = Source[Int]() { implicit b ⇒
+          import FlowGraphImplicits._
+          Source(1 to 5) ~> Flow[Int].map(_ * 2) ~> out
+          out
+        }
+        val source2 = Source[Int]() { implicit b ⇒
           import FlowGraphImplicits._
           Source(1 to 5) ~> Flow[Int].map(_ * 2) ~> out
           out
@@ -211,8 +216,8 @@ class GraphFlowSpec extends AkkaSpec {
         FlowGraph { implicit b ⇒
           import FlowGraphImplicits._
           val merge = Merge[Int]("merge")
-          source ~> merge ~> Sink(probe)
-          source ~> Flow[Int].map(_ * 10) ~> merge
+          source1 ~> merge ~> Sink(probe)
+          source2 ~> Flow[Int].map(_ * 10) ~> merge
         }.run()
 
         validateProbe(probe, 10, Set(2, 4, 6, 8, 10, 20, 40, 60, 80, 100))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/ActorFlowSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/ActorFlowSource.scala
@@ -87,6 +87,7 @@ private[scaladsl] final case class SubscriberSource[Out]() extends KeyedActorFlo
 
   override def attach(flowSubscriber: Subscriber[Out], materializer: ActorBasedFlowMaterializer, flowName: String): Subscriber[Out] =
     flowSubscriber
+
 }
 
 /**


### PR DESCRIPTION
This can / should wait for Patrik's move-all-the-things PR.
Refs #16069 
