### PR TITLE
+per #17894 Support Future(Nil) in asyncWriteMessages

### DIFF
--- a/akka-bench-jmh/build.sbt
+++ b/akka-bench-jmh/build.sbt
@@ -7,3 +7,5 @@ disablePlugins(Unidoc)
 AkkaBuild.defaultSettings
 
 AkkaBuild.dontPublishSettings
+
+Dependencies.benchJmh

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -119,4 +119,6 @@ object Dependencies {
   val docs = l ++= Seq(Test.scalatest.value, Test.junit, Test.junitIntf, Docs.sprayJson, Docs.gson)
 
   val contrib = l ++= Seq(Test.junitIntf, Test.commonsIo)
+  
+  val benchJmh = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 }


### PR DESCRIPTION
Future.successful(Nil) is an alternative way to signal all good
in the happy case, for reduced allocations.
