### PR TITLE
!str #17189 Add withAttributes and named to Graph

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/engine/server/HttpServerBluePrint.scala
@@ -88,7 +88,7 @@ private[http] object HttpServerBluePrint {
       (requestParsing, renderer) ⇒
         import FlowGraph.Implicits._
 
-        val bypassFanout = b.add(Broadcast[RequestOutput](2, OperationAttributes.name("bypassFanout")))
+        val bypassFanout = b.add(Broadcast[RequestOutput](2).named("bypassFanout"))
         val bypassMerge = b.add(new BypassMerge(settings, log))
         val bypassInput = bypassMerge.in0
         val bypassOneHundredContinueInput = bypassMerge.in1

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/FusableProcessorTest.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/FusableProcessorTest.scala
@@ -19,7 +19,7 @@ class FusableProcessorTest extends AkkaIdentityProcessorVerification[Int] {
 
     processorFromFlow(
       // withAttributes "wraps" the underlying identity and protects it from automatic removal
-      Flow[Int].andThen(Identity()).withAttributes(OperationAttributes.name("identity")))
+      Flow[Int].andThen(Identity()).named("identity"))
   }
 
   override def createElement(element: Int): Int = element

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/MapTest.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/MapTest.scala
@@ -14,7 +14,7 @@ class MapTest extends AkkaIdentityProcessorVerification[Int] {
     implicit val materializer = ActorFlowMaterializer()(system)
 
     processorFromFlow(
-      Flow[Int].map(elem ⇒ elem).withAttributes(OperationAttributes.name("identity")))
+      Flow[Int].map(elem ⇒ elem).named("identity"))
   }
 
   override def createElement(element: Int): Int = element

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/ChainSetup.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/ChainSetup.scala
@@ -24,7 +24,7 @@ class ChainSetup[In, Out](
 
   val upstream = StreamTestKit.PublisherProbe[In]()
   val downstream = StreamTestKit.SubscriberProbe[Out]()
-  private val s = Source(upstream).via(stream(Flow[In].map(x ⇒ x).withAttributes(OperationAttributes.name("buh"))))
+  private val s = Source(upstream).via(stream(Flow[In].map(x ⇒ x).named("buh")))
   val publisher = toPublisher(s, materializer)
   val upstreamSubscription = upstream.expectSubscription()
   publisher.subscribe(downstream)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphJunctionAttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphJunctionAttributesSpec.scala
@@ -32,7 +32,7 @@ class GraphJunctionAttributesSpec extends AkkaSpec {
         val slow = Source(0.seconds, 100.millis, SlowTick)
         val fast = Source(0.seconds, 10.millis, FastTick)
 
-        val zip = b add Zip[SlowTick, List[FastTick]](inputBuffer(1, 1))
+        val zip = b add Zip[SlowTick, List[FastTick]]().withAttributes(inputBuffer(1, 1))
 
         slow ~> zip.in0
         fast.conflate(tick ⇒ List(tick)) { case (list, tick) ⇒ tick :: list } ~> zip.in1

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -3,8 +3,9 @@
  */
 package akka.stream.scaladsl
 
+import akka.stream.impl.StreamLayout
 import akka.stream.impl.StreamLayout.Module
-import akka.stream.{ Graph, Shape }
+import akka.stream.{ Graph, OperationAttributes, Shape }
 
 trait GraphApply {
 
@@ -29,10 +30,7 @@ trait GraphApply {
     val s = buildBlock(builder)
     val mod = builder.module.wrap().replaceShape(s)
 
-    new Graph[S, Unit] {
-      override def shape: S = s
-      override private[stream] def module: Module = mod
-    }
+    new GraphApply.GraphImpl(s, mod)
   }
 
   /**
@@ -60,10 +58,7 @@ trait GraphApply {
     val s = buildBlock(builder)(s1)
     val mod = builder.module.wrap().replaceShape(s)
 
-    new Graph[S, Mat] {
-      override def shape: S = s
-      override private[stream] def module: Module = mod
-    }
+    new GraphApply.GraphImpl(s, mod)
   }
 
 
@@ -98,13 +93,25 @@ trait GraphApply {
     val s = buildBlock(builder)([#s1#])
     val mod = builder.module.wrap().replaceShape(s)
 
-    new Graph[S, Mat] {
-      override def shape: S = s
-      override private[stream] def module: Module = mod
-    }
+    new GraphApply.GraphImpl(s, mod)
   }#
 
   ]
 
+
+}
+
+/**
+ * INTERNAL API
+ */
+private[stream] object GraphApply {
+  class GraphImpl[S <: Shape, Mat](override val shape: S, private[stream] override val module: StreamLayout.Module)
+    extends Graph[S, Mat] {
+
+    override def withAttributes(attr: OperationAttributes): Graph[S, Mat] =
+      new GraphImpl(shape, module.withAttributes(attr).wrap())
+
+    override def named(name: String): Graph[S, Mat] = withAttributes(OperationAttributes.name(name))
+  }
 
 }

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
@@ -3,8 +3,9 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.impl.GenJunctions._
 import akka.stream._
+import akka.stream.impl.GenJunctions._
+import akka.stream.impl.StreamLayout
 
 trait ZipWithApply {
 
@@ -14,13 +15,25 @@ trait ZipWithApply {
    * @param f zipping-function from the input values to the output value
    * @param attributes optional attributes for this vertex
    */
-  def apply[[#A1#], O](zipper: ([#A1#]) ⇒ O): Graph[FanInShape1[[#A1#], O], Unit] =
-    new Graph[FanInShape1[[#A1#], O], Unit] {
-      val shape = new FanInShape1[[#A1#], O]("ZipWith1")
-      val module = new ZipWith1Module(shape, zipper, OperationAttributes.name("ZipWith1"))
+  def apply[[#A1#], O](zipper: ([#A1#]) ⇒ O): ZipWith1[[#A1#], O] = {
+    val shape = new FanInShape1[[#A1#], O]("ZipWith1")
+    new ZipWith1(shape, new ZipWith1Module(shape, zipper, OperationAttributes.name("ZipWith1")))
     }
     #
 
   ]
 
 }
+
+[2..20#/** `ZipWith` specialized for 1 inputs */
+class ZipWith1[[#A1#], O] private[stream] (override val shape: FanInShape1[[#A1#], O],
+                         private[stream] override val module: StreamLayout.Module)
+  extends Graph[FanInShape1[[#A1#], O], Unit] {
+
+  override def withAttributes(attr: OperationAttributes): ZipWith1[[#A1#], O] =
+    new ZipWith1(shape, module.withAttributes(attr).wrap())
+
+  override def named(name: String): ZipWith1[[#A1#], O] = withAttributes(OperationAttributes.name(name))
+}
+#
+]

--- a/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
@@ -235,7 +235,7 @@ final case class ActorFlowMaterializerSettings(
   /**
    * Scala API: Decides how exceptions from application code are to be handled, unless
    * overridden for specific flows of the stream operations with
-   * [[akka.stream.scaladsl.OperationAttributes#supervisionStrategy]].
+   * [[akka.stream.OperationAttributes#supervisionStrategy]].
    */
   def withSupervisionStrategy(decider: Supervision.Decider): ActorFlowMaterializerSettings =
     copy(supervisionDecider = decider)
@@ -243,7 +243,7 @@ final case class ActorFlowMaterializerSettings(
   /**
    * Java API: Decides how exceptions from application code are to be handled, unless
    * overridden for specific flows of the stream operations with
-   * [[akka.stream.javadsl.OperationAttributes#supervisionStrategy]].
+   * [[akka.stream.OperationAttributes#supervisionStrategy]].
    */
   def withSupervisionStrategy(decider: japi.Function[Throwable, Supervision.Directive]): ActorFlowMaterializerSettings = {
     import Supervision._

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -21,4 +21,8 @@ trait Graph[+S <: Shape, +M] {
    * Every materializable element must be backed by a stream layout module
    */
   private[stream] def module: StreamLayout.Module
+
+  def withAttributes(attr: OperationAttributes): Graph[S, M]
+
+  def named(name: String): Graph[S, M] = withAttributes(OperationAttributes.name(name))
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/Junctions.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Junctions.scala
@@ -63,7 +63,7 @@ private[stream] object Junctions {
   final case class FlexiMergeModule[T, S <: Shape](
     shape: S,
     flexi: S ⇒ MergeLogic[T],
-    override val attributes: OperationAttributes = name("flexiMerge")) extends FanInModule {
+    override val attributes: OperationAttributes) extends FanInModule {
 
     require(shape.outlets.size == 1, "FlexiMerge can have only one output port")
 
@@ -75,7 +75,7 @@ private[stream] object Junctions {
   final case class FlexiRouteModule[T, S <: Shape](
     shape: S,
     flexi: S ⇒ RouteLogic[T],
-    override val attributes: OperationAttributes = name("flexiRoute")) extends FanOutModule {
+    override val attributes: OperationAttributes) extends FanOutModule {
 
     require(shape.inlets.size == 1, "FlexiRoute can have only one input port")
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -6,6 +6,7 @@ package akka.stream.javadsl
 import akka.stream.scaladsl
 import akka.stream.Graph
 import akka.stream.BidiShape
+import akka.stream.OperationAttributes
 
 object BidiFlow {
 
@@ -122,4 +123,7 @@ class BidiFlow[-I1, +O1, -I2, +O2, +Mat](delegate: scaladsl.BidiFlow[I1, O1, I2,
    * Turn this BidiFlow around by 180 degrees, logically flipping it upside down in a protocol stack.
    */
   def reversed: BidiFlow[I2, O2, I1, O1, Mat] = new BidiFlow(delegate.reversed)
+
+  override def withAttributes(attr: OperationAttributes): BidiFlow[I1, O1, I2, O2, Mat] =
+    new BidiFlow(delegate.withAttributes(attr))
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -408,10 +408,10 @@ class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Graph
   def concat[M](second: javadsl.Source[Out @uncheckedVariance, M]): javadsl.Flow[In, Out, Mat @uncheckedVariance Pair M] =
     new Flow(delegate.concat(second.asScala).mapMaterialized(p ⇒ Pair(p._1, p._2)))
 
-  def withAttributes(attr: OperationAttributes): javadsl.Flow[In, Out, Mat] =
+  override def withAttributes(attr: OperationAttributes): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.withAttributes(attr))
 
-  def named(name: String): javadsl.Flow[In, Out, Mat] =
+  override def named(name: String): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.named(name))
 }
 
@@ -438,4 +438,10 @@ private[akka] class RunnableFlowAdapter[Mat](runnable: scaladsl.RunnableFlow[Mat
   override def mapMaterialized[Mat2](f: japi.Function[Mat, Mat2]): RunnableFlow[Mat2] =
     new RunnableFlowAdapter(runnable.mapMaterialized(f.apply _))
   override def run(materializer: FlowMaterializer): Mat = runnable.run()(materializer)
+
+  override def withAttributes(attr: OperationAttributes): RunnableFlow[Mat] =
+    new RunnableFlowAdapter(runnable.withAttributes(attr))
+
+  override def named(name: String): RunnableFlow[Mat] =
+    new RunnableFlowAdapter(runnable.named(name))
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -21,30 +21,15 @@ import akka.japi.Pair
 object Merge {
 
   /**
-   * Create a new `Merge` vertex with the specified output type and attributes.
-   *
-   * @param attributes optional attributes for this vertex
-   */
-  def create[T](outputCount: Int, attributes: OperationAttributes): Graph[UniformFanInShape[T, T], Unit] =
-    scaladsl.Merge(outputCount, attributes)
-
-  /**
    * Create a new `Merge` vertex with the specified output type.
    */
-  def create[T](outputCount: Int): Graph[UniformFanInShape[T, T], Unit] = create(outputCount, OperationAttributes.none)
+  def create[T](outputCount: Int): Graph[UniformFanInShape[T, T], Unit] =
+    scaladsl.Merge(outputCount)
 
   /**
    * Create a new `Merge` vertex with the specified output type.
    */
   def create[T](clazz: Class[T], outputCount: Int): Graph[UniformFanInShape[T, T], Unit] = create(outputCount)
-
-  /**
-   * Create a new `Merge` vertex with the specified output type and attributes.
-   *
-   * @param attributes optional attributes for this vertex
-   */
-  def create[T](clazz: Class[T], outputCount: Int, attributes: OperationAttributes): Graph[UniformFanInShape[T, T], Unit] =
-    create(outputCount, attributes)
 
 }
 
@@ -62,30 +47,15 @@ object Merge {
  */
 object MergePreferred {
   /**
-   * Create a new `MergePreferred` vertex with the specified output type and attributes.
-   *
-   * @param attributes optional attributes for this vertex
-   */
-  def create[T](outputCount: Int, attributes: OperationAttributes): Graph[scaladsl.MergePreferred.MergePreferredShape[T], Unit] =
-    scaladsl.MergePreferred(outputCount, attributes)
-
-  /**
    * Create a new `MergePreferred` vertex with the specified output type.
    */
-  def create[T](outputCount: Int): Graph[scaladsl.MergePreferred.MergePreferredShape[T], Unit] = create(outputCount, OperationAttributes.none)
+  def create[T](outputCount: Int): Graph[scaladsl.MergePreferred.MergePreferredShape[T], Unit] =
+    scaladsl.MergePreferred(outputCount)
 
   /**
    * Create a new `MergePreferred` vertex with the specified output type.
    */
   def create[T](clazz: Class[T], outputCount: Int): Graph[scaladsl.MergePreferred.MergePreferredShape[T], Unit] = create(outputCount)
-
-  /**
-   * Create a new `MergePreferred` vertex with the specified output type and attributes.
-   *
-   * @param attributes optional attributes for this vertex
-   */
-  def create[T](clazz: Class[T], outputCount: Int, attributes: OperationAttributes): Graph[scaladsl.MergePreferred.MergePreferredShape[T], Unit] =
-    create(outputCount, attributes)
 
 }
 
@@ -101,30 +71,16 @@ object MergePreferred {
  */
 object Broadcast {
   /**
-   * Create a new `Broadcast` vertex with the specified input type and attributes.
-   *
-   * @param attributes optional attributes for this vertex
-   */
-  def create[T](outputCount: Int, attributes: OperationAttributes): Graph[UniformFanOutShape[T, T], Unit] =
-    scaladsl.Broadcast(outputCount, attributes)
-
-  /**
    * Create a new `Broadcast` vertex with the specified input type.
    */
-  def create[T](outputCount: Int): Graph[UniformFanOutShape[T, T], Unit] = create(outputCount, OperationAttributes.none)
+  def create[T](outputCount: Int): Graph[UniformFanOutShape[T, T], Unit] =
+    scaladsl.Broadcast(outputCount)
 
   /**
    * Create a new `Broadcast` vertex with the specified input type.
    */
   def create[T](clazz: Class[T], outputCount: Int): Graph[UniformFanOutShape[T, T], Unit] = create(outputCount)
 
-  /**
-   * Create a new `Broadcast` vertex with the specified input type and attributes.
-   *
-   * @param attributes optional attributes for this vertex
-   */
-  def create[T](clazz: Class[T], outputCount: Int, attributes: OperationAttributes): Graph[UniformFanOutShape[T, T], Unit] =
-    create(outputCount, attributes)
 }
 
 /**
@@ -139,24 +95,18 @@ object Broadcast {
  */
 object Balance {
   /**
-   * Create a new `Balance` vertex with the specified input type and attributes.
+   * Create a new `Balance` vertex with the specified input type.
    *
    * @param waitForAllDownstreams if `true` it will not start emitting
    *   elements to downstream outputs until all of them have requested at least one element
-   * @param attributes optional attributes for this vertex
    */
-  def create[T](outputCount: Int, waitForAllDownstreams: Boolean, attributes: OperationAttributes): Graph[UniformFanOutShape[T, T], Unit] =
-    scaladsl.Balance(outputCount, waitForAllDownstreams, attributes)
+  def create[T](outputCount: Int, waitForAllDownstreams: Boolean): Graph[UniformFanOutShape[T, T], Unit] =
+    scaladsl.Balance(outputCount, waitForAllDownstreams)
 
   /**
    * Create a new `Balance` vertex with the specified input type.
    */
-  def create[T](outputCount: Int): Graph[UniformFanOutShape[T, T], Unit] = create(outputCount, false, OperationAttributes.none)
-
-  /**
-   * Create a new `Balance` vertex with the specified input type.
-   */
-  def create[T](outputCount: Int, attributes: OperationAttributes): Graph[UniformFanOutShape[T, T], Unit] = create(outputCount, false, attributes)
+  def create[T](outputCount: Int): Graph[UniformFanOutShape[T, T], Unit] = create(outputCount, false)
 
   /**
    * Create a new `Balance` vertex with the specified input type.
@@ -164,12 +114,13 @@ object Balance {
   def create[T](clazz: Class[T], outputCount: Int): Graph[UniformFanOutShape[T, T], Unit] = create(outputCount)
 
   /**
-   * Create a new `Balance` vertex with the specified input type and attributes.
+   * Create a new `Balance` vertex with the specified input type.
    *
-   * @param attributes optional attributes for this vertex
+   * @param waitForAllDownstreams if `true` it will not start emitting
+   *   elements to downstream outputs until all of them have requested at least one element
    */
-  def create[T](clazz: Class[T], outputCount: Int, attributes: OperationAttributes): Graph[UniformFanOutShape[T, T], Unit] =
-    create(outputCount, false, attributes)
+  def create[T](clazz: Class[T], outputCount: Int, waitForAllDownstreams: Boolean): Graph[UniformFanOutShape[T, T], Unit] =
+    create(outputCount, waitForAllDownstreams)
 }
 
 object Zip {
@@ -196,35 +147,20 @@ object Zip {
 object Unzip {
 
   /**
-   * Creates a new `Unzip` vertex with the specified output types and attributes.
-   *
-   * @param attributes attributes for this vertex
+   * Creates a new `Unzip` vertex with the specified output types.
    */
-  def create[A, B](attributes: OperationAttributes): Graph[FanOutShape2[A Pair B, A, B], Unit] =
+  def create[A, B](): Graph[FanOutShape2[A Pair B, A, B], Unit] =
     scaladsl.FlowGraph.partial() { implicit b ⇒
-      val unzip = b.add(scaladsl.Unzip[A, B](attributes))
+      val unzip = b.add(scaladsl.Unzip[A, B]())
       val tuple = b.add(scaladsl.Flow[A Pair B].map(p ⇒ (p.first, p.second)))
       b.addEdge(tuple.outlet, unzip.in)
       new FanOutShape2(FanOutShape.Ports(tuple.inlet, unzip.out0 :: unzip.out1 :: Nil))
     }
 
   /**
-   * Creates a new `Unzip` vertex with the specified output types and attributes.
-   */
-  def create[A, B](): Graph[FanOutShape2[A Pair B, A, B], Unit] = create(OperationAttributes.none)
-
-  /**
    * Creates a new `Unzip` vertex with the specified output types.
    */
   def create[A, B](left: Class[A], right: Class[B]): Graph[FanOutShape2[A Pair B, A, B], Unit] = create[A, B]()
-
-  /**
-   * Creates a new `Unzip` vertex with the specified output types and attributes.
-   *
-   * @param attributes optional attributes for this vertex
-   */
-  def create[A, B](left: Class[A], right: Class[B], attributes: OperationAttributes): Graph[FanOutShape2[A Pair B, A, B], Unit] =
-    create[A, B](attributes)
 
 }
 
@@ -245,7 +181,7 @@ object Concat {
    * in the `FlowGraph`. This method creates a new instance every time it
    * is called and those instances are not `equal`.
    */
-  def create[T](): Graph[UniformFanInShape[T, T], Unit] = create(OperationAttributes.none)
+  def create[T](): Graph[UniformFanInShape[T, T], Unit] = scaladsl.Concat[T]()
 
   /**
    * Create a new anonymous `Concat` vertex with the specified input types.
@@ -253,15 +189,7 @@ object Concat {
    * in the `FlowGraph`. This method creates a new instance every time it
    * is called and those instances are not `equal`.
    */
-  def create[T](attributes: OperationAttributes): Graph[UniformFanInShape[T, T], Unit] = scaladsl.Concat[T](attributes)
-
-  /**
-   * Create a new anonymous `Concat` vertex with the specified input types.
-   * Note that a `Concat` instance can only be used at one place (one vertex)
-   * in the `FlowGraph`. This method creates a new instance every time it
-   * is called and those instances are not `equal`.
-   */
-  def create[T](clazz: Class[T], attributes: OperationAttributes): Graph[UniformFanInShape[T, T], Unit] = create(attributes)
+  def create[T](clazz: Class[T]): Graph[UniformFanInShape[T, T], Unit] = create()
 
 }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -148,9 +148,9 @@ class Sink[-In, +Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkShape[
   def mapMaterialized[Mat2](f: japi.Function[Mat, Mat2]): Sink[In, Mat2] =
     new Sink(delegate.mapMaterialized(f.apply _))
 
-  def withAttributes(attr: OperationAttributes): javadsl.Sink[In, Mat] =
+  override def withAttributes(attr: OperationAttributes): javadsl.Sink[In, Mat] =
     new Sink(delegate.withAttributes(attr))
 
-  def named(name: String): javadsl.Sink[In, Mat] =
+  override def named(name: String): javadsl.Sink[In, Mat] =
     new Sink(delegate.named(name))
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -498,10 +498,10 @@ class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[Sour
   def flatten[U](strategy: FlattenStrategy[Out, U]): javadsl.Source[U, Mat] =
     new Source(delegate.flatten(strategy))
 
-  def withAttributes(attr: OperationAttributes): javadsl.Source[Out, Mat] =
+  override def withAttributes(attr: OperationAttributes): javadsl.Source[Out, Mat] =
     new Source(delegate.withAttributes(attr))
 
-  def named(name: String): javadsl.Source[Out, Mat] =
+  override def named(name: String): javadsl.Source[Out, Mat] =
     new Source(delegate.named(name))
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -7,6 +7,7 @@ import akka.stream.Graph
 import akka.stream.BidiShape
 import akka.stream.impl.StreamLayout.Module
 import akka.stream.FlowShape
+import akka.stream.OperationAttributes
 
 final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](private[stream] override val module: Module) extends Graph[BidiShape[I1, O1, I2, O2], Mat] {
   override val shape = module.shape.asInstanceOf[BidiShape[I1, O1, I2, O2]]
@@ -119,6 +120,12 @@ final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](private[stream] override val modu
     val outs = shape.outlets
     new BidiFlow(module.replaceShape(shape.copyFromPorts(ins.reverse, outs.reverse)))
   }
+
+  override def withAttributes(attr: OperationAttributes): BidiFlow[I1, O1, I2, O2, Mat] =
+    new BidiFlow(module.withAttributes(attr).wrap())
+
+  override def named(name: String): BidiFlow[I1, O1, I2, O2, Mat] =
+    withAttributes(OperationAttributes.name(name))
 }
 
 object BidiFlow extends BidiFlowApply {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiMerge.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiMerge.scala
@@ -9,6 +9,7 @@ import scala.collection.immutable
 import scala.collection.immutable.Seq
 import akka.stream.impl.StreamLayout
 import akka.stream.impl.Junctions.FlexiMergeModule
+import akka.stream.impl.Stages.DefaultAttributes
 
 object FlexiMerge {
 
@@ -223,7 +224,11 @@ object FlexiMerge {
  * @param attributes optional attributes for this junction
  */
 abstract class FlexiMerge[Out, S <: Shape](val shape: S, attributes: OperationAttributes) extends Graph[S, Unit] {
-  val module: StreamLayout.Module = new FlexiMergeModule(shape, createMergeLogic)
+  /**
+   * INTERNAL API
+   */
+  private[stream] val module: StreamLayout.Module =
+    new FlexiMergeModule(shape, createMergeLogic, attributes and DefaultAttributes.flexiMerge)
 
   type PortT = S
 
@@ -233,4 +238,10 @@ abstract class FlexiMerge[Out, S <: Shape](val shape: S, attributes: OperationAt
     case Some(n) ⇒ n
     case None    ⇒ super.toString
   }
+
+  override def withAttributes(attr: OperationAttributes): Graph[S, Unit] =
+    throw new UnsupportedOperationException(
+      "withAttributes not supported by default by FlexiMerge, subclass may override and implement it")
+
+  override def named(name: String): Graph[S, Unit] = withAttributes(OperationAttributes.name(name))
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiRoute.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlexiRoute.scala
@@ -7,6 +7,7 @@ import akka.stream.impl.StreamLayout
 import akka.stream.{ Outlet, Shape, OutPort, Graph, OperationAttributes }
 import scala.collection.immutable
 import akka.stream.impl.Junctions.FlexiRouteModule
+import akka.stream.impl.Stages.DefaultAttributes
 
 object FlexiRoute {
 
@@ -192,7 +193,11 @@ object FlexiRoute {
 abstract class FlexiRoute[In, S <: Shape](val shape: S, attributes: OperationAttributes) extends Graph[S, Unit] {
   import akka.stream.scaladsl.FlexiRoute._
 
-  val module: StreamLayout.Module = new FlexiRouteModule(shape, createRouteLogic)
+  /**
+   * INTERNAL API
+   */
+  private[stream] val module: StreamLayout.Module =
+    new FlexiRouteModule(shape, createRouteLogic, attributes and DefaultAttributes.flexiRoute)
 
   /**
    * This allows a type-safe mini-DSL for selecting one of several ports, very useful in
@@ -234,4 +239,11 @@ abstract class FlexiRoute[In, S <: Shape](val shape: S, attributes: OperationAtt
     case Some(n) ⇒ n
     case None    ⇒ super.toString
   }
+
+  // FIXME what to do about this?
+  override def withAttributes(attr: OperationAttributes): Graph[S, Unit] =
+    throw new UnsupportedOperationException(
+      "withAttributes not supported by default by FlexiRoute, subclass may override and implement it")
+
+  override def named(name: String): Graph[S, Unit] = withAttributes(OperationAttributes.name(name))
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -268,6 +268,8 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
     else new Flow(module.withAttributes(attr).wrap())
   }
 
+  override def named(name: String): Repr[Out, Mat] = withAttributes(OperationAttributes.name(name))
+
   /**
    * Connect the `Source` to this `Flow` and then connect it to the `Sink` and run it. The returned tuple contains
    * the materialized values of the `Source` and `Sink`, e.g. the `Subscriber` of a of a [[Source#subscriber]] and
@@ -317,6 +319,12 @@ case class RunnableFlow[+Mat](private[stream] val module: StreamLayout.Module) e
    * Run this flow and return the materialized instance from the flow.
    */
   def run()(implicit materializer: FlowMaterializer): Mat = materializer.materialize(this)
+
+  override def withAttributes(attr: OperationAttributes): RunnableFlow[Mat] =
+    new RunnableFlow(module.withAttributes(attr).wrap)
+
+  override def named(name: String): RunnableFlow[Mat] = withAttributes(OperationAttributes.name(name))
+
 }
 
 /**
@@ -658,8 +666,6 @@ trait FlowOps[+Out, +Mat] {
     andThen(TimerTransform(mkStage.asInstanceOf[() ⇒ TimerTransformer[Any, Any]]))
 
   def withAttributes(attr: OperationAttributes): Repr[Out, Mat]
-
-  def named(name: String): Repr[Out, Mat] = withAttributes(OperationAttributes.name(name))
 
   /** INTERNAL API */
   private[scaladsl] def andThen[U](op: StageModule): Repr[U, Mat]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -38,10 +38,10 @@ final class Sink[-In, +Mat](private[stream] override val module: Module)
   def mapMaterialized[Mat2](f: Mat ⇒ Mat2): Sink[In, Mat2] =
     new Sink(module.transformMaterializedValue(f.asInstanceOf[Any ⇒ Any]))
 
-  def withAttributes(attr: OperationAttributes): Sink[In, Mat] =
+  override def withAttributes(attr: OperationAttributes): Sink[In, Mat] =
     new Sink(module.withAttributes(attr).wrap())
 
-  def named(name: String): Sink[In, Mat] = withAttributes(OperationAttributes.name(name))
+  override def named(name: String): Sink[In, Mat] = withAttributes(OperationAttributes.name(name))
 
   /** Converts this Scala DSL element to it's Java DSL counterpart. */
   def asJava: javadsl.Sink[In, Mat] = new javadsl.Sink(this)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -148,6 +148,8 @@ final class Source[+Out, +Mat](private[stream] override val module: Module)
   override def withAttributes(attr: OperationAttributes): Repr[Out, Mat] =
     new Source(module.withAttributes(attr).wrap())
 
+  override def named(name: String): Repr[Out, Mat] = withAttributes(OperationAttributes.name(name))
+
   /** Converts this Scala DSL element to it's Java DSL counterpart. */
   def asJava: javadsl.Source[Out, Mat] = new javadsl.Source(this)
 


### PR DESCRIPTION
- Remove optional attributes parameter in favor of withAttributes
- Overload explosion when trying to add attributes to ZipWith.
- Aligned with Flow and Source.

This is a rather intrusive change, but I think it is necessary.
Not sure what to do with FlexiMerge and FlexiRoute yet.

Note that the usage of scaladsl.OperationAttributes in javadsl will be eliminated when OperationAttributes are unified in the other PR for #16951 that I have not yet submitted.
