### PR TITLE
2.4.0-M1: Wrong version of com.typesafe.config in OSGi manifest

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -58,7 +58,7 @@ object OSGi {
   )
   def defaultImports(scalaVersion: String) = Seq("!sun.misc", akkaImport(), configImport(), scalaImport(scalaVersion), "*")
   def akkaImport(packageName: String = "akka.*") = versionedImport(packageName, "2.4", "2.5")
-  def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.2.0", "1.3.0")
+  def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.3.0", "1.4.0")
   def protobufImport(packageName: String = "com.google.protobuf.*") = versionedImport(packageName, "2.5.0", "2.6.0")
   def scalaImport(version: String) = {
     val packageName = "scala.*"


### PR DESCRIPTION
Changed version for com.typesafe.config in OSGi manifest (was 1.2.x) to same as in Dependencies (1.3.0)
