### PR TITLE
=str #17732 covered all client APIs to check if idle timeouts work

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -579,7 +579,7 @@ private[stream] final class GraphInterpreter(
       logic.afterPostStop()
     } catch {
       case NonFatal(e) ⇒
-        log.error(s"Error during postStop in [${assembly.stages(logic.stageId)}]", e)
+        log.error(e, s"Error during postStop in [${assembly.stages(logic.stageId)}]")
     }
   }
 


### PR DESCRIPTION
To have a clear concience when closing https://github.com/akka/akka/issues/17732 added some tests to check all client apis for idleTimeouts.
Feature implemented in https://github.com/akka/akka/pull/18770, this only adds tests.

Also found typo in error logging in the GraphInterpreter: https://github.com/akka/akka/commit/d77f217d4d05fa36c0cd6dfacf5d0f72aeda3abe
It would not log the exception properly (which actually I bumped into - didn't get nice errors).
