### PR TITLE
+str - #17662 - Changes Sink.ignore to return a Future[Unit]

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -106,8 +106,8 @@ class TwitterStreamQuickstartDocSpec extends AkkaSpec {
   }
 
   "simple broadcast" in {
-    val writeAuthors: Sink[Author, Unit] = Sink.ignore
-    val writeHashtags: Sink[Hashtag, Unit] = Sink.ignore
+    val writeAuthors: Sink[Author, Future[Unit]] = Sink.ignore
+    val writeHashtags: Sink[Hashtag, Future[Unit]] = Sink.ignore
 
     // format: OFF
     //#flow-graph-broadcast

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/TwitterStreamQuickstartDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/TwitterStreamQuickstartDocTest.java
@@ -265,8 +265,8 @@ public class TwitterStreamQuickstartDocTest {
   
   @Test
   public void demonstrateBroadcast() {
-    final Sink<Author, BoxedUnit> writeAuthors = Sink.ignore();
-    final Sink<Hashtag, BoxedUnit> writeHashtags = Sink.ignore();
+    final Sink<Author, Future<BoxedUnit>> writeAuthors = Sink.ignore();
+    final Sink<Hashtag, Future<BoxedUnit>> writeHashtags = Sink.ignore();
 
     //#flow-graph-broadcast
     FlowGraph.factory().closed(b -> {

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/BlackholeSubscriberTest.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/BlackholeSubscriberTest.scala
@@ -4,12 +4,13 @@
 package akka.stream.tck
 
 import akka.stream.impl.BlackholeSubscriber
+import scala.concurrent.Promise
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 
 class BlackholeSubscriberTest extends AkkaSubscriberBlackboxVerification[Int] {
 
-  override def createSubscriber(): Subscriber[Int] = new BlackholeSubscriber[Int](2)
+  override def createSubscriber(): Subscriber[Int] = new BlackholeSubscriber[Int](2, Promise[Unit]())
 
   override def createElement(element: Int): Int = element
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -47,7 +47,7 @@ object Sink {
   /**
    * A `Sink` that will consume the stream and discard the elements.
    */
-  def ignore[T](): Sink[T, Unit] =
+  def ignore[T](): Sink[T, Future[Unit]] =
     new Sink(scaladsl.Sink.ignore)
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -95,7 +95,7 @@ object Sink extends SinkApply {
   /**
    * A `Sink` that will consume the stream and discard the elements.
    */
-  def ignore: Sink[Any, Unit] =
+  def ignore: Sink[Any, Future[Unit]] =
     new Sink(new BlackholeSink(DefaultAttributes.ignoreSink, shape("BlackholeSink")))
 
   /**


### PR DESCRIPTION
Not only does a Future signal that the processing happens elsewhere, but it is also highly useful when wanting to do something at the end of processing a stream (or substream for that matter) or join a substream with its enclosing stream (mapAsync for instance)
