### PR TITLE
=act reimplement actor path validation without regex

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
@@ -3,9 +3,10 @@
  */
 package akka.actor
 
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
 import java.net.MalformedURLException
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
 
 class ActorPathSpec extends WordSpec with Matchers {
 
@@ -71,7 +72,6 @@ class ActorPathSpec extends WordSpec with Matchers {
       rootA.toStringWithAddress(b) should be("akka.tcp://mysys@aaa:2552/")
       (rootA / "user").toStringWithAddress(b) should be("akka.tcp://mysys@aaa:2552/user")
       (rootA / "user" / "foo").toStringWithAddress(b) should be("akka.tcp://mysys@aaa:2552/user/foo")
-
     }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -116,12 +116,16 @@ class LocalActorRefProviderSpec extends AkkaSpec(LocalActorRefProviderSpec.confi
     "throw suitable exceptions for malformed actor names" in {
       intercept[InvalidActorNameException](system.actorOf(Props.empty, null)).getMessage.contains("null") should be(true)
       intercept[InvalidActorNameException](system.actorOf(Props.empty, "")).getMessage.contains("empty") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "$hallo")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a%")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%3")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%1t")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a?")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "üß")).getMessage.contains("conform") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "$hallo")).getMessage.contains("not start with `$`") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a%")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%3")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%xx")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%0G")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%gg")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%1t")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a?")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "üß")).getMessage.contains("include only ASCII") should be(true)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -17,12 +17,38 @@ object ActorPath {
     case _                               ⇒ throw new MalformedURLException("cannot parse as ActorPath: " + s)
   }
 
-  /**
-   * This Regular Expression is used to validate a path element (Actor Name).
-   * Since Actors form a tree, it is addressable using an URL, therefore an Actor Name has to conform to:
-   * http://www.ietf.org/rfc/rfc2396.txt
-   */
+  @deprecated("Use `isValidPathElement` instead", since = "2.3.8")
   val ElementRegex = """(?:[-\w:@&=+,.!~*'_;]|%\p{XDigit}{2})(?:[-\w:@&=+,.!~*'$_;]|%\p{XDigit}{2})*""".r
+
+  /** INTERNAL API */
+  private[akka] final val ValidSymbols = """-_.*$+:@&=,!~';"""
+
+  /**
+   * This method is used to validate a path element (Actor Name).
+   * Since Actors form a tree, it is addressable using an URL, therefore an Actor Name has to conform to:
+   * [[http://www.ietf.org/rfc/rfc2396.txt RFC-2396]].
+   *
+   * User defined Actor names may not start from a `$` sign - these are reserved for system names.
+   */
+  final def isValidPathElement(s: String): Boolean = {
+    def isValidChar(c: Char): Boolean =
+      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (ValidSymbols.indexOf(c) != -1)
+
+    def isHexChar(c: Char): Boolean =
+      (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || (c >= '0' && c <= '9')
+
+    val len = s.length
+    def validate(pos: Int): Boolean =
+      if (pos < len)
+        s.charAt(pos) match {
+          case c if isValidChar(c) ⇒ validate(pos + 1)
+          case '%' if pos + 2 < len && isHexChar(s.charAt(pos + 1)) && isHexChar(s.charAt(pos + 2)) ⇒ validate(pos + 3)
+          case _ ⇒ false
+        }
+      else true
+
+    len > 0 && s.charAt(0) != '$' && validate(0)
+  }
 
   private[akka] final val emptyActorPath: immutable.Iterable[String] = List("")
 }

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -4,13 +4,12 @@
 
 package akka.actor
 
-import scala.concurrent.duration.Duration
-import com.typesafe.config._
-import akka.routing._
-import akka.japi.Util.immutableSeq
-import java.util.concurrent.{ TimeUnit }
-import akka.util.WildcardTree
 import java.util.concurrent.atomic.AtomicReference
+
+import akka.routing._
+import akka.util.WildcardTree
+import com.typesafe.config._
+
 import scala.annotation.tailrec
 
 object Deploy {
@@ -155,14 +154,13 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
 
   def deploy(d: Deploy): Unit = {
     @tailrec def add(path: Array[String], d: Deploy, w: WildcardTree[Deploy] = deployments.get): Unit = {
-      import ActorPath.ElementRegex
       for (i ← 0 until path.length) path(i) match {
         case "" ⇒
           throw new InvalidActorNameException(s"actor name in deployment [${d.path}] must not be empty")
-        case ElementRegex() ⇒ // ok
+        case el if ActorPath.isValidPathElement(el) ⇒ // ok
         case name ⇒
           throw new InvalidActorNameException(
-            s"illegal actor name [$name] in deployment [${d.path}], must conform to $ElementRegex")
+            s"Illegal actor name [$name] in deployment [${d.path}]. Actor paths MUST: not start with `$$`, include only ASCII letters and can only contain these special characters: ${ActorPath.ValidSymbols}.")
       }
 
       if (!deployments.compareAndSet(w, w.insert(path.iterator, d))) add(path, d)

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -8,7 +8,6 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import scala.collection.immutable
 import akka.actor._
-import akka.actor.ActorPath.ElementRegex
 import akka.serialization.SerializationExtension
 import akka.util.{ Unsafe, Helpers }
 
@@ -176,10 +175,10 @@ private[akka] trait Children { this: ActorCell ⇒
 
   private def checkName(name: String): String = {
     name match {
-      case null           ⇒ throw new InvalidActorNameException("actor name must not be null")
-      case ""             ⇒ throw new InvalidActorNameException("actor name must not be empty")
-      case ElementRegex() ⇒ name
-      case _              ⇒ throw new InvalidActorNameException(s"illegal actor name [$name], must conform to $ElementRegex")
+      case null                                    ⇒ throw new InvalidActorNameException("actor name must not be null")
+      case ""                                      ⇒ throw new InvalidActorNameException("actor name must not be empty")
+      case _ if ActorPath.isValidPathElement(name) ⇒ name
+      case _                                       ⇒ throw new InvalidActorNameException(s"Illegal actor name [$name]. Actor paths MUST: not start with `$$`, include only ASCII letters and can only contain these special characters: ${ActorPath.ValidSymbols}.")
     }
   }
 

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+/*
+regex checking:
+[info] a.a.ActorCreationBenchmark.synchronousStarting       ss    120000       28.285        0.481       us
+
+hand checking:
+[info] a.a.ActorCreationBenchmark.synchronousStarting       ss    120000       21.496        0.502       us
+
+
+*/
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@Fork(5)
+@Warmup(iterations = 1000)
+@Measurement(iterations = 4000)
+class ActorCreationBenchmark {
+  implicit val system: ActorSystem = ActorSystem()
+
+  final val props = Props[MyActor]
+
+  var i = 1
+  def name = {
+    i +=1
+    "some-rather-long-actor-name-actor-" + i
+  }
+
+  @TearDown(Level.Trial)
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def synchronousStarting =
+    system.actorOf(props, name)
+}
+
+class MyActor extends Actor {
+  override def receive: Receive = {
+    case _ ⇒
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorPathValidationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorPathValidationBenchmark.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+
+/*
+[info] Benchmark                                            Mode   Samples        Score  Score error    Units
+[info] a.a.ActorPathValidationBenchmark.handLoop7000       thrpt        20        0.070        0.002   ops/us
+[info] a.a.ActorPathValidationBenchmark.old7000            -- blows up (stack overflow) --
+
+[info] a.a.ActorPathValidationBenchmark.handLoopActor_1    thrpt        20       38.825        3.378   ops/us
+[info] a.a.ActorPathValidationBenchmark.oldActor_1         thrpt        20        1.585        0.090   ops/us
+ */
+@Fork(2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class ActorPathValidationBenchmark {
+
+  final val a = "actor-1"
+  final val s = "687474703a2f2f74686566727569742e636f6d2f26683d37617165716378357926656e" * 100
+
+  final val ElementRegex = """(?:[-\w:@&=+,.!~*'_;]|%\p{XDigit}{2})(?:[-\w:@&=+,.!~*'$_;]|%\p{XDigit}{2})*""".r
+
+
+//  @Benchmark // blows up with stack overflow, we know
+  def old7000: Option[List[String]] = ElementRegex.unapplySeq(s)
+
+  @Benchmark
+  def handLoop7000: Boolean = ActorPath.isValidPathElement(s)
+
+  @Benchmark
+  def oldActor_1: Option[List[String]] = ElementRegex.unapplySeq(a)
+
+  @Benchmark
+  def handLoopActor_1: Boolean = ActorPath.isValidPathElement(a)
+
+}

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalJavaSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalJavaSpec.scala
@@ -1,12 +1,11 @@
 package akka.persistence.journal.leveldb
 
 import akka.persistence.journal.JournalSpec
-import akka.persistence.{PersistenceSpec, PluginCleanup}
+import akka.persistence.{ PersistenceSpec, PluginCleanup }
 
 class LeveldbJournalJavaSpec extends JournalSpec with PluginCleanup {
   lazy val config = PersistenceSpec.config(
-      "leveldb",
-      "LeveldbJournalJavaSpec",
-      extraConfig = Some("akka.persistence.journal.leveldb.native = off")
-    )
+    "leveldb",
+    "LeveldbJournalJavaSpec",
+    extraConfig = Some("akka.persistence.journal.leveldb.native = off"))
 }

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
@@ -3,8 +3,8 @@
  */
 package akka.persistence.journal.leveldb
 
-import akka.persistence.journal.{JournalPerfSpec, JournalSpec}
-import akka.persistence.{PersistenceSpec, PluginCleanup}
+import akka.persistence.journal.{ JournalPerfSpec, JournalSpec }
+import akka.persistence.{ PersistenceSpec, PluginCleanup }
 import org.scalatest.DoNotDiscover
 
 @DoNotDiscover // only for validating compilation of `JournalSpec with JournalPerfSpec`
@@ -12,6 +12,5 @@ class LeveldbJournalNativePerfSpec extends JournalSpec with JournalPerfSpec with
   lazy val config = PersistenceSpec.config(
     "leveldb",
     "LeveldbJournalNativePerfSpec",
-    extraConfig = Some("akka.persistence.journal.leveldb.native = on")
-  )
+    extraConfig = Some("akka.persistence.journal.leveldb.native = on"))
 }

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativeSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativeSpec.scala
@@ -1,13 +1,12 @@
 package akka.persistence.journal.leveldb
 
 import akka.persistence.journal.JournalSpec
-import akka.persistence.{PersistenceSpec, PluginCleanup}
+import akka.persistence.{ PersistenceSpec, PluginCleanup }
 
 class LeveldbJournalNativeSpec extends JournalSpec with PluginCleanup {
   lazy val config = PersistenceSpec.config(
     "leveldb",
     "LeveldbJournalNativeSpec",
-    extraConfig = Some("akka.persistence.journal.leveldb.native = on")
-  )
+    extraConfig = Some("akka.persistence.journal.leveldb.native = on"))
 
 }

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -192,9 +192,7 @@ object AkkaBuild extends Build {
     dependencies = Seq(actor, stream, persistence, testkit).map(_ % "compile;compile->test"),
     settings = defaultSettings ++ Seq(
       libraryDependencies ++= Dependencies.testkit
-    ) ++ settings ++ jmhSettings ++ Seq(
-      outputTarget in Jmh := target.value
-    )
+    ) ++ settings ++ jmhSettings
   )
 
   lazy val actorTests = Project(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.5")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.6")
 
 // needed for the akka-sample-hello-kernel
 // it is also defined in akka-samples/akka-sample-hello-kernel/project/plugins.sbt


### PR DESCRIPTION
While working on fixing https://github.com/akka/akka/pull/16347 I decided to let go of the regexp and impl simpler methods.

I found that on a smaller scale the new methods are way better, but in the grand scheme of things there seems to be a larger trade off at higher percentiles.

I got to:

```
+[info] a.a.ActorCreationBenchmark.synchronousStarting       ss     20000       16.413        1.494       us
```

from an initial:

```
+[info] a.a.ActorCreationBenchmark.synchronousStarting       ss     20000       27.022        1.903       us
```

but the higher percentiles got hit quite hard (_averages mean nothing_ mantra kicks in...).

Note: These implementations pass tests in akka actor and survive the `...|%67` which caused the regex based impl to blow up.

Do you think it is worth trying one of these impls or am I on the wrong way?
