### PR TITLE
=str #18040 unhandled ResumeReading

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpConnectionStream.scala
@@ -70,15 +70,13 @@ private[akka] abstract class TcpStreamActor(val settings: ActorMaterializerSetti
 
     def handleRead: Receive = {
       case Received(data) ⇒
-        if (closed) connection ! ResumeReading
-        else {
+        if (closed) {
+          connection ! ResumeReading
+        } else {
           pendingElement = data
           readPump.pump()
         }
-      case ConfirmedClosed ⇒
-        cancel()
-        readPump.pump()
-      case PeerClosed ⇒
+      case ConfirmedClosed | PeerClosed ⇒
         cancel()
         readPump.pump()
     }
@@ -91,7 +89,6 @@ private[akka] abstract class TcpStreamActor(val settings: ActorMaterializerSetti
       if (!closed) {
         closed = true
         pendingElement = null
-        if (!tcpOutputs.isFlushed && (connection ne null)) connection ! ResumeReading
       }
     }
 


### PR DESCRIPTION
issue was that it was trying to send ResumeReading message when it's in half closed state.
Almost all warnings (maybe except one) with "unhandled message ResumeReading" must gone from build logs
