### PR TITLE
=doc: Update withRangeSupport.rst reference to RFC7233

### DIFF
--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/range-directives/withRangeSupport.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/range-directives/withRangeSupport.rst
@@ -38,7 +38,7 @@ settings from the ``akka.http.routing`` configuration.
 
 This directive is transparent to non-``GET`` requests.
 
-See also: https://tools.ietf.org/html/draft-ietf-httpbis-p5-range/
+See also: https://tools.ietf.org/html/rfc7233
 
 
 Example


### PR DESCRIPTION
Linked http-bis-draft is now RFC7233. I checked the [delta](https://www.ietf.org/rfcdiff?url1=draft-ietf-httpbis-p5-range-24&url2=rfc7233) and there are no functional changes compared to the original implementation against `draft-ietf-httpbis-p5-range-24` (https://github.com/spray/spray/pull/612) 
