### PR TITLE
=con #18459 Detect quick server restart in ClusterClient

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterClient.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ClusterClient.scala
@@ -200,7 +200,11 @@ class ClusterClient(
         // heartbeat messages for compatibility with 2.3.12
         receptionist ! Identify(Heartbeat)
       }
-    case ActorIdentity(Heartbeat, _) ⇒
+    case ActorIdentity(Heartbeat, None) ⇒
+      // Server replied, but without ref, i.e. new incarnation (new uid) of receptionist,
+      // which may happen if server is restarted. Don't call failureDetector.
+      ()
+    case ActorIdentity(Heartbeat, Some(_)) ⇒
       // heartbeat reply, using Identify/ActorIdentify messages instead
       // of specialized heartbeat messages for compatibility with 2.3.12
       failureDetector.heartbeat()


### PR DESCRIPTION
- the problem was that the new server replied with ActorIdentity("H", None)
  which is the auto-reply from EmptyLocalActorRef and we treated that as
  valid heartbeat replies
- including test case that fails before the fix
