### PR TITLE
=htp #18661 EffectiveUri in Java Testkit

### DIFF
--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
@@ -32,7 +32,7 @@ public class HeaderRequestValsExampleTest extends JUnitRouteTest {
     final HttpRequest request =
       HttpRequest
         .GET("http://akka.io/")
-      .addHeader(Host.create("akka.io", 80));
+      .addHeader(Host.create("akka.io"));
     testRoute(route).run(request).assertEntity("Host header was: akka.io");
 
     //#by-class

--- a/akka-docs-dev/rst/java/code/docs/http/javadsl/server/directives/HostDirectivesExamplesTest.java
+++ b/akka-docs-dev/rst/java/code/docs/http/javadsl/server/directives/HostDirectivesExamplesTest.java
@@ -18,9 +18,6 @@ import org.junit.Test;
 
 public class HostDirectivesExamplesTest extends JUnitRouteTest {
 
-  //FIXME The GET requests should work with HttpRequest.GET("/").addHeader(Host.create
-  //      instead of absolute paths. That is tracked by issue: https://github.com/akka/akka/issues/18661
-
   @Test
   public void testListOfHost() {
     //#host1
@@ -28,7 +25,7 @@ public class HostDirectivesExamplesTest extends JUnitRouteTest {
         Arrays.asList("api.company.com", "rest.company.com"),
         completeWithStatus(StatusCodes.OK));
 
-    testRoute(matchListOfHosts).run(HttpRequest.GET("http://api.company.com/"))
+    testRoute(matchListOfHosts).run(HttpRequest.GET("/").addHeader(Host.create("api.company.com")))
         .assertStatusCode(StatusCodes.OK);
     //#host1
   }
@@ -39,10 +36,10 @@ public class HostDirectivesExamplesTest extends JUnitRouteTest {
     final Route shortOnly = host(hostname -> hostname.length() < 10,
         completeWithStatus(StatusCodes.OK));
 
-    testRoute(shortOnly).run(HttpRequest.GET("http://short.com/"))
+    testRoute(shortOnly).run(HttpRequest.GET("/").addHeader(Host.create("short.com")))
         .assertStatusCode(StatusCodes.OK);
 
-    testRoute(shortOnly).run(HttpRequest.GET("http://verylonghostname.com/"))
+    testRoute(shortOnly).run(HttpRequest.GET("/").addHeader(Host.create("verylonghostname.com")))
         .assertStatusCode(StatusCodes.NOT_FOUND);
     //#host2
   }
@@ -55,7 +52,7 @@ public class HostDirectivesExamplesTest extends JUnitRouteTest {
     final Route route = handleWith1(host,
         (ctx, hn) -> ctx.complete("Hostname: " + hn));
 
-    testRoute(route).run(HttpRequest.GET("http://company.com:9090/"))
+    testRoute(route).run(HttpRequest.GET("/").addHeader(Host.create("company.com", 9090)))
         .assertEntity("Hostname: company.com");
     //#extractHostname
   }
@@ -79,10 +76,10 @@ public class HostDirectivesExamplesTest extends JUnitRouteTest {
 
     final Route route = route(hostPrefixRoute, hostPartRoute);
 
-    testRoute(route).run(HttpRequest.GET("http://api.company.com/"))
+    testRoute(route).run(HttpRequest.GET("/").addHeader(Host.create("api.company.com")))
         .assertStatusCode(StatusCodes.OK).assertEntity("Extracted prefix: api");
 
-    testRoute(route).run(HttpRequest.GET("http://public.mycompany.com/"))
+    testRoute(route).run(HttpRequest.GET("/").addHeader(Host.create("public.mycompany.com")))
         .assertStatusCode(StatusCodes.OK)
         .assertEntity("You came through my company");
     //#matchAndExtractHost

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/DefaultHostInfo.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/DefaultHostInfo.scala
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.http.javadsl.testkit
+
+import akka.http.javadsl.model.headers.Host
+
+final case class DefaultHostInfo(private val host: Host, private val securedConnection: Boolean) {
+
+  def getHost(): Host = host
+
+  def isSecuredConnection(): Boolean = securedConnection
+
+}

--- a/akka-http-tests-java8/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
+++ b/akka-http-tests-java8/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
@@ -49,14 +49,14 @@ public class HandlerExampleDocTest extends JUnitRouteTest {
         TestRoute r = testRoute(new TestHandler().createRoute());
         r.run(HttpRequest.GET("/test"))
             .assertStatusCode(200)
-            .assertEntity("This was a GET request to /test");
+            .assertEntity("This was a GET request to http://example.com/test");
 
         r.run(HttpRequest.POST("/test"))
             .assertStatusCode(404);
 
         r.run(HttpRequest.POST("/abc"))
             .assertStatusCode(200)
-            .assertEntity("This was a POST request to /abc");
+            .assertEntity("This was a POST request to http://example.com/abc");
         //#simple-handler-example-full
     }
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/PathDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/PathDirectivesTest.java
@@ -5,6 +5,7 @@
 package akka.http.javadsl.server.directives;
 
 import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.headers.Host;
 import akka.http.javadsl.server.values.PathMatcher;
 import org.junit.Test;
 
@@ -337,9 +338,9 @@ public class PathDirectivesTest extends JUnitRouteTest {
                 redirectToTrailingSlashIfMissing(StatusCodes.FOUND, complete("Ok"))
             );
 
-        route.run(HttpRequest.GET("/home"))
+        route.run(HttpRequest.GET("/home").addHeader(Host.create("example.com")))
             .assertStatusCode(302)
-            .assertHeaderExists("Location", "/home/");
+            .assertHeaderExists("Location", "http://example.com/home/");
 
         route.run(HttpRequest.GET("/home/"))
             .assertStatusCode(200)
@@ -353,9 +354,9 @@ public class PathDirectivesTest extends JUnitRouteTest {
                 redirectToNoTrailingSlashIfPresent(StatusCodes.FOUND, complete("Ok"))
             );
 
-        route.run(HttpRequest.GET("/home/"))
+        route.run(HttpRequest.GET("/home/").addHeader(Host.create("example.com")))
             .assertStatusCode(302)
-            .assertHeaderExists("Location", "/home");
+            .assertHeaderExists("Location", "http://example.com/home");
 
         route.run(HttpRequest.GET("/home"))
             .assertStatusCode(200)


### PR DESCRIPTION
The Java testkit now uses effectiveUri to behave just like the Scala testkit so that

The host header and path is joined. This allows for test calls that use just a relative URI.
A default host-port is provided if no host header is present - example.com

Refs #18661 
