### PR TITLE
=doc #18306 resolve problem with navigating using right-hand TOC

### DIFF
--- a/akka-docs/_sphinx/themes/akka/layout.html
+++ b/akka-docs/_sphinx/themes/akka/layout.html
@@ -354,9 +354,6 @@
   var $toc = $('#toc');
   $toc.toc();
 
-  // change hash when TOC link clicked:
-  $toc.find("a").click(function() { window.location.hash = $(this).attr('href'); });
-
   // show clickable section sign when section header hovered:
   $('.section h2,.section h3,.section h4,.section h5').each(function(i, el) {
       var $el = $(el);

--- a/akka-docs/_sphinx/themes/akka/static/scrollTo.js
+++ b/akka-docs/_sphinx/themes/akka/static/scrollTo.js
@@ -1,9 +1,8 @@
-jQuery(document).ready(function($) {
+jQuery(document).ready(function ($) {
 
-      $(".scroll").click(function(event){		
-        event.preventDefault();
-        $('html,body').animate({scrollTop:$(this.hash).offset().top}, 300);
-        $('html,body').animate({scrollTop:$(this.hash).offset().top-=5}, 300);
-        $(this.hash).effect("highlight", {color: "#FFCC85"}, 2000);
-      });
+  $(".scroll").click(function (event) {
+    event.preventDefault();
+    window.location.hash = $(this).attr('href');
+    $(this.hash).effect("highlight", {color: "#15A9CE"}, 2000);
+  });
 });

--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -148,7 +148,7 @@ In case you have implemented a custom Pool you will have to update the method's 
 however the implementation can remain the same if you don't need to rely on an ActorSystem in your logic.
 
 Group routers paths method now takes ActorSystem
-===============================================
+================================================
 
 In order to make cluster routers smarter about when they can start local routees,
 ``paths`` defined on ``Group`` now takes ``ActorSystem`` as an argument.


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/18306

The right-hand-side TOC navigation now properly works - there was too much stuff going on at the same click()
