### PR TITLE
=ben update JMH to 0.1.10 (JMH 1.5), compile benchmarks on PR validation

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
@@ -54,7 +54,7 @@ class ActorCreationBenchmark {
 
   import ActorCreationPerfSpec._
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(100000)
   def actor_creation_time_for_actorOf_Props_EmptyActor__each_time_new__100k_actors() {
     val propsCreator = () => Props[EmptyActor]
@@ -62,7 +62,7 @@ class ActorCreationBenchmark {
     test(propsCreator)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(100000)
   def actor_creation_time_for_actorOf_Props_EmptyActor__each_time_same__100k_actors() {
     val p = Props[EmptyActor]
@@ -71,7 +71,7 @@ class ActorCreationBenchmark {
     test(propsCreator)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(100000)
   def actor_creation_time_for_actorOf_Props_new_EmptyActor__each_time_new__100k_actors() {
     val propsCreator = () => { Props(new EmptyActor) }
@@ -79,7 +79,7 @@ class ActorCreationBenchmark {
     test(propsCreator)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(100000)
   def actor_creation_time_for_actorOf_Props_new_EmptyActor__each_time_same__100k_actors() {
     val p = Props(new EmptyActor)
@@ -95,7 +95,7 @@ class ActorCreationBenchmark {
     test(propsCreator)
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(100000)
   def actor_creation_time_for_actorOf_Props_classOf_EmptyArgsActor__each_time_same__100k_actors() {
     val p = Props(classOf[EmptyArgsActor], 4711, 1729)

--- a/akka-bench-jmh/src/main/scala/akka/actor/TellPingPongBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/TellPingPongBenchmark.scala
@@ -54,7 +54,7 @@ class TellPingPongBenchmark {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   @BenchmarkMode(Array(Mode.Throughput))
   @OperationsPerInvocation(200000) // twice as much messages are sent, because ping<->pong
-  @GenerateMicroBenchmark
+  @Benchmark
   def tell_100000_msgs_a() {
     waiter ! AwaitUntil(100000)
     worker.tell("ping", waiter)
@@ -65,7 +65,7 @@ class TellPingPongBenchmark {
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   @BenchmarkMode(Array(Mode.SampleTime))
   @OperationsPerInvocation(200000) // twice as much messages are sent, because ping<->pong
-  @GenerateMicroBenchmark
+  @Benchmark
   def tell_100000_msgs_b() {
     waiter ! AwaitUntil(100000)
     worker.tell("ping", waiter)

--- a/akka-bench-jmh/src/main/scala/akka/event/EventStreamPublishingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/event/EventStreamPublishingBenchmark.scala
@@ -4,10 +4,10 @@
 
 package akka.event
 
-import org.openjdk.jmh.annotations._
-import com.typesafe.config.ConfigFactory
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.ActorSystem
 import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -67,25 +67,25 @@ class EventStreamPublishingBenchmark {
   }
 
   @Threads(1)
-  @GenerateMicroBenchmark
+  @Benchmark
   def publish_matching_events_to_event_stream_1_thread() {
     eventStream.publish(a)
   }
 
   @Threads(8)
-  @GenerateMicroBenchmark
+  @Benchmark
   def publish_matching_events_to_event_stream_8_threads() {
     eventStream.publish(a)
   }
 
   @Threads(1)
-  @GenerateMicroBenchmark
+  @Benchmark
   def publish_notMatching_events_to_event_stream_1_threads() {
     eventStream.publish(c)
   }
 
   @Threads(8)
-  @GenerateMicroBenchmark
+  @Benchmark
   def publish_notMatching_events_to_event_stream_8_threads() {
     eventStream.publish(c)
   }

--- a/akka-bench-jmh/src/main/scala/akka/event/EventStreamSubscriptionsBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/event/EventStreamSubscriptionsBenchmark.scala
@@ -60,27 +60,27 @@ class EventStreamSubscriptionsBenchmark {
   }
 
   @Threads(1)
-  @GenerateMicroBenchmark
+  @Benchmark
   def subscribe_unsubscribe_same_actor_1_thread() {
     eventStream.subscribe(subs, channelA)
     eventStream.unsubscribe(subs)
   }
 
   @Threads(8)
-  @GenerateMicroBenchmark
+  @Benchmark
   def subscribe_unsubscribe_same_actor_8_threads() {
     eventStream.subscribe(subs, channelA)
     eventStream.unsubscribe(subs)
   }
 
   @Group("subscribe_vs_unsubscribe")
-  @GenerateMicroBenchmark
+  @Benchmark
   def subscribing_in_group_vs_unsubscribing() {
     eventStream.subscribe(subs, channelA)
   }
 
   @Group("subscribe_vs_unsubscribe")
-  @GenerateMicroBenchmark
+  @Benchmark
   def unsubscribing_in_group_vs_subscribing() {
     eventStream.unsubscribe(subs)
   }

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -49,7 +49,7 @@ class FlowMapBenchmark {
   final val successFailure = Success(new Exception)
 
   // safe to be benchmark scoped because the flows we construct in this bench are stateless
-  var flow: Flow[Int] = _
+  var flow: Source[Int] = _
 
   @Param(Array("2", "8")) // todo
   val initialInputBufferSize = 0
@@ -61,11 +61,10 @@ class FlowMapBenchmark {
   def setup() {
     val settings = MaterializerSettings(system)
       .withInputBuffer(initialInputBufferSize, 16)
-      .withFanOutBuffer(1, 16)
 
     materializer = FlowMaterializer(settings)
 
-    flow = mkMaps(Flow(data100k), numberOfMapOps)(identity)
+    flow = mkMaps(Source(data100k), numberOfMapOps)(identity)
   }
 
   @TearDown
@@ -74,20 +73,20 @@ class FlowMapBenchmark {
     system.awaitTermination()
   }
 
-  @GenerateMicroBenchmark
+  @Benchmark
   @OperationsPerInvocation(100000)
   def flow_map_100k_elements() {
     val lock = new Lock() // todo rethink what is the most lightweight way to await for a streams completion
     lock.acquire()
 
-    flow.onComplete({ _ => lock.release() })(materializer)
+    flow.runWith(Sink.onComplete(_ ⇒ lock.release()))(materializer)
 
     lock.acquire()
   }
 
-  // flow setup
-  private def mkMaps[O](flow: Flow[O], count: Int)(op: O ⇒ O): Flow[O] = {
-    var f = flow
+  // source setup
+  private def mkMaps[O](source: Source[O], count: Int)(op: O ⇒ O): Source[O] = {
+    var f = source
     for (i ← 1 to count)
       f = f.map(op)
     f

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -81,7 +81,8 @@ object AkkaBuild extends Build {
       validatePullRequest <<= Seq(SphinxSupport.generate in Sphinx in docsDev,
         test in Test in stream, test in Test in streamTestkit, test in Test in streamTests, test in Test in streamTck,
         test in Test in httpCore, test in Test in http, test in Test in httpJavaTests, test in Test in httpJava8Tests,
-        test in Test in httpTestkit, test in Test in httpTests, test in Test in docsDev).dependOn,
+        test in Test in httpTestkit, test in Test in httpTests, test in Test in docsDev,
+        compile in Compile in benchJmh).dependOn,
       aggregate in publishM2 := false // REMOVE DURING MERGE INTO release-2.3
     ),
     aggregate = Seq(streamAndHttp) // FIXME DURING MERGE INTO release-2.3
@@ -198,7 +199,8 @@ object AkkaBuild extends Build {
     base = file("akka-bench-jmh"),
     dependencies = Seq(actor, stream, persistence, testkit).map(_ % "compile;compile->test"),
     settings = defaultSettings ++ Seq(
-      libraryDependencies ++= Dependencies.testkit
+      libraryDependencies ++= Dependencies.testkit,
+      publishArtifact in Compile := false
     ) ++ settings ++ jmhSettings
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.2")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.10")
 
 libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"
 


### PR DESCRIPTION
Minor update which I noticed seemed needed yesterday when I released sbt-jmh `0.1.10` ( https://github.com/ktoso/sbt-jmh/milestones?state=closed ).

This PR adds:
- compiling the benchmarks to PR validation - so we don't have non compiling code in the benchmarks project (we had this currently, because `Flow => Source` change)
- bumps JMH to 1.5 (previously we had 1.3.1, rather old).
