### PR TITLE
=pro genjavadoc 0.9 for release-2.3

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -57,7 +57,7 @@ object AkkaBuild extends Build {
       Publish.defaultPublishTo in ThisBuild <<= crossTarget / "repository",
       unidocExclude := Seq(samples.id, remoteTests.id),
       sources in JavaDoc <<= junidocSources,
-      javacOptions in JavaDoc := Seq(),
+      javacOptions in JavaDoc := (if (sys.props("java.version").startsWith("1.8")) Seq("-Xdoclint:none") else Seq()),
       artifactName in packageDoc in JavaDoc := ((sv, mod, art) => "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar"),
       packageDoc in Compile <<= packageDoc in JavaDoc,
       Dist.distExclude := Seq(actorTests.id, docs.id, samples.id, osgi.id),
@@ -758,7 +758,8 @@ object AkkaBuild extends Build {
     // compile options
     scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint"),
     javacOptions in compile ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
-    javacOptions in doc ++= Seq("-encoding", "UTF-8", "-source", "1.6"),
+    javacOptions in doc ++= Seq("-encoding", "UTF-8", "-source", "1.6") ++ 
+                            (if (sys.props("java.version").startsWith("1.8")) Seq("-Xdoclint:none") else Seq()),
 
     crossVersion := CrossVersion.binary,
 
@@ -1221,7 +1222,7 @@ object Dependencies {
     val crossScala = Seq("2.10.4", "2.11.5")
     val scala = crossScala.head
     val scalaStmVersion  = System.getProperty("akka.build.scalaStmVersion", "0.7")
-    val genJavaDocVersion = System.getProperty("akka.build.genJavaDocVersion", "0.8")
+    val genJavaDocVersion = System.getProperty("akka.build.genJavaDocVersion", "0.9")
     val scalaTestVersion = System.getProperty("akka.build.scalaTestVersion", "2.1.3")
     val scalaCheckVersion = System.getProperty("akka.build.scalaCheckVersion", "1.11.3")
     val scalaContinuationsVersion = System.getProperty("akka.build.scalaContinuationsVersion", "1.0.2")

--- a/project/Unidoc.scala
+++ b/project/Unidoc.scala
@@ -17,7 +17,7 @@ object Unidoc {
         sources in JavaDoc <<= (target, compile in Compile, sources in Compile) map ((t, c, s) =>
           (t / "java" ** "*.java").get ++ s.filter(_.getName.endsWith(".java"))
         ),
-        javacOptions in JavaDoc := Seq(),
+        javacOptions in JavaDoc := (if (sys.props("java.version").startsWith("1.8")) Seq("-Xdoclint:none") else Seq()),
         artifactName in packageDoc in JavaDoc := ((sv, mod, art) => "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar"),
         libraryDependencies += Dependencies.Compile.genjavadoc,
         scalacOptions <+= target map (t => "-P:genjavadoc:out=" + (t / "java"))


### PR DESCRIPTION
- need genjavadoc 0.9 because pr-validation is run
  with jdk8
- use -Xdoclint:none when running with jdk8, we will
  still release with jdk6
