### PR TITLE
Backporting PR #1970 into 2.3 branch to fix #16327

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -601,6 +601,7 @@ private[akka] class ActorSystemImpl(val name: String, applicationConfig: Config,
     dynamicAccess.getObjectFor[ExecutionContext]("scala.concurrent.Future$InternalCallbackExecutor$").getOrElse(
       new ExecutionContext with BatchingExecutor {
         override protected def unbatchedExecute(r: Runnable): Unit = r.run()
+        override protected def resubmitOnBlock: Boolean = false // Since we execute inline, no gain in resubmitting
         override def reportFailure(t: Throwable): Unit = dispatcher reportFailure t
       })
 

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -72,6 +72,7 @@ object ExecutionContexts {
    */
   private[akka] object sameThreadExecutionContext extends ExecutionContext with BatchingExecutor {
     override protected def unbatchedExecute(runnable: Runnable): Unit = runnable.run()
+    override protected def resubmitOnBlock: Boolean = false // No point since we execute on same thread
     override def reportFailure(t: Throwable): Unit =
       throw new IllegalStateException("exception in sameThreadExecutionContext", t)
   }


### PR DESCRIPTION
Backporting PR #1970 into 2.3 branch according to comments from Roland Kuhn: 
https://github.com/akka/akka/pull/16752#issuecomment-72188277

=act - Refactored the BatchingExecutor to support both managed blocking and not. (cherry picked from commit 52408c7)
