### PR TITLE
=act #13935 Throw same exception when extension init fails

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -18,6 +18,7 @@ import com.typesafe.config.Config
 import java.util.concurrent.{ LinkedBlockingQueue, BlockingQueue, TimeUnit }
 import akka.util.Switch
 import akka.util.Helpers.ConfigOps
+import scala.util.control.NoStackTrace
 
 class JavaExtensionSpec extends JavaExtension with JUnitSuiteLike
 
@@ -28,6 +29,23 @@ object TestExtension extends ExtensionId[TestExtension] with ExtensionIdProvider
 
 // Dont't place inside ActorSystemSpec object, since it will not be garbage collected and reference to system remains
 class TestExtension(val system: ExtendedActorSystem) extends Extension
+
+object FailingTestExtension extends ExtensionId[FailingTestExtension] with ExtensionIdProvider {
+  def lookup = this
+  def createExtension(s: ExtendedActorSystem) = new FailingTestExtension(s)
+
+  class TestException extends IllegalArgumentException("ERR") with NoStackTrace
+}
+
+// Dont't place inside ActorSystemSpec object, since it will not be garbage collected and reference to system remains
+class FailingTestExtension(val system: ExtendedActorSystem) extends Extension {
+  // first time the actor is created
+  val ref = system.actorOf(Props.empty, "uniqueName")
+  // but the extension initialization fails
+  // second time it will throw exception when trying to create actor with same name,
+  // but we want to see the first exception every time
+  throw new FailingTestExtension.TestException
+}
 
 object ActorSystemSpec {
 
@@ -166,6 +184,16 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
       system.hasExtension(TestExtension) should ===(true)
       TestExtension(system).system should ===(system)
       system.extension(TestExtension).system should ===(system)
+    }
+
+    "handle extensions that fail to initialize" in {
+      intercept[FailingTestExtension.TestException] {
+        FailingTestExtension(system)
+      }
+      // same exception should be reported next time
+      intercept[FailingTestExtension.TestException] {
+        FailingTestExtension(system)
+      }
     }
 
     "log dead letters" in {


### PR DESCRIPTION
- The problem is that when an extension partly fails the next
  attempt will typically generate another failure, such as
  "actor name [snapshot-store] is not unique"
- We have seen this problem for both persistence and cluster
  extensions
- Extensions are now only given one chance to initialize and
  thereafter fail fast with same exception as the the first failure
