### PR TITLE
akka-remote - TcpNoDelay should have been set on child channels in NettyTransport

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -365,7 +365,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
   private def setupBootstrap[B <: Bootstrap](bootstrap: B, pipelineFactory: ChannelPipelineFactory): B = {
     bootstrap.setPipelineFactory(pipelineFactory)
     bootstrap.setOption("backlog", settings.Backlog)
-    bootstrap.setOption("tcpNoDelay", settings.TcpNodelay)
+    bootstrap.setOption("child.tcpNoDelay", settings.TcpNodelay)
     bootstrap.setOption("child.keepAlive", settings.TcpKeepalive)
     bootstrap.setOption("reuseAddress", settings.TcpReuseAddr)
     if (isDatagram) bootstrap.setOption("receiveBufferSizePredictorFactory", new FixedReceiveBufferSizePredictorFactory(ReceiveBufferSize.get))


### PR DESCRIPTION
I had problems with latency in test application which sending messages between cluster members using DistributedPubSub pattern. 
Always the same node is sending messages to many other members and occurence of the problem depends on start order of cluster members. While sending node is running and any of receiving node connects to the cluster average delay in received messages is about 2-3ms in this node. After restart the receiving node average delay is 0ms.
After a while of debbuging I found that tcpNoDelay is not set during opening child channels in ServerBootstrap from Netty. Restart receiving node helps because of different cluster initialization sequence I guess.

In my case problem exists on Ubuntu 12.04 and 14.04, on Windows and OSX everything is ok.
Let me know if you want source code for testing.
