### PR TITLE
=htp #16808 fix unnecessary reverse DNS lookups for >Java1.7

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -30,14 +30,14 @@ private[http] class HttpRequestRendererFactory(userAgentHeader: Option[headers.`
    * using the getHostString() method. This avoids a reverse DNS query from calling getHostName()
    * if the original host string is an IP address.
    */
-  private[http] val hostString: InetSocketAddress ⇒ String =
-    try {
-      val m = classOf[InetSocketAddress].getDeclaredMethod("getHostString")
-      require(m.getReturnType == classOf[String])
-      address ⇒ m.invoke(address).asInstanceOf[String]
+  private[http] val hostString: InetSocketAddress ⇒ String = {
+    val m = classOf[InetSocketAddress].getDeclaredMethod("getHostString")
+    address ⇒ try {
+      m.invoke(address).asInstanceOf[String]
     } catch {
-      case NonFatal(_) ⇒ _.getHostName
+      case NonFatal(_) ⇒ address.getHostName
     }
+  }
 
   final class HttpRequestRenderer extends PushStage[RequestRenderingContext, Source[ByteString, Any]] {
 


### PR DESCRIPTION
this is fixing  DNS lookup under Java 1.6  and relates to #17657.
It's the second version (first one is available here #17681). 
This is catching all possible exceptions of getHostString method in lazy mode. This version is covering more unexpected issues of reflection.
