### PR TITLE
+doc fails fast when includecode has no content

### DIFF
--- a/akka-docs-dev/_sphinx/exts/includecode.py
+++ b/akka-docs-dev/_sphinx/exts/includecode.py
@@ -109,6 +109,12 @@ class IncludeCode(Directive):
                     return count
 
         nonempty = filter(lambda l: l.strip(), lines)
+        if not nonempty:
+            return [document.reporter.error(
+                "Snippet ({}#{}) not found!".format(filename, section),
+                line=self.lineno
+            )]
+
         tabcounts = map(lambda l: countwhile(lambda c: c == ' ', l), nonempty)
         tabshift = min(tabcounts) if tabcounts else 0
 

--- a/akka-docs-dev/_sphinx/exts/includecode2.py
+++ b/akka-docs-dev/_sphinx/exts/includecode2.py
@@ -98,6 +98,7 @@ class IncludeCode2(Directive):
         text = ''.join(res)
 
         if text == "":
+            # in includecode2 it indeed is a warning, an empty code block will be inserted
             return [document.reporter.warning('Snippet "' + snippet + '" not found!', line=self.lineno)]
 
         retnode = nodes.literal_block(text, text, source=fn)

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authorize.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/security-directives/authorize.rst
@@ -8,8 +8,6 @@ Applies the given authorization check to the request.
 Signature
 ---------
 
-.. includecode:: /../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala#authorize
-
 .. includecode2:: /../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
    :snippet: authorize
 

--- a/akka-docs-dev/rst/scala/http/routing-dsl/testkit.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/testkit.rst
@@ -91,7 +91,7 @@ with HTTP response parts or rejections. Sometimes, however, you will want to ver
 :ref:`Rejections` to HTTP responses in the way you expect.
 
 You do this by wrapping your route with the ``akka.http.scaladsl.server.Route.seal``.
-The ``seal`` wrapper applies the logic of the in-scope :ref:`ExceptionHandler <Exception Handling>` and
+The ``seal`` wrapper applies the logic of the in-scope :ref:`ExceptionHandler <exception-handling-scala>` and
 :ref:`RejectionHandler <The RejectionHandler>` to all exceptions and rejections coming back from the route,
 and translates them to the respective ``HttpResponse``.
 


### PR DESCRIPTION
Will now eagerly log errors (sadly does not fail the build, that's doable with exceptions, but then the cause is hidden inside `last`, so it's less visible - esp. on jenkins).

> [error] /Users/ktoso/code/akka/akka-docs-dev/rst_preprocessed/scala/http/routing-dsl/directives/security-directives/authorize.rst:11: ERROR: Snippet (/../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala#authorize) 
> not found!
