### PR TITLE
=cls #17846 Use provided scope for the distributed-data dependency

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -110,6 +110,9 @@ final class ClusterShardingSettings(
   val tuningParameters: ClusterShardingSettings.TuningParameters,
   val coordinatorSingletonSettings: ClusterSingletonManagerSettings) extends NoSerializationVerificationNeeded {
 
+  require(stateStoreMode == "persistence" || stateStoreMode == "ddata",
+    s"Unknown 'state-store-mode' [$stateStoreMode], valid values are 'persistence' or 'ddata'")
+
   def withRole(role: String): ClusterShardingSettings = copy(role = ClusterShardingSettings.roleOption(role))
 
   def withRole(role: Option[String]): ClusterShardingSettings = copy(role = role)

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -135,8 +135,12 @@ object AkkaBuild extends Build {
   lazy val clusterSharding = Project(
     id = "akka-cluster-sharding",
     base = file("akka-cluster-sharding"),
+    // TODO akka-distributed-data dependency should be provided in pom.xml artifact.
+    //      If I only use "provided" here it works, but then we can't run tests.
+    //      Scope "test" is alright in the pom.xml, but would have been nicer with
+    //      provided.
     dependencies = Seq(cluster % "compile->compile;test->test;multi-jvm->multi-jvm",
-        persistence % "compile;test->provided", distributedData % "compile;test->provided", clusterTools)
+        persistence % "compile;test->provided", distributedData % "provided;test", clusterTools)
   ) configs (MultiJvm)
 
   lazy val distributedData = Project(


### PR DESCRIPTION
The scope in the pom.xml was "compile".
