### PR TITLE
Additional apply() methods for TestActorRef and TestFSMRef

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
@@ -136,6 +136,11 @@ object TestActorRef {
   def apply[T <: Actor](props: Props, name: String)(implicit system: ActorSystem): TestActorRef[T] =
     apply[T](props, system.asInstanceOf[ActorSystemImpl].guardian, name)
 
+  def apply[T <: Actor](props: Props, supervisor: ActorRef)(implicit system: ActorSystem): TestActorRef[T] = {
+    val sysImpl = system.asInstanceOf[ActorSystemImpl]
+    new TestActorRef(sysImpl, props, supervisor.asInstanceOf[InternalActorRef], randomName)
+  }
+
   def apply[T <: Actor](props: Props, supervisor: ActorRef, name: String)(implicit system: ActorSystem): TestActorRef[T] = {
     val sysImpl = system.asInstanceOf[ActorSystemImpl]
     new TestActorRef(sysImpl, props, supervisor.asInstanceOf[InternalActorRef], name)
@@ -143,15 +148,40 @@ object TestActorRef {
 
   def apply[T <: Actor](implicit t: ClassTag[T], system: ActorSystem): TestActorRef[T] = apply[T](randomName)
 
+  private def dynamicCreateRecover[U]: PartialFunction[Throwable, U] = {
+    case exception ⇒ throw ActorInitializationException(null,
+      "Could not instantiate Actor" +
+        "\nMake sure Actor is NOT defined inside a class/trait," +
+        "\nif so put it outside the class/trait, f.e. in a companion object," +
+        "\nOR try to change: 'actorOf(Props[MyActor]' to 'actorOf(Props(new MyActor)'.", exception)
+  }
+
   def apply[T <: Actor](name: String)(implicit t: ClassTag[T], system: ActorSystem): TestActorRef[T] = apply[T](Props({
-    system.asInstanceOf[ExtendedActorSystem].dynamicAccess.createInstanceFor[T](t.runtimeClass, Nil).recover({
-      case exception ⇒ throw ActorInitializationException(null,
-        "Could not instantiate Actor" +
-          "\nMake sure Actor is NOT defined inside a class/trait," +
-          "\nif so put it outside the class/trait, f.e. in a companion object," +
-          "\nOR try to change: 'actorOf(Props[MyActor]' to 'actorOf(Props(new MyActor)'.", exception)
-    }).get
+    system.asInstanceOf[ExtendedActorSystem].dynamicAccess
+      .createInstanceFor[T](t.runtimeClass, Nil).recover(dynamicCreateRecover).get
   }), name)
+
+  def apply[T <: Actor](supervisor: ActorRef)(implicit t: ClassTag[T], system: ActorSystem): TestActorRef[T] = apply[T](Props({
+    system.asInstanceOf[ExtendedActorSystem].dynamicAccess
+      .createInstanceFor[T](t.runtimeClass, Nil).recover(dynamicCreateRecover).get
+  }), supervisor)
+
+  def apply[T <: Actor](supervisor: ActorRef, name: String)(implicit t: ClassTag[T], system: ActorSystem): TestActorRef[T] = apply[T](Props({
+    system.asInstanceOf[ExtendedActorSystem]
+      .dynamicAccess.createInstanceFor[T](t.runtimeClass, Nil).recover(dynamicCreateRecover).get
+  }), supervisor, name)
+
+  /**
+   * Java API: create a TestActorRef in the given system for the given props,
+   * with the given supervisor and name.
+   */
+  def create[T <: Actor](system: ActorSystem, props: Props, supervisor: ActorRef, name: String): TestActorRef[T] = apply(props, supervisor, name)(system)
+
+  /**
+   * Java API: create a TestActorRef in the given system for the given props,
+   * with the given supervisor and a random name.
+   */
+  def create[T <: Actor](system: ActorSystem, props: Props, supervisor: ActorRef): TestActorRef[T] = apply(props, supervisor)(system)
 
   /**
    * Java API: create a TestActorRef in the given system for the given props,

--- a/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
@@ -91,12 +91,22 @@ class TestFSMRef[S, D, T <: Actor](
 object TestFSMRef {
 
   def apply[S, D, T <: Actor: ClassTag](factory: ⇒ T)(implicit ev: T <:< FSM[S, D], system: ActorSystem): TestFSMRef[S, D, T] = {
-    val impl = system.asInstanceOf[ActorSystemImpl] //TODO ticket #1559
+    val impl = system.asInstanceOf[ActorSystemImpl]
     new TestFSMRef(impl, Props(factory), impl.guardian.asInstanceOf[InternalActorRef], TestActorRef.randomName)
   }
 
   def apply[S, D, T <: Actor: ClassTag](factory: ⇒ T, name: String)(implicit ev: T <:< FSM[S, D], system: ActorSystem): TestFSMRef[S, D, T] = {
-    val impl = system.asInstanceOf[ActorSystemImpl] //TODO ticket #1559
+    val impl = system.asInstanceOf[ActorSystemImpl]
     new TestFSMRef(impl, Props(factory), impl.guardian.asInstanceOf[InternalActorRef], name)
+  }
+
+  def apply[S, D, T <: Actor: ClassTag](factory: ⇒ T, supervisor: ActorRef, name: String)(implicit ev: T <:< FSM[S, D], system: ActorSystem): TestFSMRef[S, D, T] = {
+    val impl = system.asInstanceOf[ActorSystemImpl]
+    new TestFSMRef(impl, Props(factory), supervisor.asInstanceOf[InternalActorRef], name)
+  }
+
+  def apply[S, D, T <: Actor: ClassTag](factory: ⇒ T, supervisor: ActorRef)(implicit ev: T <:< FSM[S, D], system: ActorSystem): TestFSMRef[S, D, T] = {
+    val impl = system.asInstanceOf[ActorSystemImpl]
+    new TestFSMRef(impl, Props(factory), supervisor.asInstanceOf[InternalActorRef], TestActorRef.randomName)
   }
 }

--- a/akka-testkit/src/test/java/akka/testkit/TestActorRefJavaCompile.java
+++ b/akka-testkit/src/test/java/akka/testkit/TestActorRefJavaCompile.java
@@ -10,8 +10,14 @@ import akka.actor.Props;
 public class TestActorRefJavaCompile {
 
   public void shouldBeAbleToCompileWhenUsingApply() {
-  	//Just a dummy call to make sure it compiles
-    TestActorRef<Actor> ref = TestActorRef.apply(Props.empty(), null);
+  	//Just dummy calls to make sure it compiles
+    TestActorRef<Actor> ref = TestActorRef.create(null, Props.empty());
     ref.toString();
+    TestActorRef<Actor> namedRef = TestActorRef.create(null, Props.empty(), "namedActor");
+    namedRef.toString();
+    TestActorRef<Actor> supervisedRef = TestActorRef.create(null, Props.empty(), ref);
+    supervisedRef.toString();
+    TestActorRef<Actor> namedSupervisedRef = TestActorRef.create(null, Props.empty(), ref, "namedActor");
+    namedSupervisedRef.toString();
   }
 }


### PR DESCRIPTION
Fixes for

https://github.com/akka/akka/issues/13980
https://github.com/akka/akka/issues/17276
https://github.com/akka/akka/issues/18077

There were no existing Unit tests for the `apply()` methods in place,
wasn't comfortable committing with no tests so have added simple
tests for the `apply()` methods both new and existing, but if
these are overkill, happy to remove them.
