### PR TITLE
=act #16330 deprecating akka.util.Crypt

### DIFF
--- a/akka-actor/src/main/scala/akka/util/Crypt.scala
+++ b/akka-actor/src/main/scala/akka/util/Crypt.scala
@@ -5,7 +5,7 @@
 package akka.util
 
 import java.security.{ MessageDigest, SecureRandom }
-//FIXME DOCS
+@deprecated(message = "Not in use.", since = "2.4-M1")
 object Crypt {
   val hex = "0123456789ABCDEF"
   val lineSeparator = System.getProperty("line.separator")

--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -444,27 +444,6 @@ untrusted mode when incoming via the remoting layer:
   within the same JVM), you can restrict the messages on this interface by
   marking them :class:`PossiblyHarmful` so that a client cannot forge them.
 
-Secure Cookie Handshake
------------------------
-
-Akka remoting also allows you to specify a secure cookie that will be exchanged and ensured to be identical
-in the connection handshake between the client and the server. If they are not identical then the client
-will be refused to connect to the server.
-
-The secure cookie can be any kind of string. But the recommended approach is to generate a cryptographically
-secure cookie using this script ``$AKKA_HOME/scripts/generate_config_with_secure_cookie.sh`` or from code
-using the ``akka.util.Crypt.generateSecureCookie()`` utility method.
-
-You have to ensure that both the connecting client and the server have the same secure cookie as well
-as the ``require-cookie`` option turned on.
-
-Here is an example config::
-
-    akka.remote {
-      secure-cookie = "090A030E0F0A05010900000A0C0E0C0B03050D05"
-      require-cookie = on
-    }
-
 SSL
 ---
 

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -153,11 +153,15 @@ persistenceId
 It is now mandatory to define the ``persistenceId`` in subclasses of ``PersistentActor``, ``UntypedPersistentActor``
 and ``AbstractPersistentId``.
 
-The rationale behind this change being stricter de-coupling of your Actor hierarchy and the logical 
+The rationale behind this change being stricter de-coupling of your Actor hierarchy and the logical
 "which persistent entity this actor represents".
 
 In case you want to perserve the old behavior of providing the actor's path as the default ``persistenceId``, you can easily
 implement it yourself either as a helper trait or simply by overriding ``persistenceId`` as follows::
 
     override def persistenceId = self.path.toStringWithoutAddress
+Secure Cookies
+==============
+
+`Secure cookies` feature was deprecated.
 

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -448,27 +448,6 @@ untrusted mode when incoming via the remoting layer:
   within the same JVM), you can restrict the messages on this interface by
   marking them :class:`PossiblyHarmful` so that a client cannot forge them.
 
-Secure Cookie Handshake
------------------------
-
-Akka remoting also allows you to specify a secure cookie that will be exchanged and ensured to be identical
-in the connection handshake between the client and the server. If they are not identical then the client
-will be refused to connect to the server.
-
-The secure cookie can be any kind of string. But the recommended approach is to generate a cryptographically
-secure cookie using this script ``$AKKA_HOME/scripts/generate_config_with_secure_cookie.sh`` or from code
-using the ``akka.util.Crypt.generateSecureCookie()`` utility method.
-
-You have to ensure that both the connecting client and the server have the same secure cookie as well
-as the ``require-cookie`` option turned on.
-
-Here is an example config::
-
-    akka.remote {
-      secure-cookie = "090A030E0F0A05010900000A0C0E0C0B03050D05"
-      require-cookie = on
-    }
-
 SSL
 ---
 

--- a/akka-kernel/src/main/dist/scripts/generate_config_with_secure_cookie.sh
+++ b/akka-kernel/src/main/dist/scripts/generate_config_with_secure_cookie.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+echo "Warning: Please note that this feature deprecated since 2.4-M1"
 exec scala "$0" "$@"
 !#
 
@@ -44,6 +45,7 @@ object Crypt {
 print("""
 akka {
   remote {
+    // secure cookies was deprecated
     secure-cookie = "%s"
     require-cookie = on
   }

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -111,9 +111,7 @@ akka {
     # message contains a mismatching cookie or the cookie is missing.
     require-cookie = off
 
-    # Generate your own with the script availbale in
-    # '$AKKA_HOME/scripts/generate_config_with_secure_cookie.sh' or using
-    # 'akka.util.Crypt.generateSecureCookie'
+    # Deprecated since 2.4-M1
     secure-cookie = ""
 
     ### Logging


### PR DESCRIPTION
- Fix for #16330 
- Additionally clean several files up: final modifiers on objects and final class members, unused imports, iterators.nonEmpty instead of !iterators.isEmpty
