### PR TITLE
Round robin logic sequencing fix

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -5,8 +5,6 @@ package akka.routing
 
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.immutable
-import akka.actor.ActorContext
-import akka.actor.Props
 import akka.dispatch.Dispatchers
 import com.typesafe.config.Config
 import akka.actor.SupervisorStrategy
@@ -23,11 +21,14 @@ object RoundRobinRoutingLogic {
  */
 @SerialVersionUID(1L)
 final class RoundRobinRoutingLogic extends RoutingLogic {
-  val next = new AtomicLong(0)
+  val next = new AtomicLong
 
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =
-    if (routees.isEmpty) NoRoutee
-    else routees((next.getAndIncrement % routees.size).asInstanceOf[Int])
+    if (routees.nonEmpty) {
+      val size = routees.size
+      val nextSeq = next.getAndIncrement
+      routees((if (nextSeq < 0) size + (nextSeq % size) - 1 else nextSeq % size).asInstanceOf[Int])
+    } else NoRoutee
 
 }
 


### PR DESCRIPTION
Round robin logic sequencing will fail when it reaches Long.MAX_VALUE + 1 due to negative modulus result - fixes #17738

Will sign the agreement in a minute.
