### PR TITLE
=str #17308: Don't do blocking prefetch before subscription in fileSource

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/io/impl/SynchronousFilePublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/impl/SynchronousFilePublisher.scala
@@ -47,7 +47,6 @@ private[akka] class SynchronousFilePublisher(f: File, bytesReadPromise: Promise[
     try {
       raf = new RandomAccessFile(f, "r") // best way to express this in JDK6, OpenOption are available since JDK7
       chan = raf.getChannel
-      readAndSignal(initialBuffer)
     } catch {
       case ex: Exception ⇒
         onErrorThenStop(ex)


### PR DESCRIPTION
Actually I did not change the timeouts, but avoided the blocking call on the actor that happens before subscribing. If this does not make the timeouts go away, we can increase them later.
