### PR TITLE
=pro load sample builds with project dependencies

### DIFF
--- a/akka-samples/akka-sample-camel-java/build.sbt
+++ b/akka-samples/akka-sample-camel-java/build.sbt
@@ -11,4 +11,3 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.2",
   "ch.qos.logback" % "logback-classic" % "1.0.7"
 )
-

--- a/akka-samples/akka-sample-camel-scala/build.sbt
+++ b/akka-samples/akka-sample-camel-scala/build.sbt
@@ -5,10 +5,10 @@ version := "2.4-SNAPSHOT"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT",
   "com.typesafe.akka" %% "akka-camel" % "2.4-SNAPSHOT",
   "org.apache.camel" % "camel-jetty" % "2.10.3",
   "org.apache.camel" % "camel-quartz" % "2.10.3",
   "org.slf4j" % "slf4j-api" % "1.7.2",
   "ch.qos.logback" % "logback-classic" % "1.0.7"
 )
-

--- a/akka-samples/akka-sample-cluster-java/build.sbt
+++ b/akka-samples/akka-sample-cluster-java/build.sbt
@@ -12,11 +12,13 @@ val project = Project(
     scalaVersion := "2.10.4",
     scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint"),
     javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
+    javacOptions in doc in Compile := Seq("-source", "1.6"), // javadoc does not support -target and -Xlint flags
     libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-contrib" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,
-      "org.scalatest" %% "scalatest" % "2.0" % "test",
+      "org.scalatest" %% "scalatest" % "2.2.1" % "test",
       "org.fusesource" % "sigar" % "1.6.4"),
     javaOptions in run ++= Seq(
       "-Djava.library.path=./sigar",

--- a/akka-samples/akka-sample-cluster-scala/build.sbt
+++ b/akka-samples/akka-sample-cluster-scala/build.sbt
@@ -13,10 +13,11 @@ val project = Project(
     scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint"),
     javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
     libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-contrib" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,
-      "org.scalatest" %% "scalatest" % "2.0" % "test",
+      "org.scalatest" %% "scalatest" % "2.2.1" % "test",
       "org.fusesource" % "sigar" % "1.6.4"),
     javaOptions in run ++= Seq(
       "-Djava.library.path=./sigar",

--- a/akka-samples/akka-sample-main-scala/build.sbt
+++ b/akka-samples/akka-sample-main-scala/build.sbt
@@ -7,4 +7,3 @@ scalaVersion := "2.10.4"
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT"
 )
-

--- a/akka-samples/akka-sample-multi-node-scala/build.sbt
+++ b/akka-samples/akka-sample-multi-node-scala/build.sbt
@@ -13,7 +13,7 @@ val project = Project(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-remote" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,
-      "org.scalatest" %% "scalatest" % "2.0" % "test"),
+      "org.scalatest" %% "scalatest" % "2.2.1" % "test"),
     // make sure that MultiJvm test are compiled by the default test compilation
     compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in Test),
     // disable parallel tests

--- a/akka-samples/akka-sample-persistence-scala/build.sbt
+++ b/akka-samples/akka-sample-persistence-scala/build.sbt
@@ -5,6 +5,6 @@ version := "2.3-SNAPSHOT"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT",
   "com.typesafe.akka" %% "akka-persistence-experimental" % "2.4-SNAPSHOT"
 )
-

--- a/akka-samples/akka-sample-remote-java/build.sbt
+++ b/akka-samples/akka-sample-remote-java/build.sbt
@@ -5,6 +5,6 @@ version := "2.4-SNAPSHOT"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT",
   "com.typesafe.akka" %% "akka-remote" % "2.4-SNAPSHOT"
 )
-

--- a/akka-samples/akka-sample-remote-scala/build.sbt
+++ b/akka-samples/akka-sample-remote-scala/build.sbt
@@ -5,6 +5,6 @@ version := "2.4-SNAPSHOT"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT",
   "com.typesafe.akka" %% "akka-remote" % "2.4-SNAPSHOT"
 )
-

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,40 +18,23 @@ object Dependencies {
   object Compile {
     import Versions._
 
-    // Several dependencies are mirrored in the OSGi Dining Hackers maven project
-    // They need to be changed in this file as well:
-    //   akka-samples/akka-sample-osgi-dining-hakkers/pom.xml
-
     // Compile
     val camelCore     = "org.apache.camel"            % "camel-core"                   % "2.13.0" exclude("org.slf4j", "slf4j-api") // ApacheV2
 
     // when updating config version, update links ActorSystem ScalaDoc to link to the updated version
     val config        = "com.typesafe"                % "config"                       % "1.2.1"       // ApacheV2
-    // mirrored in OSGi sample
     val netty         = "io.netty"                    % "netty"                        % "3.8.0.Final" // ApacheV2
-    // mirrored in OSGi sample
     val protobuf      = "com.google.protobuf"         % "protobuf-java"                % "2.5.0"       // New BSD
     val scalaStm      = "org.scala-stm"              %% "scala-stm"                    % scalaStmVersion // Modified BSD (Scala)
 
     val slf4jApi      = "org.slf4j"                   % "slf4j-api"                    % "1.7.5"       // MIT
     val zeroMQClient  = "org.zeromq"                 %% "zeromq-scala-binding"         % scalaZeroMQVersion // ApacheV2
-    // mirrored in OSGi sample
     val uncommonsMath = "org.uncommons.maths"         % "uncommons-maths"              % "1.2.2a" exclude("jfree", "jcommon") exclude("jfree", "jfreechart")      // ApacheV2
-    // mirrored in OSGi sample
     val osgiCore      = "org.osgi"                    % "org.osgi.core"                % "4.3.1"       // ApacheV2
     val osgiCompendium= "org.osgi"                    % "org.osgi.compendium"          % "4.3.1"       // ApacheV2
-    // mirrored in OSGi sample
     val levelDB       = "org.iq80.leveldb"            % "leveldb"                      % "0.7"         // ApacheV2
-    // mirrored in OSGi sample
     val levelDBNative = "org.fusesource.leveldbjni"   % "leveldbjni-all"               % "1.7"         // New BSD
-
-    // Camel Sample
-    val camelJetty  = "org.apache.camel"              % "camel-jetty"                  % camelCore.revision // ApacheV2
-
-    // Cluster Sample
-    val sigar       = "org.fusesource"                   % "sigar"                        % "1.6.4"            // ApacheV2
-
-    // Test
+    val sigar         = "org.fusesource"              % "sigar"                        % "1.6.4"       // ApacheV2
 
     object Test {
       val commonsMath  = "org.apache.commons"          % "commons-math"                 % "2.1"              % "test" // ApacheV2
@@ -61,18 +44,12 @@ object Dependencies {
       val logback      = "ch.qos.logback"              % "logback-classic"              % "1.0.13"           % "test" // EPL 1.0 / LGPL 2.1
       val mockito      = "org.mockito"                 % "mockito-all"                  % "1.9.5"            % "test" // MIT
       // changing the scalatest dependency must be reflected in akka-docs/rst/dev/multi-jvm-testing.rst
-      // mirrored in OSGi sample
       val scalatest    = "org.scalatest"              %% "scalatest"                    % scalaTestVersion   % "test" // ApacheV2
       val scalacheck   = "org.scalacheck"             %% "scalacheck"                   % scalaCheckVersion  % "test" // New BSD
       val pojosr       = "com.googlecode.pojosr"       % "de.kalpatec.pojosr.framework" % "0.2.1"            % "test" // ApacheV2
       val tinybundles  = "org.ops4j.pax.tinybundles"   % "tinybundles"                  % "1.0.0"            % "test" // ApacheV2
       val log4j        = "log4j"                       % "log4j"                        % "1.2.14"           % "test" // ApacheV2
       val junitIntf    = "com.novocode"                % "junit-interface"              % "0.8"              % "test" // MIT
-      // dining hakkers integration test using pax-exam
-      // mirrored in OSGi sample
-      val karafExam    = "org.apache.karaf.tooling.exam" % "org.apache.karaf.tooling.exam.container" % "2.3.1" % "test" // ApacheV2
-      // mirrored in OSGi sample
-      val paxExam      = "org.ops4j.pax.exam"          % "pax-exam-junit4"              % "2.6.0"            % "test" // ApacheV2
       val scalaXml     = post210Dependency("org.scala-lang.modules" %% "scala-xml" % "1.0.1"  % "test")
 
       // metrics, measurements, perf testing
@@ -110,27 +87,13 @@ object Dependencies {
 
   val camel = Seq(camelCore, Test.scalatest, Test.junit, Test.mockito, Test.logback, Test.commonsIo, Test.junitIntf)
 
-  val camelSample = Seq(camelJetty)
-
   val osgi = Seq(osgiCore, osgiCompendium, Test.logback, Test.commonsIo, Test.pojosr, Test.tinybundles, Test.scalatest, Test.junit)
-
-  val osgiDiningHakkersSampleCore = Seq(config, osgiCore, osgiCompendium)
-
-  val osgiDiningHakkersSampleCommand = Seq(osgiCore, osgiCompendium)
-
-  val osgiDiningHakkersSampleTest = Seq(osgiCore, osgiCompendium, Test.karafExam, Test.paxExam, Test.junit, Test.scalatest)
-
-  val uncommons = Seq(uncommonsMath)
 
   val docs = Seq(Test.scalatest, Test.junit, Test.junitIntf)
 
   val zeroMQ = Seq(protobuf, zeroMQClient, Test.scalatest, Test.junit)
 
-  val clusterSample = Seq(Test.scalatest, sigar)
-
   val contrib = Seq(Test.junitIntf, Test.commonsIo)
-
-  val multiNodeSample = Seq(Test.scalatest)
 }
 
 object DependencyHelpers {

--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -32,14 +32,6 @@ object OSGi {
 
   val osgi = exports(Seq("akka.osgi.*"))
 
-  val osgiDiningHakkersSampleApi = exports(Seq("akka.sample.osgi.api"))
-
-  val osgiDiningHakkersSampleCommand = osgiSettings ++ Seq(OsgiKeys.bundleActivator := Option("akka.sample.osgi.command.Activator"), OsgiKeys.privatePackage := Seq("akka.sample.osgi.command"))
-
-  val osgiDiningHakkersSampleCore = exports(Seq("")) ++ Seq(OsgiKeys.bundleActivator := Option("akka.sample.osgi.activation.Activator"), OsgiKeys.privatePackage := Seq("akka.sample.osgi.internal", "akka.sample.osgi.activation", "akka.sample.osgi.service"))
-
-  val osgiDiningHakkersSampleUncommons = exports(Seq("org.uncommons.maths.random")) ++ Seq(OsgiKeys.privatePackage := Seq("org.uncommons.maths.binary", "org.uncommons.maths", "org.uncommons.maths.number"))
-
   val remote = exports(Seq("akka.remote.*"), imports = Seq(protobufImport()))
 
   val slf4j = exports(Seq("akka.event.slf4j.*"))

--- a/project/Sample.scala
+++ b/project/Sample.scala
@@ -1,0 +1,67 @@
+package akka
+
+import sbt._
+import sbt.Keys._
+
+object Sample {
+
+  final val akkaOrganization = "com.typesafe.akka"
+
+  def buildTransformer = (ti: BuildLoader.TransformInfo) => ti.base.name match {
+    case s if s.startsWith("akka-sample") =>
+      ti.unit.copy(
+        loadedDefinitions = ti.unit.definitions.copy(
+          projects = libraryToProjectDeps(ti.unit.definitions.projects)))
+    case _ => ti.unit
+  }
+
+  def project(name: String) =
+    ProjectRef(file(s"akka-samples/$name"), name)
+
+  private def libraryToProjectDeps(projects: Seq[Project]) =
+    projects.map(addProjectDependencies andThen excludeLibraryDependencies)
+
+  private val addProjectDependencies = (project: Project) => {
+    project.settings(
+      buildDependencies := {
+        val projectDependencies = libraryDependencies.value.collect {
+          case module if module.organization == akkaOrganization => ProjectRef(file("").toURI, module.name)
+        }
+        val dependencies = buildDependencies.value
+        val classpathWithProjectDependencies = dependencies.classpath.map {
+          case (proj, deps) if proj.project == project.id =>
+            // add project dependency for every akka library dependnecy
+            (proj, deps ++ projectDependencies.map(ResolvedClasspathDependency(_, None)))
+          case (project, deps) => (project, deps)
+        }
+        BuildDependencies(classpathWithProjectDependencies, dependencies.aggregate)
+      }
+    )
+  }
+
+  private val excludeLibraryDependencies = (project: Project) => {
+    project.settings(
+      libraryDependencies := libraryDependencies.value.map {
+        case module if module.organization == akkaOrganization =>
+          /**
+           * Exclude self, so it is still possible to know what project dependencies to add.
+           * This leaves all transitive dependencies (such as typesafe-config library).
+           * However it means that if a sample uses typesafe-config library it must have a
+           * library dependency which has a direct transitive dependency to typesafe-config.
+           */
+          module.excludeAll(ExclusionRule(organization=module.organization))
+        case module => module
+      }
+    )
+  }
+
+  private implicit class RichLoadedDefinitions(ld: LoadedDefinitions) {
+    def copy(projects: Seq[Project]) =
+      new LoadedDefinitions(ld.base, ld.target, ld.loader, ld.builds, projects, ld.buildNames)
+  }
+
+  private implicit class RichBuildUnit(bu: BuildUnit) {
+    def copy(loadedDefinitions: LoadedDefinitions) =
+      new BuildUnit(bu.uri, bu.localBase, loadedDefinitions, bu.plugins)
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,17 +15,13 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
-
-// needed for the akka-sample-hello-kernel
-// it is also defined in akka-samples/akka-sample-hello-kernel/project/plugins.sbt
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0-M2")
 
 // stats reporting
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"


### PR DESCRIPTION
- load sample builds from their definitions and replace library dependencies with project ones
- remove redefined sample build definitions
- test osgi sample by running a maven command

This unblocks #16096 because after SBT 0.13.6 project definitions defined in sbt files take precedence over same projects defined in `... extends Build {}` definitions. This prevents us redefining sample build definitions in `AkkaBuild.scala`.

OSGi dining hakkers is tested by running maven command. I tried to write `.sbt` files for that sample but was hit by various OSGi related errors when running tests. Therefore I delegated for maven to do all the work.

This is one more step to the direction of #15863 and #15031.
