### PR TITLE
=rem #16616 Reproduce missing scheduled AttemptSysMsgRedelivery

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import scala.concurrent.duration._
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.Identify
+import akka.actor.Props
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import akka.remote.testkit.{ STMultiNodeSpec, MultiNodeConfig, MultiNodeSpec }
+import akka.actor.PoisonPill
+
+object AttemptSysMsgRedeliveryMultiJvmSpec extends MultiNodeConfig {
+
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false).withFallback(MultiNodeClusterSpec.clusterConfig))
+
+  testTransport(on = true)
+
+  class Echo extends Actor {
+    def receive = {
+      case m ⇒ sender ! m
+    }
+  }
+}
+
+class AttemptSysMsgRedeliveryMultiJvmNode1 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec
+
+class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryMultiJvmSpec)
+  with MultiNodeClusterSpec with ImplicitSender with DefaultTimeout {
+  import AttemptSysMsgRedeliveryMultiJvmSpec._
+
+  "AttemptSysMsgRedelivery" must {
+    "reach initial convergence" taggedAs LongRunningTest in {
+      awaitClusterUp(first, second, third)
+
+      enterBarrier("after-1")
+    }
+
+    "redeliver system message after inactivity" taggedAs LongRunningTest in {
+      system.actorOf(Props[Echo], "echo")
+      enterBarrier("echo-started")
+
+      system.actorSelection(node(first) / "user" / "echo") ! Identify(None)
+      val firstRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      system.actorSelection(node(second) / "user" / "echo") ! Identify(None)
+      val secondRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      enterBarrier("refs-retrieved")
+
+      runOn(first) {
+        testConductor.blackhole(first, second, Direction.Both).await
+      }
+      enterBarrier("blackhole")
+
+      Thread.sleep(200)
+
+      runOn(first, third) {
+        watch(secondRef)
+      }
+      runOn(second) {
+        watch(firstRef)
+      }
+      enterBarrier("watch-established")
+      Thread.sleep(500)
+
+      runOn(first) {
+        testConductor.passThrough(first, second, Direction.Both).await
+      }
+      enterBarrier("pass-through")
+
+      system.actorSelection("/user/echo") ! PoisonPill
+
+      runOn(first, third) {
+        expectTerminated(secondRef, 10.seconds)
+      }
+      runOn(second) {
+        expectTerminated(firstRef, 10.seconds)
+      }
+
+      enterBarrier("done")
+    }
+  }
+
+}
+

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.remote
+
+import scala.concurrent.duration._
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.Identify
+import akka.actor.Props
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import testkit.{ STMultiNodeSpec, MultiNodeConfig, MultiNodeSpec }
+import akka.actor.PoisonPill
+
+object AttemptSysMsgRedeliveryMultiJvmSpec extends MultiNodeConfig {
+
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false))
+
+  testTransport(on = true)
+
+  class Echo extends Actor {
+    def receive = {
+      case m ⇒ sender ! m
+    }
+  }
+}
+
+class AttemptSysMsgRedeliveryMultiJvmNode1 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec
+class AttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec
+
+class AttemptSysMsgRedeliverySpec extends MultiNodeSpec(AttemptSysMsgRedeliveryMultiJvmSpec)
+  with STMultiNodeSpec with ImplicitSender with DefaultTimeout {
+  import AttemptSysMsgRedeliveryMultiJvmSpec._
+
+  def initialParticipants = roles.size
+
+  "AttemptSysMsgRedelivery" must {
+    "redeliver system message after inactivity" taggedAs LongRunningTest in {
+      system.actorOf(Props[Echo], "echo")
+      enterBarrier("echo-started")
+
+      system.actorSelection(node(first) / "user" / "echo") ! Identify(None)
+      val firstRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      system.actorSelection(node(second) / "user" / "echo") ! Identify(None)
+      val secondRef: ActorRef = expectMsgType[ActorIdentity].ref.get
+      enterBarrier("refs-retrieved")
+
+      runOn(first) {
+        testConductor.blackhole(first, second, Direction.Both).await
+      }
+      enterBarrier("blackhole")
+
+      Thread.sleep(200)
+
+      runOn(first, third) {
+        watch(secondRef)
+      }
+      runOn(second) {
+        watch(firstRef)
+      }
+      enterBarrier("watch-established")
+      Thread.sleep(500)
+
+      runOn(first) {
+        testConductor.passThrough(first, second, Direction.Both).await
+      }
+      enterBarrier("pass-through")
+
+      system.actorSelection("/user/echo") ! PoisonPill
+
+      runOn(first, third) {
+        expectTerminated(secondRef, 10.seconds)
+      }
+      runOn(second) {
+        expectTerminated(firstRef, 10.seconds)
+      }
+
+      enterBarrier("done")
+    }
+  }
+
+}
+


### PR DESCRIPTION
Delicate! The test is successful when running with plain remoting, but when using clustering it reproduces the issue. Note that I temproarily have added the "same" test in akka.remote and in akka.cluster.
The test in akka.cluster is also successful when removing the first step ""reach initial convergence".

Might be something with how the connections are established between the nodes?

Ping @drewhk 
