### PR TITLE
+htp extract multiple occurrences in the parameters/formFields directives by suffixing with *

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -95,6 +95,50 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec {
       responseAs[String] shouldEqual "The query parameter 'count' was malformed:\n'blub' is not a valid 32-bit signed integer value"
     }
   }
+  "repeated" in {
+    val route =
+      parameters('color, 'city.*) { (color, cities) =>
+        cities.toList match {
+          case Nil         => complete(s"The color is '$color' and there are no cities.")
+          case city :: Nil => complete(s"The color is '$color' and the city is $city.")
+          case multiple    => complete(s"The color is '$color' and the cities are ${multiple.mkString(", ")}.")
+        }
+      }
+
+    Get("/?color=blue") ~> route ~> check {
+      responseAs[String] === "The color is 'blue' and there are no cities."
+    }
+
+    Get("/?color=blue&city=Chicago") ~> Route.seal(route) ~> check {
+      responseAs[String] === "The color is 'blue' and the city is Chicago."
+    }
+
+    Get("/?color=blue&city=Chicago&city=Boston") ~> Route.seal(route) ~> check {
+      responseAs[String] === "The color is 'blue' and the cities are Chicago, Boston."
+    }
+  }
+  "mapped-repeated" in {
+    val route =
+      parameters('color, 'distance.as[Int].*) { (color, cities) =>
+        cities.toList match {
+          case Nil             => complete(s"The color is '$color' and there are no distances.")
+          case distance :: Nil => complete(s"The color is '$color' and the distance is $distance.")
+          case multiple        => complete(s"The color is '$color' and the distances are ${multiple.mkString(", ")}.")
+        }
+      }
+
+    Get("/?color=blue") ~> route ~> check {
+      responseAs[String] === "The color is 'blue' and there are no distances."
+    }
+
+    Get("/?color=blue&distance=5") ~> Route.seal(route) ~> check {
+      responseAs[String] === "The color is 'blue' and the distance is 5."
+    }
+
+    Get("/?color=blue&distance=5&distance=14") ~> Route.seal(route) ~> check {
+      responseAs[String] === "The color is 'blue' and the distances are 5, 14."
+    }
+  }
   "parameterMap" in {
     val route =
       parameterMap { params =>

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFields.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFields.rst
@@ -25,7 +25,7 @@ Description
 
 Form fields can be either extracted as a String or can be converted to another type. The parameter name
 can be supplied either as a String or as a Symbol. Form field extraction can be modified to mark a field
-as required or optional or to filter requests where a form field has a certain value:
+as required, optional, or repeated, or to filter requests where a form field has a certain value:
 
 ``"color"``
     extract value of field "color" as ``String``
@@ -40,6 +40,13 @@ as required or optional or to filter requests where a form field has a certain v
     (see also :ref:`http-unmarshalling-scala`)
 ``"amount".as(deserializer)``
     extract value of field "amount" with an explicit ``Deserializer``
+``"distance".*``
+    extract multiple occurrences of field "distance" as ``Iterable[String]``
+``"distance".as[Int].*``
+    extract multiple occurrences of field "distance" as ``Iterable[Int]``, you need a matching implicit ``Deserializer`` in scope for that to work
+    (see also :ref:`unmarshalling`)
+``"distance".as(deserializer).*``
+    extract multiple occurrences of field "distance" with an explicit ``Deserializer``
 
 You can use :ref:`Case Class Extraction` to group several extracted values together into a case-class
 instance.

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/index.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/index.rst
@@ -25,7 +25,7 @@ to use which shows properties of different parameter directives.
 directive                  level  ordering multi
 ========================== ====== ======== =====
 :ref:`-parameter-`         high   no       no
-:ref:`-parameters-`        high   no       no
+:ref:`-parameters-`        high   no       yes
 :ref:`-parameterMap-`      low    no       no
 :ref:`-parameterMultiMap-` low    no       yes
 :ref:`-parameterSeq-`      low    yes      yes

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameters.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameters.rst
@@ -24,7 +24,7 @@ Description
 -----------
 Query parameters can be either extracted as a String or can be converted to another type. The parameter name
 can be supplied either as a String or as a Symbol. Parameter extraction can be modified to mark a query parameter
-as required or optional or to filter requests where a parameter has a certain value:
+as required, optional, or repeated, or to filter requests where a parameter has a certain value:
 
 ``"color"``
     extract value of parameter "color" as ``String``
@@ -39,6 +39,13 @@ as required or optional or to filter requests where a parameter has a certain va
     (see also :ref:`http-unmarshalling-scala`)
 ``"amount".as(deserializer)``
     extract value of parameter "amount" with an explicit ``Deserializer``
+``"distance".*``
+    extract multiple occurrences of parameter "distance" as ``Iterable[String]``
+``"distance".as[Int].*``
+    extract multiple occurrences of parameter "distance" as ``Iterable[Int]``, you need a matching ``Deserializer`` in scope for that to work
+    (see also :ref:`unmarshalling`)
+``"distance".as(deserializer).*``
+    extract multiple occurrences of parameter "distance" with an explicit ``Deserializer``
 
 You can use :ref:`Case Class Extraction` to group several extracted values together into a case-class
 instance.
@@ -80,3 +87,15 @@ Deserialized parameter
 
 ... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: mapped-value
+
+Repeated parameter
++++++++++++++++++++++++++++++
+
+... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+   :snippet: repeated
+
+Repeated, deserialized parameter
+++++++++++++++++++++++
+
+... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+   :snippet: mapped-repeated

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -137,4 +137,26 @@ class FormFieldDirectivesSpec extends RoutingSpec {
     }
   }
 
+  "The 'formField' repeated directive" should {
+    "extract an empty Iterable when the parameter is absent" in {
+      Post("/", FormData("age" -> "42")) ~> {
+        formFields('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List()" }
+    }
+    "extract all occurrences into an Iterable when parameter is present" in {
+      Post("/", FormData("age" -> "42", "hobby" -> "cooking", "hobby" -> "reading")) ~> {
+        formFields('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List(cooking, reading)" }
+    }
+    "extract as Iterable[Int]" in {
+      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "5")) ~> {
+        formFields('number.as[Int]*) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 5)" }
+    }
+    "extract as Iterable[Int] with an explicit deserializer" in {
+      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "A")) ~> {
+        formFields('number.as(HexInt)*) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 10)" }
+    }
+  }
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -182,4 +182,27 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
       Get() ~> route ~> check { responseAs[String] shouldEqual "GET" }
     }
   }
+
+  "The 'parameter' repeated directive should" - {
+    "extract an empty Iterable when the parameter is absent" in {
+      Get("/person?age=19") ~> {
+        parameter('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List()" }
+    }
+    "extract all occurrences into an Iterable when parameter is present" in {
+      Get("/person?age=19&hobby=cooking&hobby=reading") ~> {
+        parameter('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List(cooking, reading)" }
+    }
+    "extract as Iterable[Int]" in {
+      Get("/person?age=19&number=3&number=5") ~> {
+        parameter('number.as[Int]*) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 5)" }
+    }
+    "extract as Iterable[Int] with an explicit deserializer" in {
+      Get("/person?age=19&number=3&number=A") ~> {
+        parameter('number.as(HexInt)*) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 10)" }
+    }
+  }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
@@ -18,12 +18,14 @@ class NameReceptacle[T](val name: String) {
   def ? = new NameOptionReceptacle[T](name)
   def ?[B](default: B) = new NameDefaultReceptacle(name, default)
   def ![B](requiredValue: B) = new RequiredValueReceptacle(name, requiredValue)
+  def * = new RepeatedValueReceptacle[T](name)
 }
 
 class NameUnmarshallerReceptacle[T](val name: String, val um: FSU[T]) {
   def ? = new NameOptionUnmarshallerReceptacle[T](name, um)
   def ?(default: T) = new NameDefaultUnmarshallerReceptacle(name, default, um)
   def !(requiredValue: T) = new RequiredValueUnmarshallerReceptacle(name, requiredValue, um)
+  def * = new RepeatedValueUnmarshallerReceptacle[T](name, um)
 }
 
 class NameOptionReceptacle[T](val name: String)
@@ -32,8 +34,12 @@ class NameDefaultReceptacle[T](val name: String, val default: T)
 
 class RequiredValueReceptacle[T](val name: String, val requiredValue: T)
 
+class RepeatedValueReceptacle[T](val name: String)
+
 class NameOptionUnmarshallerReceptacle[T](val name: String, val um: FSU[T])
 
 class NameDefaultUnmarshallerReceptacle[T](val name: String, val default: T, val um: FSU[T])
 
 class RequiredValueUnmarshallerReceptacle[T](val name: String, val requiredValue: T, val um: FSU[T])
+
+class RepeatedValueUnmarshallerReceptacle[T](val name: String, val um: FSU[T])


### PR DESCRIPTION
To extract an:
- `Iterable[String]`: `'amount*`
- `Iterable[Int]`: `'amount.as[Int]*`
- `Iterable[Int]` with an explicit deserializer: `'amount.as(HexInt)*`

This feature came in handy when implementing a geospatial HTTP-based standard called WCS (for the curious, the `subset` parameter of the `GetCoverage` request in the [spec](https://portal.opengeospatial.org/files/09-147r3)).

This change was originally submitted as spray/spray#955. I was able to take advantage of internal design improvements to make this version more compact, and the external API more intuitive (`amount.as(HexInt)*` rather than `amount.as[Int].*(HexInt)`). I would have migrated the documentation changes as well, but I couldn't find the target files (shouldn't they be somewhere under `akka-docs-dev/rst/scala/http/directives`?).
