### PR TITLE
=pro make samples optional

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -188,9 +188,10 @@ object AkkaBuild extends Build {
     id = "akka-samples",
     base = file("akka-samples"),
     settings = parentSettings ++ ActivatorDist.settings,
-    aggregate = Seq(sampleCamelJava, sampleCamelScala, sampleClusterJava, sampleClusterScala, sampleFsmScala,
-      sampleHelloKernel, sampleMainJava, sampleMainScala, sampleMultiNodeScala, osgiDiningHakkersSampleMavenTest,
-      samplePersistenceJava, samplePersistenceScala, sampleRemoteJava, sampleRemoteScala)
+    aggregate = if (!CommandLineOptions.aggregateSamples) Nil else
+      Seq(sampleCamelJava, sampleCamelScala, sampleClusterJava, sampleClusterScala, sampleFsmScala,
+        sampleHelloKernel, sampleMainJava, sampleMainScala, sampleMultiNodeScala, osgiDiningHakkersSampleMavenTest,
+        samplePersistenceJava, samplePersistenceScala, sampleRemoteJava, sampleRemoteScala)
   )
 
   lazy val sampleCamelJava = Sample.project("akka-sample-camel-java")

--- a/project/CommandLineOptions.scala
+++ b/project/CommandLineOptions.scala
@@ -1,0 +1,13 @@
+package akka
+
+object CommandLineOptions {
+
+  /**
+   * Aggregated sample builds are transformed by swapping library dependencies to project ones.
+   * This does work play well with dbuild and breaks scala community build. Therefore it was made
+   * optional.
+   *
+   * Default: true
+   */
+  val aggregateSamples  = sys.props.getOrElse("akka.build.aggregateSamples", "true") == "true"
+}


### PR DESCRIPTION
Samples are still aggregated by default.

Aggregation can be turned off by `-Dakka.build.aggregateSamples=false`. This is needed for scala community build, because dbuild does not really like build transformations.
