### PR TITLE
=cls #15646 Optimize the initial watch in shard coordinator

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
@@ -432,7 +432,6 @@ abstract class ClusterShardingSpec(config: ClusterShardingSpecConfig) extends Mu
 
     "use third and fourth node" in within(15 seconds) {
       join(third, first)
-      join(fourth, first)
 
       runOn(third) {
         for (_ ← 1 to 10)
@@ -442,6 +441,8 @@ abstract class ClusterShardingSpec(config: ClusterShardingSpecConfig) extends Mu
         lastSender.path should ===(region.path / "3" / "3") // local
       }
       enterBarrier("third-update")
+
+      join(fourth, first)
 
       runOn(fourth) {
         for (_ ← 1 to 20)


### PR DESCRIPTION
Two improvements to the coordinator startup (state recovery) that
should make it operational faster and reduce the amount of lost messages
during startup.
- Let the quick (those not involving failure detection) Terminated messages
  be processed before starting to reply to GetShardHome.
- Consider regions that don't belong to the current cluster
  to be terminated.
