### PR TITLE
refactor SslTlsActor and stop it reliably

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
@@ -92,7 +92,7 @@ private[akka] case class ActorFlowMaterializerImpl(
 
           case tls: TlsModule ⇒
             val es = effectiveSettings(effectiveAttributes)
-            val props = SslTlsCipherActor.props(es, tls.sslContext, tls.firstSession, tracing = true, tls.role, tls.closing)
+            val props = SslTlsCipherActor.props(es, tls.sslContext, tls.firstSession, tracing = false, tls.role, tls.closing)
             val impl = actorOf(props, stageName(effectiveAttributes), es.dispatcher)
             def factory(id: Int) = new ActorPublisher[Any](impl) {
               override val wakeUpMsg = FanOut.SubstreamSubscribePending(id)

--- a/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
@@ -186,7 +186,7 @@ private[akka] object FanIn {
     }
 
     def inputsAvailableFor(id: Int) = new TransferState {
-      override def isCompleted: Boolean = depleted(id)
+      override def isCompleted: Boolean = depleted(id) || cancelled(id)
       override def isReady: Boolean = pending(id)
     }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/FanOut.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanOut.scala
@@ -69,6 +69,8 @@ private[akka] object FanOut {
 
     def isCancelled(output: Int): Boolean = cancelled(output)
 
+    def isErrored(output: Int): Boolean = errored(output)
+
     def complete(): Unit =
       if (!bunchCancelled) {
         bunchCancelled = true
@@ -187,7 +189,7 @@ private[akka] object FanOut {
     def onCancel(output: Int): Unit = ()
 
     def demandAvailableFor(id: Int) = new TransferState {
-      override def isCompleted: Boolean = cancelled(id) || completed(id)
+      override def isCompleted: Boolean = cancelled(id) || completed(id) || errored(id)
       override def isReady: Boolean = pending(id)
     }
 


### PR DESCRIPTION
- this also discovered two omissions in the Transfer infrastructure:
  - inputsAvailableFor should be completed when the input is cancelled
  - demandAvailableFor should be completed when the output is errored
