### PR TITLE
Improve docs for Actors and Fault Tolerance

### DIFF
--- a/akka-docs/rst/java/fault-tolerance.rst
+++ b/akka-docs/rst/java/fault-tolerance.rst
@@ -18,7 +18,7 @@ but in this sample we use a best effort re-connect approach.
 
 Read the following source code. The inlined comments explain the different pieces of
 the fault handling and why they are added. It is also highly recommended to run this
-sample as it is easy to follow the log output to understand what is happening in runtime.
+sample as it is easy to follow the log output to understand what is happening at runtime.
 
 .. toctree::
 

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -948,7 +948,7 @@ Initialization via preStart
 
 The method ``preStart()`` of an actor is only called once directly during the initialization of the first instance, that
 is, at creation of its ``ActorRef``. In the case of restarts, ``preStart()`` is called from ``postRestart()``, therefore
-if not overridden, ``preStart()`` is called on every incarnation. However, overriding ``postRestart()`` one can disable
+if not overridden, ``preStart()`` is called on every incarnation. However, by overriding ``postRestart()`` one can disable
 this behavior, and ensure that there is only one call to ``preStart()``.
 
 One useful usage of this pattern is to disable creation of new ``ActorRefs`` for children during restarts. This can be

--- a/akka-docs/rst/scala/fault-tolerance.rst
+++ b/akka-docs/rst/scala/fault-tolerance.rst
@@ -18,7 +18,7 @@ but in this sample we use a best effort re-connect approach.
 
 Read the following source code. The inlined comments explain the different pieces of
 the fault handling and why they are added. It is also highly recommended to run this
-sample as it is easy to follow the log output to understand what is happening in runtime.
+sample as it is easy to follow the log output to understand what is happening at runtime.
 
 .. toctree::
 


### PR DESCRIPTION
Fixes some more issues I found while reading the docs:
- missing `by` in the `Actors` docs
- replace `in runtime` with `at runtime` in the `Fault Tolerance` docs
