### PR TITLE
=act #16361 Added more information to AskTimeoutException

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
@@ -49,7 +49,7 @@ trait GracefulStopSupport {
     if (target.isTerminated) Future successful true
     else {
       val internalTarget = target.asInstanceOf[InternalActorRef]
-      val ref = PromiseActorRef(internalTarget.provider, Timeout(timeout), targetName = target.toString)
+      val ref = PromiseActorRef(internalTarget.provider, Timeout(timeout), targetName = target.toString, message = stopMessage)
       internalTarget.sendSystemMessage(Watch(internalTarget, ref))
       target.tell(stopMessage, Actor.noSender)
       ref.result.future.transform(

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -298,7 +298,7 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport) extends A
     if (target.isTerminated) Future successful SetThrottleAck
     else {
       val internalTarget = target.asInstanceOf[InternalActorRef]
-      val ref = PromiseActorRef(internalTarget.provider, timeout, target.toString)
+      val ref = PromiseActorRef(internalTarget.provider, timeout, target.toString, mode)
       internalTarget.sendSystemMessage(Watch(internalTarget, ref))
       target.tell(mode, ref)
       ref.result.future.transform({


### PR DESCRIPTION
This could be very useful for debug. Very often timeouts occurs inside external library and you are not able to attach failure handler to them and to understand what happens.
If code diff is too big then I could reduce it by removing a sender.
