### PR TITLE
=str more robust dispatcher checking in FileSource specs

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -8,9 +8,9 @@ import akka.actor.ActorSystem
 import akka.actor.DeadLetterSuppression
 import akka.stream._
 import akka.stream.impl._
+import akka.testkit.TestProbe
 import akka.stream.impl.StreamLayout.Module
 import akka.stream.scaladsl._
-import akka.testkit.TestProbe
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import scala.collection.immutable
 import scala.concurrent.duration._

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSink.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSink.scala
@@ -3,13 +3,11 @@
  */
 package akka.stream.testkit.scaladsl
 
-import akka.stream._
-import akka.stream.impl._
+import akka.actor.ActorSystem
 import akka.stream.OperationAttributes.none
+import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit._
-
-import akka.actor.ActorSystem;
 
 /**
  * Factory methods for test sinks.

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
@@ -1,6 +1,7 @@
 package akka.stream.testkit
 
 import akka.actor.ActorRef
+import akka.actor.ActorRefWithCell
 import akka.stream.FlowMaterializer
 import akka.stream.impl._
 import akka.testkit.TestProbe
@@ -33,4 +34,11 @@ object Utils {
       case _ ⇒ block
     }
 
+  def assertDispatcher(ref: ActorRef, dispatcher: String): Unit = ref match {
+    case r: ActorRefWithCell ⇒
+      if (r.underlying.props.dispatcher != dispatcher)
+        throw new AssertionError(s"Expected $ref to use dispatcher [$dispatcher], yet used: [${r.underlying.props.dispatcher}]")
+    case _ ⇒
+      throw new Exception(s"Unable to determine dispatcher of $ref")
+  }
 }

--- a/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSource.scala
@@ -29,6 +29,7 @@ object SynchronousFileSource {
    */
   def apply(f: File, chunkSize: Int = DefaultChunkSize): Source[ByteString, Future[Long]] =
     new Source(new SynchronousFileSource(f, chunkSize, DefaultAttributes, Source.shape("SynchronousFileSource")))
+      .named(DefaultAttributes.nameOption.get)
 
   /**
    * Creates a synchronous (Java 6 compatible) Source from a Files contents.


### PR DESCRIPTION
More stable way to test for proper dispatcher being used in tests introduced in https://github.com/akka/akka/pull/17211
