### PR TITLE
+act #17576 Support serializer with string manifest

### DIFF
--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -7,7 +7,6 @@ package akka.util
 import java.io.{ ObjectInputStream, ObjectOutputStream }
 import java.nio.{ ByteBuffer, ByteOrder }
 import java.lang.{ Iterable ⇒ JIterable }
-
 import scala.annotation.varargs
 import scala.collection.IndexedSeqOptimized
 import scala.collection.mutable.{ Builder, WrappedArray }
@@ -15,6 +14,7 @@ import scala.collection.immutable
 import scala.collection.immutable.{ IndexedSeq, VectorBuilder }
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
+import java.nio.charset.StandardCharsets
 
 object ByteString {
 
@@ -42,7 +42,7 @@ object ByteString {
   /**
    * Creates a new ByteString by encoding a String as UTF-8.
    */
-  def apply(string: String): ByteString = apply(string, "UTF-8")
+  def apply(string: String): ByteString = apply(string, UTF_8)
 
   /**
    * Creates a new ByteString by encoding a String with a charset.
@@ -78,6 +78,11 @@ object ByteString {
    * Creates a new ByteString which will contain the representation of the given String in the given charset
    */
   def fromString(string: String, charset: String): ByteString = apply(string, charset)
+
+  /**
+   * Standard "UTF-8" charset
+   */
+  val UTF_8: String = StandardCharsets.UTF_8.name()
 
   /**
    * Creates a new ByteString by copying bytes out of a ByteBuffer.
@@ -484,7 +489,7 @@ sealed abstract class ByteString extends IndexedSeq[Byte] with IndexedSeqOptimiz
   /**
    * Decodes this ByteString as a UTF-8 encoded String.
    */
-  final def utf8String: String = decodeString("UTF-8")
+  final def utf8String: String = decodeString(ByteString.UTF_8)
 
   /**
    * Decodes this ByteString using a charset to produce a String.
@@ -539,7 +544,7 @@ object CompactByteString {
   /**
    * Creates a new CompactByteString by encoding a String as UTF-8.
    */
-  def apply(string: String): CompactByteString = apply(string, "UTF-8")
+  def apply(string: String): CompactByteString = apply(string, ByteString.UTF_8)
 
   /**
    * Creates a new CompactByteString by encoding a String with a charset.

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
@@ -24,7 +24,7 @@ class MessageSerializerSpec extends AkkaSpec(
 
   def checkSerialization(obj: AnyRef): Unit = {
     val blob = serializer.toBinary(obj)
-    val ref = serializer.fromBinary(blob, obj.getClass)
+    val ref = serializer.fromBinary(blob, serializer.manifest(obj))
     obj match {
       case _ ⇒
         ref should ===(obj)

--- a/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
@@ -17,7 +17,7 @@ class DistributedPubSubMessageSerializerSpec extends AkkaSpec {
 
   def checkSerialization(obj: AnyRef): Unit = {
     val blob = serializer.toBinary(obj)
-    val ref = serializer.fromBinary(blob, obj.getClass)
+    val ref = serializer.fromBinary(blob, serializer.manifest(obj))
     ref should ===(obj)
   }
 

--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -103,8 +103,37 @@ which is done by extending ``akka.serialization.JSerializer``, like this:
    :include: my-own-serializer
    :exclude: ...
 
+The manifest is a type hint so that the same serializer can be used for different
+classes. The manifest parameter in ``fromBinaryJava`` is the class of the object that
+was serialized. In ``fromBinary`` you can match on the class and deserialize the
+bytes to different objects.
+
 Then you only need to fill in the blanks, bind it to a name in your :ref:`configuration` and then
 list which classes that should be serialized using it.
+
+Serializer with String Manifest
+-------------------------------
+
+The ``Serializer`` illustrated above supports a class based manifest (type hint).
+For serialization of data that need to evolve over time the `SerializerWithStringManifest`
+is recommended instead of ``Serializer`` because the manifest (type hint) is a ``String``
+instead of a ``Class``. That means that the class can be moved/removed and the serializer
+can still deserialize old data by matching  on the ``String``. This is especially useful
+for :ref:`persistence-java`.
+
+The manifest string can also encode a version number that can be used in ``fromBinary`` to
+deserialize in different ways to migrate old data to new domain objects.
+
+If the data was originally serialized with ``Serializer`` and in a later version of the
+system you change to ``SerializerWithStringManifest`` the manifest string will be the full
+class name if you used ``includeManifest=true``, otherwise it will be the empty string.
+
+This is how a ``SerializerWithStringManifest`` looks like:
+
+.. includecode:: code/docs/serialization/SerializationDocTest.java#my-own-serializer2
+
+You must also bind it to a name in your :ref:`configuration` and then list which classes
+that should be serialized using it.
 
 Serializing ActorRefs
 ---------------------

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -95,8 +95,37 @@ First you need to create a class definition of your ``Serializer`` like so:
    :include: imports,my-own-serializer
    :exclude: ...
 
+The manifest is a type hint so that the same serializer can be used for different
+classes. The manifest parameter in ``fromBinary`` is the class of the object that
+was serialized. In ``fromBinary`` you can match on the class and deserialize the
+bytes to different objects.
+
 Then you only need to fill in the blanks, bind it to a name in your :ref:`configuration` and then
 list which classes that should be serialized using it.
+
+Serializer with String Manifest
+-------------------------------
+
+The ``Serializer`` illustrated above supports a class based manifest (type hint).
+For serialization of data that need to evolve over time the `SerializerWithStringManifest`
+is recommended instead of ``Serializer`` because the manifest (type hint) is a ``String``
+instead of a ``Class``. That means that the class can be moved/removed and the serializer
+can still deserialize old data by matching  on the ``String``. This is especially useful
+for :ref:`persistence-scala`.
+
+The manifest string can also encode a version number that can be used in ``fromBinary`` to
+deserialize in different ways to migrate old data to new domain objects.
+
+If the data was originally serialized with ``Serializer`` and in a later version of the
+system you change to ``SerializerWithStringManifest`` the manifest string will be the full
+class name if you used ``includeManifest=true``, otherwise it will be the empty string.
+
+This is how a ``SerializerWithStringManifest`` looks like:
+
+.. includecode:: code/docs/serialization/SerializationDocSpec.scala#my-own-serializer2
+
+You must also bind it to a name in your :ref:`configuration` and then list which classes
+that should be serialized using it.
 
 Serializing ActorRefs
 ---------------------

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbIdMapping.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbIdMapping.scala
@@ -7,6 +7,7 @@ package akka.persistence.journal.leveldb
 import org.iq80.leveldb.DBIterator
 
 import akka.actor.Actor
+import akka.util.ByteString.UTF_8
 
 /**
  * INTERNAL API.
@@ -38,7 +39,7 @@ private[persistence] trait LeveldbIdMapping extends Actor { this: LeveldbStore â
       val nextEntry = iter.next()
       val nextKey = keyFromBytes(nextEntry.getKey)
       if (!isMappingKey(nextKey)) pathMap else {
-        val nextVal = new String(nextEntry.getValue, "UTF-8")
+        val nextVal = new String(nextEntry.getValue, UTF_8)
         readIdMap(pathMap + (nextVal -> nextKey.mappingId), iter)
       }
     }
@@ -46,7 +47,7 @@ private[persistence] trait LeveldbIdMapping extends Actor { this: LeveldbStore â
 
   private def writeIdMapping(id: String, numericId: Int): Int = {
     idMap = idMap + (id -> numericId)
-    leveldb.put(keyToBytes(mappingKey(numericId)), id.getBytes("UTF-8"))
+    leveldb.put(keyToBytes(mappingKey(numericId)), id.getBytes(UTF_8))
     numericId
   }
 

--- a/akka-persistence/src/main/scala/akka/persistence/snapshot/local/LocalSnapshotStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/snapshot/local/LocalSnapshotStore.scala
@@ -17,6 +17,7 @@ import akka.persistence._
 import akka.persistence.snapshot._
 import akka.persistence.serialization._
 import akka.serialization.SerializationExtension
+import akka.util.ByteString.UTF_8
 
 /**
  * INTERNAL API.
@@ -102,13 +103,13 @@ private[persistence] class LocalSnapshotStore extends SnapshotStore with ActorLo
     try { p(stream) } finally { stream.close() }
 
   private def snapshotFile(metadata: SnapshotMetadata, extension: String = ""): File =
-    new File(snapshotDir, s"snapshot-${URLEncoder.encode(metadata.persistenceId, "UTF-8")}-${metadata.sequenceNr}-${metadata.timestamp}${extension}")
+    new File(snapshotDir, s"snapshot-${URLEncoder.encode(metadata.persistenceId, UTF_8)}-${metadata.sequenceNr}-${metadata.timestamp}${extension}")
 
   private def snapshotMetadata(persistenceId: String, criteria: SnapshotSelectionCriteria): immutable.Seq[SnapshotMetadata] = {
     val files = snapshotDir.listFiles(new SnapshotFilenameFilter(persistenceId))
     if (files eq null) Nil // if the dir was removed
     else files.map(_.getName).collect {
-      case FilenamePattern(pid, snr, tms) ⇒ SnapshotMetadata(URLDecoder.decode(pid, "UTF-8"), snr.toLong, tms.toLong)
+      case FilenamePattern(pid, snr, tms) ⇒ SnapshotMetadata(URLDecoder.decode(pid, UTF_8), snr.toLong, tms.toLong)
     }.filter(md ⇒ criteria.matches(md) && !saving.contains(md)).toVector
   }
 

--- a/akka-persistence/src/test/scala/akka/persistence/serialization/SerializerSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/serialization/SerializerSpec.scala
@@ -10,12 +10,14 @@ import akka.actor._
 import akka.persistence._
 import akka.serialization._
 import akka.testkit._
-
 import akka.persistence.AtLeastOnceDelivery.AtLeastOnceDeliverySnapshot
 import akka.persistence.AtLeastOnceDelivery.UnconfirmedDelivery
+import akka.util.ByteString.UTF_8
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import org.apache.commons.codec.binary.Hex.decodeHex
+
+import SerializerSpecConfigs._
 
 object SerializerSpecConfigs {
   val customSerializers = ConfigFactory.parseString(
@@ -23,11 +25,19 @@ object SerializerSpecConfigs {
       akka.actor {
         serializers {
           my-payload = "akka.persistence.serialization.MyPayloadSerializer"
+          my-payload2 = "akka.persistence.serialization.MyPayload2Serializer"
           my-snapshot = "akka.persistence.serialization.MySnapshotSerializer"
+          my-snapshot2 = "akka.persistence.serialization.MySnapshotSerializer2"
+          old-payload = "akka.persistence.serialization.OldPayloadSerializer"
         }
         serialization-bindings {
           "akka.persistence.serialization.MyPayload" = my-payload
+          "akka.persistence.serialization.MyPayload2" = my-payload2
           "akka.persistence.serialization.MySnapshot" = my-snapshot
+          "akka.persistence.serialization.MySnapshot2" = my-snapshot2
+          # this entry was used when creating the data for the test
+          # "deserialize data when class is removed"
+          #"akka.persistence.serialization.OldPayload" = old-payload
         }
       }
     """)
@@ -53,6 +63,7 @@ object SerializerSpecConfigs {
 
   def config(configs: String*): Config =
     configs.foldLeft(ConfigFactory.empty)((r, c) ⇒ r.withFallback(ConfigFactory.parseString(c)))
+
 }
 
 import SerializerSpecConfigs._
@@ -71,9 +82,19 @@ class SnapshotSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
       deserialized should ===(Snapshot(MySnapshot(".a.")))
     }
 
+    "handle custom snapshot Serialization with string manifest" in {
+      val wrapped = Snapshot(MySnapshot2("a"))
+      val serializer = serialization.findSerializerFor(wrapped)
+
+      val bytes = serializer.toBinary(wrapped)
+      val deserialized = serializer.fromBinary(bytes, None)
+
+      deserialized should ===(Snapshot(MySnapshot2(".a.")))
+    }
+
     "be able to read snapshot created with akka 2.3.6 and Scala 2.10" in {
       val dataStr = "abc"
-      val snapshot = Snapshot(dataStr.getBytes("utf-8"))
+      val snapshot = Snapshot(dataStr.getBytes(UTF_8))
       val serializer = serialization.findSerializerFor(snapshot)
 
       // the oldSnapshot was created with Akka 2.3.6 and it is using JavaSerialization
@@ -91,13 +112,13 @@ class SnapshotSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
       val bytes = decodeHex(oldSnapshot.toCharArray)
       val deserialized = serializer.fromBinary(bytes, None).asInstanceOf[Snapshot]
 
-      val deserializedDataStr = new String(deserialized.data.asInstanceOf[Array[Byte]], "utf-8")
+      val deserializedDataStr = new String(deserialized.data.asInstanceOf[Array[Byte]], UTF_8)
       dataStr should ===(deserializedDataStr)
     }
 
     "be able to read snapshot created with akka 2.3.6 and Scala 2.11" in {
       val dataStr = "abc"
-      val snapshot = Snapshot(dataStr.getBytes("utf-8"))
+      val snapshot = Snapshot(dataStr.getBytes(UTF_8))
       val serializer = serialization.findSerializerFor(snapshot)
 
       // the oldSnapshot was created with Akka 2.3.6 and it is using JavaSerialization
@@ -115,7 +136,7 @@ class SnapshotSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
       val bytes = decodeHex(oldSnapshot.toCharArray)
       val deserialized = serializer.fromBinary(bytes, None).asInstanceOf[Snapshot]
 
-      val deserializedDataStr = new String(deserialized.data.asInstanceOf[Array[Byte]], "utf-8")
+      val deserializedDataStr = new String(deserialized.data.asInstanceOf[Array[Byte]], UTF_8)
       dataStr should ===(deserializedDataStr)
     }
   }
@@ -136,6 +157,7 @@ class MessageSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
         deserialized should ===(persistent.withPayload(MyPayload(".a.")))
       }
     }
+
     "given a PersistentRepr manifest" must {
       "handle custom Persistent message serialization" in {
         val persistent = PersistentRepr(MyPayload("b"), 13, "p1", true, testActor)
@@ -145,6 +167,57 @@ class MessageSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
         val deserialized = serializer.fromBinary(bytes, Some(classOf[PersistentRepr]))
 
         deserialized should ===(persistent.withPayload(MyPayload(".b.")))
+      }
+    }
+
+    "given payload serializer with string manifest" must {
+      "handle serialization" in {
+        val persistent = PersistentRepr(MyPayload2("a", 17), 13, "p1", true, testActor)
+        val serializer = serialization.findSerializerFor(persistent)
+
+        val bytes = serializer.toBinary(persistent)
+        val deserialized = serializer.fromBinary(bytes, None)
+
+        deserialized should ===(persistent.withPayload(MyPayload2(".a.", 17)))
+      }
+
+      "be able to evolve the data types" in {
+        val oldEvent = MyPayload("a")
+        val serializer1 = serialization.findSerializerFor(oldEvent)
+        val bytes = serializer1.toBinary(oldEvent)
+
+        // now the system is updated to version 2 with new class MyPayload2
+        // and MyPayload2Serializer that handles migration from old MyPayload
+        val serializer2 = serialization.serializerFor(classOf[MyPayload2])
+        val deserialized = serializer2.fromBinary(bytes, Some(oldEvent.getClass))
+
+        deserialized should be(MyPayload2(".a.", 0))
+      }
+
+      "be able to deserialize data when class is removed" in {
+        val serializer = serialization.findSerializerFor(PersistentRepr("x", 13, "p1", true, testActor))
+
+        // It was created with:
+        // val old = PersistentRepr(OldPayload('A'), 13, "p1", true, testActor)
+        // import org.apache.commons.codec.binary.Hex._
+        // println(s"encoded OldPayload: " + String.valueOf(encodeHex(serializer.toBinary(old))))
+        //
+        val oldData =
+          "0a3e08c7da04120d4f6c645061796c6f61642841291a2" +
+            "9616b6b612e70657273697374656e63652e7365726961" +
+            "6c697a6174696f6e2e4f6c645061796c6f6164100d1a0" +
+            "2703120015a45616b6b613a2f2f4d6573736167655365" +
+            "7269616c697a657250657273697374656e63655370656" +
+            "32f73797374656d2f746573744163746f722d31233133" +
+            "3137373931343033"
+
+        // now the system is updated, OldPayload is replaced by MyPayload, and the
+        // OldPayloadSerializer is adjusted to migrate OldPayload
+        val bytes = decodeHex(oldData.toCharArray)
+
+        val deserialized = serializer.fromBinary(bytes, None).asInstanceOf[PersistentRepr]
+
+        deserialized.payload should be(MyPayload("OldPayload(A)"))
       }
     }
 
@@ -173,7 +246,6 @@ class MessageSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
 
         deserialized should ===(snap)
       }
-
     }
 
   }
@@ -222,7 +294,13 @@ class MessageSerializerRemotingSpec extends AkkaSpec(remote.withFallback(customS
 }
 
 final case class MyPayload(data: String)
+final case class MyPayload2(data: String, n: Int)
 final case class MySnapshot(data: String)
+final case class MySnapshot2(data: String)
+
+// this class was used when creating the data for the test
+// "deserialize data when class is removed"
+//final case class OldPayload(c: Char)
 
 class MyPayloadSerializer extends Serializer {
   val MyPayloadClass = classOf[MyPayload]
@@ -231,13 +309,38 @@ class MyPayloadSerializer extends Serializer {
   def includeManifest: Boolean = true
 
   def toBinary(o: AnyRef): Array[Byte] = o match {
-    case MyPayload(data) ⇒ s".${data}".getBytes("UTF-8")
+    case MyPayload(data) ⇒ s".${data}".getBytes(UTF_8)
   }
 
   def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
-    case Some(MyPayloadClass) ⇒ MyPayload(s"${new String(bytes, "UTF-8")}.")
+    case Some(MyPayloadClass) ⇒ MyPayload(s"${new String(bytes, UTF_8)}.")
     case Some(c)              ⇒ throw new Exception(s"unexpected manifest ${c}")
     case None                 ⇒ throw new Exception("no manifest")
+  }
+}
+
+class MyPayload2Serializer extends SerializerWithStringManifest {
+  val MyPayload2Class = classOf[MyPayload]
+
+  val ManifestV1 = classOf[MyPayload].getName
+  val ManifestV2 = "MyPayload-V2"
+
+  def identifier: Int = 77125
+
+  def manifest(o: AnyRef): String = ManifestV2
+
+  def toBinary(o: AnyRef): Array[Byte] = o match {
+    case MyPayload2(data, n) ⇒ s".$data:$n".getBytes(UTF_8)
+  }
+
+  def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
+    case ManifestV2 ⇒
+      val parts = new String(bytes, UTF_8).split(":")
+      MyPayload2(data = parts(0) + ".", n = parts(1).toInt)
+    case ManifestV1 ⇒
+      MyPayload2(data = s"${new String(bytes, UTF_8)}.", n = 0)
+    case other ⇒
+      throw new Exception(s"unexpected manifest [$other]")
   }
 }
 
@@ -248,12 +351,55 @@ class MySnapshotSerializer extends Serializer {
   def includeManifest: Boolean = true
 
   def toBinary(o: AnyRef): Array[Byte] = o match {
-    case MySnapshot(data) ⇒ s".${data}".getBytes("UTF-8")
+    case MySnapshot(data) ⇒ s".${data}".getBytes(UTF_8)
   }
 
   def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
-    case Some(MySnapshotClass) ⇒ MySnapshot(s"${new String(bytes, "UTF-8")}.")
+    case Some(MySnapshotClass) ⇒ MySnapshot(s"${new String(bytes, UTF_8)}.")
     case Some(c)               ⇒ throw new Exception(s"unexpected manifest ${c}")
     case None                  ⇒ throw new Exception("no manifest")
+  }
+}
+
+class MySnapshotSerializer2 extends SerializerWithStringManifest {
+  val CurrentManifest = "MySnapshot-V2"
+  val OldManifest = classOf[MySnapshot].getName
+
+  def identifier: Int = 77126
+
+  def manifest(o: AnyRef): String = CurrentManifest
+
+  def toBinary(o: AnyRef): Array[Byte] = o match {
+    case MySnapshot2(data) ⇒ s".${data}".getBytes(UTF_8)
+  }
+
+  def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
+    case CurrentManifest | OldManifest ⇒
+      MySnapshot2(s"${new String(bytes, UTF_8)}.")
+    case other ⇒
+      throw new Exception(s"unexpected manifest [$other]")
+  }
+}
+
+class OldPayloadSerializer extends SerializerWithStringManifest {
+
+  def identifier: Int = 77127
+  val OldPayloadClassName = "akka.persistence.serialization.OldPayload"
+  val MyPayloadClassName = classOf[MyPayload].getName
+
+  def manifest(o: AnyRef): String = o.getClass.getName
+
+  def toBinary(o: AnyRef): Array[Byte] = o match {
+    case MyPayload(data) ⇒ s".${data}".getBytes(UTF_8)
+    case old if old.getClass.getName == OldPayloadClassName ⇒
+      o.toString.getBytes(UTF_8)
+  }
+
+  def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
+    case OldPayloadClassName ⇒
+      MyPayload(new String(bytes, UTF_8))
+    case MyPayloadClassName ⇒ MyPayload(s"${new String(bytes, UTF_8)}.")
+    case other ⇒
+      throw new Exception(s"unexpected manifest [$other]")
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -22,12 +22,13 @@ import scala.util.{ Failure, Success }
 import akka.remote.transport.AkkaPduCodec.Message
 import java.util.concurrent.ConcurrentHashMap
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
+import akka.util.ByteString.UTF_8
 
 /**
  * INTERNAL API
  */
 private[remote] object AddressUrlEncoder {
-  def apply(address: Address): String = URLEncoder.encode(address.toString, "utf-8")
+  def apply(address: Address): String = URLEncoder.encode(address.toString, UTF_8)
 }
 
 /**

--- a/akka-remote/src/main/scala/akka/remote/serialization/MessageContainerSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/MessageContainerSerializer.scala
@@ -14,11 +14,14 @@ import akka.actor.SelectionPathElement
 import akka.remote.ContainerFormats
 import akka.serialization.SerializationExtension
 import akka.serialization.BaseSerializer
+import akka.serialization.SerializerWithStringManifest
 
 class MessageContainerSerializer(val system: ExtendedActorSystem) extends BaseSerializer {
 
   @deprecated("Use constructor with ExtendedActorSystem", "2.4")
   def this() = this(null)
+
+  private lazy val serialization = SerializationExtension(system)
 
   // TODO remove this when deprecated this() is removed
   override val identifier: Int =
@@ -37,14 +40,21 @@ class MessageContainerSerializer(val system: ExtendedActorSystem) extends BaseSe
   private def serializeSelection(sel: ActorSelectionMessage): Array[Byte] = {
     val builder = ContainerFormats.SelectionEnvelope.newBuilder()
     val message = sel.msg.asInstanceOf[AnyRef]
-    val serializer = SerializationExtension(system).findSerializerFor(message)
+    val serializer = serialization.findSerializerFor(message)
     builder.
       setEnclosedMessage(ByteString.copyFrom(serializer.toBinary(message))).
       setSerializerId(serializer.identifier).
       setWildcardFanOut(sel.wildcardFanOut)
 
-    if (serializer.includeManifest)
-      builder.setMessageManifest(ByteString.copyFromUtf8(message.getClass.getName))
+    serializer match {
+      case ser2: SerializerWithStringManifest ⇒
+        val manifest = ser2.manifest(message)
+        if (manifest != "")
+          builder.setMessageManifest(ByteString.copyFromUtf8(manifest))
+      case _ ⇒
+        if (serializer.includeManifest)
+          builder.setMessageManifest(ByteString.copyFromUtf8(message.getClass.getName))
+    }
 
     sel.elements.foreach {
       case SelectChildName(name) ⇒
@@ -66,11 +76,11 @@ class MessageContainerSerializer(val system: ExtendedActorSystem) extends BaseSe
 
   def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
     val selectionEnvelope = ContainerFormats.SelectionEnvelope.parseFrom(bytes)
-    val msg = SerializationExtension(system).deserialize(
+    val manifest = if (selectionEnvelope.hasMessageManifest) selectionEnvelope.getMessageManifest.toStringUtf8 else ""
+    val msg = serialization.deserialize(
       selectionEnvelope.getEnclosedMessage.toByteArray,
       selectionEnvelope.getSerializerId,
-      if (selectionEnvelope.hasMessageManifest)
-        Some(system.dynamicAccess.getClassFor[AnyRef](selectionEnvelope.getMessageManifest.toStringUtf8).get) else None).get
+      manifest).get
 
     import scala.collection.JavaConverters._
     val elements: immutable.Iterable[SelectionPathElement] = selectionEnvelope.getPatternList.asScala.map { x ⇒


### PR DESCRIPTION
- useful when evolution is needed, e.g. Akka Persistence
