### PR TITLE
=mnt #17317 Harden reconnect when attaching to test conductor

### DIFF
--- a/akka-multi-node-testkit/src/main/resources/reference.conf
+++ b/akka-multi-node-testkit/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ akka {
     connect-timeout = 20s
     
     # Number of connect attempts to be made to the conductor controller
-    client-reconnects = 10
+    client-reconnects = 30
     
     # minimum time interval which is to be inserted between reconnect attempts
     reconnect-backoff = 1s

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -162,10 +162,11 @@ private[akka] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress)
     case Event(Connected(channel), _) ⇒
       channel.write(Hello(name.name, TestConductor().address))
       goto(AwaitDone) using Data(Some(channel), None)
-    case Event(_: ConnectionFailure, _) ⇒
+    case Event(e: ConnectionFailure, _) ⇒
+      log.error(e, "ConnectionFailure")
       goto(Failed)
     case Event(StateTimeout, _) ⇒
-      log.error("connect timeout to TestConductor")
+      log.error("Failed to connect to test conductor within {} ms.", settings.ConnectTimeout.toMillis)
       goto(Failed)
   }
 


### PR DESCRIPTION
The failing tests showed big variations in startup times, i.e.
JVM1 not started/bound when other JVMs tries to connect to the
test conductor. The reconnect logic was in place but it was
bound to 10 client-reconnects (10 seconds). It's better to let
it by default reconnect until the connect-timeout (20 seconds)
is elapsed.
