### PR TITLE
=doc remove duplicated word typos

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -147,7 +147,7 @@ final case class ActorKilledException private[akka] (message: String) extends Ak
 final case class InvalidActorNameException(message: String) extends AkkaException(message)
 
 /**
- * An ActorInitializationException is thrown when the the initialization logic for an Actor fails.
+ * An ActorInitializationException is thrown when the initialization logic for an Actor fails.
  *
  * There is an extractor which works for ActorInitializationException and its subtypes:
  *

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -317,7 +317,7 @@ final case class ConsistentHashingPool(
    * Uses the resizer and/or the supervisor strategy of the given RouterConfig
    * if this RouterConfig doesn't have one, i.e. the resizer defined in code is used if
    * resizer was not defined in config.
-   * Uses the the `hashMapping` defined in code, since that can't be defined in configuration.
+   * Uses the `hashMapping` defined in code, since that can't be defined in configuration.
    */
   override def withFallback(other: RouterConfig): RouterConfig = other match {
     case _: FromConfig | _: NoRouter        ⇒ this.overrideUnsetConfig(other)
@@ -385,7 +385,7 @@ final case class ConsistentHashingGroup(
     copy(hashMapping = ConsistentHashingRouter.hashMappingAdapter(mapper))
 
   /**
-   * Uses the the `hashMapping` defined in code, since that can't be defined in configuration.
+   * Uses the `hashMapping` defined in code, since that can't be defined in configuration.
    */
   override def withFallback(other: RouterConfig): RouterConfig = other match {
     case _: FromConfig | _: NoRouter         ⇒ super.withFallback(other)

--- a/akka-actor/src/main/scala/akka/util/Reflect.scala
+++ b/akka-actor/src/main/scala/akka/util/Reflect.scala
@@ -58,7 +58,7 @@ private[akka] object Reflect {
 
   /**
    * INTERNAL API
-   * Invokes the constructor with the the given arguments.
+   * Invokes the constructor with the given arguments.
    */
   private[akka] def instantiate[T](constructor: Constructor[T], args: immutable.Seq[Any]): T = {
     constructor.setAccessible(true)

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
@@ -395,7 +395,7 @@ object MetricsSelector {
 @SerialVersionUID(1L)
 trait MetricsSelector extends Serializable {
   /**
-   * The weights per address, based on the the nodeMetrics.
+   * The weights per address, based on the nodeMetrics.
    */
   def weights(nodeMetrics: Set[NodeMetrics]): Map[Address, Int]
 }

--- a/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
@@ -395,7 +395,7 @@ object MetricsSelector {
 @deprecated("Superseded by akka.cluster.metrics (in akka-cluster-metrics jar)", "2.4")
 trait MetricsSelector extends Serializable {
   /**
-   * The weights per address, based on the the nodeMetrics.
+   * The weights per address, based on the nodeMetrics.
    */
   def weights(nodeMetrics: Set[NodeMetrics]): Map[Address, Int]
 }

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
@@ -74,7 +74,7 @@ object LWWRegister {
  * It is described in the paper
  * <a href="http://hal.upmc.fr/file/index/docid/555588/filename/techreport.pdf">A comprehensive study of Convergent and Commutative Replicated Data Types</a>.
  *
- * Merge takes the the register with highest timestamp. Note that this
+ * Merge takes the register with highest timestamp. Note that this
  * relies on synchronized clocks. `LWWRegister` should only be used when the choice of
  * value is not important for concurrent updates occurring within the clock skew.
  *

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -588,7 +588,7 @@ object Replicator {
  * == Update ==
  *
  * To modify and replicate a [[ReplicatedData]] value you send a [[Replicator.Update]] message
- * to the the local `Replicator`.
+ * to the local `Replicator`.
  * The current data value for the `key` of the `Update` is passed as parameter to the `modify`
  * function of the `Update`. The function is supposed to return the new value of the data, which
  * will then be replicated according to the given consistency level.

--- a/akka-docs/rst/java/distributed-data.rst
+++ b/akka-docs/rst/java/distributed-data.rst
@@ -51,7 +51,7 @@ changes of this.
 Update
 ------
 
-To modify and replicate a data value you send a ``Replicator.Update`` message to the the local
+To modify and replicate a data value you send a ``Replicator.Update`` message to the local
 ``Replicator``.
 
 The current data value for the ``key`` of the ``Update`` is passed as parameter to the ``modify``
@@ -350,7 +350,7 @@ to ``true``. Thereafter it cannot be changed. ``true`` wins over ``false`` in me
 
 ``LWWRegister`` (last writer wins register) can hold any (serializable) value.
 
-Merge of a ``LWWRegister`` takes the the register with highest timestamp. Note that this
+Merge of a ``LWWRegister`` takes the register with highest timestamp. Note that this
 relies on synchronized clocks. `LWWRegister` should only be used when the choice of
 value is not important for concurrent updates occurring within the clock skew.
 

--- a/akka-docs/rst/scala/distributed-data.rst
+++ b/akka-docs/rst/scala/distributed-data.rst
@@ -51,7 +51,7 @@ changes of this.
 Update
 ------
 
-To modify and replicate a data value you send a ``Replicator.Update`` message to the the local
+To modify and replicate a data value you send a ``Replicator.Update`` message to the local
 ``Replicator``.
 
 The current data value for the ``key`` of the ``Update`` is passed as parameter to the ``modify``
@@ -346,7 +346,7 @@ to ``true``. Thereafter it cannot be changed. ``true`` wins over ``false`` in me
 
 ``LWWRegister`` (last writer wins register) can hold any (serializable) value.
 
-Merge of a ``LWWRegister`` takes the the register with highest timestamp. Note that this
+Merge of a ``LWWRegister`` takes the register with highest timestamp. Note that this
 relies on synchronized clocks. `LWWRegister` should only be used when the choice of
 value is not important for concurrent updates occurring within the clock skew.
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -172,7 +172,7 @@ private[akka] class RemoteSystemDaemon(
       val (concatenatedChildNames, m) = {
         val iter = sel.elements.iterator
         // find child elements, and the message to send, which is a remaining ActorSelectionMessage
-        // in case of SelectChildPattern, otherwise the the actual message of the selection
+        // in case of SelectChildPattern, otherwise the actual message of the selection
         @tailrec def rec(acc: List[String]): (List[String], Any) =
           if (iter.isEmpty)
             (acc.reverse, sel.msg)

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -114,7 +114,7 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
 }
 
 /**
- * [[akka.event.LoggingFilter]] that uses the log level defined in in the SLF4J
+ * [[akka.event.LoggingFilter]] that uses the log level defined in the SLF4J
  * backend configuration (e.g. logback.xml) to filter log events before publishing
  * the log events to the `eventStream`.
  */


### PR DESCRIPTION
Inspired by @2beaucoup's comment https://github.com/akka/akka/pull/17889#discussion_r33718378 grepped for those silly mistakes and fixed them.

`the the` => `the`
`in in` => `in`
