### PR TITLE
=doc Fix sentence in `Actors/Send messages/Ask`

### DIFF
--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -580,8 +580,8 @@ See :ref:`futures-scala` for more information on how to await or query a
 future.
 
 The ``onComplete``, ``onSuccess``, or ``onFailure`` methods of the ``Future`` can be
-used to register a callback to get a notification when the Future completes.
-Gives you a way to avoid blocking.
+used to register a callback to get a notification when the Future completes, giving
+you a way to avoid blocking.
 
 .. warning::
 


### PR DESCRIPTION
The sentence

> Gives you a way to avoid blocking.

does not make sense alone, I added it to the previous one.

The relevant part was introduced in ce128740abf8272d795d528ce58e043747e7636d, maybe @patriknw can have a look and see whether that matches his intended meaning?
