### PR TITLE
= #17240 Use some more DeadLetterSuppression (for validation)

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -28,7 +28,7 @@ trait PossiblyHarmful
  */
 trait NoSerializationVerificationNeeded
 
-abstract class PoisonPill extends AutoReceivedMessage with PossiblyHarmful
+abstract class PoisonPill extends AutoReceivedMessage with PossiblyHarmful with DeadLetterSuppression
 
 /**
  * A message all Actors will understand, that when processed will terminate the Actor permanently.
@@ -95,7 +95,8 @@ final case class ActorIdentity(correlationId: Any, ref: Option[ActorRef]) {
 @SerialVersionUID(1L)
 final case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
   @BeanProperty val existenceConfirmed: Boolean,
-  @BeanProperty val addressTerminated: Boolean) extends AutoReceivedMessage with PossiblyHarmful
+  @BeanProperty val addressTerminated: Boolean)
+  extends AutoReceivedMessage with PossiblyHarmful with DeadLetterSuppression
 
 /**
  * INTERNAL API
@@ -107,7 +108,8 @@ final case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
  * and translates this event to [[akka.actor.Terminated]], which is sent itself.
  */
 @SerialVersionUID(1L)
-private[akka] final case class AddressTerminated(address: Address) extends AutoReceivedMessage with PossiblyHarmful
+private[akka] final case class AddressTerminated(address: Address)
+  extends AutoReceivedMessage with PossiblyHarmful with DeadLetterSuppression
 
 abstract class ReceiveTimeout extends PossiblyHarmful
 

--- a/akka-actor/src/main/scala/akka/dispatch/sysmsg/SystemMessage.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/sysmsg/SystemMessage.scala
@@ -5,6 +5,7 @@ package akka.dispatch.sysmsg
 
 import scala.annotation.tailrec
 import akka.actor.{ ActorInitializationException, InternalActorRef, ActorRef, PossiblyHarmful }
+import akka.actor.DeadLetterSuppression
 
 /**
  * INTERNAL API
@@ -227,7 +228,8 @@ private[akka] final case class Resume(causedByFailure: Throwable) extends System
  * INTERNAL API
  */
 @SerialVersionUID(1L)
-private[akka] final case class Terminate() extends SystemMessage // sent to self from ActorCell.stop
+private[akka] final case class Terminate() extends SystemMessage with DeadLetterSuppression // sent to self from ActorCell.stop
+
 /**
  * INTERNAL API
  */
@@ -261,4 +263,4 @@ private[akka] final case class Failed(child: ActorRef, cause: Throwable, uid: In
 private[akka] final case class DeathWatchNotification(
   actor: ActorRef,
   existenceConfirmed: Boolean,
-  addressTerminated: Boolean) extends SystemMessage
+  addressTerminated: Boolean) extends SystemMessage with DeadLetterSuppression

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -457,7 +457,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * This is the common interface for all events which indicate that a connection
    * has been closed or half-closed.
    */
-  sealed trait ConnectionClosed extends Event {
+  sealed trait ConnectionClosed extends Event with DeadLetterSuppression {
     /**
      * `true` iff the connection has been closed in response to an [[Abort]] command.
      */

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -12,6 +12,7 @@ import akka.cluster.ClusterEvent._
 import akka.routing.MurmurHash
 import akka.remote.FailureDetectorRegistry
 import akka.remote.PriorityMessage
+import akka.actor.DeadLetterSuppression
 
 /**
  * INTERNAL API.
@@ -36,12 +37,12 @@ private[cluster] object ClusterHeartbeatSender {
   /**
    * Sent at regular intervals for failure detection.
    */
-  final case class Heartbeat(from: Address) extends ClusterMessage with PriorityMessage
+  final case class Heartbeat(from: Address) extends ClusterMessage with PriorityMessage with DeadLetterSuppression
 
   /**
    * Sent as reply to [[Heartbeat]] messages.
    */
-  final case class HeartbeatRsp(from: UniqueAddress) extends ClusterMessage with PriorityMessage
+  final case class HeartbeatRsp(from: UniqueAddress) extends ClusterMessage with PriorityMessage with DeadLetterSuppression
 
   // sent to self only
   case object HeartbeatTick

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -26,6 +26,7 @@ import akka.ConfigurationException
 import akka.AkkaException
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.actor.Deploy
+import akka.actor.DeadLetterSuppression
 
 /**
  * The conductor is the one orchestrating the test: it governs the
@@ -367,7 +368,7 @@ private[akka] class ServerFSM(val controller: ActorRef, val channel: Channel) ex
  * INTERNAL API.
  */
 private[akka] object Controller {
-  final case class ClientDisconnected(name: RoleName)
+  final case class ClientDisconnected(name: RoleName) extends DeadLetterSuppression
   class ClientDisconnectedException(msg: String) extends AkkaException(msg) with NoStackTrace
   case object GetNodes
   case object GetSockAddr

--- a/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
@@ -14,6 +14,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Promise, Future }
 import akka.dispatch.{ UnboundedMessageQueueSemantics, RequiresMessageQueue }
 import akka.remote.transport.AssociationHandle.DisassociateInfo
+import akka.actor.DeadLetterSuppression
 
 trait TransportAdapterProvider {
   /**
@@ -128,7 +129,8 @@ object ActorTransportAdapter {
   final case class AssociateUnderlying(remoteAddress: Address, statusPromise: Promise[AssociationHandle]) extends TransportOperation
   final case class ListenUnderlying(listenAddress: Address,
                                     upstreamListener: Future[AssociationEventListener]) extends TransportOperation
-  final case class DisassociateUnderlying(info: DisassociateInfo = AssociationHandle.Unknown) extends TransportOperation
+  final case class DisassociateUnderlying(info: DisassociateInfo = AssociationHandle.Unknown)
+    extends TransportOperation with DeadLetterSuppression
 
   implicit val AskTimeout = Timeout(5.seconds)
 }

--- a/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
@@ -9,6 +9,7 @@ import akka.util.ByteString
 import akka.remote.transport.AssociationHandle.HandleEventListener
 import akka.AkkaException
 import scala.util.control.NoStackTrace
+import akka.actor.DeadLetterSuppression
 
 object Transport {
 
@@ -170,7 +171,7 @@ object AssociationHandle {
    * @param info
    *   information about the reason of disassociation
    */
-  final case class Disassociated(info: DisassociateInfo) extends HandleEvent
+  final case class Disassociated(info: DisassociateInfo) extends HandleEvent with DeadLetterSuppression
 
   /**
    * Supertype of possible disassociation reasons


### PR DESCRIPTION
- sysmsg.Terminate, sysmsg.DeathWatchNotification, io.Tcp.Closed
  were needed to silence normal usage of http client/server
- other things based on jenkins logs, but not a complete audit

(cherry picked from commit 270e3b2f49af3c34fd5ea4c3bcfd8257402b5cbe)
