### PR TITLE
=str Add missing abstract modifier to ActorPublisherMessage.Cancel

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
@@ -52,7 +52,7 @@ object ActorPublisherMessage {
    * subscription.
    */
   final case object Cancel extends Cancel with NoSerializationVerificationNeeded
-  sealed class Cancel extends ActorPublisherMessage
+  sealed abstract class Cancel extends ActorPublisherMessage
 
   /**
    * This message is delivered to the [[ActorPublisher]] actor in order to signal the exceeding of an subscription timeout.

--- a/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
@@ -53,6 +53,10 @@ object ActorPublisherMessage {
    */
   final case object Cancel extends Cancel with NoSerializationVerificationNeeded
   sealed abstract class Cancel extends ActorPublisherMessage
+  /**
+   * Java API: get the singleton instance of the `Cancel` message
+   */
+  def cancelInstance = Cancel
 
   /**
    * This message is delivered to the [[ActorPublisher]] actor in order to signal the exceeding of an subscription timeout.
@@ -60,12 +64,10 @@ object ActorPublisherMessage {
    */
   final case object SubscriptionTimeoutExceeded extends SubscriptionTimeoutExceeded with NoSerializationVerificationNeeded
   sealed abstract class SubscriptionTimeoutExceeded extends ActorPublisherMessage
-
   /**
-   * Java API: get the singleton instance of the `Cancel` message
+   * Java API: get the singleton instance of the `SubscriptionTimeoutExceeded` message
    */
-  def cancelInstance = Cancel
-
+  def subscriptionTimeoutExceededInstance = SubscriptionTimeoutExceeded
 }
 
 /**


### PR DESCRIPTION
This marker base class is missing an "abstract" modifier.

This is causing "warning: match may not be exhaustive" for me in certain cases
