### PR TITLE
=act #18187 Make Props.producer private[akka]

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Props.scala
+++ b/akka-actor/src/main/scala/akka/actor/Props.scala
@@ -169,7 +169,10 @@ final case class Props(deploy: Deploy, clazz: Class[_], args: immutable.Seq[Any]
   @transient
   private[this] var _cachedActorClass: Class[_ <: Actor] = _
 
-  private[this] def producer: IndirectActorProducer = {
+  /**
+   * INTERNAL API
+   */
+  private[akka] def producer: IndirectActorProducer = {
     if (_producer eq null)
       _producer = IndirectActorProducer(clazz, args)
 


### PR DESCRIPTION
- to make it possible to access producer.actorClass for validation
  purposes, as requested for Akka Streams ActorPublisher/Subscriber
