### PR TITLE
-str #16393 removes timerTransform mentions from scaladocs

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/TimerTransformer.scala
+++ b/akka-stream/src/main/scala/akka/stream/TimerTransformer.scala
@@ -11,7 +11,9 @@ import scala.concurrent.duration.FiniteDuration
 /**
  * Transformer with support for scheduling keyed (named) timer events.
  */
-abstract class TimerTransformer[-T, +U] extends TransformerLike[T, U] {
+// TODO: TimerTransformer is meant to be replaced; See https://github.com/akka/akka/issues/16410
+@deprecated("TimerTransformer is meant to be replaced; See https://github.com/akka/akka/issues/16410")
+private[akka] abstract class TimerTransformer[-T, +U] extends TransformerLike[T, U] {
   import TimerTransformer._
   private val timers = mutable.Map[Any, Timer]()
   private val timerIdGen = Iterator from 1

--- a/akka-stream/src/main/scala/akka/stream/Transformer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Transformer.scala
@@ -5,7 +5,7 @@ package akka.stream
 
 import scala.collection.immutable
 
-abstract class TransformerLike[-T, +U] {
+private[akka] abstract class TransformerLike[-T, +U] {
   /**
    * Invoked for each element to produce a (possibly empty) sequence of
    * output elements.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -284,8 +284,6 @@ class Flow[-In, +Out](delegate: scaladsl.Flow[In, Out]) {
    * Generic transformation of a stream with a custom processing [[akka.stream.stage.Stage]].
    * This operator makes it possible to extend the `Flow` API when there is no specialized
    * operator that performs the transformation.
-   *
-   * Note that you can use [[#timerTransform]] if you need support for scheduled events in the transformer.
    */
   def transform[U](name: String, mkStage: japi.Creator[Stage[Out, U]]): javadsl.Flow[In, U] =
     new Flow(delegate.transform(name, () ⇒ mkStage.create()))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -389,8 +389,6 @@ class Source[+Out](delegate: scaladsl.Source[Out]) {
    * Generic transformation of a stream with a custom processing [[akka.stream.stage.Stage]].
    * This operator makes it possible to extend the `Flow` API when there is no specialized
    * operator that performs the transformation.
-   *
-   * Note that you can use [[#timerTransform]] if you need support for scheduled events in the transformer.
    */
   def transform[U](name: String, mkStage: japi.Creator[Stage[Out, U]]): javadsl.Source[U] =
     new Source(delegate.transform(name, () ⇒ mkStage.create()))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -309,8 +309,6 @@ trait FlowOps[+Out] {
    * Generic transformation of a stream with a custom processing [[akka.stream.stage.Stage]].
    * This operator makes it possible to extend the `Flow` API when there is no specialized
    * operator that performs the transformation.
-   *
-   * Note that you can use [[#timerTransform]] if you need support for scheduled events in the transformer.
    */
   def transform[T](name: String, mkStage: () ⇒ Stage[Out, T]): Repr[T] =
     andThen(StageFactory(mkStage, name))


### PR DESCRIPTION
This addresses removing references from scaladocs to `timerTransform` that I have missed during this PR: https://github.com/akka/akka/pull/16397

Thanks @patriknw for spotting those, https://github.com/akka/akka/pull/16397#discussion_r20986169
