### PR TITLE
=per #18527 fix race condition in async stash test

### DIFF
--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorStashingSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorStashingSpec.scala
@@ -163,8 +163,12 @@ class SteppingInMemPersistentActorStashingSpec extends PersistenceSpec(
       SteppingInmemJournal.step(journal)
       SteppingInmemJournal.step(journal)
 
-      persistentActor ! GetState
-      expectMsg(List("a", "c", "b"))
+      within(3.seconds) {
+        awaitAssert {
+          persistentActor ! GetState
+          expectMsg(List("a", "c", "b"))
+        }
+      }
     }
 
   }


### PR DESCRIPTION
I think there may have been a race between the next message being received and the async callback block being triggered in the test. Fixed with retrying within 3 seconds.
