### PR TITLE
-str #16393 removes timerTransform from public API

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/HttpEntity.scala
@@ -61,6 +61,8 @@ sealed trait HttpEntity extends japi.HttpEntity {
           throw new java.util.concurrent.TimeoutException(
             s"HttpEntity.toStrict timed out after $timeout while still waiting for outstanding data")
       }
+
+    // TODO timerTransform is meant to be replaced / rewritten, it's currently private[akka]; See https://github.com/akka/akka/issues/16393
     dataBytes.timerTransform("toStrict", transformer).runWith(Sink.head)
   }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
@@ -28,12 +28,18 @@ class DslConsistencySpec extends WordSpec with Matchers {
   val ignore =
     Set("equals", "hashCode", "notify", "notifyAll", "wait", "toString", "getClass") ++
       Set("create", "apply", "ops", "appendJava", "andThen") ++
-      Seq("asScala", "asJava")
+      Set("asScala", "asJava")
 
   val allowMissing: Map[Class[_], Set[String]] = Map(
     sFlowClass -> Set("of"),
     sSourceClass -> Set("adapt", "from"),
     sSinkClass -> Set("adapt"),
+
+    // TODO timerTransform is to be removed or replaced.  See https://github.com/akka/akka/issues/16393
+    jFlowClass -> Set("timerTransform"),
+    jSourceClass -> Set("timerTransform"),
+    jSinkClass -> Set(),
+
     sFlowGraphClass -> Set("builder"),
     jFlowGraphClass → Set("graph"),
     jPartialFlowGraphClass → Set("graph"))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -291,33 +291,6 @@ class Flow[-In, +Out](delegate: scaladsl.Flow[In, Out]) {
     new Flow(delegate.transform(name, () ⇒ mkStage.create()))
 
   /**
-   * Transformation of a stream, with additional support for scheduled events.
-   *
-   * For each element the [[akka.stream.TransformerLike#onNext]]
-   * function is invoked, expecting a (possibly empty) sequence of output elements
-   * to be produced.
-   * After handing off the elements produced from one input element to the downstream
-   * subscribers, the [[akka.stream.TransformerLike#isComplete]] predicate determines whether to end
-   * stream processing at this point; in that case the upstream subscription is
-   * canceled. Before signaling normal completion to the downstream subscribers,
-   * the [[akka.stream.TransformerLike#onTermination]] function is invoked to produce a (possibly empty)
-   * sequence of elements in response to the end-of-stream event.
-   *
-   * [[akka.stream.TransformerLike#onError]] is called when failure is signaled from upstream.
-   *
-   * After normal completion or error the [[akka.stream.TransformerLike#cleanup]] function is called.
-   *
-   * It is possible to keep state in the concrete [[akka.stream.Transformer]] instance with
-   * ordinary instance variables. The [[akka.stream.Transformer]] is executed by an actor and
-   * therefore you do not have to add any additional thread safety or memory
-   * visibility constructs to access the state from the callback methods.
-   *
-   * Note that you can use [[#transform]] if you just need to transform elements time plays no role in the transformation.
-   */
-  def timerTransform[U](name: String, mkStage: japi.Creator[TimerTransformer[Out, U]]): javadsl.Flow[In, U] =
-    new Flow(delegate.timerTransform(name, () ⇒ mkStage.create()))
-
-  /**
    * Takes up to `n` elements from the stream and returns a pair containing a strict sequence of the taken element
    * and a stream representing the remaining elements. If ''n'' is zero or negative, then this will return a pair
    * of an empty collection and a stream containing the whole upstream unchanged.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -396,33 +396,6 @@ class Source[+Out](delegate: scaladsl.Source[Out]) {
     new Source(delegate.transform(name, () ⇒ mkStage.create()))
 
   /**
-   * Transformation of a stream, with additional support for scheduled events.
-   *
-   * For each element the [[akka.stream.TransformerLike#onNext]]
-   * function is invoked, expecting a (possibly empty) sequence of output elements
-   * to be produced.
-   * After handing off the elements produced from one input element to the downstream
-   * subscribers, the [[akka.stream.TransformerLike#isComplete]] predicate determines whether to end
-   * stream processing at this point; in that case the upstream subscription is
-   * canceled. Before signaling normal completion to the downstream subscribers,
-   * the [[akka.stream.TransformerLike#onTermination]] function is invoked to produce a (possibly empty)
-   * sequence of elements in response to the end-of-stream event.
-   *
-   * [[akka.stream.TransformerLike#onError]] is called when failure is signaled from upstream.
-   *
-   * After normal completion or error the [[akka.stream.TransformerLike#cleanup]] function is called.
-   *
-   * It is possible to keep state in the concrete [[akka.stream.TimerTransformer]] instance with
-   * ordinary instance variables. The [[akka.stream.TimerTransformer]] is executed by an actor and
-   * therefore you do not have to add any additional thread safety or memory
-   * visibility constructs to access the state from the callback methods.
-   *
-   * Note that you can use [[#transform]] if you just need to transform elements time plays no role in the transformation.
-   */
-  def timerTransform[U](name: String, mkStage: japi.Creator[TimerTransformer[Out, U]]): javadsl.Source[U] =
-    new Source(delegate.timerTransform(name, () ⇒ mkStage.create()))
-
-  /**
    * Takes up to `n` elements from the stream and returns a pair containing a strict sequence of the taken element
    * and a stream representing the remaining elements. If ''n'' is zero or negative, then this will return a pair
    * of an empty collection and a stream containing the whole upstream unchanged.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -364,6 +364,8 @@ trait FlowOps[+Out] {
   }
 
   /**
+   * INTERNAL API - meant for removal / rewrite. See https://github.com/akka/akka/issues/16393
+   *
    * Transformation of a stream, with additional support for scheduled events.
    *
    * For each element the [[akka.stream.TransformerLike#onNext]]
@@ -387,7 +389,7 @@ trait FlowOps[+Out] {
    *
    * Note that you can use [[#transform]] if you just need to transform elements time plays no role in the transformation.
    */
-  def timerTransform[U](name: String, mkStage: () ⇒ TimerTransformer[Out, U]): Repr[U] =
+  private[akka] def timerTransform[U](name: String, mkStage: () ⇒ TimerTransformer[Out, U]): Repr[U] =
     andThen(TimerTransform(mkStage.asInstanceOf[() ⇒ TimerTransformer[Any, Any]], name))
 
   /** INTERNAL API */


### PR DESCRIPTION
removal of `timerTransform` from public APIs.
Removed completely from javadsl, hidden in scaladsl - because of use case in `toStrict`.

refs https://github.com/akka/akka/issues/16393
