### PR TITLE
=str #16314 harden GraphConcatSpec, it can error as soon as possible

### DIFF
--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestKit.scala
@@ -111,6 +111,16 @@ object StreamTestKit {
     def expectError(cause: Throwable): Unit = probe.expectMsg(OnError(cause))
     def expectError(): Throwable = probe.expectMsgType[OnError].cause
 
+    def expectNextOrError(element: I, cause: Throwable): Either[Throwable, I] = {
+      probe.fishForMessage(hint = s"OnNext($element) or ${cause.getClass.getName}") {
+        case OnNext(n)        ⇒ true
+        case OnError(`cause`) ⇒ true
+      } match {
+        case OnNext(n: I) ⇒ Right(n)
+        case OnError(err) ⇒ Left(err)
+      }
+    }
+
     def expectErrorOrSubscriptionFollowedByError(cause: Throwable): Unit = {
       val t = expectErrorOrSubscriptionFollowedByError()
       assert(t == cause, s"expected $cause, found $cause")


### PR DESCRIPTION
I had been thinking about Concat semantics a bit (see below), but after @drewhk's feedback decided that keeping current semantics is fine - when the other stream fails "on initial request" it's ok for us to fail "as soon as we notice".

This also means that this onError signal will come concurrently, and we're not sure when exactly - thus this test based around `||=`.

Please have a look and confirm that's the semantics we like here.

resolves https://github.com/akka/akka/issues/16314
