### PR TITLE
=rem,clu #17750 Decrease default expected-response-after

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -146,9 +146,9 @@ akka {
       monitored-by-nr-of-members = 5
       
       # After the heartbeat request has been sent the first failure detection
-      # will start after this period, even though no heartbeat mesage has
+      # will start after this period, even though no heartbeat message has
       # been received.
-      expected-response-after = 5 s
+      expected-response-after = 1 s
 
     }
 

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
@@ -34,7 +34,7 @@ class ClusterConfigSpec extends AkkaSpec {
       GossipTimeToLive should ===(2 seconds)
       HeartbeatInterval should ===(1 second)
       MonitoredByNrOfMembers should ===(5)
-      HeartbeatExpectedResponseAfter should ===(5 seconds)
+      HeartbeatExpectedResponseAfter should ===(1 seconds)
       LeaderActionsInterval should ===(1 second)
       UnreachableNodesReaperInterval should ===(1 second)
       PublishStatsInterval should ===(Duration.Undefined)

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -225,7 +225,7 @@ akka {
       # After the heartbeat request has been sent the first failure detection
       # will start after this period, even though no heartbeat mesage has
       # been received.
-      expected-response-after = 3 s
+      expected-response-after = 1 s
 
     }
 

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -53,7 +53,7 @@ class RemoteConfigSpec extends AkkaSpec(
 
       WatchFailureDetectorImplementationClass should ===(classOf[PhiAccrualFailureDetector].getName)
       WatchHeartBeatInterval should ===(1 seconds)
-      WatchHeartbeatExpectedResponseAfter should ===(3 seconds)
+      WatchHeartbeatExpectedResponseAfter should ===(1 seconds)
       WatchUnreachableReaperInterval should ===(1 second)
       WatchFailureDetectorConfig.getDouble("threshold") should ===(10.0 +- 0.0001)
       WatchFailureDetectorConfig.getInt("max-sample-size") should ===(200)


### PR DESCRIPTION
`expected-response-after` is used by remote watcher and cluster failure detector as an extra margin for when establishing heartbeating for a new connection. I don't want to remove it now. It could be good for compensating for extra delays for new connections such as dns lookups and handshakes. The default value can be decreased though.
