### PR TITLE
!str #17393: Make stream-tests pass with serialize-messages=on

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 import scala.concurrent.{ Future, Promise }
 import akka.http.HostConnectionPoolSetup
-import akka.actor.{ Props, ActorSystem, ActorRef }
+import akka.actor.{ Deploy, Props, ActorSystem, ActorRef }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpResponse, HttpRequest }
 import akka.stream.FlowMaterializer
@@ -40,7 +40,7 @@ private[http] class PoolGateway(hcps: HostConnectionPoolSetup,
 
   private val state = {
     val shutdownCompletedPromise = Promise[Unit]()
-    val props = Props(new PoolInterfaceActor(hcps, shutdownCompletedPromise, this))
+    val props = Props(new PoolInterfaceActor(hcps, shutdownCompletedPromise, this)).withDeploy(Deploy.local)
     val ref = system.actorOf(props, PoolInterfaceActor.name.next())
     new AtomicReference[State](Running(ref, _shutdownStartedPromise, shutdownCompletedPromise))
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
@@ -8,7 +8,7 @@ import java.net.InetSocketAddress
 import scala.annotation.tailrec
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
-import akka.actor.{ PoisonPill, DeadLetterSuppression, ActorLogging, Cancellable }
+import akka.actor._
 import akka.stream.FlowMaterializer
 import akka.stream.actor.{ ActorPublisher, ActorSubscriber, ZeroRequestStrategy }
 import akka.stream.actor.ActorPublisherMessage._
@@ -22,7 +22,7 @@ import akka.http.scaladsl.Http
 import PoolFlow._
 
 private object PoolInterfaceActor {
-  final case class PoolRequest(request: HttpRequest, responsePromise: Promise[HttpResponse])
+  final case class PoolRequest(request: HttpRequest, responsePromise: Promise[HttpResponse]) extends NoSerializationVerificationNeeded
 
   case object Shutdown extends DeadLetterSuppression
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -10,7 +10,7 @@ import org.reactivestreams.{ Subscriber, Publisher }
 import scala.util.control.NonFatal
 import akka.util.ByteString
 import akka.event.LoggingAdapter
-import akka.actor.{ ActorRef, Props }
+import akka.actor.{ Deploy, ActorRef, Props }
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.stage.PushPullStage
@@ -52,7 +52,7 @@ private[http] object HttpServerBluePrint {
         val actor = new TokenSourceActor(OneHundredContinue)
         oneHundredContinueRef = Some(actor.context.self)
         actor
-      }
+      }.withDeploy(Deploy.local)
     }, errorMsg = "Http.serverLayer is currently not reusable. You need to create a new instance for each materialization.")
 
     val requestParsingFlow = Flow[ByteString].transform(() ⇒

--- a/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
@@ -80,7 +80,7 @@ package object util {
   private[http] def installEventStreamLoggerFor(channel: Class[_])(implicit system: ActorSystem): Unit = {
     synchronized {
       if (eventStreamLogger == null)
-        eventStreamLogger = system.actorOf(Props[util.EventStreamLogger], name = "event-stream-logger")
+        eventStreamLogger = system.actorOf(Props[util.EventStreamLogger].withDeploy(Deploy.local), name = "event-stream-logger")
     }
     system.eventStream.subscribe(eventStreamLogger, channel)
   }

--- a/akka-http-core/src/test/resources/reference.conf
+++ b/akka-http-core/src/test/resources/reference.conf
@@ -1,0 +1,6 @@
+akka {
+  actor {
+    serialize-creators = on
+    serialize-messages = on
+  }
+}

--- a/akka-http-tests-java8/src/test/resources/reference.conf
+++ b/akka-http-tests-java8/src/test/resources/reference.conf
@@ -1,0 +1,6 @@
+akka {
+  actor {
+    serialize-creators = on
+    serialize-messages = on
+  }
+}

--- a/akka-http-tests/src/test/resources/reference.conf
+++ b/akka-http-tests/src/test/resources/reference.conf
@@ -1,0 +1,6 @@
+akka {
+  actor {
+    serialize-creators = on
+    serialize-messages = on
+  }
+}

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -4,8 +4,7 @@
 package akka.stream.testkit
 
 import scala.language.existentials
-import akka.actor.ActorSystem
-import akka.actor.DeadLetterSuppression
+import akka.actor.{ NoSerializationVerificationNeeded, ActorSystem, DeadLetterSuppression }
 import akka.stream._
 import akka.stream.impl._
 import akka.testkit.TestProbe
@@ -359,12 +358,12 @@ private[testkit] object StreamTestKit {
   import TestPublisher._
   import TestSubscriber._
 
-  sealed trait PublisherEvent extends DeadLetterSuppression
+  sealed trait PublisherEvent extends DeadLetterSuppression with NoSerializationVerificationNeeded
   final case class Subscribe(subscription: Subscription) extends PublisherEvent
   final case class CancelSubscription(subscription: Subscription) extends PublisherEvent
   final case class RequestMore(subscription: Subscription, elements: Long) extends PublisherEvent
 
-  sealed trait SubscriberEvent extends DeadLetterSuppression
+  sealed trait SubscriberEvent extends DeadLetterSuppression with NoSerializationVerificationNeeded
   final case class OnSubscribe(subscription: Subscription) extends SubscriberEvent
   final case class OnNext[I](element: I) extends SubscriberEvent
   final case object OnComplete extends SubscriberEvent

--- a/akka-stream-tests/src/test/resources/reference.conf
+++ b/akka-stream-tests/src/test/resources/reference.conf
@@ -1,0 +1,6 @@
+akka {
+  actor {
+    serialize-creators = on
+    serialize-messages = on
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
@@ -59,7 +59,7 @@ class FlowSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug.rece
 
   val faultyFlow: Flow[Any, Any, _] ⇒ Flow[Any, Any, _] = in ⇒ in.andThenMat { () ⇒
     val props = Props(new BrokenActorInterpreter(settings, List(fusing.Map({ x: Any ⇒ x }, stoppingDecider)), "a3"))
-      .withDispatcher("akka.test.stream-dispatcher")
+      .withDispatcher("akka.test.stream-dispatcher").withDeploy(Deploy.local)
     val processor = ActorProcessorFactory[Any, Any](system.actorOf(
       props,
       "borken-stage-actor"))

--- a/akka-stream/src/main/boilerplate/akka/stream/impl/GenJunctions.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/impl/GenJunctions.scala.template
@@ -4,6 +4,7 @@
 package akka.stream.impl
 
 import akka.actor.Props
+import akka.actor.Deploy
 import akka.stream._
 import akka.stream.impl.Junctions.FanInModule
 import akka.stream.impl.StreamLayout.Module
@@ -29,7 +30,7 @@ private[akka] object GenJunctions {
     override def carbonCopy: Module = ZipWith1Module(shape.deepCopy(), f, attributes)
 
     override def props(settings: ActorFlowMaterializerSettings): Props =
-      Props(new Zip1With(settings, f.asInstanceOf[Function1[[#Any#], Any]]))
+      Props(new Zip1With(settings, f.asInstanceOf[Function1[[#Any#], Any]])).withDeploy(Deploy.local)
   }#
   ]
 

--- a/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
@@ -4,21 +4,11 @@
 package akka.stream.actor
 
 import java.util.concurrent.ConcurrentHashMap
-import akka.actor.Cancellable
+import akka.actor._
 import akka.stream.impl.{ ReactiveStreamsCompliance, StreamSubscriptionTimeoutSupport }
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
-import akka.actor.AbstractActor
-import akka.actor.Actor
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.ExtendedActorSystem
-import akka.actor.Extension
-import akka.actor.ExtensionId
-import akka.actor.ExtensionIdProvider
-import akka.actor.UntypedActor
 import concurrent.duration.Duration
 import concurrent.duration.FiniteDuration
-import akka.actor.DeadLetterSuppression
 import akka.stream.impl.CancelledSubscription
 import akka.stream.impl.ReactiveStreamsCompliance._
 
@@ -35,7 +25,7 @@ object ActorPublisher {
    * INTERNAL API
    */
   private[akka] object Internal {
-    final case class Subscribe(subscriber: Subscriber[Any]) extends DeadLetterSuppression
+    final case class Subscribe(subscriber: Subscriber[Any]) extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
     sealed trait LifecycleState
     case object PreSubscriber extends LifecycleState
@@ -55,20 +45,20 @@ object ActorPublisherMessage {
    * more elements.
    * @param n number of requested elements
    */
-  @SerialVersionUID(1L) final case class Request(n: Long) extends ActorPublisherMessage
+  final case class Request(n: Long) extends ActorPublisherMessage with NoSerializationVerificationNeeded
 
   /**
    * This message is delivered to the [[ActorPublisher]] actor when the stream subscriber cancels the
    * subscription.
    */
-  @SerialVersionUID(1L) final case object Cancel extends Cancel
+  final case object Cancel extends Cancel with NoSerializationVerificationNeeded
   sealed class Cancel extends ActorPublisherMessage
 
   /**
    * This message is delivered to the [[ActorPublisher]] actor in order to signal the exceeding of an subscription timeout.
    * Once the actor receives this message, this publisher will already be in cancelled state, thus the actor should clean-up and stop itself.
    */
-  @SerialVersionUID(1L) final case object SubscriptionTimeoutExceeded extends SubscriptionTimeoutExceeded
+  final case object SubscriptionTimeoutExceeded extends SubscriptionTimeoutExceeded with NoSerializationVerificationNeeded
   sealed abstract class SubscriptionTimeoutExceeded extends ActorPublisherMessage
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/actor/ActorSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorSubscriber.scala
@@ -5,16 +5,7 @@ package akka.stream.actor
 
 import java.util.concurrent.ConcurrentHashMap
 import org.reactivestreams.{ Subscriber, Subscription }
-import akka.actor.AbstractActor
-import akka.actor.Actor
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.ExtendedActorSystem
-import akka.actor.Extension
-import akka.actor.ExtensionId
-import akka.actor.ExtensionIdProvider
-import akka.actor.UntypedActor
-import akka.actor.DeadLetterSuppression
+import akka.actor._
 import akka.stream.impl.ReactiveStreamsCompliance
 
 object ActorSubscriber {
@@ -28,17 +19,17 @@ object ActorSubscriber {
   /**
    * INTERNAL API
    */
-  @SerialVersionUID(1L) private[akka] final case class OnSubscribe(subscription: Subscription)
-    extends DeadLetterSuppression
+  private[akka] final case class OnSubscribe(subscription: Subscription)
+    extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
 }
 
-sealed abstract class ActorSubscriberMessage extends DeadLetterSuppression
+sealed abstract class ActorSubscriberMessage extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
 object ActorSubscriberMessage {
-  @SerialVersionUID(1L) final case class OnNext(element: Any) extends ActorSubscriberMessage
-  @SerialVersionUID(1L) final case class OnError(cause: Throwable) extends ActorSubscriberMessage
-  @SerialVersionUID(1L) case object OnComplete extends ActorSubscriberMessage
+  final case class OnNext(element: Any) extends ActorSubscriberMessage
+  final case class OnError(cause: Throwable) extends ActorSubscriberMessage
+  case object OnComplete extends ActorSubscriberMessage
 
   /**
    * Java API: get the singleton instance of the `OnComplete` message

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
@@ -248,7 +248,7 @@ private[akka] class FlowNameCounter extends Extension {
 private[akka] object StreamSupervisor {
   def props(settings: ActorFlowMaterializerSettings): Props = Props(new StreamSupervisor(settings)).withDeploy(Deploy.local)
 
-  final case class Materialize(props: Props, name: String) extends DeadLetterSuppression
+  final case class Materialize(props: Props, name: String) extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
   /** Testing purpose */
   final case object GetChildren

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorFlowMaterializerImpl.scala
@@ -246,7 +246,7 @@ private[akka] class FlowNameCounter extends Extension {
  * INTERNAL API
  */
 private[akka] object StreamSupervisor {
-  def props(settings: ActorFlowMaterializerSettings): Props = Props(new StreamSupervisor(settings))
+  def props(settings: ActorFlowMaterializerSettings): Props = Props(new StreamSupervisor(settings)).withDeploy(Deploy.local)
 
   final case class Materialize(props: Props, name: String) extends DeadLetterSuppression
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ConcatAllImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ConcatAllImpl.scala
@@ -5,14 +5,14 @@ package akka.stream.impl
 
 import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Sink
-import akka.actor.Props
+import akka.actor.{ Deploy, Props }
 
 /**
  * INTERNAL API
  */
 private[akka] object ConcatAllImpl {
   def props(materializer: ActorFlowMaterializer): Props =
-    Props(new ConcatAllImpl(materializer))
+    Props(new ConcatAllImpl(materializer)).withDeploy(Deploy.local)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanIn.scala
@@ -3,13 +3,11 @@
  */
 package akka.stream.impl
 
-import akka.actor.{ ActorRef, ActorLogging, Actor }
-import akka.actor.Props
+import akka.actor._
 import akka.stream.{ AbruptTerminationException, ActorFlowMaterializerSettings, InPort, Shape }
 import akka.stream.actor.{ ActorSubscriberMessage, ActorSubscriber }
 import akka.stream.scaladsl.FlexiMerge.MergeLogic
 import org.reactivestreams.{ Subscription, Subscriber }
-import akka.actor.DeadLetterSuppression
 
 import scala.collection.immutable
 
@@ -18,10 +16,10 @@ import scala.collection.immutable
  */
 private[akka] object FanIn {
 
-  final case class OnError(id: Int, cause: Throwable) extends DeadLetterSuppression
-  final case class OnComplete(id: Int) extends DeadLetterSuppression
-  final case class OnNext(id: Int, e: Any) extends DeadLetterSuppression
-  final case class OnSubscribe(id: Int, subscription: Subscription) extends DeadLetterSuppression
+  final case class OnError(id: Int, cause: Throwable) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  final case class OnComplete(id: Int) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  final case class OnNext(id: Int, e: Any) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  final case class OnSubscribe(id: Int, subscription: Subscription) extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
   private[akka] final case class SubInput[T](impl: ActorRef, id: Int) extends Subscriber[T] {
     override def onError(cause: Throwable): Unit = {
@@ -264,7 +262,7 @@ private[akka] abstract class FanIn(val settings: ActorFlowMaterializerSettings, 
  */
 private[akka] object FairMerge {
   def props(settings: ActorFlowMaterializerSettings, inputPorts: Int): Props =
-    Props(new FairMerge(settings, inputPorts))
+    Props(new FairMerge(settings, inputPorts)).withDeploy(Deploy.local)
 }
 
 /**
@@ -287,7 +285,7 @@ private[akka] object UnfairMerge {
   val DefaultPreferred = 0
 
   def props(settings: ActorFlowMaterializerSettings, inputPorts: Int): Props =
-    Props(new UnfairMerge(settings, inputPorts, DefaultPreferred))
+    Props(new UnfairMerge(settings, inputPorts, DefaultPreferred)).withDeploy(Deploy.local)
 }
 
 /**
@@ -309,14 +307,14 @@ private[akka] final class UnfairMerge(_settings: ActorFlowMaterializerSettings,
  */
 private[akka] object FlexiMerge {
   def props[T, S <: Shape](settings: ActorFlowMaterializerSettings, ports: S, mergeLogic: MergeLogic[T]): Props =
-    Props(new FlexiMergeImpl(settings, ports, mergeLogic))
+    Props(new FlexiMergeImpl(settings, ports, mergeLogic)).withDeploy(Deploy.local)
 }
 
 /**
  * INTERNAL API
  */
 private[akka] object Concat {
-  def props(settings: ActorFlowMaterializerSettings): Props = Props(new Concat(settings))
+  def props(settings: ActorFlowMaterializerSettings): Props = Props(new Concat(settings)).withDeploy(Deploy.local)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/FuturePublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FuturePublisher.scala
@@ -7,16 +7,11 @@ import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import akka.actor.Actor
-import akka.actor.ActorRef
-import akka.actor.Props
-import akka.actor.Status
-import akka.actor.SupervisorStrategy
+import akka.actor._
 import akka.stream.ActorFlowMaterializerSettings
 import akka.pattern.pipe
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
-import akka.actor.DeadLetterSuppression
 import scala.util.control.NonFatal
 
 /**
@@ -24,11 +19,11 @@ import scala.util.control.NonFatal
  */
 private[akka] object FuturePublisher {
   def props(future: Future[Any], settings: ActorFlowMaterializerSettings): Props =
-    Props(new FuturePublisher(future, settings)).withDispatcher(settings.dispatcher)
+    Props(new FuturePublisher(future, settings)).withDispatcher(settings.dispatcher).withDeploy(Deploy.local)
 
   object FutureSubscription {
-    final case class Cancel(subscription: FutureSubscription) extends DeadLetterSuppression
-    final case class RequestMore(subscription: FutureSubscription, elements: Long) extends DeadLetterSuppression
+    final case class Cancel(subscription: FutureSubscription) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+    final case class RequestMore(subscription: FutureSubscription, elements: Long) extends DeadLetterSuppression with NoSerializationVerificationNeeded
   }
 
   class FutureSubscription(ref: ActorRef) extends Subscription {

--- a/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
@@ -4,7 +4,7 @@
 package akka.stream.impl
 
 import scala.util.control.NonFatal
-import akka.actor.Props
+import akka.actor.{ Deploy, Props }
 import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.Supervision
 import akka.stream.scaladsl.Source
@@ -14,7 +14,7 @@ import akka.stream.scaladsl.Source
  */
 private[akka] object GroupByProcessorImpl {
   def props(settings: ActorFlowMaterializerSettings, keyFor: Any ⇒ Any): Props =
-    Props(new GroupByProcessorImpl(settings, keyFor))
+    Props(new GroupByProcessorImpl(settings, keyFor)).withDeploy(Deploy.local)
 
   private case object Drop
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/Messages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Messages.scala
@@ -5,28 +5,28 @@ package akka.stream.impl
 
 import language.existentials
 import org.reactivestreams.Subscription
-import akka.actor.DeadLetterSuppression
+import akka.actor.{ NoSerializationVerificationNeeded, DeadLetterSuppression }
 
 /**
  * INTERNAL API
  */
-private[akka] case object SubscribePending extends DeadLetterSuppression
+private[akka] case object SubscribePending extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
 /**
  * INTERNAL API
  */
 private[akka] final case class RequestMore(subscription: ActorSubscription[_], demand: Long)
-  extends DeadLetterSuppression
+  extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
 /**
  * INTERNAL API
  */
 private[akka] final case class Cancel(subscription: ActorSubscription[_])
-  extends DeadLetterSuppression
+  extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
 /**
  * INTERNAL API
  */
 private[akka] final case class ExposedPublisher(publisher: ActorPublisher[Any])
-  extends DeadLetterSuppression
+  extends DeadLetterSuppression with NoSerializationVerificationNeeded
 

--- a/akka-stream/src/main/scala/akka/stream/impl/PrefixAndTailImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PrefixAndTailImpl.scala
@@ -6,14 +6,14 @@ package akka.stream.impl
 import scala.collection.immutable
 import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.scaladsl.Source
-import akka.actor.Props
+import akka.actor.{ Deploy, Props }
 
 /**
  * INTERNAL API
  */
 private[akka] object PrefixAndTailImpl {
   def props(settings: ActorFlowMaterializerSettings, takeMax: Int): Props =
-    Props(new PrefixAndTailImpl(settings, takeMax))
+    Props(new PrefixAndTailImpl(settings, takeMax)).withDeploy(Deploy.local)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -5,7 +5,7 @@ package akka.stream.impl
 
 import java.io.File
 import java.util.concurrent.atomic.AtomicReference
-import akka.actor.{ ActorRef, Props }
+import akka.actor.{ Deploy, ActorRef, Props }
 import akka.stream.ActorOperationAttributes.Dispatcher
 import akka.stream.impl.StreamLayout.Module
 import akka.stream.OperationAttributes
@@ -83,7 +83,7 @@ private[akka] final class FanoutPublisherSink[In](
     val actorMaterializer = ActorFlowMaterializer.downcast(context.materializer)
     val fanoutActor = actorMaterializer.actorOf(context,
       Props(new FanoutProcessorImpl(actorMaterializer.effectiveSettings(context.effectiveAttributes),
-        initialBufferSize, maximumBufferSize)))
+        initialBufferSize, maximumBufferSize)).withDeploy(Deploy.local))
     val fanoutProcessor = ActorProcessorFactory[In, In](fanoutActor)
     (fanoutProcessor, fanoutProcessor)
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/SplitWhereProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SplitWhereProcessorImpl.scala
@@ -3,7 +3,7 @@
  */
 package akka.stream.impl
 
-import akka.actor.Props
+import akka.actor.{ Deploy, Props }
 import akka.stream.impl.SplitDecision.SplitDecision
 import akka.stream.scaladsl.Source
 import akka.stream.{ ActorFlowMaterializerSettings, Supervision }
@@ -35,7 +35,7 @@ private[akka] object SplitDecision {
  */
 private[akka] object SplitWhereProcessorImpl {
   def props(settings: ActorFlowMaterializerSettings, splitPredicate: Any ⇒ SplitDecision): Props =
-    Props(new SplitWhereProcessorImpl(settings, in ⇒ splitPredicate(in)))
+    Props(new SplitWhereProcessorImpl(settings, in ⇒ splitPredicate(in))).withDeploy(Deploy.local)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
@@ -4,24 +4,21 @@
 package akka.stream.impl
 
 import java.util.concurrent.atomic.AtomicReference
-import akka.actor.ActorLogging
-import akka.actor.Cancellable
-import akka.actor.{ Actor, ActorRef }
+import akka.actor._
 import akka.stream.ActorFlowMaterializerSettings
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
-import akka.actor.DeadLetterSuppression
 
 /**
  * INTERNAL API
  */
 private[akka] object MultiStreamOutputProcessor {
   final case class SubstreamKey(id: Long)
-  final case class SubstreamRequestMore(substream: SubstreamKey, demand: Long) extends DeadLetterSuppression
-  final case class SubstreamCancel(substream: SubstreamKey) extends DeadLetterSuppression
-  final case class SubstreamSubscribe(substream: SubstreamKey, subscriber: Subscriber[Any]) extends DeadLetterSuppression
-  final case class SubstreamSubscriptionTimeout(substream: SubstreamKey) extends DeadLetterSuppression
+  final case class SubstreamRequestMore(substream: SubstreamKey, demand: Long) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  final case class SubstreamCancel(substream: SubstreamKey) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  final case class SubstreamSubscribe(substream: SubstreamKey, subscriber: Subscriber[Any]) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  final case class SubstreamSubscriptionTimeout(substream: SubstreamKey) extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
   class SubstreamSubscription(val parent: ActorRef, val substreamKey: SubstreamKey) extends Subscription {
     override def request(elements: Long): Unit = parent ! SubstreamRequestMore(substreamKey, elements)
@@ -316,10 +313,10 @@ private[akka] object MultiStreamInputProcessor {
     }
   }
 
-  case class SubstreamOnComplete(key: SubstreamKey) extends DeadLetterSuppression
-  case class SubstreamOnNext(key: SubstreamKey, element: Any) extends DeadLetterSuppression
-  case class SubstreamOnError(key: SubstreamKey, e: Throwable) extends DeadLetterSuppression
-  case class SubstreamStreamOnSubscribe(key: SubstreamKey, subscription: Subscription) extends DeadLetterSuppression
+  case class SubstreamOnComplete(key: SubstreamKey) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  case class SubstreamOnNext(key: SubstreamKey, element: Any) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  case class SubstreamOnError(key: SubstreamKey, e: Throwable) extends DeadLetterSuppression with NoSerializationVerificationNeeded
+  case class SubstreamStreamOnSubscribe(key: SubstreamKey, subscription: Subscription) extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
   class SubstreamInput(val key: SubstreamKey, bufferSize: Int, processor: MultiStreamInputProcessorLike, pump: Pump) extends BatchingInputBuffer(bufferSize, pump) {
     // Not driven directly

--- a/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TickPublisher.scala
@@ -4,13 +4,12 @@
 package akka.stream.impl
 
 import java.util.concurrent.atomic.AtomicBoolean
-import akka.actor.{ Actor, ActorRef, Cancellable, Props, SupervisorStrategy }
+import akka.actor._
 import akka.stream.ActorFlowMaterializerSettings
 import org.reactivestreams.{ Subscriber, Subscription }
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
-import akka.actor.DeadLetterSuppression
 import akka.event.Logging
 
 /**
@@ -19,7 +18,9 @@ import akka.event.Logging
 private[akka] object TickPublisher {
   def props(initialDelay: FiniteDuration, interval: FiniteDuration, tick: Any,
             settings: ActorFlowMaterializerSettings, cancelled: AtomicBoolean): Props =
-    Props(new TickPublisher(initialDelay, interval, tick, settings, cancelled)).withDispatcher(settings.dispatcher)
+    Props(new TickPublisher(initialDelay, interval, tick, settings, cancelled))
+      .withDispatcher(settings.dispatcher)
+      .withDeploy(Deploy.local)
 
   object TickPublisherSubscription {
     case object Cancel extends DeadLetterSuppression

--- a/akka-stream/src/main/scala/akka/stream/impl/TimerTransformerProcessorsImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TimerTransformerProcessorsImpl.scala
@@ -7,11 +7,11 @@ import java.util.LinkedList
 import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.TimerTransformer
 import scala.util.control.NonFatal
-import akka.actor.Props
+import akka.actor.{ Deploy, Props }
 
 private[akka] object TimerTransformerProcessorsImpl {
   def props(settings: ActorFlowMaterializerSettings, transformer: TimerTransformer[Any, Any]): Props =
-    Props(new TimerTransformerProcessorsImpl(settings, transformer))
+    Props(new TimerTransformerProcessorsImpl(settings, transformer)).withDeploy(Deploy.local)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorInterpreter.scala
@@ -154,7 +154,7 @@ private[akka] object ActorOutputBoundary {
   /**
    * INTERNAL API.
    */
-  private case object ContinuePulling extends DeadLetterSuppression
+  private case object ContinuePulling extends DeadLetterSuppression with NoSerializationVerificationNeeded
 }
 
 /**
@@ -308,9 +308,9 @@ private[akka] class ActorOutputBoundary(val actor: ActorRef,
  */
 private[akka] object ActorInterpreter {
   def props(settings: ActorFlowMaterializerSettings, ops: Seq[Stage[_, _]], materializer: ActorFlowMaterializer, attributes: OperationAttributes = OperationAttributes.none): Props =
-    Props(new ActorInterpreter(settings, ops, materializer, attributes))
+    Props(new ActorInterpreter(settings, ops, materializer, attributes)).withDeploy(Deploy.local)
 
-  case class AsyncInput(op: AsyncStage[Any, Any, Any], ctx: AsyncContext[Any, Any], event: Any) extends DeadLetterSuppression
+  case class AsyncInput(op: AsyncStage[Any, Any, Any], ctx: AsyncContext[Any, Any], event: Any) extends DeadLetterSuppression with NoSerializationVerificationNeeded
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSettings.scala
@@ -1,4 +1,4 @@
-package akka.stream.io.impl
+package akka.stream.impl.io
 
 import akka.stream.ActorOperationAttributes.Dispatcher
 import akka.stream.{ ActorFlowMaterializer, MaterializationContext }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
@@ -1,13 +1,12 @@
 /**
  * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package akka.stream.io.impl
+package akka.stream.impl.io
 
 import java.io.{ File, OutputStream }
 
 import akka.stream.impl.SinkModule
 import akka.stream.impl.StreamLayout.Module
-import akka.stream.io.impl.IOSettings._
 import akka.stream.{ ActorFlowMaterializer, MaterializationContext, OperationAttributes, SinkShape }
 import akka.util.ByteString
 
@@ -27,7 +26,7 @@ private[akka] final class SynchronousFileSink(f: File, append: Boolean, val attr
 
     val bytesWrittenPromise = Promise[Long]()
     val props = SynchronousFileSubscriber.props(f, bytesWrittenPromise, settings.maxInputBufferSize, append)
-    val dispatcher = fileIoDispatcher(context)
+    val dispatcher = IOSettings.fileIoDispatcher(context)
 
     val ref = mat.actorOf(context, props.withDispatcher(dispatcher))
     (akka.stream.actor.ActorSubscriber[ByteString](ref), bytesWrittenPromise.future)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package akka.stream.io.impl
+package akka.stream.impl.io
 
 import java.io.{ File, InputStream }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
@@ -1,52 +1,51 @@
 /**
  * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package akka.stream.io.impl
+package akka.stream.impl.io
 
-import java.io.{ File, RandomAccessFile }
-import java.nio.ByteBuffer
-import java.nio.channels.FileChannel
+import java.io.InputStream
 
-import akka.actor.{ ActorLogging, DeadLetterSuppression, Props }
+import akka.actor.{ Deploy, ActorLogging, DeadLetterSuppression, Props }
+import akka.io.DirectByteBufferPool
 import akka.stream.actor.ActorPublisherMessage
 import akka.util.ByteString
+import akka.util.ByteString.ByteString1C
 
 import scala.annotation.tailrec
 import scala.concurrent.Promise
 
 /** INTERNAL API */
-private[akka] object SynchronousFilePublisher {
-  def props(f: File, completionPromise: Promise[Long], chunkSize: Int, initialBuffer: Int, maxBuffer: Int) = {
+private[akka] object InputStreamPublisher {
+
+  def props(is: InputStream, completionPromise: Promise[Long], chunkSize: Int, initialBuffer: Int, maxBuffer: Int): Props = {
     require(chunkSize > 0, s"chunkSize must be > 0 (was $chunkSize)")
     require(initialBuffer > 0, s"initialBuffer must be > 0 (was $initialBuffer)")
     require(maxBuffer >= initialBuffer, s"maxBuffer must be >= initialBuffer (was $maxBuffer)")
 
-    Props(classOf[SynchronousFilePublisher], f, completionPromise, chunkSize, initialBuffer, maxBuffer)
+    Props(classOf[InputStreamPublisher], is, completionPromise, chunkSize, initialBuffer, maxBuffer).withDeploy(Deploy.local)
   }
 
   private final case object Continue extends DeadLetterSuppression
-
 }
 
 /** INTERNAL API */
-private[akka] class SynchronousFilePublisher(f: File, bytesReadPromise: Promise[Long], chunkSize: Int, initialBuffer: Int, maxBuffer: Int)
+private[akka] class InputStreamPublisher(is: InputStream, bytesReadPromise: Promise[Long], chunkSize: Int, initialBuffer: Int, maxBuffer: Int)
   extends akka.stream.actor.ActorPublisher[ByteString]
   with ActorLogging {
 
-  import SynchronousFilePublisher._
+  // TODO possibly de-duplicate with SynchronousFilePublisher?
 
+  import InputStreamPublisher._
+
+  val buffs = new DirectByteBufferPool(chunkSize, maxBuffer)
   var eofReachedAtOffset = Long.MinValue
 
   var readBytesTotal = 0L
-  var availableChunks: Vector[ByteString] = Vector.empty // TODO possibly resign read-ahead-ing and make fusable as Stage
-
-  private var raf: RandomAccessFile = _
-  private var chan: FileChannel = _
+  var availableChunks: Vector[ByteString] = Vector.empty
 
   override def preStart() = {
     try {
-      raf = new RandomAccessFile(f, "r") // best way to express this in JDK6, OpenOption are available since JDK7
-      chan = raf.getChannel
+      readAndSignal(initialBuffer)
     } catch {
       case ex: Exception ⇒
         onErrorThenStop(ex)
@@ -88,20 +87,23 @@ private[akka] class SynchronousFilePublisher(f: File, bytesReadPromise: Promise[
 
   /** BLOCKING I/O READ */
   def loadChunk() = try {
-    val buf = ByteBuffer.allocate(chunkSize)
+    val arr = Array.ofDim[Byte](chunkSize)
 
     // blocking read
-    val readBytes = chan.read(buf)
+    val readBytes = is.read(arr)
 
     readBytes match {
       case -1 ⇒
         // had nothing to read into this chunk
-        eofReachedAtOffset = chan.position
+        eofReachedAtOffset = readBytes
         log.debug("No more bytes available to read (got `-1` or `0` from `read`), marking final bytes of file @ " + eofReachedAtOffset)
 
       case _ ⇒
         readBytesTotal += readBytes
-        availableChunks :+= ByteString(buf.array).take(readBytes)
+        if (readBytes == chunkSize) availableChunks :+= ByteString1C(arr)
+        else availableChunks :+= ByteString1C(arr).take(readBytes)
+
+      // valid read, continue
     }
   } catch {
     case ex: Exception ⇒
@@ -114,7 +116,6 @@ private[akka] class SynchronousFilePublisher(f: File, bytesReadPromise: Promise[
     super.postStop()
     bytesReadPromise.trySuccess(readBytesTotal)
 
-    try if (chan ne null) chan.close()
-    finally if (raf ne null) raf.close()
+    if (is ne null) is.close()
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
@@ -1,11 +1,11 @@
 /**
  * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package akka.stream.io.impl
+package akka.stream.impl.io
 
 import java.io.OutputStream
 
-import akka.actor.{ ActorLogging, Props }
+import akka.actor.{ Deploy, ActorLogging, Props }
 import akka.stream.actor.{ ActorSubscriberMessage, WatermarkRequestStrategy }
 import akka.util.ByteString
 
@@ -15,7 +15,7 @@ import scala.concurrent.Promise
 private[akka] object OutputStreamSubscriber {
   def props(os: OutputStream, completionPromise: Promise[Long], bufSize: Int) = {
     require(bufSize > 0, "buffer size must be > 0")
-    Props(classOf[OutputStreamSubscriber], os, completionPromise, bufSize)
+    Props(classOf[OutputStreamSubscriber], os, completionPromise, bufSize).withDeploy(Deploy.local)
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/SslTls.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/SslTls.scala
@@ -10,7 +10,7 @@ import javax.net.ssl.SSLEngineResult.HandshakeStatus
 import javax.net.ssl.SSLEngineResult.HandshakeStatus._
 import javax.net.ssl.SSLEngineResult.Status._
 import javax.net.ssl._
-import akka.actor.{ Props, Actor, ActorLogging, ActorRef }
+import akka.actor._
 import akka.stream.ActorFlowMaterializerSettings
 import akka.stream.impl.FanIn.InputBunch
 import akka.stream.impl.FanOut.OutputBunch
@@ -35,7 +35,7 @@ private[akka] object SslTlsCipherActor {
             tracing: Boolean,
             role: Role,
             closing: Closing): Props =
-    Props(new SslTlsCipherActor(settings, sslContext, firstSession, tracing, role, closing))
+    Props(new SslTlsCipherActor(settings, sslContext, firstSession, tracing, role, closing)).withDeploy(Deploy.local)
 
   final val TransportIn = 0
   final val TransportOut = 0

--- a/akka-stream/src/main/scala/akka/stream/impl/io/StreamTcpManager.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/StreamTcpManager.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
-import akka.actor.Actor
+import akka.actor.{ NoSerializationVerificationNeeded, Actor, DeadLetterSuppression }
 import akka.io.Inet.SocketOption
 import akka.io.Tcp
 import akka.stream.ActorFlowMaterializerSettings
@@ -20,7 +20,6 @@ import akka.stream.scaladsl.{ Tcp ⇒ StreamTcp }
 import akka.util.ByteString
 import org.reactivestreams.Processor
 import org.reactivestreams.Subscriber
-import akka.actor.DeadLetterSuppression
 
 /**
  * INTERNAL API
@@ -37,7 +36,7 @@ private[akka] object StreamTcpManager {
     options: immutable.Traversable[SocketOption],
     connectTimeout: Duration,
     idleTimeout: Duration)
-    extends DeadLetterSuppression
+    extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
   /**
    * INTERNAL API
@@ -50,13 +49,13 @@ private[akka] object StreamTcpManager {
     backlog: Int,
     options: immutable.Traversable[SocketOption],
     idleTimeout: Duration)
-    extends DeadLetterSuppression
+    extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
   /**
    * INTERNAL API
    */
   private[akka] final case class ExposedProcessor(processor: Processor[ByteString, ByteString])
-    extends DeadLetterSuppression
+    extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/SynchronousFileSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/SynchronousFileSubscriber.scala
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package akka.stream.io.impl
+package akka.stream.impl.io
 
 import java.io.{ File, RandomAccessFile }
 import java.nio.channels.FileChannel
 
-import akka.actor.{ ActorLogging, Props }
+import akka.actor.{ Deploy, ActorLogging, Props }
 import akka.stream.actor.{ ActorSubscriberMessage, WatermarkRequestStrategy }
 import akka.util.ByteString
 
@@ -16,7 +16,7 @@ import scala.concurrent.Promise
 private[akka] object SynchronousFileSubscriber {
   def props(f: File, completionPromise: Promise[Long], bufSize: Int, append: Boolean) = {
     require(bufSize > 0, "buffer size must be > 0")
-    Props(classOf[SynchronousFileSubscriber], f, completionPromise, bufSize, append)
+    Props(classOf[SynchronousFileSubscriber], f, completionPromise, bufSize, append).withDeploy(Deploy.local)
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
@@ -27,10 +27,10 @@ private[akka] object TcpStreamActor {
                     connectCmd: Connect,
                     materializerSettings: ActorFlowMaterializerSettings): Props =
     Props(new OutboundTcpStreamActor(processorPromise, localAddressPromise, connectCmd,
-      materializerSettings)).withDispatcher(materializerSettings.dispatcher)
+      materializerSettings)).withDispatcher(materializerSettings.dispatcher).withDeploy(Deploy.local)
 
   def inboundProps(connection: ActorRef, settings: ActorFlowMaterializerSettings): Props =
-    Props(new InboundTcpStreamActor(connection, settings)).withDispatcher(settings.dispatcher)
+    Props(new InboundTcpStreamActor(connection, settings)).withDispatcher(settings.dispatcher).withDeploy(Deploy.local)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpListenStreamActor.scala
@@ -5,9 +5,7 @@ package akka.stream.impl.io
 
 import java.net.InetSocketAddress
 import scala.concurrent.{ Future, Promise }
-import akka.actor.Actor
-import akka.actor.ActorRef
-import akka.actor.Props
+import akka.actor._
 import akka.io.{ IO, Tcp }
 import akka.io.Tcp._
 import akka.stream.{ FlowMaterializer, ActorFlowMaterializerSettings }
@@ -18,7 +16,6 @@ import akka.util.ByteString
 import org.reactivestreams.Subscriber
 import akka.stream.ConnectionException
 import akka.stream.BindFailedException
-import akka.actor.ActorLogging
 
 /**
  * INTERNAL API
@@ -29,6 +26,7 @@ private[akka] object TcpListenStreamActor {
             flowSubscriber: Subscriber[StreamTcp.IncomingConnection],
             bindCmd: Tcp.Bind, materializerSettings: ActorFlowMaterializerSettings): Props = {
     Props(new TcpListenStreamActor(localAddressPromise, unbindPromise, flowSubscriber, bindCmd, materializerSettings))
+      .withDeploy(Deploy.local)
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/io/InputStreamSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/InputStreamSource.scala
@@ -6,7 +6,7 @@ package akka.stream.io
 import java.io.InputStream
 
 import akka.japi.function.Creator
-import akka.stream.io.impl.InputStreamSource
+import akka.stream.impl.io.InputStreamSource
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.Source._
 import akka.stream.{ OperationAttributes, javadsl }

--- a/akka-stream/src/main/scala/akka/stream/io/OutputStreamSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/OutputStreamSink.scala
@@ -6,7 +6,7 @@ package akka.stream.io
 import java.io.OutputStream
 
 import akka.japi.function.Creator
-import akka.stream.io.impl.OutputStreamSink
+import akka.stream.impl.io.OutputStreamSink
 import akka.stream.scaladsl.Sink
 import akka.stream.{ ActorOperationAttributes, OperationAttributes, javadsl }
 import akka.util.ByteString

--- a/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSink.scala
@@ -5,8 +5,8 @@ package akka.stream.io
 
 import java.io.File
 
+import akka.stream.impl.io.SynchronousFileSink
 import akka.stream.{ OperationAttributes, javadsl, ActorOperationAttributes }
-import akka.stream.io.impl.SynchronousFileSink
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 
@@ -28,7 +28,7 @@ object SynchronousFileSink {
    * unless configured otherwise by using [[ActorOperationAttributes]].
    */
   def apply(f: File, append: Boolean = false): Sink[ByteString, Future[Long]] =
-    new Sink(new impl.SynchronousFileSink(f, append, DefaultAttributes, Sink.shape("SynchronousFileSink")))
+    new Sink(new SynchronousFileSink(f, append, DefaultAttributes, Sink.shape("SynchronousFileSink")))
 
   /**
    * Java API

--- a/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSource.scala
@@ -4,8 +4,7 @@
 package akka.stream.io
 
 import java.io.File
-
-import akka.stream.io.impl.SynchronousFileSource
+import akka.stream.impl.io.SynchronousFileSource
 import akka.stream.scaladsl.Source
 import akka.stream.{ ActorOperationAttributes, OperationAttributes, javadsl }
 import akka.util.ByteString

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -10,13 +10,7 @@ import scala.concurrent.{ Promise, ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success }
 import scala.util.control.NoStackTrace
-import akka.actor.Actor
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.ExtendedActorSystem
-import akka.actor.ExtensionId
-import akka.actor.ExtensionIdProvider
-import akka.actor.Props
+import akka.actor._
 import akka.io.Inet.SocketOption
 import akka.io.{ Tcp ⇒ IoTcp }
 import akka.stream._
@@ -25,7 +19,6 @@ import akka.stream.impl.ReactiveStreamsCompliance._
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import org.reactivestreams.{ Publisher, Processor, Subscriber, Subscription }
-import akka.actor.actorRef2Scala
 import akka.stream.impl.io.TcpStreamActor
 import akka.stream.impl.io.TcpListenStreamActor
 import akka.stream.impl.io.DelayedInitProcessor
@@ -77,7 +70,7 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   import Tcp._
 
   private val manager: ActorRef = system.systemActorOf(Props[StreamTcpManager]
-    .withDispatcher(IoTcp(system).Settings.ManagementDispatcher), name = "IO-TCP-STREAM")
+    .withDispatcher(IoTcp(system).Settings.ManagementDispatcher).withDeploy(Deploy.local), name = "IO-TCP-STREAM")
 
   private class BindSource(
     val endpoint: InetSocketAddress,


### PR DESCRIPTION
Please note that ActorPublisher and ActorSubscriber messages are no longer having a SerialVersionUID and I think they should not be allowed to be serialized. Most of the Subscriptions and Subscribers are not serializable therefore the handshake won't work anyway in quite a lot of the cases.
- [x] Http
