### PR TITLE
=str #17351: Fix pushAndFinish improper stage termination

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
@@ -92,6 +92,11 @@ trait InterpreterSpecKit extends AkkaSpec {
 
       def onNext(elem: Any): Unit = enterAndPush(elem)
       def onComplete(): Unit = enterAndFinish()
+      def onNextAndComplete(elem: Any): Unit = {
+        context.enter()
+        context.pushAndFinish(elem)
+        context.execute()
+      }
       def onError(cause: Throwable): Unit = enterAndFail(cause)
 
     }


### PR DESCRIPTION
The call to pushAndFinish did not properly finish the op that it was called upon, therefore not preventing an onPull from dowstream stages that came from the forked execution of pushAndFinish: first a push, then a finish is executed, but onPull could arrive first.

This fix adds a new PushFinished op type, that has the only difference from Finished that it propagates onUpstreamFinish. This is to ensure that the forked onUpstreamFinish from the original stage still take effect. 
