### PR TITLE
+str #17298 include stream supervisor in log() source

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
@@ -4,10 +4,10 @@
 package akka.stream.scaladsl
 
 import akka.event.{ DummyClassForStringSources, Logging }
-import akka.stream._
-import akka.stream.OperationAttributes
 import akka.stream.OperationAttributes.LogLevels
 import akka.stream.testkit.{ AkkaSpec, ScriptedTest }
+import akka.stream.javadsl
+import akka.stream.{ ActorFlowMaterializer, FlowMaterializer, OperationAttributes }
 import akka.testkit.TestProbe
 
 import scala.util.control.NoStackTrace
@@ -24,8 +24,9 @@ class FlowLogSpec extends AkkaSpec("akka.loglevel = DEBUG") with ScriptedTest {
 
   "A Log" must {
 
-    val LogSrc = s"akka.stream.Log(akka://${Logging.simpleName(classOf[FlowLogSpec])})"
-    val LogClazz = classOf[DummyClassForStringSources]
+    val supervisorPath = "akka://FlowLogSpec/user/$a"
+    val LogSrc = s"akka.stream.Log($supervisorPath)"
+    val LogClazz = classOf[FlowMaterializer]
 
     "on Flow" must {
 

--- a/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorFlowMaterializer.scala
@@ -157,6 +157,9 @@ abstract class ActorFlowMaterializer extends FlowMaterializer {
    */
   private[akka] def system: ActorSystem
 
+  /** INTERNAL API */
+  private[akka] def supervisor: ActorRef
+
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/stage/Stage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/Stage.scala
@@ -3,7 +3,8 @@
  */
 package akka.stream.stage
 
-import akka.stream.{ FlowMaterializer, OperationAttributes, Supervision }
+import akka.event.{ Logging, LogSource }
+import akka.stream.{ ActorFlowMaterializer, FlowMaterializer, OperationAttributes, Supervision }
 
 /**
  * General interface for stream transformation.


### PR DESCRIPTION
In order to make it use a _nice_ LogSource some implicit resolution trickery was needed, reason: if LogSource is a String it appends `...(systemName)` so we'd get `name(supervisorAddr)(systemName)`, which is overdoing it since `supervisorAddr` contains the system name already.

Resolves #17298
