### PR TITLE
=clu #15412 Add paths(system) method to Group router

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/Broadcast.scala
+++ b/akka-actor/src/main/scala/akka/routing/Broadcast.scala
@@ -120,7 +120,7 @@ final case class BroadcastPool(
  */
 @SerialVersionUID(1L)
 final case class BroadcastGroup(
-  paths: immutable.Iterable[String],
+  override val paths: immutable.Iterable[String],
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
   extends Group {
 
@@ -133,6 +133,8 @@ final case class BroadcastGroup(
    *   sent with [[akka.actor.ActorSelection]] to these paths
    */
   def this(routeePaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeePaths))
+
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
 
   override def createRouter(system: ActorSystem): Router = new Router(BroadcastRoutingLogic())
 

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -364,6 +364,8 @@ final case class ConsistentHashingGroup(
    */
   def this(routeePaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeePaths))
 
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
+
   override def createRouter(system: ActorSystem): Router =
     new Router(ConsistentHashingRoutingLogic(system, virtualNodesFactor, hashMapping))
 

--- a/akka-actor/src/main/scala/akka/routing/Random.scala
+++ b/akka-actor/src/main/scala/akka/routing/Random.scala
@@ -135,6 +135,8 @@ final case class RandomGroup(
    */
   def this(routeePaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeePaths))
 
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
+
   override def createRouter(system: ActorSystem): Router = new Router(RandomRoutingLogic())
 
   /**

--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -141,6 +141,8 @@ final case class RoundRobinGroup(
    */
   def this(routeePaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeePaths))
 
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
+
   override def createRouter(system: ActorSystem): Router = new Router(RoundRobinRoutingLogic())
 
   /**

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
@@ -109,7 +109,10 @@ private[akka] class RoutedActorCell(
         if (nrOfRoutees > 0)
           addRoutees(Vector.fill(nrOfRoutees)(pool.newRoutee(routeeProps, this)))
       case group: Group ⇒
-        val paths = group.paths
+        // must not use group.paths(system) for old (not re-compiled) custom routers
+        // for binary backwards compatibility reasons
+        val deprecatedPaths = group.paths
+        val paths = if (deprecatedPaths == null) group.paths(system) else deprecatedPaths
         if (paths.nonEmpty)
           addRoutees(paths.map(p ⇒ group.routeeFor(p, this))(collection.breakOut))
       case _ ⇒

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -128,9 +128,16 @@ private[akka] trait PoolOverrideUnsetConfig[T <: Pool] extends Pool {
  * Java API: Base class for custom router [[Group]]
  */
 abstract class GroupBase extends Group {
-  def getPaths: java.lang.Iterable[String]
+  @deprecated("Implement getPaths with ActorSystem parameter instead", "2.4")
+  def getPaths: java.lang.Iterable[String] = null
 
+  @deprecated("Use paths with ActorSystem parameter instead", "2.4")
   override final def paths: immutable.Iterable[String] = immutableSeq(getPaths)
+
+  def getPaths(system: ActorSystem): java.lang.Iterable[String]
+
+  override final def paths(system: ActorSystem): immutable.Iterable[String] =
+    immutableSeq(getPaths(system))
 }
 
 /**
@@ -140,7 +147,10 @@ abstract class GroupBase extends Group {
  */
 trait Group extends RouterConfig {
 
-  def paths: immutable.Iterable[String]
+  @deprecated("Implement paths with ActorSystem parameter instead", "2.4")
+  def paths: immutable.Iterable[String] = null
+
+  def paths(system: ActorSystem): immutable.Iterable[String]
 
   /**
    * [[akka.actor.Props]] for a group router based on the settings defined by

--- a/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
+++ b/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
@@ -188,6 +188,8 @@ final case class ScatterGatherFirstCompletedGroup(
   def this(routeePaths: java.lang.Iterable[String], within: FiniteDuration) =
     this(paths = immutableSeq(routeePaths), within = within)
 
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
+
   override def createRouter(system: ActorSystem): Router = new Router(ScatterGatherFirstCompletedRoutingLogic(within))
 
   /**

--- a/akka-actor/src/main/scala/akka/routing/TailChopping.scala
+++ b/akka-actor/src/main/scala/akka/routing/TailChopping.scala
@@ -222,6 +222,8 @@ final case class TailChoppingGroup(
   override def createRouter(system: ActorSystem): Router =
     new Router(TailChoppingRoutingLogic(system.scheduler, within, interval, system.dispatchers.lookup(routerDispatcher)))
 
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
+
   /**
    * Setting the dispatcher to be used for the router head actor, which handles
    * router management messages

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
@@ -201,7 +201,7 @@ final case class AdaptiveLoadBalancingPool(
 @SerialVersionUID(1L)
 final case class AdaptiveLoadBalancingGroup(
   metricsSelector: MetricsSelector = MixMetricsSelector,
-  paths: immutable.Iterable[String] = Nil,
+  override val paths: immutable.Iterable[String] = Nil,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
   extends Group {
 
@@ -218,6 +218,8 @@ final case class AdaptiveLoadBalancingGroup(
    */
   def this(metricsSelector: MetricsSelector,
            routeesPaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeesPaths))
+
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
 
   override def createRouter(system: ActorSystem): Router =
     new Router(AdaptiveLoadBalancingRoutingLogic(system, metricsSelector))

--- a/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
@@ -213,7 +213,7 @@ final case class AdaptiveLoadBalancingPool(
 @deprecated("Superseded by akka.cluster.metrics (in akka-cluster-metrics jar)", "2.4")
 final case class AdaptiveLoadBalancingGroup(
   metricsSelector: MetricsSelector = MixMetricsSelector,
-  paths: immutable.Iterable[String] = Nil,
+  override val paths: immutable.Iterable[String] = Nil,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
   extends Group {
 
@@ -230,6 +230,8 @@ final case class AdaptiveLoadBalancingGroup(
    */
   def this(metricsSelector: MetricsSelector,
            routeesPaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeesPaths))
+
+  override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
 
   override def createRouter(system: ActorSystem): Router =
     new Router(AdaptiveLoadBalancingRoutingLogic(system, metricsSelector))

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -128,7 +128,14 @@ private[akka] trait ClusterRouterSettingsBase {
 @SerialVersionUID(1L)
 final case class ClusterRouterGroup(local: Group, settings: ClusterRouterGroupSettings) extends Group with ClusterRouterConfigBase {
 
-  override def paths: immutable.Iterable[String] = if (settings.allowLocalRoutees) settings.routeesPaths else Nil
+  override def paths(system: ActorSystem): immutable.Iterable[String] =
+    if (settings.allowLocalRoutees && settings.useRole.isDefined) {
+      if (Cluster(system).selfRoles.contains(settings.useRole.get)) {
+        settings.routeesPaths
+      } else Nil
+    } else if (settings.allowLocalRoutees && settings.useRole.isEmpty) {
+      settings.routeesPaths
+    } else Nil
 
   /**
    * INTERNAL API

--- a/akka-docs/rst/java/code/docs/jrouting/RedundancyGroup.java
+++ b/akka-docs/rst/java/code/docs/jrouting/RedundancyGroup.java
@@ -40,7 +40,7 @@ public class RedundancyGroup extends GroupBase {
   }
   
   @Override
-  public java.lang.Iterable<String> getPaths() {
+  public java.lang.Iterable<String> getPaths(ActorSystem system) {
     return paths;
   }
 

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -147,6 +147,14 @@ In order to make cluster routers smarter about when they can start local routees
 In case you have implemented a custom Pool you will have to update the method's signature,
 however the implementation can remain the same if you don't need to rely on an ActorSystem in your logic.
 
+Group routers paths method now takes ActorSystem
+===============================================
+
+In order to make cluster routers smarter about when they can start local routees,
+``paths`` defined on ``Group`` now takes ``ActorSystem`` as an argument.
+In case you have implemented a custom Group you will have to update the method's signature,
+however the implementation can remain the same if you don't need to rely on an ActorSystem in your logic.
+
 Logger names use full class name 
 ================================
 Previously, few places in akka used "simple" logger names, such as ``Cluster`` or ``Remoting``.

--- a/akka-docs/rst/scala/code/docs/routing/CustomRouterDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/routing/CustomRouterDocSpec.scala
@@ -77,11 +77,13 @@ import akka.routing.Router
 import akka.japi.Util.immutableSeq
 import com.typesafe.config.Config
 
-final case class RedundancyGroup(override val paths: immutable.Iterable[String], nbrCopies: Int) extends Group {
+final case class RedundancyGroup(routeePaths: immutable.Iterable[String], nbrCopies: Int) extends Group {
 
   def this(config: Config) = this(
-    paths = immutableSeq(config.getStringList("routees.paths")),
+    routeePaths = immutableSeq(config.getStringList("routees.paths")),
     nbrCopies = config.getInt("nbr-copies"))
+
+  override def paths(system: ActorSystem): immutable.Iterable[String] = routeePaths
 
   override def createRouter(system: ActorSystem): Router =
     new Router(new RedundancyRoutingLogic(nbrCopies))

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -417,9 +417,14 @@ object MiMa extends AutoPlugin {
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.testkit.MultiNodeSpec#Replacement.akka$remote$testkit$MultiNodeSpec$Replacement$$$outer"),
 
 
-      // method nrOfInstances(akka.actor.ActorSystem)Int in trait akka.routing.Pool does not have a correspondent in old version
+      // method nrOfInstances(akka.actor.ActorSystem) in trait akka.routing.Pool does not have a correspondent in old version
       // ok to exclude, since we don't call nrOfInstances(sys) for old implementations
       ProblemFilters.exclude[MissingMethodProblem]("akka.routing.Pool.nrOfInstances"),
+      
+      // method paths(akka.actor.ActorSystem) in trait akka.routing.Group does not have a correspondent in old version
+      // ok to exclude, since we don't call paths(sys) for old implementations
+      ProblemFilters.exclude[MissingMethodProblem]("akka.routing.Group.paths"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.routing.GroupBase.getPaths"),
 
       // removed deprecated
       ProblemFilters.exclude[MissingClassProblem]("akka.actor.UntypedActorFactory"),


### PR DESCRIPTION
to be able to use the role correctly in cluster aware routers

This solution is very similar to what we did for nrOfInstances
in Pool routers, see PR https://github.com/akka/akka/pull/15822
