### PR TITLE
=sam update dependencies from snapshot to RC2

### DIFF
--- a/akka-samples/akka-sample-persistence-java-lambda/build.sbt
+++ b/akka-samples/akka-sample-persistence-java-lambda/build.sbt
@@ -2,13 +2,15 @@ name := "akka-sample-persistence-java-lambda"
 
 version := "1.0"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
 javacOptions in compile ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-Xlint")
 
 javacOptions in doc ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-Xdoclint:none")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-persistence" % "2.4-SNAPSHOT"
+  "com.typesafe.akka" %% "akka-persistence" % "2.4-SNAPSHOT",
+  "org.iq80.leveldb" % "leveldb" % "0.7",
+  "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8"
 )
 

--- a/akka-samples/akka-sample-persistence-java-lambda/src/main/resources/application.conf
+++ b/akka-samples/akka-sample-persistence-java-lambda/src/main/resources/application.conf
@@ -1,3 +1,6 @@
+akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+
 akka.persistence.journal.leveldb.dir = "target/example/journal"
 akka.persistence.snapshot-store.local.dir = "target/example/snapshots"
 

--- a/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
@@ -28,7 +28,7 @@ Custom storage locations for the journal and snapshots can be defined in
 <h2>Persistent actor</h2>
 <p>
 <a href="#code/src/main/java/sample/persistence/PersistentActorExample.java" class="shortcut">PersistentActorExample.java</a>
-is described in detail in the <a href="http://doc.akka.io/docs/akka/2.3-SNAPSHOT/java/lambda-persistence.html#event-sourcing-java-lambda" target="_blank">Event sourcing</a>
+is described in detail in the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/lambda-persistence.html#event-sourcing-java-lambda" target="_blank">Event sourcing</a>
 section of the user documentation. With every application run, the <code>ExamplePersistentActor</code> is recovered from
 events stored in previous application runs, processes new commands, stores new events and snapshots and prints the
 current persistent actor state to <code>stdout</code>.

--- a/akka-samples/akka-sample-persistence-java/build.sbt
+++ b/akka-samples/akka-sample-persistence-java/build.sbt
@@ -2,9 +2,11 @@ name := "akka-sample-persistence-java"
 
 version := "2.4-SNAPSHOT"
 
-scalaVersion := "2.11.5"
+scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-persistence" % "2.4-SNAPSHOT"
+  "com.typesafe.akka" %% "akka-persistence" % "2.4-SNAPSHOT",
+  "org.iq80.leveldb" % "leveldb" % "0.7",
+  "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8"
 )
 

--- a/akka-samples/akka-sample-persistence-java/src/main/resources/application.conf
+++ b/akka-samples/akka-sample-persistence-java/src/main/resources/application.conf
@@ -1,3 +1,6 @@
+akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+
 akka.persistence.journal.leveldb.dir = "target/example/journal"
 akka.persistence.snapshot-store.local.dir = "target/example/snapshots"
 

--- a/akka-samples/akka-sample-persistence-java/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java/tutorial/index.html
@@ -28,7 +28,7 @@ Custom storage locations for the journal and snapshots can be defined in
 <h2>Persistent actor</h2>
 <p>
 <a href="#code/src/main/java/sample/persistence/PersistentActorExample.java" class="shortcut">PersistentActorExample.java</a>
-is described in detail in the <a href="http://doc.akka.io/docs/akka/2.3-SNAPSHOT/java/persistence.html#event-sourcing-java" target="_blank">Event sourcing</a>
+is described in detail in the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/persistence.html#event-sourcing-java" target="_blank">Event sourcing</a>
 section of the user documentation. With every application run, the <code>ExamplePersistentActor</code> is recovered from
 events stored in previous application runs, processes new commands, stores new events and snapshots and prints the
 current persistent actor state to <code>stdout</code>.

--- a/akka-samples/akka-sample-persistence-scala/build.sbt
+++ b/akka-samples/akka-sample-persistence-scala/build.sbt
@@ -2,9 +2,10 @@ name := "akka-sample-persistence-scala"
 
 version := "2.4-SNAPSHOT"
 
-scalaVersion := "2.11.5"
+scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT",
-  "com.typesafe.akka" %% "akka-persistence" % "2.4-SNAPSHOT"
+  "com.typesafe.akka" %% "akka-persistence" % "2.4-SNAPSHOT",
+  "org.iq80.leveldb"            % "leveldb"          % "0.7",
+  "org.fusesource.leveldbjni"   % "leveldbjni-all"   % "1.8"
 )

--- a/akka-samples/akka-sample-persistence-scala/src/main/resources/application.conf
+++ b/akka-samples/akka-sample-persistence-scala/src/main/resources/application.conf
@@ -1,3 +1,6 @@
+akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+
 akka.persistence.journal.leveldb.dir = "target/example/journal"
 akka.persistence.snapshot-store.local.dir = "target/example/snapshots"
 

--- a/akka-samples/akka-sample-persistence-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-scala/tutorial/index.html
@@ -27,7 +27,7 @@ Custom storage locations for the journal and snapshots can be defined in
 <h2>Persistent actor</h2>
 <p>
 <a href="#code/src/main/scala/sample/persistence/PersistentActorExample.scala" class="shortcut">PersistentActorExample.scala</a>
-is described in detail in the <a href="http://doc.akka.io/docs/akka/2.3-SNAPSHOT/scala/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
+is described in detail in the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
 section of the user documentation. With every application run, the <code>ExamplePersistentActor</code> is recovered from
 events stored in previous application runs, processes new commands, stores new events and snapshots and prints the
 current persistent actor state to <code>stdout</code>.


### PR DESCRIPTION
As I mentioned to @ktoso on gitter...

Makes the examples buildable and runnable.

Although now PersistentView is deprecated (raises warning in ViewExample). Should I also replace it with Persistence Queries ?
