### PR TITLE
Logging with log() stage for streams

### DIFF
--- a/akka-docs-dev/rst/scala/stream-cookbook.rst
+++ b/akka-docs-dev/rst/scala/stream-cookbook.rst
@@ -39,7 +39,7 @@ handlers, emitting log information through an Akka :class:`LoggingAdapter`. This
 the elements flowing in the stream, it just emits them unmodified by calling ``ctx.push(elem)`` in its ``onPush``
 event handler logic.
 
-.. includecode:: code/docs/stream/cookbook/RecipeLoggingElements.scala#loggingadapter
+.. includecode:: code/docs/stream/cookbook/RecipeLoggingElements.scala#log-custom
 
 Flattening a stream of sequences
 --------------------------------

--- a/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
@@ -5,7 +5,9 @@
 package akka.stream;
 
 import akka.actor.ActorSystem;
+import akka.event.Logging;
 import akka.stream.javadsl.AkkaJUnitActorSystemResource;
+import akka.stream.OperationAttributes;
 
 public abstract class StreamTest {
     final protected ActorSystem system;

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
@@ -3,6 +3,7 @@
  */
 package akka.stream.impl.fusing
 
+import akka.stream.OperationAttributes
 import akka.stream.testkit.AkkaSpec
 import akka.stream.stage._
 import akka.testkit.TestProbe
@@ -61,6 +62,7 @@ trait InterpreterSpecKit extends AkkaSpec {
     val interpreter = new OneBoundedInterpreter(upstream +: ops :+ downstream,
       (op, ctx, event) ⇒ sidechannel.ref ! ActorInterpreter.AsyncInput(op, ctx, event),
       ActorFlowMaterializer(),
+      OperationAttributes.none,
       forkLimit, overflowToHeap)
     interpreter.init()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2014-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.event.{ DummyClassForStringSources, Logging }
+import akka.stream._
+import akka.stream.OperationAttributes
+import akka.stream.OperationAttributes.LogLevels
+import akka.stream.testkit.{ AkkaSpec, ScriptedTest }
+import akka.testkit.TestProbe
+
+import scala.util.control.NoStackTrace
+
+class FlowLogSpec extends AkkaSpec("akka.loglevel = DEBUG") with ScriptedTest {
+
+  implicit val mat: FlowMaterializer = ActorFlowMaterializer()
+
+  val logProbe = {
+    val p = TestProbe()
+    system.eventStream.subscribe(p.ref, classOf[Logging.LogEvent])
+    p
+  }
+
+  "A Log" must {
+
+    val LogSrc = s"akka.stream.Log(akka://${Logging.simpleName(classOf[FlowLogSpec])})"
+    val LogClazz = classOf[DummyClassForStringSources]
+
+    "on Flow" must {
+
+      "debug each element" in {
+        val debugging = Flow[Int].log("my-debug")
+        Source(1 to 2).via(debugging).runWith(Sink.ignore)
+
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-debug] Element: 1"))
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-debug] Element: 2"))
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-debug] Upstream finished."))
+      }
+
+      "allow disabling element logging" in {
+        val disableElementLogging = OperationAttributes.logLevels(
+          onElement = LogLevels.Off,
+          onFinish = Logging.DebugLevel,
+          onFailure = Logging.DebugLevel)
+
+        val debugging = Flow[Int].log("my-debug")
+        Source(1 to 2)
+          .via(debugging)
+          .withAttributes(disableElementLogging)
+          .runWith(Sink.ignore)
+
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-debug] Upstream finished."))
+      }
+
+    }
+
+    "on javadsl.Flow" must {
+      "debug each element" in {
+        val log = Logging(system, "com.example.ImportantLogger")
+
+        val debugging: javadsl.Flow[Integer, Integer, Unit] = javadsl.Flow.of(classOf[Integer])
+          .log("log-1")
+          .log("log-2", new akka.japi.function.Function[Integer, Integer] { def apply(i: Integer) = i })
+          .log("log-3", new akka.japi.function.Function[Integer, Integer] { def apply(i: Integer) = i }, log)
+          .log("log-4", log)
+
+        javadsl.Source.single[Integer](1).via(debugging).runWith(javadsl.Sink.ignore(), mat)
+
+        var counter = 0
+        var finishCounter = 0
+        import scala.concurrent.duration._
+        logProbe.fishForMessage(3.seconds) {
+          case Logging.Debug(_, _, msg: String) if msg contains "Element: 1" ⇒
+            counter += 1
+            counter == 4 && finishCounter == 4
+
+          case Logging.Debug(_, _, msg: String) if msg contains "Upstream finished" ⇒
+            finishCounter += 1
+            counter == 4 && finishCounter == 4
+        }
+      }
+    }
+
+    "on Source" must {
+      "debug each element" in {
+        Source(1 to 2).log("flow-s2").runWith(Sink.ignore)
+
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[flow-s2] Element: 1"))
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[flow-s2] Element: 2"))
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[flow-s2] Upstream finished."))
+      }
+
+      "allow extracting value to be logged" in {
+        case class Complex(a: Int, b: String)
+        Source.single(Complex(1, "42")).log("flow-s3", _.b).runWith(Sink.ignore)
+
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[flow-s3] Element: 42"))
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[flow-s3] Upstream finished."))
+      }
+
+      "log upstream failure" in {
+        val cause = new TestException
+        Source.failed(cause).log("flow-4").runWith(Sink.ignore)
+        logProbe.expectMsg(Logging.Error(cause, LogSrc, LogClazz, "[flow-4] Upstream failed."))
+      }
+
+      "allow passing in custom LoggingAdapter" in {
+        val log = Logging(system, "com.example.ImportantLogger")
+
+        Source.single(42).log("flow-5")(log).runWith(Sink.ignore)
+
+        val src = "com.example.ImportantLogger(akka://FlowLogSpec)"
+        val clazz = classOf[DummyClassForStringSources]
+        logProbe.expectMsg(Logging.Debug(src, clazz, "[flow-5] Element: 42"))
+        logProbe.expectMsg(Logging.Debug(src, clazz, "[flow-5] Upstream finished."))
+      }
+
+      "allow configuring log levels via OperationAttributes" in {
+        val logAttrs = OperationAttributes.logLevels(
+          onElement = Logging.WarningLevel,
+          onFinish = Logging.InfoLevel,
+          onFailure = Logging.DebugLevel)
+
+        Source.single(42)
+          .log("flow-6")
+          .withAttributes(OperationAttributes.logLevels(
+            onElement = Logging.WarningLevel,
+            onFinish = Logging.InfoLevel,
+            onFailure = Logging.DebugLevel))
+          .runWith(Sink.ignore)
+
+        logProbe.expectMsg(Logging.Warning(LogSrc, LogClazz, "[flow-6] Element: 42"))
+        logProbe.expectMsg(Logging.Info(LogSrc, LogClazz, "[flow-6] Upstream finished."))
+
+        val cause = new TestException
+        Source.failed(cause)
+          .log("flow-6e")
+          .withAttributes(logAttrs)
+          .runWith(Sink.ignore)
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[flow-6e] Upstream failed, cause: FlowLogSpec$TestException: Boom!"))
+      }
+    }
+
+    "on javadsl.Source" must {
+      "debug each element" in {
+        val log = Logging(system, "com.example.ImportantLogger")
+
+        javadsl.Source.single[Integer](1)
+          .log("log-1")
+          .log("log-2", new akka.japi.function.Function[Integer, Integer] { def apply(i: Integer) = i })
+          .log("log-3", new akka.japi.function.Function[Integer, Integer] { def apply(i: Integer) = i }, log)
+          .log("log-4", log)
+          .runWith(javadsl.Sink.ignore(), mat)
+
+        var counter = 1
+        import scala.concurrent.duration._
+        logProbe.fishForMessage(3.seconds) {
+          case Logging.Debug(_, _, msg: String) if msg contains "Element: 1" ⇒
+            counter += 1
+            counter == 4
+
+          case Logging.Debug(_, _, msg: String) if msg contains "Upstream finished" ⇒
+            false
+        }
+      }
+    }
+
+  }
+
+  final class TestException extends RuntimeException("Boom!") with NoStackTrace
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
@@ -11,8 +11,7 @@ import akka.stream.stage.Stage
 import scala.collection.immutable
 import scala.concurrent.duration._
 import akka.actor._
-import akka.stream.ActorFlowMaterializerSettings
-import akka.stream.ActorFlowMaterializer
+import akka.stream.{ OperationAttributes, ActorFlowMaterializerSettings, ActorFlowMaterializer }
 import akka.stream.impl._
 import akka.stream.testkit._
 import akka.stream.testkit.Utils._
@@ -45,7 +44,7 @@ class FlowSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug.rece
     _settings: ActorFlowMaterializerSettings,
     _ops: Seq[Stage[_, _]],
     brokenMessage: Any)
-    extends ActorInterpreter(_settings, _ops, mat) {
+    extends ActorInterpreter(_settings, _ops, mat, OperationAttributes.none) {
 
     import akka.stream.actor.ActorSubscriberMessage._
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowStageSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowStageSpec.scala
@@ -3,6 +3,9 @@
  */
 package akka.stream.scaladsl
 
+import akka.actor.PoisonPill
+import akka.stream.{ OperationAttributes, OverflowStrategy, ActorFlowMaterializer, ActorFlowMaterializerSettings }
+import akka.stream.stage._
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -12,7 +15,9 @@ import akka.stream.testkit._
 import akka.stream.testkit.Utils._
 import akka.testkit.{ EventFilter, TestProbe }
 import com.typesafe.config.ConfigFactory
-import akka.stream.stage._
+
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 class FlowStageSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug.receive=off\nakka.loglevel=INFO")) {
 
@@ -418,6 +423,7 @@ class FlowStageSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug
       val upsub = up.expectSubscription()
       upsub.expectCancellation()
     }
+
   }
 
 }

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -37,7 +37,7 @@ akka {
       
       # Enable additional troubleshooting logging at DEBUG log level
       debug-logging = off
-      
+
       # Maximum number of elements emitted in batch if downstream signals large demand
       output-burst-limit = 1000
     }

--- a/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
@@ -11,7 +11,7 @@ import akka.stream.impl._
 import com.typesafe.config.Config
 
 import scala.concurrent.duration._
-import akka.japi.{ function ⇒ japi }
+import akka.japi.function
 
 object ActorFlowMaterializer {
 
@@ -145,13 +145,15 @@ abstract class ActorFlowMaterializer extends FlowMaterializer {
 
   def effectiveSettings(opAttr: OperationAttributes): ActorFlowMaterializerSettings
 
-  /** INTERNAL API */
-  private[akka] def system: ActorSystem
-
   /**
    * INTERNAL API: this might become public later
    */
   private[akka] def actorOf(context: MaterializationContext, props: Props): ActorRef
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def system: ActorSystem
 
 }
 
@@ -247,7 +249,7 @@ final case class ActorFlowMaterializerSettings(
    * overridden for specific flows of the stream operations with
    * [[akka.stream.OperationAttributes#supervisionStrategy]].
    */
-  def withSupervisionStrategy(decider: japi.Function[Throwable, Supervision.Directive]): ActorFlowMaterializerSettings = {
+  def withSupervisionStrategy(decider: function.Function[Throwable, Supervision.Directive]): ActorFlowMaterializerSettings = {
     import Supervision._
     copy(supervisionDecider = decider match {
       case `resumingDecider`   ⇒ resumingDecider

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.impl
 
-import akka.event.Logging
+import akka.event.{ LoggingAdapter, Logging }
 import akka.stream.{ OverflowStrategy, TimerTransformer }
 import akka.stream.OperationAttributes
 import akka.stream.OperationAttributes._
@@ -128,6 +128,11 @@ private[stream] object Stages {
   }
 
   final case class Map(f: Any ⇒ Any, attributes: OperationAttributes = map) extends StageModule {
+    def withAttributes(attributes: OperationAttributes) = copy(attributes = attributes)
+    override protected def newInstance: StageModule = this.copy()
+  }
+
+  final case class Log(name: String, extract: Any ⇒ Any, loggingAdapter: Option[LoggingAdapter], attributes: OperationAttributes = map) extends StageModule {
     def withAttributes(attributes: OperationAttributes) = copy(attributes = attributes)
     override protected def newInstance: StageModule = this.copy()
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -8,6 +8,7 @@ import akka.japi.function
 import scala.collection.immutable
 import java.util.concurrent.Callable
 import akka.actor.{ Cancellable, ActorRef, Props }
+import akka.event.LoggingAdapter
 import akka.japi.Util
 import akka.stream.OperationAttributes._
 import akka.stream._
@@ -523,5 +524,87 @@ class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[Sour
 
   override def named(name: String): javadsl.Source[Out, Mat] =
     new Source(delegate.named(name))
+
+  /**
+   * Logs elements flowing through the stream as well as completion and erroring.
+   *
+   * By default element and completion signals are logged on debug level, and errors are logged on Error level.
+   * This can be adjusted according to your needs by providing a custom [[OperationAttributes.LogLevels]] atrribute on the given Flow:
+   *
+   * The `extract` function will be applied to each element before logging, so it is possible to log only those fields
+   * of a complex object flowing through this element.
+   *
+   * Uses the given [[LoggingAdapter]] for logging.
+   *
+   * '''Emits when''' the mapping function returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def log(name: String, extract: function.Function[Out, Any], log: LoggingAdapter): javadsl.Source[Out, Mat] =
+    new Source(delegate.log(name, e ⇒ extract.apply(e))(log))
+
+  /**
+   * Logs elements flowing through the stream as well as completion and erroring.
+   *
+   * By default element and completion signals are logged on debug level, and errors are logged on Error level.
+   * This can be adjusted according to your needs by providing a custom [[OperationAttributes.LogLevels]] atrribute on the given Flow:
+   *
+   * The `extract` function will be applied to each element before logging, so it is possible to log only those fields
+   * of a complex object flowing through this element.
+   *
+   * Uses an internally created [[LoggingAdapter]] which uses `akka.stream.Log` as it's source (use this class to configure slf4j loggers).
+   *
+   * '''Emits when''' the mapping function returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def log(name: String, extract: function.Function[Out, Any]): javadsl.Source[Out, Mat] =
+    this.log(name, extract, null)
+
+  /**
+   * Logs elements flowing through the stream as well as completion and erroring.
+   *
+   * By default element and completion signals are logged on debug level, and errors are logged on Error level.
+   * This can be adjusted according to your needs by providing a custom [[OperationAttributes.LogLevels]] atrribute on the given Flow:
+   *
+   * Uses the given [[LoggingAdapter]] for logging.
+   *
+   * '''Emits when''' the mapping function returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def log(name: String, log: LoggingAdapter): javadsl.Source[Out, Mat] =
+    this.log(name, javaIdentityFunction[Out], log)
+
+  /**
+   * Logs elements flowing through the stream as well as completion and erroring.
+   *
+   * By default element and completion signals are logged on debug level, and errors are logged on Error level.
+   * This can be adjusted according to your needs by providing a custom [[OperationAttributes.LogLevels]] atrribute on the given Flow:
+   *
+   * Uses an internally created [[LoggingAdapter]] which uses `akka.stream.Log` as it's source (use this class to configure slf4j loggers).
+   *
+   * '''Emits when''' the mapping function returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def log(name: String): javadsl.Source[Out, Mat] =
+    this.log(name, javaIdentityFunction[Out], null)
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/package.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/package.scala
@@ -3,7 +3,16 @@
  */
 package akka.stream
 
+import akka.japi.function.Function
+
 package object javadsl {
+
+  val JavaIdentityFunction = new Function[Any, Any] {
+    @throws(classOf[Exception])
+    override def apply(param: Any): Any = param
+  }
+
+  def javaIdentityFunction[T] = JavaIdentityFunction.asInstanceOf[Function[T, T]]
 
   def combinerToScala[M1, M2, M](f: akka.japi.function.Function2[M1, M2, M]): (M1, M2) ⇒ M =
     f match {

--- a/akka-stream/src/main/scala/akka/stream/stage/Stage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/Stage.scala
@@ -3,8 +3,7 @@
  */
 package akka.stream.stage
 
-import akka.stream.Supervision
-import akka.stream.FlowMaterializer
+import akka.stream.{ FlowMaterializer, OperationAttributes, Supervision }
 
 /**
  * General interface for stream transformation.
@@ -571,6 +570,9 @@ sealed trait Context[Out] {
    * It can be used to materialize sub-flows.
    */
   def materializer: FlowMaterializer
+
+  /** Returns operation attributes associated with the this Stage */
+  def attributes: OperationAttributes
 }
 
 /**
@@ -643,3 +645,4 @@ trait AsyncContext[Out, Ext] extends DetachedContext[Out] {
 private[akka] trait BoundaryContext extends Context[Any] {
   def exit(): FreeDirective
 }
+


### PR DESCRIPTION
This WIP is a bit in the middle between "very outside" (how the `.debug()` is attached) and adding ast nodes etc so "inside". I got the feeling that since I need "more things" from the materializer (the flow's name - `materializationName` how I call it), it needs to be a proper built-in thing with it's proper AST node etc. - looking for opinions about that.

Looking for feedback around things that have TODOs. Esp. If this should simply be put on Source / Flow instead of trying to make it opt-in via import like I started out.

refs https://github.com/akka/akka/issues/16378
