### PR TITLE
=str #16652 Convert 'Working with Graphs' to java

### DIFF
--- a/akka-docs-dev/rst/java/stream-graphs.rst
+++ b/akka-docs-dev/rst/java/stream-graphs.rst
@@ -1,4 +1,4 @@
-.. _stream-graph-scala:
+.. _stream-graph-java:
 
 ###################
 Working with Graphs
@@ -15,7 +15,7 @@ Some graph operations which are common enough and fit the linear style of Flows,
 streams, such that the second one is consumed after the first one has completed), may have shorthand methods defined on
 :class:`Flow` or :class:`Source` themselves, however you should keep in mind that those are also implemented as graph junctions.
 
-.. _flow-graph-scala:
+.. _flow-graph-java:
 
 Constructing Flow Graphs
 ------------------------
@@ -27,19 +27,19 @@ Akka Streams currently provide these junctions:
 
 * **Fan-out**
 
- - ``Broadcast[T]`` – (1 input, n outputs) signals each output given an input signal,
- - ``Balance[T]`` – (1 input => n outputs), signals one of its output ports given an input signal,
- - ``UnZip[A,B]`` – (1 input => 2 outputs), which is a specialized element which is able to split a stream of ``(A,B)`` tuples into two streams one type ``A`` and one of type ``B``,
- - ``FlexiRoute[In]`` – (1 input, n outputs), which enables writing custom fan out elements using a simple DSL,
+ - ``Broadcast<T>`` – (1 input, n outputs) signals each output given an input signal,
+ - ``Balance<T>`` – (1 input => n outputs), signals one of its output ports given an input signal,
+ - ``UnZip<A,B>`` – (1 input => 2 outputs), which is a specialized element which is able to split a stream of ``Pair<A,B>`` into two streams one type ``A`` and one of type ``B``,
+ - ``FlexiRoute<In>`` – (1 input, n outputs), which enables writing custom fan out elements using a simple DSL,
 
 * **Fan-in**
 
- - ``Merge[In]`` – (n inputs , 1 output), picks signals randomly from inputs pushing them one by one to its output,
- - ``MergePreferred[In]`` – like :class:`Merge` but if elements are available on ``preferred`` port, it picks from it, otherwise randomly from ``others``,
- - ``ZipWith[A,B,...,Out]`` – (n inputs (defined upfront), 1 output), which takes a function of n inputs that, given all inputs are signalled, transforms and emits 1 output,
- - ``Zip[A,B]`` – (2 inputs, 1 output), which is a :class:`ZipWith` specialised to zipping input streams of ``A`` and ``B`` into an ``(A,B)`` tuple stream,
- - ``Concat[A]`` – (2 inputs, 1 output), which enables to concatenate streams (first consume one, then the second one), thus the order of which stream is ``first`` and which ``second`` matters,
- - ``FlexiMerge[Out]`` – (n inputs, 1 output), which enables writing custom fan out elements using a simple DSL.
+ - ``Merge<In>`` – (n inputs , 1 output), picks signals randomly from inputs pushing them one by one to its output,
+ - ``MergePreferred<In>`` – like :class:`Merge` but if elements are available on ``preferred`` port, it picks from it, otherwise randomly from ``others``,
+ - ``ZipWith<A,B,...,Out>`` – (n inputs (defined upfront), 1 output), which takes a function of n inputs that, given all inputs are signalled, transforms and emits 1 output,
+ - ``Zip<A,B>`` – (2 inputs, 1 output), which is a :class:`ZipWith` specialised to zipping input streams of ``A`` and ``B`` into a ``Pair<A,B>`` stream,
+ - ``Concat<A>`` – (2 inputs, 1 output), which enables to concatenate streams (first consume one, then the second one), thus the order of which stream is ``first`` and which ``second`` matters,
+ - ``FlexiMerge<Out>`` – (n inputs, 1 output), which enables writing custom fan out elements using a simple DSL.
 
 One of the goals of the FlowGraph DSL is to look similar to how one would draw a graph on a whiteboard, so that it is
 simple to translate a design from whiteboard to code and be able to relate those two. Let's illustrate this by translating
@@ -49,22 +49,16 @@ the below hand drawn graph into Akka Streams:
 
 Such graph is simple to translate to the Graph DSL since each linear element corresponds to a :class:`Flow`,
 and each circle corresponds to either a :class:`Junction` or a :class:`Source` or :class:`Sink` if it is beginning
-or ending a :class:`Flow`. Junctions must always be created with defined type parameters, as otherwise the ``Nothing`` type
-will be inferred.
+or ending a :class:`Flow`. Those are connected with the ``addEdge`` method of the :class:`FlowGraphBuilder`.
 
-.. includecode:: code/docs/stream/FlowGraphDocSpec.scala#simple-flow-graph
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/FlowGraphDocTest.java#simple-flow-graph
 
 .. note::
    Junction *reference equality* defines *graph node equality* (i.e. the same merge *instance* used in a FlowGraph
    refers to the same location in the resulting graph).
 
-Notice the ``import FlowGraphImplicits._`` which brings into scope the ``~>`` operator (read as "edge", "via" or "to").
-It is also possible to construct graphs without the ``~>`` operator in case you prefer to use the graph builder explicitly:
-
-.. includecode:: code/docs/stream/FlowGraphDocSpec.scala#simple-flow-graph-no-implicits
 
 By looking at the snippets above, it should be apparent that the :class:`FlowGraphBuilder` object is *mutable*.
-It is also used (implicitly) by the ``~>`` operator, also making it a mutable operation as well.
 The reason for this design choice is to enable simpler creation of complex graphs, which may even contain cycles.
 Once the FlowGraph has been constructed though, the :class:`FlowGraph` instance *is immutable, thread-safe, and freely shareable*.
 
@@ -73,9 +67,9 @@ This means that you can safely re-use one given Flow in multiple places in a pro
 we prepare a graph that consists of two parallel streams, in which we re-use the same instance of :class:`Flow`,
 yet it will properly be materialized as two connections between the corresponding Sources and Sinks:
 
-.. includecode:: code/docs/stream/FlowGraphDocSpec.scala#flow-graph-reusing-a-flow
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/FlowGraphDocTest.java#flow-graph-reusing-a-flow
 
-.. _partial-flow-graph-scala:
+.. _partial-flow-graph-java:
 
 Constructing and combining Partial Flow Graphs
 ----------------------------------------------
@@ -88,12 +82,12 @@ time, which helps to avoid simple wiring errors while working with graphs. A par
 this validation, and allows graphs that are not yet fully connected.
 
 A :class:`PartialFlowGraph` is defined as a :class:`FlowGraph` which contains so called "undefined elements",
-such as ``UndefinedSink[T]`` or ``UndefinedSource[T]``, which can be reused and plugged into by consumers of that
+such as ``UndefinedSink<T>`` or ``UndefinedSource<T>``, which can be reused and plugged into by consumers of that
 partial flow graph. Let's imagine we want to provide users with a specialized element that given 3 inputs will pick
 the greatest int value of each zipped triple. We'll want to expose 3 input ports (undefined sources) and one output port
 (undefined sink).
 
-.. includecode:: code/docs/stream/StreamPartialFlowGraphDocSpec.scala#simple-partial-flow-graph
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java#simple-partial-flow-graph
 
 As you can see, first we construct the partial graph that contains all the zipping and comparing of stream
 elements, then we import it (all of its nodes and connections) explicitly to the :class:`FlowGraph` instance in which all
@@ -103,7 +97,7 @@ the undefined elements are rewired to real sources and sinks. The graph can then
    Please note that a :class:`FlowGraph` is not able to provide compile time type-safety about whether or not all
    elements have been properly connected - this validation is performed as a runtime check during the graph's instantiation.
 
-.. _constructing-sources-sinks-flows-from-partial-graphs-scala:
+.. _constructing-sources-sinks-flows-from-partial-graphs-java:
 
 Constructing Sources, Sinks and Flows from Partial Graphs
 ---------------------------------------------------------
@@ -125,14 +119,14 @@ that must return an ``UndefinedSink``. This undefined sink will become "the sink
 can run". Refer to the example below, in which we create a Source that zips together two numbers, to see this graph
 construction in action:
 
-.. includecode:: code/docs/stream/StreamPartialFlowGraphDocSpec.scala#source-from-partial-flow-graph
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java#source-from-partial-flow-graph
 
-Similarly the same can be done for a ``Sink[T]``, in which case the returned value must be an ``UndefinedSource[T]``.
-For defining a ``Flow[T]`` we need to expose both an undefined source and sink:
+Similarly the same can be done for a ``Sink<T>``, in which case the returned value must be an ``UndefinedSource<T>``.
+For defining a ``Flow<T>`` we need to expose both an undefined source and sink:
 
-.. includecode:: code/docs/stream/StreamPartialFlowGraphDocSpec.scala#flow-from-partial-flow-graph
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java#flow-from-partial-flow-graph
 
-.. _graph-cycles-scala:
+.. _graph-cycles-java:
 
 Graph cycles, liveness and deadlocks
 ------------------------------------
@@ -147,7 +141,7 @@ The first example demonstrates a graph that contains a naive cycle (the presence
 to a consumer (we just used ``Sink.ignore`` for now) and to a feedback arc that is merged back into the main stream via
 a ``Merge`` junction.
 
-.. includecode:: code/docs/stream/GraphCyclesSpec.scala#deadlocked
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/GraphCyclesDocTest.java#deadlocked
 
 Running this we observe that after a few numbers have been printed, no more elements are logged to the console -
 all processing stops after some time. After some investigation we observe that:
@@ -165,7 +159,7 @@ If we modify our feedback loop by replacing the ``Merge`` junction with a ``Merg
 before trying the other lower priority input ports. Since we feed back through the preferred port it is always guaranteed
 that the elements in the cycles can flow.
 
-.. includecode:: code/docs/stream/GraphCyclesSpec.scala#unfair
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/GraphCyclesDocTest.java#unfair
 
 If we run the example we see that the same sequence of numbers are printed
 over and over again, but the processing does not stop. Hence, we avoided the deadlock, but ``source`` is still
@@ -180,7 +174,7 @@ of initial elements from ``source``.
 To make our cycle both live (not deadlocking) and fair we can introduce a dropping element on the feedback arc. In this
 case we chose the ``buffer()`` operation giving it a dropping strategy ``OverflowStrategy.dropHead``.
 
-.. includecode:: code/docs/stream/GraphCyclesSpec.scala#dropping
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/GraphCyclesDocTest.java#dropping
 
 If we run this example we see that
 
@@ -199,7 +193,7 @@ the beginning instead. To achieve this we modify our first graph by replacing th
 Since ``ZipWith`` takes one element from ``source`` *and* from the feedback arc to inject one element into the cycle,
 we maintain the balance of elements.
 
-.. includecode:: code/docs/stream/GraphCyclesSpec.scala#zipping-dead
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/GraphCyclesDocTest.java#zipping-dead
 
 Still, when we try to run the example it turns out that no element is printed at all! After some investigation we
 realize that:
@@ -211,7 +205,7 @@ These two conditions are a typical "chicken-and-egg" problem. The solution is to
 element into the cycle that is independent from ``source``. We do this by using a ``Concat`` junction on the backwards
 arc that injects a single element using ``Source.single``.
 
-.. includecode:: code/docs/stream/GraphCyclesSpec.scala#zipping-live
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/GraphCyclesDocTest.java#zipping-live
 
 When we run the above example we see that processing starts and never stops. The important takeaway from this example
 is that balanced cycles often need an initial "kick-off" element to be injected into the cycle.

--- a/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
@@ -105,8 +105,8 @@ class StreamPartialFlowGraphDocSpec extends AkkaSpec {
     }
 
     val firstPair: Future[(Int, Int)] = pairs.runWith(Sink.head)
-    Await.result(firstPair, 300.millis) should equal(1 → 2)
     //#source-from-partial-flow-graph
+    Await.result(firstPair, 300.millis) should equal(1 -> 2)
   }
 
   "build flow from partial flow graph" in {
@@ -140,6 +140,6 @@ class StreamPartialFlowGraphDocSpec extends AkkaSpec {
     //#flow-from-partial-flow-graph
     // format: ON
 
-    Await.result(matSink, 300.millis) should equal(1 → "1")
+    Await.result(matSink, 300.millis) should equal(1 -> "1")
   }
 }

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/FlowGraphDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/FlowGraphDocTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package docs.stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.stream.FlowMaterializer;
+import akka.stream.javadsl.Broadcast;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.FlowGraph;
+import akka.stream.javadsl.KeyedSink;
+import akka.stream.javadsl.MaterializedMap;
+import akka.stream.javadsl.Merge;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.javadsl.Zip;
+import akka.stream.javadsl.Zip2With;
+import akka.testkit.JavaTestKit;
+
+public class FlowGraphDocTest {
+
+  static ActorSystem system;
+  
+
+  @BeforeClass
+  public static void setup() {
+    system = ActorSystem.create("FlowGraphDocTest");
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    JavaTestKit.shutdownActorSystem(system);
+    system = null;
+  }
+  
+  final FlowMaterializer mat = FlowMaterializer.create(system);
+  
+  @Test
+  public void demonstrateBuildSimpleGraph() {
+    //#simple-flow-graph
+    final Source<Integer> in = Source.from(Arrays.asList(1, 2, 3, 4, 5));
+    final Sink<String> out = Sink.ignore();
+    final Broadcast<Integer> bcast = Broadcast.create();
+    final Merge<Integer> merge = Merge.create();
+    final Flow<Integer, Integer> f1 = Flow.of(Integer.class).map(elem -> elem + 10);
+    final Flow<Integer, Integer> f2 = Flow.of(Integer.class).map(elem -> elem + 20);;
+    final Flow<Integer, String> f3 = Flow.of(Integer.class).map(elem -> elem.toString());
+    final Flow<Integer, Integer> f4 = Flow.of(Integer.class).map(elem -> elem + 30);;
+        
+    final FlowGraph g = FlowGraph.builder()
+      .addEdge(in, f1, bcast)
+      .addEdge(bcast, f2, merge)
+      .addEdge(merge, f3, out)
+      .addEdge(bcast, f4, merge)
+      .build();
+    //#simple-flow-graph
+    
+    g.run(mat);
+  }
+  
+  @Test
+  @SuppressWarnings("unused")
+  public void demonstrateConnectErrors() {
+    try {
+      //#simple-graph
+      final Source<Integer> source1 = Source.from(Arrays.asList(1, 2, 3, 4, 5));
+      final Source<Integer> source2 = Source.from(Arrays.asList(1, 2, 3, 4, 5));
+      final Zip2With<Integer, Integer, Pair<Integer, Integer>> zip = Zip.create();
+      final FlowGraph g = FlowGraph.builder()
+        .addEdge(source1, zip.left())
+        .addEdge(source2, zip.right())
+        .build();
+        // unconnected zip.out (!) => "must have at least 1 outgoing edge"
+      
+      //#simple-graph
+      fail("expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("must have at least 1 outgoing edge"));  
+    }
+  }
+  
+  @Test
+  public void demonstrateReusingFlowInGraph() throws Exception {
+    //#flow-graph-reusing-a-flow
+
+    final KeyedSink<Integer, Future<Integer>> topHeadSink = Sink.<Integer>head();
+    final KeyedSink<Integer, Future<Integer>> bottomHeadSink = Sink.<Integer>head();
+    final Flow<Integer, Integer> sharedDoubler = Flow.of(Integer.class).map(elem -> elem * 2);
+
+    final Broadcast<Integer> broadcast = Broadcast.create();
+    //#flow-graph-reusing-a-flow
+    final FlowGraph g =
+    //#flow-graph-reusing-a-flow
+    FlowGraph.builder()
+      .addEdge(Source.single(1), broadcast)
+      .addEdge(broadcast, sharedDoubler, topHeadSink)
+      .addEdge(broadcast, sharedDoubler, bottomHeadSink)
+      .build();
+    //#flow-graph-reusing-a-flow
+    final MaterializedMap map = g.run(mat);
+    assertEquals(Integer.valueOf(2), Await.result(map.get(topHeadSink), Duration.create(3, TimeUnit.SECONDS)));
+    assertEquals(Integer.valueOf(2), Await.result(map.get(bottomHeadSink), Duration.create(3, TimeUnit.SECONDS)));
+  }
+  
+}

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/GraphCyclesDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/GraphCyclesDocTest.java
@@ -1,0 +1,162 @@
+package docs.stream;
+
+import java.util.Arrays;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import akka.actor.ActorSystem;
+import akka.stream.FlowMaterializer;
+import akka.stream.OverflowStrategy;
+import akka.stream.javadsl.Broadcast;
+import akka.stream.javadsl.Concat;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.FlowGraph;
+import akka.stream.javadsl.Merge;
+import akka.stream.javadsl.MergePreferred;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.javadsl.Zip2With;
+import akka.stream.javadsl.ZipWith;
+import akka.testkit.JavaTestKit;
+
+
+public class GraphCyclesDocTest {
+
+  static ActorSystem system;
+  
+
+  @BeforeClass
+  public static void setup() {
+    system = ActorSystem.create("GraphCyclesDocTest");
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    JavaTestKit.shutdownActorSystem(system);
+    system = null;
+  }
+  
+  final FlowMaterializer mat = FlowMaterializer.create(system);
+  
+  final Source<Integer> source = Source.from(Arrays.asList(1, 2, 3, 4, 5));
+  
+  @Test
+  public void demonstrateDeadlockedCycle() {
+    //#deadlocked
+    // WARNING! The graph below deadlocks!
+    final Merge<Integer> merge = Merge.create();
+    final Broadcast<Integer> bcast = Broadcast.create();
+    
+    final Flow<Integer, Integer> printFlow = 
+      Flow.of(Integer.class).map(s -> {
+        System.out.println(s); 
+        return s;
+      });
+    
+    FlowGraph.builder()
+      .allowCycles()
+      .addEdge(source, merge)
+      .addEdge(merge, printFlow, bcast)
+      .addEdge(bcast, Sink.ignore())
+      .addEdge(bcast, merge)
+      .build();
+    //#deadlocked
+  }
+  
+  @Test
+  public void demonstrateUnfairCycle() {
+    //#unfair
+    // WARNING! The graph below stops consuming from "source" after a few steps
+    final MergePreferred<Integer> merge = MergePreferred.create();
+    final Broadcast<Integer> bcast = Broadcast.create();
+    
+    final Flow<Integer, Integer> printFlow = 
+        Flow.of(Integer.class).map(s -> {
+          System.out.println(s); 
+          return s;
+        });
+    
+    FlowGraph.builder()
+      .allowCycles()
+      .addEdge(source, merge)
+      .addEdge(merge, printFlow, bcast)
+      .addEdge(bcast, Sink.ignore())
+      .addEdge(bcast, merge.preferred())
+      .build();
+    //#unfair
+  }
+
+  @Test
+  public void demonstrateDroppingCycle() {
+    //#dropping
+    final Merge<Integer> merge = Merge.create();
+    final Broadcast<Integer> bcast = Broadcast.create();
+    
+    final Flow<Integer, Integer> printFlow = 
+      Flow.of(Integer.class).map(s -> {
+        System.out.println(s); 
+        return s;
+      });
+    
+    FlowGraph.builder()
+      .allowCycles()
+      .addEdge(source, merge)
+      .addEdge(merge, printFlow, bcast)
+      .addEdge(bcast, Sink.ignore())
+      .addEdge(bcast, Flow.of(Integer.class).buffer(10, OverflowStrategy.dropHead()), merge)
+      .build();
+    //#dropping
+  }
+  
+  @Test
+  public void demonstrateZippingCycle() {
+    //#zipping-dead
+    // WARNING! The graph below never processes any elements
+    final Broadcast<Integer> bcast = Broadcast.create();
+    final Zip2With<Integer, Integer, Integer> zip = 
+      ZipWith.create((left, right) -> right);
+    
+    final Flow<Integer, Integer> printFlow = 
+        Flow.of(Integer.class).map(s -> {
+          System.out.println(s); 
+          return s;
+        });
+    
+    FlowGraph.builder()
+      .allowCycles()
+      .addEdge(source, zip.left())
+      .addEdge(zip.out(), printFlow, bcast)
+      .addEdge(bcast, Sink.ignore())
+      .addEdge(bcast, zip.right())
+      .build();
+    //#zipping-dead
+  }
+
+  @Test
+  public void demonstrateLiveZippingCycle() {
+    //#zipping-live
+    final Broadcast<Integer> bcast = Broadcast.create();
+    final Concat<Integer> concat = Concat.create();
+    final Zip2With<Integer, Integer, Integer> zip = 
+        ZipWith.create((left, right) -> left);
+    
+    final Flow<Integer, Integer> printFlow = 
+        Flow.of(Integer.class).map(s -> {
+          System.out.println(s); 
+          return s;
+        });
+    
+    FlowGraph.builder()
+      .allowCycles()
+      .addEdge(source, zip.left())
+      .addEdge(zip.out(), printFlow, bcast)
+      .addEdge(bcast, Sink.ignore())
+      .addEdge(bcast, concat.second())
+      .addEdge(concat.out(), zip.right())
+      .addEdge(Source.single(0), concat.first())
+      .build();
+    //#zipping-live
+  }
+     
+}

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package docs.stream;
+
+import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.stream.FlowMaterializer;
+import akka.stream.javadsl.Broadcast;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.FlowGraph;
+import akka.stream.javadsl.FlowGraphBuilder;
+import akka.stream.javadsl.KeyedSink;
+import akka.stream.javadsl.MaterializedMap;
+import akka.stream.javadsl.PartialFlowGraph;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.javadsl.UndefinedSink;
+import akka.stream.javadsl.UndefinedSource;
+import akka.stream.javadsl.Zip;
+import akka.stream.javadsl.Zip2With;
+import akka.stream.javadsl.ZipWith;
+import akka.testkit.JavaTestKit;
+
+public class StreamPartialFlowGraphDocTest {
+
+  static ActorSystem system;
+  
+
+  @BeforeClass
+  public static void setup() {
+    system = ActorSystem.create("StreamPartialFlowGraphDocTest");
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    JavaTestKit.shutdownActorSystem(system);
+    system = null;
+  }
+  
+  final FlowMaterializer mat = FlowMaterializer.create(system);
+  
+  @Test
+  public void demonstrateBuildWithOpenPorts() throws Exception {
+    //#simple-partial-flow-graph
+    // defined outside as they will be used by different FlowGraphs
+    // 1) first by the PartialFlowGraph to mark its open input and output ports
+    // 2) then by the assembling FlowGraph which will attach real sinks and sources to them
+    final UndefinedSource<Integer> in1 = UndefinedSource.create();
+    final UndefinedSource<Integer> in2 = UndefinedSource.create();
+    final UndefinedSource<Integer> in3 = UndefinedSource.create();
+    final UndefinedSink<Integer> out = UndefinedSink.create();
+
+    final Zip2With<Integer, Integer, Integer> zip1 = ZipWith.create((a, b) -> Math.max(a, b));
+    final Zip2With<Integer, Integer, Integer> zip2 = ZipWith.create((a, b) -> Math.max(a, b));
+        
+    final PartialFlowGraph pickMaxOfThree = FlowGraph.builder()
+      .addEdge(in1, zip1.left())
+      .addEdge(in2, zip1.right())
+      .addEdge(zip1.out(), zip2.left())
+      .addEdge(in3, zip2.right())
+      .addEdge(zip2.out(), out)
+      .buildPartial();
+    //#simple-partial-flow-graph
+    
+    //#simple-partial-flow-graph
+
+    final KeyedSink<Integer, Future<Integer>> resultSink = Sink.<Integer>head();
+
+    final FlowGraphBuilder b = FlowGraph.builder();
+    // import the partial flow graph explicitly
+    b.importPartialFlowGraph(pickMaxOfThree);
+
+    b.attachSource(in1, Source.single(1));
+    b.attachSource(in2, Source.single(2));
+    b.attachSource(in3, Source.single(3));
+    b.attachSink(out, resultSink);
+
+    final MaterializedMap materialized = b.build().run(mat);
+    final Future<Integer> max = materialized.get(resultSink);
+    //#simple-partial-flow-graph
+    assertEquals(Integer.valueOf(3), Await.result(max, Duration.create(3, TimeUnit.SECONDS)));
+
+    //#simple-partial-flow-graph-import-shorthand
+    final FlowGraphBuilder b2 = FlowGraph.builder(pickMaxOfThree);
+    b2.attachSource(in1, Source.single(1));
+    b2.attachSource(in2, Source.single(2));
+    b2.attachSource(in3, Source.single(3));
+    b2.attachSink(out, resultSink);
+    //#simple-partial-flow-graph-import-shorthand
+    final MaterializedMap materialized2 = b2.run(mat);
+    final Future<Integer> max2 = materialized2.get(resultSink);
+    assertEquals(Integer.valueOf(3), Await.result(max2, Duration.create(3, TimeUnit.SECONDS)));
+  }
+  
+  @Test
+  public void demonstrateBuildSourceFromPartialFlowGraph() throws Exception {
+    //#source-from-partial-flow-graph
+    // prepare graph elements
+    final UndefinedSink<Pair<Integer, Integer>> undefinedSink = UndefinedSink.create();
+    final Zip2With<Integer, Integer, Pair<Integer, Integer>> zip = Zip.create();
+    final Source<Integer> ints = Source.from(Arrays.asList(1, 2, 3, 4, 5));
+    final Source<Pair<Integer, Integer>> pairs = Source.fromGraph(builder -> {
+      // connect the graph
+      builder
+        .addEdge(ints, Flow.of(Integer.class).filter(e -> e % 2 != 0), zip.left())
+        .addEdge(ints, Flow.of(Integer.class).filter(e -> e % 2 == 0), zip.right())
+        .addEdge(zip.out(), undefinedSink);
+      // expose undefinedSink
+      return undefinedSink;
+    });
+
+    final Future<Pair<Integer, Integer>> firstPair = 
+        pairs.runWith(Sink.<Pair<Integer, Integer>>head(), mat);
+    //#source-from-partial-flow-graph
+    assertEquals(new Pair<>(1, 2), Await.result(firstPair, Duration.create(3, TimeUnit.SECONDS)));
+  }
+  
+  @Test
+  public void demonstrateBuildFlowFromPartialFlowGraph() throws Exception {
+    //#flow-from-partial-flow-graph
+    // prepare graph elements
+    final UndefinedSource<Integer> undefinedSource = UndefinedSource.create();
+    final UndefinedSink<Pair<Integer, String>> undefinedSink = UndefinedSink.create();
+    final Broadcast<Integer> broadcast = Broadcast.create();
+    final Zip2With<Integer, String, Pair<Integer, String>> zip = Zip.create();
+    final Flow<Integer, Pair<Integer, String>> pairUpWithToString = 
+      Flow.create(builder -> {
+        // connect the graph
+        builder
+          .addEdge(undefinedSource, broadcast)
+          .addEdge(broadcast, Flow.of(Integer.class).map(e -> e), zip.left())
+          .addEdge(broadcast, Flow.of(Integer.class).map(e -> e.toString()), zip.right())
+          .addEdge(zip.out(), undefinedSink);
+
+        // expose undefined ports
+        return new Pair<>(undefinedSource, undefinedSink);
+      });
+      
+    //#flow-from-partial-flow-graph
+
+    final Future<Pair<Integer, String>> matSink =
+    //#flow-from-partial-flow-graph
+    Source.single(1).via(pairUpWithToString).runWith(Sink.<Pair<Integer, String>>head(), mat);
+    //#flow-from-partial-flow-graph
+
+    assertEquals(new Pair<>(1, "1"), Await.result(matSink, Duration.create(3, TimeUnit.SECONDS)));
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -108,8 +108,15 @@ object Source {
    * Creates a `Source` by using a [[FlowGraphBuilder]] from this [[PartialFlowGraph]] on a block that expects
    * a [[FlowGraphBuilder]] and returns the `UndefinedSink`.
    */
-  def from[T](graph: PartialFlowGraph, block: japi.Function[FlowGraphBuilder, UndefinedSink[T]]): Source[T] =
+  def fromGraph[T](graph: PartialFlowGraph, block: japi.Function[FlowGraphBuilder, UndefinedSink[T]]): Source[T] =
     new Source(scaladsl.Source(graph.asScala)(x ⇒ block.apply(x.asJava).asScala))
+
+  /**
+   * Creates a `Source` by using a [[FlowGraphBuilder]] from on a block that expects
+   * a [[FlowGraphBuilder]] and returns the `UndefinedSink`.
+   */
+  def fromGraph[T](block: japi.Function[FlowGraphBuilder, UndefinedSink[T]]): Source[T] =
+    new Source(scaladsl.Source()(x ⇒ block.apply(x.asJava).asScala))
 
   /**
    * Creates a `Source` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor


### PR DESCRIPTION
- fixed missing or wrong javadsl

There is on FIXME related to the `Source.fromGraph` rename that I must investigate before we can merge.
