### PR TITLE
Rebased 16537 - Constant moved to val, will removed unneccesary allocation

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
@@ -49,7 +49,7 @@ trait GracefulStopSupport {
     if (target.isTerminated) Future successful true
     else {
       val internalTarget = target.asInstanceOf[InternalActorRef]
-      val ref = PromiseActorRef(internalTarget.provider, Timeout(timeout), targetName = target.toString, message = stopMessage)
+      val ref = PromiseActorRef(internalTarget.provider, Timeout(timeout), targetName = target, message = stopMessage)
       internalTarget.sendSystemMessage(Watch(internalTarget, ref))
       target.tell(stopMessage, Actor.noSender)
       ref.result.future.transform(

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -298,7 +298,7 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport) extends A
     if (target.isTerminated) Future successful SetThrottleAck
     else {
       val internalTarget = target.asInstanceOf[InternalActorRef]
-      val ref = PromiseActorRef(internalTarget.provider, timeout, target.toString, mode)
+      val ref = PromiseActorRef(internalTarget.provider, timeout, target, mode)
       internalTarget.sendSystemMessage(Watch(internalTarget, ref))
       target.tell(mode, ref)
       ref.result.future.transform({


### PR DESCRIPTION
Constant value made a val to avoid unnecessary allocation
Parameter made by-name since it's not always used and allocates a lot of char[] and stringbuffers, often unnecessary
