### PR TITLE
=doc Fixes for genjavadoc

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -171,7 +171,7 @@ import ReliableProxy._
  *
  * This actor is an [[akka.actor.FSM]], hence it offers the service of
  * transition callbacks to those actors which subscribe using the
- * ``SubscribeTransitionCallBack`` and ``UnsubscribeTransitionCallBack``
+ * `SubscribeTransitionCallBack` and `UnsubscribeTransitionCallBack`
  * messages; see [[akka.actor.FSM]] for more documentation. The proxy will
  * transition into `ReliableProxy.Active` state when ACKs
  * are outstanding and return to the `ReliableProxy.Idle`
@@ -211,8 +211,8 @@ import ReliableProxy._
  * See the constructor below for the arguments for this actor.  However, prefer using
  * [[akka.contrib.pattern.ReliableProxy#props]] to this actor's constructor.
  *
- * @param targetPath is the ``ActorPath`` to the actor to which all messages will be forwarded.
- *   ``targetPath`` can point to a local or remote actor, but the tunnel endpoint will be
+ * @param targetPath is the `ActorPath` to the actor to which all messages will be forwarded.
+ *   `targetPath` can point to a local or remote actor, but the tunnel endpoint will be
  *   deployed remotely on the node where the target actor lives.
  * @param retryAfter is the ACK timeout after which all outstanding messages
  *   will be resent. There is no limit on the queue size or the number of retries.

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/TransparentExponentialBackoffSupervisor.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/TransparentExponentialBackoffSupervisor.scala
@@ -29,9 +29,9 @@ object TransparentExponentialBackoffSupervisor {
    *       maxBackoff,
    *       (random_delay_factor * calculated_backoff) + calculated_backoff)
    *   }}}
-   * @param decider an [[akka.actor.SupervisorStrategy.Decider]] to specify how the supervisor
+   * @param decider an `Decider` to specify how the supervisor
    *   should behave for different exceptions. If no cases are matched, the default decider of
-   *   [[akka.actor.Actor]] is used. When the [[akka.actor.SupervisorStrategy.Restart]] directive
+   *   [[akka.actor.Actor]] is used. When the `Restart` directive
    *   is returned by the decider, this supervisor will apply an exponential back off restart.
    */
   def propsWithDecider(

--- a/akka-docs/rst/scala/testing.rst
+++ b/akka-docs/rst/scala/testing.rst
@@ -748,13 +748,13 @@ options:
 
 .. includecode:: code/docs/testkit/TestkitDocSpec.scala#logging-receive
 
-  If the aforementioned setting is not given in the :ref:`configuration`, this method will
-  pass through the given :class:`Receive` function unmodified, meaning that
-  there is no runtime cost unless actually enabled.
+If the aforementioned setting is not given in the :ref:`configuration`, this method will
+pass through the given :class:`Receive` function unmodified, meaning that
+there is no runtime cost unless actually enabled.
 
-  The logging feature is coupled to this specific local mark-up because
-  enabling it uniformly on all actors is not usually what you need, and it
-  would lead to endless loops if it were applied to event bus logger listeners.
+The logging feature is coupled to this specific local mark-up because
+enabling it uniformly on all actors is not usually what you need, and it
+would lead to endless loops if it were applied to event bus logger listeners.
 
 * *Logging of special messages*
 


### PR DESCRIPTION
- removed double backticks
- removed javadoc link where the class is not available in Java source
- formatted documentation for proper sphinx syntax
