### PR TITLE
=rem #17554 Improve flow control of system message delivery

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -258,6 +258,14 @@ akka {
     # Messages that were negatively acknowledged are always immediately
     # resent.
     resend-interval = 2 s
+    
+    # Maximum number of unacknowledged system messages that will be resent
+    # each 'resend-interval'. If you watch many (> 1000) remote actors you can
+    # increase this value to for example 600, but a too large limit (e.g. 10000)
+    # may flood the connection and might cause false failure detection to trigger.
+    # Test such a configuration by watching all actors at the same time and stop
+    # all watched actors at the same time.
+    resend-limit = 200
 
     # WARNING: this setting should not be not changed unless all of its consequences
     # are properly understood which assumes experience with remoting internals

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -83,6 +83,10 @@ final class RemoteSettings(val config: Config) {
     config.getMillisDuration("akka.remote.resend-interval")
   } requiring (_ > Duration.Zero, "resend-interval must be > 0")
 
+  val SysResendLimit: Int = {
+    config.getInt("akka.remote.resend-limit")
+  } requiring (_ > 0, "resend-limit must be > 0")
+
   val SysMsgBufferSize: Int = {
     getInt("akka.remote.system-message-buffer-size")
   } requiring (_ > 0, "system-message-buffer-size must be > 0")

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -40,6 +40,7 @@ class RemoteConfigSpec extends AkkaSpec(
       LogBufferSizeExceeding should be(50000)
       SysMsgAckTimeout should be(0.3 seconds)
       SysResendTimeout should be(2 seconds)
+      SysResendLimit should be(200)
       SysMsgBufferSize should be(20000)
       InitialSysMsgDeliveryTimeout should be(3 minutes)
       QuarantineDuration should be(5 days)


### PR DESCRIPTION
When watching many (5000) actors at the same time the
following problems were found:
- first send of a sys msg is sent without any flow control
  => limit the number of outstanding sys msg by using
     the buffer to send them later (ordinary resend)
- when msg cannot be written sys msg is dropped (relying on resend),
  but that cause message re-ordering and negative acknowledgment,
  which is very costly
  => buffer the sys msg on write failure
  => minor optimization of AckedReceiveBuffer

I also made the resend-limit configurable.
