### PR TITLE
+str #15588 Additional way of using IO sink/source

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
@@ -146,7 +146,7 @@ abstract class ActorFlowMaterializer extends FlowMaterializer {
   def effectiveSettings(opAttr: OperationAttributes): ActorFlowMaterializerSettings
 
   /** INTERNAL API */
-  def system: ActorSystem
+  private[akka] def system: ActorSystem
 
   /**
    * INTERNAL API: this might become public later

--- a/akka-stream/src/main/scala/akka/stream/io/Implicits.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/Implicits.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.io
+
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+
+import scala.language.implicitConversions
+
+/**
+ * Provides implicit conversions such that sources and sinks contained within `akka.stream.io`
+ * as if they were defined on [[Source]] or [[Sink]] directly.
+ *
+ * Example:
+ * {{{
+ *   import akka.stream.scaladsl.Source
+ *   import akka.stream.io._
+ *
+ *   // explicitly using IO Source:
+ *   SynchronousFileSource(file).map(...)
+ *
+ *   // using implicit conversion:
+ *   import akka.stream.io.Implicits._
+ *   Source.synchronousFile(file).map(...)
+ * }}}
+ */
+object Implicits {
+
+  // ---- Sources ----
+
+  implicit final class AddSynchronousFileSource(val s: Source.type) extends AnyVal {
+    def synchronousFile: SynchronousFileSource.type = SynchronousFileSource
+  }
+
+  implicit final class AddInputStreamSource(val s: Source.type) extends AnyVal {
+    def inputStream: InputStreamSource.type = InputStreamSource
+  }
+
+  // ---- Sinks ----
+
+  implicit final class AddSynchronousFileSink(val s: Sink.type) extends AnyVal {
+    def synchronousFile: SynchronousFileSink.type = SynchronousFileSink
+  }
+
+  implicit final class AddOutputStreamSink(val s: Sink.type) extends AnyVal {
+    def outputStream: OutputStreamSink.type = OutputStreamSink
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/io/impl/InputStreamPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/impl/InputStreamPublisher.scala
@@ -48,7 +48,7 @@ private[akka] class InputStreamPublisher(is: InputStream, bytesReadPromise: Prom
       readAndSignal(initialBuffer)
     } catch {
       case ex: Exception ⇒
-        onError(ex)
+        onErrorThenStop(ex)
     }
 
     super.preStart()
@@ -83,7 +83,7 @@ private[akka] class InputStreamPublisher(is: InputStream, bytesReadPromise: Prom
 
         if (totalDemand > 0) signalOnNexts()
       }
-    } else if (eofEncountered) onComplete()
+    } else if (eofEncountered) onCompleteThenStop()
 
   /** BLOCKING I/O READ */
   def loadChunk() = try {
@@ -107,7 +107,7 @@ private[akka] class InputStreamPublisher(is: InputStream, bytesReadPromise: Prom
     }
   } catch {
     case ex: Exception ⇒
-      onError(ex)
+      onErrorThenStop(ex)
   }
 
   private final def eofEncountered: Boolean = eofReachedAtOffset != Long.MinValue

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -6,9 +6,12 @@ package akka.stream.scaladsl
 import akka.stream.javadsl
 import akka.actor.{ ActorRef, Props }
 import akka.stream._
+import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl.StreamLayout.Module
 import akka.stream.impl._
 import akka.stream.impl.Stages.DefaultAttributes
+import akka.stream.stage.Context
+import akka.stream.stage.PushStage
 import akka.stream.stage.SyncDirective
 import akka.stream.{ SinkShape, Inlet, Outlet, Graph, OperationAttributes }
 import akka.stream.OperationAttributes._
@@ -47,8 +50,6 @@ final class Sink[-In, +Mat](private[stream] override val module: Module)
 }
 
 object Sink extends SinkApply {
-
-  import OperationAttributes.none
 
   /** INTERNAL API */
   private[stream] def shape[T](name: String): SinkShape[T] = SinkShape(new Inlet(name + ".in"))


### PR DESCRIPTION
I personally very much like this style of importing more capabilities, but may be subject to fierce debate so made it a separate PR (depends on https://github.com/akka/akka/pull/17211) :wink: 

See only this commit in this PR: https://github.com/akka/akka/commit/1cfe2250a0a5c3569d0987cd0a1652e3e2e530a5

Note: we already have this style (but for ops) in `akka.stream.extra` (which currently just is the `timed` thingy) ( https://github.com/akka/akka/blob/release-2.3-dev/akka-stream/src/main/scala/akka/stream/extra/Implicits.scala )
