### PR TITLE
=act #16295 Temporary disable windows-connection-abort-workaround

### DIFF
--- a/akka-actor-tests/src/test/resources/reference.conf
+++ b/akka-actor-tests/src/test/resources/reference.conf
@@ -3,3 +3,7 @@ akka {
     serialize-messages = on    
   }
 }
+
+# FIXME Some test depend on this setting when running on windows.
+#       It should be removed when #17122 is solved. 
+akka.io.tcp.windows-connection-abort-workaround-enabled = auto

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -600,7 +600,7 @@ akka {
       # and undefined behavior.
       # Possible values of this key are on, off and auto where auto will enable the
       # workaround if Windows is detected automatically.
-      windows-connection-abort-workaround-enabled = auto
+      windows-connection-abort-workaround-enabled = off
     }
 
     udp {


### PR DESCRIPTION
Until we have a working solution.

Are there any tests that will fail on windows because of this change? Then those tests could be configured with `auto`.
