### PR TITLE
=str #16163 allow connecting GraphSource to GraphSink directly

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorBasedFlowMaterializer.scala
@@ -85,6 +85,10 @@ private[akka] object Ast {
   sealed trait FanInAstNode extends JunctionAstNode
   sealed trait FanOutAstNode extends JunctionAstNode
 
+  case object IdentityAstNode extends JunctionAstNode {
+    override def name = "identity"
+  }
+
   case object Merge extends FanInAstNode {
     override def name = "merge"
   }
@@ -274,6 +278,10 @@ case class ActorBasedFlowMaterializer(override val settings: MaterializerSetting
         impl ! FanOut.ExposedPublishers(publishers.asInstanceOf[immutable.Seq[ActorPublisher[Any]]])
         val subscriber = ActorSubscriber[In](impl)
         (List(subscriber), publishers)
+
+      case identity @ Ast.IdentityAstNode ⇒
+        val id: Processor[In, Out] = processorForNode(identityTransform, identity.name, 1).asInstanceOf[Processor[In, Out]]
+        (List(id), List(id))
     }
 
   }


### PR DESCRIPTION
- introduce Identity junction, which is used to connect GraphSource to GraphSink
- only materialize ActorFlowSource and ActorFlowSink as a Flow

The solution is identical to a solution in a Flow materialization when if both Source and Sink are passive an identity transformer is used to connect the two.

Fixes #16163
