### PR TITLE
=htc optimize rendering for Strict entities

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpRequestRendererFactory.scala
@@ -111,7 +111,7 @@ private[http] class HttpRequestRendererFactory(userAgentHeader: Option[headers.`
 
           case HttpEntity.Strict(_, data) ⇒
             renderContentLength(data.length)
-            Source(r.get :: data :: Nil) :: Nil
+            Source.singleton(r.get ++ data) :: Nil
 
           case HttpEntity.Default(_, contentLength, data) ⇒
             renderContentLength(contentLength)

--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpResponseRendererFactory.scala
@@ -143,8 +143,8 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
             renderHeaders(headers.toList)
             renderEntityContentType(r, entity)
             r ~~ `Content-Length` ~~ data.length ~~ CrLf ~~ CrLf
-            val entityBytes = if (noEntity) Nil else data :: Nil
-            Source(r.get :: entityBytes) :: Nil
+            val entityBytes = if (noEntity) ByteString.empty else data
+            Source.singleton(r.get ++ entityBytes) :: Nil
 
           case HttpEntity.Default(_, contentLength, data) ⇒
             renderHeaders(headers.toList)


### PR DESCRIPTION
This amounts to 50% more RPS in the simple TestServer ping example on my machine.
