### PR TITLE
=str removing duplicate fold sink definition on Sink

### DIFF
--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
@@ -6,6 +6,7 @@ package akka.stream.javadsl;
 import java.util.ArrayList;
 import java.util.List;
 
+import akka.stream.javadsl.japi.Function2;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
@@ -42,6 +43,16 @@ public class SinkTest {
     list.add(1);
     final Future<Integer> future = Source.from(list).runWith(futSink, materializer);
     assert Await.result(future, Duration.create("1 second")).equals(1);
+  }
+
+  @Test
+  public void mustBeAbleToUseFold() throws Exception {
+    KeyedSink<Integer, Future<Integer>> foldSink = Sink.fold(0, new Function2<Integer, Integer, Integer>() {
+      @Override public Integer apply(Integer arg1, Integer arg2) throws Exception {
+        return arg1 + arg2;
+      }
+    });
+    Future<Integer> integerFuture = Source.from(new ArrayList<Integer>()).runWith(foldSink, materializer);
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -109,18 +109,6 @@ object Sink {
   def future[In]: KeyedSink[In, Future[In]] =
     new KeyedSink(scaladsl.Sink.future[In])
 
-  /**
-   * A `Sink` that will invoke the given function for every received element, giving it its previous
-   * output (or the given `zero` value) and the element as input.
-   * The returned [[scala.concurrent.Future]] will be completed with value of the final
-   * function evaluation when the input stream ends, or completed with `Failure`
-   * if there is an error is signaled in the stream.
-   */
-  def fold[U, T](zero: U, f: Function[akka.japi.Pair[U, T], U]): KeyedSink[T, Future[U]] = {
-    val sSink = scaladsl.Sink.fold[U, T](zero) { case (a, b) ⇒ f.apply(akka.japi.Pair(a, b)) }
-    new KeyedSink(sSink)
-  }
-
 }
 
 /**


### PR DESCRIPTION
Noticed accidental duplication of fold, with different but equivalent signatures.
Removing the one with additional tuple inside. 
Adding test to validate fold is usable.
