### PR TITLE
Remove simple line parsing, exposing explicit delimiter stage instead

### DIFF
--- a/akka-docs-dev/rst/java/stream-io.rst
+++ b/akka-docs-dev/rst/java/stream-io.rst
@@ -23,7 +23,7 @@ which will emit an :class:`IncomingConnection` element for each new connection t
 
 Next, we simply handle *each* incoming connection using a :class:`Flow` which will be used as the processing stage
 to handle and emit ByteStrings from and to the TCP Socket. Since one :class:`ByteString` does not have to necessarily
-correspond to exactly one line of text (the client might be sending the line in chunks) we use the ``lines``
+correspond to exactly one line of text (the client might be sending the line in chunks) we use the ``delimiter``
 helper Flow from ``akka.stream.io.Framing`` to chunk the inputs up into actual lines of text. The last boolean
 argument indicates that we require an explicit line ending even for the last message before the connection is closed.
 In this example we simply add exclamation marks to each incoming text message and push it through the flow:

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeParseLines.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeParseLines.scala
@@ -22,7 +22,8 @@ class RecipeParseLines extends RecipeSpec {
 
       //#parse-lines
       import akka.stream.io.Framing
-      val linesStream = rawData.via(Framing.lines("\r\n", maximumLineBytes = 100))
+      val linesStream = rawData.via(
+        Framing.delimiter(ByteString("\r\n"), maximumFrameLength = 100, allowTruncation = true)).map(_.utf8String)
       //#parse-lines
 
       Await.result(linesStream.grouped(10).runWith(Sink.head), 3.seconds) should be(List(

--- a/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
@@ -47,7 +47,8 @@ class StreamTcpDocSpec extends AkkaSpec {
         println(s"New connection from: ${connection.remoteAddress}")
 
         val echo = Flow[ByteString]
-          .via(Framing.lines("\n", maximumLineBytes = 256, allowTruncation = false))
+          .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = 256, allowTruncation = true))
+          .map(_.utf8String)
           .map(_ + "!!!\n")
           .map(ByteString(_))
 
@@ -85,7 +86,8 @@ class StreamTcpDocSpec extends AkkaSpec {
 
         val welcome = Source.single(ByteString(welcomeMsg))
         val echo = b.add(Flow[ByteString]
-          .via(Framing.lines("\n", maximumLineBytes = 256, allowTruncation = false))
+          .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = 256, allowTruncation = true))
+          .map(_.utf8String)
           //#welcome-banner-chat-server
           .map { command ⇒ serverProbe.ref ! command; command }
           //#welcome-banner-chat-server
@@ -136,7 +138,8 @@ class StreamTcpDocSpec extends AkkaSpec {
       }
 
       val repl = Flow[ByteString]
-        .via(Framing.lines("\n", maximumLineBytes = 256, allowTruncation = false))
+        .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = 256, allowTruncation = true))
+        .map(_.utf8String)
         .map(text => println("Server: " + text))
         .map(_ => readLine("> "))
         .transform(() ⇒ replParser)

--- a/akka-docs-dev/rst/scala/stream-cookbook.rst
+++ b/akka-docs-dev/rst/scala/stream-cookbook.rst
@@ -96,8 +96,7 @@ Parsing lines from a stream of ByteStrings
 characters (or, alternatively, containing binary frames delimited by a special delimiter byte sequence) which
 needs to be parsed.
 
-The :class:`Framing` helper object contains a convenience method to parse messages from a stream of ``ByteStrings``
-and in particular it has basic support for parsing text lines:
+The :class:`Framing` helper object contains a convenience method to parse messages from a stream of ``ByteStrings``:
 
 .. includecode:: code/docs/stream/cookbook/RecipeParseLines.scala#parse-lines
 

--- a/akka-docs-dev/rst/scala/stream-io.rst
+++ b/akka-docs-dev/rst/scala/stream-io.rst
@@ -23,7 +23,7 @@ which will emit an :class:`IncomingConnection` element for each new connection t
 
 Next, we simply handle *each* incoming connection using a :class:`Flow` which will be used as the processing stage
 to handle and emit ByteStrings from and to the TCP Socket. Since one :class:`ByteString` does not have to necessarily
-correspond to exactly one line of text (the client might be sending the line in chunks) we use the ``Framing.lines``
+correspond to exactly one line of text (the client might be sending the line in chunks) we use the ``Framing.delmiter``
 helper Flow to chunk the inputs up into actual lines of text. The last boolean
 argument indicates that we require an explicit line ending even for the last message before the connection is closed.
 In this example we simply add exclamation marks to each incoming text message and push it through the flow:

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/io/StreamTcpDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/io/StreamTcpDocTest.java
@@ -75,7 +75,8 @@ public class StreamTcpDocTest {
         System.out.println("New connection from: " + connection.remoteAddress());
 
         final Flow<ByteString, ByteString, BoxedUnit> echo = Flow.of(ByteString.class)
-          .via(Framing.lines("\n", 256, false))
+          .via(Framing.delimiter(ByteString.fromString("\n"), 256, false))
+          .map(bytes -> bytes.utf8String())
           .map(s -> s + "!!!\n")
           .map(s -> ByteString.fromString(s));
 
@@ -113,7 +114,8 @@ public class StreamTcpDocTest {
           Source.single(ByteString.fromString(welcomeMsg));
       final Flow<ByteString, ByteString, BoxedUnit> echoFlow =
           Flow.of(ByteString.class)
-            .via(Framing.lines("\n", 256, false))
+            .via(Framing.delimiter(ByteString.fromString("\n"), 256, false))
+            .map(bytes -> bytes.utf8String())
             //#welcome-banner-chat-server
             .map(command -> {
               serverProbe.ref().tell(command, null);
@@ -164,7 +166,8 @@ public class StreamTcpDocTest {
       };
   
       final Flow<ByteString, ByteString, BoxedUnit> repl = Flow.of(ByteString.class)
-        .via(Framing.lines("\n", 256, false))
+        .via(Framing.delimiter(ByteString.fromString("\n"), 256, false))
+        .map(bytes -> bytes.utf8String())
         .map(text -> {System.out.println("Server: " + text); return "next";})
         .map(elem -> readLine("> "))
         .transform(() -> replParser);

--- a/akka-stream/src/main/scala/akka/stream/io/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/Framing.scala
@@ -35,26 +35,6 @@ object Framing {
       .named("delimiterFraming")
 
   /**
-   * A convenience wrapper on top of [[Framing#delimiter]] using ''String'' as the output and separator sequence types.
-   * Returns a Flow that decodes an unstructured input stream of byte chunks, decoding them to Strings using a separator
-   * String as end-of-line marker.
-   *
-   * This decoder stage treats decoded frames as simple byte sequences, converting to UTF-8 only after the frame
-   * boundary has been found. This means that this is not a fully UTF-8 compliant line parser.
-   *
-   * @param delimiter String to be used as a delimiter. Be aware that not all UTF-8 strings are safe to use as a
-   *                  delimiter when the input bytes are UTF-8 encoded.
-   * @param allowTruncation If turned on, then when the last string being decoded contains no valid delimiter this Flow
-   *                        fails the stream instead of returning a truncated string.
-   * @param maximumLineBytes
-   *                  The maximum allowed length for decoded strings in bytes (not in characters).
-   * @return
-   */
-  def lines(delimiter: String, maximumLineBytes: Int, allowTruncation: Boolean = true): Flow[ByteString, String, Unit] =
-    Framing.delimiter(ByteString(delimiter), maximumLineBytes, allowTruncation).map(_.utf8String)
-      .named("lineFraming")
-
-  /**
    * Creates a Flow that decodes an incoming stream of unstructured byte chunks into a stream of frames, assuming that
    * incoming frames have a field that encodes their length.
    *


### PR DESCRIPTION
The real text-parsing will be addressed by: https://github.com/akka/akka/issues/17810
