### PR TITLE
=pro update to Akka 2.3.12

### DIFF
--- a/akka-samples/akka-docs-java-lambda/pom.xml
+++ b/akka-samples/akka-docs-java-lambda/pom.xml
@@ -6,7 +6,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <publishedAkkaVersion>2.3.11</publishedAkkaVersion>
+    <publishedAkkaVersion>2.3.12</publishedAkkaVersion>
   </properties>
 
   <groupId>sample</groupId>

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1457,7 +1457,7 @@ object Dependencies {
     val reactiveStreamsVersion = System.getProperty("akka.build.reactiveStreamsVersion", "1.0.0")
 
     // also change pom.xml and build.sbt in akka-samples/akka-docs-java-lambda
-    val publishedAkkaVersion = "2.3.11"
+    val publishedAkkaVersion = "2.3.12"
   }
 
   object Compile {


### PR DESCRIPTION
Only updating to 2.3.12 now. Using tuples from 2.3.12 will come after 1.0 with a rebase of #17562
