### PR TITLE
!htc #16988 hide model.parser.HeaderParser from public API, add proper `HeaderParser.parse`

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/engine/parsing/SpecializedHeaderValueParsers.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/parsing/SpecializedHeaderValueParsers.scala
@@ -19,7 +19,7 @@ private object SpecializedHeaderValueParsers {
   def specializedHeaderValueParsers = Seq(ContentLengthParser)
 
   object ContentLengthParser extends HeaderValueParser("Content-Length", maxValueCount = 1) {
-    def apply(input: ByteString, valueStart: Int, warnOnIllegalHeader: ErrorInfo ⇒ Unit): (HttpHeader, Int) = {
+    def apply(input: ByteString, valueStart: Int, onIllegalHeader: ErrorInfo ⇒ Unit): (HttpHeader, Int) = {
       @tailrec def recurse(ix: Int = valueStart, result: Long = 0): (HttpHeader, Int) = {
         val c = byteChar(input, ix)
         if (result < 0) fail("`Content-Length` header value must not exceed 63-bit integer range")

--- a/akka-http-core/src/main/scala/akka/http/model/HttpHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/HttpHeader.scala
@@ -4,7 +4,11 @@
 
 package akka.http.model
 
+import scala.util.{ Success, Failure }
+import akka.parboiled2.ParseError
 import akka.http.util.ToStringRenderable
+import akka.http.model.parser.{ CharacterClasses, HeaderParser }
+import akka.http.model.headers._
 
 /**
  * The model of an HTTP header. In its most basic form headers are simple name-value pairs. Header names
@@ -24,4 +28,69 @@ object HttpHeader {
    * CAUTION: The name must be matched in *all-lowercase*!.
    */
   def unapply(header: HttpHeader): Option[(String, String)] = Some((header.lowercaseName, header.value))
+
+  /**
+   * Attempts to parse the given header name and value string into a header model instance.
+   *
+   * This process has several possible outcomes:
+   *
+   * 1. The header name corresponds to a properly modelled header and
+   *    a) the value is valid for this header type.
+   *       In this case the method returns a `ParsingResult.Ok` with the respective header instance and no errors.
+   *    b) the value consists of a number elements, some of which valid and some invalid, and the header type supports
+   *       partial value parsing. In this case the method returns a `ParsingResult.Ok` with the respective header
+   *       instance holding the valid value elements and an [[ErrorInfo]] for each invalid value.
+   *    c) the value has invalid elements and the header type doesn't support partial value parsing.
+   *       In this case the method returns a `ParsingResult.Ok` with a [[RawHeader]] instance and
+   *       a single [[ErrorInfo]] for the value parsing problem.
+   *
+   * 2. The header name does not correspond to a properly modelled header but the header name and the value are both
+   *    syntactically legal according to the basic header requirements from the HTTP specification.
+   *    (http://tools.ietf.org/html/rfc7230#section-3.2)
+   *    In this case the method returns a `ParsingResult.Ok` with a [[RawHeader]] instance and no errors.
+   *
+   * 3. The header name or value are illegal according to the basic requirements for HTTP headers
+   *    (http://tools.ietf.org/html/rfc7230#section-3.2). In this case the method returns a `ParsingResult.Error`.
+   */
+  def parse(name: String, value: String): ParsingResult =
+    if (name.forall(CharacterClasses.tchar)) {
+      import akka.parboiled2.Parser.DeliveryScheme.Try
+      val parser = new HeaderParser(value)
+      parser.`header-field-value`.run() match {
+        case Success(preProcessedValue) ⇒
+          try {
+            HeaderParser.dispatch(new HeaderParser(preProcessedValue), name.toLowerCase) match {
+              case Right(header) ⇒ ParsingResult.Ok(header, Nil)
+              case Left(info) ⇒
+                val errors = info.withSummaryPrepended(s"Illegal HTTP header '$name'") :: Nil
+                ParsingResult.Ok(RawHeader(name, preProcessedValue), errors)
+            }
+          } catch {
+            case HeaderParser.RuleNotFoundException ⇒ ParsingResult.Ok(RawHeader(name, preProcessedValue), Nil)
+          }
+        case Failure(error) ⇒
+          val info = error match {
+            case e: ParseError ⇒ parser.parseError(e)
+            case e             ⇒ parser.failure(e)
+          }
+          ParsingResult.Error(info.left.get.withSummaryPrepended(s"Illegal HTTP header value"))
+      }
+    } else ParsingResult.Error(ErrorInfo(s"Illegal HTTP header name", name))
+
+  sealed trait ParsingResult {
+    def errors: List[ErrorInfo]
+  }
+
+  object ParsingResult {
+    /**
+     * The parsing run produced a result. If there were parsing errors (which did not prevent the run from
+     * completing) they are reported in the given error list.
+     */
+    final case class Ok(header: HttpHeader, errors: List[ErrorInfo]) extends ParsingResult
+
+    /**
+     * The parsing run failed due to a fatal parsing error.
+     */
+    final case class Error(error: ErrorInfo) extends ParsingResult { def errors = error :: Nil }
+  }
 }

--- a/akka-http-core/src/main/scala/akka/http/model/parser/Base64Parsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/parser/Base64Parsing.scala
@@ -23,7 +23,7 @@ import akka.parboiled2.util.Base64
 /**
  * Rules for parsing Base-64 encoded strings.
  */
-trait Base64Parsing { this: Parser ⇒
+private[parser] trait Base64Parsing { this: Parser ⇒
   import Base64Parsing._
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/model/parser/StringBuilding.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/parser/StringBuilding.scala
@@ -24,7 +24,7 @@ import akka.parboiled2._
  *
  * Mixing this trait into your parser gives you a simple facility to support this.
  */
-trait StringBuilding { this: Parser ⇒
+private[parser] trait StringBuilding { this: Parser ⇒
   protected val sb = new java.lang.StringBuilder
 
   def clearSB(): Rule0 = rule { run(sb.setLength(0)) }

--- a/akka-http-tests/src/test/scala/akka/http/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/marshalling/ContentNegotiationSpec.scala
@@ -8,9 +8,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.scalatest.{ Matchers, FreeSpec }
 import akka.http.util.FastFuture._
-import akka.http.model.parser.HeaderParser
 import akka.http.model._
-import headers._
 import MediaTypes._
 import HttpCharsets._
 
@@ -116,9 +114,9 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
       if (example != "(without headers)") {
         example.split('\n').toList map { rawHeader ⇒
           val Array(name, value) = rawHeader.split(':')
-          HeaderParser.parseHeader(RawHeader(name.trim, value.trim)) match {
-            case Right(header) ⇒ header
-            case Left(err)     ⇒ fail(err.formatPretty)
+          HttpHeader.parse(name.trim, value) match {
+            case HttpHeader.ParsingResult.Ok(header, Nil) ⇒ header
+            case result                                   ⇒ fail(result.errors.head.formatPretty)
           }
         }
       } else Nil


### PR DESCRIPTION
Closes #16988.

The previously used `model.parser.HeaderParser.parseHeader(s)` was no proper user-facing API.
This PR fixes this by removing outside access to the `model.parser.HeaderParser` completely and providing a clean API for parsing a String/String pair into a header model instance.
