### PR TITLE
=str  #16109: Replace ScalaGraph with custom graph impl

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/DirectedGraphBuilderSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/DirectedGraphBuilderSpec.scala
@@ -1,0 +1,382 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl
+
+import akka.stream.testkit.AkkaSpec
+
+class DirectedGraphBuilderSpec extends AkkaSpec {
+
+  "DirectedGraphBuilder" must {
+
+    "add and remove vertices" in {
+      val g = new DirectedGraphBuilder[String, Int]
+      g.contains(1) should be(false)
+      g.nodes.isEmpty should be(true)
+      g.edges.isEmpty should be(true)
+      g.find(1) should be(None)
+
+      g.addVertex(1)
+
+      g.contains(1) should be(true)
+      g.nodes.size should be(1)
+      g.edges.isEmpty should be(true)
+      g.find(1) should be(Some(Vertex(1)))
+
+      g.addVertex(1)
+
+      g.contains(1) should be(true)
+      g.nodes.size should be(1)
+      g.edges.isEmpty should be(true)
+      g.find(1) should be(Some(Vertex(1)))
+
+      g.addVertex(2)
+
+      g.contains(1) should be(true)
+      g.contains(2) should be(true)
+      g.nodes.size should be(2)
+      g.find(1) should be(Some(Vertex(1)))
+      g.find(2) should be(Some(Vertex(2)))
+
+      g.remove(2)
+      g.contains(1) should be(true)
+      g.contains(2) should be(false)
+      g.nodes.size should be(1)
+      g.edges.isEmpty should be(true)
+      g.find(1) should be(Some(Vertex(1)))
+      g.find(2) should be(None)
+    }
+
+    "add and remove edges" in {
+      val g = new DirectedGraphBuilder[String, Int]
+
+      g.nodes.size should be(0)
+      g.edges.size should be(0)
+      g.contains(1) should be(false)
+      g.contains(2) should be(false)
+      g.contains(3) should be(false)
+      g.containsEdge("1 -> 2") should be(false)
+      g.containsEdge("2 -> 3") should be(false)
+
+      g.addEdge(1, 2, "1 -> 2")
+
+      g.nodes.size should be(2)
+      g.edges.size should be(1)
+      g.contains(1) should be(true)
+      g.contains(2) should be(true)
+      g.containsEdge("1 -> 2") should be(true)
+      g.get(1).incoming.isEmpty should be(true)
+      g.get(1).outgoing.head.label should be("1 -> 2")
+      g.get(2).outgoing.isEmpty should be(true)
+      g.get(2).incoming.head.label should be("1 -> 2")
+      g.get(1).outgoing.head.from.label should be(1)
+      g.get(1).outgoing.head.to.label should be(2)
+
+      g.addEdge(2, 3, "2 -> 3")
+
+      g.nodes.size should be(3)
+      g.edges.size should be(2)
+      g.contains(1) should be(true)
+      g.contains(2) should be(true)
+      g.contains(3) should be(true)
+      g.containsEdge("1 -> 2") should be(true)
+      g.containsEdge("2 -> 3") should be(true)
+      g.get(1).incoming.isEmpty should be(true)
+      g.get(1).outgoing.head.label should be("1 -> 2")
+      g.get(2).outgoing.head.label should be("2 -> 3")
+      g.get(2).incoming.head.label should be("1 -> 2")
+      g.get(3).incoming.head.label should be("2 -> 3")
+      g.get(3).outgoing.isEmpty should be(true)
+      g.get(1).outgoing.head.from.label should be(1)
+      g.get(1).outgoing.head.to.label should be(2)
+      g.get(2).outgoing.head.from.label should be(2)
+      g.get(2).outgoing.head.to.label should be(3)
+
+      // Will reposition edge
+      g.addEdge(2, 4, "2 -> 3")
+
+      g.nodes.size should be(4)
+      g.edges.size should be(2)
+      g.contains(1) should be(true)
+      g.contains(2) should be(true)
+      g.contains(3) should be(true)
+      g.contains(4) should be(true)
+      g.containsEdge("1 -> 2") should be(true)
+      g.containsEdge("2 -> 3") should be(true)
+      g.get(1).incoming.isEmpty should be(true)
+      g.get(1).outgoing.head.label should be("1 -> 2")
+      g.get(2).outgoing.head.label should be("2 -> 3")
+      g.get(2).incoming.head.label should be("1 -> 2")
+      g.get(3).incoming.isEmpty should be(true)
+      g.get(3).outgoing.isEmpty should be(true)
+      g.get(4).incoming.head.label should be("2 -> 3")
+      g.get(4).outgoing.isEmpty should be(true)
+      g.get(1).outgoing.head.from.label should be(1)
+      g.get(1).outgoing.head.to.label should be(2)
+      g.get(2).outgoing.head.from.label should be(2)
+      g.get(2).outgoing.head.to.label should be(4)
+
+      // Will remove dangling edge
+      g.remove(4)
+
+      g.nodes.size should be(3)
+      g.edges.size should be(1)
+      g.contains(1) should be(true)
+      g.contains(2) should be(true)
+      g.contains(3) should be(true)
+      g.contains(4) should be(false)
+      g.containsEdge("1 -> 2") should be(true)
+      g.containsEdge("2 -> 3") should be(false)
+      g.get(1).incoming.isEmpty should be(true)
+      g.get(1).outgoing.head.label should be("1 -> 2")
+      g.get(2).outgoing.isEmpty should be(true)
+      g.get(2).incoming.head.label should be("1 -> 2")
+      g.get(3).incoming.isEmpty should be(true)
+      g.get(3).outgoing.isEmpty should be(true)
+      g.get(1).outgoing.head.from.label should be(1)
+      g.get(1).outgoing.head.to.label should be(2)
+
+      // Remove remaining edge
+      g.removeEdge("1 -> 2")
+
+      g.nodes.size should be(3)
+      g.edges.isEmpty should be(true)
+      g.contains(1) should be(true)
+      g.contains(2) should be(true)
+      g.contains(3) should be(true)
+      g.contains(4) should be(false)
+      g.containsEdge("1 -> 2") should be(false)
+      g.containsEdge("2 -> 3") should be(false)
+      g.get(1).incoming.isEmpty should be(true)
+      g.get(1).outgoing.isEmpty should be(true)
+      g.get(2).outgoing.isEmpty should be(true)
+      g.get(2).incoming.isEmpty should be(true)
+      g.get(3).incoming.isEmpty should be(true)
+      g.get(3).outgoing.isEmpty should be(true)
+    }
+  }
+
+  "work correctly with isolated nodes" in {
+    val g = new DirectedGraphBuilder[String, Int]
+    (1 to 99) foreach { i ⇒
+      g.addVertex(i)
+      g.nodes.size should be(i)
+      g.find(i) should be(Some(Vertex(i)))
+    }
+
+    g.isWeaklyConnected should be(false)
+    g.findCycle.isEmpty should be(true)
+    g.edgePredecessorBFSfoldLeft(g.get(99))(true) { (_, _) ⇒ false } should be(true)
+  }
+
+  "work correctly with simple chains" in {
+    val g = new DirectedGraphBuilder[String, Int]
+
+    (1 to 99) foreach { i ⇒
+      g.addEdge(i, i + 1, s"$i -> ${i + 1}")
+      g.nodes.size should be(i + 1)
+      g.edges.size should be(i)
+      g.find(i) should be(Some(Vertex(i)))
+      g.find(i + 1) should be(Some(Vertex(i + 1)))
+      g.edges.contains(s"$i -> ${i + 1}")
+    }
+
+    g.isWeaklyConnected should be(true)
+    g.findCycle.isEmpty should be(true)
+    g.edgePredecessorBFSfoldLeft(g.get(100))(100) { (sum, e) ⇒ sum + e.from.label } should be(5050)
+
+    (1 to 100) foreach (g.remove(_))
+    g.nodes.isEmpty should be(true)
+    g.edges.isEmpty should be(true)
+  }
+
+  "work correctly with weakly connected chains" in {
+    val g = new DirectedGraphBuilder[String, Int]
+
+    (1 to 49) foreach { i ⇒
+      g.addEdge(i, i + 1, s"$i -> ${i + 1}")
+      g.nodes.size should be(i + 1)
+      g.edges.size should be(i)
+      g.find(i) should be(Some(Vertex(i)))
+      g.find(i + 1) should be(Some(Vertex(i + 1)))
+      g.edges.contains(s"$i -> ${i + 1}")
+    }
+
+    (100 to 51 by -1) foreach { i ⇒
+      g.addEdge(i, i - 1, s"$i -> ${i - 1}")
+      g.find(i) should be(Some(Vertex(i)))
+      g.find(i - 1) should be(Some(Vertex(i - 1)))
+      g.edges.contains(s"$i -> ${i - 1}")
+    }
+
+    g.nodes.size should be(100)
+    g.edges.size should be(99)
+
+    g.isWeaklyConnected should be(true)
+    g.findCycle.isEmpty should be(true)
+    g.edgePredecessorBFSfoldLeft(g.get(50))(50) { (sum, e) ⇒ sum + e.from.label } should be(5050)
+
+    (1 to 100) foreach (g.remove(_))
+    g.nodes.isEmpty should be(true)
+    g.edges.isEmpty should be(true)
+  }
+
+  "work correctly with directed cycles" in {
+    val g = new DirectedGraphBuilder[String, Int]
+
+    (1 to 99) foreach { i ⇒
+      g.addEdge(i, i + 1, s"$i -> ${i + 1}")
+      g.nodes.size should be(i + 1)
+      g.edges.size should be(i)
+      g.find(i) should be(Some(Vertex(i)))
+      g.find(i + 1) should be(Some(Vertex(i + 1)))
+      g.edges.contains(s"$i -> ${i + 1}")
+    }
+    g.addEdge(100, 1, "100 -> 1")
+    g.nodes.size should be(100)
+    g.edges.size should be(100)
+
+    g.isWeaklyConnected should be(true)
+    g.findCycle.toSet.size should be(100)
+    g.findCycle.toSet should be((1 to 100).map(Vertex(_)).toSet)
+    g.edgePredecessorBFSfoldLeft(g.get(100))(0) { (sum, e) ⇒ sum + e.from.label } should be(5050)
+
+    (1 to 100) foreach (g.remove(_))
+    g.nodes.isEmpty should be(true)
+    g.edges.isEmpty should be(true)
+  }
+
+  "work correctly with undirected cycles" in {
+    val g = new DirectedGraphBuilder[String, Int]
+
+    (1 to 49) foreach { i ⇒
+      g.addEdge(i, i + 1, s"$i -> ${i + 1}")
+      g.nodes.size should be(i + 1)
+      g.edges.size should be(i)
+      g.find(i) should be(Some(Vertex(i)))
+      g.find(i + 1) should be(Some(Vertex(i + 1)))
+      g.edges.contains(s"$i -> ${i + 1}")
+    }
+
+    (100 to 51 by -1) foreach { i ⇒
+      g.addEdge(i, i - 1, s"$i -> ${i - 1}")
+      g.find(i) should be(Some(Vertex(i)))
+      g.find(i - 1) should be(Some(Vertex(i - 1)))
+      g.edges.contains(s"$i -> ${i - 1}")
+    }
+
+    g.addEdge(100, 1, "100 -> 1")
+    g.nodes.size should be(100)
+    g.edges.size should be(100)
+
+    g.isWeaklyConnected should be(true)
+    g.findCycle.isEmpty should be(true)
+    g.edgePredecessorBFSfoldLeft(g.get(50))(50) { (sum, e) ⇒ sum + e.from.label } should be(5150)
+
+    (1 to 100) foreach (g.remove(_))
+    g.nodes.isEmpty should be(true)
+    g.edges.isEmpty should be(true)
+  }
+
+  "work correctly with two linked cycles, both directed" in {
+    val g = new DirectedGraphBuilder[String, Int]
+    g.addEdge(0, 1, "0 -> 1")
+    g.addEdge(1, 2, "1 -> 2")
+    g.addEdge(2, 0, "2 -> 0")
+
+    g.addEdge(1, 3, "1 -> 3")
+    g.addEdge(3, 0, "3 -> 0")
+
+    g.nodes.size should be(4)
+    g.isWeaklyConnected should be(true)
+    g.findCycle.nonEmpty should be(true)
+    g.findCycle.size should be(3)
+
+    g.removeEdge("1 -> 2")
+    g.isWeaklyConnected should be(true)
+    g.findCycle.nonEmpty should be(true)
+    g.findCycle.size should be(3)
+    g.findCycle.map(_.label).toSet should be(Set(0, 1, 3))
+
+    g.removeEdge("1 -> 3")
+    g.addEdge(1, 2, "1 -> 2")
+    g.nodes.size should be(4)
+    g.isWeaklyConnected should be(true)
+    g.findCycle.nonEmpty should be(true)
+    g.findCycle.size should be(3)
+    g.findCycle.map(_.label).toSet should be(Set(0, 1, 2))
+
+    g.removeEdge("1 -> 2")
+    g.isWeaklyConnected should be(true)
+    g.findCycle.isEmpty should be(true)
+  }
+
+  "work correctly with two linked cycles, one undirected" in {
+    val g = new DirectedGraphBuilder[String, Int]
+    g.addEdge(0, 1, "0 -> 1")
+    g.addEdge(1, 2, "1 -> 2")
+    g.addEdge(2, 0, "2 -> 0")
+
+    g.addEdge(1, 3, "1 -> 3")
+    g.addEdge(0, 3, "3 <- 0")
+
+    g.nodes.size should be(4)
+    g.isWeaklyConnected should be(true)
+    g.findCycle.nonEmpty should be(true)
+    g.findCycle.size should be(3)
+    g.findCycle.map(_.label).toSet should be(Set(0, 1, 2))
+
+    g.removeEdge("1 -> 2")
+    g.isWeaklyConnected should be(true)
+    g.findCycle.isEmpty should be(true)
+
+    g.removeEdge("1 -> 3")
+    g.isWeaklyConnected should be(true)
+    g.findCycle.isEmpty should be(true)
+
+    g.remove(0)
+    g.isWeaklyConnected should be(false)
+    g.findCycle.isEmpty should be(true)
+  }
+
+  "copy correctly" in {
+    val g1 = new DirectedGraphBuilder[String, Int]
+
+    (1 to 49) foreach { i ⇒
+      g1.addEdge(i, i + 1, s"$i -> ${i + 1}")
+    }
+
+    (100 to 51 by -1) foreach { i ⇒
+      g1.addEdge(i, i - 1, s"$i -> ${i - 1}")
+    }
+
+    g1.addEdge(0, 1, "0 -> 1")
+    g1.addEdge(2, 0, "2 -> 0")
+
+    g1.addEdge(1, 3, "1 -> 3")
+    g1.addEdge(3, 0, "3 -> 0")
+
+    g1.addVertex(200)
+
+    val g2 = g1.copy()
+
+    g2.nodes.size should be(102)
+    g2.nodes.toSet should be(g1.nodes.toSet)
+    g2.edges.toSet should be(g1.edges.toSet)
+
+    g2.nodes foreach { v2 ⇒
+      val v1 = g1.find(v2.label).get
+
+      v1.label should be(v2.label)
+      v1.incoming should be(v2.incoming)
+      v1.outgoing should be(v2.outgoing)
+
+      v1.incoming.map(_.to) should be(v2.incoming.map(_.to))
+      v1.incoming.map(_.from) should be(v2.incoming.map(_.from))
+
+      v1.outgoing.map(_.to) should be(v2.outgoing.map(_.to))
+      v1.outgoing.map(_.from) should be(v2.outgoing.map(_.from))
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphCompileSpec.scala
@@ -303,6 +303,7 @@ class FlowGraphCompileSpec extends AkkaSpec {
           val merge = Merge[String]
           import FlowGraphImplicits._
           in1 ~> merge ~> out1
+          in2 ~> merge
           merge ~> out2 // wrong
         }
       }.getMessage should include("at most 1 outgoing")

--- a/akka-stream/src/main/scala/akka/stream/impl/DirectedGraphBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/DirectedGraphBuilder.scala
@@ -1,0 +1,247 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl
+
+import scala.annotation.tailrec
+import scala.collection.immutable
+
+/**
+ * INTERNAL API
+ */
+private[akka] final case class Vertex[E, V](label: V) {
+  private var inEdgeSet = Set.empty[Edge[E, V]]
+  private var outEdgeSet = Set.empty[Edge[E, V]]
+
+  def addOutEdge(e: Edge[E, V]): Unit = outEdgeSet += e
+  def addInEdge(e: Edge[E, V]): Unit = inEdgeSet += e
+
+  def removeOutEdge(e: Edge[E, V]): Unit = outEdgeSet -= e
+  def removeInEdge(e: Edge[E, V]): Unit = inEdgeSet -= e
+
+  def inDegree: Int = inEdgeSet.size
+  def outDegree: Int = outEdgeSet.size
+
+  def isolated: Boolean = inDegree == 0 && outDegree == 0
+
+  def isSink: Boolean = outEdgeSet.isEmpty
+
+  def successors: Set[Vertex[E, V]] = outEdgeSet.map(_.to)
+  def predecessors: Set[Vertex[E, V]] = inEdgeSet.map(_.from)
+
+  def neighbors: Set[Vertex[E, V]] = successors ++ predecessors
+
+  def incoming: Set[Edge[E, V]] = inEdgeSet
+  def outgoing: Set[Edge[E, V]] = outEdgeSet
+
+  override def equals(obj: Any): Boolean = obj match {
+    case v: Vertex[_, _] ⇒ label.equals(v.label)
+    case _               ⇒ false
+  }
+
+  override def hashCode(): Int = label.hashCode()
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] final case class Edge[E, V](label: E, from: Vertex[E, V], to: Vertex[E, V]) {
+
+  override def equals(obj: Any): Boolean = obj match {
+    case e: Edge[_, _] ⇒ label.equals(e.label)
+    case _             ⇒ false
+  }
+
+  override def hashCode(): Int = label.hashCode()
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class DirectedGraphBuilder[E, V] {
+  private var vertexMap = Map.empty[V, Vertex[E, V]]
+  private var edgeMap = Map.empty[E, Edge[E, V]]
+
+  def edges: immutable.Seq[Edge[E, V]] = edgeMap.values.toVector
+
+  def nodes: immutable.Seq[Vertex[E, V]] = vertexMap.values.toVector
+
+  def nonEmpty: Boolean = vertexMap.nonEmpty
+
+  def addVertex(v: V): Vertex[E, V] = vertexMap.get(v) match {
+    case None ⇒
+      val vx = Vertex[E, V](v)
+      vertexMap += v -> vx
+      vx
+
+    case Some(vx) ⇒ vx
+  }
+
+  def addEdge(from: V, to: V, label: E): Unit = {
+    val vfrom = addVertex(from)
+    val vto = addVertex(to)
+
+    removeEdge(label) // Need to remap existing labels
+    val edge = Edge[E, V](label, vfrom, vto)
+    edgeMap += label -> edge
+
+    vfrom.addOutEdge(edge)
+    vto.addInEdge(edge)
+
+  }
+
+  def find(v: V): Option[Vertex[E, V]] = vertexMap.get(v)
+
+  def get(v: V): Vertex[E, V] = vertexMap(v)
+
+  def contains(v: V): Boolean = vertexMap.contains(v)
+
+  def containsEdge(e: E): Boolean = edgeMap.contains(e)
+
+  def exists(p: Vertex[E, V] ⇒ Boolean) = vertexMap.values.exists(p)
+
+  def removeEdge(label: E): Unit = edgeMap.get(label) match {
+    case Some(e) ⇒
+      edgeMap -= label
+      e.from.removeOutEdge(e)
+      e.to.removeInEdge(e)
+    case None ⇒
+  }
+
+  def remove(v: V): Unit = vertexMap.get(v) match {
+    case Some(vx) ⇒
+      vertexMap -= v
+
+      vx.incoming foreach { edge ⇒ removeEdge(edge.label) }
+      vx.outgoing foreach { edge ⇒ removeEdge(edge.label) }
+
+    case None ⇒
+  }
+
+  /**
+   * Performs a deep copy of the builder. Since the builder is mutable it is not safe to share instances of it
+   * without making a defensive copy first.
+   */
+  def copy(): DirectedGraphBuilder[E, V] = {
+    val result = new DirectedGraphBuilder[E, V]()
+
+    edgeMap.foreach {
+      case (label, e) ⇒
+        result.addEdge(e.from.label, e.to.label, e.label)
+    }
+
+    vertexMap.filter(_._2.isolated) foreach {
+      case (_, n) ⇒
+        result.addVertex(n.label)
+    }
+
+    result
+  }
+
+  /**
+   * Returns true if for every vertex pair there is an undirected path connecting them
+   */
+  def isWeaklyConnected: Boolean = {
+    if (vertexMap.isEmpty) true
+    else {
+      var unvisited = vertexMap.values.toSet
+      var toVisit = Set(unvisited.head)
+
+      while (toVisit.nonEmpty) {
+        val v = toVisit.head
+        unvisited -= v
+        toVisit = toVisit.tail
+        toVisit ++= v.neighbors.iterator.filter(unvisited.contains) // visit all unvisited neighbors of v (neighbors are undirected)
+      }
+
+      unvisited.isEmpty // if we ended up with unvisited nodes starting from one node we are unconnected
+    }
+  }
+
+  /**
+   * Finds a directed cycle in the graph
+   */
+  def findCycle: immutable.Seq[Vertex[E, V]] = {
+    if (vertexMap.size < 2 || edgeMap.size < 2) Nil
+    else {
+      // Vertices we have not visited at all yet
+      var unvisited = vertexMap.values.toSet
+
+      // Attempts to find a cycle in a connected component
+      def findCycleInComponent(
+        componentEntryVertex: Vertex[E, V],
+        toVisit: Vertex[E, V],
+        cycleCandidate: List[Vertex[E, V]]): List[Vertex[E, V]] = {
+
+        if (!unvisited(toVisit)) Nil
+        else {
+          unvisited -= toVisit
+
+          val successors = toVisit.successors
+          if (successors.contains(componentEntryVertex)) toVisit :: cycleCandidate
+          else {
+            val newCycleCandidate = toVisit :: cycleCandidate
+
+            // search in all successors
+            @tailrec def traverse(toTraverse: Set[Vertex[E, V]]): List[Vertex[E, V]] = {
+              if (toTraverse.isEmpty) Nil
+              else {
+                val c = findCycleInComponent(componentEntryVertex, toVisit = toTraverse.head, newCycleCandidate)
+                if (c.nonEmpty) c
+                else traverse(toTraverse = toTraverse.tail)
+              }
+            }
+
+            traverse(toTraverse = successors)
+          }
+        }
+
+      }
+
+      // Traverse all weakly connected components and try to find cycles in each of them
+      @tailrec def findNextCycle(): List[Vertex[E, V]] = {
+        if (unvisited.size < 2) Nil
+        else {
+          // Pick a node to recursively start visiting its successors
+          val componentEntry = unvisited.head
+
+          if (componentEntry.inDegree < 1 || componentEntry.outDegree < 1) {
+            unvisited -= componentEntry
+            findNextCycle()
+          } else {
+            val cycleCandidate =
+              findCycleInComponent(componentEntry, toVisit = componentEntry, cycleCandidate = Nil)
+
+            if (cycleCandidate.nonEmpty) cycleCandidate
+            else findNextCycle()
+          }
+
+        }
+
+      }
+
+      findNextCycle()
+    }
+  }
+
+  def edgePredecessorBFSfoldLeft[T](start: Vertex[E, V])(zero: T)(f: (T, Edge[E, V]) ⇒ T): T = {
+    var aggr: T = zero
+    var unvisited = edgeMap.values.toSet
+    // Queue to maintain BFS state
+    var toVisit = immutable.Queue() ++ start.incoming
+
+    while (toVisit.nonEmpty) {
+      val (e, nextToVisit) = toVisit.dequeue
+      toVisit = nextToVisit
+
+      unvisited -= e
+      aggr = f(aggr, e)
+      val unvisitedPredecessors = e.from.incoming.filter(unvisited.contains)
+      unvisited --= unvisitedPredecessors
+      toVisit = toVisit ++ unvisitedPredecessors
+    }
+
+    aggr
+  }
+
+}

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1390,9 +1390,6 @@ object Dependencies {
 
     // Cluster Sample
     val sigar       = "org.fusesource"                % "sigar"                        % "1.6.4"       // ApacheV2
-    
-    // Graph for Scala
-    val scalaGraph = "com.assembla.scala-incubator"  %% "graph-core"                   % "1.9.0"       // ApacheV2
 
     // Compiler plugins
     val genjavadoc    = compilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % genJavaDocVersion cross CrossVersion.full) // ApacheV2
@@ -1474,7 +1471,7 @@ object Dependencies {
     // FIXME use project dependency when akka-stream-experimental-2.3.x is released
     "com.typesafe.akka" %% "akka-actor" % Versions.publishedAkkaVersion,
     "com.typesafe.akka" %% "akka-persistence-experimental" % Versions.publishedAkkaVersion,
-    scalaGraph, reactiveStreams,
+    reactiveStreams,
     Test.junitIntf,
     Test.scalatest)
 


### PR DESCRIPTION
Minimalistic replacement for ScalaGraph. Not speed optimized so far, and it only provides a mutable representation (builder) yet.

If immutability is required it can be implemented, will take a little time. I can do it in this PR or we can open a ticket.

As for speed optimizations, if we get rid of the remove operation (we only use it to fuse graphs together) then we keep the following invariants:
- all connected components remain connected, but they might get connected together
- all cycles remain cylces

So we will be able to do inremental calculation of these which can be very fast with appropriate data structures.

**No unit tests yet, TBD**
