### PR TITLE
!htc HTTPS-enable server- and client-side APIs

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/HttpsContext.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/HttpsContext.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.javadsl;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import akka.japi.Option;
+import akka.stream.io.ClientAuth;
+
+import java.util.Collection;
+
+public abstract class HttpsContext {
+    
+    public abstract SSLContext getSslContext();
+
+    public abstract Option<Collection<String>> getEnabledCipherSuites();
+
+    public abstract Option<Collection<String>> getEnabledProtocols();
+
+    public abstract Option<ClientAuth> getClientAuth();
+
+    public abstract Option<SSLParameters> getSslParameters();
+    
+    public static HttpsContext create(SSLContext sslContext,
+                                      Option<Collection<String>> enabledCipherSuites,
+                                      Option<Collection<String>> enabledProtocols,
+                                      Option<ClientAuth> clientAuth,
+                                      Option<SSLParameters> sslParameters) {
+        return akka.http.scaladsl.HttpsContext.create(sslContext, enabledCipherSuites, enabledProtocols,
+                clientAuth, sslParameters);
+    }
+}

--- a/akka-http-core/src/main/scala/akka/http/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/ConnectionPoolSettings.scala
@@ -5,11 +5,11 @@
 package akka.http
 
 import java.lang.{ Iterable ⇒ JIterable }
+import akka.http.scaladsl.HttpsContext
 import com.typesafe.config.Config
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
 import akka.japi.Util._
-
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.http.impl.util._
@@ -18,18 +18,18 @@ import akka.io.Inet
 final case class HostConnectionPoolSetup(host: String, port: Int, setup: ConnectionPoolSetup)
 
 final case class ConnectionPoolSetup(
-  encrypted: Boolean,
   options: immutable.Traversable[Inet.SocketOption],
   settings: ConnectionPoolSettings,
+  httpsContext: Option[HttpsContext],
   log: LoggingAdapter)
 
 object ConnectionPoolSetup {
   /** Java API */
-  def create(encrypted: Boolean,
-             options: JIterable[Inet.SocketOption],
+  def create(options: JIterable[Inet.SocketOption],
              settings: ConnectionPoolSettings,
+             httpsContext: akka.japi.Option[akka.http.javadsl.HttpsContext],
              log: LoggingAdapter): ConnectionPoolSetup =
-    ConnectionPoolSetup(encrypted, immutableSeq(options), settings, log)
+    ConnectionPoolSetup(immutableSeq(options), settings, httpsContext.map(_.asInstanceOf[HttpsContext]), log)
 }
 
 final case class ConnectionPoolSettings(

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
@@ -1,10 +1,9 @@
 package akka.http.impl.engine.client
 
 import java.util.concurrent.atomic.AtomicReference
-import akka.http.HostConnectionPoolSetup
-
 import scala.annotation.tailrec
 import scala.concurrent.{ Future, Promise }
+import akka.http.HostConnectionPoolSetup
 import akka.actor.{ Props, ActorSystem, ActorRef }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpResponse, HttpRequest }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
@@ -4,14 +4,13 @@
 
 package akka.http.impl.engine.client
 
-import akka.http.ConnectionPoolSettings
-
 import language.existentials
 import java.net.InetSocketAddress
 import scala.util.{ Failure, Success }
 import scala.collection.immutable
 import akka.actor._
 import akka.http.scaladsl.model.{ HttpResponse, HttpRequest }
+import akka.http.ConnectionPoolSettings
 import akka.http.impl.util._
 import akka.stream.impl.{ SubscribePending, ExposedPublisher, ActorProcessor }
 import akka.stream.actor._

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
@@ -14,16 +14,16 @@ import akka.http.impl.util._
 
 object TestClient extends App {
   val testConf: Config = ConfigFactory.parseString("""
-    akka.loglevel = INFO
+    akka.loglevel = DEBUG
     akka.log-dead-letters = off
-    akka.io.tcp.trace-logging = on""")
+    akka.io.tcp.trace-logging = off""")
   implicit val system = ActorSystem("ServerTest", testConf)
   implicit val fm = ActorFlowMaterializer()
   import system.dispatcher
 
   installEventStreamLoggerFor[UnhandledMessage]
 
-  val host = "spray.io"
+  val host = "github.com"
 
   fetchServerVersion1()
 
@@ -31,9 +31,9 @@ object TestClient extends App {
   //  system.shutdown()
 
   def fetchServerVersion1(): Unit = {
-    println(s"Fetching HTTP server version of host `$host` via a direct low-level connection ...")
+    println(s"Fetching HTTPS server version of host `$host` via a direct low-level connection ...")
 
-    val connection = Http().outgoingConnection(host)
+    val connection = Http().outgoingConnectionTls(host)
     val result = Source.single(HttpRequest()).via(connection).runWith(Sink.head)
     result.map(_.header[headers.Server]) onComplete {
       case Success(res) ⇒
@@ -50,7 +50,7 @@ object TestClient extends App {
 
   def fetchServerVersion2(): Unit = {
     println(s"Fetching HTTP server version of host `$host` via the high-level API ...")
-    val result = Http().singleRequest(HttpRequest(uri = s"http://$host/"))
+    val result = Http().singleRequest(HttpRequest(uri = s"https://$host/"))
     result.map(_.header[headers.Server]) onComplete {
       case Success(res) ⇒
         println(s"$host is running ${res mkString ", "}")


### PR DESCRIPTION
This extends the akka-http-core APIs with optional support for HTTPS connection.
Currently there is no deeper support for actively reacting to or triggering session renegotiations but everything should be working nicely.

I have updated the `akka.http.scaladsl.TestClient` in _akka-http-core_ to talk to `https://github.com`, which works on the connection-level but somehow fails when going through a pool.
I'll try to dig up the problem and add a fix to this PR, but this shouldn't keep you from reviewing. 

/cc @jrudolph 
