### PR TITLE
=doc #15677 Document how to use native-packager

### DIFF
--- a/akka-docs/rst/java/microkernel.rst
+++ b/akka-docs/rst/java/microkernel.rst
@@ -2,42 +2,60 @@
 .. _microkernel-java:
 
 Microkernel
-==================
+===========
 
 The purpose of the Akka Microkernel is to offer a bundling mechanism so that you can distribute
 an Akka application as a single payload, without the need to run in a Java Application Server or manually
 having to create a launcher script.
 
-The Akka Microkernel is included in the Akka download found at `downloads`_.
+.. warning:: Akka Microkernel will be deprecated and removed. It will be replaced by using an ordinary
+   user defined main class and packaging with `sbt-native-packager <https://github.com/sbt/sbt-native-packager>`_
+   or `Typesafe ConductR <http://typesafe.com/products/conductr>`_.
 
-.. _downloads: http://akka.io/downloads
-
-To run an application with the microkernel you need to create a Bootable class
-that handles the startup and shutdown the application. An example is included below.
-
-Put your application jar in the ``deploy`` directory and additional dependencies in the ``lib`` directory
-to have them automatically loaded and placed on the classpath.
-
-To start the kernel use the scripts in the ``bin`` directory, passing the boot
-classes for your application. 
-
-The start script adds ``config`` directory first in the classpath, followed by ``lib/*``.
-It runs java with main class ``akka.kernel.Main`` and the supplied Bootable class as
-argument.
-
-Example command (on a unix-based system):
-
-.. code-block:: none
-
-   bin/akka sample.kernel.hello.HelloKernel
-
-Use ``Ctrl-C`` to interrupt and exit the microkernel.
-
-On a Windows machine you can also use the bin/akka.bat script.
+To run an application with the microkernel you need to create a Bootable class 
+that handles the startup and shutdown the application.
 
 The code for the Hello Kernel example (see the ``HelloKernel`` class for an example
 of creating a Bootable):
 
 .. includecode:: ../../../akka-samples/akka-sample-hello-kernel/src/main/java/sample/kernel/hello/java/HelloKernel.java
 
+`sbt-native-packager <https://github.com/sbt/sbt-native-packager>`_ is the recommended tool for creating
+distributions of Akka applications when using sbt.
+
+Define sbt version in ``project/build.properties`` file: 
+
+.. code-block:: none
+
+    sbt.version=0.13.7
+
+Add `sbt-native-packager <https://github.com/sbt/sbt-native-packager>`_ in ``project/plugins.sbt`` file:
+
+.. code-block:: none
+
+   addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")
+
+Use the package settings and specify the mainClass in ``build.sbt`` file:
+
+.. includecode:: ../../../akka-samples/akka-sample-hello-kernel/build.sbt
+
+
+.. note:: Use the ``JavaServerAppPackaging``. Don't use ``AkkaAppPackaging`` (previously named 
+   ``packageArchetype.akka_application``, since it doesn't have the same flexibility and quality
+   as the ``JavaServerAppPackaging``.
+
+Use sbt task ``dist`` package the application.
+
+To start the application (on a unix-based system):
+
+.. code-block:: none
+
+   cd target/universal/
+   unzip hello-kernel-0.1.zip
+   chmod u+x hello-kernel-0.1/bin/hello-kernel
+   hello-kernel-0.1/bin/hello-kernel sample.kernel.hello.java.HelloKernel
+
+Use ``Ctrl-C`` to interrupt and exit the microkernel.
+
+On a Windows machine you can also use the ``bin\hello-kernel.bat`` script.
 

--- a/akka-docs/rst/scala/microkernel.rst
+++ b/akka-docs/rst/scala/microkernel.rst
@@ -2,15 +2,15 @@
 .. _microkernel-scala:
 
 Microkernel
-===================
+===========
 
 The purpose of the Akka Microkernel is to offer a bundling mechanism so that you can distribute
 an Akka application as a single payload, without the need to run in a Java Application Server or manually
 having to create a launcher script.
 
-The Akka Microkernel is included in the Akka download found at `downloads`_.
-
-.. _downloads: http://akka.io/downloads
+.. warning:: Akka Microkernel will be deprecated and removed. It will be replaced by using an ordinary
+   user defined main class and packaging with `sbt-native-packager <https://github.com/sbt/sbt-native-packager>`_
+   or `Typesafe ConductR <http://typesafe.com/products/conductr>`_.
 
 To run an application with the microkernel you need to create a Bootable class 
 that handles the startup and shutdown the application.
@@ -20,28 +20,43 @@ of creating a Bootable):
 
 .. includecode:: ../../../akka-samples/akka-sample-hello-kernel/src/main/scala/sample/kernel/hello/HelloKernel.scala
 
+`sbt-native-packager <https://github.com/sbt/sbt-native-packager>`_ is the recommended tool for creating
+distributions of Akka applications when using sbt.
 
-Add `sbt-native-packager <https://github.com/sbt/sbt-native-packager>`_ to the plugins.sbt
+Define sbt version in ``project/build.properties`` file: 
 
 .. code-block:: none
 
-   addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0-M2")
+    sbt.version=0.13.7
 
-Use the package settings for ``akka_application``, and specify the mainClass in build.sbt
+Add `sbt-native-packager <https://github.com/sbt/sbt-native-packager>`_ in ``project/plugins.sbt`` file:
+
+.. code-block:: none
+
+   addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")
+
+Use the package settings and specify the mainClass in ``build.sbt`` file:
 
 .. includecode:: ../../../akka-samples/akka-sample-hello-kernel/build.sbt
 
 
-Use sbt task ``stage`` to generate the start script. Also you can use task ``universal:packageZipTarball`` to package the application.
+.. note:: Use the ``JavaServerAppPackaging``. Don't use ``AkkaAppPackaging`` (previously named 
+   ``packageArchetype.akka_application``, since it doesn't have the same flexibility and quality
+   as the ``JavaServerAppPackaging``.
+
+Use sbt task ``dist`` package the application.
 
 To start the application (on a unix-based system):
 
 .. code-block:: none
 
-   ./target/universal/stage/bin/hello-kernel
+   cd target/universal/
+   unzip hello-kernel-0.1.zip
+   chmod u+x hello-kernel-0.1/bin/hello-kernel
+   hello-kernel-0.1/bin/hello-kernel sample.kernel.hello.HelloKernel
 
 Use ``Ctrl-C`` to interrupt and exit the microkernel.
 
-On a Windows machine you can also use the ``target\universal\stage\bin\hello-kernel.bat`` script.
+On a Windows machine you can also use the ``bin\hello-kernel.bat`` script.
 
 

--- a/akka-samples/akka-sample-hello-kernel/build.sbt
+++ b/akka-samples/akka-sample-hello-kernel/build.sbt
@@ -1,12 +1,30 @@
-import NativePackagerKeys._
+import NativePackagerHelper._
 
-packageArchetype.akka_application
+name := "hello-kernel"
 
-name := """hello-kernel"""
+version := "0.1"
 
-mainClass in Compile := Some("sample.kernel.hello.HelloKernel")
+val akkaVersion = "2.3-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-kernel" % "2.3-SNAPSHOT",
-  "com.typesafe.akka" %% "akka-actor" % "2.3-SNAPSHOT"
+  "com.typesafe.akka" %% "akka-kernel" % akkaVersion,
+  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+  "ch.qos.logback" % "logback-classic" % "1.0.7"
 )
+
+mainClass in Compile := Some("akka.kernel.Main")
+
+enablePlugins(JavaServerAppPackaging)
+
+mappings in Universal ++= {
+  // optional example illustrating how to copy additional directory
+  directory("scripts") ++
+  // copy configuration files to config directory
+  contentOf("src/main/resources").toMap.mapValues("config/" + _)
+}
+
+// add 'config' directory first in the classpath of the start script,
+// an alternative is to set the config file locations via CLI parameters
+// when starting the application
+scriptClasspath := Seq("../config/") ++ scriptClasspath.value

--- a/akka-samples/akka-sample-hello-kernel/project/build.properties
+++ b/akka-samples/akka-sample-hello-kernel/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7

--- a/akka-samples/akka-sample-hello-kernel/project/plugins.sbt
+++ b/akka-samples/akka-sample-hello-kernel/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0-M2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")

--- a/akka-samples/akka-sample-hello-kernel/src/main/resources/application.conf
+++ b/akka-samples/akka-sample-hello-kernel/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+akka {
+  loglevel = INFO
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+}

--- a/akka-samples/akka-sample-hello-kernel/src/main/resources/logback.xml
+++ b/akka-samples/akka-sample-hello-kernel/src/main/resources/logback.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="false" debug="false">
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} %-5level [%X{akkaSource}] : %m%n</pattern>
+    </encoder>
+  </appender>
+  
+  <appender name="R" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <File>${hello-kernel.log-dir:-logs}/hello-kernel.log</File>
+    <encoder>
+      <pattern>%date{ISO8601} %-5level [%X{akkaSource}] : %m%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${hello-kernel.log-dir:-logs}/hello-kernel.log.%d{yyyy-MM-dd}</fileNamePattern>
+    </rollingPolicy>
+  </appender>
+  
+  <root level="DEBUG">
+    <appender-ref ref="R"/>
+    <appender-ref ref="stdout"/>
+  </root>
+</configuration>


### PR DESCRIPTION
- replace docs of AkkaAppPackaging with JavaServerAppPackaging,
  since the former doesn't have the same flexibility and quality
- warn about microkernel deprecation
