### PR TITLE
=doc code snippet include in persistence docs (scala) was broken

### DIFF
--- a/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistencePluginDocSpec.scala
@@ -120,6 +120,7 @@ trait SharedLeveldbPluginDocSpec {
 
   new AnyRef {
     import akka.actor._
+    //#shared-store-creation
     import akka.persistence.journal.leveldb.SharedLeveldbStore
 
     val store = system.actorOf(Props[SharedLeveldbStore], "store")


### PR DESCRIPTION
Without this the import imports from the next line to "end of file".
