### PR TITLE
!per #17249 Avoid init problems of persistence tck

### DIFF
--- a/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
@@ -145,24 +145,22 @@ object PersistenceTCKDoc {
     import akka.persistence.journal.JournalSpec
 
     //#journal-tck-scala
-    class MyJournalSpec extends JournalSpec {
-      override val config = ConfigFactory.parseString(
+    class MyJournalSpec extends JournalSpec(
+      config = ConfigFactory.parseString(
         """
         akka.persistence.journal.plugin = "my.journal.plugin"
-        """)
-    }
+        """))
     //#journal-tck-scala
   }
   new AnyRef {
     import akka.persistence.snapshot.SnapshotStoreSpec
 
     //#snapshot-store-tck-scala
-    class MySnapshotStoreSpec extends SnapshotStoreSpec {
-      override val config = ConfigFactory.parseString(
+    class MySnapshotStoreSpec extends SnapshotStoreSpec(
+      config = ConfigFactory.parseString(
         """
         akka.persistence.snapshot-store.plugin = "my.snapshot-store.plugin"
-        """)
-    }
+        """))
     //#snapshot-store-tck-scala
   }
   new AnyRef {
@@ -172,11 +170,11 @@ object PersistenceTCKDoc {
     import org.iq80.leveldb.util.FileUtils
 
     //#journal-tck-before-after-scala
-    class MyJournalSpec extends JournalSpec {
-      override val config = ConfigFactory.parseString(
+    class MyJournalSpec extends JournalSpec(
+      config = ConfigFactory.parseString(
         """
         akka.persistence.journal.plugin = "my.journal.plugin"
-        """)
+        """)) {
 
       val storageLocations = List(
         new File(system.settings.config.getString("akka.persistence.journal.leveldb.dir")),

--- a/akka-persistence-tck/src/main/scala/akka/persistence/PluginSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/PluginSpec.scala
@@ -11,7 +11,7 @@ import com.typesafe.config._
 
 import org.scalatest._
 
-trait PluginSpec extends TestKitBase with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+abstract class PluginSpec(val config: Config) extends TestKitBase with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
   private val counter = new AtomicInteger(0)
 
   private var _extension: Persistence = _
@@ -21,16 +21,14 @@ trait PluginSpec extends TestKitBase with WordSpecLike with Matchers with Before
   // this is akka-persistence internals and journals themselfes don't really care
   protected val actorInstanceId = 1
 
-  override protected def beforeEach(): Unit = {
+  override protected def beforeEach(): Unit =
     _pid = s"p-${counter.incrementAndGet()}"
-  }
+
   override protected def beforeAll(): Unit =
     _extension = Persistence(system)
 
   override protected def afterAll(): Unit =
     shutdown(system)
-
-  val config: Config
 
   def extension: Persistence =
     _extension

--- a/akka-persistence-tck/src/main/scala/akka/persistence/japi/journal/JavaJournalPerfSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/japi/journal/JavaJournalPerfSpec.scala
@@ -43,7 +43,7 @@ import org.scalatest.junit.JUnitRunner
  * @param config configures the Journal plugin to be tested
  */
 @RunWith(classOf[JUnitRunner])
-class JavaJournalPerfSpec(val config: Config) extends JournalSpec with JournalPerfSpec {
+class JavaJournalPerfSpec(config: Config) extends JournalPerfSpec(config) {
   override protected def info: Informer = new Informer {
     override def apply(message: String, payload: Option[Any]): Unit = System.out.println(message)
   }

--- a/akka-persistence-tck/src/main/scala/akka/persistence/japi/journal/JavaJournalSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/japi/journal/JavaJournalSpec.scala
@@ -21,4 +21,4 @@ import org.scalatest.junit.JUnitRunner
  * @param config configures the Journal plugin to be tested
  */
 @RunWith(classOf[JUnitRunner])
-class JavaJournalSpec(val config: Config) extends JournalSpec
+class JavaJournalSpec(config: Config) extends JournalSpec(config)

--- a/akka-persistence-tck/src/main/scala/akka/persistence/japi/snapshot/JavaSnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/japi/snapshot/JavaSnapshotStoreSpec.scala
@@ -20,4 +20,4 @@ import org.scalatest.junit.JUnitRunner
  * @see [[akka.persistence.snapshot.SnapshotStoreSpec]]
  */
 @RunWith(classOf[JUnitRunner])
-class JavaSnapshotStoreSpec(val config: Config) extends SnapshotStoreSpec
+class JavaSnapshotStoreSpec(config: Config) extends SnapshotStoreSpec(config)

--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
@@ -7,9 +7,9 @@ import akka.actor.{ ActorLogging, ActorRef, Props }
 import akka.persistence.journal.JournalPerfSpec.{ BenchActor, Cmd, ResetCounter }
 import akka.persistence.{ PersistentActor, PluginSpec }
 import akka.testkit.TestProbe
-
 import scala.collection.immutable
 import scala.concurrent.duration._
+import com.typesafe.config.Config
 
 object JournalPerfSpec {
   class BenchActor(override val persistenceId: String, replyTo: ActorRef, replyAfter: Int) extends PersistentActor
@@ -75,8 +75,7 @@ object JournalPerfSpec {
  *
  * @see [[akka.persistence.journal.JournalSpec]]
  */
-trait JournalPerfSpec extends PluginSpec {
-  this: JournalSpec ⇒
+abstract class JournalPerfSpec(config: Config) extends JournalSpec(config) {
 
   private val testProbe = TestProbe()
 

--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
@@ -28,8 +28,7 @@ object JournalSpec {
  * @see [[akka.persistence.journal.JournalPerfSpec]]
  * @see [[akka.persistence.japi.journal.JavaJournalPerfSpec]]
  */
-trait JournalSpec extends PluginSpec {
-  import JournalSpec._
+abstract class JournalSpec(config: Config) extends PluginSpec(config) {
 
   implicit lazy val system: ActorSystem = ActorSystem("JournalSpec", config.withFallback(JournalSpec.config))
 

--- a/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
@@ -1,13 +1,12 @@
 package akka.persistence.snapshot
 
 import scala.collection.immutable.Seq
-
 import akka.actor._
 import akka.persistence._
 import akka.persistence.SnapshotProtocol._
 import akka.testkit.TestProbe
-
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
 
 object SnapshotStoreSpec {
   val config = ConfigFactory.parseString("akka.persistence.publish-plugin-commands = on")
@@ -24,7 +23,7 @@ object SnapshotStoreSpec {
  *
  * @see [[akka.persistence.japi.snapshot.JavaSnapshotStoreSpec]]
  */
-trait SnapshotStoreSpec extends PluginSpec {
+abstract class SnapshotStoreSpec(config: Config) extends PluginSpec(config) {
   implicit lazy val system = ActorSystem("SnapshotStoreSpec", config.withFallback(SnapshotStoreSpec.config))
 
   private var senderProbe: TestProbe = _

--- a/akka-persistence-tck/src/test/scala/akka/persistence/PluginCleanup.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/PluginCleanup.scala
@@ -1,10 +1,10 @@
 package akka.persistence
 
 import java.io.File
-
 import org.apache.commons.io.FileUtils
+import org.scalatest.BeforeAndAfterAll
 
-trait PluginCleanup extends PluginSpec {
+trait PluginCleanup extends BeforeAndAfterAll { _: PluginSpec ⇒
   val storageLocations = List(
     "akka.persistence.journal.leveldb.dir",
     "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalJavaSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalJavaSpec.scala
@@ -3,9 +3,9 @@ package akka.persistence.journal.leveldb
 import akka.persistence.journal.JournalSpec
 import akka.persistence.{ PersistenceSpec, PluginCleanup }
 
-class LeveldbJournalJavaSpec extends JournalSpec with PluginCleanup {
-  lazy val config = PersistenceSpec.config(
+class LeveldbJournalJavaSpec extends JournalSpec(
+  config = PersistenceSpec.config(
     "leveldb",
     "LeveldbJournalJavaSpec",
-    extraConfig = Some("akka.persistence.journal.leveldb.native = off"))
-}
+    extraConfig = Some("akka.persistence.journal.leveldb.native = off")))
+  with PluginCleanup

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
@@ -8,9 +8,9 @@ import akka.persistence.{ PersistenceSpec, PluginCleanup }
 import org.scalatest.DoNotDiscover
 
 @DoNotDiscover // because only checking that compilation is OK with JournalPerfSpec
-class LeveldbJournalNativePerfSpec extends JournalSpec with JournalPerfSpec with PluginCleanup {
-  lazy val config = PersistenceSpec.config(
+class LeveldbJournalNativePerfSpec extends JournalPerfSpec(
+  config = PersistenceSpec.config(
     "leveldb",
     "LeveldbJournalNativePerfSpec",
-    extraConfig = Some("akka.persistence.journal.leveldb.native = on"))
-}
+    extraConfig = Some("akka.persistence.journal.leveldb.native = on")))
+  with PluginCleanup

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativeSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativeSpec.scala
@@ -3,10 +3,9 @@ package akka.persistence.journal.leveldb
 import akka.persistence.journal.JournalSpec
 import akka.persistence.{ PersistenceSpec, PluginCleanup }
 
-class LeveldbJournalNativeSpec extends JournalSpec with PluginCleanup {
-  lazy val config = PersistenceSpec.config(
+class LeveldbJournalNativeSpec extends JournalSpec(
+  config = PersistenceSpec.config(
     "leveldb",
     "LeveldbJournalNativeSpec",
-    extraConfig = Some("akka.persistence.journal.leveldb.native = on"))
-
-}
+    extraConfig = Some("akka.persistence.journal.leveldb.native = on")))
+  with PluginCleanup

--- a/akka-persistence-tck/src/test/scala/akka/persistence/snapshot/local/LocalSnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/snapshot/local/LocalSnapshotStoreSpec.scala
@@ -5,12 +5,11 @@ import com.typesafe.config.ConfigFactory
 import akka.persistence.PluginCleanup
 import akka.persistence.snapshot.SnapshotStoreSpec
 
-class LocalSnapshotStoreSpec extends SnapshotStoreSpec with PluginCleanup {
-  lazy val config = ConfigFactory.parseString(
+class LocalSnapshotStoreSpec extends SnapshotStoreSpec(
+  config = ConfigFactory.parseString(
     """
     akka.test.timefactor = 3
     akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
     akka.persistence.snapshot-store.local.dir = "target/snapshots"
-    """)
-
-}
+    """))
+  with PluginCleanup


### PR DESCRIPTION
- in the end TestKitBase eagerly initialize the ActorSystem and
  to avoid the need for using lazy val tricks I changed the trait
  to abstract class with config constructor parameter
