### PR TITLE
=act #17690 add additional validation for name param in RootActorPath

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
@@ -76,5 +76,15 @@ class ActorPathSpec extends WordSpec with Matchers {
       (rootA / "user").toStringWithAddress(b) should ===("akka.tcp://mysys@aaa:2552/user")
       (rootA / "user" / "foo").toStringWithAddress(b) should ===("akka.tcp://mysys@aaa:2552/user/foo")
     }
+
+    "not allow path separators in RootActorPath's name" in {
+      intercept[IllegalArgumentException] {
+        RootActorPath(Address("akka.tcp", "mysys"), "/user/boom/*") // illegally pass in a path where name is expected
+      }.getMessage should include("is a path separator")
+
+      // sanity check that creating such path still works
+      ActorPath.fromString("akka://mysys/user/boom/*")
+    }
+
   }
 }

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -254,6 +254,10 @@ sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
  */
 @SerialVersionUID(1L)
 final case class RootActorPath(address: Address, name: String = "/") extends ActorPath {
+  require(name.length == 1 || name.indexOf('/', 1) == -1,
+    "/ may only exist at the beginning of the root actors name, " +
+      "it is a path separator and is not legal in ActorPath names: [%s]" format name)
+  require(name.indexOf('#') == -1, "# is a fragment separator and is not legal in ActorPath names: [%s]" format name)
 
   override def parent: ActorPath = this
 

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -30,6 +30,16 @@ in practice. No changes were needed to the Akka source code for this update. Use
 depend on 3.8.0.Final that break with 3.10.3.Final should be able to manually downgrade the dependency
 to 3.8.0.Final and Akka will still work with that version.
 
+Added parameter validation to RootActorPath
+===========================================
+Previously ``akka.actor.RootActorPath`` allowed passing in arbitrary strings into its name parameter,
+which is meant to be the *name* of the root Actor. Subsequently, if constructed with an invalid name
+such as a full path for example (``/user/Full/Path``) some features using this path may transparently fail -
+such as using ``actorSelection`` on such invalid path.
+
+In Akka 2.4.x the ``RootActorPath`` validates the input and may throw an ``IllegalArgumentException`` if
+the passed in name string is illegal (contains ``/`` elsewhere than in the begining of the string or contains ``#``).
+
 Advanced Notice: TypedActors will go away
 =========================================
 


### PR DESCRIPTION
The `RootActorPath` is a very specific thing - the ref to the root Actor.
The use case described in #17690 worked (after toString-ing) by accident, and we should not allow constructing such RootActorPath - the parameter is a name which may not include path separators (same as path element).

Resolves #17690
