### PR TITLE
htc: Preview of client-side connection pooling

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -107,6 +107,40 @@ akka.http {
     parsing = ${akka.http.parsing}
   }
 
+  host-connection-pool {
+    # The maximum number of parallel connections that a connection pool to a
+    # single host endpoint is allowed to establish. Must be greater than zero.
+    max-connections = 4
+
+    # The maximum number of times failed requests are attempted again,
+    # (if the request can be safely retried) before giving up and returning an error.
+    max-retries = 5
+
+    # The maximum number of requests that are dispatched to the target host in
+    # batch-mode across a single connection (HTTP pipelining).
+    # A setting of 1 disables HTTP pipelining, since only one request per
+    # connection can be "in flight" at any time.
+    # Set to higher values to enable HTTP pipelining.
+    # This value must be > 0.
+    # (Note that, independently of this setting, pipelining will never be done
+    # on a connection that still has a non-idempotent request in flight.
+    # See http://tools.ietf.org/html/rfc7230#section-6.3.2 for more info.)
+    pipelining-limit = 1
+
+    # The time after which an idle connection pool (without open connections)
+    # will automatically terminate itself. Set to `infinite` to disable idle timeouts.
+    idle-timeout = 30 s
+
+    # Grace period between beginning a connection pool shutdown and the (internal)
+    # gateway actor not accepting any more requests into the pool. Protects racy
+    # requests that were dispatched to the pool after the Shutdown message was
+    # queued. Should rarely require adjustment.
+    shutdown-grace-period = 2 s
+
+    # Modify to tweak client settings for host connection pools only.
+    client = ${akka.http.client}
+  }
+
   # The (default) configuration of the HTTP message parser for the server and the client.
   # IMPORTANT: These settings (i.e. children of `akka.http.parsing`) can't be directly
   # overridden in `application.conf` to change the parser settings for client and server

--- a/akka-http-core/src/main/scala/akka/http/engine/client/ConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/ConnectionPool.scala
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.engine.client
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
+import scala.annotation.tailrec
+import scala.concurrent.{ Promise, Future }
+import akka.event.LoggingAdapter
+import akka.actor._
+import akka.stream.FlowMaterializer
+import akka.stream.scaladsl._
+import akka.http.model._
+import akka.http.util._
+import akka.http.Http
+
+private[http] object ConnectionPool {
+  import HostConnectionPoolGateway._
+
+  case class PoolRequest(request: HttpRequest, responsePromise: Promise[HttpResponse])
+  case object BeginShutdown extends DeadLetterSuppression
+
+  /**
+   * Starts a new host connection pool and returns its gateway actor.
+   *
+   * A host connection pool for a given [[HostConnectionPoolSetup]] is a running stream, whose outside interface is
+   * provided by its [[PoolGateway]] actor.
+   * This gateway actor accepts [[PoolRequest]] messages and completes their `responsePromise` whenever the respective
+   * response has been received (or an error occurred).
+   * A gateway actor can be orderly shut down by sending it a [[BeginShutdown]] message.
+   *
+   * A running host connection pool automatically shuts down itself after the configured idle timeout.
+   */
+  def startHostConnectionPool(hcps: HostConnectionPoolSetup)(implicit system: ActorSystem,
+                                                             fm: FlowMaterializer): Gateway = {
+    import hcps._
+    import setup._
+    val connectionFlow = Http().outgoingConnection(host, port, None, options, Some(settings.connectionSettings), log)
+    val poolFlow = newPoolFlow(connectionFlow, new InetSocketAddress(host, port), settings, log)
+    val gateway = new Gateway(new PoolGateway(poolFlow, hcps, _))
+    gateway.actorRef() // trigger eager start of pool gateway (and pool)
+    gateway
+  }
+
+  /*
+    Pool Flow Stream Setup
+    ======================
+                                               +-------------------+                             
+                                               |                   |                             
+                                        +----> | Connection Slot 1 +---->                        
+                                        |      |                   |    |                        
+                                        |      +---+---------------+    |                        
+                                        |          |                    |                        
+                       +-----------+    |      +-------------------+    |      +---------------+
+      RequestContext   |           +----+      |                   |    +----> |               |  ResponseContext
+    +----------------> | Conductor |---------> | Connection Slot 2 +---------> | responseMerge +------------------>
+                       |           +----+      |                   |    +----> |               |
+                       +-----------+    |      +---------+---------+    |      +---------------+
+                             ^          |          |     |              |                        
+                             |          |      +-------------------+    |                        
+                             |          |      |                   |    |                        
+                   SlotEvent |          +----> | Connection Slot 3 +---->                        
+                             |                 |                   |                             
+                             |                 +---------------+---+                             
+                             |                     |     |     |                                    
+                       +-----------+    SlotEvent  |     |     | 
+                       | slotEvent | <-------------+     |     |
+                       |   Merge   | <-------------------+     |                                  
+                       |           | <-------------------------+                                  
+                       +-----------+
+
+    Conductor:
+    - Maintains slot state overview by running a simple state machine per Connection Slot
+    - Decides which slot will receive the next request from upstream according to current slot state and dispatch configuration
+    - Forwards demand from selected slot to upstream
+    - Always maintains demand for SlotEvents from the Connection Slots
+    - Implemented as a sub-graph
+
+    Connection Slot:
+    - Wraps a low-level outgoing connection flow and (re-)materializes and uses it whenever necessary
+    - Directly forwards demand from the underlying connection to the Conductor
+    - Dispatches SlotEvents to the Conductor (via the SlotEventMerge)
+    - Implemented as a sub-graph
+
+    Response Merge:
+    - Simple merge of the Connection Slots' outputs
+
+  */
+  private def newPoolFlow(connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]],
+                          remoteAddress: InetSocketAddress, settings: HostConnectionPoolSettings, log: LoggingAdapter)(
+                            implicit system: ActorSystem, fm: FlowMaterializer): Flow[RequestContext, ResponseContext, Any] =
+    Flow() { implicit b ⇒
+      import settings._
+      import FlowGraph.Implicits._
+
+      val conductor = b.add(HostConnectionPoolConductor(maxConnections, maxRetries, pipeliningLimit, log))
+      val slots = Vector
+        .tabulate(maxConnections)(HostConnectionPoolSlot(_, connectionFlow, remoteAddress, settings))
+        .map(b.add(_))
+      val responseMerge = b.add(Merge[ResponseContext](maxConnections,
+        OperationAttributes.name("HostConnectionPoolFlow.responseMerge")))
+      val slotEventMerge = b.add(Merge[HostConnectionPoolSlot.SlotEvent](maxConnections,
+        OperationAttributes.name("HostConnectionPoolFlow.slotEventMerge")))
+
+      slotEventMerge.out ~> conductor.slotEventIn
+      for ((slot, ix) ← slots.zipWithIndex) {
+        conductor.slotOuts(ix) ~> slot.requestContextIn
+        slot.slotEventOut ~> slotEventMerge.in(ix)
+        slot.responseOut ~> responseMerge.in(ix)
+      }
+      (conductor.requestIn, responseMerge.out)
+    }
+
+  // for reigning in potentially approaching thundering herds
+  val CowboyGateway = new Gateway(null)(null)
+  private val CowboyGatewayRef = new GateWayRef(null, null)
+
+  private val poolGatewayActorName = new SeqActorName("PoolGateway")
+
+  final class Gateway(actorCreator: Promise[Future[Unit]] ⇒ PoolGateway)(implicit system: ActorSystem) {
+    private[this] val cell = new AtomicReference(new GateWayRef(null, Promise.successful(Future.successful(()))))
+
+    // completed with a "shutdown-finished" future when the shutdown is started
+    def whenShuttingDown: Future[Future[Unit]] = cell.get.whenShuttingDown.future
+
+    // triggers a shutdown of this gateways pool
+    def shutdown(): Future[Unit] = {
+      val fut = whenShuttingDown
+      if (!fut.isCompleted) // try to avoid a restart just for shutting down
+        actorRef() ! ConnectionPool.BeginShutdown
+      fut.flatMap(identityFunc)(system.dispatcher)
+    }
+
+    // retrieves the ActorRef for the running Gateway actor
+    // or starts a new one it if the gateway is already in (or finished with) the shutdown process
+    @tailrec def actorRef(): ActorRef = {
+      var ref = cell.get
+      if (ref ne CowboyGatewayRef) {
+        if (ref.whenShuttingDown.isCompleted) {
+          if (cell.compareAndSet(ref, CowboyGatewayRef)) {
+            try {
+              val promise = Promise[Future[Unit]]()
+              val gatewayActorRef = system.actorOf(Props(actorCreator(promise)), poolGatewayActorName.next())
+              ref = new GateWayRef(gatewayActorRef, promise)
+              gatewayActorRef
+            } finally {
+              cell.set(ref)
+            }
+          } else actorRef() // spin while other thread is starting a new gateway actor
+        } else ref.actorRef // gateway actor hasn't started the shutdown process until recently
+      } else actorRef() // spin while other thread is starting a new gateway actor
+    }
+  }
+
+  private final class GateWayRef(val actorRef: ActorRef, val whenShuttingDown: Promise[Future[Unit]])
+}

--- a/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolConductor.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolConductor.scala
@@ -1,0 +1,230 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.engine.client
+
+import language.existentials
+import scala.annotation.tailrec
+import scala.collection.immutable
+import akka.event.LoggingAdapter
+import akka.stream.scaladsl._
+import akka.stream._
+import akka.http.model.HttpMethod
+import akka.http.util._
+
+private object HostConnectionPoolConductor {
+  import HostConnectionPoolGateway.RequestContext
+  import HostConnectionPoolSlot.{ SlotEvent, SimpleSlotEvent }
+
+  case class Ports(
+    requestIn: Inlet[RequestContext],
+    slotEventIn: Inlet[SlotEvent],
+    slotOuts: immutable.Seq[Outlet[RequestContext]]) extends Shape {
+
+    override val inlets = requestIn :: slotEventIn :: Nil
+    override def outlets = slotOuts
+
+    override def deepCopy(): Shape =
+      Ports(
+        new Inlet(requestIn.toString),
+        new Inlet(slotEventIn.toString),
+        slotOuts.map(o ⇒ new Outlet(o.toString)))
+
+    override def copyFromPorts(inlets: immutable.Seq[Inlet[_]], outlets: immutable.Seq[Outlet[_]]): Shape =
+      Ports(
+        inlets.head.asInstanceOf[Inlet[RequestContext]],
+        inlets.last.asInstanceOf[Inlet[SlotEvent]],
+        outlets.asInstanceOf[immutable.Seq[Outlet[RequestContext]]])
+  }
+
+  /*
+    Stream Setup
+    ============
+                                                                                                  Request- 
+    Request-   +-----------+     +-----------+    Switch-    +-------------+     +-----------+    Context
+    Context    |   merge1  |     |   merge2  |    Command    |   doubler   |     |   route   +-------------->
+    +--------->|  (Merge-  +---->|  (Flexi   +-------------->| (MapConcat) +---->|  (Flexi   +-------------->
+               | Preferred)|     |   Merge)  |               |             |     |   Route)  +-------------->
+               +----+------+     +-----+-----+               +-------------+     +-----------+       to slots     
+                    ^                  ^                                                               
+                    |                  | SimpleSlotEvent                                              
+                    | Request-         |                                                               
+                    | Context     +---------+
+                    +-------------+  retry  |<-------- Slot Event (from slotEventMerge)
+                                  |  Split  |
+                                  +---------+
+
+  */
+  def apply(slotCount: Int, maxRetries: Int, pipeliningLimit: Int, log: LoggingAdapter): Graph[Ports, Any] =
+    FlowGraph.partial() { implicit b ⇒
+      import FlowGraph.Implicits._
+
+      val merge1 = b.add(new Merge1)
+      val merge2 = b.add(new Merge2(slotCount, maxRetries, pipeliningLimit, log))
+      val doubler = Flow[SwitchCommand].mapConcat(x ⇒ x :: x :: Nil)
+      val route = b.add(new Route(slotCount))
+      val retrySplit = b.add(new RetrySplit())
+
+      merge1.out ~> merge2.in0
+      merge2.out ~> doubler ~> route.in
+      retrySplit.out0 ~> merge2.in1
+      retrySplit.out1 ~> merge1.in1
+
+      Ports(merge1.in0, retrySplit.in, route.outlets.asInstanceOf[immutable.Seq[Outlet[RequestContext]]])
+    }
+
+  // almost the same as a MergePreferred,
+  // but as MergePreferred doesn't appear to propagate completion on the secondary input we can use it here
+  private class Merge1 extends FlexiMerge[RequestContext, FanInShape2[RequestContext, RequestContext, RequestContext]](
+    new FanInShape2("Merge1"), OperationAttributes.name("Merge1")) {
+    import FlexiMerge._
+
+    def createMergeLogic(shape: FanInShape2[RequestContext, RequestContext, RequestContext]) =
+      new MergeLogic[RequestContext] {
+        val freshInlet = shape.in0
+        val retryInlet = shape.in1
+
+        override def initialState = State(ReadAny(retryInlet, freshInlet)) {
+          case (ctx, `retryInlet`, rc: RequestContext) ⇒ { ctx.emit(rc); SameState }
+          case (ctx, `freshInlet`, rc: RequestContext) ⇒ { ctx.emit(rc); SameState }
+        }
+
+        override def initialCompletionHandling = eagerClose
+      }
+  }
+
+  private case class SwitchCommand(rc: RequestContext, slotIx: Int)
+
+  private sealed trait SlotState
+  private case object Unconnected extends SlotState
+  private case object Idle extends SlotState
+  private final case class Loaded(openIdempotentRequests: Int) extends SlotState { require(openIdempotentRequests > 0) }
+  private case class Busy(openRequests: Int) extends SlotState { require(openRequests > 0) }
+  private object Busy extends Busy(1)
+
+  private class Merge2(slotCount: Int, maxRetries: Int, pipeliningLimit: Int, log: LoggingAdapter)
+    extends FlexiMerge[SwitchCommand, FanInShape2[RequestContext, SimpleSlotEvent, SwitchCommand]](
+      new FanInShape2("HostConnectionPoolConductor.merge2"),
+      OperationAttributes.name("HostConnectionPoolConductor.merge2")) {
+    import FlexiMerge._
+
+    def createMergeLogic(s: FanInShape2[RequestContext, SimpleSlotEvent, SwitchCommand]): MergeLogic[SwitchCommand] =
+      new MergeLogic[SwitchCommand] {
+        val slotStates = Array.fill[SlotState](slotCount)(Unconnected)
+        def initialState = nextState(0)
+        override def initialCompletionHandling = eagerClose
+
+        def nextState(currentSlot: Int): State[_] = {
+          val read: ReadCondition[_] = currentSlot match {
+            case -1 ⇒ Read(s.in1) // if we have no slot available we are not reading from upstream (only SlotEvents)
+            case _  ⇒ ReadAny(s) // otherwise we read SlotEvent *as well as* from upstream
+          }
+          State(read) { (ctx, inlet, element) ⇒
+            element match {
+              case rc: RequestContext ⇒
+                ctx.emit(SwitchCommand(rc, currentSlot))
+                slotStates(currentSlot) = slotStateAfterDispatch(slotStates(currentSlot), rc.request.method)
+              case SlotEvent.RequestCompleted(slotIx) ⇒
+                slotStates(slotIx) = slotStateAfterRequestCompleted(slotStates(slotIx))
+              case SlotEvent.Disconnected(slotIx, failed) ⇒
+                slotStates(slotIx) = slotStateAfterDisconnect(slotStates(slotIx), failed)
+            }
+            nextState(bestSlot())
+          }
+        }
+
+        def slotStateAfterDispatch(slotState: SlotState, method: HttpMethod): SlotState =
+          slotState match {
+            case (Unconnected | Idle) if method.isIdempotent ⇒ Loaded(1)
+            case Unconnected | Idle                          ⇒ Busy(1)
+            case Loaded(n) if method.isIdempotent            ⇒ Loaded(n + 1)
+            case Loaded(n)                                   ⇒ Busy(n + 1)
+            case Busy(_)                                     ⇒ throw new IllegalStateException("Request scheduled onto busy connection?")
+          }
+
+        def slotStateAfterRequestCompleted(slotState: SlotState): SlotState =
+          slotState match {
+            case Loaded(1) ⇒ Idle
+            case Loaded(n) ⇒ Loaded(n - 1)
+            case Busy(1)   ⇒ Idle
+            case Busy(n)   ⇒ Busy(n - 1)
+            case _         ⇒ throw new IllegalStateException(s"RequestCompleted on $slotState connection?")
+          }
+
+        def slotStateAfterDisconnect(slotState: SlotState, failed: Int): SlotState =
+          slotState match {
+            case Idle if failed == 0      ⇒ Unconnected
+            case Loaded(n) if n > failed  ⇒ Loaded(n - failed)
+            case Loaded(n) if n == failed ⇒ Unconnected
+            case Busy(n) if n > failed    ⇒ Busy(n - failed)
+            case Busy(n) if n == failed   ⇒ Unconnected
+            case _                        ⇒ throw new IllegalStateException(s"Disconnect(_, $failed) on $slotState connection?")
+          }
+
+        /**
+         * Implements the following Connection Slot selection strategy
+         *  - Select the first idle connection in the pool, if there is one.
+         *  - If none is idle select the first unconnected connection, if there is one.
+         *  - If all are loaded select the connection with the least open requests (< pipeliningLimit)
+         *    that only has requests with idempotent methods scheduled to it, if there is one.
+         *  - Otherwise return -1 (which applies back-pressure to the request source)
+         *
+         *  See http://tools.ietf.org/html/rfc7230#section-6.3.2 for more info on HTTP pipelining.
+         */
+        @tailrec def bestSlot(ix: Int = 0, bestIx: Int = -1, bestState: SlotState = Busy): Int =
+          if (ix < slotStates.length) {
+            def isBetterThanBest(arg: Loaded) = bestState match {
+              case Unconnected ⇒ false
+              case Loaded(x) if x <= arg.openIdempotentRequests ⇒ false
+              case _ ⇒ arg.openIdempotentRequests < pipeliningLimit
+            }
+            slotStates(ix) match {
+              case Idle                             ⇒ ix
+              case Unconnected                      ⇒ bestSlot(ix + 1, ix, Unconnected)
+              case x: Loaded if isBetterThanBest(x) ⇒ bestSlot(ix + 1, ix, x)
+              case _                                ⇒ bestSlot(ix + 1, bestIx, bestState)
+            }
+          } else bestIx
+      }
+  }
+
+  private class Route(slotCount: Int) extends FlexiRoute[SwitchCommand, UniformFanOutShape[SwitchCommand, RequestContext]](
+    new UniformFanOutShape(slotCount, "HostConnectionPoolConductor.Route"),
+    OperationAttributes.name("HostConnectionPoolConductor.Route")) {
+    import FlexiRoute._
+
+    def createRouteLogic(s: UniformFanOutShape[SwitchCommand, RequestContext]): RouteLogic[SwitchCommand] =
+      new RouteLogic[SwitchCommand] {
+        val initialState: State[_] = State(DemandFromAny(s)) {
+          case (_, _, SwitchCommand(req, slotIx)) ⇒
+            State(DemandFrom(s.out(slotIx))) { (ctx, out, _) ⇒
+              ctx.emit(out)(req)
+              initialState
+            }
+        }
+        override def initialCompletionHandling = CompletionHandling(
+          onUpstreamFinish = ctx ⇒ { ctx.finish(); SameState },
+          onUpstreamFailure = (ctx, cause) ⇒ { ctx.fail(cause); SameState },
+          onDownstreamFinish = (ctx, _) ⇒ SameState)
+      }
+  }
+
+  // FIXME: remove when #17038 is cleared
+  private class RetrySplit extends FlexiRoute[SlotEvent, FanOutShape2[SlotEvent, SimpleSlotEvent, RequestContext]](
+    new FanOutShape2("HostConnectionPoolConductor.RetrySplit"),
+    OperationAttributes.name("HostConnectionPoolConductor.RetrySplit")) {
+    import FlexiRoute._
+
+    def createRouteLogic(s: FanOutShape2[SlotEvent, SimpleSlotEvent, RequestContext]): RouteLogic[SlotEvent] =
+      new RouteLogic[SlotEvent] {
+        def initialState: State[_] = State(DemandFromAll(s)) { (ctx, _, ev) ⇒
+          ev match {
+            case x: SimpleSlotEvent         ⇒ ctx.emit(s.out0)(x)
+            case SlotEvent.RetryRequest(rc) ⇒ ctx.emit(s.out1)(rc)
+          }
+          SameState
+        }
+      }
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolGateway.scala
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.engine.client
+
+import scala.annotation.tailrec
+import scala.collection.immutable
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+import akka.actor.Cancellable
+import akka.stream.FlowMaterializer
+import akka.stream.actor.{ ActorPublisher, ActorSubscriber, ZeroRequestStrategy }
+import akka.stream.actor.ActorPublisherMessage._
+import akka.stream.actor.ActorSubscriberMessage._
+import akka.stream.scaladsl.{ Sink, Source, Flow }
+import akka.http.model._
+import akka.http.util._
+
+private object HostConnectionPoolGateway {
+  import ConnectionPool.{ PoolRequest, BeginShutdown }
+
+  case class RequestContext(request: HttpRequest, responsePromise: Promise[HttpResponse], retriesLeft: Int) {
+    require(retriesLeft >= 0)
+  }
+  case class ResponseContext(rc: RequestContext, response: Try[HttpResponse])
+
+  private case object ShutdownNow
+
+  class PoolGateway(poolFlow: Flow[RequestContext, ResponseContext, Any],
+                    hcps: HostConnectionPoolSetup,
+                    whenShuttingDown: Promise[Future[Unit]])(implicit fm: FlowMaterializer)
+    extends ActorSubscriber with ActorPublisher[RequestContext] with LogMessages {
+    import context.dispatcher
+
+    private[this] var inputBuffer = immutable.Queue.empty[PoolRequest]
+    private[this] var activeIdleTimeout: Option[Cancellable] = None
+    private[this] val effectiveDefaultHeaders =
+      if (!hcps.setup.defaultHeaders.exists(_.isInstanceOf[headers.Host])) {
+        import Uri._
+        val normalizedPort = normalizePort(hcps.port, httpScheme(securedConnection = hcps.setup.encrypted))
+        headers.Host(hcps.host, normalizedPort) :: hcps.setup.defaultHeaders
+      } else hcps.setup.defaultHeaders
+
+    // start the pool flow with this actor acting as source as well as sink
+    Source(ActorPublisher(self)).via(poolFlow).runWith(Sink(ActorSubscriber[ResponseContext](self)))
+
+    activateIdleTimeoutIfNecessary()
+
+    def requestStrategy = ZeroRequestStrategy
+
+    def receive: Receive = logMessages() {
+
+      /////////////// FROM POOL DOWNSTREAM //////////////
+
+      case Request(_) ⇒ dispatchRequests() // the pool is ready to take on more requests
+
+      case Cancel ⇒
+        // somehow the pool shut down, however, we don't do anything here because we'll also see an
+        // OnComplete or OnError which we use as the sole trigger for cleaning up
+        ()
+
+      /////////////// FROM POOL UPSTREAM //////////////
+
+      case OnNext(ResponseContext(rc, responseTry)) ⇒
+        rc.responsePromise.complete(responseTry)
+        activateIdleTimeoutIfNecessary()
+
+      case OnComplete ⇒ // the pool shut down
+        if (!whenShuttingDown.trySuccess(Future.successful(())))
+          whenShuttingDown.future.foreach(_.asInstanceOf[Promise[Unit]].success(()))
+        context.stop(self)
+
+      case OnError(e) ⇒ // the pool shut down
+        if (!whenShuttingDown.trySuccess(Future.failed(e)))
+          whenShuttingDown.future.foreach(_.asInstanceOf[Promise[Unit]].failure(e))
+        context.stop(self)
+
+      /////////////// FROM CLIENT //////////////
+
+      case x: PoolRequest ⇒
+        activeIdleTimeout foreach { timeout ⇒
+          timeout.cancel()
+          activeIdleTimeout = None
+        }
+        if (totalDemand > 0) dispatchRequest(x)
+        else inputBuffer = inputBuffer.enqueue(x)
+        request(1) // for every incoming request we demand one response from the pool
+
+      case BeginShutdown ⇒
+        // signal that we don't want to accept new requests and will shutdown soon
+        if (whenShuttingDown.trySuccess(Promise[Unit]().future))
+          context.system.scheduler.scheduleOnce(hcps.setup.settings.shutdownGracePeriod, self, ShutdownNow)
+
+      case ShutdownNow ⇒ onComplete() // grace period is over, we can now safely tear down the pool
+    }
+
+    @tailrec private def dispatchRequests(): Unit =
+      if (totalDemand > 0 && inputBuffer.nonEmpty) {
+        dispatchRequest(inputBuffer.head)
+        inputBuffer = inputBuffer.tail
+        dispatchRequests()
+      }
+
+    def dispatchRequest(pr: PoolRequest): Unit = {
+      val effectiveRequest = pr.request withDefaultHeaders effectiveDefaultHeaders
+      val retries = if (pr.request.method.isIdempotent) hcps.setup.settings.maxRetries else 0
+      onNext(RequestContext(effectiveRequest, pr.responsePromise, retries))
+    }
+
+    def activateIdleTimeoutIfNecessary(): Unit =
+      if (remainingRequested == 0 && hcps.setup.settings.idleTimeout.isFinite) {
+        import context.dispatcher
+        val timeout = hcps.setup.settings.idleTimeout.asInstanceOf[FiniteDuration]
+        activeIdleTimeout = Some(context.system.scheduler.scheduleOnce(timeout, self, BeginShutdown))
+      }
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolSettings.scala
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.engine.client
+
+import akka.event.LoggingAdapter
+import akka.http.model.HttpHeader
+import akka.io.Inet
+import com.typesafe.config.Config
+import scala.collection.immutable
+import scala.concurrent.duration.{ FiniteDuration, Duration }
+import akka.actor.ActorRefFactory
+import akka.http.util._
+
+final case class HostConnectionPoolSetup(host: String, port: Int, setup: ConnectionPoolSetup)
+
+final case class ConnectionPoolSetup(
+  encrypted: Boolean,
+  options: immutable.Traversable[Inet.SocketOption],
+  settings: HostConnectionPoolSettings,
+  defaultHeaders: List[HttpHeader],
+  log: LoggingAdapter)
+
+final case class HostConnectionPoolSettings(
+  maxConnections: Int,
+  maxRetries: Int,
+  pipeliningLimit: Int,
+  idleTimeout: Duration,
+  shutdownGracePeriod: FiniteDuration,
+  connectionSettings: ClientConnectionSettings) {
+
+  require(maxConnections > 0, "max-connections must be > 0")
+  require(maxRetries >= 0, "max-retries must be >= 0")
+  require(pipeliningLimit > 0, "pipelining-limit must be > 0")
+  require(idleTimeout >= Duration.Zero, "idleTimeout must be >= 0")
+  require(shutdownGracePeriod > Duration.Zero, "shutdownGracePeriod must be > 0")
+}
+
+object HostConnectionPoolSettings extends SettingsCompanion[HostConnectionPoolSettings]("akka.http.host-connection-pool") {
+  def fromSubConfig(c: Config) = {
+    apply(
+      c getInt "max-connections",
+      c getInt "max-retries",
+      c getInt "pipelining-limit",
+      c getPotentiallyInfiniteDuration "idle-timeout",
+      c getFiniteDuration "shutdown-grace-period",
+      ClientConnectionSettings fromSubConfig c.getConfig("client"))
+  }
+
+  def apply(optionalSettings: Option[HostConnectionPoolSettings])(implicit actorRefFactory: ActorRefFactory): HostConnectionPoolSettings =
+    optionalSettings getOrElse apply(actorSystem)
+}

--- a/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/HostConnectionPoolSlot.scala
@@ -1,0 +1,242 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.engine.client
+
+import language.existentials
+import java.net.InetSocketAddress
+import scala.util.{ Failure, Success }
+import scala.collection.immutable
+import akka.actor._
+import akka.http.model.{ HttpResponse, HttpRequest }
+import akka.http.util._
+import akka.stream.impl.{ SubscribePending, ExposedPublisher, ActorProcessor }
+import akka.stream.actor._
+import akka.stream.scaladsl._
+import akka.stream._
+
+private object HostConnectionPoolSlot {
+  import HostConnectionPoolGateway.{ RequestContext, ResponseContext }
+
+  sealed trait ProcessorOut
+  final case class ResponseDelivery(response: ResponseContext) extends ProcessorOut
+  sealed trait SlotEvent extends ProcessorOut
+  sealed trait SimpleSlotEvent extends SlotEvent
+  object SlotEvent {
+    final case class RequestCompleted(slotIx: Int) extends SimpleSlotEvent
+    final case class Disconnected(slotIx: Int, failedRequests: Int) extends SimpleSlotEvent
+    final case class RetryRequest(rc: RequestContext) extends SlotEvent
+  }
+
+  case class Ports(
+    requestContextIn: Inlet[RequestContext],
+    responseOut: Outlet[ResponseContext],
+    slotEventOut: Outlet[SlotEvent]) extends Shape {
+
+    override val inlets = requestContextIn :: Nil
+    override def outlets = responseOut :: slotEventOut :: Nil
+
+    override def deepCopy(): Shape = Ports(
+      new Inlet(requestContextIn.toString),
+      new Outlet(responseOut.toString),
+      new Outlet(slotEventOut.toString))
+
+    override def copyFromPorts(inlets: immutable.Seq[Inlet[_]], outlets: immutable.Seq[Outlet[_]]): Shape =
+      Ports(
+        inlets.head.asInstanceOf[Inlet[RequestContext]],
+        outlets.head.asInstanceOf[Outlet[ResponseContext]],
+        outlets.last.asInstanceOf[Outlet[SlotEvent]])
+  }
+
+  private val slotProcessorActorName = new SeqActorName("SlotProcessor")
+
+  /*
+    Stream Setup
+    ============
+
+    Request-   +-----------+                       +-------------+                +------------+ 
+    Context    | Slot-     |  List[ProcessorOut]   |   flatten   |  ProcessorOut  | SlotEvent- |    ReponseContext
+    +--------->| Processor +---------------------->| (MapConcat) +--------------->| Split      +------------------>
+               |           |                       |             |                |            |                                    
+               +-----------+                       +-------------+                +-----+------+                                    
+                                                                                        | SlotEvent                                                    
+                                                                                        | (to Conductor
+                                                                                        |  via slotEventMerge)
+                                                                                        v 
+   */
+  def apply(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any],
+            remoteAddress: InetSocketAddress, // TODO: remove after #16168 is cleared
+            settings: HostConnectionPoolSettings)(implicit system: ActorSystem, fm: FlowMaterializer): Graph[Ports, Any] =
+    FlowGraph.partial() { implicit b ⇒
+      import FlowGraph.Implicits._
+
+      val slotProcessor = b.add {
+        Flow[RequestContext] andThenMat { () ⇒
+          val actor = system.actorOf(Props(new SlotProcessor(slotIx, connectionFlow, settings)), slotProcessorActorName.next())
+          (ActorProcessor[RequestContext, List[ProcessorOut]](actor), ())
+        }
+      }
+      val flatten = Flow[List[ProcessorOut]].mapConcat(identityFunc)
+      val split = b.add(new SlotEventSplit)
+
+      slotProcessor ~> flatten ~> split.in
+      Ports(slotProcessor.inlet, split.out0, split.out1)
+    }
+
+  import ActorSubscriberMessage._
+  import ActorPublisherMessage._
+
+  private class SlotProcessor(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any],
+                              settings: HostConnectionPoolSettings)(implicit fm: FlowMaterializer)
+    extends ActorSubscriber with ActorPublisher[List[ProcessorOut]] with LogMessages {
+
+    var exposedPublisher: akka.stream.impl.ActorPublisher[Any] = _
+    var inflightRequests = immutable.Queue.empty[RequestContext]
+    val runnableFlow = Source.actorPublisher[HttpRequest](Props(new FlowInportActor(self)))
+      .via(connectionFlow)
+      .toMat(Sink.actorSubscriber[HttpResponse](Props(new FlowOutportActor(self))))(_ -> _)
+
+    def requestStrategy = ZeroRequestStrategy
+    def receive = waitingExposedPublisher
+
+    def waitingExposedPublisher: Receive = {
+      case ExposedPublisher(publisher) ⇒
+        exposedPublisher = publisher
+        context.become(waitingForSubscribePending)
+      case other ⇒ throw new IllegalStateException(s"The first message must be `ExposedPublisher` but was [$other]")
+    }
+
+    def waitingForSubscribePending: Receive = {
+      case SubscribePending ⇒
+        exposedPublisher.takePendingSubscribers() foreach (s ⇒ self ! ActorPublisher.Internal.Subscribe(s))
+        context.become(unconnected)
+    }
+
+    val unconnected: Receive = logMessages("unconnected") {
+      case OnNext(rc: RequestContext) ⇒
+        assert(totalDemand > 0)
+        val (connInport, connOutport) = runnableFlow.run()
+        connOutport ! Request(totalDemand)
+        context.become(waitingForDemandFromConnection(connInport, connOutport, rc))
+
+      case Request(_) ⇒ if (remainingRequested == 0) request(1) // ask for first request if necessary
+
+      case Cancel     ⇒ { cancel(); shutdown() }
+      case OnComplete ⇒ onComplete()
+      case OnError(e) ⇒ onError(e)
+    }
+
+    def waitingForDemandFromConnection(connInport: ActorRef, connOutport: ActorRef,
+                                       firstRequest: RequestContext): Receive = logMessages("waitingForDemandFromConnection") {
+      case ev @ (Request(_) | Cancel)     ⇒ connOutport ! ev
+      case ev @ (OnComplete | OnError(_)) ⇒ connInport ! ev
+      case OnNext(x)                      ⇒ throw new IllegalStateException("Unrequested RequestContext: " + x)
+
+      case FromConnection(Request(_)) ⇒
+        inflightRequests = inflightRequests.enqueue(firstRequest)
+        request(totalDemand - remainingRequested)
+        connInport ! OnNext(firstRequest.request)
+        context.become(running(connInport, connOutport))
+
+      case FromConnection(Cancel)     ⇒ if (!isActive) { cancel(); shutdown() } // else ignore and wait for accompanying OnComplete or OnError
+      case FromConnection(OnComplete) ⇒ handleDisconnect(None)
+      case FromConnection(OnError(e)) ⇒ handleDisconnect(Some(e))
+      case FromConnection(OnNext(x))  ⇒ throw new IllegalStateException("Unexpected HttpResponse: " + x)
+    }
+
+    def running(connInport: ActorRef, connOutport: ActorRef): Receive = logMessages("running") {
+      case ev @ (Request(_) | Cancel)     ⇒ connOutport ! ev
+      case ev @ (OnComplete | OnError(_)) ⇒ connInport ! ev
+      case OnNext(rc: RequestContext) ⇒
+        inflightRequests = inflightRequests.enqueue(rc)
+        connInport ! OnNext(rc.request)
+
+      case FromConnection(Request(n)) ⇒ request(n)
+      case FromConnection(Cancel)     ⇒ if (!isActive) { cancel(); shutdown() } // else ignore and wait for accompanying OnComplete or OnError
+
+      case FromConnection(OnNext(response: HttpResponse)) ⇒
+        val requestContext = inflightRequests.head
+        inflightRequests = inflightRequests.tail
+        val delivery = ResponseDelivery(ResponseContext(requestContext, Success(response)))
+        val requestCompleted = SlotEvent.RequestCompleted(slotIx)
+        onNext(delivery :: requestCompleted :: Nil)
+
+      case FromConnection(OnComplete) ⇒ handleDisconnect(None)
+      case FromConnection(OnError(e)) ⇒ handleDisconnect(Some(e))
+    }
+
+    def handleDisconnect(error: Option[Throwable]): Unit = {
+      log.debug("Slot {} disconnected after {}", slotIx, error getOrElse "regular connection close")
+      val results: List[ProcessorOut] = inflightRequests.map { rc ⇒
+        if (rc.retriesLeft == 0) {
+          val reason = error.fold[Throwable](new RuntimeException("Unexpected disconnect"))(identityFunc)
+          ResponseDelivery(ResponseContext(rc, Failure(reason)))
+        } else SlotEvent.RetryRequest(rc.copy(retriesLeft = rc.retriesLeft - 1))
+      }(collection.breakOut)
+      inflightRequests = immutable.Queue.empty
+      onNext(SlotEvent.Disconnected(slotIx, results.size) :: results)
+      if (canceled) onComplete()
+
+      context.become(unconnected)
+    }
+
+    override def onComplete(): Unit = {
+      exposedPublisher.shutdown(None)
+      super.onComplete()
+      shutdown()
+    }
+
+    override def onError(cause: Throwable): Unit = {
+      exposedPublisher.shutdown(Some(cause))
+      super.onError(cause)
+      shutdown()
+    }
+
+    def shutdown(): Unit = {
+      context.become { case _ ⇒ }
+      context.stop(self)
+    }
+  }
+
+  private case class FromConnection(ev: Any)
+
+  private class FlowInportActor(slotProcessor: ActorRef) extends ActorPublisher[HttpRequest] {
+    def receive: Receive = {
+      case ev: Request            ⇒ slotProcessor ! FromConnection(ev)
+      case Cancel                 ⇒ { slotProcessor ! FromConnection(Cancel); context.stop(self) }
+      case OnNext(r: HttpRequest) ⇒ onNext(r)
+      case OnComplete             ⇒ { onComplete(); context.stop(self) }
+      case OnError(e)             ⇒ { onError(e); context.stop(self) }
+    }
+  }
+
+  private class FlowOutportActor(slotProcessor: ActorRef) extends ActorSubscriber {
+    def requestStrategy = ZeroRequestStrategy
+    def receive: Receive = {
+      case Request(n)                     ⇒ request(n)
+      case Cancel                         ⇒ cancel()
+      case ev: OnNext                     ⇒ slotProcessor ! FromConnection(ev)
+      case ev @ (OnComplete | OnError(_)) ⇒ { slotProcessor ! FromConnection(ev); context.stop(self) }
+    }
+  }
+
+  // FIXME: remove when #17038 is cleared
+  private class SlotEventSplit extends FlexiRoute[ProcessorOut, FanOutShape2[ProcessorOut, ResponseContext, SlotEvent]](
+    new FanOutShape2("HostConnectionPoolSlot.SlotEventSplit"),
+    OperationAttributes.name("HostConnectionPoolSlot.SlotEventSplit")) {
+    import FlexiRoute._
+
+    def createRouteLogic(s: FanOutShape2[ProcessorOut, ResponseContext, SlotEvent]): RouteLogic[ProcessorOut] =
+      new RouteLogic[ProcessorOut] {
+        def initialState: State[_] =
+          State(DemandFromAll(s)) { (ctx, _, ev) ⇒
+            ev match {
+              case ResponseDelivery(x) ⇒ ctx.emit(s.out0)(x)
+              case x: SlotEvent        ⇒ ctx.emit(s.out1)(x)
+            }
+            SameState
+          }
+      }
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/util/package.scala
@@ -7,11 +7,13 @@ package akka.http
 import language.implicitConversions
 import language.higherKinds
 import java.nio.charset.Charset
+import java.util.concurrent.atomic.AtomicInteger
 import com.typesafe.config.Config
 import akka.stream.scaladsl.{ FlattenStrategy, Flow, Source }
 import akka.stream.stage._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
+import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
 import scala.util.matching.Regex
 import akka.event.LoggingAdapter
@@ -54,10 +56,14 @@ package object util {
   }
 
   def printEvent[T](marker: String): Flow[T, T, Unit] =
-    Flow[T].transform(() ⇒ new PushStage[T, T] {
+    Flow[T].transform(() ⇒ new PushPullStage[T, T] {
       override def onPush(element: T, ctx: Context[T]): SyncDirective = {
         println(s"$marker: $element")
         ctx.push(element)
+      }
+      override def onPull(ctx: Context[T]): SyncDirective = {
+        println(s"$marker: PULL")
+        ctx.pull()
       }
       override def onUpstreamFailure(cause: Throwable, ctx: Context[T]): TerminationDirective = {
         println(s"$marker: Error $cause")
@@ -72,6 +78,17 @@ package object util {
         super.onDownstreamFinish(ctx)
       }
     })
+
+  private[this] var eventStreamLogger: ActorRef = _
+  private[http] def installEventStreamLoggerFor(channel: Class[_])(implicit system: ActorSystem): Unit = {
+    synchronized {
+      if (eventStreamLogger == null)
+        eventStreamLogger = system.actorOf(Props[util.EventStreamLogger], name = "event-stream-logger")
+    }
+    system.eventStream.subscribe(eventStreamLogger, channel)
+  }
+  private[http] def installEventStreamLoggerFor[T](implicit ct: ClassTag[T], system: ActorSystem): Unit =
+    installEventStreamLoggerFor(ct.runtimeClass)
 
   private[http] implicit class AddFutureAwaitResult[T](future: Future[T]) {
     /** "Safe" Await.result that doesn't throw away half of the stacktrace */
@@ -104,5 +121,28 @@ package object util {
       val pre = if (si) "kMGTPE".charAt(exp - 1).toString else "KMGTPE".charAt(exp - 1).toString + 'i'
       "%.1f %sB" format (bytes / math.pow(unit, exp), pre)
     } else bytes.toString + "  B"
+  }
+}
+
+package util {
+
+  private[http] class EventStreamLogger extends Actor with ActorLogging {
+    def receive = { case x ⇒ log.warning(x.toString) }
+  }
+
+  // Provisioning of actor names composed of a common prefix + a counter. According to #16613 not in scope as public API.
+  private[http] final class SeqActorName(prefix: String) extends AtomicInteger {
+    def next(): String = prefix + '-' + getAndIncrement()
+  }
+
+  private[http] trait LogMessages extends ActorLogging { this: Actor ⇒
+    def logMessages(mark: String = "")(r: Receive): Receive =
+      new Receive {
+        def isDefinedAt(x: Any): Boolean = r.isDefinedAt(x)
+        def apply(x: Any): Unit = {
+          log.debug(s"[$mark] received: $x")
+          r(x)
+        }
+      }
   }
 }

--- a/akka-http-core/src/test/scala/akka/http/TestClient.scala
+++ b/akka-http-core/src/test/scala/akka/http/TestClient.scala
@@ -6,30 +6,61 @@ package akka.http
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.util.{ Failure, Success }
-import akka.actor.ActorSystem
+import akka.actor.{ UnhandledMessage, ActorSystem }
 import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.http.model._
+import akka.http.util._
 
 object TestClient extends App {
   val testConf: Config = ConfigFactory.parseString("""
     akka.loglevel = INFO
     akka.log-dead-letters = off
-    """)
+    akka.io.tcp.trace-logging = on""")
   implicit val system = ActorSystem("ServerTest", testConf)
   implicit val fm = ActorFlowMaterializer()
   import system.dispatcher
 
+  installEventStreamLoggerFor[UnhandledMessage]
+
   val host = "spray.io"
 
-  println(s"Fetching HTTP server version of host `$host` ...")
+  fetchServerVersion1()
 
-  val connection = Http().outgoingConnection(host)
-  val result = Source.single(HttpRequest()).via(connection).runWith(Sink.head)
+  //  Console.readLine()
+  //  system.shutdown()
 
-  result.map(_.header[headers.Server]) onComplete {
-    case Success(res)   ⇒ println(s"$host is running ${res mkString ", "}")
-    case Failure(error) ⇒ println(s"Error: $error")
+  def fetchServerVersion1(): Unit = {
+    println(s"Fetching HTTP server version of host `$host` via a direct low-level connection ...")
+
+    val connection = Http().outgoingConnection(host)
+    val result = Source.single(HttpRequest()).via(connection).runWith(Sink.head)
+    result.map(_.header[headers.Server]) onComplete {
+      case Success(res) ⇒
+        println(s"$host is running ${res mkString ", "}")
+        println()
+        fetchServerVersion2()
+
+      case Failure(error) ⇒
+        println(s"Error: $error")
+        println()
+        fetchServerVersion2()
+    }
   }
-  result onComplete { _ ⇒ system.shutdown() }
+
+  def fetchServerVersion2(): Unit = {
+    println(s"Fetching HTTP server version of host `$host` via the high-level API ...")
+    val result = Http().singleRequest(HttpRequest(uri = s"http://$host/"))
+    result.map(_.header[headers.Server]) onComplete {
+      case Success(res) ⇒
+        println(s"$host is running ${res mkString ", "}")
+        Http().shutdownAllConnectionPools().onComplete { _ ⇒ system.log.info("STOPPED"); shutdown() }
+
+      case Failure(error) ⇒
+        println(s"Error: $error")
+        shutdown()
+    }
+  }
+
+  def shutdown(): Unit = system.shutdown()
 }

--- a/akka-http-core/src/test/scala/akka/http/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/client/HostConnectionPoolSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.engine.client
+
+import scala.util.{ Success, Try }
+import akka.stream.ActorFlowMaterializer
+import akka.stream.testkit.{ AkkaSpec, StreamTestKit }
+import akka.stream.scaladsl._
+import akka.http.{ Http, TestUtils }
+import akka.http.model.headers._
+import akka.http.model._
+
+class HostConnectionPoolSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF") {
+  implicit val materializer = ActorFlowMaterializer()
+
+  "The host-level client infrastructure" should {
+
+    "properly complete a simple request/response cycle" in new TestSetup {
+      val (requestIn, responseOut, hcp) = cachedHostConnectionPool[Int]()
+
+      val reqSub = requestIn.expectSubscription()
+      reqSub.expectRequest(4)
+      reqSub.sendNext(HttpRequest(uri = "/") -> 42)
+
+      val respSub = responseOut.expectSubscription()
+      respSub.request(1)
+      val (Success(response), 42) = responseOut.expectNext()
+      response.headers should contain(RawHeader("Req-Host", s"localhost:$serverPort"))
+    }
+
+    "add default headers to requests if they don't contain them" in new TestSetup {
+      val (requestIn, responseOut, hcp) =
+        cachedHostConnectionPool[Int](defaultHeaders = List(RawHeader("X-Custom-Header", "Default")))
+
+      val reqSub = requestIn.expectSubscription()
+      reqSub.expectRequest(4)
+      reqSub.sendNext(HttpRequest(uri = "/") -> 42)
+
+      val respSub = responseOut.expectSubscription()
+      respSub.request(1)
+      val (Success(response), 42) = responseOut.expectNext()
+      response.headers should contain(RawHeader("Req-X-Custom-Header", "Default"))
+    }
+  }
+
+  class TestSetup {
+    val (serverHostName, serverPort) = TestUtils.temporaryServerHostnameAndPort()
+
+    { // bind test server which simply echos incoming requests
+      val handler: HttpRequest ⇒ HttpResponse = {
+        case HttpRequest(_, uri, headers, entity, _) ⇒
+          val responseHeaders = RawHeader("Req-Uri", uri.toString) +: headers.map(h ⇒ RawHeader("Req-" + h.name, h.value))
+          HttpResponse(headers = responseHeaders, entity = entity)
+      }
+      Http().bindAndHandleSync(handler, serverHostName, serverPort)
+    }
+
+    def cachedHostConnectionPool[T](settings: Option[HostConnectionPoolSettings] = None,
+                                    defaultHeaders: List[HttpHeader] = Nil) = {
+      val requestIn = StreamTestKit.PublisherProbe[(HttpRequest, T)]
+      val responseOut = StreamTestKit.SubscriberProbe[(Try[HttpResponse], T)]
+      val poolFlow = Http().cachedHostConnectionPool[T](serverHostName, serverPort, Nil, settings, defaultHeaders)
+      val hcp = Source(requestIn).viaMat(poolFlow)(Keep.right).toMat(Sink(responseOut))(Keep.left).run()
+      (requestIn, responseOut, hcp)
+    }
+
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -252,7 +252,7 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
     else new Flow(module.growConnect(op, shape.outlet, op.inPort, Keep.right).replaceShape(FlowShape(shape.inlet, op.outPort)))
   }
 
-  private[stream] def andThenMat[U, Mat2, O >: Out](processorFactory: () ⇒ (Processor[O, U], Mat2)): Repr[U, Mat2] = {
+  private[akka] def andThenMat[U, Mat2, O >: Out](processorFactory: () ⇒ (Processor[O, U], Mat2)): Repr[U, Mat2] = {
     val op = Stages.DirectProcessor(processorFactory.asInstanceOf[() ⇒ (Processor[Any, Any], Any)])
     if (this.isIdentity) new Flow(op).asInstanceOf[Repr[U, Mat2]]
     else new Flow[In, U, Mat2](module.growConnect(op, shape.outlet, op.inPort, Keep.right).replaceShape(FlowShape(shape.inlet, op.outPort)))


### PR DESCRIPTION
**[Not for merge yet]**

This PR brings client-side connection pooling to akka-http-core (#15681).

The implementation as such is complete.
The only thing not yet completed (and therefore not contained yet) is the tests.

I'm putting it here to enable feedback even before all the remaining implementation kinks have been ironed out.

/cc @jrudolph 
