### PR TITLE
Enable java-lambda doc sample build in PR validation

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/utils/TestUtils.scala
+++ b/akka-docs-dev/rst/scala/code/docs/utils/TestUtils.scala
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package docs.utils
+
+import java.net.InetSocketAddress
+import java.nio.channels.ServerSocketChannel
+
+object TestUtils {
+  def temporaryServerAddress(interface: String = "127.0.0.1"): InetSocketAddress = {
+    val serverSocket = ServerSocketChannel.open()
+    try {
+      serverSocket.socket.bind(new InetSocketAddress(interface, 0))
+      val port = serverSocket.socket.getLocalPort
+      new InetSocketAddress(interface, port)
+    } finally serverSocket.close()
+  }
+
+  def temporaryServerHostnameAndPort(interface: String = "127.0.0.1"): (String, Int) = {
+    val socketAddress = temporaryServerAddress(interface)
+    socketAddress.getHostName -> socketAddress.getPort
+  }
+}

--- a/akka-samples/akka-docs-java-lambda/src/test/java/util/SocketUtils.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/util/SocketUtils.java
@@ -1,0 +1,27 @@
+package util;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.channels.ServerSocketChannel;
+
+public class SocketUtils {
+
+  public static InetSocketAddress temporaryServerAddress(String hostname) {
+    try {
+      ServerSocket socket = ServerSocketChannel.open().socket();
+      socket.bind(new InetSocketAddress(hostname, 0));
+      InetSocketAddress address = new InetSocketAddress(hostname, socket.getLocalPort());
+      socket.close();
+      return address;
+    }
+    catch (IOException io) {
+      throw new RuntimeException(io);
+    }
+  }
+
+  public static InetSocketAddress temporaryServerAddress() {
+    return temporaryServerAddress("127.0.0.1");
+  }
+
+}

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -79,12 +79,9 @@ object AkkaBuild extends Build {
         archivesPathFinder.get.map(file => (file -> ("akka/" + file.getName)))
       },
       Maven.projects in Maven.mvn := Seq(file("akka-samples") / "akka-docs-java-lambda"),
-      // FIXME when jenkins issue is solved, re-enable pr validation of:
-      //       Maven.mvnExec
-      //       test in Test in httpJava8Tests
       validatePullRequest <<= Seq(test in Test in stream, SphinxSupport.generate in Sphinx in docsDev,
-      test in Test in streamTestkit, test in Test in streamTests, test in Test in streamTck,
-      test in Test in httpCore, test in Test in http, test in Test in httpJavaTests,
+      Maven.mvnExec, test in Test in streamTestkit, test in Test in streamTests, test in Test in streamTck,
+      test in Test in httpCore, test in Test in http, test in Test in httpJavaTests, test in Test in httpJava8Tests,
       test in Test in httpTestkit, test in Test in httpTests, test in Test in docsDev,
       compile in Compile in benchJmh
       ).dependOn
@@ -1154,6 +1151,7 @@ object AkkaBuild extends Build {
         Try("/usr/libexec/java_home -v 1.8".!!).toOption.toSeq // OS/X method
         )
         .find(isJavaHome)
+        .orElse { sLog.value.warn("Java 8 installation has not been found. Java 8 tasks will not be run."); None }
         .map(dirName => file(dirName.trim))
     },
 


### PR DESCRIPTION
Fixes #16905.
- use a free port instead of a hardcoded one
- do not use null for stream elements
- use defined java8 home key
