### PR TITLE
-str #18829 remove auto import in graph DSL

### DIFF
--- a/akka-docs-dev/rst/scala/code/docs/stream/StreamBuffersRateSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/StreamBuffersRateSpec.scala
@@ -44,12 +44,12 @@ class StreamBuffersRateSpec extends AkkaSpec {
 
       val zipper = b.add(ZipWith[Tick, Int, Int]((tick, count) => count))
 
-      Source(initialDelay = 3.second, interval = 3.second, Tick()) ~> zipper.in0
+      b.add(Source(initialDelay = 3.second, interval = 3.second, Tick())) ~> zipper.in0
 
-      Source(initialDelay = 1.second, interval = 1.second, "message!")
-        .conflate(seed = (_) => 1)((count, _) => count + 1) ~> zipper.in1
+      b.add(Source(initialDelay = 1.second, interval = 1.second, "message!")
+        .conflate(seed = (_) => 1)((count, _) => count + 1)) ~> zipper.in1
 
-      zipper.out ~> Sink.foreach(println)
+      zipper.out ~> b.add(Sink.foreach(println))
       ClosedShape
     })
     //#buffering-abstraction-leak

--- a/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/StreamPartialFlowGraphDocSpec.scala
@@ -38,9 +38,9 @@ class StreamPartialFlowGraphDocSpec extends AkkaSpec {
         // importing the partial graph will return its shape (inlets & outlets)
         val pm3 = b.add(pickMaxOfThree)
 
-        Source.single(1) ~> pm3.in(0)
-        Source.single(2) ~> pm3.in(1)
-        Source.single(3) ~> pm3.in(2)
+        b.add(Source.single(1)) ~> pm3.in(0)
+        b.add(Source.single(2)) ~> pm3.in(1)
+        b.add(Source.single(3)) ~> pm3.in(2)
         pm3.out ~> sink.inlet
         ClosedShape
     })
@@ -60,8 +60,8 @@ class StreamPartialFlowGraphDocSpec extends AkkaSpec {
       def ints = Source(() => Iterator.from(1))
 
       // connect the graph
-      ints.filter(_ % 2 != 0) ~> zip.in0
-      ints.filter(_ % 2 == 0) ~> zip.in1
+      b.add(ints.filter(_ % 2 != 0)) ~> zip.in0
+      b.add(ints.filter(_ % 2 == 0)) ~> zip.in1
 
       // expose port
       SourceShape(zip.out)

--- a/akka-docs-dev/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -122,9 +122,10 @@ class TwitterStreamQuickstartDocSpec extends AkkaSpec {
       import FlowGraph.Implicits._
 
       val bcast = b.add(Broadcast[Tweet](2))
-      tweets ~> bcast.in
-      bcast.out(0) ~> Flow[Tweet].map(_.author) ~> writeAuthors 
-      bcast.out(1) ~> Flow[Tweet].mapConcat(_.hashtags.toList) ~> writeHashtags
+
+      b.add(tweets) ~> bcast.in
+      bcast.out(0) ~>  b.add(Flow[Tweet].map(_.author))                 ~>  b.add(writeAuthors)
+      bcast.out(1) ~>  b.add(Flow[Tweet].mapConcat(_.hashtags.toList))  ~>  b.add(writeHashtags)
       ClosedShape
     })
     g.run()

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeDroppyBroadcast.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeDroppyBroadcast.scala
@@ -18,7 +18,7 @@ class RecipeDroppyBroadcast extends RecipeSpec {
       val sub1 = TestSubscriber.manualProbe[Int]()
       val sub2 = TestSubscriber.manualProbe[Int]()
       val sub3 = TestSubscriber.probe[Int]()
-      val futureSink = Sink.head[Seq[Int]]
+
       val mySink1 = Sink(sub1)
       val mySink2 = Sink(sub2)
       val mySink3 = Sink(sub3)
@@ -29,7 +29,8 @@ class RecipeDroppyBroadcast extends RecipeSpec {
           import FlowGraph.Implicits._
 
           val bcast = b.add(Broadcast[Int](3))
-          myElements ~> bcast
+
+          b.add(myElements) ~> bcast
 
           bcast.buffer(10, OverflowStrategy.dropHead) ~> sink1
           bcast.buffer(10, OverflowStrategy.dropHead) ~> sink2

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeGlobalRateLimit.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeGlobalRateLimit.scala
@@ -102,8 +102,10 @@ class RecipeGlobalRateLimit extends RecipeSpec {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b =>
         import FlowGraph.Implicits._
         val merge = b.add(Merge[String](2))
-        source1 ~> merge ~> Sink(probe)
-        source2 ~> merge
+        val sink = b.add(Sink(probe))
+
+        b.add(source1) ~> merge ~> sink
+        b.add(source2) ~> merge
         ClosedShape
       }).run()
 

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeKeepAlive.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeKeepAlive.scala
@@ -29,10 +29,14 @@ class RecipeKeepAlive extends RecipeSpec {
       val graph = RunnableGraph.fromGraph(FlowGraph.create() { implicit builder =>
         import FlowGraph.Implicits._
         val unfairMerge = builder.add(MergePreferred[ByteString](1))
+        val addedDataStream = builder.add(dataStream)
+        val addedTickToKeepAlivePacket = builder.add(tickToKeepAlivePacket)
+        val addedTicks = builder.add(ticks)
+        val addedSink = builder.add(sink)
 
         // If data is available then no keepalive is injected
-        dataStream ~> unfairMerge.preferred
-        ticks ~> tickToKeepAlivePacket ~> unfairMerge ~> sink
+        addedDataStream ~> unfairMerge.preferred
+        addedTicks ~> addedTickToKeepAlivePacket ~> unfairMerge ~> addedSink
         ClosedShape
       })
       //#inject-keepalive

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeWorkerPool.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeWorkerPool.scala
@@ -28,7 +28,7 @@ class RecipeWorkerPool extends RecipeSpec {
           for (_ <- 1 to workerCount) {
             // for each worker, add an edge from the balancer to the worker, then wire
             // it to the merge element
-            balancer ~> worker ~> merge
+            balancer ~> b.add(worker) ~> merge
           }
 
           FlowShape(balancer.in, merge.out)

--- a/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
@@ -89,7 +89,7 @@ class StreamTcpDocSpec extends AkkaSpec {
         import connection._
         val welcomeMsg = s"Welcome to: $localAddress, you are: $remoteAddress!\n"
 
-        val welcome = Source.single(ByteString(welcomeMsg))
+        val welcome = b.add(Source.single(ByteString(welcomeMsg)))
         val echo = b.add(Flow[ByteString]
           .via(Framing.delimiter(
             ByteString("\n"),

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
@@ -72,11 +72,11 @@ private object PoolConductor {
       val slotSelector = b.add(new SlotSelector(slotCount, pipeliningLimit, log))
       val route = b.add(new Route(slotCount))
       val retrySplit = b.add(Broadcast[RawSlotEvent](2))
-      val flatten = Flow[RawSlotEvent].mapAsyncUnordered(slotCount) {
+      val flatten = b.add(Flow[RawSlotEvent].mapAsyncUnordered(slotCount) {
         case x: SlotEvent.Disconnected                ⇒ FastFuture.successful(x)
         case SlotEvent.RequestCompletedFuture(future) ⇒ future
         case x                                        ⇒ throw new IllegalStateException("Unexpected " + x)
-      }
+      })
 
       retryMerge.out ~> slotSelector.in0
       slotSelector.out ~> route.in

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
@@ -35,7 +35,7 @@ private object RenderSupport {
     Source.fromGraph(FlowGraph.create(first) { implicit b ⇒
       frst ⇒
         import FlowGraph.Implicits._
-        second ~> Sink.cancelled
+        b.add(second) ~> b.add(Sink.cancelled)
         SourceShape(frst.outlet)
     })
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Websocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Websocket.scala
@@ -125,7 +125,7 @@ private[http] object Websocket {
       import FlowGraph.Implicits._
 
       val split = b.add(BypassRouter)
-      val tick = Source(closeTimeout, closeTimeout, Tick)
+      val tick = b.add(Source(closeTimeout, closeTimeout, Tick))
       val merge = b.add(BypassMerge)
       val messagePreparation = b.add(prepareMessages)
       val messageRendering = b.add(renderMessages.via(LiftCompletions))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
@@ -51,7 +51,7 @@ class HighLevelOutgoingConnectionSpec extends AkkaSpec {
         val merge = b.add(Merge[HttpResponse](C))
 
         for (i ← 0 until C)
-          bcast.out(i) ~> connFlow ~> merge.in(i)
+          bcast.out(i) ~> b.add(connFlow) ~> merge.in(i)
         FlowShape(bcast.in, merge.out)
       })
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -362,10 +362,10 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
       RunnableGraph.fromGraph(FlowGraph.create(OutgoingConnectionBlueprint(Host("example.com"), settings, NoLogging)) { implicit b ⇒
         client ⇒
           import FlowGraph.Implicits._
-          Source(netIn) ~> Flow[ByteString].map(SessionBytes(null, _)) ~> client.in2
-          client.out1 ~> Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x } ~> Sink(netOut)
-          Source(requests) ~> client.in1
-          client.out2 ~> Sink(responses)
+          b.add(Source(netIn)) ~> b.add(Flow[ByteString].map(SessionBytes(null, _))) ~> client.in2
+          client.out1 ~> b.add(Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x }) ~> b.add(Sink(netOut))
+          b.add(Source(requests)) ~> client.in1
+          client.out2 ~> b.add(Sink(responses))
           ClosedShape
       }).run()
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -44,10 +44,10 @@ abstract class HttpServerTestSetupBase {
     RunnableGraph.fromGraph(FlowGraph.create(HttpServerBluePrint(settings, remoteAddress = remoteAddress, log = NoLogging)) { implicit b ⇒
       server ⇒
         import FlowGraph.Implicits._
-        Source(netIn) ~> Flow[ByteString].map(SessionBytes(null, _)) ~> server.in2
-        server.out1 ~> Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x } ~> netOut.sink
-        server.out2 ~> Sink(requests)
-        Source(responses) ~> server.in1
+        b.add(Source(netIn)) ~> b.add(Flow[ByteString].map(SessionBytes(null, _))) ~> server.in2
+        server.out1 ~> b.add(Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x }) ~> b.add(netOut.sink)
+        server.out2 ~> b.add(Sink(requests))
+        b.add(Source(responses)) ~> server.in1
         ClosedShape
     }).run()
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebsocketClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebsocketClientSpec.scala
@@ -315,9 +315,9 @@ class WebsocketClientSpec extends FreeSpec with Matchers with WithMaterializerSp
         RunnableGraph.fromGraph(FlowGraph.create(clientLayer) { implicit b ⇒
           client ⇒
             import FlowGraph.Implicits._
-            Source(netIn) ~> Flow[ByteString].map(SessionBytes(null, _)) ~> client.in2
-            client.out1 ~> Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x } ~> netOut.sink
-            client.out2 ~> clientImplementation ~> client.in1
+            b.add(Source(netIn)) ~> b.add(Flow[ByteString].map(SessionBytes(null, _))) ~> client.in2
+            client.out1 ~> b.add(Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x }) ~> b.add(netOut.sink)
+            client.out2 ~> b.add(clientImplementation) ~> client.in1
             ClosedShape
         })
 

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/TwoStreamsSetup.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/TwoStreamsSetup.scala
@@ -23,9 +23,9 @@ abstract class TwoStreamsSetup extends BaseTwoStreamsSetup {
       import FlowGraph.Implicits._
       val f = fixture(b)
 
-      Source(p1) ~> f.left
-      Source(p2) ~> f.right
-      f.out ~> Sink(subscriber)
+      b.add(Source(p1)) ~> f.left
+      b.add(Source(p2)) ~> f.right
+      f.out ~> b.add(Sink(subscriber))
       ClosedShape
     }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/actor/ActorPublisherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/actor/ActorPublisherSpec.scala
@@ -356,14 +356,17 @@ class ActorPublisherSpec extends AkkaSpec(ActorPublisherSpec.config) with Implic
 
           val merge = b.add(Merge[Int](2))
           val bcast = b.add(Broadcast[String](2))
+          val source1Outlet = b.add(source1)
+          val sink1Inlet = b.add(sink1)
+          val sink2Inlet = b.add(sink2)
 
-          source1 ~> merge.in(0)
+          source1Outlet ~> merge.in(0)
           source2.outlet ~> merge.in(1)
 
           merge.out.map(_.toString) ~> bcast.in
 
-          bcast.out(0).map(_ + "mark") ~> sink1
-          bcast.out(1) ~> sink2
+          bcast.out(0).map(_ + "mark") ~> sink1Inlet
+          bcast.out(1) ~> sink2Inlet
           ClosedShape
       }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/TimeoutsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/TimeoutsSpec.scala
@@ -177,10 +177,10 @@ class TimeoutsSpec extends AkkaSpec {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         import FlowGraph.Implicits._
         val timeoutStage = b.add(BidiFlow.bidirectionalIdleTimeout[String, Int](2.seconds))
-        Source(upWrite) ~> timeoutStage.in1;
-        timeoutStage.out1 ~> Sink(downRead)
-        Sink(upRead) <~ timeoutStage.out2;
-        timeoutStage.in2 <~ Source(downWrite)
+        b.add(Source(upWrite)) ~> timeoutStage.in1;
+        timeoutStage.out1 ~> b.add(Sink(downRead))
+        b.add(Sink(upRead)) <~ timeoutStage.out2;
+        timeoutStage.in2 <~ b.add(Source(downWrite))
         ClosedShape
       }).run()
 
@@ -225,10 +225,10 @@ class TimeoutsSpec extends AkkaSpec {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         import FlowGraph.Implicits._
         val timeoutStage = b.add(BidiFlow.bidirectionalIdleTimeout[String, Int](2.seconds))
-        Source(upWrite) ~> timeoutStage.in1;
-        timeoutStage.out1 ~> Sink(downRead)
-        Sink(upRead) <~ timeoutStage.out2;
-        timeoutStage.in2 <~ Source(downWrite)
+        b.add(Source(upWrite)) ~> timeoutStage.in1
+        timeoutStage.out1 ~> b.add(Sink(downRead))
+        b.add(Sink(upRead)) <~ timeoutStage.out2
+        timeoutStage.in2 <~ b.add(Source(downWrite))
         ClosedShape
       }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -219,10 +219,10 @@ class ActorGraphInterpreterSpec extends AkkaSpec {
           import FlowGraph.Implicits._
           val bidi = b.add(rotatedBidi)
 
-          Source(1 to 10) ~> bidi.in1
+          b.add(Source(1 to 10)) ~> bidi.in1
           out2 <~ bidi.out2
 
-          bidi.in2 <~ Source(1 to 100)
+          bidi.in2 <~ b.add(Source(1 to 100))
           bidi.out1 ~> out1
           ClosedShape
       }).run()

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -403,7 +403,7 @@ class TlsSpec extends AkkaSpec("akka.loglevel=INFO\nakka.actor.debug.receive=off
           (s, o1, o2) ⇒
             val tls = b.add(clientTls(EagerClose))
             s ~> tls.in1; tls.out1 ~> o1
-            o2 <~ tls.out2; tls.in2 <~ Source.failed(ex)
+            o2 <~ tls.out2; tls.in2 <~ b.add(Source.failed(ex))
             ClosedShape
         }).run()
       the[Exception] thrownBy Await.result(out1, 1.second) should be(ex)
@@ -420,7 +420,7 @@ class TlsSpec extends AkkaSpec("akka.loglevel=INFO\nakka.actor.debug.receive=off
         RunnableGraph.fromGraph(FlowGraph.create(Source.subscriber[ByteString], Sink.head[ByteString], Sink.head[SslTlsInbound])((_, _, _)) { implicit b ⇒
           (s, o1, o2) ⇒
             val tls = b.add(clientTls(EagerClose))
-            Source.failed[SslTlsOutbound](ex) ~> tls.in1; tls.out1 ~> o1
+            b.add(Source.failed[SslTlsOutbound](ex)) ~> tls.in1; tls.out1 ~> o1
             o2 <~ tls.out2; tls.in2 <~ s
             ClosedShape
         }).run()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
@@ -28,9 +28,9 @@ class FlowJoinSpec extends AkkaSpec(ConfigFactory.parseString("akka.loglevel=INF
         import FlowGraph.Implicits._
         val merge = b.add(Merge[Int](2))
         val broadcast = b.add(Broadcast[Int](2))
-        source ~> merge.in(0)
+        b.add(source) ~> merge.in(0)
         merge.out ~> broadcast.in
-        broadcast.out(0).grouped(1000) ~> Sink(probe)
+        broadcast.out(0).grouped(1000) ~> b.add(Sink(probe))
 
         FlowShape(merge.in(1), broadcast.out(1))
       })

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
@@ -30,7 +30,7 @@ class FlowJoinSpec extends AkkaSpec(ConfigFactory.parseString("akka.loglevel=INF
         val broadcast = b.add(Broadcast[Int](2))
         b.add(source) ~> merge.in(0)
         merge.out ~> broadcast.in
-        broadcast.out(0).grouped(1000) ~> b.add(Sink(probe))
+        broadcast.out(0) ~> b.add(Flow[Int].grouped(1000)) ~> b.add(Sink(probe))
 
         FlowShape(merge.in(1), broadcast.out(1))
       })

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSectionSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSectionSpec.scala
@@ -37,7 +37,7 @@ class FlowSectionSpec extends AkkaSpec(FlowSectionSpec.config) {
         import FlowGraph.Implicits._
         val bcast1 = b.add(Broadcast[Int](1))
         val bcast2 = b.add(Broadcast[Int](1))
-        bcast1 ~> Flow[Int].map(sendThreadNameTo(testActor)) ~> bcast2.in
+        bcast1 ~> b.add(Flow[Int].map(sendThreadNameTo(testActor))) ~> bcast2.in
         FlowShape(bcast1.in, bcast2.out(0))
       }).withAttributes(dispatcher("my-dispatcher1"))
 
@@ -55,7 +55,7 @@ class FlowSectionSpec extends AkkaSpec(FlowSectionSpec.config) {
         import FlowGraph.Implicits._
         val bcast1 = b.add(Broadcast[Int](1))
         val bcast2 = b.add(Broadcast[Int](1))
-        bcast1 ~> Flow[Int].map(sendThreadNameTo(probe1.ref)) ~> bcast2.in
+        bcast1 ~> b.add(Flow[Int].map(sendThreadNameTo(probe1.ref))) ~> bcast2.in
         FlowShape(bcast1.in, bcast2.out(0))
       }).withAttributes(dispatcher("my-dispatcher1"))
 
@@ -63,7 +63,7 @@ class FlowSectionSpec extends AkkaSpec(FlowSectionSpec.config) {
         import FlowGraph.Implicits._
         val bcast1 = b.add(Broadcast[Int](1))
         val bcast2 = b.add(Broadcast[Int](1))
-        bcast1 ~> flow1.via(Flow[Int].map(sendThreadNameTo(probe2.ref))) ~> bcast2.in
+        bcast1 ~> b.add(flow1.via(Flow[Int].map(sendThreadNameTo(probe2.ref)))) ~> bcast2.in
         FlowShape(bcast1.in, bcast2.out(0))
       }).withAttributes(dispatcher("my-dispatcher2"))
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
@@ -116,13 +116,15 @@ class GraphBalanceSpec extends AkkaSpec {
       val (s1, s2, s3, s4, s5) = RunnableGraph.fromGraph(FlowGraph.create(sink, sink, sink, sink, sink)(Tuple5.apply) {
         implicit b ⇒
           (f1, f2, f3, f4, f5) ⇒
+
+            def grouped = b.add(Flow[Int].grouped(15))
             val balance = b.add(Balance[Int](5, waitForAllDownstreams = true))
             b.add(Source(0 to 14)) ~> balance.in
-            balance.out(0).grouped(15) ~> f1
-            balance.out(1).grouped(15) ~> f2
-            balance.out(2).grouped(15) ~> f3
-            balance.out(3).grouped(15) ~> f4
-            balance.out(4).grouped(15) ~> f5
+            balance.out(0) ~> grouped ~> f1
+            balance.out(1) ~> grouped ~> f2
+            balance.out(2) ~> grouped ~> f3
+            balance.out(3) ~> grouped ~> f4
+            balance.out(4) ~> grouped ~> f5
             ClosedShape
       }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBalanceSpec.scala
@@ -25,9 +25,9 @@ class GraphBalanceSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val balance = b.add(Balance[Int](2))
-        Source(List(1, 2, 3)) ~> balance.in
-        balance.out(0) ~> Sink(c1)
-        balance.out(1) ~> Sink(c2)
+        b.add(Source(List(1, 2, 3))) ~> balance.in
+        balance.out(0) ~> b.add(Sink(c1))
+        balance.out(1) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -50,8 +50,8 @@ class GraphBalanceSpec extends AkkaSpec {
       val p2 = RunnableGraph.fromGraph(FlowGraph.create(Sink.publisher[Int]) { implicit b ⇒
         p2Sink ⇒
           val balance = b.add(Balance[Int](2, waitForAllDownstreams = true))
-          Source(List(1, 2, 3)) ~> balance.in
-          balance.out(0) ~> Sink(s1)
+          b.add(Source(List(1, 2, 3))) ~> balance.in
+          balance.out(0) ~> b.add(Sink(s1))
           balance.out(1) ~> p2Sink
           ClosedShape
       }).run()
@@ -81,8 +81,8 @@ class GraphBalanceSpec extends AkkaSpec {
       val (p2, p3) = RunnableGraph.fromGraph(FlowGraph.create(Sink.publisher[Int], Sink.publisher[Int])(Keep.both) { implicit b ⇒
         (p2Sink, p3Sink) ⇒
           val balance = b.add(Balance[Int](3, waitForAllDownstreams = true))
-          Source(List(1, 2, 3)) ~> balance.in
-          balance.out(0) ~> Sink(s1)
+          b.add(Source(List(1, 2, 3))) ~> balance.in
+          balance.out(0) ~> b.add(Sink(s1))
           balance.out(1) ~> p2Sink
           balance.out(2) ~> p3Sink
           ClosedShape
@@ -117,7 +117,7 @@ class GraphBalanceSpec extends AkkaSpec {
         implicit b ⇒
           (f1, f2, f3, f4, f5) ⇒
             val balance = b.add(Balance[Int](5, waitForAllDownstreams = true))
-            Source(0 to 14) ~> balance.in
+            b.add(Source(0 to 14)) ~> balance.in
             balance.out(0).grouped(15) ~> f1
             balance.out(1).grouped(15) ~> f2
             balance.out(2).grouped(15) ~> f3
@@ -136,7 +136,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val results = RunnableGraph.fromGraph(FlowGraph.create(outputs, outputs, outputs)(List(_, _, _)) { implicit b ⇒
         (o1, o2, o3) ⇒
           val balance = b.add(Balance[Int](3, waitForAllDownstreams = true))
-          Source.repeat(1).take(numElementsForSink * 3) ~> balance.in
+          b.add(Source.repeat(1).take(numElementsForSink * 3)) ~> balance.in
           balance.out(0) ~> o1
           balance.out(1) ~> o2
           balance.out(2) ~> o3
@@ -156,7 +156,7 @@ class GraphBalanceSpec extends AkkaSpec {
       val (p1, p2, p3) = RunnableGraph.fromGraph(FlowGraph.create(probe, probe, probe)(Tuple3.apply) { implicit b ⇒
         (o1, o2, o3) ⇒
           val balance = b.add(Balance[Int](3))
-          Source(1 to 7) ~> balance.in
+          b.add(Source(1 to 7)) ~> balance.in
           balance.out(0) ~> o1
           balance.out(1) ~> o2
           balance.out(2) ~> o3
@@ -182,9 +182,9 @@ class GraphBalanceSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val balance = b.add(Balance[Int](2))
-        Source(List(1, 2, 3)) ~> balance.in
-        balance.out(0) ~> Sink(c1)
-        balance.out(1) ~> Sink(c2)
+        b.add(Source(List(1, 2, 3))) ~> balance.in
+        balance.out(0) ~> b.add(Sink(c1))
+        balance.out(1) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -204,9 +204,9 @@ class GraphBalanceSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val balance = b.add(Balance[Int](2))
-        Source(List(1, 2, 3)) ~> balance.in
-        balance.out(0) ~> Sink(c1)
-        balance.out(1) ~> Sink(c2)
+        b.add(Source(List(1, 2, 3))) ~> balance.in
+        balance.out(0) ~> b.add(Sink(c1))
+        balance.out(1) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -227,9 +227,9 @@ class GraphBalanceSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val balance = b.add(Balance[Int](2))
-        Source(p1.getPublisher) ~> balance.in
-        balance.out(0) ~> Sink(c1)
-        balance.out(1) ~> Sink(c2)
+        b.add(Source(p1.getPublisher)) ~> balance.in
+        balance.out(0) ~> b.add(Sink(c1))
+        balance.out(1) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
@@ -25,9 +25,9 @@ class GraphBroadcastSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val bcast = b.add(Broadcast[Int](2))
-        Source(List(1, 2, 3)) ~> bcast.in
-        bcast.out(0) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink(c1)
-        bcast.out(1) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink(c2)
+        b.add(Source(List(1, 2, 3))) ~> bcast.in
+        bcast.out(0) ~> b.add(Flow[Int].buffer(16, OverflowStrategy.backpressure)) ~> b.add(Sink(c1))
+        bcast.out(1) ~> b.add(Flow[Int].buffer(16, OverflowStrategy.backpressure)) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -62,7 +62,7 @@ class GraphBroadcastSpec extends AkkaSpec {
           (fut1, fut2, fut3, fut4, fut5) ⇒ Future.sequence(List(fut1, fut2, fut3, fut4, fut5))) { implicit b ⇒
             (p1, p2, p3, p4, p5) ⇒
               val bcast = b.add(Broadcast[Int](5))
-              Source(List(1, 2, 3)) ~> bcast.in
+              b.add(Source(List(1, 2, 3))) ~> bcast.in
               bcast.out(0).grouped(5) ~> p1.inlet
               bcast.out(1).grouped(5) ~> p2.inlet
               bcast.out(2).grouped(5) ~> p3.inlet
@@ -93,7 +93,7 @@ class GraphBroadcastSpec extends AkkaSpec {
           implicit b ⇒
             (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22) ⇒
               val bcast = b.add(Broadcast[Int](22))
-              Source(List(1, 2, 3)) ~> bcast.in
+              b.add(Source(List(1, 2, 3))) ~> bcast.in
               bcast.out(0).grouped(5) ~> p1.inlet
               bcast.out(1).grouped(5) ~> p2.inlet
               bcast.out(2).grouped(5) ~> p3.inlet
@@ -128,9 +128,9 @@ class GraphBroadcastSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val bcast = b.add(Broadcast[Int](2))
-        Source(List(1, 2, 3)) ~> bcast.in
-        bcast.out(0) ~> Flow[Int] ~> Sink(c1)
-        bcast.out(1) ~> Flow[Int] ~> Sink(c2)
+        b.add(Source(List(1, 2, 3))) ~> bcast.in
+        bcast.out(0) ~> b.add(Flow[Int]) ~> b.add(Sink(c1))
+        bcast.out(1) ~> b.add(Flow[Int]) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -150,9 +150,9 @@ class GraphBroadcastSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val bcast = b.add(Broadcast[Int](2))
-        Source(List(1, 2, 3)) ~> bcast.in
-        bcast.out(0) ~> Flow[Int].named("identity-a") ~> Sink(c1)
-        bcast.out(1) ~> Flow[Int].named("identity-b") ~> Sink(c2)
+        b.add(Source(List(1, 2, 3))) ~> bcast.in
+        bcast.out(0) ~> b.add(Flow[Int].named("identity-a")) ~> b.add(Sink(c1))
+        bcast.out(1) ~> b.add(Flow[Int].named("identity-b")) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -173,9 +173,9 @@ class GraphBroadcastSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val bcast = b.add(Broadcast[Int](2))
-        Source(p1.getPublisher) ~> bcast.in
-        bcast.out(0) ~> Flow[Int] ~> Sink(c1)
-        bcast.out(1) ~> Flow[Int] ~> Sink(c2)
+        b.add(Source(p1.getPublisher)) ~> bcast.in
+        bcast.out(0) ~> b.add(Flow[Int]) ~> b.add(Sink(c1))
+        bcast.out(1) ~> b.add(Flow[Int]) ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -202,8 +202,8 @@ class GraphBroadcastSpec extends AkkaSpec {
 
       val sink = Sink.fromGraph(FlowGraph.create() { implicit b ⇒
         val bcast = b.add(Broadcast[Int](2))
-        bcast.out(0) ~> Sink(c1)
-        bcast.out(1) ~> Sink(c2)
+        bcast.out(0) ~> b.add(Sink(c1))
+        bcast.out(1) ~> b.add(Sink(c2))
         SinkShape(bcast.in)
       })
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBroadcastSpec.scala
@@ -62,12 +62,14 @@ class GraphBroadcastSpec extends AkkaSpec {
           (fut1, fut2, fut3, fut4, fut5) ⇒ Future.sequence(List(fut1, fut2, fut3, fut4, fut5))) { implicit b ⇒
             (p1, p2, p3, p4, p5) ⇒
               val bcast = b.add(Broadcast[Int](5))
+              def grouped = b.add(Flow[Int].grouped(5))
+
               b.add(Source(List(1, 2, 3))) ~> bcast.in
-              bcast.out(0).grouped(5) ~> p1.inlet
-              bcast.out(1).grouped(5) ~> p2.inlet
-              bcast.out(2).grouped(5) ~> p3.inlet
-              bcast.out(3).grouped(5) ~> p4.inlet
-              bcast.out(4).grouped(5) ~> p5.inlet
+              bcast.out(0) ~> grouped ~> p1.inlet
+              bcast.out(1) ~> grouped ~> p2.inlet
+              bcast.out(2) ~> grouped ~> p3.inlet
+              bcast.out(3) ~> grouped ~> p4.inlet
+              bcast.out(4) ~> grouped ~> p5.inlet
               ClosedShape
           }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphConcatSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphConcatSpec.scala
@@ -35,13 +35,13 @@ class GraphConcatSpec extends TwoStreamsSetup {
         val concat1 = b add Concat[Int]()
         val concat2 = b add Concat[Int]()
 
-        Source(List.empty[Int]) ~> concat1.in(0)
-        Source(1 to 4) ~> concat1.in(1)
+        b.add(Source(List.empty[Int])) ~> concat1.in(0)
+        b.add(Source(1 to 4)) ~> concat1.in(1)
 
         concat1.out ~> concat2.in(0)
-        Source(5 to 10) ~> concat2.in(1)
+        b.add(Source(5 to 10)) ~> concat2.in(1)
 
-        concat2.out ~> Sink(probe)
+        concat2.out ~> b.add(Sink(probe))
         ClosedShape
       }).run()
 
@@ -143,9 +143,9 @@ class GraphConcatSpec extends TwoStreamsSetup {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val concat = b add Concat[Int]()
-        Source(List(1, 2, 3)) ~> concat.in(0)
-        Source(promise.future) ~> concat.in(1)
-        concat.out ~> Sink(subscriber)
+        b.add(Source(List(1, 2, 3))) ~> concat.in(0)
+        b.add(Source(promise.future)) ~> concat.in(1)
+        concat.out ~> b.add(Sink(subscriber))
         ClosedShape
       }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePreferredSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePreferredSpec.scala
@@ -35,12 +35,12 @@ class GraphMergePreferredSpec extends TwoStreamsSetup {
       val result = RunnableGraph.fromGraph(FlowGraph.create(Sink.head[Seq[Int]]) { implicit b ⇒
         sink ⇒
           val merge = b.add(MergePreferred[Int](3))
-          preferred ~> merge.preferred
+          b.add(preferred) ~> merge.preferred
 
           merge.out.grouped(numElements * 2) ~> sink.inlet
-          aux ~> merge.in(0)
-          aux ~> merge.in(1)
-          aux ~> merge.in(2)
+          b.add(aux) ~> merge.in(0)
+          b.add(aux) ~> merge.in(1)
+          b.add(aux) ~> merge.in(2)
           ClosedShape
       }).run()
 
@@ -51,12 +51,12 @@ class GraphMergePreferredSpec extends TwoStreamsSetup {
       val result = RunnableGraph.fromGraph(FlowGraph.create(Sink.head[Seq[Int]]) { implicit b ⇒
         sink ⇒
           val merge = b.add(MergePreferred[Int](3))
-          Source(1 to 100) ~> merge.preferred
+          b.add(Source(1 to 100)) ~> merge.preferred
 
           merge.out.grouped(500) ~> sink.inlet
-          Source(101 to 200) ~> merge.in(0)
-          Source(201 to 300) ~> merge.in(1)
-          Source(301 to 400) ~> merge.in(2)
+          b.add(Source(101 to 200)) ~> merge.in(0)
+          b.add(Source(201 to 300)) ~> merge.in(1)
+          b.add(Source(301 to 400)) ~> merge.in(2)
           ClosedShape
       }).run()
 
@@ -70,11 +70,11 @@ class GraphMergePreferredSpec extends TwoStreamsSetup {
         val g = RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
           val merge = b.add(MergePreferred[Int](1))
 
-          s ~> merge.preferred
-          s ~> merge.preferred
-          s ~> merge.in(0)
+          b.add(s) ~> merge.preferred
+          b.add(s) ~> merge.preferred
+          b.add(s) ~> merge.in(0)
 
-          merge.out ~> Sink.head[Int]
+          merge.out ~> b.add(Sink.head[Int])
           ClosedShape
         })
       }).getMessage should include("[MergePreferred.preferred] is already connected")

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePreferredSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePreferredSpec.scala
@@ -35,9 +35,10 @@ class GraphMergePreferredSpec extends TwoStreamsSetup {
       val result = RunnableGraph.fromGraph(FlowGraph.create(Sink.head[Seq[Int]]) { implicit b ⇒
         sink ⇒
           val merge = b.add(MergePreferred[Int](3))
-          b.add(preferred) ~> merge.preferred
+          val group = b.add(Flow[Int].grouped(numElements * 2))
 
-          merge.out.grouped(numElements * 2) ~> sink.inlet
+          b.add(preferred) ~> merge.preferred
+          merge ~> group ~> sink.inlet
           b.add(aux) ~> merge.in(0)
           b.add(aux) ~> merge.in(1)
           b.add(aux) ~> merge.in(2)
@@ -52,8 +53,9 @@ class GraphMergePreferredSpec extends TwoStreamsSetup {
         sink ⇒
           val merge = b.add(MergePreferred[Int](3))
           b.add(Source(1 to 100)) ~> merge.preferred
+          val group = b.add(Flow[Int].grouped(500))
 
-          merge.out.grouped(500) ~> sink.inlet
+          merge ~> group ~> sink.inlet
           b.add(Source(101 to 200)) ~> merge.in(0)
           b.add(Source(201 to 300)) ~> merge.in(1)
           b.add(Source(301 to 400)) ~> merge.in(2)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
@@ -36,12 +36,15 @@ class GraphMergeSpec extends TwoStreamsSetup {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val m1 = b.add(Merge[Int](2))
         val m2 = b.add(Merge[Int](2))
+        val s1 = b.add(source1)
+        val s2 = b.add(source2)
+        val s3 = b.add(source3)
 
-        source1 ~> m1.in(0)
-        m1.out ~> Flow[Int].map(_ * 2) ~> m2.in(0)
-        m2.out ~> Flow[Int].map(_ / 2).map(_ + 1) ~> Sink(probe)
-        source2 ~> m1.in(1)
-        source3 ~> m2.in(1)
+        s1 ~> m1.in(0)
+        m1.out ~> b.add(Flow[Int].map(_ * 2)) ~> m2.in(0)
+        m2.out ~> b.add(Flow[Int].map(_ / 2).map(_ + 1)) ~> b.add(Sink(probe))
+        s2 ~> m1.in(1)
+        s3 ~> m2.in(1)
 
         ClosedShape
       }).run()
@@ -71,13 +74,13 @@ class GraphMergeSpec extends TwoStreamsSetup {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val merge = b.add(Merge[Int](6))
 
-        source1 ~> merge.in(0)
-        source2 ~> merge.in(1)
-        source3 ~> merge.in(2)
-        source4 ~> merge.in(3)
-        source5 ~> merge.in(4)
-        source6 ~> merge.in(5)
-        merge.out ~> Sink(probe)
+        b.add(source1) ~> merge.in(0)
+        b.add(source2) ~> merge.in(1)
+        b.add(source3) ~> merge.in(2)
+        b.add(source4) ~> merge.in(3)
+        b.add(source5) ~> merge.in(4)
+        b.add(source6) ~> merge.in(5)
+        merge.out ~> b.add(Sink(probe))
 
         ClosedShape
       }).run()
@@ -159,7 +162,7 @@ class GraphMergeSpec extends TwoStreamsSetup {
           val merge = b.add(Merge[Int](2))
           s1.outlet ~> merge.in(0)
           s2.outlet ~> merge.in(1)
-          merge.out ~> Sink(down)
+          merge.out ~> b.add(Sink(down))
           ClosedShape
       }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphPartialSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphPartialSpec.scala
@@ -29,7 +29,7 @@ class GraphPartialSpec extends AkkaSpec {
 
       val (_, _, result) = RunnableGraph.fromGraph(FlowGraph.create(doubler, doubler, Sink.head[Seq[Int]])(Tuple3.apply) { implicit b ⇒
         (d1, d2, sink) ⇒
-          Source(List(1, 2, 3)) ~> d1.inlet
+          b.add(Source(List(1, 2, 3))) ~> d1.inlet
           d1.outlet ~> d2.inlet
           d2.outlet.grouped(100) ~> sink.inlet
           ClosedShape
@@ -52,7 +52,7 @@ class GraphPartialSpec extends AkkaSpec {
 
       val (sub1, sub2, result) = RunnableGraph.fromGraph(FlowGraph.create(doubler, doubler, Sink.head[Seq[Int]])(Tuple3.apply) { implicit b ⇒
         (d1, d2, sink) ⇒
-          Source(List(1, 2, 3)) ~> d1.inlet
+          b.add(Source(List(1, 2, 3))) ~> d1.inlet
           d1.outlet ~> d2.inlet
           d2.outlet.grouped(100) ~> sink.inlet
           ClosedShape
@@ -84,7 +84,7 @@ class GraphPartialSpec extends AkkaSpec {
 
       val (sub1, sub2, result) = RunnableGraph.fromGraph(FlowGraph.create(doubler, doubler, Sink.head[Seq[Int]])(Tuple3.apply) { implicit b ⇒
         (d1, d2, sink) ⇒
-          Source(List(1, 2, 3)) ~> d1.inlet
+          b.add(Source(List(1, 2, 3))) ~> d1.inlet
           d1.outlet ~> d2.inlet
           d2.outlet.grouped(100) ~> sink.inlet
           ClosedShape
@@ -106,7 +106,7 @@ class GraphPartialSpec extends AkkaSpec {
       val fut = RunnableGraph.fromGraph(FlowGraph.create(Sink.head[Int], p)(Keep.left) { implicit b ⇒
         (sink, flow) ⇒
           import FlowGraph.Implicits._
-          Source.single(0) ~> flow.inlet
+          b.add(Source.single(0)) ~> flow.inlet
           flow.outlet ~> sink.inlet
           ClosedShape
       }).run()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipSpec.scala
@@ -25,9 +25,9 @@ class GraphUnzipSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val unzip = b.add(Unzip[Int, String]())
-        Source(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
-        unzip.out1 ~> Flow[String].buffer(16, OverflowStrategy.backpressure) ~> Sink(c2)
-        unzip.out0 ~> Flow[Int].buffer(16, OverflowStrategy.backpressure).map(_ * 2) ~> Sink(c1)
+        b.add(Source(List(1 -> "a", 2 -> "b", 3 -> "c"))) ~> unzip.in
+        unzip.out1 ~> b.add(Flow[String].buffer(16, OverflowStrategy.backpressure)) ~> b.add(Sink(c2))
+        unzip.out0 ~> b.add(Flow[Int].buffer(16, OverflowStrategy.backpressure).map(_ * 2)) ~> b.add(Sink(c1))
         ClosedShape
       }).run()
 
@@ -55,9 +55,9 @@ class GraphUnzipSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val unzip = b.add(Unzip[Int, String]())
-        Source(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
-        unzip.out0 ~> Sink(c1)
-        unzip.out1 ~> Sink(c2)
+        b.add(Source(List(1 -> "a", 2 -> "b", 3 -> "c"))) ~> unzip.in
+        unzip.out0 ~> b.add(Sink(c1))
+        unzip.out1 ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -77,9 +77,9 @@ class GraphUnzipSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val unzip = b.add(Unzip[Int, String]())
-        Source(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
-        unzip.out0 ~> Sink(c1)
-        unzip.out1 ~> Sink(c2)
+        b.add(Source(List(1 -> "a", 2 -> "b", 3 -> "c"))) ~> unzip.in
+        unzip.out0 ~> b.add(Sink(c1))
+        unzip.out1 ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -100,9 +100,9 @@ class GraphUnzipSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val unzip = b.add(Unzip[Int, String]())
-        Source(p1.getPublisher) ~> unzip.in
-        unzip.out0 ~> Sink(c1)
-        unzip.out1 ~> Sink(c2)
+        b.add(Source(p1.getPublisher)) ~> unzip.in
+        unzip.out0 ~> b.add(Sink(c1))
+        unzip.out1 ~> b.add(Sink(c2))
         ClosedShape
       }).run()
 
@@ -128,10 +128,10 @@ class GraphUnzipSpec extends AkkaSpec {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val zip = b.add(Zip[Int, String]())
         val unzip = b.add(Unzip[Int, String]())
-        Source(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in
+        b.add(Source(List(1 -> "a", 2 -> "b", 3 -> "c"))) ~> unzip.in
         unzip.out0 ~> zip.in0
         unzip.out1 ~> zip.in1
-        zip.out ~> Sink(c1)
+        zip.out ~> b.add(Sink(c1))
         ClosedShape
       }).run()
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipWithSpec.scala
@@ -51,9 +51,9 @@ class GraphUnzipWithSpec extends AkkaSpec {
     RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
       val f = fixture(b)
 
-      Source(p) ~> f.in
-      f.left ~> Sink(leftSubscriber)
-      f.right ~> Sink(rightSubscriber)
+      b.add(Source(p)) ~> f.in
+      f.left ~> b.add(Sink(leftSubscriber))
+      f.right ~> b.add(Sink(rightSubscriber))
 
       ClosedShape
     }).run()
@@ -99,10 +99,10 @@ class GraphUnzipWithSpec extends AkkaSpec {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val unzip = b.add(UnzipWith(f))
-        Source(1 to 4) ~> unzip.in
+        b.add(Source(1 to 4)) ~> unzip.in
 
-        unzip.out0 ~> Flow[LeftOutput].buffer(4, OverflowStrategy.backpressure) ~> Sink(leftProbe)
-        unzip.out1 ~> Flow[RightOutput].buffer(4, OverflowStrategy.backpressure) ~> Sink(rightProbe)
+        unzip.out0 ~> b.add(Flow[LeftOutput].buffer(4, OverflowStrategy.backpressure)) ~> b.add(Sink(leftProbe))
+        unzip.out1 ~> b.add(Flow[RightOutput].buffer(4, OverflowStrategy.backpressure)) ~> b.add(Sink(rightProbe))
 
         ClosedShape
       }).run()
@@ -150,10 +150,10 @@ class GraphUnzipWithSpec extends AkkaSpec {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val unzip = b.add(UnzipWith[Int, Int, String]((b: Int) ⇒ (1 / b, 1 + "/" + b)))
 
-        Source(-2 to 2) ~> unzip.in
+        b.add(Source(-2 to 2)) ~> unzip.in
 
-        unzip.out0 ~> Sink(leftProbe)
-        unzip.out1 ~> Sink(rightProbe)
+        unzip.out0 ~> b.add(Sink(leftProbe))
+        unzip.out1 ~> b.add(Sink(rightProbe))
 
         ClosedShape
       }).run()
@@ -195,11 +195,11 @@ class GraphUnzipWithSpec extends AkkaSpec {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val unzip = b.add(UnzipWith((a: Person) ⇒ Person.unapply(a).get))
 
-        Source.single(Person("Caplin", "Capybara", 3)) ~> unzip.in
+        b.add(Source.single(Person("Caplin", "Capybara", 3))) ~> unzip.in
 
-        unzip.out0 ~> Sink(probe0)
-        unzip.out1 ~> Sink(probe1)
-        unzip.out2 ~> Sink(probe2)
+        unzip.out0 ~> b.add(Sink(probe0))
+        unzip.out1 ~> b.add(Sink(probe1))
+        unzip.out2 ~> b.add(Sink(probe2))
 
         ClosedShape
       }).run()
@@ -245,35 +245,35 @@ class GraphUnzipWithSpec extends AkkaSpec {
         // odd input ports will be Int, even input ports will be String
         val unzip = b.add(UnzipWith(split20))
 
-        Source.single((0 to 19).toList) ~> unzip.in
+        b.add(Source.single((0 to 19).toList)) ~> unzip.in
 
         def createSink[T](o: Outlet[T]) =
-          o ~> Flow[T].buffer(1, OverflowStrategy.backpressure) ~> Sink(TestSubscriber.manualProbe[T]())
+          o ~> b.add(Flow[T].buffer(1, OverflowStrategy.backpressure)) ~> b.add(Sink(TestSubscriber.manualProbe[T]()))
 
-        unzip.out0 ~> Sink(probe0)
+        unzip.out0 ~> b.add(Sink(probe0))
         createSink(unzip.out1)
         createSink(unzip.out2)
         createSink(unzip.out3)
         createSink(unzip.out4)
 
-        unzip.out5 ~> Sink(probe5)
+        unzip.out5 ~> b.add(Sink(probe5))
         createSink(unzip.out6)
         createSink(unzip.out7)
         createSink(unzip.out8)
         createSink(unzip.out9)
 
-        unzip.out10 ~> Sink(probe10)
+        unzip.out10 ~> b.add(Sink(probe10))
         createSink(unzip.out11)
         createSink(unzip.out12)
         createSink(unzip.out13)
         createSink(unzip.out14)
 
-        unzip.out15 ~> Sink(probe15)
+        unzip.out15 ~> b.add(Sink(probe15))
         createSink(unzip.out16)
         createSink(unzip.out17)
         createSink(unzip.out18)
 
-        unzip.out19 ~> Sink(probe19)
+        unzip.out19 ~> b.add(Sink(probe19))
 
         ClosedShape
       }).run()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipSpec.scala
@@ -28,10 +28,10 @@ class GraphZipSpec extends TwoStreamsSetup {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val zip = b.add(Zip[Int, String]())
 
-        Source(1 to 4) ~> zip.in0
-        Source(List("A", "B", "C", "D", "E", "F")) ~> zip.in1
+        b.add(Source(1 to 4)) ~> zip.in0
+        b.add(Source(List("A", "B", "C", "D", "E", "F"))) ~> zip.in1
 
-        zip.out ~> Sink(probe)
+        zip.out ~> b.add(Sink(probe))
 
         ClosedShape
       }).run()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithSpec.scala
@@ -144,24 +144,24 @@ class GraphZipWithSpec extends TwoStreamsSetup {
         // odd input ports will be Int, even input ports will be String
         val zip = b.add(ZipWith(sum19))
 
-        b.add(Source.single(2)).map(_.toString) ~> zip.in1
+        b.add(Source.single(2).map(_.toString)) ~> zip.in1
         b.add(Source.single(1)) ~> zip.in0
         b.add(Source.single(3)) ~> zip.in2
-        b.add(Source.single(4)).map(_.toString) ~> zip.in3
+        b.add(Source.single(4).map(_.toString)) ~> zip.in3
         b.add(Source.single(5)) ~> zip.in4
-        b.add(Source.single(6)).map(_.toString) ~> zip.in5
+        b.add(Source.single(6).map(_.toString)) ~> zip.in5
         b.add(Source.single(7)) ~> zip.in6
-        b.add(Source.single(8)).map(_.toString) ~> zip.in7
+        b.add(Source.single(8).map(_.toString)) ~> zip.in7
         b.add(Source.single(9)) ~> zip.in8
-        b.add(Source.single(10)).map(_.toString) ~> zip.in9
+        b.add(Source.single(10).map(_.toString)) ~> zip.in9
         b.add(Source.single(11)) ~> zip.in10
-        b.add(Source.single(12)).map(_.toString) ~> zip.in11
+        b.add(Source.single(12).map(_.toString)) ~> zip.in11
         b.add(Source.single(13)) ~> zip.in12
-        b.add(Source.single(14)).map(_.toString) ~> zip.in13
+        b.add(Source.single(14).map(_.toString)) ~> zip.in13
         b.add(Source.single(15)) ~> zip.in14
-        b.add(Source.single(16)).map(_.toString) ~> zip.in15
+        b.add(Source.single(16).map(_.toString)) ~> zip.in15
         b.add(Source.single(17)) ~> zip.in16
-        b.add(Source.single(18)).map(_.toString) ~> zip.in17
+        b.add(Source.single(18).map(_.toString)) ~> zip.in17
         b.add(Source.single(19)) ~> zip.in18
 
         zip.out ~> b.add(Sink(probe))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithSpec.scala
@@ -23,10 +23,10 @@ class GraphZipWithSpec extends TwoStreamsSetup {
 
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val zip = b.add(ZipWith((_: Int) + (_: Int)))
-        Source(1 to 4) ~> zip.in0
-        Source(10 to 40 by 10) ~> zip.in1
+        b.add(Source(1 to 4)) ~> zip.in0
+        b.add(Source(10 to 40 by 10)) ~> zip.in1
 
-        zip.out ~> Sink(probe)
+        zip.out ~> b.add(Sink(probe))
 
         ClosedShape
       }).run()
@@ -51,10 +51,10 @@ class GraphZipWithSpec extends TwoStreamsSetup {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val zip = b.add(ZipWith[Int, Int, Int]((_: Int) / (_: Int)))
 
-        Source(1 to 4) ~> zip.in0
-        Source(-2 to 2) ~> zip.in1
+        b.add(Source(1 to 4)) ~> zip.in0
+        b.add(Source(-2 to 2)) ~> zip.in1
 
-        zip.out ~> Sink(probe)
+        zip.out ~> b.add(Sink(probe))
 
         ClosedShape
       }).run()
@@ -114,11 +114,11 @@ class GraphZipWithSpec extends TwoStreamsSetup {
       RunnableGraph.fromGraph(FlowGraph.create() { implicit b ⇒
         val zip = b.add(ZipWith(Person.apply _))
 
-        Source.single("Caplin") ~> zip.in0
-        Source.single("Capybara") ~> zip.in1
-        Source.single(3) ~> zip.in2
+        b.add(Source.single("Caplin")) ~> zip.in0
+        b.add(Source.single("Capybara")) ~> zip.in1
+        b.add(Source.single(3)) ~> zip.in2
 
-        zip.out ~> Sink(probe)
+        zip.out ~> b.add(Sink(probe))
 
         ClosedShape
       }).run()
@@ -144,27 +144,27 @@ class GraphZipWithSpec extends TwoStreamsSetup {
         // odd input ports will be Int, even input ports will be String
         val zip = b.add(ZipWith(sum19))
 
-        Source.single(1) ~> zip.in0
-        Source.single(2).map(_.toString) ~> zip.in1
-        Source.single(3) ~> zip.in2
-        Source.single(4).map(_.toString) ~> zip.in3
-        Source.single(5) ~> zip.in4
-        Source.single(6).map(_.toString) ~> zip.in5
-        Source.single(7) ~> zip.in6
-        Source.single(8).map(_.toString) ~> zip.in7
-        Source.single(9) ~> zip.in8
-        Source.single(10).map(_.toString) ~> zip.in9
-        Source.single(11) ~> zip.in10
-        Source.single(12).map(_.toString) ~> zip.in11
-        Source.single(13) ~> zip.in12
-        Source.single(14).map(_.toString) ~> zip.in13
-        Source.single(15) ~> zip.in14
-        Source.single(16).map(_.toString) ~> zip.in15
-        Source.single(17) ~> zip.in16
-        Source.single(18).map(_.toString) ~> zip.in17
-        Source.single(19) ~> zip.in18
+        b.add(Source.single(2)).map(_.toString) ~> zip.in1
+        b.add(Source.single(1)) ~> zip.in0
+        b.add(Source.single(3)) ~> zip.in2
+        b.add(Source.single(4)).map(_.toString) ~> zip.in3
+        b.add(Source.single(5)) ~> zip.in4
+        b.add(Source.single(6)).map(_.toString) ~> zip.in5
+        b.add(Source.single(7)) ~> zip.in6
+        b.add(Source.single(8)).map(_.toString) ~> zip.in7
+        b.add(Source.single(9)) ~> zip.in8
+        b.add(Source.single(10)).map(_.toString) ~> zip.in9
+        b.add(Source.single(11)) ~> zip.in10
+        b.add(Source.single(12)).map(_.toString) ~> zip.in11
+        b.add(Source.single(13)) ~> zip.in12
+        b.add(Source.single(14)).map(_.toString) ~> zip.in13
+        b.add(Source.single(15)) ~> zip.in14
+        b.add(Source.single(16)).map(_.toString) ~> zip.in15
+        b.add(Source.single(17)) ~> zip.in16
+        b.add(Source.single(18)).map(_.toString) ~> zip.in17
+        b.add(Source.single(19)) ~> zip.in18
 
-        zip.out ~> Sink(probe)
+        zip.out ~> b.add(Sink(probe))
 
         ClosedShape
       }).run()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
@@ -25,7 +25,7 @@ class PublisherSinkSpec extends AkkaSpec {
 
           val bcast = b.add(Broadcast[Int](2))
 
-          Source(0 to 5) ~> bcast.in
+          b.add(Source(0 to 5)) ~> bcast.in
           bcast.out(0).map(_ * 2) ~> p1.inlet
           bcast.out(1) ~> p2.inlet
           ClosedShape

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -116,12 +116,15 @@ object Sink {
     Sink.fromGraph(FlowGraph.create() { implicit b ⇒
       import FlowGraph.Implicits._
       val d = b.add(strategy(rest.size + 2))
-      d.out(0) ~> first
-      d.out(1) ~> second
+      val firstInlet = b.add(first)
+      val secondInlet = b.add(second)
+      d.out(0) ~> firstInlet
+      d.out(1) ~> secondInlet
 
       @tailrec def combineRest(idx: Int, i: Iterator[Sink[U, _]]): SinkShape[T] =
         if (i.hasNext) {
-          d.out(idx) ~> i.next()
+          val inlet = b.add(i.next())
+          d.out(idx) ~> inlet
           combineRest(idx + 1, i)
         } else new SinkShape(d.in)
 


### PR DESCRIPTION
Implicit DSL arrows to and from Graph[T, _] removed requiring an explicit
builder.add to get a shape

Refs #18829 
