### PR TITLE
!htc allow configuration of cookie parsing mode, fixes #16828

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookiePair.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookiePair.java
@@ -19,6 +19,10 @@ public abstract class HttpCookiePair {
     public abstract HttpCookie toCookie();
 
     public static HttpCookiePair create(String name, String value) {
-        return new akka.http.scaladsl.model.headers.HttpCookiePair(name, value);
+        return akka.http.scaladsl.model.headers.HttpCookiePair.apply(name, value);
+    }
+
+    public static HttpCookiePair createRaw(String name, String value) {
+        return akka.http.scaladsl.model.headers.HttpCookiePair.raw(name, value);
     }
 }

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -279,6 +279,18 @@ akka.http {
     #
     uri-parsing-mode = strict
 
+    # Sets the parsing mode for parsing cookies.
+    # The following value are defined:
+    #
+    # `rfc6265`: Only RFC6265-compliant cookies are parsed. Surrounding double-quotes are accepted and
+    #   automatically removed. Non-compliant cookies are silently discarded.
+    # `raw`: Raw parsing allows any non-control character but ';' to appear in a cookie value. There's no further
+    #   post-processing applied, so that the resulting value string may contain any number of whitespace, unicode,
+    #   double quotes, or '=' characters at any position.
+    #   The rules for parsing the cookie name are the same ones from RFC 6265.
+    #
+    cookie-parsing-mode = rfc6265
+
     # Enables/disables the logging of warning messages in case an incoming
     # message (request or response) contains an HTTP header which cannot be
     # parsed into its high-level model class due to incompatible syntax.

--- a/akka-http-core/src/main/scala/akka/http/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/ParserSettings.scala
@@ -23,6 +23,7 @@ final case class ParserSettings(
   maxChunkExtLength: Int,
   maxChunkSize: Int,
   uriParsingMode: Uri.ParsingMode,
+  cookieParsingMode: ParserSettings.CookieParsingMode,
   illegalHeaderWarnings: Boolean,
   errorLoggingVerbosity: ParserSettings.ErrorLoggingVerbosity,
   headerValueCacheLimits: Map[String, Int],
@@ -70,6 +71,7 @@ object ParserSettings extends SettingsCompanion[ParserSettings]("akka.http.parsi
       c getIntBytes "max-chunk-ext-length",
       c getIntBytes "max-chunk-size",
       Uri.ParsingMode(c getString "uri-parsing-mode"),
+      CookieParsingMode(c getString "cookie-parsing-mode"),
       c getBoolean "illegal-header-warnings",
       ErrorLoggingVerbosity(c getString "error-logging-verbosity"),
       cacheConfig.entrySet.asScala.map(kvp ⇒ kvp.getKey -> cacheConfig.getInt(kvp.getKey))(collection.breakOut),
@@ -84,12 +86,23 @@ object ParserSettings extends SettingsCompanion[ParserSettings]("akka.http.parsi
     case object Full extends ErrorLoggingVerbosity
 
     def apply(string: String): ErrorLoggingVerbosity =
-      string.toLowerCase(Locale.ROOT) match {
+      string.toRootLowerCase match {
         case "off"    ⇒ Off
         case "simple" ⇒ Simple
         case "full"   ⇒ Full
         case x        ⇒ throw new IllegalArgumentException(s"[$x] is not a legal `error-logging-verbosity` setting")
       }
+  }
+
+  sealed trait CookieParsingMode
+  object CookieParsingMode {
+    case object RFC6265 extends CookieParsingMode
+    case object Raw extends CookieParsingMode
+
+    def apply(mode: String): CookieParsingMode = mode.toRootLowerCase match {
+      case "rfc6265" ⇒ RFC6265
+      case "raw"     ⇒ Raw
+    }
   }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BodyPartParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BodyPartParser.scala
@@ -4,6 +4,8 @@
 
 package akka.http.impl.engine.parsing
 
+import akka.http.ParserSettings
+
 import scala.annotation.tailrec
 import akka.event.LoggingAdapter
 import akka.parboiled2.CharPredicate
@@ -274,7 +276,8 @@ private[http] object BodyPartParser {
     maxHeaderCount: Int,
     illegalHeaderWarnings: Boolean,
     headerValueCacheLimit: Int,
-    uriParsingMode: Uri.ParsingMode) extends HttpHeaderParser.Settings {
+    uriParsingMode: Uri.ParsingMode,
+    cookieParsingMode: ParserSettings.CookieParsingMode) extends HttpHeaderParser.Settings {
     require(maxHeaderNameLength > 0, "maxHeaderNameLength must be > 0")
     require(maxHeaderValueLength > 0, "maxHeaderValueLength must be > 0")
     require(maxHeaderCount > 0, "maxHeaderCount must be > 0")
@@ -289,5 +292,6 @@ private[http] object BodyPartParser {
     maxHeaderCount = 64,
     illegalHeaderWarnings = true,
     headerValueCacheLimit = 8,
-    uriParsingMode = Uri.ParsingMode.Relaxed)
+    uriParsingMode = Uri.ParsingMode.Relaxed,
+    cookieParsingMode = ParserSettings.CookieParsingMode.RFC6265)
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CharacterClasses.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CharacterClasses.scala
@@ -60,7 +60,11 @@ private[http] object CharacterClasses {
   val `token68-start` = ALPHA ++ DIGIT ++ "-._~+/"
 
   // https://tools.ietf.org/html/rfc6265#section-4.1.1
-  val `cookie-octet` = CharPredicate('\u0021', '\u0023' to '\u002b', '\u002d' to '\u003a', '\u003c' to '\u005b', '\u005d' to '\u007e')
+  val `cookie-octet-rfc-6265` = CharPredicate('\u0021', '\u0023' to '\u002b', '\u002d' to '\u003a', '\u003c' to '\u005b', '\u005d' to '\u007e')
+  val `cookie-separator` = CharPredicate(akka.parboiled2.EOI, ';')
+  val `cookie-octet-raw` =
+    CharPredicate('\u0020' to '\u007e') ++
+      CharPredicate((x: Char) ⇒ x > 0x7f && java.lang.Character.isDefined(x)) -- `cookie-separator`
   val `av-octet` = CharPredicate('\u0020' to '\u003a', '\u003c' to '\u007e') // http://www.rfc-editor.org/errata_search.php?rfc=6265
 
   // http://tools.ietf.org/html/rfc5988#section-5

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -120,8 +120,8 @@ sealed trait BodyPartEntity extends HttpEntity with jm.BodyPartEntity {
   def withContentType(contentType: ContentType): BodyPartEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): BodyPartEntity
 }
 
@@ -134,8 +134,8 @@ sealed trait RequestEntity extends HttpEntity with jm.RequestEntity with Respons
   def withContentType(contentType: ContentType): RequestEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): RequestEntity
 
   def transformDataBytes(transformer: Flow[ByteString, ByteString, Any]): RequestEntity
@@ -150,8 +150,8 @@ sealed trait ResponseEntity extends HttpEntity with jm.ResponseEntity {
   def withContentType(contentType: ContentType): ResponseEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): ResponseEntity
 
   def transformDataBytes(transformer: Flow[ByteString, ByteString, Any]): ResponseEntity
@@ -161,8 +161,8 @@ sealed trait UniversalEntity extends jm.UniversalEntity with MessageEntity with 
   def withContentType(contentType: ContentType): UniversalEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): UniversalEntity
 
   def contentLength: Long
@@ -233,8 +233,8 @@ object HttpEntity {
       if (contentType == this.contentType) this else copy(contentType = contentType)
 
     /**
-      * See [[HttpEntity#withSizeLimit]].
-      */
+     * See [[HttpEntity#withSizeLimit]].
+     */
     def withSizeLimit(maxBytes: Long): UniversalEntity =
       if (data.length <= maxBytes) this
       else Default(contentType, data.length, limitableByteSource(Source.single(data))) withSizeLimit maxBytes
@@ -265,8 +265,8 @@ object HttpEntity {
       if (contentType == this.contentType) this else copy(contentType = contentType)
 
     /**
-      * See [[HttpEntity#withSizeLimit]].
-      */
+     * See [[HttpEntity#withSizeLimit]].
+     */
     def withSizeLimit(maxBytes: Long): Default =
       copy(data = data withAttributes Attributes(SizeLimit(maxBytes, Some(contentLength))))
 
@@ -287,8 +287,8 @@ object HttpEntity {
     def dataBytes: Source[ByteString, Any] = data
 
     /**
-      * See [[HttpEntity#withSizeLimit]].
-      */
+     * See [[HttpEntity#withSizeLimit]].
+     */
     def withSizeLimit(maxBytes: Long): Self =
       withData(data withAttributes Attributes(SizeLimit(maxBytes)))
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
@@ -53,14 +53,14 @@ object HttpHeader {
    * 3. The header name or value are illegal according to the basic requirements for HTTP headers
    *    (http://tools.ietf.org/html/rfc7230#section-3.2). In this case the method returns a `ParsingResult.Error`.
    */
-  def parse(name: String, value: String): ParsingResult =
+  def parse(name: String, value: String, settings: HeaderParser.Settings = HeaderParser.DefaultSettings): ParsingResult =
     if (name.forall(CharacterClasses.tchar)) {
       import akka.parboiled2.Parser.DeliveryScheme.Try
-      val parser = new HeaderParser(value)
+      val parser = new HeaderParser(value, settings)
       parser.`header-field-value`.run() match {
         case Success(preProcessedValue) ⇒
           try {
-            HeaderParser.parseFull(name.toLowerCase, preProcessedValue) match {
+            HeaderParser.parseFull(name.toLowerCase, preProcessedValue, settings) match {
               case Right(header) ⇒ ParsingResult.Ok(header, Nil)
               case Left(info) ⇒
                 val errors = info.withSummaryPrepended(s"Illegal HTTP header '$name'") :: Nil


### PR DESCRIPTION
Here's the implementation of what was outlined in the discussion in #16828.

The new rule for parsing cookies is this: every cookie is treated separately and a cookie that cannot be parsed using the configured parsing mode is silently discarded.

There are now two modes that can be configured:
- rfc6265 which corresponds to the existing implementation
- raw which will accept almost everything (including any combination of whitespace, dquotes, commas, or unicode characters)

This enables two new things:
- you can use existing infrastructure to read your (well-formed, RFC 6265 compliant) cookie values regardless of the existence of other cookie values that would have previously prevented the cookie to be parsed at all
- you can relax parsing rules further to enable access to other cookies out there in the wild

Fixes #16828.
