### PR TITLE
=typ #17460 fix message order in typed.ActorContextSpec

### DIFF
--- a/akka-typed/src/test/scala/akka/typed/ActorContextSpec.scala
+++ b/akka-typed/src/test/scala/akka/typed/ActorContextSpec.scala
@@ -96,8 +96,8 @@ object ActorContextSpec {
           replyTo ! TimeoutSet
           Same
         case Schedule(delay, target, msg, replyTo) ⇒
-          ctx.schedule(delay, target, msg)
           replyTo ! Scheduled
+          ctx.schedule(delay, target, msg)
           Same
         case Stop ⇒ Stopped
         case Kill(ref, replyTo) ⇒


### PR DESCRIPTION
- if the scheduled send happens before (in another thread) the send of
  Scheduled the expected order is violated
