### PR TITLE
+str #17399 add boilerplate remover for fan-in junctions

### DIFF
--- a/akka-docs-dev/rst/java/stream-graphs.rst
+++ b/akka-docs-dev/rst/java/stream-graphs.rst
@@ -143,6 +143,19 @@ For defining a ``Flow<T>`` we need to expose both an undefined source and sink:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java#flow-from-partial-flow-graph
 
+Combining Sources and Sinks with simplified API
+-----------------------------------------------
+
+There is simplified API you can use to combine sources and sinks with junctions like: ``Broadcast<T>``, ``Balance<T>``,
+``Merge<In>`` and ``Concat<A>`` without the need for using the Graph DSL. The combine method takes care of constructing
+the necessary graph underneath. In following example we combine two sources into one (fan-in):
+
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java#source-combine
+
+The same can be done for a ``Sink`` but in this case it will be fan-out:
+
+.. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/StreamPartialFlowGraphDocTest.java#sink-combine
+
 .. _bidi-flow-java:
 
 Bidirectional Flows

--- a/akka-docs-dev/rst/scala/stream-graphs.rst
+++ b/akka-docs-dev/rst/scala/stream-graphs.rst
@@ -152,6 +152,19 @@ For defining a ``Flow[T]`` we need to expose both an inlet and an outlet:
 
 .. includecode:: code/docs/stream/StreamPartialFlowGraphDocSpec.scala#flow-from-partial-flow-graph
 
+Combining Sources and Sinks with simplified API
+-----------------------------------------------
+
+There is simplified API you can use to combine sources and sinks with junctions like: ``Broadcast[T]``, ``Balance[T]``,
+``Merge[In]`` and ``Concat[A]`` without the need for using the Graph DSL. The combine method takes care of constructing
+the necessary graph underneath. In following example we combine two sources into one (fan-in):
+
+.. includecode:: code/docs/stream/StreamPartialFlowGraphDocSpec.scala#source-combine
+
+The same can be done for a ``Sink[T]`` but in this case it will be fan-out:
+
+.. includecode:: code/docs/stream/StreamPartialFlowGraphDocSpec.scala#sink-combine
+
 Building reusable Graph components
 ----------------------------------
 

--- a/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
@@ -29,6 +29,7 @@ class DslFactoriesConsistencySpec extends WordSpec with Matchers {
   val `scala -> java types` =
     (classOf[scala.collection.immutable.Iterable[_]],   classOf[java.lang.Iterable[_]]) ::
       (classOf[scala.collection.Iterator[_]],           classOf[java.util.Iterator[_]]) ::
+      (classOf[scala.collection.Seq[_]],                classOf[java.util.List[_]]) ::
       (classOf[scala.Function0[_]],                     classOf[akka.japi.function.Creator[_]]) ::
       (classOf[scala.Function0[_]],                     classOf[java.util.concurrent.Callable[_]]) ::
       (classOf[scala.Function0[_]],                     classOf[akka.japi.function.Creator[_]]) ::

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -137,6 +137,16 @@ object Sink {
       case s: Sink[T, M] ⇒ s
       case other         ⇒ new Sink(scaladsl.Sink.wrap(other))
     }
+
+  /**
+   * Combine several sinks with fan-out strategy like `Broadcast` or `Balance` and returns `Sink`.
+   */
+  def combine[T, U](output1: Sink[U, _], output2: Sink[U, _], rest: java.util.List[Sink[U, _]], strategy: function.Function[java.lang.Integer, Graph[UniformFanOutShape[T, U], Unit]]): Sink[T, Unit] = {
+    import scala.collection.JavaConverters._
+    val seq = if (rest != null) rest.asScala.map(_.asScala) else Seq()
+    new Sink(scaladsl.Sink.combine(output1.asScala, output2.asScala, seq: _*)(num ⇒ strategy.apply(num)))
+  }
+
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -226,6 +226,15 @@ object Source {
       case s: Source[T, M] ⇒ s
       case other           ⇒ new Source(scaladsl.Source.wrap(other))
     }
+
+  /**
+   * Combines several sources with fan-in strategy like `Merge` or `Concat` and returns `Source`.
+   */
+  def combine[T, U](first: Source[T, _], second: Source[T, _], rest: java.util.List[Source[T, _]], strategy: function.Function[java.lang.Integer, Graph[UniformFanInShape[T, U], Unit]]): Source[U, Unit] = {
+    import scala.collection.JavaConverters._
+    val seq = if (rest != null) rest.asScala.map(_.asScala) else Seq()
+    new Source(scaladsl.Source.combine(first.asScala, second.asScala, seq: _*)(num ⇒ strategy.apply(num)))
+  }
 }
 
 /**


### PR DESCRIPTION
Please verify if implementation approach is good enough. I'm still not sure about return type for sink mirrored version.
If it's Ok I'll need to add following: 
- docs
- java API
- sink tests
- more source tests
- check formatting for boilerplate code  
