### PR TITLE
=clu #13875 Exclude unreachability observations from downed (for validation)

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -237,7 +237,8 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
   var gossipStats = GossipStats()
 
   var seedNodeProcess: Option[ActorRef] = None
-  var seedNodeProcessCounter = 0 // for unique names 
+  var seedNodeProcessCounter = 0 // for unique names
+  var leaderActionCounter = 0
 
   /**
    * Looks up and returns the remote cluster command connection for the specific address.
@@ -609,9 +610,6 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
     } else if (envelope.to != selfUniqueAddress) {
       logInfo("Ignoring received gossip intended for someone else, from [{}] to [{}]", from.address, envelope.to)
       Ignored
-    } else if (!remoteGossip.overview.reachability.isReachable(selfUniqueAddress)) {
-      logInfo("Ignoring received gossip with myself as unreachable, from [{}]", from.address)
-      Ignored
     } else if (!localGossip.overview.reachability.isReachable(selfUniqueAddress, from)) {
       logInfo("Ignoring received gossip from unreachable [{}] ", from)
       Ignored
@@ -759,8 +757,21 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
   def leaderActions(): Unit =
     if (latestGossip.isLeader(selfUniqueAddress)) {
       // only run the leader actions if we are the LEADER
-      if (latestGossip.convergence)
+      val firstNotice = 20
+      val periodicNotice = 60
+      if (latestGossip.convergence(selfUniqueAddress)) {
+        if (leaderActionCounter >= firstNotice)
+          logInfo("Leader can perform its duties again")
+        leaderActionCounter = 0
         leaderActionsOnConvergence()
+      } else {
+        leaderActionCounter += 1
+        if (leaderActionCounter == firstNotice || leaderActionCounter % periodicNotice == 0)
+          logInfo("Leader can currently not perform its duties, reachability status: [{}], member status: [{}]",
+            latestGossip.reachabilityExcludingDownedObservers,
+            latestGossip.members.map(m ⇒
+              s"${m.address} ${m.status} seen=${latestGossip.seenByNode(m.uniqueAddress)}").mkString(", "))
+      }
     }
 
   /**
@@ -957,7 +968,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
 
   def validNodeForGossip(node: UniqueAddress): Boolean =
     (node != selfUniqueAddress && latestGossip.hasMember(node) &&
-      latestGossip.overview.reachability.isReachable(node))
+      latestGossip.reachabilityExcludingDownedObservers.isReachable(node))
 
   def updateLatestGossip(newGossip: Gossip): Unit = {
     // Updating the vclock version for the changes

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -20,7 +20,7 @@ private[cluster] object Gossip {
     if (members.isEmpty) empty else empty.copy(members = members)
 
   private val leaderMemberStatus = Set[MemberStatus](Up, Leaving)
-  private val convergenceMemberStatus = Set[MemberStatus](Up, Leaving)
+  val convergenceMemberStatus = Set[MemberStatus](Up, Leaving) // FIXME private
   val convergenceSkipUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
   val removeUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
 
@@ -159,17 +159,24 @@ private[cluster] case class Gossip(
    *
    * @return true if convergence have been reached and false if not
    */
-  def convergence: Boolean = {
+  def convergence(selfUniqueAddress: UniqueAddress): Boolean = {
     // First check that:
-    //   1. we don't have any members that are unreachable, or
+    //   1. we don't have any members that are unreachable, excluding observations from members
+    //      that have status DOWN, or
     //   2. all unreachable members in the set have status DOWN or EXITING
     // Else we can't continue to check for convergence
     // When that is done we check that all members with a convergence
-    // status is in the seen table and has the latest vector clock
-    // version
-    val unreachable = overview.reachability.allUnreachableOrTerminated map member
+    // status is in the seen table, i.e. has seen this version
+    val unreachable = reachabilityExcludingDownedObservers.allUnreachableOrTerminated.collect {
+      case node if (node != selfUniqueAddress) ⇒ member(node)
+    }
     unreachable.forall(m ⇒ Gossip.convergenceSkipUnreachableWithMemberStatus(m.status)) &&
       !members.exists(m ⇒ Gossip.convergenceMemberStatus(m.status) && !seenByNode(m.uniqueAddress))
+  }
+
+  lazy val reachabilityExcludingDownedObservers: Reachability = {
+    val downed = members.collect { case m if m.status == Down ⇒ m }
+    overview.reachability.removeObservers(downed.map(_.uniqueAddress))
   }
 
   def isLeader(node: UniqueAddress): Boolean = leader == Some(node)

--- a/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
@@ -187,6 +187,18 @@ private[cluster] class Reachability private (
     }
   }
 
+  def removeObservers(nodes: Set[UniqueAddress]): Reachability =
+    if (nodes.isEmpty)
+      this
+    else {
+      val newRecords = records.filterNot(r ⇒ nodes(r.observer))
+      if (newRecords.size == records.size) this
+      else {
+        val newVersions = versions -- nodes
+        Reachability(newRecords, newVersions)
+      }
+    }
+
   def status(observer: UniqueAddress, subject: UniqueAddress): ReachabilityStatus =
     observerRows(observer) match {
       case None ⇒ Reachable

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventPublisherSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventPublisherSpec.scala
@@ -19,8 +19,15 @@ import akka.testkit.ImplicitSender
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
 
+object ClusterDomainEventPublisherSpec {
+  val config = """
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.remote.netty.tcp.port = 0
+    """
+}
+
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ClusterDomainEventPublisherSpec extends AkkaSpec
+class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublisherSpec.config)
   with BeforeAndAfterEach with ImplicitSender {
 
   var publisher: ActorRef = _

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
@@ -64,6 +64,19 @@ class ReachabilitySpec extends WordSpec with Matchers {
       r.isReachable(nodeA) should be(true)
     }
 
+    "exclude observations from specific (downed) nodes" in {
+      val r = Reachability.empty.
+        unreachable(nodeC, nodeA).reachable(nodeC, nodeA).
+        unreachable(nodeC, nodeB).
+        unreachable(nodeB, nodeA).unreachable(nodeB, nodeC)
+
+      r.isReachable(nodeA) should be(false)
+      r.isReachable(nodeB) should be(false)
+      r.isReachable(nodeC) should be(false)
+      r.allUnreachableOrTerminated should be(Set(nodeA, nodeB, nodeC))
+      r.removeObservers(Set(nodeB)).allUnreachableOrTerminated should be(Set(nodeB))
+    }
+
     "be pruned when all records of an observer are Reachable" in {
       val r = Reachability.empty.
         unreachable(nodeB, nodeA).unreachable(nodeB, nodeC).

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1093,7 +1093,15 @@ object AkkaBuild extends Build {
       ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.BatchingExecutor#Batch.blockOn"),
       ProblemFilters.exclude[FinalMethodProblem]("akka.dispatch.BatchingExecutor#Batch.run"),
       ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.BatchingExecutor#Batch.akka$dispatch$BatchingExecutor$Batch$$parentBlockContext_="),
-      ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.BatchingExecutor#Batch.this")
+      ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.BatchingExecutor#Batch.this"),
+      
+      // Exclude observations from downed, #13875
+      ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.ClusterEvent.diffReachable"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.ClusterEvent.diffSeen"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.ClusterEvent.diffUnreachable"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.Gossip.convergence"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.Gossip.akka$cluster$Gossip$$convergenceMemberStatus")
+      
     )
   }
 


### PR DESCRIPTION
- Skip observations from downed node (quarantined is marked down immediately)
  in convergence check
- Skip observations from downed node when picking "reachable" targets for gossip.
- This also means that we must accept gossip with own node marked as unreachable,
  but that should not be spread to the external membership events.

(cherry picked from commit 71ccb4c21b1acd11650315d536997ea5247c547b)

Conflicts:
    akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
- Also added mima filters for the changes of the internal classes
