### PR TITLE
=clt #17735 Harden ClusterClientSpec

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -308,9 +308,13 @@ final class ClusterClient(settings: ClusterClientSettings) extends Actor with Ac
   }
 
   def sendGetContacts(): Unit = {
-    if (contacts.isEmpty) initialContactsSel foreach { _ ! GetContacts }
-    else if (contacts.size == 1) (initialContactsSel ++ contacts) foreach { _ ! GetContacts }
-    else contacts foreach { _ ! GetContacts }
+    val sendTo =
+      if (contacts.isEmpty) initialContactsSel
+      else if (contacts.size == 1) (initialContactsSel ++ contacts)
+      else contacts
+    if (log.isDebugEnabled)
+      log.debug(s"""Sending GetContacts to [${sendTo.mkString(",")}]""")
+    sendTo.foreach { _ ! GetContacts }
   }
 
   def buffer(msg: Any): Unit =

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
@@ -35,6 +35,8 @@ object ClusterClientSpec extends MultiNodeConfig {
     akka.cluster.auto-down-unreachable-after = 0s
     akka.cluster.client.heartbeat-interval = 1s
     akka.cluster.client.acceptable-heartbeat-pause = 3s
+    # number-of-contacts must be >= 4 because we shutdown all but one in the end
+    akka.cluster.client.number-of-contacts = 4
     """))
 
   testTransport(on = true)


### PR DESCRIPTION
- number-of-contacts is by default 3, and in this test
  with 4 server nodes we shutdown all but one in the end
  and sometimes the client has all other except the remaining
  node in its list of contacts, so it will never get contact
  with the remaining node
