### PR TITLE
!str #16425: Fix bind failure tests, unbind should not fail on bind errors

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/Http.scala
@@ -32,7 +32,7 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
     val effectiveSettings = ServerSettings(settings)
     val tcpBinding = StreamTcp().bind(endpoint, backlog, options, effectiveSettings.timeouts.idleTimeout)
     new ServerBinding {
-      def localAddress(mm: MaterializedMap) = tcpBinding.localAddress(mm)
+      def localAddress(mm: MaterializedMap): Future[InetSocketAddress] = tcpBinding.localAddress(mm)
       val connections = tcpBinding.connections map { tcpConn ⇒
         new IncomingConnection {
           def localAddress = tcpConn.localAddress

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
@@ -89,7 +89,7 @@ private[akka] class TcpListenStreamActor(localAddressPromise: Promise[InetSocket
       case f: CommandFailed ⇒
         val ex = BindFailedException
         localAddressPromise.failure(ex)
-        unbindPromise.failure(ex)
+        unbindPromise.success(() ⇒ Future.successful(()))
         try tryOnError(flowSubscriber, ex)
         finally fail(ex)
     }
@@ -100,7 +100,7 @@ private[akka] class TcpListenStreamActor(localAddressPromise: Promise[InetSocket
         pump()
       case f: CommandFailed ⇒
         val ex = new ConnectionException(s"Command [${f.cmd}] failed")
-        unbindPromise.tryFailure(ex)
+        if (f.cmd.isInstanceOf[Unbind.type]) unboundPromise.tryFailure(BindFailedException)
         fail(ex)
       case Unbind ⇒
         if (!closed && listener != null) listener ! Unbind


### PR DESCRIPTION
**DO NOT MERGE YET**
- Changes the test so that it does not involve concurrency between the two binds and it is guaranteed that the _second_ attempt will get the bind failure
- Corrected assumption in the test that onError is immediately signaled, now we check expectErrorOrSubscriptionFollowedByError
- Changed semantics of the unbind Future: It now does _not_ fail if the bind itself has failed. I guess most people don't care whether there was a real unbind, they care about that after the (successful) future completion there are no dangling bound ports.

For some reson on my machine the Http version of the test fails (I cannot bind after unbind) but the Tcp version passes. Let's see if this is Win specific.
