### PR TITLE
=act #16745 Improve error logging in akka.io.SelectionHandler

### DIFF
--- a/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
+++ b/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
@@ -257,7 +257,12 @@ private[io] class SelectionHandler(settings: SelectionHandlerSettings) extends A
                               decision: SupervisorStrategy.Directive): Unit =
         try {
           val logMessage = cause match {
-            case e: ActorInitializationException if e.getCause ne null ⇒ e.getCause.getMessage
+            case e: ActorInitializationException if (e.getCause ne null) && (e.getCause.getMessage ne null) ⇒ e.getCause.getMessage
+            case e: ActorInitializationException if e.getCause ne null ⇒
+              e.getCause match {
+                case ie: java.lang.reflect.InvocationTargetException ⇒ ie.getTargetException.toString
+                case t: Throwable                                    ⇒ Logging.simpleName(t)
+              }
             case e ⇒ e.getMessage
           }
           context.system.eventStream.publish(


### PR DESCRIPTION
When a java.net.BindException occurs, it produces an exception with a cause and
message that is "null" because it's cause returns no message. This notably occurs
when a java.net.BindException occurs during construction of a TCP selector. This
patch causes a log message like this:
    java.net.BindException: Can't assign requested address
instead of like this:
    null
which is quite a bit more helpful when diagnosing connection issues.
