### PR TITLE
Add spec for extractUri directive

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/server/directives/BasicDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/server/directives/BasicDirectivesSpec.scala
@@ -5,6 +5,9 @@
 package akka.http.server
 package directives
 
+import akka.http.model._
+import headers._
+
 class BasicDirectivesSpec extends RoutingSpec {
 
   "The `mapUnmatchedPath` directive" should {
@@ -24,6 +27,24 @@ class BasicDirectivesSpec extends RoutingSpec {
           echoComplete
         }
       } ~> check { responseAs[String] shouldEqual "GET" }
+    }
+  }
+
+  "The `extractUri` directive" should {
+    "extract from the request url" in {
+      Get("https://example.com/foo") ~> {
+        extractUri { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "https://example.com/foo" }
+    }
+    "extract from a X-Request-URI header" in {
+      Get() ~> addHeader(RawHeader("x-request-uri", "http://example.com/foo")) ~> {
+        extractUri { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "http://example.com/" }
+    }
+    "extract from request path and a Host header" in {
+      Get("/foo/bar") ~> addHeader(`Host`("example.com")) ~> {
+        extractUri { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "http://example.com/foo/bar" }
     }
   }
 }


### PR DESCRIPTION
I was trying to understand the behavior of `request.uri` for an akka-http server behind a reverse proxy. This is a test case to clarify the same.
