### PR TITLE
=htc #18518 make it simpler to unmarshal csv values from params

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -7,8 +7,9 @@ package directives
 
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.unmarshalling.PredefinedFromStringUnmarshallers
 
-class ParameterDirectivesExamplesSpec extends RoutingSpec {
+class ParameterDirectivesExamplesSpec extends RoutingSpec with PredefinedFromStringUnmarshallers {
   "example-1" in {
     val route =
       parameter('color) { color =>
@@ -178,6 +179,19 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec {
     }
     Get("/?x=1&x=2") ~> route ~> check {
       responseAs[String] shouldEqual "The parameters are x = '1', x = '2'"
+    }
+  }
+  "csv" in {
+    val route =
+      parameter("names".as(CsvString)) { names =>
+        complete(s"The parameters are ${names.mkString(", ")}")
+      }
+
+    Get("/?names=Caplin") ~> route ~> check {
+      responseAs[String] shouldEqual "The parameters are Caplin"
+    }
+    Get("/?names=Caplin,John") ~> route ~> check {
+      responseAs[String] shouldEqual "The parameters are Caplin, John"
     }
   }
 }

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameters.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/parameter-directives/parameters.rst
@@ -94,6 +94,12 @@ Repeated parameter
 .. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: repeated
 
+Csv valued parameter
+++++++++++++++++++++
+
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+   :snippet: csv
+
 Repeated, deserialized parameter
 ++++++++++++++++++++++++++++++++
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -7,6 +7,7 @@ package directives
 
 import org.scalatest.{ FreeSpec, Inside }
 import akka.http.scaladsl.unmarshalling.Unmarshaller.HexInt
+import akka.http.scaladsl.unmarshalling.Unmarshaller.CsvString
 
 class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Inside {
   "when used with 'as[Int]' the parameter directive should" - {
@@ -48,6 +49,24 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
             case MalformedQueryParamRejection("amount", "'x' is not a valid 32-bit signed integer value", Some(_)) ⇒
           }
         }
+      }
+    }
+  }
+
+  "when used with 'as(CsvString)' the parameter directive should" - {
+    val route =
+      parameter("names".as(CsvString)) { names ⇒
+        complete(s"The parameters are ${names.mkString(", ")}")
+      }
+
+    "extract a single name" in {
+      Get("/?names=Caplin") ~> route ~> check {
+        responseAs[String] shouldEqual "The parameters are Caplin"
+      }
+    }
+    "extract a number of names" in {
+      Get("/?names=Caplin,John") ~> route ~> check {
+        responseAs[String] shouldEqual "The parameters are Caplin, John"
       }
     }
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
@@ -7,8 +7,8 @@ package akka.http.scaladsl.common
 import akka.http.scaladsl.unmarshalling.{ FromStringUnmarshaller ⇒ FSU }
 
 private[http] trait ToNameReceptacleEnhancements {
-  implicit def symbol2NR(symbol: Symbol) = new NameReceptacle[String](symbol.name)
-  implicit def string2NR(string: String) = new NameReceptacle[String](string)
+  implicit def symbol2NR(symbol: Symbol): NameReceptacle[String] = new NameReceptacle[String](symbol.name)
+  implicit def string2NR(string: String): NameReceptacle[String] = new NameReceptacle[String](string)
 }
 object ToNameReceptacleEnhancements extends ToNameReceptacleEnhancements
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
@@ -4,6 +4,8 @@
 
 package akka.http.scaladsl.unmarshalling
 
+import scala.collection.immutable
+
 trait PredefinedFromStringUnmarshallers {
 
   implicit val byteFromStringUnmarshaller: Unmarshaller[String, Byte] =
@@ -74,6 +76,11 @@ trait PredefinedFromStringUnmarshallers {
         case ""                     ⇒ throw Unmarshaller.NoContentException
         case x                      ⇒ throw new IllegalArgumentException(s"'$x' is not a valid Boolean value")
       }
+    }
+
+  val CsvString: Unmarshaller[String, immutable.Seq[String]] =
+    Unmarshaller.strict[String, immutable.Seq[String]] { string ⇒
+      string.split(",").toList
     }
 
   private def numberFormatError(value: String, target: String): PartialFunction[Throwable, Nothing] = {


### PR DESCRIPTION
It's simple enough for us to provide it, and first fits in into the style how we provide the "less typical" ways to unmarshal params (we also have `as(HexInt)`).

Please review @sirthias @jrudolph or, as always, anyone else interested in it

Refs #18518
