### PR TITLE
=htc Parse Sunday dates in Set-Cookie headers

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/parser/CommonRules.scala
@@ -77,7 +77,7 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
   }
 
   def `day-name` = rule(
-    "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) | "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6) | "Sun" ~ push(7))
+    "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) | "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6))
 
   def date1 = rule { day ~ ' ' ~ month ~ ' ' ~ year }
 
@@ -101,8 +101,8 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
   def date2 = rule { day ~ '-' ~ month ~ '-' ~ digit2 }
 
   def `day-name-l` = rule(
-    "Monday" ~ push(1) | "Tuesday" ~ push(2) | "Wednesday" ~ push(3) | "Thursday" ~ push(4) | "Friday" ~ push(5) |
-      "Saturday" ~ push(6) | "Sunday" ~ push(7))
+    "Sunday" ~ push(0) | "Monday" ~ push(1) | "Tuesday" ~ push(2) | "Wednesday" ~ push(3) | "Thursday" ~ push(4) |
+      "Friday" ~ push(5) | "Saturday" ~ push(6))
 
   def `asctime-date` = rule {
     `day-name` ~ ' ' ~ date3 ~ ' ' ~ `time-of-day` ~ ' ' ~ year ~> {

--- a/akka-http-core/src/test/scala/akka/http/engine/parsing/SetCookieHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/parsing/SetCookieHeaderParserSpec.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.engine.parsing
+
+import org.scalatest.{ WordSpec, Matchers }
+import akka.util.ByteString
+import akka.http.model.{ ErrorInfo, HttpHeader }
+import akka.http.model.headers._
+import akka.http.model.parser.HeaderParser
+import akka.http.util.DateTime
+
+class SetCookieHeaderParserSpec extends WordSpec with Matchers {
+
+  "Set-Cookie parser" should {
+    "parse cookies" in {
+      parse("SID=\"31d4d96e407aad42\"") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("SID", "31d4d96e407aad42")))
+      parse("SID=31d4d96e407aad42; Domain=example.com; Path=/") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("SID", "31d4d96e407aad42", path = Some("/"), domain = Some("example.com"))))
+      parse("lang=en-US; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Path=/hello") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "en-US", expires = Some(DateTime(2021, 6, 9, 10, 18, 14)), path = Some("/hello"))))
+      parse("lang=; Expires=Sun, 06 Nov 1994 08:49:37 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(1994, 11, 6, 8, 49, 37)))))
+      parse("name=123; Max-Age=12345; Secure") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("name", "123", maxAge = Some(12345), secure = true)))
+      parse("name=123; HttpOnly; fancyPants") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("name", "123", httpOnly = true, extension = Some("fancyPants"))))
+      parse("foo=bar; domain=example.com; Path=/this is a path with blanks; extension with blanks") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("foo", "bar", domain = Some("example.com"), path = Some("/this is a path with blanks"),
+          extension = Some("extension with blanks"))))
+    }
+
+    "parse expiry dates from each day of the week" in {
+      parse("lang=; Expires=Mon, 08 Dec 2014 00:42:55 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(2014, 12, 8, 0, 42, 55)))))
+      parse("lang=; Expires=Tue, 09 Dec 2014 00:42:55 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(2014, 12, 9, 0, 42, 55)))))
+      parse("lang=; Expires=Wed, 10 Dec 2014 00:42:55 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(2014, 12, 10, 0, 42, 55)))))
+      parse("lang=; Expires=Thu, 11 Dec 2014 00:42:55 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(2014, 12, 11, 0, 42, 55)))))
+      parse("lang=; Expires=Fri, 12 Dec 2014 00:42:55 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(2014, 12, 12, 0, 42, 55)))))
+      parse("lang=; Expires=Sat, 13 Dec 2014 00:42:55 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(2014, 12, 13, 0, 42, 55)))))
+      parse("lang=; Expires=Sun, 14 Dec 2014 00:42:55 GMT") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime(2014, 12, 14, 0, 42, 55)))))
+    }
+
+    "parse cookie examples from Play" in {
+      parse("PLAY_FLASH=\"success=found\"; Path=/; HTTPOnly") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("PLAY_FLASH", "success=found", path = Some("/"), httpOnly = true)))
+      parse("PLAY_FLASH=; Expires=Sun, 07 Dec 2014 22:48:47 GMT; Path=/; HTTPOnly") shouldEqual
+        Right(`Set-Cookie`(HttpCookie("PLAY_FLASH", "", expires = Some(DateTime(2014, 12, 7, 22, 48, 47)), path = Some("/"), httpOnly = true)))
+    }
+
+  }
+
+  def parse(setCookieString: String): Either[ErrorInfo, HttpHeader] = {
+    HeaderParser.parseHeader(RawHeader("Set-Cookie", setCookieString))
+  }
+
+}


### PR DESCRIPTION
The `Set-Cookie` header would always fail to parse when given a an expires date for a Sunday. I've updated the parsing code for both "Sun" and "Sunday", however I have only managed to test "Sun". I was never able to get an expires value for "Sunday" to parse, even though the HTTP-date parsing code seems to suggest that long day names are supported.

Cc @sirthias, @jrudolph.
