### PR TITLE
+ akka-persistence: add internal message protocol traits

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
@@ -24,6 +24,7 @@ final case class SnapshotMetadata(persistenceId: String, sequenceNr: Long, times
  */
 @SerialVersionUID(1L)
 final case class SaveSnapshotSuccess(metadata: SnapshotMetadata)
+  extends SnapshotProtocol.Response
 
 /**
  * Sent to a [[PersistentActor]] after failed saving of a snapshot.
@@ -33,6 +34,7 @@ final case class SaveSnapshotSuccess(metadata: SnapshotMetadata)
  */
 @SerialVersionUID(1L)
 final case class SaveSnapshotFailure(metadata: SnapshotMetadata, cause: Throwable)
+  extends SnapshotProtocol.Response
 
 /**
  * Offers a [[PersistentActor]] a previously saved `snapshot` during recovery. This offer is received


### PR DESCRIPTION
2 more snapshot messages used for internal plugin acknowledgement in
https://github.com/akka/akka/blob/master/akka-persistence/src/main/scala/akka/persistence/snapshot/SnapshotStore.scala
- see #16612 
- see #16633
