### PR TITLE
=htc Enable rendering of HTTP/1.0 responses, increase test coverage for connection closing logic

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/engine/parsing/ParserOutput.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/parsing/ParserOutput.scala
@@ -30,14 +30,14 @@ private[http] object ParserOutput {
     headers: List[HttpHeader],
     createEntity: Source[RequestOutput, Unit] ⇒ RequestEntity,
     expect100ContinueResponsePending: Boolean,
-    closeAfterResponseCompletion: Boolean) extends MessageStart with RequestOutput
+    closeRequested: Boolean) extends MessageStart with RequestOutput
 
   final case class ResponseStart(
     statusCode: StatusCode,
     protocol: HttpProtocol,
     headers: List[HttpHeader],
     createEntity: Source[ResponseOutput, Unit] ⇒ ResponseEntity,
-    closeAfterResponseCompletion: Boolean) extends MessageStart with ResponseOutput
+    closeRequested: Boolean) extends MessageStart with ResponseOutput
 
   case object MessageEnd extends MessageOutput
 


### PR DESCRIPTION
This is a smaller improvement I've been wanting to do for some time already.
A recent discussion with the play team also triggered a more in-depth specification of the somewhat involved logic for when exactly we render a `Connection` response header and close the connection.
