### PR TITLE
=str add toString to TickSource

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -294,5 +294,7 @@ object GraphStages {
 
       (logic, cancellable)
     }
+    
+    override def toString = s"TickSource($initialDelay, $interval, ...)"
   }
 }


### PR DESCRIPTION
Does it make sense to include the durations in the `toString`? Could be a nice thing hm...
