### PR TITLE
=htp add explicit result types to formField/parameter implicits

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
@@ -9,9 +9,6 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model._
 
 class FormFieldDirectivesExamplesSpec extends RoutingSpec {
-  // FIXME: investigate why it doesn't work without this import
-  import akka.http.scaladsl.server.directives.FormFieldDirectives.FieldMagnet
-
   "formFields" in {
     val route =
       formFields('color, 'age.as[Int]) { (color, age) =>

--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -9,9 +9,6 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
 
 class ParameterDirectivesExamplesSpec extends RoutingSpec {
-  // FIXME: investigate why it doesn't work without this import
-  import akka.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet
-
   "example-1" in {
     val route =
       parameter('color) { color =>

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -59,19 +59,20 @@ object ParameterDirectives extends ParameterDirectives {
     def apply(): Out
   }
   object ParamMagnet {
-    implicit def apply[T](value: T)(implicit pdef: ParamDef[T]) =
+    implicit def apply[T](value: T)(implicit pdef: ParamDef[T]): ParamMagnet { type Out = pdef.Out } =
       new ParamMagnet {
         type Out = pdef.Out
         def apply() = pdef(value)
       }
   }
 
+  type ParamDefAux[T, U] = ParamDef[T] { type Out = U }
   sealed trait ParamDef[T] {
     type Out
     def apply(value: T): Out
   }
   object ParamDef {
-    def paramDef[A, B](f: A ⇒ B) =
+    def paramDef[A, B](f: A ⇒ B): ParamDefAux[A, B] =
       new ParamDef[A] {
         type Out = B
         def apply(value: A) = f(value)
@@ -85,7 +86,7 @@ object ParameterDirectives extends ParameterDirectives {
 
     //////////////////// "regular" parameter extraction //////////////////////
 
-    private def extractParameter[A, B](f: A ⇒ Directive1[B]) = paramDef(f)
+    private def extractParameter[A, B](f: A ⇒ Directive1[B]): ParamDefAux[A, Directive1[B]] = paramDef(f)
     private def filter[T](paramName: String, fsou: FSOU[T]): Directive1[T] =
       extractRequestContext flatMap { ctx ⇒
         import ctx.executionContext
@@ -95,21 +96,21 @@ object ParameterDirectives extends ParameterDirectives {
           case Failure(x)                               ⇒ reject(MalformedQueryParamRejection(paramName, x.getMessage.nullAsEmpty, Option(x.getCause)))
         }
       }
-    implicit def forString(implicit fsu: FSU[String]) =
+    implicit def forString(implicit fsu: FSU[String]): ParamDefAux[String, Directive1[String]] =
       extractParameter[String, String] { string ⇒ filter(string, fsu) }
-    implicit def forSymbol(implicit fsu: FSU[String]) =
+    implicit def forSymbol(implicit fsu: FSU[String]): ParamDefAux[Symbol, Directive1[String]] =
       extractParameter[Symbol, String] { symbol ⇒ filter(symbol.name, fsu) }
-    implicit def forNR[T](implicit fsu: FSU[T]) =
+    implicit def forNR[T](implicit fsu: FSU[T]): ParamDefAux[NameReceptacle[T], Directive1[T]] =
       extractParameter[NameReceptacle[T], T] { nr ⇒ filter(nr.name, fsu) }
-    implicit def forNUR[T] =
+    implicit def forNUR[T]: ParamDefAux[NameUnmarshallerReceptacle[T], Directive1[T]] =
       extractParameter[NameUnmarshallerReceptacle[T], T] { nr ⇒ filter(nr.name, nr.um) }
-    implicit def forNOR[T](implicit fsou: FSOU[T]) =
+    implicit def forNOR[T](implicit fsou: FSOU[T]): ParamDefAux[NameOptionReceptacle[T], Directive1[Option[T]]] =
       extractParameter[NameOptionReceptacle[T], Option[T]] { nr ⇒ filter[Option[T]](nr.name, fsou) }
-    implicit def forNDR[T](implicit fsou: FSOU[T]) =
+    implicit def forNDR[T](implicit fsou: FSOU[T]): ParamDefAux[NameDefaultReceptacle[T], Directive1[T]] =
       extractParameter[NameDefaultReceptacle[T], T] { nr ⇒ filter[T](nr.name, fsou withDefaultValue nr.default) }
-    implicit def forNOUR[T] =
+    implicit def forNOUR[T]: ParamDefAux[NameOptionUnmarshallerReceptacle[T], Directive1[Option[T]]] =
       extractParameter[NameOptionUnmarshallerReceptacle[T], Option[T]] { nr ⇒ filter(nr.name, nr.um: FSOU[T]) }
-    implicit def forNDUR[T] =
+    implicit def forNDUR[T]: ParamDefAux[NameDefaultUnmarshallerReceptacle[T], Directive1[T]] =
       extractParameter[NameDefaultUnmarshallerReceptacle[T], T] { nr ⇒ filter[T](nr.name, (nr.um: FSOU[T]) withDefaultValue nr.default) }
 
     //////////////////// required parameter support ////////////////////
@@ -122,9 +123,9 @@ object ParameterDirectives extends ParameterDirectives {
           case _                                        ⇒ reject
         }
       }
-    implicit def forRVR[T](implicit fsu: FSU[T]) =
+    implicit def forRVR[T](implicit fsu: FSU[T]): ParamDefAux[RequiredValueReceptacle[T], Directive0] =
       paramDef[RequiredValueReceptacle[T], Directive0] { rvr ⇒ requiredFilter(rvr.name, fsu, rvr.requiredValue) }
-    implicit def forRVDR[T] =
+    implicit def forRVDR[T]: ParamDefAux[RequiredValueUnmarshallerReceptacle[T], Directive0] =
       paramDef[RequiredValueUnmarshallerReceptacle[T], Directive0] { rvr ⇒ requiredFilter(rvr.name, rvr.um, rvr.requiredValue) }
 
     //////////////////// tuple support ////////////////////
@@ -132,7 +133,7 @@ object ParameterDirectives extends ParameterDirectives {
     import akka.http.scaladsl.server.util.TupleOps._
     import akka.http.scaladsl.server.util.BinaryPolyFunc
 
-    implicit def forTuple[T](implicit fold: FoldLeft[Directive0, T, ConvertParamDefAndConcatenate.type]) =
+    implicit def forTuple[T](implicit fold: FoldLeft[Directive0, T, ConvertParamDefAndConcatenate.type]): ParamDefAux[T, fold.Out] =
       paramDef[T, fold.Out](fold(BasicDirectives.pass, _))
 
     object ConvertParamDefAndConcatenate extends BinaryPolyFunc {


### PR DESCRIPTION
Otherwise, the applicability of the implicit conversions can depend on the order of compiler-internal loading/typing which is hardly predictable.

Thanks to @odersky for [giving the right hint](https://groups.google.com/d/topic/scala-language/KZhcHb6e8DI/discussion).

/cc @sirthias 
