### PR TITLE
add akka.util.TypedMultiMap

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.util
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+import org.scalautils.ConversionCheckedTripleEquals
+
+object TypedMultiMapSpec {
+  trait AbstractKey { type Type }
+  final case class Key[T](t: T) extends AbstractKey { final override type Type = T }
+  final case class MyValue[T](t: T)
+
+  type KV[K <: AbstractKey] = MyValue[K#Type]
+}
+
+class TypedMultiMapSpec extends WordSpec with Matchers with ConversionCheckedTripleEquals {
+  import TypedMultiMapSpec._
+
+  "A TypedMultiMap" must {
+
+    "retain and remove values for the same key" in {
+      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      val m2 = m1.inserted(Key(1))(MyValue(42))
+      m2.get(Key(1)) should ===(Set(MyValue(42)))
+      m2.removed(Key(1))(MyValue(42)).get(Key(1)) should ===(Set.empty[MyValue[Int]])
+      val m3 = m2.inserted(Key(1))(MyValue(43))
+      m3.get(Key(1)) should ===(Set(MyValue(42), MyValue(43)))
+      m3.removed(Key(1))(MyValue(42)).get(Key(1)) should ===(Set(MyValue(43)))
+    }
+
+    "retain and remove values for multiple keys" in {
+      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      val m2 = m1.inserted(Key(1))(MyValue(42)).inserted(Key(2))(MyValue(43))
+      m2.get(Key(1)) should ===(Set(MyValue(42)))
+      m2.removed(Key(1))(MyValue(42)).get(Key(1)) should ===(Set.empty[MyValue[Int]])
+      m2.get(Key(2)) should ===(Set(MyValue(43)))
+      m2.removed(Key(1))(MyValue(42)).get(Key(2)) should ===(Set(MyValue(43)))
+    }
+
+    "remove a value from all keys" in {
+      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      val m2 = m1.inserted(Key(1))(MyValue(42)).inserted(Key(2))(MyValue(43)).inserted(Key(2))(MyValue(42))
+      val m3 = m2.valueRemoved(MyValue(42))
+      m3.get(Key(1)) should ===(Set.empty[MyValue[Int]])
+      m3.get(Key(2)) should ===(Set(MyValue(43)))
+      m3.keySet should ===(Set[AbstractKey](Key(2)))
+    }
+
+    "remove all values from a key" in {
+      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      val m2 = m1.inserted(Key(1))(MyValue(42)).inserted(Key(2))(MyValue(43)).inserted(Key(2))(MyValue(42))
+      val m3 = m2.keyRemoved(Key(1))
+      m3.get(Key(1)) should ===(Set.empty[MyValue[Int]])
+      m3.get(Key(2)) should ===(Set(MyValue(42), MyValue(43)))
+      m3.keySet should ===(Set[AbstractKey](Key(2)))
+    }
+
+    "reject invalid insertions" in {
+      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      "m1.inserted(Key(1))(MyValue(42L))" shouldNot compile
+    }
+
+    "reject invalid removals" in {
+      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      "m1.removed(Key(1))(MyValue(42L))" shouldNot compile
+    }
+
+  }
+
+}

--- a/akka-actor/src/main/scala/akka/util/TypedMultiMap.scala
+++ b/akka-actor/src/main/scala/akka/util/TypedMultiMap.scala
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.util
+
+import language.higherKinds
+
+/**
+ * An immutable multi-map that expresses the value type as a type function of the key
+ * type. Create it with a type constructor that expresses the relationship:
+ *
+ * {{{
+ * trait Key { type Type = T }
+ * case class MyValue[T](...)
+ *
+ * // type function from Key to MyValue
+ * type KV[K <: Key] = MyValue[K#Type]
+ *
+ * val map = TypedMultiMap.empty[Key, KV]
+ *
+ * // a plain Int => String map would use this function:
+ * type plain[K <: Int] = String
+ *
+ * // a map T => T would use this function:
+ * type identity[T <: AnyRef] = T
+ * }}}
+ *
+ * Caveat: using keys which take type parameters does not work due to conflicts
+ * with the existential interpretation of `Key[_]`. A workaround is to define
+ * a key type like above and provide a subtype that provides its type parameter
+ * as type member `Type`.
+ */
+class TypedMultiMap[T <: AnyRef, K[_ <: T]] private (private val map: Map[T, Set[Any]]) {
+
+  /**
+   * Return the set of keys which are mapped to non-empty value sets.
+   */
+  def keySet: Set[T] = map.keySet
+
+  /**
+   * Return a map that has the given value added to the mappings for the given key.
+   */
+  def inserted(key: T)(value: K[key.type]): TypedMultiMap[T, K] = {
+    val set = map.get(key) match {
+      case Some(s) ⇒ s
+      case None    ⇒ Set.empty[Any]
+    }
+    new TypedMultiMap[T, K](map.updated(key, set + value))
+  }
+
+  /**
+   * Obtain all mappings for the given key.
+   */
+  def get(key: T): Set[K[key.type]] =
+    map.get(key) match {
+      case Some(s) ⇒ s.asInstanceOf[Set[K[key.type]]]
+      case None    ⇒ Set.empty
+    }
+
+  /**
+   * Return a map that has the given value removed from all keys.
+   */
+  def valueRemoved(value: Any): TypedMultiMap[T, K] = {
+    val s = Set(value)
+    val m = map.collect {
+      case (k, set) if set != s ⇒ (k, set - value)
+    }
+    new TypedMultiMap[T, K](m)
+  }
+
+  /**
+   * Return a map that has all mappings for the given key removed.
+   */
+  def keyRemoved(key: T): TypedMultiMap[T, K] = new TypedMultiMap[T, K](map - key)
+
+  /**
+   * Return a map that has the given mapping from the given key removed.
+   */
+  def removed(key: T)(value: K[key.type]): TypedMultiMap[T, K] = {
+    map.get(key) match {
+      case None ⇒ this
+      case Some(set) ⇒
+        if (set(value)) {
+          val newset = set - value
+          val newmap = if (newset.isEmpty) map - key else map.updated(key, newset)
+          new TypedMultiMap[T, K](newmap)
+        } else this
+    }
+  }
+
+  override def toString: String = s"TypedMultiMap($map)"
+  override def equals(other: Any) = other match {
+    case o: TypedMultiMap[_, _] ⇒ map == o.map
+    case _                      ⇒ false
+  }
+  override def hashCode: Int = map.hashCode
+}
+
+object TypedMultiMap {
+  private val _empty = new TypedMultiMap[Nothing, Nothing](Map.empty)
+
+  /**
+   * Obtain the empty map for the given key type and key–value type function.
+   */
+  def empty[T <: AnyRef, K[_ <: T]]: TypedMultiMap[T, K] = _empty.asInstanceOf[TypedMultiMap[T, K]]
+}

--- a/akka-typed/src/main/scala/akka/typed/patterns/Receptionist.scala
+++ b/akka-typed/src/main/scala/akka/typed/patterns/Receptionist.scala
@@ -7,6 +7,7 @@ import akka.typed.ScalaDSL._
 import akka.typed.ActorRef
 import akka.typed.Behavior
 import akka.typed.Terminated
+import akka.util.TypedMultiMap
 
 /**
  * A Receptionist is an entry point into an Actor hierarchy where select Actors
@@ -17,12 +18,23 @@ import akka.typed.Terminated
 object Receptionist {
 
   /**
+   * Internal representation of [[Receptionist$.ServiceKey]] which is needed
+   * in order to use a TypedMultiMap (using keys with a type parameter does not
+   * work in Scala 2.x).
+   */
+  trait AbstractServiceKey {
+    type Type
+  }
+
+  /**
    * A service key is an object that implements this trait for a given protocol
    * T, meaning that it signifies that the type T is the entry point into the
    * protocol spoken by that service (think of it as the set of first messages
    * that a client could send).
    */
-  trait ServiceKey[T]
+  trait ServiceKey[T] extends AbstractServiceKey {
+    final override type Type = T
+  }
 
   /**
    * The set of commands accepted by a Receptionist.
@@ -56,54 +68,20 @@ object Receptionist {
    * val receptionist: ActorRef[Receptionist.Command] = ctx.spawn(Props(Receptionist.behavior), "receptionist")
    * }}}
    */
-  val behavior: Behavior[Command] = behavior(Map.empty)
+  val behavior: Behavior[Command] = behavior(TypedMultiMap.empty[AbstractServiceKey, KV])
 
-  /*
-   * These wrappers are just there to get around the type madness that would otherwise ensue
-   * by declaring a Map[ServiceKey[_], Set[ActorRef[_]]] (and actually trying to use it).
-   */
-  private class Key(val key: ServiceKey[_]) {
-    override def equals(other: Any) = other match {
-      case k: Key ⇒ key == k.key
-      case _      ⇒ false
-    }
-    override def hashCode = key.hashCode
-  }
-  private object Key {
-    def apply(r: Register[_]) = new Key(r.key)
-    def apply(f: Find[_]) = new Key(f.key)
-  }
+  private type KV[K <: AbstractServiceKey] = ActorRef[K#Type]
 
-  private class Address(val address: ActorRef[_]) {
-    def extract[T]: ActorRef[T] = address.asInstanceOf[ActorRef[T]]
-    override def equals(other: Any) = other match {
-      case a: Address ⇒ address == a.address
-      case _          ⇒ false
-    }
-    override def hashCode = address.hashCode
-  }
-  private object Address {
-    def apply(r: Register[_]) = new Address(r.address)
-    def apply(r: ActorRef[_]) = new Address(r)
-  }
-
-  private def behavior(map: Map[Key, Set[Address]]): Behavior[Command] = Full {
+  private def behavior(map: TypedMultiMap[AbstractServiceKey, KV]): Behavior[Command] = Full {
     case Msg(ctx, r: Register[t]) ⇒
       ctx.watch(r.address)
-      val key = Key(r)
-      val set = map get key match {
-        case Some(old) ⇒ old + Address(r)
-        case None      ⇒ Set(Address(r))
-      }
       r.replyTo ! Registered(r.key, r.address)
-      behavior(map.updated(key, set))
+      behavior(map.inserted(r.key)(r.address))
     case Msg(ctx, f: Find[t]) ⇒
-      val set = map get Key(f) getOrElse Set.empty
-      f.replyTo ! Listing(f.key, set.map(_.extract[t]))
+      val set = map get f.key
+      f.replyTo ! Listing(f.key, set)
       Same
     case Sig(ctx, Terminated(ref)) ⇒
-      val addr = Address(ref)
-      // this is not at all optimized
-      behavior(map.map { case (k, v) ⇒ k -> (v - addr) })
+      behavior(map valueRemoved ref)
   }
 }


### PR DESCRIPTION
This greatly simplifies the Receptionist by providing the ability to
express a polymorphic map that calculates the type of each value from
the type of its key. Another possible use of this map is to express the
Extensions map in a type-safe fashion (no casts needed).
