### PR TITLE
+doc, str #16716: Table summarizing built-in processing stages

### DIFF
--- a/akka-docs-dev/rst/java/stream-flows-and-basics.rst
+++ b/akka-docs-dev/rst/java/stream-flows-and-basics.rst
@@ -30,6 +30,7 @@ Processing Stage
   The common name for all building blocks that build up a Flow or FlowGraph.
   Examples of a processing stage would be  operations like ``map()``, ``filter()``, stages added by ``transform()`` like
   :class:`PushStage`, :class:`PushPullStage`, :class:`StatefulStage` and graph junctions like ``Merge`` or ``Broadcast``.
+  For the full list of built-in processing stages see :ref:`stages-overview`
 
 Defining and running streams
 ----------------------------

--- a/akka-docs-dev/rst/java/stream-graphs.rst
+++ b/akka-docs-dev/rst/java/stream-graphs.rst
@@ -23,7 +23,7 @@ Flow graphs are built from simple Flows which serve as the linear connections wi
 which serve as fan-in and fan-out points for Flows. Thanks to the junctions having meaningful types based on their behaviour
 and making them explicit elements these elements should be rather straightforward to use.
 
-Akka Streams currently provide these junctions:
+Akka Streams currently provide these junctions (for a detailed list see :ref:`stages-overview`):
 
 * **Fan-out**
 

--- a/akka-docs-dev/rst/java/stream-index.rst
+++ b/akka-docs-dev/rst/java/stream-index.rst
@@ -18,5 +18,6 @@ Streams
    stream-io
    stream-parallelism
    stream-testkit
+   ../stages-overview
    stream-cookbook
    ../stream-configuration

--- a/akka-docs-dev/rst/java/stream-introduction.rst
+++ b/akka-docs-dev/rst/java/stream-introduction.rst
@@ -78,6 +78,8 @@ and for best results we recommend the following approach:
   point.
 * The bottom-up learners may feel more at home rummaging through the
   :ref:`stream-cookbook-java`.
+* For a complete overview of the built-in processing stages you can look at the
+  table in :ref:`stages-overview`
 * The other sections can be read sequentially or as needed during the previous
   steps, each digging deeper into specific topics.
 

--- a/akka-docs-dev/rst/scala/stream-cookbook.rst
+++ b/akka-docs-dev/rst/scala/stream-cookbook.rst
@@ -16,6 +16,8 @@ This part also serves as supplementary material for the main body of documentati
 open while reading the manual and look for examples demonstrating various streaming concepts
 as they appear in the main body of documentation.
 
+If you need a quick reference of the available processing stages used in the recipes see :ref:`stages-overview`.
+
 Working with Flows
 ==================
 

--- a/akka-docs-dev/rst/scala/stream-flows-and-basics.rst
+++ b/akka-docs-dev/rst/scala/stream-flows-and-basics.rst
@@ -30,6 +30,7 @@ Processing Stage
   The common name for all building blocks that build up a Flow or FlowGraph.
   Examples of a processing stage would be  operations like ``map()``, ``filter()``, stages added by ``transform()`` like
   :class:`PushStage`, :class:`PushPullStage`, :class:`StatefulStage` and graph junctions like ``Merge`` or ``Broadcast``.
+  For the full list of built-in processing stages see :ref:`stages-overview`
 
 Defining and running streams
 ----------------------------

--- a/akka-docs-dev/rst/scala/stream-graphs.rst
+++ b/akka-docs-dev/rst/scala/stream-graphs.rst
@@ -24,7 +24,7 @@ Flow graphs are built from simple Flows which serve as the linear connections wi
 which serve as fan-in and fan-out points for Flows. Thanks to the junctions having meaningful types based on their behaviour
 and making them explicit elements these elements should be rather straightforward to use.
 
-Akka Streams currently provide these junctions:
+Akka Streams currently provide these junctions (for a detailed list see :ref:`stages-overview`):
 
 * **Fan-out**
 

--- a/akka-docs-dev/rst/scala/stream-index.rst
+++ b/akka-docs-dev/rst/scala/stream-index.rst
@@ -18,5 +18,6 @@ Streams
    stream-io
    stream-parallelism
    stream-testkit
+   ../stages-overview
    stream-cookbook
    ../stream-configuration

--- a/akka-docs-dev/rst/scala/stream-introduction.rst
+++ b/akka-docs-dev/rst/scala/stream-introduction.rst
@@ -78,6 +78,8 @@ and for best results we recommend the following approach:
   point.
 * The bottom-up learners may feel more at home rummaging through the
   :ref:`stream-cookbook-scala`.
+* For a complete overview of the built-in processing stages you can look at the
+  table in :ref:`stages-overview`
 * The other sections can be read sequentially or as needed during the previous
   steps, each digging deeper into specific topics.
 

--- a/akka-docs-dev/rst/stages-overview.rst
+++ b/akka-docs-dev/rst/stages-overview.rst
@@ -1,0 +1,142 @@
+.. _stages-overview:
+
+###############################################
+Overview of built-in stages and their semantics
+###############################################
+
+All stages by default backpressure if the computation they encapsulate is not fast enough to keep up with the rate of
+incoming elements from the preceding stage. There are differences though how the different stages handle when some of
+their downstream stages backpressure them. This table provides a summary of all built-in stages and their semantics.
+
+All stages stop and propagate the failure downstream as soon as any of their upstreams emit a failure unless supervision
+is used. This happens to ensure reliable teardown of streams and cleanup when failures happen. Failures are meant to
+be to model unrecoverable conditions, therefore they are always eagerly propagated.
+For in-band error handling of normal errors (dropping elements if a map fails for example) you should use the
+upervision support, or explicitly wrap your element types in a proper container that can express error or success
+states (for example ``Try`` in Scala).
+
+Custom components are not covered by this table since their semantics are defined by the user.
+
+Simple processing stages
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+These stages are all expressible as a ``PushPullStage``. These stages can transform the rate of incoming elements
+since there are stages that emit multiple elements for a single input (e.g. `mapConcat') or consume
+multiple elements before emitting one output (e.g. ``filter``). However, these rate transformations are data-driven, i.e. it is
+the incoming elements that define how the rate is affected. This is in contrast with :ref:`detached-stages-overview`
+which can change their processing behavior depending on being backpressured by downstream or not.
+
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+Stage                  Emits when                                                                                                                  Backpressures when                                                                                                              Completes when
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+map                    the mapping function returns an element                                                                                     downstream backpressures                                                                                                        upstream completes
+mapConcat              the mapping function returns an element or there are still remaining elements from the previously calculated collection     downstream backpressures or there are still available elements from the previously calculated collection                        upstream completes and all remaining elements has been emitted
+filter                 the given predicate returns true for the element                                                                            the given predicate returns true for the element and downstream backpressures                                                   upstream completes
+collect                the provided partial function is defined for the element                                                                    the partial function is defined for the element and downstream backpressures                                                    upstream completes
+grouped                the specified number of elements has been accumulated or upstream completed                                                 a group has been assembled and downstream backpressures                                                                         upstream completes
+scan                   the function scanning the element returns a new element                                                                     downstream backpressures                                                                                                        upstream completes
+drop                   the specified number of elements has been dropped already                                                                   the specified number of elements has been dropped and downstream backpressures                                                  upstream completes
+take                   the specified number of elements to take has not yet been reached                                                           downstream backpressures                                                                                                        the defined number of elements has been taken or upstream completes
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+
+Asynchronous processing stages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These stages encapsulate an asynchronous computation, properly handling backpressure while taking care of the asynchronous
+operation at the same time (usually handling the completion of a Future).
+
+**It is currently not possible to build custom asynchronous processing stages**
+
+=====================  =========================================================================================================================   ==============================================================================================================================  =============================================================================================
+Stage                  Emits when                                                                                                                  Backpressures when                                                                                                              Completes when
+=====================  =========================================================================================================================   ==============================================================================================================================  =============================================================================================
+mapAsync               the Future returned by the provided function finishes for the next element in sequence                                      the number of futures reaches the configured parallelism and the downstream backpressures                                       upstream completes and all futures has been completed  and all elements has been emitted [1]_
+mapAsyncUnordered      any of the Futures returned by the provided function complete                                                               the number of futures reaches the configured parallelism and the downstream backpressures                                       upstream completes and all futures has been completed  and all elements has been emitted [1]_
+=====================  =========================================================================================================================   ==============================================================================================================================  =============================================================================================
+
+Timer driven stages
+^^^^^^^^^^^^^^^^^^^
+
+These stages process elements using timers, delaying, dropping or grouping elements for certain time durations.
+
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+Stage                  Emits when                                                                                                                  Backpressures when                                                                                                              Completes when
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+takeWithin             an upstream element arrives                                                                                                 downstream backpressures                                                                                                        upstream completes or timer fires
+dropWithin             after the timer fired and a new upstream element arrives                                                                    downstream backpressures                                                                                                        upstream completes
+groupedWithin          the configured time elapses since the last group has been emitted                                                           the group has been assembled (the duration elapsed) and downstream backpressures                                                upstream completes
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+
+**It is currently not possible to build custom timer driven stages**
+
+.. _detached-stages-overview:
+Backpressure aware stages
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These stages are all expressible as a ``DetachedStage``. These stages are aware of the backpressure provided by their
+downstreams and able to adapt their behavior to that signal.
+
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+Stage                  Emits when                                                                                                                  Backpressures when                                                                                                              Completes when
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+conflate               downstream stops backpressuring and there is a conflated element available                                                  never [2]_                                                                                                                      upstream completes
+expand                 downstream stops backpressuring                                                                                             downstream backpressures                                                                                                        upstream completes
+buffer (Backpressure)  downstream stops backpressuring and there is a pending element in the buffer                                                buffer is full                                                                                                                  upstream completes and buffered elements has been drained
+buffer (DropX)         downstream stops backpressuring and there is a pending element in the buffer                                                never [2]_                                                                                                                      upstream completes and buffered elements has been drained
+buffer (Fail)          downstream stops backpressuring and there is a pending element in the buffer                                                fails the stream instead of backpressuring when buffer is full                                                                  upstream completes and buffered elements has been drained
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+
+Nesting and flattening stages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These stages either take a stream and turn it into a stream of streams (nesting) or they take a stream that contains
+nested streams and turn them into a stream of elements instead (flattening).
+
+**It is currently not possible to build custom nesting or flattening stages**
+
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+Stage                  Emits when                                                                                                                  Backpressures when                                                                                                              Completes when
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+prefixAndTail          the configured number of prefix elements are available. Emits this prefix, and the rest as a substream                      downstream backpressures or substream backpressures                                                                             prefix elements has been consumed and substream has been consumed
+groupBy                an element for which the grouping function returns a group that has not yet been created. Emits the new group               there is an element pending for a group whose substream backpressures                                                           upstream completes [3]_
+splitWhen              an element for which the provided predicate is true, opening and emitting a new substream for subsequent elements           there is an element pending for the next substream, but the previous is not fully consumed yet, or the substream backpressures  upstream completes [3]_
+flatten (Concat)       the current consumed substream has an element available                                                                     downstream backpressures                                                                                                        upstream completes and all consumed substreams complete
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+
+Fan-in stages
+^^^^^^^^^^^^^
+
+Most of these stages can be expressible as a ``FlexiMerge``. These stages take multiple streams as their input and provide
+a single output combining the elements from all of the inputs in different ways.
+
+**The custom fan-in stages that can be built currently are limited**
+
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+Stage                  Emits when                                                                                                                  Backpressures when                                                                                                              Completes when
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+merge                  one of the inputs has an element available                                                                                  downstream backpressures                                                                                                        all upstreams complete
+mergePreferred         one of the inputs has an element available, preferring a defined input if multiple have elements available                  downstream backpressures                                                                                                        all upstreams complete
+zip                    all of the inputs has an element available                                                                                  downstream backpressures                                                                                                        any upstream completes
+zipWith                all of the inputs has an element available                                                                                  downstream backpressures                                                                                                        any upstream completes
+concat                 the current stream has an element available; if the current input completes, it tries the next one                          downstream backpressures                                                                                                        all upstreams complete
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+
+Fan-out stages
+^^^^^^^^^^^^^^
+
+Most of these stages can be expressible as a ``FlexiRoute``. These have one input and multiple outputs. They might
+route the elements between different outputs, or emit elements on multiple outputs at the same time.
+
+**The custom fan-out stages that can be built currently are limited**
+
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+Stage                  Emits when                                                                                                                  Backpressures when                                                                                                              Completes when
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+unzip                  all of the outputs stops backpressuring and there is an input element available                                             any of the outputs backpressures                                                                                                upstream completes
+broadcast              all of the outputs stops backpressuring and there is an input element available                                             any of the outputs backpressures                                                                                                upstream completes
+balance                any of the outputs stops backpressuring; emits the element to the first available output                                    all of the outputs backpressure                                                                                                 upstream completes
+=====================  =========================================================================================================================   ==============================================================================================================================  =====================================================================================
+
+.. [1] If a Future fails, the stream also fails (unless a different supervision strategy is applied)
+.. [2] Except if the encapsulated computation is not fast enough
+.. [3] Until the end of stream it is not possible to know whether new substreams will be needed or not

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
@@ -6,6 +6,17 @@ package akka.stream.javadsl
 import akka.stream._
 import akka.stream.scaladsl
 
+/**
+ * Combine the elements of multiple streams into a stream of combined elements using a combiner function.
+ *
+ * '''Emits when''' all of the inputs has an element available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' any upstream completes
+ *
+ * '''Cancels when''' downstream cancels
+ */
 object ZipWith {
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -17,6 +17,14 @@ import akka.japi.Pair
  * that multiple flows can be attached to; if you want to have multiple independent
  * junctions within the same `FlowGraph` then you will have to create multiple such
  * instances.
+ *
+ * '''Emits when''' one of the inputs has an element available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' all upstreams complete
+ *
+ * '''Cancels when''' downstream cancels
  */
 object Merge {
 
@@ -44,6 +52,15 @@ object Merge {
  * that multiple flows can be attached to; if you want to have multiple independent
  * junctions within the same `FlowGraph` then you will have to create multiple such
  * instances.
+ *
+ * '''Emits when''' one of the inputs has an element available, preferring
+ * a specified input if multiple have elements available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' all upstreams complete
+ *
+ * '''Cancels when''' downstream cancels
  */
 object MergePreferred {
   /**
@@ -60,14 +77,22 @@ object MergePreferred {
 }
 
 /**
- * Fan-out the stream to several streams. Each element is produced to
- * the other streams. It will not shutdown until the subscriptions for at least
+ * Fan-out the stream to several streams. emitting each incoming upstream element to all downstream consumers.
+ * It will not shutdown until the subscriptions for at least
  * two downstream subscribers have been established.
  *
  * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
  * that multiple flows can be attached to; if you want to have multiple independent
  * junctions within the same `FlowGraph` then you will have to create multiple such
  * instances.
+ *
+ * '''Emits when''' all of the outputs stops backpressuring and there is an input element available
+ *
+ * '''Backpressures when''' any of the outputs backpressure
+ *
+ * '''Completes when''' upstream completes
+ *
+ * '''Cancels when''' all downstreams cancel
  */
 object Broadcast {
   /**
@@ -84,14 +109,22 @@ object Broadcast {
 }
 
 /**
- * Fan-out the stream to several streams. Each element is produced to
- * one of the other streams. It will not shutdown until the subscriptions for at least
+ * Fan-out the stream to several streams. Each upstream element is emitted to the first available downstream consumer.
+ * It will not shutdown until the subscriptions for at least
  * two downstream subscribers have been established.
  *
  * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
  * that multiple flows can be attached to; if you want to have multiple independent
  * junctions within the same `FlowGraph` then you will have to create multiple such
  * instances.
+ *
+ * '''Emits when''' any of the outputs stops backpressuring; emits the element to the first available output
+ *
+ * '''Backpressures when''' all of the outputs backpressure
+ *
+ * '''Completes when''' upstream completes
+ *
+ * '''Cancels when''' all downstreams cancel
  */
 object Balance {
   /**
@@ -123,6 +156,19 @@ object Balance {
     create(outputCount, waitForAllDownstreams)
 }
 
+/**
+ * Combine the elements of 2 streams into a stream of tuples.
+ *
+ * A `Zip` has a `left` and a `right` input port and one `out` port
+ *
+ * '''Emits when''' all of the inputs has an element available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' any upstream completes
+ *
+ * '''Cancels when''' downstream cancels
+ */
 object Zip {
   import akka.stream.javadsl.japi.Function2
   import akka.japi.Pair
@@ -139,10 +185,17 @@ object Zip {
 }
 
 /**
- * Note that a junction instance describes exactly one place (vertex) in the `FlowGraph`
- * that multiple flows can be attached to; if you want to have multiple independent
- * junctions within the same `FlowGraph` then you will have to create multiple such
- * instances.
+ * Takes a stream of pair elements and splits each pair to two output streams.
+ *
+ * An `Unzip` has one `in` port and one `left` and one `right` output port.
+ *
+ * '''Emits when''' all of the outputs stops backpressuring and there is an input element available
+ *
+ * '''Backpressures when''' any of the outputs backpressures
+ *
+ * '''Completes when''' upstream completes
+ *
+ * '''Cancels when''' any downstream cancels
  */
 object Unzip {
 
@@ -173,6 +226,14 @@ object Unzip {
  * that multiple flows can be attached to; if you want to have multiple independent
  * junctions within the same `FlowGraph` then you will have to create multiple such
  * instances.
+ *
+ * '''Emits when''' the current stream has an element available; if the current input completes, it tries the next one
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' all upstreams complete
+ *
+ * '''Cancels when''' downstream cancels
  */
 object Concat {
   /**


### PR DESCRIPTION
Missing:
- [x] Timer driven stages
- [x] Make scaladocs consistent with table after the table has been reviewed
- [ ] Make javadocs consistent with scaladocs after it has been reviewed
- [x] Link from relevant documentation pages

Please look through this carefully (I will do the same) since it is easy to make typos and mistakes in such a large table. Sorry for the overly long lines, it is hard to make the table relatively maintainable and at the same time keep reStructuredText happy.
