### PR TITLE
=doc #15569 document TestActorRef being bad for persistence

### DIFF
--- a/akka-docs/rst/java/testing.rst
+++ b/akka-docs/rst/java/testing.rst
@@ -65,6 +65,16 @@ obtaining a reference to the underlying actor instance, or by invoking or
 querying the actor's behaviour (:meth:`receive`). Each one warrants its own
 section below.
 
+.. note::
+  It is highly recommended to stick to traditional behavioural testing (using messaging
+  to ask the Actor to reply with the state you want to run assertions against),
+  instead of using ``TestActorRef`` whenever possible.
+
+  Due to the synchronous nature of ``TestActorRef`` it will **not** work with some support
+  traits that Akka provides as they require asynchronous behaviours to function properly.
+  Examples of traits that do not mix well with test actor refs are :ref:`PersistentActor <event-sourcing-java>`
+  and :ref:`AtLeastOnceDelivery <at-least-once-delivery-java>` provided by :ref:`Akka Persistence <persistence-java>`.
+
 Obtaining a Reference to an :class:`Actor`
 ------------------------------------------
 

--- a/akka-docs/rst/scala/testing.rst
+++ b/akka-docs/rst/scala/testing.rst
@@ -54,6 +54,16 @@ obtaining a reference to the underlying actor instance, or by invoking or
 querying the actor's behaviour (:meth:`receive`). Each one warrants its own
 section below.
 
+.. note::
+  It is highly recommended to stick to traditional behavioural testing (using messaging
+  to ask the Actor to reply with the state you want to run assertions against),
+  instead of using ``TestActorRef`` whenever possible.
+
+  Due to the synchronous nature of ``TestActorRef`` it will **not** work with some support
+  traits that Akka provides as they require asynchronous behaviours to function properly.
+  Examples of traits that do not mix well with test actor refs are :ref:`PersistentActor <event-sourcing>`
+  and :ref:`AtLeastOnceDelivery <at-least-once-delivery>` provided by :ref:`Akka Persistence <persistence-scala>`.
+
 Obtaining a Reference to an :class:`Actor`
 ------------------------------------------
 


### PR DESCRIPTION
Initial resolution of https://github.com/akka/akka/issues/15569 such that people don't try to combine `TestActorRef` with Persistence, it just won't work - persistence needs async things to happen for it to work.

In the long run, this could be reworded once we have a test-kit for persistence and point to it instead.
