### PR TITLE
!per #17799 Remove support for non-permanent deletes

### DIFF
--- a/akka-docs/rst/java/code/docs/persistence/PersistencePluginDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistencePluginDocTest.java
@@ -90,7 +90,7 @@ public class PersistencePluginDocTest {
         }
 
         @Override
-        public Future<Void> doAsyncDeleteMessagesTo(String persistenceId, long toSequenceNr, boolean permanent) {
+        public Future<Void> doAsyncDeleteMessagesTo(String persistenceId, long toSequenceNr) {
             return null;
         }
 

--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -323,11 +323,6 @@ Message deletion
 To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors may call the ``deleteMessages`` method.
 
-An optional ``permanent`` parameter specifies whether the message shall be permanently
-deleted from the journal or only marked as deleted. In both cases, the message won't be replayed. Later extensions
-to Akka persistence will allow to replay messages that have been marked as deleted which can be useful for debugging
-purposes, for example.
-
 .. _persistent-views-java-lambda:
 
 Views

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -326,11 +326,6 @@ Message deletion
 To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors may call the ``deleteMessages`` method.
 
-An optional ``permanent`` parameter specifies whether the message shall be permanently
-deleted from the journal or only marked as deleted. In both cases, the message won't be replayed. Later extensions
-to Akka persistence will allow to replay messages that have been marked as deleted which can be useful for debugging
-purposes, for example.
-
 .. _persistent-views-java:
 
 Persistent Views

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -317,6 +317,12 @@ The ``persist`` method that takes a ``Seq`` (Scala) or ``Iterable`` (Java) of ev
 renamed to ``persistAll`` to avoid mistakes of persisting other collection types as one single event by calling
 the overloaded ``persist(event)`` method.
 
+non-permanent deletion
+----------------------
+
+The ``permanent`` flag in ``deleteMessages`` was removed. non-permanent deletes are not supported
+any more.
+
 Persistence Plugin APIs
 =======================
 
@@ -422,4 +428,10 @@ asyncReplayMessages Java API
 
 The signature of `asyncReplayMessages` in the Java API changed from ``akka.japi.Procedure``
 to ``java.util.function.Consumer``.
+
+asyncDeleteMessagesTo
+---------------------
+
+The ``permanent`` deletion flag was removed. Support for non-permanent deletions was
+removed.
 

--- a/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
@@ -128,8 +128,7 @@ trait SharedLeveldbPluginDocSpec {
 
 class MyJournal extends AsyncWriteJournal {
   def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = ???
-  def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long,
-                            permanent: Boolean): Future[Unit] = ???
+  def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = ???
   def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long,
                           toSequenceNr: Long, max: Long)(
                             replayCallback: (PersistentRepr) => Unit): Future[Unit] = ???

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -315,11 +315,6 @@ Message deletion
 To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors may call the ``deleteMessages`` method.
 
-An optional ``permanent`` parameter specifies whether the message shall be permanently
-deleted from the journal or only marked as deleted. In both cases, the message won't be replayed. Later extensions
-to Akka persistence will allow to replay messages that have been marked as deleted which can be useful for debugging
-purposes, for example.
-
 .. _persistent-views:
 
 Persistent Views

--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
@@ -130,7 +130,7 @@ abstract class JournalSpec(config: Config) extends PluginSpec(config) {
       receiverProbe.expectMsg(ReplayMessagesSuccess)
     }
     "not replay permanently deleted messages (range deletion)" in {
-      val cmd = DeleteMessagesTo(pid, 3, true)
+      val cmd = DeleteMessagesTo(pid, 3)
       val sub = TestProbe()
 
       subscribe[DeleteMessagesTo](sub.ref)
@@ -139,20 +139,6 @@ abstract class JournalSpec(config: Config) extends PluginSpec(config) {
 
       journal ! ReplayMessages(1, Long.MaxValue, Long.MaxValue, pid, receiverProbe.ref)
       List(4, 5) foreach { i ⇒ receiverProbe.expectMsg(replayedMessage(i)) }
-    }
-    "replay logically deleted messages with deleted field set to true (range deletion)" in {
-      val cmd = DeleteMessagesTo(pid, 3, false)
-      val sub = TestProbe()
-
-      subscribe[DeleteMessagesTo](sub.ref)
-      journal ! cmd
-      sub.expectMsg(cmd)
-
-      journal ! ReplayMessages(1, Long.MaxValue, Long.MaxValue, pid, receiverProbe.ref, replayDeleted = true)
-      (1 to 5).foreach {
-        case i @ (1 | 2 | 3) ⇒ receiverProbe.expectMsg(replayedMessage(i, deleted = true))
-        case i @ (4 | 5)     ⇒ receiverProbe.expectMsg(replayedMessage(i))
-      }
     }
 
     "return a highest stored sequence number > 0 if the persistent actor has already written messages and the message log is non-empty" in {

--- a/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
@@ -83,20 +83,23 @@ abstract class SnapshotStoreSpec(config: Config) extends PluginSpec(config) {
       val sub = TestProbe()
 
       subscribe[DeleteSnapshot](sub.ref)
-      snapshotStore ! cmd
+      snapshotStore.tell(cmd, senderProbe.ref)
       sub.expectMsg(cmd)
+      senderProbe.expectMsg(DeleteSnapshotSuccess(md))
 
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria(md.sequenceNr, md.timestamp), Long.MaxValue), senderProbe.ref)
       senderProbe.expectMsg(LoadSnapshotResult(Some(SelectedSnapshot(metadata(1), s"s-2")), Long.MaxValue))
     }
     "delete all snapshots matching upper sequence number and timestamp bounds" in {
       val md = metadata(2)
-      val cmd = DeleteSnapshots(pid, SnapshotSelectionCriteria(md.sequenceNr, md.timestamp))
+      val criteria = SnapshotSelectionCriteria(md.sequenceNr, md.timestamp)
+      val cmd = DeleteSnapshots(pid, criteria)
       val sub = TestProbe()
 
       subscribe[DeleteSnapshots](sub.ref)
-      snapshotStore ! cmd
+      snapshotStore.tell(cmd, senderProbe.ref)
       sub.expectMsg(cmd)
+      senderProbe.expectMsg(DeleteSnapshotsSuccess(criteria))
 
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria(md.sequenceNr, md.timestamp), Long.MaxValue), senderProbe.ref)
       senderProbe.expectMsg(LoadSnapshotResult(None, Long.MaxValue))

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
@@ -60,11 +60,10 @@ interface AsyncWritePlugin {
 
   /**
    * Java API, Plugin API: synchronously deletes all persistent messages up to
-   * `toSequenceNr`. If `permanent` is set to `false`, the persistent messages
-   * are marked as deleted, otherwise they are permanently deleted.
+   * `toSequenceNr`.
    *
    * @see AsyncRecoveryPlugin
    */
-  Future<Void> doAsyncDeleteMessagesTo(String persistenceId, long toSequenceNr, boolean permanent);
+  Future<Void> doAsyncDeleteMessagesTo(String persistenceId, long toSequenceNr);
   //#async-write-plugin-api
 }

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/SyncWritePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/SyncWritePlugin.java
@@ -58,11 +58,10 @@ interface SyncWritePlugin {
 
   /**
    * Java API, Plugin API: synchronously deletes all persistent messages up to
-   * `toSequenceNr`. If `permanent` is set to `false`, the persistent messages
-   * are marked as deleted, otherwise they are permanently deleted.
+   * `toSequenceNr`.
    *
    * @see AsyncRecoveryPlugin
    */
-  void doDeleteMessagesTo(String persistenceId, long toSequenceNr, boolean permanent);
+  void doDeleteMessagesTo(String persistenceId, long toSequenceNr);
   //#sync-write-plugin-api
 }

--- a/akka-persistence/src/main/protobuf/MessageFormats.proto
+++ b/akka-persistence/src/main/protobuf/MessageFormats.proto
@@ -9,7 +9,7 @@ message PersistentMessage {
   optional PersistentPayload payload = 1;
   optional int64 sequenceNr = 2;
   optional string persistenceId = 3;
-  optional bool deleted = 4;
+  optional bool deleted = 4; // not used in new records from 2.4
   // optional int32 redeliveries = 6; // Removed in 2.4
   // repeated string confirms = 7; // Removed in 2.4
   // optional bool confirmable = 8;  // Removed in 2.4

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -378,21 +378,8 @@ private[persistence] trait Eventsourced extends Snapshotter with Stash with Stas
    *
    * @param toSequenceNr upper sequence number bound of persistent messages to be deleted.
    */
-  def deleteMessages(toSequenceNr: Long): Unit = {
-    deleteMessages(toSequenceNr, permanent = true)
-  }
-
-  /**
-   * Deletes all persistent messages with sequence numbers less than or equal `toSequenceNr`. If `permanent`
-   * is set to `false`, the persistent messages are marked as deleted in the journal, otherwise
-   * they permanently deleted from the journal.
-   *
-   * @param toSequenceNr upper sequence number bound of persistent messages to be deleted.
-   * @param permanent if `false`, the message is marked as deleted, otherwise it is permanently deleted.
-   */
-  def deleteMessages(toSequenceNr: Long, permanent: Boolean): Unit = {
-    journal ! DeleteMessagesTo(persistenceId, toSequenceNr, permanent)
-  }
+  def deleteMessages(toSequenceNr: Long): Unit =
+    deleteMessages(toSequenceNr)
 
   /**
    * Returns `true` if this persistent actor is currently recovering.

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -30,10 +30,9 @@ private[persistence] object JournalProtocol {
 
   /**
    * Request to delete all persistent messages with sequence numbers up to `toSequenceNr`
-   * (inclusive). If `permanent` is set to `false`, the persistent messages are marked
-   * as deleted in the journal, otherwise they are permanently deleted from the journal.
+   * (inclusive).
    */
-  final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long, permanent: Boolean)
+  final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long)
     extends Request
 
   /**
@@ -107,10 +106,9 @@ private[persistence] object JournalProtocol {
    * @param max maximum number of messages to be replayed.
    * @param persistenceId requesting persistent actor id.
    * @param persistentActor requesting persistent actor.
-   * @param replayDeleted `true` if messages marked as deleted shall be replayed.
    */
-  final case class ReplayMessages(fromSequenceNr: Long, toSequenceNr: Long, max: Long, persistenceId: String, persistentActor: ActorRef, replayDeleted: Boolean = false)
-    extends Request
+  final case class ReplayMessages(fromSequenceNr: Long, toSequenceNr: Long, max: Long,
+                                  persistenceId: String, persistentActor: ActorRef) extends Request
 
   /**
    * Reply message to a [[ReplayMessages]] request. A separate reply is sent to the requestor for each

--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -82,7 +82,9 @@ trait PersistentRepr extends Message {
   def withManifest(manifest: String): PersistentRepr
 
   /**
-   * `true` if this message is marked as deleted.
+   * Not used in new records stored with Akka v2.4, but
+   * old records from v2.3 may have this as `true` if
+   * it was a non-permanent delete.
    */
   def deleted: Boolean
 

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteProxy.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteProxy.scala
@@ -43,8 +43,8 @@ private[persistence] trait AsyncWriteProxy extends AsyncWriteJournal with Stash 
   def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] =
     (store ? WriteMessages(messages)).mapTo[immutable.Seq[Try[Unit]]]
 
-  def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long, permanent: Boolean): Future[Unit] =
-    (store ? DeleteMessagesTo(persistenceId, toSequenceNr, permanent)).mapTo[Unit]
+  def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] =
+    (store ? DeleteMessagesTo(persistenceId, toSequenceNr)).mapTo[Unit]
 
   def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(replayCallback: PersistentRepr ⇒ Unit): Future[Unit] = {
     val replayCompletionPromise = Promise[Unit]()
@@ -72,7 +72,7 @@ private[persistence] object AsyncWriteTarget {
   final case class WriteMessages(messages: immutable.Seq[AtomicWrite])
 
   @SerialVersionUID(1L)
-  final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long, permanent: Boolean)
+  final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long)
 
   @SerialVersionUID(1L)
   final case class ReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/inmem/InmemJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/inmem/InmemJournal.scala
@@ -82,9 +82,7 @@ private[persistence] class InmemStore extends Actor with InmemMessages with Writ
           Try(a.payload.foreach(add))
         }
       sender() ! results
-    case DeleteMessagesTo(pid, tsnr, false) ⇒
-      sender() ! (1L to tsnr foreach { snr ⇒ update(pid, snr)(_.update(deleted = true)) })
-    case DeleteMessagesTo(pid, tsnr, true) ⇒
+    case DeleteMessagesTo(pid, tsnr) ⇒
       sender() ! (1L to tsnr foreach { snr ⇒ delete(pid, snr) })
     case ReplayMessages(pid, fromSnr, toSnr, max) ⇒
       read(pid, fromSnr, toSnr, max).foreach { sender() ! _ }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
@@ -28,6 +28,6 @@ abstract class AsyncWriteJournal extends AsyncRecovery with SAsyncWriteJournal w
       }(collection.breakOut)
     }
 
-  final def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long, permanent: Boolean) =
-    doAsyncDeleteMessagesTo(persistenceId, toSequenceNr, permanent).map(Unit.unbox)
+  final def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long) =
+    doAsyncDeleteMessagesTo(persistenceId, toSequenceNr).map(Unit.unbox)
 }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/SyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/SyncWriteJournal.scala
@@ -26,6 +26,6 @@ abstract class SyncWriteJournal extends AsyncRecovery with SSyncWriteJournal wit
       else successUnit
     }(collection.breakOut)
 
-  final def deleteMessagesTo(persistenceId: String, toSequenceNr: Long, permanent: Boolean): Unit =
-    doDeleteMessagesTo(persistenceId, toSequenceNr, permanent)
+  final def deleteMessagesTo(persistenceId: String, toSequenceNr: Long): Unit =
+    doDeleteMessagesTo(persistenceId, toSequenceNr)
 }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbRecovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbRecovery.scala
@@ -47,7 +47,7 @@ private[persistence] trait LeveldbRecovery extends AsyncRecovery { this: Leveldb
           val msg = persistentFromBytes(nextEntry.getValue)
           val del = deletion(iter, nextKey)
           if (ctr < max) {
-            replayCallback(msg.update(deleted = del))
+            if (!del) replayCallback(msg)
             go(iter, nextKey, ctr + 1L, replayCallback)
           }
         }

--- a/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
@@ -133,7 +133,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
 
     builder.setPayload(persistentPayloadBuilder(persistent.payload.asInstanceOf[AnyRef]))
     builder.setSequenceNr(persistent.sequenceNr)
-    builder.setDeleted(persistent.deleted)
+    // deleted is not used in new records from 2.4
     builder
   }
 
@@ -174,7 +174,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
       persistentMessage.getSequenceNr,
       if (persistentMessage.hasPersistenceId) persistentMessage.getPersistenceId else Undefined,
       if (persistentMessage.hasManifest) persistentMessage.getManifest else Undefined,
-      persistentMessage.getDeleted,
+      if (persistentMessage.hasDeleted) persistentMessage.getDeleted else false,
       if (persistentMessage.hasSender) system.provider.resolveActorRef(persistentMessage.getSender) else Actor.noSender)
   }
 

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentViewSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentViewSpec.scala
@@ -283,9 +283,9 @@ abstract class PersistentViewSpec(config: Config) extends PersistenceSpec(config
       viewProbe.expectMsg("replicated-c-3")
       viewProbe.expectMsg("replicated-d-4")
 
-      replayProbe.expectMsgPF() { case ReplayMessages(1L, _, 2L, _, _, _) ⇒ }
-      replayProbe.expectMsgPF() { case ReplayMessages(3L, _, 2L, _, _, _) ⇒ }
-      replayProbe.expectMsgPF() { case ReplayMessages(5L, _, 2L, _, _, _) ⇒ }
+      replayProbe.expectMsgPF() { case ReplayMessages(1L, _, 2L, _, _) ⇒ }
+      replayProbe.expectMsgPF() { case ReplayMessages(3L, _, 2L, _, _) ⇒ }
+      replayProbe.expectMsgPF() { case ReplayMessages(5L, _, 2L, _, _) ⇒ }
     }
     "support context.become" in {
       view = system.actorOf(Props(classOf[BecomingPersistentView], name, viewProbe.ref))

--- a/akka-persistence/src/test/scala/akka/persistence/journal/chaos/ChaosJournal.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/journal/chaos/ChaosJournal.scala
@@ -46,10 +46,9 @@ class ChaosJournal extends SyncWriteJournal {
         SyncWriteJournal.successUnit
       }
 
-  def deleteMessagesTo(persistenceId: String, toSequenceNr: Long, permanent: Boolean): Unit = {
+  def deleteMessagesTo(persistenceId: String, toSequenceNr: Long): Unit = {
     (1L to toSequenceNr).foreach { snr ⇒
-      if (permanent) update(persistenceId, snr)(_.update(deleted = true))
-      else del(persistenceId, snr)
+      del(persistenceId, snr)
     }
   }
 

--- a/akka-persistence/src/test/scala/akka/persistence/serialization/SerializerSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/serialization/SerializerSpec.scala
@@ -145,7 +145,7 @@ class MessageSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
   "A message serializer" when {
     "not given a manifest" must {
       "handle custom Persistent message serialization" in {
-        val persistent = PersistentRepr(MyPayload("a"), 13, "p1", "", true)
+        val persistent = PersistentRepr(MyPayload("a"), 13, "p1", "")
         val serializer = serialization.findSerializerFor(persistent)
 
         val bytes = serializer.toBinary(persistent)
@@ -157,7 +157,7 @@ class MessageSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
 
     "given a PersistentRepr manifest" must {
       "handle custom Persistent message serialization" in {
-        val persistent = PersistentRepr(MyPayload("b"), 13, "p1", "", true)
+        val persistent = PersistentRepr(MyPayload("b"), 13, "p1", "")
         val serializer = serialization.findSerializerFor(persistent)
 
         val bytes = serializer.toBinary(persistent)
@@ -169,7 +169,7 @@ class MessageSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
 
     "given payload serializer with string manifest" must {
       "handle serialization" in {
-        val persistent = PersistentRepr(MyPayload2("a", 17), 13, "p1", "", true)
+        val persistent = PersistentRepr(MyPayload2("a", 17), 13, "p1", "")
         val serializer = serialization.findSerializerFor(persistent)
 
         val bytes = serializer.toBinary(persistent)
@@ -192,7 +192,7 @@ class MessageSerializerPersistenceSpec extends AkkaSpec(customSerializers) {
       }
 
       "be able to deserialize data when class is removed" in {
-        val serializer = serialization.findSerializerFor(PersistentRepr("x", 13, "p1", "", true))
+        val serializer = serialization.findSerializerFor(PersistentRepr("x", 13, "p1", ""))
 
         // It was created with:
         // val old = PersistentRepr(OldPayload('A'), 13, "p1", true, testActor)

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistencePluginDocTest.java
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/java/doc/LambdaPersistencePluginDocTest.java
@@ -83,7 +83,7 @@ public class LambdaPersistencePluginDocTest {
     }
 
     @Override
-    public Future<Void> doAsyncDeleteMessagesTo(String persistenceId, long toSequenceNr, boolean permanent) {
+    public Future<Void> doAsyncDeleteMessagesTo(String persistenceId, long toSequenceNr) {
       return null;
     }
 


### PR DESCRIPTION
**Skip the first commit, it is from PR #17818, which will be merged first.**
- Remove the permanent flag in deleteMessages
- old records stored with deletion flag are still not replayed
