### PR TITLE
!per #16797 rename defer to deferAsync, remove Seq version

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
@@ -86,7 +86,7 @@ class `persistAsync, defer`(respondAfter: Int) extends PersistentActor {
   override def receiveCommand = {
     case n: Int =>
       persistAsync(Evt(n)) { e => }
-      defer(Evt(n)) { e => if (e.i == respondAfter) sender() ! e.i }
+      deferAsync(Evt(n)) { e => if (e.i == respondAfter) sender() ! e.i }
   }
   override def receiveRecover = {
     case _ => // do nothing
@@ -99,7 +99,7 @@ class `persistAsync, defer, respond ASAP`(respondAfter: Int) extends PersistentA
   override def receiveCommand = {
     case n: Int =>
       persistAsync(Evt(n)) { e => }
-      defer(Evt(n)) { e => }
+      deferAsync(Evt(n)) { e => }
       if (n == respondAfter) sender() ! n
   }
   override def receiveRecover = {

--- a/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceDocTest.java
@@ -13,12 +13,8 @@ import akka.japi.Function;
 import akka.japi.Procedure;
 import akka.persistence.*;
 import scala.Option;
-import scala.concurrent.duration.Duration;
+
 import java.io.Serializable;
-
-import java.util.concurrent.TimeUnit;
-
-import static java.util.Arrays.asList;
 
 public class PersistenceDocTest {
 
@@ -367,7 +363,7 @@ public class PersistenceDocTest {
 
                 persistAsync(String.format("evt-%s-1", msg), replyToSender);
                 persistAsync(String.format("evt-%s-2", msg), replyToSender);
-                defer(String.format("evt-%s-3", msg), replyToSender);
+                deferAsync(String.format("evt-%s-3", msg), replyToSender);
             }
         }
         //#defer

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -1,8 +1,8 @@
 .. _migration-2.4:
 
-################################
- Migration Guide 2.3.x to 2.4.x
-################################
+##############################
+Migration Guide 2.3.x to 2.4.x
+##############################
 
 The 2.4 release contains some structural changes that require some
 simple, mechanical source-level changes in client code.
@@ -160,8 +160,11 @@ Default interval for TestKit.awaitAssert changed to 100 ms
 Default check interval changed from 800 ms to 100 ms. You can define the interval explicitly if you need a
 longer interval.
 
-persistenceId
-=============
+Akka Persistence
+================
+
+Mendatory persistenceId
+-----------------------
 
 It is now mandatory to define the ``persistenceId`` in subclasses of ``PersistentActor``, ``UntypedPersistentActor``
 and ``AbstractPersistentId``.

--- a/akka-docs/rst/project/migration-guide-persistence-experimental-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-persistence-experimental-2.3.x-2.4.x.rst
@@ -8,6 +8,14 @@ Migration Guide Akka Persistence (experimental) 2.3.3 to 2.3.4 (and 2.4.x)
 is provided for Persistence while under the *experimental* flag. The goal of this phase is to gather user feedback
 before we freeze the APIs in a major release.
 
+
+defer renamed to deferAsync
+===========================
+The ``defer`` method in ``PersistentActor`` was renamed to ``deferAsync`` as it matches the semantics
+of ``persistAsync`` more closely than ``persist``, which was causing confusion for users.
+
+Its semantics remain unchanged.
+
 Renamed EventsourcedProcessor to PersistentActor
 ================================================
 ``EventsourcedProcessor`` is now deprecated and replaced by ``PersistentActor`` which provides the same (and more) API.

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -240,7 +240,7 @@ object PersistenceDocSpec {
           sender() ! c
           persistAsync(s"evt-$c-1") { e => sender() ! e }
           persistAsync(s"evt-$c-2") { e => sender() ! e }
-          defer(s"evt-$c-3") { e => sender() ! e }
+          deferAsync(s"evt-$c-3") { e => sender() ! e }
         }
       }
     }

--- a/akka-persistence/src/test/scala/akka/persistence/PerformanceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PerformanceSpec.scala
@@ -46,7 +46,7 @@ object PerformanceSpec {
     }
 
     val controlBehavior: Receive = {
-      case StopMeasure        ⇒ defer(StopMeasure)(_ ⇒ sender() ! StopMeasure)
+      case StopMeasure        ⇒ deferAsync(StopMeasure)(_ ⇒ sender() ! StopMeasure)
       case FailAt(sequenceNr) ⇒ failAt = sequenceNr
     }
 

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
@@ -4,18 +4,17 @@
 
 package akka.persistence
 
-import scala.collection.immutable.Seq
-import scala.concurrent.duration._
-import com.typesafe.config.Config
-import akka.actor._
-import akka.testkit.{ ImplicitSender, AkkaSpec }
-import akka.testkit.EventFilter
-import akka.testkit.TestProbe
 import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor._
+import akka.testkit.{ AkkaSpec, ImplicitSender, TestLatch, TestProbe }
+import com.typesafe.config.Config
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Await
+import scala.concurrent.duration._
 import scala.util.Random
 import scala.util.control.NoStackTrace
-import akka.testkit.TestLatch
-import scala.concurrent.Await
 
 object PersistentActorSpec {
   final case class Cmd(data: Any)
@@ -370,19 +369,19 @@ object PersistentActorSpec {
   class DeferringWithPersistActor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = {
       case Cmd(data) ⇒
-        defer("d-1") { sender() ! _ }
+        deferAsync("d-1") { sender() ! _ }
         persist(s"$data-2") { sender() ! _ }
-        defer("d-3") { sender() ! _ }
-        defer("d-4") { sender() ! _ }
+        deferAsync("d-3") { sender() ! _ }
+        deferAsync("d-4") { sender() ! _ }
     }
   }
   class DeferringWithAsyncPersistActor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = {
       case Cmd(data) ⇒
-        defer(s"d-$data-1") { sender() ! _ }
+        deferAsync(s"d-$data-1") { sender() ! _ }
         persistAsync(s"pa-$data-2") { sender() ! _ }
-        defer(s"d-$data-3") { sender() ! _ }
-        defer(s"d-$data-4") { sender() ! _ }
+        deferAsync(s"d-$data-3") { sender() ! _ }
+        deferAsync(s"d-$data-4") { sender() ! _ }
     }
   }
   class DeferringMixedCallsPPADDPADPersistActor(name: String) extends ExamplePersistentActor(name) {
@@ -390,18 +389,18 @@ object PersistentActorSpec {
       case Cmd(data) ⇒
         persist(s"p-$data-1") { sender() ! _ }
         persistAsync(s"pa-$data-2") { sender() ! _ }
-        defer(s"d-$data-3") { sender() ! _ }
-        defer(s"d-$data-4") { sender() ! _ }
+        deferAsync(s"d-$data-3") { sender() ! _ }
+        deferAsync(s"d-$data-4") { sender() ! _ }
         persistAsync(s"pa-$data-5") { sender() ! _ }
-        defer(s"d-$data-6") { sender() ! _ }
+        deferAsync(s"d-$data-6") { sender() ! _ }
     }
   }
   class DeferringWithNoPersistCallsPersistActor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = {
       case Cmd(data) ⇒
-        defer("d-1") { sender() ! _ }
-        defer("d-2") { sender() ! _ }
-        defer("d-3") { sender() ! _ }
+        deferAsync("d-1") { sender() ! _ }
+        deferAsync("d-2") { sender() ! _ }
+        deferAsync("d-3") { sender() ! _ }
     }
   }
 

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java
@@ -13,13 +13,8 @@ import akka.japi.pf.ReceiveBuilder;
 import akka.persistence.*;
 import scala.Option;
 import scala.PartialFunction;
-import scala.concurrent.duration.Duration;
 import scala.runtime.BoxedUnit;
 import java.io.Serializable;
-
-import java.util.concurrent.TimeUnit;
-
-import static java.util.Arrays.asList;
 
 public class LambdaPersistenceDocTest {
 
@@ -373,7 +368,7 @@ public class LambdaPersistenceDocTest {
           sender().tell(e, self());
         });
 
-        defer(String.format("evt-%s-3", c), e -> {
+        deferAsync(String.format("evt-%s-3", c), e -> {
           sender().tell(e, self());
         });
       }


### PR DESCRIPTION
Renames defer to deferAsync and also removes Seq version of this method.

Resolves #16797 
