### PR TITLE
=act #16653 swallow exception from setTcpNoDelay

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -181,7 +181,12 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   def completeConnect(registration: ChannelRegistration, commander: ActorRef,
                       options: immutable.Traversable[SocketOption]): Unit = {
     // Turn off Nagle's algorithm by default
-    channel.socket.setTcpNoDelay(true)
+    try channel.socket.setTcpNoDelay(true) catch {
+      case e: SocketException ⇒
+        // as reported in #16653 some versions of netcat (`nc -z`) doesn't allow setTcpNoDelay
+        // continue anyway
+        log.debug("Could not enable TcpNoDelay: {}", e.getMessage)
+    }
     options.foreach(_.afterConnect(channel.socket))
 
     commander ! Connected(


### PR DESCRIPTION
- some versions of netcat (`nc -z`) doesn't allow setTcpNoDelay

@bantonsson provided an excellent reproducer in https://github.com/akka/akka/pull/16654
