### PR TITLE
+str #18486 Source.subscriber's Subscriber throws if subscribed more than once

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubscriberSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubscriberSourceSpec.scala
@@ -3,9 +3,9 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.ActorMaterializer
+import akka.stream.{ StreamTcpException, ActorMaterializer }
 
-import akka.stream.testkit.AkkaSpec
+import akka.stream.testkit.{ TestPublisher, TestSubscriber, AkkaSpec }
 import akka.stream.testkit.Utils._
 import scala.concurrent.duration._
 
@@ -23,6 +23,24 @@ class SubscriberSourceSpec extends AkkaSpec("akka.loglevel=DEBUG\nakka.actor.deb
           .runWith(Sink.fold[Int, Int](0)(_ + _))
 
       Await.result(f, 3.seconds) should be(6)
+    }
+
+    "throw exception if subscribe more then once" in {
+      val sub = TestSubscriber.manualProbe[String]
+      val sub1 = Source.subscriber[String].to(Sink(sub)).run()
+      val source = Source.apply(List("1", "2", "3"))
+
+      val pub1 = source.runWith(Sink.publisher)
+      val pub2 = source.runWith(Sink.publisher)
+
+      pub1.subscribe(sub1)
+      val s = sub.expectSubscription()
+
+      a[IllegalStateException] should be thrownBy pub2.subscribe(sub1)
+
+      s.request(3)
+      sub.expectNext("1", "2", "3")
+      sub.expectComplete()
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -379,11 +379,9 @@ private[stream] final class VirtualProcessor[T] extends Processor[T, T] {
               case Completed  ⇒ tryOnComplete(s)
               case Failed(ex) ⇒ tryOnError(s, ex)
               case Allowed    ⇒ // all good
-
             }
           } catch {
-            case ex @ canNotSubscribeTheSameSubscriberMultipleTimesException ⇒ throw ex
-            case NonFatal(ex) ⇒ sub.cancel()
+            case NonFatal(ex) ⇒ if (isCancelled) throw ex else sub.cancel()
           }
       }
   }


### PR DESCRIPTION
The idea here is to throw IlligalStateException from VirtualProcessor.subscribe when tryOnSubscribe closed subscription (when Subscriber already has subscription per reactive spec).
Ref #18486
