### PR TITLE
=per #18646 Remove double wrapping of PersistentRepr in JournalSpec

### DIFF
--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
@@ -71,7 +71,7 @@ abstract class JournalSpec(config: Config) extends PluginSpec(config) {
         }
       } else {
         (fromSnr to toSnr).map { i ⇒
-          AtomicWrite(PersistentRepr(persistentRepr(i)))
+          AtomicWrite(persistentRepr(i))
         }
       }
 

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNoAtomicPersistMultipleEventsSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNoAtomicPersistMultipleEventsSpec.scala
@@ -1,0 +1,18 @@
+package akka.persistence.journal.leveldb
+
+import akka.persistence.journal.JournalSpec
+import akka.persistence.{ PersistenceSpec, PluginCleanup }
+
+class LeveldbJournalNoAtomicPersistMultipleEventsSpec extends JournalSpec(
+  config = PersistenceSpec.config(
+    "leveldb",
+    "LeveldbJournalNoAtomicPersistMultipleEventsSpec",
+    extraConfig = Some("akka.persistence.journal.leveldb.native = off")))
+  with PluginCleanup {
+
+  /**
+   * Setting to false to test the single message atomic write behaviour of JournalSpec
+   */
+  override def supportsAtomicPersistAllOfSeveralEvents = false
+}
+


### PR DESCRIPTION
With the `supportsAtomicPersistAllOfSeveralEvents` flag set to false, there was a bug in `writeMessages` in `JournalSpec` that created `AtomicWrite`s that contained `PersistentRepr`s that was wrapped in yet another `PersistentRepr` instance. Hence, no plugins could pass the TCK tests with this setting set. This (very) small fix removes this double wrapping.
