### PR TITLE
=rem #xxxx use a Map watchee -> watchers in RemoteWatcher

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -102,10 +102,8 @@ private[cluster] class ClusterRemoteWatcher(
    * by super RemoteWatcher.
    */
   def takeOverResponsibility(address: Address): Unit = {
-    watching foreach {
-      case (watchee, watcher) ⇒ if (watchee.path.address == address)
-        unwatchRemote(watchee, watcher)
-    }
+    watching.keys.withFilter(_.path.address == address).foreach(clearAllWatches)
+    unwatchNode(address)
   }
 
 }

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -36,7 +36,7 @@ private[cluster] object ClusterRemoteWatcher {
  *
  * Specialization of [[akka.remote.RemoteWatcher]] that keeps
  * track of cluster member nodes and is responsible for watchees on cluster nodes.
- * [[akka.actor.AddressTerminate]] is published when node is removed from cluster.
+ * [[akka.actor.AddressTerminated]] is published when node is removed from cluster.
  *
  * `RemoteWatcher` handles non-cluster nodes. `ClusterRemoteWatcher` will take
  * over responsibility from `RemoteWatcher` if a watch is added before a node is member
@@ -52,8 +52,6 @@ private[cluster] class ClusterRemoteWatcher(
     heartbeatInterval,
     unreachableReaperInterval,
     heartbeatExpectedResponseAfter) {
-
-  import RemoteWatcher._
 
   val cluster = Cluster(context.system)
   import cluster.selfAddress
@@ -73,8 +71,6 @@ private[cluster] class ClusterRemoteWatcher(
   override def receive = receiveClusterEvent orElse super.receive
 
   def receiveClusterEvent: Actor.Receive = {
-    case WatchRemote(watchee, watcher) if clusterNodes(watchee.path.address) ⇒
-      () // cluster managed node, don't propagate to super
     case state: CurrentClusterState ⇒
       clusterNodes = state.members.collect { case m if m.address != selfAddress ⇒ m.address }
       clusterNodes foreach takeOverResponsibility
@@ -96,14 +92,18 @@ private[cluster] class ClusterRemoteWatcher(
     case _: MemberEvent ⇒ // not interesting
   }
 
+  override def watchNode(watcheeAddress: Address) =
+    if (!clusterNodes(watcheeAddress)) super.watchNode(watcheeAddress)
+
   /**
    * When a cluster node is added this class takes over the
    * responsibility for watchees on that node already handled
    * by super RemoteWatcher.
    */
-  def takeOverResponsibility(address: Address): Unit = {
-    watching.keys.withFilter(_.path.address == address).foreach(clearAllWatches)
-    unwatchNode(address)
-  }
+  def takeOverResponsibility(address: Address): Unit =
+    if (watchingNodes.contains(address)) {
+      log.debug("Cluster is taking over responsibility of node: [{}]", address)
+      unwatchNode(address)
+    }
 
 }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -5,18 +5,14 @@ package akka.cluster
 
 import language.postfixOps
 import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfter
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 import akka.testkit.TestEvent._
 import akka.actor.Props
 import akka.actor.Actor
-import akka.actor.Address
 import akka.actor.RootActorPath
 import akka.actor.Terminated
-import akka.actor.Address
 import akka.remote.RemoteActorRef
 import java.util.concurrent.TimeoutException
 import akka.actor.ActorSystemImpl
@@ -171,7 +167,9 @@ abstract class ClusterDeathWatchSpec
         // fifth is not cluster member, so the watch is handled by the RemoteWatcher
         awaitAssert {
           remoteWatcher ! RemoteWatcher.Stats
-          expectMsgType[RemoteWatcher.Stats].watchingRefs(subject5) should contain(testActor)
+          val stats = expectMsgType[RemoteWatcher.Stats]
+          stats.watchingRefs(subject5) should contain(testActor)
+          stats.watchingAddresses should contain(address(fifth))
         }
       }
       enterBarrier("remote-watch")
@@ -180,13 +178,13 @@ abstract class ClusterDeathWatchSpec
       awaitClusterUp(first, fourth, fifth)
 
       runOn(first) {
-        // fifth is member, so the watch is handled by the ClusterRemoteWatcher,
-        // and cleaned up from RemoteWatcher
+        // fifth is member, so the node is handled by the ClusterRemoteWatcher,
+        // but the watch is still in RemoteWatcher
         awaitAssert {
           remoteWatcher ! RemoteWatcher.Stats
-          expectMsgType[RemoteWatcher.Stats].watchingRefs.map {
-            case (watchee, watcher) ⇒ watchee.path.name
-          } should not contain ("subject5")
+          val stats = expectMsgType[RemoteWatcher.Stats]
+          stats.watchingRefs.keys.map(_.path.name) should contain("subject5")
+          stats.watchingAddresses should not contain address(fifth)
         }
       }
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -171,7 +171,7 @@ abstract class ClusterDeathWatchSpec
         // fifth is not cluster member, so the watch is handled by the RemoteWatcher
         awaitAssert {
           remoteWatcher ! RemoteWatcher.Stats
-          expectMsgType[RemoteWatcher.Stats].watchingRefs should contain((subject5, testActor))
+          expectMsgType[RemoteWatcher.Stats].watchingRefs(subject5) should contain(testActor)
         }
       }
       enterBarrier("remote-watch")

--- a/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
@@ -14,7 +14,6 @@ import akka.actor.ExtendedActorSystem
 import akka.actor.RootActorPath
 import akka.actor.Identify
 import akka.actor.ActorIdentity
-import akka.actor.PoisonPill
 import akka.actor.Address
 
 object RemoteWatcherSpec {
@@ -124,9 +123,8 @@ class RemoteWatcherSpec extends AkkaSpec(
       monitorA ! WatchRemote(b2, a1)
       monitorA ! WatchRemote(b2, a2)
       monitorA ! Stats
-      // for each watchee the RemoteWatcher also adds its own watch: 5 = 3 + 2
       // (a1->b1), (a1->b2), (a2->b2)
-      expectMsg(Stats.counts(watching = 5, watchingNodes = 1))
+      expectMsg(Stats.counts(watching = 3, watchingNodes = 1))
       expectNoMsg(100 millis)
       monitorA ! HeartbeatTick
       expectMsg(Heartbeat)
@@ -142,7 +140,7 @@ class RemoteWatcherSpec extends AkkaSpec(
       monitorA ! UnwatchRemote(b1, a1)
       // still (a1->b2) and (a2->b2) left
       monitorA ! Stats
-      expectMsg(Stats.counts(watching = 3, watchingNodes = 1))
+      expectMsg(Stats.counts(watching = 2, watchingNodes = 1))
       expectNoMsg(100 millis)
       monitorA ! HeartbeatTick
       expectMsg(Heartbeat)
@@ -151,7 +149,7 @@ class RemoteWatcherSpec extends AkkaSpec(
       monitorA ! UnwatchRemote(b2, a2)
       // still (a1->b2) left
       monitorA ! Stats
-      expectMsg(Stats.counts(watching = 2, watchingNodes = 1))
+      expectMsg(Stats.counts(watching = 1, watchingNodes = 1))
       expectNoMsg(100 millis)
       monitorA ! HeartbeatTick
       expectMsg(Heartbeat)


### PR DESCRIPTION
This commit replace the set of  (Watchee, Watchers) by a Map of Watchee -> Set of Watchers (a multimap actually)
This aims to remove whole iteration on all watches in most cases.

Some more commit should follow with other optimizations, especially for 1 watchee, N watchers case.
