### PR TITLE
!per #18050 Make event adapter lookup more efficient

### DIFF
--- a/akka-persistence-query/src/test/scala/akka/persistence/query/PersistenceQuerySpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/PersistenceQuerySpec.scala
@@ -5,12 +5,11 @@
 package akka.persistence.query
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.actor.ActorSystem
-import akka.persistence.journal.{ EventAdapter, EventSeq }
+import akka.persistence.journal.EventSeq
+import akka.persistence.journal.ReadEventAdapter
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -73,9 +72,6 @@ object ExampleQueryModels {
   case class NewModel(value: String)
 }
 
-class PrefixStringWithPAdapter extends EventAdapter {
+class PrefixStringWithPAdapter extends ReadEventAdapter {
   override def fromJournal(event: Any, manifest: String) = EventSeq.single("p-" + event)
-
-  override def manifest(event: Any) = ""
-  override def toJournal(event: Any) = throw new Exception("toJournal should not be called by query side")
 }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
@@ -16,8 +16,10 @@ import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.util.Try
 
-/** INTERNAL API */
-private[akka] class EventAdapters(
+/**
+ * `EventAdapters` serves as a per-journal collection of bound event adapters.
+ */
+class EventAdapters(
   map: ConcurrentHashMap[Class[_], EventAdapter],
   bindings: immutable.Seq[(Class[_], EventAdapter)],
   log: LoggingAdapter) {
@@ -62,7 +64,10 @@ private[akka] object EventAdapters {
   def apply(system: ExtendedActorSystem, config: Config): EventAdapters = {
     val adapters = configToMap(config, "event-adapters")
     val adapterBindings = configToListMap(config, "event-adapter-bindings")
-    apply(system, adapters, adapterBindings)
+    if (adapters.isEmpty && adapterBindings.isEmpty)
+      IdentityEventAdapters
+    else
+      apply(system, adapters, adapterBindings)
   }
 
   private def apply(

--- a/akka-persistence/src/main/scala/akka/persistence/journal/WriteJournalBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/WriteJournalBase.scala
@@ -13,8 +13,8 @@ import akka.persistence.AtomicWrite
 private[akka] trait WriteJournalBase {
   this: Actor ⇒
 
-  lazy val persistence = Persistence(context.system)
-  private def eventAdapters = persistence.adaptersFor(self)
+  val persistence = Persistence(context.system)
+  private val eventAdapters = persistence.adaptersFor(self)
 
   protected def preparePersistentBatch(rb: immutable.Seq[PersistentEnvelope]): immutable.Seq[AtomicWrite] =
     rb.collect { // collect instead of flatMap to avoid Some allocations


### PR DESCRIPTION
When looking into "Integrate EventAdapters to the Query side" I found a few other things.

It looks like `adaptFromJournal` is rather inefficient since the `eventAdapters` is a `def` and `adaptersFor` is O(n) with number of configured plugins (and rather costly also for 1 plugin).

The bigger problem is that we can't change this without breaking binary compatibility. At least I have not found a way. Breaking the journal plugins that was built for 2.4.0-RC2 is not nice, but now is better than later.

I'm not sure if this is the right thing to do, or if there is some alternative. Also, do we have to make another RC because of this? Let's discuss on Monday.
