### PR TITLE
=htc #16954 Fix handling of empty authority in Uris

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/Uri.scala
@@ -790,12 +790,15 @@ object UriRendering {
   def renderUriWithoutFragment[R <: Rendering](r: R, value: Uri, charset: Charset): r.type = {
     import value._
     if (isAbsolute) r ~~ scheme ~~ ':'
-    renderAuthority(r, authority, scheme, charset)
+    renderAuthority(r, authority, path, scheme, charset)
     renderPath(r, path, charset, encodeFirstSegmentColons = isRelative)
     if (query.nonEmpty) renderQuery(r ~~ '?', query, charset) else r
   }
 
   def renderAuthority[R <: Rendering](r: R, authority: Authority, scheme: String, charset: Charset): r.type =
+    renderAuthority(r, authority, Path.Empty, scheme, charset)
+
+  def renderAuthority[R <: Rendering](r: R, authority: Authority, path: Path, scheme: String, charset: Charset): r.type =
     if (authority.nonEmpty) {
       import authority._
       r ~~ '/' ~~ '/'
@@ -804,7 +807,7 @@ object UriRendering {
       if (port != 0) r ~~ ':' ~~ port else r
     } else scheme match {
       case "" | "mailto" ⇒ r
-      case _             ⇒ r ~~ '/' ~~ '/'
+      case _             ⇒ if (path.isEmpty || path.startsWithSlash) r ~~ '/' ~~ '/' else r
     }
 
   def renderPath[R <: Rendering](r: R, path: Path, charset: Charset, encodeFirstSegmentColons: Boolean = false): r.type =

--- a/akka-http-core/src/test/scala/akka/http/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/model/UriSpec.scala
@@ -401,7 +401,7 @@ class UriSpec extends WordSpec with Matchers {
       normalize("http://:80/foo") shouldEqual "http:///foo"
       normalize("http://:8080/foo") shouldEqual "http://:8080/foo"
       normalize("ftp://example.com:21") shouldEqual "ftp://example.com"
-      normalize("example.com:21") shouldEqual "example.com://21" // example.com is parsed as the SCHEME (which is correct)
+      normalize("example.com:21") shouldEqual "example.com:21" // example.com is parsed as the SCHEME (which is correct)
       normalize("//example.com:21") shouldEqual "//example.com:21"
       normalize("ftp://example.com:22") shouldEqual "ftp://example.com:22"
 
@@ -512,7 +512,7 @@ class UriSpec extends WordSpec with Matchers {
       def resolve(uri: String) = parseAndResolve(uri, base).toString
 
       "normal examples" in {
-        resolve("g:h") shouldEqual "g://h"
+        resolve("g:h") shouldEqual "g:h"
         resolve("g") shouldEqual "http://a/b/c/g"
         resolve("./g") shouldEqual "http://a/b/c/g"
         resolve("g/") shouldEqual "http://a/b/c/g/"
@@ -560,7 +560,7 @@ class UriSpec extends WordSpec with Matchers {
         resolve("g#s/./x") shouldEqual "http://a/b/c/g#s/./x"
         resolve("g#s/../x") shouldEqual "http://a/b/c/g#s/../x"
 
-        resolve("http:g") shouldEqual "http://g"
+        resolve("http:g") shouldEqual "http:g"
       }
     }
 


### PR DESCRIPTION
This is a fix to fix #16953. During backport to Spray (https://github.com/spray/spray/issues/1014#issuecomment-81522243) new flaws were discovered. This PR fixes the discovered bugs in Uris rendering.
