### PR TITLE
idleTimeout in HTTP

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
@@ -74,7 +74,7 @@ private object PoolFlow {
       import settings._
       import FlowGraph.Implicits._
 
-      val conductor = b.add(PoolConductor(maxConnections, maxRetries, pipeliningLimit, log))
+      val conductor = b.add(PoolConductor(maxConnections, pipeliningLimit, log))
       val slots = Vector
         .tabulate(maxConnections)(PoolSlot(_, connectionFlow, remoteAddress, settings))
         .map(b.add(_))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -7,31 +7,26 @@ package akka.http.impl.engine.server
 import java.net.InetSocketAddress
 import java.util.Random
 
-import akka.http.ServerSettings
-import akka.http.scaladsl.model.ws.Message
-import akka.stream.io._
-import org.reactivestreams.{ Subscriber, Publisher }
-import scala.util.control.NonFatal
-import akka.util.ByteString
+import akka.actor.{ ActorRef, Deploy, Props }
 import akka.event.LoggingAdapter
-import akka.actor.{ Deploy, ActorRef, Props }
-import akka.stream._
-import akka.stream.scaladsl._
-import akka.stream.stage.PushPullStage
-import akka.http.impl.engine.parsing._
-import akka.http.impl.engine.rendering.{ ResponseRenderingOutput, ResponseRenderingContext, HttpResponseRendererFactory }
+import akka.http.ServerSettings
 import akka.http.impl.engine.TokenSourceActor
+import akka.http.impl.engine.parsing.ParserOutput._
+import akka.http.impl.engine.parsing._
+import akka.http.impl.engine.rendering.{ HttpResponseRendererFactory, ResponseRenderingContext, ResponseRenderingOutput }
+import akka.http.impl.engine.ws.Websocket.SwitchToWebsocketToken
+import akka.http.impl.engine.ws._
+import akka.http.impl.util._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
-import akka.http.impl.util._
-import akka.http.impl.engine.ws._
-import Websocket.SwitchToWebsocketToken
-import ParserOutput._
-import akka.stream.stage.GraphStage
-import akka.stream.stage.GraphStageLogic
-import akka.stream.stage.OutHandler
-import akka.stream.stage.InHandler
-import akka.http.impl.engine.rendering.ResponseRenderingContext
+import akka.stream._
+import akka.stream.io._
+import akka.stream.scaladsl._
+import akka.stream.stage._
+import akka.util.ByteString
+import org.reactivestreams.{ Publisher, Subscriber }
+
+import scala.util.control.NonFatal
 
 /**
  * INTERNAL API

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -4,18 +4,19 @@
 
 package akka.http.impl.util
 
-import java.io.InputStream
-import java.util.concurrent.atomic.{ AtomicReference, AtomicBoolean }
-import akka.stream.impl.StreamLayout.Module
-import akka.stream.impl.{ SourceModule, SinkModule, PublisherSink }
-import org.reactivestreams.{ Subscription, Processor, Subscriber, Publisher }
-import scala.collection.immutable
-import scala.concurrent.{ Promise, ExecutionContext, Future }
-import akka.util.ByteString
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
+
 import akka.http.scaladsl.model.RequestEntity
 import akka.stream._
+import akka.stream.impl.StreamLayout.Module
+import akka.stream.impl.{ PublisherSink, SinkModule, SourceModule }
 import akka.stream.scaladsl._
 import akka.stream.stage._
+import akka.util.ByteString
+import org.reactivestreams.{ Processor, Publisher, Subscriber, Subscription }
+
+import scala.collection.immutable
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 /**
  * INTERNAL API
@@ -305,7 +306,7 @@ private[http] object StreamUtils {
   }
 
   /**
-   * Similar to Source.lazyEmpty but doesn't rely on materialization. Can only be used once.
+   * Similar to Source.maybe but doesn't rely on materialization. Can only be used once.
    */
   trait OneTimeValve {
     def source[T]: Source[T, Unit]

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -5,9 +5,8 @@
 package akka.http.scaladsl
 
 import java.net.InetSocketAddress
-import java.security.SecureRandom
 import java.util.concurrent.ConcurrentHashMap
-import java.util.{ Collection ⇒ JCollection, Random }
+import java.util.{ Collection ⇒ JCollection }
 import javax.net.ssl.{ SSLContext, SSLParameters }
 
 import akka.actor._
@@ -15,8 +14,8 @@ import akka.event.LoggingAdapter
 import akka.http._
 import akka.http.impl.engine.client._
 import akka.http.impl.engine.server._
-import akka.http.impl.util.{ ReadTheDocumentationException, Java6Compat, StreamUtils }
 import akka.http.impl.engine.ws.WebsocketClientBlueprint
+import akka.http.impl.util.{ Java6Compat, ReadTheDocumentationException, StreamUtils }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Host
 import akka.http.scaladsl.model.ws.{ WebsocketUpgradeResponse, WebsocketRequest, Message }
@@ -25,7 +24,6 @@ import akka.japi
 import akka.stream.Materializer
 import akka.stream.io._
 import akka.stream.scaladsl._
-import akka.util.ByteString
 import com.typesafe.config.Config
 
 import scala.collection.immutable

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -10,6 +10,7 @@ import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.stream.io.{ SendBytes, SslTlsOutbound, SessionBytes }
 
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
 import akka.event.NoLogging
@@ -32,7 +33,8 @@ abstract class HttpServerTestSetupBase {
   val requests = TestSubscriber.probe[HttpRequest]
   val responses = TestPublisher.probe[HttpResponse]()
 
-  def settings = ServerSettings(system).copy(serverHeader = Some(Server(List(ProductVersion("akka-http", "test")))))
+  def settings = ServerSettings(system)
+    .copy(serverHeader = Some(Server(List(ProductVersion("akka-http", "test")))))
   def remoteAddress: Option[InetSocketAddress] = None
 
   val (netIn, netOut) = {
@@ -68,6 +70,8 @@ abstract class HttpServerTestSetupBase {
 
   def expectRequest: HttpRequest = requests.requestNext()
   def expectNoRequest(max: FiniteDuration): Unit = requests.expectNoMsg(max)
+  def expectSubscribe(): Unit = netOut.expectComplete()
+  def expectSubscribeAndNetworkClose(): Unit = netOut.expectSubscriptionAndComplete()
   def expectNetworkClose(): Unit = netOut.expectComplete()
 
   def send(data: ByteString): Unit = netIn.sendNext(data)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -5,7 +5,7 @@
 package akka.http.impl.engine.ws
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{ Source, Sink }
+import akka.stream.scaladsl.Sink
 import akka.stream.testkit.TestSubscriber
 import akka.util.ByteString
 
@@ -23,6 +23,7 @@ trait ByteStringSinkProbe {
   def expectNoBytes(): Unit
   def expectNoBytes(timeout: FiniteDuration): Unit
 
+  def expectSubscriptionAndComplete(): Unit
   def expectComplete(): Unit
   def expectError(): Throwable
   def expectError(cause: Throwable): Unit
@@ -62,6 +63,7 @@ object ByteStringSinkProbe {
       def expectUtf8EncodedString(string: String): Unit =
         expectBytes(ByteString(string, "utf8"))
 
+      def expectSubscriptionAndComplete(): Unit = probe.expectSubscriptionAndComplete()
       def expectComplete(): Unit = probe.expectComplete()
       def expectError(): Throwable = probe.expectError()
       def expectError(cause: Throwable): Unit = probe.expectError(cause)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -6,6 +6,7 @@ package akka.http.scaladsl.server
 
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import akka.http.scaladsl.server.directives.Credentials
+import akka.stream.scaladsl._
 import com.typesafe.config.{ ConfigFactory, Config }
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer

--- a/akka-stream/src/main/scala/akka/stream/impl/io/StreamTcpManager.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/StreamTcpManager.scala
@@ -74,18 +74,18 @@ private[akka] class StreamTcpManager extends Actor {
   }
 
   def receive: Receive = {
-    case Connect(processorPromise, localAddressPromise, remoteAddress, localAddress, halfClose, options, connectTimeout, _) ⇒
+    case Connect(processorPromise, localAddressPromise, remoteAddress, localAddress, halfClose, options, connectTimeout, idleTimeout) ⇒
       val connTimeout = connectTimeout match {
         case x: FiniteDuration ⇒ Some(x)
         case _                 ⇒ None
       }
-      val processorActor = context.actorOf(TcpStreamActor.outboundProps(processorPromise, localAddressPromise, halfClose,
+      val processorActor = context.actorOf(TcpStreamActor.outboundProps(processorPromise, localAddressPromise, halfClose, idleTimeout,
         Tcp.Connect(remoteAddress, localAddress, options, connTimeout, pullMode = true),
         materializerSettings = ActorMaterializerSettings(context.system)), name = encName("client", remoteAddress))
       processorActor ! ExposedProcessor(ActorProcessor[ByteString, ByteString](processorActor))
 
-    case Bind(localAddressPromise, unbindPromise, flowSubscriber, endpoint, backlog, halfClose, options, _) ⇒
-      val props = TcpListenStreamActor.props(localAddressPromise, unbindPromise, flowSubscriber, halfClose,
+    case Bind(localAddressPromise, unbindPromise, flowSubscriber, endpoint, backlog, halfClose, options, idleTimeout) ⇒
+      val props = TcpListenStreamActor.props(localAddressPromise, unbindPromise, flowSubscriber, halfClose, idleTimeout,
         Tcp.Bind(context.system.deadLetters, endpoint, backlog, options, pullMode = true),
         ActorMaterializerSettings(context.system))
         .withDispatcher(context.props.dispatcher)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
@@ -13,6 +13,7 @@ import akka.stream.{ AbruptTerminationException, ActorMaterializerSettings, Stre
 import org.reactivestreams.Processor
 import akka.stream.impl._
 
+import scala.concurrent.duration.Duration
 import scala.util.control.NoStackTrace
 
 /**
@@ -24,9 +25,10 @@ private[akka] object TcpStreamActor {
   def outboundProps(processorPromise: Promise[Processor[ByteString, ByteString]],
                     localAddressPromise: Promise[InetSocketAddress],
                     halfClose: Boolean,
+                    idleTimeout: Duration,
                     connectCmd: Connect,
                     materializerSettings: ActorMaterializerSettings): Props =
-    Props(new OutboundTcpStreamActor(processorPromise, localAddressPromise, halfClose, connectCmd,
+    Props(new OutboundTcpStreamActor(processorPromise, localAddressPromise, halfClose, idleTimeout, connectCmd,
       materializerSettings)).withDispatcher(materializerSettings.dispatcher).withDeploy(Deploy.local)
 
   def inboundProps(connection: ActorRef, halfClose: Boolean, settings: ActorMaterializerSettings): Props =
@@ -302,6 +304,7 @@ private[akka] class InboundTcpStreamActor(
 private[akka] class OutboundTcpStreamActor(processorPromise: Promise[Processor[ByteString, ByteString]],
                                            localAddressPromise: Promise[InetSocketAddress],
                                            _halfClose: Boolean,
+                                           idleTimeout: Duration,
                                            val connectCmd: Connect, _settings: ActorMaterializerSettings)
   extends TcpStreamActor(_settings, _halfClose) {
   import context.system

--- a/akka-stream/src/main/scala/akka/stream/io/Timeouts.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/Timeouts.scala
@@ -2,11 +2,10 @@ package akka.stream.io
 
 import java.util.concurrent.{ TimeUnit, TimeoutException }
 
-import akka.actor.{ Cancellable, ActorSystem }
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
-import akka.stream.{ FlowShape, Outlet, Inlet, BidiShape }
 import akka.stream.scaladsl.{ BidiFlow, Flow }
-import akka.stream.stage.{ OutHandler, InHandler, GraphStageLogic, GraphStage }
+import akka.stream.stage._
+import akka.stream.{ BidiShape, Inlet, Outlet }
 
 import scala.concurrent.duration.{ Deadline, FiniteDuration }
 


### PR DESCRIPTION
I'm not sure it covers all the cases yet

Behaviour is:

Server:

```
[DEBUG] [10/23/2015 17:17:49.873] [ServerTest-akka.actor.default-dispatcher-3] [akka://ServerTest/system/IO-TCP/selectors/$a/0] New connection accepted
timeout = 5 seconds
[DEBUG] [10/23/2015 17:17:49.935] [ServerTest-akka.io.pinned-dispatcher-5] [akka.serialization.Serialization(akka://ServerTest)] Using serializer[akka.serialization.JavaSerializer] for message [akka.io.SelectionHandler$ChannelReadable$]
key = IdleTimeoutCheckTimer until 5 seconds // my debug println
... 
key = IdleTimeoutCheckTimer until 5 seconds
key = IdleTimeoutCheckTimer until 5 seconds
[DEBUG] [10/23/2015 17:17:55.208] [ServerTest-akka.actor.defa

ult-dispatcher-3] [akka.serialization.Serialization(akka://ServerTest)] Using serializer[akka.serialization.JavaSerializer] for message [akka.actor.Terminated]
[ERROR] [10/23/2015 17:17:55.209] [ServerTest-akka.actor.default-dispatcher-14] [ActorSystem(ServerTest)] Internal server error, sending 500 response
java.util.concurrent.TimeoutException: No elements passed in the last 5 seconds.
    at akka.stream.io.Timeouts$IdleTimeout$$anon$4.onTimer(Timeouts.scala:122)
    at akka.stream.stage.GraphStageLogic.akka$stream$stage$GraphStageLogic$$onInternalTimer(GraphStage.scala:323)
    at akka.stream.stage.GraphStageLogic$$anonfun$akka$stream$stage$GraphStageLogic$$getTimerAsyncCallback$1.apply(GraphStage.scala:101)
    at akka.stream.stage.GraphStageLogic$$anonfun$akka$stream$stage$GraphStageLogic$$getTimerAsyncCallback$1.apply(GraphStage.scala:101)
    at akka.stream.impl.fusing.ActorGraphInterpreter$$anonfun$receive$1.applyOrElse(ActorGraphInterpreter.scala:355)
    at akka.actor.Actor$class.aroundReceive(Actor.scala:467)
    at akka.stream.impl.fusing.ActorGraphInterpreter.aroundReceive(ActorGraphInterpreter.scala:291)
    at akka.actor.ActorCell.receiveMessage(ActorCell.scala:516)
    at akka.actor.ActorCell.invoke(ActorCell.scala:487)
    at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:238)
    at akka.dispatch.Mailbox.run(Mailbox.scala:220)
    at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397)
    at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
    at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
    at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
    at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

client:

```
$ REQ="POST / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nAccept: *\r\nContent-Length: 17\r\n"
ktoso @ 月~/code/akka [wip-idleTimeout-ktoso*]
$ (echo -ne $REQ; sleep 10;) | netcat localhost 8080
read(net): Connection reset by peer
```

<img width="709" alt="capturing_from_loopback__lo0" src="https://cloud.githubusercontent.com/assets/120979/10697582/7d88426e-7961-11e5-887f-3e652da310b1.png">

It can/will be cleaned up a bit (want to add more tests), but general place where to put it seems OK.
