### PR TITLE
+str #16547 "lazyEmpty" source, allowing external completion

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -59,10 +59,10 @@ class FlowMapBenchmark {
 
   @Setup
   def setup() {
-    val settings = MaterializerSettings(system)
+    val settings = ActorFlowMaterializerSettings(system)
       .withInputBuffer(initialInputBufferSize, 16)
 
-    materializer = FlowMaterializer(settings)
+    materializer = ActorFlowMaterializer(settings)
 
     flow = mkMaps(Source(data100k), numberOfMapOps)(identity)
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -7,7 +7,6 @@ import java.util.concurrent.Callable
 import akka.actor.{ Cancellable, ActorRef, Props }
 import akka.japi.Util
 import akka.stream._
-import akka.stream.scaladsl.PropsSource
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import scala.annotation.unchecked.uncheckedVariance
@@ -33,6 +32,18 @@ object Source {
    */
   def empty[O](): Source[O] =
     new Source(scaladsl.Source.empty())
+
+  /**
+   * Create a `Source` with no elements, which does not complete its downstream,
+   * until externally triggered to do so.
+   *
+   * It materializes a [[scala.concurrent.Promise]] which will be completed
+   * when the downstream stage of this source cancels. This promise can also
+   * be used to externally trigger completion, which the source then signalls
+   * to its downstream.
+   */
+  def lazyEmpty[T]() =
+    new Source(scaladsl.Source.lazyEmpty())
 
   /**
    * Helper to create [[Source]] from `Publisher`.
@@ -188,7 +199,7 @@ class Source[+Out](delegate: scaladsl.Source[Out]) {
    * @tparam S materialized type of the given Sink
    */
   def runWith[S](sink: KeyedSink[Out, S], materializer: FlowMaterializer): S =
-    asScala.runWith(sink.asScala)(materializer).asInstanceOf[S]
+    asScala.runWith(sink.asScala)(materializer)
 
   /**
    * Connect this `Source` to a `Sink` and run it. The returned value is the materialized value

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -178,6 +178,17 @@ object Source {
   private[this] val _empty: Source[Nothing] = apply(EmptyPublisher)
 
   /**
+   * Create a `Source` with no elements, which does not complete its downstream,
+   * until externally triggered to do so.
+   *
+   * It materializes a [[scala.concurrent.Promise]] which will be completed
+   * when the downstream stage of this source cancels. This promise can also
+   * be used to externally trigger completion, which the source then signalls
+   * to its downstream.
+   */
+  def lazyEmpty[T]() = LazyEmptySource[T]()
+
+  /**
    * Create a `Source` that immediately ends the stream with the `cause` error to every connected `Sink`.
    */
   def failed[T](cause: Throwable): Source[T] = apply(ErrorPublisher(cause, "failed"))


### PR DESCRIPTION
Implemented this guy during a meetup yesterday, short and nice :-)

The TCK verification for this one is pending, because RC1 TCK does not allow empty publishers. But that's solved on reactive-streams master. I'll create a ticket to bump the dependency and remember to add such (we also have empty) publishers to TCK verification (its only one or two tests for those).

resolves #16547
