### PR TITLE
=clu #16726 Down member automatically when restarted

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -20,7 +20,7 @@ private[cluster] object Gossip {
     if (members.isEmpty) empty else empty.copy(members = members)
 
   private val leaderMemberStatus = Set[MemberStatus](Up, Leaving)
-  val convergenceMemberStatus = Set[MemberStatus](Up, Leaving) // FIXME private
+  private val convergenceMemberStatus = Set[MemberStatus](Up, Leaving)
   val convergenceSkipUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
   val removeUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartFirstSeedNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartFirstSeedNodeSpec.scala
@@ -25,7 +25,10 @@ object RestartFirstSeedNodeMultiJvmSpec extends MultiNodeConfig {
   val seed3 = role("seed3")
 
   commonConfig(debugConfig(on = false).
-    withFallback(ConfigFactory.parseString("akka.cluster.auto-down-unreachable-after = 0s")).
+    withFallback(ConfigFactory.parseString("""
+      akka.cluster.auto-down-unreachable-after = off
+      akka.cluster.retry-unsuccessful-join-after = 3s
+      """)).
     withFallback(MultiNodeClusterSpec.clusterConfig))
 }
 
@@ -100,17 +103,15 @@ abstract class RestartFirstSeedNodeSpec
       runOn(seed1) {
         shutdown(seed1System, remainingOrDefault)
       }
-      runOn(seed2, seed3) {
-        awaitMembersUp(2, canNotBePartOfMemberRing = Set(seedNodes.head))
-        awaitAssert(clusterView.unreachableMembers.map(_.address) should not contain (seedNodes.head))
-      }
       enterBarrier("seed1-shutdown")
 
       // then start restartedSeed1System, which has the same address as seed1System
       runOn(seed1) {
         Cluster(restartedSeed1System).joinSeedNodes(seedNodes)
-        awaitAssert(Cluster(restartedSeed1System).readView.members.size should be(3))
-        awaitAssert(Cluster(restartedSeed1System).readView.members.map(_.status) should be(Set(Up)))
+        within(20.seconds) {
+          awaitAssert(Cluster(restartedSeed1System).readView.members.size should be(3))
+          awaitAssert(Cluster(restartedSeed1System).readView.members.map(_.status) should be(Set(Up)))
+        }
       }
       runOn(seed2, seed3) {
         awaitMembersUp(3)


### PR DESCRIPTION
- When new uid is seen in join attempt we can down existing
  member and thereby new restarted node will be able to join
  in later retried join attempt without relying on auto-down.
