### PR TITLE
=clm #17768 Silence stacktrace in cluster sample

### DIFF
--- a/akka-samples/akka-sample-cluster-java/build.sbt
+++ b/akka-samples/akka-sample-cluster-java/build.sbt
@@ -21,9 +21,9 @@ val project = Project(
       "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,
       "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-      "io.kamon" % "sigar-loader" % "1.6.5-rev001"),
+      "io.kamon" % "sigar-loader" % "1.6.6-rev002"),
     javaOptions in run ++= Seq(
-      "-Xms128m", "-Xmx1024m"),
+      "-Xms128m", "-Xmx1024m", "-Djava.library.path=./target/native"),
     Keys.fork in run := true,  
     mainClass in (Compile, run) := Some("sample.cluster.simple.SimpleClusterApp"),
     // make sure that MultiJvm test are compiled by the default test compilation

--- a/akka-samples/akka-sample-cluster-scala/build.sbt
+++ b/akka-samples/akka-sample-cluster-scala/build.sbt
@@ -20,9 +20,9 @@ val project = Project(
       "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,
       "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-      "io.kamon" % "sigar-loader" % "1.6.5-rev001"),
+      "io.kamon" % "sigar-loader" % "1.6.6-rev002"),
     javaOptions in run ++= Seq(
-      "-Xms128m", "-Xmx1024m"),
+      "-Xms128m", "-Xmx1024m", "-Djava.library.path=./target/native"),
     Keys.fork in run := true,  
     mainClass in (Compile, run) := Some("sample.cluster.simple.SimpleClusterApp"),
     // make sure that MultiJvm test are compiled by the default test compilation

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,7 @@ object Dependencies {
 
     object Provided {
       // TODO remove from "test" config
-      val sigarLoader  = "io.kamon"         % "sigar-loader"        % "1.6.5-rev001"     %     "optional;provided;test" // ApacheV2
+      val sigarLoader  = "io.kamon"         % "sigar-loader"        % "1.6.6-rev002"     %     "optional;provided;test" // ApacheV2
       
       val levelDB       = "org.iq80.leveldb"            % "leveldb"          % "0.7"    %  "optional;provided"     // ApacheV2
       val levelDBNative = "org.fusesource.leveldbjni"   % "leveldbjni-all"   % "1.8"    %  "optional;provided"     // New BSD


### PR DESCRIPTION
It works, but the stack trace is very annoying since it will always be printed by Sigar itself
(so stupid of such a library to use stderr and stdout).

```
[error] org.hyperic.sigar.SigarException: no libsigar-universal64-macosx.dylib in java.library.path
[error]     at org.hyperic.sigar.Sigar.loadLibrary(Sigar.java:174)
[error]     at org.hyperic.sigar.Sigar.<clinit>(Sigar.java:102)
```

A workaround is to run with `-Djava.library.path=./target/native`, then it will only print
the stack trace when it is not provisioned and next time it's silent.

Also updated to latest sigar-loader, but that did not make
any difference for this issue
