### PR TITLE
=rem #17729 Don't use Implicits.global in remoting shutdown

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -136,7 +136,6 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
     eventPublisher.notifyListeners(RemotingErrorEvent(new RemoteTransportException(msg, cause)))
 
   override def shutdown(): Future[Unit] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     endpointManager match {
       case Some(manager) ⇒
         implicit val timeout = ShutdownTimeout
@@ -146,6 +145,7 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
           endpointManager = None
         }
 
+        import system.dispatcher
         (manager ? ShutdownAndFlush).mapTo[Boolean].andThen {
           case Success(flushSuccessful) ⇒
             if (!flushSuccessful)


### PR DESCRIPTION
I have verified (with printlns) that the callback is running with the system.dispatcher in all cases when running the tests in akka-remote.
