### PR TITLE
=cls #17846 Use CRDTs instead of PersistentActor to remember the state of the ShardCoordinator

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -13,77 +13,89 @@ akka.cluster.sharding {
   # The extension creates a top level actor with this name in top level system scope,
   # e.g. '/system/sharding'
   guardian-name = sharding
-  
+
   # Specifies that entities runs on cluster nodes with a specific role.
   # If the role is not specified (or empty) all nodes in the cluster are used.
   role = ""
-  
+
   # When this is set to 'on' the active entity actors will automatically be restarted
   # upon Shard restart. i.e. if the Shard is started on a different ShardRegion
   # due to rebalance or crash.
   remember-entities = off
-  
+
   # If the coordinator can't store state changes it will be stopped
   # and started again after this duration, with an exponential back-off
   # of up to 5 times this duration.
   coordinator-failure-backoff = 5 s
-  
+
   # The ShardRegion retries registration and shard location requests to the
   # ShardCoordinator with this interval if it does not reply.
   retry-interval = 2 s
-  
+
   # Maximum number of messages that are buffered by a ShardRegion actor.
   buffer-size = 100000
-  
+
   # Timeout of the shard rebalancing process.
   handoff-timeout = 60 s
-  
+
   # Time given to a region to acknowledge it's hosting a shard.
   shard-start-timeout = 10 s
-  
+
   # If the shard is remembering entities and can't store state changes
   # will be stopped and then started again after this duration. Any messages
   # sent to an affected entity may be lost in this process.
   shard-failure-backoff = 10 s
-  
+
   # If the shard is remembering entities and an entity stops itself without
   # using passivate. The entity will be restarted after this duration or when
   # the next message for it is received, which ever occurs first.
   entity-restart-backoff = 10 s
-  
+
   # Rebalance check is performed periodically with this interval.
   rebalance-interval = 10 s
-  
+
   # Absolute path to the journal plugin configuration entity that is to be
   # used for the internal persistence of ClusterSharding. If not defined
-  # the default journal plugin is used. Note that this is not related to 
+  # the default journal plugin is used. Note that this is not related to
   # persistence used by the entity actors.
   journal-plugin-id = ""
-  
+
   # Absolute path to the snapshot plugin configuration entity that is to be
   # used for the internal persistence of ClusterSharding. If not defined
-  # the default snapshot plugin is used. Note that this is not related to 
+  # the default snapshot plugin is used. Note that this is not related to
   # persistence used by the entity actors.
   snapshot-plugin-id = ""
-  
-  # The coordinator saves persistent snapshots after this number of persistent
-  # events. Snapshots are used to reduce recovery times. 
+
+  # Parameter which determines how the coordinator will be store a state
+  # valid values either "persistence" or "ddata"
+  state-store-mode = "persistence"
+
+  # The shard saves persistent snapshots after this number of persistent
+  # events. Snapshots are used to reduce recovery times.
   snapshot-after = 1000
-  
+
   # Setting for the default shard allocation strategy
   least-shard-allocation-strategy {
     # Threshold of how large the difference between most and least number of
     # allocated shards must be to begin the rebalancing.
     rebalance-threshold = 10
-    
+
     # The number of ongoing rebalancing processes is limited to this number.
     max-simultaneous-rebalance = 3
   }
-  
-  # Settings for the coordinator singleton. Same layout as akka.cluster.singleton.  
+
+  # Timeout of waiting the initial distributed state (an initial state will be queried again if the timeout happened)
+  # works only for state-store-mode = "ddata"
+  waiting-for-state-timeout = 5 s
+
+  # Timeout of waiting for update the distributed state (update will be retried if the timeout happened)
+  # works only for state-store-mode = "ddata"
+  updating-state-timeout = 5 s
+
+  # Settings for the coordinator singleton. Same layout as akka.cluster.singleton.
   coordinator-singleton = ${akka.cluster.singleton}
-  
-  # The id of the dispatcher to use for ClusterSharding actors. 
+
+  # The id of the dispatcher to use for ClusterSharding actors.
   # If not specified default dispatcher is used.
   # If specified you need to define the settings of the actual dispatcher.
   # This dispatcher for the entity actors is defined by the user provided

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -19,6 +19,7 @@ import akka.actor.NoSerializationVerificationNeeded
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.cluster.Cluster
+import akka.cluster.ddata.DistributedData
 import akka.cluster.singleton.ClusterSingletonManager
 import akka.pattern.BackoffSupervisor
 import akka.util.ByteString
@@ -414,6 +415,7 @@ private[akka] class ClusterShardingGuardian extends Actor {
 
   val cluster = Cluster(context.system)
   val sharding = ClusterSharding(context.system)
+  lazy val replicator = DistributedData(context.system).replicator
 
   private def coordinatorSingletonManagerName(encName: String): String =
     encName + "Coordinator"
@@ -425,12 +427,17 @@ private[akka] class ClusterShardingGuardian extends Actor {
     case Start(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, handOffStopMessage) ⇒
       import settings.role
       import settings.tuningParameters.coordinatorFailureBackoff
+
       val encName = URLEncoder.encode(typeName, ByteString.UTF_8)
       val cName = coordinatorSingletonManagerName(encName)
       val cPath = coordinatorPath(encName)
       val shardRegion = context.child(encName).getOrElse {
         if (context.child(cName).isEmpty) {
-          val coordinatorProps = ShardCoordinator.props(typeName, settings, allocationStrategy)
+          val coordinatorProps =
+            if (settings.stateStoreMode == "persistence")
+              ShardCoordinator.props(typeName, settings, allocationStrategy)
+            else
+              ShardCoordinator.props(typeName, settings, allocationStrategy, replicator)
           val singletonProps = BackoffSupervisor.props(
             childProps = coordinatorProps,
             childName = "coordinator",

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -36,7 +36,9 @@ object ClusterShardingSettings {
       leastShardAllocationRebalanceThreshold =
         config.getInt("least-shard-allocation-strategy.rebalance-threshold"),
       leastShardAllocationMaxSimultaneousRebalance =
-        config.getInt("least-shard-allocation-strategy.max-simultaneous-rebalance"))
+        config.getInt("least-shard-allocation-strategy.max-simultaneous-rebalance"),
+      waitingForStateTimeout = config.getDuration("waiting-for-state-timeout", MILLISECONDS).millis,
+      updatingStateTimeout = config.getDuration("updating-state-timeout", MILLISECONDS).millis)
 
     val coordinatorSingletonSettings = ClusterSingletonManagerSettings(config.getConfig("coordinator-singleton"))
 
@@ -45,6 +47,7 @@ object ClusterShardingSettings {
       rememberEntities = config.getBoolean("remember-entities"),
       journalPluginId = config.getString("journal-plugin-id"),
       snapshotPluginId = config.getString("snapshot-plugin-id"),
+      stateStoreMode = config.getString("state-store-mode"),
       tuningParameters,
       coordinatorSingletonSettings)
   }
@@ -78,7 +81,9 @@ object ClusterShardingSettings {
     val rebalanceInterval: FiniteDuration,
     val snapshotAfter: Int,
     val leastShardAllocationRebalanceThreshold: Int,
-    val leastShardAllocationMaxSimultaneousRebalance: Int)
+    val leastShardAllocationMaxSimultaneousRebalance: Int,
+    val waitingForStateTimeout: FiniteDuration,
+    val updatingStateTimeout: FiniteDuration)
 }
 
 /**
@@ -101,6 +106,7 @@ final class ClusterShardingSettings(
   val rememberEntities: Boolean,
   val journalPluginId: String,
   val snapshotPluginId: String,
+  val stateStoreMode: String,
   val tuningParameters: ClusterShardingSettings.TuningParameters,
   val coordinatorSingletonSettings: ClusterSingletonManagerSettings) extends NoSerializationVerificationNeeded {
 
@@ -127,6 +133,7 @@ final class ClusterShardingSettings(
                    rememberEntities: Boolean = rememberEntities,
                    journalPluginId: String = journalPluginId,
                    snapshotPluginId: String = snapshotPluginId,
+                   stateStoreMode: String = stateStoreMode,
                    tuningParameters: ClusterShardingSettings.TuningParameters = tuningParameters,
                    coordinatorSingletonSettings: ClusterSingletonManagerSettings = coordinatorSingletonSettings): ClusterShardingSettings =
     new ClusterShardingSettings(
@@ -134,6 +141,7 @@ final class ClusterShardingSettings(
       rememberEntities,
       journalPluginId,
       snapshotPluginId,
+      stateStoreMode,
       tuningParameters,
       coordinatorSingletonSettings)
 }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -98,7 +98,7 @@ private[akka] class Shard(
   extractShardId: ShardRegion.ExtractShardId,
   handOffStopMessage: Any) extends Actor with ActorLogging {
 
-  import ShardRegion.{ handOffStopperProps, EntityId, Msg, Passivate }
+  import ShardRegion.{ handOffStopperProps, EntityId, Msg, Passivate, ShardInitialized }
   import ShardCoordinator.Internal.{ HandOff, ShardStopped }
   import Shard.{ State, RestartEntity, EntityStopped, EntityStarted }
   import akka.cluster.sharding.ShardCoordinator.Internal.CoordinatorMessage
@@ -112,6 +112,10 @@ private[akka] class Shard(
   var messageBuffers = Map.empty[EntityId, Vector[(Msg, ActorRef)]]
 
   var handOffStopper: Option[ActorRef] = None
+
+  initialized()
+
+  def initialized(): Unit = context.parent ! ShardInitialized(shardId)
 
   def totalBufferSize = messageBuffers.foldLeft(0) { (sum, entity) ⇒ sum + entity._2.size }
 
@@ -297,6 +301,9 @@ private[akka] class PersistentShard(
 
   var persistCount = 0
 
+  // would be initialized after recovery completed
+  override def initialized(): Unit = {}
+
   override def receive = receiveCommand
 
   override def processChange[A](event: A)(handler: A ⇒ Unit): Unit = {
@@ -316,7 +323,10 @@ private[akka] class PersistentShard(
     case EntityStarted(id)                 ⇒ state = state.copy(state.entities + id)
     case EntityStopped(id)                 ⇒ state = state.copy(state.entities - id)
     case SnapshotOffer(_, snapshot: State) ⇒ state = snapshot
-    case RecoveryCompleted                 ⇒ state.entities foreach getEntity
+    case RecoveryCompleted ⇒
+      state.entities foreach getEntity
+      super.initialized()
+      log.debug("Shard recovery completed {}", shardId)
   }
 
   override def entityTerminated(ref: ActorRef): Unit = {

--- a/akka-docs/rst/java/cluster-sharding.rst
+++ b/akka-docs/rst/java/cluster-sharding.rst
@@ -176,6 +176,18 @@ unused shards due to the round-trip to the coordinator. Rebalancing of shards ma
 also add latency. This should be considered when designing the application specific
 shard resolution, e.g. to avoid too fine grained shards.
 
+Distributed Data Mode
+---------------------
+
+Instead of using ``akka-persistence`` is possible to use ``akka-distributed-data`` module. In such case
+state of the ``ShardCoordinator`` will be replicated inside a cluster by the ``akka-distributed-data``
+module with the ``WriteMajority`` consistency. This mode could be enabled by setting up
+``akka.cluster.sharding.state-store-mode`` as ``ddata``.
+It make possible to remove ``akka-persistence`` dependency from a project if this dependency
+has not using in user code and ``remember-entities`` is ``off``.
+Note that option also could lead to the shards duplication in case of a cluster fragmentation
+due to a broken replication between nodes.
+
 Proxy Only Mode
 ---------------
 

--- a/akka-docs/rst/scala/cluster-sharding.rst
+++ b/akka-docs/rst/scala/cluster-sharding.rst
@@ -179,6 +179,18 @@ unused shards due to the round-trip to the coordinator. Rebalancing of shards ma
 also add latency. This should be considered when designing the application specific
 shard resolution, e.g. to avoid too fine grained shards.
 
+Distributed Data Mode
+---------------------
+
+Instead of using ``akka-persistence`` is possible to use ``akka-distributed-data`` module. In such case
+state of the ``ShardCoordinator`` will be replicated inside a cluster by the ``akka-distributed-data``
+module with the ``WriteMajority`` consistency. This mode could be enabled by setting up
+``akka.cluster.sharding.state-store-mode`` as ``ddata``.
+It make possible to remove ``akka-persistence`` dependency from a project if this dependency
+has not using in user code and ``remember-entities`` is ``off``.
+Note that option also could lead to the shards duplication in case of a cluster fragmentation
+due to a broken replication between nodes.
+
 Proxy Only Mode
 ---------------
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -52,7 +52,7 @@ object AkkaBuild extends Build {
         archivesPathFinder.get.map(file => (file -> ("akka/" + file.getName)))
       }
     ),
-    aggregate = Seq(actor, testkit, actorTests, remote, remoteTests, camel, 
+    aggregate = Seq(actor, testkit, actorTests, remote, remoteTests, camel,
       cluster, clusterMetrics, clusterTools, clusterSharding, distributedData,
       slf4j, agent, persistence, persistenceQuery, persistenceTck, kernel, osgi, docs, contrib, samples, multiNodeTestkit, benchJmh, typed)
   )
@@ -62,7 +62,7 @@ object AkkaBuild extends Build {
     base = file("akka-scala-nightly"),
     // remove dependencies that we have to build ourselves (Scala STM)
     // samples don't work with dbuild right now
-    aggregate = Seq(actor, testkit, actorTests, remote, remoteTests, camel, 
+    aggregate = Seq(actor, testkit, actorTests, remote, remoteTests, camel,
       cluster, clusterMetrics, clusterTools, clusterSharding, distributedData,
       slf4j, persistence, persistenceQuery, persistenceTck, kernel, osgi, contrib, multiNodeTestkit, benchJmh, typed)
   ).disablePlugins(ValidatePullRequest)
@@ -136,9 +136,9 @@ object AkkaBuild extends Build {
     id = "akka-cluster-sharding",
     base = file("akka-cluster-sharding"),
     dependencies = Seq(cluster % "compile->compile;test->test;multi-jvm->multi-jvm",
-        persistence % "compile;test->provided", clusterTools)
+        persistence % "compile;test->provided", distributedData % "compile;test->provided", clusterTools)
   ) configs (MultiJvm)
-  
+
   lazy val distributedData = Project(
     id = "akka-distributed-data-experimental",
     base = file("akka-distributed-data"),
@@ -244,7 +244,7 @@ object AkkaBuild extends Build {
   lazy val sampleRemoteScala = Sample.project("akka-sample-remote-scala")
 
   lazy val sampleSupervisionJavaLambda = Sample.project("akka-sample-supervision-java-lambda")
-  
+
   lazy val sampleDistributedDataScala = Sample.project("akka-sample-distributed-data-scala")
   lazy val sampleDistributedDataJava = Sample.project("akka-sample-distributed-data-java")
 


### PR DESCRIPTION
Currently this is not real PR. Only to show my attempt to change the claster-sharding dependency from the akka-persistence to the akka-ddata. I would incrementally update it when found time for this .

Idea:
1) Distributed state of the ShardRegions are all we need in the cluster-sharding.
2) Distributed state can be handled by akka-ddata module.
3) Inconsistency is possible if only we allowing two ShardRegions allocate equals Shards simultaneously.
4) It is possible avoid inconsistency if we have singleton Coordinator who can allow to the ShardRegion allocate the Shard. R1 ask C to allow him allocate the S1. C1 allow. R1 allocate S1 and then change DData + inner state. The Coordinator will be receiving these changes and then update inner state.
5) If the Coordinator fails, then it can be recovered from DData which be actual for all nodes inside a cluster. 

Welcome for comments!

It is very possible if I missing something in this concept. Correct me please.

And I am sorry for my English.
