### PR TITLE
=act #16327 fix BatchingExecutor.blockOn (for verification)

### DIFF
--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -21,6 +21,8 @@ object MiMa extends AutoPlugin {
   val mimaIgnoredProblems = {
     Seq(
       // add filters here, see release-2.3 branch
+      ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.BatchingExecutor.akka$dispatch$BatchingExecutor$_setter_$akka$dispatch$BatchingExecutor$$_blockContext_="),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.dispatch.BatchingExecutor.akka$dispatch$BatchingExecutor$$_blockContext")
      )
   }
 }


### PR DESCRIPTION
It contained a difficult to hit race condition that was exploited with
the help of a custom same-thread execution context by Play (its Iteratee
trampoline). In short: don’t resubmit the current Batch if it contains
an unsynchronized variable.
