### PR TITLE
=act #17206 properly document semantics of context.stop(self)

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -333,6 +333,10 @@ trait ActorRefFactory {
   /**
    * Stop the actor pointed to by the given [[akka.actor.ActorRef]]; this is
    * an asynchronous operation, i.e. involves a message send.
+   * If this method is applied to the `self` reference from inside an Actor
+   * then that Actor is guaranteed to not process any further messages after
+   * this call; please note that the processing of the current message will
+   * continue, this method does not immediately terminate this actor.
    */
   def stop(actor: ActorRef): Unit
 }


### PR DESCRIPTION
backport for #17206 
