### PR TITLE
=str #16553: Fix TCP stream shutdown scenarios

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpHelper.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpHelper.scala
@@ -4,6 +4,7 @@
 package akka.stream.io
 
 import akka.actor.{ Actor, ActorRef, Props }
+import akka.io.Tcp.{ ResumeReading, Register, ConnectionClosed, Closed }
 import akka.io.{ IO, Tcp }
 import akka.stream.testkit.StreamTestKit
 import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings }
@@ -17,6 +18,11 @@ object TcpHelper {
   case class ClientWrite(bytes: ByteString)
   case class ClientRead(count: Int, readTo: ActorRef)
   case class ClientClose(cmd: Tcp.CloseCommand)
+
+  // FIXME: Workaround object just to force a ResumeReading that will poll for a possibly pending close event
+  // See https://github.com/akka/akka/issues/16552
+  // remove this and corresponding code path once above is fixed
+  case class PingClose(requester: ActorRef)
 
   case object WriteAck extends Tcp.Event
 
@@ -66,7 +72,12 @@ object TcpHelper {
           toRead = 0
           readTo = context.system.deadLetters
         } else connection ! Tcp.ResumeReading
-
+      case PingClose(requester) ⇒
+        readTo = requester
+        connection ! ResumeReading
+      case c: ConnectionClosed ⇒
+        readTo ! c
+        if (!c.isPeerClosed) context.stop(self)
       case ClientClose(cmd) ⇒
         if (!writePending) connection ! cmd
         else closeAfterWrite = Some(cmd)
@@ -118,6 +129,7 @@ trait TcpHelper { this: TestKitBase ⇒
 
   class ServerConnection(val connectionActor: ActorRef) {
     val connectionProbe = TestProbe()
+
     def write(bytes: ByteString): Unit = connectionActor ! ClientWrite(bytes)
 
     def read(count: Int): Unit = connectionActor ! ClientRead(count, connectionProbe.ref)
@@ -126,6 +138,21 @@ trait TcpHelper { this: TestKitBase ⇒
     def confirmedClose(): Unit = connectionActor ! ClientClose(Tcp.ConfirmedClose)
     def close(): Unit = connectionActor ! ClientClose(Tcp.Close)
     def abort(): Unit = connectionActor ! ClientClose(Tcp.Abort)
+
+    def expectClosed(expected: ConnectionClosed): Unit = expectClosed(_ == expected)
+
+    def expectClosed(p: (ConnectionClosed) ⇒ Boolean): Unit = {
+      connectionActor ! PingClose(connectionProbe.ref)
+      connectionProbe.fishForMessage() {
+        case c: ConnectionClosed if p(c) ⇒ true
+        case other                       ⇒ false
+      }
+    }
+
+    def expectTerminated(): Unit = {
+      connectionProbe.watch(connectionActor)
+      connectionProbe.expectTerminated(connectionActor)
+    }
   }
 
   class TcpReadProbe() {


### PR DESCRIPTION
Properly handle various stream and TCP shutdown scenarios
- Upgraded tests to cover various closing scenarios
- Even upon downstream cancel we pull the events from TCP by sending ResumeReading and draining ignored bytes if needed
- Now also tests if the test connection actor terminates
- workaround for #16552, before we wait on close events in the tests, we send a ResumeReading first
- tests even cancellation after PeerClosed by trying to write (otherwise no ErrorClosed is generated)

Fixes #16653
