### PR TITLE
=act #18613 Optimize RepointableActorRef for only sys msg

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/actor/RouterPoolCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/RouterPoolCreationBenchmark.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import akka.routing.RoundRobinPool
+import akka.testkit.TestActors
+import akka.testkit.TestProbe
+import org.openjdk.jmh.annotations._
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@Fork(3)
+@Warmup(iterations = 20)
+@Measurement(iterations = 100)
+class RouterPoolCreationBenchmark {
+  implicit val system: ActorSystem = ActorSystem()
+  val probe = TestProbe()
+
+  Props[TestActors.EchoActor]
+
+  @Param(Array("1000", "2000", "3000", "4000"))
+  var size = 0
+
+  @TearDown(Level.Trial)
+  def shutdown() {
+    system.terminate()
+    Await.ready(system.whenTerminated, 15.seconds)
+  }
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def testCreation: Boolean = {
+    val pool = system.actorOf(RoundRobinPool(size).props(TestActors.echoActorProps))
+    pool.tell("hello", probe.ref)
+    probe.expectMsg(5.seconds, "hello")
+    true
+  }
+}
+


### PR DESCRIPTION
- Before the cell is started the RepointableActorRef queue the messages
  (both system and non-system messages) into a queue. System messages
  are inserted right before the last non-system message by iterating
  the queue, i.e. becomes slow when there are many system messages already
  enqueued.
- This is a problem for pools with many routees.
- The fix is to keep track of that there are only system messages
  and then only add the message to the queue without any iteration.

JMH benchmark before:

```
[info] Benchmark                                 (size)  Mode  Cnt       Score      Error  Units
[info] RouterPoolCreationBenchmark.testCreation    1000    ss  300   13204.048 ± 3081.576  us/op
[info] RouterPoolCreationBenchmark.testCreation    2000    ss  300   41939.524 ± 6178.087  us/op
[info] RouterPoolCreationBenchmark.testCreation    3000    ss  300   70752.881 ± 4344.992  us/op
[info] RouterPoolCreationBenchmark.testCreation    4000    ss  300  120620.885 ± 3296.342  us/op
```

JMH benchmark after:

```
[info] Benchmark                                 (size)  Mode  Cnt      Score       Error  Units
[info] RouterPoolCreationBenchmark.testCreation    1000    ss  300  10867.705 ±  2817.712  us/op
[info] RouterPoolCreationBenchmark.testCreation    2000    ss  300  21018.967 ±  5363.646  us/op
[info] RouterPoolCreationBenchmark.testCreation    3000    ss  300  33191.025 ± 14053.836  us/op
[info] RouterPoolCreationBenchmark.testCreation    4000    ss  300  41751.298 ± 12960.081  us/op
```
