### PR TITLE
+per #17799 Fix refactoring bug in deleteMessages

### DIFF
--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -291,6 +291,9 @@ next message.
 If there is a problem with recovering the state of the actor from the journal when the actor is
 started, ``onReplayFailure`` is called (logging the error by default) and the actor will be stopped.
 
+If the ``deleteMessages`` fails ``onDeleteMessagesFailure`` will be called (logging a warning by default) 
+and the actor continues with next message.
+
 Atomic writes
 -------------
 
@@ -322,6 +325,9 @@ Message deletion
 
 To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors may call the ``deleteMessages`` method.
+
+If the delete fails ``onDeleteMessagesFailure`` will be called (logging a warning by default) 
+and the actor continues with next message.
 
 .. _persistent-views-java-lambda:
 

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -326,6 +326,12 @@ Message deletion
 To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors may call the ``deleteMessages`` method.
 
+If the delete fails ``onDeleteMessagesFailure`` will be called (logging a warning by default) 
+and the actor continues with next message.
+
+If the ``deleteMessages`` fails ``onDeleteMessagesFailure`` will be called (logging a warning by default) 
+and the actor continues with next message.
+
 .. _persistent-views-java:
 
 Persistent Views

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -280,6 +280,9 @@ next message.
 If there is a problem with recovering the state of the actor from the journal when the actor is
 started, ``onReplayFailure`` is called (logging the error by default) and the actor will be stopped.
 
+If the ``deleteMessages`` fails ``onDeleteMessagesFailure`` will be called (logging a warning by default) 
+and the actor continues with next message.
+
 Atomic writes
 -------------
 
@@ -314,6 +317,9 @@ Message deletion
 
 To delete all messages (journaled by a single persistent actor) up to a specified sequence number,
 persistent actors may call the ``deleteMessages`` method.
+
+If the delete fails ``onDeleteMessagesFailure`` will be called (logging a warning by default) 
+and the actor continues with next message.
 
 .. _persistent-views:
 

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -25,14 +25,14 @@ private[persistence] object JournalProtocol {
   /**
    * Reply message to a failed [[DeleteMessagesTo]] request.
    */
-  final case class DeleteMessagesFailure(cause: Throwable)
+  final case class DeleteMessagesFailure(cause: Throwable, toSequenceNr: Long)
     extends Response
 
   /**
    * Request to delete all persistent messages with sequence numbers up to `toSequenceNr`
    * (inclusive).
    */
-  final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long)
+  final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long, persistentActor: ActorRef)
     extends Request
 
   /**

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -117,10 +117,10 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
         case e ⇒ ReadHighestSequenceNrFailure(e)
       } pipeTo persistentActor
 
-    case d @ DeleteMessagesTo(persistenceId, toSequenceNr) ⇒
+    case d @ DeleteMessagesTo(persistenceId, toSequenceNr, persistentActor) ⇒
       asyncDeleteMessagesTo(persistenceId, toSequenceNr) onComplete {
         case Success(_) ⇒ if (publish) context.system.eventStream.publish(d)
-        case Failure(e) ⇒
+        case Failure(e) ⇒ persistentActor ! DeleteMessagesFailure(e, toSequenceNr)
       }
   }
 


### PR DESCRIPTION
**Skip the first commit, it comes from #17838, which will be merged first**
- add missing test
- use DeleteMessagesFailure and add onDeleteMessagesFailure (logging)
