### PR TITLE
=str #16924: Fix FanoutProcessor to not overwrite last termination cause

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorPublisher.scala
@@ -16,8 +16,10 @@ import org.reactivestreams.Subscription
  * INTERNAL API
  */
 private[akka] object ActorPublisher {
-  class NormalShutdownException extends IllegalStateException("Cannot subscribe to shut-down Publisher") with NoStackTrace
-  val NormalShutdownReason: Option[Throwable] = Some(new NormalShutdownException)
+  val NormalShutdownReasonMessage = "Cannot subscribe to shut-down Publisher"
+  class NormalShutdownException extends IllegalStateException(NormalShutdownReasonMessage) with NoStackTrace
+  val NormalShutdownReason: Throwable = new NormalShutdownException
+  val SomeNormalShutdownReason: Some[Throwable] = Some(NormalShutdownReason)
 
   def apply[T](impl: ActorRef): ActorPublisher[T] = {
     val a = new ActorPublisher[T](impl)

--- a/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
@@ -42,8 +42,8 @@ private[akka] abstract class FanoutOutputs(val maxBufferSize: Int, val initialBu
     if (!downstreamCompleted) {
       downstreamCompleted = true
       abortDownstream(e)
+      if (exposedPublisher ne null) exposedPublisher.shutdown(Some(e))
     }
-    if (exposedPublisher ne null) exposedPublisher.shutdown(Some(e))
   }
 
   def isClosed: Boolean = downstreamCompleted
@@ -58,7 +58,7 @@ private[akka] abstract class FanoutOutputs(val maxBufferSize: Int, val initialBu
   override protected def shutdown(completed: Boolean): Unit = {
     if (exposedPublisher ne null) {
       if (completed) exposedPublisher.shutdown(None)
-      else exposedPublisher.shutdown(ActorPublisher.NormalShutdownReason)
+      else exposedPublisher.shutdown(ActorPublisher.SomeNormalShutdownReason)
     }
     afterShutdown()
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/FuturePublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FuturePublisher.scala
@@ -54,7 +54,7 @@ private[akka] class FuturePublisher(future: Future[Any], settings: ActorFlowMate
   var subscriptions = Map.empty[FutureSubscription, Subscriber[Any]]
   var subscriptionsReadyForPush = Set.empty[FutureSubscription]
   var futureValue: Option[Try[Any]] = future.value
-  var shutdownReason = ActorPublisher.NormalShutdownReason
+  var shutdownReason: Option[Throwable] = ActorPublisher.SomeNormalShutdownReason
 
   override val supervisorStrategy = SupervisorStrategy.stoppingStrategy
 

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
@@ -277,7 +277,7 @@ private[akka] abstract class TwoStreamInputProcessor(_settings: ActorFlowMateria
       case OtherStreamOnError(e)      ⇒ TwoStreamInputProcessor.this.onError(e)
     }
     override protected def completed: Actor.Receive = {
-      case OtherStreamOnSubscribe(_) ⇒ throw new IllegalStateException("Cannot subscribe shutdown subscriber")
+      case OtherStreamOnSubscribe(_) ⇒ throw ActorPublisher.NormalShutdownReason
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/SubscriberManagement.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SubscriberManagement.scala
@@ -32,7 +32,7 @@ private[akka] object SubscriberManagement {
     def apply[T](subscriber: Subscriber[T]): Unit = tryOnError(subscriber, cause)
   }
 
-  val ShutDown = new ErrorCompleted(new IllegalStateException("Cannot subscribe to shut-down Publisher"))
+  val ShutDown = new ErrorCompleted(ActorPublisher.NormalShutdownReason)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
@@ -124,7 +124,7 @@ private[akka] class TickPublisher(initialDelay: FiniteDuration, interval: Finite
     tickTask.foreach(_.cancel)
     cancelled.set(true)
     if (exposedPublisher ne null)
-      exposedPublisher.shutdown(ActorPublisher.NormalShutdownReason)
+      exposedPublisher.shutdown(ActorPublisher.SomeNormalShutdownReason)
     if (subscriber ne null)
       tryOnComplete(subscriber)
   }


### PR DESCRIPTION
Also fix FlowSpec to expect onError instead of onComplete for late subscribers
