### PR TITLE
=pro Disable helloKernelSample

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -405,7 +405,7 @@ object AkkaBuild extends Build {
     aggregate = Seq(camelSampleJava, camelSampleScala, mainSampleJava, mainSampleScala, 
           remoteSampleJava, remoteSampleScala, clusterSampleJava, clusterSampleScala,
           fsmSampleScala, persistenceSampleJava, persistenceSampleScala,
-          multiNodeSampleScala, helloKernelSample, osgiDiningHakkersSample)
+          multiNodeSampleScala, osgiDiningHakkersSample)
   )
 
   lazy val camelSampleJava = Project(
@@ -443,12 +443,16 @@ object AkkaBuild extends Build {
     settings = sampleSettings
   )
 
+  /* FIXME helloKernelSample is not included due to conflicting dependency to
+           bouncycastle openpgp from sbt-native-packager and sbt-pgp
+           java.lang.NoSuchMethodError: org.bouncycastle.openpgp.PGPSecretKeyRing
   lazy val helloKernelSample = Project(
     id = "akka-sample-hello-kernel",
     base = file("akka-samples/akka-sample-hello-kernel"),
     dependencies = Seq(kernel),
     settings = sampleSettings
   )
+  */
 
   lazy val remoteSampleJava = Project(
     id = "akka-sample-remote-java",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
@@ -21,6 +21,6 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.6")
 
 // needed for the akka-sample-hello-kernel
 // it is also defined in akka-samples/akka-sample-hello-kernel/project/plugins.sbt
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0-M2")
+//addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0-M2")
 
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"


### PR DESCRIPTION
- conflicting dependency to bouncycastle openpgp from
  sbt-native-packager and sbt-pgp
  java.lang.NoSuchMethodError: org.bouncycastle.openpgp.PGPSecretKeyRing

I need this to be able to publish 2.3.9 now. It works fine on master, so upgrading sbt and plugins might solve it, but I want low risk changes right now.
