### PR TITLE
=clu #13875 Exclude unreachability observations from downed

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -222,12 +222,12 @@ object ClusterEvent {
   /**
    * INTERNAL API
    */
-  private[cluster] def diffUnreachable(oldGossip: Gossip, newGossip: Gossip): immutable.Seq[UnreachableMember] =
+  private[cluster] def diffUnreachable(oldGossip: Gossip, newGossip: Gossip, selfUniqueAddress: UniqueAddress): immutable.Seq[UnreachableMember] =
     if (newGossip eq oldGossip) Nil
     else {
       val oldUnreachableNodes = oldGossip.overview.reachability.allUnreachableOrTerminated
       (newGossip.overview.reachability.allUnreachableOrTerminated.collect {
-        case node if !oldUnreachableNodes.contains(node) ⇒
+        case node if !oldUnreachableNodes.contains(node) && node != selfUniqueAddress ⇒
           UnreachableMember(newGossip.member(node))
       })(collection.breakOut)
     }
@@ -235,11 +235,11 @@ object ClusterEvent {
   /**
    * INTERNAL API
    */
-  private[cluster] def diffReachable(oldGossip: Gossip, newGossip: Gossip): immutable.Seq[ReachableMember] =
+  private[cluster] def diffReachable(oldGossip: Gossip, newGossip: Gossip, selfUniqueAddress: UniqueAddress): immutable.Seq[ReachableMember] =
     if (newGossip eq oldGossip) Nil
     else {
       (oldGossip.overview.reachability.allUnreachable.collect {
-        case node if newGossip.hasMember(node) && newGossip.overview.reachability.isReachable(node) ⇒
+        case node if newGossip.hasMember(node) && newGossip.overview.reachability.isReachable(node) && node != selfUniqueAddress ⇒
           ReachableMember(newGossip.member(node))
       })(collection.breakOut)
 
@@ -291,12 +291,12 @@ object ClusterEvent {
   /**
    * INTERNAL API
    */
-  private[cluster] def diffSeen(oldGossip: Gossip, newGossip: Gossip): immutable.Seq[SeenChanged] =
+  private[cluster] def diffSeen(oldGossip: Gossip, newGossip: Gossip, selfUniqueAddress: UniqueAddress): immutable.Seq[SeenChanged] =
     if (newGossip eq oldGossip) Nil
     else {
-      val newConvergence = newGossip.convergence
+      val newConvergence = newGossip.convergence(selfUniqueAddress)
       val newSeenBy = newGossip.seenBy
-      if (newConvergence != oldGossip.convergence || newSeenBy != oldGossip.seenBy)
+      if (newConvergence != oldGossip.convergence(selfUniqueAddress) || newSeenBy != oldGossip.seenBy)
         List(SeenChanged(newConvergence, newSeenBy.map(_.address)))
       else Nil
     }
@@ -319,6 +319,7 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
   with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import InternalClusterAction._
 
+  val selfUniqueAddress = Cluster(context.system).selfUniqueAddress
   var latestGossip: Gossip = Gossip.empty
 
   override def preRestart(reason: Throwable, message: Option[Any]) {
@@ -346,9 +347,12 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
    * to mimic what you would have seen if you were listening to the events.
    */
   def sendCurrentClusterState(receiver: ActorRef): Unit = {
+    val unreachable: Set[Member] = latestGossip.overview.reachability.allUnreachableOrTerminated.collect {
+      case node if node != selfUniqueAddress ⇒ latestGossip.member(node)
+    }
     val state = CurrentClusterState(
       members = latestGossip.members,
-      unreachable = latestGossip.overview.reachability.allUnreachableOrTerminated map latestGossip.member,
+      unreachable = unreachable,
       seenBy = latestGossip.seenBy.map(_.address),
       leader = latestGossip.leader.map(_.address),
       roleLeaderMap = latestGossip.allRoles.map(r ⇒ r -> latestGossip.roleLeader(r).map(_.address))(collection.breakOut))
@@ -384,12 +388,12 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
 
   def publishDiff(oldGossip: Gossip, newGossip: Gossip, pub: AnyRef ⇒ Unit): Unit = {
     diffMemberEvents(oldGossip, newGossip) foreach pub
-    diffUnreachable(oldGossip, newGossip) foreach pub
-    diffReachable(oldGossip, newGossip) foreach pub
+    diffUnreachable(oldGossip, newGossip, selfUniqueAddress) foreach pub
+    diffReachable(oldGossip, newGossip, selfUniqueAddress) foreach pub
     diffLeader(oldGossip, newGossip) foreach pub
     diffRolesLeader(oldGossip, newGossip) foreach pub
     // publish internal SeenState for testing purposes
-    diffSeen(oldGossip, newGossip) foreach pub
+    diffSeen(oldGossip, newGossip, selfUniqueAddress) foreach pub
     diffReachability(oldGossip, newGossip) foreach pub
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
@@ -187,6 +187,18 @@ private[cluster] class Reachability private (
     }
   }
 
+  def removeObservers(nodes: Set[UniqueAddress]): Reachability =
+    if (nodes.isEmpty)
+      this
+    else {
+      val newRecords = records.filterNot(r ⇒ nodes(r.observer))
+      if (newRecords.size == records.size) this
+      else {
+        val newVersions = versions -- nodes
+        Reachability(newRecords, newVersions)
+      }
+    }
+
   def status(observer: UniqueAddress, subject: UniqueAddress): ReachabilityStatus =
     observerRows(observer) match {
       case None ⇒ Reachable

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventPublisherSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventPublisherSpec.scala
@@ -19,8 +19,15 @@ import akka.testkit.ImplicitSender
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
 
+object ClusterDomainEventPublisherSpec {
+  val config = """
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.remote.netty.tcp.port = 0
+    """
+}
+
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ClusterDomainEventPublisherSpec extends AkkaSpec
+class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublisherSpec.config)
   with BeforeAndAfterEach with ImplicitSender {
 
   var publisher: ActorRef = _

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
@@ -64,6 +64,19 @@ class ReachabilitySpec extends WordSpec with Matchers {
       r.isReachable(nodeA) should be(true)
     }
 
+    "exclude observations from specific (downed) nodes" in {
+      val r = Reachability.empty.
+        unreachable(nodeC, nodeA).reachable(nodeC, nodeA).
+        unreachable(nodeC, nodeB).
+        unreachable(nodeB, nodeA).unreachable(nodeB, nodeC)
+
+      r.isReachable(nodeA) should be(false)
+      r.isReachable(nodeB) should be(false)
+      r.isReachable(nodeC) should be(false)
+      r.allUnreachableOrTerminated should be(Set(nodeA, nodeB, nodeC))
+      r.removeObservers(Set(nodeB)).allUnreachableOrTerminated should be(Set(nodeB))
+    }
+
     "be pruned when all records of an observer are Reachable" in {
       val r = Reachability.empty.
         unreachable(nodeB, nodeA).unreachable(nodeB, nodeC).


### PR DESCRIPTION
- Skip observations from downed node (quarantined is marked down immediately)
  in convergence check
- Skip observations from downed node when picking "reachable" targets for gossip.
- This also means that we must accept gossip with own node marked as unreachable,
  but that should not be spread to the external membership events.

The SurviveNetworkInstabilitySpec failed a lot before this patch. I have verified that it does not fail any more by letting jenkins run this over the weekend.
744 successful runs of SurviveNetworkInstabilitySpec
90  successful runs of all tests in akka-cluster.

This PR also contains a cherry-pick of forgotten forward port of adjustments to SurviveNetworkInstabilitySpec.
