### PR TITLE
=con #18302 Backport ClusterClient failure detection improvement

### DIFF
--- a/akka-contrib/src/main/resources/reference.conf
+++ b/akka-contrib/src/main/resources/reference.conf
@@ -64,6 +64,18 @@ akka.contrib.cluster.receptionist {
 
 # //#cluster-client-mailbox-config
 akka.contrib.cluster.client {
+
+  # How often failure detection heartbeat messages should be sent
+  heartbeat-interval = 2s
+  
+  # Number of potentially lost/delayed heartbeats that will be
+  # accepted before considering it to be an anomaly.
+  # The ClusterClient is using the akka.remote.DeadlineFailureDetector, which
+  # will trigger if there are no heartbeats within the duration 
+  # heartbeat-interval + acceptable-heartbeat-pause, i.e. 15 seconds with
+  # the default settings.
+  acceptable-heartbeat-pause = 15s
+
   mailbox {
     mailbox-type = "akka.dispatch.UnboundedDequeBasedMailbox"
     stash-capacity = 1000


### PR DESCRIPTION
Note that this implementation of the ClusterClient cannot be used with old server, i.e. 2.3.12 and 2.3.13 compatibility. I think that is fair enough since this is in contrib and the old implementation was seriously broken. 
