### PR TITLE
use .head when could not inference whether the seq type is inde…

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -270,7 +270,7 @@ final case class BidiShape[-In1, +Out1, -In2, +Out2](in1: Inlet[In1 @uncheckedVa
   override def copyFromPorts(inlets: immutable.Seq[Inlet[_]], outlets: immutable.Seq[Outlet[_]]): Shape = {
     require(inlets.size == 2, s"proposed inlets [${inlets.mkString(", ")}] do not fit BidiShape")
     require(outlets.size == 2, s"proposed outlets [${outlets.mkString(", ")}] do not fit BidiShape")
-    BidiShape(inlets(0), outlets(0), inlets(1), outlets(1))
+    BidiShape(inlets.head, outlets.head, inlets(1), outlets(1))
   }
   def reversed: Shape = copyFromPorts(inlets.reverse, outlets.reverse)
   //#implementation-details-elided

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -54,9 +54,9 @@ final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](private[stream] override val modu
     val outs = copy.shape.outlets
     new BidiFlow(module
       .compose(copy, combine)
-      .wire(shape.out1, ins(0))
+      .wire(shape.out1, ins.head)
       .wire(outs(1), shape.in2)
-      .replaceShape(BidiShape(shape.in1, outs(0), ins(1), shape.out2)))
+      .replaceShape(BidiShape(shape.in1, outs.head, ins(1), shape.out2)))
   }
 
   /**


### PR DESCRIPTION
use .head when could not inference whether the seq type is indexed or not.
