### PR TITLE
=clu #17253 Improve cluster startup thread usage

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -22,7 +22,9 @@ import akka.actor.DeadLetterSuppression
 private[cluster] final class ClusterHeartbeatReceiver extends Actor with ActorLogging {
   import ClusterHeartbeatSender._
 
-  val selfHeartbeatRsp = HeartbeatRsp(Cluster(context.system).selfUniqueAddress)
+  // Important - don't use Cluster(context.system) in constructor because that would
+  // cause deadlock. See startup sequence in ClusterDaemon.
+  lazy val selfHeartbeatRsp = HeartbeatRsp(Cluster(context.system).selfUniqueAddress)
 
   def receive = {
     case Heartbeat(from) ⇒ sender() ! selfHeartbeatRsp

--- a/akka-cluster/src/test/scala/akka/cluster/StartupWithOneThreadSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/StartupWithOneThreadSpec.scala
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.cluster
+
+import language.postfixOps
+import language.reflectiveCalls
+import scala.concurrent.duration._
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.actor.ExtendedActorSystem
+import akka.actor.Address
+import akka.cluster.InternalClusterAction._
+import java.lang.management.ManagementFactory
+import javax.management.ObjectName
+import akka.actor.ActorRef
+import akka.testkit.TestProbe
+import akka.actor.Props
+import akka.actor.Actor
+import akka.actor.ActorLogging
+
+object StartupWithOneThreadSpec {
+  val config = """
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.actor.creation-timeout = 10s
+    akka.remote.netty.tcp.port = 0
+
+    akka.actor.default-dispatcher {
+      executor = thread-pool-executor
+      thread-pool-executor {
+        core-pool-size-min = 1
+        core-pool-size-max = 1
+      }
+    }
+    """
+
+  final case class GossipTo(address: Address)
+
+  def testProps = Props(new Actor with ActorLogging {
+    val cluster = Cluster(context.system)
+    log.debug(s"started ${cluster.selfAddress} ${Thread.currentThread().getName}")
+    def receive = {
+      case msg ⇒ sender() ! msg
+    }
+  })
+}
+
+class StartupWithOneThreadSpec(startTime: Long) extends AkkaSpec(StartupWithOneThreadSpec.config) with ImplicitSender {
+  import StartupWithOneThreadSpec._
+
+  def this() = this(System.nanoTime())
+
+  "A Cluster" must {
+
+    "startup with one dispatcher thread" in {
+      // This test failed before fixing #17253 when adding a sleep before the
+      // Await of GetClusterCoreRef in the Cluster extension constructor.
+      // The reason was that other cluster actors were started too early and
+      // they also tried to get the Cluster extension and thereby blocking
+      // dispatcher threads.
+      // Note that the Cluster extension is started via ClusterActorRefProvider
+      // before ActorSystem.apply returns, i.e. in the constructor of AkkaSpec.
+      (System.nanoTime - startTime).nanos.toMillis should be <
+        (system.settings.CreationTimeout.duration - 2.second).toMillis
+      system.actorOf(testProps) ! "hello"
+      system.actorOf(testProps) ! "hello"
+      system.actorOf(testProps) ! "hello"
+
+      val cluster = Cluster(system)
+      (System.nanoTime - startTime).nanos.toMillis should be <
+        (system.settings.CreationTimeout.duration - 2.second).toMillis
+
+      expectMsg("hello")
+      expectMsg("hello")
+      expectMsg("hello")
+    }
+
+  }
+}

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -545,7 +545,12 @@ object MiMa extends AutoPlugin {
       ProblemFilters.exclude[MissingMethodProblem]("akka.japi.Pair.toString"),
       
       // #17805
-      ProblemFilters.exclude[MissingMethodProblem]("akka.actor.ActorCell.clearActorFields")
+      ProblemFilters.exclude[MissingMethodProblem]("akka.actor.ActorCell.clearActorFields"),
+      
+      // internal changes introduced by #17253
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.ClusterDaemon.coreSupervisor"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.ClusterCoreSupervisor.publisher"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.ClusterCoreSupervisor.coreDaemon")
 
      )
   }


### PR DESCRIPTION
When using a dispatcher (default or separate cluster dispatcher)
with less than 5 threads the Cluster extension initialization
could deadlock.

It was reproducable by adding a sleep before the Await of GetClusterCoreRef
in the Cluster extension constructor. The reason was that other cluster actors were
started too early and they also tried to get the Cluster extension and thereby blocking
dispatcher threads.

Note that the Cluster extension is started via ClusterActorRefProvider before
ActorSystem.apply returns.

The improvement is to start the cluster child actors lazily when the
GetClusterCoreRef is received.
