### PR TITLE
=act: TCP actor should unwatch handler/commander after Close

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
@@ -23,7 +23,7 @@ private[io] class TcpIncomingConnection(_tcp: TcpExt,
                                         readThrottling: Boolean)
   extends TcpConnection(_tcp, _channel, readThrottling) {
 
-  context.watch(bindHandler) // sign death pact
+  signDeathPact(bindHandler)
 
   registry.register(channel, initialOps = 0)
 

--- a/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -28,7 +28,7 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
 
   import connect._
 
-  context.watch(commander) // sign death pact
+  signDeathPact(commander)
 
   options.foreach(_.beforeConnect(channel.socket))
   localAddress.foreach(channel.socket.bind)


### PR DESCRIPTION
/cc @sirthias @jrudolph 

This supposedly fixes the issue when Terminated for watched handler actor comes immediately after Close, while the TCP actor still has a pending write.
