### PR TITLE
=sam Updated invalid doc links

### DIFF
--- a/akka-samples/akka-sample-camel-java/tutorial/index.html
+++ b/akka-samples/akka-sample-camel-java/tutorial/index.html
@@ -8,7 +8,7 @@
 <div>
 <p>
 This tutorial contains 3 samples of 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/camel.html" target="_blank">Akka Camel</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/camel.html" target="_blank">Akka Camel</a>.
 </p>
 
 <ul>
@@ -26,7 +26,7 @@ This tutorial contains 3 samples of
 <p>
 This example demonstrates how to implement consumer and producer actors that
 support 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/camel.html#Asynchronous_routing" target="_blank">
+<a href="http://doc.akka.io/docs/akka/snapshot/java/camel.html#Asynchronous_routing" target="_blank">
 Asynchronous routing</a> with their Camel endpoints. The sample
 application transforms the content of the Akka homepage, <a href="http://akka.io" target="_blank">http://akka.io</a>,
 by replacing every occurrence of *Akka* with *AKKA*.

--- a/akka-samples/akka-sample-camel-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-camel-scala/tutorial/index.html
@@ -8,7 +8,7 @@
 <div>
 <p>
 This tutorial contains 3 samples of 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/camel.html" target="_blank">Akka Camel</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/camel.html" target="_blank">Akka Camel</a>.
 </p>
 
 <ul>
@@ -26,7 +26,7 @@ This tutorial contains 3 samples of
 <p>
 This example demonstrates how to implement consumer and producer actors that
 support 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/camel.html#Asynchronous_routing" target="_blank">
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/camel.html#Asynchronous_routing" target="_blank">
 Asynchronous routing</a> with their Camel endpoints. The sample
 application transforms the content of the Akka homepage, <a href="http://akka.io" target="_blank">http://akka.io</a>,
 by replacing every occurrence of *Akka* with *AKKA*.

--- a/akka-samples/akka-sample-cluster-java/tutorial/index.html
+++ b/akka-samples/akka-sample-cluster-java/tutorial/index.html
@@ -8,7 +8,7 @@
 <div>
 <p>
 This tutorial contains 4 samples illustrating different 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/cluster-usage.html" target="_blank">Akka cluster</a> features.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/cluster-usage.html" target="_blank">Akka cluster</a> features.
 </p>
 <ul>
 <li>Subscribe to cluster membership events</li>
@@ -54,7 +54,7 @@ actor.
 
 <p>
 You can read more about the cluster concepts in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/cluster-usage.html" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/cluster-usage.html" target="_blank">documentation</a>.
 </p>
 
 <p>
@@ -143,7 +143,7 @@ that happen in the cluster.
 <p>
 In the previous sample we saw how to subscribe to cluster membership events.
 You can read more about it in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/cluster-usage.html#Subscribe_to_Cluster_Events" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/cluster-usage.html#Subscribe_to_Cluster_Events" target="_blank">documentation</a>.
 How can cluster membership events be used?
 </p>
 
@@ -233,7 +233,7 @@ interesting to run them in separate processes. Stop the application in the
 <h2>Cluster Aware Routers</h2>
 
 <p>
-All <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/routing.html" target="_blank">routers</a>
+All <a href="http://doc.akka.io/docs/akka/snapshot/java/routing.html" target="_blank">routers</a>
 can be made aware of member nodes in the cluster, i.e. deploying new routees or looking up routees
 on nodes in the cluster.
 When a node becomes unreachable or leaves the cluster the routees of that node are
@@ -244,7 +244,7 @@ when a node becomes reachable again, after having been unreachable.
 
 <p>
 You can read more about cluster aware routers in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/cluster-usage.html#Cluster_Aware_Routers" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/cluster-usage.html#Cluster_Aware_Routers" target="_blank">documentation</a>.
 </p>
 
 <p>
@@ -346,7 +346,7 @@ and deploys workers instead of looking them up.
 
 <p>
 Open <a href="#code/src/main/java/sample/cluster/stats/StatsSampleOneMasterMain.java" class="shortcut">StatsSampleOneMasterMain.java</a>.
-To keep track of a single master we use the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/contrib/cluster-singleton.html" target="_blank">Cluster Singleton</a>
+To keep track of a single master we use the <a href="http://doc.akka.io/docs/akka/snapshot/contrib/cluster-singleton.html" target="_blank">Cluster Singleton</a>
 in the contrib module. The <code>ClusterSingletonManager</code> is started on each node.
 </p>
 
@@ -411,7 +411,7 @@ the <code>AdaptiveLoadBalancingPool</code> and <code>AdaptiveLoadBalancingGroup<
 
 <p>
 You can read more about cluster metrics in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/cluster-usage.html#Cluster_Metrics" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/cluster-usage.html#Cluster_Metrics" target="_blank">documentation</a>.
 </p>
 
 <p>

--- a/akka-samples/akka-sample-cluster-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-cluster-scala/tutorial/index.html
@@ -8,7 +8,7 @@
 <div>
 <p>
 This tutorial contains 4 samples illustrating different 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/cluster-usage.html" target="_blank">Akka cluster</a> features.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/cluster-usage.html" target="_blank">Akka cluster</a> features.
 </p>
 <ul>
 <li>Subscribe to cluster membership events</li>
@@ -54,7 +54,7 @@ actor.
 
 <p>
 You can read more about the cluster concepts in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/cluster-usage.html" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/cluster-usage.html" target="_blank">documentation</a>.
 </p>
 
 <p>
@@ -143,7 +143,7 @@ that happen in the cluster.
 <p>
 In the previous sample we saw how to subscribe to cluster membership events.
 You can read more about it in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/cluster-usage.html#Subscribe_to_Cluster_Events" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/cluster-usage.html#Subscribe_to_Cluster_Events" target="_blank">documentation</a>.
 How can cluster membership events be used?
 </p>
 
@@ -233,7 +233,7 @@ interesting to run them in separate processes. Stop the application in the
 <h2>Cluster Aware Routers</h2>
 
 <p>
-All <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/routing.html" target="_blank">routers</a>
+All <a href="http://doc.akka.io/docs/akka/snapshot/scala/routing.html" target="_blank">routers</a>
 can be made aware of member nodes in the cluster, i.e. deploying new routees or looking up routees
 on nodes in the cluster.
 When a node becomes unreachable or leaves the cluster the routees of that node are
@@ -244,7 +244,7 @@ when a node becomes reachable again, after having been unreachable.
 
 <p>
 You can read more about cluster aware routers in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/cluster-usage.html#Cluster_Aware_Routers" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/cluster-usage.html#Cluster_Aware_Routers" target="_blank">documentation</a>.
 </p>
 
 <p>
@@ -345,7 +345,7 @@ and deploys workers instead of looking them up.
 
 <p>
 Open <a href="#code/src/main/scala/sample/cluster/stats/StatsSampleOneMaster.scala" class="shortcut">StatsSampleOneMaster.scala</a>.
-To keep track of a single master we use the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/contrib/cluster-singleton.html" target="_blank">Cluster Singleton</a>
+To keep track of a single master we use the <a href="http://doc.akka.io/docs/akka/snapshot/contrib/cluster-singleton.html" target="_blank">Cluster Singleton</a>
 in the contrib module. The <code>ClusterSingletonManager</code> is started on each node.
 </p>
 
@@ -410,7 +410,7 @@ the <code>AdaptiveLoadBalancingPool</code> and <code>AdaptiveLoadBalancingGroup<
 
 <p>
 You can read more about cluster metrics in the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/cluster-usage.html#Cluster_Metrics" target="_blank">documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/cluster-usage.html#Cluster_Metrics" target="_blank">documentation</a>.
 </p>
 
 <p>

--- a/akka-samples/akka-sample-distributed-data-java/tutorial/index.html
+++ b/akka-samples/akka-sample-distributed-data-java/tutorial/index.html
@@ -8,7 +8,7 @@
 <div>
 <p>
 This tutorial contains 5 samples illustrating how to use  
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html" target="_blank">Akka Distributed Data</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html" target="_blank">Akka Distributed Data</a>.
 </p>
 <ul>
 <li>Low Latency Voting Service</li>
@@ -47,7 +47,7 @@ out-of-date value.
 
 <p>
 Note that there are some 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html#Limitations" target="_blank">Limitations</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html#Limitations" target="_blank">Limitations</a>
 that you should be aware of. For example, Akka Distributed Data is not intended for <i>Big Data</i>.
 </p>
 
@@ -71,7 +71,7 @@ Open <a href="#code/src/main/java/sample/distributeddata/VotingService.java" cla
 of the grand total number of votes. The actor is started on each cluster node. First it expects an 
 <code>OPEN</code> message on one or several nodes. After that the counting can begin. The open
 signal is immediately replicated to all nodes with a boolean
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html#Flags_and_Registers" target="_blank">Flag</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html#Flags_and_Registers" target="_blank">Flag</a>.
 Note <code>writeAll</code>.  
 </p>
 
@@ -94,7 +94,7 @@ replicator.tell(new Subscribe&lt;&gt;(openedKey, self()), ActorRef.noSender());
 
 <p>
 The counters are kept in a 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html#Counters" target="_blank">PNCounterMap</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html#Counters" target="_blank">PNCounterMap</a>
 and updated with:
 </p>
 
@@ -139,7 +139,7 @@ The multi-node test for the <code>VotingService</code> can be found in
 
 <p>
 Read the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html#Using_the_Replicator" target="_blank">Using the Replicator</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html#Using_the_Replicator" target="_blank">Using the Replicator</a>
 documentation for more details of how to use <code>Get</code>, <code>Update</code>, and <code>Subscribe</code>.
 </p>
 
@@ -165,7 +165,7 @@ instances may be started on different nodes and used at the same time.
 
 <p>
 Each product in the cart is represented by a <code>LineItem</code> and all items in the cart
-is collected in a <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html#Maps" target="_blank">LWWMap</a>.
+is collected in a <a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html#Maps" target="_blank">LWWMap</a>.
 </p>
 
 <p>
@@ -187,7 +187,7 @@ The multi-node test for the <code>ShoppingCart</code> can be found in
 
 <p>
 Read the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html#Consistency" target="_blank">Consistency</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html#Consistency" target="_blank">Consistency</a>
 section in the documentation to understand the consistency considerations.
 </p>
 
@@ -218,7 +218,7 @@ It supports two basic commands:
 
 <p>
 For each named service it is using an
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/distributed-data.html#Sets" target="_blank">ORSet</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/distributed-data.html#Sets" target="_blank">ORSet</a>.
 Here we are using top level <code>ORSet</code> entries. An alternative would have been to use a 
 <code>ORMultiMap</code> holding all services. That would have a disadvantage if we have many services.
 When a data entry is changed the full state of that entry is replicated to other nodes, i.e. when you 

--- a/akka-samples/akka-sample-distributed-data-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-distributed-data-scala/tutorial/index.html
@@ -8,7 +8,7 @@
 <div>
 <p>
 This tutorial contains 5 samples illustrating how to use  
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html" target="_blank">Akka Distributed Data</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html" target="_blank">Akka Distributed Data</a>.
 </p>
 <ul>
 <li>Low Latency Voting Service</li>
@@ -47,7 +47,7 @@ out-of-date value.
 
 <p>
 Note that there are some 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Limitations" target="_blank">Limitations</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Limitations" target="_blank">Limitations</a>
 that you should be aware of. For example, Akka Distributed Data is not intended for <i>Big Data</i>.
 </p>
 
@@ -71,7 +71,7 @@ Open <a href="#code/src/main/scala/sample/distributeddata/VotingService.scala" c
 of the grand total number of votes. The actor is started on each cluster node. First it expects an 
 <code>Open</code> message on one or several nodes. After that the counting can begin. The open
 signal is immediately replicated to all nodes with a boolean
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Flags_and_Registers" target="_blank">Flag</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Flags_and_Registers" target="_blank">Flag</a>.
 Note <code>WriteAll</code>.  
 </p>
 
@@ -94,7 +94,7 @@ case c @ Changed(OpenedKey) if c.get(OpenedKey).enabled
 
 <p>
 The counters are kept in a 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Counters" target="_blank">PNCounterMap</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Counters" target="_blank">PNCounterMap</a>
 and updated with:
 </p>
 
@@ -131,7 +131,7 @@ The multi-node test for the <code>VotingService</code> can be found in
 
 <p>
 Read the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Using_the_Replicator" target="_blank">Using the Replicator</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Using_the_Replicator" target="_blank">Using the Replicator</a>
 documentation for more details of how to use <code>Get</code>, <code>Update</code>, and <code>Subscribe</code>.
 </p>
 
@@ -157,7 +157,7 @@ instances may be started on different nodes and used at the same time.
 
 <p>
 Each product in the cart is represented by a <code>LineItem</code> and all items in the cart
-is collected in a <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Maps" target="_blank">LWWMap</a>.
+is collected in a <a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Maps" target="_blank">LWWMap</a>.
 </p>
 
 <p>
@@ -179,7 +179,7 @@ The multi-node test for the <code>ShoppingCart</code> can be found in
 
 <p>
 Read the 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Consistency" target="_blank">Consistency</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Consistency" target="_blank">Consistency</a>
 section in the documentation to understand the consistency considerations.
 </p>
 
@@ -210,7 +210,7 @@ It supports two basic commands:
 
 <p>
 For each named service it is using an
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Sets" target="_blank">ORSet</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Sets" target="_blank">ORSet</a>.
 Here we are using top level <code>ORSet</code> entries. An alternative would have been to use a 
 <code>ORMultiMap</code> holding all services. That would have a disadvantage if we have many services.
 When a data entry is changed the full state of that entry is replicated to other nodes, i.e. when you 

--- a/akka-samples/akka-sample-fsm-java-lambda/tutorial/index.html
+++ b/akka-samples/akka-sample-fsm-java-lambda/tutorial/index.html
@@ -40,7 +40,7 @@ In the log output you can see the actions of the <code>Hakker</code> actors.
 
 <p>
 Read more about <code>become</code> in
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/lambda-actors.html#Become_Unbecome" target="_blank">the documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/lambda-actors.html#Become_Unbecome" target="_blank">the documentation</a>.
 </p>
 
 </div>
@@ -64,7 +64,7 @@ In the log output you can see the actions of the <code>Hakker</code> actors.
 
 <p>
 Read more about <code>akka.actor.FSM</code> in
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/lambda-fsm.html" target="_blank">the documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/lambda-fsm.html" target="_blank">the documentation</a>.
 </p>
 
 </div>

--- a/akka-samples/akka-sample-fsm-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-fsm-scala/tutorial/index.html
@@ -41,7 +41,7 @@ In the log output you can see the actions of the <code>Hakker</code> actors.
 
 <p>
 Read more about <code>become</code> in
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/actors.html#Become_Unbecome" target="_blank">the documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/actors.html#Become_Unbecome" target="_blank">the documentation</a>.
 </p>
 
 </div>
@@ -65,7 +65,7 @@ In the log output you can see the actions of the <code>Hakker</code> actors.
 
 <p>
 Read more about <code>akka.actor.FSM</code> in
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/fsm.html" target="_blank">the documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/fsm.html" target="_blank">the documentation</a>.
 </p>
 
 </div>

--- a/akka-samples/akka-sample-main-java-lambda/tutorial/index.html
+++ b/akka-samples/akka-sample-main-java-lambda/tutorial/index.html
@@ -76,7 +76,7 @@ This conveniently assumes placement of the above class definitions in package
 <code>sample.hello</code> and it further assumes that you have the required JAR files for
 <code>scala-library</code>, <code>typesafe-config</code> and <code>akka-actor</code> available.
 The easiest would be to manage these dependencies with a
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/intro/getting-started.html#Using_a_build_tool" target="_blank">build tool</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/intro/getting-started.html#Using_a_build_tool" target="_blank">build tool</a>.
 </p>
 
 <p>

--- a/akka-samples/akka-sample-main-java/tutorial/index.html
+++ b/akka-samples/akka-sample-main-java/tutorial/index.html
@@ -76,7 +76,7 @@ This conveniently assumes placement of the above class definitions in package
 <code>sample.hello</code> and it further assumes that you have the required JAR files for
 <code>scala-library</code>, <code>typesafe-config</code> and <code>akka-actor</code> available.
 The easiest would be to manage these dependencies with a 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/intro/getting-started.html#Using_a_build_tool" target="_blank">build tool</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/intro/getting-started.html#Using_a_build_tool" target="_blank">build tool</a>.
 </p>
 
 <p>

--- a/akka-samples/akka-sample-main-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-main-scala/tutorial/index.html
@@ -76,7 +76,7 @@ This conveniently assumes placement of the above class definitions in package
 <code>sample.hello</code> and it further assumes that you have the required JAR files for
 <code>scala-library</code>, <code>typesafe-config</code> and <code>akka-actor</code> available.
 The easiest would be to manage these dependencies with a 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/intro/getting-started.html#Using_a_build_tool" target="_blank">build tool</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/intro/getting-started.html#Using_a_build_tool" target="_blank">build tool</a>.
 </p>
 
 <p>

--- a/akka-samples/akka-sample-multi-node-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-multi-node-scala/tutorial/index.html
@@ -13,12 +13,12 @@ and test classes for illustrating multi-node testing with Akka.
 
 <p>
 Please refer to the full documentation of 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/dev/multi-node-testing.html" target="_blank">multi-node testing</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/dev/multi-node-testing.html" target="_blank">multi-node testing</a>
 and the closely related
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/dev/multi-jvm-testing.html" target="_blank">multi-jvm testing</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/dev/multi-jvm-testing.html" target="_blank">multi-jvm testing</a>
 for details.
 There is also an section on 
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/cluster-usage.html#How_to_Test" target="_blank">cluster testing</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/cluster-usage.html#How_to_Test" target="_blank">cluster testing</a>.
 </p>
 
 </div>
@@ -79,7 +79,7 @@ the sbt prompt:
 
 <p>
 The same test can be run on multiple machines as described in the
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/dev/multi-node-testing.html" target="_blank">multi-node testing documentation</a>.
+<a href="http://doc.akka.io/docs/akka/snapshot/dev/multi-node-testing.html" target="_blank">multi-node testing documentation</a>.
 </p> 
 
 

--- a/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java-lambda/tutorial/index.html
@@ -9,7 +9,7 @@
 <h2>Akka Persistence Samples</h2>
 <p>
 This tutorial contains examples that illustrate a subset of
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/lambda-persistence.html" target="_blank">Akka Persistence</a> features.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/lambda-persistence.html" target="_blank">Akka Persistence</a> features.
 </p>
 <ul>
 <li>persistent actor</li>
@@ -28,7 +28,7 @@ Custom storage locations for the journal and snapshots can be defined in
 <h2>Persistent actor</h2>
 <p>
 <a href="#code/src/main/java/sample/persistence/PersistentActorExample.java" class="shortcut">PersistentActorExample.java</a>
-is described in detail in the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/lambda-persistence.html#event-sourcing-java-lambda" target="_blank">Event sourcing</a>
+is described in detail in the <a href="http://doc.akka.io/docs/akka/snapshot/java/lambda-persistence.html#event-sourcing-java-lambda" target="_blank">Event sourcing</a>
 section of the user documentation. With every application run, the <code>ExamplePersistentActor</code> is recovered from
 events stored in previous application runs, processes new commands, stores new events and snapshots and prints the
 current persistent actor state to <code>stdout</code>.

--- a/akka-samples/akka-sample-persistence-java/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-java/tutorial/index.html
@@ -9,7 +9,7 @@
 <h2>Akka Persistence Samples</h2>
 <p>
 This tutorial contains examples that illustrate a subset of
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/persistence.html" target="_blank">Akka Persistence</a> features.
+<a href="http://doc.akka.io/docs/akka/snapshot/java/persistence.html" target="_blank">Akka Persistence</a> features.
 </p>
 <ul>
 <li>persistent actor</li>
@@ -28,7 +28,7 @@ Custom storage locations for the journal and snapshots can be defined in
 <h2>Persistent actor</h2>
 <p>
 <a href="#code/src/main/java/sample/persistence/PersistentActorExample.java" class="shortcut">PersistentActorExample.java</a>
-is described in detail in the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/persistence.html#event-sourcing-java" target="_blank">Event sourcing</a>
+is described in detail in the <a href="http://doc.akka.io/docs/akka/snapshot/java/persistence.html#event-sourcing-java" target="_blank">Event sourcing</a>
 section of the user documentation. With every application run, the <code>ExamplePersistentActor</code> is recovered from
 events stored in previous application runs, processes new commands, stores new events and snapshots and prints the
 current persistent actor state to <code>stdout</code>.
@@ -86,7 +86,7 @@ To run this example, go to the <a href="#run" class="shortcut">Run</a> tab, and 
 </p>
 
 <p>
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/java/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
 on the other hand, does not persist commands directly but rather events that have been derived from received commands
 (not shown here). These events are known to be successfully applicable to current processor state i.e. there's
 no need for deleting them from the journal. Event sourced processors usually have a lower throughput than command

--- a/akka-samples/akka-sample-persistence-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-persistence-scala/tutorial/index.html
@@ -8,7 +8,7 @@
 <div>
 <p>
 This tutorial contains examples that illustrate a subset of
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/persistence.html" target="_blank">Akka Persistence</a> features.
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/persistence.html" target="_blank">Akka Persistence</a> features.
 </p>
 <ul>
 <li>persistent actor</li>
@@ -27,7 +27,7 @@ Custom storage locations for the journal and snapshots can be defined in
 <h2>Persistent actor</h2>
 <p>
 <a href="#code/src/main/scala/sample/persistence/PersistentActorExample.scala" class="shortcut">PersistentActorExample.scala</a>
-is described in detail in the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
+is described in detail in the <a href="http://doc.akka.io/docs/akka/snapshot/scala/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
 section of the user documentation. With every application run, the <code>ExamplePersistentActor</code> is recovered from
 events stored in previous application runs, processes new commands, stores new events and snapshots and prints the
 current persistent actor state to <code>stdout</code>.
@@ -85,7 +85,7 @@ To run this example, go to the <a href="#run" class="shortcut">Run</a> tab, and 
 </p>
 
 <p>
-<a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
+<a href="http://doc.akka.io/docs/akka/snapshot/scala/persistence.html#event-sourcing" target="_blank">Event sourcing</a>
 on the other hand, does not persist commands directly but rather events that have been derived from received commands
 (not shown here). These events are known to be successfully applicable to current processor state i.e. there's
 no need for deleting them from the journal. Event sourced processors usually have a lower throughput than command

--- a/akka-samples/akka-sample-remote-java/tutorial/index.html
+++ b/akka-samples/akka-sample-remote-java/tutorial/index.html
@@ -7,7 +7,7 @@
 
 <div>
 <p>
-In order to showcase the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/remoting.html" target="_blank">remote capabilities of Akka</a>
+In order to showcase the <a href="http://doc.akka.io/docs/akka/snapshot/java/remoting.html" target="_blank">remote capabilities of Akka</a>
 we thought a remote calculator could do the trick.
 This sample demonstrates both remote deployment and look-up of remote actors.
 </p>

--- a/akka-samples/akka-sample-remote-scala/tutorial/index.html
+++ b/akka-samples/akka-sample-remote-scala/tutorial/index.html
@@ -7,7 +7,7 @@
 
 <div>
 <p>
-In order to showcase the <a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/remoting.html" target="_blank">remote capabilities of Akka</a>
+In order to showcase the <a href="http://doc.akka.io/docs/akka/snapshot/scala/remoting.html" target="_blank">remote capabilities of Akka</a>
 we thought a remote calculator could do the trick.
 This sample demonstrates both remote deployment and look-up of remote actors.
 </p>

--- a/akka-samples/akka-sample-supervision-java-lambda/tutorial/index.html
+++ b/akka-samples/akka-sample-supervision-java-lambda/tutorial/index.html
@@ -240,10 +240,10 @@ new Divide(
 
     <p>You should also visit</p>
     <ul>
-        <li><a href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java.html"
+        <li><a href="http://doc.akka.io/docs/akka/snapshot/java.html"
                target="_blank">The Akka documentation</a></li>
         <li><a
-               href="http://doc.akka.io/docs/akka/2.4-SNAPSHOT/java/lambda-fault-tolerance.html"
+               href="http://doc.akka.io/docs/akka/snapshot/java/lambda-fault-tolerance.html"
                target="_blank">Documentation of supervision</a></li>
         <li><a href="http://letitcrash.com" target="_blank">The Akka Team blog</a></li>
     </ul>


### PR DESCRIPTION
I'm reading some tutorial pages from akka-samples and noticed that the doc links are pointing to **2.4-SNAPSHOT** which is not working, I guess the correct one should be **snapshot** (correct me if I'm wrong)...

For eg, 
    http://doc.akka.io/docs/akka/2.4-SNAPSHOT/scala/distributed-data.html#Limitations
vs
    http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html#Limitations

I have did a _grep_ and updated them, appreciate if you could review it 
