### PR TITLE
=doc #16122 improve color of strong elements inside note/warn

### DIFF
--- a/akka-docs/_sphinx/themes/akka/static/docs.css
+++ b/akka-docs/_sphinx/themes/akka/static/docs.css
@@ -128,11 +128,15 @@ strong {color: #0B5567; }
   text-decoration: underline;
 }
 .admonition p.admonition-title {
-	color: #ffffff;
-	margin-bottom: 6px;
-	font-size: 16px;
-	font-weight: bold;
-	line-height: 20px;
+  color: #ffffff;
+  margin-bottom: 6px;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 20px;
+}
+
+.admonition strong, .warning strong {
+  color: #ffffff;
 }
 
 .topic {


### PR DESCRIPTION
Minor style improvement, which actually goes back to the one observed initially in #16122 :wink: 

previous:
<img width="210" alt="remoting_ _akka_documentation" src="https://cloud.githubusercontent.com/assets/120979/9452397/9e1c7816-4abc-11e5-9a92-30895fbc37c4.png">

now:
<img width="203" alt="remoting_ _akka_documentation" src="https://cloud.githubusercontent.com/assets/120979/9452405/a626914a-4abc-11e5-8e6f-bbb16e29cbb4.png">

Let me know if you think it's an improvement or not and merge or close please :)
