### PR TITLE
=per #16542 Don't store sender in PersistentRepr

### DIFF
--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
@@ -46,7 +46,7 @@ abstract class JournalSpec(config: Config) extends PluginSpec(config) {
     extension.journalFor(null)
 
   def replayedMessage(snr: Long, deleted: Boolean = false, confirms: Seq[String] = Nil): ReplayedMessage =
-    ReplayedMessage(PersistentImpl(s"a-${snr}", snr, pid, deleted, senderProbe.ref))
+    ReplayedMessage(PersistentImpl(s"a-${snr}", snr, pid, deleted, Actor.noSender))
 
   def writeMessages(from: Int, to: Int, pid: String, sender: ActorRef): Unit = {
     val msgs = from to to map { i ⇒ PersistentRepr(payload = s"a-${i}", sequenceNr = i, persistenceId = pid, sender = sender) }

--- a/akka-persistence/src/main/java/akka/persistence/serialization/MessageFormats.java
+++ b/akka-persistence/src/main/java/akka/persistence/serialization/MessageFormats.java
@@ -69,7 +69,7 @@ public final class MessageFormats {
      * repeated string confirms = 7; // Removed in 2.4
      * optional bool confirmable = 8;  // Removed in 2.4
      * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-     * optional string confirmTarget = 10;
+     * optional string confirmTarget = 10; // Removed in 2.4
      * </pre>
      */
     boolean hasSender();
@@ -81,7 +81,7 @@ public final class MessageFormats {
      * repeated string confirms = 7; // Removed in 2.4
      * optional bool confirmable = 8;  // Removed in 2.4
      * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-     * optional string confirmTarget = 10;
+     * optional string confirmTarget = 10; // Removed in 2.4
      * </pre>
      */
     java.lang.String getSender();
@@ -93,7 +93,7 @@ public final class MessageFormats {
      * repeated string confirms = 7; // Removed in 2.4
      * optional bool confirmable = 8;  // Removed in 2.4
      * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-     * optional string confirmTarget = 10;
+     * optional string confirmTarget = 10; // Removed in 2.4
      * </pre>
      */
     com.google.protobuf.ByteString
@@ -331,7 +331,7 @@ public final class MessageFormats {
      * repeated string confirms = 7; // Removed in 2.4
      * optional bool confirmable = 8;  // Removed in 2.4
      * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-     * optional string confirmTarget = 10;
+     * optional string confirmTarget = 10; // Removed in 2.4
      * </pre>
      */
     public boolean hasSender() {
@@ -345,7 +345,7 @@ public final class MessageFormats {
      * repeated string confirms = 7; // Removed in 2.4
      * optional bool confirmable = 8;  // Removed in 2.4
      * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-     * optional string confirmTarget = 10;
+     * optional string confirmTarget = 10; // Removed in 2.4
      * </pre>
      */
     public java.lang.String getSender() {
@@ -370,7 +370,7 @@ public final class MessageFormats {
      * repeated string confirms = 7; // Removed in 2.4
      * optional bool confirmable = 8;  // Removed in 2.4
      * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-     * optional string confirmTarget = 10;
+     * optional string confirmTarget = 10; // Removed in 2.4
      * </pre>
      */
     public com.google.protobuf.ByteString
@@ -974,7 +974,7 @@ public final class MessageFormats {
        * repeated string confirms = 7; // Removed in 2.4
        * optional bool confirmable = 8;  // Removed in 2.4
        * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-       * optional string confirmTarget = 10;
+       * optional string confirmTarget = 10; // Removed in 2.4
        * </pre>
        */
       public boolean hasSender() {
@@ -988,7 +988,7 @@ public final class MessageFormats {
        * repeated string confirms = 7; // Removed in 2.4
        * optional bool confirmable = 8;  // Removed in 2.4
        * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-       * optional string confirmTarget = 10;
+       * optional string confirmTarget = 10; // Removed in 2.4
        * </pre>
        */
       public java.lang.String getSender() {
@@ -1010,7 +1010,7 @@ public final class MessageFormats {
        * repeated string confirms = 7; // Removed in 2.4
        * optional bool confirmable = 8;  // Removed in 2.4
        * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-       * optional string confirmTarget = 10;
+       * optional string confirmTarget = 10; // Removed in 2.4
        * </pre>
        */
       public com.google.protobuf.ByteString
@@ -1034,7 +1034,7 @@ public final class MessageFormats {
        * repeated string confirms = 7; // Removed in 2.4
        * optional bool confirmable = 8;  // Removed in 2.4
        * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-       * optional string confirmTarget = 10;
+       * optional string confirmTarget = 10; // Removed in 2.4
        * </pre>
        */
       public Builder setSender(
@@ -1055,7 +1055,7 @@ public final class MessageFormats {
        * repeated string confirms = 7; // Removed in 2.4
        * optional bool confirmable = 8;  // Removed in 2.4
        * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-       * optional string confirmTarget = 10;
+       * optional string confirmTarget = 10; // Removed in 2.4
        * </pre>
        */
       public Builder clearSender() {
@@ -1072,7 +1072,7 @@ public final class MessageFormats {
        * repeated string confirms = 7; // Removed in 2.4
        * optional bool confirmable = 8;  // Removed in 2.4
        * optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-       * optional string confirmTarget = 10;
+       * optional string confirmTarget = 10; // Removed in 2.4
        * </pre>
        */
       public Builder setSenderBytes(

--- a/akka-persistence/src/main/protobuf/MessageFormats.proto
+++ b/akka-persistence/src/main/protobuf/MessageFormats.proto
@@ -14,8 +14,8 @@ message PersistentMessage {
   // repeated string confirms = 7; // Removed in 2.4
   // optional bool confirmable = 8;  // Removed in 2.4
   // optional DeliveredMessage confirmMessage = 9; // Removed in 2.4
-  // optional string confirmTarget = 10;
-  optional string sender = 11;
+  // optional string confirmTarget = 10; // Removed in 2.4
+  optional string sender = 11; // not stored in journal, needed for remote serialization 
 }
 
 message PersistentPayload {

--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -73,17 +73,6 @@ trait PersistentRepr extends PersistentEnvelope with Message {
   def sender: ActorRef
 
   /**
-   * INTERNAL API.
-   */
-  private[persistence] def prepareWrite(sender: ActorRef): PersistentRepr
-
-  /**
-   * INTERNAL API.
-   */
-  private[persistence] def prepareWrite()(implicit context: ActorContext): PersistentRepr =
-    prepareWrite(if (sender.isInstanceOf[PromiseActorRef]) context.system.deadLetters else sender)
-
-  /**
    * Creates a new copy of this [[PersistentRepr]].
    */
   def update(
@@ -134,9 +123,6 @@ private[persistence] final case class PersistentImpl(
 
   def withPayload(payload: Any): PersistentRepr =
     copy(payload = payload)
-
-  def prepareWrite(sender: ActorRef) =
-    copy(sender = sender)
 
   def update(
     sequenceNr: Long,

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -47,7 +47,7 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
       // Send replayed messages and replay result to persistentActor directly. No need
       // to resequence replayed messages relative to written and looped messages.
       asyncReplayMessages(persistenceId, fromSequenceNr, toSequenceNr, max) { p ⇒
-        if (!p.deleted || replayDeleted) persistentActor.tell(ReplayedMessage(p), p.sender)
+        if (!p.deleted || replayDeleted) persistentActor.tell(ReplayedMessage(p), Actor.noSender)
       } map {
         case _ ⇒ ReplayMessagesSuccess
       } recover {

--- a/akka-persistence/src/main/scala/akka/persistence/journal/WriteJournalBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/WriteJournalBase.scala
@@ -12,13 +12,8 @@ private[akka] trait WriteJournalBase {
   this: Actor ⇒
 
   protected def preparePersistentBatch(rb: immutable.Seq[PersistentEnvelope]): immutable.Seq[PersistentRepr] =
-    rb.filter(persistentPrepareWrite).asInstanceOf[immutable.Seq[PersistentRepr]] // filter instead of flatMap to avoid Some allocations
-
-  private def persistentPrepareWrite(r: PersistentEnvelope): Boolean = r match {
-    case p: PersistentRepr ⇒
-      p.prepareWrite(); true
-    case _ ⇒
-      false
-  }
+    rb.collect {
+      case p: PersistentRepr ⇒ p.update(sender = Actor.noSender) // don't store sender
+    }
 
 }

--- a/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
@@ -17,6 +17,7 @@ import akka.persistence.AtLeastOnceDelivery.{ AtLeastOnceDeliverySnapshot ⇒ At
 import akka.persistence.AtLeastOnceDelivery.UnconfirmedDelivery
 import scala.collection.immutable.VectorBuilder
 import akka.persistence.fsm.PersistentFsmActor.StateChangeEvent
+import akka.actor.Actor
 
 /**
  * Marker trait for all protobuf-serializable messages in `akka.persistence`.
@@ -119,7 +120,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
     val builder = PersistentMessage.newBuilder
 
     if (persistent.persistenceId != Undefined) builder.setPersistenceId(persistent.persistenceId)
-    if (persistent.sender != null) builder.setSender(Serialization.serializedActorPath(persistent.sender))
+    if (persistent.sender != Actor.noSender) builder.setSender(Serialization.serializedActorPath(persistent.sender))
 
     builder.setPayload(persistentPayloadBuilder(persistent.payload.asInstanceOf[AnyRef]))
     builder.setSequenceNr(persistent.sequenceNr)
@@ -164,7 +165,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
       persistentMessage.getSequenceNr,
       if (persistentMessage.hasPersistenceId) persistentMessage.getPersistenceId else Undefined,
       persistentMessage.getDeleted,
-      if (persistentMessage.hasSender) system.provider.resolveActorRef(persistentMessage.getSender) else null)
+      if (persistentMessage.hasSender) system.provider.resolveActorRef(persistentMessage.getSender) else Actor.noSender)
   }
 
   private def payload(persistentPayload: PersistentPayload): Any = {


### PR DESCRIPTION
- I think it originated from channels, or some idea that
  the sender should be revived (as good as possible) during replay,
  but that is pretty useless
- It must still be in PersistentRepr for remote serialization
- I didn't want to change to the built in sender when looping to the
  journal because keeping it together with the message makes it easier
  to do batching (queueing)
