### PR TITLE
=doc #16910 Fix include sections in fault tolerance docs (for validation)

### DIFF
--- a/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.java
+++ b/akka-docs/rst/java/code/docs/actor/FaultHandlingTest.java
@@ -20,7 +20,6 @@ import scala.collection.immutable.Seq;
 import scala.concurrent.Await;
 import static akka.pattern.Patterns.ask;
 import scala.concurrent.duration.Duration;
-import akka.testkit.AkkaSpec;
 import akka.testkit.TestProbe;
 
 //#testkit
@@ -151,7 +150,7 @@ public class FaultHandlingTest {
 
   @BeforeClass
   public static void start() {
-    system = ActorSystem.create("test", AkkaSpec.testConf());
+    system = ActorSystem.create("test");
   }
 
   @AfterClass

--- a/akka-docs/rst/scala/code/docs/actor/FaultHandlingDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/actor/FaultHandlingDocSpec.scala
@@ -4,12 +4,13 @@
 package docs.actor
 
 import language.postfixOps
+import akka.actor.{ ActorSystem, ActorRef, Props, Terminated }
+import FaultHandlingDocSpec._
 
 //#testkit
-import akka.testkit.{ TestKit, ImplicitSender, EventFilter }
-import akka.actor.{ ActorRef, Props, ActorSystem, Terminated }
-import org.scalatest._
 import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ FlatSpecLike, Matchers, BeforeAndAfterAll }
+import akka.testkit.{ TestActors, TestKit, ImplicitSender, EventFilter }
 
 //#testkit
 object FaultHandlingDocSpec {
@@ -97,14 +98,20 @@ object FaultHandlingDocSpec {
       }
   """)
 }
-
-import FaultHandlingDocSpec._
 //#testkit
-class FaultHandlingDocSpec extends TestKit(ActorSystem("FaultHandlingDocSpec", testConf))
-  with FlatSpecLike with BeforeAndAfterAll with ImplicitSender {
+class FaultHandlingDocSpec(_system: ActorSystem) extends TestKit(_system)
+  with ImplicitSender with FlatSpecLike with Matchers with BeforeAndAfterAll {
 
-  override def afterAll() {
-    system.terminate()
+  def this() = this(ActorSystem("FaultHandlingDocSpec",
+    ConfigFactory.parseString("""
+      akka {
+        loggers = ["akka.testkit.TestEventListener"]
+        loglevel = "WARNING"
+      }
+      """)))
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
   }
 
   "A supervisor" must "apply the chosen strategy for its child" in {

--- a/akka-docs/rst/scala/fault-tolerance.rst
+++ b/akka-docs/rst/scala/fault-tolerance.rst
@@ -126,9 +126,7 @@ This supervisor will be used to create a child, with which we can experiment:
 .. includecode:: code/docs/actor/FaultHandlingDocSpec.scala
    :include: child
 
-The test is easier by using the utilities described in :ref:`akka-testkit`,
-where ``AkkaSpec`` is a convenient mixture of
-``TestKit with WordSpec with MustMatchers``
+The test is easier by using the utilities described in :ref:`akka-testkit`.
 
 .. includecode:: code/docs/actor/FaultHandlingDocSpec.scala
    :include: testkit


### PR DESCRIPTION
- and don't show AkkaSpec in doc code

(cherry picked from commit 23be60395cdea846ef168960cd05e88c6bd29556)

Conflicts:
    akka-docs/rst/scala/code/docs/actor/FaultHandlingDocSpec.scala
    akka-docs/rst/scala/fault-tolerance.rst
