### PR TITLE
=pro workaround for scalaunidoc:doc issues

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -17,6 +17,8 @@ import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import sbt.Keys._
 import sbt._
+import sbtunidoc.Plugin.ScalaUnidoc
+import sbtunidoc.Plugin.UnidocKeys._
 
 object AkkaBuild extends Build {
   System.setProperty("akka.mode", "test") // Is there better place for this?
@@ -44,6 +46,14 @@ object AkkaBuild extends Build {
       parallelExecution in GlobalScope := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
       Dist.distExclude := Seq(actorTests.id, docs.id, samples.id, osgi.id),
 
+      // FIXME problem with scalaunidoc:doc, there must be a better way
+      unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(protobuf, samples,
+        sampleCamelJava, sampleCamelScala, sampleClusterJava, sampleClusterScala, sampleFsmScala, sampleFsmJavaLambda,
+        sampleMainJava, sampleMainScala, sampleMainJavaLambda, sampleMultiNodeScala,
+        samplePersistenceJava, samplePersistenceScala, samplePersistenceJavaLambda,
+        sampleRemoteJava, sampleRemoteScala, sampleSupervisionJavaLambda,
+        sampleDistributedDataScala, sampleDistributedDataJava),
+      
       S3.host in S3.upload := "downloads.typesafe.com.s3.amazonaws.com",
       S3.progress in S3.upload := true,
       mappings in S3.upload <<= (Release.releaseDirectory, version) map { (d, v) =>


### PR DESCRIPTION
```
[error] /Users/patrik/dev/akka/akka-protobuf/src/main/java/akka/protobuf/Descriptors.java:1282: private trait GenericDescriptor escapes its defining scope as part of type akka.protobuf.Descriptors.GenericDescriptor
[error]       implements GenericDescriptor, Internal.EnumLite {
[error]                  ^
[info] No documentation generated with unsuccessful compiler run
[warn] one warning found
[error] one error found
[error] (akka/scalaunidoc:doc) Scaladoc generation failed
```

Disabled scalaunidoc for the protobuf project and all samples (I have no clue why samples started failing).
