### PR TITLE
=ben http microbech

### DIFF
--- a/akka-bench-jmh-dev/src/main/scala/akka/http/HttpBenchmark.scala
+++ b/akka-bench-jmh-dev/src/main/scala/akka/http/HttpBenchmark.scala
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.unmarshalling._
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Try
+import com.typesafe.config.ConfigFactory
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Array(Mode.SampleTime))
+class HttpBenchmark {
+
+  val config = ConfigFactory.parseString(
+    """
+      akka {
+        loglevel = "ERROR"
+      }""".stripMargin).withFallback(ConfigFactory.load())
+
+  implicit val system = ActorSystem("HttpBenchmark", config)
+  implicit val materializer = ActorMaterializer()
+
+  var binding: ServerBinding = _
+  var request: HttpRequest = _
+  var pool: Flow[(HttpRequest, Int), (Try[HttpResponse], Int), _] = _
+
+  @Setup
+  def setup() = {
+    val route = {
+      path("test") {
+        get {
+          complete("ok")
+        }
+      }
+    }
+
+    binding = Await.result(Http().bindAndHandle(route, "127.0.0.1", 0), 1.second)
+    request = HttpRequest(uri = s"http://${binding.localAddress.getHostString}:${binding.localAddress.getPort}/test")
+    pool = Http().cachedHostConnectionPool[Int](binding.localAddress.getHostString, binding.localAddress.getPort)
+  }
+
+  @TearDown
+  def shutdown() = {
+    Await.ready(Http().shutdownAllConnectionPools(), 1.second)
+    binding.unbind()
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @Benchmark
+  def single_request() = {
+    import system.dispatcher
+    val response = Await.result(Http().singleRequest(request), 1.second)
+    Await.result(Unmarshal(response.entity).to[String], 1.second)
+  }
+
+  @Benchmark
+  def single_request_pool() = {
+    import system.dispatcher
+    val (response, id) = Await.result(Source.single(HttpRequest(uri = "/test") -> 42).via(pool).runWith(Sink.head), 1.second)
+    Await.result(Unmarshal(response.get.entity).to[String], 1.second)
+  }
+}

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -85,7 +85,8 @@ object AkkaBuild extends Build {
       test in Test in httpTestkit,
       test in Test in httpTests, test in Test in httpTestsJava8,
       test in Test in docsDev,
-      compile in Compile in benchJmh
+      compile in Compile in benchJmh,
+      compile in Compile in benchJmhDev
       ).dependOn
     ),
     aggregate = Seq(streamAndHttp) // FIXME DURING MERGE INTO release-2.3
@@ -203,6 +204,15 @@ object AkkaBuild extends Build {
     dependencies = Seq(actor, persistence, testkit, stream, http, httpCore).map(_ % "compile;compile->test"),
     settings = defaultSettings ++ Seq(
       libraryDependencies ++= Dependencies.testkit ++ Dependencies.Compile.metricsAll,
+      publishArtifact in Compile := false
+    ) ++ settings ++ jmhSettings
+  )
+
+  lazy val benchJmhDev = Project(
+    id = "akka-bench-jmh-dev",
+    base = file("akka-bench-jmh-dev"),
+    dependencies = Seq(stream, http, httpCore),
+    settings = defaultSettings ++ Seq(
       publishArtifact in Compile := false
     ) ++ settings ++ jmhSettings
   )


### PR DESCRIPTION
Interesting that using pool is consistently a bit slower.

```
[info] Benchmark                            Mode    Cnt    Score    Error  Units
[info] HttpBenchmark.single_request       sample  61408  653.282 ± 31.117  us/op
[info] HttpBenchmark.single_request_pool  sample  56476  710.526 ± 33.105  us/op
```
