### PR TITLE
=cdd #18328 Optimize ORSet merge

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetMergeBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetMergeBenchmark.scala
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster.ddata
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.{ Scope => JmhScope }
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import akka.actor.ActorPath
+import akka.cluster.UniqueAddress
+import akka.actor.Address
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.Level
+
+@Fork(2)
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@Warmup(iterations = 4)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class ORSetMergeBenchmark {
+
+  @Param(Array("1", "10", "20", "100"))
+  var set1Size = 0
+
+  val nodeA = UniqueAddress(Address("akka.tcp", "Sys", "aaaa", 2552), 1)
+  val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2)
+  val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3)
+  val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4)
+  val nodeE = UniqueAddress(nodeA.address.copy(host = Some("eeee")), 5)
+  val nodes = Vector(nodeA, nodeB, nodeC, nodeD, nodeE)
+  val nodesIndex = Iterator.from(0)
+  def nextNode(): UniqueAddress = nodes(nodesIndex.next() % nodes.size)
+
+  var set1: ORSet[String] = _
+  var addFromSameNode: ORSet[String] = _
+  var addFromOtherNode: ORSet[String] = _
+  var complex1: ORSet[String] = _
+  var complex2: ORSet[String] = _
+  var elem1: String = _
+  var elem2: String = _
+
+  @Setup(Level.Trial)
+  def setup() {
+    set1 = (1 to set1Size).foldLeft(ORSet.empty[String])((s, n) => s.add(nextNode(), "elem" + n))
+    addFromSameNode = set1.add(nodeA, "elem" + set1Size + 1).merge(set1)
+    addFromOtherNode = set1.add(nodeB, "elem" + set1Size + 1).merge(set1)
+    complex1 = set1.add(nodeB, "a").add(nodeC, "b").remove(nodeD, "elem" + set1Size).merge(set1)
+    complex2 = set1.add(nodeA, "a").add(nodeA, "c").add(nodeB, "d").merge(set1)
+    elem1 = "elem" + (set1Size + 1)
+    elem2 = "elem" + (set1Size + 2)
+  }
+
+  @Benchmark
+  def mergeAddFromSameNode: ORSet[String] = {
+    // this is the scenario when updating and then merging with local value
+    // set2 produced by modify function
+    val set2 = set1.add(nodeA, elem1).add(nodeA, elem2)
+    // replicator merges with local value
+    set1.merge(set2)
+  }
+
+  @Benchmark
+  def mergeAddFromOtherNode: ORSet[String] = set1.merge(addFromOtherNode)
+
+  @Benchmark
+  def mergeAddFromBothNodes: ORSet[String] = addFromSameNode.merge(addFromOtherNode)
+
+  @Benchmark
+  def mergeComplex: ORSet[String] = complex1.merge(complex2)
+
+}

--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
@@ -51,7 +51,7 @@ class VersionVectorBenchmark {
     vv1 = (1 to size).foldLeft(VersionVector.empty)((vv, n) => vv + nextNode())
     vv2 = vv1 + nextNode()
     vv3 = vv1 + nextNode()
-    dot1 = VersionVector(TreeMap(nodeA -> vv1.versions(nodeA)))
+    dot1 = VersionVector(nodeA, vv1.versionAt(nodeA))
   }
 
   @Benchmark

--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster.ddata
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.{ Scope => JmhScope }
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import akka.actor.ActorPath
+import akka.cluster.UniqueAddress
+import akka.actor.Address
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.Level
+import scala.collection.immutable.TreeMap
+
+@Fork(2)
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@Warmup(iterations = 4)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class VersionVectorBenchmark {
+
+  @Param(Array("1", "2", "5"))
+  var size = 0
+
+  val nodeA = UniqueAddress(Address("akka.tcp", "Sys", "aaaa", 2552), 1)
+  val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2)
+  val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3)
+  val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4)
+  val nodeE = UniqueAddress(nodeA.address.copy(host = Some("eeee")), 5)
+  val nodes = Vector(nodeA, nodeB, nodeC, nodeD, nodeE)
+  val nodesIndex = Iterator.from(0)
+  def nextNode(): UniqueAddress = nodes(nodesIndex.next() % nodes.size)
+
+  var vv1: VersionVector = _
+  var vv2: VersionVector = _
+  var vv3: VersionVector = _
+  var dot1: VersionVector = _
+
+  @Setup(Level.Trial)
+  def setup() {
+    vv1 = (1 to size).foldLeft(VersionVector.empty)((vv, n) => vv + nextNode())
+    vv2 = vv1 + nextNode()
+    vv3 = vv1 + nextNode()
+    dot1 = VersionVector(TreeMap(nodeA -> vv1.versions(nodeA)))
+  }
+
+  @Benchmark
+  def increment: VersionVector = (vv1 + nodeA)
+
+  @Benchmark
+  def compareSame1: Boolean = (vv1 == dot1)
+
+  @Benchmark
+  def compareSame2: Boolean = (vv2 == dot1)
+
+  @Benchmark
+  def compareGreaterThan1: Boolean = (vv1 > dot1)
+
+  @Benchmark
+  def compareGreaterThan2: Boolean = (vv2 > dot1)
+
+  @Benchmark
+  def merge: VersionVector = vv1.merge(vv2)
+
+  @Benchmark
+  def mergeConflicting: VersionVector = vv2.merge(vv3)
+
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/FastMerge.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/FastMerge.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.cluster.ddata
+
+/**
+ * INTERNAL API
+ *
+ * Optimization for add/remove followed by merge and merge should just fast forward to
+ * the new instance.
+ *
+ * It's like a cache between calls of the same thread, you can think of it as a thread local.
+ * The Replicator actor invokes the user's modify function, which returns a new ReplicatedData instance,
+ * with the ancestor field set (see for example the add method in ORSet). Then (in same thread) the
+ * Replication calls merge, which makes use of the ancestor field to perform quick merge
+ * (see for example merge method in ORSet).
+ *
+ * It's not thread safe if the modifying function and merge are called from different threads,
+ * i.e. if used outside the Replicator infrastructure, but the worst thing that can happen is that
+ * a full merge is performed instead of the fast forward merge.
+ */
+private[akka] trait FastMerge { self: ReplicatedData ⇒
+
+  private var ancestor: FastMerge = null
+
+  /** INTERNAL API: should be called from "updating" methods */
+  private[akka] def assignAncestor(newData: T with FastMerge): T = {
+    newData.ancestor = if (this.ancestor eq null) this else this.ancestor
+    this.ancestor = null // only one level, for GC
+    newData
+  }
+
+  /** INTERNAL API: should be used from merge */
+  private[akka] def isAncestorOf(that: T with FastMerge): Boolean =
+    that.ancestor eq this
+
+  /** INTERNAL API: should be called from merge */
+  private[akka] def clearAncestor(): self.type = {
+    ancestor = null
+    this
+  }
+
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/GSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/GSet.scala
@@ -27,7 +27,7 @@ object GSet {
  * This class is immutable, i.e. "modifying" methods return a new instance.
  */
 @SerialVersionUID(1L)
-final case class GSet[A](elements: Set[A]) extends ReplicatedData with ReplicatedDataSerialization {
+final case class GSet[A](elements: Set[A]) extends ReplicatedData with ReplicatedDataSerialization with FastMerge {
 
   type T = GSet[A]
 
@@ -53,9 +53,15 @@ final case class GSet[A](elements: Set[A]) extends ReplicatedData with Replicate
   /**
    * Adds an element to the set
    */
-  def add(element: A): GSet[A] = copy(elements + element)
+  def add(element: A): GSet[A] = assignAncestor(copy(elements + element))
 
-  override def merge(that: GSet[A]): GSet[A] = copy(elements ++ that.elements)
+  override def merge(that: GSet[A]): GSet[A] =
+    if ((this eq that) || that.isAncestorOf(this)) this.clearAncestor()
+    else if (this.isAncestorOf(that)) that.clearAncestor()
+    else {
+      clearAncestor()
+      copy(elements ++ that.elements)
+    }
 }
 
 object GSetKey {

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/GSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/GSet.scala
@@ -60,7 +60,7 @@ final case class GSet[A](elements: Set[A]) extends ReplicatedData with Replicate
     else if (this.isAncestorOf(that)) that.clearAncestor()
     else {
       clearAncestor()
-      copy(elements ++ that.elements)
+      copy(elements union that.elements)
     }
 }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
@@ -10,8 +10,6 @@ import akka.cluster.Cluster
 import akka.cluster.UniqueAddress
 import akka.util.HashCode
 
-// TODO this class can be optimized, but I wanted to start with correct functionality and comparability with riak_dt_orswot
-
 object ORSet {
   private val _empty: ORSet[Any] = new ORSet(Map.empty, VersionVector.empty)
   def empty[A]: ORSet[A] = _empty.asInstanceOf[ORSet[A]]

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PruningState.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PruningState.scala
@@ -28,7 +28,7 @@ private[akka] final case class PruningState(owner: UniqueAddress, phase: Pruning
       case (_, PruningPerformed) ⇒ that
       case (PruningInitialized(thisSeen), PruningInitialized(thatSeen)) ⇒
         if (this.owner == that.owner)
-          copy(phase = PruningInitialized(thisSeen ++ thatSeen))
+          copy(phase = PruningInitialized(thisSeen union thatSeen))
         else if (Member.addressOrdering.compare(this.owner.address, that.owner.address) > 0)
           that
         else

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -1045,7 +1045,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
     val myKeys =
       if (totChunks == 1) dataEntries.keySet
       else dataEntries.keysIterator.filter(_.hashCode % totChunks == chunk).toSet
-    val otherMissingKeys = myKeys -- otherKeys
+    val otherMissingKeys = myKeys diff otherKeys
     val keys = (otherDifferentKeys ++ otherMissingKeys).take(maxDeltaElements)
     if (keys.nonEmpty) {
       if (log.isDebugEnabled)
@@ -1053,7 +1053,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
       val g = Gossip(keys.map(k ⇒ k -> getData(k).get)(collection.breakOut), sendBack = otherDifferentKeys.nonEmpty)
       sender() ! g
     }
-    val myMissingKeys = otherKeys -- myKeys
+    val myMissingKeys = otherKeys diff myKeys
     if (myMissingKeys.nonEmpty) {
       if (log.isDebugEnabled)
         log.debug("Sending gossip status to [{}], requesting missing [{}]", sender().path.address, myMissingKeys.mkString(", "))

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/VersionVector.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/VersionVector.scala
@@ -16,7 +16,11 @@ import akka.cluster.UniqueAddress
  */
 object VersionVector {
 
-  val empty: VersionVector = new VersionVector(TreeMap.empty[UniqueAddress, Long])
+  /**
+   * INTERNAL API
+   */
+  private[akka] val emptyVersions: TreeMap[UniqueAddress, Long] = TreeMap.empty
+  val empty: VersionVector = new VersionVector(emptyVersions)
   def apply(): VersionVector = empty
   /**
    * Java API

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/VersionVector.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/VersionVector.scala
@@ -3,12 +3,12 @@
  */
 package akka.cluster.ddata
 
+import scala.collection.immutable
 import java.util.concurrent.atomic.AtomicLong
-
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
-
 import akka.cluster.Cluster
+import akka.cluster.UniqueAddress
 import akka.cluster.UniqueAddress
 
 /**
@@ -16,12 +16,24 @@ import akka.cluster.UniqueAddress
  */
 object VersionVector {
 
-  /**
-   * INTERNAL API
-   */
-  private[akka] val emptyVersions: TreeMap[UniqueAddress, Long] = TreeMap.empty
-  val empty: VersionVector = new VersionVector(emptyVersions)
+  private val emptyVersions: TreeMap[UniqueAddress, Long] = TreeMap.empty
+  val empty: VersionVector = ManyVersionVector(emptyVersions)
+
   def apply(): VersionVector = empty
+
+  def apply(versions: TreeMap[UniqueAddress, Long]): VersionVector =
+    if (versions.isEmpty) empty
+    else if (versions.size == 1) apply(versions.head._1, versions.head._2)
+    else ManyVersionVector(versions)
+
+  def apply(node: UniqueAddress, version: Long): VersionVector = OneVersionVector(node, version)
+
+  /** INTERNAL API */
+  private[akka] def apply(versions: List[(UniqueAddress, Long)]): VersionVector =
+    if (versions.isEmpty) empty
+    else if (versions.tail.isEmpty) apply(versions.head._1, versions.head._2)
+    else apply(emptyVersions ++ versions)
+
   /**
    * Java API
    */
@@ -57,7 +69,8 @@ object VersionVector {
    */
   def ConcurrentInstance = Concurrent
 
-  private object Timestamp {
+  /** INTERNAL API */
+  private[akka] object Timestamp {
     final val Zero = 0L
     final val EndMarker = Long.MinValue
     val counter = new AtomicLong(1L)
@@ -83,8 +96,7 @@ object VersionVector {
  * This class is immutable, i.e. "modifying" methods return a new instance.
  */
 @SerialVersionUID(1L)
-final case class VersionVector private[akka] (
-  private[akka] val versions: TreeMap[UniqueAddress, Long])
+sealed abstract class VersionVector
   extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
 
   type T = VersionVector
@@ -107,12 +119,28 @@ final case class VersionVector private[akka] (
    */
   def increment(node: Cluster): VersionVector = increment(node.selfUniqueAddress)
 
+  def isEmpty: Boolean
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def size: Int
+
   /**
    * INTERNAL API
    * Increment the version for the node passed as argument. Returns a new VersionVector.
    */
-  private[akka] def increment(node: UniqueAddress): VersionVector =
-    copy(versions = versions.updated(node, Timestamp.counter.getAndIncrement()))
+  private[akka] def increment(node: UniqueAddress): VersionVector
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def versionAt(node: UniqueAddress): Long
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def contains(node: UniqueAddress): Boolean
 
   /**
    * Returns true if <code>this</code> and <code>that</code> are concurrent else false.
@@ -187,9 +215,14 @@ final case class VersionVector private[akka] (
       compareNext(nextOrElse(i1, cmpEndMarker), nextOrElse(i2, cmpEndMarker), Same)
     }
 
-    if ((this eq that) || (this.versions eq that.versions)) Same
-    else compare(this.versions.iterator, that.versions.iterator, if (order eq Concurrent) FullOrder else order)
+    if (this eq that) Same
+    else compare(this.versionsIterator, that.versionsIterator, if (order eq Concurrent) FullOrder else order)
   }
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def versionsIterator: Iterator[(UniqueAddress, Long)]
 
   /**
    * Compare two version vectors. The outcome will be one of the following:
@@ -208,23 +241,128 @@ final case class VersionVector private[akka] (
   /**
    * Merges this VersionVector with another VersionVector. E.g. merges its versioned history.
    */
-  def merge(that: VersionVector): VersionVector = {
-    var mergedVersions = that.versions
-    for ((node, time) ← versions) {
-      val mergedVersionsCurrentTime = mergedVersions.getOrElse(node, Timestamp.Zero)
-      if (time > mergedVersionsCurrentTime)
-        mergedVersions = mergedVersions.updated(node, time)
+  def merge(that: VersionVector): VersionVector
+
+  override def needPruningFrom(removedNode: UniqueAddress): Boolean
+
+  override def prune(removedNode: UniqueAddress, collapseInto: UniqueAddress): VersionVector
+
+  override def pruningCleanup(removedNode: UniqueAddress): VersionVector
+
+}
+
+final case class OneVersionVector private[akka] (node: UniqueAddress, version: Long) extends VersionVector {
+  import VersionVector.Timestamp
+
+  override def isEmpty: Boolean = false
+
+  /** INTERNAL API */
+  private[akka] override def size: Int = 1
+
+  /** INTERNAL API */
+  private[akka] override def increment(n: UniqueAddress): VersionVector = {
+    val v = Timestamp.counter.getAndIncrement()
+    if (n == node) copy(version = v)
+    else ManyVersionVector(TreeMap(node -> version, n -> v))
+  }
+
+  /** INTERNAL API */
+  private[akka] override def versionAt(n: UniqueAddress): Long =
+    if (n == node) version
+    else Timestamp.Zero
+
+  /** INTERNAL API */
+  private[akka] override def contains(n: UniqueAddress): Boolean =
+    n == node
+
+  /** INTERNAL API */
+  private[akka] override def versionsIterator: Iterator[(UniqueAddress, Long)] =
+    Iterator.single((node, version))
+
+  override def merge(that: VersionVector): VersionVector = {
+    that match {
+      case OneVersionVector(n2, v2) ⇒
+        if (node == n2) if (version >= v2) this else OneVersionVector(n2, v2)
+        else ManyVersionVector(TreeMap(node -> version, n2 -> v2))
+      case ManyVersionVector(vs2) ⇒
+        val v2 = vs2.getOrElse(node, Timestamp.Zero)
+        val mergedVersions =
+          if (v2 >= version) vs2
+          else vs2.updated(node, version)
+        VersionVector(mergedVersions)
     }
-    VersionVector(mergedVersions)
+  }
+
+  override def needPruningFrom(removedNode: UniqueAddress): Boolean =
+    node == removedNode
+
+  override def prune(removedNode: UniqueAddress, collapseInto: UniqueAddress): VersionVector =
+    (if (node == removedNode) VersionVector.empty else this) + collapseInto
+
+  override def pruningCleanup(removedNode: UniqueAddress): VersionVector =
+    if (node == removedNode) VersionVector.empty else this
+
+  override def toString: String =
+    s"VersionVector($node -> $version)"
+
+}
+
+final case class ManyVersionVector(versions: TreeMap[UniqueAddress, Long]) extends VersionVector {
+  import VersionVector.Timestamp
+
+  override def isEmpty: Boolean = versions.isEmpty
+
+  /** INTERNAL API */
+  private[akka] override def size: Int = versions.size
+
+  /** INTERNAL API */
+  private[akka] override def increment(node: UniqueAddress): VersionVector = {
+    val v = Timestamp.counter.getAndIncrement()
+    VersionVector(versions.updated(node, v))
+  }
+
+  /** INTERNAL API */
+  private[akka] override def versionAt(node: UniqueAddress): Long = versions.get(node) match {
+    case Some(v) ⇒ v
+    case None    ⇒ Timestamp.Zero
+  }
+
+  /** INTERNAL API */
+  private[akka] override def contains(node: UniqueAddress): Boolean =
+    versions.contains(node)
+
+  /** INTERNAL API */
+  private[akka] override def versionsIterator: Iterator[(UniqueAddress, Long)] =
+    versions.iterator
+
+  override def merge(that: VersionVector): VersionVector = {
+    that match {
+      case ManyVersionVector(vs2) ⇒
+        var mergedVersions = vs2
+        for ((node, time) ← versions) {
+          val mergedVersionsCurrentTime = mergedVersions.getOrElse(node, Timestamp.Zero)
+          if (time > mergedVersionsCurrentTime)
+            mergedVersions = mergedVersions.updated(node, time)
+        }
+        VersionVector(mergedVersions)
+      case OneVersionVector(n2, v2) ⇒
+        val v1 = versions.getOrElse(n2, Timestamp.Zero)
+        val mergedVersions =
+          if (v1 >= v2) versions
+          else versions.updated(n2, v2)
+        VersionVector(mergedVersions)
+    }
   }
 
   override def needPruningFrom(removedNode: UniqueAddress): Boolean =
     versions.contains(removedNode)
 
   override def prune(removedNode: UniqueAddress, collapseInto: UniqueAddress): VersionVector =
-    copy(versions = versions - removedNode) + collapseInto
+    VersionVector(versions = versions - removedNode) + collapseInto
 
-  override def pruningCleanup(removedNode: UniqueAddress): VersionVector = copy(versions = versions - removedNode)
+  override def pruningCleanup(removedNode: UniqueAddress): VersionVector =
+    VersionVector(versions = versions - removedNode)
 
-  override def toString = versions.map { case ((n, t)) ⇒ n + " -> " + t }.mkString("VersionVector(", ", ", ")")
+  override def toString: String =
+    versions.map { case ((n, v)) ⇒ n + " -> " + v }.mkString("VersionVector(", ", ", ")")
 }

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
@@ -101,7 +101,7 @@ class ORMapSpec extends WordSpec with Matchers {
 
       val m3 = merged1.remove(node1, "b").put(node1, "b", GSet.empty + "B2")
       // same thing if only put is used
-      // val m3 = merged1.put(node1, "b", GSet() + "B2")
+      //      val m3 = merged1.put(node1, "b", GSet.empty + "B2")
       val merged2 = merged1 merge m3
 
       merged2.entries("a").elements should be(Set("A"))

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
@@ -59,6 +59,14 @@ class ORSetSpec extends WordSpec with Matchers {
 
       c5.elements should not contain (user1)
       c5.elements should not contain (user2)
+
+      val c6 = c3.merge(c5)
+      c6.elements should not contain (user1)
+      c6.elements should not contain (user2)
+
+      val c7 = c5.merge(c3)
+      c7.elements should not contain (user1)
+      c7.elements should not contain (user2)
     }
 
     "be able to add removed" in {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
@@ -12,6 +12,7 @@ import akka.cluster.ddata.Replicator.Changed
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ORSetSpec extends WordSpec with Matchers {
 
   val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1)
@@ -228,30 +229,30 @@ class ORSetSpec extends WordSpec with Matchers {
 
   "ORSet unit test" must {
     "verify subtractDots" in {
-      val dot = new VersionVector(TreeMap(nodeA -> 3, nodeB -> 2, nodeD -> 14, nodeG -> 22))
-      val vvector = new VersionVector(TreeMap(nodeA -> 4, nodeB -> 1, nodeC -> 1, nodeD -> 14, nodeE -> 5, nodeF -> 2))
-      val expected = new VersionVector(TreeMap(nodeB -> 2, nodeG -> 22))
+      val dot = VersionVector(TreeMap(nodeA -> 3L, nodeB -> 2L, nodeD -> 14L, nodeG -> 22L))
+      val vvector = VersionVector(TreeMap(nodeA -> 4L, nodeB -> 1L, nodeC -> 1L, nodeD -> 14L, nodeE -> 5L, nodeF -> 2L))
+      val expected = VersionVector(TreeMap(nodeB -> 2L, nodeG -> 22L))
       ORSet.subtractDots(dot, vvector) should be(expected)
     }
 
     "verify mergeCommonKeys" in {
       val commonKeys: Set[String] = Set("K1", "K2")
-      val thisDot1 = new VersionVector(TreeMap(nodeA -> 3, nodeD -> 7))
-      val thisDot2 = new VersionVector(TreeMap(nodeB -> 5, nodeC -> 2))
-      val thisVvector = new VersionVector(TreeMap(nodeA -> 3, nodeB -> 5, nodeC -> 2, nodeD -> 7))
+      val thisDot1 = VersionVector(TreeMap(nodeA -> 3L, nodeD -> 7L))
+      val thisDot2 = VersionVector(TreeMap(nodeB -> 5L, nodeC -> 2L))
+      val thisVvector = VersionVector(TreeMap(nodeA -> 3L, nodeB -> 5L, nodeC -> 2L, nodeD -> 7L))
       val thisSet = new ORSet(
         elementsMap = Map("K1" -> thisDot1, "K2" -> thisDot2),
         vvector = thisVvector)
-      val thatDot1 = new VersionVector(TreeMap(nodeA -> 3))
-      val thatDot2 = new VersionVector(TreeMap(nodeB -> 6))
-      val thatVvector = new VersionVector(TreeMap(nodeA -> 3, nodeB -> 6, nodeC -> 1, nodeD -> 8))
+      val thatDot1 = VersionVector(nodeA, 3L)
+      val thatDot2 = VersionVector(nodeB, 6L)
+      val thatVvector = VersionVector(TreeMap(nodeA -> 3L, nodeB -> 6L, nodeC -> 1L, nodeD -> 8L))
       val thatSet = new ORSet(
         elementsMap = Map("K1" -> thatDot1, "K2" -> thatDot2),
         vvector = thatVvector)
 
       val expectedDots = Map(
-        "K1" -> new VersionVector(TreeMap(nodeA -> 3)),
-        "K2" -> new VersionVector(TreeMap(nodeB -> 6, nodeC -> 2)))
+        "K1" -> VersionVector(nodeA, 3L),
+        "K2" -> VersionVector(TreeMap(nodeB -> 6L, nodeC -> 2L)))
 
       ORSet.mergeCommonKeys(commonKeys, thisSet, thatSet) should be(expectedDots)
     }
@@ -259,14 +260,14 @@ class ORSetSpec extends WordSpec with Matchers {
     "verify mergeDisjointKeys" in {
       val keys: Set[Any] = Set("K3", "K4", "K5")
       val elements: Map[Any, VersionVector] = Map(
-        "K3" -> new VersionVector(TreeMap(nodeA -> 4)),
-        "K4" -> new VersionVector(TreeMap(nodeA -> 3, nodeD -> 8)),
-        "K5" -> new VersionVector(TreeMap(nodeA -> 2)))
-      val vvector = new VersionVector(TreeMap(nodeA -> 3, nodeD -> 7))
-      val acc: Map[Any, VersionVector] = Map("K1" -> new VersionVector(TreeMap(nodeA -> 3)))
+        "K3" -> VersionVector(nodeA, 4L),
+        "K4" -> VersionVector(TreeMap(nodeA -> 3L, nodeD -> 8L)),
+        "K5" -> VersionVector(nodeA, 2L))
+      val vvector = VersionVector(TreeMap(nodeA -> 3L, nodeD -> 7L))
+      val acc: Map[Any, VersionVector] = Map("K1" -> VersionVector(nodeA, 3L))
       val expectedDots = acc ++ Map(
-        "K3" -> new VersionVector(TreeMap(nodeA -> 4)),
-        "K4" -> new VersionVector(TreeMap(nodeD -> 8))) // "a" -> 3 removed, optimized to include only those unseen
+        "K3" -> VersionVector(nodeA, 4L),
+        "K4" -> VersionVector(nodeD, 8L)) // "a" -> 3 removed, optimized to include only those unseen
 
       ORSet.mergeDisjointKeys(keys, elements, vvector, acc) should be(expectedDots)
     }

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/VersionVectorSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/VersionVectorSpec.scala
@@ -28,7 +28,7 @@ class VersionVectorSpec extends TestKit(ActorSystem("VersionVectorSpec"))
 
     "have zero versions when created" in {
       val vv = VersionVector()
-      vv.versions should be(Map())
+      vv.size should be(0)
     }
 
     "not happen before itself" in {
@@ -36,6 +36,18 @@ class VersionVectorSpec extends TestKit(ActorSystem("VersionVectorSpec"))
       val vv2 = VersionVector()
 
       vv1 <> vv2 should be(false)
+    }
+
+    "increment correctly" in {
+      val vv1 = VersionVector()
+      val vv2 = vv1 + node1
+      vv2.versionAt(node1) should be > vv1.versionAt(node1)
+      val vv3 = vv2 + node1
+      vv3.versionAt(node1) should be > vv2.versionAt(node1)
+
+      val vv4 = vv3 + node2
+      vv4.versionAt(node1) should be(vv3.versionAt(node1))
+      vv4.versionAt(node2) should be > vv3.versionAt(node2)
     }
 
     "pass misc comparison test 1" in {
@@ -159,16 +171,16 @@ class VersionVectorSpec extends TestKit(ActorSystem("VersionVectorSpec"))
       val vv3_2 = vv2_2 + node2
 
       val merged1 = vv3_2 merge vv5_1
-      merged1.versions.size should be(3)
-      merged1.versions.contains(node1) should be(true)
-      merged1.versions.contains(node2) should be(true)
-      merged1.versions.contains(node3) should be(true)
+      merged1.size should be(3)
+      merged1.contains(node1) should be(true)
+      merged1.contains(node2) should be(true)
+      merged1.contains(node3) should be(true)
 
       val merged2 = vv5_1 merge vv3_2
-      merged2.versions.size should be(3)
-      merged2.versions.contains(node1) should be(true)
-      merged2.versions.contains(node2) should be(true)
-      merged2.versions.contains(node3) should be(true)
+      merged2.size should be(3)
+      merged2.contains(node1) should be(true)
+      merged2.contains(node2) should be(true)
+      merged2.contains(node3) should be(true)
 
       vv3_2 < merged1 should be(true)
       vv5_1 < merged1 should be(true)
@@ -192,18 +204,18 @@ class VersionVectorSpec extends TestKit(ActorSystem("VersionVectorSpec"))
       val vv3_2 = vv2_2 + node4
 
       val merged1 = vv3_2 merge vv5_1
-      merged1.versions.size should be(4)
-      merged1.versions.contains(node1) should be(true)
-      merged1.versions.contains(node2) should be(true)
-      merged1.versions.contains(node3) should be(true)
-      merged1.versions.contains(node4) should be(true)
+      merged1.size should be(4)
+      merged1.contains(node1) should be(true)
+      merged1.contains(node2) should be(true)
+      merged1.contains(node3) should be(true)
+      merged1.contains(node4) should be(true)
 
       val merged2 = vv5_1 merge vv3_2
-      merged2.versions.size should be(4)
-      merged2.versions.contains(node1) should be(true)
-      merged2.versions.contains(node2) should be(true)
-      merged2.versions.contains(node3) should be(true)
-      merged2.versions.contains(node4) should be(true)
+      merged2.size should be(4)
+      merged2.contains(node1) should be(true)
+      merged2.contains(node2) should be(true)
+      merged2.contains(node3) should be(true)
+      merged2.contains(node4) should be(true)
 
       vv3_2 < merged1 should be(true)
       vv5_1 < merged1 should be(true)

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
@@ -86,6 +86,7 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem("ReplicatedDataSe
 
       val s1 = ORSet().add(address1, "a").add(address2, "b")
       val s2 = ORSet().add(address2, "b").add(address1, "a")
+
       checkSameContent(s1.merge(s2), s2.merge(s1))
 
       val s3 = ORSet().add(address1, "a").add(address2, 17).remove(address3, 17)

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -103,7 +103,7 @@ object AkkaBuild extends Build {
   lazy val benchJmh = Project(
     id = "akka-bench-jmh",
     base = file("akka-bench-jmh"),
-    dependencies = Seq(actor, persistence, testkit).map(_ % "compile;compile->test;provided->provided")
+    dependencies = Seq(actor, persistence, distributedData, testkit).map(_ % "compile;compile->test;provided->provided")
   ).disablePlugins(ValidatePullRequest)
 
   lazy val protobuf = Project(

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -577,7 +577,10 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.EndpointManager.pruneTimerCancellable"),
         
         // #18722 internal changes to actor
-        FilterAnyProblem("akka.cluster.sharding.DDataShardCoordinator")
+        FilterAnyProblem("akka.cluster.sharding.DDataShardCoordinator"),
+
+        // #18328 optimize VersionVector for size 1
+        FilterAnyProblem("akka.cluster.ddata.VersionVector")
       )
     )
   }


### PR DESCRIPTION
Some Sunday amusement.

I was able to completely eliminate the overhead of the extra merge that was introduced by #18106. Several other optimizations resulted in speedups of 4-5 times. Overview of the JMH benchmark results in attached [ORSetBenchmark.pdf](https://github.com/akka/akka/files/3105/ORSetBenchmark.pdf) 

Each commit contains one improvement and the commit message the JMH results for the change.
