### PR TITLE
=per #17820 avoid depending on ordering of redelivery (when slow)

### DIFF
--- a/akka-persistence/src/test/scala/akka/persistence/AtLeastOnceDeliverySpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/AtLeastOnceDeliverySpec.scala
@@ -253,8 +253,9 @@ abstract class AtLeastOnceDeliverySpec(config: Config) extends PersistenceSpec(c
       // and then re-delivered
       probeA.expectMsg(Action(2, "a-2")) // re-delivered
       // a-4 was re-delivered but lost
-      probeA.expectMsg(Action(5, "a-5")) // re-delivered
-      probeA.expectMsg(Action(4, "a-4")) // re-delivered, 3rd time
+      probeA.expectMsgAllOf(
+        Action(5, "a-5"), // re-delivered
+        Action(4, "a-4")) // re-delivered, 3rd time
 
       probeA.expectNoMsg(1.second)
     }


### PR DESCRIPTION
The failure in #17820 was caused by the same kind of problem as here: https://github.com/akka/akka/pull/17478

If the re-delivery happens "too quick" because of some slowness in the system then `a-4` would arrive before `a-5`. Technically it's OK, amount of message exchanges is valid either way, it's just ordering that in that case is "nicer than expected".

Instead of increasing re-delivery ticks above a second just living with "yes this can happen".
