### PR TITLE
suppress Tcp.CloseCommand from deadLetters logging

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -172,8 +172,12 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
 
   /**
    * Common interface for all commands which aim to close down an open connection.
+   *
+   * These messages are suppressed from dead letters as they are
+   * highly likely to be received on actor paths that have recently
+   * been terminated.
    */
-  sealed trait CloseCommand extends Command {
+  sealed trait CloseCommand extends Command with DeadLetterSuppression {
     /**
      * The corresponding event which is sent as an acknowledgment once the
      * close operation is finished.


### PR DESCRIPTION
As requested from the mailing list. I trust you agree that `Close`-style messages are more likely than most to arrive in deadLetters and are hence more likely to be spam than something the user wants to hear about.

Please note that it is quite difficult for me to make changes to the akka repo due to #17570
