### PR TITLE
=doc Fix wrong rst format

### DIFF
--- a/akka-docs/rst/java/futures.rst
+++ b/akka-docs/rst/java/futures.rst
@@ -172,7 +172,7 @@ To better explain what happened in the example, ``Future.sequence`` is taking th
 and turning it into a ``Future<Iterable<Integer>>``. We can then use ``map`` to work with the ``Iterable<Integer>`` directly,
 and we aggregate the sum of the ``Iterable``.
 
-The ``traverse`` method is similar to ``sequence``, but it takes a sequence of ``A``s and applies a function from ``A`` to ``Future<B>``
+The ``traverse`` method is similar to ``sequence``, but it takes a sequence of ``A`` and applies a function from ``A`` to ``Future<B>``
 and returns a ``Future<Iterable<B>>``, enabling parallel ``map`` over the sequence, if you use ``Futures.future`` to create the ``Future``.
 
 .. includecode:: code/docs/future/FutureDocTest.java

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -408,8 +408,8 @@ the persistent actor will resend these before sending any other messages.
 
 Deliver also requires a function to pass the ``deliveryId`` into the message. A ``deliveryId`` is required to acknowledge 
 receipt of a message, and is also used in playback, when the actor is recovering so that messages received can be correctly acknowledged. 
-A function can be created to map your own ``messageId`` with ``deliveryId``s, which may come from your own domain model. 
-This function must keep track of which ``messageId``s have been acknowledged.
+A function can be created to map your own ``messageId`` to ``deliveryId``, which may come from your own domain model. 
+This function must keep track of which ``messageId`` have been acknowledged.
 Alternatively, the Persistence module provides a default sequence number implementation which can also be used as the ``deliveryId`` 
 for messages. The default sequence increases monotonically, without gaps.
 

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -414,8 +414,8 @@ the persistent actor will resend these before sending any other messages.
 
 Deliver also requires a function to pass the ``deliveryId`` into the message. A ``deliveryId`` is required to acknowledge 
 receipt of a message, and is also used in playback, when the actor is recovering so that messages received can be correctly acknowledged. 
-A function can be created to map your own ``messageId`` with ``deliveryId``s, which may come from your own domain model. 
-This function must keep track of which ``messageId``s have been acknowledged.
+A function can be created to map your own ``messageId`` to ``deliveryId``, which may come from your own domain model. 
+This function must keep track of which ``messageId`` have been acknowledged.
 Alternatively, the Persistence module provides a default sequence number implementation which can also be used as the ``deliveryId`` 
 for messages. The default sequence increases monotonically, without gaps.
 

--- a/akka-docs/rst/java/typed-actors.rst
+++ b/akka-docs/rst/java/typed-actors.rst
@@ -192,7 +192,7 @@ Receive arbitrary messages
 --------------------------
 
 If your implementation class of your TypedActor extends ``akka.actor.TypedActor.Receiver``,
-all messages that are not ``MethodCall``s will be passed into the ``onReceive``-method.
+all messages that are not ``MethodCall`` instances will be passed into the ``onReceive``-method.
 
 This allows you to react to DeathWatch ``Terminated``-messages and other types of messages,
 e.g. when interfacing with untyped actors.

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -412,8 +412,8 @@ the persistent actor will resend these before sending any other messages.
 
 Deliver also requires a function to pass the ``deliveryId`` into the message. A ``deliveryId`` is required to acknowledge 
 receipt of a message, and is also used in playback, when the actor is recovering so that messages received can be correctly acknowledged. 
-A function can be created to map your own ``messageId`` with ``deliveryId``s, which may come from your own domain model. 
-This function must keep track of which ``messageId``s have been acknowledged.
+A function can be created to map your own ``messageId`` to ``deliveryId``, which may come from your own domain model. 
+This function must keep track of which ``messageId`` have been acknowledged.
 Alternatively, the Persistence module provides a default sequence number implementation which can also be used as the ``deliveryId`` 
 for messages. The default sequence increases monotonically, without gaps.
 

--- a/akka-docs/rst/scala/typed-actors.rst
+++ b/akka-docs/rst/scala/typed-actors.rst
@@ -184,7 +184,7 @@ Receive arbitrary messages
 --------------------------
 
 If your implementation class of your TypedActor extends ``akka.actor.TypedActor.Receiver``,
-all messages that are not ``MethodCall``s will be passed into the ``onReceive``-method.
+all messages that are not ``MethodCall`` instances will be passed into the ``onReceive``-method.
 
 This allows you to react to DeathWatch ``Terminated``-messages and other types of messages,
 e.g. when interfacing with untyped actors.


### PR DESCRIPTION
broken rendering, see here: http://doc.akka.io/docs/akka/snapshot/scala/persistence.html#At-Least-Once_Delivery
