### PR TITLE
JMH Benchmarks and optimised ActorPath parser (for Validation)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
@@ -3,9 +3,10 @@
  */
 package akka.actor
 
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
 import java.net.MalformedURLException
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
 
 class ActorPathSpec extends WordSpec with Matchers {
 
@@ -71,7 +72,6 @@ class ActorPathSpec extends WordSpec with Matchers {
       rootA.toStringWithAddress(b) should be("akka.tcp://mysys@aaa:2552/")
       (rootA / "user").toStringWithAddress(b) should be("akka.tcp://mysys@aaa:2552/user")
       (rootA / "user" / "foo").toStringWithAddress(b) should be("akka.tcp://mysys@aaa:2552/user/foo")
-
     }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -116,12 +116,16 @@ class LocalActorRefProviderSpec extends AkkaSpec(LocalActorRefProviderSpec.confi
     "throw suitable exceptions for malformed actor names" in {
       intercept[InvalidActorNameException](system.actorOf(Props.empty, null)).getMessage.contains("null") should be(true)
       intercept[InvalidActorNameException](system.actorOf(Props.empty, "")).getMessage.contains("empty") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "$hallo")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a%")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%3")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%1t")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a?")).getMessage.contains("conform") should be(true)
-      intercept[InvalidActorNameException](system.actorOf(Props.empty, "üß")).getMessage.contains("conform") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "$hallo")).getMessage.contains("not start with `$`") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a%")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%3")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%xx")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%0G")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%gg")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "%1t")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "a?")).getMessage.contains("Illegal actor name") should be(true)
+      intercept[InvalidActorNameException](system.actorOf(Props.empty, "üß")).getMessage.contains("include only ASCII") should be(true)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -4,13 +4,12 @@
 
 package akka.actor
 
-import scala.concurrent.duration.Duration
-import com.typesafe.config._
-import akka.routing._
-import akka.japi.Util.immutableSeq
-import java.util.concurrent.{ TimeUnit }
-import akka.util.WildcardTree
 import java.util.concurrent.atomic.AtomicReference
+
+import akka.routing._
+import akka.util.WildcardTree
+import com.typesafe.config._
+
 import scala.annotation.tailrec
 
 object Deploy {
@@ -155,14 +154,13 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
 
   def deploy(d: Deploy): Unit = {
     @tailrec def add(path: Array[String], d: Deploy, w: WildcardTree[Deploy] = deployments.get): Unit = {
-      import ActorPath.ElementRegex
       for (i ← 0 until path.length) path(i) match {
         case "" ⇒
           throw new InvalidActorNameException(s"actor name in deployment [${d.path}] must not be empty")
-        case ElementRegex() ⇒ // ok
+        case el if ActorPath.isValidPathElement(el) ⇒ // ok
         case name ⇒
           throw new InvalidActorNameException(
-            s"illegal actor name [$name] in deployment [${d.path}], must conform to $ElementRegex")
+            s"Illegal actor name [$name] in deployment [${d.path}]. Actor paths MUST: not start with `$$`, include only ASCII letters and can only contain these special characters: ${ActorPath.ValidSymbols}.")
       }
 
       if (!deployments.compareAndSet(w, w.insert(path.iterator, d))) add(path, d)

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -8,7 +8,6 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import scala.collection.immutable
 import akka.actor._
-import akka.actor.ActorPath.ElementRegex
 import akka.serialization.SerializationExtension
 import akka.util.{ Unsafe, Helpers }
 
@@ -176,10 +175,10 @@ private[akka] trait Children { this: ActorCell ⇒
 
   private def checkName(name: String): String = {
     name match {
-      case null           ⇒ throw new InvalidActorNameException("actor name must not be null")
-      case ""             ⇒ throw new InvalidActorNameException("actor name must not be empty")
-      case ElementRegex() ⇒ name
-      case _              ⇒ throw new InvalidActorNameException(s"illegal actor name [$name], must conform to $ElementRegex")
+      case null                                    ⇒ throw new InvalidActorNameException("actor name must not be null")
+      case ""                                      ⇒ throw new InvalidActorNameException("actor name must not be empty")
+      case _ if ActorPath.isValidPathElement(name) ⇒ name
+      case _                                       ⇒ throw new InvalidActorNameException(s"Illegal actor name [$name]. Actor paths MUST: not start with `$$`, include only ASCII letters and can only contain these special characters: ${ActorPath.ValidSymbols}.")
     }
   }
 

--- a/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
+++ b/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
@@ -4,7 +4,7 @@
 
 package akka.japi.pf
 
-import FI.{UnitApply, Apply, Predicate}
+import FI.{ UnitApply, Apply, Predicate }
 
 private[pf] object CaseStatement {
   def empty[F, T](): PartialFunction[F, T] = PartialFunction.empty

--- a/akka-bench-jmh/build.sbt
+++ b/akka-bench-jmh/build.sbt
@@ -1,0 +1,7 @@
+import akka.{ AkkaBuild, Dependencies, Formatting, Unidoc }
+
+import pl.project13.scala.sbt.SbtJmh._
+import pl.project13.scala.sbt.SbtJmh.JmhKeys._
+
+jmhSettings
+

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+/*
+regex checking:
+[info] a.a.ActorCreationBenchmark.synchronousStarting       ss    120000       28.285        0.481       us
+
+hand checking:
+[info] a.a.ActorCreationBenchmark.synchronousStarting       ss    120000       21.496        0.502       us
+
+
+*/
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@Fork(5)
+@Warmup(iterations = 1000)
+@Measurement(iterations = 4000)
+class ActorCreationBenchmark {
+  implicit val system: ActorSystem = ActorSystem()
+
+  final val props = Props[MyActor]
+
+  var i = 1
+  def name = {
+    i +=1
+    "some-rather-long-actor-name-actor-" + i
+  }
+
+  @TearDown(Level.Trial)
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def synchronousStarting =
+    system.actorOf(props, name)
+}
+
+class MyActor extends Actor {
+  override def receive: Receive = {
+    case _ ⇒
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorPathValidationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorPathValidationBenchmark.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+
+/*
+[info] Benchmark                                            Mode   Samples        Score  Score error    Units
+[info] a.a.ActorPathValidationBenchmark.handLoop7000       thrpt        20        0.070        0.002   ops/us
+[info] a.a.ActorPathValidationBenchmark.old7000            -- blows up (stack overflow) --
+
+[info] a.a.ActorPathValidationBenchmark.handLoopActor_1    thrpt        20       38.825        3.378   ops/us
+[info] a.a.ActorPathValidationBenchmark.oldActor_1         thrpt        20        1.585        0.090   ops/us
+ */
+@Fork(2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class ActorPathValidationBenchmark {
+
+  final val a = "actor-1"
+  final val s = "687474703a2f2f74686566727569742e636f6d2f26683d37617165716378357926656e" * 100
+
+  final val ElementRegex = """(?:[-\w:@&=+,.!~*'_;]|%\p{XDigit}{2})(?:[-\w:@&=+,.!~*'$_;]|%\p{XDigit}{2})*""".r
+
+
+//  @Benchmark // blows up with stack overflow, we know
+  def old7000: Option[List[String]] = ElementRegex.unapplySeq(s)
+
+  @Benchmark
+  def handLoop7000: Boolean = ActorPath.isValidPathElement(s)
+
+  @Benchmark
+  def oldActor_1: Option[List[String]] = ElementRegex.unapplySeq(a)
+
+  @Benchmark
+  def handLoopActor_1: Boolean = ActorPath.isValidPathElement(a)
+
+}

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh._
+import com.typesafe.config.ConfigFactory
+import akka.actor._
+import akka.testkit.TestProbe
+import java.io.File
+import org.apache.commons.io.FileUtils
+import org.openjdk.jmh.annotations.Scope
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class PersistentActorThroughputBenchmark {
+
+  val config = PersistenceSpec.config("leveldb", "benchmark")
+
+  lazy val storageLocations = List(
+    "akka.persistence.journal.leveldb.dir",
+    "akka.persistence.journal.leveldb-shared.store.dir",
+    "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
+
+  var system: ActorSystem = _
+
+  var probe: TestProbe = _
+  var actor: ActorRef = _
+  var persistPersistentActor: ActorRef = _
+  var persistProcessor: ActorRef = _
+  var persistAsync1PersistentActor: ActorRef = _
+  var noPersistPersistentActor: ActorRef = _
+  var persistAsyncQuickReplyPersistentActor: ActorRef = _
+
+  val data10k = (1 to 10000).toArray
+
+  @Setup
+  def setup() {
+    system = ActorSystem("test", config)
+
+    probe = TestProbe()(system)
+
+    storageLocations.foreach(FileUtils.deleteDirectory)
+
+    actor = system.actorOf(Props(classOf[BaselineActor], data10k.last), "a-1")
+    
+    persistProcessor = system.actorOf(Props(classOf[PersistProcessor], data10k.last), "p-1")
+
+    noPersistPersistentActor = system.actorOf(Props(classOf[NoPersistPersistentActor], data10k.last), "nop-1")
+    persistPersistentActor = system.actorOf(Props(classOf[PersistPersistentActor], data10k.last), "ep-1")
+    persistAsync1PersistentActor = system.actorOf(Props(classOf[PersistAsyncPersistentActor], data10k.last), "epa-1")
+
+    persistAsyncQuickReplyPersistentActor = system.actorOf(Props(classOf[PersistAsyncQuickReplyPersistentActor], data10k.last), "epa-2")
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+
+    storageLocations.foreach(FileUtils.deleteDirectory)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def actor_normalActor_reply_baseline() {
+    for (i <- data10k) actor.tell(i, probe.ref)
+
+    probe.expectMsg(data10k.last)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def persistentActor_persist_reply() {
+    for (i <- data10k) persistPersistentActor.tell(i, probe.ref)
+
+    probe.expectMsg(Evt(data10k.last))
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def processor_persist_reply() {
+    for (i <- data10k) persistProcessor.tell(Persistent(i), probe.ref)
+
+    probe.expectMsg(Evt(data10k.last))
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def processor_noPersist_reply() {
+    for (i <- data10k) persistProcessor.tell(i, probe.ref)
+
+    probe.expectMsg(Evt(data10k.last))
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def persistentActor_persistAsync_reply() {
+    for (i <- data10k) persistAsync1PersistentActor.tell(i, probe.ref)
+
+    probe.expectMsg(Evt(data10k.last))
+  }
+  
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def persistentActor_noPersist_reply() {
+    for (i <- data10k) noPersistPersistentActor.tell(i, probe.ref)
+
+    probe.expectMsg(Evt(data10k.last))
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def persistentActor_persistAsync_replyRightOnCommandReceive() {
+    for (i <- data10k) persistAsyncQuickReplyPersistentActor.tell(i, probe.ref)
+
+    probe.expectMsg(Evt(data10k.last))
+  }
+
+}
+
+class NoPersistPersistentActor(respondAfter: Int) extends PersistentActor {
+
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
+    case n: Int => if (n == respondAfter) sender() ! Evt(n)
+  }
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+
+}
+class PersistPersistentActor(respondAfter: Int) extends PersistentActor {
+
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
+    case n: Int => persist(Evt(n)) { e => if (e.i == respondAfter) sender() ! e }
+  }
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+
+}
+class PersistProcessor(respondAfter: Int) extends Processor {
+  override def receive = {
+    case Persistent(n: Int, _) => if (n == respondAfter) sender() ! Evt(n)
+    case n: Int => if (n == respondAfter) sender() ! Evt(n)
+  }
+}
+
+class PersistAsyncPersistentActor(respondAfter: Int) extends PersistentActor {
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
+    case n: Int =>
+      persistAsync(Evt(n)) { e => if (e.i == respondAfter) sender() ! e }
+  }
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+}
+
+class PersistAsyncQuickReplyPersistentActor(respondAfter: Int) extends PersistentActor {
+
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
+    case n: Int =>
+      val e = Evt(n)
+      if (n == respondAfter) sender() ! e
+      persistAsync(e)(identity)
+  }
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorWithAtLeastOnceDeliveryBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorWithAtLeastOnceDeliveryBenchmark.scala
@@ -1,0 +1,214 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence
+
+
+import org.openjdk.jmh.annotations._
+import akka.actor._
+import akka.testkit.TestProbe
+import java.io.File
+import org.apache.commons.io.FileUtils
+import org.openjdk.jmh.annotations.Scope
+
+import scala.concurrent.duration._
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class PersistentActorWithAtLeastOnceDeliveryBenchmark {
+
+  val config = PersistenceSpec.config("leveldb", "benchmark")
+
+  lazy val storageLocations = List(
+    "akka.persistence.journal.leveldb.dir",
+    "akka.persistence.journal.leveldb-shared.store.dir",
+    "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
+
+  var system: ActorSystem = _
+
+  var probe: TestProbe = _
+  var actor: ActorRef = _
+  var persistPersistentActorWithAtLeastOnceDelivery: ActorRef = _
+  var persistAsyncPersistentActorWithAtLeastOnceDelivery: ActorRef = _
+  var noPersistPersistentActorWithAtLeastOnceDelivery: ActorRef = _
+  var destinationActor: ActorRef = _
+
+  val dataCount = 10000
+
+  @Setup
+  def setup() {
+    system = ActorSystem("PersistentActorWithAtLeastOnceDeliveryBenchmark", config)
+
+    probe = TestProbe()(system)
+
+    storageLocations.foreach(FileUtils.deleteDirectory)
+
+    destinationActor = system.actorOf(Props[DestinationActor], "destination")
+
+    noPersistPersistentActorWithAtLeastOnceDelivery = system.actorOf(Props(classOf[NoPersistPersistentActorWithAtLeastOnceDelivery], dataCount, probe.ref, destinationActor.path), "nop-1")
+    persistPersistentActorWithAtLeastOnceDelivery = system.actorOf(Props(classOf[PersistPersistentActorWithAtLeastOnceDelivery], dataCount, probe.ref, destinationActor.path), "ep-1")
+    persistAsyncPersistentActorWithAtLeastOnceDelivery = system.actorOf(Props(classOf[PersistAsyncPersistentActorWithAtLeastOnceDelivery], dataCount, probe.ref, destinationActor.path), "epa-1")
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+
+    storageLocations.foreach(FileUtils.deleteDirectory)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def persistentActor_persistAsync_with_AtLeastOnceDelivery() {
+    for (i <- 1 to dataCount)
+      persistAsyncPersistentActorWithAtLeastOnceDelivery.tell(i, probe.ref)
+    probe.expectMsg(20 seconds, Evt(dataCount))
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def persistentActor_persist_with_AtLeastOnceDelivery() {
+    for (i <- 1 to dataCount)
+      persistPersistentActorWithAtLeastOnceDelivery.tell(i, probe.ref)
+    probe.expectMsg(2 minutes, Evt(dataCount))
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(10000)
+  def persistentActor_noPersist_with_AtLeastOnceDelivery() {
+    for (i <- 1 to dataCount)
+      noPersistPersistentActorWithAtLeastOnceDelivery.tell(i, probe.ref)
+    probe.expectMsg(20 seconds, Evt(dataCount))
+  }
+}
+
+class NoPersistPersistentActorWithAtLeastOnceDelivery(respondAfter: Int, val upStream: ActorRef, val downStream: ActorPath) extends PersistentActor with AtLeastOnceDelivery {
+
+  override def redeliverInterval = 100.milliseconds
+
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
+    case n: Int =>
+      deliver(downStream, deliveryId =>
+        Msg(deliveryId, n))
+      if (n == respondAfter)
+      //switch to wait all message confirmed
+        context.become(waitConfirm)
+    case Confirm(deliveryId) =>
+      confirmDelivery(deliveryId)
+    case _ => // do nothing
+  }
+
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+
+  val waitConfirm: Actor.Receive = {
+    case Confirm(deliveryId) =>
+      confirmDelivery(deliveryId)
+      if (numberOfUnconfirmed == 0) {
+        upStream ! Evt(respondAfter)
+        context.unbecome()
+      }
+    case _ => // do nothing
+  }
+}
+
+class PersistPersistentActorWithAtLeastOnceDelivery(respondAfter: Int, val upStream: ActorRef, val downStream: ActorPath) extends PersistentActor with AtLeastOnceDelivery {
+
+  override def redeliverInterval = 100.milliseconds
+
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
+    case n: Int =>
+      persist(MsgSent(n)) { e =>
+        deliver(downStream, deliveryId =>
+          Msg(deliveryId, n))
+        if (n == respondAfter)
+        //switch to wait all message confirmed
+          context.become(waitConfirm)
+    }
+    case Confirm(deliveryId) =>
+      confirmDelivery(deliveryId)
+    case _ => // do nothing
+  }
+
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+
+  val waitConfirm: Actor.Receive = {
+    case Confirm(deliveryId) =>
+      confirmDelivery(deliveryId)
+      if (numberOfUnconfirmed == 0) {
+        upStream ! Evt(respondAfter)
+        context.unbecome()
+      }
+    case _ => // do nothing
+  }
+}
+
+class PersistAsyncPersistentActorWithAtLeastOnceDelivery(respondAfter: Int, val upStream: ActorRef, val downStream: ActorPath) extends PersistentActor with AtLeastOnceDelivery {
+
+  override def redeliverInterval = 100.milliseconds
+
+  override def persistenceId: String = self.path.name
+
+  override def receiveCommand = {
+    case n: Int =>
+      persistAsync(MsgSent(n)) { e =>
+        deliver(downStream, deliveryId =>
+          Msg(deliveryId, n))
+        if (n == respondAfter)
+        //switch to wait all message confirmed
+          context.become(waitConfirm)
+      }
+    case Confirm(deliveryId) =>
+      confirmDelivery(deliveryId)
+    case _ => // do nothing
+  }
+
+  override def receiveRecover = {
+    case _ => // do nothing
+  }
+
+  val waitConfirm: Actor.Receive = {
+    case Confirm(deliveryId) =>
+      confirmDelivery(deliveryId)
+      if (numberOfUnconfirmed == 0) {
+        upStream ! Evt(respondAfter)
+        context.unbecome()
+      }
+    case _ => // do nothing
+  }
+}
+
+case class Msg(deliveryId: Long, n: Int)
+
+case class Confirm(deliveryId: Long)
+
+sealed trait Event
+
+case class MsgSent(n: Int) extends Event
+
+case class MsgConfirmed(deliveryId: Long) extends Event
+
+class DestinationActor extends Actor {
+  var seqNr = 0L
+
+  override def receive = {
+    case n: Int =>
+      sender() ! Confirm(n)
+    case Msg(deliveryId, _) =>
+      seqNr += 1
+      if (seqNr % 11 == 0) {
+        //drop it
+      } else {
+        sender() ! Confirm(deliveryId)
+      }
+    case _ => // do nothing
+  }
+}

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -4,18 +4,23 @@
 
 package akka
 
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.FileInputStream
+import java.io.InputStreamReader
 import java.util.Properties
 
-import akka.Formatting.docFormatSettings
-import akka.MultiNode.multiJvmSettings
-import akka.TestExtras.{GraphiteBuildEvents, JUnitFileReporting, StatsDMetrics}
-import akka.Unidoc.{scaladocSettings, unidocSettings}
-import com.typesafe.sbt.S3Plugin.{S3, s3Settings}
-import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.{MultiJvm, extraOptions}
+import akka.TestExtras.GraphiteBuildEvents
+import akka.TestExtras.JUnitFileReporting
+import akka.TestExtras.StatsDMetrics
+import akka.Unidoc.scaladocSettings
+import akka.Unidoc.unidocSettings
+import com.typesafe.sbt.S3Plugin.S3
+import com.typesafe.sbt.S3Plugin.s3Settings
+import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import com.typesafe.sbt.site.SphinxSupport
 import com.typesafe.sbt.site.SphinxSupport.Sphinx
-import com.typesafe.tools.mima.plugin.MimaKeys.{binaryIssueFilters, previousArtifact, reportBinaryIssues}
+import com.typesafe.tools.mima.plugin.MimaKeys.binaryIssueFilters
+import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
+import com.typesafe.tools.mima.plugin.MimaKeys.reportBinaryIssues
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import sbt.Keys._
 import sbt._
@@ -85,6 +90,12 @@ object AkkaBuild extends Build {
     id = "akka-actor-tests",
     base = file("akka-actor-tests"),
     dependencies = Seq(testkit % "compile;test->test")
+  )
+
+  lazy val benchJmh = Project(
+    id = "akka-bench-jmh",
+    base = file("akka-bench-jmh"),
+    dependencies = Seq(actor, persistence, testkit).map(_ % "compile;compile->test")
   )
 
   lazy val remote = Project(
@@ -340,7 +351,6 @@ object AkkaBuild extends Build {
   val validatePullRequestTask = validatePullRequest := ()
 
   lazy val mimaIgnoredProblems = {
-    import com.typesafe.tools.mima.core._
     Seq(
       // add filters here, see release-2.2 branch
      )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,5 +23,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.6")
+
 // stats reporting
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"


### PR DESCRIPTION
This ports the new actor path parser from PR: https://github.com/akka/akka/pull/16352 to master and
brings back JMH benchmarks to master (issue https://github.com/akka/akka/issues/16372) as well (so that the ActorPath PR can include it's benchmarks).

The field which we had to keep as deprecated in ActorPath (the regex) in 2.3 is removed from this commit - we do not need to keep it for binary compat on 2.4.x

refs #16344
refs #16372
