### PR TITLE
=pro update sbt-unidoc to 0.3.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 


### PR DESCRIPTION
This update solves our blocker issue about compile not being triggered properly before genjavadoc kicks in.
