### PR TITLE
!cto #17454 Add/change settings for cluster-tools

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -609,10 +609,8 @@ object ShardRegion {
 
   private case object Retry extends ShardRegionCommand
 
-  private def roleOption(role: String): Option[String] = role match {
-    case null | "" ⇒ None
-    case _         ⇒ Some(role)
-  }
+  private def roleOption(role: String): Option[String] =
+    if (role == "") None else Option(role)
 
   /**
    * INTERNAL API. Sends `PoisonPill` to the entries and when all of them have terminated

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -7,7 +7,6 @@ import java.net.URLEncoder
 import java.util.concurrent.ConcurrentHashMap
 import akka.cluster.sharding.Shard.{ ShardCommand, StateChange }
 import akka.cluster.sharding.ShardCoordinator.Internal.SnapshotTick
-
 import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -39,6 +38,7 @@ import akka.pattern.ask
 import akka.persistence._
 import akka.cluster.ClusterEvent.ClusterDomainEvent
 import akka.cluster.singleton.ClusterSingletonManager
+import akka.cluster.singleton.ClusterSingletonManagerSettings
 
 /**
  * This extension provides sharding functionality of actors in a cluster.
@@ -405,11 +405,12 @@ private[akka] class ClusterShardingGuardian extends Actor {
           val coordinatorProps = ShardCoordinator.props(handOffTimeout = HandOffTimeout, shardStartTimeout = ShardStartTimeout,
             rebalanceInterval = RebalanceInterval, snapshotInterval = SnapshotInterval, allocationStrategy)
           val singletonProps = ShardCoordinatorSupervisor.props(CoordinatorFailureBackoff, coordinatorProps)
+          val singletonSettings = ClusterSingletonManagerSettings(context.system)
+            .withSingletonName("singleton").withRole(role)
           context.actorOf(ClusterSingletonManager.props(
             singletonProps,
-            singletonName = "singleton",
             terminationMessage = PoisonPill,
-            role = role),
+            singletonSettings),
             name = coordinatorSingletonManagerName)
         }
 

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
@@ -5,7 +5,6 @@ package akka.cluster.sharding
 
 import akka.cluster.sharding.ShardCoordinator.Internal.{ ShardStopped, HandOff }
 import akka.cluster.sharding.ShardRegion.Passivate
-
 import language.postfixOps
 import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
@@ -24,6 +23,7 @@ import akka.testkit.TestEvent.Mute
 import java.io.File
 import org.apache.commons.io.FileUtils
 import akka.cluster.singleton.ClusterSingletonManager
+import akka.cluster.singleton.ClusterSingletonManagerSettings
 
 object ClusterShardingSpec extends MultiNodeConfig {
   val controller = role("controller")
@@ -194,9 +194,8 @@ class ClusterShardingSpec extends MultiNodeSpec(ClusterShardingSpec) with STMult
         val rebalanceEnabled = coordinatorName.toLowerCase.startsWith("rebalancing")
         system.actorOf(ClusterSingletonManager.props(
           singletonProps = ShardCoordinatorSupervisor.props(failureBackoff = 5.seconds, coordinatorProps(rebalanceEnabled)),
-          singletonName = "singleton",
           terminationMessage = PoisonPill,
-          role = None),
+          settings = ClusterSingletonManagerSettings(system)),
           name = coordinatorName + "Coordinator")
       }
   }

--- a/akka-cluster-tools/src/main/resources/reference.conf
+++ b/akka-cluster-tools/src/main/resources/reference.conf
@@ -6,7 +6,7 @@
 # Make your edits/overrides in your application.conf.
 
 # //#pub-sub-ext-config
-# Settings for the DistributedPubSubExtension
+# Settings for the DistributedPubSub extension
 akka.cluster.pub-sub {
   # Actor name of the mediator actor, /user/distributedPubSubMediator
   name = distributedPubSubMediator

--- a/akka-cluster-tools/src/main/resources/reference.conf
+++ b/akka-cluster-tools/src/main/resources/reference.conf
@@ -47,7 +47,7 @@ akka.actor {
 
 
 # //#receptionist-ext-config
-# Settings for the ClusterReceptionistExtension
+# Settings for the ClusterClientReceptionist extension
 akka.cluster.client.receptionist {
   # Actor name of the ClusterReceptionist actor, /user/receptionist
   name = receptionist
@@ -64,6 +64,24 @@ akka.cluster.client.receptionist {
   response-tunnel-receive-timeout = 30s
 }
 # //#receptionist-ext-config
+
+# Settings for the ClusterClient
+akka.cluster.client {
+  # Actor paths of the ClusterReceptionist actors on the servers (cluster nodes)
+  # that the client will try to contact initially. It is mandatory to specify
+  # at least one initial contact. 
+  # Comma separated full actor paths defined by a string on the form of
+  # "akka.tcp://system@hostname:port/user/receptionist"
+  initial-contacts = []
+  
+  # Interval at which the client retries to establish contact with one of 
+  # ClusterReceptionist on the servers (cluster nodes)
+  establishing-get-contacts-interval = 3s
+  
+  # Interval at which the client will ask the ClusterReceptionist for
+  # new contact points to be used for next reconnect.
+  refresh-contacts-interval = 60s
+}
 
 # //#cluster-client-mailbox-config
 akka.cluster.client {

--- a/akka-cluster-tools/src/main/resources/reference.conf
+++ b/akka-cluster-tools/src/main/resources/reference.conf
@@ -75,3 +75,44 @@ akka.cluster.client {
 # //#cluster-client-mailbox-config
 
 
+akka.cluster.singleton {
+  # The actor name of the child singleton actor.
+  singleton-name = "singleton"
+  
+  # Singleton among the nodes tagged with specified role.
+  # If the role is not specified it's a singleton among all nodes in the cluster.
+  role = ""
+  
+  # When a node is becoming oldest it sends hand-over request to previous oldest. 
+  # This is retried with the 'retry-interval' until the previous oldest confirms
+  # that the hand over has started, or this -max-hand-over-retries' limit has been
+  # reached. If the retry limit is reached it takes the decision to be the new oldest
+  # if previous oldest is unknown (typically removed), otherwise it initiates a new
+  # round by throwing 'akka.cluster.singleton.ClusterSingletonManagerIsStuck' and expecting
+  # restart with fresh state. For a cluster with many members you might need to increase
+  # this retry limit because it takes longer time to propagate changes across all nodes.
+  max-hand-over-retries = 10
+  
+  # When a oldest node leaves the cluster it is not oldest any more and then it sends
+  # take over request to the new oldest to initiate the hand-over process. This is
+  # retried with the 'retry-interval' until this retry limit has been reached. If the
+  # retry limit is reached it initiates a new round by throwing 
+  # 'akka.cluster.singleton.ClusterSingletonManagerIsStuck' and expecting restart with
+  # fresh state. This will also cause the singleton actor to be stopped.
+  # 'max-take-over-retries` must be less than 'max-hand-over-retries' to ensure that
+  # new oldest doesn't start singleton actor before previous is stopped for certain
+  # corner cases.
+  max-take-over-retries = 5
+  
+  # Interval for hand over and take over messages
+  retry-interval = 1s
+}
+
+akka.cluster.singleton-proxy {
+  # The role of the cluster nodes where the singleton can be deployed. 
+  # If the role is not specified then any node will do.
+  role = ""
+  
+  # Interval at which the proxy will try to resolve the singleton instance.
+  singleton-identification-interval = 1s 
+}

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -196,7 +196,7 @@ class ClusterClient(
 /**
  * Extension that starts [[ClusterReceptionist]] and accompanying [[akka.cluster.pubsub.DistributedPubSubMediator]]
  * with settings defined in config section `akka.cluster.client.receptionist`.
- * The [[akka.cluster.pubsub.DistributedPubSubMediator]] is started by the [[akka.cluster.pubsub.DistributedPubSubExtension]].
+ * The [[akka.cluster.pubsub.DistributedPubSubMediator]] is started by the [[akka.cluster.pubsub.DistributedPubSubExtension]] extension.
  */
 object ClusterReceptionistExtension extends ExtensionId[ClusterReceptionistExtension] with ExtensionIdProvider {
   override def get(system: ActorSystem): ClusterReceptionistExtension = super.get(system)
@@ -224,7 +224,7 @@ class ClusterReceptionistExtension(system: ExtendedActorSystem) extends Extensio
   /**
    * Register the actors that should be reachable for the clients in this [[DistributedPubSubMediator]].
    */
-  private def pubSubMediator: ActorRef = DistributedPubSubExtension(system).mediator
+  private def pubSubMediator: ActorRef = DistributedPubSub(system).mediator
 
   /**
    * Register an actor that should be reachable for the clients.

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -4,64 +4,113 @@
 package akka.cluster.client
 
 import java.net.URLEncoder
+
 import scala.collection.immutable
 import scala.concurrent.duration._
+
 import akka.actor.Actor
 import akka.actor.ActorIdentity
 import akka.actor.ActorLogging
+import akka.actor.ActorPath
 import akka.actor.ActorRef
 import akka.actor.ActorSelection
 import akka.actor.ActorSystem
 import akka.actor.Address
+import akka.actor.Cancellable
+import akka.actor.Deploy
 import akka.actor.ExtendedActorSystem
 import akka.actor.Extension
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.actor.Identify
+import akka.actor.NoSerializationVerificationNeeded
 import akka.actor.Props
 import akka.actor.ReceiveTimeout
+import akka.actor.Stash
 import akka.actor.Terminated
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent._
 import akka.cluster.Member
 import akka.cluster.MemberStatus
+import akka.cluster.pubsub._
+import akka.japi.Util.immutableSeq
 import akka.routing.ConsistentHash
 import akka.routing.MurmurHash
-import akka.actor.Stash
-import akka.actor.Cancellable
-import akka.cluster.pubsub._
+import com.typesafe.config.Config
+
+object ClusterClientSettings {
+  /**
+   * Create settings from the default configuration
+   * `akka.cluster.client`.
+   */
+  def apply(system: ActorSystem): ClusterClientSettings =
+    apply(system.settings.config.getConfig("akka.cluster.client"))
+
+  /**
+   * Create settings from a configuration with the same layout as
+   * the default configuration `akka.cluster.client`.
+   */
+  def apply(config: Config): ClusterClientSettings = {
+    val initialContacts = immutableSeq(config.getStringList("initial-contacts")).map(ActorPath.fromString).toSet
+    new ClusterClientSettings(
+      initialContacts,
+      establishingGetContactsInterval = config.getDuration("establishing-get-contacts-interval", MILLISECONDS).millis,
+      refreshContactsInterval = config.getDuration("refresh-contacts-interval", MILLISECONDS).millis)
+  }
+
+  /**
+   * Java API: Create settings from the default configuration
+   * `akka.cluster.client`.
+   */
+  def create(system: ActorSystem): ClusterClientSettings = apply(system)
+
+  /**
+   * Java API: Create settings from a configuration with the same layout as
+   * the default configuration `akka.cluster.client`.
+   */
+  def create(config: Config): ClusterClientSettings = apply(config)
+
+}
+
+/**
+ * @param initialContacts Actor paths of the `ClusterReceptionist` actors on
+ *   the servers (cluster nodes) that the client will try to contact initially.
+ * @param establishingGetContactsInterval Interval at which the client retries
+ *   to establish contact with one of ClusterReceptionist on the servers (cluster nodes)
+ * @param refreshContactsInterval Interval at which the client will ask the
+ *   `ClusterReceptionist` for new contact points to be used for next reconnect.
+ */
+final class ClusterClientSettings(
+  val initialContacts: Set[ActorPath],
+  val establishingGetContactsInterval: FiniteDuration,
+  val refreshContactsInterval: FiniteDuration) extends NoSerializationVerificationNeeded {
+
+  def withInitialContacts(initialContacts: Set[ActorPath]): ClusterClientSettings = {
+    require(initialContacts.nonEmpty, "initialContacts must be defined")
+    copy(initialContacts = initialContacts)
+  }
+
+  def withEstablishingGetContactsInterval(establishingGetContactsInterval: FiniteDuration): ClusterClientSettings =
+    copy(establishingGetContactsInterval = establishingGetContactsInterval)
+
+  def withRefreshContactsInterval(refreshContactsInterval: FiniteDuration): ClusterClientSettings =
+    copy(refreshContactsInterval = refreshContactsInterval)
+
+  private def copy(
+    initialContacts: Set[ActorPath] = initialContacts,
+    establishingGetContactsInterval: FiniteDuration = establishingGetContactsInterval,
+    refreshContactsInterval: FiniteDuration = refreshContactsInterval): ClusterClientSettings =
+    new ClusterClientSettings(initialContacts, establishingGetContactsInterval, refreshContactsInterval)
+
+}
 
 object ClusterClient {
 
   /**
    * Scala API: Factory method for `ClusterClient` [[akka.actor.Props]].
    */
-  def props(
-    initialContacts: Set[ActorSelection],
-    establishingGetContactsInterval: FiniteDuration = 3.second,
-    refreshContactsInterval: FiniteDuration = 1.minute): Props =
-    Props(classOf[ClusterClient], initialContacts, establishingGetContactsInterval, refreshContactsInterval).
-      withMailbox("akka.cluster.client.mailbox")
-
-  /**
-   * Java API: Factory method for `ClusterClient` [[akka.actor.Props]].
-   */
-  def props(
-    initialContacts: java.util.Set[ActorSelection],
-    establishingGetContactsInterval: FiniteDuration,
-    refreshContactsInterval: FiniteDuration): Props = {
-    import scala.collection.JavaConverters._
-    props(initialContacts.asScala.toSet, establishingGetContactsInterval, refreshContactsInterval)
-  }
-
-  /**
-   * Java API: Factory method for `ClusterClient` [[akka.actor.Props]] with
-   * default values.
-   */
-  def defaultProps(initialContacts: java.util.Set[ActorSelection]): Props = {
-    import scala.collection.JavaConverters._
-    props(initialContacts.asScala.toSet)
-  }
+  def props(settings: ClusterClientSettings): Props =
+    Props(new ClusterClient(settings)).withDeploy(Deploy.local).withMailbox("akka.cluster.client.mailbox")
 
   @SerialVersionUID(1L)
   final case class Send(path: String, msg: Any, localAffinity: Boolean) {
@@ -116,17 +165,18 @@ object ClusterClient {
  *  Use the factory method [[ClusterClient#props]]) to create the
  * [[akka.actor.Props]] for the actor.
  */
-class ClusterClient(
-  initialContacts: Set[ActorSelection],
-  establishingGetContactsInterval: FiniteDuration,
-  refreshContactsInterval: FiniteDuration)
-  extends Actor with Stash with ActorLogging {
+class ClusterClient(settings: ClusterClientSettings) extends Actor with Stash with ActorLogging {
 
   import ClusterClient._
   import ClusterClient.Internal._
   import ClusterReceptionist.Internal._
+  import settings._
 
-  var contacts: immutable.IndexedSeq[ActorSelection] = initialContacts.toVector
+  require(initialContacts.nonEmpty, "initialContacts must be defined")
+
+  val initialContactsSel: immutable.IndexedSeq[ActorSelection] =
+    initialContacts.map(context.actorSelection).toVector
+  var contacts = initialContactsSel
   sendGetContacts()
 
   import context.dispatcher
@@ -187,27 +237,27 @@ class ClusterClient(
   }
 
   def sendGetContacts(): Unit = {
-    if (contacts.isEmpty) initialContacts foreach { _ ! GetContacts }
-    else if (contacts.size == 1) (initialContacts ++ contacts) foreach { _ ! GetContacts }
+    if (contacts.isEmpty) initialContactsSel foreach { _ ! GetContacts }
+    else if (contacts.size == 1) (initialContactsSel ++ contacts) foreach { _ ! GetContacts }
     else contacts foreach { _ ! GetContacts }
   }
+}
+
+object ClusterClientReceptionist extends ExtensionId[ClusterClientReceptionist] with ExtensionIdProvider {
+  override def get(system: ActorSystem): ClusterClientReceptionist = super.get(system)
+
+  override def lookup = ClusterClientReceptionist
+
+  override def createExtension(system: ExtendedActorSystem): ClusterClientReceptionist =
+    new ClusterClientReceptionist(system)
 }
 
 /**
  * Extension that starts [[ClusterReceptionist]] and accompanying [[akka.cluster.pubsub.DistributedPubSubMediator]]
  * with settings defined in config section `akka.cluster.client.receptionist`.
- * The [[akka.cluster.pubsub.DistributedPubSubMediator]] is started by the [[akka.cluster.pubsub.DistributedPubSubExtension]] extension.
+ * The [[akka.cluster.pubsub.DistributedPubSubMediator]] is started by the [[akka.cluster.pubsub.DistributedPubSub]] extension.
  */
-object ClusterReceptionistExtension extends ExtensionId[ClusterReceptionistExtension] with ExtensionIdProvider {
-  override def get(system: ActorSystem): ClusterReceptionistExtension = super.get(system)
-
-  override def lookup = ClusterReceptionistExtension
-
-  override def createExtension(system: ExtendedActorSystem): ClusterReceptionistExtension =
-    new ClusterReceptionistExtension(system)
-}
-
-class ClusterReceptionistExtension(system: ExtendedActorSystem) extends Extension {
+class ClusterClientReceptionist(system: ExtendedActorSystem) extends Extension {
 
   private val config = system.settings.config.getConfig("akka.cluster.client.receptionist")
   private val role: Option[String] = config.getString("role") match {
@@ -264,16 +314,80 @@ class ClusterReceptionistExtension(system: ExtendedActorSystem) extends Extensio
     if (isTerminated)
       system.deadLetters
     else {
-      val numberOfContacts: Int = config.getInt("number-of-contacts")
-      val responseTunnelReceiveTimeout =
-        config.getDuration("response-tunnel-receive-timeout", MILLISECONDS).millis
       val name = config.getString("name")
       // important to use val mediator here to activate it outside of ClusterReceptionist constructor
       val mediator = pubSubMediator
-      system.actorOf(ClusterReceptionist.props(mediator, role, numberOfContacts,
-        responseTunnelReceiveTimeout), name)
+      system.actorOf(ClusterReceptionist.props(mediator, ClusterReceptionistSettings(config)), name)
     }
   }
+}
+
+object ClusterReceptionistSettings {
+  /**
+   * Create settings from the default configuration
+   * `akka.cluster.client.receptionist`.
+   */
+  def apply(system: ActorSystem): ClusterReceptionistSettings =
+    apply(system.settings.config.getConfig("akka.cluster.client.receptionist"))
+
+  /**
+   * Create settings from a configuration with the same layout as
+   * the default configuration `akka.cluster.client.receptionist`.
+   */
+  def apply(config: Config): ClusterReceptionistSettings =
+    new ClusterReceptionistSettings(
+      role = roleOption(config.getString("role")),
+      numberOfContacts = config.getInt("number-of-contacts"),
+      responseTunnelReceiveTimeout = config.getDuration("response-tunnel-receive-timeout", MILLISECONDS).millis)
+
+  /**
+   * Java API: Create settings from the default configuration
+   * `akka.cluster.client.receptionist`.
+   */
+  def create(system: ActorSystem): ClusterReceptionistSettings = apply(system)
+
+  /**
+   * Java API: Create settings from a configuration with the same layout as
+   * the default configuration `akka.cluster.client.receptionist`.
+   */
+  def create(config: Config): ClusterReceptionistSettings = apply(config)
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def roleOption(role: String): Option[String] =
+    if (role == "") None else Option(role)
+
+}
+
+/**
+ * @param role Start the receptionist on members tagged with this role.
+ *   All members are used if undefined.
+ * @param numberOfContacts The receptionist will send this number of contact points to the client
+ * @param responseTunnelReceiveTimeout The actor that tunnel response messages to the
+ *   client will be stopped after this time of inactivity.
+ */
+final class ClusterReceptionistSettings(
+  val role: Option[String],
+  val numberOfContacts: Int,
+  val responseTunnelReceiveTimeout: FiniteDuration) extends NoSerializationVerificationNeeded {
+
+  def withRole(role: String): ClusterReceptionistSettings = copy(role = ClusterReceptionistSettings.roleOption(role))
+
+  def withRole(role: Option[String]): ClusterReceptionistSettings = copy(role = role)
+
+  def withNumberOfContacts(numberOfContacts: Int): ClusterReceptionistSettings =
+    copy(numberOfContacts = numberOfContacts)
+
+  def withResponseTunnelReceiveTimeout(responseTunnelReceiveTimeout: FiniteDuration): ClusterReceptionistSettings =
+    copy(responseTunnelReceiveTimeout = responseTunnelReceiveTimeout)
+
+  private def copy(
+    role: Option[String] = role,
+    numberOfContacts: Int = numberOfContacts,
+    responseTunnelReceiveTimeout: FiniteDuration = responseTunnelReceiveTimeout): ClusterReceptionistSettings =
+    new ClusterReceptionistSettings(role, numberOfContacts, responseTunnelReceiveTimeout)
+
 }
 
 object ClusterReceptionist {
@@ -283,29 +397,8 @@ object ClusterReceptionist {
    */
   def props(
     pubSubMediator: ActorRef,
-    role: Option[String],
-    numberOfContacts: Int = 3,
-    responseTunnelReceiveTimeout: FiniteDuration = 30.seconds): Props =
-    Props(classOf[ClusterReceptionist], pubSubMediator, role, numberOfContacts, responseTunnelReceiveTimeout)
-
-  /**
-   * Java API: Factory method for `ClusterReceptionist` [[akka.actor.Props]].
-   */
-  def props(
-    pubSubMediator: ActorRef,
-    role: String,
-    numberOfContacts: Int,
-    responseTunnelReceiveTimeout: FiniteDuration): Props =
-    props(pubSubMediator, Internal.roleOption(role), numberOfContacts, responseTunnelReceiveTimeout)
-
-  /**
-   * Java API: Factory method for `ClusterReceptionist` [[akka.actor.Props]]
-   * with default values.
-   */
-  def props(
-    pubSubMediator: ActorRef,
-    role: String): Props =
-    props(pubSubMediator, Internal.roleOption(role))
+    settings: ClusterReceptionistSettings): Props =
+    Props(new ClusterReceptionist(pubSubMediator, settings)).withDeploy(Deploy.local)
 
   /**
    * INTERNAL API
@@ -317,11 +410,6 @@ object ClusterReceptionist {
     final case class Contacts(contactPoints: immutable.IndexedSeq[ActorSelection])
     @SerialVersionUID(1L)
     case object Ping
-
-    def roleOption(role: String): Option[String] = role match {
-      case null | "" ⇒ None
-      case _         ⇒ Some(role)
-    }
 
     /**
      * Replies are tunneled via this actor, child of the receptionist, to avoid
@@ -344,7 +432,7 @@ object ClusterReceptionist {
 /**
  * [[ClusterClient]] connects to this actor to retrieve. The `ClusterReceptionist` is
  * supposed to be started on all nodes, or all nodes with specified role, in the cluster.
- * The receptionist can be started with the [[ClusterReceptionistExtension]] or as an
+ * The receptionist can be started with the [[ClusterClientReceptionist]] or as an
  * ordinary actor (use the factory method [[ClusterReceptionist#props]]).
  *
  * The receptionist forwards messages from the client to the associated [[akka.cluster.pubsub.DistributedPubSubMediator]],
@@ -361,16 +449,13 @@ object ClusterReceptionist {
  * as the original sender, so the client can choose to send subsequent messages
  * directly to the actor in the cluster.
  */
-class ClusterReceptionist(
-  pubSubMediator: ActorRef,
-  role: Option[String],
-  numberOfContacts: Int,
-  responseTunnelReceiveTimeout: FiniteDuration)
+class ClusterReceptionist(pubSubMediator: ActorRef, settings: ClusterReceptionistSettings)
   extends Actor with ActorLogging {
 
   import DistributedPubSubMediator.{ Send, SendToAll, Publish }
 
   import ClusterReceptionist.Internal._
+  import settings._
 
   val cluster = Cluster(context.system)
   import cluster.selfAddress

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
@@ -72,7 +72,7 @@ class ClusterClientSpec extends MultiNodeSpec(ClusterClientSpec) with STMultiNod
 
   def awaitCount(expected: Int): Unit = {
     awaitAssert {
-      DistributedPubSubExtension(system).mediator ! DistributedPubSubMediator.Count
+      DistributedPubSub(system).mediator ! DistributedPubSubMediator.Count
       expectMsgType[Int] should ===(expected)
     }
   }

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
@@ -64,7 +64,7 @@ object DistributedPubSubMediatorSpec extends MultiNodeConfig {
   class Publisher extends Actor {
     import DistributedPubSubMediator.Publish
     // activate the extension
-    val mediator = DistributedPubSubExtension(context.system).mediator
+    val mediator = DistributedPubSub(context.system).mediator
 
     def receive = {
       case in: String ⇒
@@ -77,7 +77,7 @@ object DistributedPubSubMediatorSpec extends MultiNodeConfig {
   //#subscriber
   class Subscriber extends Actor with ActorLogging {
     import DistributedPubSubMediator.{ Subscribe, SubscribeAck }
-    val mediator = DistributedPubSubExtension(context.system).mediator
+    val mediator = DistributedPubSub(context.system).mediator
     // subscribe to the topic named "content"
     mediator ! Subscribe("content", self)
 
@@ -114,8 +114,8 @@ class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMedia
     enterBarrier(from.name + "-joined")
   }
 
-  def createMediator(): ActorRef = DistributedPubSubExtension(system).mediator
-  def mediator: ActorRef = DistributedPubSubExtension(system).mediator
+  def createMediator(): ActorRef = DistributedPubSub(system).mediator
+  def mediator: ActorRef = DistributedPubSub(system).mediator
 
   var chatUsers: Map[String, ActorRef] = Map.empty
 

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerChaosSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerChaosSpec.scala
@@ -79,9 +79,8 @@ class ClusterSingletonManagerChaosSpec extends MultiNodeSpec(ClusterSingletonMan
   def createSingleton(): ActorRef = {
     system.actorOf(ClusterSingletonManager.props(
       singletonProps = Props(classOf[Echo], testActor),
-      singletonName = "echo",
       terminationMessage = PoisonPill,
-      role = None),
+      settings = ClusterSingletonManagerSettings(system).withSingletonName("echo")),
       name = "singleton")
   }
 

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaveSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaveSpec.scala
@@ -77,16 +77,15 @@ class ClusterSingletonManagerLeaveSpec extends MultiNodeSpec(ClusterSingletonMan
   def createSingleton(): ActorRef = {
     system.actorOf(ClusterSingletonManager.props(
       singletonProps = Props(classOf[Echo], testActor),
-      singletonName = "echo",
       terminationMessage = PoisonPill,
-      role = None),
+      settings = ClusterSingletonManagerSettings(system).withSingletonName("echo")),
       name = "singleton")
   }
 
   lazy val echoProxy: ActorRef = {
     system.actorOf(ClusterSingletonProxy.props(
       singletonPath = "/user/singleton/echo",
-      role = None),
+      settings = ClusterSingletonProxySettings(system)),
       name = "echoProxy")
   }
 

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerSpec.scala
@@ -259,9 +259,9 @@ class ClusterSingletonManagerSpec extends MultiNodeSpec(ClusterSingletonManagerS
     //#create-singleton-manager
     system.actorOf(ClusterSingletonManager.props(
       singletonProps = Props(classOf[Consumer], queue, testActor),
-      singletonName = "consumer",
       terminationMessage = End,
-      role = Some("worker")),
+      settings = ClusterSingletonManagerSettings(system)
+        .withSingletonName("consumer").withRole("worker")),
       name = "singleton")
     //#create-singleton-manager
   }
@@ -270,7 +270,7 @@ class ClusterSingletonManagerSpec extends MultiNodeSpec(ClusterSingletonManagerS
     //#create-singleton-proxy
     system.actorOf(ClusterSingletonProxy.props(
       singletonPath = "/user/singleton/consumer",
-      role = Some("worker")),
+      settings = ClusterSingletonProxySettings(system).withRole("worker")),
       name = "consumerProxy")
     //#create-singleton-proxy
   }

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerStartupSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerStartupSpec.scala
@@ -71,16 +71,15 @@ class ClusterSingletonManagerStartupSpec extends MultiNodeSpec(ClusterSingletonM
   def createSingleton(): ActorRef = {
     system.actorOf(ClusterSingletonManager.props(
       singletonProps = Props(classOf[Echo], testActor),
-      singletonName = "echo",
       terminationMessage = PoisonPill,
-      role = None),
+      settings = ClusterSingletonManagerSettings(system).withSingletonName("echo")),
       name = "singleton")
   }
 
   lazy val echoProxy: ActorRef = {
     system.actorOf(ClusterSingletonProxy.props(
       singletonPath = "/user/singleton/echo",
-      role = None),
+      settings = ClusterSingletonProxySettings(system)),
       name = "echoProxy")
   }
 

--- a/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
@@ -4,7 +4,10 @@
 
 package akka.cluster.pubsub;
 
+import com.typesafe.config.ConfigFactory;
+
 import akka.testkit.AkkaJUnitActorSystemResource;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -19,7 +22,10 @@ public class DistributedPubSubMediatorTest {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =
-    new AkkaJUnitActorSystemResource("DistributedPubSubMediatorTest");
+    new AkkaJUnitActorSystemResource("DistributedPubSubMediatorTest", 
+        ConfigFactory.parseString(
+            "akka.actor.provider = \"akka.cluster.ClusterActorRefProvider\"\n" +
+            "akka.remote.netty.tcp.port=0"));
 
   private final ActorSystem system = actorSystemResource.getSystem();
 
@@ -47,7 +53,7 @@ public class DistributedPubSubMediatorTest {
 
     public Subscriber() {
       ActorRef mediator = 
-        DistributedPubSubExtension.get(getContext().system()).mediator();
+        DistributedPubSub.get(getContext().system()).mediator();
       // subscribe to the topic named "content"
       mediator.tell(new DistributedPubSubMediator.Subscribe("content", getSelf()), 
         getSelf());
@@ -70,7 +76,7 @@ public class DistributedPubSubMediatorTest {
 
     // activate the extension
     ActorRef mediator = 
-      DistributedPubSubExtension.get(getContext().system()).mediator();
+      DistributedPubSub.get(getContext().system()).mediator();
 
     public void onReceive(Object msg) {
       if (msg instanceof String) {

--- a/akka-cluster-tools/src/test/java/akka/cluster/singleton/ClusterSingletonManagerTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/singleton/ClusterSingletonManagerTest.java
@@ -31,12 +31,16 @@ public class ClusterSingletonManagerTest {
     final ActorRef testActor = null;
 
     //#create-singleton-manager
-    system.actorOf(ClusterSingletonManager.defaultProps(Props.create(Consumer.class, queue, testActor), "consumer",
-        new End(), "worker"), "singleton");
+    final ClusterSingletonManagerSettings settings = ClusterSingletonManagerSettings.create(system)
+        .withSingletonName("consumer").withRole("worker");
+    system.actorOf(ClusterSingletonManager.props(Props.create(Consumer.class, queue, testActor), 
+        new End(), settings), "singleton");
     //#create-singleton-manager
 
     //#create-singleton-proxy
-    system.actorOf(ClusterSingletonProxy.defaultProps("user/singleton/consumer", "worker"), "consumerProxy");
+    ClusterSingletonProxySettings proxySettings = 
+        ClusterSingletonProxySettings.create(system).withRole("worker");
+    system.actorOf(ClusterSingletonProxy.props("user/singleton/consumer", proxySettings), "consumerProxy");
     //#create-singleton-proxy
   }
 

--- a/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
@@ -40,14 +40,14 @@ object ClusterSingletonProxySpec {
     cluster.registerOnMemberUp {
       system.actorOf(ClusterSingletonManager.props(
         singletonProps = Props[Singleton],
-        singletonName = "singleton",
         terminationMessage = PoisonPill,
-        role = None,
-        maxHandOverRetries = 5,
-        maxTakeOverRetries = 2), name = "singletonManager")
+        settings = ClusterSingletonManagerSettings(system)
+          .withRetry(maxHandOverRetries = 5, maxTakeOverRetries = 2, retryInterval = 1.second)),
+        name = "singletonManager")
     }
 
-    val proxy = system.actorOf(ClusterSingletonProxy.props("user/singletonManager/singleton", None), s"singletonProxy-${cluster.selfAddress.port.getOrElse(0)}")
+    val proxy = system.actorOf(ClusterSingletonProxy.props("user/singletonManager/singleton",
+      settings = ClusterSingletonProxySettings(system)), s"singletonProxy-${cluster.selfAddress.port.getOrElse(0)}")
 
     def testProxy(msg: String) {
       val probe = TestProbe()

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -217,3 +217,11 @@ named ``akka-cluster-sharding``. You need to replace this dependency if you use 
 The classes changed package name from ``akka.contrib.pattern`` to ``akka.cluster.sharding``.
 
 The configuration properties changed name to ``akka.cluster.sharding``.
+
+ClusterSingletonManager and ClusterSingletonProxy construction
+==============================================================
+
+Parameters to the ``Props`` factory methods have been moved to settings object ``ClusterSingletonManagerSettings`
+and ``ClusterSingletonProxySettings``. These can be created from system configuration properties and also
+amended with API as needed.
+

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -228,10 +228,23 @@ amended with API as needed.
 DistributedPubSub construction
 ==============================
 
-Normally, the ``DistributedPubSubMediator`` is started by the ``DistributedPubSubExtension``.
+Normally, the ``DistributedPubSubMediator`` actor is started by the ``DistributedPubSubExtension``.
 This extension has been renamed to ``DistributedPubSub``. It is also possible to start
 it as an ordinary actor if you need multiple instances of it with different settings.
 The parameters of the ``Props`` factory methods in the ``DistributedPubSubMediator`` companion
 has been moved to settings object ``DistributedPubSubSettings``. This can be created from
 system configuration properties and also amended with API as needed.
- 
+
+ClusterClient construction
+==========================
+
+The parameters of the ``Props`` factory methods in the ``ClusterClient`` companion
+has been moved to settings object ``ClusterClientSettings``. This can be created from
+system configuration properties and also amended with API as needed.
+
+Normally, the ``ClusterReceptionist`` actor is started by the ``ClusterReceptionistExtension``.
+This extension has been renamed to ``ClusterClientReceptionist``. It is also possible to start
+it as an ordinary actor if you need multiple instances of it with different settings.
+The parameters of the ``Props`` factory methods in the ``ClusterReceptionist`` companion
+has been moved to settings object ``ClusterReceptionistSettings``. This can be created from
+system configuration properties and also amended with API as needed.

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -221,7 +221,17 @@ The configuration properties changed name to ``akka.cluster.sharding``.
 ClusterSingletonManager and ClusterSingletonProxy construction
 ==============================================================
 
-Parameters to the ``Props`` factory methods have been moved to settings object ``ClusterSingletonManagerSettings`
+Parameters to the ``Props`` factory methods have been moved to settings object ``ClusterSingletonManagerSettings``
 and ``ClusterSingletonProxySettings``. These can be created from system configuration properties and also
 amended with API as needed.
 
+DistributedPubSub construction
+==============================
+
+Normally, the ``DistributedPubSubMediator`` is started by the ``DistributedPubSubExtension``.
+This extension has been renamed to ``DistributedPubSub``. It is also possible to start
+it as an ordinary actor if you need multiple instances of it with different settings.
+The parameters of the ``Props`` factory methods in the ``DistributedPubSubMediator`` companion
+has been moved to settings object ``DistributedPubSubSettings``. This can be created from
+system configuration properties and also amended with API as needed.
+ 

--- a/akka-docs/rst/scala/cluster-client.rst
+++ b/akka-docs/rst/scala/cluster-client.rst
@@ -18,12 +18,12 @@ the cluster client.
 
 
 The receptionist is supposed to be started on all nodes, or all nodes with specified role,
-in the cluster. The receptionist can be started with the ``ClusterReceptionistExtension``
+in the cluster. The receptionist can be started with the ``ClusterClientReceptionist`` extension
 or as an ordinary actor.
 
 You can send messages via the ``ClusterClient`` to any actor in the cluster that is registered
 in the ``DistributedPubSubMediator`` used by the ``ClusterReceptionist``.
-The ``ClusterReceptionistExtension`` provides methods for registration of actors that
+The ``ClusterClientReceptionist`` provides methods for registration of actors that
 should be reachable from the client. Messages are wrapped in ``ClusterClient.Send``,
 ``ClusterClient.SendToAll`` or ``ClusterClient.Publish``.
 
@@ -67,7 +67,7 @@ An Example
 On the cluster nodes first start the receptionist. Note, it is recommended to load the extension 
 when the actor system is started by defining it in the ``akka.extensions`` configuration property::
 
-   akka.extensions = ["akka.cluster.client.ClusterReceptionistExtension"]
+   akka.extensions = ["akka.cluster.client.ClusterClientReceptionist"]
 
 Next, register the actors that should be available for the client.
 
@@ -89,25 +89,25 @@ A more comprehensive sample is available in the `Typesafe Activator <http://www.
 tutorial named `Distributed workers with Akka and Scala! <http://www.typesafe.com/activator/template/akka-distributed-workers>`_
 and `Distributed workers with Akka and Java! <http://www.typesafe.com/activator/template/akka-distributed-workers-java>`_.
 
-ClusterReceptionistExtension
+ClusterClientReceptionist
 ----------------------------
 
-In the example above the receptionist is started and accessed with the ``akka.cluster.client.ClusterReceptionistExtension``.
+In the example above the receptionist is started and accessed with the ``akka.cluster.client.ClusterClientReceptionist``.
 That is convenient and perfectly fine in most cases, but it can be good to know that it is possible to
 start the ``akka.cluster.client.ClusterReceptionist`` actor as an ordinary actor and you can have several
 different receptionists at the same time, serving different types of clients.
 
-The ``ClusterReceptionistExtension`` can be configured with the following properties:
+The ``ClusterClientReceptionist`` can be configured with the following properties:
 
 .. includecode:: ../../../akka-cluster-tools/src/main/resources/reference.conf#receptionist-ext-config
 
-Note that the ``ClusterReceptionistExtension`` uses the ``DistributedPubSub`` extension, which is described
+Note that the ``ClusterClientReceptionist`` uses the ``DistributedPubSub`` extension, which is described
 in :ref:`distributed-pub-sub`.
 
 It is recommended to load the extension when the actor system is started by defining it in the
 ``akka.extensions`` configuration property::
 
-   akka.extensions = ["akka.cluster.client.ClusterReceptionistExtension"]
+   akka.extensions = ["akka.cluster.client.ClusterClientReceptionist"]
 
 Dependencies
 ------------

--- a/akka-docs/rst/scala/cluster-client.rst
+++ b/akka-docs/rst/scala/cluster-client.rst
@@ -101,7 +101,7 @@ The ``ClusterReceptionistExtension`` can be configured with the following proper
 
 .. includecode:: ../../../akka-cluster-tools/src/main/resources/reference.conf#receptionist-ext-config
 
-Note that the ``ClusterReceptionistExtension`` uses the ``DistributedPubSubExtension``, which is described
+Note that the ``ClusterReceptionistExtension`` uses the ``DistributedPubSub`` extension, which is described
 in :ref:`distributed-pub-sub`.
 
 It is recommended to load the extension when the actor system is started by defining it in the

--- a/akka-docs/rst/scala/distributed-pub-sub.rst
+++ b/akka-docs/rst/scala/distributed-pub-sub.rst
@@ -14,7 +14,7 @@ actors among all cluster nodes or a group of nodes tagged with a specific role.
 
 The `DistributedPubSubMediator` is supposed to be started on all nodes,
 or all nodes with specified role, in the cluster. The mediator can be
-started with the ``DistributedPubSubExtension`` or as an ordinary actor.
+started with the ``DistributedPubSub`` or as an ordinary actor.
 
 Changes are only performed in the own part of the registry and those changes
 are versioned. Deltas are disseminated in a scalable way to other nodes with
@@ -122,16 +122,16 @@ It can publish messages to the topic from anywhere in the cluster:
 A more comprehensive sample is available in the `Typesafe Activator <http://www.typesafe.com/platform/getstarted>`_
 tutorial named `Akka Clustered PubSub with Scala! <http://www.typesafe.com/activator/template/akka-clustering>`_.
 
-DistributedPubSubExtension
+DistributedPubSub
 --------------------------
 
-In the example above the mediator is started and accessed with the ``akka.cluster.pubsub.DistributedPubSubExtension``.
+In the example above the mediator is started and accessed with the ``akka.cluster.pubsub.DistributedPubSub``.
 That is convenient and perfectly fine in most cases, but it can be good to know that it is possible to
 start the mediator actor as an ordinary actor and you can have several different mediators at the same
 time to be able to divide a large number of actors/topics to different mediators. For example you might
 want to use different cluster roles for different mediators.
 
-The ``DistributedPubSubExtension`` can be configured with the following properties:
+The ``DistributedPubSub`` can be configured with the following properties:
 
 .. includecode:: ../../../akka-cluster-tools/src/main/resources/reference.conf#pub-sub-ext-config
 
@@ -141,7 +141,7 @@ and then it takes a while for it to be populated.
 
 ::
 
-   akka.extensions = ["akka.cluster.pubsub.DistributedPubSubExtension"]
+   akka.extensions = ["akka.cluster.pubsub.DistributedPubSub"]
 
 Dependencies
 ------------

--- a/akka-samples/akka-sample-cluster-java/src/main/java/sample/cluster/stats/StatsSampleOneMasterMain.java
+++ b/akka-samples/akka-sample-cluster-java/src/main/java/sample/cluster/stats/StatsSampleOneMasterMain.java
@@ -7,7 +7,9 @@ import akka.actor.ActorSystem;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.cluster.singleton.ClusterSingletonManager;
+import akka.cluster.singleton.ClusterSingletonManagerSettings;
 import akka.cluster.singleton.ClusterSingletonProxy;
+import akka.cluster.singleton.ClusterSingletonProxySettings;
 
 public class StatsSampleOneMasterMain {
 
@@ -32,14 +34,18 @@ public class StatsSampleOneMasterMain {
       ActorSystem system = ActorSystem.create("ClusterSystem", config);
 
       //#create-singleton-manager
-      system.actorOf(ClusterSingletonManager.defaultProps(
-          Props.create(StatsService.class), "statsService",
-          PoisonPill.getInstance(), "compute"), "singleton");
+      ClusterSingletonManagerSettings settings = ClusterSingletonManagerSettings.create(system)
+          .withSingletonName("statsService").withRole("compute");
+      system.actorOf(ClusterSingletonManager.props(
+          Props.create(StatsService.class), PoisonPill.getInstance(), settings),
+          "singleton");
       //#create-singleton-manager
 
       //#singleton-proxy
-      system.actorOf(ClusterSingletonProxy.defaultProps("/user/singleton/statsService",
-        "compute"), "statsServiceProxy");
+      ClusterSingletonProxySettings proxySettings =
+          ClusterSingletonProxySettings.create(system).withRole("compute");
+      system.actorOf(ClusterSingletonProxy.props("/user/singleton/statsService",
+          proxySettings), "statsServiceProxy");
       //#singleton-proxy
     }
 

--- a/akka-samples/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -15,11 +15,13 @@ import akka.cluster.MemberStatus
 import akka.cluster.ClusterEvent.CurrentClusterState
 import akka.cluster.ClusterEvent.MemberUp
 import akka.cluster.singleton.ClusterSingletonManager
+import akka.cluster.singleton.ClusterSingletonManagerSettings
 import akka.cluster.singleton.ClusterSingletonProxy
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
 import akka.testkit.ImplicitSender
 import sample.cluster.stats.StatsMessages._
+import akka.cluster.singleton.ClusterSingletonProxySettings
 
 object StatsSampleSingleMasterSpecConfig extends MultiNodeConfig {
   // register the named roles (nodes) of the test
@@ -100,14 +102,14 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
 
       Cluster(system).unsubscribe(testActor)
 
-      system.actorOf(ClusterSingletonManager.defaultProps(
+      system.actorOf(ClusterSingletonManager.props(
         Props[StatsService],
-        singletonName = "statsService",
         terminationMessage = PoisonPill,
-        role = null), name = "singleton")
+        settings = ClusterSingletonManagerSettings(system).withSingletonName("statsService")),
+        name = "singleton")
 
-      system.actorOf(ClusterSingletonProxy.defaultProps("/user/singleton/statsService",
-        "compute"), "statsServiceProxy");
+      system.actorOf(ClusterSingletonProxy.props("/user/singleton/statsService",
+        ClusterSingletonProxySettings(system).withRole("compute")), "statsServiceProxy")
 
       testConductor.enter("all-up")
     }

--- a/akka-samples/akka-sample-cluster-scala/src/main/scala/sample/cluster/stats/StatsSampleOneMaster.scala
+++ b/akka-samples/akka-sample-cluster-scala/src/main/scala/sample/cluster/stats/StatsSampleOneMaster.scala
@@ -5,7 +5,9 @@ import akka.actor.ActorSystem
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.cluster.singleton.ClusterSingletonManager
+import akka.cluster.singleton.ClusterSingletonManagerSettings
 import akka.cluster.singleton.ClusterSingletonProxy
+import akka.cluster.singleton.ClusterSingletonProxySettings
 
 object StatsSampleOneMaster {
   def main(args: Array[String]): Unit = {
@@ -29,14 +31,17 @@ object StatsSampleOneMaster {
 
       //#create-singleton-manager
       system.actorOf(ClusterSingletonManager.props(
-        singletonProps = Props[StatsService], singletonName = "statsService",
-        terminationMessage = PoisonPill, role = Some("compute")),
+        singletonProps = Props[StatsService],
+        terminationMessage = PoisonPill,
+        settings = ClusterSingletonManagerSettings(system)
+          .withSingletonName("statsService").withRole("compute")),
         name = "singleton")
       //#create-singleton-manager
 
       //#singleton-proxy
       system.actorOf(ClusterSingletonProxy.props(singletonPath = "/user/singleton/statsService",
-        role = Some("compute")), name = "statsServiceProxy")
+        settings = ClusterSingletonProxySettings(system).withRole("compute")),
+        name = "statsServiceProxy")
       //#singleton-proxy
     }
   }

--- a/akka-samples/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-samples/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -10,6 +10,7 @@ import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.RootActorPath
 import akka.cluster.singleton.ClusterSingletonManager
+import akka.cluster.singleton.ClusterSingletonManagerSettings
 import akka.cluster.singleton.ClusterSingletonProxy
 import akka.cluster.Cluster
 import akka.cluster.Member
@@ -19,6 +20,7 @@ import akka.cluster.ClusterEvent.MemberUp
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
 import akka.testkit.ImplicitSender
+import akka.cluster.singleton.ClusterSingletonProxySettings
 
 object StatsSampleSingleMasterSpecConfig extends MultiNodeConfig {
   // register the named roles (nodes) of the test
@@ -100,11 +102,14 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
       Cluster(system).unsubscribe(testActor)
 
       system.actorOf(ClusterSingletonManager.props(
-        singletonProps = Props[StatsService], singletonName = "statsService",
-        terminationMessage = PoisonPill, role = Some("compute")), name = "singleton")
+        singletonProps = Props[StatsService], terminationMessage = PoisonPill,
+        settings = ClusterSingletonManagerSettings(system)
+          .withSingletonName("statsService").withRole("compute")),
+        name = "singleton")
 
       system.actorOf(ClusterSingletonProxy.props(singletonPath = "/user/singleton/statsService",
-        role = Some("compute")), name = "statsServiceProxy")
+        ClusterSingletonProxySettings(system).withRole("compute")),
+        name = "statsServiceProxy")
 
       testConductor.enter("all-up")
     }


### PR DESCRIPTION
Default values should be in config. The number of parameters for props factories have grown beyond manageable.

Using same structure as the settings in Akka Streams, i.e. can be created from system/config, and amended by `withX` methods.
