### PR TITLE
~per #15640 support nested persist calls 

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -3,21 +3,21 @@
  */
 package akka.event
 
-import language.existentials
-import akka.actor._
-import akka.{ ConfigurationException, AkkaException }
-import akka.actor.ActorSystem.Settings
-import akka.util.ReentrantGuard
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.Locale
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.ActorSystem.Settings
+import akka.actor._
+import akka.dispatch.RequiresMessageQueue
+import akka.util.ReentrantGuard
+import akka.{ AkkaException, ConfigurationException }
+
 import scala.annotation.implicitNotFound
 import scala.collection.immutable
-import scala.concurrent.duration._
 import scala.concurrent.Await
-import scala.util.control.NoStackTrace
-import scala.util.control.NonFatal
-import java.util.Locale
-import akka.dispatch.RequiresMessageQueue
+import scala.language.existentials
+import scala.util.control.{ NoStackTrace, NonFatal }
 
 /**
  * This trait brings log level handling to the EventStream: it reads the log
@@ -1132,9 +1132,11 @@ class DefaultLoggingFilter(logLevel: () ⇒ Logging.LogLevel) extends LoggingFil
  */
 trait DiagnosticLoggingAdapter extends LoggingAdapter {
 
-  import Logging._
-  import scala.collection.JavaConverters._
   import java.{ util ⇒ ju }
+
+  import Logging._
+
+  import scala.collection.JavaConverters._
 
   private var _mdc = emptyMDC
 

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -249,7 +249,7 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 .. _defer-java-lambda:
 
 Deferring actions until preceding persist handlers have executed
------------------------------------------------------------------
+----------------------------------------------------------------
 
 Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
 ''happens-after the previous ``persistAsync`` handlers have been invoked''. ``PersistentActor`` provides an utility method
@@ -269,6 +269,41 @@ of the command for which this ``defer`` handler was called.
 .. warning::
   The callback will not be invoked if the actor is restarted (or stopped) in between the call to
   ``defer`` and the journal has processed and confirmed all preceding writes.
+
+.. _nested-persist-calls-lambda:
+
+Nested persist calls
+--------------------
+It is possible to call ``persist`` and ``persistAsync`` inside their respective callback blocks and they will properly
+retain both the thread safety (including the right value of ``sender()``) as well as stashing guarantees.
+
+In general it is encouraged to create command handlers which do not need to resort to nested event persisting,
+however there are situations where it may be useful. It is important to understand the ordering of callback execution in
+those situations, as well as their implication on the stashing behaviour (that ``persist()`` enforces). In the following
+example two persist calls are issued, and each of them issues another persist inside its callback:
+
+.. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#nested-persist-persist
+
+When sending two commands to this ``PersistentActor``, the persist handlers will be executed in the following order:
+
+.. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#nested-persist-persist-caller
+
+First the "outer layer" of persist calls is issued and their callbacks applied, after these have successfully completed
+the inner callbacks will be invoked (once the events they are persisting have been confirmed to be persisted by the journal).
+And only after all these handlers have been successfully invoked, the next command will delivered to the persistent Actor.
+In other words, the stashing of incoming commands that is guaranteed by initially calling ``persist()`` on the outer layer
+is extended until all nested ``persist`` callbacks have been handled.
+
+It is also possible to nest ``persistAsync`` calls, using the same pattern:
+
+.. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#nested-persistAsync-persistAsync
+
+In this case no stashing is happening, yet the events are still persisted and callbacks executed in the expected order:
+
+.. includecode:: ../../../akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistenceDocTest.java#nested-persistAsync-persistAsync-caller
+
+While it is possible to nest mixed ``persist`` and ``persistAsync`` with keeping their respective semantics
+it is not a recommended practice as it may lead to overly complex nesting.
 
 Failures
 --------

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -280,6 +280,103 @@ object PersistenceDocSpec {
     //#defer-caller
   }
 
+  object NestedPersists {
+
+    class MyPersistentActor extends PersistentActor {
+      override def persistenceId = "my-stable-persistence-id"
+
+      override def receiveRecover: Receive = {
+        case _ => // handle recovery here
+      }
+
+      //#nested-persist-persist
+      override def receiveCommand: Receive = {
+        case c: String =>
+          sender() ! c
+
+          persist(s"$c-1-outer") { outer1 =>
+            sender() ! outer1
+            persist(s"$c-1-inner") { inner1 =>
+              sender() ! inner1
+            }
+          }
+
+          persist(s"$c-2-outer") { outer2 =>
+            sender() ! outer2
+            persist(s"$c-2-inner") { inner2 =>
+              sender() ! inner2
+            }
+          }
+      }
+      //#nested-persist-persist
+    }
+
+    //#nested-persist-persist-caller
+    persistentActor ! "a"
+    persistentActor ! "b"
+
+    // order of received messages:
+    // a
+    // a-outer-1
+    // a-outer-2
+    // a-inner-1
+    // a-inner-2
+    // and only then process "b"
+    // b
+    // b-outer-1
+    // b-outer-2
+    // b-inner-1
+    // b-inner-2
+
+    //#nested-persist-persist-caller
+
+
+    class MyPersistAsyncActor extends PersistentActor {
+      override def persistenceId = "my-stable-persistence-id"
+
+      override def receiveRecover: Receive = {
+        case _ => // handle recovery here
+      }
+
+      //#nested-persistAsync-persistAsync
+      override def receiveCommand: Receive = {
+        case c: String =>
+          sender() ! c
+          persistAsync(c + "-outer-1") { outer ⇒
+            sender() ! outer
+            persistAsync(c + "-inner-1") { inner ⇒ sender() ! inner }
+          }
+          persistAsync(c + "-outer-2") { outer ⇒
+            sender() ! outer
+            persistAsync(c + "-inner-2") { inner ⇒ sender() ! inner }
+          }
+      }
+    //#nested-persistAsync-persistAsync
+    }
+
+    //#nested-persistAsync-persistAsync-caller
+    persistentActor ! "a"
+    persistentActor ! "b"
+
+    // order of received messages:
+    // a
+    // b
+    // a-outer-1
+    // a-outer-2
+    // b-outer-1
+    // b-outer-2
+    // a-inner-1
+    // a-inner-2
+    // b-inner-1
+    // b-inner-2
+
+    // which can be seen as the following causal relationship:
+    // a -> a-outer-1 -> a-outer-2 -> a-inner-1 -> a-inner-2
+    // b -> b-outer-1 -> b-outer-2 -> b-inner-1 -> b-inner-2
+
+    //#nested-persistAsync-persistAsync-caller
+  }
+
   object View {
     import akka.actor.Props
 

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -236,7 +236,7 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 .. _defer-scala:
 
 Deferring actions until preceding persist handlers have executed
------------------------------------------------------------------
+----------------------------------------------------------------
 
 Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
 ''happens-after the previous ``persistAsync`` handlers have been invoked''. ``PersistentActor`` provides an utility method
@@ -258,6 +258,41 @@ The calling side will get the responses in this (guaranteed) order:
 .. warning::
   The callback will not be invoked if the actor is restarted (or stopped) in between the call to
   ``defer`` and the journal has processed and confirmed all preceding writes.
+
+.. _nested-persist-calls-scala:
+
+Nested persist calls
+--------------------
+It is possible to call ``persist`` and ``persistAsync`` inside their respective callback blocks and they will properly
+retain both the thread safety (including the right value of ``sender()``) as well as stashing guarantees.
+
+In general it is encouraged to create command handlers which do not need to resort to nested event persisting,
+however there are situations where it may be useful. It is important to understand the ordering of callback execution in
+those situations, as well as their implication on the stashing behaviour (that ``persist()`` enforces). In the following
+example two persist calls are issued, and each of them issues another persist inside its callback:
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#nested-persist-persist
+
+When sending two commands to this ``PersistentActor``, the persist handlers will be executed in the following order:
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#nested-persist-persist-caller
+
+First the "outer layer" of persist calls is issued and their callbacks applied, after these have successfully completed
+the inner callbacks will be invoked (once the events they are persisting have been confirmed to be persisted by the journal).
+And only after all these handlers have been successfully invoked, the next command will delivered to the persistent Actor.
+In other words, the stashing of incoming commands that is guaranteed by initially calling ``persist()`` on the outer layer
+is extended until all nested ``persist`` callbacks have been handled.
+
+It is also possible to nest ``persistAsync`` calls, using the same pattern:
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#nested-persistAsync-persistAsync
+
+In this case no stashing is happening, yet the events are still persisted and callbacks executed in the expected order:
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#nested-persistAsync-persistAsync-caller
+
+While it is possible to nest mixed ``persist`` and ``persistAsync`` with keeping their respective semantics
+it is not a recommended practice as it may lead to overly complex nesting.
 
 Failures
 --------

--- a/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
@@ -7,6 +7,9 @@ package akka.persistence
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
+import org.scalatest.matchers.{ MatchResult, Matcher }
+
+import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 
@@ -18,7 +21,8 @@ import org.scalatest.BeforeAndAfterEach
 import akka.actor.Props
 import akka.testkit.AkkaSpec
 
-abstract class PersistenceSpec(config: Config) extends AkkaSpec(config) with BeforeAndAfterEach with Cleanup { this: AkkaSpec ⇒
+abstract class PersistenceSpec(config: Config) extends AkkaSpec(config) with BeforeAndAfterEach with Cleanup
+  with PersistenceMatchers { this: AkkaSpec ⇒
   private var _name: String = _
 
   lazy val extension = Persistence(system)
@@ -87,3 +91,28 @@ trait TurnOffRecoverOnStart { this: Eventsourced ⇒
 class TestException(msg: String) extends Exception(msg) with NoStackTrace
 
 case object GetState
+
+/** Additional ScalaTest matchers useful in persistence tests */
+trait PersistenceMatchers {
+  /** Use this matcher to verify in-order execution of independent "streams" of events */
+  final class IndependentlyOrdered(prefixes: immutable.Seq[String]) extends Matcher[immutable.Seq[Any]] {
+    override def apply(_left: immutable.Seq[Any]) = {
+      val left = _left.map(_.toString)
+      val mapped = left.groupBy(l ⇒ prefixes.indexWhere(p ⇒ l.startsWith(p))) - (-1) // ignore other messages
+      val results = for {
+        (pos, seq) ← mapped
+        nrs = seq.map(_.replaceFirst(prefixes(pos), "").toInt)
+        sortedNrs = nrs.sorted
+        if nrs != sortedNrs
+      } yield MatchResult(
+        false,
+        s"""Messages sequence with prefix ${prefixes(pos)} was not sorted! Was: $seq"""",
+        s"""Messages sequence with prefix ${prefixes(pos)} was sorted! Was: $seq"""")
+
+      if (results.forall(_.matches)) MatchResult(true, "", "")
+      else results.find(r ⇒ !r.matches).get
+    }
+  }
+
+  def beIndependentlyOrdered(prefixes: String*) = new IndependentlyOrdered(prefixes.toList)
+}


### PR DESCRIPTION
It is safe and "makes sense" to have nested persist calls, so that's supported now.
It is a bit confusing with nesting persistAsync, and while it can be made work I think it would require some more work, so I'm not doing that now - instead explicitly throwing if this is detected. If that's reasonable I'll add docs about it.

Refs #15640
