### PR TITLE
+str 18735: Added keepalive inject and initial delay ops

### DIFF
--- a/akka-docs-dev/rst/java/stream-cookbook.rst
+++ b/akka-docs-dev/rst/java/stream-cookbook.rst
@@ -379,8 +379,6 @@ Injecting keep-alive messages into a stream of ByteStrings
 **Situation:** Given a communication channel expressed as a stream of ByteStrings we want to inject keep-alive messages
 but only if this does not interfere with normal traffic.
 
-All this recipe needs is the ``MergePreferred`` element which is a version of a merge that is not fair. In other words,
-whenever the merge can choose because multiple upstream producers have elements to produce it will always choose the
-preferred upstream effectively giving it an absolute priority.
+There is a built-in operation that allows to do this directly:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeKeepAlive.java#inject-keepalive

--- a/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeKeepAlive.scala
+++ b/akka-docs-dev/rst/scala/code/docs/stream/cookbook/RecipeKeepAlive.scala
@@ -10,68 +10,16 @@ class RecipeKeepAlive extends RecipeSpec {
   "Recipe for injecting keepalive messages" must {
 
     "work" in {
-
-      type Tick = Unit
-
-      val tickPub = TestPublisher.probe[Tick]()
-      val dataPub = TestPublisher.probe[ByteString]()
-      val sub = TestSubscriber.manualProbe[ByteString]()
-      val ticks = Source(tickPub)
-
-      val dataStream = Source(dataPub)
       val keepaliveMessage = ByteString(11)
-      val sink = Sink(sub)
 
       //#inject-keepalive
-      val tickToKeepAlivePacket: Flow[Tick, ByteString, Unit] = Flow[Tick]
-        .conflate(seed = (tick) => keepaliveMessage)((msg, newTick) => msg)
-
-      val graph = RunnableGraph.fromGraph(FlowGraph.create() { implicit builder =>
-        import FlowGraph.Implicits._
-        val unfairMerge = builder.add(MergePreferred[ByteString](1))
-
-        // If data is available then no keepalive is injected
-        dataStream ~> unfairMerge.preferred
-        ticks ~> tickToKeepAlivePacket ~> unfairMerge ~> sink
-        ClosedShape
-      })
+      import scala.concurrent.duration._
+      val injectKeepAlive: Flow[ByteString, ByteString, Unit] =
+        Flow[ByteString].keepAlive(1.second, () => keepaliveMessage)
       //#inject-keepalive
 
-      graph.run()
-
-      val subscription = sub.expectSubscription()
-
-      // FIXME RK: remove (because I think this cannot deterministically be tested and it might also not do what it should anymore)
-
-      tickPub.sendNext(())
-
-      // pending data will overcome the keepalive
-      dataPub.sendNext(ByteString(1))
-      dataPub.sendNext(ByteString(2))
-      dataPub.sendNext(ByteString(3))
-
-      subscription.request(1)
-      sub.expectNext(ByteString(1))
-      subscription.request(2)
-      sub.expectNext(ByteString(2))
-      // This still gets through because there is some intrinsic fairness caused by the FIFO queue in the interpreter
-      // Expecting here a preferred element also only worked true accident with the old Pump.
-      sub.expectNext(keepaliveMessage)
-
-      subscription.request(1)
-      sub.expectNext(ByteString(3))
-
-      subscription.request(1)
-      tickPub.sendNext(())
-      sub.expectNext(keepaliveMessage)
-
-      dataPub.sendComplete()
-      tickPub.sendComplete()
-
-      sub.expectComplete()
-
+      // No need to test, this is a built-in stage with proper tests
     }
-
   }
 
 }

--- a/akka-docs-dev/rst/scala/stream-cookbook.rst
+++ b/akka-docs-dev/rst/scala/stream-cookbook.rst
@@ -368,8 +368,6 @@ Injecting keep-alive messages into a stream of ByteStrings
 **Situation:** Given a communication channel expressed as a stream of ByteStrings we want to inject keep-alive messages
 but only if this does not interfere with normal traffic.
 
-All this recipe needs is the ``MergePreferred`` element which is a version of a merge that is not fair. In other words,
-whenever the merge can choose because multiple upstream producers have elements to produce it will always choose the
-preferred upstream effectively giving it an absolute priority.
+There is a built-in operation that allows to do this directly:
 
 .. includecode:: code/docs/stream/cookbook/RecipeKeepAlive.scala#inject-keepalive

--- a/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeKeepAlive.java
+++ b/akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/cookbook/RecipeKeepAlive.java
@@ -5,12 +5,8 @@ package docs.stream.cookbook;
 
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
-import akka.stream.FlowShape;
 import akka.stream.Materializer;
-import akka.stream.ClosedShape;
 import akka.stream.javadsl.*;
-import akka.stream.javadsl.RunnableGraph;
-import akka.stream.scaladsl.MergePreferred.MergePreferredShape;
 import akka.stream.testkit.TestPublisher;
 import akka.stream.testkit.TestSubscriber;
 import akka.stream.testkit.javadsl.TestSink;
@@ -23,6 +19,8 @@ import org.reactivestreams.Subscription;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
 
 public class RecipeKeepAlive extends RecipeTest {
   static ActorSystem system;
@@ -47,62 +45,18 @@ public class RecipeKeepAlive extends RecipeTest {
   public void workForVersion1() throws Exception {
     new JavaTestKit(system) {
       {
-        final TestPublisher.Probe<Tick> tickPub = TestPublisher.<Tick>probe(0, system);
-        final TestPublisher.Probe<ByteString> dataPub = TestPublisher.<ByteString>probe(0, system);
-        final TestSubscriber.ManualProbe<ByteString> sub = TestSubscriber.<ByteString>manualProbe(system);
-        final Source<Tick, BoxedUnit> ticks = Source.from(tickPub);
-
-        final Source<ByteString, BoxedUnit> dataStream = Source.from(dataPub);
         final ByteString keepAliveMessage = ByteString.fromArray(new byte[]{11});
-        final Sink<ByteString, BoxedUnit> sink = Sink.create(sub);
 
         //@formatter:off
         //#inject-keepalive
-        Flow<Tick, ByteString, BoxedUnit> tickToKeepAlivePacket =
-          Flow.of(Tick.class).conflate(tick -> keepAliveMessage, (msg, newTick) -> msg);
-
-        final RunnableGraph<BoxedUnit> graph = RunnableGraph.fromGraph(
-          FlowGraph.create((builder) -> {
-            final int secondaryPorts = 1;
-              final MergePreferredShape<ByteString> unfairMerge =
-                builder.add(MergePreferred.create(secondaryPorts));
-              // If data is available then no keepalive is injected
-              builder.from(builder.add(dataStream)).toInlet(unfairMerge.preferred());
-              builder.from(builder.add(ticks))
-                     .via(builder.add(tickToKeepAlivePacket))
-                     .toInlet(unfairMerge.in(0));
-              builder.from(unfairMerge.out()).to(builder.add(sink));
-              return ClosedShape.getInstance();
-            }
-          )
-        );
+        Flow<ByteString, ByteString, BoxedUnit> keepAliveInject =
+          Flow.of(ByteString.class).keepAlive(
+              scala.concurrent.duration.Duration.create(1, TimeUnit.SECONDS),
+              () -> keepAliveMessage);
         //#inject-keepalive
         //@formatter:on
-        graph.run(mat);
-        final Subscription subscription = sub.expectSubscription();
-        tickPub.sendNext(TICK);
 
-        // pending data will overcome the keepalive
-        dataPub.sendNext(ByteString.fromArray(new byte[]{1}));
-        dataPub.sendNext(ByteString.fromArray(new byte[]{2}));
-        dataPub.sendNext(ByteString.fromArray(new byte[]{3}));
-
-        subscription.request(1);
-        sub.expectNext(ByteString.fromArray(new byte[]{1}));
-        subscription.request(2);
-        sub.expectNext(ByteString.fromArray(new byte[]{2}));
-        sub.expectNext(keepAliveMessage);
-        subscription.request(1);
-        sub.expectNext(ByteString.fromArray(new byte[]{3}));
-
-        subscription.request(1);
-        tickPub.sendNext(TICK);
-        sub.expectNext(keepAliveMessage);
-
-        dataPub.sendComplete();
-        tickPub.sendComplete();
-
-        sub.expectComplete();
+        // Enough to compile, tested elsewhere as a built-in stage
       }
     };
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIdleInjectSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIdleInjectSpec.scala
@@ -1,0 +1,149 @@
+package akka.stream.scaladsl
+
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.testkit.{ TestSubscriber, TestPublisher, Utils, AkkaSpec }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class FlowIdleInjectSpec extends AkkaSpec {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  "keepAlive" must {
+
+    "not emit additional elements if upstream is fast enough" in Utils.assertAllStagesStopped {
+      Await.result(
+        Source(1 to 10).keepAlive(1.second, () ⇒ 0).grouped(1000).runWith(Sink.head),
+        3.seconds) should ===(1 to 10)
+    }
+
+    "emit elements periodically after silent periods" in Utils.assertAllStagesStopped {
+      val sourceWithIdleGap = Source(1 to 5) ++ Source(6 to 10).initialDelay(2.second)
+
+      val result = Await.result(
+        sourceWithIdleGap.keepAlive(0.6.seconds, () ⇒ 0).grouped(1000).runWith(Sink.head),
+        3.seconds) should ===(List(1, 2, 3, 4, 5, 0, 0, 0, 6, 7, 8, 9, 10))
+    }
+
+    "immediately pull upstream" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      Source(upstream).keepAlive(1.second, () ⇒ 0).runWith(Sink(downstream))
+
+      downstream.request(1)
+
+      upstream.sendNext(1)
+      downstream.expectNext(1)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "immediately pull upstream after busy period" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      (Source(1 to 10) ++ Source(upstream)).keepAlive(1.second, () ⇒ 0).runWith(Sink(downstream))
+
+      downstream.request(10)
+      downstream.expectNextN(1 to 10)
+
+      downstream.request(1)
+
+      upstream.sendNext(1)
+      downstream.expectNext(1)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "work if timer fires before initial request" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      Source(upstream).keepAlive(1.second, () ⇒ 0).runWith(Sink(downstream))
+
+      downstream.ensureSubscription()
+      downstream.expectNoMsg(1.5.second)
+      downstream.request(1)
+      downstream.expectNext(0)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "work if timer fires before initial request after busy period" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      (Source(1 to 10) ++ Source(upstream)).keepAlive(1.second, () ⇒ 0).runWith(Sink(downstream))
+
+      downstream.request(10)
+      downstream.expectNextN(1 to 10)
+
+      downstream.expectNoMsg(1.5.second)
+      downstream.request(1)
+      downstream.expectNext(0)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "prefer upstream element over injected" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      Source(upstream).keepAlive(1.second, () ⇒ 0).runWith(Sink(downstream))
+
+      downstream.ensureSubscription()
+      downstream.expectNoMsg(1.5.second)
+      upstream.sendNext(1)
+      downstream.expectNoMsg(0.5.second)
+      downstream.request(1)
+      downstream.expectNext(1)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "prefer upstream element over injected after busy period" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      (Source(1 to 10) ++ Source(upstream)).keepAlive(1.second, () ⇒ 0).runWith(Sink(downstream))
+
+      downstream.request(10)
+      downstream.expectNextN(1 to 10)
+
+      downstream.expectNoMsg(1.5.second)
+      upstream.sendNext(1)
+      downstream.expectNoMsg(0.5.second)
+      downstream.request(1)
+      downstream.expectNext(1)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "reset deadline properly after injected element" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      Source(upstream).keepAlive(1.second, () ⇒ 0).runWith(Sink(downstream))
+
+      downstream.request(2)
+      downstream.expectNoMsg(0.5.second)
+      downstream.expectNext(0)
+
+      downstream.expectNoMsg(0.5 second)
+      downstream.expectNext(0)
+    }
+
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowInitialDelaySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowInitialDelaySpec.scala
@@ -1,0 +1,52 @@
+package akka.stream.scaladsl
+
+import java.util.concurrent.TimeoutException
+
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.testkit.{ Utils, TestSubscriber, AkkaSpec }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class FlowInitialDelaySpec extends AkkaSpec {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  "Flow initialDelay" must {
+
+    "work with zero delay" in Utils.assertAllStagesStopped {
+      Await.result(
+        Source(1 to 10).initialDelay(Duration.Zero).grouped(100).runWith(Sink.head),
+        1.second) should ===(1 to 10)
+    }
+
+    "delay elements by the specified time but not more" in Utils.assertAllStagesStopped {
+      a[TimeoutException] shouldBe thrownBy {
+        Await.result(
+          Source(1 to 10).initialDelay(2.seconds).initialTimeout(1.second).runWith(Sink.ignore),
+          2.seconds)
+      }
+
+      Await.ready(
+        Source(1 to 10).initialDelay(1.seconds).initialTimeout(2.second).runWith(Sink.ignore),
+        2.seconds)
+    }
+
+    "properly ignore timer while backpressured" in Utils.assertAllStagesStopped {
+      val probe = TestSubscriber.probe[Int]()
+      Source(1 to 10).initialDelay(0.5.second).runWith(Sink(probe))
+
+      probe.ensureSubscription()
+      probe.expectNoMsg(1.5.second)
+      probe.request(20)
+      probe.expectNextN(1 to 10)
+
+      probe.expectComplete()
+    }
+
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -5,6 +5,7 @@ package akka.stream.javadsl
 
 import akka.event.LoggingAdapter
 import akka.japi.{ function, Pair }
+import akka.stream.impl.Timers.{ DelayInitial, IdleInject }
 import akka.stream.impl.{ ConstantFun, StreamLayout }
 import akka.stream.{ scaladsl, _ }
 import akka.stream.stage.Stage
@@ -999,6 +1000,14 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   /**
    * If the first element has not passed through this stage before the provided timeout, the stream is failed
    * with a [[java.util.concurrent.TimeoutException]].
+   *
+   * '''Emits when''' upstream emits an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or fails if timeout elapses before first element arrives
+   *
+   * '''Cancels when''' downstream cancels
    */
   def initialTimeout(timeout: FiniteDuration): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.initialTimeout(timeout))
@@ -1006,6 +1015,14 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   /**
    * If the completion of the stream does not happen until the provided timeout, the stream is failed
    * with a [[java.util.concurrent.TimeoutException]].
+   *
+   * '''Emits when''' upstream emits an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or fails if timeout elapses before upstream completes
+   *
+   * '''Cancels when''' downstream cancels
    */
   def completionTimeout(timeout: FiniteDuration): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.completionTimeout(timeout))
@@ -1013,9 +1030,51 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   /**
    * If the time between two processed elements exceed the provided timeout, the stream is failed
    * with a [[java.util.concurrent.TimeoutException]].
+   *
+   * '''Emits when''' upstream emits an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or fails if timeout elapses between two emitted elements
+   *
+   * '''Cancels when''' downstream cancels
    */
   def idleTimeout(timeout: FiniteDuration): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.idleTimeout(timeout))
+
+  /**
+   * Injects additional elements if the upstream does not emit for a configured amount of time. In other words, this
+   * stage attempts to maintains a base rate of emitted elements towards the downstream.
+   *
+   * If the downstream backpressures then no element is injected until downstream demand arrives. Injected elements
+   * do not accumulate during this period.
+   *
+   * Upstream elements are always preferred over injected elements.
+   *
+   * '''Emits when''' upstream emits an element or if the upstream was idle for the configured period
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def keepAlive[U >: Out](maxIdle: FiniteDuration, injectedElem: function.Creator[U]): javadsl.Flow[In, U, Mat] =
+    new Flow(delegate.keepAlive(maxIdle, () ⇒ injectedElem.create()))
+
+  /**
+   * Delays the initial element by the specified duration.
+   *
+   * '''Emits when''' upstream emits an element if the initial delay already elapsed
+   *
+   * '''Backpressures when''' downstream backpressures or initial delay not yet elapsed
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def initialDelay(delay: FiniteDuration): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.initialDelay(delay))
 
   override def withAttributes(attr: Attributes): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.withAttributes(attr))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -5,7 +5,7 @@ package akka.stream.scaladsl
 
 import akka.stream._
 import akka.stream.impl.StreamLayout.Module
-import akka.stream.impl.Timeouts
+import akka.stream.impl.Timers
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -207,5 +207,5 @@ object BidiFlow {
    * the *joint* frequencies of the elements in both directions.
    */
   def bidirectionalIdleTimeout[I, O](timeout: FiniteDuration): BidiFlow[I, I, O, O, Unit] =
-    fromGraph(new Timeouts.IdleBidi(timeout))
+    fromGraph(new Timers.IdleBidi(timeout))
 }


### PR DESCRIPTION
Also, improved documentation of timeout operations
Added missing Java DSL smoke tests

Fixes #18735 
