### PR TITLE
=clu #16624 Expand the monitored nodes when unreachable (for validation)

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderDowningAllOtherNodesSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderDowningAllOtherNodesSpec.scala
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import scala.concurrent.duration._
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+
+object LeaderDowningAllOtherNodesMultiJvmSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+  val fourth = role("fourth")
+  val fifth = role("fifth")
+  val sixth = role("sixth")
+
+  commonConfig(debugConfig(on = false).withFallback(
+    ConfigFactory.parseString("""
+      akka.cluster.failure-detector.monitored-by-nr-of-members = 2
+      akka.cluster.auto-down-unreachable-after = 1s
+      """)).
+    withFallback(MultiNodeClusterSpec.clusterConfig))
+}
+
+class LeaderDowningAllOtherNodesMultiJvmNode1 extends LeaderDowningAllOtherNodesSpec
+class LeaderDowningAllOtherNodesMultiJvmNode2 extends LeaderDowningAllOtherNodesSpec
+class LeaderDowningAllOtherNodesMultiJvmNode3 extends LeaderDowningAllOtherNodesSpec
+class LeaderDowningAllOtherNodesMultiJvmNode4 extends LeaderDowningAllOtherNodesSpec
+class LeaderDowningAllOtherNodesMultiJvmNode5 extends LeaderDowningAllOtherNodesSpec
+class LeaderDowningAllOtherNodesMultiJvmNode6 extends LeaderDowningAllOtherNodesSpec
+
+abstract class LeaderDowningAllOtherNodesSpec
+  extends MultiNodeSpec(LeaderDowningAllOtherNodesMultiJvmSpec)
+  with MultiNodeClusterSpec {
+
+  import LeaderDowningAllOtherNodesMultiJvmSpec._
+  import ClusterEvent._
+
+  "A cluster of 6 nodes with monitored-by-nr-of-members=2" must {
+    "setup" taggedAs LongRunningTest in {
+      // start some
+      awaitClusterUp(roles: _*)
+      enterBarrier("after-1")
+    }
+
+    "remove all shutdown nodes" taggedAs LongRunningTest in {
+      val others = roles.drop(1)
+      val shutdownAddresses = others.map(address).toSet
+      runOn(first) {
+        for (node ← others)
+          testConductor.exit(node, 0).await
+      }
+      enterBarrier("all-other-shutdown")
+      awaitMembersUp(numberOfMembers = 1, canNotBePartOfMemberRing = shutdownAddresses, 30.seconds)
+    }
+
+  }
+}

--- a/akka-cluster/src/test/scala/akka/cluster/HeartbeatNodeRingPerfSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/HeartbeatNodeRingPerfSpec.scala
@@ -18,7 +18,7 @@ class HeartbeatNodeRingPerfSpec extends WordSpec with Matchers {
   def createHeartbeatNodeRingOfSize(size: Int): HeartbeatNodeRing = {
     val nodes = (1 to size).map(n ⇒ UniqueAddress(Address("akka.tcp", "sys", "node-" + n, 2552), n))
     val selfAddress = nodes(size / 2)
-    HeartbeatNodeRing(selfAddress, nodes.toSet, 5)
+    HeartbeatNodeRing(selfAddress, nodes.toSet, Set.empty, 5)
   }
 
   val heartbeatNodeRing = createHeartbeatNodeRingOfSize(nodesSize)
@@ -27,7 +27,7 @@ class HeartbeatNodeRingPerfSpec extends WordSpec with Matchers {
     for (i ← 1 to times) thunk(ring)
 
   def myReceivers(ring: HeartbeatNodeRing): Unit = {
-    val r = HeartbeatNodeRing(ring.selfAddress, ring.nodes, ring.monitoredByNrOfMembers)
+    val r = HeartbeatNodeRing(ring.selfAddress, ring.nodes, Set.empty, ring.monitoredByNrOfMembers)
     r.myReceivers.isEmpty should be(false)
   }
 


### PR DESCRIPTION
- Otherwise the leader might stall (cannot remove downed nodes)
  if many nodes are shutdown at the same time and nobody in the
  remaining cluster is monitoring some of the shutdown nodes.

(cherry picked from commit 1354524c4fde6f40499833bdd4c0edd479e6f906)

Conflicts:
    akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
    project/AkkaBuild.scala
