### PR TITLE
Fix caching of HTTP Date header

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -37,18 +37,19 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
 
   private def dateHeader: Array[Byte] = {
     var (cachedSeconds, cachedBytes) = cachedDateHeader
-    val now = System.currentTimeMillis
-    if (now - 1000 > cachedSeconds) {
+    val now = currentTimeMillis()
+    if (now / 1000 > cachedSeconds) {
       cachedSeconds = now / 1000
       val r = new ByteArrayRendering(48)
-      dateTime(now).renderRfc1123DateTimeString(r ~~ headers.Date) ~~ CrLf
+      DateTime(now).renderRfc1123DateTimeString(r ~~ headers.Date) ~~ CrLf
       cachedBytes = r.get
       cachedDateHeader = cachedSeconds -> cachedBytes
     }
     cachedBytes
   }
 
-  protected def dateTime(now: Long) = DateTime(now) // split out so we can stabilize by overriding in tests
+  // split out so we can stabilize by overriding in tests
+  protected def currentTimeMillis(): Long = System.currentTimeMillis()
 
   def newRenderer: HttpResponseRenderer = new HttpResponseRenderer
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -74,6 +74,23 @@ class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll
             |"""
         }
       }
+      "a custom status code and no headers and different dates" in new TestSetup() {
+        val initial = DateTime(2011, 8, 25, 9, 10, 0).clicks
+        var extraMillis = 0L
+        (0 until 10000 by 500) foreach { millis ⇒
+          extraMillis = millis
+          HttpResponse(200) should renderTo {
+            s"""HTTP/1.1 200 OK
+              |Server: akka-http/1.0.0
+              |Date: Thu, 25 Aug 2011 09:10:0${extraMillis / 1000 % 60} GMT
+              |Content-Length: 0
+              |
+              |"""
+          }
+        }
+
+        override def currentTimeMillis() = initial + extraMillis
+      }
 
       "to a transparent HEAD request (Strict response entity)" in new TestSetup() {
         ResponseRenderingContext(
@@ -559,7 +576,7 @@ class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll
         Await.result(future, 250.millis) -> renderer.isComplete
       }
 
-    override def dateTime(now: Long) = DateTime(2011, 8, 25, 9, 10, 29) // provide a stable date for testing
+    override def currentTimeMillis() = DateTime(2011, 8, 25, 9, 10, 29).clicks // provide a stable date for testing
   }
 
   def source[T](elems: T*) = Source(elems.toList)


### PR DESCRIPTION
I noticed that the code to cache the HTTP date header in the `HttpResponseRenderer` is comparing milliseconds to seconds in `now - 1000 > cachedSeconds`. That would mean it updates the cached value every time the method is called. Also the method of overriding the date in tests only overrides the generated date string, not the date used for caching.
