### PR TITLE
+str: Add Sink.toSeq and Sink.single

### DIFF
--- a/akka-docs-dev/rst/java/stream-cookbook.rst
+++ b/akka-docs-dev/rst/java/stream-cookbook.rst
@@ -54,14 +54,9 @@ collection itself, so we can just call ``mapConcat(l -> l)``.
 Draining a stream to a strict collection
 ----------------------------------------
 
-**Situation:** A finite sequence of elements is given as a stream, but a scala collection is needed instead.
+**Situation:** A finite sequence of elements is given as a stream, but a Java collection is needed instead.
 
-In this recipe we will use the ``grouped`` stream operation that groups incoming elements into a stream of limited
-size collections (it can be seen as the almost opposite version of the "Flattening a stream of sequences" recipe
-we showed before). By using a ``grouped(MAX_ALLOWED_SIZE)`` we create a stream of groups
-with maximum size of ``MaxAllowedSeqSize`` and then we take the first element of this stream by attaching a ``Sink.head()``. What we get is a
-:class:`Future` containing a sequence with all the elements of the original up to ``MAX_ALLOWED_SIZE`` size (further
-elements are dropped).
+The ``Sink.toList`` built-in sink can drain a finite stream into a Java collection.
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeToStrict.java#draining-to-list
 

--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -20,6 +20,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers {
 
     implicit val system = ActorSystem()
     implicit val materializer = ActorMaterializer()
+    import system.dispatcher
 
     val connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] =
       Http().outgoingConnection("akka.io")
@@ -42,6 +43,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers {
 
     implicit val system = ActorSystem()
     implicit val materializer = ActorMaterializer()
+    import system.dispatcher
 
     // construct a pool client flow with context type `Int`
     val poolClientFlow = Http().cachedHostConnectionPool[Int]("akka.io")

--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -26,7 +26,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers {
     val responseFuture: Future[HttpResponse] =
       Source.single(HttpRequest(uri = "/"))
         .via(connectionFlow)
-        .runWith(Sink.head)
+        .runWith(Sink.single)
     //#outgoing-connection-example
   }
 
@@ -48,7 +48,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers {
     val responseFuture: Future[(Try[HttpResponse], Int)] =
       Source.single(HttpRequest(uri = "/") -> 42)
         .via(poolClientFlow)
-        .runWith(Sink.head)
+        .runWith(Sink.single)
     //#host-level-example
   }
 

--- a/akka-docs-dev/rst/scala/code/docs/stream/FlowErrorDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/FlowErrorDocSpec.scala
@@ -69,6 +69,7 @@ class FlowErrorDocSpec extends AkkaSpec {
   "demonstrate restart section" in {
     //#restart-section
     implicit val mat = ActorMaterializer()
+    import mat.executionContext
     val decider: Supervision.Decider = {
       case _: IllegalArgumentException => Supervision.Restart
       case _                           => Supervision.Stop
@@ -80,7 +81,7 @@ class FlowErrorDocSpec extends AkkaSpec {
       }
       .withAttributes(ActorAttributes.supervisionStrategy(decider))
     val source = Source(List(1, 3, -1, 5, 7)).via(flow)
-    val result = source.grouped(1000).runWith(Sink.head)
+    val result = source.runWith(Sink.toSeq)
     // the negative element cause the scan stage to be restarted,
     // i.e. start from 0 again
     // result here will be a Future completed with Success(Vector(0, 1, 4, 0, 5, 12))

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeByteStrings.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeByteStrings.scala
@@ -41,7 +41,7 @@ class RecipeByteStrings extends RecipeSpec {
       val chunksStream = rawBytes.transform(() => new Chunker(ChunkLimit))
       //#bytestring-chunker
 
-      val chunksFuture = chunksStream.grouped(10).runWith(Sink.head)
+      val chunksFuture = chunksStream.runWith(Sink.toSeq)
 
       val chunks = Await.result(chunksFuture, 3.seconds)
 
@@ -70,11 +70,11 @@ class RecipeByteStrings extends RecipeSpec {
       val bytes1 = Source(List(ByteString(1, 2), ByteString(3), ByteString(4, 5, 6), ByteString(7, 8, 9)))
       val bytes2 = Source(List(ByteString(1, 2), ByteString(3), ByteString(4, 5, 6), ByteString(7, 8, 9, 10)))
 
-      Await.result(bytes1.via(limiter).grouped(10).runWith(Sink.head), 3.seconds)
+      Await.result(bytes1.via(limiter).runWith(Sink.toSeq), 3.seconds)
         .fold(ByteString())(_ ++ _) should be(ByteString(1, 2, 3, 4, 5, 6, 7, 8, 9))
 
       an[IllegalStateException] must be thrownBy {
-        Await.result(bytes2.via(limiter).grouped(10).runWith(Sink.head), 3.seconds)
+        Await.result(bytes2.via(limiter).runWith(Sink.toSeq), 3.seconds)
       }
     }
 
@@ -86,7 +86,7 @@ class RecipeByteStrings extends RecipeSpec {
       val compacted: Source[ByteString, Unit] = data.map(_.compact)
       //#compacting-bytestrings
 
-      Await.result(compacted.grouped(10).runWith(Sink.head), 3.seconds).forall(_.isCompact) should be(true)
+      Await.result(compacted.runWith(Sink.toSeq), 3.seconds).forall(_.isCompact) should be(true)
     }
 
   }

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeFlattenSeq.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeFlattenSeq.scala
@@ -19,7 +19,7 @@ class RecipeFlattenSeq extends RecipeSpec {
       val flattened: Source[Message, Unit] = myData.mapConcat(identity)
       //#flattening-seqs
 
-      Await.result(flattened.grouped(8).runWith(Sink.head), 3.seconds) should be(List("1", "2", "3", "4", "5", "6", "7"))
+      Await.result(flattened.runWith(Sink.toSeq), 3.seconds) should be(List("1", "2", "3", "4", "5", "6", "7"))
 
     }
 

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeGlobalRateLimit.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeGlobalRateLimit.scala
@@ -29,7 +29,6 @@ class RecipeGlobalRateLimit extends RecipeSpec {
       val tokenRefreshPeriod: FiniteDuration,
       val tokenRefreshAmount: Int) extends Actor {
       import Limiter._
-      import context.dispatcher
       import akka.actor.Status
 
       private var waitQueue = immutable.Queue.empty[ActorRef]
@@ -81,7 +80,6 @@ class RecipeGlobalRateLimit extends RecipeSpec {
         import akka.pattern.ask
         import akka.util.Timeout
         Flow[T].mapAsync(4)((element: T) => {
-          import system.dispatcher
           implicit val triggerTimeout = Timeout(maxAllowedWait)
           val limiterTriggerFuture = limiter ? Limiter.WantToPass
           limiterTriggerFuture.map((_) => element)

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeMultiGroupBy.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeMultiGroupBy.scala
@@ -40,7 +40,7 @@ class RecipeMultiGroupBy extends RecipeSpec {
 
       val result = multiGroups.map {
         case (topic, topicMessages) => topicMessages.grouped(10).map(topic.name + _.mkString("[", ", ", "]")).runWith(Sink.head)
-      }.mapAsync(4)(identity).grouped(10).runWith(Sink.head)
+      }.mapAsync(4)(identity).runWith(Sink.toSeq)
 
       Await.result(result, 3.seconds).toSet should be(Set(
         "1[1: a, 1: b, all: c, all: d, 1: e]",

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeParseLines.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeParseLines.scala
@@ -27,7 +27,7 @@ class RecipeParseLines extends RecipeSpec {
         .map(_.utf8String)
       //#parse-lines
 
-      Await.result(linesStream.grouped(10).runWith(Sink.head), 3.seconds) should be(List(
+      Await.result(linesStream.runWith(Sink.toSeq), 3.seconds) should be(List(
         "Hello World\r!",
         "Hello Akka!",
         "Hello Streams!",

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeReduceByKey.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeReduceByKey.scala
@@ -35,7 +35,7 @@ class RecipeReduceByKey extends RecipeSpec {
           .mapAsync(4)(identity)
       //#word-count
 
-      Await.result(counts.grouped(10).runWith(Sink.head), 3.seconds).toSet should be(Set(
+      Await.result(counts.runWith(Sink.toSeq), 3.seconds).toSet should be(Set(
         ("hello", 2),
         ("world", 1),
         ("and", 1),
@@ -72,7 +72,7 @@ class RecipeReduceByKey extends RecipeSpec {
 
       //#reduce-by-key-general
 
-      Await.result(wordCounts.grouped(10).runWith(Sink.head), 3.seconds).toSet should be(Set(
+      Await.result(wordCounts.runWith(Sink.toSeq), 3.seconds).toSet should be(Set(
         ("hello", 2),
         ("world", 1),
         ("and", 1),

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeSpec.scala
@@ -6,6 +6,7 @@ import akka.stream.testkit.AkkaSpec
 trait RecipeSpec extends AkkaSpec {
 
   implicit val m = ActorMaterializer()
+  implicit val ec = m.executionContext
   type Message = String
   type Trigger = Unit
   type Job = String

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeToStrict.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeToStrict.scala
@@ -12,11 +12,9 @@ class RecipeToStrict extends RecipeSpec {
 
     "work" in {
       val myData = Source(List("1", "2", "3"))
-      val MaxAllowedSeqSize = 100
 
       //#draining-to-seq
-      val strict: Future[immutable.Seq[Message]] =
-        myData.grouped(MaxAllowedSeqSize).runWith(Sink.head)
+      val strict: Future[immutable.Seq[Message]] = myData.runWith(Sink.toSeq)
       //#draining-to-seq
 
       Await.result(strict, 3.seconds) should be(List("1", "2", "3"))

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeWorkerPool.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeWorkerPool.scala
@@ -37,7 +37,7 @@ class RecipeWorkerPool extends RecipeSpec {
       val processedJobs: Source[Result, Unit] = myJobs.via(balancer(worker, 3))
       //#worker-pool
 
-      Await.result(processedJobs.grouped(10).runWith(Sink.head), 3.seconds).toSet should be(Set(
+      Await.result(processedJobs.runWith(Sink.toSeq), 3.seconds).toSet should be(Set(
         "1 done", "2 done", "3 done", "4 done", "5 done"))
 
     }

--- a/akka-docs-dev/rst/scala/stream-cookbook.rst
+++ b/akka-docs-dev/rst/scala/stream-cookbook.rst
@@ -56,12 +56,7 @@ Draining a stream to a strict collection
 
 **Situation:** A finite sequence of elements is given as a stream, but a scala collection is needed instead.
 
-In this recipe we will use the ``grouped`` stream operation that groups incoming elements into a stream of limited
-size collections (it can be seen as the almost opposite version of the "Flattening a stream of sequences" recipe
-we showed before). By using a ``grouped(MaxAllowedSeqSize)`` we create a stream of groups
-with maximum size of ``MaxAllowedSeqSize`` and then we take the first element of this stream by attaching a ``Sink.head``. What we get is a
-:class:`Future` containing a sequence with all the elements of the original up to ``MaxAllowedSeqSize`` size (further
-elements are dropped).
+The ``Sink.toSeq`` built-in sink can drain a finite stream into a scala collection.
 
 .. includecode:: code/docs/stream/cookbook/RecipeToStrict.scala#draining-to-seq
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -75,6 +75,7 @@ sealed trait HttpEntity extends jm.HttpEntity {
       }
 
     // TODO timerTransform is meant to be replaced / rewritten, it's currently private[akka]; See https://github.com/akka/akka/issues/16393
+    import fm.executionContext
     dataBytes.via(Flow[ByteString].timerTransform(transformer).named("toStrict")).runWith(Sink.single)
   }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -75,7 +75,7 @@ sealed trait HttpEntity extends jm.HttpEntity {
       }
 
     // TODO timerTransform is meant to be replaced / rewritten, it's currently private[akka]; See https://github.com/akka/akka/issues/16393
-    dataBytes.via(Flow[ByteString].timerTransform(transformer).named("toStrict")).runWith(Sink.head)
+    dataBytes.via(Flow[ByteString].timerTransform(transformer).named("toStrict")).runWith(Sink.single)
   }
 
   /**

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -27,6 +27,7 @@ class TlsEndpointVerificationSpec extends AkkaSpec("""
     akka.io.tcp.trace-logging = off
     akka.io.tcp.windows-connection-abort-workaround-enabled=auto""") with ScalaFutures {
   implicit val materializer = ActorMaterializer()
+  import materializer.executionContext
   val timeout = Timeout(Span(3, Seconds))
 
   "The client implementation" should {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -54,7 +54,7 @@ class TlsEndpointVerificationSpec extends AkkaSpec("""
   }
 
   def pipeline(clientContext: HttpsContext, hostname: String): HttpRequest ⇒ Future[HttpResponse] = req ⇒
-    Source.single(req).via(pipelineFlow(clientContext, hostname)).runWith(Sink.head)
+    Source.single(req).via(pipelineFlow(clientContext, hostname)).runWith(Sink.single)
 
   def pipelineFlow(clientContext: HttpsContext, hostname: String): Flow[HttpRequest, HttpResponse, Unit] = {
     val handler: HttpRequest ⇒ HttpResponse = _ ⇒ HttpResponse()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -241,7 +241,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
           val parser = newParser
           val result = multiParse(newParser)(Seq(prep(start + manyChunks)))
           val HttpEntity.Chunked(_, chunks) = result.head.right.get.req.entity
-          val strictChunks = chunks.grouped(100000).runWith(Sink.head).awaitResult(awaitAtMost)
+          val strictChunks = chunks.runWith(Sink.toSeq).awaitResult(awaitAtMost)
           strictChunks.size shouldEqual numChunks
         }
       }
@@ -531,7 +531,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
         }
         .flatten(FlattenStrategy.concat)
         .map(strictEqualify)
-        .grouped(100000).runWith(Sink.head)
+        .runWith(Sink.toSeq)
         .awaitResult(awaitAtMost)
 
     protected def parserSettings: ParserSettings = ParserSettings(system)
@@ -544,7 +544,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
       }
 
     private def compactEntityChunks(data: Source[ChunkStreamPart, Any]): Future[Seq[ChunkStreamPart]] =
-      data.grouped(100000).runWith(Sink.head)
+      data.runWith(Sink.toSeq)
         .fast.recover { case _: NoSuchElementException ⇒ Nil }
 
     def prep(response: String) = response.stripMarginWithNewline("\r\n")

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -345,7 +345,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
               }
               .flatten(FlattenStrategy.concat)
               .map(strictEqualify)
-              .grouped(100000).runWith(Sink.head)
+              .runWith(Sink.toSeq)
           Await.result(future, 500.millis)
         }
 
@@ -364,7 +364,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
       }
 
     private def compactEntityChunks(data: Source[ChunkStreamPart, Any]): Future[Source[ChunkStreamPart, Any]] =
-      data.grouped(100000).runWith(Sink.head)
+      data.runWith(Sink.toSeq)
         .fast.map(source(_: _*))
         .fast.recover { case _: NoSuchElementException ⇒ source() }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -312,7 +312,7 @@ class RequestRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll 
     def renderTo(expected: String): Matcher[HttpRequest] =
       equal(expected.stripMarginWithNewline("\r\n")).matcher[String] compose { request ⇒
         val byteStringSource = renderToSource(RequestRenderingContext(request, Host(serverAddress)))
-        val future = byteStringSource.grouped(1000).runWith(Sink.head).map(_.reduceLeft(_ ++ _).utf8String)
+        val future = byteStringSource.runWith(Sink.toSeq).map(_.reduceLeft(_ ++ _).utf8String)
         Await.result(future, 250.millis)
       }
   }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -92,7 +92,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       val b1 = Await.result(binding, 3.seconds)
 
       val (_, f) = Http().outgoingConnection(hostname, port)
-        .runWith(Source.single(HttpRequest(uri = "/abc")), Sink.head)
+        .runWith(Source.single(HttpRequest(uri = "/abc")), Sink.single)
 
       Await.result(f, 1.second)
       Await.result(b1.unbind(), 1.second)
@@ -121,7 +121,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
       def runRequest(uri: Uri): Unit =
         Http().outgoingConnection(hostname, port)
-          .runWith(Source.single(HttpRequest(uri = uri)), Sink.head)
+          .runWith(Source.single(HttpRequest(uri = uri)), Sink.single)
 
       runRequest("/slow")
 
@@ -148,7 +148,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
         EventFilter[RuntimeException](message = "BOOM", occurrences = 1).intercept {
           val (_, responseFuture) =
-            Http(system2).outgoingConnection(hostname, port).runWith(Source.single(HttpRequest()), Sink.head)(materializer2)
+            Http(system2).outgoingConnection(hostname, port).runWith(Source.single(HttpRequest()), Sink.single)(materializer2)
           try Await.result(responseFuture, 5.second).status should ===(StatusCodes.InternalServerError)
           catch {
             case _: StreamTcpException ⇒
@@ -167,7 +167,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
         EventFilter[RuntimeException](message = "BOOM", occurrences = 1).intercept {
           val (_, responseFuture) =
-            Http(system2).outgoingConnection(hostname, port).runWith(Source.single(HttpRequest()), Sink.head)(materializer2)
+            Http(system2).outgoingConnection(hostname, port).runWith(Source.single(HttpRequest()), Sink.single)(materializer2)
           try Await.result(responseFuture, 5.seconds).status should ===(StatusCodes.InternalServerError)
           catch {
             case _: StreamTcpException ⇒

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -229,7 +229,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
         private val HttpRequest(POST, uri, List(Accept(Seq(MediaRanges.`*/*`)), Host(_, _), `User-Agent`(_)),
           Chunked(`chunkedContentType`, chunkStream), HttpProtocols.`HTTP/1.1`) = serverIn.expectNext()
         uri shouldEqual Uri(s"http://$hostname:$port/chunked")
-        Await.result(chunkStream.grouped(4).runWith(Sink.head), 100.millis) shouldEqual chunks
+        Await.result(chunkStream.runWith(Sink.toSeq), 100.millis) shouldEqual chunks
 
         val serverOutSub = serverOut.expectSubscription()
         serverOutSub.expectRequest()
@@ -239,7 +239,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
         clientInSub.request(1)
         val HttpResponse(StatusCodes.PartialContent, List(Age(42), Server(_), Date(_)),
           Chunked(`chunkedContentType`, chunkStream2), HttpProtocols.`HTTP/1.1`) = clientIn.expectNext()
-        Await.result(chunkStream2.grouped(1000).runWith(Sink.head), 100.millis) shouldEqual chunks
+        Await.result(chunkStream2.runWith(Sink.toSeq), 100.millis) shouldEqual chunks
 
         clientOutSub.sendComplete()
         serverInSub.request(1) // work-around for #16552

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -123,7 +123,7 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
 
   def collectBytesTo(bytes: ByteString*): Matcher[HttpEntity] =
     equal(bytes.toVector).matcher[Seq[ByteString]].compose { entity ⇒
-      val future = entity.dataBytes.grouped(1000).runWith(Sink.head)
+      val future = entity.dataBytes.runWith(Sink.toSeq)
       Await.result(future, 250.millis)
     }
 

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -23,6 +23,7 @@ trait RouteTestResultComponent {
    * A receptacle for the response or rejections created by a route.
    */
   class RouteTestResult(timeout: FiniteDuration)(implicit fm: Materializer) {
+    import fm.executionContext
     private[this] var result: Option[Either[immutable.Seq[Rejection], HttpResponse]] = None
     private[this] val latch = new CountDownLatch(1)
 
@@ -96,6 +97,6 @@ trait RouteTestResultComponent {
       failTest("Request was neither completed nor rejected within " + timeout)
 
     private def awaitAllElements[T](data: Source[T, _]): immutable.Seq[T] =
-      data.grouped(100000).runWith(Sink.head).awaitResult(timeout)
+      data.runWith(Sink.toSeq).awaitResult(timeout)
   }
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CoderSpec.scala
@@ -106,7 +106,7 @@ abstract class CoderSpec extends WordSpec with CodecSpecSupport with Inspectors 
       val resultBs =
         Source.single(compressed)
           .via(Coder.withMaxBytesPerChunk(limit).decoderFlow)
-          .grouped(4200).runWith(Sink.head)
+          .runWith(Sink.toSeq)
           .awaitResult(1.second)
 
       forAll(resultBs) { bs ⇒

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RangeDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RangeDirectivesSpec.scala
@@ -99,7 +99,7 @@ class RangeDirectivesSpec extends RoutingSpec with Inspectors with Inside {
         wrs { complete("Some random and not super short entity.") }
       } ~> check {
         header[`Content-Range`] should be(None)
-        val parts = Await.result(responseAs[Multipart.ByteRanges].parts.grouped(1000).runWith(Sink.head), 1.second)
+        val parts = Await.result(responseAs[Multipart.ByteRanges].parts.runWith(Sink.toSeq), 1.second)
         parts.size shouldEqual 2
         inside(parts(0)) {
           case Multipart.ByteRanges.BodyPart(range, entity, unit, headers) ⇒
@@ -124,7 +124,7 @@ class RangeDirectivesSpec extends RoutingSpec with Inspectors with Inside {
         wrs { complete(HttpEntity.Default(MediaTypes.`text/plain`, content.length, entityData())) }
       } ~> check {
         header[`Content-Range`] should be(None)
-        val parts = Await.result(responseAs[Multipart.ByteRanges].parts.grouped(1000).runWith(Sink.head), 1.second)
+        val parts = Await.result(responseAs[Multipart.ByteRanges].parts.runWith(Sink.toSeq), 1.second)
         parts.size shouldEqual 2
       }
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
@@ -28,7 +28,7 @@ trait Decoder {
 
   def decoderFlow: Flow[ByteString, ByteString, Unit]
   def decode(input: ByteString)(implicit mat: Materializer): Future[ByteString] =
-    Source.single(input).via(decoderFlow).runWith(Sink.single)
+    Source.single(input).via(decoderFlow).runWith(Sink.single(mat.executionContext))
 }
 object Decoder {
   val MaxBytesPerChunkDefault: Int = 65536

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
@@ -28,7 +28,7 @@ trait Decoder {
 
   def decoderFlow: Flow[ByteString, ByteString, Unit]
   def decode(input: ByteString)(implicit mat: Materializer): Future[ByteString] =
-    Source.single(input).via(decoderFlow).runWith(Sink.head)
+    Source.single(input).via(decoderFlow).runWith(Sink.single)
 }
 object Decoder {
   val MaxBytesPerChunkDefault: Int = 65536

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/FlowStagesDocTest.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/FlowStagesDocTest.java
@@ -154,8 +154,6 @@ public class FlowStagesDocTest {
 
   @Test
   public void demonstrateVariousPushPullStages() throws Exception {
-    final Sink<Integer, Future<List<Integer>>> sink =
-        Flow.of(Integer.class).grouped(10).toMat(Sink.head(), Keep.right());
 
     //#stage-chain
     final RunnableGraph<Future<List<Integer>>> runnable =
@@ -164,7 +162,7 @@ public class FlowStagesDocTest {
         .transform(() -> new Filter<Integer>(elem -> elem % 2 == 0))
         .transform(() -> new Duplicator<Integer>())
         .transform(() -> new Map<Integer, Integer>(elem -> elem / 2))
-        .toMat(sink, Keep.right());
+        .toMat(Sink.toList(mat.executionContext), Keep.right());
     //#stage-chain
 
     assertEquals(Arrays.asList(1, 1, 2, 2, 3, 3, 4, 4, 5, 5),

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeByteStrings.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeByteStrings.java
@@ -96,7 +96,7 @@ public class RecipeByteStrings extends RecipeTest {
           rawBytes.transform(() -> new Chunker(CHUNK_LIMIT));
         //#bytestring-chunker2
 
-        Future<List<ByteString>> chunksFuture = chunksStream.grouped(10).runWith(Sink.head(), mat);
+        Future<List<ByteString>> chunksFuture = chunksStream.runWith(Sink.toList(mat.executionContext), mat);
 
         List<ByteString> chunks = Await.result(chunksFuture, FiniteDuration.create(3, TimeUnit.SECONDS));
 
@@ -160,7 +160,7 @@ public class RecipeByteStrings extends RecipeTest {
 
         FiniteDuration threeSeconds = FiniteDuration.create(3, TimeUnit.SECONDS);
 
-        List<ByteString> got = Await.result(bytes1.via(limiter).grouped(10).runWith(Sink.head(), mat), threeSeconds);
+        List<ByteString> got = Await.result(bytes1.via(limiter).runWith(Sink.toList(mat.executionContext), mat), threeSeconds);
         ByteString acc = ByteString.empty();
         for (ByteString b : got) {
           acc = acc.concat(b);
@@ -169,7 +169,7 @@ public class RecipeByteStrings extends RecipeTest {
 
         boolean thrown = false;
         try {
-          Await.result(bytes2.via(limiter).grouped(10).runWith(Sink.head(), mat), threeSeconds);
+          Await.result(bytes2.via(limiter).runWith(Sink.toList(mat.executionContext), mat), threeSeconds);
         } catch (IllegalStateException ex) {
           thrown = true;
         }
@@ -194,7 +194,7 @@ public class RecipeByteStrings extends RecipeTest {
         //#compacting-bytestrings
 
         FiniteDuration timeout = FiniteDuration.create(3, TimeUnit.SECONDS);
-        List<ByteString> got = Await.result(compacted.grouped(10).runWith(Sink.head(), mat), timeout);
+        List<ByteString> got = Await.result(compacted.runWith(Sink.toList(mat.executionContext), mat), timeout);
 
         for (ByteString byteString : got) {
           assertTrue(byteString.isCompact());

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeFlattenList.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeFlattenList.java
@@ -50,7 +50,7 @@ public class RecipeFlattenList extends RecipeTest {
         Source<Message, BoxedUnit> flattened = myData.mapConcat(i -> i);
         //#flattening-lists
 
-        List<Message> got = Await.result(flattened.grouped(10).runWith(Sink.head(), mat),
+        List<Message> got = Await.result(flattened.runWith(Sink.toList(mat.executionContext), mat),
           new FiniteDuration(1, TimeUnit.SECONDS));
         assertEquals(got.get(0), new Message("1"));
         assertEquals(got.get(1), new Message("2"));

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeParseLines.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeParseLines.java
@@ -54,7 +54,7 @@ public class RecipeParseLines extends RecipeTest {
       .map(b -> b.utf8String());
     //#parse-lines
 
-    Await.result(lines.grouped(10).runWith(Sink.head(), mat), new FiniteDuration(1, TimeUnit.SECONDS));
+    Await.result(lines.runWith(Sink.toList(mat.executionContext), mat), new FiniteDuration(1, TimeUnit.SECONDS));
   }
 
 }

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeToStrict.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeToStrict.java
@@ -42,11 +42,9 @@ public class RecipeToStrict extends RecipeTest {
     new JavaTestKit(system) {
       {
         final Source<String, BoxedUnit> myData = Source.from(Arrays.asList("1", "2", "3"));
-        final int MAX_ALLOWED_SIZE = 100;
-
         //#draining-to-list
         final Future<List<String>> strings = myData
-          .grouped(MAX_ALLOWED_SIZE).runWith(Sink.head(), mat);
+          .runWith(Sink.toSeq(mat.executionContext), mat);
         //#draining-to-list
 
         Await.result(strings, new FiniteDuration(1, TimeUnit.SECONDS));

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeWorkerPool.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeWorkerPool.java
@@ -77,7 +77,7 @@ public class RecipeWorkerPool extends RecipeTest {
         //#worker-pool2
 
         FiniteDuration timeout = FiniteDuration.create(200, TimeUnit.MILLISECONDS);
-        Future<List<String>> future = processedJobs.map(m -> m.msg).grouped(10).runWith(Sink.head(), mat);
+        Future<List<String>> future = processedJobs.map(m -> m.msg).runWith(Sink.toList(mat.executionContext), mat);
         List<String> got = Await.result(future, timeout);
         assertTrue(got.contains("1 done"));
         assertTrue(got.contains("2 done"));

--- a/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
@@ -7,13 +7,17 @@ package akka.stream;
 import akka.actor.ActorSystem;
 import akka.stream.javadsl.AkkaJUnitActorSystemResource;
 
+import scala.concurrent.ExecutionContext;
+
 public abstract class StreamTest {
     final protected ActorSystem system;
     final protected ActorMaterializer materializer;
+    final protected ExecutionContext ec;
 
     protected StreamTest(AkkaJUnitActorSystemResource actorSystemResource) {
         system = actorSystemResource.getSystem();
         ActorMaterializerSettings settings = ActorMaterializerSettings.create(system);
         materializer = ActorMaterializer.create(settings, system);
+        ec = system.dispatcher();
     }
 }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/BidiFlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/BidiFlowTest.java
@@ -158,7 +158,7 @@ public class BidiFlowTest extends StreamTest {
             return ByteString.fromString("Hello " + arg);
           }
         }));
-    final Future<List<String>> result = Source.from(list).via(f).grouped(10).runWith(Sink.<List<String>> head(), materializer);
+    final Future<List<String>> result = Source.from(list).via(f).runWith(Sink.<String>toList(ec), materializer);
     assertEquals(Arrays.asList("Hello 3", "Hello 4", "Hello 5"), Await.result(result, oneSec));
   }
 
@@ -171,7 +171,7 @@ public class BidiFlowTest extends StreamTest {
           }
         }).join(bidi);
     final List<ByteString> inputs = Arrays.asList(ByteString.fromString("1"), ByteString.fromString("2"));
-    final Future<List<Long>> result = Source.from(inputs).via(f).grouped(10).runWith(Sink.<List<Long>> head(), materializer);
+    final Future<List<Long>> result = Source.from(inputs).via(f).runWith(Sink.<Long>toList(ec), materializer);
     assertEquals(Arrays.asList(3L, 4L), Await.result(result, oneSec));
   }
 
@@ -183,7 +183,7 @@ public class BidiFlowTest extends StreamTest {
             return arg.toString();
           }
         }));
-    final Future<List<String>> result = Source.from(list).via(f).grouped(10).runWith(Sink.<List<String>> head(), materializer);
+    final Future<List<String>> result = Source.from(list).via(f).runWith(Sink.<String>toList(ec), materializer);
     assertEquals(Arrays.asList("5", "6", "7"), Await.result(result, oneSec));
   }
 
@@ -195,7 +195,7 @@ public class BidiFlowTest extends StreamTest {
             return arg.toString();
           }
         }).join(inverse.reversed()).join(bidi.reversed());
-    final Future<List<String>> result = Source.from(list).via(f).grouped(10).runWith(Sink.<List<String>> head(), materializer);
+    final Future<List<String>> result = Source.from(list).via(f).runWith(Sink.<String>toList(ec), materializer);
     assertEquals(Arrays.asList("5", "6", "7"), Await.result(result, oneSec));
   }
 

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowGraphTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowGraphTest.java
@@ -81,7 +81,7 @@ public class FlowGraphTest extends StreamTest {
 
     // collecting
     final Publisher<String> pub = source.runWith(publisher, materializer);
-    final Future<List<String>> all = Source.from(pub).grouped(100).runWith(Sink.<List<String>>head(), materializer);
+    final Future<List<String>> all = Source.from(pub).runWith(Sink.<String>toList(ec), materializer);
 
     final List<String> result = Await.result(all, Duration.apply(200, TimeUnit.MILLISECONDS));
     assertEquals(new HashSet<Object>(Arrays.asList("a", "b", "c", "d", "e", "f")), new HashSet<String>(result));

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -351,7 +351,7 @@ public class FlowTest extends StreamTest {
 
     // collecting
     final Publisher<String> pub = source.runWith(publisher, materializer);
-    final Future<List<String>> all = Source.from(pub).grouped(100).runWith(Sink.<List<String>>head(), materializer);
+    final Future<List<String>> all = Source.from(pub).runWith(Sink.<String>toList(ec), materializer);
 
     final List<String> result = Await.result(all, Duration.apply(200, TimeUnit.MILLISECONDS));
     assertEquals(new HashSet<Object>(Arrays.asList("a", "b", "c", "d", "e", "f")), new HashSet<String>(result));
@@ -418,7 +418,7 @@ public class FlowTest extends StreamTest {
         probe.dilated(FiniteDuration.create(3, TimeUnit.SECONDS)));
     assertEquals(Arrays.asList(1, 2, 3), result.first());
 
-    Future<List<Integer>> tailFuture = result.second().grouped(4).runWith(Sink.<List<Integer>>head(), materializer);
+    Future<List<Integer>> tailFuture = result.second().runWith(Sink.<Integer>toList(ec), materializer);
     List<Integer> tailResult = Await.result(tailFuture, probe.dilated(FiniteDuration.create(3, TimeUnit.SECONDS)));
     assertEquals(Arrays.asList(4, 5, 6), tailResult);
   }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
@@ -331,7 +331,7 @@ public class SourceTest extends StreamTest {
       probe.dilated(FiniteDuration.create(3, TimeUnit.SECONDS)));
     assertEquals(Arrays.asList(1, 2, 3), result.first());
 
-    Future<List<Integer>> tailFuture = result.second().grouped(4).runWith(Sink.<List<Integer>>head(), materializer);
+    Future<List<Integer>> tailFuture = result.second().runWith(Sink.<Integer>toList(ec), materializer);
     List<Integer> tailResult = Await.result(tailFuture, probe.dilated(FiniteDuration.create(3, TimeUnit.SECONDS)));
     assertEquals(Arrays.asList(4, 5, 6), tailResult);
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
@@ -19,6 +19,7 @@ class BidiFlowSpec extends AkkaSpec with ConversionCheckedTripleEquals {
   import FlowGraph.Implicits._
 
   implicit val mat = ActorMaterializer()
+  import mat.executionContext
 
   val bidi = BidiFlow() { b ⇒
     val top = b.add(Flow[Int].map(x ⇒ x.toLong + 2).withAttributes(name("top")))
@@ -61,26 +62,26 @@ class BidiFlowSpec extends AkkaSpec with ConversionCheckedTripleEquals {
 
     "work as a Flow that is open on the left" in {
       val f = bidi.join(Flow[Long].map(x ⇒ ByteString(s"Hello $x")))
-      val result = Source(List(1, 2, 3)).via(f).grouped(10).runWith(Sink.head)
+      val result = Source(List(1, 2, 3)).via(f).runWith(Sink.toSeq)
       Await.result(result, 1.second) should ===(Seq("Hello 3", "Hello 4", "Hello 5"))
     }
 
     "work as a Flow that is open on the right" in {
       val f = Flow[String].map(Integer.valueOf(_).toInt).join(bidi)
-      val result = Source(List(ByteString("1"), ByteString("2"))).via(f).grouped(10).runWith(Sink.head)
+      val result = Source(List(ByteString("1"), ByteString("2"))).via(f).runWith(Sink.toSeq)
       Await.result(result, 1.second) should ===(Seq(3L, 4L))
     }
 
     "work when atop its inverse" in {
       val f = bidi.atop(inverse).join(Flow[Int].map(_.toString))
-      val result = Source(List(1, 2, 3)).via(f).grouped(10).runWith(Sink.head)
+      val result = Source(List(1, 2, 3)).via(f).runWith(Sink.toSeq)
       Await.result(result, 1.second) should ===(Seq("5", "6", "7"))
     }
 
     "work when reversed" in {
       // just reversed from the case above; observe that Flow inverts itself automatically by being on the left side
       val f = Flow[Int].map(_.toString).join(inverse.reversed).join(bidi.reversed)
-      val result = Source(List(1, 2, 3)).via(f).grouped(10).runWith(Sink.head)
+      val result = Source(List(1, 2, 3)).via(f).runWith(Sink.toSeq)
       Await.result(result, 1.second) should ===(Seq("5", "6", "7"))
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
@@ -257,7 +257,7 @@ class FlowMapAsyncSpec extends AkkaSpec {
       val f = Source(1 to N).transform(() ⇒ new MapAsyncOne(i ⇒ {
         probe.ref ! i
         Future { Thread.sleep(10); probe.ref ! (i + 10); i * 2 }
-      })).grouped(N + 10).runWith(Sink.head)
+      })).runWith(Sink.toSeq)
       Await.result(f, 2.seconds) should ===((1 to N).map(_ * 2))
       probe.receiveN(2 * N) should ===((1 to N).flatMap(x ⇒ List(x, x + 10)))
       probe.expectNoMsg(100.millis)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
@@ -37,6 +37,7 @@ class FlowSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug.rece
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
   implicit val mat = ActorMaterializer(settings)
+  import mat.executionContext
 
   val identity: Flow[Any, Any, _] ⇒ Flow[Any, Any, _] = in ⇒ in.map(e ⇒ e)
   val identity2: Flow[Any, Any, _] ⇒ Flow[Any, Any, _] = in ⇒ identity(in)
@@ -317,12 +318,12 @@ class FlowSpec extends AkkaSpec(ConfigFactory.parseString("akka.actor.debug.rece
       val identity1 = Flow[Int].toProcessor
       val identity2 = Flow(() ⇒ identity1.run())
       Await.result(
-        Source(1 to 10).via(identity2).grouped(100).runWith(Sink.head),
+        Source(1 to 10).via(identity2).runWith(Sink.toSeq),
         3.seconds) should ===(1 to 10)
 
       // Reusable:
       Await.result(
-        Source(1 to 10).via(identity2).grouped(100).runWith(Sink.head),
+        Source(1 to 10).via(identity2).runWith(Sink.toSeq),
         3.seconds) should ===(1 to 10)
     }
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSupervisionSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSupervisionSpec.scala
@@ -18,13 +18,14 @@ class FlowSupervisionSpec extends AkkaSpec {
   import ActorAttributes.supervisionStrategy
 
   implicit val materializer = ActorMaterializer()(system)
+  import materializer.executionContext
 
   val exc = new RuntimeException("simulated exc") with NoStackTrace
 
   val failingMap = Flow[Int].map(n ⇒ if (n == 3) throw exc else n)
 
   def run(f: Flow[Int, Int, Unit]): immutable.Seq[Int] =
-    Await.result(Source((1 to 5).toSeq ++ (1 to 5)).via(f).grouped(1000).runWith(Sink.head), 3.seconds)
+    Await.result(Source((1 to 5).toSeq ++ (1 to 5)).via(f).runWith(Sink.toSeq), 3.seconds)
 
   "Stream supervision" must {
 
@@ -46,7 +47,7 @@ class FlowSupervisionSpec extends AkkaSpec {
 
     "complete stream with NPE failure when null is emitted" in {
       intercept[NullPointerException] {
-        Await.result(Source(List("a", "b")).map(_ ⇒ null).grouped(1000).runWith(Sink.head), 3.seconds)
+        Await.result(Source(List("a", "b")).map(_ ⇒ null).runWith(Sink.toSeq), 3.seconds)
       }.getMessage should be(ReactiveStreamsCompliance.ElementMustNotBeNullMsg)
     }
 
@@ -54,7 +55,7 @@ class FlowSupervisionSpec extends AkkaSpec {
       val nullMap = Flow[String].map(elem ⇒ if (elem == "b") null else elem)
         .withAttributes(supervisionStrategy(Supervision.resumingDecider))
       val result = Await.result(Source(List("a", "b", "c")).via(nullMap)
-        .grouped(1000).runWith(Sink.head), 3.seconds)
+        .runWith(Sink.toSeq), 3.seconds)
       result should be(List("a", "c"))
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Await
 class PublisherSinkSpec extends AkkaSpec {
 
   implicit val materializer = ActorMaterializer()
+  import materializer.executionContext
 
   "A PublisherSink" must {
 
@@ -41,7 +42,7 @@ class PublisherSinkSpec extends AkkaSpec {
     "work with SubscriberSource" in {
       val (sub, pub) = Source.subscriber[Int].toMat(Sink.publisher)(Keep.both).run()
       Source(1 to 100).to(Sink(sub)).run()
-      Await.result(Source(pub).grouped(1000).runWith(Sink.head), 3.seconds) should ===(1 to 100)
+      Await.result(Source(pub).runWith(Sink.toSeq), 3.seconds) should ===(1 to 100)
     }
 
     "be able to use Publisher in materialized value transformation" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -5,6 +5,7 @@ package akka.stream.scaladsl
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.util.Failure
 
 import akka.stream.testkit._
 import akka.stream.ActorMaterializer
@@ -105,6 +106,29 @@ class SinkSpec extends AkkaSpec {
     "collect all elements when empty" in {
       val f = Source.empty.runWith(Sink.toSeq)
       Await.result(f, 100.millis) should be(Nil)
+    }
+  }
+
+  "Sink.single" must {
+    "return the sole element if there is one" in {
+      val f = Source.single("test").runWith(Sink.single)
+      Await.result(f, 100.millis) should be("test")
+    }
+
+    "throw if no elements are returned" in {
+      val f = Source.empty.runWith(Sink.single)
+      Await.ready(f, 100.millis)
+      (f.value.get: @unchecked) match {
+        case Failure(e) ⇒ e.getMessage should include("empty stream")
+      }
+    }
+
+    "throw if two elements are returned" in {
+      val f = Source(List("a", "b")).runWith(Sink.single)
+      Await.ready(f, 100.millis)
+      (f.value.get: @unchecked) match {
+        case Failure(e) ⇒ e.getMessage should include("Expected exactly one element")
+      }
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -3,6 +3,9 @@
  */
 package akka.stream.scaladsl
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
 import akka.stream.testkit._
 import akka.stream.ActorMaterializer
 
@@ -10,6 +13,7 @@ class SinkSpec extends AkkaSpec {
   import FlowGraph.Implicits._
 
   implicit val mat = ActorMaterializer()
+  import mat.executionContext
 
   "A Sink" must {
 
@@ -91,4 +95,16 @@ class SinkSpec extends AkkaSpec {
 
   }
 
+  "Sink.toSeq" must {
+
+    "collect all elements when non-empty" in {
+      val f = Source(List(1, 2, 3)).runWith(Sink.toSeq)
+      Await.result(f, 100.millis) should be(List(1, 2, 3))
+    }
+
+    "collect all elements when empty" in {
+      val f = Source.empty.runWith(Sink.toSeq)
+      Await.result(f, 100.millis) should be(Nil)
+    }
+  }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -125,6 +125,15 @@ object Sink {
       .mapMaterializedValue { _.map { _.asJava }(ec) })
 
   /**
+   * A `Sink` that drains a stream and returns the sole element
+   * that the stream produced.
+   * If the stream did not produce exactly one element, a failed Future will be
+   * returned.
+   */
+  def single[In](ec: ExecutionContext): Sink[In, Future[In]] =
+    new Sink(scaladsl.Sink.single[In](ec))
+
+  /**
    * Sends the elements of the stream to the given `ActorRef`.
    * If the target actor terminates the stream will be cancelled.
    * When the stream is completed successfully the given `onCompleteMessage`

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -9,6 +9,8 @@ import akka.stream.impl.StreamLayout
 import akka.stream.{ javadsl, scaladsl, _ }
 import org.reactivestreams.{ Publisher, Subscriber }
 
+import scala.collection.immutable
+import scala.collection.JavaConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
@@ -100,6 +102,27 @@ object Sink {
    */
   def head[In](): Sink[In, Future[In]] =
     new Sink(scaladsl.Sink.head[In])
+
+  /**
+   * A `Sink` that materializes into a `Future` of all elements in the stream
+   * as a strict collection.
+   * If the stream is inifite, this will never complete but it will consume
+   * all of your memory.
+   *
+   * (This is the same as [[toSeq]], but with a more Java friendly name.)
+   */
+  def toList[In](ec: ExecutionContext): Sink[In, Future[java.util.List[In]]] =
+    toSeq(ec)
+
+  /**
+   * A `Sink` that materializes into a `Future` of all elements in the stream
+   * as a strict collection.
+   * If the stream is inifite, this will never complete but it will consume
+   * all of your memory.
+   */
+  def toSeq[In](ec: ExecutionContext): Sink[In, Future[java.util.List[In]]] =
+    new Sink(scaladsl.Sink.toSeq[In](ec)
+      .mapMaterializedValue { _.map { _.asJava }(ec) })
 
   /**
    * Sends the elements of the stream to the given `ActorRef`.


### PR DESCRIPTION
I thought that the "Draining a stream to a strict collection" recipe could do with moving into the `Sink` helper in Akka, because it seems like such a fundamental operation that it was strange not to have a built in op for it.

I also added a "`single`" sink because this is another very common pattern which I think could do with a canonical implementation.

I have updated the documentation examples and the Akka source to use the new `Sink.toSeq` and `Sink.single` where appropriate. Hopefully this demonstrates the ubiquity of these two use-cases.

In both cases, the recipe is a little fiddly so I think users would benefit from a correct and tested canonical implementation in the base library.
### Implementation notes

The [recipe given in the docs](http://doc.akka.io/docs/akka-stream-and-http-experimental/1.0/scala/stream-cookbook.html#Draining_a_stream_to_a_strict_collection) for `Sink.toSeq` uses "`group`" + "`head`". I've ported that into `Sink` directly here.
Is that more efficient than using "`fold`" to aggregate a collection? 

What happens if the collection is empty? I don't see a "`headOption`" Sink. I've added a "recover", but it seems like it might be better to write a new `Subscriber` for "`toSeq`" like the "`HeadSinkSubscriber`"? How would the performance of that compare to the "group" version?

I had to introduce an implicit `ExecutionContext` for both Sinks. This makes them awkward to use in places. This would go away if they used a custom subscriber like the "`HeadSinkSubscriber`". Or they could require an implicit `FlowMaterializer`? (The latter is more heavyweight, but more likely to be in scope.)
### Java DSL naming

The "`DslFactoriesConsistencySpec`" test forces me to name the Sink "toSeq" in the Java version as well.
I've added a "toList" alias for it, as this is a much more natural name in Java.
