### PR TITLE
WIP proposal for a little bit of support for N ports in graphs

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -59,10 +59,10 @@ class FlowMapBenchmark {
 
   @Setup
   def setup() {
-    val settings = MaterializerSettings(system)
+    val settings = ActorFlowMaterializerSettings(system)
       .withInputBuffer(initialInputBufferSize, 16)
 
-    materializer = FlowMaterializer(settings)
+    materializer = ActorFlowMaterializer(settings)
 
     flow = mkMaps(Source(data100k), numberOfMapOps)(identity)
   }

--- a/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
@@ -90,20 +90,17 @@ class StreamPartialFlowGraphDocSpec extends AkkaSpec {
   "build source from partial flow graph" in {
     //#source-from-partial-flow-graph
     val pairs: Source[(Int, Int)] = Source() { implicit b =>
-      import FlowGraphImplicits._
+      out =>
+        import FlowGraphImplicits._
 
-      // prepare graph elements
-      val undefinedSink = UndefinedSink[(Int, Int)]
-      val zip = Zip[Int, Int]
-      def ints = Source(() => Iterator.from(1))
+        // prepare graph elements
+        val zip = Zip[Int, Int]
+        def ints = Source(() => Iterator.from(1))
 
-      // connect the graph
-      ints ~> Flow[Int].filter(_ % 2 != 0) ~> zip.left
-      ints ~> Flow[Int].filter(_ % 2 == 0) ~> zip.right
-      zip.out ~> undefinedSink
-
-      // expose undefined sink
-      undefinedSink
+        // connect the graph
+        ints ~> Flow[Int].filter(_ % 2 != 0) ~> zip.left
+        ints ~> Flow[Int].filter(_ % 2 == 0) ~> zip.right
+        zip.out ~> out
     }
 
     val firstPair: Future[(Int, Int)] = pairs.runWith(Sink.head)
@@ -137,7 +134,7 @@ class StreamPartialFlowGraphDocSpec extends AkkaSpec {
 
     // format: OFF
     val (_, matSink: Future[(Int, String)]) =
-      //#flow-from-partial-flow-graph
+    //#flow-from-partial-flow-graph
     pairUpWithToString.runWith(Source(List(1)), Sink.head)
     //#flow-from-partial-flow-graph
     // format: ON

--- a/akka-http-core/src/main/scala/akka/http/engine/client/HttpClient.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/HttpClient.scala
@@ -57,9 +57,6 @@ private[http] object HttpClient {
                                     +------------+
     */
 
-    val requestIn = UndefinedSource[HttpRequest]
-    val responseOut = UndefinedSink[HttpResponse]
-
     val methodBypassFanout = Broadcast[HttpRequest]
     val responseParsingMerge = new ResponseParsingMerge(rootParser)
 
@@ -91,7 +88,10 @@ private[http] object HttpClient {
 
     import FlowGraphImplicits._
 
-    Flow() { implicit b ⇒
+    Flow[HttpRequest, HttpResponse]() { implicit b ⇒ p ⇒
+      val requestIn = p.in
+      val responseOut = p.out
+      
       requestIn ~> methodBypassFanout ~> terminationMerge.requestInput ~> requestRendering ~> transportFlow ~>
         responseParsingMerge.dataInput ~> responsePrep ~> terminationFanout ~> responseOut
       methodBypassFanout ~> methodBypass ~> responseParsingMerge.methodBypassInput

--- a/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
@@ -28,8 +28,8 @@ class DslConsistencySpec extends WordSpec with Matchers {
   val jFlowGraphClass = classOf[akka.stream.javadsl.FlowGraph]
   val sFlowGraphClass = classOf[akka.stream.scaladsl.FlowGraph]
 
-  val jPartialFlowGraphClass = classOf[akka.stream.javadsl.PartialFlowGraph]
-  val sPartialFlowGraphClass = classOf[akka.stream.scaladsl.PartialFlowGraph]
+  val jPartialFlowGraphClass = classOf[akka.stream.javadsl.PartialFlowGraph] // TODO [_] soon...
+  val sPartialFlowGraphClass = classOf[akka.stream.scaladsl.PartialFlowGraph[_]]
 
   val ignore =
     Set("equals", "hashCode", "notify", "notifyAll", "wait", "toString", "getClass") ++

--- a/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
@@ -41,7 +41,7 @@ class DslFactoriesConsistencySpec extends WordSpec with Matchers {
       (classOf[akka.stream.scaladsl.KeyedSink[_, _]],      classOf[akka.stream.javadsl.KeyedSink[_, _]]) ::
       (classOf[akka.stream.scaladsl.Flow[_, _]],        classOf[akka.stream.javadsl.Flow[_, _]]) ::
       (classOf[akka.stream.scaladsl.FlowGraph],         classOf[akka.stream.javadsl.FlowGraph]) ::
-      (classOf[akka.stream.scaladsl.PartialFlowGraph],  classOf[akka.stream.javadsl.PartialFlowGraph]) ::
+      (classOf[akka.stream.scaladsl.PartialFlowGraph[_]],  classOf[akka.stream.javadsl.PartialFlowGraph]) :: // TODO [_] javadsl soon
       Nil
   // format: ON
 

--- a/akka-stream/src/main/boilerplate/akka/stream/impl/ZipWith.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/impl/ZipWith.scala.template
@@ -13,7 +13,7 @@ private[akka] object ZipWith {
 
   /** @param f MUST be a FunctionN type. */
   def props(settings: ActorFlowMaterializerSettings, f: Any): Props = f match {
-    [2..#case f1: Function1[[#Any#], Any] => Props(new Zip1With(settings, f1))#
+    [2..#case f1: Function1[[#_#], _] => Props(new Zip1With(settings, f1.asInstanceOf[Function1[[#Any#], Any]]))#
     ]
   }
 

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
@@ -4,7 +4,6 @@
 package akka.stream.javadsl
 
 import akka.stream.scaladsl
-import akka.stream.javadsl.japi
 
 object ZipWith {
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -37,9 +37,10 @@ object Flow {
    * returns the `UndefinedSource` and `UndefinedSink`.
    */
   def create[I, O](block: japi.Function[FlowGraphBuilder, akka.japi.Pair[UndefinedSource[I], UndefinedSink[O]]]): Flow[I, O] = {
-    val sFlow = scaladsl.Flow() { b ⇒
-      val pair = block.apply(b.asJava)
-      pair.first.asScala → pair.second.asScala
+    val sFlow = scaladsl.Flow[I, O]() { b ⇒
+      p ⇒
+        val pair = block.apply(b.asJava)
+        pair.first.asScala → pair.second.asScala // TODO still old api
     }
     new javadsl.Flow[I, O](sFlow)
   }
@@ -48,12 +49,8 @@ object Flow {
    * Creates a `Flow` by using a [[FlowGraphBuilder]] from this [[PartialFlowGraph]] on a block that expects
    * a [[FlowGraphBuilder]] and returns the `UndefinedSource` and `UndefinedSink`.
    */
-  def create[P <: Ports, I, O](graph: PartialFlowGraph[P], block: japi.Function[javadsl.FlowGraphBuilder, akka.japi.Pair[UndefinedSource[I], UndefinedSink[O]]]): Flow[I, O] = {
-    val sFlow = scaladsl.Flow(graph.asScala) { b ⇒
-      val pair = block.apply(b.asJava)
-      pair.first.asScala → pair.second.asScala
-    }
-    new Flow[I, O](sFlow)
+  def create[I, O](graph: PartialFlowGraph, block: japi.Function[javadsl.FlowGraphBuilder, akka.japi.Pair[UndefinedSource[I], UndefinedSink[O]]]): Flow[I, O] = {
+    ??? // TODO implement this
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -6,6 +6,7 @@ package akka.stream.javadsl
 import akka.stream._
 import akka.japi.Util
 import akka.stream.scaladsl
+import akka.stream.scaladsl.FlowPorts
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -47,7 +48,7 @@ object Flow {
    * Creates a `Flow` by using a [[FlowGraphBuilder]] from this [[PartialFlowGraph]] on a block that expects
    * a [[FlowGraphBuilder]] and returns the `UndefinedSource` and `UndefinedSink`.
    */
-  def create[I, O](graph: PartialFlowGraph, block: japi.Function[javadsl.FlowGraphBuilder, akka.japi.Pair[UndefinedSource[I], UndefinedSink[O]]]): Flow[I, O] = {
+  def create[P <: Ports, I, O](graph: PartialFlowGraph[P], block: japi.Function[javadsl.FlowGraphBuilder, akka.japi.Pair[UndefinedSource[I], UndefinedSink[O]]]): Flow[I, O] = {
     val sFlow = scaladsl.Flow(graph.asScala) { b ⇒
       val pair = block.apply(b.asJava)
       pair.first.asScala → pair.second.asScala

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowGraph.scala
@@ -4,7 +4,6 @@
 package akka.stream.javadsl
 
 import akka.stream._
-import akka.stream.scaladsl
 
 trait JunctionInPort[-T] {
   /** Convert this element to it's `scaladsl` equivalent. */
@@ -460,7 +459,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](source: javadsl.UndefinedSource[T], junctionIn: javadsl.JunctionInPort[T]) =
-    addEdge[T, T](source, javadsl.Flow.empty[T], junctionIn);
+    addEdge[T, T](source, javadsl.Flow.empty[T], junctionIn)
 
   def addEdge[In, Out](junctionOut: javadsl.JunctionOutPort[In], flow: javadsl.Flow[In, Out], sink: javadsl.UndefinedSink[Out]): FlowGraphBuilder = {
     b.addEdge(junctionOut.asScala, flow.asScala, sink.asScala)
@@ -468,7 +467,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](junctionOut: javadsl.JunctionOutPort[T], sink: javadsl.UndefinedSink[T]): FlowGraphBuilder =
-    addEdge[T, T](junctionOut, javadsl.Flow.empty[T], sink);
+    addEdge[T, T](junctionOut, javadsl.Flow.empty[T], sink)
 
   def addEdge[In, Out](junctionOut: javadsl.JunctionOutPort[In], flow: javadsl.Flow[In, Out], junctionIn: javadsl.JunctionInPort[Out]): FlowGraphBuilder = {
     b.addEdge(junctionOut.asScala, flow.asScala, junctionIn.asScala)
@@ -476,7 +475,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](junctionOut: javadsl.JunctionOutPort[T], junctionIn: javadsl.JunctionInPort[T]): FlowGraphBuilder =
-    addEdge[T, T](junctionOut, javadsl.Flow.empty[T], junctionIn);
+    addEdge[T, T](junctionOut, javadsl.Flow.empty[T], junctionIn)
 
   def addEdge[In, Out](source: javadsl.Source[In], flow: javadsl.Flow[In, Out], junctionIn: javadsl.JunctionInPort[Out]): FlowGraphBuilder = {
     b.addEdge(source.asScala, flow.asScala, junctionIn.asScala)
@@ -484,7 +483,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](source: javadsl.Source[T], junctionIn: javadsl.JunctionInPort[T]): FlowGraphBuilder =
-    addEdge[T, T](source, javadsl.Flow.empty[T], junctionIn);
+    addEdge[T, T](source, javadsl.Flow.empty[T], junctionIn)
 
   def addEdge[In, Out](junctionOut: javadsl.JunctionOutPort[In], flow: javadsl.Flow[In, Out], sink: Sink[Out]): FlowGraphBuilder = {
     b.addEdge(junctionOut.asScala, flow.asScala, sink.asScala)
@@ -492,7 +491,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](junctionOut: javadsl.JunctionOutPort[T], sink: Sink[T]): FlowGraphBuilder =
-    addEdge[T, T](junctionOut, javadsl.Flow.empty[T], sink);
+    addEdge[T, T](junctionOut, javadsl.Flow.empty[T], sink)
 
   def addEdge[In, Out](source: javadsl.Source[In], flow: javadsl.Flow[In, Out], sink: Sink[Out]): FlowGraphBuilder = {
     b.addEdge(source.asScala, flow.asScala, sink.asScala)
@@ -500,7 +499,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](source: javadsl.Source[T], sink: Sink[T]): FlowGraphBuilder =
-    addEdge[T, T](source, javadsl.Flow.empty[T], sink);
+    addEdge[T, T](source, javadsl.Flow.empty[T], sink)
 
   def addEdge[In, Out](source: javadsl.UndefinedSource[In], flow: javadsl.Flow[In, Out], sink: javadsl.UndefinedSink[Out]): FlowGraphBuilder = {
     b.addEdge(source.asScala, flow.asScala, sink.asScala)
@@ -508,7 +507,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](source: javadsl.UndefinedSource[T], sink: javadsl.UndefinedSink[T]): FlowGraphBuilder =
-    addEdge[T, T](source, javadsl.Flow.empty[T], sink);
+    addEdge[T, T](source, javadsl.Flow.empty[T], sink)
 
   def addEdge[In, Out](source: javadsl.UndefinedSource[In], flow: javadsl.Flow[In, Out], sink: javadsl.Sink[Out]): FlowGraphBuilder = {
     b.addEdge(source.asScala, flow.asScala, sink.asScala)
@@ -516,7 +515,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](source: javadsl.UndefinedSource[T], sink: javadsl.Sink[T]): FlowGraphBuilder =
-    addEdge[T, T](source, javadsl.Flow.empty[T], sink);
+    addEdge[T, T](source, javadsl.Flow.empty[T], sink)
 
   def addEdge[In, Out](source: javadsl.Source[In], flow: javadsl.Flow[In, Out], sink: javadsl.UndefinedSink[Out]): FlowGraphBuilder = {
     b.addEdge(source.asScala, flow.asScala, sink.asScala)
@@ -524,7 +523,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
   }
 
   def addEdge[T](source: javadsl.Source[T], sink: javadsl.UndefinedSink[T]): FlowGraphBuilder =
-    addEdge[T, T](source, javadsl.Flow.empty[T], sink);
+    addEdge[T, T](source, javadsl.Flow.empty[T], sink)
 
   def attachSink[Out](token: javadsl.UndefinedSink[Out], sink: Sink[Out]): FlowGraphBuilder = {
     b.attachSink(token.asScala, sink.asScala)
@@ -572,8 +571,8 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
     new javadsl.FlowGraph(b.build())
 
   /** Build the [[PartialFlowGraph]] but do not materialize it. */
-  def buildPartial(): javadsl.PartialFlowGraph =
-    new PartialFlowGraph(b.partialBuild())
+  def buildPartial[P <: JPorts](ports: P): javadsl.PartialFlowGraph[P] =
+    new PartialFlowGraph(b.partialBuild(ports))
 
   /** Build the [[FlowGraph]] and materialize it. */
   def run(materializer: FlowMaterializer): javadsl.MaterializedMap =
@@ -581,12 +580,12 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
 
 }
 
-class PartialFlowGraph(delegate: scaladsl.PartialFlowGraph) {
+class PartialFlowGraph[P <: JPorts](delegate: scaladsl.PartialFlowGraph[P]) {
   import akka.stream.scaladsl.JavaConverters._
 
   import collection.JavaConverters._
 
-  def asScala: scaladsl.PartialFlowGraph = delegate
+  def asScala: scaladsl.PartialFlowGraph[P] = delegate
 
   def undefinedSources(): java.util.Set[UndefinedSource[Any]] =
     delegate.undefinedSources.map(s ⇒ s.asJava).asJava
@@ -599,7 +598,7 @@ class PartialFlowGraph(delegate: scaladsl.PartialFlowGraph) {
    * no [[UndefinedSource]] in the graph, and you need to provide it as a parameter.
    */
   def toSource[O](out: javadsl.UndefinedSink[O]): javadsl.Source[O] =
-    delegate.toSource(out.asScala).asJava
+    delegate.toSource().asJava
 
   /**
    * Creates a [[Flow]] from this `PartialFlowGraph`. There needs to be only one [[UndefinedSource]] and
@@ -629,3 +628,4 @@ class FlowGraph(delegate: scaladsl.FlowGraph) extends RunnableFlow {
     delegate.runWith(key.asScala)(materializer)
 }
 
+abstract class JPorts extends scaladsl.Ports

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowGraph.scala
@@ -571,7 +571,7 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
     new javadsl.FlowGraph(b.build())
 
   /** Build the [[PartialFlowGraph]] but do not materialize it. */
-  def buildPartial[P <: JPorts](ports: P): javadsl.PartialFlowGraph[P] =
+  def buildPartial[P <: Ports](ports: P): javadsl.PartialFlowGraph =
     new PartialFlowGraph(b.partialBuild(ports))
 
   /** Build the [[FlowGraph]] and materialize it. */
@@ -580,12 +580,12 @@ class FlowGraphBuilder(b: scaladsl.FlowGraphBuilder) {
 
 }
 
-class PartialFlowGraph[P <: JPorts](delegate: scaladsl.PartialFlowGraph[P]) {
+class PartialFlowGraph(delegate: scaladsl.PartialFlowGraph[_]) {
   import akka.stream.scaladsl.JavaConverters._
 
   import collection.JavaConverters._
 
-  def asScala: scaladsl.PartialFlowGraph[P] = delegate
+  def asScala: scaladsl.PartialFlowGraph[_] = delegate
 
   def undefinedSources(): java.util.Set[UndefinedSource[Any]] =
     delegate.undefinedSources.map(s ⇒ s.asJava).asJava
@@ -598,21 +598,23 @@ class PartialFlowGraph[P <: JPorts](delegate: scaladsl.PartialFlowGraph[P]) {
    * no [[UndefinedSource]] in the graph, and you need to provide it as a parameter.
    */
   def toSource[O](out: javadsl.UndefinedSink[O]): javadsl.Source[O] =
-    delegate.toSource().asJava
+    delegate.toSource[O]().asJava
 
   /**
    * Creates a [[Flow]] from this `PartialFlowGraph`. There needs to be only one [[UndefinedSource]] and
    * one [[UndefinedSink]] in the graph, and you need to provide them as parameters.
    */
   def toFlow[I, O](in: javadsl.UndefinedSource[I], out: javadsl.UndefinedSink[O]): Flow[I, O] =
-    delegate.toFlow(in.asScala, out.asScala).asJava
+    ??? // TODO pending
+  //    delegate.toFlow(in.asScala, out.asScala).asJava
 
   /**
    * Creates a [[Sink]] from this `PartialFlowGraph`. There needs to be only one [[UndefinedSource]] and
    * no [[UndefinedSink]] in the graph, and you need to provide it as a parameter.
    */
   def toSink[I](in: UndefinedSource[I]): javadsl.Sink[I] =
-    delegate.toSink(in.asScala).asJava
+    ??? // TODO pending
+  //    delegate.toSink(in.asScala).asJava
 
 }
 
@@ -628,4 +630,4 @@ class FlowGraph(delegate: scaladsl.FlowGraph) extends RunnableFlow {
     delegate.runWith(key.asScala)(materializer)
 }
 
-abstract class JPorts extends scaladsl.Ports
+abstract class Ports extends scaladsl.Ports

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -42,8 +42,8 @@ object Sink {
    * Creates a `Sink` by using an empty [[FlowGraphBuilder]] on a block that expects a [[FlowGraphBuilder]] and
    * returns the `UndefinedSource`.
    */
-  def create[T]()(block: japi.Function[FlowGraphBuilder, UndefinedSource[T]]): Sink[T] =
-    new Sink(scaladsl.Sink.apply() { b ⇒ block.apply(b.asJava).asScala })
+  def create[T]()(block: japi.Procedure2[FlowGraphBuilder, UndefinedSource[T]]): Sink[T] =
+    new Sink(scaladsl.Sink.apply() { b ⇒ in ⇒ block.apply(b.asJava, in.asJava) })
 
   /**
    * Creates a `Sink` by using a FlowGraphBuilder from this [[PartialFlowGraph]] on a block that expects

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -43,14 +43,15 @@ object Sink {
    * returns the `UndefinedSource`.
    */
   def create[T]()(block: japi.Procedure2[FlowGraphBuilder, UndefinedSource[T]]): Sink[T] =
-    new Sink(scaladsl.Sink.apply() { b ⇒ in ⇒ block.apply(b.asJava, in.asJava) })
+    new Sink[T](scaladsl.Sink[T]() { b ⇒ p ⇒ block.apply(b.asJava, p.in.asJava) })
 
   /**
    * Creates a `Sink` by using a FlowGraphBuilder from this [[PartialFlowGraph]] on a block that expects
    * a [[FlowGraphBuilder]] and returns the `UndefinedSource`.
    */
   def create[T](graph: PartialFlowGraph, block: japi.Function[FlowGraphBuilder, UndefinedSource[T]]): Sink[T] =
-    new Sink[T](scaladsl.Sink.apply(graph.asScala) { b ⇒ block.apply(b.asJava).asScala })
+    ??? // TODO NEEDS TYPED JAVA PARTIAL GRAPHS
+  //    new Sink[T](scaladsl.Sink(graph.asScala.) { b ⇒ block.apply(b.asJava).asScala })
 
   /**
    * Creates a `Sink` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor
@@ -132,7 +133,7 @@ class Sink[-In](delegate: scaladsl.Sink[In]) {
    * @tparam T materialized type of given Source
    */
   def runWith[T](source: javadsl.KeyedSource[In, T], materializer: FlowMaterializer): T =
-    asScala.runWith(source.asScala)(materializer).asInstanceOf[T]
+    asScala.runWith(source.asScala)(materializer)
 
   /**
    * Connect this `Sink` to a `Source` and run it.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -115,8 +115,8 @@ object Source {
    * Creates a `Source` by using a [[FlowGraphBuilder]] from on a block that expects
    * a [[FlowGraphBuilder]] and returns the `UndefinedSink`.
    */
-  def fromGraph[T](block: japi.Function[FlowGraphBuilder, UndefinedSink[T]]): Source[T] =
-    new Source(scaladsl.Source()(x ⇒ block.apply(x.asJava).asScala))
+  def fromGraph[T](block: japi.Procedure2[FlowGraphBuilder, UndefinedSink[T]]): Source[T] =
+    new Source(scaladsl.Source()(x ⇒ out ⇒ block.apply(x.asJava, out.asJava)))
 
   /**
    * Creates a `Source` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -3,25 +3,22 @@
  */
 package akka.stream.javadsl
 
-import java.util.concurrent.Callable
-import akka.actor.{ Cancellable, ActorRef, Props }
+import akka.actor.{ ActorRef, Cancellable, Props }
 import akka.japi.Util
 import akka.stream._
-import akka.stream.scaladsl.PropsSource
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
+import akka.stream.stage.Stage
+import org.reactivestreams.{ Publisher, Subscriber }
+
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-import scala.language.higherKinds
-import scala.language.implicitConversions
-import akka.stream.stage.Stage
+import scala.language.{ higherKinds, implicitConversions }
 
 /** Java API */
 object Source {
 
-  import scaladsl.JavaConverters._
+  import akka.stream.scaladsl.JavaConverters._
 
   /** Adapt [[scaladsl.Source]] for use within JavaDSL */
   def adapt[O](source: scaladsl.Source[O]): Source[O] =
@@ -188,7 +185,7 @@ class Source[+Out](delegate: scaladsl.Source[Out]) {
    * @tparam S materialized type of the given Sink
    */
   def runWith[S](sink: KeyedSink[Out, S], materializer: FlowMaterializer): S =
-    asScala.runWith(sink.asScala)(materializer).asInstanceOf[S]
+    asScala.runWith(sink.asScala)(materializer)
 
   /**
    * Connect this `Source` to a `Sink` and run it. The returned value is the materialized value

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -106,14 +106,16 @@ object Source {
    * a [[FlowGraphBuilder]] and returns the `UndefinedSink`.
    */
   def fromGraph[T](graph: PartialFlowGraph, block: japi.Function[FlowGraphBuilder, UndefinedSink[T]]): Source[T] =
-    new Source(scaladsl.Source(graph.asScala)(x ⇒ block.apply(x.asJava).asScala))
+    ??? // TODO: needs java typed partial graphs
+  //    new Source(scaladsl.Source(graph.asScala)(x ⇒ block.apply(x.asJava).asScala))
 
   /**
    * Creates a `Source` by using a [[FlowGraphBuilder]] from on a block that expects
    * a [[FlowGraphBuilder]] and returns the `UndefinedSink`.
    */
   def fromGraph[T](block: japi.Procedure2[FlowGraphBuilder, UndefinedSink[T]]): Source[T] =
-    new Source(scaladsl.Source()(x ⇒ out ⇒ block.apply(x.asJava, out.asJava)))
+    ??? // TODO: needs java typed partial graphs
+  //    new Source(scaladsl.Source()(x ⇒ out ⇒ block.apply(x.asJava, out.asJava)))
 
   /**
    * Creates a `Source` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor

--- a/akka-stream/src/main/scala/akka/stream/javadsl/japi/WithVariance.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/japi/WithVariance.scala
@@ -46,6 +46,15 @@ trait Procedure[-T] {
 }
 
 /**
+ * A Procedure is like a Function2, but it doesn't produce a return value.
+ */
+@SerialVersionUID(1L) // FIXME: add variance to akka.japi and remove this akka.stream.japi!
+trait Procedure2[-T1, -T2] {
+  @throws(classOf[Exception])
+  def apply(first: T1, second: T2): Unit
+}
+
+/**
  * Java API: Defines a criteria and determines whether the parameter meets this criteria.
  */
 @SerialVersionUID(1L) // FIXME: add variance to akka.japi and remove this akka.stream.japi!

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -52,7 +52,7 @@ trait Flow[-In, +Out] extends FlowOps[Out] {
    * the first element emitted by the given ("second") source is emitted after the last element of this Flow.
    */
   def concat(second: Source[In]): Flow[In, Out] = {
-    Flow() { b ⇒
+    Flow[In, Out]() { b ⇒
       ports ⇒
         import ports._
         import FlowGraphImplicits._

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowGraph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowGraph.scala
@@ -1301,13 +1301,14 @@ object PartialFlowGraph {
   def apply(partialFlowGraph: PartialFlowGraph)(block: FlowGraphBuilder ⇒ Unit): PartialFlowGraph =
     apply(new FlowGraphBuilder(partialFlowGraph))(block)
 
-  def apply(p: Ports, requireAllPorts: Boolean = true)(block: FlowGraphBuilder ⇒ Unit): PartialFlowGraph = {
-    val partial = apply(block)
-    
+  def apply[P <: Ports](p: P, requireAllPorts: Boolean = true)(block: FlowGraphBuilder ⇒ P ⇒ Unit): PartialFlowGraph = {
+    val partial = apply(block(_)(p))
+
     // TODO: validation could point out which ones are not connected here
     // TODO: We could also have "OptionalInput", have not thought that one through yet though
     if (requireAllPorts)
-      require(p.allPorts.forall(partial.graph.contains(_)), s"PartialFlowGraph using $p must contain all ports contained within this Ports object")
+      p.validateAllIncluded(partial)
+
     partial
   }
 
@@ -1415,6 +1416,10 @@ object FlowGraphImplicits {
     def ~>(sink: UndefinedSink[Out])(implicit builder: FlowGraphBuilder): Unit =
       builder.addEdge(source, sink)
 
+    /** Attaches this [[Source]] to the [[UndefinedSource]]. */
+    def ~>(undefined: UndefinedSource[Out])(implicit builder: FlowGraphBuilder): Unit =
+      builder.attachSource(undefined, source)
+
     def ~>(sink: Sink[Out])(implicit builder: FlowGraphBuilder): Unit =
       builder.addEdge(source, sink)
   }
@@ -1483,6 +1488,14 @@ object FlowGraphImplicits {
       builder.addEdge(source, sink)
   }
 
+  implicit class UndefinedSinkOps[In](val undefined: UndefinedSink[In]) extends AnyVal {
+
+    /** Attaches this [[Sink]] to the [[UndefinedSink]]. */
+    def ~>(sink: Sink[In])(implicit builder: FlowGraphBuilder): Unit =
+      builder.attachSink(undefined, sink)
+
+  }
+
   class UndefinedSourceNextStep[In, Out](source: UndefinedSource[In], flow: Flow[In, Out], builder: FlowGraphBuilder) {
     def ~>[T](otherFlow: Flow[Out, T]): UndefinedSourceNextStep[In, T] =
       new UndefinedSourceNextStep(source, flow.via(otherFlow), builder)
@@ -1504,35 +1517,33 @@ trait Ports {
   private var inputs: List[UndefinedSource[_]] = Nil
   private var outputs: List[UndefinedSink[_]] = Nil
 
-  // TODO draft - could simply be also defined on Undefined elements
-  implicit class DefinableSink[T](undefined: UndefinedSink[T]) {
-    def apply(s: Sink[T])(implicit builder: FlowGraphBuilder) = builder.attachSink(undefined, s) // TODO `apply` or `attach`?
-  }
-  // TODO draft - could simply be also defined on Undefined elements
-  implicit class DefinableSource[T](undefined: UndefinedSource[T]) {
-    def apply(s: Source[T])(implicit builder: FlowGraphBuilder) = builder.attachSource(undefined, s) // TODO `apply` or `attach`?
-  }
-
   // TODO: input / output words match "Ports" nicely, but maybe keeping undefinedSource adds "less words"?
-  protected def Input[T]: UndefinedSource[T] = {
+  protected def InputPort[T]: UndefinedSource[T] = {
     val port = UndefinedSource[T]
     inputs = port :: inputs
     port
   }
 
-  protected def Output[T]: UndefinedSink[T] = {
+  protected def OutputPort[T]: UndefinedSink[T] = {
     val port = UndefinedSink[T]
     outputs = port :: outputs
     port
   }
 
-  // TODO probably "nope."
-  def connect(g: PartialFlowGraph): FlowGraph = {
-    FlowGraph(g) { b ⇒
-      ???
-    }
-  }
+  /**
+   * INTERNAL API
+   * @throws IllegalArgumentException when not all ports are included in the given graph
+   */
+  private[akka] def validateAllIncluded(graph: FlowGraphLike): Unit =
+    require(allPorts.forall(graph.graph.contains(_)),
+      s"PartialFlowGraph using ${this} must contain all ports contained within this Ports object")
 
   // for validating all were connected, in case we want to make sure (I'd say most common case?)
+  /** INTERNAL API */
   private[stream] def allPorts: List[InternalVertex] = inputs ::: outputs
+}
+
+object OutputPort {
+  def apply[T] = UndefinedSink[T]
+
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -29,12 +29,23 @@ object Sink {
    */
   def apply[T](subscriber: Subscriber[T]): Sink[T] = SubscriberSink(subscriber)
 
+  //  /**
+  //   * Creates a `Sink` by using an empty [[FlowGraphBuilder]] on a block that expects a [[FlowGraphBuilder]] and
+  //   * returns the `UndefinedSource`.
+  //   */
+  //  def apply[T]()(block: FlowGraphBuilder ⇒ UndefinedSource[T]): Sink[T] =
+  //    createSinkFromBuilder(new FlowGraphBuilder(), block)
+
   /**
-   * Creates a `Sink` by using an empty [[FlowGraphBuilder]] on a block that expects a [[FlowGraphBuilder]] and
-   * returns the `UndefinedSource`.
+   * Creates a `Source` by using an empty [[FlowGraphBuilder]] on a block that expects a [[FlowGraphBuilder]] and
+   * returns the `UndefinedSink`.
    */
-  def apply[T]()(block: FlowGraphBuilder ⇒ UndefinedSource[T]): Sink[T] =
-    createSinkFromBuilder(new FlowGraphBuilder(), block)
+  def apply[T]()(block: FlowGraphBuilder ⇒ UndefinedSource[T] ⇒ Unit): Sink[T] = {
+    val in = UndefinedSource[T]
+    val builder = new FlowGraphBuilder()
+    block(builder)(in)
+    builder.partialBuild().toSink(in)
+  }
 
   /**
    * Creates a `Sink` by using a FlowGraphBuilder from this [[PartialFlowGraph]] on a block that expects

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -51,12 +51,13 @@ object Sink {
    * Creates a `Sink` by using a FlowGraphBuilder from this [[PartialFlowGraph]] on a block that expects
    * a [[FlowGraphBuilder]] and returns the `UndefinedSource`.
    */
-  def apply[T](graph: PartialFlowGraph)(block: FlowGraphBuilder ⇒ UndefinedSource[T]): Sink[T] =
-    createSinkFromBuilder(new FlowGraphBuilder(graph), block)
-
-  private def createSinkFromBuilder[T](builder: FlowGraphBuilder, block: FlowGraphBuilder ⇒ UndefinedSource[T]): Sink[T] = {
-    val in = block(builder)
-    builder.partialBuild().toSink(in)
+  def apply[P <: Ports, T](graph: PartialFlowGraph[P])(block: FlowGraphBuilder ⇒ P ⇒ UndefinedSource[T]): Sink[T] = {
+    val builder = new FlowGraphBuilder(graph)
+    val ports = graph.ports
+    val out = block(builder)(ports)
+    val sink = builder.partialBuild(ports).toSink()
+    // should be able to validate the out == sink.in
+    sink
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -40,11 +40,11 @@ object Sink {
    * Creates a `Source` by using an empty [[FlowGraphBuilder]] on a block that expects a [[FlowGraphBuilder]] and
    * returns the `UndefinedSink`.
    */
-  def apply[T]()(block: FlowGraphBuilder ⇒ UndefinedSource[T] ⇒ Unit): Sink[T] = {
-    val in = UndefinedSource[T]
+  def apply[T]()(block: FlowGraphBuilder ⇒ SinkPort[T] ⇒ Unit): Sink[T] = {
+    val port = SinkPort[T]()
     val builder = new FlowGraphBuilder()
-    block(builder)(in)
-    builder.partialBuild().toSink(in)
+    block(builder)(port)
+    builder.partialBuild(port).toSink()
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -192,13 +192,12 @@ object Source {
    * source.
    */
   def concat[T](source1: Source[T], source2: Source[T]): Source[T] = {
-    val concat = Concat[T]
-    Source() { b ⇒
-      output ⇒
+    Source[T]() { b ⇒
+      port ⇒
+        val concat = Concat[T]
         b.addEdge(source1, Pipe.empty[T], concat.first)
           .addEdge(source2, Pipe.empty[T], concat.second)
-          .addEdge(concat.out, Pipe.empty[T], output)
-        output
+          .addEdge(concat.out, Pipe.empty[T], port.out) // TODO pass in `out` instead of ports perhaps?
     }
   }
 


### PR DESCRIPTION
WIP, A draft of an idea addressing a perhaps nicer way to deal with "[LEGO style](https://github.com/akka/akka/blob/release-2.3-dev/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala#L37)" of exposing multiple ports.
Triggered by discussion in https://github.com/akka/akka/issues/16715

Does this look helpful enough for exposing multiple inputs / outputs you think?

// cc @13h3r @drewhk 
