### PR TITLE
=rem bind the remote test to random open port

### DIFF
--- a/akka-remote-tests/src/test/resources/reference.conf
+++ b/akka-remote-tests/src/test/resources/reference.conf
@@ -3,4 +3,5 @@ akka {
     serialize-creators = on
     serialize-messages = on
   }
+  remote.netty.tcp.port = 0
 }

--- a/akka-remote/src/test/resources/reference.conf
+++ b/akka-remote/src/test/resources/reference.conf
@@ -3,4 +3,5 @@ akka {
     serialize-creators = on
     serialize-messages = on
   }
+  remote.netty.tcp.port = 0
 }


### PR DESCRIPTION
This solves a problem running the remote tests under ScalaTest runner for Ant and opens a possibility to run multiple tests in parallel because they will not conflict on binding to the same TCP port.
