### PR TITLE
consider akka.test.timefactor when using akka.test.filter-leeway

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -105,7 +105,7 @@ abstract class EventFilter(occurrences: Int) {
    */
   def intercept[T](code: ⇒ T)(implicit system: ActorSystem): T = {
     system.eventStream publish TestEvent.Mute(this)
-    val leeway = TestKitExtension(system).TestEventFilterLeeway
+    val leeway = TestKitExtension(system).TestEventFilterLeeway.dilated
     try {
       val result = code
       if (!awaitDone(leeway))

--- a/akka-testkit/src/main/scala/akka/testkit/package.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/package.scala
@@ -21,8 +21,8 @@ package object testkit {
       val result = block
 
       val testKitSettings = TestKitExtension(system)
-      val stop = now + testKitSettings.TestEventFilterLeeway.toMillis
-      val failed = eventFilters filterNot (_.awaitDone(Duration(stop - now, MILLISECONDS))) map ("Timeout (" + testKitSettings.TestEventFilterLeeway + ") waiting for " + _)
+      val stop = now + testKitSettings.TestEventFilterLeeway.dilated.toMillis
+      val failed = eventFilters filterNot (_.awaitDone(Duration(stop - now, MILLISECONDS))) map ("Timeout (" + testKitSettings.TestEventFilterLeeway.dilated + ") waiting for " + _)
       if (failed.nonEmpty)
         throw new AssertionError("Filter completion error:\n" + failed.mkString("\n"))
 


### PR DESCRIPTION
Maybe this was a small oversight. At the moment the akka.test.timefactor is not considered for the akka.test.filter-leeway.
