### PR TITLE
=htc #17683 drop already consumed input in `continue` (+ ByteString compaction)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -252,7 +252,9 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
   def continue(input: ByteString, offset: Int)(next: (ByteString, Int) ⇒ StateResult): StateResult = {
     state =
       math.signum(offset - input.length) match {
-        case -1 ⇒ more ⇒ next(input ++ more, offset)
+        case -1 ⇒
+          val remaining = input.drop(offset)
+          (more ⇒ next(remaining ++ more, 0))
         case 0 ⇒ next(_, 0)
         case 1 ⇒ throw new IllegalStateException
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -170,11 +170,11 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
     val remainingInputBytes = input.length - bodyStart
     if (remainingInputBytes > 0) {
       if (remainingInputBytes < remainingBodyBytes) {
-        emit(EntityPart(input drop bodyStart))
+        emit(EntityPart(input.drop(bodyStart).compact))
         continue(parseFixedLengthBody(remainingBodyBytes - remainingInputBytes, isLastMessage))
       } else {
         val offset = bodyStart + remainingBodyBytes.toInt
-        emit(EntityPart(input.slice(bodyStart, offset)))
+        emit(EntityPart(input.slice(bodyStart, offset).compact))
         emit(MessageEnd)
         setCompletionHandling(CompletionOk)
         if (isLastMessage) terminate()
@@ -211,7 +211,7 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
       if (chunkSize > 0) {
         val chunkBodyEnd = cursor + chunkSize
         def result(terminatorLen: Int) = {
-          emit(EntityChunk(HttpEntity.Chunk(input.slice(cursor, chunkBodyEnd), extension)))
+          emit(EntityChunk(HttpEntity.Chunk(input.slice(cursor, chunkBodyEnd).compact, extension)))
           Trampoline(_ ⇒ parseChunk(input, chunkBodyEnd + terminatorLen, isLastMessage))
         }
         byteChar(input, chunkBodyEnd) match {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -132,7 +132,7 @@ private[http] class HttpResponseParser(_settings: ParserSettings, _headerParser:
   // currently we do not check for `settings.maxContentLength` overflow
   def parseToCloseBody(input: ByteString, bodyStart: Int): StateResult = {
     if (input.length > bodyStart)
-      emit(EntityPart(input drop bodyStart))
+      emit(EntityPart(input.drop(bodyStart).compact))
     continue(parseToCloseBody)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventParser.scala
@@ -87,7 +87,7 @@ private[http] class FrameEventParser extends ByteStringParserStage[FrameEvent] {
         if (thisFrameData.length == length) ReadFrameHeader
         else readData(length - thisFrameData.length)
 
-      pushAndBecomeWithRemaining(FrameStart(header, thisFrameData), nextState, remaining, ctx)
+      pushAndBecomeWithRemaining(FrameStart(header, thisFrameData.compact), nextState, remaining, ctx)
     }
   }
 
@@ -103,7 +103,7 @@ private[http] class FrameEventParser extends ByteStringParserStage[FrameEvent] {
           val frameData = elem.take(remaining.toInt)
           val remainingData = elem.drop(remaining.toInt)
 
-          pushAndBecomeWithRemaining(FrameData(frameData, lastPart = true), ReadFrameHeader, remainingData, ctx)
+          pushAndBecomeWithRemaining(FrameData(frameData.compact, lastPart = true), ReadFrameHeader, remainingData, ctx)
         }
     }
 


### PR DESCRIPTION
Fixes #17683.

/cc @sirthias 
