### PR TITLE
=str #16272 splitWhen should drop reference when done with substream

### DIFF
--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -257,10 +257,10 @@ public class FlowTest {
   @Test
   public void mustBeAbleToUseSplitWhen() {
     final JavaTestKit probe = new JavaTestKit(system);
-    final Iterable<String> input = Arrays.asList("A", "B", "C", "\n", "D", "\n", "E", "F");
+    final Iterable<String> input = Arrays.asList("A", "B", "C", ".", "D", ".", "E", "F");
     Source.from(input).splitWhen(new Predicate<String>() {
       public boolean test(String elem) {
-        return elem.equals("\n");
+        return elem.equals(".");
       }
     }).foreach(new Procedure<Source<String>>() {
       @Override
@@ -268,7 +268,7 @@ public class FlowTest {
         subStream.filter(new Predicate<String>() {
           @Override
           public boolean test(String elem) {
-            return !elem.equals("\n");
+            return !elem.equals(".");
           }
         }).grouped(10).foreach(new Procedure<List<String>>() {
           @Override

--- a/akka-stream/src/main/scala/akka/stream/impl/SplitWhenProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SplitWhenProcessorImpl.scala
@@ -38,7 +38,7 @@ private[akka] class SplitWhenProcessorImpl(_settings: MaterializerSettings, val 
   def serveSubstreamRest(substream: SubstreamOutput) = TransferPhase(primaryInputs.NeedsInput && substream.NeedsDemand) { () ⇒
     val elem = primaryInputs.dequeueInputElement()
     if (splitPredicate(elem)) {
-      currentSubstream.complete()
+      completeSubstreamOutput(currentSubstream.key)
       currentSubstream = null
       nextPhase(openSubstream(elem))
     } else substream.enqueueOutputElement(elem)
@@ -52,9 +52,9 @@ private[akka] class SplitWhenProcessorImpl(_settings: MaterializerSettings, val 
 
   nextPhase(waitFirst)
 
-  override def invalidateSubstreamOutput(substream: SubstreamKey): Unit = {
+  override def completeSubstreamOutput(substream: SubstreamKey): Unit = {
     if ((currentSubstream ne null) && substream == currentSubstream.key) nextPhase(ignoreUntilNewSubstream)
-    super.invalidateSubstreamOutput(substream)
+    super.completeSubstreamOutput(substream)
   }
 
 }


### PR DESCRIPTION
The completeSubstreamOutput is used to not early complete the stream,
where as invalidating would shutdown the stream too early (and elements
wouldn't be emitted as expected).

Please review @drewhk @patriknw 
cc @jrudolph 
