### PR TITLE
=doc Add missing `by` in Routing docs

### DIFF
--- a/akka-docs/rst/java/routing.rst
+++ b/akka-docs/rst/java/routing.rst
@@ -581,7 +581,7 @@ Management Messages
 * Sending ``akka.routing.AdjustPoolSize`` to a pool router actor will add or remove that number of routees to
   its collection of routees.
 
-These management messages may be handled after other messages, so if you send ``AddRoutee`` immediately followed
+These management messages may be handled after other messages, so if you send ``AddRoutee`` immediately followed by
 an ordinary message you are not guaranteed that the routees have been changed when the ordinary message
 is routed. If you need to know when the change has been applied you can send ``AddRoutee`` followed by ``GetRoutees``
 and when you receive the ``Routees`` reply you know that the preceding change has been applied.

--- a/akka-docs/rst/scala/routing.rst
+++ b/akka-docs/rst/scala/routing.rst
@@ -580,7 +580,7 @@ Management Messages
 * Sending ``akka.routing.AdjustPoolSize`` to a pool router actor will add or remove that number of routees to
   its collection of routees.
 
-These management messages may be handled after other messages, so if you send ``AddRoutee`` immediately followed
+These management messages may be handled after other messages, so if you send ``AddRoutee`` immediately followed by
 an ordinary message you are not guaranteed that the routees have been changed when the ordinary message
 is routed. If you need to know when the change has been applied you can send ``AddRoutee`` followed by ``GetRoutees``
 and when you receive the ``Routees`` reply you know that the preceding change has been applied.


### PR DESCRIPTION
Add a missing `by` to the Routing docs, Specially Handled Messages section.
