### PR TITLE
!str #18760 hide Graph.shape() from users

### DIFF
--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -5,7 +5,7 @@ package akka.stream.scaladsl
 
 import akka.stream.impl.StreamLayout
 import akka.stream.impl.StreamLayout.Module
-import akka.stream.{ Graph, Attributes, Shape }
+import akka.stream.{ InternalGraph, Graph, Attributes, Shape }
 
 trait GraphApply {
 
@@ -106,7 +106,7 @@ trait GraphApply {
  */
 private[stream] object GraphApply {
   class GraphImpl[S <: Shape, Mat](override val shape: S, private[stream] override val module: StreamLayout.Module)
-    extends Graph[S, Mat] {
+    extends InternalGraph[S, Mat] {
 
     override def withAttributes(attr: Attributes): Graph[S, Mat] =
       new GraphImpl(shape, module.withAttributes(attr).nest())

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -6,15 +6,13 @@ package akka.stream
 import akka.stream.impl.StreamLayout
 import scala.annotation.unchecked.uncheckedVariance
 
-trait Graph[+S <: Shape, +M] {
+trait Graph[+S <: Shape, +M] { this: InternalGraph[S, M] ⇒
+
   /**
    * Type-level accessor for the shape parameter of this graph.
    */
   type Shape = S @uncheckedVariance
-  /**
-   * The shape of a graph is all that is externally visible: its inlets and outlets.
-   */
-  def shape: S
+
   /**
    * INTERNAL API.
    *
@@ -25,4 +23,16 @@ trait Graph[+S <: Shape, +M] {
   def withAttributes(attr: Attributes): Graph[S, M]
 
   def named(name: String): Graph[S, M] = withAttributes(Attributes.name(name))
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] trait InternalGraph[+S <: Shape, +M] extends Graph[S, M] {
+
+  /**
+   * The shape of a graph is all that is externally visible: its inlets and outlets.
+   */
+  def shape: S
+
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -55,7 +55,7 @@ object BidiFlow {
 
 }
 
-class BidiFlow[-I1, +O1, -I2, +O2, +Mat](delegate: scaladsl.BidiFlow[I1, O1, I2, O2, Mat]) extends Graph[BidiShape[I1, O1, I2, O2], Mat] {
+class BidiFlow[-I1, +O1, -I2, +O2, +Mat](delegate: scaladsl.BidiFlow[I1, O1, I2, O2, Mat]) extends InternalGraph[BidiShape[I1, O1, I2, O2], Mat] {
   private[stream] override def module = delegate.module
   override def shape = delegate.shape
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -59,7 +59,7 @@ object Flow {
 }
 
 /** Create a `Flow` which can process elements of type `T`. */
-class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Graph[FlowShape[In, Out], Mat] {
+class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends InternalGraph[FlowShape[In, Out], Mat] {
   import scala.collection.JavaConverters._
 
   override def shape: FlowShape[In, Out] = delegate.shape
@@ -1079,7 +1079,7 @@ class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Graph
  *
  * Flow with attached input and output, can be executed.
  */
-trait RunnableGraph[+Mat] extends Graph[ClosedShape, Mat] {
+trait RunnableGraph[+Mat] extends InternalGraph[ClosedShape, Mat] {
   /**
    * Run this flow and return the materialized values of the flow.
    */

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -170,7 +170,7 @@ object Sink {
  * A `Sink` is a set of stream processing steps that has one open input and an attached output.
  * Can be used as a `Subscriber`
  */
-class Sink[-In, +Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkShape[In], Mat] {
+class Sink[-In, +Mat](delegate: scaladsl.Sink[In, Mat]) extends InternalGraph[SinkShape[In], Mat] {
 
   override def shape: SinkShape[In] = delegate.shape
   private[stream] def module: StreamLayout.Module = delegate.module

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -246,7 +246,7 @@ object Source {
  * A `Source` is a set of stream processing steps that has one open output and an attached input.
  * Can be used as a `Publisher`
  */
-class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[SourceShape[Out], Mat] {
+class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends InternalGraph[SourceShape[Out], Mat] {
   import scala.collection.JavaConverters._
 
   override def shape: SourceShape[Out] = delegate.shape

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -3,13 +3,10 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.Graph
-import akka.stream.BidiShape
+import akka.stream._
 import akka.stream.impl.StreamLayout.Module
-import akka.stream.FlowShape
-import akka.stream.Attributes
 
-final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](private[stream] override val module: Module) extends Graph[BidiShape[I1, O1, I2, O2], Mat] {
+final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](private[stream] override val module: Module) extends InternalGraph[BidiShape[I1, O1, I2, O2], Mat] {
   override val shape = module.shape.asInstanceOf[BidiShape[I1, O1, I2, O2]]
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -24,7 +24,7 @@ import scala.language.higherKinds
  * A `Flow` is a set of stream processing steps that has one open input and one open output.
  */
 final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
-  extends FlowOps[Out, Mat] with Graph[FlowShape[In, Out], Mat] {
+  extends FlowOps[Out, Mat] with InternalGraph[FlowShape[In, Out], Mat] {
 
   override val shape: FlowShape[In, Out] = module.shape.asInstanceOf[FlowShape[In, Out]]
 
@@ -288,7 +288,7 @@ object Flow extends FlowApply {
 /**
  * Flow with attached input and output, can be executed.
  */
-case class RunnableGraph[+Mat](private[stream] val module: StreamLayout.Module) extends Graph[ClosedShape, Mat] {
+case class RunnableGraph[+Mat](private[stream] val module: StreamLayout.Module) extends InternalGraph[ClosedShape, Mat] {
   require(module.isRunnable)
   def shape = ClosedShape
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -589,6 +589,8 @@ object FlowGraph extends GraphApply {
       moduleInProgress = moduleInProgress.wire(from, to)
     }
 
+    private def shape[S <: Shape](g: Graph[S, _]): S = g.asInstanceOf[InternalGraph[S, _]].shape
+
     /**
      * Import a graph into this module, performing a deep copy, discarding its
      * materialized value and returning the copied Ports that are now to be
@@ -598,7 +600,7 @@ object FlowGraph extends GraphApply {
       if (StreamLayout.Debug) StreamLayout.validate(graph.module)
       val copy = graph.module.carbonCopy
       moduleInProgress = moduleInProgress.compose(copy)
-      graph.shape.copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
+      shape(graph).copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
     }
 
     /**
@@ -611,7 +613,7 @@ object FlowGraph extends GraphApply {
       if (StreamLayout.Debug) StreamLayout.validate(graph.module)
       val copy = graph.module.carbonCopy
       moduleInProgress = moduleInProgress.compose(copy.transformMaterializedValue(transform.asInstanceOf[Any ⇒ Any]))
-      graph.shape.copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
+      shape(graph).copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
     }
 
     /**
@@ -624,7 +626,7 @@ object FlowGraph extends GraphApply {
       if (StreamLayout.Debug) StreamLayout.validate(graph.module)
       val copy = graph.module.carbonCopy
       moduleInProgress = moduleInProgress.compose(copy, combine)
-      graph.shape.copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
+      shape(graph).copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
     }
 
     def add[T](s: Source[T, _]): Outlet[T] = add(s: Graph[SourceShape[T], _]).outlet

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -22,7 +22,7 @@ import scala.util.{ Failure, Success, Try }
  * Can be used as a `Subscriber`
  */
 final class Sink[-In, +Mat](private[stream] override val module: Module)
-  extends Graph[SinkShape[In], Mat] {
+  extends InternalGraph[SinkShape[In], Mat] {
 
   override val shape: SinkShape[In] = module.shape.asInstanceOf[SinkShape[In]]
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -25,7 +25,7 @@ import scala.language.higherKinds
  * a Reactive Streams `Publisher` (at least conceptually).
  */
 final class Source[+Out, +Mat](private[stream] override val module: Module)
-  extends FlowOps[Out, Mat] with Graph[SourceShape[Out], Mat] {
+  extends FlowOps[Out, Mat] with InternalGraph[SourceShape[Out], Mat] {
 
   override type Repr[+O, +M] = Source[O, M]
 

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -12,7 +12,7 @@ import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration.FiniteDuration
 import scala.collection.mutable.ArrayBuffer
 
-abstract class GraphStageWithMaterializedValue[S <: Shape, M] extends Graph[S, M] {
+abstract class GraphStageWithMaterializedValue[S <: Shape, M] extends InternalGraph[S, M] {
   def shape: S
   def createLogicAndMaterializedValue: (GraphStageLogic, M)
 
@@ -42,7 +42,7 @@ abstract class GraphStageWithMaterializedValue[S <: Shape, M] extends Graph[S, M
    * This method throws an [[UnsupportedOperationException]] by default. The subclass can override this method
    * and provide a correct implementation that creates an exact copy of the stage with the provided new attributes.
    */
-  final override def withAttributes(attr: Attributes): Graph[S, M] = new Graph[S, M] {
+  final override def withAttributes(attr: Attributes): Graph[S, M] = new InternalGraph[S, M] {
     override def shape = GraphStageWithMaterializedValue.this.shape
     override private[stream] def module = GraphStageWithMaterializedValue.this.module.withAttributes(attr)
 


### PR DESCRIPTION
This method is only used by the FlowGraph.Builder when importing a
Graph. Users currently may be tricked into calling merge.shape() instead
of using b.add(merge) as they should.

fixes #18760
