### PR TITLE
=str #17453: Fix substream RS compliance, awaitAllStagesStopped and FanIn leak

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
@@ -256,6 +256,8 @@ private[akka] object StreamSupervisor {
   final case class Children(children: Set[ActorRef])
   /** Testing purpose */
   final case object StopChildren
+  /** Testing purpose */
+  final case object StoppedChildren
 }
 
 private[akka] class StreamSupervisor(settings: ActorFlowMaterializerSettings) extends Actor {
@@ -267,8 +269,10 @@ private[akka] class StreamSupervisor(settings: ActorFlowMaterializerSettings) ex
     case Materialize(props, name) ⇒
       val impl = context.actorOf(props, name)
       sender() ! impl
-    case GetChildren  ⇒ sender() ! Children(context.children.toSet)
-    case StopChildren ⇒ context.children.foreach(context.stop)
+    case GetChildren ⇒ sender() ! Children(context.children.toSet)
+    case StopChildren ⇒
+      context.children.foreach(context.stop)
+      sender() ! StoppedChildren
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -201,7 +201,7 @@ private[akka] class SimpleOutputs(val actor: ActorRef, val pump: Pump) extends D
     }
   }
 
-  override def isClosed: Boolean = downstreamCompleted
+  override def isClosed: Boolean = downstreamCompleted && (subscriber ne null)
 
   protected def createSubscription(): Subscription = new ActorSubscription(actor, subscriber)
 

--- a/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
@@ -241,7 +241,7 @@ private[akka] abstract class FanIn(val settings: ActorFlowMaterializerSettings, 
   protected def fail(e: Throwable): Unit = {
     if (settings.debugLogging)
       log.debug("fail due to: {}", e.getMessage)
-    inputBunch.cancel()
+    nextPhase(completedPhase)
     primaryOutputs.error(e)
     pump()
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/PrefixAndTailImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PrefixAndTailImpl.scala
@@ -50,7 +50,7 @@ private[akka] class PrefixAndTailImpl(_settings: ActorFlowMaterializerSettings, 
   }
 
   def emitEmptyTail(): Unit = {
-    primaryOutputs.enqueueOutputElement((taken, Source(EmptyPublisher[Any])))
+    primaryOutputs.enqueueOutputElement((taken, Source.empty))
     nextPhase(completedPhase)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
@@ -82,9 +82,11 @@ private[akka] object MultiStreamOutputProcessor {
     private def closePublisher(withState: CompletedState): Unit = {
       subscriptionTimeout.cancel()
       state.getAndSet(withState) match {
-        case Attached(sub)     ⇒ closeSubscriber(sub, withState)
         case _: CompletedState ⇒ throw new IllegalStateException("Attempted to double shutdown publisher")
-        case Open              ⇒ // No action needed
+        case Attached(sub) ⇒
+          if (subscriber eq null) tryOnSubscribe(sub, CancelledSubscription)
+          closeSubscriber(sub, withState)
+        case Open ⇒ // No action needed
       }
     }
 


### PR DESCRIPTION
- Substreams emitted were not RS compliant
- awaitAllStagesStopped was racy and therefore did not check the right thing and sometimes caused innocent tests to fail
- FanIn did not stop the actor on early failures and did not wait properly for all Subscriptions
