### PR TITLE
Ensure OutboundTcpStreamActor's promises are completed if the connection fails

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
@@ -335,4 +335,10 @@ private[akka] class OutboundTcpStreamActor(processorPromise: Promise[Processor[B
       processorPromise.failure(ex)
       fail(ex)
   }
+
+  override def fail(e: Throwable): Unit = {
+    processorPromise.tryFailure(e)
+    localAddressPromise.tryFailure(e)
+    super.fail(e)
+  }
 }


### PR DESCRIPTION
Fixes #18151 
