### PR TITLE
!str #15851 Rename FlowMaterializer and settings

### DIFF
--- a/akka-docs-dev/rst/java/stream-quickstart.rst
+++ b/akka-docs-dev/rst/java/stream-quickstart.rst
@@ -19,12 +19,12 @@ Here's the data model we'll be working with throughout the quickstart examples:
 
 Transforming and consuming simple streams
 -----------------------------------------
-In order to prepare our environment by creating an :class:`ActorSystem` and :class:`FlowMaterializer`,
+In order to prepare our environment by creating an :class:`ActorSystem` and :class:`ActorFlowMaterializer`,
 which will be responsible for materializing and running the streams we are about to create:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/TwitterStreamQuickstartDocTest.java#materializer-setup
 
-The :class:`FlowMaterializer` can optionally take :class:`MaterializerSettings` which can be used to define
+The :class:`ActorFlowMaterializer` can optionally take :class:`ActorFlowMaterializerSettings` which can be used to define
 materialization properties, such as default buffer sizes (see also :ref:`stream-buffering-explained-scala`), the dispatcher to
 be used by the pipeline etc. These can be overridden on an element-by-element basis or for an entire section, but this
 will be discussed in depth in :ref:`stream-section-configuration`.
@@ -55,8 +55,8 @@ or by using the shorthand version (which are defined only for the most popular s
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/TwitterStreamQuickstartDocTest.java#authors-foreach-println
 
-Materializing and running a stream always requires a :class:`FlowMaterializer` to be in implicit scope (or passed in explicitly,
-like this: ``.run(mat)``).
+Materializing and running a stream always requires a :class:`FlowMaterializer` to be passed in explicitly,
+like this: ``.run(mat)``.
 
 Flattening sequences in streams
 -------------------------------
@@ -141,7 +141,7 @@ First, we prepare the :class:`FoldSink` which will be used to sum all ``Integer`
 Next we connect the ``tweets`` stream though a ``map`` step which converts each tweet into the number ``1``,
 finally we connect the flow ``to`` the previously prepared Sink. Notice that this step does *not* yet materialize the
 processing pipeline, it merely prepares the description of the Flow, which is now connected to a Sink, and therefore can
-be ``run()``, as indicated by its type: :class:`RunnableFlow`. Next we call ``run()`` which uses the implicit :class:`FlowMaterializer`
+be ``run()``, as indicated by its type: :class:`RunnableFlow`. Next we call ``run()`` which uses the implicit :class:`ActorFlowMaterializer`
 to materialize and run the flow. The value returned by calling ``run()`` on a ``RunnableFlow`` or ``FlowGraph`` is ``MaterializedMap``,
 which can be used to retrieve materialized values from the running stream.
 

--- a/akka-docs-dev/rst/scala/code/docs/http/HttpServerExampleSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/HttpServerExampleSpec.scala
@@ -16,10 +16,10 @@ class HttpServerExampleSpec
   "binding example" in {
     //#bind-example
     import akka.http.Http
-    import akka.stream.FlowMaterializer
+    import akka.stream.ActorFlowMaterializer
 
     implicit val system = ActorSystem()
-    implicit val materializer = FlowMaterializer()
+    implicit val materializer = ActorFlowMaterializer()
 
     val serverBinding = Http(system).bind(interface = "localhost", port = 8080)
     serverBinding.connections.foreach { connection => // foreach materializes the source
@@ -30,10 +30,10 @@ class HttpServerExampleSpec
 
   "full-server-example" in {
     import akka.http.Http
-    import akka.stream.FlowMaterializer
+    import akka.stream.ActorFlowMaterializer
 
     implicit val system = ActorSystem()
-    implicit val materializer = FlowMaterializer()
+    implicit val materializer = ActorFlowMaterializer()
 
     val serverBinding = Http(system).bind(interface = "localhost", port = 8080)
 

--- a/akka-docs-dev/rst/scala/code/docs/http/server/ExceptionHandlerExamplesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/server/ExceptionHandlerExamplesSpec.scala
@@ -6,7 +6,7 @@ package docs.http.server
 
 import akka.actor.ActorSystem
 import akka.http.server.Route
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 object MyHandler {
   //# example-1
@@ -27,7 +27,7 @@ object MyHandler {
   object MyApp {
     implicit val system = ActorSystem()
     import system.dispatcher
-    implicit val materializer = FlowMaterializer()
+    implicit val materializer = ActorFlowMaterializer()
 
     def handler = Route.handlerFlow(`<my-route-definition>`)
   }

--- a/akka-docs-dev/rst/scala/code/docs/http/server/RejectionHandlerExamplesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/server/RejectionHandlerExamplesSpec.scala
@@ -5,7 +5,7 @@
 package docs.http.server
 
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 import akka.http.server.{ Route, MissingCookieRejection }
 
@@ -26,7 +26,7 @@ object MyRejectionHandler {
   object MyApp {
     implicit val system = ActorSystem()
     import system.dispatcher
-    implicit val materializer = FlowMaterializer()
+    implicit val materializer = ActorFlowMaterializer()
 
     def handler = Route.handlerFlow(`<my-route-definition>`)
   }

--- a/akka-docs-dev/rst/scala/code/docs/stream/ActorPublisherDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/ActorPublisherDocSpec.scala
@@ -5,7 +5,7 @@ package docs.stream
 
 import scala.annotation.tailrec
 import akka.actor.Props
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.actor.ActorPublisher
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
@@ -70,7 +70,7 @@ object ActorPublisherDocSpec {
 class ActorPublisherDocSpec extends AkkaSpec {
   import ActorPublisherDocSpec._
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "illustrate usage of ActorPublisher" in {
     def println(s: String): Unit =

--- a/akka-docs-dev/rst/scala/code/docs/stream/ActorSubscriberDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/ActorSubscriberDocSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.Props
 import akka.routing.ActorRefRoutee
 import akka.routing.RoundRobinRoutingLogic
 import akka.routing.Router
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.actor.ActorSubscriber
 import akka.stream.actor.ActorSubscriberMessage
 import akka.stream.actor.MaxInFlightRequestStrategy
@@ -72,7 +72,7 @@ object ActorSubscriberDocSpec {
 class ActorSubscriberDocSpec extends AkkaSpec {
   import ActorSubscriberDocSpec._
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "illustrate usage of ActorSubscriber" in {
     val replyTo = testActor

--- a/akka-docs-dev/rst/scala/code/docs/stream/FlexiDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/FlexiDocSpec.scala
@@ -3,7 +3,7 @@
  */
 package docs.stream
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl._
 import akka.stream.testkit.AkkaSpec
 
@@ -15,7 +15,7 @@ import scala.util.control.NoStackTrace
 class FlexiDocSpec extends AkkaSpec {
 
   implicit val ec = system.dispatcher
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "implement zip using readall" in {
     //#fleximerge-zip-readall

--- a/akka-docs-dev/rst/scala/code/docs/stream/FlowDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/FlowDocSpec.scala
@@ -14,10 +14,10 @@ class FlowDocSpec extends AkkaSpec {
   implicit val ec = system.dispatcher
 
   //#imports
-  import akka.stream.FlowMaterializer
+  import akka.stream.ActorFlowMaterializer
   //#imports
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "source is immutable" in {
     //#source-immutable

--- a/akka-docs-dev/rst/scala/code/docs/stream/FlowGraphDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/FlowGraphDocSpec.scala
@@ -3,7 +3,7 @@
  */
 package docs.stream
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Broadcast
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.FlowGraph
@@ -22,7 +22,7 @@ class FlowGraphDocSpec extends AkkaSpec {
 
   implicit val ec = system.dispatcher
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "build simple graph" in {
     //format: OFF

--- a/akka-docs-dev/rst/scala/code/docs/stream/FlowStagesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/FlowStagesSpec.scala
@@ -1,6 +1,6 @@
 package docs.stream
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.{ RunnableFlow, Sink, Source, Flow }
 import akka.stream.stage.PushPullStage
 import akka.stream.testkit.AkkaSpec
@@ -14,7 +14,7 @@ class FlowStagesSpec extends AkkaSpec {
   import akka.stream.stage._
   //#import-stage
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "stages demo" must {
 

--- a/akka-docs-dev/rst/scala/code/docs/stream/GraphCyclesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/GraphCyclesSpec.scala
@@ -1,12 +1,12 @@
 package docs.stream
 
-import akka.stream.{ OverflowStrategy, FlowMaterializer }
+import akka.stream.{ OverflowStrategy, ActorFlowMaterializer }
 import akka.stream.scaladsl._
 import akka.stream.testkit.AkkaSpec
 
 class GraphCyclesSpec extends AkkaSpec {
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "Cycle demonstration" must {
     val source = Source(() => Iterator.from(0))

--- a/akka-docs-dev/rst/scala/code/docs/stream/IntegrationDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/IntegrationDocSpec.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 import akka.stream.testkit.AkkaSpec
 import akka.stream.scaladsl.Source
 import java.util.Date
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import scala.concurrent.Future
 import akka.stream.scaladsl.RunnableFlow
 import akka.stream.scaladsl.Sink
@@ -20,7 +20,7 @@ import akka.pattern.ask
 import akka.util.Timeout
 import akka.stream.scaladsl.OperationAttributes
 import scala.concurrent.ExecutionContext
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import java.util.concurrent.atomic.AtomicInteger
 
 object IntegrationDocSpec {
@@ -117,7 +117,7 @@ class IntegrationDocSpec extends AkkaSpec(IntegrationDocSpec.config) {
   import TwitterStreamQuickstartDocSpec._
   import IntegrationDocSpec._
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "calling external service with mapAsync" in {
     val probe = TestProbe()
@@ -301,8 +301,8 @@ class IntegrationDocSpec extends AkkaSpec(IntegrationDocSpec.config) {
     implicit val blockingExecutionContext = system.dispatchers.lookup("blocking-dispatcher")
     val service = new SometimesSlowService
 
-    implicit val mat = FlowMaterializer(
-      MaterializerSettings(system).withInputBuffer(initialSize = 4, maxSize = 4))
+    implicit val mat = ActorFlowMaterializer(
+      ActorFlowMaterializerSettings(system).withInputBuffer(initialSize = 4, maxSize = 4))
 
     Source(List("a", "B", "C", "D", "e", "F", "g", "H", "i", "J"))
       .map(elem => { println(s"before: $elem"); elem })
@@ -333,8 +333,8 @@ class IntegrationDocSpec extends AkkaSpec(IntegrationDocSpec.config) {
     implicit val blockingExecutionContext = system.dispatchers.lookup("blocking-dispatcher")
     val service = new SometimesSlowService
 
-    implicit val mat = FlowMaterializer(
-      MaterializerSettings(system).withInputBuffer(initialSize = 4, maxSize = 4))
+    implicit val mat = ActorFlowMaterializer(
+      ActorFlowMaterializerSettings(system).withInputBuffer(initialSize = 4, maxSize = 4))
 
     Source(List("a", "B", "C", "D", "e", "F", "g", "H", "i", "J"))
       .map(elem => { println(s"before: $elem"); elem })

--- a/akka-docs-dev/rst/scala/code/docs/stream/ReactiveStreamsDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/ReactiveStreamsDocSpec.scala
@@ -3,7 +3,7 @@
  */
 package docs.stream
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.testkit.AkkaSpec
 import akka.stream.scaladsl.Sink
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Source
 class ReactiveStreamsDocSpec extends AkkaSpec {
   import TwitterStreamQuickstartDocSpec._
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   //#imports
   import org.reactivestreams.Publisher

--- a/akka-docs-dev/rst/scala/code/docs/stream/StreamBuffersRateSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/StreamBuffersRateSpec.scala
@@ -1,11 +1,11 @@
 package docs.stream
 
-import akka.stream.{ OverflowStrategy, MaterializerSettings, FlowMaterializer }
+import akka.stream.{ OverflowStrategy, ActorFlowMaterializerSettings, ActorFlowMaterializer }
 import akka.stream.scaladsl._
 import akka.stream.testkit.AkkaSpec
 
 class StreamBuffersRateSpec extends AkkaSpec {
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "Demonstrate pipelining" in {
     def println(s: Any) = ()
@@ -20,8 +20,8 @@ class StreamBuffersRateSpec extends AkkaSpec {
 
   "Demonstrate buffer sizes" in {
     //#materializer-buffer
-    val materializer = FlowMaterializer(
-      MaterializerSettings(system)
+    val materializer = ActorFlowMaterializer(
+      ActorFlowMaterializerSettings(system)
         .withInputBuffer(
           initialSize = 64,
           maxSize = 64))

--- a/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
@@ -3,7 +3,7 @@
  */
 package docs.stream
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Broadcast
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.FlowGraph
@@ -25,7 +25,7 @@ class StreamPartialFlowGraphDocSpec extends AkkaSpec {
 
   implicit val ec = system.dispatcher
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "build with open ports" in {
     // format: OFF

--- a/akka-docs-dev/rst/scala/code/docs/stream/StreamTcpDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/StreamTcpDocSpec.scala
@@ -21,12 +21,12 @@ class StreamTcpDocSpec extends AkkaSpec {
   implicit val ec = system.dispatcher
 
   //#setup
-  import akka.stream.FlowMaterializer
+  import akka.stream.ActorFlowMaterializer
   import akka.stream.scaladsl.StreamTcp
   import akka.stream.scaladsl.StreamTcp._
 
   implicit val sys = ActorSystem("stream-tcp-system")
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
   //#setup
 
   val localhost = new InetSocketAddress("127.0.0.1", 8888)

--- a/akka-docs-dev/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -6,7 +6,7 @@ package docs.stream
 //#imports
 
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Broadcast
 import akka.stream.scaladsl.Flow
@@ -66,11 +66,11 @@ class TwitterStreamQuickstartDocSpec extends AkkaSpec {
   trait Example1 {
     //#materializer-setup
     implicit val system = ActorSystem("reactive-tweets")
-    implicit val mat = FlowMaterializer()
+    implicit val mat = ActorFlowMaterializer()
     //#materializer-setup
   }
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "filter and map" in {
     //#authors-filter-map

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeCollectingMetrics.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeCollectingMetrics.scala
@@ -1,6 +1,6 @@
 package docs.stream.cookbook
 
-import akka.stream.{ MaterializerSettings, FlowMaterializer }
+import akka.stream.{ ActorFlowMaterializerSettings, ActorFlowMaterializer }
 import akka.stream.scaladsl._
 import akka.stream.testkit.StreamTestKit
 import akka.stream.testkit.StreamTestKit.{ SubscriberProbe, PublisherProbe }
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 class RecipeCollectingMetrics extends RecipeSpec {
   import HoldOps._
-  implicit val m2 = FlowMaterializer(MaterializerSettings(system).withInputBuffer(1, 1))
+  implicit val m2 = ActorFlowMaterializer(ActorFlowMaterializerSettings(system).withInputBuffer(1, 1))
 
   "Recipe for periodically collecting metrics" must {
 

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeSpec.scala
@@ -1,11 +1,11 @@
 package docs.stream.cookbook
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 
 trait RecipeSpec extends AkkaSpec {
 
-  implicit val m = FlowMaterializer()
+  implicit val m = ActorFlowMaterializer()
   type Message = String
   type Trigger = Unit
   type Job = String

--- a/akka-docs-dev/rst/scala/stream-flows-and-basics.rst
+++ b/akka-docs-dev/rst/scala/stream-flows-and-basics.rst
@@ -190,7 +190,7 @@ well-known sinks, such as ``foreach(el => )`` (being an alias to ``runWith(Sink.
 Materialization is currently performed synchronously on the materializing thread.
 Tha actual stream processing is handled by :ref:`Actors actor-scala` started up during the streams materialization,
 which will be running on the thread pools they have been configured to run on - which defaults to the dispatcher set in
-:class:`MaterializationSettings` while constructing the :class:`FlowMaterializer`.
+:class:`MaterializationSettings` while constructing the :class:`ActorFlowMaterializer`.
 
 .. note::
    Reusing *instances* of linear computation stages (Source, Sink, Flow) inside FlowGraphs is legal,

--- a/akka-docs-dev/rst/scala/stream-integrations.rst
+++ b/akka-docs-dev/rst/scala/stream-integrations.rst
@@ -254,7 +254,7 @@ is ``completed`` before ``g``, but still emitted afterwards.
 
 The numbers in parenthesis illustrates how many calls that are in progress at
 the same time. Here the downstream demand and thereby the number of concurrent
-calls are limited by the buffer size (4) of the :class:`MaterializerSettings`.
+calls are limited by the buffer size (4) of the :class:`ActorFlowMaterializerSettings`.
 
 Here is how we can use the same service with ``mapAsyncUnordered``:
 
@@ -310,7 +310,7 @@ Note that ``after`` lines are not in the same order as the ``before`` lines. For
 
 The numbers in parenthesis illustrates how many calls that are in progress at
 the same time. Here the downstream demand and thereby the number of concurrent
-calls are limited by the buffer size (4) of the :class:`MaterializerSettings`.
+calls are limited by the buffer size (4) of the :class:`ActorFlowMaterializerSettings`.
 
 .. _reactive-streams-integration-scala:
 

--- a/akka-docs-dev/rst/scala/stream-quickstart.rst
+++ b/akka-docs-dev/rst/scala/stream-quickstart.rst
@@ -19,12 +19,12 @@ Here's the data model we'll be working with throughout the quickstart examples:
 
 Transforming and consuming simple streams
 -----------------------------------------
-In order to prepare our environment by creating an :class:`ActorSystem` and :class:`FlowMaterializer`,
+In order to prepare our environment by creating an :class:`ActorSystem` and :class:`ActorFlowMaterializer`,
 which will be responsible for materializing and running the streams we are about to create:
 
 .. includecode:: code/docs/stream/TwitterStreamQuickstartDocSpec.scala#materializer-setup
 
-The :class:`FlowMaterializer` can optionally take :class:`MaterializerSettings` which can be used to define
+The :class:`ActorFlowMaterializer` can optionally take :class:`ActorFlowMaterializerSettings` which can be used to define
 materialization properties, such as default buffer sizes (see also :ref:`stream-buffering-explained-scala`), the dispatcher to
 be used by the pipeline etc. These can be overridden on an element-by-element basis or for an entire section, but this
 will be discussed in depth in :ref:`stream-section-configuration`.
@@ -146,7 +146,7 @@ First, we prepare the :class:`FoldSink` which will be used to sum all ``Int`` el
 Next we connect the ``tweets`` stream though a ``map`` step which converts each tweet into the number ``1``,
 finally we connect the flow ``to`` the previously prepared Sink. Notice that this step does *not* yet materialize the
 processing pipeline, it merely prepares the description of the Flow, which is now connected to a Sink, and therefore can
-be ``run()``, as indicated by its type: :class:`RunnableFlow`. Next we call ``run()`` which uses the implicit :class:`FlowMaterializer`
+be ``run()``, as indicated by its type: :class:`RunnableFlow`. Next we call ``run()`` which uses the implicit :class:`ActorFlowMaterializer`
 to materialize and run the flow. The value returned by calling ``run()`` on a ``RunnableFlow`` or ``FlowGraph`` is ``MaterializedMap``,
 which can be used to retrieve materialized values from the running stream.
 

--- a/akka-docs-dev/rst/scala/stream-rate.rst
+++ b/akka-docs-dev/rst/scala/stream-rate.rst
@@ -62,7 +62,7 @@ to a level that throughput requirements of the application require. Default buff
 
     akka.stream.materializer.max-input-buffer-size = 16
 
-Alternatively they can be set by passing a :class:`MaterializerSettings` to the materializer:
+Alternatively they can be set by passing a :class:`ActorFlowMaterializerSettings` to the materializer:
 
 .. includecode:: code/docs/stream/StreamBuffersRateSpec.scala#materializer-buffer
 

--- a/akka-http-core/src/main/java/akka/http/model/japi/Http.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/Http.java
@@ -6,7 +6,6 @@ package akka.http.model.japi;
 
 import akka.actor.ActorSystem;
 import akka.http.HttpExt;
-import akka.stream.MaterializerSettings;
 
 public final class Http {
     private Http(){}

--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/RenderSupport.scala
@@ -5,7 +5,7 @@
 package akka.http.engine.rendering
 
 import akka.parboiled2.CharUtils
-import akka.stream.impl.ActorBasedFlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.util.ByteString
 import akka.event.LoggingAdapter
 import akka.stream.scaladsl._
@@ -34,7 +34,7 @@ private object RenderSupport {
   // allows us to not take a FlowMaterializer but delegate the cancellation to the point when the whole stream
   // materializes
   private case class CancelSecond[T](first: Source[T], second: Source[T]) extends SimpleActorFlowSource[T] {
-    override def attach(flowSubscriber: Subscriber[T], materializer: ActorBasedFlowMaterializer, flowName: String): Unit = {
+    override def attach(flowSubscriber: Subscriber[T], materializer: ActorFlowMaterializer, flowName: String): Unit = {
       first.to(Sink(flowSubscriber)).run()(materializer)
       second.to(Sink.cancelled).run()(materializer)
     }

--- a/akka-http-core/src/main/scala/akka/http/model/japi/Accessors.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/japi/Accessors.scala
@@ -5,7 +5,6 @@
 package akka.http.model.japi
 
 import akka.http.model
-import akka.stream.MaterializerSettings
 
 /**
  *  INTERNAL API

--- a/akka-http-core/src/test/scala/akka/http/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/ClientServerSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.StreamTcp
 import akka.stream.BindFailedException
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.StreamTestKit
 import akka.stream.testkit.StreamTestKit.{ PublisherProbe, SubscriberProbe }
 import akka.stream.scaladsl._
@@ -34,7 +34,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "The low-level HTTP infrastructure" should {
 

--- a/akka-http-core/src/test/scala/akka/http/TestClient.scala
+++ b/akka-http-core/src/test/scala/akka/http/TestClient.scala
@@ -7,7 +7,7 @@ package akka.http
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.util.{ Failure, Success }
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.http.model._
 
@@ -17,7 +17,7 @@ object TestClient extends App {
     akka.log-dead-letters = off
     """)
   implicit val system = ActorSystem("ServerTest", testConf)
-  implicit val fm = FlowMaterializer()
+  implicit val fm = ActorFlowMaterializer()
   import system.dispatcher
 
   val host = "spray.io"

--- a/akka-http-core/src/test/scala/akka/http/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/TestServer.scala
@@ -6,7 +6,7 @@ package akka.http
 
 import akka.actor.ActorSystem
 import akka.http.model._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Flow
 import com.typesafe.config.{ ConfigFactory, Config }
 import HttpMethods._
@@ -17,7 +17,7 @@ object TestServer extends App {
     akka.log-dead-letters = off
     """)
   implicit val system = ActorSystem("ServerTest", testConf)
-  implicit val fm = FlowMaterializer()
+  implicit val fm = ActorFlowMaterializer()
 
   val binding = Http().bind(interface = "localhost", port = 8080)
 

--- a/akka-http-core/src/test/scala/akka/http/engine/client/HttpClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/client/HttpClientSpec.scala
@@ -8,7 +8,7 @@ import java.net.InetSocketAddress
 import org.scalatest.Inside
 import akka.util.ByteString
 import akka.event.NoLogging
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.stream.scaladsl._
 import akka.http.model.HttpEntity._
@@ -18,7 +18,7 @@ import akka.http.model.headers._
 import akka.http.util._
 
 class HttpClientSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF") with Inside {
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "The client implementation" should {
 

--- a/akka-http-core/src/test/scala/akka/http/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/parsing/RequestParserSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.Matcher
 import akka.stream.scaladsl._
 import akka.stream.scaladsl.OperationAttributes._
 import akka.stream.FlattenStrategy
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.util._
@@ -37,7 +37,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   import system.dispatcher
 
   val BOLT = HttpMethod.custom("BOLT", safe = false, idempotent = true, entityAccepted = true)
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "The request parsing logic should" - {
     "properly parse a request" - {

--- a/akka-http-core/src/test/scala/akka/http/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/parsing/ResponseParserSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.Matcher
 import akka.stream.scaladsl._
 import akka.stream.scaladsl.OperationAttributes._
 import akka.stream.FlattenStrategy
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.util._
@@ -34,7 +34,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
   val ServerOnTheMove = StatusCodes.custom(331, "Server on the move")
 
   "The response parsing logic should" - {

--- a/akka-http-core/src/test/scala/akka/http/engine/rendering/RequestRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/rendering/RequestRendererSpec.scala
@@ -17,7 +17,7 @@ import akka.http.model.headers._
 import akka.http.util._
 import akka.stream.scaladsl._
 import akka.stream.scaladsl.OperationAttributes._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.impl.SynchronousIterablePublisher
 import HttpEntity._
 import HttpMethods._
@@ -29,7 +29,7 @@ class RequestRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll 
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "The request preparation logic should" - {
     "properly render an unchunked" - {

--- a/akka-http-core/src/test/scala/akka/http/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/rendering/ResponseRendererSpec.scala
@@ -17,7 +17,7 @@ import akka.http.util._
 import akka.util.ByteString
 import akka.stream.scaladsl._
 import akka.stream.scaladsl.OperationAttributes._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import HttpEntity._
 
 class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
@@ -28,7 +28,7 @@ class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll
   import system.dispatcher
 
   val ServerOnTheMove = StatusCodes.custom(330, "Server on the move")
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "The response preparation logic should properly render" - {
     "a response with no body," - {

--- a/akka-http-core/src/test/scala/akka/http/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/server/HttpServerSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Inside
 import akka.event.NoLogging
 import akka.util.ByteString
 import akka.stream.scaladsl._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.http.model._
 import akka.http.util._
@@ -21,7 +21,7 @@ import MediaTypes._
 import HttpMethods._
 
 class HttpServerSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF") with Inside {
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "The server implementation" should {
 

--- a/akka-http-core/src/test/scala/akka/http/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/model/HttpEntitySpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.matchers.Matcher
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.stream.scaladsl._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.http.model.HttpEntity._
 import akka.http.util.StreamUtils
 
@@ -32,7 +32,7 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
   override def afterAll() = system.shutdown()
 
   "HttpEntity" - {

--- a/akka-http-core/src/test/scala/akka/http/model/MultipartSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/model/MultipartSpec.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.scalatest.{ BeforeAndAfterAll, Inside, Matchers, WordSpec }
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import akka.actor.ActorSystem
@@ -21,7 +21,7 @@ class MultipartSpec extends WordSpec with Matchers with Inside with BeforeAndAft
   akka.loglevel = WARNING""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
   override def afterAll() = system.shutdown()
 
   "Multipart.General" should {

--- a/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -14,7 +14,7 @@ import akka.http.model.parser.HeaderParser
 import akka.http.model._
 import akka.stream.scaladsl._
 import headers._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 /**
  * Integration test for external HTTP libraries that are built on top of
@@ -43,7 +43,7 @@ class HttpModelIntegrationSpec extends WordSpec with Matchers with BeforeAndAfte
 
   override def afterAll() = system.shutdown()
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "External HTTP libraries" should {
 

--- a/akka-http-java-testkit/src/main/scala/akka.http.server.japi.testkit/JUnitRouteTest.scala
+++ b/akka-http-java-testkit/src/main/scala/akka.http.server.japi.testkit/JUnitRouteTest.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
 import akka.http.model.HttpResponse
+import akka.stream.ActorFlowMaterializer
 import akka.stream.FlowMaterializer
 
 /**
@@ -46,7 +47,7 @@ abstract class JUnitRouteTest extends JUnitRouteTestBase {
 
 class ActorSystemResource extends ExternalResource {
   protected def createSystem(): ActorSystem = ActorSystem()
-  protected def createFlowMaterializer(system: ActorSystem): FlowMaterializer = FlowMaterializer()(system)
+  protected def createFlowMaterializer(system: ActorSystem): FlowMaterializer = ActorFlowMaterializer()(system)
 
   implicit def system: ActorSystem = _system
   implicit def materializer: FlowMaterializer = _materializer

--- a/akka-http-java/src/main/scala/akka/http/server/japi/HttpService.scala
+++ b/akka-http-java/src/main/scala/akka/http/server/japi/HttpService.scala
@@ -9,6 +9,7 @@ import akka.http.Http.ServerBinding
 import akka.actor.ActorSystem
 import akka.http.Http
 import akka.http.server.japi.impl.RouteImplementation
+import akka.stream.ActorFlowMaterializer
 import akka.stream.FlowMaterializer
 import akka.stream.javadsl.MaterializedMap
 
@@ -18,7 +19,7 @@ trait HttpServiceBase {
    */
   def bindRoute(interface: String, port: Int, route: Route, system: ActorSystem): MaterializedMap = {
     implicit val sys = system
-    implicit val mat = FlowMaterializer()
+    implicit val mat = ActorFlowMaterializer()
     handleConnectionsWithRoute(Http(system).bind(interface, port), route, system, mat)
   }
 

--- a/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/testkit/RouteTest.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 import scala.util.DynamicVariable
 import scala.reflect.ClassTag
 import akka.actor.ActorSystem
+import akka.stream.ActorFlowMaterializer
 import akka.stream.FlowMaterializer
 import akka.http.client.RequestBuilding
 import akka.http.util.FastFuture
@@ -41,7 +42,7 @@ trait RouteTest extends RequestBuilding with RouteTestResultComponent with Marsh
   }
   implicit val system = createActorSystem()
   implicit def executor = system.dispatcher
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   def cleanUp(): Unit = system.shutdown()
 

--- a/akka-http-tests/src/test/scala/akka/http/FormDataSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/FormDataSpec.scala
@@ -8,14 +8,14 @@ import scala.concurrent.duration._
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 import org.scalatest.concurrent.ScalaFutures
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.http.unmarshalling.Unmarshal
 import akka.http.marshalling.Marshal
 import akka.http.model._
 
 class FormDataSpec extends WordSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
   import system.dispatcher
 
   val formData = FormData(Map("surname" -> "Smith", "age" -> "42"))

--- a/akka-http-tests/src/test/scala/akka/http/coding/CodecSpecSupport.scala
+++ b/akka-http-tests/src/test/scala/akka/http/coding/CodecSpecSupport.scala
@@ -9,7 +9,7 @@ import org.scalatest.{ Suite, BeforeAndAfterAll, Matchers }
 import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.util.ByteString
 
 trait CodecSpecSupport extends Matchers with BeforeAndAfterAll { self: Suite ⇒
@@ -70,7 +70,7 @@ voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita ka
 est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy e""".replace("\r\n", "\n")
 
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   override def afterAll() = {
     system.shutdown()

--- a/akka-http-tests/src/test/scala/akka/http/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/marshalling/MarshallingSpec.scala
@@ -10,7 +10,7 @@ import akka.http.marshallers.xml.ScalaXmlSupport._
 import scala.collection.immutable.ListMap
 import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Source
 import akka.http.util._
 import akka.http.model._
@@ -20,7 +20,7 @@ import MediaTypes._
 
 class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with MultipartMarshallers with MarshallingTestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
   import system.dispatcher
 
   "The PredefinedToEntityMarshallers." - {

--- a/akka-http-tests/src/test/scala/akka/http/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/server/TestServer.scala
@@ -8,7 +8,7 @@ import akka.http.marshallers.xml.ScalaXmlSupport
 import akka.http.server.directives.AuthenticationDirectives._
 import com.typesafe.config.{ ConfigFactory, Config }
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.http.Http
 
 object TestServer extends App {
@@ -17,7 +17,7 @@ object TestServer extends App {
     akka.log-dead-letters = off""")
   implicit val system = ActorSystem("ServerTest", testConf)
   import system.dispatcher
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   import ScalaXmlSupport._
   import Directives._

--- a/akka-http-tests/src/test/scala/akka/http/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/unmarshalling/UnmarshallingSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ Future, Await }
 import org.scalatest.matchers.Matcher
 import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl._
 import akka.http.model._
 import akka.http.util._
@@ -22,7 +22,7 @@ import FastFuture._
 
 class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
   import system.dispatcher
 
   "The PredefinedFromEntityUnmarshallers." - {

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
@@ -7,7 +7,7 @@ import akka.event.Logging
 
 import scala.collection.{ mutable, immutable }
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.AkkaSpec
@@ -40,7 +40,7 @@ abstract class AkkaIdentityProcessorVerification[T](val system: ActorSystem, env
   override def createErrorStatePublisher(): Publisher[T] =
     StreamTestKit.errorPublisher(new Exception("Unable to serve subscribers right now!"))
 
-  def createSimpleIntPublisher(elements: Long)(implicit mat: FlowMaterializer): Publisher[Int] = {
+  def createSimpleIntPublisher(elements: Long)(implicit mat: ActorFlowMaterializer): Publisher[Int] = {
     val iterable: immutable.Iterable[Int] =
       if (elements == Long.MaxValue) 1 to Int.MaxValue
       else 0 until elements.toInt

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
@@ -8,8 +8,8 @@ import akka.event.Logging
 import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
-import akka.stream.MaterializerSettings
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 import org.reactivestreams.Publisher
@@ -33,7 +33,7 @@ abstract class AkkaPublisherVerification[T](val system: ActorSystem, env: TestEn
     this(false)
   }
 
-  implicit val materializer = FlowMaterializer(MaterializerSettings(system).copy(maxInputBufferSize = 512))(system)
+  implicit val materializer = ActorFlowMaterializer(ActorFlowMaterializerSettings(system).copy(maxInputBufferSize = 512))(system)
 
   @AfterClass
   def shutdownActorSystem(): Unit = {

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaSubscriberVerification.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/AkkaSubscriberVerification.scala
@@ -8,8 +8,8 @@ import akka.event.Logging
 import scala.collection.immutable
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
-import akka.stream.MaterializerSettings
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.AkkaSpec
@@ -57,7 +57,7 @@ abstract class AkkaSubscriberWhiteboxVerification[T](val system: ActorSystem, en
 trait AkkaSubscriberVerificationLike {
   implicit def system: ActorSystem
 
-  implicit val materializer = FlowMaterializer(MaterializerSettings(system))
+  implicit val materializer = ActorFlowMaterializer(ActorFlowMaterializerSettings(system))
 
   def createSimpleIntPublisher(elements: Long): Publisher[Int] = {
     val iterable: immutable.Iterable[Int] =

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/FusableProcessorTest.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/FusableProcessorTest.scala
@@ -4,10 +4,10 @@
 package akka.stream.tck
 
 import java.util.concurrent.atomic.AtomicInteger
-import akka.stream.impl.{ Ast, ActorBasedFlowMaterializer }
+import akka.stream.impl.{ Ast, ActorFlowMaterializerImpl }
 import akka.stream.scaladsl.MaterializedMap
 import akka.stream.scaladsl.OperationAttributes._
-import akka.stream.{ FlowMaterializer, MaterializerSettings }
+import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings }
 import org.reactivestreams.{ Publisher, Processor }
 import akka.stream.impl.fusing.Map
 
@@ -18,21 +18,21 @@ class FusableProcessorTest extends AkkaIdentityProcessorVerification[Int] {
   val processorCounter = new AtomicInteger
 
   override def createIdentityProcessor(maxBufferSize: Int): Processor[Int, Int] = {
-    val settings = MaterializerSettings(system)
+    val settings = ActorFlowMaterializerSettings(system)
       .withInputBuffer(initialSize = maxBufferSize / 2, maxSize = maxBufferSize)
 
-    implicit val materializer = FlowMaterializer(settings)(system)
+    implicit val materializer = ActorFlowMaterializer(settings)(system)
 
     val flowName = getClass.getSimpleName + "-" + processorCounter.incrementAndGet()
 
-    val (processor, _ns) = materializer.asInstanceOf[ActorBasedFlowMaterializer].processorForNode(
+    val (processor, _ns) = materializer.asInstanceOf[ActorFlowMaterializerImpl].processorForNode(
       Ast.Fused(List(Map[Int, Int](identity)), name("identity")), flowName, 1)
 
     processor.asInstanceOf[Processor[Int, Int]]
   }
 
   override def createHelperPublisher(elements: Long): Publisher[Int] = {
-    implicit val mat = FlowMaterializer()(system)
+    implicit val mat = ActorFlowMaterializer()(system)
 
     createSimpleIntPublisher(elements)(mat)
   }

--- a/akka-stream-testkit/src/test/resources/reference.conf
+++ b/akka-stream-testkit/src/test/resources/reference.conf
@@ -1,11 +1,11 @@
-# The StreamTestDefaultMailbox verifies that stream actors are using the dispatcher defined in MaterializerSettings.
+# The StreamTestDefaultMailbox verifies that stream actors are using the dispatcher defined in ActorFlowMaterializerSettings.
 #
 # All stream tests should use the dedicated `akka.test.stream-dispatcher` or disable this validation by defining:
 # akka.actor.default-mailbox.mailbox-type = "akka.dispatch.UnboundedMailbox"
 akka.actor.default-mailbox.mailbox-type = "akka.stream.testkit.StreamTestDefaultMailbox"
 
 # Dispatcher for stream actors. Specified in tests with
-# MaterializerSettings(dispatcher = "akka.test.stream-dispatcher")
+# ActorFlowMaterializerSettings(dispatcher = "akka.test.stream-dispatcher")
 akka.test.stream-dispatcher {
   type = Dispatcher
   executor = "fork-join-executor"

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/ChainSetup.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/ChainSetup.scala
@@ -1,21 +1,21 @@
 package akka.stream.testkit
 
 import akka.actor.{ ActorRefFactory, ActorSystem }
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl._
 import org.reactivestreams.Publisher
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 class ChainSetup[In, Out](
   stream: Flow[In, In] ⇒ Flow[In, Out],
-  val settings: MaterializerSettings,
-  materializer: FlowMaterializer,
-  toPublisher: (Source[Out], FlowMaterializer) ⇒ Publisher[Out])(implicit val system: ActorSystem) {
+  val settings: ActorFlowMaterializerSettings,
+  materializer: ActorFlowMaterializer,
+  toPublisher: (Source[Out], ActorFlowMaterializer) ⇒ Publisher[Out])(implicit val system: ActorSystem) {
 
-  def this(stream: Flow[In, In] ⇒ Flow[In, Out], settings: MaterializerSettings, toPublisher: (Source[Out], FlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
-    this(stream, settings, FlowMaterializer(settings)(system), toPublisher)(system)
+  def this(stream: Flow[In, In] ⇒ Flow[In, Out], settings: ActorFlowMaterializerSettings, toPublisher: (Source[Out], ActorFlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
+    this(stream, settings, ActorFlowMaterializer(settings)(system), toPublisher)(system)
 
-  def this(stream: Flow[In, In] ⇒ Flow[In, Out], settings: MaterializerSettings, materializerCreator: (MaterializerSettings, ActorRefFactory) ⇒ FlowMaterializer, toPublisher: (Source[Out], FlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
+  def this(stream: Flow[In, In] ⇒ Flow[In, Out], settings: ActorFlowMaterializerSettings, materializerCreator: (ActorFlowMaterializerSettings, ActorRefFactory) ⇒ ActorFlowMaterializer, toPublisher: (Source[Out], ActorFlowMaterializer) ⇒ Publisher[Out])(implicit system: ActorSystem) =
     this(stream, settings, materializerCreator(settings, system), toPublisher)(system)
 
   val upstream = StreamTestKit.PublisherProbe[In]()

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/ScriptedTest.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/ScriptedTest.scala
@@ -4,7 +4,7 @@
 package akka.stream.testkit
 
 import akka.actor.ActorSystem
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl.{ Sink, Source, Flow }
 import akka.stream.testkit.StreamTestKit._
 import org.reactivestreams.Publisher
@@ -12,13 +12,13 @@ import org.scalatest.Matchers
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.concurrent.forkjoin.ThreadLocalRandom
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 trait ScriptedTest extends Matchers {
 
   class ScriptException(msg: String) extends RuntimeException(msg)
 
-  def toPublisher[In, Out]: (Source[Out], FlowMaterializer) ⇒ Publisher[Out] =
+  def toPublisher[In, Out]: (Source[Out], ActorFlowMaterializer) ⇒ Publisher[Out] =
     (f, m) ⇒ f.runWith(Sink.publisher)(m)
 
   object Script {
@@ -82,7 +82,7 @@ trait ScriptedTest extends Matchers {
 
   class ScriptRunner[In, Out](
     op: Flow[In, In] ⇒ Flow[In, Out],
-    settings: MaterializerSettings,
+    settings: ActorFlowMaterializerSettings,
     script: Script[In, Out],
     maximumOverrun: Int,
     maximumRequest: Int,
@@ -190,7 +190,7 @@ trait ScriptedTest extends Matchers {
 
   }
 
-  def runScript[In, Out](script: Script[In, Out], settings: MaterializerSettings, maximumOverrun: Int = 3, maximumRequest: Int = 3, maximumBuffer: Int = 3)(
+  def runScript[In, Out](script: Script[In, Out], settings: ActorFlowMaterializerSettings, maximumOverrun: Int = 3, maximumRequest: Int = 3, maximumBuffer: Int = 3)(
     op: Flow[In, In] ⇒ Flow[In, Out])(implicit system: ActorSystem): Unit = {
     new ScriptRunner(op, settings, script, maximumOverrun, maximumRequest, maximumBuffer).run()
   }

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestDefaultMailbox.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestDefaultMailbox.scala
@@ -14,7 +14,7 @@ import akka.actor.Actor
 /**
  * INTERNAL API
  * This mailbox is only used in tests to verify that stream actors are using
- * the dispatcher defined in MaterializerSettings.
+ * the dispatcher defined in ActorFlowMaterializerSettings.
  */
 private[akka] final case class StreamTestDefaultMailbox() extends MailboxType with ProducesMessageQueue[UnboundedMailbox.MessageQueue] {
 
@@ -31,7 +31,7 @@ private[akka] final case class StreamTestDefaultMailbox() extends MailboxType wi
             s"$r with actor class [${actorClass.getName}] must not run on default dispatcher in tests. " +
               "Did you forget to define `props.withDispatcher` when creating the actor? " +
               "Or did you forget to configure the `akka.stream.materializer` setting accordingly or force the " +
-              """dispatcher using `MaterializerSettings(sys).withDispatcher("akka.test.stream-dispatcher")` in the test?""")
+              """dispatcher using `ActorFlowMaterializerSettings(sys).withDispatcher("akka.test.stream-dispatcher")` in the test?""")
         } catch {
           // this logging should not be needed when issue #15947 has been fixed
           case e: AssertionError ⇒

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/TwoStreamsSetup.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/TwoStreamsSetup.scala
@@ -1,18 +1,18 @@
 package akka.stream.testkit
 
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl._
 import org.reactivestreams.Publisher
 import scala.collection.immutable
 import scala.util.control.NoStackTrace
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 abstract class TwoStreamsSetup extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   val TestException = new RuntimeException("test") with NoStackTrace
 

--- a/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
@@ -9,11 +9,11 @@ import akka.stream.javadsl.AkkaJUnitActorSystemResource;
 
 public abstract class StreamTest {
     final protected ActorSystem system;
-    final protected FlowMaterializer materializer;
+    final protected ActorFlowMaterializer materializer;
 
     protected StreamTest(AkkaJUnitActorSystemResource actorSystemResource) {
         system = actorSystemResource.getSystem();
-        MaterializerSettings settings = MaterializerSettings.create(system);
-        materializer = FlowMaterializer.create(settings, system);
+        ActorFlowMaterializerSettings settings = ActorFlowMaterializerSettings.create(system);
+        materializer = ActorFlowMaterializer.create(settings, system);
     }
 }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiMergeTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiMergeTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.concurrent.TimeUnit;
 import org.reactivestreams.Publisher;
 import akka.actor.ActorSystem;
-import akka.stream.FlowMaterializer;
+import akka.stream.ActorFlowMaterializer;
 import akka.stream.testkit.AkkaSpec;
 import akka.stream.javadsl.FlexiMerge;
 import scala.concurrent.Await;
@@ -30,7 +30,7 @@ public class FlexiMergeTest {
 
   final ActorSystem system = actorSystemResource.getSystem();
 
-  final FlowMaterializer materializer = FlowMaterializer.create(system);
+  final ActorFlowMaterializer materializer = ActorFlowMaterializer.create(system);
 
   final Source<String> in1 = Source.from(Arrays.asList("a", "b", "c", "d"));
   final Source<String> in2 = Source.from(Arrays.asList("e", "f"));

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiRouteTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlexiRouteTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.concurrent.TimeUnit;
 
 import akka.actor.ActorSystem;
-import akka.stream.FlowMaterializer;
+import akka.stream.ActorFlowMaterializer;
 import akka.stream.testkit.AkkaSpec;
 import akka.stream.javadsl.FlexiRoute;
 import akka.japi.Pair;
@@ -29,7 +29,7 @@ public class FlexiRouteTest {
 
   final ActorSystem system = actorSystemResource.getSystem();
 
-  final FlowMaterializer materializer = FlowMaterializer.create(system);
+  final ActorFlowMaterializer materializer = ActorFlowMaterializer.create(system);
 
   final Source<String> in = Source.from(Arrays.asList("a", "b", "c", "d", "e"));
 

--- a/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
@@ -50,7 +50,7 @@ class DslConsistencySpec extends WordSpec with Matchers {
     jFlowGraphClass → Set("graph", "cyclesAllowed"),
     jPartialFlowGraphClass → Set("graph", "cyclesAllowed", "disconnectedAllowed"))
 
-  def materializing(m: Method): Boolean = m.getParameterTypes.contains(classOf[FlowMaterializer])
+  def materializing(m: Method): Boolean = m.getParameterTypes.contains(classOf[ActorFlowMaterializer])
 
   def assertHasMethod(c: Class[_], name: String): Unit = {
     // include class name to get better error message

--- a/akka-stream-tests/src/test/scala/akka/stream/actor/ActorPublisherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/actor/ActorPublisherSpec.scala
@@ -11,7 +11,7 @@ import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.FlowGraph
 import akka.stream.scaladsl.FlowGraphImplicits
 import akka.stream.scaladsl.Merge
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.AkkaSpec
@@ -256,7 +256,7 @@ class ActorPublisherSpec extends AkkaSpec with ImplicitSender {
     }
 
     "work together with Flow and ActorSubscriber" in {
-      implicit val materializer = FlowMaterializer()
+      implicit val materializer = ActorFlowMaterializer()
       val probe = TestProbe()
 
       val source = Source[Int](senderProps)
@@ -285,7 +285,7 @@ class ActorPublisherSpec extends AkkaSpec with ImplicitSender {
     }
 
     "work in a FlowGraph" in {
-      implicit val materializer = FlowMaterializer()
+      implicit val materializer = ActorFlowMaterializer()
       val probe1 = TestProbe()
       val probe2 = TestProbe()
 
@@ -325,7 +325,7 @@ class ActorPublisherSpec extends AkkaSpec with ImplicitSender {
     }
 
     "be able to define a subscription-timeout, after which it should shut down" in {
-      implicit val materializer = FlowMaterializer()
+      implicit val materializer = ActorFlowMaterializer()
       val timeout = 150.millis
       val a = system.actorOf(timeoutingProps(testActor, timeout))
       val pub = ActorPublisher(a)
@@ -345,7 +345,7 @@ class ActorPublisherSpec extends AkkaSpec with ImplicitSender {
     }
 
     "be able to define a subscription-timeout, which is cancelled by the first incoming Subscriber" in {
-      implicit val materializer = FlowMaterializer()
+      implicit val materializer = ActorFlowMaterializer()
       val timeout = 500.millis
       val sub = StreamTestKit.SubscriberProbe[Int]()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala
@@ -5,7 +5,7 @@ package akka.stream.actor
 
 import akka.actor.{ Actor, ActorRef, Props }
 import akka.routing.{ ActorRefRoutee, RoundRobinRoutingLogic, Router }
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.AkkaSpec
@@ -95,7 +95,7 @@ class ActorSubscriberSpec extends AkkaSpec with ImplicitSender {
   import ActorSubscriberMessage._
   import ActorSubscriberSpec._
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "An ActorSubscriber" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/extra/FlowTimedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/extra/FlowTimedSpec.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.extra
 
-import akka.stream.{ MaterializerSettings, FlowMaterializer }
+import akka.stream.{ ActorFlowMaterializerSettings, ActorFlowMaterializer }
 import akka.stream.scaladsl.{ Source, Flow }
 import akka.stream.scaladsl.Sink
 import akka.stream.testkit.{ AkkaSpec, ScriptedTest, StreamTestKit }
@@ -14,10 +14,10 @@ class FlowTimedSpec extends AkkaSpec with ScriptedTest {
 
   import scala.concurrent.duration._
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "Timed Source" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpHelper.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpHelper.scala
@@ -6,7 +6,7 @@ package akka.stream.io
 import akka.actor.{ Actor, ActorRef, Props }
 import akka.io.{ IO, Tcp }
 import akka.stream.testkit.StreamTestKit
-import akka.stream.{ FlowMaterializer, MaterializerSettings }
+import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings }
 import akka.testkit.{ TestKitBase, TestProbe }
 import akka.util.ByteString
 import java.net.InetSocketAddress
@@ -102,10 +102,10 @@ object TcpHelper {
 trait TcpHelper { this: TestKitBase ⇒
   import akka.stream.io.TcpHelper._
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 4, maxSize = 4)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   class Server(val address: InetSocketAddress = temporaryServerAddress()) {
     val serverProbe = TestProbe()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowAppendSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowAppendSpec.scala
@@ -4,16 +4,16 @@
 package akka.stream.scaladsl
 
 import akka.actor.ActorSystem
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import org.reactivestreams.Subscriber
 import org.scalatest.Matchers
 
 class FlowAppendSpec extends AkkaSpec with River {
 
-  val settings = MaterializerSettings(system)
-  implicit val materializer = FlowMaterializer(settings)
+  val settings = ActorFlowMaterializerSettings(system)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "Flow" should {
     "append Flow" in riverOf[String] { subscriber ⇒

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowBufferSpec.scala
@@ -7,18 +7,18 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.OverflowStrategy
 import akka.stream.OverflowStrategy.Error.BufferOverflowException
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 
 class FlowBufferSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 1, maxSize = 1)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "Buffer" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectSpec.scala
@@ -7,13 +7,13 @@ import java.io.{ File, FileInputStream }
 
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.ScriptedTest
 
 class FlowCollectSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
 
   "A Collect" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCompileSpec.scala
@@ -6,8 +6,8 @@ package akka.stream.scaladsl
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 
 class FlowCompileSpec extends AkkaSpec {
@@ -17,7 +17,7 @@ class FlowCompileSpec extends AkkaSpec {
 
   import scala.concurrent.ExecutionContext.Implicits.global
   val intFut = Source(Future { 3 })
-  implicit val materializer = FlowMaterializer(MaterializerSettings(system))
+  implicit val materializer = ActorFlowMaterializer(ActorFlowMaterializerSettings(system))
 
   "Flow" should {
     "should not run" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatAllSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatAllSpec.scala
@@ -6,16 +6,16 @@ package akka.stream.scaladsl
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 import akka.stream.FlattenStrategy
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ StreamTestKit, AkkaSpec }
 
 class FlowConcatAllSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "ConcatAll" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConflateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConflateSpec.scala
@@ -6,15 +6,15 @@ package akka.stream.scaladsl
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.forkjoin.ThreadLocalRandom
-import akka.stream.{ OverflowStrategy, FlowMaterializer, MaterializerSettings }
+import akka.stream.{ OverflowStrategy, ActorFlowMaterializer, ActorFlowMaterializerSettings }
 import akka.stream.testkit.{ StreamTestKit, AkkaSpec }
 
 class FlowConflateSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "Conflate" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDispatcherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDispatcherSpec.scala
@@ -5,16 +5,16 @@ package akka.stream.scaladsl
 
 import akka.testkit.TestProbe
 import akka.stream.testkit.AkkaSpec
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 
 class FlowDispatcherSpec extends AkkaSpec("my-dispatcher = ${akka.test.stream-dispatcher}") {
 
-  val defaultSettings = MaterializerSettings(system)
+  val defaultSettings = ActorFlowMaterializerSettings(system)
 
-  def testDispatcher(settings: MaterializerSettings = defaultSettings, dispatcher: String = "akka.test.stream-dispatcher") = {
+  def testDispatcher(settings: ActorFlowMaterializerSettings = defaultSettings, dispatcher: String = "akka.test.stream-dispatcher") = {
 
-    implicit val materializer = FlowMaterializer(settings)
+    implicit val materializer = ActorFlowMaterializer(settings)
 
     val probe = TestProbe()
     val p = Source(List(1, 2, 3)).map(i ⇒

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropSpec.scala
@@ -5,18 +5,18 @@ package akka.stream.scaladsl
 
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.ScriptedTest
 import akka.stream.testkit.StreamTestKit
 
 class FlowDropSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Drop" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropWithinSpec.scala
@@ -5,13 +5,13 @@ package akka.stream.scaladsl
 
 import scala.concurrent.duration._
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 
 class FlowDropWithinSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A DropWithin" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExpandSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExpandSpec.scala
@@ -7,17 +7,17 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.forkjoin.ThreadLocalRandom
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 
 import akka.stream.testkit.{ StreamTestKit, AkkaSpec }
 
 class FlowExpandSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "Expand" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFilterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFilterSpec.scala
@@ -5,14 +5,14 @@ package akka.stream.scaladsl
 
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.stream.testkit.ScriptedTest
 
 class FlowFilterSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
   "A Filter" must {
@@ -23,9 +23,9 @@ class FlowFilterSpec extends AkkaSpec with ScriptedTest {
     }
 
     "not blow up with high request counts" in {
-      val settings = MaterializerSettings(system)
+      val settings = ActorFlowMaterializerSettings(system)
         .withInputBuffer(initialSize = 1, maxSize = 1)
-      implicit val materializer = FlowMaterializer(settings)
+      implicit val materializer = ActorFlowMaterializer(settings)
 
       val probe = StreamTestKit.SubscriberProbe[Int]()
       Source(List.fill(1000)(0) ::: List(1)).filter(_ != 0).runWith(Sink(probe))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldSpec.scala
@@ -6,12 +6,12 @@ package akka.stream.scaladsl
 import scala.concurrent.Await
 import scala.util.control.NoStackTrace
 
-import akka.stream.{ OverflowStrategy, FlowMaterializer }
+import akka.stream.{ OverflowStrategy, ActorFlowMaterializer }
 import akka.stream.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout
 
 class FlowFoldSpec extends AkkaSpec with DefaultTimeout {
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "A Fold" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowForeachSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowForeachSpec.scala
@@ -5,12 +5,12 @@ package akka.stream.scaladsl
 
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 
 class FlowForeachSpec extends AkkaSpec {
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
   import system.dispatcher
 
   "A Foreach" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFromFutureSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFromFutureSpec.scala
@@ -7,16 +7,16 @@ import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 
 class FlowFromFutureSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Flow based on a Future" must {
     "produce one element from already successful Future" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphCompileSpec.scala
@@ -4,7 +4,7 @@
 package akka.stream.scaladsl
 
 import akka.stream.scaladsl.OperationAttributes._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.OverflowStrategy
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit.{ PublisherProbe, SubscriberProbe }
@@ -18,7 +18,7 @@ object FlowGraphCompileSpec {
 class FlowGraphCompileSpec extends AkkaSpec {
   import FlowGraphCompileSpec._
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   def op[In, Out]: () ⇒ PushStage[In, Out] = { () ⇒
     new PushStage[In, Out] {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphInitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGraphInitSpec.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 
 import scala.concurrent.Await
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 class FlowGraphInitSpec extends AkkaSpec {
 
   import system.dispatcher
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "Initialization of FlowGraph" should {
     "be thread safe" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
@@ -6,17 +6,17 @@ package akka.stream.scaladsl
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit._
 import org.reactivestreams.Publisher
 
 class FlowGroupBySpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   case class StreamPuppet(p: Publisher[Int]) {
     val probe = StreamTestKit.SubscriberProbe[Int]()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupedSpec.scala
@@ -6,13 +6,13 @@ package akka.stream.scaladsl
 import scala.collection.immutable
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.ScriptedTest
 
 class FlowGroupedSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
   "A Grouped" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupedWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupedWithinSpec.scala
@@ -7,17 +7,17 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.ScriptedTest
 import akka.stream.testkit.StreamTestKit
 
 class FlowGroupedWithinSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A GroupedWithin" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIteratorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIteratorSpec.scala
@@ -6,8 +6,8 @@ package akka.stream.scaladsl
 import scala.collection.immutable
 import scala.concurrent.duration._
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 import akka.stream.testkit.StreamTestKit.OnComplete
@@ -28,10 +28,10 @@ class FlowIterableSpec extends AbstractFlowIteratorSpec {
 
 abstract class AbstractFlowIteratorSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   def testName: String
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.{ FlowMaterializer, MaterializerSettings }
+import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings }
 import akka.stream.testkit.{ StreamTestKit, AkkaSpec }
 import com.typesafe.config.ConfigFactory
 import scala.concurrent.Await
@@ -11,10 +11,10 @@ import scala.concurrent.duration._
 
 class FlowJoinSpec extends AkkaSpec(ConfigFactory.parseString("akka.loglevel=INFO")) {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val mat = FlowMaterializer(settings)
+  implicit val mat = ActorFlowMaterializer(settings)
 
   "A Flow using join" must {
     "allow for cycles" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import scala.concurrent.forkjoin.ThreadLocalRandom
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 import akka.testkit.TestLatch
@@ -17,7 +17,7 @@ import akka.testkit.TestProbe
 
 class FlowMapAsyncSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A Flow with mapAsync" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 import akka.testkit.TestLatch
@@ -16,7 +16,7 @@ import akka.testkit.TestProbe
 
 class FlowMapAsyncUnorderedSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A Flow with mapAsyncUnordered" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapConcatSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapConcatSpec.scala
@@ -4,15 +4,15 @@
 package akka.stream.scaladsl
 
 import scala.concurrent.duration._
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.ScriptedTest
 import akka.stream.testkit.StreamTestKit.SubscriberProbe
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 class FlowMapConcatSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
   "A MapConcat" must {
@@ -29,9 +29,9 @@ class FlowMapConcatSpec extends AkkaSpec with ScriptedTest {
     }
 
     "map and concat grouping with slow downstream" in {
-      val settings = MaterializerSettings(system)
+      val settings = ActorFlowMaterializerSettings(system)
         .withInputBuffer(initialSize = 2, maxSize = 2)
-      implicit val materializer = FlowMaterializer(settings)
+      implicit val materializer = ActorFlowMaterializer(settings)
       val s = SubscriberProbe[Int]
       val input = (1 to 20).grouped(5).toList
       Source(input).mapConcat(identity).map(x ⇒ { Thread.sleep(10); x }).runWith(Sink(s))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapSpec.scala
@@ -5,17 +5,17 @@ package akka.stream.scaladsl
 
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.stream.testkit.ScriptedTest
 
 class FlowMapSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Map" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOnCompleteSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOnCompleteSpec.scala
@@ -7,8 +7,8 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.ScriptedTest
@@ -16,10 +16,10 @@ import akka.testkit.TestProbe
 
 class FlowOnCompleteSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Flow with onComplete" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
@@ -8,17 +8,17 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.stream.testkit.StreamTestKit.SubscriberProbe
 
 class FlowPrefixAndTailSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "PrefixAndTail" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanSpec.scala
@@ -9,16 +9,16 @@ import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
 import scala.collection.immutable
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 
 class FlowScanSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Scan" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSectionSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSectionSpec.scala
@@ -4,7 +4,7 @@
 package akka.stream.scaladsl
 
 import akka.stream.scaladsl.OperationAttributes._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
@@ -15,7 +15,7 @@ object FlowSectionSpec {
 
 class FlowSectionSpec extends AkkaSpec(FlowSectionSpec.config) {
 
-  implicit val mat = FlowMaterializer()
+  implicit val mat = ActorFlowMaterializer()
 
   "A flow" can {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitWhenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitWhenSpec.scala
@@ -5,18 +5,18 @@ package akka.stream.scaladsl
 
 import scala.concurrent.duration._
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 import org.reactivestreams.Publisher
 
 class FlowSplitWhenSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   case class StreamPuppet(p: Publisher[Int]) {
     val probe = StreamTestKit.SubscriberProbe[Int]()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowStageSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowStageSpec.scala
@@ -6,8 +6,8 @@ package akka.stream.scaladsl
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.testkit.{ EventFilter, TestProbe }
 import com.typesafe.config.ConfigFactory
@@ -15,10 +15,10 @@ import akka.stream.stage._
 
 class FlowStageSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug.receive=off\nakka.loglevel=INFO")) {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Flow with transform operations" must {
     "produce one-to-one transformation as expected" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeSpec.scala
@@ -5,8 +5,8 @@ package akka.stream.scaladsl
 
 import scala.concurrent.forkjoin.ThreadLocalRandom.{ current ⇒ random }
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.actor.ActorSubscriberMessage.OnComplete
 import akka.stream.actor.ActorSubscriberMessage.OnNext
 import akka.stream.impl.RequestMore
@@ -16,10 +16,10 @@ import akka.stream.testkit.StreamTestKit
 
 class FlowTakeSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   muteDeadLetters(classOf[OnNext], OnComplete.getClass, classOf[RequestMore])()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeWithinSpec.scala
@@ -5,13 +5,13 @@ package akka.stream.scaladsl
 
 import scala.concurrent.duration._
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 
 class FlowTakeWithinSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A TakeWithin" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTimerTransformerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTimerTransformerSpec.scala
@@ -6,14 +6,14 @@ package akka.stream.scaladsl
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.TimerTransformer
 
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 
 class FlowTimerTransformerSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A Flow with TimerTransformer operations" must {
     "produce scheduled ticks as expected" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureSinkSpec.scala
@@ -8,17 +8,17 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 import akka.stream.testkit.ScriptedTest
 
 class HeadSinkSpec extends AkkaSpec with ScriptedTest {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Flow with Sink.head" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
@@ -4,17 +4,17 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import FlowGraphImplicits._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
 
 class GraphBalanceSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A balance" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
@@ -4,16 +4,16 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import FlowGraphImplicits._
-import akka.stream.{ OverflowStrategy, MaterializerSettings }
-import akka.stream.FlowMaterializer
+import akka.stream.{ OverflowStrategy, ActorFlowMaterializerSettings }
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.{ StreamTestKit, AkkaSpec }
 
 class GraphBroadcastSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A broadcast" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiMergeSpec.scala
@@ -1,7 +1,7 @@
 package akka.stream.scaladsl
 
 import FlowGraphImplicits._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit.AutoPublisher
 import akka.stream.testkit.StreamTestKit.OnNext
@@ -271,7 +271,7 @@ class TestMerge extends FlexiMerge[String] {
 class GraphFlexiMergeSpec extends AkkaSpec {
   import GraphFlexiMergeSpec._
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   val in1 = Source(List("a", "b", "c", "d"))
   val in2 = Source(List("e", "f"))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiRouteSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlexiRouteSpec.scala
@@ -3,7 +3,7 @@ package akka.stream.scaladsl
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 import FlowGraphImplicits._
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit.AutoPublisher
 import akka.stream.testkit.StreamTestKit.OnNext
@@ -147,7 +147,7 @@ object GraphFlexiRouteSpec {
     }
   }
 
-  class TestFixture(implicit val system: ActorSystem, implicit val materializer: FlowMaterializer) {
+  class TestFixture(implicit val system: ActorSystem, implicit val materializer: ActorFlowMaterializer) {
     val publisher = PublisherProbe[String]
     val s1 = SubscriberProbe[String]
     val s2 = SubscriberProbe[String]
@@ -172,7 +172,7 @@ object GraphFlexiRouteSpec {
 class GraphFlexiRouteSpec extends AkkaSpec {
   import GraphFlexiRouteSpec._
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   val in = Source(List("a", "b", "c", "d", "e"))
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphFlowSpec.scala
@@ -3,8 +3,8 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit.SubscriberProbe
 import akka.stream.testkit.StreamTestKit
@@ -35,10 +35,10 @@ class GraphFlowSpec extends AkkaSpec {
 
   import GraphFlowSpec._
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   def validateProbe(probe: SubscriberProbe[Int], requests: Int, result: Set[Int]): Unit = {
     val subscription = probe.expectSubscription()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphJunctionAttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphJunctionAttributesSpec.scala
@@ -4,8 +4,8 @@
 package akka.stream.scaladsl
 
 import akka.stream.scaladsl.OperationAttributes._
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 import scala.concurrent.duration._
@@ -13,8 +13,8 @@ import scala.concurrent.Await
 
 class GraphJunctionAttributesSpec extends AkkaSpec {
 
-  implicit val set = MaterializerSettings(system).withInputBuffer(4, 4)
-  implicit val mat = FlowMaterializer(set)
+  implicit val set = ActorFlowMaterializerSettings(system).withInputBuffer(4, 4)
+  implicit val mat = ActorFlowMaterializer(set)
 
   "A zip" should {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala
@@ -3,8 +3,8 @@ package akka.stream.scaladsl
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl.FlowGraphImplicits._
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit.{ OnNext, SubscriberProbe }
@@ -43,7 +43,7 @@ object GraphOpsIntegrationSpec {
       new Lego(this.in, that.out, newGraph)
     }
 
-    def run(source: Source[String], sink: Sink[ByteString])(implicit materializer: FlowMaterializer): Unit =
+    def run(source: Source[String], sink: Sink[ByteString])(implicit materializer: ActorFlowMaterializer): Unit =
       FlowGraph(graph) { builder ⇒
         builder.attachSource(in, source)
         builder.attachSink(out, sink)
@@ -55,10 +55,10 @@ object GraphOpsIntegrationSpec {
 class GraphOpsIntegrationSpec extends AkkaSpec {
   import akka.stream.scaladsl.GraphOpsIntegrationSpec._
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "FlowGraphs" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipSpec.scala
@@ -2,17 +2,17 @@ package akka.stream.scaladsl
 
 import scala.concurrent.duration._
 
-import akka.stream.{ OverflowStrategy, MaterializerSettings }
-import akka.stream.FlowMaterializer
+import akka.stream.{ OverflowStrategy, ActorFlowMaterializerSettings }
+import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.FlowGraphImplicits._
 import akka.stream.testkit.{ StreamTestKit, AkkaSpec }
 
 class GraphUnzipSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A unzip" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ImplicitFlowMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ImplicitFlowMaterializerSpec.scala
@@ -4,7 +4,7 @@
 package akka.stream.scaladsl
 
 import akka.actor.{ Actor, Props }
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.testkit._
 import akka.pattern.pipe
@@ -12,14 +12,14 @@ import akka.pattern.pipe
 object ImplicitFlowMaterializerSpec {
   class SomeActor(input: List[String]) extends Actor with ImplicitFlowMaterializer {
 
-    override def flowMaterializerSettings = MaterializerSettings(context.system)
+    override def flowMaterializerSettings = ActorFlowMaterializerSettings(context.system)
       .withInputBuffer(initialSize = 2, maxSize = 16)
 
     val flow = Source(input).map(_.toUpperCase())
 
     def receive = {
       case "run" ⇒
-        // run takes an implicit FlowMaterializer parameter, which is provided by ImplicitFlowMaterializer
+        // run takes an implicit ActorFlowMaterializer parameter, which is provided by ImplicitFlowMaterializer
         import context.dispatcher
         flow.fold("")(_ + _) pipeTo sender()
     }
@@ -31,7 +31,7 @@ class ImplicitFlowMaterializerSpec extends AkkaSpec with ImplicitSender {
 
   "An ImplicitFlowMaterializer" must {
 
-    "provide implicit FlowMaterializer" in {
+    "provide implicit ActorFlowMaterializer" in {
       val actor = system.actorOf(Props(classOf[SomeActor], List("a", "b", "c")).withDispatcher("akka.test.stream-dispatcher"))
       actor ! "run"
       expectMsg("ABC")

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/OptimizingActorBasedFlowMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/OptimizingActorBasedFlowMaterializerSpec.scala
@@ -4,20 +4,19 @@
 package akka.stream.scaladsl
 
 import akka.stream.scaladsl.OperationAttributes._
-import akka.stream.{ FlowMaterializer, MaterializerSettings }
-import akka.stream.impl.{ Optimizations, ActorBasedFlowMaterializer }
+import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings, Optimizations }
 import akka.stream.testkit.AkkaSpec
 import akka.testkit._
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-class OptimizingActorBasedFlowMaterializerSpec extends AkkaSpec with ImplicitSender {
+class OptimizingActorFlowMaterializerSpec extends AkkaSpec with ImplicitSender {
 
-  "ActorBasedFlowMaterializer" must {
+  "ActorFlowMaterializer" must {
     //FIXME Add more and meaningful tests to verify that optimizations occur and have the same semantics as the non-optimized code
     "optimize filter + map" in {
-      implicit val mat = FlowMaterializer().asInstanceOf[ActorBasedFlowMaterializer].copy(optimizations = Optimizations.all)
+      implicit val mat = ActorFlowMaterializer(ActorFlowMaterializerSettings(system).withOptimizations(Optimizations.all))
       val f = Source(1 to 100).
         drop(4).
         drop(5).
@@ -42,7 +41,7 @@ class OptimizingActorBasedFlowMaterializerSpec extends AkkaSpec with ImplicitSen
     }
 
     "optimize map + map" in {
-      implicit val mat = FlowMaterializer().asInstanceOf[ActorBasedFlowMaterializer].copy(optimizations = Optimizations.all)
+      implicit val mat = ActorFlowMaterializer(ActorFlowMaterializerSettings(system).withOptimizations(Optimizations.all))
 
       val fl = Source(1 to 100).map(_ + 2).map(_ * 2).fold(0)(_ + _)
       val expected = (1 to 100).map(_ + 2).map(_ * 2).fold(0)(_ + _)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
@@ -3,14 +3,14 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 
 import akka.stream.testkit.AkkaSpec
 import org.scalatest.concurrent.ScalaFutures._
 
 class PublisherSinkSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A PublisherSink" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -6,13 +6,13 @@ package akka.stream.scaladsl
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 
 class SourceSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "Singleton Source" must {
     "produce element" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubscriberSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubscriberSinkSpec.scala
@@ -3,17 +3,17 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.FlowMaterializer
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
 
 class SubscriberSinkSpec extends AkkaSpec {
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "A Flow with SubscriberSink" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubstreamSubscriptionTimeoutSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubstreamSubscriptionTimeoutSpec.scala
@@ -4,7 +4,7 @@
 package akka.stream.scaladsl
 
 import akka.actor.{ ExtendedActorSystem, ActorIdentity, ActorRef, Identify }
-import akka.stream.{ FlowMaterializer, MaterializerSettings }
+import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings }
 import akka.stream.impl.SubscriptionTimeoutException
 import akka.stream.testkit._
 import akka.util.Timeout
@@ -30,11 +30,11 @@ class SubstreamSubscriptionTimeoutSpec(conf: String) extends AkkaSpec(conf) {
     this(300.millis)
   }
 
-  val settings = MaterializerSettings(system)
+  val settings = ActorFlowMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 2)
 
   implicit val dispatcher = system.dispatcher
-  implicit val materializer = FlowMaterializer(settings)
+  implicit val materializer = ActorFlowMaterializer(settings)
 
   "groupBy" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TickSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TickSourceSpec.scala
@@ -5,14 +5,14 @@ package akka.stream.scaladsl
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.testkit.AkkaSpec
 import akka.stream.testkit.StreamTestKit
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 
 class TickSourceSpec extends AkkaSpec {
 
-  implicit val materializer = FlowMaterializer()
+  implicit val materializer = ActorFlowMaterializer()
 
   "A Flow based on tick publisher" must {
     "produce ticks" in {

--- a/akka-stream/src/main/boilerplate/akka/stream/impl/ZipWith.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/impl/ZipWith.scala.template
@@ -4,7 +4,7 @@
 package akka.stream.impl
 
 import akka.actor.Props
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 
 /**
  * INTERNAL API
@@ -12,18 +12,18 @@ import akka.stream.MaterializerSettings
 private[akka] object ZipWith {
 
   /** @param f MUST be a FunctionN type. */
-  def props(settings: MaterializerSettings, f: Any): Props = f match {
+  def props(settings: ActorFlowMaterializerSettings, f: Any): Props = f match {
     [2..#case f1: Function1[[#Any#], Any] => Props(new Zip1With(settings, f1))#
     ]
   }
 
-  [2..#def props(settings: MaterializerSettings, f: Function1[[#Any#], Any]): Props =
+  [2..#def props(settings: ActorFlowMaterializerSettings, f: Function1[[#Any#], Any]): Props =
     Props(new Zip1With(settings, f))#
   ]
 }
 
 [2..#/** INTERNAL API */
-private[akka] final class Zip1With(_settings: MaterializerSettings, f: Function1[[#Any#], Any]) extends FanIn(_settings, inputPorts = 1) {
+private[akka] final class Zip1With(_settings: ActorFlowMaterializerSettings, f: Function1[[#Any#], Any]) extends FanIn(_settings, inputPorts = 1) {
   inputBunch.markAllInputs()
 
   nextPhase(TransferPhase(inputBunch.AllOfMarkedInputs && primaryOutputs.NeedsDemand) { () ⇒

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -6,7 +6,7 @@ package akka.stream.impl
 import java.util.Arrays
 
 import akka.actor._
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.actor.ActorSubscriber.OnSubscribe
 import akka.stream.actor.ActorSubscriberMessage.{ OnNext, OnComplete, OnError }
 import org.reactivestreams.{ Subscriber, Subscription, Processor }
@@ -220,7 +220,7 @@ private[akka] class SimpleOutputs(val actor: ActorRef, val pump: Pump) extends D
 /**
  * INTERNAL API
  */
-private[akka] abstract class ActorProcessorImpl(val settings: MaterializerSettings)
+private[akka] abstract class ActorProcessorImpl(val settings: ActorFlowMaterializerSettings)
   extends Actor
   with ActorLogging
   with Pump

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorPublisher.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.{ NoStackTrace, NonFatal }
 import akka.actor.{ Actor, ActorLogging, ActorRef, Props, Terminated }
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import org.reactivestreams.{ Publisher, Subscriber }
 import org.reactivestreams.Subscription
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ConcatAllImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ConcatAllImpl.scala
@@ -3,22 +3,22 @@
  */
 package akka.stream.impl
 
-import akka.stream.FlowMaterializer
 import akka.stream.scaladsl.Sink
 import akka.actor.Props
+import akka.stream.ActorFlowMaterializer
 
 /**
  * INTERNAL API
  */
 private[akka] object ConcatAllImpl {
-  def props(materializer: FlowMaterializer): Props =
+  def props(materializer: ActorFlowMaterializer): Props =
     Props(new ConcatAllImpl(materializer))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class ConcatAllImpl(materializer: FlowMaterializer)
+private[akka] class ConcatAllImpl(materializer: ActorFlowMaterializer)
   extends MultiStreamInputProcessor(materializer.settings) {
 
   import akka.stream.impl.MultiStreamInputProcessor._

--- a/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
@@ -5,7 +5,7 @@ package akka.stream.impl
 
 import akka.actor.{ ActorRef, ActorLogging, Actor }
 import akka.actor.Props
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.actor.{ ActorSubscriberMessage, ActorSubscriber }
 import org.reactivestreams.{ Subscription, Subscriber }
 import akka.actor.DeadLetterSuppression
@@ -197,7 +197,7 @@ private[akka] object FanIn {
 /**
  * INTERNAL API
  */
-private[akka] abstract class FanIn(val settings: MaterializerSettings, val inputPorts: Int) extends Actor with ActorLogging with Pump {
+private[akka] abstract class FanIn(val settings: ActorFlowMaterializerSettings, val inputPorts: Int) extends Actor with ActorLogging with Pump {
   import FanIn._
 
   protected val primaryOutputs: Outputs = new SimpleOutputs(self, this)
@@ -240,14 +240,14 @@ private[akka] abstract class FanIn(val settings: MaterializerSettings, val input
  * INTERNAL API
  */
 private[akka] object FairMerge {
-  def props(settings: MaterializerSettings, inputPorts: Int): Props =
+  def props(settings: ActorFlowMaterializerSettings, inputPorts: Int): Props =
     Props(new FairMerge(settings, inputPorts))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] final class FairMerge(_settings: MaterializerSettings, _inputPorts: Int) extends FanIn(_settings, _inputPorts) {
+private[akka] final class FairMerge(_settings: ActorFlowMaterializerSettings, _inputPorts: Int) extends FanIn(_settings, _inputPorts) {
   inputBunch.markAllInputs()
 
   nextPhase(TransferPhase(inputBunch.AnyOfMarkedInputs && primaryOutputs.NeedsDemand) { () ⇒
@@ -263,14 +263,14 @@ private[akka] final class FairMerge(_settings: MaterializerSettings, _inputPorts
 private[akka] object UnfairMerge {
   val DefaultPreferred = 0
 
-  def props(settings: MaterializerSettings, inputPorts: Int): Props =
+  def props(settings: ActorFlowMaterializerSettings, inputPorts: Int): Props =
     Props(new UnfairMerge(settings, inputPorts, DefaultPreferred))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] final class UnfairMerge(_settings: MaterializerSettings,
+private[akka] final class UnfairMerge(_settings: ActorFlowMaterializerSettings,
                                       _inputPorts: Int,
                                       val preferred: Int) extends FanIn(_settings, _inputPorts) {
   inputBunch.markAllInputs()
@@ -285,13 +285,13 @@ private[akka] final class UnfairMerge(_settings: MaterializerSettings,
  * INTERNAL API
  */
 private[akka] object Concat {
-  def props(settings: MaterializerSettings): Props = Props(new Concat(settings))
+  def props(settings: ActorFlowMaterializerSettings): Props = Props(new Concat(settings))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] final class Concat(_settings: MaterializerSettings) extends FanIn(_settings, inputPorts = 2) {
+private[akka] final class Concat(_settings: ActorFlowMaterializerSettings) extends FanIn(_settings, inputPorts = 2) {
   val First = 0
   val Second = 1
 

--- a/akka-stream/src/main/scala/akka/stream/impl/FanOut.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanOut.scala
@@ -8,7 +8,7 @@ import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.ActorRef
 import akka.actor.Props
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import org.reactivestreams.Subscription
 import akka.actor.DeadLetterSuppression
 
@@ -227,7 +227,7 @@ private[akka] object FanOut {
 /**
  * INTERNAL API
  */
-private[akka] abstract class FanOut(val settings: MaterializerSettings, val outputPorts: Int) extends Actor with ActorLogging with Pump {
+private[akka] abstract class FanOut(val settings: ActorFlowMaterializerSettings, val outputPorts: Int) extends Actor with ActorLogging with Pump {
   import FanOut._
 
   protected val outputBunch = new OutputBunch(outputPorts, self, this)
@@ -270,14 +270,14 @@ private[akka] abstract class FanOut(val settings: MaterializerSettings, val outp
  * INTERNAL API
  */
 private[akka] object Broadcast {
-  def props(settings: MaterializerSettings, outputPorts: Int): Props =
+  def props(settings: ActorFlowMaterializerSettings, outputPorts: Int): Props =
     Props(new Broadcast(settings, outputPorts))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class Broadcast(_settings: MaterializerSettings, _outputPorts: Int) extends FanOut(_settings, _outputPorts) {
+private[akka] class Broadcast(_settings: ActorFlowMaterializerSettings, _outputPorts: Int) extends FanOut(_settings, _outputPorts) {
   outputBunch.markAllOutputs()
 
   nextPhase(TransferPhase(primaryInputs.NeedsInput && outputBunch.AllOfMarkedOutputs) { () ⇒
@@ -290,14 +290,14 @@ private[akka] class Broadcast(_settings: MaterializerSettings, _outputPorts: Int
  * INTERNAL API
  */
 private[akka] object Balance {
-  def props(settings: MaterializerSettings, outputPorts: Int, waitForAllDownstreams: Boolean): Props =
+  def props(settings: ActorFlowMaterializerSettings, outputPorts: Int, waitForAllDownstreams: Boolean): Props =
     Props(new Balance(settings, outputPorts, waitForAllDownstreams))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class Balance(_settings: MaterializerSettings, _outputPorts: Int, waitForAllDownstreams: Boolean) extends FanOut(_settings, _outputPorts) {
+private[akka] class Balance(_settings: ActorFlowMaterializerSettings, _outputPorts: Int, waitForAllDownstreams: Boolean) extends FanOut(_settings, _outputPorts) {
   outputBunch.markAllOutputs()
 
   val runningPhase = TransferPhase(primaryInputs.NeedsInput && outputBunch.AnyOfMarkedOutputs) { () ⇒
@@ -317,14 +317,14 @@ private[akka] class Balance(_settings: MaterializerSettings, _outputPorts: Int, 
  * INTERNAL API
  */
 private[akka] object Unzip {
-  def props(settings: MaterializerSettings): Props =
+  def props(settings: ActorFlowMaterializerSettings): Props =
     Props(new Unzip(settings))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class Unzip(_settings: MaterializerSettings) extends FanOut(_settings, outputPorts = 2) {
+private[akka] class Unzip(_settings: ActorFlowMaterializerSettings) extends FanOut(_settings, outputPorts = 2) {
   outputBunch.markAllOutputs()
 
   nextPhase(TransferPhase(primaryInputs.NeedsInput && outputBunch.AllOfMarkedOutputs) { () ⇒

--- a/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
@@ -1,7 +1,7 @@
 package akka.stream.impl
 
 import akka.actor.{ Actor, ActorRef }
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import org.reactivestreams.Subscriber
 
 /**
@@ -91,7 +91,7 @@ private[akka] abstract class FanoutOutputs(val maxBufferSize: Int, val initialBu
  * INTERNAL API
  */
 private[akka] class FanoutProcessorImpl(
-  _settings: MaterializerSettings,
+  _settings: ActorFlowMaterializerSettings,
   initialFanoutBufferSize: Int,
   maximumFanoutBufferSize: Int) extends ActorProcessorImpl(_settings) {
 

--- a/akka-stream/src/main/scala/akka/stream/impl/FlexiMergeImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlexiMergeImpl.scala
@@ -4,7 +4,7 @@
 package akka.stream.impl
 
 import akka.actor.Props
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl.OperationAttributes
 import akka.stream.scaladsl.FlexiMerge
 import scala.collection.breakOut
@@ -14,7 +14,7 @@ import scala.util.control.NonFatal
  * INTERNAL API
  */
 private[akka] object FlexiMergeImpl {
-  def props(settings: MaterializerSettings, inputCount: Int, mergeLogic: FlexiMerge.MergeLogic[Any]): Props =
+  def props(settings: ActorFlowMaterializerSettings, inputCount: Int, mergeLogic: FlexiMerge.MergeLogic[Any]): Props =
     Props(new FlexiMergeImpl(settings, inputCount, mergeLogic))
 
   trait MergeLogicFactory[Out] {
@@ -26,7 +26,7 @@ private[akka] object FlexiMergeImpl {
 /**
  * INTERNAL API
  */
-private[akka] class FlexiMergeImpl(_settings: MaterializerSettings,
+private[akka] class FlexiMergeImpl(_settings: ActorFlowMaterializerSettings,
                                    inputCount: Int,
                                    mergeLogic: FlexiMerge.MergeLogic[Any])
   extends FanIn(_settings, inputCount) {

--- a/akka-stream/src/main/scala/akka/stream/impl/FlexiRouteImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlexiRouteImpl.scala
@@ -7,7 +7,7 @@ import akka.stream.scaladsl.OperationAttributes
 import scala.collection.breakOut
 import akka.actor.Props
 import akka.stream.scaladsl.FlexiRoute
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.impl.FanOut.OutputBunch
 import scala.util.control.NonFatal
 
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
  * INTERNAL API
  */
 private[akka] object FlexiRouteImpl {
-  def props(settings: MaterializerSettings, outputCount: Int, routeLogic: FlexiRoute.RouteLogic[Any]): Props =
+  def props(settings: ActorFlowMaterializerSettings, outputCount: Int, routeLogic: FlexiRoute.RouteLogic[Any]): Props =
     Props(new FlexiRouteImpl(settings, outputCount, routeLogic))
 
   trait RouteLogicFactory[In] {
@@ -27,7 +27,7 @@ private[akka] object FlexiRouteImpl {
 /**
  * INTERNAL API
  */
-private[akka] class FlexiRouteImpl(_settings: MaterializerSettings,
+private[akka] class FlexiRouteImpl(_settings: ActorFlowMaterializerSettings,
                                    outputCount: Int,
                                    routeLogic: FlexiRoute.RouteLogic[Any])
   extends FanOut(_settings, outputCount) {

--- a/akka-stream/src/main/scala/akka/stream/impl/FuturePublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FuturePublisher.scala
@@ -12,7 +12,7 @@ import akka.actor.ActorRef
 import akka.actor.Props
 import akka.actor.Status
 import akka.actor.SupervisorStrategy
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.pattern.pipe
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
@@ -22,7 +22,7 @@ import akka.actor.DeadLetterSuppression
  * INTERNAL API
  */
 private[akka] object FuturePublisher {
-  def props(future: Future[Any], settings: MaterializerSettings): Props =
+  def props(future: Future[Any], settings: ActorFlowMaterializerSettings): Props =
     Props(new FuturePublisher(future, settings)).withDispatcher(settings.dispatcher)
 
   object FutureSubscription {
@@ -42,7 +42,7 @@ private[akka] object FuturePublisher {
  * INTERNAL API
  */
 // FIXME why do we need to have an actor to drive a Future?
-private[akka] class FuturePublisher(future: Future[Any], settings: MaterializerSettings) extends Actor with SoftShutdown {
+private[akka] class FuturePublisher(future: Future[Any], settings: ActorFlowMaterializerSettings) extends Actor with SoftShutdown {
   import akka.stream.impl.FuturePublisher.FutureSubscription
   import akka.stream.impl.FuturePublisher.FutureSubscription.Cancel
   import akka.stream.impl.FuturePublisher.FutureSubscription.RequestMore

--- a/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.impl
 
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl.Source
 import akka.actor.Props
 
@@ -11,14 +11,14 @@ import akka.actor.Props
  * INTERNAL API
  */
 private[akka] object GroupByProcessorImpl {
-  def props(settings: MaterializerSettings, keyFor: Any ⇒ Any): Props =
+  def props(settings: ActorFlowMaterializerSettings, keyFor: Any ⇒ Any): Props =
     Props(new GroupByProcessorImpl(settings, keyFor))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class GroupByProcessorImpl(settings: MaterializerSettings, val keyFor: Any ⇒ Any)
+private[akka] class GroupByProcessorImpl(settings: ActorFlowMaterializerSettings, val keyFor: Any ⇒ Any)
   extends MultiStreamOutputProcessor(settings) {
 
   import MultiStreamOutputProcessor._

--- a/akka-stream/src/main/scala/akka/stream/impl/IteratorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/IteratorPublisher.scala
@@ -8,7 +8,7 @@ import scala.util.control.NonFatal
 import akka.actor.Actor
 import akka.actor.Props
 import akka.event.Logging
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 
 import org.reactivestreams.Subscriber
 
@@ -16,7 +16,7 @@ import org.reactivestreams.Subscriber
  * INTERNAL API
  */
 private[akka] object IteratorPublisher {
-  def props(iterator: Iterator[Any], settings: MaterializerSettings): Props =
+  def props(iterator: Iterator[Any], settings: ActorFlowMaterializerSettings): Props =
     Props(new IteratorPublisher(iterator, settings)).withDispatcher(settings.dispatcher)
 
   private case object PushMore
@@ -34,7 +34,7 @@ private[akka] object IteratorPublisher {
  * INTERNAL API
  * Elements are produced from the iterator.
  */
-private[akka] class IteratorPublisher(iterator: Iterator[Any], settings: MaterializerSettings) extends Actor {
+private[akka] class IteratorPublisher(iterator: Iterator[Any], settings: ActorFlowMaterializerSettings) extends Actor {
   import IteratorPublisher._
   import ReactiveStreamsCompliance._
 

--- a/akka-stream/src/main/scala/akka/stream/impl/MapAsyncProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/MapAsyncProcessorImpl.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 import scala.collection.immutable.TreeSet
 import scala.concurrent.Future
 import scala.util.control.NonFatal
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.pattern.pipe
 import scala.annotation.tailrec
 import akka.actor.Props
@@ -19,7 +19,7 @@ import akka.actor.DeadLetterSuppression
  */
 private[akka] object MapAsyncProcessorImpl {
 
-  def props(settings: MaterializerSettings, f: Any ⇒ Future[Any]): Props =
+  def props(settings: ActorFlowMaterializerSettings, f: Any ⇒ Future[Any]): Props =
     Props(new MapAsyncProcessorImpl(settings, f))
 
   object FutureElement {
@@ -37,7 +37,7 @@ private[akka] object MapAsyncProcessorImpl {
 /**
  * INTERNAL API
  */
-private[akka] class MapAsyncProcessorImpl(_settings: MaterializerSettings, f: Any ⇒ Future[Any])
+private[akka] class MapAsyncProcessorImpl(_settings: ActorFlowMaterializerSettings, f: Any ⇒ Future[Any])
   extends ActorProcessorImpl(_settings) {
   import MapAsyncProcessorImpl._
 

--- a/akka-stream/src/main/scala/akka/stream/impl/MapAsyncUnorderedProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/MapAsyncUnorderedProcessorImpl.scala
@@ -5,8 +5,8 @@ package akka.stream.impl
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
-import akka.stream.MaterializerSettings
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.pattern.pipe
 import akka.actor.Props
 import akka.actor.DeadLetterSuppression
@@ -15,7 +15,7 @@ import akka.actor.DeadLetterSuppression
  * INTERNAL API
  */
 private[akka] object MapAsyncUnorderedProcessorImpl {
-  def props(settings: MaterializerSettings, f: Any ⇒ Future[Any]): Props =
+  def props(settings: ActorFlowMaterializerSettings, f: Any ⇒ Future[Any]): Props =
     Props(new MapAsyncUnorderedProcessorImpl(settings, f))
 
   final case class FutureElement(element: Any) extends DeadLetterSuppression
@@ -25,7 +25,7 @@ private[akka] object MapAsyncUnorderedProcessorImpl {
 /**
  * INTERNAL API
  */
-private[akka] class MapAsyncUnorderedProcessorImpl(_settings: MaterializerSettings, f: Any ⇒ Future[Any])
+private[akka] class MapAsyncUnorderedProcessorImpl(_settings: ActorFlowMaterializerSettings, f: Any ⇒ Future[Any])
   extends ActorProcessorImpl(_settings) {
   import MapAsyncUnorderedProcessorImpl._
 

--- a/akka-stream/src/main/scala/akka/stream/impl/PrefixAndTailImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PrefixAndTailImpl.scala
@@ -4,7 +4,7 @@
 package akka.stream.impl
 
 import scala.collection.immutable
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl.Source
 import akka.actor.Props
 
@@ -12,14 +12,14 @@ import akka.actor.Props
  * INTERNAL API
  */
 private[akka] object PrefixAndTailImpl {
-  def props(settings: MaterializerSettings, takeMax: Int): Props =
+  def props(settings: ActorFlowMaterializerSettings, takeMax: Int): Props =
     Props(new PrefixAndTailImpl(settings, takeMax))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class PrefixAndTailImpl(_settings: MaterializerSettings, val takeMax: Int)
+private[akka] class PrefixAndTailImpl(_settings: ActorFlowMaterializerSettings, val takeMax: Int)
   extends MultiStreamOutputProcessor(_settings) {
 
   import MultiStreamOutputProcessor._

--- a/akka-stream/src/main/scala/akka/stream/impl/SplitWhenProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SplitWhenProcessorImpl.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.impl
 
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl.Source
 import akka.actor.Props
 
@@ -11,14 +11,14 @@ import akka.actor.Props
  * INTERNAL API
  */
 private[akka] object SplitWhenProcessorImpl {
-  def props(settings: MaterializerSettings, splitPredicate: Any ⇒ Boolean): Props =
+  def props(settings: ActorFlowMaterializerSettings, splitPredicate: Any ⇒ Boolean): Props =
     Props(new SplitWhenProcessorImpl(settings, splitPredicate))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class SplitWhenProcessorImpl(_settings: MaterializerSettings, val splitPredicate: Any ⇒ Boolean)
+private[akka] class SplitWhenProcessorImpl(_settings: ActorFlowMaterializerSettings, val splitPredicate: Any ⇒ Boolean)
   extends MultiStreamOutputProcessor(_settings) {
 
   import MultiStreamOutputProcessor._

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicReference
 import akka.actor.ActorLogging
 import akka.actor.Cancellable
 import akka.actor.{ Actor, ActorRef }
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
@@ -175,7 +175,7 @@ private[akka] trait MultiStreamOutputProcessorLike extends Pump with StreamSubsc
 /**
  * INTERNAL API
  */
-private[akka] abstract class MultiStreamOutputProcessor(_settings: MaterializerSettings) extends ActorProcessorImpl(_settings) with MultiStreamOutputProcessorLike {
+private[akka] abstract class MultiStreamOutputProcessor(_settings: ActorFlowMaterializerSettings) extends ActorProcessorImpl(_settings) with MultiStreamOutputProcessorLike {
   private var _nextId = 0L
   protected def nextId(): Long = { _nextId += 1; _nextId }
 
@@ -214,7 +214,7 @@ private[akka] object TwoStreamInputProcessor {
 /**
  * INTERNAL API
  */
-private[akka] abstract class TwoStreamInputProcessor(_settings: MaterializerSettings, val other: Publisher[Any])
+private[akka] abstract class TwoStreamInputProcessor(_settings: ActorFlowMaterializerSettings, val other: Publisher[Any])
   extends ActorProcessorImpl(_settings) {
   import akka.stream.impl.TwoStreamInputProcessor._
 
@@ -341,7 +341,7 @@ private[akka] trait MultiStreamInputProcessorLike extends Pump { this: Actor ⇒
 /**
  * INTERNAL API
  */
-private[akka] abstract class MultiStreamInputProcessor(_settings: MaterializerSettings) extends ActorProcessorImpl(_settings) with MultiStreamInputProcessorLike {
+private[akka] abstract class MultiStreamInputProcessor(_settings: ActorFlowMaterializerSettings) extends ActorProcessorImpl(_settings) with MultiStreamInputProcessorLike {
   private var _nextId = 0L
   protected def nextId(): Long = { _nextId += 1; _nextId }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
@@ -5,7 +5,7 @@ package akka.stream.impl
 
 import java.util.concurrent.atomic.AtomicBoolean
 import akka.actor.{ Actor, ActorRef, Cancellable, Props, SupervisorStrategy }
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import org.reactivestreams.{ Subscriber, Subscription }
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
@@ -17,7 +17,7 @@ import akka.actor.DeadLetterSuppression
  */
 private[akka] object TickPublisher {
   def props(initialDelay: FiniteDuration, interval: FiniteDuration, tick: Any,
-            settings: MaterializerSettings, cancelled: AtomicBoolean): Props =
+            settings: ActorFlowMaterializerSettings, cancelled: AtomicBoolean): Props =
     Props(new TickPublisher(initialDelay, interval, tick, settings, cancelled)).withDispatcher(settings.dispatcher)
 
   object TickPublisherSubscription {
@@ -43,7 +43,7 @@ private[akka] object TickPublisher {
  * otherwise the tick element is dropped.
  */
 private[akka] class TickPublisher(initialDelay: FiniteDuration, interval: FiniteDuration, tick: Any,
-                                  settings: MaterializerSettings, cancelled: AtomicBoolean) extends Actor with SoftShutdown {
+                                  settings: ActorFlowMaterializerSettings, cancelled: AtomicBoolean) extends Actor with SoftShutdown {
   import akka.stream.impl.TickPublisher.TickPublisherSubscription._
   import akka.stream.impl.TickPublisher._
   import ReactiveStreamsCompliance._

--- a/akka-stream/src/main/scala/akka/stream/impl/TimerTransformerProcessorsImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TimerTransformerProcessorsImpl.scala
@@ -4,13 +4,13 @@
 package akka.stream.impl
 
 import java.util.LinkedList
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.TimerTransformer
 import scala.util.control.NonFatal
 import akka.actor.Props
 
 private[akka] object TimerTransformerProcessorsImpl {
-  def props(settings: MaterializerSettings, transformer: TimerTransformer[Any, Any]): Props =
+  def props(settings: ActorFlowMaterializerSettings, transformer: TimerTransformer[Any, Any]): Props =
     Props(new TimerTransformerProcessorsImpl(settings, transformer))
 }
 
@@ -18,7 +18,7 @@ private[akka] object TimerTransformerProcessorsImpl {
  * INTERNAL API
  */
 private[akka] class TimerTransformerProcessorsImpl(
-  _settings: MaterializerSettings,
+  _settings: ActorFlowMaterializerSettings,
   transformer: TimerTransformer[Any, Any])
   extends ActorProcessorImpl(_settings) with Emit {
   import TimerTransformer._

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorInterpreter.scala
@@ -6,7 +6,7 @@ package akka.stream.impl.fusing
 import java.util.Arrays
 import akka.actor.{ Actor, ActorRef }
 import akka.event.Logging
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.actor.ActorSubscriber.OnSubscribe
 import akka.stream.actor.ActorSubscriberMessage.{ OnNext, OnError, OnComplete }
 import akka.stream.impl._
@@ -255,14 +255,14 @@ private[akka] class ActorOutputBoundary(val actor: ActorRef, debugLogging: Boole
  * INTERNAL API
  */
 private[akka] object ActorInterpreter {
-  def props(settings: MaterializerSettings, ops: Seq[Stage[_, _]]): Props =
+  def props(settings: ActorFlowMaterializerSettings, ops: Seq[Stage[_, _]]): Props =
     Props(new ActorInterpreter(settings, ops))
 }
 
 /**
  * INTERNAL API
  */
-private[akka] class ActorInterpreter(val settings: MaterializerSettings, val ops: Seq[Stage[_, _]])
+private[akka] class ActorInterpreter(val settings: ActorFlowMaterializerSettings, val ops: Seq[Stage[_, _]])
   extends Actor with ActorLogging {
 
   private val upstream = new BatchingActorInputBoundary(settings.initialInputBufferSize)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/StreamTcpManager.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/StreamTcpManager.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.actor.Actor
 import akka.io.Inet.SocketOption
 import akka.io.Tcp
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.impl.ActorProcessor
 import akka.stream.impl.ActorPublisher
 import akka.stream.scaladsl.StreamTcp
@@ -80,13 +80,13 @@ private[akka] class StreamTcpManager extends Actor {
       }
       val processorActor = context.actorOf(TcpStreamActor.outboundProps(processorPromise, localAddressPromise,
         Tcp.Connect(remoteAddress, localAddress, options, connTimeout, pullMode = true),
-        materializerSettings = MaterializerSettings(context.system)), name = encName("client", remoteAddress))
+        materializerSettings = ActorFlowMaterializerSettings(context.system)), name = encName("client", remoteAddress))
       processorActor ! ExposedProcessor(ActorProcessor[ByteString, ByteString](processorActor))
 
     case Bind(localAddressPromise, unbindPromise, flowSubscriber, endpoint, backlog, options, _) ⇒
       val publisherActor = context.actorOf(TcpListenStreamActor.props(localAddressPromise, unbindPromise,
         flowSubscriber, Tcp.Bind(context.system.deadLetters, endpoint, backlog, options, pullMode = true),
-        MaterializerSettings(context.system)), name = encName("server", endpoint))
+        ActorFlowMaterializerSettings(context.system)), name = encName("server", endpoint))
       // this sends the ExposedPublisher message to the publisher actor automatically
       ActorPublisher[Any](publisherActor)
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
@@ -10,7 +10,7 @@ import scala.util.control.NoStackTrace
 import akka.actor.{ ActorRefFactory, Actor, Props, ActorRef, Status }
 import akka.util.ByteString
 import akka.io.Tcp._
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.StreamTcpException
 import org.reactivestreams.Processor
 import akka.actor.Stash
@@ -26,18 +26,18 @@ private[akka] object TcpStreamActor {
   def outboundProps(processorPromise: Promise[Processor[ByteString, ByteString]],
                     localAddressPromise: Promise[InetSocketAddress],
                     connectCmd: Connect,
-                    materializerSettings: MaterializerSettings): Props =
+                    materializerSettings: ActorFlowMaterializerSettings): Props =
     Props(new OutboundTcpStreamActor(processorPromise, localAddressPromise, connectCmd,
       materializerSettings)).withDispatcher(materializerSettings.dispatcher)
 
-  def inboundProps(connection: ActorRef, settings: MaterializerSettings): Props =
+  def inboundProps(connection: ActorRef, settings: ActorFlowMaterializerSettings): Props =
     Props(new InboundTcpStreamActor(connection, settings)).withDispatcher(settings.dispatcher)
 }
 
 /**
  * INTERNAL API
  */
-private[akka] abstract class TcpStreamActor(val settings: MaterializerSettings) extends Actor with Stash
+private[akka] abstract class TcpStreamActor(val settings: ActorFlowMaterializerSettings) extends Actor with Stash
   with ActorLogging {
 
   import TcpStreamActor._
@@ -201,7 +201,7 @@ private[akka] abstract class TcpStreamActor(val settings: MaterializerSettings) 
  * INTERNAL API
  */
 private[akka] class InboundTcpStreamActor(
-  val connection: ActorRef, _settings: MaterializerSettings)
+  val connection: ActorRef, _settings: ActorFlowMaterializerSettings)
   extends TcpStreamActor(_settings) {
 
   connection ! Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
@@ -214,7 +214,7 @@ private[akka] class InboundTcpStreamActor(
  */
 private[akka] class OutboundTcpStreamActor(processorPromise: Promise[Processor[ByteString, ByteString]],
                                            localAddressPromise: Promise[InetSocketAddress],
-                                           val connectCmd: Connect, _settings: MaterializerSettings)
+                                           val connectCmd: Connect, _settings: ActorFlowMaterializerSettings)
   extends TcpStreamActor(_settings) {
   import TcpStreamActor._
   import context.system

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
@@ -11,7 +11,7 @@ import akka.actor.Props
 import akka.actor.Stash
 import akka.io.{ IO, Tcp }
 import akka.io.Tcp._
-import akka.stream.{ FlowMaterializer, MaterializerSettings }
+import akka.stream.{ FlowMaterializer, ActorFlowMaterializerSettings }
 import akka.stream.impl._
 import akka.stream.scaladsl.{ Flow, Pipe }
 import akka.stream.scaladsl.StreamTcp
@@ -28,7 +28,7 @@ private[akka] object TcpListenStreamActor {
   def props(localAddressPromise: Promise[InetSocketAddress],
             unbindPromise: Promise[() ⇒ Future[Unit]],
             flowSubscriber: Subscriber[StreamTcp.IncomingConnection],
-            bindCmd: Tcp.Bind, materializerSettings: MaterializerSettings): Props = {
+            bindCmd: Tcp.Bind, materializerSettings: ActorFlowMaterializerSettings): Props = {
     Props(new TcpListenStreamActor(localAddressPromise, unbindPromise, flowSubscriber, bindCmd, materializerSettings))
   }
 }
@@ -39,7 +39,7 @@ private[akka] object TcpListenStreamActor {
 private[akka] class TcpListenStreamActor(localAddressPromise: Promise[InetSocketAddress],
                                          unbindPromise: Promise[() ⇒ Future[Unit]],
                                          flowSubscriber: Subscriber[StreamTcp.IncomingConnection],
-                                         bindCmd: Tcp.Bind, settings: MaterializerSettings) extends Actor
+                                         bindCmd: Tcp.Bind, settings: ActorFlowMaterializerSettings) extends Actor
   with Pump with Stash with ActorLogging {
   import context.system
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/ImplicitFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/ImplicitFlowMaterializer.scala
@@ -4,23 +4,23 @@
 package akka.stream.scaladsl
 
 import akka.actor.Actor
-import akka.stream.MaterializerSettings
-import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializerSettings
+import akka.stream.ActorFlowMaterializer
 
 /**
  * Mix this trait into your [[akka.actor.Actor]] if you need an implicit
- * [[akka.stream.FlowMaterializer]] in scope.
+ * [[akka.stream.ActorFlowMaterializer]] in scope.
  *
  * Subclass may override [[#flowMaterializerSettings]] to define custom
- * [[akka.stream.MaterializerSettings]] for the `FlowMaterializer`.
+ * [[akka.stream.ActorFlowMaterializerSettings]] for the `ActorFlowMaterializer`.
  */
 trait ImplicitFlowMaterializer { this: Actor ⇒
 
   /**
    * Subclass may override this to define custom
-   * [[akka.stream.MaterializerSettings]] for the `FlowMaterializer`.
+   * [[akka.stream.ActorFlowMaterializerSettings]] for the `ActorFlowMaterializer`.
    */
-  def flowMaterializerSettings: MaterializerSettings = MaterializerSettings(context.system)
+  def flowMaterializerSettings: ActorFlowMaterializerSettings = ActorFlowMaterializerSettings(context.system)
 
-  final implicit val flowMaterializer: FlowMaterializer = FlowMaterializer(Some(flowMaterializerSettings))
+  final implicit val flowMaterializer: ActorFlowMaterializer = ActorFlowMaterializer(Some(flowMaterializerSettings))
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/OperationAttributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/OperationAttributes.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.impl.Ast.AstNode
 
 /**
@@ -33,10 +33,10 @@ final case class OperationAttributes private (private val attributes: List[Opera
     case _          ⇒ "unknown-operation"
   }
 
-  private[akka] def settings: MaterializerSettings ⇒ MaterializerSettings =
+  private[akka] def settings: ActorFlowMaterializerSettings ⇒ ActorFlowMaterializerSettings =
     attributes.collect {
-      case InputBuffer(initial, max) ⇒ (s: MaterializerSettings) ⇒ s.withInputBuffer(initial, max)
-      case Dispatcher(dispatcher) ⇒ (s: MaterializerSettings) ⇒ s.withDispatcher(dispatcher)
+      case InputBuffer(initial, max) ⇒ (s: ActorFlowMaterializerSettings) ⇒ s.withInputBuffer(initial, max)
+      case Dispatcher(dispatcher) ⇒ (s: ActorFlowMaterializerSettings) ⇒ s.withDispatcher(dispatcher)
     }.reduceOption(_ andThen _).getOrElse(identity) // FIXME is this the optimal way of encoding this?
 
   private[akka] def transform(node: AstNode): AstNode =

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamTcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamTcp.scala
@@ -18,12 +18,12 @@ import akka.actor.ExtensionIdProvider
 import akka.actor.Props
 import akka.io.Inet.SocketOption
 import akka.io.Tcp
-import akka.stream.{ FlowMaterializer, MaterializerSettings }
+import akka.stream.FlowMaterializer
+import akka.stream.ActorFlowMaterializer
 import akka.stream.impl._
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import org.reactivestreams.{ Processor, Subscriber, Subscription }
-import akka.actor.actorRef2Scala
 import akka.stream.impl.io.TcpStreamActor
 import akka.stream.impl.io.TcpListenStreamActor
 import akka.stream.impl.io.DelayedInitProcessor
@@ -155,7 +155,7 @@ class StreamTcp(system: ExtendedActorSystem) extends akka.actor.Extension {
            idleTimeout: Duration = Duration.Inf): ServerBinding = {
     val connectionSource = new KeyedActorFlowSource[IncomingConnection, (Future[InetSocketAddress], Future[() ⇒ Future[Unit]])] {
       override def attach(flowSubscriber: Subscriber[IncomingConnection],
-                          materializer: ActorBasedFlowMaterializer,
+                          materializer: ActorFlowMaterializer,
                           flowName: String): MaterializedType = {
         val localAddressPromise = Promise[InetSocketAddress]()
         val unbindPromise = Promise[() ⇒ Future[Unit]]()

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/package.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/package.scala
@@ -43,12 +43,12 @@ package akka.stream
  *
  * By default every operation is executed within its own [[akka.actor.Actor]]
  * to enable full pipelining of the chained set of computations. This behavior
- * is determined by the [[akka.stream.FlowMaterializer]] which is required
+ * is determined by the [[akka.stream.ActorFlowMaterializer]] which is required
  * by those methods that materialize the Flow into a series of
  * [[org.reactivestreams.Processor]] instances. The returned reactive stream
  * is fully started and active.
  *
- * Use [[ImplicitFlowMaterializer]] to define an implicit [[akka.stream.FlowMaterializer]]
+ * Use [[ImplicitFlowMaterializer]] to define an implicit [[akka.stream.ActorFlowMaterializer]]
  * inside an [[akka.actor.Actor]].
  */
 package object scaladsl {

--- a/akka-stream/src/main/scala/akka/stream/ssl/SslTlsCipher.scala
+++ b/akka-stream/src/main/scala/akka/stream/ssl/SslTlsCipher.scala
@@ -17,7 +17,7 @@ import javax.net.ssl.SSLSession
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.ActorRef
-import akka.stream.MaterializerSettings
+import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.impl._
 import akka.util.ByteString
 import akka.util.ByteStringBuilder
@@ -97,7 +97,7 @@ class SslTlsCipherActor(val requester: ActorRef, val sessionNegotioation: SslTls
   with MultiStreamOutputProcessorLike
   with MultiStreamInputProcessorLike {
 
-  override val subscriptionTimeoutSettings = MaterializerSettings(context.system).subscriptionTimeoutSettings
+  override val subscriptionTimeoutSettings = ActorFlowMaterializerSettings(context.system).subscriptionTimeoutSettings
 
   def this(requester: ActorRef, sessionNegotioation: SslTlsCipher.SessionNegotiation) =
     this(requester, sessionNegotioation, false)


### PR DESCRIPTION
- FlowMaterializer is now the actor independent interface
- ActorFlowMaterializer is the actor based interface
- MaterializerSettings renamed to ActorFlowMaterializerSettings
- impl.ActorBasedFlowMaterializer renamed to impl.ActorFlowMaterializerImpl
- Optimizations included in ActorFlowMaterializerSettings
- Note that http is using FlowMaterializer in api, but I suspect that it
  will currently only run with a ActorFlowMaterializer
