### PR TITLE
=str #16385 update reactive streams to RC1, enable fixed TCK tests

### DIFF
--- a/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
@@ -37,11 +37,6 @@ abstract class AkkaIdentityProcessorVerification[T](val system: ActorSystem, env
     this(false)
   }
 
-  override def skipStochasticTests() = true // TODO maybe enable?
-
-  // TODO re-enable this test once 1.0.0.RC1 is released, with https://github.com/reactive-streams/reactive-streams/pull/154
-  override def spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue() = notVerified("TODO Enable this test once https://github.com/reactive-streams/reactive-streams/pull/154 is merged (ETA 1.0.0.RC1)")
-
   override def createErrorStatePublisher(): Publisher[T] =
     StreamTestKit.errorPublisher(new Exception("Unable to serve subscribers right now!"))
 

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
@@ -35,8 +35,6 @@ abstract class AkkaPublisherVerification[T](val system: ActorSystem, env: TestEn
 
   implicit val materializer = FlowMaterializer(MaterializerSettings(system).copy(maxInputBufferSize = 512))(system)
 
-  override def skipStochasticTests() = true // TODO maybe enable?
-
   @AfterClass
   def shutdownActorSystem(): Unit = {
     system.shutdown()

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1116,8 +1116,6 @@ object AkkaBuild extends Build {
 
     logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
 
-    resolvers += "Akka Repo Snapshots" at "http://repo.akka.io/snapshots", // TODO Remove once reactive streams TCK is released
-
     excludeTestNames := useExcludeTestNames,
     excludeTestTags := useExcludeTestTags,
     onlyTestTags := useOnlyTestTags,
@@ -1502,7 +1500,7 @@ object Dependencies {
     val scalaCheckVersion = System.getProperty("akka.build.scalaCheckVersion", "1.11.3")
     val scalaContinuationsVersion = System.getProperty("akka.build.scalaContinuationsVersion", "1.0.1")
 
-    val reactiveStreamsVersion = System.getProperty("akka.build.reactiveStreamsVersion", "1.0.0.M3")
+    val reactiveStreamsVersion = System.getProperty("akka.build.reactiveStreamsVersion", "1.0.0.RC1")
 
     val publishedAkkaVersion = "2.3.7"
   }


### PR DESCRIPTION
Bumps to current released reactive streams version. 
RC1 included fixes for stochastic tests, regression fixes and more - details https://github.com/reactive-streams/reactive-streams/issues?q=milestone%3A1.0.0-RC1

Would be good to have it on jenkins for a while before the RC2 gets shipped, as it's a published dep now we can also enable https://jenkins.akka.io:8498/job/akka-release-2.3-dev/ again.
