### PR TITLE
=pro Disable doclint

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -317,7 +317,7 @@ object AkkaBuild extends Build {
     // -XDignore.symbol.file suppresses sun.misc.Unsafe warnings
     javacOptions in compile ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-XDignore.symbol.file"),
     javacOptions in compile ++= (if (allWarnings) Seq("-Xlint:deprecation") else Nil),
-    javacOptions in doc ++= Seq("-encoding", "UTF-8", "-source", "1.8"),
+    javacOptions in doc ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-Xdoclint:none"),
     incOptions := incOptions.value.withNameHashing(true),
 
     crossVersion := CrossVersion.binary,

--- a/project/Unidoc.scala
+++ b/project/Unidoc.scala
@@ -25,6 +25,7 @@ object Unidoc {
     if (genjavadocEnabled)
       (scalaJavaUnidocSettings, genjavadocExtraSettings ++ Seq(
         scalacOptions in Compile += "-P:genjavadoc:fabricateParams=true",
+        javacOptions in JavaUnidoc ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-Xdoclint:none"),
         unidocGenjavadocVersion in Global := "0.9"))
     else (scalaUnidocSettings, Nil)
 


### PR DESCRIPTION
- release script fails, probably due to
  `[error] (akka-actor/genjavadoc:doc) javadoc returned nonzero exit code`
- I don't know why, but this is is a workaround to be able to release
