### PR TITLE
=pro #16371 enable cross builds (forward-port)

### DIFF
--- a/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
+++ b/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
@@ -4,7 +4,7 @@
 
 package akka.japi.pf
 
-import FI.{UnitApply, Apply, Predicate}
+import FI.{ UnitApply, Apply, Predicate }
 
 private[pf] object CaseStatement {
   def empty[F, T](): PartialFunction[F, T] = PartialFunction.empty

--- a/akka-zeromq/build.sbt
+++ b/akka-zeromq/build.sbt
@@ -11,6 +11,6 @@ Unidoc.javadocSettings
 
 OSGi.zeroMQ
 
-libraryDependencies ++= Dependencies.zeroMQ
+Dependencies.zeroMQ
 
 MimaKeys.previousArtifact := akkaPreviousArtifact("akka-zeromq").value

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -32,9 +32,10 @@ object AkkaBuild extends Build {
   val enableMiMa = false
 
   lazy val buildSettings = Seq(
-    organization := "com.typesafe.akka",
-    version      := "2.4-SNAPSHOT",
-    scalaVersion := Dependencies.Versions.scalaVersion
+    organization        := "com.typesafe.akka",
+    version             := "2.4-SNAPSHOT",
+    scalaVersion        := Dependencies.Versions.scalaVersion,
+    crossScalaVersions  := Dependencies.Versions.crossScala
   )
 
   lazy val root = Project(
@@ -51,7 +52,7 @@ object AkkaBuild extends Build {
       S3.progress in S3.upload := true,
       mappings in S3.upload <<= (Release.releaseDirectory, version) map { (d, v) =>
         val downloads = d / "downloads"
-        val archivesPathFinder = (downloads * ("*" + v + ".zip")) +++ (downloads * ("*" + v + ".tgz"))
+        val archivesPathFinder = downloads * s"*$v.zip"
         archivesPathFinder.get.map(file => (file -> ("akka/" + file.getName)))
       },
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,12 +5,12 @@ import sbt._
 object Dependencies {
 
   import DependencyHelpers._
-  import DependencyHelpers.ScalaVersionDependentModuleID.post210Dependency
+  import DependencyHelpers.ScalaVersionDependentModuleID._
 
   object Versions {
-    val scalaVersion = sys.props.get("akka.scalaVersion").getOrElse("2.10.4")
+    val crossScala = Seq("2.10.4", "2.11.4")
+    val scalaVersion = crossScala.head
     val scalaStmVersion  = sys.props.get("akka.build.scalaStmVersion").getOrElse("0.7")
-    val scalaZeroMQVersion = sys.props.get("akka.build.scalaZeroMQVersion").getOrElse("0.0.7")
     val scalaTestVersion = sys.props.get("akka.build.scalaTestVersion").getOrElse("2.1.3")
     val scalaCheckVersion = sys.props.get("akka.build.scalaCheckVersion").getOrElse("1.11.3")
   }
@@ -28,7 +28,7 @@ object Dependencies {
     val scalaStm      = "org.scala-stm"              %% "scala-stm"                    % scalaStmVersion // Modified BSD (Scala)
 
     val slf4jApi      = "org.slf4j"                   % "slf4j-api"                    % "1.7.5"       // MIT
-    val zeroMQClient  = "org.zeromq"                 %% "zeromq-scala-binding"         % scalaZeroMQVersion // ApacheV2
+    val zeroMQClient  = "org.spark-project.zeromq"   %% "zeromq-scala-binding"         % "0.0.7-spark"  // ApacheV2
     val uncommonsMath = "org.uncommons.maths"         % "uncommons-maths"              % "1.2.2a" exclude("jfree", "jcommon") exclude("jfree", "jfreechart")      // ApacheV2
     val osgiCore      = "org.osgi"                    % "org.osgi.core"                % "4.3.1"       // ApacheV2
     val osgiCompendium= "org.osgi"                    % "org.osgi.compendium"          % "4.3.1"       // ApacheV2
@@ -91,7 +91,7 @@ object Dependencies {
 
   val docs = Seq(Test.scalatest, Test.junit, Test.junitIntf)
 
-  val zeroMQ = Seq(protobuf, zeroMQClient, Test.scalatest, Test.junit)
+  val zeroMQ = deps(protobuf, zeroMQClient, Test.scalatest, Test.junit)
 
   val contrib = Seq(Test.junitIntf, Test.commonsIo)
 }

--- a/project/scripts/release
+++ b/project/scripts/release
@@ -75,9 +75,9 @@
 #
 # Run the script in two stages.
 #  First a dry run:
-#    shell> project/scripts/release --dry-run <version>
-#  And if all goes well a real run:
 #    shell> project/scripts/release <version>
+#  And if all goes well a real run:
+#    shell> project/scripts/release --real-run <version>
 #
 # The artifacts published to oss.sonatype.org needs to be released by following the
 # instructions under release here
@@ -91,10 +91,12 @@ declare -r default_path="www"
 declare -r release_dir="target/release"
 declare release_server=${default_server}
 declare release_path=${default_path}
-declare -r unzipped_dir="target/dist/unzipped"
 
 # flags
 unset run_tests dry_run no_mima no_revert
+
+# dry-run is the default
+dry_run=true
 
 # get the source location for this script; handles symlinks
 function get_script_path {
@@ -113,12 +115,13 @@ declare -r script_dir="$(cd -P "$(dirname "${script_path}")" && pwd)"
 # print usage info
 function usage {
   cat <<EOM
+Dry run is be default.
 Usage: ${script_name} [options] VERSION
   -h | --help            Print this usage message
   -t | --run-tests       Run all tests before releasing
   -s | --server SERVER   Set the release server (default ${default_server})
   -p | --path PATH       Set the path on the release server (default ${default_path})
-  -n | --dry-run         Build everything but do not push the release
+  -e | --real-run        Build everything and push the release
   -m | --no-mima         Skip binary compatibility check in dry-run
   -r | --no-revert       On dry-run don't revert git commits and tags
 EOM
@@ -152,7 +155,7 @@ while true; do
     -t | --run-tests ) run_tests=true; shift ;;
     -s | --server ) release_server=$2; shift 2 ;;
     -p | --path ) release_path=$2; shift 2 ;;
-    -n | --dry-run) dry_run=true; shift ;;
+    -e | --real-run) dry_run=false; shift ;;
     -m | --no-mima) no_mima=true; shift ;;
     -r | --no-revert) no_revert=true; shift ;;
     * ) break ;;
@@ -192,15 +195,6 @@ function get_current_branch {
 # a little messy as the ansi escape codes are included
 function get_current_version {
   local result=$(sbt version | tail -1 | cut -f2)
-  # remove ansi escape code from end
-  local code0=$(echo -e "\033[0m")
-  echo ${result%$code0}
-}
-
-# get the scalaBinaryVersion from sbt
-# a little messy as the ansi escape codes are included
-function get_scala_binary_version {
-  local result=$(sbt scalaBinaryVersion | tail -1 | cut -f2)
   # remove ansi escape code from end
   local code0=$(echo -e "\033[0m")
   echo ${result%$code0}
@@ -273,10 +267,6 @@ else
   echolog "Publishing to ${publish_path}"
 fi
 
-echolog "Getting scalaBinaryVersion from sbt..."
-declare -r scala_binary_version=$(get_scala_binary_version)
-echolog "scalaBinaryVersion is ${scala_binary_version}"
-
 [[ $run_tests ]] && echolog "All tests will be run"
 
 # try ssh'ing to the release server
@@ -310,9 +300,7 @@ if [ ! $dry_run ]; then
 else
   RELEASE_OPT="-Dakka.genjavadoc.enabled=true"
 fi
-try sbt $RELEASE_OPT build-release
-echolog "Creating gzipped tar download..."
-try tar -cz -C ${unzipped_dir} -f ${release_dir}/downloads/akka_${scala_binary_version}-${version}.tgz akka-${version}
+try sbt $RELEASE_OPT +build-release
 echolog "Successfully created local release"
 
 # check binary compatibility for dry run


### PR DESCRIPTION
- changed zeromq-scala-binding library
- modified build-release task to include distributions from cross builds
- removed tar-zip step from release script, because tgz package is not used from the website
- release script now releases for all crossScalaVersions
- dry run is the default now

This is #16144 ported to master
