### PR TITLE
=sam #16402 #16402 add explicit dependencies to samples

### DIFF
--- a/akka-samples/akka-sample-cluster-java/build.sbt
+++ b/akka-samples/akka-sample-cluster-java/build.sbt
@@ -15,6 +15,7 @@ val project = Project(
     javacOptions in doc in Compile := Seq("-source", "1.6"), // javadoc does not support -target and -Xlint flags
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+      "com.typesafe.akka" %% "akka-remote" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-contrib" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,

--- a/akka-samples/akka-sample-cluster-scala/build.sbt
+++ b/akka-samples/akka-sample-cluster-scala/build.sbt
@@ -14,6 +14,7 @@ val project = Project(
     javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+      "com.typesafe.akka" %% "akka-remote" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-contrib" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,

--- a/akka-samples/akka-sample-multi-node-scala/build.sbt
+++ b/akka-samples/akka-sample-multi-node-scala/build.sbt
@@ -11,6 +11,7 @@ val project = Project(
     version := "2.4-SNAPSHOT",
     scalaVersion := "2.10.4",
     libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
       "com.typesafe.akka" %% "akka-remote" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,
       "org.scalatest" %% "scalatest" % "2.2.1" % "test"),


### PR DESCRIPTION
Only first level transitive dependencies are left, when transforming sample build definitions from library to project dependencies. Therefore explicitly add akka dependencies that samples use.

Tested on my machine and `akka-samples/multi-jvm:test` passed with success.
