### PR TITLE
=htc #16804 make `akka.http.model.RangeUnit.Bytes` a `case object`

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/model/headers/RangeUnit.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/headers/RangeUnit.scala
@@ -12,7 +12,7 @@ sealed abstract class RangeUnit extends japi.headers.RangeUnit with ValueRendera
 }
 
 object RangeUnits {
-  object Bytes extends RangeUnit {
+  case object Bytes extends RangeUnit {
     def name = "Bytes"
 
     def render[R <: Rendering](r: R): r.type = r ~~ "bytes"


### PR DESCRIPTION
Closes #16804.

I also went through the complete model package structure and verified that all other `object` instances are indeed either case objects or extend a `case class`.

/cc @jrudolph 
