### PR TITLE
str, htc, htp: Change default materialization placeholder type from `Unit` to `Any`

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -85,7 +85,7 @@ class FlowMapBenchmark {
   }
 
   // source setup
-  private def mkMaps[O](source: Source[O, Unit], count: Int)(op: O ⇒ O): Source[O, Unit] = {
+  private def mkMaps[O, Mat](source: Source[O, Mat], count: Int)(op: O ⇒ O): Source[O, Mat] = {
     var f = source
     for (i ← 1 to count)
       f = f.map(op)

--- a/akka-docs-dev/rst/scala/code/docs/stream/FlowGraphDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/FlowGraphDocSpec.scala
@@ -149,7 +149,7 @@ class FlowGraphDocSpec extends AkkaSpec {
     //#flow-graph-components-create
     object PriorityWorkerPool {
       def apply[In, Out](
-        worker: Flow[In, Out, _],
+        worker: Flow[In, Out, Any],
         workerCount: Int): Graph[PriorityWorkerPoolShape[In, Out], Unit] = {
 
         FlowGraph.partial() { implicit b ⇒

--- a/akka-docs-dev/rst/scala/code/docs/stream/IntegrationDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/IntegrationDocSpec.scala
@@ -5,12 +5,9 @@ package docs.stream
 
 import scala.concurrent.duration._
 import akka.stream.testkit.AkkaSpec
-import akka.stream.scaladsl.Source
-import java.util.Date
+import akka.stream.scaladsl._
 import akka.stream.ActorFlowMaterializer
 import scala.concurrent.Future
-import akka.stream.scaladsl.RunnableFlow
-import akka.stream.scaladsl.Sink
 import akka.testkit.TestProbe
 import akka.actor.ActorRef
 import com.typesafe.config.ConfigFactory
@@ -18,7 +15,6 @@ import akka.actor.Actor
 import akka.actor.Props
 import akka.pattern.ask
 import akka.util.Timeout
-import akka.stream.scaladsl.OperationAttributes
 import scala.concurrent.ExecutionContext
 import akka.stream.ActorFlowMaterializerSettings
 import java.util.concurrent.atomic.AtomicInteger

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeWorkerPool.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeWorkerPool.scala
@@ -17,7 +17,7 @@ class RecipeWorkerPool extends RecipeSpec {
       val worker = Flow[String].map(_ + " done")
 
       //#worker-pool
-      def balancer[In, Out](worker: Flow[In, Out, Unit], workerCount: Int): Flow[In, Out, Unit] = {
+      def balancer[In, Out](worker: Flow[In, Out, Any], workerCount: Int): Flow[In, Out, Unit] = {
         import FlowGraph.Implicits._
 
         Flow() { implicit b =>

--- a/akka-http-core/src/main/java/akka/http/model/japi/HttpEntities.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/HttpEntities.java
@@ -42,19 +42,19 @@ public final class HttpEntities {
         return HttpEntity$.MODULE$.apply((akka.http.model.ContentType) contentType, file);
     }
 
-    public static HttpEntityDefault create(ContentType contentType, long contentLength, Source<ByteString, scala.runtime.BoxedUnit> data) {
+    public static HttpEntityDefault create(ContentType contentType, long contentLength, Source<ByteString, Object> data) {
         return new akka.http.model.HttpEntity.Default((akka.http.model.ContentType) contentType, contentLength, data);
     }
 
-    public static HttpEntityCloseDelimited createCloseDelimited(ContentType contentType, Source<ByteString, scala.runtime.BoxedUnit> data) {
+    public static HttpEntityCloseDelimited createCloseDelimited(ContentType contentType, Source<ByteString, Object> data) {
         return new akka.http.model.HttpEntity.CloseDelimited((akka.http.model.ContentType) contentType, data);
     }
 
-    public static HttpEntityIndefiniteLength createIndefiniteLength(ContentType contentType, Source<ByteString, scala.runtime.BoxedUnit> data) {
+    public static HttpEntityIndefiniteLength createIndefiniteLength(ContentType contentType, Source<ByteString, Object> data) {
         return new akka.http.model.HttpEntity.IndefiniteLength((akka.http.model.ContentType) contentType, data);
     }
 
-    public static HttpEntityChunked createChunked(ContentType contentType, Source<ByteString, scala.runtime.BoxedUnit> data) {
+    public static HttpEntityChunked createChunked(ContentType contentType, Source<ByteString, Object> data) {
         return akka.http.model.HttpEntity.Chunked$.MODULE$.fromData(
                 (akka.http.model.ContentType) contentType,
                 data);

--- a/akka-http-core/src/main/java/akka/http/model/japi/HttpEntity.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/HttpEntity.java
@@ -73,5 +73,5 @@ public interface HttpEntity {
     /**
      * Returns a stream of data bytes this entity consists of.
      */
-    public abstract Source<ByteString, scala.Unit> getDataBytes();
+    public abstract Source<ByteString, ?> getDataBytes();
 }

--- a/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityChunked.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityChunked.java
@@ -11,5 +11,5 @@ import akka.stream.scaladsl.Source;
  * stream of {@link ChunkStreamPart}.
  */
 public abstract class HttpEntityChunked implements RequestEntity, ResponseEntity {
-    public abstract Source<ChunkStreamPart, scala.Unit> getChunks();
+    public abstract Source<ChunkStreamPart, ?> getChunks();
 }

--- a/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityCloseDelimited.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityCloseDelimited.java
@@ -13,5 +13,5 @@ import akka.stream.scaladsl.Source;
  * available for Http responses.
  */
 public abstract class HttpEntityCloseDelimited implements ResponseEntity {
-    public abstract Source<ByteString, scala.Unit> data();
+    public abstract Source<ByteString, ?> data();
 }

--- a/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityDefault.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityDefault.java
@@ -12,5 +12,5 @@ import akka.stream.scaladsl.Source;
  */
 public abstract class HttpEntityDefault implements BodyPartEntity, RequestEntity, ResponseEntity {
     public abstract long contentLength();
-    public abstract Source<ByteString, scala.Unit> data();
+    public abstract Source<ByteString, ?> data();
 }

--- a/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityIndefiniteLength.java
+++ b/akka-http-core/src/main/java/akka/http/model/japi/HttpEntityIndefiniteLength.java
@@ -11,5 +11,5 @@ import akka.stream.scaladsl.Source;
  * Represents an entity without a predetermined content-length to use in a BodyParts.
  */
 public abstract class HttpEntityIndefiniteLength implements BodyPartEntity {
-    public abstract Source<ByteString, scala.Unit> data();
+    public abstract Source<ByteString, ?> data();
 }

--- a/akka-http-core/src/main/scala/akka/http/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/Http.scala
@@ -110,7 +110,7 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
    *                +------+
    * }}}
    */
-  type ServerLayer = BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, Any]
+  type ServerLayer = BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, Unit]
 
   /**
    * Constructs a [[ServerLayer]] stage using the configured default [[ServerSettings]].
@@ -158,7 +158,7 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
    *                +------+
    * }}}
    */
-  type ClientLayer = BidiFlow[HttpRequest, ByteString, ByteString, HttpResponse, Any]
+  type ClientLayer = BidiFlow[HttpRequest, ByteString, ByteString, HttpResponse, Unit]
 
   /**
    * Constructs a [[ClientLayer]] stage using the configured default [[ClientConnectionSettings]].
@@ -200,7 +200,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
   case class IncomingConnection(
     localAddress: InetSocketAddress,
     remoteAddress: InetSocketAddress,
-    flow: Flow[HttpResponse, HttpRequest, Any]) {
+    flow: Flow[HttpResponse, HttpRequest, Unit]) {
 
     /**
      * Handles the connection with the given flow, which is materialized exactly once

--- a/akka-http-core/src/main/scala/akka/http/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/Http.scala
@@ -5,8 +5,6 @@
 package akka.http
 
 import java.net.InetSocketAddress
-import akka.http.engine.server.HttpServer.HttpServerPorts
-import akka.stream.Graph
 import com.typesafe.config.Config
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -15,16 +13,23 @@ import akka.util.ByteString
 import akka.io.Inet
 import akka.stream.FlowMaterializer
 import akka.stream.scaladsl._
-import akka.http.engine.client.{ HttpClient, ClientConnectionSettings }
-import akka.http.engine.server.{ HttpServer, ServerSettings }
-import akka.http.model.{ HttpResponse, HttpRequest }
+import akka.http.engine.client._
+import akka.http.engine.server._
+import akka.http.model.{ HttpHeader, HttpResponse, HttpRequest }
 import akka.actor._
 
 class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.Extension {
   import Http._
 
   /**
-   * Creates a [[ServerBinding]] instance which represents a prospective HTTP server binding on the given `endpoint`.
+   * Creates a [[Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
+   * on the given `endpoint`.
+   * If the given port is 0 the resulting source can be materialized several times. Each materialization will
+   * then be assigned a new local port by the operating system, which can then be retrieved by the materialized
+   * [[ServerBinding]].
+   * If the given port is non-zero subsequent materialization attempts of the produced source will immediately
+   * fail, unless the first materialization has already been unbound. Unbinding can be triggered via the materialized
+   * [[ServerBinding]].
    */
   def bind(interface: String, port: Int = 80, backlog: Int = 100,
            options: immutable.Traversable[Inet.SocketOption] = Nil,
@@ -33,28 +38,28 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
     val endpoint = new InetSocketAddress(interface, port)
     val effectiveSettings = ServerSettings(settings)
 
-    val connections: Source[StreamTcp.IncomingConnection, Future[StreamTcp.ServerBinding]] = StreamTcp().bind(endpoint, backlog, options, effectiveSettings.timeouts.idleTimeout)
-    val serverBlueprint: Graph[HttpServerPorts, Unit] = HttpServer.serverBlueprint(effectiveSettings, log)
+    val connections: Source[StreamTcp.IncomingConnection, Future[StreamTcp.ServerBinding]] =
+      StreamTcp().bind(endpoint, backlog, options, effectiveSettings.timeouts.idleTimeout)
+    val bluePrint = HttpServerBluePrint(effectiveSettings, log)
 
     connections.map { conn ⇒
-      val flow = Flow(conn.flow, serverBlueprint)(Keep.right) { implicit b ⇒
+      val flow = Flow(conn.flow, bluePrint)(Keep.right) { implicit b ⇒
         (tcp, http) ⇒
           import FlowGraph.Implicits._
           tcp.outlet ~> http.bytesIn
           http.bytesOut ~> tcp.inlet
           (http.httpResponses, http.httpRequests)
       }
-
       IncomingConnection(conn.localAddress, conn.remoteAddress, flow)
     }.mapMaterialized { tcpBindingFuture ⇒
       import system.dispatcher
       tcpBindingFuture.map { tcpBinding ⇒ ServerBinding(tcpBinding.localAddress)(() ⇒ tcpBinding.unbind()) }
     }
-
   }
 
   /**
-   * Materializes the `connections` [[Source]] and handles all connections with the given flow.
+   * Convenience method which starts a new HTTP server at the given endpoint and uses the given ``handler``
+   * [[Flow]] for processing all incoming connections.
    *
    * Note that there is no backpressure being applied to the `connections` [[Source]], i.e. all
    * connections are being accepted at maximum rate, which, depending on the applications, might
@@ -71,7 +76,8 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
   }
 
   /**
-   * Materializes the `connections` [[Source]] and handles all connections with the given flow.
+   * Convenience method which starts a new HTTP server at the given endpoint and uses the given ``handler``
+   * [[Flow]] for processing all incoming connections.
    *
    * Note that there is no backpressure being applied to the `connections` [[Source]], i.e. all
    * connections are being accepted at maximum rate, which, depending on the applications, might
@@ -85,7 +91,8 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
     bindAndHandle(Flow[HttpRequest].map(handler), interface, port, backlog, options, settings, log)
 
   /**
-   * Materializes the `connections` [[Source]] and handles all connections with the given flow.
+   * Convenience method which starts a new HTTP server at the given endpoint and uses the given ``handler``
+   * [[Flow]] for processing all incoming connections.
    *
    * Note that there is no backpressure being applied to the `connections` [[Source]], i.e. all
    * connections are being accepted at maximum rate, which, depending on the applications, might
@@ -105,21 +112,20 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
                                  settings: Option[ServerSettings] = None,
                                  log: LoggingAdapter = system.log)(implicit mat: FlowMaterializer): Flow[ByteString, ByteString, Mat] = {
     val effectiveSettings = ServerSettings(settings)
-    val serverBlueprint: Graph[HttpServerPorts, Unit] = HttpServer.serverBlueprint(effectiveSettings, log)
+    val bluePrint = HttpServerBluePrint(effectiveSettings, log)
 
-    Flow(serverBlueprint, serverFlow)(Keep.right) { implicit b ⇒
+    Flow(bluePrint, serverFlow)(Keep.right) { implicit b ⇒
       (server, user) ⇒
         import FlowGraph.Implicits._
         server.httpRequests ~> user.inlet
         user.outlet ~> server.httpResponses
-
         (server.bytesIn, server.bytesOut)
     }
-
   }
 
   /**
-   * Creates an [[OutgoingConnection]] instance representing a prospective HTTP client connection to the given endpoint.
+   * Creates a [[Flow]] representing a prospective HTTP client connection to the given endpoint.
+   * Every materialization of the produced flow will attempt to establish a new outgoing connection.
    */
   def outgoingConnection(host: String, port: Int = 80,
                          localAddress: Option[InetSocketAddress] = None,
@@ -128,41 +134,30 @@ class HttpExt(config: Config)(implicit system: ActorSystem) extends akka.actor.E
                          log: LoggingAdapter = system.log): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {
     val effectiveSettings = ClientConnectionSettings(settings)
     val remoteAddr = new InetSocketAddress(host, port)
-    val transportFlow = StreamTcp().outgoingConnection(remoteAddr, localAddress,
+    val transport = StreamTcp().outgoingConnection(remoteAddr, localAddress,
       options, effectiveSettings.connectingTimeout, effectiveSettings.idleTimeout)
-    val clientBluePrint = HttpClient.clientBlueprint(remoteAddr, effectiveSettings, log)
-
-    Flow(transportFlow, clientBluePrint)(Keep.left) { implicit b ⇒
-      (tcp, client) ⇒
-        import FlowGraph.Implicits._
-
-        tcp.outlet ~> client.bytesIn
-        client.bytesOut ~> tcp.inlet
-
-        (client.httpRequests, client.httpResponses)
-    }.mapMaterialized { tcpConnFuture ⇒
-      import system.dispatcher
-      tcpConnFuture.map { tcpConn ⇒ OutgoingConnection(tcpConn.localAddress, tcpConn.remoteAddress) }
-    }
-
+    transportToConnectionClientFlow(transport, remoteAddr, Some(effectiveSettings), log)
+      .mapMaterialized { tcpConnFuture ⇒
+        import system.dispatcher
+        tcpConnFuture.map { tcpConn ⇒ OutgoingConnection(tcpConn.localAddress, tcpConn.remoteAddress) }
+      }
   }
 
   /**
    * Transforms the given low-level TCP client transport [[Flow]] into a higher-level HTTP client flow.
    */
   def transportToConnectionClientFlow[Mat](transport: Flow[ByteString, ByteString, Mat],
-                                           remoteAddress: InetSocketAddress, // TODO: removed after #16168 is cleared
+                                           remoteAddress: InetSocketAddress, // TODO: remove after #16168 is cleared
                                            settings: Option[ClientConnectionSettings] = None,
                                            log: LoggingAdapter = system.log): Flow[HttpRequest, HttpResponse, Mat] = {
     val effectiveSettings = ClientConnectionSettings(settings)
-    val clientBlueprint = HttpClient.clientBlueprint(remoteAddress, effectiveSettings, log)
+    val bluePrint = OutgoingConnectionBlueprint(remoteAddress, effectiveSettings, log)
 
-    Flow(clientBlueprint, transport)(Keep.right) { implicit b ⇒
+    Flow(bluePrint, transport)(Keep.right) { implicit b ⇒
       (client, tcp) ⇒
         import FlowGraph.Implicits._
         client.bytesOut ~> tcp.inlet
         tcp.outlet ~> client.bytesIn
-
         (client.httpRequests, client.httpResponses)
     }
   }
@@ -185,7 +180,6 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
      * The produced [[Future]] is fulfilled when the unbinding has been completed.
      */
     def unbind(): Future[Unit] = unbindAction()
-
   }
 
   /**
@@ -221,9 +215,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
   /**
    * Represents a prospective outgoing HTTP connection.
    */
-  case class OutgoingConnection(localAddress: InetSocketAddress, remoteAddress: InetSocketAddress) {
-
-  }
+  case class OutgoingConnection(localAddress: InetSocketAddress, remoteAddress: InetSocketAddress)
 
   //////////////////// EXTENSION SETUP ///////////////////
 

--- a/akka-http-core/src/main/scala/akka/http/engine/client/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/ClientConnectionSettings.scala
@@ -18,7 +18,7 @@ final case class ClientConnectionSettings(
   requestHeaderSizeHint: Int,
   parserSettings: ParserSettings) {
 
-  require(connectingTimeout >= Duration.Zero, "connectingTimeout must be > 0")
+  require(connectingTimeout >= Duration.Zero, "connectingTimeout must be >= 0")
   require(requestHeaderSizeHint > 0, "request-size-hint must be > 0")
 }
 

--- a/akka-http-core/src/main/scala/akka/http/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/client/OutgoingConnectionBlueprint.scala
@@ -4,8 +4,8 @@
 
 package akka.http.engine.client
 
+import language.existentials
 import java.net.InetSocketAddress
-
 import scala.annotation.tailrec
 import scala.collection.immutable.Seq
 import scala.collection.mutable.ListBuffer
@@ -23,9 +23,9 @@ import akka.http.util._
 /**
  * INTERNAL API
  */
-private[http] object HttpClient {
+private[http] object OutgoingConnectionBlueprint {
 
-  case class HttpClientPorts(
+  case class Ports(
     bytesIn: Inlet[ByteString],
     bytesOut: Outlet[ByteString],
     httpRequests: Inlet[HttpRequest],
@@ -34,26 +34,40 @@ private[http] object HttpClient {
     override val inlets: Seq[Inlet[_]] = bytesIn :: httpRequests :: Nil
     override val outlets: Seq[Outlet[_]] = bytesOut :: httpResponses :: Nil
 
-    override def deepCopy(): Shape = HttpClientPorts(
+    override def deepCopy(): Shape = Ports(
       new Inlet(bytesIn.toString),
       new Outlet(bytesOut.toString),
       new Inlet(httpResponses.toString),
       new Outlet(httpRequests.toString))
 
-    override def copyFromPorts(inlets: Seq[Inlet[_]], outlets: Seq[Outlet[_]]): Shape = {
-      val bIn :: htpIn :: Nil = inlets
-      val bOut :: htpOut :: Nil = outlets
-      HttpClientPorts(
-        bIn.asInstanceOf[Inlet[ByteString]],
-        bOut.asInstanceOf[Outlet[ByteString]],
-        htpIn.asInstanceOf[Inlet[HttpRequest]],
-        htpOut.asInstanceOf[Outlet[HttpResponse]])
-    }
+    override def copyFromPorts(inlets: Seq[Inlet[_]], outlets: Seq[Outlet[_]]): Shape =
+      Ports(
+        inlets.head.asInstanceOf[Inlet[ByteString]],
+        outlets.head.asInstanceOf[Outlet[ByteString]],
+        inlets.last.asInstanceOf[Inlet[HttpRequest]],
+        outlets.last.asInstanceOf[Outlet[HttpResponse]])
   }
 
-  def clientBlueprint(remoteAddress: InetSocketAddress,
-                      settings: ClientConnectionSettings,
-                      log: LoggingAdapter): Graph[HttpClientPorts, Unit] = {
+  /*
+    Stream Setup
+    ============
+
+    requestIn                                            +----------+
+    +-----------------------------------------------+--->|  Termi-  |   requestRendering
+                                                    |    |  nation  +---------------------> |
+                 +-------------------------------------->|  Merge   |                       |
+                 | Termination Backchannel          |    +----------+                       |  TCP-
+                 |                                  |                                       |  level
+                 |                                  | Method                                |  client
+                 |                +------------+    | Bypass                                |  flow
+    responseOut  |  responsePrep  |  Response  |<---+                                       |
+    <------------+----------------|  Parsing   |                                            |
+                                  |  Merge     |<------------------------------------------ V
+                                  +------------+
+  */
+  def apply(remoteAddress: InetSocketAddress,
+            settings: ClientConnectionSettings,
+            log: LoggingAdapter): Graph[Ports, Unit] = {
     import settings._
 
     // the initial header parser we initially use for every connection,
@@ -64,24 +78,6 @@ private[http] object HttpClient {
     })
 
     val requestRendererFactory = new HttpRequestRendererFactory(userAgentHeader, requestHeaderSizeHint, log)
-
-    /*
-      Basic Stream Setup
-      ==================
-
-      requestIn                                            +----------+
-      +-----------------------------------------------+--->|  Termi-  |   requestRendering
-                                                      |    |  nation  +---------------------> |
-                   +-------------------------------------->|  Merge   |                       |
-                   | Termination Backchannel          |    +----------+                       |  TCP-
-                   |                                  |                                       |  level
-                   |                                  | Method                                |  client
-                   |                +------------+    | Bypass                                |  flow
-      responseOut  |  responsePrep  |  Response  |<---+                                       |
-      <------------+----------------|  Parsing   |                                            |
-                                    |  Merge     |<------------------------------------------ V
-                                    +------------+
-    */
 
     val requestRendering: Flow[HttpRequest, ByteString, Unit] = Flow[HttpRequest]
       .map(RequestRenderingContext(_, remoteAddress))
@@ -122,7 +118,7 @@ private[http] object HttpClient {
       responseParsingMerge.out ~> responsePrep ~> terminationFanout.in
       terminationFanout.out(0) ~> terminationMerge.in1
 
-      HttpClientPorts(bytesIn, bytesOut, methodBypassFanout.in, terminationFanout.out(1))
+      Ports(bytesIn, bytesOut, methodBypassFanout.in, terminationFanout.out(1))
     }
   }
 

--- a/akka-http-core/src/main/scala/akka/http/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/parsing/HttpRequestParser.scala
@@ -9,7 +9,7 @@ import scala.annotation.tailrec
 import akka.actor.ActorRef
 import akka.stream.scaladsl.OperationAttributes._
 import akka.stream.stage.{ Context, PushPullStage }
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{ Keep, Source }
 import akka.util.ByteString
 import akka.http.model.parser.CharacterClasses
 import akka.http.util.identityFunc
@@ -126,7 +126,7 @@ private[http] class HttpRequestParser(_settings: ParserSettings,
         emit(RequestStart(method, uri, protocol, allHeaders, createEntity, expect100continue, closeAfterResponseCompletion))
       }
 
-      def expect100continueHandling[T]: Source[T, Unit] ⇒ Source[T, Unit] =
+      def expect100continueHandling[T, Mat]: Source[T, Mat] ⇒ Source[T, Mat] =
         if (expect100continue) {
           _.section(name("expect100continueTrigger"))(_.transform(() ⇒ new PushPullStage[T, T] {
             private var oneHundredContinueSent = false

--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpRequestRendererFactory.scala
@@ -25,9 +25,9 @@ private[http] class HttpRequestRendererFactory(userAgentHeader: Option[headers.`
 
   def newRenderer: HttpRequestRenderer = new HttpRequestRenderer
 
-  final class HttpRequestRenderer extends PushStage[RequestRenderingContext, Source[ByteString, Unit]] {
+  final class HttpRequestRenderer extends PushStage[RequestRenderingContext, Source[ByteString, Any]] {
 
-    override def onPush(ctx: RequestRenderingContext, opCtx: Context[Source[ByteString, Unit]]): SyncDirective = {
+    override def onPush(ctx: RequestRenderingContext, opCtx: Context[Source[ByteString, Any]]): SyncDirective = {
       val r = new ByteStringRendering(requestHeaderSizeHint)
       import ctx.request._
 
@@ -102,7 +102,7 @@ private[http] class HttpRequestRendererFactory(userAgentHeader: Option[headers.`
       def renderContentLength(contentLength: Long) =
         if (method.isEntityAccepted) r ~~ `Content-Length` ~~ contentLength ~~ CrLf else r
 
-      def completeRequestRendering(): Source[ByteString, Unit] =
+      def completeRequestRendering(): Source[ByteString, Any] =
         entity match {
           case x if x.isKnownEmpty ⇒
             renderContentLength(0) ~~ CrLf

--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/HttpResponseRendererFactory.scala
@@ -51,14 +51,14 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
 
   def newRenderer: HttpResponseRenderer = new HttpResponseRenderer
 
-  final class HttpResponseRenderer extends PushStage[ResponseRenderingContext, Source[ByteString, Unit]] {
+  final class HttpResponseRenderer extends PushStage[ResponseRenderingContext, Source[ByteString, Any]] {
 
     private[this] var close = false // signals whether the connection is to be closed after the current response
 
     // need this for testing
     private[http] def isComplete = close
 
-    override def onPush(ctx: ResponseRenderingContext, opCtx: Context[Source[ByteString, Unit]]): SyncDirective = {
+    override def onPush(ctx: ResponseRenderingContext, opCtx: Context[Source[ByteString, Any]]): SyncDirective = {
       val r = new ByteStringRendering(responseHeaderSizeHint)
 
       import ctx.response._
@@ -156,10 +156,10 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
       def renderContentLengthHeader(contentLength: Long) =
         if (status.allowsEntity) r ~~ `Content-Length` ~~ contentLength ~~ CrLf else r
 
-      def byteStrings(entityBytes: ⇒ Source[ByteString, Unit]): Source[ByteString, Unit] =
+      def byteStrings(entityBytes: ⇒ Source[ByteString, Any]): Source[ByteString, Any] =
         renderByteStrings(r, entityBytes, skipEntity = noEntity)
 
-      def completeResponseRendering(entity: ResponseEntity): Source[ByteString, Unit] =
+      def completeResponseRendering(entity: ResponseEntity): Source[ByteString, Any] =
         entity match {
           case HttpEntity.Strict(_, data) ⇒
             renderHeaders(headers.toList)

--- a/akka-http-core/src/main/scala/akka/http/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/rendering/RenderSupport.scala
@@ -29,24 +29,24 @@ private object RenderSupport {
 
   val defaultLastChunkBytes: ByteString = renderChunk(HttpEntity.LastChunk)
 
-  def CancelSecond[T](first: Source[T, _], second: Source[T, _]): Source[T, Unit] = {
+  def CancelSecond[T, Mat](first: Source[T, Mat], second: Source[T, Any]): Source[T, Mat] = {
     Source(first) { implicit b ⇒
       frst ⇒
         import FlowGraph.Implicits._
         second ~> Sink.cancelled
         frst.outlet
-    }.mapMaterialized((_) ⇒ ())
+    }
   }
 
   def renderEntityContentType(r: Rendering, entity: HttpEntity) =
     if (entity.contentType != ContentTypes.NoContentType) r ~~ headers.`Content-Type` ~~ entity.contentType ~~ CrLf
     else r
 
-  def renderByteStrings(r: ByteStringRendering, entityBytes: ⇒ Source[ByteString, Unit],
-                        skipEntity: Boolean = false): Source[ByteString, Unit] = {
+  def renderByteStrings(r: ByteStringRendering, entityBytes: ⇒ Source[ByteString, Any],
+                        skipEntity: Boolean = false): Source[ByteString, Any] = {
     val messageStart = Source.single(r.get)
     val messageBytes =
-      if (!skipEntity) (messageStart ++ entityBytes).mapMaterialized((_) ⇒ ())
+      if (!skipEntity) (messageStart ++ entityBytes).mapMaterialized(_ ⇒ ())
       else CancelSecond(messageStart, entityBytes)
     messageBytes
   }

--- a/akka-http-core/src/main/scala/akka/http/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/server/HttpServerBluePrint.scala
@@ -26,7 +26,7 @@ private[http] object HttpServerBluePrint {
 
   type ServerShape = BidiShape[HttpResponse, ByteString, ByteString, HttpRequest]
 
-  def apply(settings: ServerSettings, log: LoggingAdapter)(implicit mat: FlowMaterializer): Graph[ServerShape, Any] = {
+  def apply(settings: ServerSettings, log: LoggingAdapter)(implicit mat: FlowMaterializer): Graph[ServerShape, Unit] = {
     import settings._
 
     // the initial header parser we initially use for every connection,

--- a/akka-http-core/src/main/scala/akka/http/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/model/HttpMessage.scala
@@ -143,6 +143,9 @@ final case class HttpRequest(method: HttpMethod = HttpMethods.GET,
   /**
    * Resolve this request's URI according to the logic defined at
    * http://tools.ietf.org/html/rfc7230#section-5.5
+   *
+   * Throws an [[IllegalUriException]] if the URI is relative and the `headers` don't
+   * include a valid [[Host]] header or if URI authority and [[Host]] header don't match.
    */
   def effectiveUri(securedConnection: Boolean, defaultHostHeader: Host = Host.empty): Uri =
     HttpRequest.effectiveUri(uri, headers, securedConnection, defaultHostHeader)
@@ -263,6 +266,9 @@ object HttpRequest {
   /**
    * Determines the effective request URI according to the logic defined at
    * http://tools.ietf.org/html/rfc7230#section-5.5
+   *
+   * Throws an [[IllegalUriException]] if the URI is relative and the `headers` don't
+   * include a valid [[Host]] header or if URI authority and [[Host]] header don't match.
    */
   def effectiveUri(uri: Uri, headers: immutable.Seq[HttpHeader], securedConnection: Boolean, defaultHostHeader: Host): Uri = {
     val hostHeader = headers.collectFirst { case x: Host ⇒ x }

--- a/akka-http-core/src/main/scala/akka/http/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/util/package.scala
@@ -41,13 +41,13 @@ package object util {
   private[http] implicit def enhanceByteStrings[Mat](byteStrings: Source[ByteString, Mat]): EnhancedByteStringSource[Mat] =
     new EnhancedByteStringSource(byteStrings)
 
-  private[http] implicit class SourceWithHeadAndTail[T, Mat](val underlying: Source[Source[T, Unit], Mat]) extends AnyVal {
+  private[http] implicit class SourceWithHeadAndTail[T, Mat](val underlying: Source[Source[T, Any], Mat]) extends AnyVal {
     def headAndTail: Source[(T, Source[T, Unit]), Mat] =
       underlying.map { _.prefixAndTail(1).map { case (prefix, tail) ⇒ (prefix.head, tail) } }
         .flatten(FlattenStrategy.concat)
   }
 
-  private[http] implicit class FlowWithHeadAndTail[In, Out, Mat](val underlying: Flow[In, Source[Out, Unit], Mat]) extends AnyVal {
+  private[http] implicit class FlowWithHeadAndTail[In, Out, Mat](val underlying: Flow[In, Source[Out, Any], Mat]) extends AnyVal {
     def headAndTail: Flow[In, (Out, Source[Out, Unit]), Mat] =
       underlying.map { _.prefixAndTail(1).map { case (prefix, tail) ⇒ (prefix.head, tail) } }
         .flatten(FlattenStrategy.concat)

--- a/akka-http-core/src/test/scala/akka/http/engine/client/OutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/client/OutgoingConnectionSpec.scala
@@ -17,7 +17,7 @@ import akka.http.model._
 import akka.http.model.headers._
 import akka.http.util._
 
-class HttpClientSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF") with Inside {
+class OutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF") with Inside {
   implicit val materializer = ActorFlowMaterializer()
 
   "The client implementation" should {
@@ -359,7 +359,7 @@ class HttpClientSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF")
       val netOut = StreamTestKit.SubscriberProbe[ByteString]
       val netIn = StreamTestKit.PublisherProbe[ByteString]
 
-      FlowGraph.closed(HttpClient.clientBlueprint(remoteAddress, settings, NoLogging)) { implicit b ⇒
+      FlowGraph.closed(OutgoingConnectionBlueprint(remoteAddress, settings, NoLogging)) { implicit b ⇒
         client ⇒
           import FlowGraph.Implicits._
           Source(netIn) ~> client.bytesIn

--- a/akka-http-core/src/test/scala/akka/http/engine/client/OutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/client/OutgoingConnectionSpec.scala
@@ -362,10 +362,10 @@ class OutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel
       FlowGraph.closed(OutgoingConnectionBlueprint(remoteAddress, settings, NoLogging)) { implicit b ⇒
         client ⇒
           import FlowGraph.Implicits._
-          Source(netIn) ~> client.bytesIn
-          client.bytesOut ~> Sink(netOut)
-          Source(requests) ~> client.httpRequests
-          client.httpResponses ~> Sink(responses)
+          Source(netIn) ~> client.in2
+          client.out1 ~> Sink(netOut)
+          Source(requests) ~> client.in1
+          client.out2 ~> Sink(responses)
       }.run()
 
       netOut -> netIn

--- a/akka-http-core/src/test/scala/akka/http/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/parsing/RequestParserSpec.scala
@@ -474,7 +474,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
         case _          ⇒ entity.toStrict(awaitAtMost)
       }
 
-    private def compactEntityChunks(data: Source[ChunkStreamPart, Unit]): Future[Seq[ChunkStreamPart]] =
+    private def compactEntityChunks(data: Source[ChunkStreamPart, Any]): Future[Seq[ChunkStreamPart]] =
       data.grouped(100000).runWith(Sink.head)
         .fast.recover { case _: NoSuchElementException ⇒ Nil }
 

--- a/akka-http-core/src/test/scala/akka/http/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/parsing/ResponseParserSpec.scala
@@ -297,7 +297,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
         case _                     ⇒ entity.toStrict(250.millis)
       }
 
-    private def compactEntityChunks(data: Source[ChunkStreamPart, Unit]): Future[Source[ChunkStreamPart, Unit]] =
+    private def compactEntityChunks(data: Source[ChunkStreamPart, Any]): Future[Source[ChunkStreamPart, Any]] =
       data.grouped(100000).runWith(Sink.head)
         .fast.map(source(_: _*))
         .fast.recover { case _: NoSuchElementException ⇒ source() }

--- a/akka-http-core/src/test/scala/akka/http/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/server/HttpServerSpec.scala
@@ -660,7 +660,7 @@ class HttpServerSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF")
       val netIn = StreamTestKit.PublisherProbe[ByteString]
       val netOut = StreamTestKit.SubscriberProbe[ByteString]
 
-      FlowGraph.closed(HttpServer.serverBlueprint(settings, NoLogging)) { implicit b ⇒
+      FlowGraph.closed(HttpServerBluePrint(settings, NoLogging)) { implicit b ⇒
         server ⇒
           import FlowGraph.Implicits._
           Source(netIn) ~> server.bytesIn

--- a/akka-http-core/src/test/scala/akka/http/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/engine/server/HttpServerSpec.scala
@@ -663,10 +663,10 @@ class HttpServerSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF")
       FlowGraph.closed(HttpServerBluePrint(settings, NoLogging)) { implicit b ⇒
         server ⇒
           import FlowGraph.Implicits._
-          Source(netIn) ~> server.bytesIn
-          server.bytesOut ~> Sink(netOut)
-          server.httpRequests ~> Sink(requests)
-          Source(responses) ~> server.httpResponses
+          Source(netIn) ~> server.in2
+          server.out1 ~> Sink(netOut)
+          server.out2 ~> Sink(requests)
+          Source(responses) ~> server.in1
       }.run()
 
       netIn -> netOut

--- a/akka-http/src/main/scala/akka/http/unmarshalling/MultipartUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/unmarshalling/MultipartUnmarshallers.scala
@@ -54,7 +54,7 @@ trait MultipartUnmarshallers {
   def multipartUnmarshaller[T <: Multipart, BP <: Multipart.BodyPart, BPS <: Multipart.BodyPart.Strict](mediaRange: MediaRange,
                                                                                                         defaultContentType: ContentType,
                                                                                                         createBodyPart: (BodyPartEntity, List[HttpHeader]) ⇒ BP,
-                                                                                                        createStreamed: (MultipartMediaType, Source[BP, Unit]) ⇒ T,
+                                                                                                        createStreamed: (MultipartMediaType, Source[BP, Any]) ⇒ T,
                                                                                                         createStrictBodyPart: (HttpEntity.Strict, List[HttpHeader]) ⇒ BPS,
                                                                                                         createStrict: (MultipartMediaType, immutable.Seq[BPS]) ⇒ T)(implicit ec: ExecutionContext, log: LoggingAdapter = NoLogging): FromEntityUnmarshaller[T] =
     Unmarshaller { entity ⇒

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowGraphTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowGraphTest.java
@@ -66,10 +66,10 @@ public class FlowGraphTest extends StreamTest {
         .of(String.class)
         .section(
             OperationAttributes.name("f1"),
-            new Function<Flow<String, String, BoxedUnit>, Flow<String, String, BoxedUnit>>() {
+            new Function<Flow<String, String, Object>, Flow<String, String, Object>>() {
               @Override
-              public Flow<String, String, BoxedUnit> apply(
-                  Flow<String, String, BoxedUnit> flow) {
+              public Flow<String, String, Object> apply(
+                  Flow<String, String, Object> flow) {
                 return flow.transform(FlowGraphTest.this.<String> op());
               }
             });
@@ -77,10 +77,10 @@ public class FlowGraphTest extends StreamTest {
         .of(String.class)
         .section(
             OperationAttributes.name("f2"),
-            new Function<Flow<String, String, BoxedUnit>, Flow<String, String, BoxedUnit>>() {
+            new Function<Flow<String, String, Object>, Flow<String, String, Object>>() {
               @Override
-              public Flow<String, String, BoxedUnit> apply(
-                  Flow<String, String, BoxedUnit> flow) {
+              public Flow<String, String, Object> apply(
+                  Flow<String, String, Object> flow) {
                 return flow.transform(FlowGraphTest.this.<String> op());
               }
             });
@@ -88,10 +88,10 @@ public class FlowGraphTest extends StreamTest {
         .of(String.class)
         .section(
             OperationAttributes.name("f3"),
-            new Function<Flow<String, String, BoxedUnit>, Flow<String, String, BoxedUnit>>() {
+            new Function<Flow<String, String, Object>, Flow<String, String, Object>>() {
               @Override
-              public Flow<String, String, BoxedUnit> apply(
-                  Flow<String, String, BoxedUnit> flow) {
+              public Flow<String, String, Object> apply(
+                  Flow<String, String, Object> flow) {
                 return flow.transform(FlowGraphTest.this.<String> op());
               }
             });

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -19,6 +19,7 @@ import akka.testkit.JavaTestKit;
 
 import org.reactivestreams.Publisher;
 
+import scala.runtime.Boxed;
 import scala.runtime.BoxedUnit;
 
 import org.junit.ClassRule;
@@ -245,10 +246,10 @@ public class FlowTest extends StreamTest {
         .of(String.class)
         .section(
             OperationAttributes.name("f1"),
-            new Function<Flow<String, String, BoxedUnit>, Flow<String, String, BoxedUnit>>() {
+            new Function<Flow<String, String, Object>, Flow<String, String, Object>>() {
               @Override
-              public Flow<String, String, BoxedUnit> apply(
-                  Flow<String, String, BoxedUnit> flow) {
+              public Flow<String, String, Object> apply(
+                  Flow<String, String, Object> flow) {
                 return flow.transform(FlowTest.this.<String> op());
               }
             });
@@ -256,10 +257,10 @@ public class FlowTest extends StreamTest {
         .of(String.class)
         .section(
             OperationAttributes.name("f2"),
-            new Function<Flow<String, String, BoxedUnit>, Flow<String, String, BoxedUnit>>() {
+            new Function<Flow<String, String, Object>, Flow<String, String, Object>>() {
               @Override
-              public Flow<String, String, BoxedUnit> apply(
-                  Flow<String, String, BoxedUnit> flow) {
+              public Flow<String, String, Object> apply(
+                  Flow<String, String, Object> flow) {
                 return flow.transform(FlowTest.this.<String> op());
               }
             });
@@ -267,10 +268,10 @@ public class FlowTest extends StreamTest {
         .of(String.class)
         .section(
             OperationAttributes.name("f3"),
-            new Function<Flow<String, String, BoxedUnit>, Flow<String, String, BoxedUnit>>() {
+            new Function<Flow<String, String, Object>, Flow<String, String, Object>>() {
               @Override
-              public Flow<String, String, BoxedUnit> apply(
-                  Flow<String, String, BoxedUnit> flow) {
+              public Flow<String, String, Object> apply(
+                  Flow<String, String, Object> flow) {
                 return flow.transform(FlowTest.this.<String> op());
               }
             });
@@ -375,7 +376,7 @@ public class FlowTest extends StreamTest {
     mainInputs.add(Source.from(input2));
 
     final Flow<Source<Integer, BoxedUnit>, List<Integer>, BoxedUnit> flow = Flow.<Source<Integer, BoxedUnit>>create().
-      flatten(akka.stream.javadsl.FlattenStrategy.<Integer> concat()).grouped(6);
+      flatten(akka.stream.javadsl.FlattenStrategy.<Integer, BoxedUnit> concat()).grouped(6);
     Future<List<Integer>> future = Source.from(mainInputs).via(flow)
         .runWith(Sink.<List<Integer>>head(), materializer);
 

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
@@ -342,7 +342,7 @@ public class SourceTest extends StreamTest {
     mainInputs.add(Source.from(input2));
 
     Future<List<Integer>> future = Source.from(mainInputs)
-      .flatten(akka.stream.javadsl.FlattenStrategy.<Integer>concat()).grouped(6)
+      .flatten(akka.stream.javadsl.FlattenStrategy.<Integer, BoxedUnit>concat()).grouped(6)
       .runWith(Sink.<List<Integer>>head(), materializer);
 
     List<Integer> result = Await.result(future, probe.dilated(FiniteDuration.create(3, TimeUnit.SECONDS)));

--- a/akka-stream/src/main/boilerplate/akka/stream/FanInShape.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/FanInShape.scala.template
@@ -57,6 +57,21 @@ class UniformFanInShape[T, O](val n: Int, _init: FanInShape.Init[O]) extends Fan
   def in(n: Int): Inlet[T] = inArray(n)
 }
 
+class FanInShape1N[T0, T1, O](val n: Int, _init: FanInShape.Init[O]) extends FanInShape[O](_init) {
+  def this(n: Int) = this(n, FanInShape.Name("FanInShape1N"))
+  def this(n: Int, name: String) = this(n, FanInShape.Name(name))
+  def this(outlet: Outlet[O], in0: Inlet[T0], inlets1: Array[Inlet[T1]]) = this(inlets1.length, FanInShape.Ports(outlet, in0 :: inlets1.toList))
+  override protected def construct(init: FanInShape.Init[O]): FanInShape[O] = new FanInShape1N(n, init)
+  override def deepCopy(): FanInShape1N[T0, T1, O] = super.deepCopy().asInstanceOf[FanInShape1N[T0, T1, O]]
+
+  val in0 = newInlet[T0]("in0")
+  val in1Seq: immutable.IndexedSeq[Inlet[T1]] = Vector.tabulate(n)(i => newInlet[T1](s"in${i+1}"))
+  def in(n: Int): Inlet[T1] = {
+    require(n > 0, "n must be > 0")
+    in1Seq(n - 1)
+  }
+}
+
 [2..#class FanInShape1[[#T0#], O](_init: FanInShape.Init[O]) extends FanInShape[O](_init) {
   def this(name: String) = this(FanInShape.Name(name))
   def this([#in0: Inlet[T0]#], out: Outlet[O]) = this(FanInShape.Ports(out, [#in0# :: ] :: Nil))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -12,7 +12,7 @@ object BidiFlow {
   val factory: BidiFlowCreate = new BidiFlowCreate {}
 
   /**
-   * A graph with the shape of a flow logically is a flow, this method makes
+   * A graph with the shape of a BidiFlow logically is a BidiFlow, this method makes
    * it so also in type.
    */
   def wrap[I1, O1, I2, O2, M](g: Graph[BidiShape[I1, O1, I2, O2], M]): BidiFlow[I1, O1, I2, O2, M] = new BidiFlow(scaladsl.BidiFlow.wrap(g))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlattenStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlattenStrategy.scala
@@ -17,11 +17,11 @@ object FlattenStrategy {
    * emitting its elements directly to the output until it completes and then taking the next stream. This has the
    * consequence that if one of the input stream is infinite, no other streams after that will be consumed from.
    */
-  def concat[T]: FlattenStrategy[Source[T, Unit], T] = Concat[T]()
+  def concat[T, U]: FlattenStrategy[Source[T, U], T] = Concat[T, U]()
 
   /**
    * INTERNAL API
    */
-  private[akka] final case class Concat[T]() extends FlattenStrategy[Source[T, _], T]
+  private[akka] final case class Concat[T, U]() extends FlattenStrategy[Source[T, U], T]
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -411,10 +411,10 @@ class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Graph
   /**
    * Applies given [[OperationAttributes]] to a given section.
    */
-  def section[O, M](attributes: OperationAttributes, section: japi.Function[javadsl.Flow[Out, Out, Unit], javadsl.Flow[Out, O, M]] @uncheckedVariance): javadsl.Flow[In, O, M] =
+  def section[O](attributes: OperationAttributes, section: japi.Function[javadsl.Flow[Out, Out, Any], javadsl.Flow[Out, O, Any]] @uncheckedVariance): javadsl.Flow[In, O, Mat] =
     new Flow(delegate.section(attributes.asScala) {
-      val scalaToJava = (flow: scaladsl.Flow[Out, Out, Unit]) ⇒ new javadsl.Flow(flow)
-      val javaToScala = (flow: javadsl.Flow[Out, O, M]) ⇒ flow.asScala
+      val scalaToJava = (flow: scaladsl.Flow[Out, Out, Any]) ⇒ new javadsl.Flow(flow)
+      val javaToScala = (flow: javadsl.Flow[Out, O, Any]) ⇒ flow.asScala
       scalaToJava andThen section.apply andThen javaToScala
     })
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -501,10 +501,10 @@ class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[Sour
   /**
    * Applies given [[OperationAttributes]] to a given section.
    */
-  def section[O, M](attributes: OperationAttributes, section: japi.Function[javadsl.Flow[Out, Out, Unit], javadsl.Flow[Out, O, M]] @uncheckedVariance): javadsl.Source[O, M] =
+  def section[O](attributes: OperationAttributes, section: japi.Function[javadsl.Flow[Out, Out, Any], javadsl.Flow[Out, O, Any]] @uncheckedVariance): javadsl.Source[O, Mat] =
     new Source(delegate.section(attributes.asScala) {
-      val scalaToJava = (source: scaladsl.Flow[Out, Out, Unit]) ⇒ new javadsl.Flow(source)
-      val javaToScala = (source: javadsl.Flow[Out, O, M]) ⇒ source.asScala
+      val scalaToJava = (source: scaladsl.Flow[Out, Out, Any]) ⇒ new javadsl.Flow(source)
+      val javaToScala = (source: javadsl.Flow[Out, O, Any]) ⇒ source.asScala
       scalaToJava andThen section.apply andThen javaToScala
     })
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlattenStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlattenStrategy.scala
@@ -3,12 +3,10 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.javadsl
-
 /**
  * Strategy that defines how a stream of streams should be flattened into a stream of simple elements.
  */
-abstract class FlattenStrategy[-S, T]
+abstract class FlattenStrategy[-S, +T]
 
 object FlattenStrategy {
 
@@ -17,7 +15,7 @@ object FlattenStrategy {
    * emitting its elements directly to the output until it completes and then taking the next stream. This has the
    * consequence that if one of the input stream is infinite, no other streams after that will be consumed from.
    */
-  def concat[T]: FlattenStrategy[Source[T, _], T] = Concat[T]()
+  def concat[T]: FlattenStrategy[Source[T, Any], T] = Concat[T]()
 
-  private[akka] final case class Concat[T]() extends FlattenStrategy[Source[T, _], T]
+  private[akka] final case class Concat[T]() extends FlattenStrategy[Source[T, Any], T]
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -221,15 +221,24 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
    * The resulting Flow’s materialized value is a Tuple2 containing both materialized
    * values (of this Flow and that Source).
    */
-  def concat[Out2 >: Out, Mat2](source: Source[Out2, Mat2]): Flow[In, Out2, (Mat, Mat2)] = {
+  def concat[Out2 >: Out, Mat2](source: Source[Out2, Mat2]): Flow[In, Out2, (Mat, Mat2)] =
+    concatMat[Out2, Mat2, (Mat, Mat2)](source, Keep.both)
+
+  /**
+   * Concatenate the given [[Source]] to this [[Flow]], meaning that once this
+   * Flow’s input is exhausted and all result elements have been generated,
+   * the Source’s elements will be produced. Note that the Source is materialized
+   * together with this Flow and just kept from producing elements by asserting
+   * back-pressure until its time comes.
+   */
+  def concatMat[Out2 >: Out, Mat2, Mat3](source: Source[Out2, Mat2], combine: (Mat, Mat2) ⇒ Mat3): Flow[In, Out2, Mat3] =
     this.viaMat(Flow(source) { implicit builder ⇒
       s ⇒
         import FlowGraph.Implicits._
         val concat = builder.add(Concat[Out2]())
         s.outlet ~> concat.in(1)
         (concat.in(0), concat.out)
-    })(Keep.both)
-  }
+    })(combine)
 
   /** INTERNAL API */
   override private[stream] def andThen[U](op: StageModule): Repr[U, Mat] = {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -327,7 +327,7 @@ object FlowGraph extends GraphApply {
         b.addEdge(importAndGetPort(b), to)
       }
 
-      def ~>[Out](via: Flow[T, Out, _])(implicit b: Builder[_]): PortOps[Out, Unit] = {
+      def ~>[Out](via: Flow[T, Out, Any])(implicit b: Builder[_]): PortOps[Out, Unit] = {
         val s = b.add(via)
         b.addEdge(importAndGetPort(b), s.inlet)
         s.outlet

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -147,9 +147,8 @@ final class Source[+Out, +Mat](private[stream] override val module: Module)
         .replaceShape(SourceShape(subFlow.shape.outlets.head)))
   }
 
-  def section[O, O2 >: Out, Mat2](attributes: OperationAttributes)(section: Flow[O2, O2, Unit] ⇒ Flow[O2, O, Mat2]): Source[O, Mat2] = {
-    this.section[O, O2, Mat2, Mat2](attributes, (parentm: Mat, subm: Mat2) ⇒ subm)(section)
-  }
+  def section[O, O2 >: Out](attributes: OperationAttributes)(section: Flow[O2, O2, Unit] ⇒ Flow[O2, O, Any]): Source[O, Mat] =
+    this.section[O, O2, Any, Mat](attributes, Keep.left)(section)
 
   override def withAttributes(attr: OperationAttributes): Repr[Out, Mat] =
     new Source(module.withAttributes(attr).wrap())


### PR DESCRIPTION
Closes #17039 and #16933.

I needed this a basis for the current work in HTTP so I simply got it done altogether.
(For making things a bit easier for me) this PR builds on #17126, so please review the first 3 commits there. Also #17126 should be merged first.
