### PR TITLE
=doc #18012 rate transformation doc improvements

### DIFF
--- a/akka-docs-dev/rst/java/stream-rate.rst
+++ b/akka-docs-dev/rst/java/stream-rate.rst
@@ -166,4 +166,4 @@ Expand also allows to keep some state between demand requests from the downstrea
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/RateTransformationDocTest.java#expand-drift
 
-Note that all of the elements coming from upstream will go through expand at least once. This means that the output of this flow is going to report a drift of zero if producer if fast enough, of a larger drift otherwise.
+Note that all of the elements coming from upstream will go through expand at least once. This means that the output of this flow is going to report a drift of zero if producer is fast enough, or a larger drift otherwise.

--- a/akka-docs-dev/rst/scala/code/docs/stream/RateTransformationDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/RateTransformationDocSpec.scala
@@ -51,12 +51,12 @@ class RateTransformationDocSpec extends AkkaSpec {
       .mapConcat(identity)
     //#conflate-sample
 
-    val fut = Source(1 to 10000)
+    val fut = Source(1 to 1000)
       .map(_.toDouble)
       .via(sampleFlow)
       .runWith(Sink.fold(Seq.empty[Double])(_ :+ _))
 
-    val count = Await.result(fut, 100.millis).size
+    val count = Await.result(fut, 1000.millis).size
   }
 
   "expand should repeat last" in {
@@ -69,7 +69,7 @@ class RateTransformationDocSpec extends AkkaSpec {
       .via(lastFlow)
       .grouped(10)
       .toMat(Sink.head)(Keep.both)
-      .run
+      .run()
 
     probe.sendNext(1.0)
     val expanded = Await.result(fut, 100.millis)
@@ -88,7 +88,7 @@ class RateTransformationDocSpec extends AkkaSpec {
     val (pub, sub) = TestSource.probe[Double]
       .via(driftFlow)
       .toMat(TestSink.probe[(Double, Int)])(Keep.both)
-      .run
+      .run()
 
     sub.request(1)
     pub.sendNext(1.0)

--- a/akka-docs-dev/rst/scala/stream-rate.rst
+++ b/akka-docs-dev/rst/scala/stream-rate.rst
@@ -166,4 +166,4 @@ Expand also allows to keep some state between demand requests from the downstrea
 
 .. includecode:: code/docs/stream/RateTransformationDocSpec.scala#expand-drift
 
-Note that all of the elements coming from upstream will go through expand at least once. This means that the output of this flow is going to report a drift of zero if producer if fast enough, of a larger drift otherwise.
+Note that all of the elements coming from upstream will go through expand at least once. This means that the output of this flow is going to report a drift of zero if producer is fast enough, or a larger drift otherwise.


### PR DESCRIPTION
Addresses feedback from #18024. Thanks @ktoso!
- use () when calling scala methods with side effects
- concat immutable lists instead of modifying mutable ones
- use Collections.singletonList instead of sublassing ArrayList
- and typo fixes
