### PR TITLE
Fix for exception

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -22,7 +22,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers {
     implicit val materializer = ActorFlowMaterializer()
 
     val connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] =
-      Http().outgoingConnection("http://akka.io")
+      Http().outgoingConnection("akka.io")
     val responseFuture: Future[HttpResponse] =
       Source.single(HttpRequest(uri = "/"))
         .via(connectionFlow)
@@ -44,7 +44,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers {
     implicit val materializer = ActorFlowMaterializer()
 
     // construct a pool client flow with context type `Int`
-    val poolClientFlow = Http().cachedHostConnectionPool[Int]("http://akka.io")
+    val poolClientFlow = Http().cachedHostConnectionPool[Int]("akka.io")
     val responseFuture: Future[(Try[HttpResponse], Int)] =
       Source.single(HttpRequest(uri = "/") -> 42)
         .via(poolClientFlow)
@@ -64,7 +64,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers {
     implicit val materializer = ActorFlowMaterializer()
 
     val responseFuture: Future[HttpResponse] =
-      Http().singleRequest(HttpRequest(uri = "http://akka.io"))
+      Http().singleRequest(HttpRequest(uri = "akka.io"))
     //#single-request-example
   }
 


### PR DESCRIPTION
If I'm using an url starting with `http://` I get:    

```
Illegal URI host: Invalid input ':', expected lower-reg-name-char, UPPER_ALPHA, '%' or 'EOI' (line 1, column 5): http://google.com
```
