### PR TITLE
+str #16209 Add convenience for unbuffered zip

### DIFF
--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
@@ -12,18 +12,66 @@ object ZipWith {
    * Create a new `ZipWith` vertex with the specified input types and zipping-function `f`.
    *
    * @param f zipping-function from the input values to the output value
-   * @param attributes optional attributes for this vertex
    */
   def create[A, B, Out](f: japi.Function2[A, B, Out]): Graph[FanInShape2[A, B, Out], Unit] =
-    scaladsl.ZipWith(f.apply _)
+    create(OperationAttributes.none, f)
+    
+  /**
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function `f`.
+   *
+   * @param attributes optional attributes for this vertex
+   * @param f zipping-function from the input values to the output value
+   */
+  def create[A, B, Out](attributes: OperationAttributes, f: japi.Function2[A, B, Out]): Graph[FanInShape2[A, B, Out], Unit] =
+    scaladsl.ZipWith(attributes.asScala, f.apply _)
+    
+  /**
+   * Create a new unbuffered `ZipWith` vertex with the specified input types and zipping-function `f`.
+   * Unbuffered `ZipWith` is useful for time or rate driven streams.
+   *
+   * @param f zipping-function from the input values to the output value
+   */
+  def createUnbuffered[A, B, Out](f: japi.Function2[A, B, Out]): Graph[FanInShape2[A, B, Out], Unit] =
+    createUnbuffered(OperationAttributes.none, f)
+    
+  /**
+   * Create a new unbuffered `ZipWith` vertex with the specified input types and zipping-function `f`.
+   * Unbuffered `ZipWith` is useful for time or rate driven streams.
+   *
+   * @param attributes optional attributes for this vertex
+   * @param f zipping-function from the input values to the output value
+   */
+  def createUnbuffered[A, B, Out](attributes: OperationAttributes, f: japi.Function2[A, B, Out]): Graph[FanInShape2[A, B, Out], Unit] =
+    scaladsl.ZipWith.unbuffered(attributes.asScala, f.apply _)
 
   [3..20#/** Create a new `ZipWith` specialized for 1 inputs.
    *
    * @param f zipping-function from the input values to the output value
-   * @param attributes optional attributes for this vertex
    */
   def create1[[#T1#], Out](f: japi.Function1[[#T1#], Out]): Graph[FanInShape1[[#T1#], Out], Unit] =
-    scaladsl.ZipWith(f.apply _)#
+    create1(OperationAttributes.none, f)
+    
+  /** Create a new `ZipWith` specialized for 1 inputs.
+   * @param attributes optional attributes for this vertex
+   * @param f zipping-function from the input values to the output value
+   */
+  def create1[[#T1#], Out](attributes: OperationAttributes, f: japi.Function1[[#T1#], Out]): Graph[FanInShape1[[#T1#], Out], Unit] =
+    scaladsl.ZipWith(attributes.asScala, f.apply _)
+  
+  /** Create a new `ZipWith` specialized for 1 inputs.
+   * Unbuffered `ZipWith` is useful for time or rate driven streams.
+   * @param f zipping-function from the input values to the output value
+   */
+  def createUnbuffered1[[#T1#], Out](f: japi.Function1[[#T1#], Out]): Graph[FanInShape1[[#T1#], Out], Unit] =
+    createUnbuffered1(OperationAttributes.none, f)
+    
+  /** Create a new `ZipWith` specialized for 1 inputs.
+   * Unbuffered `ZipWith` is useful for time or rate driven streams.
+   * @param attributes optional attributes for this vertex
+   * @param f zipping-function from the input values to the output value
+   */
+  def createUnbuffered1[[#T1#], Out](attributes: OperationAttributes, f: japi.Function1[[#T1#], Out]): Graph[FanInShape1[[#T1#], Out], Unit] =
+    scaladsl.ZipWith.unbuffered(attributes.asScala, f.apply _)#
     
   ]
 

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
@@ -12,13 +12,44 @@ trait ZipWithApply {
    * Create a new `ZipWith` specialized for 1 inputs.
    *
    * @param f zipping-function from the input values to the output value
-   * @param attributes optional attributes for this vertex
    */
   def apply[[#A1#], O](zipper: ([#A1#]) ⇒ O): Graph[FanInShape1[[#A1#], O], Unit] =
+    apply(OperationAttributes.none, zipper)
+    
+  /**
+   * Create a new `ZipWith` specialized for 1 inputs.
+   *
+   * @param attributes optional attributes for this vertex
+   * @param f zipping-function from the input values to the output value
+   */
+  def apply[[#A1#], O](attributes: OperationAttributes, zipper: ([#A1#]) ⇒ O): Graph[FanInShape1[[#A1#], O], Unit] =
     new Graph[FanInShape1[[#A1#], O], Unit] {
       val shape = new FanInShape1[[#A1#], O]("ZipWith1")
-      val module = new ZipWith1Module(shape, zipper, OperationAttributes.name("ZipWith1"))
+      val module = new ZipWith1Module(shape, zipper, OperationAttributes.name("ZipWith1") and attributes)
     }
+    
+  /**
+   * Create a new unbuffered `ZipWith` specialized for 1 inputs.
+   * Unbuffered `ZipWith` is useful for time or rate driven streams.
+   *
+   * @param f zipping-function from the input values to the output value
+   */
+  def unbuffered[[#A1#], O](zipper: ([#A1#]) ⇒ O): Graph[FanInShape1[[#A1#], O], Unit] =
+    unbuffered(OperationAttributes.none, zipper)
+    
+  /**
+   * Create a new unbuffered `ZipWith` specialized for 1 inputs.
+   * Unbuffered `ZipWith` is useful for time or rate driven streams.
+   *
+   * @param attributes optional attributes for this vertex
+   * @param f zipping-function from the input values to the output value
+   */
+  def unbuffered[[#A1#], O](attributes: OperationAttributes, zipper: ([#A1#]) ⇒ O): Graph[FanInShape1[[#A1#], O], Unit] =
+    new Graph[FanInShape1[[#A1#], O], Unit] {
+      val shape = new FanInShape1[[#A1#], O]("ZipWith1")
+      val module = new ZipWith1Module(shape, zipper, 
+        OperationAttributes.name("ZipWith1") and OperationAttributes.inputBuffer(1, 1) and attributes)
+    }    
     #
 
   ]

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -180,8 +180,16 @@ object Zip {
    * Create a new `ZipWith` vertex with the specified input types and zipping-function
    * which creates `akka.japi.Pair`s.
    */
-  def create[A, B]: Graph[FanInShape2[A, B, A Pair B], Unit] =
-    ZipWith.create(_toPair.asInstanceOf[Function2[A, B, A Pair B]])
+  def create[A, B]: Graph[FanInShape2[A, B, A Pair B], Unit] = create(OperationAttributes.none)
+
+  /**
+   * Create a new `ZipWith` vertex with the specified input types and zipping-function
+   * which creates `akka.japi.Pair`s.
+   *
+   * @param attributes optional attributes for this vertex
+   */
+  def create[A, B](attributes: OperationAttributes): Graph[FanInShape2[A, B, A Pair B], Unit] =
+    ZipWith.create(attributes, _toPair.asInstanceOf[Function2[A, B, A Pair B]])
 
   private[this] final val _toPair: Function2[Any, Any, Any Pair Any] =
     new Function2[Any, Any, Any Pair Any] { override def apply(a: Any, b: Any): Any Pair Any = new Pair(a, b) }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -124,6 +124,15 @@ object Zip {
       val shape = new FanInShape2[A, B, (A, B)]("Zip")
       val module = new ZipWith2Module[A, B, (A, B)](shape, Keep.both, OperationAttributes.name("Zip") and attributes)
     }
+
+  /**
+   * Create a new unbuffered `Zip` with the specified attributes.
+   * Unbuffered `Zip` is useful for time or rate driven streams.
+   *
+   * @param attributes optional attributes
+   */
+  def unbuffered[A, B](attributes: OperationAttributes = OperationAttributes.none): Graph[FanInShape2[A, B, (A, B)], Unit] =
+    apply(attributes and OperationAttributes.inputBuffer(1, 1))
 }
 
 /**


### PR DESCRIPTION
- also add missing OperationAttributes param for ZipWith

DOES NOT COMPILE

Would like input before fighting this further. Might be going in wrong direction.
I noticed that OperationAttributes parameter was missing for `ZipWith` and that is not easy to add.
I have tried various types of overloads but it currently fails with:

```
val zip = b.add(ZipWith[Int, Int, Int](_ + _))

missing parameter type for expanded function ((x$3: <error>, x$4) ⇒ x$3.$plus(x$4))
missing parameter type for expanded function ((x$3, x$4) ⇒ x$3.$plus(x$4))
```
