### PR TITLE
=act #17216 fix DirectByteBufferPoll locking

### DIFF
--- a/akka-actor/src/main/scala/akka/io/DirectByteBufferPool.scala
+++ b/akka-actor/src/main/scala/akka/io/DirectByteBufferPool.scala
@@ -4,9 +4,9 @@
 
 package akka.io
 
-import java.util.concurrent.atomic.AtomicBoolean
 import java.nio.ByteBuffer
-import annotation.tailrec
+import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.TimeUnit
 
 trait BufferPool {
   def acquire(): ByteBuffer
@@ -23,9 +23,9 @@ trait BufferPool {
  * being freed by normal garbage collection.
  */
 private[akka] class DirectByteBufferPool(defaultBufferSize: Int, maxPoolEntries: Int) extends BufferPool {
-  private[this] val locked = new AtomicBoolean(false)
-  private[this] val pool: Array[ByteBuffer] = new Array[ByteBuffer](maxPoolEntries)
-  private[this] var buffersInPool: Int = 0
+  private[this] val lock = new ReentrantLock
+  private[this] val pool = new Array[ByteBuffer](maxPoolEntries)
+  private[this] var buffersInPool = 0
 
   def acquire(): ByteBuffer =
     takeBufferFromPool()
@@ -36,32 +36,32 @@ private[akka] class DirectByteBufferPool(defaultBufferSize: Int, maxPoolEntries:
   private def allocate(size: Int): ByteBuffer =
     ByteBuffer.allocateDirect(size)
 
-  @tailrec
-  private final def takeBufferFromPool(): ByteBuffer =
-    if (locked.compareAndSet(false, true)) {
-      val buffer =
-        try if (buffersInPool > 0) {
+  private final def takeBufferFromPool(): ByteBuffer = {
+    var buffer: ByteBuffer = null
+
+    if (lock.tryLock(1, TimeUnit.MILLISECONDS))
+      try
+        if (buffersInPool > 0) {
           buffersInPool -= 1
-          pool(buffersInPool)
-        } else null
-        finally locked.set(false)
+          buffer = pool(buffersInPool)
+        }
+      finally lock.unlock()
 
-      // allocate new and clear outside the lock
-      if (buffer == null)
-        allocate(defaultBufferSize)
-      else {
-        buffer.clear()
-        buffer
-      }
-    } else takeBufferFromPool() // spin while locked
+    // allocate new and clear outside the lock
+    if (buffer == null)
+      allocate(defaultBufferSize)
+    else {
+      buffer.clear()
+      buffer
+    }
+  }
 
-  @tailrec
   private final def offerBufferToPool(buf: ByteBuffer): Unit =
-    if (locked.compareAndSet(false, true))
-      try if (buffersInPool < maxPoolEntries) {
-        pool(buffersInPool) = buf
-        buffersInPool += 1
-      } // else let the buffer be gc'd
-      finally locked.set(false)
-    else offerBufferToPool(buf) // spin while locked
+    if (lock.tryLock(1, TimeUnit.MILLISECONDS))
+      try
+        if (buffersInPool < maxPoolEntries) {
+          pool(buffersInPool) = buf
+          buffersInPool += 1
+        } // else let the buffer be gc'd
+      finally lock.unlock()
 }


### PR DESCRIPTION
instead of spinning unboundedly use ReentrantLock.tryLock—it is a best
effort pool anyway and contention shall not lock the whole application

fixes #17216
