### PR TITLE
=pro #17956 include javadsl.testkit in http-testkit artifact by disabling osgi config

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1388,7 +1388,7 @@ object AkkaBuild extends Build {
 
     val http = Nil // FIXME #15689
 
-    val httpTestKit = exports(Seq("akka.http.scaladsl.testkit.*"))
+    val httpTestKit = Nil
 
     val stream = exports(Seq("akka.stream.*"))
 


### PR DESCRIPTION
This fixes it for now. As http and http-core don't have any OSGI configuration, not providing any for http-testkit shouldn't break things any further.
