### PR TITLE
WIP - json introspection support in RouteTests

### DIFF
--- a/akka-http-testkit-spray-json/src/main/scala/akka/http/testkit/scaladsl/SprayJsonRouteScalaTest.scala
+++ b/akka-http-testkit-spray-json/src/main/scala/akka/http/testkit/scaladsl/SprayJsonRouteScalaTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.testkit.scaladsl
+
+import akka.http.scaladsl.testkit.TestFrameworkInterface
+import org.scalactic.Equality
+import spray.json._
+
+import scala.collection.immutable
+
+// TODO we can't depend on scalatest here AFAIR
+trait SprayJsonRouteScalaTest extends SprayJsonRouteTest {
+  this: TestFrameworkInterface ⇒
+
+  //noinspection SimplifyBoolean
+  implicit val jsValueEq = new Equality[JsValue] {
+    override def areEqual(_a: JsValue, _b: Any): Boolean = (_a, _b) match {
+      case (a: JsString, b: String)          ⇒ a.value == b
+      case (a: JsString, b)                  ⇒ a == b
+
+      case (a: JsObject, b: JsObject)        ⇒ a == b
+      case (a: JsObject, b)                  ⇒ ???
+
+      case (a: JsNumber, b: JsNumber)        ⇒ a == b
+      case (a: JsNumber, b: Int)             ⇒ a.value.toIntExact == b
+      case (a: JsNumber, b: Long)            ⇒ a.value.toLongExact == b
+      case (a: JsNumber, b: Float)           ⇒ a.value == BigDecimal(b)
+      case (a: JsNumber, b: Double)          ⇒ a.value == BigDecimal(b)
+      case (a: JsNumber, b)                  ⇒ a == b
+
+      case (a: JsArray, b: JsArray)          ⇒ a == b
+      case (a: JsArray, b: immutable.Seq[_]) ⇒ ???
+      case (a: JsArray, b: Seq[_])           ⇒ ???
+      case (a: JsArray, b)                   ⇒ ???
+
+      case (JsTrue, b: Boolean)              ⇒ true == b
+      case (JsTrue, b)                       ⇒ JsTrue == b
+
+      case (JsFalse, b: Boolean)             ⇒ false == b
+      case (JsFalse, b)                      ⇒ JsFalse == b
+
+      case (JsNull, JsNull)                  ⇒ true
+      case (JsNull, b)                       ⇒ null == b
+    }
+  }
+
+}

--- a/akka-http-testkit-spray-json/src/main/scala/akka/http/testkit/scaladsl/SprayJsonRouteTest.scala
+++ b/akka-http-testkit-spray-json/src/main/scala/akka/http/testkit/scaladsl/SprayJsonRouteTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.testkit.scaladsl
+
+import akka.http.scaladsl.common.{ NameReceptacle, NameDefaultReceptacle }
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.testkit.{ TestFrameworkInterface, RouteTest }
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller, FromResponseUnmarshaller }
+import akka.http.scaladsl.util.FastFuture
+import spray.json.{ JsArray, JsValue, JsObject }
+import scala.concurrent.duration._
+import scala.annotation.tailrec
+import spray.json._
+
+import scala.reflect.ClassTag
+
+trait SprayJsonRouteTest extends RouteTest with SprayJsonSupport {
+  this: TestFrameworkInterface ⇒
+
+  def responseJson: JsValue = responseAs[String].parseJson
+
+  // TODO use marshalling infra
+  def responseJsonArray: JsArray = responseAs[String].parseJson.asInstanceOf[JsArray]
+
+  // TODO use marshalling infra
+  def responseJsonObject: JsObject = responseAs[String].parseJson.asJsObject // TODO use marshalling infra
+
+  def responseJsonIsEmpty: Boolean = responseJson match {
+    case a: JsArray  ⇒ a.elements.isEmpty
+    case o: JsObject ⇒ o.fields.isEmpty
+  }
+
+  def responseJsonNonEmpty: Boolean = !responseJsonIsEmpty
+
+  def responseJsonValueAt(key: String): JsValue = responseJsonObject.fields(key)
+
+  def responseJsonValueAt(idx: Int): JsValue = responseJsonArray.elements(idx)
+
+  def jsonValue(jsonSelector: JsonSelector): JsValue =
+    jsonSelector.selectFrom(responseJson)
+
+  trait Selection {
+    def selectFrom(js: JsValue): JsValue
+  }
+
+  final case class ArrayIndexSelection(idx: Int) extends Selection {
+    override def selectFrom(js: JsValue): JsValue = js match {
+      case a: JsArray ⇒ a.elements(idx)
+      case other      ⇒ throw new AssertionError(s"Attepmted array index extraction ([$idx]) on non-array object, was: ${other.getClass}, value: $other")
+    }
+  }
+
+  final case class ObjectFieldSelection(fieldName: String) extends Selection {
+    override def selectFrom(js: JsValue): JsValue = js match {
+      case a: JsObject ⇒ a.fields.getOrElse(fieldName, throw new AssertionError(s"""Attempted json field extraction for '$fieldName', yet object did not contain it. Keys are: ${a.fields.keys.mkString(",")}"""))
+      case other       ⇒ throw new AssertionError(s"Attepmted array index extraction ('$fieldName') on non-object, was: ${other.getClass}, value: $other")
+    }
+  }
+
+  implicit final class JsValueAs(val js: JsValue) {
+    def as[T: ClassTag](implicit reader: JsonReader[T]): T = reader.read(js)
+  }
+
+  final case class JsonSelector(path: List[Selection]) {
+    def selectFrom(js: JsValue): JsValue = {
+      val selections = path.reverse
+      @tailrec def applySelections(js: JsValue, remaining: List[Selection]): JsValue = remaining match {
+        case s :: Nil  ⇒ s.selectFrom(js)
+        case s :: rest ⇒ applySelections(s.selectFrom(js), rest)
+      }
+      applySelections(js, selections)
+    }
+
+    def /(idx: Int): JsonSelector = copy(ArrayIndexSelection(idx) :: path)
+    def /(field: String): JsonSelector = copy(ObjectFieldSelection(field) :: path)
+    def /(field: Symbol): JsonSelector = copy(ObjectFieldSelection(field.name) :: path)
+  }
+
+  implicit def int2selector(idx: Int): JsonSelector = JsonSelector(ArrayIndexSelection(idx) :: Nil)
+  implicit def symbol2selector(s: Symbol): JsonSelector = string2selector(s.name)
+  implicit def string2selector(s: String): JsonSelector = JsonSelector(ObjectFieldSelection(s) :: Nil)
+
+}

--- a/akka-http-testkit-spray-json/src/test/scala/akka/http/testkit/scaladsl/SprayJsonRouteTestTest.scala
+++ b/akka-http-testkit-spray-json/src/test/scala/akka/http/testkit/scaladsl/SprayJsonRouteTestTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.testkit.scaladsl
+
+import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.testkit.TestFrameworkInterface
+import org.scalatest.{ Matchers, WordSpec }
+import spray.json.{ JsArray, JsNumber, JsObject, JsString }
+import spray.json._
+
+class SprayJsonRouteTestTest extends WordSpec with Matchers with Directives
+  with SprayJsonRouteTest
+  with SprayJsonRouteScalaTest
+  with DefaultJsonProtocol
+  with TestFrameworkInterface.Scalatest {
+
+  import SprayJsonRouteTestTest._
+  implicit val personFormat = jsonFormat2(Person)
+
+  val route =
+    complete {
+      """
+        {
+          "top": "Top",
+          "stringArray": ["0", "1", "2"],
+          "intArray": [0, 1, 2],
+          "deeper": {
+            "inside": 42,
+            "anotherInside": "AnotherInside"
+          },
+          "nestedPerson": {
+            "name": "Kapi",
+            "age": 42
+          }
+        }
+      """.parseJson
+    }
+
+  "SprayJsonRouteTest" should {
+    "#jsonValue should introspect json and equal JsString/JsNumber/..." in {
+      Get("/") ~> route ~> check {
+        jsonValue('top) should ===(JsString("Top"))
+        jsonValue("stringArray") should ===(JsArray(JsString("0"), JsString("1"), JsString("2")))
+        jsonValue("stringArray" / 1) should ===(JsString("1"))
+        jsonValue("intArray") should ===(JsArray(JsNumber(0), JsNumber(1), JsNumber(2)))
+        jsonValue("intArray" / 0) should ===(JsNumber(0))
+        jsonValue('deeper / "inside") should ===(JsNumber(42))
+        jsonValue("deeper" / 'inside) should ===(JsNumber(42))
+        jsonValue('deeper / "anotherInside") should ===(JsString("AnotherInside"))
+      }
+    }
+    "#jsonValue should introspect json and equal String/Number/..." in {
+      Get("/") ~> route ~> check {
+        jsonValue('top) should ===("Top")
+        jsonValue('deeper / "inside") should ===(42)
+        jsonValue("deeper" / 'inside) should ===(42)
+        jsonValue('deeper / "anotherInside") should ===("AnotherInside")
+      }
+    }
+    "be able to unmarshal deep value from #jsonValue" in {
+      Get("/") ~> route ~> check {
+        jsonValue('nestedPerson).as[Person] should ===(Person("Kapi", 42))
+      }
+    }
+  }
+}
+
+object SprayJsonRouteTestTest {
+  final case class Person(name: String, age: Int)
+}

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -417,6 +417,23 @@ object AkkaBuild extends Build {
         )
   )
 
+  lazy val httpSprayJsonTestkit = Project(
+    id = "akka-http-testkit-spray-json-experimental",
+    base = file("akka-http-testkit-spray-json"),
+    dependencies = Seq(http, httpSprayJson, httpTestkit, streamTestkit),
+    settings =
+      defaultSettings ++ formatSettings ++ scaladocSettings ++
+        javadocSettings ++ OSGi.httpTestKit ++
+        Seq(
+          version := streamAndHttpVersion,
+          libraryDependencies ++= Dependencies.httpTestkit,
+          // FIXME include mima when akka-http-scala-2.3.x is released
+          //previousArtifact := akkaPreviousArtifact("akka-http-testkit-scala")
+          previousArtifact := None,
+          scalacOptions in Compile  += "-language:_"
+        )
+  ).settings(Dependencies.httpSprayJson)
+
   lazy val httpTests = Project(
     id = "akka-http-tests-experimental",
     base = file("akka-http-tests"),


### PR DESCRIPTION
**Work In Progress**
Makes testing JSON responses super simple, without needing to unmarshal them.

TODO:
- [ ] figure all equalities
- [ ] figure out where to put scalatest equalities dependency... maybe testkit can depend on scalactic?
- [ ] provide `responseAs[Source[...]]` support; after streaming JSON shipped
- [ ] provide for `json4s-ast`?
- [ ] any introspection I missed?
