### PR TITLE
=pro PR validating java8 samples of akka streams (using mvn)

### DIFF
--- a/akka-samples/akka-docs-java-lambda/pom.xml
+++ b/akka-samples/akka-docs-java-lambda/pom.xml
@@ -6,7 +6,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <publishedAkkaVersion>2.3.7</publishedAkkaVersion>
+    <publishedAkkaVersion>2.3.9</publishedAkkaVersion>
   </properties>
 
   <groupId>sample</groupId>
@@ -27,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-stream_2.10</artifactId>
+      <artifactId>akka-stream-experimental_2.10</artifactId>
       <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -84,8 +84,7 @@ object AkkaBuild extends Build {
       test in Test in httpCore, test in Test in http, test in Test in httpJavaTests, test in Test in httpJava8Tests,
       test in Test in httpTestkit, test in Test in httpTests, test in Test in docsDev,
       compile in Compile in benchJmh
-      ).dependOn,
-      aggregate in publishM2 := false // REMOVE DURING MERGE INTO release-2.3
+      ).dependOn
     ),
     aggregate = Seq(streamAndHttp) // FIXME DURING MERGE INTO release-2.3
   )

--- a/project/Maven.scala
+++ b/project/Maven.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka
+
+import java.io.File
+
+import sbt._
+
+object Maven {
+  val mvn = config("maven")
+
+  val projects = settingKey[Seq[File]]("Projects which should be built by calling maven")
+  val defaultCommands = settingKey[Seq[String]]("Commands to be called on each maven project")
+  val javaHomeOverride = settingKey[Option[File]]("JAVA_HOME to be used while building projects with maven")
+  val mavenLocalRepoOverride = settingKey[Option[File]]("Overrides local maven repository location if set")
+  
+  val mvnExec = taskKey[Unit]("Test all maven projects (as listed in projectsToTest)")
+
+  def akkaBuildJava8HomeEnv() = sys.env.get("AKKA_BUILD_JAVA8_HOME").map(file)
+
+  lazy val settings: Seq[Setting[_]] = Seq(
+    projects in mvn := Nil,
+    defaultCommands in mvn := "clean" :: "test" :: Nil,
+    javaHomeOverride in mvn := akkaBuildJava8HomeEnv(),
+    mvnExec := {
+      val javaHome = (javaHomeOverride in mvn).value
+      val prjs = (projects in mvn).value
+      val cmnds = (defaultCommands in mvn).value
+      prjs foreach { p ⇒ mvnRun(javaHome, p.getAbsolutePath, cmnds: _*) }
+    }
+  )
+
+  /** Runs maven commands (blocking) on given project directory (by cd-ing into it) */
+  def mvnRun(proj: String, commands: String*): Unit =
+    mvnRun(None, proj, commands:_ *)
+
+  /** Runs maven commands (blocking) on given project directory (by cd-ing into it) */
+  def mvnRun(javaHome: Option[File], proj: String, commands: String*): Unit = {
+    val exportJHome = javaHome.map(h ⇒ s"""export JAVA_HOME="$h" """).getOrElse("")
+    val initialCmd = s"$exportJHome; cd $proj; mvn "
+    
+    val cmd = List("sh", "-c", commands.mkString(initialCmd, " ", ""))
+    if ((cmd.!(MavenLogger)) != 0) throw new Exception(s"Failed building [$proj] using maven!")
+  }
+
+  object MavenLogger extends sbt.ProcessLogger {
+    override def info(s: ⇒ String): Unit = println("[maven-out] " + s)
+    override def error(s: ⇒ String): Unit = System.err.println("[maven-err] " + s)
+    override def buffer[T](f: ⇒ T): T = f
+  }
+
+}


### PR DESCRIPTION
Includes `akka-docs-java-lambda` in (for streams documentation) in PR validation.
Also makes it a bit more centralised how we call out to maven.
Not very fancy yet, but good enough for the task at hand - overriding javaHome can be done via env or sbt setting (via env is there for Jenkins).
