### PR TITLE
=htc #18641 request must be made to the right port

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -40,7 +40,7 @@ class TlsEndpointVerificationSpec extends AkkaSpec("""
     "accept certificates signed by known CA" in {
       val pipe = pipeline(ExampleHttpContexts.exampleClientContext, hostname = "akka.example.org") // example context does include custom CA
 
-      whenReady(pipe(HttpRequest(uri = "https://akka.example.org/")), timeout) { response ⇒
+      whenReady(pipe(HttpRequest(uri = "https://akka.example.org:8080/")), timeout) { response ⇒
         response.status shouldEqual StatusCodes.OK
       }
     }


### PR DESCRIPTION
Failure caused by more strictness introduced in: https://github.com/akka/akka/pull/18633 (ports must match)
Resolves https://github.com/akka/akka/issues/18641 

Was: 

```
[WARN] [10/02/2015 15:36:02.054] [TlsEndpointVerificationSpec-akka.test.stream-dispatcher-10] [ActorSystem(TlsEndpointVerificationSpec)] 
Illegal request, responding with status '400 Bad Request': 
Request is missing required `Host` header: 'Host' header value of 
request to `https://akka.example.org/` doesn't match request target authority: 
Host header: Some(Host: akka.example.org:8080)
request target authority: //akka.example.org
```

Please review @rkuhn @drewhk 
