### PR TITLE
=act #18371 Warn if the default Java serializer is used

### DIFF
--- a/akka-actor-tests/src/test/resources/reference.conf
+++ b/akka-actor-tests/src/test/resources/reference.conf
@@ -1,6 +1,7 @@
 akka {
   actor {
-    serialize-messages = on    
+    serialize-messages = on
+    warn-about-java-serializer-usage = off
   }
 }
 

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -416,6 +416,24 @@ class OverriddenSystemMessageSerializationSpec extends AkkaSpec(SerializationTes
   }
 }
 
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class DefaultSerializationWarningSpec extends AkkaSpec(
+  ConfigFactory.parseString("akka.actor.warn-about-java-serializer-usage = on")) {
+
+  val ser = SerializationExtension(system)
+
+  "Using the default Java serializer" must {
+
+    "log a warning" in {
+      EventFilter.warning(message = "Using the default Java serializer for class.*") intercept {
+        ser.serializerFor(classOf[java.lang.Integer])
+      }
+    }
+
+  }
+
+}
+
 protected[akka] trait TestSerializable
 
 protected[akka] class TestSerializer extends Serializer {

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -501,7 +501,13 @@ akka {
       "[B" = bytes
       "java.io.Serializable" = java
     }
-    
+
+    # Log warnings when the default Java serialization is used to serialize messages.
+    # The default serializer uses Java serialization which is not very performant and should not
+    # be used in production environments unless you don't care about performance. In that case
+    # you can turn this off.
+    warn-about-java-serializer-usage = on
+
     # Configuration namespace of serialization identifiers.
     # Each serializer implementation must have an entry in the following format:
     # `akka.actor.serialization-identifiers."FQCN" = ID`

--- a/akka-cluster/src/test/resources/reference.conf
+++ b/akka-cluster/src/test/resources/reference.conf
@@ -1,6 +1,7 @@
 akka {
   actor {
     serialize-creators = on
-    serialize-messages = on    
+    serialize-messages = on
+    warn-about-java-serializer-usage = off
   }
 }

--- a/akka-persistence/src/test/scala/akka/persistence/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/OptionalSnapshotStoreSpec.scala
@@ -38,6 +38,8 @@ class OptionalSnapshotStoreSpec extends PersistenceSpec(ConfigFactory.parseStrin
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.persistence.journal.leveldb.dir = "target/journal-${classOf[OptionalSnapshotStoreSpec].getName}"
 
+    akka.actor.warn-about-java-serializer-usage = off
+
     # snapshot store plugin is NOT defined, things should still work
     akka.persistence.snapshot-store.local.dir = "target/snapshots-${classOf[OptionalSnapshotStoreSpec].getName}/"
   """)) with ImplicitSender {

--- a/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistenceSpec.scala
@@ -56,6 +56,7 @@ object PersistenceSpec {
         s"""
       akka.actor.serialize-creators = ${serialization}
       akka.actor.serialize-messages = ${serialization}
+      akka.actor.warn-about-java-serializer-usage = off
       akka.persistence.publish-plugin-commands = on
       akka.persistence.journal.plugin = "akka.persistence.journal.${plugin}"
       akka.persistence.journal.leveldb.dir = "target/journal-${test}"

--- a/akka-remote-tests/src/test/resources/reference.conf
+++ b/akka-remote-tests/src/test/resources/reference.conf
@@ -2,5 +2,6 @@ akka {
   actor {
     serialize-creators = on
     serialize-messages = on
+    warn-about-java-serializer-usage = off
   }
 }


### PR DESCRIPTION
Unless the message is in `akka.*` or the configuration setting `'akka.actor.warn-about-java-serializer-usage'` is disabled a warning is logged for each class that the Java serializer is choosen for.
