### PR TITLE
!str #16484 #16392 Remove String identifier of junctions

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/engine/server/HttpServer.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/server/HttpServer.scala
@@ -50,7 +50,7 @@ private[http] object HttpServer {
       }
     }
 
-    val bypassFanout = Broadcast[RequestOutput]("bypassFanout")
+    val bypassFanout = Broadcast[RequestOutput](OperationAttributes.name("bypassFanout"))
     val bypassMerge = new BypassMerge(settings, log)
 
     val requestParsing = Flow[ByteString].section(name("rootParser"))(_.transform(() ⇒
@@ -93,7 +93,8 @@ private[http] object HttpServer {
     }
   }
 
-  class BypassMerge(settings: ServerSettings, log: LoggingAdapter) extends FlexiMerge[ResponseRenderingContext]("BypassMerge") {
+  class BypassMerge(settings: ServerSettings, log: LoggingAdapter)
+    extends FlexiMerge[ResponseRenderingContext](OperationAttributes.name("BypassMerge")) {
     import FlexiMerge._
     val bypassInput = createInputPort[RequestOutput]()
     val oneHundredContinueInput = createInputPort[OneHundredContinue.type]()

--- a/akka-http-core/src/main/scala/akka/http/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/util/StreamUtils.scala
@@ -108,7 +108,7 @@ private[http] object StreamUtils {
           FlowGraph { implicit b ⇒
             import FlowGraphImplicits._
 
-            val broadcast = Broadcast[ByteString]("transformMultipleInputBroadcast")
+            val broadcast = Broadcast[ByteString](OperationAttributes.name("transformMultipleInputBroadcast"))
             input ~> broadcast
             (multiple, results).zipped.foreach { (trans, sink) ⇒
               broadcast ~> trans ~> sink

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiMergeTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiMergeTest.java
@@ -123,10 +123,6 @@ public class FlexiMergeTest {
     private final InputPort<T, T> input1 = createInputPort();
     private final InputPort<T, T> input2 = createInputPort();
 
-    public Fair() {
-      super("fairMerge");
-    }
-
     public InputPort<T, T> input1() {
       return input1;
     }
@@ -166,10 +162,6 @@ public class FlexiMergeTest {
 
     private final InputPort<T, T> input1 = createInputPort();
     private final InputPort<T, T> input2 = createInputPort();
-
-    public StrictRoundRobin() {
-      super("roundRobinMerge");
-    }
 
     public InputPort<T, T> input1() {
       return input1;
@@ -252,10 +244,6 @@ public class FlexiMergeTest {
 
     public final InputPort<A, Pair<A, B>> inputA = createInputPort();
     public final InputPort<B, Pair<A, B>> inputB = createInputPort();
-
-    public Zip() {
-      super("zip");
-    }
 
     @Override
     public MergeLogic<A, Pair<A, B>> createMergeLogic() {
@@ -353,10 +341,6 @@ public class FlexiMergeTest {
     public final InputPort<A, Triple<A, B, C>> inputA = createInputPort();
     public final InputPort<B, Triple<A, B, C>> inputB = createInputPort();
     public final InputPort<C, Triple<A, B, C>> inputC = createInputPort();
-
-    public TripleZip() {
-      super("triple-zip");
-    }
 
     @Override
     public MergeLogic<ReadAllInputs, Triple<A, B, C>> createMergeLogic() {

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiRouteTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiRouteTest.java
@@ -101,10 +101,6 @@ public class FlexiRouteTest {
     private final OutputPort<T, T> output1 = createOutputPort();
     private final OutputPort<T, T> output2 = createOutputPort();
 
-    public Fair() {
-      super("fairRoute");
-    }
-
     public OutputPort<T, T> output1() {
       return output1;
     }
@@ -153,10 +149,6 @@ public class FlexiRouteTest {
     private final OutputPort<T, T> output1 = createOutputPort();
     private final OutputPort<T, T> output2 = createOutputPort();
 
-    public StrictRoundRobin() {
-      super("roundRobinRoute");
-    }
-
     public OutputPort<T, T> output1() {
       return output1;
     }
@@ -202,10 +194,6 @@ public class FlexiRouteTest {
 
     public final OutputPort<Pair<A, B>, A> outputA = createOutputPort();
     public final OutputPort<Pair<A, B>, B> outputB = createOutputPort();
-
-    public Unzip() {
-      super("unzip");
-    }
 
     @Override
     public RouteLogic<Pair<A, B>, Object> createRouteLogic() {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphCompileSpec.scala
@@ -186,11 +186,11 @@ class FlowGraphCompileSpec extends AkkaSpec {
         val undefinedSink1 = UndefinedSink[String]
         b.
           addEdge(undefinedSource1, f1, merge).
-          addEdge(UndefinedSource[String]("src2"), f2, merge).
+          addEdge(undefinedSource2, f2, merge).
           addEdge(merge, f3, undefinedSink1)
 
         b.attachSource(undefinedSource1, in1)
-        b.attachSource(UndefinedSource[String]("src2"), in2)
+        b.attachSource(undefinedSource2, in2)
         b.attachSink(undefinedSink1, out1)
 
       }.run()
@@ -212,23 +212,25 @@ class FlowGraphCompileSpec extends AkkaSpec {
       partial1.undefinedSources should be(Set(undefinedSource1, undefinedSource2))
       partial1.undefinedSinks should be(Set(undefinedSink1))
 
+      val undefinedSink2 = UndefinedSink[String]
+
       val partial2 = PartialFlowGraph(partial1) { implicit b ⇒
         import FlowGraphImplicits._
         b.attachSource(undefinedSource1, in1)
         b.attachSource(undefinedSource2, in2)
-        bcast ~> f5 ~> UndefinedSink[String]("sink2")
+        bcast ~> f5 ~> undefinedSink2
       }
       partial2.undefinedSources should be(Set.empty)
-      partial2.undefinedSinks should be(Set(undefinedSink1, UndefinedSink[String]("sink2")))
+      partial2.undefinedSinks should be(Set(undefinedSink1, undefinedSink2))
 
       FlowGraph(partial2) { b ⇒
         b.attachSink(undefinedSink1, out1)
-        b.attachSink(UndefinedSink[String]("sink2"), out2)
+        b.attachSink(undefinedSink2, out2)
       }.run()
 
       FlowGraph(partial2) { b ⇒
         b.attachSink(undefinedSink1, f1.to(out1))
-        b.attachSink(UndefinedSink[String]("sink2"), f2.to(out2))
+        b.attachSink(undefinedSink2, f2.to(out2))
       }.run()
 
       FlowGraph(partial1) { implicit b ⇒

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
@@ -23,7 +23,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance")
+        val balance = Balance[Int]
         Source(List(1, 2, 3)) ~> balance
         balance ~> Sink(c1)
         balance ~> Sink(c2)
@@ -48,7 +48,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val p2Sink = Sink.publisher[Int]
 
       val m = FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance", waitForAllDownstreams = true)
+        val balance = Balance[Int](waitForAllDownstreams = true)
         Source(List(1, 2, 3)) ~> balance
         balance ~> Sink(s1)
         balance ~> p2Sink
@@ -81,7 +81,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val p3Sink = Sink.publisher[Int]
 
       val m = FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance", waitForAllDownstreams = true)
+        val balance = Balance[Int](waitForAllDownstreams = true)
         Source(List(1, 2, 3)) ~> balance
         balance ~> Sink(s1)
         balance ~> p2Sink
@@ -121,7 +121,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val f5 = Sink.head[Seq[Int]]
 
       val g = FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance", waitForAllDownstreams = true)
+        val balance = Balance[Int](waitForAllDownstreams = true)
         Source(0 to 14) ~> balance
         balance ~> Flow[Int].grouped(15) ~> f1
         balance ~> Flow[Int].grouped(15) ~> f2
@@ -137,7 +137,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val numElementsForSink = 10000
       val outputs = Seq.fill(3)(Sink.fold[Int, Int](0)(_ + _))
       val g = FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance", waitForAllDownstreams = true)
+        val balance = Balance[Int](waitForAllDownstreams = true)
         Source(Stream.fill(numElementsForSink * outputs.size)(1)) ~> balance
         for { o ← outputs } balance ~> o
       }.run()
@@ -150,7 +150,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance")
+        val balance = Balance[Int]
         Source(List(1, 2, 3)) ~> balance
         balance ~> Flow[Int] ~> Sink(c1)
         balance ~> Flow[Int] ~> Sink(c2)
@@ -171,7 +171,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance")
+        val balance = Balance[Int]
         Source(List(1, 2, 3)) ~> balance
         balance ~> Flow[Int] ~> Sink(c1)
         balance ~> Flow[Int] ~> Sink(c2)
@@ -193,7 +193,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val balance = Balance[Int]("balance")
+        val balance = Balance[Int]
         Source(p1.getPublisher) ~> balance
         balance ~> Flow[Int] ~> Sink(c1)
         balance ~> Flow[Int] ~> Sink(c2)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
@@ -22,7 +22,7 @@ class GraphBroadcastSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val bcast = Broadcast[Int]("broadcast")
+        val bcast = Broadcast[Int]
         Source(List(1, 2, 3)) ~> bcast
         bcast ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink(c1)
         bcast ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink(c2)
@@ -54,7 +54,7 @@ class GraphBroadcastSpec extends AkkaSpec {
       val f5 = Sink.head[Seq[Int]]
 
       val g = FlowGraph { implicit b ⇒
-        val bcast = Broadcast[Int]("broadcast")
+        val bcast = Broadcast[Int]
         Source(List(1, 2, 3)) ~> bcast
         bcast ~> Flow[Int].grouped(5) ~> f1
         bcast ~> Flow[Int].grouped(5) ~> f2
@@ -75,7 +75,7 @@ class GraphBroadcastSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val bcast = Broadcast[Int]("broadcast")
+        val bcast = Broadcast[Int]
         Source(List(1, 2, 3)) ~> bcast
         bcast ~> Flow[Int] ~> Sink(c1)
         bcast ~> Flow[Int] ~> Sink(c2)
@@ -96,7 +96,7 @@ class GraphBroadcastSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val bcast = Broadcast[Int]("broadcast")
+        val bcast = Broadcast[Int]
         Source(List(1, 2, 3)) ~> bcast
         bcast ~> Flow[Int] ~> Sink(c1)
         bcast ~> Flow[Int] ~> Sink(c2)
@@ -118,7 +118,7 @@ class GraphBroadcastSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val bcast = Broadcast[Int]("broadcast")
+        val bcast = Broadcast[Int]
         Source(p1.getPublisher) ~> bcast
         bcast ~> Flow[Int] ~> Sink(c1)
         bcast ~> Flow[Int] ~> Sink(c2)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphConcatSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphConcatSpec.scala
@@ -24,8 +24,8 @@ class GraphConcatSpec extends TwoStreamsSetup {
 
       FlowGraph { implicit b ⇒
 
-        val concat1 = Concat[Int]("concat1")
-        val concat2 = Concat[Int]("concat2")
+        val concat1 = Concat[Int]
+        val concat2 = Concat[Int]
 
         Source(List.empty[Int]) ~> concat1.first
         Source(1 to 4) ~> concat1.second

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiMergeSpec.scala
@@ -17,7 +17,7 @@ object GraphFlexiMergeSpec {
    * they are available. Or in other words, if all inputs have elements available at the same
    * time then in finite steps all those elements are dequeued from them.
    */
-  class Fair[T] extends FlexiMerge[T]("fairMerge") {
+  class Fair[T] extends FlexiMerge[T] {
     import FlexiMerge._
     val input1 = createInputPort[T]()
     val input2 = createInputPort[T]()
@@ -35,7 +35,7 @@ object GraphFlexiMergeSpec {
    * It never skips an input while cycling but waits on it instead (closed inputs are skipped though).
    * The fair merge above is a non-strict round-robin (skips currently unavailable inputs).
    */
-  class StrictRoundRobin[T] extends FlexiMerge[T]("roundRobinMerge") {
+  class StrictRoundRobin[T] extends FlexiMerge[T] {
     import FlexiMerge._
     val input1 = createInputPort[T]()
     val input2 = createInputPort[T]()
@@ -77,7 +77,7 @@ object GraphFlexiMergeSpec {
     }
   }
 
-  class Zip[A, B] extends FlexiMerge[(A, B)]("zip") {
+  class Zip[A, B] extends FlexiMerge[(A, B)] {
     import FlexiMerge._
     val input1 = createInputPort[A]()
     val input2 = createInputPort[B]()
@@ -107,7 +107,7 @@ object GraphFlexiMergeSpec {
   }
 }
 
-class TripleCancellingZip[A, B, C](var cancelAfter: Int = Int.MaxValue) extends FlexiMerge[(A, B, C)]("triple-zip") {
+class TripleCancellingZip[A, B, C](var cancelAfter: Int = Int.MaxValue) extends FlexiMerge[(A, B, C)] {
   import FlexiMerge._
   val soonCancelledInput = createInputPort[A]()
   val stableInput1 = createInputPort[B]()
@@ -221,7 +221,7 @@ class PreferringMerge extends FlexiMerge[Int] {
   }
 }
 
-class TestMerge extends FlexiMerge[String]("testMerge") {
+class TestMerge extends FlexiMerge[String] {
   import FlexiMerge._
   val input1 = createInputPort[String]()
   val input2 = createInputPort[String]()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiRouteSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiRouteSpec.scala
@@ -18,7 +18,7 @@ object GraphFlexiRouteSpec {
    * they are have requested elements. Or in other words, if all outputs have demand available at the same
    * time then in finite steps all elements are enqueued to them.
    */
-  class Fair[T] extends FlexiRoute[T]("fairRoute") {
+  class Fair[T] extends FlexiRoute[T] {
     import FlexiRoute._
     val out1 = createOutputPort[T]()
     val out2 = createOutputPort[T]()
@@ -43,7 +43,7 @@ object GraphFlexiRouteSpec {
    * It never skips an output while cycling but waits on it instead (closed outputs are skipped though).
    * The fair route above is a non-strict round-robin (skips currently unavailable outputs).
    */
-  class StrictRoundRobin[T] extends FlexiRoute[T]("roundRobinRoute") {
+  class StrictRoundRobin[T] extends FlexiRoute[T] {
     import FlexiRoute._
     val out1 = createOutputPort[T]()
     val out2 = createOutputPort[T]()
@@ -66,7 +66,7 @@ object GraphFlexiRouteSpec {
     }
   }
 
-  class Unzip[A, B] extends FlexiRoute[(A, B)]("unzip") {
+  class Unzip[A, B] extends FlexiRoute[(A, B)] {
     import FlexiRoute._
     val outA = createOutputPort[A]()
     val outB = createOutputPort[B]()
@@ -89,7 +89,7 @@ object GraphFlexiRouteSpec {
     }
   }
 
-  class TestRoute extends FlexiRoute[String]("testRoute") {
+  class TestRoute extends FlexiRoute[String] {
     import FlexiRoute._
     val output1 = createOutputPort[String]()
     val output2 = createOutputPort[String]()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlowSpec.scala
@@ -11,15 +11,15 @@ import akka.stream.testkit.StreamTestKit
 
 object GraphFlowSpec {
   val source1 = Source(0 to 3)
-  val inMerge = Merge[Int]("m1")
-  val outMerge = Merge[String]("m3")
+  val inMerge = Merge[Int]
+  val outMerge = Merge[String]
 
   val partialGraph = PartialFlowGraph { implicit b ⇒
     import FlowGraphImplicits._
     val source2 = Source(4 to 9)
     val source3 = Source.empty[Int]
     val source4 = Source.empty[String]
-    val m2 = Merge[Int]("m2")
+    val m2 = Merge[Int]
 
     inMerge ~> Flow[Int].map(_ * 2) ~> m2 ~> Flow[Int].map(_ / 2).map(i ⇒ (i + 1).toString) ~> outMerge
     source2 ~> inMerge
@@ -231,7 +231,7 @@ class GraphFlowSpec extends AkkaSpec {
 
         FlowGraph { implicit b ⇒
           import FlowGraphImplicits._
-          val merge = Merge[Int]("merge")
+          val merge = Merge[Int]
           source1 ~> merge ~> Sink(probe)
           source2 ~> Flow[Int].map(_ * 10) ~> merge
         }.run()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
@@ -26,9 +26,9 @@ class GraphMergeSpec extends TwoStreamsSetup {
       val probe = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val m1 = Merge[Int]("m1")
-        val m2 = Merge[Int]("m2")
-        val m3 = Merge[Int]("m3")
+        val m1 = Merge[Int]
+        val m2 = Merge[Int]
+        val m3 = Merge[Int]
 
         source1 ~> m1 ~> Flow[Int].map(_ * 2) ~> m2 ~> Flow[Int].map(_ / 2).map(_ + 1) ~> Sink(probe)
         source2 ~> m1
@@ -59,7 +59,7 @@ class GraphMergeSpec extends TwoStreamsSetup {
       val probe = StreamTestKit.SubscriberProbe[Int]()
 
       FlowGraph { implicit b ⇒
-        val merge = Merge[Int]("merge")
+        val merge = Merge[Int]
 
         source1 ~> merge ~> Flow[Int] ~> Sink(probe)
         source2 ~> merge
@@ -132,6 +132,11 @@ class GraphMergeSpec extends TwoStreamsSetup {
     "work with one delayed failed and one nonempty publisher" in {
       // This is nondeterministic, multiple scenarios can happen
       pending
+    }
+
+    "use name in toString" in {
+      Merge[Int](OperationAttributes.name("m1")).toString should be("m1")
+      Merge[Int].toString should startWith(classOf[Merge[Int]].getName)
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala
@@ -66,8 +66,8 @@ class GraphOpsIntegrationSpec extends AkkaSpec {
       val resultFuture = Sink.head[Seq[Int]]
 
       val g = FlowGraph { implicit b ⇒
-        val bcast = Broadcast[Int]("broadcast")
-        val merge = Merge[Int]("merge")
+        val bcast = Broadcast[Int]
+        val merge = Merge[Int]
 
         Source(List(1, 2, 3)) ~> bcast
         bcast ~> merge
@@ -99,19 +99,20 @@ class GraphOpsIntegrationSpec extends AkkaSpec {
     }
 
     "support wikipedia Topological_sorting 2" in {
+      import OperationAttributes.name
       // see https://en.wikipedia.org/wiki/Topological_sorting#mediaviewer/File:Directed_acyclic_graph.png
       val resultFuture2 = Sink.head[Seq[Int]]
       val resultFuture9 = Sink.head[Seq[Int]]
       val resultFuture10 = Sink.head[Seq[Int]]
 
       val g = FlowGraph { implicit b ⇒
-        val b3 = Broadcast[Int]("b3")
-        val b7 = Broadcast[Int]("b7")
-        val b11 = Broadcast[Int]("b11")
-        val m8 = Merge[Int]("m8")
-        val m9 = Merge[Int]("m9")
-        val m10 = Merge[Int]("m10")
-        val m11 = Merge[Int]("m11")
+        val b3 = Broadcast[Int](name("b3"))
+        val b7 = Broadcast[Int](name("b7"))
+        val b11 = Broadcast[Int](name("b11"))
+        val m8 = Merge[Int](name("m8"))
+        val m9 = Merge[Int](name("m9"))
+        val m10 = Merge[Int](name("m10"))
+        val m11 = Merge[Int](name("m11"))
         val in3 = Source(List(3))
         val in5 = Source(List(5))
         val in7 = Source(List(7))
@@ -151,8 +152,8 @@ class GraphOpsIntegrationSpec extends AkkaSpec {
       val resultFuture = Sink.head[Seq[Int]]
 
       val g = FlowGraph { implicit b ⇒
-        val bcast = Broadcast[Int]("broadcast")
-        val merge = Merge[Int]("merge")
+        val bcast = Broadcast[Int]
+        val merge = Merge[Int]
 
         Source(List(1, 2, 3)) ~> Flow[Int].map(_ * 2) ~> bcast
         bcast ~> merge
@@ -184,7 +185,7 @@ class GraphOpsIntegrationSpec extends AkkaSpec {
       val output1 = UndefinedSink[Int]
       val output2 = UndefinedSink[String]
       val partial = PartialFlowGraph { implicit builder ⇒
-        val bcast = Broadcast[String]("bcast")
+        val bcast = Broadcast[String]
         input1 ~> Flow[Int].map(_.toString) ~> bcast ~> Flow[String].map(_.toInt) ~> output1
         bcast ~> Flow[String].map("elem-" + _) ~> output2
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipSpec.scala
@@ -21,7 +21,7 @@ class GraphUnzipSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[String]()
 
       FlowGraph { implicit b ⇒
-        val unzip = Unzip[Int, String]("unzip")
+        val unzip = Unzip[Int, String]
         Source(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
         unzip.right ~> Flow[String].buffer(16, OverflowStrategy.backpressure) ~> Sink(c2)
         unzip.left ~> Flow[Int].buffer(16, OverflowStrategy.backpressure).map(_ * 2) ~> Sink(c1)
@@ -50,7 +50,7 @@ class GraphUnzipSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[String]()
 
       FlowGraph { implicit b ⇒
-        val unzip = Unzip[Int, String]("unzip")
+        val unzip = Unzip[Int, String]
         Source(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
         unzip.left ~> Sink(c1)
         unzip.right ~> Sink(c2)
@@ -71,7 +71,7 @@ class GraphUnzipSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[String]()
 
       FlowGraph { implicit b ⇒
-        val unzip = Unzip[Int, String]("unzip")
+        val unzip = Unzip[Int, String]
         Source(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
         unzip.left ~> Sink(c1)
         unzip.right ~> Sink(c2)
@@ -93,7 +93,7 @@ class GraphUnzipSpec extends AkkaSpec {
       val c2 = StreamTestKit.SubscriberProbe[String]()
 
       FlowGraph { implicit b ⇒
-        val unzip = Unzip[Int, String]("unzip")
+        val unzip = Unzip[Int, String]
         Source(p1.getPublisher) ~> unzip.in
         unzip.left ~> Sink(c1)
         unzip.right ~> Sink(c2)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlexiMerge.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlexiMerge.scala
@@ -332,18 +332,15 @@ object FlexiMerge {
  * must not hold mutable state, since it may be shared across several materialized ``FlowGraph``
  * instances.
  *
- * Note that a `FlexiMerge` with a specific name can only be used at one place (one vertex)
- * in the `FlowGraph`. If the `name` is not specified the `FlexiMerge` instance can only
- * be used at one place (one vertex) in the `FlowGraph`.
+ * Note that a `FlexiMerge` instance can only be used at one place in the `FlowGraph` (one vertex).
  *
- * @param name optional name of the junction in the [[FlowGraph]],
+ * @param attributes optional attributes for this vertex
  */
 abstract class FlexiMerge[In, Out](val attributes: OperationAttributes) {
   import FlexiMerge._
   import scaladsl.FlowGraphInternal
   import akka.stream.impl.Ast
 
-  def this(name: String) = this(OperationAttributes.name(name))
   def this() = this(OperationAttributes.none)
 
   private var inputCount = 0
@@ -400,6 +397,6 @@ abstract class FlexiMerge[In, Out](val attributes: OperationAttributes) {
 
   override def toString = attributes.asScala.nameLifted match {
     case Some(n) ⇒ n
-    case None    ⇒ getClass.getSimpleName + "@" + Integer.toHexString(super.hashCode())
+    case None    ⇒ super.toString
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlexiRoute.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlexiRoute.scala
@@ -299,18 +299,15 @@ object FlexiRoute {
  * must not hold mutable state, since it may be shared across several materialized ``FlowGraph``
  * instances.
  *
- * Note that a `FlexiRoute` with a specific name can only be used at one place (one vertex)
- * in the `FlowGraph`. If the `name` is not specified the `FlexiRoute` instance can only
- * be used at one place (one vertex) in the `FlowGraph`.
+ * Note that a `FlexiRoute` instance can only be used at one place in the `FlowGraph` (one vertex).
  *
- * @param name optional name of the junction in the [[FlowGraph]],
+ * @param attributes optional attributes for this vertex
  */
 abstract class FlexiRoute[In, Out](val attributes: OperationAttributes) {
   import FlexiRoute._
   import scaladsl.FlowGraphInternal
   import akka.stream.impl.Ast
 
-  def this(name: String) = this(OperationAttributes.name(name))
   def this() = this(OperationAttributes.none)
 
   private var outputCount = 0
@@ -372,7 +369,7 @@ abstract class FlexiRoute[In, Out](val attributes: OperationAttributes) {
 
   override def toString = attributes.asScala.nameLifted match {
     case Some(n) ⇒ n
-    case None    ⇒ getClass.getSimpleName + "@" + Integer.toHexString(super.hashCode())
+    case None    ⇒ super.toString
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowGraph.scala
@@ -9,8 +9,6 @@ import akka.stream.impl.Ast
 
 import akka.stream._
 
-// elements //
-
 trait JunctionInPort[-T] {
   /** Convert this element to it's `scaladsl` equivalent. */
   def asScala: scaladsl.JunctionInPort[T]
@@ -34,37 +32,32 @@ private object JunctionPortAdapter {
 }
 
 object Merge {
-  /**
-   * Create a new anonymous `Merge` vertex with the specified output type.
-   * Note that a `Merge` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */
-  def create[T](): Merge[T] = create(name = null)
 
   /**
-   * Create a new anonymous `Merge` vertex with the specified output type.
-   * Note that a `Merge` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Merge` vertex with the specified output type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def create[T](clazz: Class[T]): Merge[T] = create[T]()
+  def create[T](attributes: OperationAttributes): Merge[T] =
+    new Merge(new scaladsl.Merge[T](attributes.asScala))
 
   /**
-   * Create a named `Merge` vertex with the specified output type.
-   * Note that a `Merge` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `Merge` vertex with the specified output type.
    */
-  def create[T](name: String): Merge[T] = new Merge(new scaladsl.Merge[T](OperationAttributes.name(name).asScala))
+  def create[T](): Merge[T] = create(OperationAttributes.none)
 
   /**
-   * Create a named `Merge` vertex with the specified output type.
-   * Note that a `Merge` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `Merge` vertex with the specified output type.
    */
-  def create[T](clazz: Class[T], name: String): Merge[T] = create[T](name)
+  def create[T](clazz: Class[T]): Merge[T] = create()
+
+  /**
+   * Create a new `Merge` vertex with the specified output type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
+   */
+  def create[T](clazz: Class[T], attributes: OperationAttributes): Merge[T] = create(attributes)
+
 }
 
 /**
@@ -73,6 +66,11 @@ object Merge {
  *
  * When building the [[FlowGraph]] you must connect one or more input sources
  * and one output sink to the `Merge` vertex.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 class Merge[T] private (delegate: scaladsl.Merge[T]) extends javadsl.Junction[T] {
   override def asScala: scaladsl.Merge[T] = delegate
@@ -80,36 +78,30 @@ class Merge[T] private (delegate: scaladsl.Merge[T]) extends javadsl.Junction[T]
 
 object MergePreferred {
   /**
-   * Create a new anonymous `MergePreferred` vertex with the specified output type.
-   * Note that a `MergePreferred` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `MergePreferred` vertex with the specified output type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def create[T](): MergePreferred[T] = create(name = null)
+  def create[T](attributes: OperationAttributes): MergePreferred[T] =
+    new MergePreferred(new scaladsl.MergePreferred[T](attributes.asScala))
 
   /**
-   * Create a new anonymous `MergePreferred` vertex with the specified output type.
-   * Note that a `MergePreferred` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `MergePreferred` vertex with the specified output type.
    */
-  def create[T](clazz: Class[T]): MergePreferred[T] = create[T]()
+  def create[T](): MergePreferred[T] = create(OperationAttributes.none)
 
   /**
-   * Create a named `MergePreferred` vertex with the specified output type.
-   * Note that a `MergePreferred` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `MergePreferred` vertex with the specified output type.
    */
-  def create[T](name: String): MergePreferred[T] = new MergePreferred(new scaladsl.MergePreferred[T](OperationAttributes.name(name).asScala))
+  def create[T](clazz: Class[T]): MergePreferred[T] = create()
 
   /**
-   * Create a named `MergePreferred` vertex with the specified output type.
-   * Note that a `MergePreferred` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `MergePreferred` vertex with the specified output type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def create[T](clazz: Class[T], name: String): MergePreferred[T] = create[T](name)
+  def create[T](clazz: Class[T], attributes: OperationAttributes): MergePreferred[T] =
+    create(attributes)
 }
 
 /**
@@ -118,6 +110,11 @@ object MergePreferred {
  *
  * When building the [[FlowGraph]] you must connect one or more input streams
  * and one output sink to the `Merge` vertex.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 class MergePreferred[T](delegate: scaladsl.MergePreferred[T]) extends javadsl.Junction[T] {
   override def asScala: scaladsl.MergePreferred[T] = delegate
@@ -125,42 +122,41 @@ class MergePreferred[T](delegate: scaladsl.MergePreferred[T]) extends javadsl.Ju
 
 object Broadcast {
   /**
-   * Create a new anonymous `Broadcast` vertex with the specified input type.
-   * Note that a `Broadcast` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Broadcast` vertex with the specified input type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def create[T](): Broadcast[T] = create(name = null)
+  def create[T](attributes: OperationAttributes): Broadcast[T] =
+    new Broadcast(new scaladsl.Broadcast(attributes.asScala))
 
   /**
-   * Create a new anonymous `Broadcast` vertex with the specified input type.
-   * Note that a `Broadcast` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Broadcast` vertex with the specified input type.
    */
-  def create[T](clazz: Class[T]): Broadcast[T] = create[T]()
+  def create[T](): Broadcast[T] = create(OperationAttributes.none)
 
   /**
-   * Create a named `Broadcast` vertex with the specified input type.
-   * Note that a `Broadcast` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `Broadcast` vertex with the specified input type.
    */
-  def create[T](name: String): Broadcast[T] = new Broadcast(new scaladsl.Broadcast(OperationAttributes.name(name).asScala))
+  def create[T](clazz: Class[T]): Broadcast[T] = create()
 
   /**
-   * Create a named `Broadcast` vertex with the specified input type.
-   * Note that a `Broadcast` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `Broadcast` vertex with the specified input type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def create[T](clazz: Class[T], name: String): Broadcast[T] = create[T](name)
+  def create[T](clazz: Class[T], attributes: OperationAttributes): Broadcast[T] =
+    create(attributes)
 }
 
 /**
  * Fan-out the stream to several streams. Each element is produced to
  * the other streams. It will not shutdown until the subscriptions for at least
  * two downstream subscribers have been established.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 class Broadcast[T](delegate: scaladsl.Broadcast[T]) extends javadsl.Junction[T] {
   override def asScala: scaladsl.Broadcast[T] = delegate
@@ -168,43 +164,48 @@ class Broadcast[T](delegate: scaladsl.Broadcast[T]) extends javadsl.Junction[T] 
 
 object Balance {
   /**
-   * Create a new anonymous `Balance` vertex with the specified input type.
-   * Note that a `Balance` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Balance` vertex with the specified input type and attributes.
+   *
+   * @param waitForAllDownstreams if `true` it will not start emitting
+   *   elements to downstream outputs until all of them have requested at least one element
+   * @param attributes optional attributes for this vertex
    */
-  def create[T](): Balance[T] = create(name = null)
+  def create[T](waitForAllDownstreams: Boolean, attributes: OperationAttributes): Balance[T] =
+    new Balance(new scaladsl.Balance(waitForAllDownstreams, attributes.asScala))
 
   /**
-   * Create a new anonymous `Balance` vertex with the specified input type.
-   * Note that a `Balance` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Balance` vertex with the specified input type.
    */
-  def create[T](clazz: Class[T]): Balance[T] = create[T]()
+  def create[T](): Balance[T] = create(false, OperationAttributes.none)
 
   /**
-   * Create a named `Balance` vertex with the specified input type.
-   * Note that a `Balance` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `Balance` vertex with the specified input type.
    */
-  def create[T](name: String): Balance[T] =
-    new Balance(new scaladsl.Balance(waitForAllDownstreams = false, OperationAttributes.name(name).asScala))
+  def create[T](attributes: OperationAttributes): Balance[T] = create(false, attributes)
 
   /**
-   * Create a named `Balance` vertex with the specified input type.
-   * Note that a `Balance` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
+   * Create a new `Balance` vertex with the specified input type.
    */
-  def create[T](clazz: Class[T], name: String): Balance[T] = create[T](name)
+  def create[T](clazz: Class[T]): Balance[T] = create()
+
+  /**
+   * Create a new `Balance` vertex with the specified input type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
+   */
+  def create[T](clazz: Class[T], attributes: OperationAttributes): Balance[T] =
+    create(false, attributes)
 }
 
 /**
  * Fan-out the stream to several streams. Each element is produced to
  * one of the other streams. It will not shutdown until the subscriptions for at least
  * two downstream subscribers have been established.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 class Balance[T](delegate: scaladsl.Balance[T]) extends javadsl.Junction[T] {
   override def asScala: scaladsl.Balance[T] = delegate
@@ -220,14 +221,19 @@ class Balance[T](delegate: scaladsl.Balance[T]) extends javadsl.Junction[T] {
 object Zip {
   import akka.japi.{ Pair, Function2 }
   /**
-   * Create a new anonymous `ZipWith` vertex with the specified input types and zipping-function
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function
    * which creates `akka.japi.Pair`s.
-   * Note that a ZipWith` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def create[A, B]: ZipWith[A, B, A Pair B] =
-    ZipWith.create(_toPair.asInstanceOf[Function2[A, B, A Pair B]])
+  def create[A, B](attributes: OperationAttributes): ZipWith[A, B, A Pair B] =
+    ZipWith.create(_toPair.asInstanceOf[Function2[A, B, A Pair B]], attributes)
+
+  /**
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function
+   * which creates `akka.japi.Pair`s.
+   */
+  def create[A, B]: ZipWith[A, B, A Pair B] = create(OperationAttributes.none)
 
   private[this] final val _toPair: Function2[Any, Any, Any Pair Any] =
     new Function2[Any, Any, Any Pair Any] { override def apply(a: Any, b: Any): Any Pair Any = new Pair(a, b) }
@@ -236,22 +242,21 @@ object Zip {
 object ZipWith {
 
   /**
-   * Creates a new anonymous `ZipWith` vertex with the specified input types and zipping-function `f`.
-   * Note that a `ZipWith` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function `f`.
+   *
+   * @param f zipping-function from the input values to the output value
+   * @param attributes optional attributes for this vertex
    */
-  def create[A, B, C](f: akka.japi.Function2[A, B, C]): ZipWith[A, B, C] =
-    create(name = null, f = f)
+  def create[A, B, C](f: akka.japi.Function2[A, B, C], attributes: OperationAttributes): ZipWith[A, B, C] =
+    new ZipWith(new scaladsl.ZipWith[A, B, C](f.apply _, attributes.asScala))
 
   /**
-   * Creates a new named `ZipWith` vertex with the specified input types and zipping-function `f`.
-   * Note that a `ZipWith` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function `f`.
+   *
+   * @param f zipping-function from the input values to the output value
    */
-  def create[A, B, C](name: String, f: akka.japi.Function2[A, B, C]): ZipWith[A, B, C] =
-    new ZipWith(new scaladsl.ZipWith[A, B, C](OperationAttributes.name(name).asScala, f.apply _))
+  def create[A, B, C](f: akka.japi.Function2[A, B, C]): ZipWith[A, B, C] =
+    create(f = f, OperationAttributes.none)
 
   final class Left[A, B, C](override val asScala: scaladsl.ZipWith.Left[A, B, C]) extends JunctionInPort[A]
   final class Right[A, B, C](override val asScala: scaladsl.ZipWith.Right[A, B, C]) extends JunctionInPort[B]
@@ -270,16 +275,32 @@ final class ZipWith[A, B, C] private (val asScala: scaladsl.ZipWith[A, B, C]) {
 }
 
 object Unzip {
-  def create[A, B](): Unzip[A, B] = create(name = null)
 
-  def create[A, B](name: String): Unzip[A, B] =
-    new Unzip[A, B](new scaladsl.Unzip[A, B](OperationAttributes.name(name).asScala))
+  /**
+   * Creates a new `Unzip` vertex with the specified output types and attributes.
+   *
+   * @param attributes optional attributes for this vertex
+   */
+  def create[A, B](attributes: OperationAttributes): Unzip[A, B] =
+    new Unzip[A, B](new scaladsl.Unzip[A, B](attributes.asScala))
 
-  def create[A, B](left: Class[A], right: Class[B]): Unzip[A, B] =
-    create[A, B]()
+  /**
+   * Creates a new `Unzip` vertex with the specified output types.
+   */
+  def create[A, B](): Unzip[A, B] = create(OperationAttributes.none)
 
-  def create[A, B](name: String, left: Class[A], right: Class[B]): Unzip[A, B] =
-    create[A, B](name)
+  /**
+   * Creates a new `Unzip` vertex with the specified output types.
+   */
+  def create[A, B](left: Class[A], right: Class[B]): Unzip[A, B] = create[A, B]()
+
+  /**
+   * Creates a new `Unzip` vertex with the specified output types and attributes.
+   *
+   * @param attributes optional attributes for this vertex
+   */
+  def create[A, B](left: Class[A], right: Class[B], attributes: OperationAttributes): Unzip[A, B] =
+    create[A, B](attributes)
 
   class In[A, B](private val unzip: Unzip[A, B]) extends JunctionInPort[akka.japi.Pair[A, B]] {
     // this cast is safe thanks to using `ZipAs` in the Ast element, Zip will emit the expected type (Pair)
@@ -296,6 +317,12 @@ object Unzip {
   }
 }
 
+/**
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
+ */
 final class Unzip[A, B] private (delegate: scaladsl.Unzip[A, B]) {
 
   /** Convert this element to it's `scaladsl` equivalent. */
@@ -308,36 +335,21 @@ final class Unzip[A, B] private (delegate: scaladsl.Unzip[A, B]) {
 
 object Concat {
   /**
-   * Create a new anonymous `Concat` vertex with the specified input types.
-   * Note that a `Concat` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Concat` vertex with the specified input types and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def create[T](): Concat[T] = new Concat(scaladsl.Concat[T])
+  def create[T](attributes: OperationAttributes): Concat[T] = new Concat(scaladsl.Concat[T])
 
   /**
-   * Create a new anonymous `Concat` vertex with the specified input types.
-   * Note that a `Concat` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Concat` vertex with the specified input types.
+   */
+  def create[T](): Concat[T] = create(OperationAttributes.none)
+
+  /**
+   * Create a new `Concat` vertex with the specified input types.
    */
   def create[T](clazz: Class[T]): Concat[T] = create()
-
-  /**
-   * Create a named `Concat` vertex with the specified input types.
-   * Note that a `Concat` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */
-  def create[T](name: String): Concat[T] = new Concat(scaladsl.Concat[T](name))
-
-  /**
-   * Create a named `Concat` vertex with the specified input types.
-   * Note that a `Concat` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */
-  def create[T](name: String, clazz: Class[T]): Concat[T] = create(name)
 
   class First[T] private[akka] (delegate: scaladsl.Concat.First[T]) extends JunctionInPort[T] {
     override def asScala: scaladsl.JunctionInPort[T] = delegate
@@ -355,6 +367,11 @@ object Concat {
  * Takes two streams and outputs an output stream formed from the two input streams
  * by consuming one stream first emitting all of its elements, then consuming the
  * second stream emitting all of its elements.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 class Concat[T] private (delegate: scaladsl.Concat[T]) {
 
@@ -370,36 +387,16 @@ class Concat[T] private (delegate: scaladsl.Concat[T]) {
 
 object UndefinedSource {
   /**
-   * Create a new anonymous `Undefinedsource` vertex with the specified input type.
-   * Note that a `Undefinedsource` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Undefinedsource` vertex with the specified output type.
    */
-  def create[T](): UndefinedSource[T] = new UndefinedSource[T](new scaladsl.UndefinedSource[T](scaladsl.OperationAttributes.none))
+  def create[T](): UndefinedSource[T] =
+    new UndefinedSource[T](new scaladsl.UndefinedSource[T](scaladsl.OperationAttributes.none))
 
   /**
-   * Create a new anonymous `Undefinedsource` vertex with the specified input type.
-   * Note that a `Undefinedsource` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Undefinedsource` vertex with the specified output type.
    */
-  def create[T](clazz: Class[T]): UndefinedSource[T] = create[T]()
+  def create[T](clazz: Class[T]): UndefinedSource[T] = create()
 
-  /**
-   * Create a named `Undefinedsource` vertex with the specified input type.
-   * Note that a `Undefinedsource` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */
-  def create[T](name: String): UndefinedSource[T] = new UndefinedSource[T](new scaladsl.UndefinedSource[T](OperationAttributes.name(name).asScala))
-
-  /**
-   * Create a named `Undefinedsource` vertex with the specified input type.
-   * Note that a `Undefinedsource` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */
-  def create[T](clazz: Class[T], name: String): UndefinedSource[T] = create[T](name)
 }
 
 /**
@@ -413,36 +410,15 @@ final class UndefinedSource[+T](delegate: scaladsl.UndefinedSource[T]) {
 
 object UndefinedSink {
   /**
-   * Create a new anonymous `Undefinedsink` vertex with the specified input type.
-   * Note that a `Undefinedsink` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Undefinedsink` vertex with the specified input type.
    */
-  def create[T](): UndefinedSink[T] = create(name = null)
+  def create[T](): UndefinedSink[T] =
+    new UndefinedSink[T](new scaladsl.UndefinedSink[T](OperationAttributes.none.asScala))
 
   /**
-   * Create a new anonymous `Undefinedsink` vertex with the specified input type.
-   * Note that a `Undefinedsink` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Undefinedsource` vertex with the specified output type.
    */
-  def create[T](clazz: Class[T]): UndefinedSink[T] = create[T]()
-
-  /**
-   * Create a named `Undefinedsink` vertex with the specified input type.
-   * Note that a `Undefinedsink` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */
-  def create[T](name: String): UndefinedSink[T] = new UndefinedSink[T](new scaladsl.UndefinedSink[T](OperationAttributes.name(name).asScala))
-
-  /**
-   * Create a named `Undefinedsink` vertex with the specified input type.
-   * Note that a `Undefinedsink` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */
-  def create[T](clazz: Class[T], name: String): UndefinedSink[T] = create[T](name)
+  def create[T](clazz: Class[T]): UndefinedSink[T] = create()
 }
 
 /**
@@ -464,8 +440,7 @@ object FlowGraph {
    * The [[FlowGraphBuilder]] is mutable and not thread-safe,
    * thus you should construct your Graph and then share the constructed immutable [[FlowGraph]].
    */
-  def builder(): FlowGraphBuilder =
-    new FlowGraphBuilder()
+  def builder(): FlowGraphBuilder = new FlowGraphBuilder()
 
 }
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiMerge.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiMerge.scala
@@ -231,16 +231,13 @@ object FlexiMerge {
  * must not hold mutable state, since it may be shared across several materialized ``FlowGraph``
  * instances.
  *
- * Note that a `FlexiMerge` with a specific name can only be used at one place (one vertex)
- * in the `FlowGraph`. If the `name` is not specified the `FlexiMerge` instance can only
- * be used at one place (one vertex) in the `FlowGraph`.
+ * Note that a `FlexiMerge` instance can only be used at one place in the `FlowGraph` (one vertex).
  *
- * @param name optional name of the junction in the [[FlowGraph]],
+ * @param attributes optional attributes for this vertex
  */
 abstract class FlexiMerge[Out](override val attributes: OperationAttributes) extends MergeLogicFactory[Out] {
   import FlexiMerge._
 
-  def this(name: String) = this(OperationAttributes.name(name))
   def this() = this(OperationAttributes.none)
 
   private var inputCount = 0
@@ -289,6 +286,6 @@ abstract class FlexiMerge[Out](override val attributes: OperationAttributes) ext
 
   override def toString = attributes.nameLifted match {
     case Some(n) ⇒ n
-    case None    ⇒ getClass.getSimpleName + "@" + Integer.toHexString(super.hashCode())
+    case None    ⇒ super.toString
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiRoute.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiRoute.scala
@@ -207,16 +207,13 @@ object FlexiRoute {
  * must not hold mutable state, since it may be shared across several materialized ``FlowGraph``
  * instances.
  *
- * Note that a `FlexiRoute` with a specific name can only be used at one place (one vertex)
- * in the `FlowGraph`. If the `name` is not specified the `FlexiRoute` instance can only
- * be used at one place (one vertex) in the `FlowGraph`.
+ * Note that a `FlexiRoute` instance can only be used at one place in the `FlowGraph` (one vertex).
  *
- * @param name optional name of the junction in the [[FlowGraph]],
+ * @param attributes optional attributes for this vertex
  */
 abstract class FlexiRoute[In](override val attributes: OperationAttributes) extends RouteLogicFactory[In] {
   import FlexiRoute._
 
-  def this(name: String) = this(OperationAttributes.name(name))
   def this() = this(OperationAttributes.none)
 
   private var outputCount = 0
@@ -266,6 +263,6 @@ abstract class FlexiRoute[In](override val attributes: OperationAttributes) exte
 
   override def toString = attributes.nameLifted match {
     case Some(n) ⇒ n
-    case None    ⇒ getClass.getSimpleName + "@" + Integer.toHexString(super.hashCode())
+    case None    ⇒ super.toString
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowGraph.scala
@@ -64,9 +64,6 @@ private[akka] object Identity {
 private[akka] final class Identity[T](override val attributes: OperationAttributes = OperationAttributes.none) extends FlowGraphInternal.InternalVertex with Junction[T] {
   import Identity._
 
-  // This vertex can not have a name or else there can only be one instance in the whole graph
-  override def name: Option[String] = None
-
   override private[akka] val vertex = this
   override val minimumInputCount: Int = 1
   override val maximumInputCount: Int = 1
@@ -80,21 +77,16 @@ private[akka] final class Identity[T](override val attributes: OperationAttribut
 
 object Merge {
   /**
-   * Create a new anonymous `Merge` vertex with the specified output type.
-   * Note that a `Merge` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Merge` vertex with the specified output type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def apply[T]: Merge[T] = new Merge[T](OperationAttributes.none)
-  /**
-   * Create a named `Merge` vertex with the specified output type.
-   * Note that a `Merge` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[T](name: String): Merge[T] = new Merge[T](OperationAttributes.name(name))
-
   def apply[T](attributes: OperationAttributes): Merge[T] = new Merge[T](attributes)
+
+  /**
+   * Create a new `Merge` vertex with the specified output type.
+   */
+  def apply[T]: Merge[T] = apply(OperationAttributes.none)
 }
 
 /**
@@ -103,6 +95,11 @@ object Merge {
  *
  * When building the [[FlowGraph]] you must connect one or more input sources
  * and one output sink to the `Merge` vertex.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 final class Merge[T](override val attributes: OperationAttributes) extends FlowGraphInternal.InternalVertex with Junction[T] {
   override private[akka] val vertex = this
@@ -123,21 +120,16 @@ object MergePreferred {
   val PreferredPort = Int.MinValue
 
   /**
-   * Create a new anonymous `MergePreferred` vertex with the specified output type.
-   * Note that a `MergePreferred` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `MergePreferred` vertex with the specified output type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def apply[T]: MergePreferred[T] = new MergePreferred[T](OperationAttributes.none)
-  /**
-   * Create a named `MergePreferred` vertex with the specified output type.
-   * Note that a `MergePreferred` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[T](name: String): MergePreferred[T] = new MergePreferred[T](OperationAttributes.name(name))
-
   def apply[T](attributes: OperationAttributes): MergePreferred[T] = new MergePreferred[T](attributes)
+
+  /**
+   * Create a new `MergePreferred` vertex with the specified output type.
+   */
+  def apply[T]: MergePreferred[T] = apply(OperationAttributes.none)
 
   class Preferred[A] private[akka] (private[akka] val vertex: MergePreferred[A]) extends JunctionInPort[A] {
     override private[akka] def port = PreferredPort
@@ -151,6 +143,11 @@ object MergePreferred {
  *
  * When building the [[FlowGraph]] you must connect one or more input sources
  * and one output sink to the `Merge` vertex.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 final class MergePreferred[T](override val attributes: OperationAttributes) extends FlowGraphInternal.InternalVertex with Junction[T] {
 
@@ -169,27 +166,28 @@ final class MergePreferred[T](override val attributes: OperationAttributes) exte
 
 object Broadcast {
   /**
-   * Create a new anonymous `Broadcast` vertex with the specified input type.
-   * Note that a `Broadcast` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Broadcast` vertex with the specified input type and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def apply[T]: Broadcast[T] = new Broadcast[T](OperationAttributes.none)
-  /**
-   * Create a named `Broadcast` vertex with the specified input type.
-   * Note that a `Broadcast` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[T](name: String): Broadcast[T] = new Broadcast[T](OperationAttributes.name(name))
-
   def apply[T](attributes: OperationAttributes): Broadcast[T] = new Broadcast[T](attributes)
+
+  /**
+   * Create a new `Broadcast` vertex with the specified input type.
+   */
+  def apply[T]: Broadcast[T] = apply(OperationAttributes.none)
+
 }
 
 /**
  * Fan-out the stream to several streams. Each element is produced to
  * the other streams. It will not shutdown until the subscriptions for at least
  * two downstream subscribers have been established.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 final class Broadcast[T](override val attributes: OperationAttributes) extends FlowGraphInternal.InternalVertex with Junction[T] {
   override private[akka] def vertex = this
@@ -204,42 +202,33 @@ final class Broadcast[T](override val attributes: OperationAttributes) extends F
 }
 
 object Balance {
-  /**
-   * Create a new anonymous `Balance` vertex with the specified input type.
-   * Note that a `Balance` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */
-  def apply[T]: Balance[T] = new Balance[T](waitForAllDownstreams = false, OperationAttributes.none)
-  /**
-   * Create a named `Balance` vertex with the specified input type.
-   * Note that a `Balance` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   *
-   * If you use `waitForAllDownstreams = true` it will not start emitting
-   * elements to downstream outputs until all of them have requested at least one element.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[T](name: String, waitForAllDownstreams: Boolean = false): Balance[T] = new Balance[T](waitForAllDownstreams, OperationAttributes.name(name))
 
   /**
-   * Create a new anonymous `Balance` vertex with the specified input type.
-   * Note that a `Balance` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Balance` vertex with the specified input type and optional attributes.
    *
-   * If you use `waitForAllDownstreams = true` it will not start emitting
-   * elements to downstream outputs until all of them have requested at least one element.
+   * @param waitForAllDownstreams if you use `waitForAllDownstreams = true` it will not start emitting
+   *   elements to downstream outputs until all of them have requested at least one element,
+   *   default value is `false`
+   * @param attributes optional attributes for this vertex
    */
-  def apply[T](waitForAllDownstreams: Boolean): Balance[T] = new Balance[T](waitForAllDownstreams, OperationAttributes.none)
+  def apply[T](waitForAllDownstreams: Boolean = false, attributes: OperationAttributes = OperationAttributes.none): Balance[T] =
+    new Balance[T](waitForAllDownstreams, attributes)
 
-  def apply[T](waitForAllDownstreams: Boolean, attributes: OperationAttributes): Balance[T] = new Balance[T](waitForAllDownstreams, attributes)
+  /**
+   * Create a new `Balance` vertex with the specified input type.
+   */
+  def apply[T]: Balance[T] = apply()
 }
 
 /**
  * Fan-out the stream to several streams. Each element is produced to
  * one of the other streams. It will not shutdown until the subscriptions for at least
  * two downstream subscribers have been established.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 final class Balance[T](val waitForAllDownstreams: Boolean, override val attributes: OperationAttributes) extends FlowGraphInternal.InternalVertex with Junction[T] {
   override private[akka] def vertex = this
@@ -255,37 +244,32 @@ final class Balance[T](val waitForAllDownstreams: Boolean, override val attribut
 
 object Zip {
   /**
-   * Create a new anonymous `ZipWith` vertex with the specified input types and zipping-function
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function
    * which creates `Tuple2`s.
-   * Note that a ZipWith` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def apply[A, B]: ZipWith[A, B, (A, B)] =
-    apply(OperationAttributes.none)
-
   def apply[A, B](attributes: OperationAttributes): ZipWith[A, B, (A, B)] =
-    new ZipWith(attributes, _toTuple.asInstanceOf[(A, B) ⇒ (A, B)])
+    new ZipWith(_toTuple.asInstanceOf[(A, B) ⇒ (A, B)], attributes)
+
+  /**
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function
+   * which creates `Tuple2`s.
+   */
+  def apply[A, B]: ZipWith[A, B, (A, B)] = apply(OperationAttributes.none)
 
   private[this] final val _toTuple: (Any, Any) ⇒ (Any, Any) = (a, b) ⇒ (a, b)
 }
 
 object ZipWith {
   /**
-   * Create a new anonymous `ZipWith` vertex with the specified input types.
-   * Note that a `ZipWith` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `ZipWith` vertex with the specified input types.
+   *
+   * @param f zipping-function from the input values to the output value
+   * @param attributes optional attributes for this vertex
    */
-  def apply[A, B, C](f: (A, B) ⇒ C): ZipWith[A, B, C] = new ZipWith[A, B, C](OperationAttributes.none, f)
-  /**
-   * Create a named `ZipWith` vertex with the specified input types.
-   * Note that a `ZipWith` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[A, B, C](name: String, f: (A, B) ⇒ C): ZipWith[A, B, C] =
-    new ZipWith[A, B, C](OperationAttributes.name(name), f)
+  def apply[A, B, C](f: (A, B) ⇒ C, attributes: OperationAttributes = OperationAttributes.none): ZipWith[A, B, C] =
+    new ZipWith[A, B, C](f, attributes)
 
   final class Left[A, B, C] private[akka] (private[akka] val vertex: ZipWith[A, B, C]) extends JunctionInPort[A] {
     type NextT = C
@@ -306,8 +290,15 @@ object ZipWith {
  * Takes two streams and outputs an output stream formed from the two input streams
  * by combining corresponding elements using the supplied function.
  * If one of the two streams is longer than the other, its remaining elements are ignored.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
-private[akka] final class ZipWith[A, B, C](override val attributes: OperationAttributes, f: (A, B) ⇒ C) extends FlowGraphInternal.InternalVertex {
+private[akka] final class ZipWith[A, B, C](f: (A, B) ⇒ C, override val attributes: OperationAttributes)
+  extends FlowGraphInternal.InternalVertex {
+
   val left = new ZipWith.Left(this)
   val right = new ZipWith.Right(this)
   val out = new ZipWith.Out(this)
@@ -320,27 +311,21 @@ private[akka] final class ZipWith[A, B, C](override val attributes: OperationAtt
   // FIXME cache
   private[akka] override def astNode: FanInAstNode = Ast.ZipWith(f.asInstanceOf[(Any, Any) ⇒ Any], zip and attributes)
 
-  private[scaladsl] final override def newInstance() = new ZipWith[A, B, C](attributes.withoutName, f = f)
+  private[scaladsl] final override def newInstance() = new ZipWith[A, B, C](f = f, attributes.withoutName)
 }
 
 object Unzip {
   /**
-   * Create a new anonymous `Unzip` vertex with the specified output types.
-   * Note that a `Unzip` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Unzip` vertex with the specified output types and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def apply[A, B]: Unzip[A, B] = new Unzip[A, B](OperationAttributes.none)
+  def apply[A, B](attributes: OperationAttributes): Unzip[A, B] = new Unzip[A, B](attributes)
 
   /**
-   * Create a named `Unzip` vertex with the specified output types.
-   * Note that a `Unzip` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[A, B](name: String): Unzip[A, B] = new Unzip[A, B](OperationAttributes.name(name))
-
-  def apply[A, B](attributes: OperationAttributes): Unzip[A, B] = new Unzip[A, B](attributes)
+   * Create a new `Unzip` vertex with the specified output types.
+   */
+  def apply[A, B]: Unzip[A, B] = apply(OperationAttributes.none)
 
   final class In[A, B] private[akka] (private[akka] val vertex: Unzip[A, B]) extends JunctionInPort[(A, B)] {
     override type NextT = Nothing
@@ -358,6 +343,11 @@ object Unzip {
 
 /**
  * Takes a stream of pair elements and splits each pair to two output streams.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 final class Unzip[A, B](override val attributes: OperationAttributes) extends FlowGraphInternal.InternalVertex {
   val in = new Unzip.In(this)
@@ -376,22 +366,16 @@ final class Unzip[A, B](override val attributes: OperationAttributes) extends Fl
 
 object Concat {
   /**
-   * Create a new anonymous `Concat` vertex with the specified input types.
-   * Note that a `Concat` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `Concat` vertex with the specified input types and attributes.
+   *
+   * @param attributes optional attributes for this vertex
    */
-  def apply[T]: Concat[T] = new Concat[T](OperationAttributes.none)
+  def apply[T](attributes: OperationAttributes): Concat[T] = new Concat[T](attributes)
 
   /**
-   * Create a named `Concat` vertex with the specified input types.
-   * Note that a `Concat` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[T](name: String): Concat[T] = new Concat[T](OperationAttributes.name(name))
-
-  def apply[T](attributes: OperationAttributes): Concat[T] = new Concat[T](attributes)
+   * Create a new `Concat` vertex with the specified input types.
+   */
+  def apply[T]: Concat[T] = apply(OperationAttributes.none)
 
   final class First[T] private[akka] (val vertex: Concat[T]) extends JunctionInPort[T] {
     override val port = 0
@@ -411,6 +395,11 @@ object Concat {
  * Takes two streams and outputs an output stream formed from the two input streams
  * by consuming one stream first emitting all of its elements, then consuming the
  * second stream emitting all of its elements.
+ *
+ * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
+ * that multiple flows can be attached to; if you want to have multiple independent
+ * junctions within the same `FlowGraph` then you will have to create multiple such
+ * instances.
  */
 final class Concat[T](override val attributes: OperationAttributes) extends FlowGraphInternal.InternalVertex {
   val first = new Concat.First(this)
@@ -429,19 +418,10 @@ final class Concat[T](override val attributes: OperationAttributes) extends Flow
 
 object UndefinedSink {
   /**
-   * Create a new anonymous `UndefinedSink` vertex with the specified input type.
-   * Note that a `UndefinedSink` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `UndefinedSink` vertex with the specified input type.
    */
   def apply[T]: UndefinedSink[T] = new UndefinedSink[T](OperationAttributes.none)
-  /**
-   * Create a named `UndefinedSink` vertex with the specified input type.
-   * Note that a `UndefinedSink` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[T](name: String): UndefinedSink[T] = new UndefinedSink[T](OperationAttributes.name(name))
+
 }
 /**
  * It is possible to define a [[PartialFlowGraph]] with output pipes that are not connected
@@ -462,19 +442,10 @@ final class UndefinedSink[-T](override val attributes: OperationAttributes) exte
 
 object UndefinedSource {
   /**
-   * Create a new anonymous `UndefinedSource` vertex with the specified input type.
-   * Note that a `UndefinedSource` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
+   * Create a new `UndefinedSource` vertex with the specified output type.
    */
   def apply[T]: UndefinedSource[T] = new UndefinedSource[T](OperationAttributes.none)
-  /**
-   * Create a named `UndefinedSource` vertex with the specified output type.
-   * Note that a `UndefinedSource` with a specific name can only be used at one place (one vertex)
-   * in the `FlowGraph`. Calling this method several times with the same name
-   * returns instances that are `equal`.
-   */ // FIXME why do we have these when we can simply tell the user to use apply(OperationAttributes.name(name))?
-  def apply[T](name: String): UndefinedSource[T] = new UndefinedSource[T](OperationAttributes.name(name))
+
 }
 /**
  * It is possible to define a [[PartialFlowGraph]] with input pipes that are not connected
@@ -503,7 +474,7 @@ private[akka] object FlowGraphInternal {
   def UnlabeledPort = -1
 
   sealed trait Vertex {
-    // must return a new instance that is uniquely identifiable (i.e. no name for hashCode or equality)
+    // must return a new instance that is uniquely identifiable
     private[scaladsl] def newInstance(): Vertex
   }
 
@@ -553,7 +524,6 @@ private[akka] object FlowGraphInternal {
 
   trait InternalVertex extends Vertex {
     def attributes: OperationAttributes
-    def name: Option[String] = attributes.nameLifted
 
     def minimumInputCount: Int
     def maximumInputCount: Int
@@ -562,21 +532,13 @@ private[akka] object FlowGraphInternal {
 
     private[akka] def astNode: Ast.JunctionAstNode
 
-    final override def equals(obj: Any): Boolean =
-      obj match {
-        case other: InternalVertex ⇒
-          if (name.isDefined) (getClass == other.getClass && name == other.name) else (this eq other)
-        case _ ⇒ false
-      }
+    // these are unique keys, case class equality would break them
+    final override def equals(other: Any): Boolean = super.equals(other)
+    final override def hashCode: Int = super.hashCode
 
-    final override def hashCode: Int = name match {
-      case Some(n) ⇒ n.hashCode()
-      case None    ⇒ super.hashCode()
-    }
-
-    override def toString = name match {
+    override def toString = attributes.nameLifted match {
       case Some(n) ⇒ n
-      case None    ⇒ getClass.getSimpleName + "@" + Integer.toHexString(super.hashCode())
+      case None    ⇒ super.toString
     }
   }
 


### PR DESCRIPTION
- descriptive name can still be defined with OperationAttributes.name
- revisit all factory methods (apply/create) and implement and document
  them in a consistent manner

Refs #16484 
Refs #16392
