### PR TITLE
+per #16348 Limit the number of messages redelivered at each interval

### DIFF
--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -448,6 +448,13 @@ The interval between redelivery attempts is defined by the ``redeliverInterval``
 The default value can be configured with the ``akka.persistence.at-least-once-delivery.redeliver-interval``
 configuration key. The method can be overridden by implementation classes to return non-default values.
 
+The maximum number of messages that will be sent at each redelivery burst is defined by the
+``redeliveryBurstLimit`` method (burst frequency is half of the redelivery interval). If there's a lot of
+unconfirmed messages (e.g. if the destination is not available for a long time), this helps to prevent an overwhelming
+amount of messages to be sent at once. The default value can be configured with the
+``akka.persistence.at-least-once-delivery.redelivery-burst-limit`` configuration key. The method can be overridden
+by implementation classes to return non-default values.
+
 After a number of delivery attempts a ``AtLeastOnceDelivery.UnconfirmedWarning`` message
 will be sent to ``self``. The re-sending will still continue, but you can choose to call
 ``confirmDelivery`` to cancel the re-sending. The number of delivery attempts before emitting the

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -446,6 +446,13 @@ The interval between redelivery attempts is defined by the ``redeliverInterval``
 The default value can be configured with the ``akka.persistence.at-least-once-delivery.redeliver-interval``
 configuration key. The method can be overridden by implementation classes to return non-default values.
 
+The maximum number of messages that will be sent at each redelivery burst is defined by the
+``redeliveryBurstLimit`` method (burst frequency is half of the redelivery interval). If there's a lot of
+unconfirmed messages (e.g. if the destination is not available for a long time), this helps to prevent an overwhelming
+amount of messages to be sent at once. The default value can be configured with the
+``akka.persistence.at-least-once-delivery.redelivery-burst-limit`` configuration key. The method can be overridden
+by implementation classes to return non-default values.
+
 After a number of delivery attempts a ``AtLeastOnceDelivery.UnconfirmedWarning`` message
 will be sent to ``self``. The re-sending will still continue, but you can choose to call
 ``confirmDelivery`` to cancel the re-sending. The number of delivery attempts before emitting the

--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -146,6 +146,9 @@ akka {
     at-least-once-delivery {
       # Interval between redelivery attempts
       redeliver-interval = 5s
+
+      # Maximum number of unconfirmed messages that will be sent in one redelivery burst
+      redelivery-burst-limit = 10000
       
       # After this number of delivery attempts a `ReliableRedelivery.UnconfirmedWarning`
       # message will be sent to the actor.

--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -47,6 +47,9 @@ final class PersistenceSettings(config: Config) {
     val redeliverInterval: FiniteDuration =
       config.getMillisDuration("at-least-once-delivery.redeliver-interval")
 
+    val redeliveryBurstLimit: Int =
+      config.getInt("at-least-once-delivery.redelivery-burst-limit")
+
     val warnAfterNumberOfUnconfirmedAttempts: Int =
       config.getInt("at-least-once-delivery.warn-after-number-of-unconfirmed-attempts")
 


### PR DESCRIPTION
Helps to prevent flooding destinations which are unavailable for a long time with messages once they become available.
