### PR TITLE
!htp Change marshalling and unmarshalling infrastructure to use ExecutionContext from RequestContext instead of an ad-hoc implicit one

### DIFF
--- a/akka-http-java/src/main/scala/akka/http/javadsl/server/RequestVals.scala
+++ b/akka-http-java/src/main/scala/akka/http/javadsl/server/RequestVals.scala
@@ -26,7 +26,7 @@ object RequestVals {
     new ExtractingStandaloneExtractionImpl[T]()(unmarshaller.classTag) {
       def extract(ctx: server.RequestContext): Future[T] = {
         val u = unmarshaller.asInstanceOf[UnmarshallerImpl[T]].scalaUnmarshaller(ctx.executionContext, ctx.flowMaterializer)
-        u(ctx.request)
+        u(ctx.request)(ctx.executionContext)
       }
     }
 

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.marshallers.sprayjson
 
 import scala.language.implicitConversions
-import scala.concurrent.ExecutionContext
 import akka.stream.FlowMaterializer
 import akka.http.scaladsl.marshalling.{ ToEntityMarshaller, Marshaller }
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
@@ -17,11 +16,11 @@ import spray.json._
  * A trait providing automatic to and from JSON marshalling/unmarshalling using an in-scope *spray-json* protocol.
  */
 trait SprayJsonSupport {
-  implicit def sprayJsonUnmarshallerConverter[T](reader: RootJsonReader[T])(implicit ec: ExecutionContext, mat: FlowMaterializer): FromEntityUnmarshaller[T] =
-    sprayJsonUnmarshaller(reader, ec, mat)
-  implicit def sprayJsonUnmarshaller[T](implicit reader: RootJsonReader[T], ec: ExecutionContext, mat: FlowMaterializer): FromEntityUnmarshaller[T] =
+  implicit def sprayJsonUnmarshallerConverter[T](reader: RootJsonReader[T])(implicit mat: FlowMaterializer): FromEntityUnmarshaller[T] =
+    sprayJsonUnmarshaller(reader, mat)
+  implicit def sprayJsonUnmarshaller[T](implicit reader: RootJsonReader[T], mat: FlowMaterializer): FromEntityUnmarshaller[T] =
     sprayJsValueUnmarshaller.map(jsonReader[T].read)
-  implicit def sprayJsValueUnmarshaller(implicit ec: ExecutionContext, mat: FlowMaterializer): FromEntityUnmarshaller[JsValue] =
+  implicit def sprayJsValueUnmarshaller(implicit mat: FlowMaterializer): FromEntityUnmarshaller[JsValue] =
     Unmarshaller.byteStringUnmarshaller.forContentTypes(`application/json`).mapWithCharset { (data, charset) ⇒
       val input =
         if (charset == HttpCharsets.`UTF-8`) ParserInput(data.toArray)
@@ -29,11 +28,11 @@ trait SprayJsonSupport {
       JsonParser(input)
     }
 
-  implicit def sprayJsonMarshallerConverter[T](writer: RootJsonWriter[T])(implicit printer: JsonPrinter = PrettyPrinter, ec: ExecutionContext): ToEntityMarshaller[T] =
-    sprayJsonMarshaller[T](writer, printer, ec)
-  implicit def sprayJsonMarshaller[T](implicit writer: RootJsonWriter[T], printer: JsonPrinter = PrettyPrinter, ec: ExecutionContext): ToEntityMarshaller[T] =
-    sprayJsValueMarshaller[T].compose(writer.write)
-  implicit def sprayJsValueMarshaller[T](implicit writer: RootJsonWriter[T], printer: JsonPrinter = PrettyPrinter, ec: ExecutionContext): ToEntityMarshaller[JsValue] =
+  implicit def sprayJsonMarshallerConverter[T](writer: RootJsonWriter[T])(implicit printer: JsonPrinter = PrettyPrinter): ToEntityMarshaller[T] =
+    sprayJsonMarshaller[T](writer, printer)
+  implicit def sprayJsonMarshaller[T](implicit writer: RootJsonWriter[T], printer: JsonPrinter = PrettyPrinter): ToEntityMarshaller[T] =
+    sprayJsValueMarshaller[T] compose writer.write
+  implicit def sprayJsValueMarshaller[T](implicit writer: RootJsonWriter[T], printer: JsonPrinter = PrettyPrinter): ToEntityMarshaller[JsValue] =
     Marshaller.StringMarshaller.wrap(ContentTypes.`application/json`)(printer.apply)
 }
 object SprayJsonSupport extends SprayJsonSupport

--- a/akka-http-marshallers-scala/akka-http-xml/src/main/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
+++ b/akka-http-marshallers-scala/akka-http-xml/src/main/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl.marshallers.xml
 
 import java.io.{ ByteArrayInputStream, InputStreamReader }
 import scala.collection.immutable
-import scala.concurrent.ExecutionContext
 import scala.xml.{ XML, NodeSeq }
 import akka.stream.FlowMaterializer
 import akka.http.scaladsl.unmarshalling._
@@ -15,18 +14,16 @@ import akka.http.scaladsl.model._
 import MediaTypes._
 
 trait ScalaXmlSupport {
-  implicit def defaultNodeSeqMarshaller(implicit ec: ExecutionContext): ToEntityMarshaller[NodeSeq] =
+  implicit def defaultNodeSeqMarshaller: ToEntityMarshaller[NodeSeq] =
     Marshaller.oneOf(ScalaXmlSupport.nodeSeqContentTypes.map(nodeSeqMarshaller): _*)
 
-  def nodeSeqMarshaller(contentType: ContentType)(implicit ec: ExecutionContext): ToEntityMarshaller[NodeSeq] =
+  def nodeSeqMarshaller(contentType: ContentType): ToEntityMarshaller[NodeSeq] =
     Marshaller.StringMarshaller.wrap(contentType)(_.toString())
 
-  implicit def defaultNodeSeqUnmarshaller(implicit fm: FlowMaterializer,
-                                          ec: ExecutionContext): FromEntityUnmarshaller[NodeSeq] =
+  implicit def defaultNodeSeqUnmarshaller(implicit fm: FlowMaterializer): FromEntityUnmarshaller[NodeSeq] =
     nodeSeqUnmarshaller(ScalaXmlSupport.nodeSeqContentTypeRanges: _*)
 
-  def nodeSeqUnmarshaller(ranges: ContentTypeRange*)(implicit fm: FlowMaterializer,
-                                                     ec: ExecutionContext): FromEntityUnmarshaller[NodeSeq] =
+  def nodeSeqUnmarshaller(ranges: ContentTypeRange*)(implicit fm: FlowMaterializer): FromEntityUnmarshaller[NodeSeq] =
     Unmarshaller.byteArrayUnmarshaller.forContentTypes(ranges: _*).mapWithCharset { (bytes, charset) ⇒
       if (bytes.length > 0) {
         val parser = XML.parser

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala
@@ -4,34 +4,40 @@
 
 package akka.http.scaladsl.marshalling
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 import scala.util.{ Try, Failure, Success }
 import akka.http.scaladsl.util.FastFuture
 import FastFuture._
 
 trait GenericMarshallers extends LowPriorityToResponseMarshallerImplicits {
 
-  implicit def throwableMarshaller[T]: Marshaller[Throwable, T] = Marshaller(FastFuture.failed)
+  implicit def throwableMarshaller[T]: Marshaller[Throwable, T] = Marshaller(_ ⇒ FastFuture.failed)
 
   implicit def optionMarshaller[A, B](implicit m: Marshaller[A, B], empty: EmptyValue[B]): Marshaller[Option[A], B] =
-    Marshaller {
-      case Some(value) ⇒ m(value)
-      case None        ⇒ FastFuture.successful(Marshalling.Opaque(() ⇒ empty.emptyValue) :: Nil)
+    Marshaller { implicit ec ⇒
+      {
+        case Some(value) ⇒ m(value)
+        case None        ⇒ FastFuture.successful(Marshalling.Opaque(() ⇒ empty.emptyValue) :: Nil)
+      }
     }
 
   implicit def eitherMarshaller[A1, A2, B](implicit m1: Marshaller[A1, B], m2: Marshaller[A2, B]): Marshaller[Either[A1, A2], B] =
-    Marshaller {
-      case Left(a1)  ⇒ m1(a1)
-      case Right(a2) ⇒ m2(a2)
+    Marshaller { implicit ec ⇒
+      {
+        case Left(a1)  ⇒ m1(a1)
+        case Right(a2) ⇒ m2(a2)
+      }
     }
 
-  implicit def futureMarshaller[A, B](implicit m: Marshaller[A, B], ec: ExecutionContext): Marshaller[Future[A], B] =
-    Marshaller(_.fast.flatMap(m(_)))
+  implicit def futureMarshaller[A, B](implicit m: Marshaller[A, B]): Marshaller[Future[A], B] =
+    Marshaller(implicit ec ⇒ _.fast.flatMap(m(_)))
 
   implicit def tryMarshaller[A, B](implicit m: Marshaller[A, B]): Marshaller[Try[A], B] =
-    Marshaller {
-      case Success(value) ⇒ m(value)
-      case Failure(error) ⇒ FastFuture.failed(error)
+    Marshaller { implicit ec ⇒
+      {
+        case Success(value) ⇒ m(value)
+        case Failure(error) ⇒ FastFuture.failed(error)
+      }
     }
 }
 

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
@@ -10,10 +10,12 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
 
-sealed abstract class Marshaller[-A, +B] extends (A ⇒ Future[List[Marshalling[B]]]) {
+sealed abstract class Marshaller[-A, +B] {
 
-  def map[C](f: B ⇒ C)(implicit ec: ExecutionContext): Marshaller[A, C] =
-    Marshaller[A, C](value ⇒ this(value).fast map (_ map (_ map f)))
+  def apply(value: A)(implicit ec: ExecutionContext): Future[List[Marshalling[B]]]
+
+  def map[C](f: B ⇒ C): Marshaller[A, C] =
+    Marshaller(implicit ec ⇒ value ⇒ this(value).fast map (_ map (_ map f)))
 
   /**
    * Reuses this Marshaller's logic to produce a new Marshaller from another type `C` which overrides
@@ -24,24 +26,41 @@ sealed abstract class Marshaller[-A, +B] extends (A ⇒ Future[List[Marshalling[
    * that has a defined charset of UTF-8, since akka-http will never recode entities.
    * If the wrapping is illegal the [[Future]] produced by the resulting marshaller will contain a [[RuntimeException]].
    */
-  def wrap[C, D >: B](contentType: ContentType)(f: C ⇒ A)(implicit ec: ExecutionContext, mto: MediaTypeOverrider[D]): Marshaller[C, D] =
-    Marshaller { value ⇒
-      import Marshalling._
-      this(f(value)).fast map {
-        _ map {
-          case WithFixedCharset(_, cs, marshal) if contentType.hasOpenCharset || contentType.charset == cs ⇒
-            WithFixedCharset(contentType.mediaType, cs, () ⇒ mto(marshal(), contentType.mediaType))
-          case WithOpenCharset(_, marshal) if contentType.hasOpenCharset ⇒
-            WithOpenCharset(contentType.mediaType, cs ⇒ mto(marshal(cs), contentType.mediaType))
-          case WithOpenCharset(_, marshal) ⇒
-            WithFixedCharset(contentType.mediaType, contentType.charset, () ⇒ mto(marshal(contentType.charset), contentType.mediaType))
-          case Opaque(marshal) if contentType.definedCharset.isEmpty ⇒ Opaque(() ⇒ mto(marshal(), contentType.mediaType))
-          case x ⇒ sys.error(s"Illegal marshaller wrapping. Marshalling `$x` cannot be wrapped with ContentType `$contentType`")
+  def wrap[C, D >: B](contentType: ContentType)(f: C ⇒ A)(implicit mto: MediaTypeOverrider[D]): Marshaller[C, D] =
+    wrapWithEC[C, D](contentType)(_ ⇒ f)
+
+  /**
+   * Reuses this Marshaller's logic to produce a new Marshaller from another type `C` which overrides
+   * the produced [[ContentType]] with another one.
+   * Depending on whether the given [[ContentType]] has a defined charset or not and whether the underlying
+   * marshaller marshals with a fixed charset it can happen, that the wrapping becomes illegal.
+   * For example, a marshaller producing content encoded with UTF-16 cannot be wrapped with a [[ContentType]]
+   * that has a defined charset of UTF-8, since akka-http will never recode entities.
+   * If the wrapping is illegal the [[Future]] produced by the resulting marshaller will contain a [[RuntimeException]].
+   */
+  def wrapWithEC[C, D >: B](contentType: ContentType)(f: ExecutionContext ⇒ C ⇒ A)(implicit mto: MediaTypeOverrider[D]): Marshaller[C, D] =
+    Marshaller { implicit ec ⇒
+      value ⇒
+        import Marshalling._
+        this(f(ec)(value)).fast map {
+          _ map {
+            case WithFixedCharset(_, cs, marshal) if contentType.hasOpenCharset || contentType.charset == cs ⇒
+              WithFixedCharset(contentType.mediaType, cs, () ⇒ mto(marshal(), contentType.mediaType))
+            case WithOpenCharset(_, marshal) if contentType.hasOpenCharset ⇒
+              WithOpenCharset(contentType.mediaType, cs ⇒ mto(marshal(cs), contentType.mediaType))
+            case WithOpenCharset(_, marshal) ⇒
+              WithFixedCharset(contentType.mediaType, contentType.charset, () ⇒ mto(marshal(contentType.charset), contentType.mediaType))
+            case Opaque(marshal) if contentType.definedCharset.isEmpty ⇒ Opaque(() ⇒ mto(marshal(), contentType.mediaType))
+            case x ⇒ sys.error(s"Illegal marshaller wrapping. Marshalling `$x` cannot be wrapped with ContentType `$contentType`")
+          }
         }
-      }
     }
 
-  override def compose[C](f: C ⇒ A): Marshaller[C, B] = Marshaller(super.compose(f))
+  def compose[C](f: C ⇒ A): Marshaller[C, B] =
+    Marshaller(implicit ec ⇒ c ⇒ apply(f(c)))
+
+  def composeWithEC[C](f: ExecutionContext ⇒ C ⇒ A): Marshaller[C, B] =
+    Marshaller(implicit ec ⇒ c ⇒ apply(f(ec)(c)))
 }
 
 object Marshaller
@@ -53,10 +72,10 @@ object Marshaller
   /**
    * Creates a [[Marshaller]] from the given function.
    */
-  def apply[A, B](f: A ⇒ Future[List[Marshalling[B]]]): Marshaller[A, B] =
+  def apply[A, B](f: ExecutionContext ⇒ A ⇒ Future[List[Marshalling[B]]]): Marshaller[A, B] =
     new Marshaller[A, B] {
-      def apply(value: A) =
-        try f(value)
+      def apply(value: A)(implicit ec: ExecutionContext) =
+        try f(ec)(value)
         catch { case NonFatal(e) ⇒ FastFuture.failed(e) }
     }
 
@@ -64,20 +83,20 @@ object Marshaller
    * Helper for creating a [[Marshaller]] using the given function.
    */
   def strict[A, B](f: A ⇒ Marshalling[B]): Marshaller[A, B] =
-    Marshaller { a ⇒ FastFuture.successful(f(a) :: Nil) }
+    Marshaller { _ ⇒ a ⇒ FastFuture.successful(f(a) :: Nil) }
 
   /**
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    */
-  def oneOf[A, B](marshallers: Marshaller[A, B]*)(implicit ec: ExecutionContext): Marshaller[A, B] =
-    Marshaller { a ⇒ FastFuture.sequence(marshallers.map(_(a))).fast.map(_.flatten.toList) }
+  def oneOf[A, B](marshallers: Marshaller[A, B]*): Marshaller[A, B] =
+    Marshaller { implicit ec ⇒ a ⇒ FastFuture.sequence(marshallers.map(_(a))).fast.map(_.flatten.toList) }
 
   /**
    * Helper for creating a "super-marshaller" from a number of values and a function producing "sub-marshallers"
    * from these values. Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    */
-  def oneOf[T, A, B](values: T*)(f: T ⇒ Marshaller[A, B])(implicit ec: ExecutionContext): Marshaller[A, B] =
+  def oneOf[T, A, B](values: T*)(f: T ⇒ Marshaller[A, B]): Marshaller[A, B] =
     oneOf(values map f: _*)
 
   /**

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.marshalling
 
 import scala.collection.immutable
-import scala.concurrent.ExecutionContext
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.util.FastFuture._
 
@@ -14,16 +13,16 @@ trait PredefinedToRequestMarshallers {
 
   implicit val fromRequest: TRM[HttpRequest] = Marshaller.opaque(identity)
 
-  implicit def fromUri(implicit ec: ExecutionContext): TRM[Uri] =
+  implicit def fromUri: TRM[Uri] =
     Marshaller strict { uri ⇒ Marshalling.Opaque(() ⇒ HttpRequest(uri = uri)) }
 
-  implicit def fromMethodAndUriAndValue[S, T](implicit mt: ToEntityMarshaller[T],
-                                              ec: ExecutionContext): TRM[(HttpMethod, Uri, T)] =
+  implicit def fromMethodAndUriAndValue[S, T](implicit mt: ToEntityMarshaller[T]): TRM[(HttpMethod, Uri, T)] =
     fromMethodAndUriAndHeadersAndValue[T] compose { case (m, u, v) ⇒ (m, u, Nil, v) }
 
-  implicit def fromMethodAndUriAndHeadersAndValue[T](implicit mt: ToEntityMarshaller[T],
-                                                     ec: ExecutionContext): TRM[(HttpMethod, Uri, immutable.Seq[HttpHeader], T)] =
-    Marshaller { case (m, u, h, v) ⇒ mt(v).fast map (_ map (_ map (HttpRequest(m, u, h, _)))) }
+  implicit def fromMethodAndUriAndHeadersAndValue[T](implicit mt: ToEntityMarshaller[T]): TRM[(HttpMethod, Uri, immutable.Seq[HttpHeader], T)] =
+    Marshaller(implicit ec ⇒ {
+      case (m, u, h, v) ⇒ mt(v).fast map (_ map (_ map (HttpRequest(m, u, h, _))))
+    })
 }
 
 object PredefinedToRequestMarshallers extends PredefinedToRequestMarshallers

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/ToResponseMarshallable.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/marshalling/ToResponseMarshallable.scala
@@ -26,5 +26,5 @@ object ToResponseMarshallable {
     }
 
   implicit val marshaller: ToResponseMarshaller[ToResponseMarshallable] =
-    Marshaller { marshallable ⇒ marshallable.marshaller(marshallable.value) }
+    Marshaller { implicit ec ⇒ marshallable ⇒ marshallable.marshaller(marshallable.value) }
 }

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -4,7 +4,6 @@
 
 package akka.http.scaladsl.server
 
-import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 import akka.http.scaladsl.model._
 import StatusCodes._
@@ -19,7 +18,7 @@ trait ExceptionHandler extends ExceptionHandler.PF {
   /**
    * "Seals" this handler by attaching a default handler as fallback if necessary.
    */
-  def seal(settings: RoutingSettings)(implicit ec: ExecutionContext): ExceptionHandler
+  def seal(settings: RoutingSettings): ExceptionHandler
 }
 
 object ExceptionHandler {
@@ -33,11 +32,11 @@ object ExceptionHandler {
       def apply(error: Throwable) = pf(error)
       def withFallback(that: ExceptionHandler): ExceptionHandler =
         if (!knownToBeSealed) ExceptionHandler(knownToBeSealed = false)(this orElse that) else this
-      def seal(settings: RoutingSettings)(implicit ec: ExecutionContext): ExceptionHandler =
+      def seal(settings: RoutingSettings): ExceptionHandler =
         if (!knownToBeSealed) ExceptionHandler(knownToBeSealed = true)(this orElse default(settings)) else this
     }
 
-  def default(settings: RoutingSettings)(implicit ec: ExecutionContext): ExceptionHandler =
+  def default(settings: RoutingSettings): ExceptionHandler =
     apply(knownToBeSealed = true) {
       case IllegalRequestException(info, status) ⇒ ctx ⇒ {
         ctx.log.warning("Illegal request {}\n\t{}\n\tCompleting with '{}' response",

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/server/RoutingSetup.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/server/RoutingSetup.scala
@@ -46,14 +46,14 @@ object RoutingSetup {
   implicit def apply(implicit routingSettings: RoutingSettings,
                      exceptionHandler: ExceptionHandler = null,
                      rejectionHandler: RejectionHandler = null,
-                     executionContext: ExecutionContext,
+                     executionContext: ExecutionContext = null,
                      flowMaterializer: FlowMaterializer,
                      routingLog: RoutingLog): RoutingSetup =
     new RoutingSetup(
       routingSettings,
       if (exceptionHandler ne null) exceptionHandler else ExceptionHandler.default(routingSettings),
-      if (rejectionHandler ne null) rejectionHandler else RejectionHandler.default(executionContext),
-      executionContext,
+      if (rejectionHandler ne null) rejectionHandler else RejectionHandler.default,
+      if (executionContext ne null) executionContext else flowMaterializer.executionContext,
       flowMaterializer,
       routingLog)
 }

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.server
 package directives
 
-import scala.concurrent.{ Future, ExecutionContext }
+import scala.concurrent.Future
 import scala.util.{ Failure, Success }
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.common._
@@ -86,13 +86,13 @@ object FormFieldDirectives extends FormFieldDirectives {
       extractField[NameReceptacle[T], T] { nr ⇒ filter(nr.name, fu) }
     implicit def forNUR[T](implicit sfu: SFU) =
       extractField[NameUnmarshallerReceptacle[T], T] { nr ⇒ filter(nr.name, StrictForm.Field.unmarshallerFromFSU(nr.um)) }
-    implicit def forNOR[T](implicit sfu: SFU, fu: FSFFOU[T], ec: ExecutionContext) =
+    implicit def forNOR[T](implicit sfu: SFU, fu: FSFFOU[T]) =
       extractField[NameOptionReceptacle[T], Option[T]] { nr ⇒ filter[Option[T]](nr.name, fu) }
-    implicit def forNDR[T](implicit sfu: SFU, fu: FSFFOU[T], ec: ExecutionContext) =
+    implicit def forNDR[T](implicit sfu: SFU, fu: FSFFOU[T]) =
       extractField[NameDefaultReceptacle[T], T] { nr ⇒ filter(nr.name, fu withDefaultValue nr.default) }
-    implicit def forNOUR[T](implicit sfu: SFU, ec: ExecutionContext) =
+    implicit def forNOUR[T](implicit sfu: SFU) =
       extractField[NameOptionUnmarshallerReceptacle[T], Option[T]] { nr ⇒ filter[Option[T]](nr.name, StrictForm.Field.unmarshallerFromFSU(nr.um): FSFFOU[T]) }
-    implicit def forNDUR[T](implicit sfu: SFU, ec: ExecutionContext) =
+    implicit def forNDUR[T](implicit sfu: SFU) =
       extractField[NameDefaultUnmarshallerReceptacle[T], T] { nr ⇒ filter(nr.name, (StrictForm.Field.unmarshallerFromFSU(nr.um): FSFFOU[T]) withDefaultValue nr.default) }
 
     //////////////////// required formField support ////////////////////

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
@@ -68,15 +68,13 @@ trait MethodDirectives {
    *  - Supporting older browsers that lack support for certain HTTP methods. E.g. IE8 does not support PATCH
    */
   def overrideMethodWithParameter(paramName: String): Directive0 =
-    extractExecutionContext flatMap { implicit ec ⇒
-      parameter(paramName?) flatMap {
-        case Some(method) ⇒
-          getForKey(method.toUpperCase) match {
-            case Some(m) ⇒ mapRequest(_.copy(method = m))
-            case _       ⇒ complete(StatusCodes.NotImplemented)
-          }
-        case None ⇒ pass
-      }
+    parameter(paramName?) flatMap {
+      case Some(method) ⇒
+        getForKey(method.toUpperCase) match {
+          case Some(m) ⇒ mapRequest(_.copy(method = m))
+          case _       ⇒ complete(StatusCodes.NotImplemented)
+        }
+      case None ⇒ pass
     }
 }
 

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/RangeDirectives.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/server/directives/RangeDirectives.scala
@@ -99,7 +99,6 @@ trait RangeDirectives {
 
       def applyRanges(ranges: Seq[ByteRange]): Directive0 =
         extractRequestContext.flatMap { ctx ⇒
-          import ctx.executionContext
           mapRouteResultWithPF {
             case Complete(HttpResponse(OK, headers, entity, protocol)) ⇒
               universal(entity) match {

--- a/akka-http-scala/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
+++ b/akka-http-scala/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
@@ -4,7 +4,7 @@
 
 package akka.http.scaladsl.unmarshalling
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 object Unmarshal {
   def apply[T](value: T): Unmarshal[T] = new Unmarshal(value)
@@ -14,5 +14,5 @@ class Unmarshal[A](val value: A) {
   /**
    * Unmarshals the value to the given Type using the in-scope Unmarshaller.
    */
-  def to[B](implicit um: Unmarshaller[A, B]): Future[B] = um(value)
+  def to[B](implicit um: Unmarshaller[A, B], ec: ExecutionContext): Future[B] = um(value)
 }

--- a/akka-http-testkit-java/src/main/scala/akka/http/javadsl/testkit/TestResponse.scala
+++ b/akka-http-testkit-java/src/main/scala/akka/http/javadsl/testkit/TestResponse.scala
@@ -32,7 +32,7 @@ abstract class TestResponse(_response: HttpResponse, awaitAtMost: FiniteDuration
   def entityBytes: ByteString = entity.data()
   def entityAs[T](unmarshaller: Unmarshaller[T]): T =
     Unmarshal(response)
-      .to(unmarshaller.asInstanceOf[UnmarshallerImpl[T]].scalaUnmarshaller(ec, materializer))
+      .to(unmarshaller.asInstanceOf[UnmarshallerImpl[T]].scalaUnmarshaller(ec, materializer), ec)
       .awaitResult(awaitAtMost)
   def entityAsString: String = entity.data().utf8String
   def status: StatusCode = response.status.asJava

--- a/akka-http-testkit-scala/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit-scala/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -126,7 +126,7 @@ trait RouteTest extends RequestBuilding with RouteTestResultComponent with Marsh
               securedConnection = defaultHostInfo.securedConnection,
               defaultHostHeader = defaultHostInfo.host)
           val ctx = new RequestContextImpl(effectiveRequest, setup.routingLog.requestLog(effectiveRequest), setup.settings)
-          val sealedExceptionHandler = setup.exceptionHandler.seal(setup.settings)(setup.executionContext)
+          val sealedExceptionHandler = setup.exceptionHandler.seal(setup.settings)
           val semiSealedRoute = // sealed for exceptions but not for rejections
             Directives.handleExceptions(sealedExceptionHandler) { route }
           val deferrableRouteResult = semiSealedRoute(ctx)


### PR DESCRIPTION
This has the advantages that implicit (un)marshaller construction doesn't require an implicit EC anymore (a point that often tripped up users because the errors are mostly unhelpful or even misleading) and the ExecutionContext for all of the routing DSL is now configured in one central point (when constructing the `RequestContext`).

(I'm splitting up @sirthias PR #17452 to allow the individual parts to be merged ASAP. I didn't change the commit from #17452, so you may have already reviewed the changes in the context of that one.)
