### PR TITLE
=str #16331 Use ReactiveStreamsCompliance utility everywhere

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/CompletedPublishers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/CompletedPublishers.scala
@@ -9,7 +9,11 @@ import org.reactivestreams.{ Subscriber, Publisher }
  * INTERNAL API
  */
 private[akka] case object EmptyPublisher extends Publisher[Nothing] {
-  override def subscribe(subscriber: Subscriber[_ >: Nothing]): Unit = subscriber.onComplete()
+  import ReactiveStreamsCompliance._
+  override def subscribe(subscriber: Subscriber[_ >: Nothing]): Unit =
+    try tryOnComplete(subscriber) catch {
+      case _: SpecViolation ⇒ // nothing to do
+    }
   def apply[T]: Publisher[T] = this.asInstanceOf[Publisher[T]]
   override def toString: String = "empty-publisher" // FIXME is this a good name?
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
@@ -55,7 +55,7 @@ private[akka] abstract class FanoutOutputs(val maxBufferSize: Int, val initialBu
   override protected def shutdown(completed: Boolean): Unit = {
     if (exposedPublisher ne null) {
       if (completed) exposedPublisher.shutdown(None)
-      else exposedPublisher.shutdown(Some(new IllegalStateException("Cannot subscribe to shutdown publisher")))
+      else exposedPublisher.shutdown(ActorPublisher.NormalShutdownReason)
     }
     afterShutdown()
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/IteratorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/IteratorPublisher.scala
@@ -129,11 +129,12 @@ private[akka] class IteratorPublisher(iterator: Iterator[Any], settings: ActorFl
       case Unitialized | Initialized | Cancelled ⇒
         if (exposedPublisher ne null) exposedPublisher.shutdown(ActorPublisher.NormalShutdownReason)
       case Completed ⇒
-        tryOnComplete(subscriber)
         exposedPublisher.shutdown(ActorPublisher.NormalShutdownReason)
+        tryOnComplete(subscriber)
       case Errored(e) ⇒
-        tryOnError(subscriber, e)
         exposedPublisher.shutdown(Some(e))
+        if (!e.isInstanceOf[SpecViolation])
+          tryOnError(subscriber, e)
     }
     // if onComplete or onError throws we let normal supervision take care of it,
     // see reactive-streams specification rule 2:13

--- a/akka-stream/src/main/scala/akka/stream/impl/SubscriberManagement.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SubscriberManagement.scala
@@ -23,11 +23,13 @@ private[akka] object SubscriberManagement {
   }
 
   object Completed extends EndOfStream {
-    def apply[T](subscriber: Subscriber[T]): Unit = subscriber.onComplete()
+    import ReactiveStreamsCompliance._
+    def apply[T](subscriber: Subscriber[T]): Unit = tryOnComplete(subscriber)
   }
 
   final case class ErrorCompleted(cause: Throwable) extends EndOfStream {
-    def apply[T](subscriber: Subscriber[T]): Unit = subscriber.onError(cause)
+    import ReactiveStreamsCompliance._
+    def apply[T](subscriber: Subscriber[T]): Unit = tryOnError(subscriber, cause)
   }
 
   val ShutDown = new ErrorCompleted(new IllegalStateException("Cannot subscribe to shut-down Publisher"))
@@ -37,9 +39,11 @@ private[akka] object SubscriberManagement {
  * INTERNAL API
  */
 private[akka] trait SubscriptionWithCursor[T] extends Subscription with ResizableMultiReaderRingBuffer.Cursor {
+  import ReactiveStreamsCompliance._
+
   def subscriber: Subscriber[_ >: T]
 
-  def dispatch(element: T): Unit = subscriber.onNext(element)
+  def dispatch(element: T): Unit = tryOnNext(subscriber, element)
 
   var active = true
 

--- a/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
@@ -43,7 +43,7 @@ private[akka] object TickPublisher {
  * otherwise the tick element is dropped.
  */
 private[akka] class TickPublisher(initialDelay: FiniteDuration, interval: FiniteDuration, tick: Any,
-                                  settings: ActorFlowMaterializerSettings, cancelled: AtomicBoolean) extends Actor with SoftShutdown {
+                                  settings: ActorFlowMaterializerSettings, cancelled: AtomicBoolean) extends Actor {
   import akka.stream.impl.TickPublisher.TickPublisherSubscription._
   import akka.stream.impl.TickPublisher._
   import ReactiveStreamsCompliance._
@@ -122,9 +122,10 @@ private[akka] class TickPublisher(initialDelay: FiniteDuration, interval: Finite
   override def postStop(): Unit = {
     tickTask.foreach(_.cancel)
     cancelled.set(true)
-    if (subscriber ne null) tryOnComplete(subscriber)
     if (exposedPublisher ne null)
       exposedPublisher.shutdown(ActorPublisher.NormalShutdownReason)
+    if (subscriber ne null)
+      tryOnComplete(subscriber)
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
@@ -40,6 +40,7 @@ private[akka] class TcpListenStreamActor(localAddressPromise: Promise[InetSocket
                                          flowSubscriber: Subscriber[StreamTcp.IncomingConnection],
                                          bindCmd: Tcp.Bind, settings: ActorFlowMaterializerSettings) extends Actor
   with Pump with ActorLogging {
+  import ReactiveStreamsCompliance._
   import context.system
 
   object primaryOutputs extends SimpleOutputs(self, pump = this) {
@@ -89,8 +90,8 @@ private[akka] class TcpListenStreamActor(localAddressPromise: Promise[InetSocket
         val ex = BindFailedException
         localAddressPromise.failure(ex)
         unbindPromise.failure(ex)
-        flowSubscriber.onError(ex)
-        fail(ex)
+        try tryOnError(flowSubscriber, ex)
+        finally fail(ex)
     }
 
     def running: Receive = {


### PR DESCRIPTION
- if onSubscribe, onError, onComplete throws exception we must not call onError,
  see 2:13 https://github.com/reactive-streams/reactive-streams
