### PR TITLE
+per #18076 makes AtomicWrite more user friendly

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -38,6 +38,20 @@ object AtomicWrite {
 }
 
 final case class AtomicWrite(payload: immutable.Seq[PersistentRepr]) extends PersistentEnvelope with Message {
+
+  // only check that all persistenceIds are equal when there's more than one in the Seq
+  if (payload match {
+    case l: List[PersistentRepr]   => l.tail.nonEmpty
+    case v: Vector[PersistentRepr] => v.size > 1
+    case _                         => true // some other collection type, let's just check
+  }) require(payload.forall(_.persistenceId == payload.head.persistenceId),
+      "AtomicWrite must contain messages for the same persistenceId, " +
+        s"yet different persistenceIds found: ${payload.map(_.persistenceId).toSet}")
+
+  def persistenceId = payload.head.persistenceId
+  def lowestSequenceNr = payload.head.sequenceNr // this assumes they're gapless; they should be (it is only our code creating AWs)
+  def highestSequenceNr = payload.last.sequenceNr // TODO: could be optimised, since above require traverses already
+
   override def sender: ActorRef = ActorRef.noSender
   override def size: Int = payload.size
 }

--- a/akka-persistence/src/test/scala/akka/persistence/AtomicWriteSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/AtomicWriteSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.persistence
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class AtomicWriteSpec extends WordSpec with Matchers {
+
+  "AtomicWrite" must {
+    "only contain messages for the same persistence id" in {
+      AtomicWrite(
+        PersistentRepr("", 1, "p1") ::
+          PersistentRepr("", 2, "p1") :: Nil).persistenceId should ===("p1")
+
+      intercept[IllegalArgumentException] {
+        AtomicWrite(
+          PersistentRepr("", 1, "p1") ::
+            PersistentRepr("", 2, "p1") ::
+            PersistentRepr("", 3, "p2") :: Nil)
+      }
+    }
+
+    "have highestSequenceNr" in {
+      AtomicWrite(
+        PersistentRepr("", 1, "p1") ::
+          PersistentRepr("", 2, "p1") ::
+          PersistentRepr("", 3, "p1") :: Nil).highestSequenceNr should ===(3)
+    }
+
+    "have lowestSequenceNr" in {
+      AtomicWrite(
+        PersistentRepr("", 2, "p1") ::
+          PersistentRepr("", 3, "p1") ::
+          PersistentRepr("", 4, "p1") :: Nil).lowestSequenceNr should ===(2)
+    }
+  }
+
+}


### PR DESCRIPTION
For our intents and purposes, an `AtomicWrite` will always contain messages to one `persistenceId`.
In theory journals could support atomic write to multiple at once, but let's not go there :wink: 

This is a small usability improvement as asked for by @chbatey in https://github.com/akka/akka/issues/18076

One thing I'm not sure about is the `require()` in the constructor... On one hand, I don't expect millions of events there, on the other hand it needs to iterate all of them...
