### PR TITLE
=rem #16623: Fixing two concurrently running ReliableDeliverySupervisors

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
@@ -61,8 +61,6 @@ class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryM
       }
       enterBarrier("blackhole")
 
-      Thread.sleep(200)
-
       runOn(first, third) {
         watch(secondRef)
       }
@@ -70,7 +68,6 @@ class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryM
         watch(firstRef)
       }
       enterBarrier("watch-established")
-      Thread.sleep(500)
 
       runOn(first) {
         testConductor.passThrough(first, second, Direction.Both).await

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import scala.concurrent.duration._
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.Identify
+import akka.actor.Props
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import akka.remote.testkit.{ STMultiNodeSpec, MultiNodeConfig, MultiNodeSpec }
+import akka.actor.PoisonPill
+
+object AttemptSysMsgRedeliveryMultiJvmSpec extends MultiNodeConfig {
+
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfig))
+
+  testTransport(on = true)
+
+  class Echo extends Actor {
+    def receive = {
+      case m ⇒ sender ! m
+    }
+  }
+}
+
+class AttemptSysMsgRedeliveryMultiJvmNode1 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec
+
+class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryMultiJvmSpec)
+  with MultiNodeClusterSpec with ImplicitSender with DefaultTimeout {
+  import AttemptSysMsgRedeliveryMultiJvmSpec._
+
+  "AttemptSysMsgRedelivery" must {
+    "reach initial convergence" taggedAs LongRunningTest in {
+      awaitClusterUp(first, second, third)
+
+      enterBarrier("after-1")
+    }
+
+    "redeliver system message after inactivity" taggedAs LongRunningTest in {
+      system.actorOf(Props[Echo], "echo")
+      enterBarrier("echo-started")
+
+      system.actorSelection(node(first) / "user" / "echo") ! Identify(None)
+      val firstRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      system.actorSelection(node(second) / "user" / "echo") ! Identify(None)
+      val secondRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      enterBarrier("refs-retrieved")
+
+      runOn(first) {
+        testConductor.blackhole(first, second, Direction.Both).await
+      }
+      enterBarrier("blackhole")
+
+      Thread.sleep(200)
+
+      runOn(first, third) {
+        watch(secondRef)
+      }
+      runOn(second) {
+        watch(firstRef)
+      }
+      enterBarrier("watch-established")
+      Thread.sleep(500)
+
+      runOn(first) {
+        testConductor.passThrough(first, second, Direction.Both).await
+      }
+      enterBarrier("pass-through")
+
+      system.actorSelection("/user/echo") ! PoisonPill
+
+      runOn(first, third) {
+        expectTerminated(secondRef, 10.seconds)
+      }
+      runOn(second) {
+        expectTerminated(firstRef, 10.seconds)
+      }
+
+      enterBarrier("done")
+    }
+  }
+
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.remote
+
+import scala.concurrent.duration._
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.Identify
+import akka.actor.Props
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import testkit.{ STMultiNodeSpec, MultiNodeConfig, MultiNodeSpec }
+import akka.actor.PoisonPill
+
+object AttemptSysMsgRedeliveryMultiJvmSpec extends MultiNodeConfig {
+
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false))
+
+  testTransport(on = true)
+
+  class Echo extends Actor {
+    def receive = {
+      case m ⇒ sender ! m
+    }
+  }
+}
+
+class AttemptSysMsgRedeliveryMultiJvmNode1 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec
+
+class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryMultiJvmSpec)
+  with STMultiNodeSpec with ImplicitSender with DefaultTimeout {
+  import AttemptSysMsgRedeliveryMultiJvmSpec._
+
+  def initialParticipants = roles.size
+
+  "AttemptSysMsgRedelivery" must {
+    "redeliver system message after inactivity" taggedAs LongRunningTest in {
+      system.actorOf(Props[Echo], "echo")
+      enterBarrier("echo-started")
+
+      system.actorSelection(node(first) / "user" / "echo") ! Identify(None)
+      val firstRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      system.actorSelection(node(second) / "user" / "echo") ! Identify(None)
+      val secondRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      enterBarrier("refs-retrieved")
+
+      runOn(first) {
+        testConductor.blackhole(first, second, Direction.Both).await
+      }
+      enterBarrier("blackhole")
+
+      Thread.sleep(200)
+
+      runOn(first, third) {
+        watch(secondRef)
+      }
+      runOn(second) {
+        watch(firstRef)
+      }
+      enterBarrier("watch-established")
+      Thread.sleep(500)
+
+      runOn(first) {
+        testConductor.passThrough(first, second, Direction.Both).await
+      }
+      enterBarrier("pass-through")
+
+      system.actorSelection("/user/echo") ! PoisonPill
+
+      runOn(first, third) {
+        expectTerminated(secondRef, 10.seconds)
+      }
+      runOn(second) {
+        expectTerminated(firstRef, 10.seconds)
+      }
+
+      enterBarrier("done")
+    }
+  }
+
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
@@ -57,8 +57,6 @@ class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryM
       }
       enterBarrier("blackhole")
 
-      Thread.sleep(200)
-
       runOn(first, third) {
         watch(secondRef)
       }
@@ -66,7 +64,6 @@ class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryM
         watch(firstRef)
       }
       enterBarrier("watch-established")
-      Thread.sleep(500)
 
       runOn(first) {
         testConductor.passThrough(first, second, Direction.Both).await

--- a/akka-remote/src/main/scala/akka/remote/AckedDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/AckedDelivery.scala
@@ -99,6 +99,8 @@ case class AckedSendBuffer[T <: HasSequenceNumber](
    * @return An updated buffer containing the remaining unacknowledged messages
    */
   def acknowledge(ack: Ack): AckedSendBuffer[T] = {
+    if (ack.cumulativeAck > maxSeq)
+      throw new IllegalArgumentException(s"Highest SEQ so far was $maxSeq but cumulative ACK is ${ack.cumulativeAck}")
     val newNacked = (nacked ++ nonAcked) filter { m ⇒ ack.nacks(m.seq) }
     if (newNacked.size < ack.nacks.size) throw new ResendUnfulfillableException
     else this.copy(
@@ -121,7 +123,7 @@ case class AckedSendBuffer[T <: HasSequenceNumber](
     this.copy(nonAcked = this.nonAcked :+ msg, maxSeq = msg.seq)
   }
 
-  override def toString = nonAcked.map(_.seq).mkString("[", ", ", "]")
+  override def toString = s"[$maxSeq ${nonAcked.map(_.seq).mkString("{", ", ", "}")}]"
 }
 
 /**

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -197,18 +197,8 @@ private[remote] class ReliableDeliverySupervisor(
   import ReliableDeliverySupervisor._
   import context.dispatcher
 
-  var autoResendTimer: Option[Cancellable] = None
-
-  def scheduleAutoResend(): Unit = if (resendBuffer.nacked.nonEmpty || resendBuffer.nonAcked.nonEmpty) {
-    if (autoResendTimer.isEmpty)
-      autoResendTimer = Some(context.system.scheduler.scheduleOnce(settings.SysResendTimeout, self, AttemptSysMsgRedelivery))
-  }
-
-  def rescheduleAutoResend(): Unit = {
-    autoResendTimer.foreach(_.cancel())
-    autoResendTimer = None
-    scheduleAutoResend()
-  }
+  val autoResendTimer = context.system.scheduler.schedule(
+    settings.SysResendTimeout, settings.SysResendTimeout, self, AttemptSysMsgRedelivery)
 
   override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
     case e @ (_: AssociationProblem) ⇒ Escalate
@@ -227,14 +217,11 @@ private[remote] class ReliableDeliverySupervisor(
   var resendBuffer: AckedSendBuffer[Send] = _
   var lastCumulativeAck: SeqNo = _
   var seqCounter: Long = _
-  var pendingAcks = Vector.empty[Ack]
 
   def reset() {
     resendBuffer = new AckedSendBuffer[Send](settings.SysMsgBufferSize)
-    scheduleAutoResend()
     lastCumulativeAck = SeqNo(-1)
     seqCounter = 0L
-    pendingAcks = Vector.empty
   }
 
   reset()
@@ -256,11 +243,6 @@ private[remote] class ReliableDeliverySupervisor(
   // (This actor is never restarted)
   var uidConfirmed: Boolean = uid.isDefined
 
-  def unstashAcks(): Unit = {
-    pendingAcks foreach (self ! _)
-    pendingAcks = Vector.empty
-  }
-
   override def postStop(): Unit = {
     // All remaining messages in the buffer has to be delivered to dead letters. It is important to clear the sequence
     // number otherwise deadLetters will ignore it to avoid reporting system messages as dead letters while they are
@@ -270,6 +252,7 @@ private[remote] class ReliableDeliverySupervisor(
     // the remote system later.
     (resendBuffer.nacked ++ resendBuffer.nonAcked) foreach { s ⇒ context.system.deadLetters ! s.copy(seqOpt = None) }
     receiveBuffers.remove(Link(localAddress, remoteAddress))
+    autoResendTimer.cancel()
   }
 
   override def postRestart(reason: Throwable): Unit = {
@@ -287,21 +270,19 @@ private[remote] class ReliableDeliverySupervisor(
     case s: Send ⇒
       handleSend(s)
     case ack: Ack ⇒
-      if (!uidConfirmed) pendingAcks = pendingAcks :+ ack
-      else {
+      // If we are not sure about the UID just ignore the ack. Ignoring is fine.
+      if (uidConfirmed) {
         try resendBuffer = resendBuffer.acknowledge(ack)
         catch {
           case NonFatal(e) ⇒
-            throw new InvalidAssociationException(s"Error encountered while processing system message acknowledgement $resendBuffer $ack", e)
+            throw new HopelessAssociation(localAddress, remoteAddress, uid,
+              new IllegalStateException(s"Error encountered while processing system message " +
+                s"acknowledgement buffer: $resendBuffer ack: $ack", e))
         }
 
         if (lastCumulativeAck < ack.cumulativeAck) {
           lastCumulativeAck = ack.cumulativeAck
-          // Cumulative ack is progressing, we might not need to resend non-acked messages yet.
-          // If this progression stops, the timer will eventually kick in, since scheduleAutoResend
-          // does not cancel existing timers (see the "else" case).
-          rescheduleAutoResend()
-        } else scheduleAutoResend()
+        }
 
         resendNacked()
       }
@@ -318,7 +299,6 @@ private[remote] class ReliableDeliverySupervisor(
       // New system that has the same address as the old - need to start from fresh state
       uidConfirmed = true
       if (uid.exists(_ != receivedUid)) reset()
-      else unstashAcks()
       uid = Some(receivedUid)
       resendAll()
 
@@ -344,6 +324,7 @@ private[remote] class ReliableDeliverySupervisor(
         // Resending will be triggered by the incoming GotUid message after the connection finished
         context.become(receive)
       } else context.become(idle)
+    case AttemptSysMsgRedelivery               ⇒ // Ignore
     case s @ Send(msg: SystemMessage, _, _, _) ⇒ tryBuffer(s.copy(seqOpt = Some(nextSeq())))
     case s: Send                               ⇒ context.system.deadLetters ! s
     case EndpointWriter.FlushAndStop           ⇒ context.stop(self)
@@ -360,9 +341,11 @@ private[remote] class ReliableDeliverySupervisor(
       handleSend(s)
       context.become(receive)
     case AttemptSysMsgRedelivery ⇒
-      writer = createWriter()
-      // Resending will be triggered by the incoming GotUid message after the connection finished
-      context.become(receive)
+      if (resendBuffer.nacked.nonEmpty || resendBuffer.nonAcked.nonEmpty) {
+        writer = createWriter()
+        // Resending will be triggered by the incoming GotUid message after the connection finished
+        context.become(receive)
+      }
     case EndpointWriter.FlushAndStop ⇒ context.stop(self)
     case EndpointWriter.StopReading(w, replyTo) ⇒
       replyTo ! EndpointWriter.StoppedReading(w)
@@ -384,7 +367,8 @@ private[remote] class ReliableDeliverySupervisor(
       tryBuffer(sequencedSend)
       // If we have not confirmed the remote UID we cannot transfer the system message at this point just buffer it.
       // GotUid will kick resendAll() causing the messages to be properly written
-      if (uidConfirmed) writer ! sequencedSend
+      if (uidConfirmed)
+        writer ! sequencedSend
     } else writer ! send
 
   private def resendNacked(): Unit = resendBuffer.nacked foreach { writer ! _ }
@@ -392,7 +376,6 @@ private[remote] class ReliableDeliverySupervisor(
   private def resendAll(): Unit = {
     resendNacked()
     resendBuffer.nonAcked foreach { writer ! _ }
-    rescheduleAutoResend()
   }
 
   private def tryBuffer(s: Send): Unit =
@@ -816,6 +799,8 @@ private[remote] class EndpointWriter(
       context.stop(self)
     case OutboundAck(ack) ⇒
       lastAck = Some(ack)
+      if (ackDeadline.isOverdue())
+        trySendPureAck()
     case AckIdleCheckTimer   ⇒ // Ignore
     case FlushAndStopTimeout ⇒ // ignore
     case BackoffTimer        ⇒ // ignore

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -471,7 +471,7 @@ private[transport] class ThrottledAssociation(
     case Event(Disassociated(info), _) ⇒
       stop() // not notifying the upstream handler is intentional: we are relying on heartbeating
     case Event(FailWith(reason), _) ⇒
-      upstreamListener notify Disassociated(reason)
+      if (upstreamListener ne null) upstreamListener notify Disassociated(reason)
       stop()
   }
 

--- a/akka-remote/src/test/scala/akka/remote/AckedDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/AckedDeliverySpec.scala
@@ -130,7 +130,7 @@ class AckedDeliverySpec extends AkkaSpec {
       val b8 = b7.acknowledge(Ack(SeqNo(2)))
       b8.nonAcked should be(Vector(msg3, msg4))
 
-      val b9 = b8.acknowledge(Ack(SeqNo(5)))
+      val b9 = b8.acknowledge(Ack(SeqNo(4)))
       b9.nonAcked should be(Vector.empty)
 
     }
@@ -164,7 +164,7 @@ class AckedDeliverySpec extends AkkaSpec {
       b6.nonAcked should be(Vector())
       b6.nacked should be(Vector(msg2, msg3))
 
-      val b7 = b6.acknowledge(Ack(SeqNo(5)))
+      val b7 = b6.acknowledge(Ack(SeqNo(4)))
       b7.nonAcked should be(Vector.empty)
       b7.nacked should be(Vector.empty)
     }

--- a/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
@@ -54,7 +54,7 @@ object SystemMessageDeliveryStressTest {
       remote.system-message-buffer-size = $msgCount
       ## Keep this setting tight, otherwise the test takes a long time or times out
       remote.resend-interval = 500 ms
-      remote.system-message-ack-piggyback-timeout = 100 ms // Force heavy Ack traffic
+      remote.system-message-ack-piggyback-timeout = 300 ms // Force heavy Ack traffic
       remote.use-passive-connections = on
 
       remote.netty.tcp {
@@ -153,15 +153,15 @@ abstract class SystemMessageDeliveryStressTest(msg: String, cfg: String)
       val transportA = RARP(systemA).provider.transport
       val transportB = RARP(systemB).provider.transport
 
-      Await.result(transportA.managementCommand(One(addressB, Drop(0.2, 0.2))), 3.seconds.dilated)
-      Await.result(transportB.managementCommand(One(addressA, Drop(0.2, 0.2))), 3.seconds.dilated)
+      Await.result(transportA.managementCommand(One(addressB, Drop(0.1, 0.1))), 3.seconds.dilated)
+      Await.result(transportB.managementCommand(One(addressA, Drop(0.1, 0.1))), 3.seconds.dilated)
 
       // Schedule peridodic disassociates
-      systemA.scheduler.schedule(1.second, 3.seconds) {
+      systemA.scheduler.schedule(1.second, 6.seconds) {
         transportA.managementCommand(ForceDisassociateExplicitly(addressB, reason = AssociationHandle.Unknown))
       }
 
-      systemB.scheduler.schedule(2.seconds, 3.seconds) {
+      systemB.scheduler.schedule(4.seconds, 6.seconds) {
         transportB.managementCommand(ForceDisassociateExplicitly(addressA, reason = AssociationHandle.Unknown))
       }
 

--- a/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
@@ -53,8 +53,8 @@ object SystemMessageDeliveryStressTest {
       }
       remote.system-message-buffer-size = $msgCount
       ## Keep this setting tight, otherwise the test takes a long time or times out
-      remote.resend-interval = 500 ms
-      remote.system-message-ack-piggyback-timeout = 300 ms // Force heavy Ack traffic
+      remote.resend-interval = 2 s
+      remote.system-message-ack-piggyback-timeout = 100 ms // Force heavy Ack traffic
       remote.use-passive-connections = on
 
       remote.netty.tcp {

--- a/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
@@ -169,11 +169,17 @@ abstract class SystemMessageDeliveryStressTest(msg: String, cfg: String)
       systemA.actorOf(Props(classOf[SystemMessageSender], msgCount, burstSize, burstDelay, targetForA))
 
       val toSend = (0 until msgCount).toList
+      var maxDelay = 0L
+
       for (m ← 0 until msgCount) {
-        probeB.expectMsg(30.seconds, m)
-        probeA.expectMsg(30.seconds, m)
+        val start = System.currentTimeMillis()
+        probeB.expectMsg(10.minutes, m)
+        probeA.expectMsg(10.minutes, m)
+        println(s" #### $m")
+        maxDelay = math.max(maxDelay, (System.currentTimeMillis() - start) / 1000)
       }
 
+      println(s" #### MAX DELAY $maxDelay seconds")
     }
   }
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1069,7 +1069,11 @@ object AkkaBuild extends Build {
       // Changes introduced to internal remoting actors by #16623
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.unstashAcks"),
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.pendingAcks_="),
-      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.pendingAcks")
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.pendingAcks"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.scheduleAutoResend"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.autoResendTimer_="),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.rescheduleAutoResend"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.ReliableDeliverySupervisor.autoResendTimer")
     )
   }
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1064,7 +1064,12 @@ object AkkaBuild extends Build {
       ProblemFilters.exclude[MissingClassProblem]("akka.io.TcpConnection$UpdatePendingWrite"),
 
       // Change to optimize use of ForkJoin with Akka's Mailbox
-      ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.Mailbox.status")
+      ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.Mailbox.status"),
+
+      // Changes introduced to internal remoting actors by #16623
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.unstashAcks"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.pendingAcks_="),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor.pendingAcks")
     )
   }
 


### PR DESCRIPTION
which cause message misordering and completely messed up system message sequence numbers. 

Bonus:
- much more aggressive system message delivery stresstest (adds ~2min to build time)
- removed unnecesessary (and also wrong) acknowledgement stashing-unstashing
- faster acking for short piggyback timeouts
- acked delivery buffer now reports problem also when aggregate ack is higher than expected
