### PR TITLE
=doc #17358 remove duplicates

### DIFF
--- a/akka-docs-dev/rst/java/stream-io.rst
+++ b/akka-docs-dev/rst/java/stream-io.rst
@@ -93,8 +93,8 @@ pipeline. In this example we use a :class:`Concat` graph processing stage to inj
 continue with handling all incoming data using the echo handler. You should use this pattern of encapsulating complex
 logic in Flows and attaching those to :class:`StreamIO` in order to implement your custom and possibly sophisticated TCP servers.
 
-In this example both client and server may need to close the stream based on a parsed command command - ``BYE`` in the case
-of the server, and ``q`` in the case of the client. This is implemented by using a custom :class:`PushStage` 
+In this example both client and server may need to close the stream based on a parsed command - ``BYE`` in the case
+of the server, and ``q`` in the case of the client. This is implemented by using a custom :class:`PushStage`
 (see :ref:`stream-using-push-pull-stage-java`) which completes the stream once it encounters such command.
 
 Streaming File IO

--- a/akka-docs-dev/rst/java/stream-quickstart.rst
+++ b/akka-docs-dev/rst/java/stream-quickstart.rst
@@ -100,8 +100,8 @@ FlowGraphs are constructed like this:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/TwitterStreamQuickstartDocTest.java#flow-graph-broadcast
 
-As you can see, we use graph builder to mutably construct the graph using the ``addEdge`` method. Once we have the 
-FlowGraph in the value ``g`` *it is immutable, thread-safe, and freely shareable*. A graph can can be ``run()`` directly - 
+As you can see, we use graph builder to mutably construct the graph using the ``addEdge`` method. Once we have the
+FlowGraph in the value ``g`` *it is immutable, thread-safe, and freely shareable*. A graph can be ``run()`` directly -
 assuming all ports (sinks/sources) within a flow have been connected properly. It is possible to construct :class:`PartialFlowGraph` s
 where this is not required but this will be covered in detail in :ref:`partial-flow-graph-java`.
 
@@ -124,7 +124,7 @@ elements*" this can be expressed using the ``buffer`` element:
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/TwitterStreamQuickstartDocTest.java#tweets-slow-consumption-dropHead
 
 The ``buffer`` element takes an explicit and required ``OverflowStrategy``, which defines how the buffer should react
-when it receives another element element while it is full. Strategies provided include dropping the oldest element (``dropHead``),
+when it receives another element while it is full. Strategies provided include dropping the oldest element (``dropHead``),
 dropping the entire buffer, signalling failures etc. Be sure to pick and choose the strategy that fits your use case best.
 
 Materialized values

--- a/akka-docs-dev/rst/scala/stream-io.rst
+++ b/akka-docs-dev/rst/scala/stream-io.rst
@@ -93,8 +93,8 @@ pipeline. In this example we use a :class:`Concat` graph processing stage to inj
 continue with handling all incoming data using the echo handler. You should use this pattern of encapsulating complex
 logic in Flows and attaching those to :class:`StreamIO` in order to implement your custom and possibly sophisticated TCP servers.
 
-In this example both client and server may need to close the stream based on a parsed command command - ``BYE`` in the case
-of the server, and ``q`` in the case of the client. This is implemented by using a custom :class:`PushStage` 
+In this example both client and server may need to close the stream based on a parsed command - ``BYE`` in the case
+of the server, and ``q`` in the case of the client. This is implemented by using a custom :class:`PushStage`
 (see :ref:`stream-using-push-pull-stage-scala`) which completes the stream once it encounters such command.
 
 Streaming File IO

--- a/akka-docs-dev/rst/scala/stream-quickstart.rst
+++ b/akka-docs-dev/rst/scala/stream-quickstart.rst
@@ -101,7 +101,7 @@ FlowGraphs are constructed like this:
 
 As you can see, inside the :class:`FlowGraph` we use an implicit graph builder to mutably construct the graph
 using the ``~>`` "edge operator" (also read as "connect" or "via" or "to"). Once we have the FlowGraph in the value ``g``
-*it is immutable, thread-safe, and freely shareable*. A graph can can be ``run()`` directly - assuming all
+*it is immutable, thread-safe, and freely shareable*. A graph can be ``run()`` directly - assuming all
 ports (sinks/sources) within a flow have been connected properly. It is possible to construct partial graphs
 where this is not required but this will be covered in detail in :ref:`partial-flow-graph-scala`.
 
@@ -124,7 +124,7 @@ elements*" this can be expressed using the ``buffer`` element:
 .. includecode:: code/docs/stream/TwitterStreamQuickstartDocSpec.scala#tweets-slow-consumption-dropHead
 
 The ``buffer`` element takes an explicit and required ``OverflowStrategy``, which defines how the buffer should react
-when it receives another element element while it is full. Strategies provided include dropping the oldest element (``dropHead``),
+when it receives another element while it is full. Strategies provided include dropping the oldest element (``dropHead``),
 dropping the entire buffer, signalling errors etc. Be sure to pick and choose the strategy that fits your use case best.
 
 Materialized values


### PR DESCRIPTION
Fixes #17358.

Regexp for word duplicates `\b(\w+)\s+\1\b`.
