### PR TITLE
=doc Add missing words in Configuration doc

### DIFF
--- a/akka-docs/rst/general/configuration.rst
+++ b/akka-docs/rst/general/configuration.rst
@@ -196,8 +196,8 @@ Logging of Configuration
 ------------------------
 
 If the system or config property ``akka.log-config-on-start`` is set to ``on``, then the
-complete configuration at INFO level when the actor system is started. This is useful
-when you are uncertain of what configuration is used.
+complete configuration is logged at INFO level when the actor system is started. This is
+useful when you are uncertain of what configuration is used.
 
 If in doubt, you can also easily and nicely inspect configuration objects
 before or after using them to construct an actor system:


### PR DESCRIPTION
The sentence is incomplete as is, this adds the words "is logged" to the
middle of:

> ..., then the complete configuration at INFO level when the
> actor system is started."
