### PR TITLE
=clu Improve cluster downing

### DIFF
--- a/akka-cluster-tools/src/main/resources/reference.conf
+++ b/akka-cluster-tools/src/main/resources/reference.conf
@@ -101,29 +101,11 @@ akka.cluster.singleton {
   # If the role is not specified it's a singleton among all nodes in the cluster.
   role = ""
   
-  # When a node is becoming oldest it sends hand-over request to previous oldest. 
-  # This is retried with the 'retry-interval' until the previous oldest confirms
-  # that the hand over has started, or this -max-hand-over-retries' limit has been
-  # reached. If the retry limit is reached it takes the decision to be the new oldest
-  # if previous oldest is unknown (typically removed), otherwise it initiates a new
-  # round by throwing 'akka.cluster.singleton.ClusterSingletonManagerIsStuck' and expecting
-  # restart with fresh state. For a cluster with many members you might need to increase
-  # this retry limit because it takes longer time to propagate changes across all nodes.
-  max-hand-over-retries = 10
-  
-  # When a oldest node leaves the cluster it is not oldest any more and then it sends
-  # take over request to the new oldest to initiate the hand-over process. This is
-  # retried with the 'retry-interval' until this retry limit has been reached. If the
-  # retry limit is reached it initiates a new round by throwing 
-  # 'akka.cluster.singleton.ClusterSingletonManagerIsStuck' and expecting restart with
-  # fresh state. This will also cause the singleton actor to be stopped.
-  # 'max-take-over-retries` must be less than 'max-hand-over-retries' to ensure that
-  # new oldest doesn't start singleton actor before previous is stopped for certain
-  # corner cases.
-  max-take-over-retries = 5
-  
-  # Interval for hand over and take over messages
-  retry-interval = 1s
+  # When a node is becoming oldest it sends hand-over request to previous oldest, 
+  # that might be leaving the cluster. This is retried with this interval until 
+  # the previous oldest confirms that the hand over has started or the previous 
+  # oldest member is removed from the cluster (+ akka.cluster.down-removal-margin).
+  hand-over-retry-interval = 1s
 }
 
 akka.cluster.singleton-proxy {

--- a/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
@@ -41,8 +41,7 @@ object ClusterSingletonProxySpec {
       system.actorOf(ClusterSingletonManager.props(
         singletonProps = Props[Singleton],
         terminationMessage = PoisonPill,
-        settings = ClusterSingletonManagerSettings(system)
-          .withRetry(maxHandOverRetries = 5, maxTakeOverRetries = 2, retryInterval = 1.second)),
+        settings = ClusterSingletonManagerSettings(system).withRemovalMargin(5.seconds)),
         name = "singletonManager")
     }
 

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -29,6 +29,12 @@ akka {
     # Disable with "off" or specify a duration to enable auto-down.
     auto-down-unreachable-after = off
     
+    # Margin until shards or singletons that belonged to a downed/removed
+    # partition are created in surviving partition. The purpose of this margin is that 
+    # in case of a network partition the persistent actors in the non-surviving partitions
+    # must be stopped before corresponding persistent actors are started somewhere else.
+    down-removal-margin = 20s
+    
     # The roles of this member. List of strings, e.g. roles = ["A", "B"].
     # The roles are part of the membership information and can be used by
     # routers or other services to distribute work to certain member types,

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -67,6 +67,11 @@ final class ClusterSettings(val config: Config, val systemName: String) {
     }
   }
 
+  val DownRemovalMargin: FiniteDuration = {
+    val key = "down-removal-margin"
+    cc.getMillisDuration(key) requiring (_ > Duration.Zero, key + " > 0s")
+  }
+
   val Roles: Set[String] = immutableSeq(cc.getStringList("roles")).toSet
   val MinNrOfMembers: Int = {
     cc.getInt("min-nr-of-members")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeDowningAndBeingRemovedSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeDowningAndBeingRemovedSpec.scala
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster
+
+import scala.collection.immutable.SortedSet
+import com.typesafe.config.ConfigFactory
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+import scala.concurrent.duration._
+
+object NodeDowningAndBeingRemovedMultiJvmSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(
+    "akka.cluster.auto-down-unreachable-after = off").withFallback(MultiNodeClusterSpec.clusterConfig)))
+}
+
+class NodeDowningAndBeingRemovedMultiJvmNode1 extends NodeDowningAndBeingRemovedSpec
+class NodeDowningAndBeingRemovedMultiJvmNode2 extends NodeDowningAndBeingRemovedSpec
+class NodeDowningAndBeingRemovedMultiJvmNode3 extends NodeDowningAndBeingRemovedSpec
+
+abstract class NodeDowningAndBeingRemovedSpec
+  extends MultiNodeSpec(NodeDowningAndBeingRemovedMultiJvmSpec)
+  with MultiNodeClusterSpec {
+
+  import NodeDowningAndBeingRemovedMultiJvmSpec._
+
+  "A node that is downed" must {
+
+    "eventually be removed from membership" taggedAs LongRunningTest in {
+
+      awaitClusterUp(first, second, third)
+
+      within(30.seconds) {
+        runOn(first) {
+          cluster.down(second)
+          cluster.down(third)
+        }
+        enterBarrier("second-and-third-down")
+
+        runOn(second, third) {
+          // verify that the node is shut down
+          awaitCond(cluster.isTerminated)
+        }
+        enterBarrier("second-and-third-shutdown")
+
+        runOn(first) {
+          // verify that the nodes are no longer part of the 'members' set
+          awaitAssert {
+            clusterView.members.map(_.address) should not contain (address(second))
+            clusterView.members.map(_.address) should not contain (address(third))
+          }
+        }
+      }
+
+      enterBarrier("finished")
+    }
+  }
+}


### PR DESCRIPTION
- avoid using Down and Exiting member from being used for joining
- delay shut down of Down member until the information is spread
  to all reachable members, e.g. downing several nodes via one node
- akka.cluster.down-removal-margin setting
  Margin until shards or singletons that belonged to a
  downed/removed partition are created in surviving partition.
  Used by singleton and sharding.
- remove the retry count parameters/settings for singleton in
  favor of deriving those from the removal-margin
