### PR TITLE
Naive implementation of client negotiable decoder

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/NegotiableDecoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/NegotiableDecoder.scala
@@ -1,0 +1,28 @@
+/**
+  * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+  */
+package akka.http.scaladsl.coding
+
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.headers.{HttpEncoding, HttpEncodings}
+import akka.stream.scaladsl.Flow
+
+/**
+  * Provides high level decoding for HTTP client by analyzing Content-Encoding header
+  * and try to find appropriate decoder. Gzip and Deflate decoders are supported.
+  * In case of unknown encoding returns response as is.
+  */
+object NegotiableDecoder {
+  private def findCodec(encoding: HttpEncoding) = encoding match {
+    case HttpEncodings.gzip | HttpEncodings.`x-zip` => Gzip
+    case HttpEncodings.deflate => Deflate
+    case _ => NoCoding
+  }
+
+  def decode(resp: HttpResponse) = findCodec(resp.encoding).decode(resp)
+
+  val flow = Flow[HttpResponse].map(decode)
+
+  def flow(decoder: Decoder) = Flow[HttpResponse].map(decoder.decode[HttpResponse])
+
+}


### PR DESCRIPTION
Related issue #16813. This PR is for feedback.
## Implementation

I am not very familiar with HTTP details and I want to confirm that idea of universal negotiable decoder is viable and correct
## API

I am not sure about creating `ResponseBuilding` as analog of `RequestBuilding` (suggested [here](https://github.com/akka/akka/issues/16813#issuecomment-150221382)). My idea is to provide universal building block in terms of functions and flows. Should we push this decoder into _Request Level API_ flow?
## Tests

I really have no idea what to test in this implementation. All tests looks like an implementation duplication.  Only viable idea is to build whole pipeline of response parsing and decoding.
