### PR TITLE
+doc #17669 better section header and TOC navigation

### DIFF
--- a/akka-docs/_sphinx/themes/akka/layout.html
+++ b/akka-docs/_sphinx/themes/akka/layout.html
@@ -351,7 +351,17 @@
 </style>
 {%- endif %}
 <script type="text/javascript">
-  $('#toc').toc();
+  var $toc = $('#toc');
+  $toc.toc();
+
+  // change hash when TOC link clicked:
+  $toc.find("a").click(function() { window.location.hash = $(this).attr('href'); });
+
+  // show clickable section sign when section header hovered:
+  $('.section h2,.section h3,.section h4,.section h5').each(function(i, el) {
+      var $el = $(el);
+      $el.prepend($("<a class='section-marker' href='#" + $el.attr("id") + "'>&sect;</a>"))
+  });
 </script>
   {% block footer %}{% endblock %}
   {%- endblock %}

--- a/akka-docs/_sphinx/themes/akka/static/docs.css
+++ b/akka-docs/_sphinx/themes/akka/static/docs.css
@@ -174,3 +174,7 @@ strong {color: #0B5567; }
 .footer h5 { text-transform: none; }
 
 .footnote .label { background-color: transparent }
+
+.section-marker { position: absolute; width: 1em; margin-left: -1em; display: block; text-decoration: none; visibility: hidden; text-align: center; font-weight: normal; }
+.section-marker:hover { text-decoration: none; }
+.section h2:hover > a,.section h3:hover > a,.section h4:hover > a,.section h5:hover > a { visibility: visible; }


### PR DESCRIPTION
Resolves #17669 and improves ToC navigation such that clicking the links actually updates the `#hash` in the window location.
