### PR TITLE
+act #16629 Possibility to receive messages that not reset receiveTimeout

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -127,6 +127,11 @@ case object ReceiveTimeout extends ReceiveTimeout {
 }
 
 /**
+ * Marker trait to indicate that a message should not reset the receive timeout.
+ */
+trait NotInfluenceReceiveTimeout
+
+/**
  * IllegalActorStateException is thrown when a core invariant in the Actor implementation has been violated.
  * For instance, if you try to create an Actor that doesn't extend Actor.
  */

--- a/akka-docs/rst/java/lambda-actors.rst
+++ b/akka-docs/rst/java/lambda-actors.rst
@@ -658,6 +658,10 @@ periods). Pass in `Duration.Undefined` to switch off this feature.
 
 .. includecode:: code/docs/actorlambda/ActorDocTest.java#receive-timeout
 
+Messages marked with ``NotInfluenceReceiveTimeout`` will not reset the timer. This can be useful when
+``ReceiveTimeout`` should be fired by external inactivity but not influenced by internal activity,
+e.g. scheduled tick messages.
+
 .. _stopping-actors-lambda:
 
 Stopping actors

--- a/akka-docs/rst/java/untyped-actors.rst
+++ b/akka-docs/rst/java/untyped-actors.rst
@@ -603,6 +603,10 @@ periods). Pass in `Duration.Undefined` to switch off this feature.
 
 .. includecode:: code/docs/actor/MyReceiveTimeoutUntypedActor.java#receive-timeout
 
+Messages marked with ``NotInfluenceReceiveTimeout`` will not reset the timer. This can be useful when
+``ReceiveTimeout`` should be fired by external inactivity but not influenced by internal activity,
+e.g. scheduled tick messages.
+
 .. _stopping-actors-java:
 
 Stopping actors

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -653,6 +653,10 @@ periods). Pass in `Duration.Undefined` to switch off this feature.
 
 .. includecode:: code/docs/actor/ActorDocSpec.scala#receive-timeout
 
+Messages marked with ``NotInfluenceReceiveTimeout`` will not reset the timer. This can be useful when
+``ReceiveTimeout`` should be fired by external inactivity but not influenced by internal activity,
+e.g. scheduled tick messages.
+
 .. _stopping-actors-scala:
 
 Stopping actors

--- a/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
 import scala.collection.breakOut
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
-import akka.actor.{ ActorSelection, Actor, ActorPath }
+import akka.actor.{ ActorSelection, Actor, ActorPath, NotInfluenceReceiveTimeout }
 import akka.persistence.serialization.Message
 
 object AtLeastOnceDelivery {
@@ -67,7 +67,7 @@ object AtLeastOnceDelivery {
    */
   private[akka] object Internal {
     case class Delivery(destination: ActorPath, message: Any, timestamp: Long, attempt: Int)
-    case object RedeliveryTick
+    case object RedeliveryTick extends NotInfluenceReceiveTimeout
   }
 
 }


### PR DESCRIPTION
Need this for AtLeastOnceDelivery

Messages marked with `NotInfluenceReceiveTimeout` will not reset the timer.
This can be useful when `ReceiveTimeout` should be fired by external inactivity
but not influenced by internal activity, e.g. scheduled tick messages.
