### PR TITLE
=act,per additional test for onTransition behaviour when initialize() called

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -3,15 +3,26 @@
  */
 package akka.actor
 
-import language.postfixOps
-
 import akka.testkit._
+
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 object FSMTransitionSpec {
 
   class Supervisor extends Actor {
     def receive = { case _ ⇒ }
+  }
+
+  class SendAnyTransitionFSM(target: ActorRef) extends Actor with FSM[Int, Int] {
+    startWith(0, 0)
+    when(0) {
+      case Event("stay", _) ⇒ stay()
+      case Event(_, _)      ⇒ goto(0)
+    }
+    onTransition { case from -> to ⇒ target ! (from -> to) }
+
+    initialize()
   }
 
   class MyFSM(target: ActorRef) extends Actor with FSM[Int, Unit] {
@@ -57,8 +68,17 @@ class FSMTransitionSpec extends AkkaSpec with ImplicitSender {
 
   "A FSM transition notifier" must {
 
+    "not trigger onTransition for stay" in {
+      val fsm = system.actorOf(Props(new SendAnyTransitionFSM(testActor)))
+      expectMsg(0 -> 0) // caused by initialize(), OK.
+      fsm ! "stay" // no transition event
+      expectNoMsg(500.millis)
+      fsm ! "goto" // goto(current state)
+      expectMsg(0 -> 0)
+    }
+
     "notify listeners" in {
-      import FSM.{ SubscribeTransitionCallBack, CurrentState, Transition }
+      import FSM.{ CurrentState, SubscribeTransitionCallBack, Transition }
 
       val fsm = system.actorOf(Props(new MyFSM(testActor)))
       within(1 second) {
@@ -113,7 +133,6 @@ class FSMTransitionSpec extends AkkaSpec with ImplicitSender {
     }
 
     "not trigger transition event on stay()" in {
-      import FSM.Transition
       val forward = system.actorOf(Props(new Forwarder(testActor)))
       val fsm = system.actorOf(Props(new OtherFSM(testActor)))
 

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -511,6 +511,8 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
    * last call within the constructor, or [[akka.actor.Actor#preStart]] and
    * [[akka.actor.Actor#postRestart]]
    *
+   * An initial `currentState -> currentState` notification will be triggered by calling this method.
+   *
    * @see [[#startWith]]
    */
   final def initialize(): Unit = makeTransition(currentState)

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/FSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/FSM.scala
@@ -503,7 +503,9 @@ trait FSM[S, D, E] extends Actor with Listeners with ActorLogging {
   /**
    * Verify existence of initial state and setup timers. This should be the
    * last call within the constructor, or [[akka.actor.Actor#preStart]] and
-   * [[akka.actor.Actor#postRestart]]
+   * [[akka.actor.Actor#postRestart]].
+   *
+   * An initial `currentState -> currentState` notification will be triggered by calling this method.
    *
    * @see [[#startWith]]
    */

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
@@ -678,7 +678,7 @@ abstract class PersistentActorSpec(config: Config) extends PersistenceSpec(confi
       persistentActor ! GetState
       expectMsg(List("a-1", "a-2", "b-10", "b-11", "b-12", "c-10", "c-11", "c-12"))
     }
-    "recover on command failure xoxo" in {
+    "recover on command failure" in {
       val persistentActor = namedPersistentActor[Behavior3PersistentActor]
       persistentActor ! Cmd("b")
       persistentActor ! "boom"


### PR DESCRIPTION
This additional test and scaladoc was added as part as "I can't remember how it works and it's not documented explicitly" when looking at issue: https://github.com/akka/akka/issues/17959#issuecomment-120131261

Behaviour remains unchanged, it's valid; but added additional scaladoc.
