### PR TITLE
=pro update to reactive-streams 1.0.0.M1

### DIFF
--- a/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
@@ -25,9 +25,6 @@ abstract class AkkaIdentityProcessorVerification[T](val system: ActorSystem, env
 
   system.eventStream.publish(TestEvent.Mute(EventFilter[RuntimeException]("Test exception")))
 
-  /** Readable way to ignore TCK specs; Return this for `createErrorStatePublisher` to skip tests including it */
-  final def ignored: mutable.Publisher[T] = null
-
   def this(system: ActorSystem, printlnDebug: Boolean) {
     this(system, new TestEnvironment(Timeouts.defaultTimeoutMillis(system), printlnDebug), Timeouts.publisherShutdownTimeoutMillis)
   }
@@ -41,6 +38,9 @@ abstract class AkkaIdentityProcessorVerification[T](val system: ActorSystem, env
   }
 
   override def skipStochasticTests() = true // TODO maybe enable?
+
+  // TODO re-enable this test once 1.0.0.RC1 is released, with https://github.com/reactive-streams/reactive-streams/pull/154
+  override def spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue() = notVerified("TODO Enable this test once https://github.com/reactive-streams/reactive-streams/pull/154 is merged (ETA 1.0.0.RC1)")
 
   override def createErrorStatePublisher(): Publisher[T] =
     StreamTestKit.errorPublisher(new Exception("Unable to serve subscribers right now!"))

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
@@ -21,9 +21,6 @@ abstract class AkkaPublisherVerification[T](val system: ActorSystem, env: TestEn
   extends PublisherVerification[T](env, publisherShutdownTimeout)
   with TestNGSuiteLike {
 
-  /** Readable way to ignore TCK specs; Return this for `createErrorStatePublisher` to skip tests including it */
-  final def ignored: Publisher[T] = null
-
   def this(system: ActorSystem, printlnDebug: Boolean) {
     this(system, new TestEnvironment(Timeouts.defaultTimeoutMillis(system), printlnDebug), Timeouts.publisherShutdownTimeoutMillis)
   }
@@ -39,6 +36,9 @@ abstract class AkkaPublisherVerification[T](val system: ActorSystem, env: TestEn
   implicit val materializer = FlowMaterializer(MaterializerSettings(system).copy(maxInputBufferSize = 512))(system)
 
   override def skipStochasticTests() = true // TODO maybe enable?
+
+  // TODO re-enable this test once 1.0.0.RC1 is released, with https://github.com/reactive-streams/reactive-streams/pull/154
+  override def spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue() = notVerified("TODO Enable this test once https://github.com/reactive-streams/reactive-streams/pull/154 is merged (ETA 1.0.0.RC1)")
 
   @AfterClass
   def shutdownActorSystem(): Unit = {

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1369,9 +1369,7 @@ object Dependencies {
     val scalaCheckVersion = System.getProperty("akka.build.scalaCheckVersion", "1.11.3")
     val scalaContinuationsVersion = System.getProperty("akka.build.scalaContinuationsVersion", "1.0.1")
 
-    val reactiveStreamsVersion = System.getProperty("akka.build.reactiveStreamsVersion", "0.4.0.M2")
-    // TODO this version should be the same as the RS version once the RS TCK has been merged and released
-    val reactiveStreamsTckVersion = System.getProperty("akka.build.reactiveStreamsVersion", "0.4.0.M2-20140910-174042-SNAPSHOT")
+    val reactiveStreamsVersion = System.getProperty("akka.build.reactiveStreamsVersion", "1.0.0.M1")
 
     val publishedAkkaVersion = "2.3.7"
   }
@@ -1447,7 +1445,7 @@ object Dependencies {
       val scalaXml     = Compile.scalaXml % "test"                                                                    // Scala License
 
       // reactive streams tck
-      val reactiveStreamsTck = "org.reactivestreams"      % "reactive-streams-tck"         % reactiveStreamsTckVersion % "test" // CC0
+      val reactiveStreamsTck = "org.reactivestreams"      % "reactive-streams-tck"         % reactiveStreamsVersion % "test" // CC0
 
       // metrics, measurements, perf testing
       val metrics         = "com.codahale.metrics"        % "metrics-core"                 % "3.0.1"            % "test" // ApacheV2


### PR DESCRIPTION
Notice that one 317 is disabled and awaiting a fix in the TCK.
It should be re-enabled once the TCK is fixed with: https://github.com/reactive-streams/reactive-streams/pull/154

Resolves #16370
