### PR TITLE
=doc update stream-io doc page to the latest API

### DIFF
--- a/akka-docs-dev/_sphinx/themes/akka/static/docs.css
+++ b/akka-docs-dev/_sphinx/themes/akka/static/docs.css
@@ -170,11 +170,10 @@ strong {color: #0B5567; }
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
-.pre { padding: 1px 2px; color: #0B5567; background-color: #EFF2F5; border: 1px solid #dee1e2; font-family: Menlo, Monaco, "Courier New", monospace; font-size: 12px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; }
+.pre { color: #0B5567; }
 .footer h5 { text-transform: none; }
 
 
 .section-marker { position: absolute; width: 1em; margin-left: -1em; display: block; text-decoration: none; visibility: hidden; text-align: center; font-weight: normal; }
 .section-marker:hover { text-decoration: none; }
 .section h2:hover > a,.section h3:hover > a,.section h4:hover > a,.section h5:hover > a { visibility: visible; }
-

--- a/akka-docs-dev/_sphinx/themes/akka/static/style.css
+++ b/akka-docs-dev/_sphinx/themes/akka/static/style.css
@@ -99,7 +99,7 @@ address{display:block;margin-bottom:18px;line-height:18px;font-style:normal;}
 small{font-size:100%;}
 cite{font-style:normal;}
 code,pre{padding:0 3px 2px;font-family:Menlo,Monaco,"Courier New",monospace;font-size:12px;color:#333333;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
-code{padding:3px 4px;color:#d14;background-color:#f7f7f9;border:1px solid #e1e1e8;}
+code{padding:1px 4px;color:#d14;background-color:#f7f7f9;border:1px solid #e1e1e8;}
 pre{display:block;padding:8.5px;margin:0 0 9px;font-size:12px;line-height:18px;background-color:#f5f5f5;border:1px solid #ccc;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;/*white-space:pre;white-space:pre-wrap*/;word-break:break-all;}pre.prettyprint{margin-bottom:18px;}
 pre code{padding:0;background-color:transparent;}
 form{margin:0 0 18px;}

--- a/akka-docs-dev/rst/java/stream-io.rst
+++ b/akka-docs-dev/rst/java/stream-io.rst
@@ -16,7 +16,7 @@ Streaming TCP
 
 Accepting connections: Echo Server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In order to implement a simple EchoServer we ``bind`` to a given address, which returns a ``Source[IncomingConnection]``,
+In order to implement a simple EchoServer we ``bind`` to a given address, which returns a ``Source<IncomingConnection, Future<ServerBinding>>``,
 which will emit an :class:`IncomingConnection` element for each new connection that the Server should handle:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/io/StreamTcpDocTest.java#echo-server-simple-bind
@@ -35,8 +35,8 @@ incoming connection Flow, since it directly corresponds to an existing, already 
 only ever be materialized *once*.
 
 Closing connections is possible by cancelling the *incoming connection* :class:`Flow` from your server logic (e.g. by
-connecting its downstream to an :class:`CancelledSink` and its upstream to a *completed* :class:`Source`).
-It is also possible to shut down the servers socket by cancelling the ``connections:Source[IncomingConnection]``.
+connecting its downstream to a :class:`Sink.cancelled()` and its upstream to a :class:`Source.empty()`).
+It is also possible to shut down the server's socket by cancelling the :class:`IncomingConnection` source ``connections``.
 
 We can then test the TCP server by sending data to the TCP Socket using ``netcat``:
 

--- a/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
@@ -47,7 +47,10 @@ class StreamTcpDocSpec extends AkkaSpec {
         println(s"New connection from: ${connection.remoteAddress}")
 
         val echo = Flow[ByteString]
-          .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = 256, allowTruncation = true))
+          .via(Framing.delimiter(
+            ByteString("\n"),
+            maximumFrameLength = 256,
+            allowTruncation = true))
           .map(_.utf8String)
           .map(_ + "!!!\n")
           .map(ByteString(_))
@@ -86,7 +89,10 @@ class StreamTcpDocSpec extends AkkaSpec {
 
         val welcome = Source.single(ByteString(welcomeMsg))
         val echo = b.add(Flow[ByteString]
-          .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = 256, allowTruncation = true))
+          .via(Framing.delimiter(
+            ByteString("\n"),
+            maximumFrameLength = 256,
+            allowTruncation = true))
           .map(_.utf8String)
           //#welcome-banner-chat-server
           .map { command ⇒ serverProbe.ref ! command; command }
@@ -106,9 +112,9 @@ class StreamTcpDocSpec extends AkkaSpec {
 
       connection.handleWith(serverLogic)
     }
+    //#welcome-banner-chat-server
 
     import akka.stream.io.Framing
-    //#welcome-banner-chat-server
 
     val input = new AtomicReference("Hello world" :: "What a lovely day" :: Nil)
     def readLine(prompt: String): String = {
@@ -138,7 +144,10 @@ class StreamTcpDocSpec extends AkkaSpec {
       }
 
       val repl = Flow[ByteString]
-        .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = 256, allowTruncation = true))
+        .via(Framing.delimiter(
+          ByteString("\n"),
+          maximumFrameLength = 256,
+          allowTruncation = true))
         .map(_.utf8String)
         .map(text => println("Server: " + text))
         .map(_ => readLine("> "))

--- a/akka-docs-dev/rst/scala/stream-io.rst
+++ b/akka-docs-dev/rst/scala/stream-io.rst
@@ -16,7 +16,7 @@ Streaming TCP
 
 Accepting connections: Echo Server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In order to implement a simple EchoServer we ``bind`` to a given address, which returns a ``Source[IncomingConnection]``,
+In order to implement a simple EchoServer we ``bind`` to a given address, which returns a ``Source[IncomingConnection, Future[ServerBinding]]``,
 which will emit an :class:`IncomingConnection` element for each new connection that the Server should handle:
 
 .. includecode:: code/docs/stream/io/StreamTcpDocSpec.scala#echo-server-simple-bind
@@ -35,8 +35,8 @@ incoming connection Flow, since it directly corresponds to an existing, already 
 only ever be materialized *once*.
 
 Closing connections is possible by cancelling the *incoming connection* :class:`Flow` from your server logic (e.g. by
-connecting its downstream to an :class:`CancelledSink` and its upstream to a *completed* :class:`Source`).
-It is also possible to shut down the servers socket by cancelling the ``connections:Source[IncomingConnection]``.
+connecting its downstream to a :class:`Sink.cancelled` and its upstream to a :class:`Source.empty`).
+It is also possible to shut down the server's socket by cancelling the :class:`IncomingConnection` source ``connections``.
 
 We can then test the TCP server by sending data to the TCP Socket using ``netcat``:
 


### PR DESCRIPTION
Updated Stream Io doc pages to conform to the latest API.

Also fixed style sheets to remove double border from inline code blocks. Inline code now looks like:

![selection_007](https://cloud.githubusercontent.com/assets/422086/9540539/835f6796-4d68-11e5-8699-3d4382b5d2d3.png)
