### PR TITLE
Bearer Token Authentication

### DIFF
--- a/akka-http-java/src/main/scala/akka/http/impl/server/RouteStructure.scala
+++ b/akka-http-java/src/main/scala/akka/http/impl/server/RouteStructure.scala
@@ -36,6 +36,7 @@ private[http] object RouteStructure {
   case class RawPathPrefix(pathElements: immutable.Seq[PathMatcher[_]], children: immutable.Seq[Route]) extends DirectiveRoute
   case class Extract(extractions: Seq[StandaloneExtractionImpl[_]], children: immutable.Seq[Route]) extends DirectiveRoute
   case class BasicAuthentication(authenticator: HttpBasicAuthenticator[_], children: immutable.Seq[Route]) extends DirectiveRoute
+  case class BearerAuthentication(authenticator: BearerTokenAuthenticator[_], children: immutable.Seq[Route]) extends DirectiveRoute
   case class EncodeResponse(coders: immutable.Seq[Coder], children: immutable.Seq[Route]) extends DirectiveRoute
 
   case class Conditional(entityTag: EntityTag, lastModified: DateTime, children: immutable.Seq[Route]) extends DirectiveRoute

--- a/akka-http-java/src/main/scala/akka/http/javadsl/server/BearerTokenAuthenticator.scala
+++ b/akka-http-java/src/main/scala/akka/http/javadsl/server/BearerTokenAuthenticator.scala
@@ -15,7 +15,7 @@ import reflect.ClassTag
 /**
  * Represents existing or missing HTTP Basic authentication credentials.
  */
-trait BasicUserCredentials {
+trait BearerTokenCredentials {
   /**
    * Were credentials provided in the request?
    */
@@ -24,7 +24,7 @@ trait BasicUserCredentials {
   /**
    * The username as sent in the request.
    */
-  def userName: String
+  def token: String
   /**
    * Verifies the given secret against the one sent in the request.
    */
@@ -36,9 +36,9 @@ trait BasicUserCredentials {
  * to check if the supplied or missing credentials are authenticated and provide a domain level object representing
  * the user as a [[RequestVal]].
  */
-abstract class HttpBasicAuthenticator[T](val realm: String) extends AbstractDirective with ExtractionImplBase[T] with RequestVal[T] {
+abstract class BearerTokenAuthenticator[T](val realm: String) extends AbstractDirective with ExtractionImplBase[T] with RequestVal[T] {
   protected[http] implicit def classTag: ClassTag[T] = reflect.classTag[AnyRef].asInstanceOf[ClassTag[T]]
-  def authenticate(credentials: BasicUserCredentials): Future[Option[T]]
+  def authenticate(credentials: BearerTokenCredentials): Future[Option[T]]
 
   /**
    * Creates a return value for use in [[authenticate]] that successfully authenticates the requests and provides
@@ -55,5 +55,5 @@ abstract class HttpBasicAuthenticator[T](val realm: String) extends AbstractDire
    * INTERNAL API
    */
   protected[http] final def createRoute(first: Route, others: Array[Route]): Route =
-    RouteStructure.BasicAuthentication(this, (first +: others).toVector)
+    RouteStructure.BearerAuthentication(this, (first +: others).toVector)
 }

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/AuthenticationDirectives.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/AuthenticationDirectives.scala
@@ -28,11 +28,11 @@ trait AuthenticationDirectives {
   type AuthenticationResult[+T] = Either[HttpChallenge, T]
 
   /**
-   * Given [[UserCredentials]] the HttpBasicAuthenticator
+   * Given [[Credentials]] the HttpBasicAuthenticator
    * returns a Future of either the authenticated user object or None of the user
    * couldn't be authenticated.
    */
-  type HttpBasicAuthenticator[T] = UserCredentials ⇒ Future[Option[T]]
+  type HttpBasicAuthenticator[T] = Credentials ⇒ Future[Option[T]]
 
   object HttpBasicAuthentication {
     def challengeFor(realm: String) = HttpChallenge(scheme = "Basic", realm = realm, params = Map.empty)
@@ -52,15 +52,51 @@ trait AuthenticationDirectives {
         }
       }
 
-    private def authDataFor(cred: Option[BasicHttpCredentials]): UserCredentials =
+    private def authDataFor(cred: Option[BasicHttpCredentials]): Credentials =
       cred match {
         case Some(BasicHttpCredentials(username, receivedSecret)) ⇒
-          new UserCredentials.Provided(username) {
-            def verifySecret(secret: String): Boolean = secret secure_== receivedSecret
+          new Credentials.Provided(username) {
+            def verify(secret: String): Boolean = secret secure_== receivedSecret
           }
-        case None ⇒ UserCredentials.Missing
+        case None ⇒ Credentials.Missing
       }
   }
+
+  /**
+   * Given [[Credentials]] the BearerTokenAuthenticator
+   * returns a Future of either the authenticated user object or None of the user
+   * couldn't be authenticated.
+   */
+  type BearerTokenAuthenticator[T] = Credentials ⇒ Future[Option[T]]
+
+  object BearerTokenAuthentication {
+    def challengeFor(realm: String) = HttpChallenge(scheme = "Bearer", realm = realm, params = Map.empty)
+
+    /**
+     * A directive that wraps the inner route with Bearer token authentication support. The given authenticator
+     * is used to determine if the credentials in the request are valid and which user object to supply
+     * to the inner route.
+     */
+    def apply[T](realm: String)(authenticator: BearerTokenAuthenticator[T]): AuthenticationDirective[T] =
+      extractExecutionContext.flatMap { implicit ctx ⇒
+        authenticateOrRejectWithChallenge[OAuth2BearerToken, T] { basic ⇒
+          authenticator(authDataFor(basic)).fast.map {
+            case Some(t) ⇒ AuthenticationResult.success(t)
+            case None    ⇒ AuthenticationResult.failWithChallenge(challengeFor(realm))
+          }
+        }
+      }
+
+    private def authDataFor(cred: Option[OAuth2BearerToken]): Credentials =
+      cred match {
+        case Some(OAuth2BearerToken(token)) ⇒
+          new Credentials.Provided(token) {
+            def verify(secret: String): Boolean = secret secure_== token
+          }
+        case None ⇒ Credentials.Missing
+      }
+  }
+
 }
 
 object AuthenticationDirectives extends AuthenticationDirectives {
@@ -71,14 +107,14 @@ object AuthenticationDirectives extends AuthenticationDirectives {
 
   /**
    * Represents authentication credentials supplied with a request. Credentials can either be
-   * [[UserCredentials.Missing]] or can be [[UserCredentials.Provided]] in which case a username is
+   * [[Credentials.Missing]] or can be [[Credentials.Provided]] in which case an identifier is
    * supplied and a function to check the known secret against the provided one in a secure fashion.
    */
-  sealed trait UserCredentials
-  object UserCredentials {
-    case object Missing extends UserCredentials
-    abstract case class Provided(username: String) extends UserCredentials {
-      def verifySecret(secret: String): Boolean
+  sealed trait Credentials
+  object Credentials {
+    case object Missing extends Credentials
+    abstract case class Provided(identifier: String) extends Credentials {
+      def verify(secret: String): Boolean
     }
   }
 
@@ -88,22 +124,40 @@ object AuthenticationDirectives extends AuthenticationDirectives {
   }
 
   object HttpBasicAuthenticator {
-    implicit def apply[T](f: UserCredentials ⇒ Future[Option[T]]): HttpBasicAuthenticator[T] =
+    implicit def apply[T](f: Credentials ⇒ Future[Option[T]]): HttpBasicAuthenticator[T] =
       new HttpBasicAuthenticator[T] {
-        def apply(credentials: UserCredentials): Future[Option[T]] = f(credentials)
+        def apply(credentials: Credentials): Future[Option[T]] = f(credentials)
       }
-    def fromPF[T](pf: PartialFunction[UserCredentials, Future[T]])(implicit ec: ExecutionContext): HttpBasicAuthenticator[T] =
+    def fromPF[T](pf: PartialFunction[Credentials, Future[T]])(implicit ec: ExecutionContext): HttpBasicAuthenticator[T] =
       new HttpBasicAuthenticator[T] {
-        def apply(credentials: UserCredentials): Future[Option[T]] =
+        def apply(credentials: Credentials): Future[Option[T]] =
           if (pf.isDefinedAt(credentials)) pf(credentials).fast.map(Some(_))
           else FastFuture.successful(None)
       }
-
-    def checkAndProvide[T](check: UserCredentials.Provided ⇒ Boolean)(provide: String ⇒ T)(implicit ec: ExecutionContext): HttpBasicAuthenticator[T] =
+    def checkAndProvide[T](check: Credentials.Provided ⇒ Boolean)(provide: String ⇒ T)(implicit ec: ExecutionContext): HttpBasicAuthenticator[T] =
       HttpBasicAuthenticator.fromPF {
-        case p @ UserCredentials.Provided(name) if check(p) ⇒ FastFuture.successful(provide(name))
+        case p @ Credentials.Provided(name) if check(p) ⇒ FastFuture.successful(provide(name))
       }
-    def provideUserName(check: UserCredentials.Provided ⇒ Boolean)(implicit ec: ExecutionContext): HttpBasicAuthenticator[String] =
+    def provideUserName(check: Credentials.Provided ⇒ Boolean)(implicit ec: ExecutionContext): HttpBasicAuthenticator[String] =
+      checkAndProvide(check)(identity)
+  }
+
+  object BearerTokenAuthenticator {
+    implicit def apply[T](f: Credentials ⇒ Future[Option[T]]): BearerTokenAuthenticator[T] =
+      new BearerTokenAuthenticator[T] {
+        def apply(credentials: Credentials): Future[Option[T]] = f(credentials)
+      }
+    def fromPF[T](pf: PartialFunction[Credentials, Future[T]])(implicit ec: ExecutionContext): BearerTokenAuthenticator[T] =
+      new BearerTokenAuthenticator[T] {
+        def apply(credentials: Credentials): Future[Option[T]] =
+          if (pf.isDefinedAt(credentials)) pf(credentials).fast.map(Some(_))
+          else FastFuture.successful(None)
+      }
+    def checkAndProvide[T](check: Credentials.Provided ⇒ Boolean)(provide: String ⇒ T)(implicit ec: ExecutionContext): HttpBasicAuthenticator[T] =
+      HttpBasicAuthenticator.fromPF {
+        case p @ Credentials.Provided(token) if check(p) ⇒ FastFuture.successful(provide(token))
+      }
+    def provideToken(check: Credentials.Provided ⇒ Boolean)(implicit ec: ExecutionContext): HttpBasicAuthenticator[String] =
       checkAndProvide(check)(identity)
   }
 

--- a/akka-http-tests-java/src/test/java/akka/http/javadsl/server/AuthenticationDirectivesTest.java
+++ b/akka-http-tests-java/src/test/java/akka/http/javadsl/server/AuthenticationDirectivesTest.java
@@ -19,7 +19,7 @@ public class AuthenticationDirectivesTest extends JUnitRouteTest {
             public Future<Option<String>> authenticate(BasicUserCredentials credentials) {
                 if (credentials.available() && // no anonymous access
                         credentials.userName().equals("sina") &&
-                        credentials.verifySecret("1234"))
+                        credentials.verify("1234"))
                     return authenticateAs("Sina");
                 else return refuseAccess();
             }

--- a/akka-http-tests-scala/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests-scala/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -24,8 +24,8 @@ object TestServer extends App {
 
   def auth =
     HttpBasicAuthenticator.provideUserName {
-      case p @ UserCredentials.Provided(name) ⇒ p.verifySecret(name + "-password")
-      case _                                  ⇒ false
+      case p @ Credentials.Provided(name) ⇒ p.verify(name + "-password")
+      case _                              ⇒ false
     }
 
   val bindingFuture = Http().bindAndHandle({

--- a/akka-http-tests-scala/src/test/scala/akka/http/scaladsl/server/directives/AuthenticationDirectivesSpec.scala
+++ b/akka-http-tests-scala/src/test/scala/akka/http/scaladsl/server/directives/AuthenticationDirectivesSpec.scala
@@ -13,13 +13,14 @@ import akka.http.scaladsl.server.directives.AuthenticationDirectives._
 import scala.concurrent.Future
 
 class AuthenticationDirectivesSpec extends RoutingSpec {
-  val dontAuth = HttpBasicAuthentication("MyRealm")(HttpBasicAuthenticator[String](_ ⇒ Future.successful(None)))
-  val doAuth = HttpBasicAuthentication("MyRealm")(HttpBasicAuthenticator.provideUserName(_ ⇒ true))
-  val authWithAnonymous = doAuth.withAnonymousUser("We are Legion")
-
-  val challenge = HttpChallenge("Basic", "MyRealm")
 
   "the 'HttpBasicAuthentication' directive" should {
+    lazy val dontAuth = HttpBasicAuthentication("MyRealm")(HttpBasicAuthenticator[String](_ ⇒ Future.successful(None)))
+    lazy val doAuth = HttpBasicAuthentication("MyRealm")(HttpBasicAuthenticator.provideUserName(_ ⇒ true))
+    lazy val authWithAnonymous = doAuth.withAnonymousUser("We are Legion")
+
+    lazy val challenge = HttpChallenge("Basic", "MyRealm")
+
     "reject requests without Authorization header with an AuthenticationFailedRejection" in {
       Get() ~> {
         dontAuth { echoComplete }
@@ -58,7 +59,56 @@ class AuthenticationDirectivesSpec extends RoutingSpec {
       } ~> check { status shouldEqual StatusCodes.InternalServerError }
     }
   }
+  "the BearerTokenAuthentication directive" should {
+    lazy val dontAuth = BearerTokenAuthentication("MyRealm")(BearerTokenAuthenticator[String](_ ⇒ Future.successful(None)))
+    lazy val doAuth = BearerTokenAuthentication("MyRealm")(BearerTokenAuthenticator.provideToken(_ ⇒ true))
+    lazy val authWithAnonymous = doAuth.withAnonymousUser("We are Legion")
+
+    lazy val challenge = HttpChallenge("Bearer", "MyRealm")
+
+    "reject requests without Authorization header with an AuthenticationFailedRejection" in {
+      Get() ~> {
+        dontAuth { echoComplete }
+      } ~> check { rejection shouldEqual AuthenticationFailedRejection(CredentialsMissing, challenge) }
+    }
+    "reject unauthenticated requests with Authorization header with an AuthenticationFailedRejection" in {
+      Get() ~> Authorization(OAuth2BearerToken("MyToken")) ~> {
+        dontAuth { echoComplete }
+      } ~> check { rejection shouldEqual AuthenticationFailedRejection(CredentialsRejected, challenge) }
+    }
+    "reject requests with illegal Authorization header with 401" in {
+      Get() ~> RawHeader("Authorization", "bob alice") ~> Route.seal {
+        dontAuth { echoComplete }
+      } ~> check {
+        status shouldEqual StatusCodes.Unauthorized
+        responseAs[String] shouldEqual "The resource requires authentication, which was not supplied with the request"
+        header[`WWW-Authenticate`] shouldEqual Some(`WWW-Authenticate`(challenge))
+      }
+    }
+    "extract the token object created by successful authentication" in {
+      Get() ~> Authorization(OAuth2BearerToken("MyToken")) ~> {
+        doAuth { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "MyToken" }
+    }
+    "extract the object representing the user identity created for the anonymous user" in {
+      Get() ~> {
+        authWithAnonymous { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "We are Legion" }
+    }
+    "properly handle exceptions thrown in its inner route" in {
+      object TestException extends RuntimeException
+      Get() ~> Authorization(OAuth2BearerToken("MyToken")) ~> {
+        Route.seal {
+          doAuth { _ ⇒ throw TestException }
+        }
+      } ~> check { status shouldEqual StatusCodes.InternalServerError }
+    }
+  }
   "AuthenticationDirectives facilities" should {
+    lazy val dontAuth = HttpBasicAuthentication("MyRealm")(HttpBasicAuthenticator[String](_ ⇒ Future.successful(None)))
+
+    lazy val challenge = HttpChallenge("Basic", "MyRealm")
+
     "properly stack several authentication directives" in {
       val otherChallenge = HttpChallenge("MyAuth", "MyRealm2")
       val otherAuth: Directive1[String] = AuthenticationDirectives.authenticateOrRejectWithChallenge { (cred: Option[HttpCredentials]) ⇒


### PR DESCRIPTION
I took a first shot at adding directives for Bearer Token Authentication, collecting input here on whether this is valuable, and if, what should be changed.

Some highlights and initial questions:
- I renamed `UserCredentials` to the more general `Credentials`, and its `username` param to the more appropriate `identifier` in case it covers both `HttpBasicAuthentication` and `BearerTokenAuthentication` (?)
- `HttpBasicAuthenticator` and `BearerTokenAuthenticator` have almost exactly the same implementation, short of the naming of `provideUserName` and `provideToken` methods. I feel this might benefit from having a single `Authenticator` implementation with a `provideIdentifier` method instead (?)

Happy to receive comments and suggestions,

pjan
