### PR TITLE
=htc #17348 don't render extra LastChunk at the and of Chunked entity

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -286,7 +286,27 @@ class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll
       "with one chunk and an explicit LastChunk" in new TestSetup() {
         HttpResponse(entity = Chunked(ContentTypes.`text/plain(UTF-8)`,
           source(Chunk(ByteString("body123"), """key=value;another="tl;dr""""),
-            LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public")))))) should renderTo {
+            LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public")))).via(printEvent("source")))) should renderTo {
+          """HTTP/1.1 200 OK
+            |Server: akka-http/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Transfer-Encoding: chunked
+            |Content-Type: text/plain; charset=UTF-8
+            |
+            |7;key=value;another="tl;dr"
+            |body123
+            |0;foo=bar
+            |Age: 30
+            |Cache-Control: public
+            |
+            |"""
+        }
+      }
+
+      "with one chunk and and extra LastChunks at the end (which should be ignored)" in new TestSetup() {
+        HttpResponse(entity = Chunked(ContentTypes.`text/plain(UTF-8)`,
+          source(Chunk(ByteString("body123"), """key=value;another="tl;dr""""),
+            LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public"))), LastChunk))) should renderTo {
           """HTTP/1.1 200 OK
             |Server: akka-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -98,6 +98,10 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
         Chunked(tpe, source(Chunk(abc), Chunk(fgh), Chunk(ijk), LastChunk)) must
           transformTo(Strict(tpe, doubleChars("abcfghijk") ++ trailer))
       }
+      "Chunked with extra LastChunk" in {
+        Chunked(tpe, source(Chunk(abc), Chunk(fgh), Chunk(ijk), LastChunk, LastChunk)) must
+          transformTo(Strict(tpe, doubleChars("abcfghijk") ++ trailer))
+      }
     }
   }
 


### PR DESCRIPTION
Tests will fail until #17351 is fixed. So, this can be reviewed but must be rebased on top of the streams fix.

Fixes #17348.

/cc @sirthias 
