### PR TITLE
Reenable and fix tests in ContentNegotiationSpec

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -303,7 +303,7 @@ class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll
       "with one chunk and an explicit LastChunk" in new TestSetup() {
         HttpResponse(entity = Chunked(ContentTypes.`text/plain(UTF-8)`,
           source(Chunk(ByteString("body123"), """key=value;another="tl;dr""""),
-            LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public")))).via(printEvent("source")))) should renderTo {
+            LastChunk("foo=bar", List(Age(30), RawHeader("Cache-Control", "public")))))) should renderTo {
           """HTTP/1.1 200 OK
             |Server: akka-http/1.0.0
             |Date: Thu, 25 Aug 2011 09:10:29 GMT

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/BitBuilder.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/BitBuilder.scala
@@ -13,10 +13,9 @@ import parboiled2._
 object BitBuilder {
   implicit class BitBuilderContext(val ctx: StringContext) {
     def b(args: Any*): ByteString = {
-      val parser = new BitSpecParser(ctx.parts.mkString)
+      val input = ctx.parts.mkString.replace("\r\n", "\n")
+      val parser = new BitSpecParser(input)
       val bits = parser.parseBits()
-      //println(bits)
-      //println(bits.get.toByteString.map(_ formatted "%02x").mkString(" "))
       bits.get.toByteString
     }
   }
@@ -76,6 +75,7 @@ class BitSpecParser(val input: ParserInput) extends parboiled2.Parser {
     bits.run() match {
       case s: Success[Bits]       ⇒ s
       case Failure(e: ParseError) ⇒ Failure(new RuntimeException(formatError(e, showTraces = true)))
+      case _                      ⇒ throw new IllegalStateException()
     }
 
   def bits: Rule1[Bits] = rule { zeroOrMore(element) ~ EOI ~> (Bits(_)) }

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -147,7 +147,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       "Authorization: QVFJQzV3TTJMWTRTZmN3Zk=" =!=
         ErrorInfo("Illegal HTTP header 'Authorization': Invalid input '=', expected tchar, '\\r', WSP, token68-start or 'EOI' (line 1, column 23)",
           """QVFJQzV3TTJMWTRTZmN3Zk=
-            |                      ^""".stripMargin)
+            |                      ^""".stripMarginWithNewline("\n"))
     }
 
     "Cache-Control" in {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.http.scaladsl.model.headers
 
+import akka.http.impl.util._
 import org.scalatest.{ FreeSpec, MustMatchers }
 
 import akka.http.scaladsl.model._
@@ -25,7 +26,7 @@ class HeaderSpec extends FreeSpec with MustMatchers {
         summary mustEqual "Illegal HTTP header 'Last-Modified': Invalid input 'a', expected 'S', 'M', 'T', 'W', 'F' or '0' (line 1, column 1)"
         detail mustEqual
           """abc
-            |^""".stripMargin
+            |^""".stripMarginWithNewline("\n")
 
       }
     }
@@ -41,7 +42,7 @@ class HeaderSpec extends FreeSpec with MustMatchers {
         summary mustEqual "Illegal HTTP header 'Content-Type': Invalid input '/', expected tchar (line 1, column 13)"
         detail mustEqual
           """application//gnutar
-            |            ^""".stripMargin
+            |            ^""".stripMarginWithNewline("\n")
       }
     }
   }
@@ -56,7 +57,7 @@ class HeaderSpec extends FreeSpec with MustMatchers {
         summary mustEqual "Illegal HTTP header 'Content-Type': Invalid input ',', expected tchar, '\\r', WSP, ';' or 'EOI' (line 1, column 11)"
         detail mustEqual
           """text/plain, charset=UTF8
-            |          ^""".stripMargin
+            |          ^""".stripMarginWithNewline("\n")
       }
     }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -5,13 +5,13 @@
 package akka.http.scaladsl.marshalling
 
 import akka.http.scaladsl.model.MediaType.Encoding
-import akka.http.scaladsl.unmarshalling.FromResponseUnmarshaller
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.scalatest.{ Matchers, FreeSpec }
 import akka.http.scaladsl.util.FastFuture._
 import akka.http.scaladsl.model._
+import akka.http.impl.util._
 import MediaTypes._
 import HttpCharsets._
 
@@ -19,7 +19,7 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
   "Content Negotiation should work properly for requests with header(s)" - {
 
     "(without headers)" test { accept ⇒
-      //accept(`text/plain`) should select(`text/plain`, `UTF-8`)
+      accept(`text/plain`) should select(`text/plain`, `UTF-8`)
       accept(`text/plain` withCharset `UTF-16`) should select(`text/plain`, `UTF-16`)
     }
 
@@ -107,7 +107,7 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
     }
 
     """Accept: text/html, text/plain;q=0.8, application/*;q=.5, *;q= .2
-       Accept-Charset: UTF-16""" test { accept ⇒
+      |Accept-Charset: UTF-16""" test { accept ⇒
       accept(`text/plain`, `text/html`, `audio/ogg`) should select(`text/html`, `UTF-16`)
       accept(`text/plain`, `text/html` withCharset `UTF-8`, `audio/ogg`) should select(`text/plain`, `UTF-16`)
       accept(`audio/ogg`, `application/javascript`, `text/plain` withCharset `UTF-8`) should select(`application/javascript`, `UTF-16`)
@@ -149,7 +149,7 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
     def test(body: ((ContentType*) ⇒ Option[ContentType]) ⇒ Unit): Unit = example in {
       val headers =
         if (example != "(without headers)") {
-          example.split('\n').toList map { rawHeader ⇒
+          example.stripMarginWithNewline("\n").split('\n').toList map { rawHeader ⇒
             val Array(name, value) = rawHeader.split(':')
             HttpHeader.parse(name.trim, value) match {
               case HttpHeader.ParsingResult.Ok(header, Nil) ⇒ header


### PR DESCRIPTION
also make it more agnostic to newline encodings

/cc @jrudolph 
