### PR TITLE
+str #17290 Adds preStart / postStop to AbstractStage

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/ActorInterpreterLifecycleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/ActorInterpreterLifecycleSpec.scala
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.stream.Supervision._
+import akka.stream._
+import akka.stream.impl.fusing.{ InterpreterLifecycleSpecKit, ActorInterpreter }
+import akka.stream.stage.Stage
+import akka.stream.testkit.Utils.TE
+import akka.stream.testkit.{ AkkaSpec, _ }
+import scala.concurrent.duration._
+
+class ActorInterpreterLifecycleSpec extends AkkaSpec with InterpreterLifecycleSpecKit {
+
+  implicit val mat = ActorFlowMaterializer()
+
+  class Setup(ops: List[Stage[_, _]] = List(fusing.Map({ x: Any ⇒ x }, stoppingDecider))) {
+    val up = TestPublisher.manualProbe[Int]
+    val down = TestSubscriber.manualProbe[Int]
+    private val props = ActorInterpreter.props(mat.settings, ops, mat).withDispatcher("akka.test.stream-dispatcher")
+    val actor = system.actorOf(props)
+    val processor = ActorProcessorFactory[Int, Int](actor)
+  }
+
+  "An ActorInterpreter" must {
+
+    "call preStart in order on stages" in new Setup(List(
+      PreStartAndPostStopIdentity(onStart = _ ⇒ testActor ! "start-a"),
+      PreStartAndPostStopIdentity(onStart = _ ⇒ testActor ! "start-b"),
+      PreStartAndPostStopIdentity(onStart = _ ⇒ testActor ! "start-c"))) {
+      processor.subscribe(down)
+      val sub = down.expectSubscription()
+      sub.cancel()
+      up.subscribe(processor)
+      val upsub = up.expectSubscription()
+      upsub.expectCancellation()
+
+      expectMsg("start-a")
+      expectMsg("start-b")
+      expectMsg("start-c")
+    }
+
+    "call postStart in order on stages - when upstream completes" in new Setup(List(
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-a"),
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-b"),
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-c"))) {
+      processor.subscribe(down)
+      val sub = down.expectSubscription()
+      up.subscribe(processor)
+      val upsub = up.expectSubscription()
+      upsub.sendComplete()
+      down.expectComplete()
+
+      expectMsg("stop-a")
+      expectMsg("stop-b")
+      expectMsg("stop-c")
+    }
+
+    "call postStart in order on stages - when downstream cancels" in new Setup(List(
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-a"),
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-b"),
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-c"))) {
+      processor.subscribe(down)
+      val sub = down.expectSubscription()
+      sub.cancel()
+      up.subscribe(processor)
+      val upsub = up.expectSubscription()
+      upsub.expectCancellation()
+
+      expectMsg("stop-c")
+      expectMsg("stop-b")
+      expectMsg("stop-a")
+    }
+
+    "onError downstream when preStart fails" in new Setup(List(
+      PreStartFailer(() ⇒ throw TE("Boom!")))) {
+      processor.subscribe(down)
+      val sub = down.expectSubscription()
+      up.subscribe(processor)
+      val upsub = up.expectSubscription()
+      down.expectError(TE("Boom!"))
+    }
+
+    "onError only once even with Supervision.restart" in new Setup(List(
+      PreStartFailer(() ⇒ throw TE("Boom!")))) {
+      processor.subscribe(down)
+      val sub = down.expectSubscription()
+      up.subscribe(processor)
+      val upsub = up.expectSubscription()
+      down.expectError(TE("Boom!"))
+      down.expectNoMsg(1.second)
+    }
+
+    "onError downstream when preStart fails with 'most downstream' failure, when multiple stages fail" in new Setup(List(
+      PreStartFailer(() ⇒ throw TE("Boom 1!")),
+      PreStartFailer(() ⇒ throw TE("Boom 2!")),
+      PreStartFailer(() ⇒ throw TE("Boom 3!")))) {
+      processor.subscribe(down)
+      val sub = down.expectSubscription()
+      up.subscribe(processor)
+      val upsub = up.expectSubscription()
+      down.expectError(TE("Boom 3!"))
+      down.expectNoMsg(300.millis)
+    }
+
+    "continue with stream shutdown when postStop fails" in new Setup(List(
+      PostStopFailer(() ⇒ throw TE("Boom!")))) {
+      processor.subscribe(down)
+      val sub = down.expectSubscription()
+      up.subscribe(processor)
+      val upsub = up.expectSubscription()
+      upsub.sendComplete()
+      down.expectComplete() // failures in postStop are logged, but not propagated // TODO Future features? make this a setting?
+    }
+
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/ActorInterpreterLifecycleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/ActorInterpreterLifecycleSpec.scala
@@ -3,14 +3,13 @@
  */
 package akka.stream.impl
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import akka.stream.Supervision._
 import akka.stream._
-import akka.stream.impl.fusing.{ InterpreterLifecycleSpecKit, ActorInterpreter }
+import akka.stream.impl.fusing.{ ActorInterpreter, InterpreterLifecycleSpecKit }
 import akka.stream.stage.Stage
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.{ AkkaSpec, _ }
+
 import scala.concurrent.duration._
 
 class ActorInterpreterLifecycleSpec extends AkkaSpec with InterpreterLifecycleSpecKit {
@@ -113,7 +112,7 @@ class ActorInterpreterLifecycleSpec extends AkkaSpec with InterpreterLifecycleSp
       up.subscribe(processor)
       val upsub = up.expectSubscription()
       upsub.sendComplete()
-      down.expectComplete() // failures in postStop are logged, but not propagated // TODO Future features? make this a setting?
+      down.expectComplete()
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
@@ -3,15 +3,10 @@
  */
 package akka.stream.impl.fusing
 
-import akka.stream.stage.{ TerminationDirective, SyncDirective, Context, PushStage }
-
-import scala.util.control.NoStackTrace
 import akka.stream.Supervision
 
 class InterpreterSpec extends InterpreterSpecKit {
   import Supervision.stoppingDecider
-  import Supervision.resumingDecider
-  import Supervision.restartingDecider
 
   "Interpreter" must {
 
@@ -460,13 +455,6 @@ class InterpreterSpec extends InterpreterSpecKit {
       downstream.requestOne()
       lastEvents() should be(Set(OnNext(2)))
 
-    }
-
-    // This test is related to issue #17351
-    class PushFinishStage extends PushStage[Any, Any] {
-      override def onPush(elem: Any, ctx: Context[Any]): SyncDirective = ctx.pushAndFinish(elem)
-      override def onUpstreamFinish(ctx: Context[Any]): TerminationDirective =
-        ctx.fail(akka.stream.testkit.Utils.TE("Cannot happen"))
     }
 
     "work with pushAndFinish if upstream completes with pushAndFinish" in new TestSetup(Seq(

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
@@ -3,13 +3,64 @@
  */
 package akka.stream.impl.fusing
 
-import akka.stream.OperationAttributes
-import akka.stream.testkit.AkkaSpec
+import akka.event.Logging
 import akka.stream.stage._
+import akka.stream.testkit.AkkaSpec
+import akka.stream.{ ActorFlowMaterializer, OperationAttributes }
 import akka.testkit.TestProbe
-import akka.stream.ActorFlowMaterializer
 
-trait InterpreterSpecKit extends AkkaSpec {
+trait InterpreterLifecycleSpecKit {
+  private[akka] case class PreStartAndPostStopIdentity[T](
+    onStart: LifecycleContext ⇒ Unit = _ ⇒ (),
+    onStop: () ⇒ Unit = () ⇒ (),
+    onUpstreamCompleted: () ⇒ Unit = () ⇒ (),
+    onUpstreamFailed: Throwable ⇒ Unit = ex ⇒ ())
+    extends PushStage[T, T] {
+    override def preStart(ctx: Context[T]) = onStart(ctx)
+
+    override def onPush(elem: T, ctx: Context[T]) = ctx.push(elem)
+
+    override def onUpstreamFinish(ctx: Context[T]): TerminationDirective = {
+      onUpstreamCompleted()
+      super.onUpstreamFinish(ctx)
+    }
+
+    override def onUpstreamFailure(cause: Throwable, ctx: Context[T]): TerminationDirective = {
+      onUpstreamFailed(cause)
+      super.onUpstreamFailure(cause, ctx)
+    }
+
+    override def postStop() = onStop()
+  }
+
+  private[akka] case class PreStartFailer[T](pleaseThrow: () ⇒ Unit) extends PushStage[T, T] {
+    override def preStart(ctx: Context[T]) = pleaseThrow()
+
+    override def onPush(elem: T, ctx: Context[T]) = ctx.push(elem)
+  }
+
+  private[akka] case class PostStopFailer[T](ex: () ⇒ Throwable) extends PushStage[T, T] {
+    override def onUpstreamFinish(ctx: Context[T]) = ctx.finish()
+    override def onPush(elem: T, ctx: Context[T]) = ctx.push(elem)
+
+    override def postStop(): Unit = throw ex()
+  }
+
+  // This test is related to issue #17351
+  private[akka] class PushFinishStage(onPostStop: () ⇒ Unit = () ⇒ ()) extends PushStage[Any, Any] {
+    override def onPush(elem: Any, ctx: Context[Any]): SyncDirective =
+      ctx.pushAndFinish(elem)
+
+    override def onUpstreamFinish(ctx: Context[Any]): TerminationDirective =
+      ctx.fail(akka.stream.testkit.Utils.TE("Cannot happen"))
+
+    override def postStop(): Unit =
+      onPostStop()
+  }
+
+}
+
+trait InterpreterSpecKit extends AkkaSpec with InterpreterLifecycleSpecKit {
 
   case object OnComplete
   case object Cancel
@@ -61,6 +112,7 @@ trait InterpreterSpecKit extends AkkaSpec {
     val sidechannel = TestProbe()
     val interpreter = new OneBoundedInterpreter(upstream +: ops :+ downstream,
       (op, ctx, event) ⇒ sidechannel.ref ! ActorInterpreter.AsyncInput(op, ctx, event),
+      Logging(system, classOf[TestSetup]),
       ActorFlowMaterializer(),
       OperationAttributes.none,
       forkLimit, overflowToHeap)

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpecKit.scala
@@ -16,7 +16,7 @@ trait InterpreterLifecycleSpecKit {
     onUpstreamCompleted: () ⇒ Unit = () ⇒ (),
     onUpstreamFailed: Throwable ⇒ Unit = ex ⇒ ())
     extends PushStage[T, T] {
-    override def preStart(ctx: Context[T]) = onStart(ctx)
+    override def preStart(ctx: LifecycleContext) = onStart(ctx)
 
     override def onPush(elem: T, ctx: Context[T]) = ctx.push(elem)
 
@@ -34,7 +34,9 @@ trait InterpreterLifecycleSpecKit {
   }
 
   private[akka] case class PreStartFailer[T](pleaseThrow: () ⇒ Unit) extends PushStage[T, T] {
-    override def preStart(ctx: Context[T]) = pleaseThrow()
+
+    override def preStart(ctx: LifecycleContext) =
+      pleaseThrow()
 
     override def onPush(elem: T, ctx: Context[T]) = ctx.push(elem)
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/LifecycleInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/LifecycleInterpreterSpec.scala
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.impl.fusing
+
+import akka.stream.testkit.Utils.TE
+
+import scala.concurrent.duration._
+
+class LifecycleInterpreterSpec extends InterpreterSpecKit {
+  import akka.stream.Supervision._
+
+  "Interpreter" must {
+
+    "call preStart in order on stages" in new TestSetup(Seq(
+      PreStartAndPostStopIdentity(onStart = _ ⇒ testActor ! "start-a"),
+      PreStartAndPostStopIdentity(onStart = _ ⇒ testActor ! "start-b"),
+      PreStartAndPostStopIdentity(onStart = _ ⇒ testActor ! "start-c"))) {
+      expectMsg("start-a")
+      expectMsg("start-b")
+      expectMsg("start-c")
+      expectNoMsg(300.millis)
+      upstream.onComplete()
+    }
+
+    "call postStop in order on stages - when upstream completes" in new TestSetup(Seq(
+      PreStartAndPostStopIdentity(onUpstreamCompleted = () ⇒ testActor ! "complete-a", onStop = () ⇒ testActor ! "stop-a"),
+      PreStartAndPostStopIdentity(onUpstreamCompleted = () ⇒ testActor ! "complete-b", onStop = () ⇒ testActor ! "stop-b"),
+      PreStartAndPostStopIdentity(onUpstreamCompleted = () ⇒ testActor ! "complete-c", onStop = () ⇒ testActor ! "stop-c"))) {
+      upstream.onComplete()
+      expectMsg("complete-a")
+      expectMsg("stop-a")
+      expectMsg("complete-b")
+      expectMsg("stop-b")
+      expectMsg("complete-c")
+      expectMsg("stop-c")
+      expectNoMsg(300.millis)
+    }
+
+    "call postStop in order on stages - when upstream onErrors" in new TestSetup(Seq(
+      PreStartAndPostStopIdentity(
+        onUpstreamFailed = ex ⇒ testActor ! ex.getMessage,
+        onStop = () ⇒ testActor ! "stop-c"))) {
+      val msg = "Boom! Boom! Boom!"
+      upstream.onError(TE(msg))
+      expectMsg(msg)
+      expectMsg("stop-c")
+      expectNoMsg(300.millis)
+    }
+
+    "call postStop in order on stages - when downstream cancels" in new TestSetup(Seq(
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-a"),
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-b"),
+      PreStartAndPostStopIdentity(onStop = () ⇒ testActor ! "stop-c"))) {
+      downstream.cancel()
+      expectMsg("stop-c")
+      expectMsg("stop-b")
+      expectMsg("stop-a")
+      expectNoMsg(300.millis)
+    }
+
+    "call preStart before postStop" in new TestSetup(Seq(
+      PreStartAndPostStopIdentity(onStart = _ ⇒ testActor ! "start-a", onStop = () ⇒ testActor ! "stop-a"))) {
+      expectMsg("start-a")
+      expectNoMsg(300.millis)
+      upstream.onComplete()
+      expectMsg("stop-a")
+      expectNoMsg(300.millis)
+    }
+
+    "onError when preStart fails" in new TestSetup(Seq(
+      PreStartFailer(() ⇒ throw TE("Boom!")))) {
+      lastEvents() should ===(Set(Cancel, OnError(TE("Boom!"))))
+    }
+
+    "not blow up when postStop fails" in new TestSetup(Seq(
+      PostStopFailer(() ⇒ throw TE("Boom!")))) {
+      upstream.onComplete()
+      lastEvents() should ===(Set(OnComplete))
+    }
+
+    "onError when preStart fails with stages after" in new TestSetup(Seq(
+      Map((x: Int) ⇒ x, stoppingDecider),
+      PreStartFailer(() ⇒ throw TE("Boom!")),
+      Map((x: Int) ⇒ x, stoppingDecider))) {
+      lastEvents() should ===(Set(Cancel, OnError(TE("Boom!"))))
+    }
+
+    "continue with stream shutdown when postStop fails" in new TestSetup(Seq(
+      PostStopFailer(() ⇒ throw TE("Boom!")))) {
+      lastEvents() should ===(Set())
+
+      upstream.onComplete()
+      lastEvents should ===(Set(OnComplete))
+    }
+
+    "postStop when pushAndFinish called if upstream completes with pushAndFinish" in new TestSetup(Seq(
+      new PushFinishStage(onPostStop = () ⇒ testActor ! "stop"))) {
+
+      lastEvents() should be(Set.empty)
+
+      downstream.requestOne()
+      lastEvents() should be(Set(RequestOne))
+
+      upstream.onNextAndComplete("foo")
+      lastEvents() should be(Set(OnNext("foo"), OnComplete))
+      expectMsg("stop")
+    }
+
+    "postStop when pushAndFinish called with pushAndFinish if indirect upstream completes with pushAndFinish" in new TestSetup(Seq(
+      Map((x: Any) ⇒ x, stoppingDecider),
+      new PushFinishStage(onPostStop = () ⇒ testActor ! "stop"),
+      Map((x: Any) ⇒ x, stoppingDecider))) {
+
+      lastEvents() should be(Set.empty)
+
+      downstream.requestOne()
+      lastEvents() should be(Set(RequestOne))
+
+      upstream.onNextAndComplete("foo")
+      lastEvents() should be(Set(OnNext("foo"), OnComplete))
+      expectMsg("stop")
+    }
+
+    "postStop when pushAndFinish called with pushAndFinish if upstream completes with pushAndFinish and downstream immediately pulls" in new TestSetup(Seq(
+      new PushFinishStage(onPostStop = () ⇒ testActor ! "stop"),
+      Fold("", (x: String, y: String) ⇒ x + y, stoppingDecider))) {
+
+      lastEvents() should be(Set.empty)
+
+      downstream.requestOne()
+      lastEvents() should be(Set(RequestOne))
+
+      upstream.onNextAndComplete("foo")
+      lastEvents() should be(Set(OnNext("foo"), OnComplete))
+      expectMsg("stop")
+    }
+
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -59,7 +59,7 @@ object TlsSpec {
   class Timeout(duration: FiniteDuration)(implicit system: ActorSystem) extends AsyncStage[ByteString, ByteString, Unit] {
     private var last: ByteString = _
 
-    override def initAsyncInput(ctx: AsyncContext[ByteString, Unit]) = {
+    override def preStart(ctx: AsyncContext[ByteString, Unit]) = {
       val cb = ctx.getAsyncCallback()
       system.scheduler.scheduleOnce(duration)(cb.invoke(()))(system.dispatcher)
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/IteratorInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/IteratorInterpreter.scala
@@ -3,8 +3,9 @@
  */
 package akka.stream.impl.fusing
 
-import akka.stream.stage._
+import akka.event.NoLogging
 import akka.stream._
+import akka.stream.stage._
 
 /**
  * INTERNAL API
@@ -97,6 +98,7 @@ private[akka] class IteratorInterpreter[I, O](val input: Iterator[I], val ops: S
   private val downstream = IteratorDownstream[O]()
   private val interpreter = new OneBoundedInterpreter(upstream +: ops.asInstanceOf[Seq[Stage[_, _]]] :+ downstream,
     (op, ctx, evt) ⇒ throw new UnsupportedOperationException("IteratorInterpreter is fully synchronous"),
+    NoLogging,
     NoFlowMaterializer)
   interpreter.init()
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -528,7 +528,7 @@ private[akka] final case class Log[T](name: String, extract: T ⇒ Any, logAdapt
 
   // TODO more optimisations can be done here - prepare logOnPush function etc
 
-  override def preStart(ctx: Context[T]): Unit = {
+  override def preStart(ctx: LifecycleContext): Unit = {
     logLevels = ctx.attributes.logLevels.getOrElse(DefaultLogLevels)
     log = logAdapter match {
       case Some(l) ⇒ l

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -381,7 +381,7 @@ private[akka] final case class MapAsync[In, Out](parallelism: Int, f: In ⇒ Fut
   private var callback: AsyncCallback[Notification] = _
   private val elemsInFlight = FixedSizeBuffer[Try[Out]](parallelism)
 
-  override def initAsyncInput(ctx: AsyncContext[Out, Notification]): Unit = {
+  override def preStart(ctx: AsyncContext[Out, Notification]): Unit = {
     callback = ctx.getAsyncCallback()
   }
 
@@ -465,9 +465,8 @@ private[akka] final case class MapAsyncUnordered[In, Out](parallelism: Int, f: I
 
   private def todo = inFlight + buffer.used
 
-  override def initAsyncInput(ctx: AsyncContext[Out, Try[Out]]): Unit = {
+  override def preStart(ctx: AsyncContext[Out, Try[Out]]): Unit =
     callback = ctx.getAsyncCallback()
-  }
 
   override def decide(ex: Throwable) = decider(ex)
 
@@ -527,17 +526,17 @@ private[akka] final case class Log[T](name: String, extract: T ⇒ Any, logAdapt
   private var logLevels: LogLevels = _
   private var log: LoggingAdapter = _
 
-  // TODO implement as real preStart once https://github.com/akka/akka/pull/17295 is done
-  def preStart(ctx: Context[T]): Unit = {
+  // TODO more optimisations can be done here - prepare logOnPush function etc
+
+  override def preStart(ctx: Context[T]): Unit = {
     logLevels = ctx.attributes.logLevels.getOrElse(DefaultLogLevels)
-    log = logAdapter getOrElse {
-      val sys = ctx.materializer.asInstanceOf[ActorFlowMaterializer].system
-      Logging(sys, DefaultLoggerName)
+    log = logAdapter match {
+      case Some(l) ⇒ l
+      case _       ⇒ Logging(ctx.materializer.asInstanceOf[ActorFlowMaterializer].system, DefaultLoggerName)
     }
   }
 
   override def onPush(elem: T, ctx: Context[T]): SyncDirective = {
-    if (log == null) preStart(ctx)
     if (isEnabled(logLevels.onElement))
       log.log(logLevels.onElement, "[{}] Element: {}", name, extract(elem))
 
@@ -545,7 +544,6 @@ private[akka] final case class Log[T](name: String, extract: T ⇒ Any, logAdapt
   }
 
   override def onUpstreamFailure(cause: Throwable, ctx: Context[T]): TerminationDirective = {
-    if (log == null) preStart(ctx)
     if (isEnabled(logLevels.onFailure))
       logLevels.onFailure match {
         case Logging.ErrorLevel ⇒ log.error(cause, "[{}] Upstream failed.", name)
@@ -556,7 +554,6 @@ private[akka] final case class Log[T](name: String, extract: T ⇒ Any, logAdapt
   }
 
   override def onUpstreamFinish(ctx: Context[T]): TerminationDirective = {
-    if (log == null) preStart(ctx)
     if (isEnabled(logLevels.onFinish))
       log.log(logLevels.onFinish, "[{}] Upstream finished.", name)
 
@@ -564,7 +561,6 @@ private[akka] final case class Log[T](name: String, extract: T ⇒ Any, logAdapt
   }
 
   override def onDownstreamFinish(ctx: Context[T]): TerminationDirective = {
-    if (log == null) preStart(ctx)
     if (isEnabled(logLevels.onFinish))
       log.log(logLevels.onFinish, "[{}] Downstream finished.", name)
 


### PR DESCRIPTION
Resolves #17290
Superseeds https://github.com/akka/akka/pull/17295
- Adds preStart / postStop
- AsyncStage now uses preStart
- Log stage now uses preStart (better perf), can be optimised more
