### PR TITLE
=str #16290 add micro benchmarks for materialization and graph builder

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.stream
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.SampleTime))
+class GraphBuilderBenchmark {
+
+  @Param(Array("1", "10", "100", "1000"))
+  val complexity = 0
+
+  @Benchmark
+  def flow_with_map() {
+    MaterializationBenchmark.flowWithMapBuilder(complexity)
+  }
+
+  @Benchmark
+  def graph_with_junctions() {
+    MaterializationBenchmark.graphWithJunctionsBuilder(complexity)
+  }
+
+  @Benchmark
+  def graph_with_nested_imports() {
+    MaterializationBenchmark.graphWithNestedImportsBuilder(complexity)
+  }
+
+  @Benchmark
+  def graph_with_imported_flow() {
+    MaterializationBenchmark.graphWithImportedFlowBuilder(complexity)
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.stream
+
+import java.util.concurrent.TimeUnit
+import akka.actor.ActorSystem
+import akka.stream.scaladsl._
+import org.openjdk.jmh.annotations._
+
+object MaterializationBenchmark {
+
+  val flowWithMapBuilder = (numOfCombinators: Int) => {
+    var source = Source.single(())
+    for (_ <- 1 to numOfCombinators) {
+      source = source.map(identity)
+    }
+    source.to(Sink.ignore)
+  }
+
+  val graphWithJunctionsBuilder = (numOfJunctions: Int) =>
+    FlowGraph.closed() { implicit b =>
+      import FlowGraph.Implicits._
+
+      val broadcast = b.add(Broadcast[Unit](numOfJunctions))
+      var outlet = broadcast.out(0)
+      for (i <- 1 until numOfJunctions) {
+        val merge = b.add(Merge[Unit](2))
+        outlet ~> merge
+        broadcast.out(i) ~> merge
+        outlet = merge.out
+      }
+
+      Source.single(()) ~> broadcast
+      outlet ~> Sink.ignore
+    }
+
+  val graphWithNestedImportsBuilder = (numOfNestedGraphs: Int) => {
+    var flow: Graph[FlowShape[Unit, Unit], Unit] = Flow[Unit].map(identity)
+    for (_ <- 1 to numOfNestedGraphs) {
+      flow = FlowGraph.partial(flow) { b ⇒
+        flow ⇒
+          FlowShape(flow.inlet, flow.outlet)
+      }
+    }
+
+    FlowGraph.closed(flow) { implicit b ⇒
+      flow ⇒
+        import FlowGraph.Implicits._
+        Source.single(()) ~> flow ~> Sink.ignore
+    }
+  }
+
+  val graphWithImportedFlowBuilder = (numOfFlows: Int) => {
+    val flow = Flow[Unit].map(identity)
+    FlowGraph.closed() { b ⇒
+      val source = b.add(Source.single(()))
+      var outlet = source
+      for (i <- 0 until numOfFlows) {
+        val flowShape = b.add(flow)
+        b.addEdge(outlet, flowShape.inlet)
+        outlet = flowShape.outlet
+      }
+
+      val sink = b.add(Sink.ignore)
+      b.addEdge(outlet, sink)
+    }
+  }
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.SampleTime))
+class MaterializationBenchmark {
+  import MaterializationBenchmark._
+
+  implicit val system = ActorSystem("MaterializationBenchmark")
+  implicit val mat = ActorFlowMaterializer()
+
+  var flowWithMap: RunnableFlow[Unit] = _
+  var graphWithJunctions: RunnableFlow[Unit] = _
+  var graphWithNestedImports: RunnableFlow[Unit] = _
+  var graphWithImportedFlow: RunnableFlow[Unit] = _
+
+  @Param(Array("1", "10", "100", "1000"))
+  val complexity = 0
+
+  @Setup
+  def setup() {
+    flowWithMap = flowWithMapBuilder(complexity)
+    graphWithJunctions = graphWithJunctionsBuilder(complexity)
+    graphWithNestedImports = graphWithNestedImportsBuilder(complexity)
+    graphWithImportedFlow = graphWithImportedFlowBuilder(complexity)
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @Benchmark
+  def flow_with_map() {
+    flowWithMap.run()
+  }
+
+  @Benchmark
+  def graph_with_junctions() {
+    graphWithJunctions.run()
+  }
+
+  @Benchmark
+  def graph_with_nested_imports() {
+    graphWithNestedImports.run()
+  }
+
+  @Benchmark
+  def graph_with_imported_flow() {
+    graphWithImportedFlow.run()
+  }
+}


### PR DESCRIPTION
Results on my machine:

```
[info] Benchmark                                             Mode  Cnt        Score        Error   Units
[info] GraphBuilderBenchmark.graph_with_100_junctions       thrpt    3    83686.308 ±  28597.452  ops/ms
[info] GraphBuilderBenchmark.graph_with_100_nested_imports  thrpt    3  1413110.778 ± 243132.891  ops/ms
```

and 

```
[info] Benchmark                                                Mode  Cnt         Score          Error   Units
[info] MaterializationBenchmark.flow_with_100_operations       thrpt    3    185240.747 ±    61163.429  ops/ms
[info] MaterializationBenchmark.graph_with_100_junctions       thrpt    3    122679.627 ±    30274.789  ops/ms
[info] MaterializationBenchmark.graph_with_100_nested_imports  thrpt    3   2659986.545 ±   954281.544  ops/ms
[info] MaterializationBenchmark.simple_flow                    thrpt    3  16856152.724 ± 28923405.310  ops/ms
[info] MaterializationBenchmark.simple_graph                   thrpt    3   5683167.370 ± 12897652.713  ops/ms
```
