### PR TITLE
(backport) =fil #16657 Fixes being unable to roll over file journal on some OSes

### DIFF
--- a/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/filebased/filequeue/Journal.scala
+++ b/akka-durable-mailboxes/akka-file-mailbox/src/main/scala/akka/actor/mailbox/filebased/filequeue/Journal.scala
@@ -71,7 +71,7 @@ class Journal(queuePath: String, syncJournal: ⇒ Boolean, log: LoggingAdapter) 
   }
 
   def roll(xid: Int, openItems: List[QItem], queue: Iterable[QItem]) {
-    writer.close
+    writer.close()
     val tmpFile = new File(queuePath + "~~" + System.currentTimeMillis)
     open(tmpFile)
     size = 0
@@ -84,14 +84,16 @@ class Journal(queuePath: String, syncJournal: ⇒ Boolean, log: LoggingAdapter) 
       add(false, item)
     }
     if (syncJournal) writer.force(false)
-    writer.close
+    writer.close()
+    // as renameTo is not guaranteed to be able to overwrite the target file, delete it explicitly
+    queueFile.delete() 
     tmpFile.renameTo(queueFile)
-    open
+    open()
   }
 
   def close() {
-    writer.close
-    for (r ← reader) r.close
+    writer.close()
+    for (r ← reader) r.close()
     reader = None
   }
 


### PR DESCRIPTION
Backport of https://github.com/akka/akka/pull/16664, resolves issue https://github.com/akka/akka/issues/16657
