### PR TITLE
+tes #17023 Adding ForwardActor among test-kit actors

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
@@ -3,7 +3,7 @@
  */
 package akka.testkit
 
-import akka.actor.{ Props, Actor }
+import akka.actor.{ Props, Actor, ActorRef }
 
 /**
  * A collection of common actor patterns used in tests.
@@ -19,6 +19,18 @@ object TestActors {
     }
   }
 
+  /**
+   * ForwardActor forwards all messages as-is to specified ActorRef.
+   *
+   * @param ref target ActorRef to forward messages to
+   */
+  class ForwardActor(ref: ActorRef) extends Actor {
+    override def receive = {
+      case message ⇒ ref forward message
+    }
+  }
+
   val echoActorProps = Props[EchoActor]()
+  def forwardActorProps(ref: ActorRef) = Props(classOf[ForwardActor], ref)
 
 }

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorsSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorsSpec.scala
@@ -5,7 +5,7 @@ package akka.testkit
 
 class TestActorsSpec extends AkkaSpec with ImplicitSender {
 
-  import TestActors.echoActorProps
+  import TestActors.{ echoActorProps, forwardActorProps }
 
   "A EchoActor" must {
     "send back messages unchanged" in {
@@ -13,6 +13,17 @@ class TestActorsSpec extends AkkaSpec with ImplicitSender {
       val echo = system.actorOf(echoActorProps)
 
       echo ! message
+
+      expectMsg(message)
+    }
+  }
+
+  "A ForwardActor" must {
+    "forward messages to target actor" in {
+      val message = "forward me"
+      val forward = system.actorOf(forwardActorProps(testActor))
+
+      forward ! message
 
       expectMsg(message)
     }


### PR DESCRIPTION
Resolves #17023 by adding ForwardActor, a dummy which forwards each message to target specified at its constructor, to TestActors in test-kit.
