### PR TITLE
+doc,htc #18600,18597 documents where/how to deal with failure in Http

### DIFF
--- a/akka-docs-dev/rst/java.rst
+++ b/akka-docs-dev/rst/java.rst
@@ -1,10 +1,10 @@
 .. _stream-java-api:
 
 Java Documentation
-===================
+==================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    java/stream-index
    java/http/index

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
@@ -31,7 +31,7 @@ public class HighLevelServerBindFailureExample {
                 System.err.println("Something very bad happened! " + failure.getMessage());
                 system.shutdown();
             }
-        });
+        }, system.dispatcher());
 
         system.shutdown();
     }

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package docs.http.javadsl.server;
+
+//#binding-failure-high-level-example
+import akka.actor.ActorSystem;
+import akka.dispatch.OnFailure;
+import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.server.*;
+import akka.http.javadsl.server.values.Parameters;
+import akka.http.scaladsl.Http;
+import scala.concurrent.Future;
+
+import java.io.IOException;
+
+@SuppressWarnings("unchecked")
+public class HighLevelServerBindFailureExample {
+    public static void main(String[] args) throws IOException {
+        // boot up server using the route as defined below
+        final ActorSystem system = ActorSystem.create();
+
+        // HttpApp.bindRoute expects a route being provided by HttpApp.createRoute
+        Future<Http.ServerBinding> bindingFuture =
+                new HighLevelServerExample().bindRoute("localhost", 8080, system);
+
+        bindingFuture.onFailure(new OnFailure() {
+            @Override
+            public void onFailure(Throwable failure) throws Throwable {
+                System.err.println("Something very bad happened! " + failure.getMessage());
+                system.shutdown();
+            }
+        });
+
+        system.shutdown();
+    }
+}
+//#binding-failure-high-level-example

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HighLevelServerExample.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HighLevelServerExample.java
@@ -6,6 +6,7 @@ package docs.http.javadsl.server;
 
 //#high-level-server-example
 import akka.actor.ActorSystem;
+import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.MediaTypes;
 import akka.http.javadsl.server.*;
 import akka.http.javadsl.server.values.Parameters;
@@ -50,7 +51,7 @@ public class HighLevelServerExample extends HttpApp {
                     // matches the empty path
                     pathSingleSlash().route(
                         // return a constant string with a certain content type
-                        complete(MediaTypes.TEXT_HTML.toContentType(),
+                        complete(ContentTypes.TEXT_HTML,
                                 "<html><body>Hello world!</body></html>")
                     ),
                     path("ping").route(

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
@@ -13,9 +13,12 @@ import akka.http.javadsl.IncomingConnection;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.model.*;
 import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.model.HttpMethods;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.Uri;
+import akka.http.scaladsl.model.*;
+import akka.http.scaladsl.model.HttpEntity;
 import akka.japi.JavaPartialFunction;
 import akka.japi.function.Function;
 import akka.japi.function.Procedure;
@@ -156,10 +159,11 @@ public class HttpServerExampleDocTest {
                 Flow.of(HttpRequest.class)
                     .via(failureDetection)
                     .map(request -> {
-                        Source<ByteString, ?> bytes = request.entity().getDataBytes();
-                        HttpEntity entity = HttpEntities.create(ContentTypes.TEXT_PLAIN, (Source<ByteString, Object>) bytes);
-                        return HttpResponse.create()
-                                .withEntity(entity);
+                      Source<ByteString, ?> bytes = request.entity().getDataBytes();
+                      HttpEntity.Chunked entity = HttpEntities.create(ContentTypes.TEXT_PLAIN, (Source<ByteString, Object>) bytes);
+
+                      return HttpResponse.create()
+                        .withEntity(entity);
                     });
 
         Future<ServerBinding> serverBindingFuture =

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
@@ -72,7 +72,7 @@ public class HttpServerExampleDocTest {
                             if (uri.path().equals("/"))
                                 return
                                     HttpResponse.create()
-                                        .withEntity(MediaTypes.TEXT_HTML.toContentType(),
+                                        .withEntity(ContentTypes.TEXT_HTML,
                                             "<html><body>Hello world!</body></html>");
                             else if (uri.path().equals("/hello")) {
                                 String name = Util.getOrElse(uri.parameter("name"), "Mister X");

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
@@ -5,26 +5,43 @@
 package docs.http.javadsl.server;
 
 import akka.actor.ActorSystem;
+import akka.dispatch.OnFailure;
+import akka.http.impl.util.JavaMapping;
 import akka.http.impl.util.Util;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.IncomingConnection;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.model.*;
+import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.Uri;
+import akka.japi.JavaPartialFunction;
 import akka.japi.function.Function;
 import akka.japi.function.Procedure;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import akka.stream.stage.Context;
+import akka.stream.stage.PushStage;
+import akka.stream.stage.SyncDirective;
+import akka.stream.stage.TerminationDirective;
+import akka.util.ByteString;
+import scala.Function1;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
+import scala.runtime.BoxedUnit;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("unused")
 public class HttpServerExampleDocTest {
+
     public static void bindingExample() throws Exception {
         //#binding-example
         ActorSystem system = ActorSystem.create();
@@ -45,6 +62,116 @@ public class HttpServerExampleDocTest {
         //#binding-example
         Await.result(serverBindingFuture, new FiniteDuration(3, TimeUnit.SECONDS));
     }
+
+    public static void bindingFailureExample() throws Exception {
+        //#binding-failure-handling
+        ActorSystem system = ActorSystem.create();
+        Materializer materializer = ActorMaterializer.create(system);
+
+        Source<IncomingConnection, Future<ServerBinding>> serverSource =
+            Http.get(system).bind("localhost", 80, materializer);
+
+        Future<ServerBinding> serverBindingFuture =
+            serverSource.to(Sink.foreach(
+                new Procedure<IncomingConnection>() {
+                    @Override
+                    public void apply(IncomingConnection connection) throws Exception {
+                        System.out.println("Accepted new connection from " + connection.remoteAddress());
+                        // ... and then actually handle the connection
+                    }
+                })).run(materializer);
+
+        serverBindingFuture.onFailure(new OnFailure() {
+            @Override
+            public void onFailure(Throwable failure) throws Throwable {
+                // possibly report the failure somewhere...
+            }
+        }, system.dispatcher());
+        //#binding-failure-handling
+        Await.result(serverBindingFuture, new FiniteDuration(3, TimeUnit.SECONDS));
+    }
+
+    public static void connectionSourceFailureExample() throws Exception {
+        //#incoming-connections-source-failure-handling
+        ActorSystem system = ActorSystem.create();
+        Materializer materializer = ActorMaterializer.create(system);
+
+        Source<IncomingConnection, Future<ServerBinding>> serverSource =
+            Http.get(system).bind("localhost", 8080, materializer);
+
+        Flow<IncomingConnection, IncomingConnection, BoxedUnit> failureDetection =
+            Flow.of(IncomingConnection.class).transform(() ->
+                new PushStage<IncomingConnection, IncomingConnection>() {
+                    @Override
+                    public SyncDirective onPush(IncomingConnection elem, Context<IncomingConnection> ctx) {
+                        return ctx.push(elem);
+                    }
+
+                    @Override
+                    public TerminationDirective onUpstreamFailure(Throwable cause, Context<IncomingConnection> ctx) {
+                        // signal the failure to external monitoring service!
+                        return super.onUpstreamFailure(cause, ctx);
+                    }
+                });
+
+        Future<ServerBinding> serverBindingFuture =
+                serverSource
+                        .via(failureDetection) // feed signals through our custom stage
+                        .to(Sink.foreach(
+                                new Procedure<IncomingConnection>() {
+                                    @Override
+                                    public void apply(IncomingConnection connection) throws Exception {
+                                        System.out.println("Accepted new connection from " + connection.remoteAddress());
+                                        // ... and then actually handle the connection
+                                    }
+                                })).run(materializer);
+        //#incoming-connections-source-failure-handling
+        Await.result(serverBindingFuture, new FiniteDuration(3, TimeUnit.SECONDS));
+    }
+
+    public static void connectionStreamFailureExample() throws Exception {
+        //#connection-stream-failure-handling
+        ActorSystem system = ActorSystem.create();
+        Materializer materializer = ActorMaterializer.create(system);
+
+        Source<IncomingConnection, Future<ServerBinding>> serverSource =
+            Http.get(system).bind("localhost", 8080, materializer);
+
+        Flow<HttpRequest, HttpRequest, BoxedUnit> failureDetection =
+                Flow.of(HttpRequest.class).transform(() ->
+                new PushStage<HttpRequest, HttpRequest>() {
+                    @Override
+                    public SyncDirective onPush(HttpRequest elem, Context<HttpRequest> ctx) {
+                        return ctx.push(elem);
+                    }
+
+                    @Override
+                    public TerminationDirective onUpstreamFailure(Throwable cause, Context<HttpRequest> ctx) {
+                        // signal the failure to external monitoring service!
+                        return super.onUpstreamFailure(cause, ctx);
+                    }
+                });
+
+        Flow<HttpRequest, HttpResponse, BoxedUnit> httpEcho =
+                Flow.of(HttpRequest.class)
+                    .via(failureDetection)
+                    .map(request -> {
+                        Source<ByteString, ?> bytes = request.entity().getDataBytes();
+                        HttpEntity entity = HttpEntities.create(ContentTypes.TEXT_PLAIN, (Source<ByteString, Object>) bytes);
+                        return HttpResponse.create()
+                                .withEntity(entity);
+                    });
+
+        Future<ServerBinding> serverBindingFuture =
+            serverSource.to(Sink.foreach(con -> {
+                        System.out.println("Accepted new connection from " + con.remoteAddress());
+                        con.handleWith(httpEcho, materializer);
+                    }
+                )).run(materializer);
+        //#connection-stream-failure-handling
+        Await.result(serverBindingFuture, new FiniteDuration(3, TimeUnit.SECONDS));
+    }
+
     public static void fullServerExample() throws Exception {
         //#full-server-example
             ActorSystem system = ActorSystem.create();

--- a/akka-docs-dev/rst/java/http/http-model.rst
+++ b/akka-docs-dev/rst/java/http/http-model.rst
@@ -42,11 +42,11 @@ HttpRequest
 
 An ``HttpRequest`` consists of
 
- - a method (GET, POST, etc.)
- - a URI
- - a seq of headers
- - an entity (body data)
- - a protocol
+- a method (GET, POST, etc.)
+- a URI
+- a seq of headers
+- an entity (body data)
+- a protocol
 
 Here are some examples how to construct an ``HttpRequest``:
 
@@ -64,10 +64,10 @@ HttpResponse
 
 An ``HttpResponse`` consists of
 
- - a status code
- - a list of headers
- - an entity (body data)
- - a protocol
+- a status code
+- a list of headers
+- an entity (body data)
+- a protocol
 
 Here are some examples how to construct an ``HttpResponse``:
 

--- a/akka-docs-dev/rst/java/http/index.rst
+++ b/akka-docs-dev/rst/java/http/index.rst
@@ -31,11 +31,11 @@ akka-http-jackson
 .. toctree::
    :maxdepth: 2
 
-   configuration
    http-model
    server-side/low-level-server-side-api
    server-side/websocket-support
    routing-dsl/index
    client-side/index
+   configuration
 
 .. _jackson: https://github.com/FasterXML/jackson

--- a/akka-docs-dev/rst/java/http/routing-dsl/directives/index.rst
+++ b/akka-docs-dev/rst/java/http/routing-dsl/directives/index.rst
@@ -6,10 +6,10 @@ Directives
 A directive is a wrapper for a route or a list of alternative routes that adds one or more of the following
 functionality to its nested route(s):
 
- * it filters the request and lets only matching requests pass (e.g. the `get` directive lets only GET-requests pass)
- * it modifies the request or the ``RequestContext`` (e.g. the `path` directives filters on the unmatched path and then
-   passes an updated ``RequestContext`` unmatched path)
- * it modifies the response coming out of the nested route
+* it filters the request and lets only matching requests pass (e.g. the `get` directive lets only GET-requests pass)
+* it modifies the request or the ``RequestContext`` (e.g. the `path` directives filters on the unmatched path and then
+  passes an updated ``RequestContext`` unmatched path)
+* it modifies the response coming out of the nested route
 
 akka-http provides a set of predefined directives for various tasks. You can access them by either extending from
 ``akka.http.javadsl.server.AllDirectives`` or by importing them statically with
@@ -46,7 +46,7 @@ MethodDirectives
 MiscDirectives
   Contains directives that validate a request by user-defined logic.
 
-:ref:`PathDirectives-java`
+:ref:`path-directives-java`
   Contains directives to match and filter on the URI path of the incoming request.
 
 RangeDirectives

--- a/akka-docs-dev/rst/java/http/routing-dsl/directives/path-directives.rst
+++ b/akka-docs-dev/rst/java/http/routing-dsl/directives/path-directives.rst
@@ -1,4 +1,4 @@
-.. _PathDirectives-java:
+.. _path-directives-java:
 
 PathDirectives
 ==============

--- a/akka-docs-dev/rst/java/http/routing-dsl/overview.rst
+++ b/akka-docs-dev/rst/java/http/routing-dsl/overview.rst
@@ -74,3 +74,27 @@ quickly without running them over the network and helps with writing assertions 
 Read more about :ref:`http-testkit-java`.
 
 .. _DRY: http://en.wikipedia.org/wiki/Don%27t_repeat_yourself
+
+.. _handling-http-server-failures-high-level-scala:
+
+Handling HTTP Server failures in the High-Level API
+---------------------------------------------------
+There are various situations when failure may occur while initialising or running an Akka HTTP server.
+Akka by default will log all these failures, however sometimes one may want to react to failures in addition
+to them just being logged, for example by shutting down the actor system, or notifying some external monitoring
+end-point explicitly.
+
+Bind failures
+^^^^^^^^^^^^^
+For example the server might be unable to bind to the given port. For example when the port
+is already taken by another application, or if the port is privileged (i.e. only usable by ``root``).
+In this case the "binding future" will fail immediatly, and we can react to if by listening on the Future's completion:
+
+.. includecode:: ../../code/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
+  :include: binding-failure-high-level-example
+
+
+.. note::
+  For a more low-level overview of the kinds of failures that can happen and also more fine-grained control over them
+  refer to the :ref:`handling-http-server-failures-low-level-java` documentation.
+

--- a/akka-docs-dev/rst/scala.rst
+++ b/akka-docs-dev/rst/scala.rst
@@ -4,7 +4,7 @@ Scala Documentation
 ===================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    scala/stream-index
    scala/http/index

--- a/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
@@ -3,19 +3,15 @@
  */
 package docs.stream.io
 
-import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.stream._
 import akka.stream.scaladsl.Tcp._
 import akka.stream.scaladsl._
-import akka.stream.stage.Context
-import akka.stream.stage.PushStage
-import akka.stream.stage.SyncDirective
+import akka.stream.stage.{ Context, PushStage, SyncDirective }
 import akka.stream.testkit.AkkaSpec
 import akka.testkit.TestProbe
 import akka.util.ByteString
-import docs.stream.cookbook.RecipeParseLines
 import docs.utils.TestUtils
 
 import scala.concurrent.Future
@@ -31,8 +27,14 @@ class StreamTcpDocSpec extends AkkaSpec {
   "simple server connection" in {
     {
       //#echo-server-simple-bind
-      val connections: Source[IncomingConnection, Future[ServerBinding]] =
-        Tcp().bind("127.0.0.1", 8888)
+      val binding: Future[ServerBinding] =
+        Tcp().bind("127.0.0.1", 8888).to(Sink.ignore).run()
+
+      binding.map { b =>
+        b.unbind() onComplete {
+          case _ => // ...
+        }
+      }
       //#echo-server-simple-bind
     }
     {

--- a/akka-docs-dev/rst/scala/http/low-level-server-side-api.rst
+++ b/akka-docs-dev/rst/scala/http/low-level-server-side-api.rst
@@ -168,3 +168,67 @@ On the server-side the stand-alone HTTP layer forms a ``BidiFlow`` that is defin
 
 You create an instance of ``Http.ServerLayer`` by calling one of the two overloads of the ``Http().serverLayer`` method,
 which also allows for varying degrees of configuration.
+
+.. _handling-http-server-failures-low-level-scala:
+
+Handling HTTP Server failures in the Low-Level API
+--------------------------------------------------
+
+There are various situations when failure may occur while initialising or running an Akka HTTP server.
+Akka by default will log all these failures, however sometimes one may want to react to failures in addition to them
+just being logged, for example by shutting down the actor system, or notifying some external monitoring end-point explicitly.
+
+There are multiple things that can fail when creating and materializing an HTTP Server (similarily, the same applied to
+a plain streaming ``Tcp()`` server). The types of failures that can happen on different layers of the stack, starting
+from being unable to start the server, and ending with failing to unmarshal an HttpRequest, examples of failures include
+(from outer-most, to inner-most):
+
+- Failure to ``bind`` to the specified address/port,
+- Failure while accepting new ``IncommingConnection`` s, for example when the OS has run out of file descriptors or memory,
+- Failure while handling a connection, for example if the incoming ``HttpRequest`` is malformed.
+
+This section describes how to handle each failure situation, and in which situations these failures may occur.
+
+Bind failures
+^^^^^^^^^^^^^
+
+The first type of failure is when the server is unable to bind to the given port. For example when the port
+is already taken by another application, or if the port is privileged (i.e. only usable by ``root``).
+In this case the "binding future" will fail immediatly, and we can react to if by listening on the Future's completion:
+
+.. includecode2:: ../code/docs/http/scaladsl/HttpServerExampleSpec.scala
+  :snippet: binding-failure-handling
+
+Once the server has successfully bound to a port, the ``Source[IncomingConnection, _]`` starts running and emiting
+new incoming connections. This source technically can signal a failure as well, however this should only happen in very
+dramantic situations such as running out of file descriptors or memory available to the system, such that it's not able
+to accept a new incoming connection. Handling failures in Akka Streams is pretty stright forward, as failures are signaled
+through the stream starting from the stage which failed, all the way downstream to the final stages.
+
+Connections Source failures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the example below we add a custom ``PushStage`` (see :ref:`stream-customize-scala`) in order to react to the
+stream's failure. We signal a ``failureMonitor`` actor with the cause why the stream is going down, and let the Actor
+handle the rest – maybe it'll decide to restart the server or shutdown the ActorSystem, that however is not our concern anymore.
+
+.. includecode2:: ../code/docs/http/scaladsl/HttpServerExampleSpec.scala
+  :snippet: incoming-connections-source-failure-handling
+
+Connection failures
+^^^^^^^^^^^^^^^^^^^
+
+The third type of failure that can occur is when the connection has been properly established,
+however afterwards is terminated abruptly – for example by the client aborting the underlying TCP connection.
+To handle this failure we can use the same pattern as in the previous snippet, however apply it to the connection's Flow:
+
+.. includecode2:: ../code/docs/http/scaladsl/HttpServerExampleSpec.scala
+  :snippet: connection-stream-failure-handling
+
+These failures can be described more or less infrastructure related, they are failing bindings or connections.
+Most of the time you won't need to dive into those very deeply, as Akka will simply log errors of this kind
+anyway, which is a reasonable default for such problems.
+
+In order to learn more about handling exceptions in the actual routing layer, which is where your application code
+comes into the picture, refer to :ref:`exception-handling-scala` which focuses explicitly on explaining how exceptions
+thrown in routes can be handled and transformed into :class:`HttpResponse` s with apropriate error codes and human-readable failure descriptions.

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/execution-directives/handleExceptions.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/execution-directives/handleExceptions.rst
@@ -17,7 +17,7 @@ Description
 Using this directive is an alternative to using a global implicitly defined ``ExceptionHandler`` that
 applies to the complete route.
 
-See :ref:`Exception Handling` for general information about options for handling exceptions.
+See :ref:`exception-handling-scala` for general information about options for handling exceptions.
 
 Example
 -------

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/failWith.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/route-directives/failWith.rst
@@ -4,7 +4,7 @@ failWith
 ========
 
 Bubbles up the given error through the route structure where it is dealt with by the closest ``handleExceptions``
-directive and its ``ExceptionHandler``.
+directive and its :class:`ExceptionHandler`.
 
 
 Signature
@@ -19,12 +19,12 @@ Description
 
 ``failWith`` explicitly raises an exception that gets bubbled up through the route structure to be picked up by the
 nearest ``handleExceptions`` directive. Using ``failWith`` rather than simply throwing an exception enables the route
-structure's :ref:`Exception Handling` mechanism to deal with the exception even if the current route is executed
+structure's :ref:`exception-handling-scala` mechanism to deal with the exception even if the current route is executed
 asynchronously on another thread (e.g. in a ``Future`` or separate actor).
 
 If no ``handleExceptions`` is present above the respective location in the
 route structure the top-level routing logic will handle the exception and translate it into a corresponding
-``HttpResponse`` using the in-scope ``ExceptionHandler`` (see also the :ref:`Exception Handling` chapter).
+``HttpResponse`` using the in-scope ``ExceptionHandler`` (see also the :ref:`exception-handling-scala` chapter).
 
 There is one notable special case: If the given exception is a ``RejectionError`` exception it is *not* bubbled up,
 but rather the wrapped exception is unpacked and "executed". This allows the "tunneling" of a rejection via an

--- a/akka-docs-dev/rst/scala/http/routing-dsl/exception-handling.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/exception-handling.rst
@@ -1,4 +1,4 @@
-.. _Exception Handling:
+.. _exception-handling-scala:
 
 Exception Handling
 ==================

--- a/akka-docs-dev/rst/scala/http/routing-dsl/index.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/index.rst
@@ -44,3 +44,33 @@ the Routing DSL will look like:
 
 .. includecode2:: ../../code/docs/http/scaladsl/HttpServerExampleSpec.scala
    :snippet: long-routing-example
+
+.. _handling-http-server-failures-high-level-scala:
+
+Handling HTTP Server failures in the High-Level API
+---------------------------------------------------
+There are various situations when failure may occur while initialising or running an Akka HTTP server.
+Akka by default will log all these failures, however sometimes one may want to react to failures in addition
+to them just being logged, for example by shutting down the actor system, or notifying some external monitoring
+end-point explicitly.
+
+Bind failures
+^^^^^^^^^^^^^
+For example the server might be unable to bind to the given port. For example when the port
+is already taken by another application, or if the port is privileged (i.e. only usable by ``root``).
+In this case the "binding future" will fail immediatly, and we can react to if by listening on the Future's completion:
+
+.. includecode2:: ../../code/docs/http/scaladsl/HttpServerExampleSpec.scala
+  :snippet: binding-failure-high-level-example
+
+
+.. note::
+  For a more low-level overview of the kinds of failures that can happen and also more fine-grained control over them
+  refer to the :ref:`handling-http-server-failures-low-level-scala` documentation.
+
+Failures and exceptions inside the Routing DSL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Exception handling within the Routing DSL is done by providing :class:`ExceptionHandler` s which are documented in-depth
+in the :ref:`exception-handling-scala` section of the documtnation. You can use them to transform exceptions into
+:class:`HttpResponse` s with apropriate error codes and human-readable failure descriptions.

--- a/akka-docs-dev/rst/scala/http/routing-dsl/routes.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/routes.rst
@@ -14,7 +14,7 @@ Generally when a route receives a request (or rather a ``RequestContext`` for it
 
 - Complete the request by returning the value of ``requestContext.complete(...)``
 - Reject the request by returning the value of ``requestContext.reject(...)`` (see :ref:`Rejections`)
-- Fail the request by returning the value of ``requestContext.fail(...)`` or by just throwing an exception (see :ref:`Exception Handling`)
+- Fail the request by returning the value of ``requestContext.fail(...)`` or by just throwing an exception (see :ref:`exception-handling-scala`)
 - Do any kind of asynchronous processing and instantly return a ``Future[RouteResult]`` to be eventually completed later
 
 The first case is pretty clear, by calling ``complete`` a given response is sent to the client as reaction to the

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http:__www.typesafe.com>
+ */
+package akka.http.javadsl.model;
+
+
+/**
+ * Contains the set of predefined content-types.
+ * <p>
+ * If the {@link ContentType} you're looking for is not pre-defined here,
+ * you can obtain it from a {@link MediaType} by using:
+ * <p>
+ * {@code MediaTypes.TEXT_HTML.toContentType()}
+ */
+public final class ContentTypes {
+    public static final ContentType APPLICATION_JSON = MediaTypes.APPLICATION_JSON.toContentType();
+    public static final ContentType TEXT_PLAIN = MediaTypes.TEXT_PLAIN.toContentType();
+    public static final ContentType TEXT_PLAIN_UTF8 = akka.http.scaladsl.model.ContentTypes.text$divplain$u0028UTF$minus8$u0029();
+    public static final ContentType TEXT_HTML = MediaTypes.TEXT_HTML.toContentType();
+    public static final ContentType APPLICATION_OCTET_STREAM = MediaTypes.APPLICATION_OCTET_STREAM.toContentType();
+}

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
@@ -5,17 +5,20 @@ package akka.http.javadsl.model;
 
 
 /**
- * Contains the set of predefined content-types.
+ * Contains the set of predefined content-types for convenience.
  * <p>
  * If the {@link ContentType} you're looking for is not pre-defined here,
- * you can obtain it from a {@link MediaType} by using:
- * <p>
- * {@code MediaTypes.TEXT_HTML.toContentType()}
+ * you can obtain it from a {@link MediaType} by using: {@code MediaTypes.TEXT_HTML.toContentType()}
  */
 public final class ContentTypes {
-    public static final ContentType APPLICATION_JSON = MediaTypes.APPLICATION_JSON.toContentType();
-    public static final ContentType TEXT_PLAIN = MediaTypes.TEXT_PLAIN.toContentType();
-    public static final ContentType TEXT_PLAIN_UTF8 = akka.http.scaladsl.model.ContentTypes.text$divplain$u0028UTF$minus8$u0029();
-    public static final ContentType TEXT_HTML = MediaTypes.TEXT_HTML.toContentType();
-    public static final ContentType APPLICATION_OCTET_STREAM = MediaTypes.APPLICATION_OCTET_STREAM.toContentType();
+  public static final ContentType APPLICATION_JSON = MediaTypes.APPLICATION_JSON.toContentType();
+  public static final ContentType APPLICATION_OCTET_STREAM = MediaTypes.APPLICATION_OCTET_STREAM.toContentType();
+
+  public static final ContentType TEXT_PLAIN = MediaTypes.TEXT_PLAIN.toContentType();
+  public static final ContentType TEXT_PLAIN_UTF8 = akka.http.scaladsl.model.ContentTypes.text$divplain$u0028UTF$minus8$u0029();
+  public static final ContentType TEXT_HTML = MediaTypes.TEXT_HTML.toContentType();
+  public static final ContentType TEXT_XML = MediaTypes.TEXT_XML.toContentType();
+
+  public static final ContentType APPLICATION_X_WWW_FORM_URLENCODED = MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED.toContentType();
+  public static final ContentType MULTIPART_FORM_DATA = MediaTypes.MULTIPART_FORM_DATA.toContentType();
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
@@ -7,8 +7,8 @@ package akka.http.javadsl.model;
 import java.io.File;
 
 import akka.http.impl.util.JavaAccessors;
-import akka.http.scaladsl.model.*;
 import akka.http.scaladsl.model.HttpEntity;
+import akka.http.scaladsl.model.HttpEntity$;
 import akka.util.ByteString;
 import akka.stream.javadsl.Source;
 

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -5,6 +5,7 @@
 package akka.http.javadsl.model;
 
 import akka.japi.Option;
+import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 
 import java.io.File;

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -90,10 +90,15 @@ object ContentType {
 
 object ContentTypes {
   val `application/json` = ContentType(MediaTypes.`application/json`)
+  val `application/octet-stream` = ContentType(MediaTypes.`application/octet-stream`)
+
   val `text/plain` = ContentType(MediaTypes.`text/plain`)
   val `text/plain(UTF-8)` = ContentType(MediaTypes.`text/plain`, HttpCharsets.`UTF-8`)
   val `text/html` = ContentType(MediaTypes.`text/html`)
-  val `application/octet-stream` = ContentType(MediaTypes.`application/octet-stream`)
+  val `text/xml` = ContentType(MediaTypes.`text/xml`)
+
+  val `application/x-www-form-urlencoded` = ContentType(MediaTypes.`application/x-www-form-urlencoded`)
+  val `multipart/form-data` = ContentType(MediaTypes.`multipart/form-data`)
 
   // used for explicitly suppressing the rendering of Content-Type headers on requests and responses
   val NoContentType = ContentType(MediaTypes.NoMediaType)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -92,6 +92,7 @@ object ContentTypes {
   val `application/json` = ContentType(MediaTypes.`application/json`)
   val `text/plain` = ContentType(MediaTypes.`text/plain`)
   val `text/plain(UTF-8)` = ContentType(MediaTypes.`text/plain`, HttpCharsets.`UTF-8`)
+  val `text/html` = ContentType(MediaTypes.`text/html`)
   val `application/octet-stream` = ContentType(MediaTypes.`application/octet-stream`)
 
   // used for explicitly suppressing the rendering of Content-Type headers on requests and responses

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -891,6 +891,7 @@ object AkkaBuild extends Build {
     base = file("akka-docs-dev"),
     dependencies = Seq(streamTestkit % "test->test", stream, httpCore, http, httpTestkit, httpSprayJson, httpXml),
     settings = defaultSettings ++ docFormatSettings ++ site.settings ++ site.sphinxSupport() ++ sphinxPreprocessing ++ Seq(
+      javacOptions in compile ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-Xlint:deprecation"), // docs-dev is allowed to use Java 8
       version := streamAndHttpVersion,
       sourceDirectory in Sphinx <<= baseDirectory / "rst",
       watchSources <++= (sourceDirectory in Sphinx, excludeFilter in Global) map { (source, excl) =>
@@ -1051,7 +1052,7 @@ object AkkaBuild extends Build {
     // compile options
     scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint"),
     javacOptions in compile ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
-    javacOptions in doc ++= Seq("-encoding", "UTF-8", "-source", "1.6") ++
+    javacOptions in doc ++= Seq("-encoding", "UTF-8", "-source", "1.8") ++
                             (if (sys.props("java.version").startsWith("1.8")) Seq("-Xdoclint:none") else Seq()),
 
     crossVersion := CrossVersion.binary,


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/18597 - missing docs on where / how to handle connection failures etc.

Resolves https://github.com/akka/akka/issues/18600 - adds missing ContentTypes java api.

Blocked by, being unable to compile Java things: https://github.com/akka/akka/issues/18601 - will keep looking into it tomorrow

// cc @jrudolph @sirthias 
