### PR TITLE
=clt #18440 Harden ClusterClientSpec again

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
@@ -39,7 +39,7 @@ object ClusterClientSpec extends MultiNodeConfig {
     akka.cluster.client.heartbeat-interval = 1s
     akka.cluster.client.acceptable-heartbeat-pause = 3s
     # number-of-contacts must be >= 4 because we shutdown all but one in the end
-    akka.cluster.client.number-of-contacts = 4
+    akka.cluster.client.receptionist.number-of-contacts = 4
     akka.test.filter-leeway = 10s
     """))
 


### PR DESCRIPTION
The fix in https://github.com/akka/akka/pull/17903 was not using
the correct configuration property. The issue in #17735 was never
fixed by that PR, but now it is.
