### PR TITLE
=pro #18447 Check binary compatibility with 2.4.0

### DIFF
--- a/akka-cluster-sharding/build.sbt
+++ b/akka-cluster-sharding/build.sbt
@@ -9,6 +9,6 @@ OSGi.clusterSharding
 
 Dependencies.clusterSharding
 
-//MimaKeys.previousArtifact := akkaPreviousArtifact("akka-cluster-sharding").value
+MimaKeys.previousArtifact := akkaPreviousArtifact("akka-cluster-sharding").value
 
 enablePlugins(MultiNode, ScaladocNoVerificationOfDiagrams)

--- a/akka-cluster-tools/build.sbt
+++ b/akka-cluster-tools/build.sbt
@@ -9,6 +9,6 @@ OSGi.clusterTools
 
 Dependencies.clusterTools
 
-//MimaKeys.previousArtifact := akkaPreviousArtifact("akka-cluster-tools").value
+MimaKeys.previousArtifact := akkaPreviousArtifact("akka-cluster-tools").value
 
 enablePlugins(MultiNode, ScaladocNoVerificationOfDiagrams)

--- a/akka-distributed-data/build.sbt
+++ b/akka-distributed-data/build.sbt
@@ -11,7 +11,7 @@ OSGi.distributedData
 
 Dependencies.distributedData
 
-//MimaKeys.previousArtifact := akkaPreviousArtifact("akka-distributed-data").value
+MimaKeys.previousArtifact := akkaPreviousArtifact("akka-distributed-data-experimental").value
 
 enablePlugins(MultiNodeScalaTest)
 

--- a/akka-persistence-query/build.sbt
+++ b/akka-persistence-query/build.sbt
@@ -11,7 +11,7 @@ OSGi.persistenceQuery
 
 Dependencies.persistenceQuery
 
-//MimaKeys.previousArtifact := akkaPreviousArtifact("akka-persistence-query-experimental").value
+MimaKeys.previousArtifact := akkaPreviousArtifact("akka-persistence-query-experimental").value
 
 enablePlugins(ScaladocNoVerificationOfDiagrams)
 

--- a/akka-persistence/build.sbt
+++ b/akka-persistence/build.sbt
@@ -9,6 +9,6 @@ OSGi.persistence
 
 Dependencies.persistence
 
-MimaKeys.previousArtifact := akkaPreviousArtifact("akka-persistence-experimental").value
+MimaKeys.previousArtifact := akkaPreviousArtifact("akka-persistence").value
 
 fork in Test := true

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -406,7 +406,7 @@ object AkkaBuild extends Build {
 
   def akkaPreviousArtifact(id: String): Def.Initialize[Option[sbt.ModuleID]] = Def.setting {
     if (enableMiMa) {
-      val version: String = "2.3.11" // FIXME verify all 2.3.x versions
+      val version: String = "2.4.0" // FIXME verify all 2.3.x versions
       val fullId = crossVersion.value match {
         case _ : CrossVersion.Binary => id + "_" + scalaBinaryVersion.value
         case _ : CrossVersion.Full => id + "_" + scalaVersion.value

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -33,7 +33,11 @@ object MiMa extends AutoPlugin {
   }
 
   val mimaIgnoredProblems = {
-      import com.typesafe.tools.mima.core._
+    import com.typesafe.tools.mima.core._
+    Seq()
+    
+    // FIXME somehow we must use different filters when akkaPreviousArtifact is 2.3.x
+    /* Below are the filters we used when comparing to 2.3.x 
     Seq(
       FilterAnyProblem("akka.remote.testconductor.Terminate"),
       FilterAnyProblem("akka.remote.testconductor.TerminateMsg"),
@@ -572,5 +576,6 @@ object MiMa extends AutoPlugin {
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.ClusterCoreDaemon.akka$cluster$ClusterCoreDaemon$$isJoiningToUp$1")
 
      )
+     */
   }
 }


### PR DESCRIPTION
This changes the binary compatibility baseline to 2.4.0. We intend to check against several versions, which is in progress in https://github.com/akka/akka/pull/17761.
