### PR TITLE
-str #17923 remove javadsl's elements method, due to compiler bug

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -147,12 +147,6 @@ object Source {
     new Source(scaladsl.Source.single(element))
 
   /**
-   * Create a `Source` with the given elements.
-   */
-  def elements[T](elems: T*): Source[T, Unit] =
-    new Source(scaladsl.Source(() ⇒ elems.iterator))
-
-  /**
    * Create a `Source` that will continually emit the given element.
    */
   def repeat[T](element: T): Source[T, Unit] =


### PR DESCRIPTION
Dropping the method because of non-working `@varargs` in this case for javadsl (there was no scaladsl version of this).

More details in the ticket https://github.com/akka/akka/issues/17923
Resolves https://github.com/akka/akka/issues/17923
