### PR TITLE
Test that reproduces the issue #16327

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -70,9 +70,8 @@ object ExecutionContexts {
    * It is very useful for actions which are known to be non-blocking and
    * non-throwing in order to save a round-trip to the thread pool.
    */
-  private[akka] object sameThreadExecutionContext extends ExecutionContext with BatchingExecutor {
-    override protected def unbatchedExecute(runnable: Runnable): Unit = runnable.run()
-    override protected def resubmitOnBlock: Boolean = false // No point since we execute on same thread
+  private[akka] object sameThreadExecutionContext extends ExecutionContext {
+    override def execute(runnable: Runnable): Unit = runnable.run()
     override def reportFailure(t: Throwable): Unit =
       throw new IllegalStateException("exception in sameThreadExecutionContext", t)
   }


### PR DESCRIPTION
Added test to master branch according to request by Roland Kuhn:
https://github.com/akka/akka/pull/16744#issuecomment-72010706

It still fails (as well as in 2.3 branch), so the root cause was because sameThreadExecutionContext cannot avoid thread starvation when Batching is used and Await/blocking is called.
