### PR TITLE
=doc #18104 fixes typo which made includecode2 not work in many places

### DIFF
--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractExecutionContext.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractExecutionContext.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0extractExecutionContext

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractLog.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractLog.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0extractLog

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractMaterializer.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractMaterializer.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0extractMaterializer

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractRequestContext.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractRequestContext.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0extractRequestContext

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractSettings.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/extractSettings.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0extractSettings

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapRouteResultFuture.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapRouteResultFuture.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0mapRouteResultFuture

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWith.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWith.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0mapRouteResultWith

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWithPF.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWithPF.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0mapRouteResultWithPF

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapSettings.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/mapSettings.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0mapSettings

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/recoverRejections.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/recoverRejections.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0recoverRejections

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/recoverRejectionsWith.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/recoverRejectionsWith.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0recoverRejectionsWith

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withExecutionContext.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withExecutionContext.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0withExecutionContext

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withLog.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withLog.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0withLog

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withMaterializer.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withMaterializer.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0withMaterializer

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withSettings.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/basic-directives/withSettings.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
    :snippet: 0withSettings

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/coding-directives/decodeRequestWith.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/coding-directives/decodeRequestWith.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala
    :snippet: 0decodeRequestWith

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/method-directives/extractMethod.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/method-directives/extractMethod.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
    :snippet: 0extractMethod

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/method-directives/overrideMethodWithParameter.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/method-directives/overrideMethodWithParameter.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
    :snippet: 0overrideMethodWithParameter

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameter.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameter.rst
@@ -19,5 +19,5 @@ See :ref:`-parameters-`
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: example-1

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameterMap.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameterMap.rst
@@ -24,5 +24,5 @@ choices.
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: parameterMap

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameterMultiMap.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameterMultiMap.rst
@@ -23,5 +23,5 @@ See :ref:`which-parameter-directive` for other choices.
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: parameterMultiMap

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameterSeq.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameterSeq.rst
@@ -22,5 +22,5 @@ See :ref:`which-parameter-directive` for other choices.
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: parameterSeq

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameters.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameters.rst
@@ -61,41 +61,41 @@ Examples
 Required parameter
 ++++++++++++++++++
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: required-1
 
 Optional parameter
 ++++++++++++++++++
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: optional
 
 Optional parameter with default value
 +++++++++++++++++++++++++++++++++++++
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: optional-with-default
 
 Parameter with required value
 +++++++++++++++++++++++++++++
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: required-value
 
 Deserialized parameter
 ++++++++++++++++++++++
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: mapped-value
 
 Repeated parameter
 ++++++++++++++++++
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: repeated
 
 Repeated, deserialized parameter
 ++++++++++++++++++++++++++++++++
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: mapped-repeated

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/path-directives/redirectToNoTrailingSlashIfPresent.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/path-directives/redirectToNoTrailingSlashIfPresent.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
    :snippet: 0redirectToNoTrailingSlashIfPresent

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/path-directives/redirectToTrailingSlashIfMissing.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/path-directives/redirectToTrailingSlashIfMissing.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
    :snippet: 0redirectToTrailingSlashIfMissing

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/range-directives/withRangeSupport.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/range-directives/withRangeSupport.rst
@@ -44,5 +44,5 @@ See also: https://tools.ietf.org/html/rfc7233
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
    :snippet: withRangeSupport

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/overrideStatusCode.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/overrideStatusCode.rst
@@ -23,5 +23,5 @@ unconditionally overriding the status code with the given one.
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
    :snippet: overrideStatusCode-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeader.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeader.rst
@@ -26,5 +26,5 @@ response. If you'd like to add more than one header you can use the :ref:`-respo
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
    :snippet: respondWithDefaultHeader-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeader.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeader.rst
@@ -24,5 +24,5 @@ If you'd like to add more than one header you can use the :ref:`-respondWithHead
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
    :snippet: respondWithHeader-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeaders.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeaders.rst
@@ -24,5 +24,5 @@ If you'd like to add just a single header you can use the :ref:`-respondWithHead
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
    :snippet: respondWithHeaders-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/complete.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/complete.rst
@@ -36,5 +36,5 @@ directives have potentially chained into the :ref:`RouteResult` future transform
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
    :snippet: complete-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/failWith.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/failWith.rst
@@ -34,5 +34,5 @@ exception.
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
    :snippet: failwith-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/redirect.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/redirect.rst
@@ -26,5 +26,5 @@ It is equivalent to this snippet relying on the ``complete`` directive:
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
    :snippet: redirect-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/reject.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/reject.rst
@@ -29,5 +29,5 @@ modifier for "filtering out" certain cases.
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
    :snippet: reject-examples

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/scheme-directives/extractScheme.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/scheme-directives/extractScheme.rst
@@ -22,5 +22,5 @@ For rejecting a request if it doesn't match a specified scheme name, see the :re
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
    :snippet: example-1

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/scheme-directives/scheme.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/scheme-directives/scheme.rst
@@ -26,6 +26,6 @@ For simply extracting the scheme name, see the :ref:`-extractScheme-` directive.
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
    :snippet: example-2
 

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasic.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasic.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
    :snippet: 0authenticateBasic

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasicAsync.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasicAsync.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
    :snippet: 0authenticateBasicAsync

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasicPF.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasicPF.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
    :snippet: 0authenticateBasicPF

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasicPFAsync.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateBasicPFAsync.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
    :snippet: 0authenticateBasicPFAsync

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
    :snippet: 0authenticateOrRejectWithChallenge

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authorize.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authorize.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
    :snippet: 0authorize

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/extractCredentials.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/extractCredentials.rst
@@ -19,5 +19,5 @@ Description
 Example
 -------
 
-... includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
    :snippet: 0extractCredentials


### PR DESCRIPTION
Note that some of the files don't exist, fixing this very soon...

Resolves https://github.com/akka/akka/issues/18104

// cc @jrudolph @sirthias (unless I missed something, the `... includecode2` does not work, and `..`does, as is expected)
