### PR TITLE
!htp #18479 defer parsing of query key-value-pairs

### DIFF
--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/FormFieldRequestValsExampleTest.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/FormFieldRequestValsExampleTest.java
@@ -4,20 +4,13 @@
 
 package docs.http.javadsl.server;
 
-import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.FormData;
 import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.headers.RawHeader;
-import akka.http.javadsl.server.Marshallers;
-import akka.http.javadsl.server.RequestVal;
 import akka.http.javadsl.server.Route;
 import akka.http.javadsl.server.values.FormField;
 import akka.http.javadsl.server.values.FormFields;
-import akka.http.javadsl.server.values.Headers;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import akka.japi.Pair;
-import docs.http.scaladsl.server.directives.Person;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class FormFieldRequestValsExampleTest extends JUnitRouteTest {

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
@@ -6,7 +6,6 @@ package docs.http.javadsl.server;
 
 import akka.actor.ActorSystem;
 import akka.dispatch.OnFailure;
-import akka.http.impl.util.JavaMapping;
 import akka.http.impl.util.Util;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.IncomingConnection;
@@ -17,9 +16,7 @@ import akka.http.javadsl.model.HttpMethods;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.Uri;
-import akka.http.scaladsl.model.*;
 import akka.http.scaladsl.model.HttpEntity;
-import akka.japi.JavaPartialFunction;
 import akka.japi.function.Function;
 import akka.japi.function.Procedure;
 import akka.stream.ActorMaterializer;
@@ -32,7 +29,6 @@ import akka.stream.stage.PushStage;
 import akka.stream.stage.SyncDirective;
 import akka.stream.stage.TerminationDirective;
 import akka.util.ByteString;
-import scala.Function1;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
@@ -206,7 +202,7 @@ public class HttpServerExampleDocTest {
                                         .withEntity(ContentTypes.TEXT_HTML,
                                             "<html><body>Hello world!</body></html>");
                             else if (uri.path().equals("/hello")) {
-                                String name = Util.getOrElse(uri.parameter("name"), "Mister X");
+                                String name = Util.getOrElse(uri.query().get("name"), "Mister X");
 
                                 return
                                     HttpResponse.create()

--- a/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
@@ -199,7 +199,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
   "textract" in {
     val pathAndQuery = textract { ctx =>
       val uri = ctx.request.uri
-      (uri.path, uri.query)
+      (uri.path, uri.query())
     }
     val route =
       pathAndQuery { (p, query) =>

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/FormData.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/FormData.java
@@ -4,34 +4,51 @@
 
 package akka.http.javadsl.model;
 
-import akka.http.impl.model.parser.CharacterClasses;
-import akka.http.impl.util.JavaMapping;
-import akka.http.impl.util.StringRendering;
-import akka.http.scaladsl.model.Uri.Query;
-import akka.http.scaladsl.model.UriRendering;
 import akka.japi.Pair;
+import java.util.Map;
 
 /**
  * Simple model for `application/x-www-form-urlencoded` form data.
  */
-public abstract class FormData {
+public final class FormData {
 
-  public abstract Query fields();
+  private final Query fields;
 
+  public FormData(Query fields) {
+    this.fields = fields;
+  }
+
+  /**
+   * Converts this FormData to a RequestEntity using UTF8 encoding.
+   */
   public RequestEntity toEntity() {
     return toEntity(HttpCharsets.UTF_8);
   }
 
+  /**
+   * Converts this FormData to a RequestEntity using the given encoding.
+   */
   public RequestEntity toEntity(HttpCharset charset) {
-    // TODO this logic is duplicated in scaladsl.model.FormData, spent hours trying to DRY it but compiler freaked out in a number of ways... -- ktoso
-    final akka.http.scaladsl.model.HttpCharset c = (akka.http.scaladsl.model.HttpCharset) charset;
-    final StringRendering render = (StringRendering) UriRendering.renderQuery(new StringRendering(), this.fields(), c.nioCharset(), CharacterClasses.unreserved());
-    return HttpEntities.create(ContentType.create(MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED, charset), render.get());
+    return HttpEntities.create(ContentType.create(MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED, charset), fields.render(charset));
   }
 
+  /**
+   * Returns empty FormData.
+   */
+  public static final FormData EMPTY = new FormData(Query.EMPTY);
+
+  /**
+   * Creates the FormData from the given parameters.
+   */
   @SafeVarargs
-  public static FormData create(Pair<String, String>... fields) {
-    return akka.http.scaladsl.model.FormData.create(fields);
+  public static FormData create(Pair<String, String>... params) {
+    return new FormData(Query.create(params));
   }
 
+  /**
+   * Creates the FormData from the given parameters.
+   */
+  public static FormData create(Map<String, String> params) {
+    return new FormData(Query.create(params));
+  }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Host.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Host.java
@@ -47,14 +47,14 @@ public abstract class Host {
     /**
      * Parse the given Host string using the given charset and the default parsing-mode.
      */
-    public static Host create(String string, Charset charset) {
-      return UriJavaAccessor.hostApply(string, charset);
+    public static Host create(String string, Uri.ParsingMode parsingMode) {
+      return UriJavaAccessor.hostApply(string, parsingMode);
     }
 
     /**
      * Parse the given Host string using the given charset and parsing-mode.
      */
     public static Host create(String string, Charset charset, Uri.ParsingMode parsingMode) {
-      return UriJavaAccessor.hostApply(string, charset, parsingMode);
+      return akka.http.scaladsl.model.Uri.Host$.MODULE$.apply(string, charset, parsingMode);
     }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharset.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharset.java
@@ -4,6 +4,8 @@
 
 package akka.http.javadsl.model;
 
+import java.nio.charset.Charset;
+
 /**
  * Represents a charset in Http. See {@link HttpCharsets} for a set of predefined charsets and
  * static constructors to create custom charsets.
@@ -37,4 +39,9 @@ public abstract class HttpCharset {
      * Returns the predefined alias names for this charset.
      */
     public abstract Iterable<String> getAliases();
+
+    /**
+     * Returns the Charset for this charset if available or throws an exception otherwise.
+     */
+    public abstract Charset nioCharset();
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -5,7 +5,6 @@
 package akka.http.javadsl.model;
 
 import akka.japi.Option;
-import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 
 import java.io.File;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Query.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Query.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.javadsl.model;
+
+import akka.http.impl.model.JavaQuery;
+import akka.http.scaladsl.model.*;
+import akka.japi.Option;
+import akka.japi.Pair;
+import akka.parboiled2.CharPredicate;
+import akka.parboiled2.ParserInput$;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+
+public abstract class Query {
+    /**
+     * Returns the value of the first parameter with the given key if it exists.
+     */
+    public abstract Option<String> get(String key);
+
+    /**
+     * Returns the value of the first parameter with the given key or the provided default value.
+     */
+    public abstract String getOrElse(String key, String _default);
+
+    /**
+     * Returns the value of all parameters with the given key.
+     */
+    public abstract List<String> getAll(String key);
+
+    /**
+     * Returns a `List` of all parameters of this Query. Use the `toMap()`
+     * method to filter out entries with duplicated keys.
+     */
+    public abstract List<Pair<String, String>> toList();
+
+    /**
+    * Returns a key/value map of the parameters of this Query. Use
+    * the `toList()` method to return all parameters if keys may occur
+    * multiple times.
+    */
+    public abstract Map<String, String> toMap();
+
+    /**
+     * Returns a `Map` of all parameters of this Query. Use the `toMap()`
+     * method to filter out entries with duplicated keys.
+     */
+    public abstract Map<String, List<String>> toMultiMap();
+
+    /**
+     * Returns a copy of this instance with a query parameter added.
+     */
+    public abstract Query withParam(String key, String value);
+
+    /**
+     * Renders this Query into its string representation using the given charset.
+     */
+    public abstract String render(HttpCharset charset);
+
+    /**
+     * Renders this Query into its string representation using the given charset and char predicate.
+     */
+    public abstract String render(HttpCharset charset, CharPredicate keep);
+
+    /**
+     * Returns an empty Query.
+     */
+    public static final Query EMPTY = new JavaQuery(UriJavaAccessor.emptyQuery());
+
+    /**
+     * Returns a Query created by parsing the given undecoded string representation.
+     */
+    public static Query create(String rawQuery) {
+        return new JavaQuery(akka.http.scaladsl.model.Uri.Query$.MODULE$.apply(rawQuery));
+    }
+
+    /**
+     * Returns a Query created by parsing the given undecoded string representation with the provided parsing mode.
+     */
+    public static Query create(String rawQuery, akka.http.scaladsl.model.Uri.ParsingMode parsingMode) {
+        return new JavaQuery(UriJavaAccessor.queryApply(rawQuery, parsingMode));
+    }
+
+    /**
+     * Returns a Query created by parsing the given undecoded string representation with the provided charset and parsing mode.
+     */
+    public static Query create(String rawQuery, Charset charset, akka.http.scaladsl.model.Uri.ParsingMode parsingMode) {
+        return new JavaQuery(akka.http.scaladsl.model.Uri.Query$.MODULE$.apply(ParserInput$.MODULE$.apply(rawQuery), charset, parsingMode));
+    }
+
+    /**
+     * Returns a Query from the given parameters.
+     */
+    @SafeVarargs
+    public static Query create(Pair<String, String>... params) {
+        return new JavaQuery(UriJavaAccessor.queryApply(params));
+    }
+
+    /**
+     * Returns a Query from the given parameters.
+     */
+    public static Query create(Map<String, String> params) {
+        return new JavaQuery(UriJavaAccessor.queryApply(params));
+    }
+}

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
@@ -4,12 +4,14 @@
 
 package akka.http.javadsl.model;
 
-import akka.http.impl.util.JavaAccessors$;
+import akka.http.impl.model.JavaUri;
 import akka.http.scaladsl.model.UriJavaAccessor;
 import akka.japi.Option;
+import akka.japi.Pair;
 import akka.parboiled2.ParserInput$;
 
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -62,32 +64,24 @@ public abstract class Uri {
     public abstract Iterable<String> pathSegments();
 
     /**
-     * Returns a String representation of the query of this Uri.
+     * Returns a decoded String representation of the query of this Uri.
      */
-    public abstract String queryString();
+    public abstract Option<String> queryString(Charset charset);
 
     /**
-     * Looks up a query parameter of this Uri.
+     * Returns an undecoded String representation of the query of this Uri.
      */
-    public abstract Option<String> parameter(String key);
+    public abstract Option<String> rawQueryString();
 
     /**
-     * Returns if the query of this Uri contains a parameter with the given key.
+     *  Returns the parsed Query instance of this Uri.
      */
-    public abstract boolean containsParameter(String key);
+    public abstract Query query();
 
     /**
-     * Returns an `Iterable` of all query parameters of this Uri. Use the `parameterMap()`
-     * method to filter out entries with duplicated keys.
+     *  Returns the parsed Query instance of this Uri using the given charset and parsing mode.
      */
-    public abstract Iterable<Map.Entry<String, String>> parameters();
-
-    /**
-     * Returns a key/value map of the query parameters of this Uri. Use
-     * the `parameters()` method to return all parameters if keys may occur
-     * multiple times.
-     */
-    public abstract Map<String, String> parameterMap();
+    public abstract Query query(Charset charset, akka.http.scaladsl.model.Uri.ParsingMode mode);
 
     /**
      * Returns the fragment part of this Uri.
@@ -132,17 +126,17 @@ public abstract class Uri {
     /**
      * Returns a copy of this instance with a new query.
      */
-    public abstract Uri query(String query);
+    public abstract Uri rawQueryString(String rawQuery);
+
+    /**
+     * Returns a copy of this instance with a new query.
+     */
+    public abstract Uri query(Query query);
 
     /**
      * Returns a copy of this instance that is relative.
      */
     public abstract Uri toRelative();
-
-    /**
-     * Returns a copy of this instance with a query parameter added.
-     */
-    public abstract Uri addParameter(String key, String value);
 
     /**
      * Returns a copy of this instance with a new fragment.
@@ -156,34 +150,31 @@ public abstract class Uri {
 
     public static final akka.http.scaladsl.model.Uri.ParsingMode STRICT = UriJavaAccessor.pmStrict();
     public static final akka.http.scaladsl.model.Uri.ParsingMode RELAXED = UriJavaAccessor.pmRelaxed();
-    public static final akka.http.scaladsl.model.Uri.ParsingMode RELAXED_WITH_RAW_QUERY = UriJavaAccessor.pmRelaxedWithRawQuery();
 
     /**
      * Creates a default Uri to be modified using the modification methods.
      */
-    public static Uri create() {
-        return JavaAccessors$.MODULE$.Uri(akka.http.scaladsl.model.Uri.Empty$.MODULE$);
-    }
+    public static final Uri EMPTY = new JavaUri(akka.http.scaladsl.model.Uri.Empty$.MODULE$);
 
     /**
      * Returns a Uri created by parsing the given string representation.
      */
     public static Uri create(String uri) {
-        return JavaAccessors$.MODULE$.Uri(akka.http.scaladsl.model.Uri.apply(uri));
+        return new JavaUri(akka.http.scaladsl.model.Uri.apply(uri));
     }
 
     /**
-     * Returns a Uri created by parsing the given string representation and parsing-mode.
+     *  Returns a Uri created by parsing the given string representation with the provided parsing mode.
      */
     public static Uri create(String uri, akka.http.scaladsl.model.Uri.ParsingMode parsingMode) {
-        return JavaAccessors$.MODULE$.Uri(akka.http.scaladsl.model.Uri.apply(ParserInput$.MODULE$.apply(uri), parsingMode));
+        return new JavaUri(akka.http.scaladsl.model.Uri.apply(ParserInput$.MODULE$.apply(uri), parsingMode));
     }
 
     /**
-     * Returns a Uri created by parsing the given string representation, charset, and parsing-mode.
+     * Returns a Uri created by parsing the given string representation with the provided charset and parsing mode.
      */
     public static Uri create(String uri, Charset charset, akka.http.scaladsl.model.Uri.ParsingMode parsingMode) {
-        return JavaAccessors$.MODULE$.Uri(akka.http.scaladsl.model.Uri.apply(ParserInput$.MODULE$.apply(uri), charset, parsingMode));
+        return new JavaUri(akka.http.scaladsl.model.Uri.apply(ParserInput$.MODULE$.apply(uri), charset, parsingMode));
     }
 
 }

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -277,10 +277,6 @@ akka.http {
     #
     # `relaxed`: all visible 7-Bit ASCII chars are allowed
     #
-    # `relaxed-with-raw-query`: like `relaxed` but additionally
-    #     the URI query is not parsed, but delivered as one raw string
-    #     as the `key` value of a single Query structure element.
-    #
     uri-parsing-mode = strict
 
     # Enables/disables the logging of warning messages in case an incoming

--- a/akka-http-core/src/main/scala/akka/http/impl/model/JavaQuery.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/JavaQuery.scala
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.impl.model
+
+import java.{ util ⇒ ju }
+import akka.http.impl.model.parser.CharacterClasses
+import akka.http.impl.util.StringRendering
+import akka.http.javadsl.model.HttpCharset
+import akka.http.javadsl.{ model ⇒ jm }
+import akka.http.scaladsl.model.UriRendering
+import akka.http.scaladsl.{ model ⇒ sm }
+import akka.japi.{ Pair, Option }
+import akka.parboiled2.CharPredicate
+
+import scala.collection.JavaConverters._
+import akka.http.impl.util.JavaMapping.Implicits._
+
+/** INTERNAL API */
+case class JavaQuery(query: sm.Uri.Query) extends jm.Query {
+  override def get(key: String): Option[String] = query.get(key)
+  override def toMap: ju.Map[String, String] = query.toMap.asJava
+  override def toList: ju.List[Pair[String, String]] = query.map(_.asJava).asJava
+  override def getOrElse(key: String, _default: String): String = query.getOrElse(key, _default)
+  override def toMultiMap: ju.Map[String, ju.List[String]] = query.toMultiMap.map { case (k, v) ⇒ (k, v.asJava) }.asJava
+  override def getAll(key: String): ju.List[String] = query.getAll(key).asJava
+  override def toString = query.toString
+  override def withParam(key: String, value: String): jm.Query = jm.Query.create(query.map(_.asJava) :+ Pair(key, value): _*)
+  override def render(charset: HttpCharset): String =
+    UriRendering.renderQuery(new StringRendering, query, charset.nioCharset, CharacterClasses.unreserved).get
+  override def render(charset: HttpCharset, keep: CharPredicate): String = render(charset, keep)
+}

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaAccessors.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaAccessors.scala
@@ -7,7 +7,6 @@ package akka.http.impl.util
 import java.io.File
 
 import JavaMapping.Implicits._
-import akka.http.impl.model.JavaUri
 import akka.http.javadsl.model._
 import akka.http.scaladsl.model
 
@@ -25,9 +24,6 @@ object JavaAccessors {
 
   /** INTERNAL API */
   def HttpResponse(): HttpResponse = model.HttpResponse()
-
-  /** INTERNAL API */
-  def Uri(uri: model.Uri): Uri = JavaUri(uri)
 
   /** INTERNAL API */
   def HttpEntity(contentType: ContentType, file: File): UniversalEntity =

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
@@ -13,12 +13,11 @@ import akka.http.scaladsl.model.MediaTypes._
 /**
  * Simple model for `application/x-www-form-urlencoded` form data.
  */
-final case class FormData(fields: Uri.Query) extends jm.FormData {
-  override def toEntity: akka.http.scaladsl.model.RequestEntity =
+final case class FormData(fields: Uri.Query) {
+  def toEntity: akka.http.scaladsl.model.RequestEntity =
     toEntity(HttpCharsets.`UTF-8`)
 
   def toEntity(charset: HttpCharset): akka.http.scaladsl.model.RequestEntity = {
-    // TODO this logic is duplicated in javadsl.model.FormData, spent hours trying to DRY it but compiler freaked out in a number of ways... -- ktoso
     val render: StringRendering = UriRendering.renderQuery(new StringRendering, this.fields, charset.nioCharset, CharacterClasses.unreserved)
     HttpEntity(ContentType(`application/x-www-form-urlencoded`, `UTF-8`), render.get)
   }
@@ -32,7 +31,4 @@ object FormData {
 
   def apply(fields: (String, String)*): FormData =
     if (fields.isEmpty) Empty else FormData(Uri.Query(fields: _*))
-
-  def create(fields: Array[akka.japi.Pair[String, String]]): FormData =
-    if (fields.isEmpty) Empty else FormData(Uri.Query(fields.map(_.toScala): _*))
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.model
 
 import java.lang.{ Iterable ⇒ JIterable }
-import akka.http.impl.util
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ Future, ExecutionContext }
@@ -14,7 +13,6 @@ import scala.reflect.{ classTag, ClassTag }
 import akka.parboiled2.CharUtils
 import akka.stream.Materializer
 import akka.util.ByteString
-import akka.http.impl.model.JavaUri
 import akka.http.impl.util._
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.util.FastFuture._
@@ -267,10 +265,11 @@ final case class HttpRequest(method: HttpMethod = HttpMethods.GET,
   override def withUri(path: String): HttpRequest = withUri(Uri(path))
   def withUri(uri: Uri): HttpRequest = copy(uri = uri)
 
+  import JavaMapping.Implicits._
   /** Java API */
-  override def getUri: jm.Uri = util.JavaAccessors.Uri(uri)
+  override def getUri: jm.Uri = uri.asJava
   /** Java API */
-  override def withUri(relativeUri: akka.http.javadsl.model.Uri): HttpRequest = copy(uri = relativeUri.asInstanceOf[JavaUri].uri)
+  override def withUri(uri: jm.Uri): HttpRequest = copy(uri = uri.asScala)
 }
 
 object HttpRequest {

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
@@ -7,6 +7,7 @@ package akka.http.javadsl.model;
 import akka.http.impl.util.Util;
 import akka.http.javadsl.model.headers.Authorization;
 import akka.http.javadsl.model.headers.HttpCredentials;
+import akka.japi.Pair;
 
 public class JavaApiTestCases {
     /** Builds a request for use on the client side */
@@ -22,7 +23,7 @@ public class JavaApiTestCases {
         if (request.method() == HttpMethods.GET) {
             Uri uri = request.getUri();
             if (uri.path().equals("/hello")) {
-                String name = Util.getOrElse(uri.parameter("name"), "Mister X");
+                String name = Util.getOrElse(uri.query().get("name"), "Mister X");
 
                 return
                     HttpResponse.create()
@@ -56,14 +57,14 @@ public class JavaApiTestCases {
 
     /** Build a uri to send a form */
     public static Uri createUriForOrder(String orderId, String price, String amount) {
-        return Uri.create()
-            .path("/order")
-            .addParameter("orderId", orderId)
-            .addParameter("price", price)
-            .addParameter("amount", amount);
+        return Uri.create("/order").query(
+                Query.create(
+                        Pair.create("orderId", orderId),
+                        Pair.create("price", price),
+                        Pair.create("amount", amount)));
     }
 
-    public static Uri addSessionId(Uri uri) {
-        return uri.addParameter("session", "abcdefghijkl");
+    public static Query addSessionId(Query query) {
+        return query.withParam("session", "abcdefghijkl");
     }
 }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -25,7 +25,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.matchers.Matcher
 import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
@@ -271,7 +271,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
           |""" should parseTo(
           HttpRequest(
             GET,
-            "/foobar?q=baz",
+            "/foobar?q=b%61z",
             List(
               `Raw-Request-URI`("/f%6f%6fbar?q=b%61z"),
               Host("ping")),

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -576,8 +576,8 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
     }
 
     "parse with custom uri parsing mode" in {
-      val targetUri = Uri("http://example.org/?abc=def=ghi", Uri.ParsingMode.RelaxedWithRawQuery)
-      HeaderParser.parseFull("location", "http://example.org/?abc=def=ghi", HeaderParser.Settings(uriParsingMode = Uri.ParsingMode.RelaxedWithRawQuery)) shouldEqual
+      val targetUri = Uri("http://example.org/?abc=def=ghi", Uri.ParsingMode.Relaxed)
+      HeaderParser.parseFull("location", "http://example.org/?abc=def=ghi", HeaderParser.Settings(uriParsingMode = Uri.ParsingMode.Relaxed)) shouldEqual
         Right(Location(targetUri))
     }
   }

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.http.javadsl.model
 
+import akka.japi.Pair
+
 import org.scalatest.{ FreeSpec, MustMatchers }
 
 import scala.collection.JavaConverters._
@@ -11,9 +13,9 @@ import scala.collection.JavaConverters._
 class JavaApiSpec extends FreeSpec with MustMatchers {
   "The Java API should work for" - {
     "work with Uris" - {
-      "addParameter" in {
+      "query" in {
         Uri.create("/abc")
-          .addParameter("name", "paul") must be(Uri.create("/abc?name=paul"))
+          .query(Query.create(Pair.create("name", "paul"))) must be(Uri.create("/abc?name=paul"))
       }
       "addSegment" in {
         Uri.create("/abc")
@@ -38,33 +40,23 @@ class JavaApiSpec extends FreeSpec with MustMatchers {
       }
       "access parameterMap" in {
         Uri.create("/abc?name=blub&age=28")
-          .parameterMap().asScala must contain allOf ("name" -> "blub", "age" -> "28")
+          .query().toMap.asScala must contain allOf ("name" -> "blub", "age" -> "28")
       }
       "access parameters" in {
         val Seq(param1, param2, param3) =
           Uri.create("/abc?name=blub&age=28&name=blub2")
-            .parameters.asScala.toSeq
+            .query().toList.asScala.map(_.toScala)
 
-        param1.getKey must be("name")
-        param1.getValue must be("blub")
-
-        param2.getKey must be("age")
-        param2.getValue must be("28")
-
-        param3.getKey must be("name")
-        param3.getValue must be("blub2")
-      }
-      "containsParameter" in {
-        val uri = Uri.create("/abc?name=blub")
-        uri.containsParameter("name") must be(true)
-        uri.containsParameter("age") must be(false)
+        param1 must be("name" -> "blub")
+        param2 must be("age" -> "28")
+        param3 must be("name" -> "blub2")
       }
       "access single parameter" in {
-        val uri = Uri.create("/abc?name=blub")
-        uri.parameter("name") must be(akka.japi.Option.some("blub"))
-        uri.parameter("age") must be(akka.japi.Option.none)
+        val query = Uri.create("/abc?name=blub").query()
+        query.get("name") must be(akka.japi.Option.some("blub"))
+        query.get("age") must be(akka.japi.Option.none)
 
-        Uri.create("/abc?name=blub&name=blib").parameter("name") must be(akka.japi.Option.some("blub"))
+        Uri.create("/abc?name=blub&name=blib").query.get("name") must be(akka.japi.Option.some("blub"))
       }
     }
   }

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiTestCaseSpecs.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiTestCaseSpecs.scala
@@ -55,8 +55,8 @@ class JavaApiTestCaseSpecs extends FreeSpec with MustMatchers {
         Uri.create("/order?orderId=123&price=149&amount=42"))
     }
     "addSessionId" in {
-      val origin = Uri.create("/order?orderId=123")
-      JavaApiTestCases.addSessionId(origin) must be(Uri.create("/order?orderId=123&session=abcdefghijkl"))
+      val orderId = Query.create("orderId=123")
+      Uri.create("/order").query(JavaApiTestCases.addSessionId(orderId)) must be(Uri.create("/order?orderId=123&session=abcdefghijkl"))
     }
     "create HttpsContext" in {
       import akka.japi.{ Option ⇒ JOption }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -57,13 +57,13 @@ object ParameterDirectives extends ParameterDirectives {
   import BasicDirectives._
 
   private val _parameterMap: Directive1[Map[String, String]] =
-    extract(_.request.uri.query.toMap)
+    extract(_.request.uri.query().toMap)
 
   private val _parameterMultiMap: Directive1[Map[String, List[String]]] =
-    extract(_.request.uri.query.toMultiMap)
+    extract(_.request.uri.query().toMultiMap)
 
   private val _parameterSeq: Directive1[immutable.Seq[(String, String)]] =
-    extract(_.request.uri.query.toSeq)
+    extract(_.request.uri.query().toSeq)
 
   sealed trait ParamMagnet {
     type Out
@@ -109,7 +109,7 @@ object ParameterDirectives extends ParameterDirectives {
       extractRequestContext flatMap { ctx ⇒
         import ctx.executionContext
         import ctx.materializer
-        handleParamResult(paramName, fsou(ctx.request.uri.query get paramName))
+        handleParamResult(paramName, fsou(ctx.request.uri.query().get(paramName)))
       }
     implicit def forString(implicit fsu: FSU[String]): ParamDefAux[String, Directive1[String]] =
       extractParameter[String, String] { string ⇒ filter(string, fsu) }
@@ -134,7 +134,7 @@ object ParameterDirectives extends ParameterDirectives {
       extractRequestContext flatMap { ctx ⇒
         import ctx.executionContext
         import ctx.materializer
-        onComplete(fsou(ctx.request.uri.query get paramName)) flatMap {
+        onComplete(fsou(ctx.request.uri.query().get(paramName))) flatMap {
           case Success(value) if value == requiredValue ⇒ pass
           case _                                        ⇒ reject
         }
@@ -150,7 +150,7 @@ object ParameterDirectives extends ParameterDirectives {
       extractRequestContext flatMap { ctx ⇒
         import ctx.executionContext
         import ctx.materializer
-        handleParamResult(paramName, Future.sequence(ctx.request.uri.query.getAll(paramName).map(fsu.apply)))
+        handleParamResult(paramName, Future.sequence(ctx.request.uri.query().getAll(paramName).map(fsu.apply)))
       }
     implicit def forRepVR[T](implicit fsu: FSU[T]): ParamDefAux[RepeatedValueReceptacle[T], Directive1[Iterable[T]]] =
       extractParameter[RepeatedValueReceptacle[T], Iterable[T]] { rvr ⇒ repeatedFilter(rvr.name, fsu) }


### PR DESCRIPTION
Contains the following changes:
- URIs now contain the raw query string with an added `query()` method that parses on demand
- removed `Uri.ParsingMode.RelaxedWithRawQuery`
- add method to add query params to scala to mirror java and switched to `japi.Pair` for the params
- introduce `akka.http.javadsl.model.Query`
- removes  `withQueryParam` (scala) and `addParameter` (java) to prevent re-parsing during query construction

/cc @sirthias @jrudolph
