### PR TITLE
=per #18162 harden PersistentFSMActorSpec, less timing sensitive

### DIFF
--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -600,16 +600,16 @@ configuration key. The method can be overridden by implementation classes to ret
 
 Persistent FSM
 ==============
-``AbstractPersistentFSMActor`` handles the incoming messages in an FSM like fashion.
+``AbstractPersistentFSM`` handles the incoming messages in an FSM like fashion.
 Its internal state is persisted as a sequence of changes, later referred to as domain events.
 Relationship between incoming messages, FSM's states and transitions, persistence of domain events is defined by a DSL.
 
 A Simple Example
 ----------------
-To demonstrate the features of the ``AbstractPersistentFSMActor``, consider an actor which represents a Web store customer.
+To demonstrate the features of the ``AbstractPersistentFSM``, consider an actor which represents a Web store customer.
 The contract of our "WebStoreCustomerFSMActor" is that it accepts the following commands:
 
-.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFsmActorTest.java#customer-commands
+.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java#customer-commands
 
 ``AddItem`` sent when the customer adds an item to a shopping cart
 ``Buy`` - when the customer finishes the purchase
@@ -618,7 +618,7 @@ The contract of our "WebStoreCustomerFSMActor" is that it accepts the following 
 
 The customer can be in one of the following states:
 
-.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFsmActorTest.java#customer-states
+.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java#customer-states
 
 ``LookingAround`` customer is browsing the site, but hasn't added anything to the shopping cart
 ``Shopping`` customer has recently added items to the shopping cart
@@ -627,29 +627,29 @@ The customer can be in one of the following states:
 
 .. note::
 
-  ``AbstractPersistentFSMActor`` states must inherit from ``PersistentFsmActor.FSMState`` and implement the
+  ``AbstractPersistentFSM`` states must inherit from ``PersistentFSM.FSMState`` and implement the
   ``String identifier()`` method. This is required in order to simplify the serialization of FSM states.
   String identifiers should be unique!
 
 Customer's actions are "recorded" as a sequence of "domain events", which are persisted. Those events are replayed on actor's
 start in order to restore the latest customer's state:
 
-.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFsmActorTest.java#customer-domain-events
+.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java#customer-domain-events
 
 Customer state data represents the items in customer's shopping cart:
 
-.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFsmActorTest.java#customer-states-data
+.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java#customer-states-data
 
 Here is how everything is wired together:
 
-.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFsmActorTest.java#customer-fsm-body
+.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java#customer-fsm-body
 
 .. note::
 
   State data can only be modified directly on initialization. Later it's modified only as a result of applying domain events.
   Override the ``applyEvent`` method to define how state data is affected by domain events, see the example below
 
-.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFsmActorTest.java#customer-apply-event
+.. includecode:: ../../../akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java#customer-apply-event
 
 Storage plugins
 ===============

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -655,16 +655,16 @@ adaptation simply return ``EventSeq.empty``. The adapted events are then deliver
 
 Persistent FSM
 ==============
-``PersistentFSMActor`` handles the incoming messages in an FSM like fashion.
+``PersistentFSM`` handles the incoming messages in an FSM like fashion.
 Its internal state is persisted as a sequence of changes, later referred to as domain events.
 Relationship between incoming messages, FSM's states and transitions, persistence of domain events is defined by a DSL.
 
 A Simple Example
 ----------------
-To demonstrate the features of the ``PersistentFSMActor`` trait, consider an actor which represents a Web store customer.
+To demonstrate the features of the ``PersistentFSM`` trait, consider an actor which represents a Web store customer.
 The contract of our "WebStoreCustomerFSMActor" is that it accepts the following commands:
 
-.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala#customer-commands
+.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala#customer-commands
 
 ``AddItem`` sent when the customer adds an item to a shopping cart
 ``Buy`` - when the customer finishes the purchase
@@ -673,7 +673,7 @@ The contract of our "WebStoreCustomerFSMActor" is that it accepts the following 
 
 The customer can be in one of the following states:
 
-.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala#customer-states
+.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala#customer-states
 
 ``LookingAround`` customer is browsing the site, but hasn't added anything to the shopping cart
 ``Shopping`` customer has recently added items to the shopping cart
@@ -682,29 +682,29 @@ The customer can be in one of the following states:
 
 .. note::
 
-  ``PersistentFSMActor`` states must inherit from trait ``PersistentFsmActor.FSMState`` and implement the
+  ``PersistentFSM`` states must inherit from trait ``PersistentFSM.FSMState`` and implement the
   ``def identifier: String`` method. This is required in order to simplify the serialization of FSM states.
   String identifiers should be unique!
 
 Customer's actions are "recorded" as a sequence of "domain events", which are persisted. Those events are replayed on actor's
 start in order to restore the latest customer's state:
 
-.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala#customer-domain-events
+.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala#customer-domain-events
 
 Customer state data represents the items in customer's shopping cart:
 
-.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala#customer-states-data
+.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala#customer-states-data
 
 Here is how everything is wired together:
 
-.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala#customer-fsm-body
+.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala#customer-fsm-body
 
 .. note::
 
   State data can only be modified directly on initialization. Later it's modified only as a result of applying domain events.
   Override the ``applyEvent`` method to define how state data is affected by domain events, see the example below
 
-.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala#customer-apply-event
+.. includecode:: ../../../akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala#customer-apply-event
 
 .. _storage-plugins:
 

--- a/akka-persistence/src/main/java/akka/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
+++ b/akka-persistence/src/main/java/akka/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
@@ -4,7 +4,8 @@
 
 package akka.persistence.fsm.japi.pf;
 
-import akka.persistence.fsm.FSM;
+import akka.persistence.fsm.PersistentFSM;
+import akka.persistence.fsm.PersistentFSMBase;
 import akka.japi.pf.FI;
 import akka.japi.pf.PFBuilder;
 import scala.PartialFunction;
@@ -23,8 +24,8 @@ import java.util.List;
 @SuppressWarnings("rawtypes")
 public class FSMStateFunctionBuilder<S, D, E> {
 
-  private PFBuilder<FSM.Event<D>, FSM.State<S, D, E>> builder =
-    new PFBuilder<FSM.Event<D>, FSM.State<S, D, E>>();
+  private PFBuilder<PersistentFSM.Event<D>, PersistentFSM.State<S, D, E>> builder =
+    new PFBuilder<PersistentFSM.Event<D>, PersistentFSM.State<S, D, E>>();
 
   /**
    * An erased processing of the event matcher. The compile time checks are enforced
@@ -47,10 +48,10 @@ public class FSMStateFunctionBuilder<S, D, E> {
                                                     final Object dataOrType,
                                                     final FI.TypedPredicate2 predicate,
                                                     final FI.Apply2 apply) {
-    builder.match(FSM.Event.class,
-      new FI.TypedPredicate<FSM.Event>() {
+    builder.match(PersistentFSM.Event.class,
+      new FI.TypedPredicate<PersistentFSM.Event>() {
         @Override
-        public boolean defined(FSM.Event e) {
+        public boolean defined(PersistentFSM.Event e) {
           boolean res = true;
           if (eventOrType != null) {
             if (eventOrType instanceof Class) {
@@ -78,10 +79,10 @@ public class FSMStateFunctionBuilder<S, D, E> {
           return res;
         }
       },
-      new FI.Apply<FSM.Event, FSM.State<S, D, E>>() {
-        public FSM.State<S, D, E> apply(FSM.Event e) throws Exception {
+      new FI.Apply<PersistentFSM.Event, PersistentFSM.State<S, D, E>>() {
+        public PersistentFSM.State<S, D, E> apply(PersistentFSM.Event e) throws Exception {
           @SuppressWarnings("unchecked")
-          FSM.State<S, D, E> res = (FSM.State<S, D, E>) apply.apply(e.event(), e.stateData());
+          PersistentFSM.State<S, D, E> res = (PersistentFSM.State<S, D, E>) apply.apply(e.event(), e.stateData());
           return res;
         }
       }
@@ -104,7 +105,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
   public final <P, Q> FSMStateFunctionBuilder<S, D, E> event(final Class<P> eventType,
                                                           final Class<Q> dataType,
                                                           final FI.TypedPredicate2<P, Q> predicate,
-                                                          final FI.Apply2<P, Q, FSM.State<S, D, E>> apply) {
+                                                          final FI.Apply2<P, Q, PersistentFSM.State<S, D, E>> apply) {
     erasedEvent(eventType, dataType, predicate, apply);
     return this;
   }
@@ -121,7 +122,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    */
   public <P, Q> FSMStateFunctionBuilder<S, D, E> event(final Class<P> eventType,
                                                     final Class<Q> dataType,
-                                                    final FI.Apply2<P, Q, FSM.State<S, D, E>> apply) {
+                                                    final FI.Apply2<P, Q, PersistentFSM.State<S, D, E>> apply) {
     return erasedEvent(eventType, dataType, null, apply);
   }
 
@@ -135,7 +136,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    */
   public <P> FSMStateFunctionBuilder<S, D, E> event(final Class<P> eventType,
                                                  final FI.TypedPredicate2<P, D> predicate,
-                                                 final FI.Apply2<P, D, FSM.State<S, D, E>> apply) {
+                                                 final FI.Apply2<P, D, PersistentFSM.State<S, D, E>> apply) {
     return erasedEvent(eventType, null, predicate, apply);
   }
 
@@ -147,7 +148,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    * @return the builder with the case statement added
    */
   public <P> FSMStateFunctionBuilder<S, D, E> event(final Class<P> eventType,
-                                                 final FI.Apply2<P, D, FSM.State<S, D, E>> apply) {
+                                                 final FI.Apply2<P, D, PersistentFSM.State<S, D, E>> apply) {
     return erasedEvent(eventType, null, null, apply);
   }
 
@@ -159,7 +160,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    * @return the builder with the case statement added
    */
   public FSMStateFunctionBuilder<S, D, E> event(final FI.TypedPredicate2<Object, D> predicate,
-                                             final FI.Apply2<Object, D, FSM.State<S, D, E>> apply) {
+                                             final FI.Apply2<Object, D, PersistentFSM.State<S, D, E>> apply) {
     return erasedEvent(null, null, predicate, apply);
   }
 
@@ -175,11 +176,11 @@ public class FSMStateFunctionBuilder<S, D, E> {
    */
   public <Q> FSMStateFunctionBuilder<S, D, E> event(final List<Object> eventMatches,
                                                  final Class<Q> dataType,
-                                                 final FI.Apply2<Object, Q, FSM.State<S, D, E>> apply) {
-    builder.match(FSM.Event.class,
-      new FI.TypedPredicate<FSM.Event>() {
+                                                 final FI.Apply2<Object, Q, PersistentFSM.State<S, D, E>> apply) {
+    builder.match(PersistentFSM.Event.class,
+      new FI.TypedPredicate<PersistentFSM.Event>() {
         @Override
-        public boolean defined(FSM.Event e) {
+        public boolean defined(PersistentFSM.Event e) {
           if (dataType != null && !dataType.isInstance(e.stateData()))
             return false;
 
@@ -198,8 +199,8 @@ public class FSMStateFunctionBuilder<S, D, E> {
           return emMatch;
         }
       },
-      new FI.Apply<FSM.Event, FSM.State<S, D, E>>() {
-        public FSM.State<S, D, E> apply(FSM.Event e) throws Exception {
+      new FI.Apply<PersistentFSM.Event, PersistentFSM.State<S, D, E>>() {
+        public PersistentFSM.State<S, D, E> apply(PersistentFSM.Event e) throws Exception {
           @SuppressWarnings("unchecked")
           Q q = (Q) e.stateData();
           return apply.apply(e.event(), q);
@@ -219,7 +220,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    * @return the builder with the case statement added
    */
   public FSMStateFunctionBuilder<S, D, E> event(final List<Object> eventMatches,
-                                             final FI.Apply2<Object, D, FSM.State<S, D, E>> apply) {
+                                             final FI.Apply2<Object, D, PersistentFSM.State<S, D, E>> apply) {
     return event(eventMatches, null, apply);
   }
 
@@ -234,7 +235,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    */
   public <P, Q> FSMStateFunctionBuilder<S, D, E> eventEquals(final P event,
                                                           final Class<Q> dataType,
-                                                          final FI.Apply2<P, Q, FSM.State<S, D, E>> apply) {
+                                                          final FI.Apply2<P, Q, PersistentFSM.State<S, D, E>> apply) {
     return erasedEvent(event, dataType, null, apply);
   }
 
@@ -246,7 +247,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    * @return the builder with the case statement added
    */
   public <P> FSMStateFunctionBuilder<S, D, E> eventEquals(final P event,
-                                                       final FI.Apply2<P, D, FSM.State<S, D, E>> apply) {
+                                                       final FI.Apply2<P, D, PersistentFSM.State<S, D, E>> apply) {
     return erasedEvent(event, null, null, apply);
   }
 
@@ -256,7 +257,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    * @param apply  an action to apply to the event and state data
    * @return the builder with the case statement added
    */
-  public FSMStateFunctionBuilder<S, D, E> anyEvent(final FI.Apply2<Object, D, FSM.State<S, D, E>> apply) {
+  public FSMStateFunctionBuilder<S, D, E> anyEvent(final FI.Apply2<Object, D, PersistentFSM.State<S, D, E>> apply) {
     return erasedEvent(null, null, null, apply);
   }
 
@@ -266,7 +267,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
    *
    * @return  a PartialFunction for this builder.
    */
-  public PartialFunction<FSM.Event<D>, FSM.State<S, D, E>> build() {
+  public PartialFunction<PersistentFSM.Event<D>, PersistentFSM.State<S, D, E>> build() {
     return builder.build();
   }
 }

--- a/akka-persistence/src/main/java/akka/persistence/fsm/japi/pf/FSMStopBuilder.java
+++ b/akka-persistence/src/main/java/akka/persistence/fsm/japi/pf/FSMStopBuilder.java
@@ -4,7 +4,8 @@
 
 package akka.persistence.fsm.japi.pf;
 
-import akka.persistence.fsm.FSM;
+import akka.persistence.fsm.PersistentFSM;
+import akka.persistence.fsm.PersistentFSMBase;
 import akka.japi.pf.FI;
 import akka.japi.pf.UnitPFBuilder;
 import scala.PartialFunction;
@@ -20,8 +21,8 @@ import scala.runtime.BoxedUnit;
  */
 public class FSMStopBuilder<S, D> {
 
-  private UnitPFBuilder<FSM.StopEvent<S, D>> builder =
-    new UnitPFBuilder<FSM.StopEvent<S, D>>();
+  private UnitPFBuilder<PersistentFSM.StopEvent<S, D>> builder =
+    new UnitPFBuilder<>();
 
   /**
    * Add a case statement that matches on an {@link akka.actor.FSM.Reason}.
@@ -30,17 +31,17 @@ public class FSMStopBuilder<S, D> {
    * @param apply  an action to apply to the event and state data if there is a match
    * @return the builder with the case statement added
    */
-  public FSMStopBuilder<S, D> stop(final FSM.Reason reason,
+  public FSMStopBuilder<S, D> stop(final PersistentFSM.Reason reason,
                                    final FI.UnitApply2<S, D> apply) {
-    builder.match(FSM.StopEvent.class,
-      new FI.TypedPredicate<FSM.StopEvent>() {
+    builder.match(PersistentFSM.StopEvent.class,
+      new FI.TypedPredicate<PersistentFSM.StopEvent>() {
         @Override
-        public boolean defined(FSM.StopEvent e) {
+        public boolean defined(PersistentFSM.StopEvent e) {
           return reason.equals(e.reason());
         }
       },
-      new FI.UnitApply<FSM.StopEvent>() {
-        public void apply(FSM.StopEvent e) throws Exception {
+      new FI.UnitApply<PersistentFSM.StopEvent>() {
+        public void apply(PersistentFSM.StopEvent e) throws Exception {
           @SuppressWarnings("unchecked")
           S s = (S) e.currentState();
           @SuppressWarnings("unchecked")
@@ -61,7 +62,7 @@ public class FSMStopBuilder<S, D> {
    * @param <P>  the reason type to match on
    * @return the builder with the case statement added
    */
-  public <P extends FSM.Reason> FSMStopBuilder<S, D> stop(final Class<P> reasonType,
+  public <P extends PersistentFSM.Reason> FSMStopBuilder<S, D> stop(final Class<P> reasonType,
                                                           final FI.UnitApply3<P, S, D> apply) {
     return this.stop(reasonType,
       new FI.TypedPredicate<P>() {
@@ -81,13 +82,13 @@ public class FSMStopBuilder<S, D> {
    * @param <P>  the reason type to match on
    * @return the builder with the case statement added
    */
-  public <P extends FSM.Reason> FSMStopBuilder<S, D> stop(final Class<P> reasonType,
+  public <P extends PersistentFSM.Reason> FSMStopBuilder<S, D> stop(final Class<P> reasonType,
                                                           final FI.TypedPredicate<P> predicate,
                                                           final FI.UnitApply3<P, S, D> apply) {
-    builder.match(FSM.StopEvent.class,
-      new FI.TypedPredicate<FSM.StopEvent>() {
+    builder.match(PersistentFSM.StopEvent.class,
+      new FI.TypedPredicate<PersistentFSM.StopEvent>() {
         @Override
-        public boolean defined(FSM.StopEvent e) {
+        public boolean defined(PersistentFSM.StopEvent e) {
           if (reasonType.isInstance(e.reason())) {
             @SuppressWarnings("unchecked")
             P p = (P) e.reason();
@@ -97,8 +98,8 @@ public class FSMStopBuilder<S, D> {
           }
         }
       },
-      new FI.UnitApply<FSM.StopEvent>() {
-        public void apply(FSM.StopEvent e) throws Exception {
+      new FI.UnitApply<PersistentFSM.StopEvent>() {
+        public void apply(PersistentFSM.StopEvent e) throws Exception {
           @SuppressWarnings("unchecked")
           P p = (P) e.reason();
           @SuppressWarnings("unchecked")
@@ -119,7 +120,7 @@ public class FSMStopBuilder<S, D> {
    *
    * @return  a PartialFunction for this builder.
    */
-  public PartialFunction<FSM.StopEvent<S, D>, BoxedUnit> build() {
+  public PartialFunction<PersistentFSM.StopEvent<S, D>, BoxedUnit> build() {
     return builder.build();
   }
 }

--- a/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
@@ -7,7 +7,7 @@ package akka.persistence.serialization
 import akka.actor.{ ActorPath, ExtendedActorSystem }
 import akka.persistence.AtLeastOnceDelivery._
 import akka.persistence._
-import akka.persistence.fsm.PersistentFsmActor.StateChangeEvent
+import akka.persistence.fsm.PersistentFSM.StateChangeEvent
 import akka.persistence.serialization.{ MessageFormats ⇒ mf }
 import akka.serialization._
 import com.google.protobuf._
@@ -23,7 +23,7 @@ import scala.language.existentials
 trait Message extends Serializable
 
 /**
- * Protobuf serializer for [[akka.persistence.PersistentRepr]], [[akka.persistence.AtLeastOnceDelivery]] and [[akka.persistence.fsm.PersistentFsmActor.StateChangeEvent]] messages.
+ * Protobuf serializer for [[akka.persistence.PersistentRepr]], [[akka.persistence.AtLeastOnceDelivery]] and [[akka.persistence.fsm.PersistentFSM.StateChangeEvent]] messages.
  */
 class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer {
   import PersistentRepr.Undefined

--- a/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala
@@ -195,7 +195,7 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       expectMsg(CurrentState(fsmRef, LookingAround))
       expectMsg(Transition(fsmRef, LookingAround, Shopping))
 
-      expectNoMsg(0.6 seconds) //randomly chosen delay, less than the timeout, before stopping the FSM
+      expectNoMsg(0.6 seconds) // arbitrarily chosen delay, less than the timeout, before stopping the FSM
       fsmRef ! PoisonPill
       expectTerminated(fsmRef)
 
@@ -203,13 +203,13 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       watch(recoveredFsmRef)
       recoveredFsmRef ! SubscribeTransitionCallBack(testActor)
 
-      expectMsg(CurrentState(recoveredFsmRef, Shopping))
+      expectMsg(CurrentState(recoveredFsmRef, Shopping, Some(1 second)))
 
       within(0.9 seconds, 1.9 seconds) {
         expectMsg(Transition(recoveredFsmRef, Shopping, Inactive))
       }
 
-      expectNoMsg(0.9 seconds) //randomly chosen delay, less than the timeout, before stopping the FSM
+      expectNoMsg(0.6 seconds) // arbitrarily chosen delay, less than the timeout, before stopping the FSM
       recoveredFsmRef ! PoisonPill
       expectTerminated(recoveredFsmRef)
 
@@ -217,11 +217,8 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       watch(recoveredFsmRef)
       recoveredFsmRef ! SubscribeTransitionCallBack(testActor)
 
-      expectMsg(CurrentState(recoveredFsmRef, Inactive))
-
-      within(1.9 seconds, 2.9 seconds) {
-        expectTerminated(recoveredFsmRef)
-      }
+      expectMsg(CurrentState(recoveredFsmRef, Inactive, Some(2 seconds)))
+      expectTerminated(recoveredFsmRef)
     }
 
     "not trigger onTransition for stay()" taggedAs TimingTest in {

--- a/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMActorSpec.scala
@@ -6,8 +6,7 @@ package akka.persistence.fsm
 
 import akka.actor._
 import akka.persistence.PersistenceSpec
-import akka.persistence.fsm.FSM.{ CurrentState, SubscribeTransitionCallBack, Transition }
-import akka.persistence.fsm.PersistentFsmActor.FSMState
+import akka.persistence.fsm.PersistentFSM._
 import akka.testkit._
 import com.typesafe.config.Config
 
@@ -16,16 +15,16 @@ import scala.language.postfixOps
 import scala.reflect.ClassTag
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(config) with ImplicitSender {
-  import PersistentFSMActorSpec._
+abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config) with ImplicitSender {
+  import PersistentFSMSpec._
 
   //Dummy report actor, for tests that don't need it
   val dummyReportActorRef = TestProbe().ref
 
-  "Persistent FSM Actor" must {
+  "PersistentFSM" must {
     "function as a regular FSM " in {
       val persistenceId = name
-      val fsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, dummyReportActorRef))
+      val fsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
 
       watch(fsmRef)
       fsmRef ! SubscribeTransitionCallBack(testActor)
@@ -45,15 +44,15 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       fsmRef ! GetCurrentCart
       fsmRef ! Leave
 
-      expectMsg(CurrentState(fsmRef, LookingAround))
+      expectMsg(CurrentState(fsmRef, LookingAround, None))
       expectMsg(EmptyShoppingCart)
 
-      expectMsg(Transition(fsmRef, LookingAround, Shopping))
+      expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
       expectMsg(NonEmptyShoppingCart(List(shirt)))
       expectMsg(NonEmptyShoppingCart(List(shirt, shoes)))
       expectMsg(NonEmptyShoppingCart(List(shirt, shoes, coat)))
 
-      expectMsg(Transition(fsmRef, Shopping, Paid))
+      expectMsg(Transition(fsmRef, Shopping, Paid, None))
       expectMsg(NonEmptyShoppingCart(List(shirt, shoes, coat)))
 
       expectTerminated(fsmRef)
@@ -61,7 +60,7 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
 
     "function as a regular FSM on state timeout" taggedAs TimingTest in {
       val persistenceId = name
-      val fsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, dummyReportActorRef))
+      val fsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
 
       watch(fsmRef)
       fsmRef ! SubscribeTransitionCallBack(testActor)
@@ -70,22 +69,20 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
 
       fsmRef ! AddItem(shirt)
 
-      expectMsg(CurrentState(fsmRef, LookingAround))
-      expectMsg(Transition(fsmRef, LookingAround, Shopping))
+      expectMsg(CurrentState(fsmRef, LookingAround, None))
+      expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
 
       within(0.9 seconds, 1.9 seconds) {
-        expectMsg(Transition(fsmRef, Shopping, Inactive))
+        expectMsg(Transition(fsmRef, Shopping, Inactive, Some(2 seconds)))
       }
 
-      within(1.9 seconds, 2.9 seconds) {
-        expectTerminated(fsmRef)
-      }
+      expectTerminated(fsmRef)
     }
 
     "recover successfully with correct state data" in {
       val persistenceId = name
 
-      val fsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, dummyReportActorRef))
+      val fsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
       watch(fsmRef)
       fsmRef ! SubscribeTransitionCallBack(testActor)
 
@@ -99,17 +96,17 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       fsmRef ! AddItem(shoes)
       fsmRef ! GetCurrentCart
 
-      expectMsg(CurrentState(fsmRef, LookingAround))
+      expectMsg(CurrentState(fsmRef, LookingAround, None))
       expectMsg(EmptyShoppingCart)
 
-      expectMsg(Transition(fsmRef, LookingAround, Shopping))
+      expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
       expectMsg(NonEmptyShoppingCart(List(shirt)))
       expectMsg(NonEmptyShoppingCart(List(shirt, shoes)))
 
       fsmRef ! PoisonPill
       expectTerminated(fsmRef)
 
-      val recoveredFsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, dummyReportActorRef))
+      val recoveredFsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
       watch(recoveredFsmRef)
       recoveredFsmRef ! SubscribeTransitionCallBack(testActor)
 
@@ -122,12 +119,12 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       recoveredFsmRef ! GetCurrentCart
       recoveredFsmRef ! Leave
 
-      expectMsg(CurrentState(recoveredFsmRef, Shopping))
+      expectMsg(CurrentState(recoveredFsmRef, Shopping, None))
       expectMsg(NonEmptyShoppingCart(List(shirt, shoes)))
 
       expectMsg(NonEmptyShoppingCart(List(shirt, shoes, coat)))
 
-      expectMsg(Transition(recoveredFsmRef, Shopping, Paid))
+      expectMsg(Transition(recoveredFsmRef, Shopping, Paid, None))
       expectMsg(NonEmptyShoppingCart(List(shirt, shoes, coat)))
 
       expectTerminated(recoveredFsmRef)
@@ -137,7 +134,7 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       val persistenceId = name
 
       val reportActorProbe = TestProbe()
-      val fsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, reportActorProbe.ref))
+      val fsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, reportActorProbe.ref))
       watch(fsmRef)
       fsmRef ! SubscribeTransitionCallBack(testActor)
 
@@ -151,9 +148,9 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       fsmRef ! Buy
       fsmRef ! Leave
 
-      expectMsg(CurrentState(fsmRef, LookingAround))
-      expectMsg(Transition(fsmRef, LookingAround, Shopping))
-      expectMsg(Transition(fsmRef, Shopping, Paid))
+      expectMsg(CurrentState(fsmRef, LookingAround, None))
+      expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
+      expectMsg(Transition(fsmRef, Shopping, Paid, None))
       reportActorProbe.expectMsg(PurchaseWasMade(List(shirt, shoes, coat)))
       expectTerminated(fsmRef)
     }
@@ -162,7 +159,7 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       val persistenceId = name
 
       val reportActorProbe = TestProbe()
-      val fsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, reportActorProbe.ref))
+      val fsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, reportActorProbe.ref))
       watch(fsmRef)
       fsmRef ! SubscribeTransitionCallBack(testActor)
 
@@ -175,15 +172,15 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
       fsmRef ! AddItem(coat)
       fsmRef ! Leave
 
-      expectMsg(CurrentState(fsmRef, LookingAround))
-      expectMsg(Transition(fsmRef, LookingAround, Shopping))
+      expectMsg(CurrentState(fsmRef, LookingAround, None))
+      expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
       reportActorProbe.expectMsg(ShoppingCardDiscarded)
       expectTerminated(fsmRef)
     }
 
     "recover successfully with correct state timeout" taggedAs TimingTest in {
       val persistenceId = name
-      val fsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, dummyReportActorRef))
+      val fsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
 
       watch(fsmRef)
       fsmRef ! SubscribeTransitionCallBack(testActor)
@@ -192,28 +189,28 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
 
       fsmRef ! AddItem(shirt)
 
-      expectMsg(CurrentState(fsmRef, LookingAround))
-      expectMsg(Transition(fsmRef, LookingAround, Shopping))
+      expectMsg(CurrentState(fsmRef, LookingAround, None))
+      expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
 
       expectNoMsg(0.6 seconds) // arbitrarily chosen delay, less than the timeout, before stopping the FSM
       fsmRef ! PoisonPill
       expectTerminated(fsmRef)
 
-      var recoveredFsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, dummyReportActorRef))
+      var recoveredFsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
       watch(recoveredFsmRef)
       recoveredFsmRef ! SubscribeTransitionCallBack(testActor)
 
       expectMsg(CurrentState(recoveredFsmRef, Shopping, Some(1 second)))
 
       within(0.9 seconds, 1.9 seconds) {
-        expectMsg(Transition(recoveredFsmRef, Shopping, Inactive))
+        expectMsg(Transition(recoveredFsmRef, Shopping, Inactive, Some(2 seconds)))
       }
 
       expectNoMsg(0.6 seconds) // arbitrarily chosen delay, less than the timeout, before stopping the FSM
       recoveredFsmRef ! PoisonPill
       expectTerminated(recoveredFsmRef)
 
-      recoveredFsmRef = system.actorOf(WebStoreCustomerFSMActor.props(persistenceId, dummyReportActorRef))
+      recoveredFsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
       watch(recoveredFsmRef)
       recoveredFsmRef ! SubscribeTransitionCallBack(testActor)
 
@@ -224,7 +221,7 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
     "not trigger onTransition for stay()" taggedAs TimingTest in {
       val persistenceId = name
       val probe = TestProbe()
-      val fsmRef = system.actorOf(SimpleTransitionFSMActor.props(persistenceId, probe.ref))
+      val fsmRef = system.actorOf(SimpleTransitionFSM.props(persistenceId, probe.ref))
 
       probe.expectMsg(3.seconds, "LookingAround -> LookingAround") // caused by initialize(), OK
 
@@ -238,7 +235,7 @@ abstract class PersistentFSMActorSpec(config: Config) extends PersistenceSpec(co
 
 }
 
-object PersistentFSMActorSpec {
+object PersistentFSMSpec {
   //#customer-states
   sealed trait UserState extends FSMState
   case object LookingAround extends UserState {
@@ -292,7 +289,7 @@ object PersistentFSMActorSpec {
   case class PurchaseWasMade(items: Seq[Item]) extends ReportEvent
   case object ShoppingCardDiscarded extends ReportEvent
 
-  class SimpleTransitionFSMActor(_persistenceId: String, reportActor: ActorRef)(implicit val domainEventClassTag: ClassTag[DomainEvent]) extends PersistentFsmActor[UserState, ShoppingCart, DomainEvent] {
+  class SimpleTransitionFSM(_persistenceId: String, reportActor: ActorRef)(implicit val domainEventClassTag: ClassTag[DomainEvent]) extends PersistentFSM[UserState, ShoppingCart, DomainEvent] {
     override val persistenceId = _persistenceId
 
     startWith(LookingAround, EmptyShoppingCart)
@@ -309,12 +306,14 @@ object PersistentFSMActorSpec {
     override def applyEvent(domainEvent: DomainEvent, currentData: ShoppingCart): ShoppingCart =
       currentData
   }
-  object SimpleTransitionFSMActor {
+  object SimpleTransitionFSM {
     def props(persistenceId: String, reportActor: ActorRef) =
-      Props(new SimpleTransitionFSMActor(persistenceId, reportActor))
+      Props(new SimpleTransitionFSM(persistenceId, reportActor))
   }
 
-  class WebStoreCustomerFSMActor(_persistenceId: String, reportActor: ActorRef)(implicit val domainEventClassTag: ClassTag[DomainEvent]) extends PersistentFsmActor[UserState, ShoppingCart, DomainEvent] {
+  class WebStoreCustomerFSM(_persistenceId: String, reportActor: ActorRef)(implicit val domainEventClassTag: ClassTag[DomainEvent])
+    extends PersistentFSM[UserState, ShoppingCart, DomainEvent] {
+
     override def persistenceId = _persistenceId
 
     //#customer-fsm-body
@@ -378,11 +377,11 @@ object PersistentFSMActorSpec {
     //#customer-apply-event
   }
 
-  object WebStoreCustomerFSMActor {
+  object WebStoreCustomerFSM {
     def props(persistenceId: String, reportActor: ActorRef) =
-      Props(new WebStoreCustomerFSMActor(persistenceId, reportActor))
+      Props(new WebStoreCustomerFSM(persistenceId, reportActor))
   }
 }
 
-class LeveldbPersistentFSMActorSpec extends PersistentFSMActorSpec(PersistenceSpec.config("leveldb", "PersistentFSMActorSpec"))
-class InmemPersistentFSMActorSpec extends PersistentFSMActorSpec(PersistenceSpec.config("inmem", "PersistentFSMActorSpec"))
+class LeveldbPersistentFSMSpec extends PersistentFSMSpec(PersistenceSpec.config("leveldb", "PersistentFSMSpec"))
+class InmemPersistentFSMSpec extends PersistentFSMSpec(PersistenceSpec.config("inmem", "PersistentFSMSpec"))


### PR DESCRIPTION
While the last assertion `within(1.9 seconds, 2.9 seconds)` "makes sense" it's very timing sensitive I'd say... Let's avoid it here;

Resovles https://github.com/akka/akka/issues/18162
