### PR TITLE
=str #18034 remove println call from OutputStreamSubscriber

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
@@ -37,7 +37,6 @@ private[akka] class OutputStreamSubscriber(os: OutputStream, bytesWrittenPromise
         bytesWritten += bytes.length
       } catch {
         case ex: Exception ⇒
-          println("ex = " + ex)
           bytesWrittenPromise.failure(ex)
           cancel()
       }


### PR DESCRIPTION
just removed it as exception is sending to user with promise.failure
