### PR TITLE
+act adds missing java api for byte string

### DIFF
--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -7,6 +7,7 @@ package akka.util
 import java.nio.{ ByteBuffer, ByteOrder }
 import java.lang.{ Iterable ⇒ JIterable }
 
+import scala.annotation.varargs
 import scala.collection.IndexedSeqOptimized
 import scala.collection.mutable.{ Builder, WrappedArray }
 import scala.collection.immutable
@@ -58,6 +59,14 @@ object ByteString {
    */
   def fromArray(array: Array[Byte], offset: Int, length: Int): ByteString =
     CompactByteString.fromArray(array, offset, length)
+
+  /**
+   * JAVA API
+   * Creates a new ByteString by copying an int array by converting from integral numbers to bytes.
+   */
+  @varargs
+  def fromInts(array: Int*): ByteString =
+    apply(array:_*)(scala.math.Numeric.IntIsIntegral)
 
   /**
    * Creates a new ByteString which will contain the UTF-8 representation of the given String


### PR DESCRIPTION
As noticed here: https://github.com/akka/akka/pull/16850#discussion_r24813909
