### PR TITLE
=act #18187 Make Props.producer private[akka] (for validation)

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Props.scala
+++ b/akka-actor/src/main/scala/akka/actor/Props.scala
@@ -171,7 +171,10 @@ final case class Props(deploy: Deploy, clazz: Class[_], args: immutable.Seq[Any]
   @transient
   private[this] var _cachedActorClass: Class[_ <: Actor] = _
 
-  private[this] def producer: IndirectActorProducer = {
+  /**
+   * INTERNAL API
+   */
+  private[akka] def producer: IndirectActorProducer = {
     if (_producer eq null)
       _producer = IndirectActorProducer(clazz, args)
 


### PR DESCRIPTION
- to make it possible to access producer.actorClass for validation
  purposes, as requested for Akka Streams ActorPublisher/Subscriber

(cherry picked from commit 48f0614b3f7da2930cbb2df81488ac15d9f356ad)
