### PR TITLE
=doc fix typo: scaladoc syntax used instead of rst syntax

### DIFF
--- a/akka-docs/rst/java/cluster-singleton.rst
+++ b/akka-docs/rst/java/cluster-singleton.rst
@@ -28,7 +28,7 @@ supplied ``Props``. ``ClusterSingletonManager`` makes sure that at most one sing
 is running at any point in time.
 
 The singleton actor is always running on the oldest member with specified role.
-The oldest member is determined by [[akka.cluster.Member#isOlderThan]].
+The oldest member is determined by ``akka.cluster.Member#isOlderThan``.
 This can change when removing that member from the cluster. Be aware that there is a short time
 period when there is no active singleton during the hand-over process.
 

--- a/akka-docs/rst/scala/cluster-singleton.rst
+++ b/akka-docs/rst/scala/cluster-singleton.rst
@@ -28,7 +28,7 @@ supplied ``Props``. ``ClusterSingletonManager`` makes sure that at most one sing
 is running at any point in time.
 
 The singleton actor is always running on the oldest member with specified role.
-The oldest member is determined by [[akka.cluster.Member#isOlderThan]].
+The oldest member is determined by ``akka.cluster.Member#isOlderThan``.
 This can change when removing that member from the cluster. Be aware that there is a short time
 period when there is no active singleton during the hand-over process.
 


### PR DESCRIPTION
Fixes simple typo: scaladoc syntax was used instead of rst syntax in one spot of the docs.
