### PR TITLE
=str fix ambigous import of akka(-stream).testkit.AkkaSpec

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
@@ -16,7 +16,7 @@ import akka.stream.{ AbruptTerminationException, Attributes, ActorMaterializerSe
 import akka.stream.impl._
 import akka.stream.testkit._
 import akka.stream.testkit.Utils._
-import akka.testkit._
+import akka.testkit.{ TestDuration, EventFilter }
 import akka.testkit.TestEvent.{ UnMute, Mute }
 import com.typesafe.config.ConfigFactory
 import org.reactivestreams.{ Subscription, Processor, Subscriber, Publisher }


### PR DESCRIPTION
In: akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala

AkkaSpec is imported twice:
- from akka-testkit
- from akka-stream-testkit

The fix replaces the akka-testkit wildcard import with an import of only necessary objects 
