### PR TITLE
+str #16191 adds Flow.concat(Source):Flow method

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -369,6 +369,13 @@ class Flow[-In, +Out](delegate: scaladsl.Flow[In, Out]) {
   def flatten[U](strategy: akka.stream.FlattenStrategy[Out, U]): javadsl.Flow[In, U] =
     new Flow(delegate.flatten(strategy))
 
+  /**
+   * Returns a new `Flow` that concatenates a secondary `Source` to this flow so that,
+   * the first element emitted by the given ("second") source is emitted after the last element of this Flow.
+   */
+  def concat(second: javadsl.Source[In]): javadsl.Flow[In, Out] =
+    new Flow(delegate.concat(second.asScala))
+
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -40,6 +40,24 @@ trait Flow[-In, +Out] extends FlowOps[Out] {
     (m.get(source), m.get(sink))
   }
 
+  /**
+   * Returns a new `Flow` that concatenates a secondary `Source` to this flow so that,
+   * the first element emitted by the given ("second") source is emitted after the last element of this Flow.
+   */
+  def concat(second: Source[In]): Flow[In, Out] = {
+    Flow() { b ⇒
+      val concatter = Concat[Out]
+      val source = UndefinedSource[In]
+      val sink = UndefinedSink[Out]
+
+      b.addEdge(source, this, concatter.first)
+        .addEdge(second, this, concatter.second)
+        .addEdge(concatter.out, sink)
+
+      source → sink
+    }
+  }
+
 }
 
 object Flow {


### PR DESCRIPTION
Had some spare minutes to implemented this.
Let me know if this is the expected semantics you were hoping for.

This is "source things get fed through the flow op", the other one that would make sense is "once the flow is drained, we use the source, without passing through the flow".

Resolves #16191
