### PR TITLE
=clu #16667 fix Inconsistent message order in ClusterMessageSerializer

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -3,22 +3,20 @@
  */
 package akka.cluster.protobuf
 
-import akka.serialization.Serializer
-import akka.cluster._
-import scala.collection.breakOut
-import akka.actor.{ ExtendedActorSystem, Address }
-import scala.Some
-import scala.collection.immutable
-import java.io.{ ByteArrayInputStream, ObjectOutputStream, ByteArrayOutputStream }
-import com.google.protobuf.ByteString
-import akka.util.ClassLoaderObjectInputStream
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream }
+import java.util.zip.{ GZIPInputStream, GZIPOutputStream }
 import java.{ lang ⇒ jl }
-import java.util.zip.GZIPOutputStream
-import java.util.zip.GZIPInputStream
-import com.google.protobuf.MessageLite
-import scala.annotation.tailrec
+
+import akka.actor.{ Address, ExtendedActorSystem }
+import akka.cluster._
 import akka.cluster.protobuf.msg.{ ClusterMessages ⇒ cm }
+import akka.serialization.Serializer
+import akka.util.ClassLoaderObjectInputStream
+import com.google.protobuf.{ ByteString, MessageLite }
+
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.collection.immutable
 import scala.concurrent.duration.Deadline
 
 /**
@@ -113,9 +111,9 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     uniqueAddressFromProto(cm.UniqueAddress.parseFrom(bytes))
 
   private def addressToProto(address: Address): cm.Address.Builder = address match {
-    case Address(protocol, system, Some(host), Some(port)) ⇒
-      cm.Address.newBuilder().setSystem(system).setHostname(host).setPort(port).setProtocol(protocol)
-    case _ ⇒ throw new IllegalArgumentException(s"Address [${address}] could not be serialized: host or port missing.")
+    case Address(protocol, actorSystem, Some(host), Some(port)) ⇒
+      cm.Address.newBuilder().setSystem(actorSystem).setHostname(host).setPort(port).setProtocol(protocol)
+    case _ ⇒ throw new IllegalArgumentException(s"Address [$address] could not be serialized: host or port missing.")
   }
 
   private def addressToProtoByteArray(address: Address): Array[Byte] = addressToProto(address).build.toByteArray
@@ -177,7 +175,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
 
   private def mapWithErrorMessage[T](map: Map[T, Int], value: T, unknown: String): Int = map.get(value) match {
     case Some(x) ⇒ x
-    case _       ⇒ throw new IllegalArgumentException(s"Unknown ${unknown} [${value}] in cluster message")
+    case _       ⇒ throw new IllegalArgumentException(s"Unknown $unknown [$value] in cluster message")
   }
 
   private def joinToProto(node: UniqueAddress, roles: Set[String]): cm.Join =
@@ -187,7 +185,6 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     cm.Welcome.newBuilder().setFrom(uniqueAddressToProto(from)).setGossip(gossipToProto(gossip)).build()
 
   private def gossipToProto(gossip: Gossip): cm.Gossip.Builder = {
-    import scala.collection.breakOut
     val allMembers = gossip.members.toVector
     val allAddresses: Vector[UniqueAddress] = allMembers.map(_.uniqueAddress)
     val addressMapping = allAddresses.zipWithIndex.toMap
@@ -293,6 +290,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
   }
 
   private def vectorClockFromProto(version: cm.VectorClock, hashMapping: immutable.Seq[String]) = {
+    import scala.collection.breakOut
     VectorClock(version.getVersionsList.asScala.map(
       v ⇒ (VectorClock.Node.fromHash(hashMapping(v.getHashIndex)), v.getTimestamp))(breakOut))
   }
@@ -308,10 +306,11 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
       status.getAllHashesList.asScala.toVector))
 
   private def metricsGossipEnvelopeToProto(envelope: MetricsGossipEnvelope): cm.MetricsGossipEnvelope = {
-    val mgossip = envelope.gossip
-    val allAddresses = mgossip.nodes.foldLeft(Set.empty[Address])((s, n) ⇒ s + n.address)
+    import scala.collection.breakOut
+    val allNodeMetrics = envelope.gossip.nodes
+    val allAddresses: Vector[Address] = allNodeMetrics.map(_.address)(breakOut)
     val addressMapping = allAddresses.zipWithIndex.toMap
-    val allMetricNames = mgossip.nodes.foldLeft(Set.empty[String])((s, n) ⇒ s ++ n.metrics.iterator.map(_.name))
+    val allMetricNames: Vector[String] = allNodeMetrics.foldLeft(Set.empty[String])((s, n) ⇒ s ++ n.metrics.iterator.map(_.name)).toVector
     val metricNamesMapping = allMetricNames.zipWithIndex.toMap
 
     def mapAddress(address: Address) = mapWithErrorMessage(addressMapping, address, "address")
@@ -328,7 +327,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
         case n: jl.Double  ⇒ Number.newBuilder().setType(NumberType.Double).setValue64(jl.Double.doubleToLongBits(n))
         case n: jl.Long    ⇒ Number.newBuilder().setType(NumberType.Long).setValue64(n)
         case n: jl.Float   ⇒ Number.newBuilder().setType(NumberType.Float).setValue32(jl.Float.floatToIntBits(n))
-        case n: jl.Integer ⇒ Number.newBuilder().setType(NumberType.Integer) setValue32 (n)
+        case n: jl.Integer ⇒ Number.newBuilder().setType(NumberType.Integer) setValue32 n
         case _ ⇒
           val bos = new ByteArrayOutputStream
           val out = new ObjectOutputStream(bos)
@@ -340,14 +339,14 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
 
     def metricToProto(metric: Metric): cm.NodeMetrics.Metric.Builder = {
       val builder = cm.NodeMetrics.Metric.newBuilder().setNameIndex(mapName(metric.name)).setNumber(numberToProto(metric.value))
-      ewmaToProto(metric.average).map(builder.setEwma(_)).getOrElse(builder)
+      ewmaToProto(metric.average).map(builder.setEwma).getOrElse(builder)
     }
 
     def nodeMetricsToProto(nodeMetrics: NodeMetrics): cm.NodeMetrics.Builder =
       cm.NodeMetrics.newBuilder().setAddressIndex(mapAddress(nodeMetrics.address)).setTimestamp(nodeMetrics.timestamp).
         addAllMetrics(nodeMetrics.metrics.map(metricToProto(_).build).asJava)
 
-    val nodeMetrics: Iterable[cm.NodeMetrics] = mgossip.nodes.map(nodeMetricsToProto(_).build)
+    val nodeMetrics: Iterable[cm.NodeMetrics] = allNodeMetrics.map(nodeMetricsToProto(_).build)
 
     cm.MetricsGossipEnvelope.newBuilder().setFrom(addressToProto(envelope.from)).setGossip(
       cm.MetricsGossip.newBuilder().addAllAllAddresses(allAddresses.map(addressToProto(_).build()).asJava).
@@ -359,6 +358,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
     metricsGossipEnvelopeFromProto(cm.MetricsGossipEnvelope.parseFrom(decompress(bytes)))
 
   private def metricsGossipEnvelopeFromProto(envelope: cm.MetricsGossipEnvelope): MetricsGossipEnvelope = {
+    import scala.collection.breakOut
     val mgossip = envelope.getGossip
     val addressMapping: Vector[Address] = mgossip.getAllAddressesList.asScala.map(addressFromProto)(breakOut)
     val metricNameMapping: Vector[String] = mgossip.getAllMetricNamesList.asScala.toVector
@@ -367,7 +367,6 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
       Some(EWMA(ewma.getValue, ewma.getAlpha))
 
     def numberFromProto(number: cm.NodeMetrics.Number): Number = {
-      import cm.NodeMetrics.Number
       import cm.NodeMetrics.NumberType
       number.getType.getNumber match {
         case NumberType.Double_VALUE  ⇒ jl.Double.longBitsToDouble(number.getValue64)


### PR DESCRIPTION
add the lost `toVector` call 
