### PR TITLE
!str #16416,#16994 BidiFlow DSL and Flow.join Mat

### DIFF
--- a/akka-docs-dev/rst/java/stream-flows-and-basics.rst
+++ b/akka-docs-dev/rst/java/stream-flows-and-basics.rst
@@ -33,7 +33,7 @@ Processing Stage
 
 Defining and running streams
 ----------------------------
-Linear processing pipelines can be expressed in Akka Streams using the following three core abstractions:
+Linear processing pipelines can be expressed in Akka Streams using the following core abstractions:
 
 Source
   A processing stage with *exactly one output*, emitting data elements whenever downstream processing stages are

--- a/akka-docs-dev/rst/java/stream-graphs.rst
+++ b/akka-docs-dev/rst/java/stream-graphs.rst
@@ -142,6 +142,58 @@ For defining a ``Flow<T>`` we need to expose both an undefined source and sink:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java#flow-from-partial-flow-graph
 
+.. _bidi-flow-java:
+
+Bidirectional Flows
+-------------------
+
+A graph topology that is often useful is that of two flows going in opposite
+directions. Take for example a codec stage that serializes outgoing messages
+and deserializes incoming octet streams. Another such stage could add a framing
+protocol that attaches a length header to outgoing data and parses incoming
+frames back into the original octet stream chunks. These two stages are meant
+to be composed, applying one atop the other as part of a protocol stack. For
+this purpose exists the special type :class:`BidiFlow` which is a graph that
+has exactly two open inlets and two open outlets. The corresponding shape is
+called :ref:`BidiShape` and is defined like this:
+
+.. includecode:: ../../../akka-stream/src/main/scala/akka/stream/Shape.scala
+   :include: bidi-shape
+   :exclude: implementation-details-elided
+
+A bidirectional flow is defined just like a unidirectional :ref:`Flow` as
+demonstrated for the codec mentioned above:
+
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/BidiFlowDocTest.java
+   :include: codec
+   :exclude: implementation-details-elided
+
+The first version resembles the partial graph constructor, while for the simple
+case of a functional 1:1 transformation there is a concise convenience method
+as shown on the last line. The implementation of the two functions is not
+difficult either:
+
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/BidiFlowDocTest.java#codec-impl
+
+In this way you could easily integrate any other serialization library that
+turns an object into a sequence of bytes.
+
+The other stage that we talked about is a little more involved since reversing
+a framing protocol means that any received chunk of bytes may correspond to
+zero or more messages. This is best implemented using a :class:`PushPullStage`
+(see also :ref:`stream-using-push-pull-stage-java`).
+
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/BidiFlowDocTest.java#framing
+
+With these implementations we can build a protocol stack and test it:
+
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/BidiFlowDocTest.java#compose
+
+This example demonstrates how :class:`BidiFlow` subgraphs can be hooked 
+together and also turned around with the ``.reversed()`` method. The test
+simulates both parties of a network communication protocol without actually
+having to open a network connection—the flows can just be connected directly.
+
 .. _graph-cycles-java:
 
 Graph cycles, liveness and deadlocks

--- a/akka-docs-dev/rst/scala/code/docs/stream/BidiFlowDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/BidiFlowDocSpec.scala
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package docs.stream
+
+import akka.stream.testkit.AkkaSpec
+import akka.stream.scaladsl._
+import akka.stream._
+import akka.util.ByteString
+import java.nio.ByteOrder
+import akka.stream.stage._
+import scala.annotation.tailrec
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import org.scalactic.ConversionCheckedTripleEquals
+
+object BidiFlowDocSpec {
+  //#codec
+  trait Message
+  case class Ping(id: Int) extends Message
+  case class Pong(id: Int) extends Message
+
+  //#codec-impl
+  def toBytes(msg: Message): ByteString = {
+    //#implementation-details-elided
+    implicit val order = ByteOrder.LITTLE_ENDIAN
+    msg match {
+      case Ping(id) => ByteString.newBuilder.putByte(1).putInt(id).result()
+      case Pong(id) => ByteString.newBuilder.putByte(2).putInt(id).result()
+    }
+    //#implementation-details-elided
+  }
+
+  def fromBytes(bytes: ByteString): Message = {
+    //#implementation-details-elided
+    implicit val order = ByteOrder.LITTLE_ENDIAN
+    val it = bytes.iterator
+    it.getByte match {
+      case 1     => Ping(it.getInt)
+      case 2     => Pong(it.getInt)
+      case other => throw new RuntimeException(s"parse error: expected 1|2 got $other")
+    }
+    //#implementation-details-elided
+  }
+  //#codec-impl
+
+  val codecVerbose = BidiFlow() { b =>
+    // construct and add the top flow, going outbound
+    val outbound = b.add(Flow[Message].map(toBytes))
+    // construct and add the bottom flow, going inbound
+    val inbound = b.add(Flow[ByteString].map(fromBytes))
+    // fuse them together into a BidiShape
+    BidiShape(outbound, inbound)
+  }
+
+  // this is the same as the above
+  val codec = BidiFlow(toBytes _, fromBytes _)
+  //#codec
+
+  //#framing
+  val framing = BidiFlow() { b =>
+    implicit val order = ByteOrder.LITTLE_ENDIAN
+
+    def addLengthHeader(bytes: ByteString) = {
+      val len = bytes.length
+      ByteString.newBuilder.putInt(len).append(bytes).result()
+    }
+
+    class FrameParser extends PushPullStage[ByteString, ByteString] {
+      // this holds the received but not yet parsed bytes
+      var stash = ByteString.empty
+      // this holds the current message length or -1 if at a boundary
+      var needed = -1
+
+      override def onPush(bytes: ByteString, ctx: Context[ByteString]) = {
+        stash ++= bytes
+        run(ctx)
+      }
+      override def onPull(ctx: Context[ByteString]) = run(ctx)
+      override def onUpstreamFinish(ctx: Context[ByteString]) =
+        if (stash.isEmpty) ctx.finish()
+        else ctx.absorbTermination() // we still have bytes to emit
+
+      private def run(ctx: Context[ByteString]): Directive =
+        if (needed == -1) {
+          // are we at a boundary? then figure out next length
+          if (stash.length < 4) pullOrFinish(ctx)
+          else {
+            needed = stash.iterator.getInt
+            stash = stash.drop(4)
+            run(ctx) // cycle back to possibly already emit the next chunk
+          }
+        } else if (stash.length < needed) {
+          // we are in the middle of a message, need more bytes
+          pullOrFinish(ctx)
+        } else {
+          // we have enough to emit at least one message, so do it
+          val emit = stash.take(needed)
+          stash = stash.drop(needed)
+          needed = -1
+          ctx.push(emit)
+        }
+
+      /*
+       * After having called absorbTermination() we cannot pull any more, so if we need
+       * more data we will just have to give up.
+       */
+      private def pullOrFinish(ctx: Context[ByteString]) =
+        if (ctx.isFinishing) ctx.finish()
+        else ctx.pull()
+    }
+
+    val outbound = b.add(Flow[ByteString].map(addLengthHeader))
+    val inbound = b.add(Flow[ByteString].transform(() => new FrameParser))
+    BidiShape(outbound, inbound)
+  }
+  //#framing
+
+  val chopUp = BidiFlow() { b =>
+    val f = Flow[ByteString].mapConcat(_.map(ByteString(_)))
+    BidiShape(b.add(f), b.add(f))
+  }
+
+  val accumulate = BidiFlow() { b =>
+    val f = Flow[ByteString].grouped(1000).map(_.fold(ByteString.empty)(_ ++ _))
+    BidiShape(b.add(f), b.add(f))
+  }
+}
+
+class BidiFlowDocSpec extends AkkaSpec with ConversionCheckedTripleEquals {
+  import BidiFlowDocSpec._
+
+  implicit val mat = ActorFlowMaterializer()
+
+  "A BidiFlow" must {
+
+    "compose" in {
+      //#compose
+      /* construct protocol stack
+       *         +------------------------------------+
+       *         | stack                              |
+       *         |                                    |
+       *         |  +-------+            +---------+  |
+       *    ~>   O~~o       |     ~>     |         o~~O    ~>
+       * Message |  | codec | ByteString | framing |  | ByteString
+       *    <~   O~~o       |     <~     |         o~~O    <~
+       *         |  +-------+            +---------+  |
+       *         +------------------------------------+
+       */
+      val stack = codec.atop(framing)
+
+      // test it by plugging it into its own inverse and closing the right end
+      val pingpong = Flow[Message].collect { case Ping(id) => Pong(id) }
+      val flow = stack.atop(stack.reversed).join(pingpong)
+      val result = Source((0 to 9).map(Ping)).via(flow).grouped(20).runWith(Sink.head)
+      Await.result(result, 1.second) should ===((0 to 9).map(Pong))
+      //#compose
+    }
+
+    "work when chopped up" in {
+      val stack = codec.atop(framing)
+      val flow = stack.atop(chopUp).atop(stack.reversed).join(Flow[Message].map { case Ping(id) => Pong(id) })
+      val f = Source((0 to 9).map(Ping)).via(flow).grouped(20).runWith(Sink.head)
+      Await.result(f, 1.second) should ===((0 to 9).map(Pong))
+    }
+
+    "work when accumulated" in {
+      val stack = codec.atop(framing)
+      val flow = stack.atop(accumulate).atop(stack.reversed).join(Flow[Message].map { case Ping(id) => Pong(id) })
+      val f = Source((0 to 9).map(Ping)).via(flow).grouped(20).runWith(Sink.head)
+      Await.result(f, 1.second) should ===((0 to 9).map(Pong))
+    }
+
+  }
+
+}

--- a/akka-docs-dev/rst/scala/stream-flows-and-basics.rst
+++ b/akka-docs-dev/rst/scala/stream-flows-and-basics.rst
@@ -33,7 +33,7 @@ Processing Stage
 
 Defining and running streams
 ----------------------------
-Linear processing pipelines can be expressed in Akka Streams using the following three core abstractions:
+Linear processing pipelines can be expressed in Akka Streams using the following core abstractions:
 
 Source
   A processing stage with *exactly one output*, emitting data elements whenever downstream processing stages are

--- a/akka-http-core/src/main/scala/akka/http/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/Http.scala
@@ -201,7 +201,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
      * and the respective materialization result returned.
      */
     def handleWith[Mat](handler: Flow[HttpRequest, HttpResponse, Mat])(implicit fm: FlowMaterializer): Mat =
-      flow.join(handler).mapMaterialized(_._2).run()
+      flow.joinMat(handler)(Keep.right).run()
 
     /**
      * Handles the connection with the given handler function.

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/BidiFlowDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/BidiFlowDocTest.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package docs.stream;
+
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import akka.actor.ActorSystem;
+import akka.japi.pf.PFBuilder;
+import akka.stream.*;
+import akka.stream.javadsl.*;
+import akka.stream.stage.Context;
+import akka.stream.stage.Directive;
+import akka.stream.stage.PushPullStage;
+import akka.stream.stage.TerminationDirective;
+import akka.testkit.JavaTestKit;
+import akka.util.ByteIterator;
+import akka.util.ByteString;
+import akka.util.ByteStringBuilder;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
+import scala.runtime.BoxedUnit;
+import static org.junit.Assert.assertArrayEquals;
+
+public class BidiFlowDocTest {
+
+  private static ActorSystem system;
+
+  @BeforeClass
+  public static void setup() {
+      system = ActorSystem.create("FlowDocTest");
+  }
+
+  @AfterClass
+  public static void tearDown() {
+      JavaTestKit.shutdownActorSystem(system);
+      system = null;
+  }
+
+  final FlowMaterializer mat = ActorFlowMaterializer.create(system);
+
+  //#codec
+  static interface Message {}
+  static class Ping implements Message {
+    final int id;
+    public Ping(int id) { this.id = id; }
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof Ping) {
+        return ((Ping) o).id == id;
+      } else return false;
+    }
+    @Override
+    public int hashCode() {
+      return id;
+    }
+  }
+  static class Pong implements Message {
+    final int id;
+    public Pong(int id) { this.id = id; }
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof Pong) {
+        return ((Pong) o).id == id;
+      } else return false;
+    }
+    @Override
+    public int hashCode() {
+      return id;
+    }
+  }
+  
+  //#codec-impl
+  public static ByteString toBytes(Message msg) {
+    //#implementation-details-elided
+    if (msg instanceof Ping) {
+      final int id = ((Ping) msg).id;
+      return new ByteStringBuilder().putByte((byte) 1)
+          .putInt(id, ByteOrder.LITTLE_ENDIAN).result();
+    } else {
+      final int id = ((Pong) msg).id;
+      return new ByteStringBuilder().putByte((byte) 2)
+          .putInt(id, ByteOrder.LITTLE_ENDIAN).result();
+    }
+    //#implementation-details-elided
+  }
+  
+  public static Message fromBytes(ByteString bytes) {
+    //#implementation-details-elided
+    final ByteIterator it = bytes.iterator();
+    switch(it.getByte()) {
+    case 1:
+      return new Ping(it.getInt(ByteOrder.LITTLE_ENDIAN));
+    case 2:
+      return new Pong(it.getInt(ByteOrder.LITTLE_ENDIAN));
+    default:
+      throw new RuntimeException("message format error");
+    }
+    //#implementation-details-elided
+  }
+  //#codec-impl
+  
+  //#codec
+  @SuppressWarnings("unused")
+  //#codec
+  public final BidiFlow<Message, ByteString, ByteString, Message, BoxedUnit> codecVerbose =
+      BidiFlow.factory().create(b -> {
+        final FlowShape<Message, ByteString> top =
+            b.graph(Flow.<Message> empty().map(BidiFlowDocTest::toBytes));
+        final FlowShape<ByteString, Message> bottom =
+            b.graph(Flow.<ByteString> empty().map(BidiFlowDocTest::fromBytes));
+        return new BidiShape<>(top, bottom);
+      });
+
+  public final BidiFlow<Message, ByteString, ByteString, Message, BoxedUnit> codec =
+      BidiFlow.fromFunctions(BidiFlowDocTest::toBytes, BidiFlowDocTest::fromBytes);
+  //#codec
+  
+  //#framing
+  public static ByteString addLengthHeader(ByteString bytes) {
+    final int len = bytes.size();
+    return new ByteStringBuilder()
+      .putInt(len, ByteOrder.LITTLE_ENDIAN)
+      .append(bytes)
+      .result();
+  }
+  
+  public static class FrameParser extends PushPullStage<ByteString, ByteString> {
+    // this holds the received but not yet parsed bytes
+    private ByteString stash = ByteString.empty();
+    // this holds the current message length or -1 if at a boundary
+    private int needed = -1;
+    
+    @Override
+    public Directive onPull(Context<ByteString> ctx) {
+      return run(ctx);
+    }
+
+    @Override
+    public Directive onPush(ByteString bytes, Context<ByteString> ctx) {
+      stash = stash.concat(bytes);
+      return run(ctx);
+    }
+    
+    @Override
+    public TerminationDirective onUpstreamFinish(Context<ByteString> ctx) {
+      if (stash.isEmpty()) return ctx.finish();
+      else return ctx.absorbTermination(); // we still have bytes to emit
+    }
+    
+    private Directive run(Context<ByteString> ctx) {
+      if (needed == -1) {
+        // are we at a boundary? then figure out next length
+        if (stash.size() < 4) return pullOrFinish(ctx);
+        else {
+          needed = stash.iterator().getInt(ByteOrder.LITTLE_ENDIAN);
+          stash = stash.drop(4);
+          return run(ctx); // cycle back to possibly already emit the next chunk
+        }
+      } else if (stash.size() < needed) {
+        // we are in the middle of a message, need more bytes
+        return pullOrFinish(ctx);
+      } else {
+        // we have enough to emit at least one message, so do it
+        final ByteString emit = stash.take(needed);
+        stash = stash.drop(needed);
+        needed = -1;
+        return ctx.push(emit);
+      }
+    }
+    
+    /*
+     * After having called absorbTermination() we cannot pull any more, so if we need
+     * more data we will just have to give up.
+     */
+    private Directive pullOrFinish(Context<ByteString> ctx) {
+      if (ctx.isFinishing()) return ctx.finish();
+      else return ctx.pull();
+    }
+  }
+  
+  public final BidiFlow<ByteString, ByteString, ByteString, ByteString, BoxedUnit> framing =
+      BidiFlow.factory().create(b -> {
+        final FlowShape<ByteString, ByteString> top =
+            b.graph(Flow.<ByteString> empty().map(BidiFlowDocTest::addLengthHeader));
+        final FlowShape<ByteString, ByteString> bottom =
+            b.graph(Flow.<ByteString> empty().transform(() -> new FrameParser()));
+        return new BidiShape<>(top, bottom);
+      });
+  //#framing
+  
+  @Test
+  public void mustCompose() throws Exception {
+    //#compose
+    /* construct protocol stack
+     *         +------------------------------------+
+     *         | stack                              |
+     *         |                                    |
+     *         |  +-------+            +---------+  |
+     *    ~>   O~~o       |     ~>     |         o~~O    ~>
+     * Message |  | codec | ByteString | framing |  | ByteString
+     *    <~   O~~o       |     <~     |         o~~O    <~
+     *         |  +-------+            +---------+  |
+     *         +------------------------------------+
+     */
+    final BidiFlow<Message, ByteString, ByteString, Message, BoxedUnit> stack =
+        codec.atop(framing);
+
+    // test it by plugging it into its own inverse and closing the right end
+    final Flow<Message, Message, BoxedUnit> pingpong = 
+        Flow.<Message> empty().collect(new PFBuilder<Message, Message>()
+            .match(Ping.class, p -> new Pong(p.id))
+            .build()
+            );
+    final Flow<Message, Message, BoxedUnit> flow =
+        stack.atop(stack.reversed()).join(pingpong);
+    final Future<List<Message>> result = Source
+        .from(Arrays.asList(0, 1, 2))
+        .<Message> map(id -> new Ping(id))
+        .via(flow)
+        .grouped(10)
+        .runWith(Sink.<List<Message>> head(), mat);
+    final FiniteDuration oneSec = Duration.create(1, TimeUnit.SECONDS);
+    assertArrayEquals(
+        new Message[] { new Pong(0), new Pong(1), new Pong(2) },
+        Await.result(result, oneSec).toArray(new Message[0]));
+    //#compose
+  }
+}

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/BidiFlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/BidiFlowTest.java
@@ -1,0 +1,270 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.javadsl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
+import scala.runtime.BoxedUnit;
+import akka.japi.Pair;
+import akka.stream.*;
+import akka.stream.testkit.AkkaSpec;
+import akka.stream.javadsl.FlowGraph.Builder;
+import akka.stream.javadsl.japi.*;
+import akka.util.ByteString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+
+public class BidiFlowTest extends StreamTest {
+  public BidiFlowTest() {
+    super(actorSystemResource);
+  }
+
+  @ClassRule
+  public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource(
+      "FlowTest", AkkaSpec.testConf());
+
+  private final BidiFlow<Integer, Long, ByteString, String, BoxedUnit> bidi = BidiFlow
+      .factory()
+      .create(
+          new Function<FlowGraph.Builder, BidiShape<Integer, Long, ByteString, String>>() {
+            @Override
+            public BidiShape<Integer, Long, ByteString, String> apply(Builder b)
+                throws Exception {
+              final FlowShape<Integer, Long> top = b.graph(Flow
+                  .<Integer> empty().map(new Function<Integer, Long>() {
+                    @Override
+                    public Long apply(Integer arg) {
+                      return (long) ((int) arg) + 2;
+                    }
+                  }));
+              final FlowShape<ByteString, String> bottom = b.graph(Flow
+                  .<ByteString> empty().map(new Function<ByteString, String>() {
+                    @Override
+                    public String apply(ByteString arg) {
+                      return arg.decodeString("UTF-8");
+                    }
+                  }));
+              return new BidiShape<Integer, Long, ByteString, String>(top
+                  .inlet(), top.outlet(), bottom.inlet(), bottom.outlet());
+            }
+          });
+
+  private final BidiFlow<Long, Integer, String, ByteString, BoxedUnit> inverse = BidiFlow
+      .factory()
+      .create(
+          new Function<FlowGraph.Builder, BidiShape<Long, Integer, String, ByteString>>() {
+            @Override
+            public BidiShape<Long, Integer, String, ByteString> apply(Builder b)
+                throws Exception {
+              final FlowShape<Long, Integer> top = b.graph(Flow.<Long> empty()
+                  .map(new Function<Long, Integer>() {
+                    @Override
+                    public Integer apply(Long arg) {
+                      return (int) ((long) arg) + 2;
+                    }
+                  }));
+              final FlowShape<String, ByteString> bottom = b.graph(Flow
+                  .<String> empty().map(new Function<String, ByteString>() {
+                    @Override
+                    public ByteString apply(String arg) {
+                      return ByteString.fromString(arg);
+                    }
+                  }));
+              return new BidiShape<Long, Integer, String, ByteString>(top
+                  .inlet(), top.outlet(), bottom.inlet(), bottom.outlet());
+            }
+          });
+
+  private final BidiFlow<Integer, Long, ByteString, String, Future<Integer>> bidiMat = BidiFlow
+      .factory()
+      .create(
+          Sink.<Integer> head(),
+          new Function2<FlowGraph.Builder, SinkShape<Integer>, BidiShape<Integer, Long, ByteString, String>>() {
+            @Override
+            public BidiShape<Integer, Long, ByteString, String> apply(Builder b, SinkShape<Integer> sink)
+                throws Exception {
+              b.from(Source.single(42)).to(sink);
+              final FlowShape<Integer, Long> top = b.graph(Flow
+                  .<Integer> empty().map(new Function<Integer, Long>() {
+                    @Override
+                    public Long apply(Integer arg) {
+                      return (long) ((int) arg) + 2;
+                    }
+                  }));
+              final FlowShape<ByteString, String> bottom = b.graph(Flow
+                  .<ByteString> empty().map(new Function<ByteString, String>() {
+                    @Override
+                    public String apply(ByteString arg) {
+                      return arg.decodeString("UTF-8");
+                    }
+                  }));
+              return new BidiShape<Integer, Long, ByteString, String>(top
+                  .inlet(), top.outlet(), bottom.inlet(), bottom.outlet());
+            }
+          });
+
+  private final String str = "Hello World";
+  private final ByteString bytes = ByteString.fromString(str);
+  private final List<Integer> list = new ArrayList<Integer>();
+  {
+    list.add(1);
+    list.add(2);
+    list.add(3);
+  }
+  private final FiniteDuration oneSec = Duration.create(1, TimeUnit.SECONDS);
+
+  @Test
+  public void mustWorkInIsolation() throws Exception {
+    final Pair<Future<Long>, Future<String>> p = FlowGraph
+        .factory()
+        .closed(Sink.<Long> head(), Sink.<String> head(),
+            Keep.<Future<Long>, Future<String>> both(),
+            new Procedure3<Builder, SinkShape<Long>, SinkShape<String>>() {
+              @Override
+              public void apply(Builder b, SinkShape<Long> st,
+                  SinkShape<String> sb) throws Exception {
+                final BidiShape<Integer, Long, ByteString, String> s = b
+                    .graph(bidi);
+                b.from(Source.single(1)).to(s.in1());
+                b.from(s.out1()).to(st);
+                b.from(Source.single(bytes)).to(s.in2());
+                b.from(s.out2()).to(sb);
+              }
+            }).run(materializer);
+
+    final Long rt = Await.result(p.first(), oneSec);
+    final String rb = Await.result(p.second(), oneSec);
+
+    assertEquals((Long) 3L, rt);
+    assertEquals(str, rb);
+  }
+
+  @Test
+  public void mustWorkAsAFlowThatIsOpenOnTheLeft() throws Exception {
+    final Flow<Integer, String, BoxedUnit> f = bidi.join(Flow.<Long> empty().map(
+        new Function<Long, ByteString>() {
+          @Override public ByteString apply(Long arg) {
+            return ByteString.fromString("Hello " + arg);
+          }
+        }));
+    final Future<List<String>> result = Source.from(list).via(f).grouped(10).runWith(Sink.<List<String>> head(), materializer);
+    assertEquals(Arrays.asList("Hello 3", "Hello 4", "Hello 5"), Await.result(result, oneSec));
+  }
+
+  @Test
+  public void mustWorkAsAFlowThatIsOpenOnTheRight() throws Exception {
+    final Flow<ByteString, Long, BoxedUnit> f = Flow.<String> empty().map(
+        new Function<String, Integer>() {
+          @Override public Integer apply(String arg) {
+            return Integer.valueOf(arg);
+          }
+        }).join(bidi);
+    final List<ByteString> inputs = Arrays.asList(ByteString.fromString("1"), ByteString.fromString("2"));
+    final Future<List<Long>> result = Source.from(inputs).via(f).grouped(10).runWith(Sink.<List<Long>> head(), materializer);
+    assertEquals(Arrays.asList(3L, 4L), Await.result(result, oneSec));
+  }
+
+  @Test
+  public void mustWorkWhenAtopItsInverse() throws Exception {
+    final Flow<Integer,String,BoxedUnit> f = bidi.atop(inverse).join(Flow.<Integer> empty().map(
+        new Function<Integer, String>() {
+          @Override public String apply(Integer arg) {
+            return arg.toString();
+          }
+        }));
+    final Future<List<String>> result = Source.from(list).via(f).grouped(10).runWith(Sink.<List<String>> head(), materializer);
+    assertEquals(Arrays.asList("5", "6", "7"), Await.result(result, oneSec));
+  }
+
+  @Test
+  public void mustWorkWhenReversed() throws Exception {
+    final Flow<Integer,String,BoxedUnit> f = Flow.<Integer> empty().map(
+        new Function<Integer, String>() {
+          @Override public String apply(Integer arg) {
+            return arg.toString();
+          }
+        }).join(inverse.reversed()).join(bidi.reversed());
+    final Future<List<String>> result = Source.from(list).via(f).grouped(10).runWith(Sink.<List<String>> head(), materializer);
+    assertEquals(Arrays.asList("5", "6", "7"), Await.result(result, oneSec));
+  }
+  
+  @Test
+  public void mustMaterializeToItsValue() throws Exception {
+    final Future<Integer> f = FlowGraph.factory().closed(bidiMat, new Procedure2<Builder, BidiShape<Integer, Long, ByteString, String>>() {
+      @Override
+      public void apply(Builder b,
+          BidiShape<Integer, Long, ByteString, String> shape) throws Exception {
+        final FlowShape<String, Integer> left = b.graph(Flow.<String> empty().map(
+            new Function<String, Integer>() {
+              @Override public Integer apply(String arg) {
+                return Integer.valueOf(arg);
+              }
+            }));
+        final FlowShape<Long, ByteString> right = b.graph(Flow.<Long> empty().map(
+            new Function<Long, ByteString>() {
+              @Override public ByteString apply(Long arg) {
+                return ByteString.fromString("Hello " + arg);
+              }
+            }));
+        b.from(shape.out2()).via(left).to(shape.in1())
+         .from(shape.out1()).via(right).to(shape.in2());
+      }
+    }).run(materializer);
+    assertEquals((Integer) 42, Await.result(f, oneSec));
+  }
+  
+  @Test
+  public void mustCombineMaterializationValues() throws Exception {
+    final Flow<String, Integer, Future<Integer>> left = Flow.factory().create(
+        Sink.<Integer> head(), new Function2<Builder, SinkShape<Integer>, Pair<Inlet<String>, Outlet<Integer>>>() {
+          @Override
+          public Pair<Inlet<String>, Outlet<Integer>> apply(Builder b,
+              SinkShape<Integer> sink) throws Exception {
+            final UniformFanOutShape<Integer, Integer> bcast = b.graph(Broadcast.<Integer> create(2));
+            final UniformFanInShape<Integer, Integer> merge = b.graph(Merge.<Integer> create(2));
+            final FlowShape<String, Integer> flow = b.graph(Flow.<String> empty().map(
+                new Function<String, Integer>() {
+                      @Override
+                      public Integer apply(String arg) {
+                        return Integer.valueOf(arg);
+                      }
+                    }));
+            b.from(bcast).to(sink)
+             .from(Source.single(1)).via(bcast).to(merge)
+             .from(flow).to(merge);
+            return new Pair<Inlet<String>, Outlet<Integer>>(flow.inlet(), merge.out());
+          }
+        });
+    final Flow<Long, ByteString, Future<List<Long>>> right = Flow.factory().create(
+        Sink.<List<Long>> head(), new Function2<Builder, SinkShape<List<Long>>, Pair<Inlet<Long>, Outlet<ByteString>>>() {
+          @Override
+          public Pair<Inlet<Long>, Outlet<ByteString>> apply(Builder b,
+              SinkShape<List<Long>> sink) throws Exception {
+            final FlowShape<Long, List<Long>> flow = b.graph(Flow.<Long> empty().grouped(10));
+            b.from(flow).to(sink);
+            return new Pair<Inlet<Long>, Outlet<ByteString>>(flow.inlet(), b.source(Source.single(ByteString.fromString("10"))));
+          }
+        });
+    final Pair<Pair<Future<Integer>, Future<Integer>>, Future<List<Long>>> result =
+        left.join(bidiMat, Keep.<Future<Integer>, Future<Integer>> both()).join(right, Keep.<Pair<Future<Integer>, Future<Integer>>, Future<List<Long>>> both()).run(materializer);
+    final Future<Integer> l = result.first().first();
+    final Future<Integer> m = result.first().second();
+    final Future<List<Long>> r = result.second();
+    assertEquals((Integer) 1, Await.result(l, oneSec));
+    assertEquals((Integer) 42, Await.result(m, oneSec));
+    final Long[] rr = Await.result(r, oneSec).toArray(new Long[0]);
+    Arrays.sort(rr);
+    assertArrayEquals(new Long[] { 3L, 12L }, rr);
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.testkit.AkkaSpec
+import org.scalactic.ConversionCheckedTripleEquals
+import akka.util.ByteString
+import akka.stream.BidiShape
+import akka.stream.ActorFlowMaterializer
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.collection.immutable
+
+class BidiFlowSpec extends AkkaSpec with ConversionCheckedTripleEquals {
+  import OperationAttributes._
+  import FlowGraph.Implicits._
+
+  implicit val mat = ActorFlowMaterializer()
+
+  val bidi = BidiFlow() { b ⇒
+    val top = b.add(Flow[Int].map(x ⇒ x.toLong + 2).withAttributes(name("top")))
+    val bottom = b.add(Flow[ByteString].map(_.decodeString("UTF-8")).withAttributes(name("bottom")))
+    BidiShape(top.inlet, top.outlet, bottom.inlet, bottom.outlet)
+  }
+
+  val inverse = BidiFlow() { b ⇒
+    val top = b.add(Flow[Long].map(x ⇒ x.toInt + 2).withAttributes(name("top")))
+    val bottom = b.add(Flow[String].map(ByteString(_)).withAttributes(name("bottom")))
+    BidiShape(top.inlet, top.outlet, bottom.inlet, bottom.outlet)
+  }
+
+  val bidiMat = BidiFlow(Sink.head[Int]) { implicit b ⇒
+    s ⇒
+      Source.single(42) ~> s
+
+      val top = b.add(Flow[Int].map(x ⇒ x.toLong + 2))
+      val bottom = b.add(Flow[ByteString].map(_.decodeString("UTF-8")))
+      BidiShape(top.inlet, top.outlet, bottom.inlet, bottom.outlet)
+  }
+
+  val str = "Hello World"
+  val bytes = ByteString(str)
+
+  "A BidiFlow" must {
+
+    "work top/bottom in isolation" in {
+      val (top, bottom) = FlowGraph.closed(Sink.head[Long], Sink.head[String])(Keep.both) { implicit b ⇒
+        (st, sb) ⇒
+          val s = b.add(bidi)
+
+          Source.single(1) ~> s.in1; s.out1 ~> st
+          sb <~ s.out2; s.in2 <~ Source.single(bytes)
+      }.run()
+
+      Await.result(top, 1.second) should ===(3)
+      Await.result(bottom, 1.second) should ===(str)
+    }
+
+    "work as a Flow that is open on the left" in {
+      val f = bidi.join(Flow[Long].map(x ⇒ ByteString(s"Hello $x")))
+      val result = Source(List(1, 2, 3)).via(f).grouped(10).runWith(Sink.head)
+      Await.result(result, 1.second) should ===(Seq("Hello 3", "Hello 4", "Hello 5"))
+    }
+
+    "work as a Flow that is open on the right" in {
+      val f = Flow[String].map(Integer.valueOf(_).toInt).join(bidi)
+      val result = Source(List(ByteString("1"), ByteString("2"))).via(f).grouped(10).runWith(Sink.head)
+      Await.result(result, 1.second) should ===(Seq(3L, 4L))
+    }
+
+    "work when atop its inverse" in {
+      val f = bidi.atop(inverse).join(Flow[Int].map(_.toString))
+      val result = Source(List(1, 2, 3)).via(f).grouped(10).runWith(Sink.head)
+      Await.result(result, 1.second) should ===(Seq("5", "6", "7"))
+    }
+
+    "work when reversed" in {
+      // just reversed from the case above; observe that Flow inverts itself automatically by being on the left side
+      val f = Flow[Int].map(_.toString).join(inverse.reversed).join(bidi.reversed)
+      val result = Source(List(1, 2, 3)).via(f).grouped(10).runWith(Sink.head)
+      Await.result(result, 1.second) should ===(Seq("5", "6", "7"))
+    }
+
+    "materialize to its value" in {
+      val f = FlowGraph.closed(bidiMat) { implicit b ⇒
+        bidi ⇒
+          Flow[String].map(Integer.valueOf(_).toInt) <~> bidi <~> Flow[Long].map(x ⇒ ByteString(s"Hello $x"))
+      }.run()
+      Await.result(f, 1.second) should ===(42)
+    }
+
+    "combine materialization values" in {
+      val left = Flow(Sink.head[Int]) { implicit b ⇒
+        sink ⇒
+          val bcast = b.add(Broadcast[Int](2))
+          val merge = b.add(Merge[Int](2))
+          val flow = b.add(Flow[String].map(Integer.valueOf(_).toInt))
+          bcast ~> sink
+          Source.single(1) ~> bcast ~> merge
+          flow ~> merge
+          (flow.inlet, merge.out)
+      }
+      val right = Flow(Sink.head[immutable.Seq[Long]]) { implicit b ⇒
+        sink ⇒
+          val flow = b.add(Flow[Long].grouped(10))
+          flow ~> sink
+          (flow.inlet, b.add(Source.single(ByteString("10"))))
+      }
+      val ((l, m), r) = left.joinMat(bidiMat)(Keep.both).joinMat(right)(Keep.both).run()
+      Await.result(l, 1.second) should ===(1)
+      Await.result(m, 1.second) should ===(42)
+      Await.result(r, 1.second).toSet should ===(Set(3L, 12L))
+    }
+
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -166,4 +166,11 @@ class SourceSpec extends AkkaSpec {
     }
   }
 
+  "Iterator Source" must {
+    "properly iterate" in {
+      val result = Await.result(Source(() ⇒ Iterator.iterate(false)(!_)).grouped(10).runWith(Sink.head), 1.second)
+      result should ===(Seq(false, true, false, true, false, true, false, true, false, true))
+    }
+  }
+
 }

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/BidiFlowCreate.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/BidiFlowCreate.scala.template
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.javadsl
+
+import akka.stream.scaladsl
+import akka.stream.{ Inlet, Outlet, Shape, Graph, BidiShape }
+import akka.stream.scaladsl.JavaConverters._
+import akka.japi.Pair
+
+trait BidiFlowCreate {
+
+  import language.implicitConversions
+  private implicit def p[A, B](pair: Pair[A, B]): (A, B) = pair.first -> pair.second
+
+  def create[I1, O1, I2, O2](block: japi.Function[FlowGraph.Builder, BidiShape[I1, O1, I2, O2]]): BidiFlow[I1, O1, I2, O2, Unit] =
+    new BidiFlow(scaladsl.BidiFlow() { b ⇒ block.apply(b.asJava) })
+
+  def create[I1, O1, I2, O2, S <: Shape, M](g1: Graph[S, M], block: japi.Function2[FlowGraph.Builder, S, BidiShape[I1, O1, I2, O2]]): BidiFlow[I1, O1, I2, O2, M] =
+    new BidiFlow(scaladsl.BidiFlow(g1) { b ⇒ s => block.apply(b.asJava, s) })
+
+  [2..21#def create[I##1, O##1, I##2, O##2, [#S1 <: Shape#], [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: japi.Function1[[#M1#], M],
+      block: japi.Function2[FlowGraph.Builder, [#S1#], BidiShape[I##1, O##1, I##2, O##2]]): BidiFlow[I##1, O##1, I##2, O##2, M] =
+    new BidiFlow(scaladsl.BidiFlow([#g1#])(combineMat.apply _) { b => ([#s1#]) => block.apply(b.asJava, [#s1#]) })#
+  
+  ]
+
+}

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/FlowCreate.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/FlowCreate.scala.template
@@ -19,7 +19,7 @@ trait FlowCreate {
   def create[I, O, S <: Shape, M](g1: Graph[S, M], block: japi.Function2[FlowGraph.Builder, S, Inlet[I] Pair Outlet[O]]): Flow[I, O, M] =
     new Flow(scaladsl.Flow(g1) { b ⇒ s => block.apply(b.asJava, s) })
 
-  [3..21#def create[I, O, [#S1 <: Shape#], [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: japi.Function1[[#M1#], M],
+  [2..21#def create[I, O, [#S1 <: Shape#], [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: japi.Function1[[#M1#], M],
       block: japi.Function2[FlowGraph.Builder, [#S1#], Inlet[I] Pair Outlet[O]]): Flow[I, O, M] =
     new Flow(scaladsl.Flow([#g1#])(combineMat.apply _) { b => ([#s1#]) => block.apply(b.asJava, [#s1#]) })#
   

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/SinkCreate.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/SinkCreate.scala.template
@@ -23,7 +23,7 @@ trait SinkCreate {
   def create[T, S <: Shape, M](g1: Graph[S, M], block: japi.Function2[FlowGraph.Builder, S, Inlet[T]]): Sink[T, M] =
     new Sink(scaladsl.Sink(g1) { b ⇒ s => block.apply(b.asJava, s) })
 
-  [3..21#def create[T, [#S1 <: Shape#], [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: japi.Function1[[#M1#], M],
+  [2..21#def create[T, [#S1 <: Shape#], [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: japi.Function1[[#M1#], M],
       block: japi.Function2[FlowGraph.Builder, [#S1#], Inlet[T]]): Sink[T, M] =
     new Sink(scaladsl.Sink([#g1#])(combineMat.apply _) { b => ([#s1#]) => block.apply(b.asJava, [#s1#]) })#
   

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/SourceCreate.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/SourceCreate.scala.template
@@ -15,7 +15,7 @@ trait SourceCreate {
   def create[T, S <: Shape, M](g1: Graph[S, M], block: japi.Function2[FlowGraph.Builder, S, Outlet[T]]): Source[T, M] =
     new Source(scaladsl.Source(g1) { b ⇒ s => block.apply(b.asJava, s) })
 
-  [3..21#def create[T, [#S1 <: Shape#], [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: japi.Function1[[#M1#], M],
+  [2..21#def create[T, [#S1 <: Shape#], [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: japi.Function1[[#M1#], M],
       block: japi.Function2[FlowGraph.Builder, [#S1#], Outlet[T]]): Source[T, M] =
     new Source(scaladsl.Source([#g1#])(combineMat.apply _) { b => ([#s1#]) => block.apply(b.asJava, [#s1#]) })#
   

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/BidiFlowApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/BidiFlowApply.scala.template
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2014-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.{ Shape, Inlet, Outlet, Graph, BidiShape }
+
+trait BidiFlowApply {
+
+  def apply[I1, O1, I2, O2]()(block: FlowGraph.Builder ⇒ BidiShape[I1, O1, I2, O2]): BidiFlow[I1, O1, I2, O2, Unit] = {
+    val builder = new FlowGraph.Builder
+    val shape = block(builder)
+    builder.buildBidiFlow(shape)
+  }
+
+  def apply[I1, O1, I2, O2, Mat](g1: Graph[Shape, Mat])(buildBlock: FlowGraph.Builder => (g1.Shape) ⇒ BidiShape[I1, O1, I2, O2]): BidiFlow[I1, O1, I2, O2, Mat] = {
+    val builder = new FlowGraph.Builder
+    val p = builder.add(g1, Keep.right)
+    val shape = buildBlock(builder)(p)
+    builder.buildBidiFlow(shape)
+  }
+  
+  [2..#def apply[I##1, O##1, I##2, O##2, [#M1#], Mat]([#g1: Graph[Shape, M1]#])(combineMat: ([#M1#]) => Mat)(
+    buildBlock: FlowGraph.Builder => ([#g1.Shape#]) ⇒ BidiShape[I##1, O##1, I##2, O##2]): BidiFlow[I##1, O##1, I##2, O##2, Mat] = {
+    val builder = new FlowGraph.Builder
+    val curried = combineMat.curried
+    val p##1 = builder.add(g##1, (_: Any, m##1: M##1) ⇒ curried(m##1))
+    [2..#val p1 = builder.add(g1, (f: M1 ⇒ Any, m1: M1) ⇒ f(m1))#
+    ]
+    val shape = buildBlock(builder)([#p1#])
+    builder.buildBidiFlow(shape)
+  }#
+  
+  ]
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -42,6 +42,7 @@ private[akka] object StreamLayout {
     def isSink: Boolean = (inPorts.size == 1) && outPorts.isEmpty
     def isSource: Boolean = (outPorts.size == 1) && inPorts.isEmpty
     def isFlow: Boolean = (inPorts.size == 1) && (outPorts.size == 1)
+    def isBidiFlow: Boolean = (inPorts.size == 2) && (outPorts.size == 2)
 
     def growConnect(that: Module, from: OutPort, to: InPort): Module =
       growConnect(that, from, to, Keep.left)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.javadsl
+
+import akka.stream.scaladsl
+import akka.stream.Graph
+import akka.stream.BidiShape
+
+object BidiFlow {
+
+  val factory: BidiFlowCreate = new BidiFlowCreate {}
+
+  /**
+   * A graph with the shape of a flow logically is a flow, this method makes
+   * it so also in type.
+   */
+  def wrap[I1, O1, I2, O2, M](g: Graph[BidiShape[I1, O1, I2, O2], M]): BidiFlow[I1, O1, I2, O2, M] = new BidiFlow(scaladsl.BidiFlow.wrap(g))
+
+  /**
+   * Create a BidiFlow where the top and bottom flows are just one simple mapping
+   * stage each, expressed by the two functions.
+   */
+  def fromFunctions[I1, O1, I2, O2](top: japi.Function[I1, O1], bottom: japi.Function[I2, O2]): BidiFlow[I1, O1, I2, O2, Unit] =
+    new BidiFlow(scaladsl.BidiFlow(top.apply _, bottom.apply _))
+
+}
+
+class BidiFlow[-I1, +O1, -I2, +O2, +Mat](delegate: scaladsl.BidiFlow[I1, O1, I2, O2, Mat]) extends Graph[BidiShape[I1, O1, I2, O2], Mat] {
+  private[stream] override def module = delegate.module
+  override def shape = delegate.shape
+
+  def asScala: scaladsl.BidiFlow[I1, O1, I2, O2, Mat] = delegate
+
+  /**
+   * Add the given BidiFlow as the next step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +----------------------------+
+   *     | Resulting BidiFlow         |
+   *     |                            |
+   *     |  +------+        +------+  |
+   * I1 ~~> |      |  ~O1~> |      | ~~> OO1
+   *     |  | this |        | bidi |  |
+   * O2 <~~ |      | <~I2~  |      | <~~ II2
+   *     |  +------+        +------+  |
+   *     +----------------------------+
+   * }}}
+   * The materialized value of the combined [[BidiFlow]] will be the materialized
+   * value of the current flow (ignoring the other BidiFlow’s value), use
+   * [[BidiFlow#atopMat atopMat]] if a different strategy is needed.
+   */
+  def atop[OO1, II2, Mat2](bidi: BidiFlow[O1, OO1, II2, I2, Mat2]): BidiFlow[I1, OO1, II2, O2, Mat] =
+    new BidiFlow(delegate.atop(bidi.asScala))
+
+  /**
+   * Add the given BidiFlow as the next step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +----------------------------+
+   *     | Resulting BidiFlow         |
+   *     |                            |
+   *     |  +------+        +------+  |
+   * I1 ~~> |      |  ~O1~> |      | ~~> OO1
+   *     |  | this |        | bidi |  |
+   * O2 <~~ |      | <~I2~  |      | <~~ II2
+   *     |  +------+        +------+  |
+   *     +----------------------------+
+   * }}}
+   * The `combine` function is used to compose the materialized values of this flow and that
+   * flow into the materialized value of the resulting BidiFlow.
+   */
+  def atop[OO1, II2, Mat2, M](bidi: BidiFlow[O1, OO1, II2, I2, Mat2], combine: japi.Function2[Mat, Mat2, M]): BidiFlow[I1, OO1, II2, O2, M] =
+    new BidiFlow(delegate.atopMat(bidi.asScala)(combinerToScala(combine)))
+
+  /**
+   * Add the given Flow as the final step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +---------------------------+
+   *     | Resulting Flow            |
+   *     |                           |
+   *     |  +------+        +------+ |
+   * I1 ~~> |      |  ~O1~> |      | |
+   *     |  | this |        | flow | |
+   * O2 <~~ |      | <~I2~  |      | |
+   *     |  +------+        +------+ |
+   *     +---------------------------+
+   * }}}
+   * The materialized value of the combined [[Flow]] will be the materialized
+   * value of the current flow (ignoring the other Flow’s value), use
+   * [[BidiFlow#joinMat joinMat]] if a different strategy is needed.
+   */
+  def join[Mat2](flow: Flow[O1, I2, Mat2]): Flow[I1, O2, Mat] =
+    new Flow(delegate.join(flow.asScala))
+
+  /**
+   * Add the given Flow as the final step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +---------------------------+
+   *     | Resulting Flow            |
+   *     |                           |
+   *     |  +------+        +------+ |
+   * I1 ~~> |      |  ~O1~> |      | |
+   *     |  | this |        | flow | |
+   * O2 <~~ |      | <~I2~  |      | |
+   *     |  +------+        +------+ |
+   *     +---------------------------+
+   * }}}
+   * The `combine` function is used to compose the materialized values of this flow and that
+   * flow into the materialized value of the resulting [[Flow]].
+   */
+  def join[Mat2, M](flow: Flow[O1, I2, Mat2], combine: japi.Function2[Mat, Mat2, M]): Flow[I1, O2, M] =
+    new Flow(delegate.joinMat(flow.asScala)(combinerToScala(combine)))
+
+  /**
+   * Turn this BidiFlow around by 180 degrees, logically flipping it upside down in a protocol stack.
+   */
+  def reversed: BidiFlow[I2, O2, I1, O1, Mat] = new BidiFlow(delegate.reversed)
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -98,6 +98,11 @@ object Sink {
   def head[In](): Sink[In, Future[In]] =
     new Sink(scaladsl.Sink.head[In])
 
+  /**
+   * A graph with the shape of a sink logically is a sink, this method makes
+   * it so also in type.
+   */
+  def wrap[T, M](g: Graph[SinkShape[T], M]): Sink[T, M] = new Sink(scaladsl.Sink.wrap(g))
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -18,6 +18,7 @@ import scala.language.higherKinds
 import scala.language.implicitConversions
 import akka.stream.stage.Stage
 import akka.stream.impl.StreamLayout
+import scala.annotation.varargs
 
 /** Java API */
 object Source {
@@ -135,6 +136,12 @@ object Source {
     new Source(scaladsl.Source.single(element))
 
   /**
+   * Create a `Source` with the given elements.
+   */
+  def elements[T](elems: T*): Source[T, Unit] =
+    new Source(scaladsl.Source(() ⇒ elems.iterator))
+
+  /**
    * Create a `Source` that will continually emit the given element.
    */
   def repeat[T](element: T): Source[T, Unit] =
@@ -159,6 +166,12 @@ object Source {
    */
   def concat[T, M1, M2](first: Source[T, M1], second: Source[T, M2]): Source[T, (M1, M2)] =
     new Source(scaladsl.Source.concat(first.asScala, second.asScala))
+
+  /**
+   * A graph with the shape of a source logically is a source, this method makes
+   * it so also in type.
+   */
+  def wrap[T, M](g: Graph[SourceShape[T], M]): Source[T, M] = new Source(scaladsl.Source.wrap(g))
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.Graph
+import akka.stream.BidiShape
+import akka.stream.impl.StreamLayout.Module
+import akka.stream.FlowShape
+
+final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](private[stream] override val module: Module) extends Graph[BidiShape[I1, O1, I2, O2], Mat] {
+  override val shape = module.shape.asInstanceOf[BidiShape[I1, O1, I2, O2]]
+
+  /**
+   * Add the given BidiFlow as the next step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +----------------------------+
+   *     | Resulting BidiFlow         |
+   *     |                            |
+   *     |  +------+        +------+  |
+   * I1 ~~> |      |  ~O1~> |      | ~~> OO1
+   *     |  | this |        | bidi |  |
+   * O2 <~~ |      | <~I2~  |      | <~~ II2
+   *     |  +------+        +------+  |
+   *     +----------------------------+
+   * }}}
+   * The materialized value of the combined [[BidiFlow]] will be the materialized
+   * value of the current flow (ignoring the other BidiFlow’s value), use
+   * [[BidiFlow#atopMat atopMat]] if a different strategy is needed.
+   */
+  def atop[OO1, II2, Mat2](bidi: BidiFlow[O1, OO1, II2, I2, Mat2]): BidiFlow[I1, OO1, II2, O2, Mat] = atopMat(bidi)(Keep.left)
+
+  /**
+   * Add the given BidiFlow as the next step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +----------------------------+
+   *     | Resulting BidiFlow         |
+   *     |                            |
+   *     |  +------+        +------+  |
+   * I1 ~~> |      |  ~O1~> |      | ~~> OO1
+   *     |  | this |        | bidi |  |
+   * O2 <~~ |      | <~I2~  |      | <~~ II2
+   *     |  +------+        +------+  |
+   *     +----------------------------+
+   * }}}
+   * The `combine` function is used to compose the materialized values of this flow and that
+   * flow into the materialized value of the resulting BidiFlow.
+   */
+  def atopMat[OO1, II2, Mat2, M](bidi: BidiFlow[O1, OO1, II2, I2, Mat2])(combine: (Mat, Mat2) ⇒ M): BidiFlow[I1, OO1, II2, O2, M] = {
+    val copy = bidi.module.carbonCopy
+    val ins = copy.shape.inlets
+    val outs = copy.shape.outlets
+    new BidiFlow(module
+      .grow(copy, combine)
+      .connect(shape.out1, ins(0))
+      .connect(outs(1), shape.in2)
+      .replaceShape(BidiShape(shape.in1, outs(0), ins(1), shape.out2)))
+  }
+
+  /**
+   * Add the given Flow as the final step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +---------------------------+
+   *     | Resulting Flow            |
+   *     |                           |
+   *     |  +------+        +------+ |
+   * I1 ~~> |      |  ~O1~> |      | |
+   *     |  | this |        | flow | |
+   * O2 <~~ |      | <~I2~  |      | |
+   *     |  +------+        +------+ |
+   *     +---------------------------+
+   * }}}
+   * The materialized value of the combined [[Flow]] will be the materialized
+   * value of the current flow (ignoring the other Flow’s value), use
+   * [[BidiFlow#joinMat joinMat]] if a different strategy is needed.
+   */
+  def join[Mat2](flow: Flow[O1, I2, Mat2]): Flow[I1, O2, Mat] = joinMat(flow)(Keep.left)
+
+  /**
+   * Add the given Flow as the final step in a bidirectional transformation
+   * pipeline. By convention protocol stacks are growing to the left: the right most is the bottom
+   * layer, the closest to the metal.
+   * {{{
+   *     +---------------------------+
+   *     | Resulting Flow            |
+   *     |                           |
+   *     |  +------+        +------+ |
+   * I1 ~~> |      |  ~O1~> |      | |
+   *     |  | this |        | flow | |
+   * O2 <~~ |      | <~I2~  |      | |
+   *     |  +------+        +------+ |
+   *     +---------------------------+
+   * }}}
+   * The `combine` function is used to compose the materialized values of this flow and that
+   * flow into the materialized value of the resulting [[Flow]].
+   */
+  def joinMat[Mat2, M](flow: Flow[O1, I2, Mat2])(combine: (Mat, Mat2) ⇒ M): Flow[I1, O2, M] = {
+    val copy = flow.module.carbonCopy
+    val in = copy.shape.inlets.head
+    val out = copy.shape.outlets.head
+    new Flow(module
+      .grow(copy, combine)
+      .connect(shape.out1, in)
+      .connect(out, shape.in2)
+      .replaceShape(FlowShape(shape.in1, shape.out2)))
+  }
+
+  /**
+   * Turn this BidiFlow around by 180 degrees, logically flipping it upside down in a protocol stack.
+   */
+  def reversed: BidiFlow[I2, O2, I1, O1, Mat] = {
+    val ins = shape.inlets
+    val outs = shape.outlets
+    new BidiFlow(module.replaceShape(shape.copyFromPorts(ins.reverse, outs.reverse)))
+  }
+}
+
+object BidiFlow extends BidiFlowApply {
+
+  /**
+   * A graph with the shape of a flow logically is a flow, this method makes
+   * it so also in type.
+   */
+  def wrap[I1, O1, I2, O2, Mat](graph: Graph[BidiShape[I1, O1, I2, O2], Mat]): BidiFlow[I1, O1, I2, O2, Mat] = new BidiFlow(graph.module)
+
+  /**
+   * Create a BidiFlow where the top and bottom flows are just one simple mapping
+   * stage each, expressed by the two functions.
+   */
+  def apply[I1, O1, I2, O2](outbound: I1 ⇒ O1, inbound: I2 ⇒ O2): BidiFlow[I1, O1, I2, O2, Unit] =
+    BidiFlow() { b ⇒
+      val top = b.add(Flow[I1].map(outbound))
+      val bottom = b.add(Flow[I2].map(inbound))
+      BidiShape(top.inlet, top.outlet, bottom.inlet, bottom.outlet)
+    }
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/JavaConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/JavaConverters.scala
@@ -17,6 +17,9 @@ private[akka] object JavaConverters {
   implicit final class AddAsJavaFlow[In, Out, Mat](val flow: scaladsl.Flow[In, Out, Mat]) extends AnyVal {
     def asJava: javadsl.Flow[In, Out, Mat] = new javadsl.Flow(flow)
   }
+  implicit final class AddAsJavaBidiFlow[I1, O1, I2, O2, Mat](val flow: scaladsl.BidiFlow[I1, O1, I2, O2, Mat]) extends AnyVal {
+    def asJava: javadsl.BidiFlow[I1, O1, I2, O2, Mat] = new javadsl.BidiFlow(flow)
+  }
   implicit final class AddAsJavaSink[In, Mat](val sink: scaladsl.Sink[In, Mat]) extends AnyVal {
     def asJava: javadsl.Sink[In, Mat] = new javadsl.Sink(sink)
   }
@@ -29,6 +32,9 @@ private[akka] object JavaConverters {
   }
   implicit final class AddAsScalaFlow[In, Out, Mat](val flow: javadsl.Flow[In, Out, Mat]) extends AnyVal {
     def asScala: scaladsl.Flow[In, Out, Mat] = flow.asScala
+  }
+  implicit final class AddAsScalaBidiFlow[I1, O1, I2, O2, Mat](val flow: javadsl.BidiFlow[I1, O1, I2, O2, Mat]) extends AnyVal {
+    def asScala: scaladsl.BidiFlow[I1, O1, I2, O2, Mat] = flow.asScala
   }
   implicit final class AddAsScalaSink[In, Mat](val sink: javadsl.Sink[In, Mat]) extends AnyVal {
     def asScala: scaladsl.Sink[In, Mat] = sink.asScala

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -49,7 +49,7 @@ object Sink extends SinkApply {
   private def shape[T](name: String): SinkShape[T] = SinkShape(new Inlet(name + ".in"))
 
   /**
-   * A graph with the shape of a source logically is a source, this method makes
+   * A graph with the shape of a sink logically is a sink, this method makes
    * it so also in type.
    */
   def wrap[T, M](g: Graph[SinkShape[T], M]): Sink[T, M] = new Sink(g.module)


### PR DESCRIPTION
- add BidiFlow, with atop and join combinators
- add Flow.join(BidiFlow)
- correct Flow.join’s default materialized value selection to Keep.left
- [x] add factory methods
- [x] add javadsl
- [x] add tests
- [x] add docs

References #16416 #16994 
