### PR TITLE
=cls #18176 Harden ClusterShardingLeavingSpec

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
@@ -125,7 +125,7 @@ abstract class ClusterShardingLeavingSpec(config: ClusterShardingLeavingSpecConf
     runOn(from) {
       cluster join node(to).address
       startSharding()
-      within(5.seconds) {
+      within(15.seconds) {
         awaitAssert(cluster.state.members.exists { m ⇒
           m.uniqueAddress == cluster.selfUniqueAddress && m.status == MemberStatus.Up
         } should be(true))


### PR DESCRIPTION
In logs it is clear that the fourth node is moved to Up,
but it takes more than 5 sec to disseminate that info
