### PR TITLE
StreamLayout debug mode

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -18,8 +18,10 @@ import akka.event.Logging.simpleName
  */
 private[akka] object StreamLayout {
 
-  // compile-time constant
-  final val Debug = true
+  // Turn this on to add run-time checks about Stream consistency during
+  // stream operations.
+  // (compile-time constant)
+  final val Debug = false
 
   // TODO: Materialization order
   // TODO: Special case linear composites


### PR DESCRIPTION
Is this "debug" val on intentionally?

I know you haven't officially addressed HTTP performance yet, but we have been doing some perf profiling of our Akka HTTP based app, and the "validate()" calls behind this "debug" flag are very expensive at runtime.

I can't find any warnings from the validate() calls in our logs, so it seems like this isn't needed at runtime.

Unless I'm missing something, this should be safe to turn off now.
