### PR TITLE
!htp #17384 - Generalised Security Directives to accept Bearer Token Authentication

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Authorization.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Authorization.java
@@ -17,4 +17,7 @@ public abstract class Authorization extends akka.http.scaladsl.model.HttpHeader 
     public static Authorization basic(String username, String password) {
         return create(HttpCredentials.createBasicHttpCredentials(username, password));
     }
+    public static Authorization oauth2(String token) {
+        return create(HttpCredentials.createOAuth2BearerToken(token));
+    }
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.server
 
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import akka.http.scaladsl.server.directives.UserCredentials
+import akka.http.scaladsl.server.directives.Credentials
 import com.typesafe.config.{ ConfigFactory, Config }
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
@@ -23,7 +23,7 @@ object TestServer extends App {
   import Directives._
 
   def auth: AuthenticatorPF[String] = {
-    case p @ UserCredentials.Provided(name) if p.verifySecret(name + "-password") ⇒ name
+    case p @ Credentials.Provided(name) if p.verify(name + "-password") ⇒ name
   }
 
   val bindingFuture = Http().bindAndHandle({

--- a/akka-http/src/main/scala/akka/http/impl/server/RouteStructure.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/RouteStructure.scala
@@ -6,7 +6,7 @@ package akka.http.impl.server
 
 import java.io.File
 import akka.http.javadsl.model.ws.Message
-import akka.http.javadsl.server.values.{ PathMatcher, HttpBasicAuthenticator }
+import akka.http.javadsl.server.values.{ PathMatcher, HttpBasicAuthenticator, OAuth2Authenticator }
 import akka.stream.javadsl.Flow
 
 import scala.language.existentials
@@ -54,6 +54,7 @@ private[http] object RouteStructure {
   }
   case class Extract(extractions: Seq[StandaloneExtractionImpl[_]])(val innerRoute: Route, val moreInnerRoutes: immutable.Seq[Route]) extends DirectiveRoute
   case class BasicAuthentication(authenticator: HttpBasicAuthenticator[_])(val innerRoute: Route, val moreInnerRoutes: immutable.Seq[Route]) extends DirectiveRoute
+  case class OAuth2Authentication(authenticator: OAuth2Authenticator[_])(val innerRoute: Route, val moreInnerRoutes: immutable.Seq[Route]) extends DirectiveRoute
   case class EncodeResponse(coders: immutable.Seq[Coder])(val innerRoute: Route, val moreInnerRoutes: immutable.Seq[Route]) extends DirectiveRoute
   case class DecodeRequest(coders: immutable.Seq[Coder])(val innerRoute: Route, val moreInnerRoutes: immutable.Seq[Route]) extends DirectiveRoute
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/values/OAuth2Authenticator.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/values/OAuth2Authenticator.scala
@@ -12,9 +12,9 @@ import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 /**
- * Represents existing or missing Http Basic authentication credentials.
+ * Represents existing or missing OAuth 2 authentication credentials.
  */
-trait BasicCredentials {
+trait OAuth2Credentials {
   /**
    * Were credentials provided in the request?
    */
@@ -32,13 +32,13 @@ trait BasicCredentials {
 }
 
 /**
- * Implement this class to provide an HTTP Basic authentication check. The [[authenticate]] method needs to be implemented
+ * Implement this class to provide an OAuth 2 Bearer Token authentication check. The [[authenticate]] method needs to be implemented
  * to check if the supplied or missing credentials are authenticated and provide a domain level object representing
  * the user as a [[RequestVal]].
  */
-abstract class HttpBasicAuthenticator[T](val realm: String) extends AbstractDirective with ExtractionImplBase[T] with RequestVal[T] {
+abstract class OAuth2Authenticator[T](val realm: String) extends AbstractDirective with ExtractionImplBase[T] with RequestVal[T] {
   protected[http] implicit def classTag: ClassTag[T] = reflect.classTag[AnyRef].asInstanceOf[ClassTag[T]]
-  def authenticate(credentials: BasicCredentials): Future[Option[T]]
+  def authenticate(credentials: OAuth2Credentials): Future[Option[T]]
 
   /**
    * Creates a return value for use in [[authenticate]] that successfully authenticates the requests and provides
@@ -55,5 +55,5 @@ abstract class HttpBasicAuthenticator[T](val realm: String) extends AbstractDire
    * INTERNAL API
    */
   protected[http] final def createRoute(first: Route, others: Array[Route]): Route =
-    RouteStructure.BasicAuthentication(this)(first, others.toList)
+    RouteStructure.OAuth2Authentication(this)(first, others.toList)
 }


### PR DESCRIPTION
As per promise to @rkuhn, an improved shot to allow Bearer Token Authentication, taking into accounts the comments made by @jrudolph in #17384, post the #17502 merge. Since the `OAuth2BearerToken` is part of the akka codebase, I opted to add support for it within the http module rather than provide additional facilities to provide it as a third party library.
- Renamed `UserCredentials` to the more general `Credentials`, and its `userName` param to the more appropriate `identifier` in case it covers both `HttpBasicAuthentication` and `BearerTokenAuthentication`.
- Dropped `Basic` from the directives, as they now similarly accept `Authenticator`s that handle `BasicHttpCredentials` and `OAuth2BearerToken`
- Added and amended the tests for both scala and java side
