### PR TITLE
+htc #18898 modeledCustomHeader to ease matching on headers

### DIFF
--- a/akka-docs-dev/rst/scala/http/common/http-model.rst
+++ b/akka-docs-dev/rst/scala/http/common/http-model.rst
@@ -216,6 +216,8 @@ header across persistent HTTP connections.
 
 .. _RFC 7230: http://tools.ietf.org/html/rfc7230#section-3.3.3
 
+.. _header-model-scala:
+
 Header Model
 ------------
 
@@ -281,6 +283,38 @@ Connection
 
 __ @github@/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala#L422
 
+Custom Headers
+--------------
+
+Sometimes you may need to model a custom header type which is not part of HTTP and still be able to use it
+as convienient as is possible with the built-in types.
+
+Because of the number of ways one may interact with headers (i.e. try to match a ``CustomHeader`` against a ``RawHeader``
+or the other way around etc), a helper trait for custom Header types and their companions classes are provided by Akka HTTP.
+Thanks to extending :class:`ModeledCustomHeader` instead of the plain ``CustomHeader`` such header can be matched
+
+.. includecode:: ../../../../../akka-http-tests/src/test/scala/akka/http/scaladsl/server/CustomHeaderRoutingSpec.scala
+   :include: modeled-api-key-custom-header
+
+Which allows the this CustomHeader to be used in the following scenarios:
+
+.. includecode:: ../../../../../akka-http-tests/src/test/scala/akka/http/scaladsl/server/CustomHeaderRoutingSpec.scala
+   :include: matching-examples
+
+Including usage within the header directives like in the following :ref:`-headerValuePF-` example:
+
+.. includecode:: ../../../../../akka-http-tests/src/test/scala/akka/http/scaladsl/server/CustomHeaderRoutingSpec.scala
+   :include: matching-in-routes
+
+One can also directly extend :class:`CustomHeader` which requires less boilerplate, however that has the downside of
+matching against :ref:`RawHeader` instances not working out-of-the-box, thus limiting its usefulnes in the routing layer
+of Akka HTTP. For only rendering such header however it would be enough.
+
+.. note::
+  When defining custom headers, prefer to extend :class:`ModeledCustomHeader` instead of :class:`CustomHeader` directly
+  as it will automatically make your header abide all the expected pattern matching semantics one is accustomed to
+  when using built-in types (such as matching a custom header against a ``RawHeader`` as is often the case in routing
+  layers of Akka HTTP applications).
 
 Parsing / Rendering
 -------------------

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -442,7 +442,7 @@ private[http] object HttpHeaderParser {
   def prime(parser: HttpHeaderParser): HttpHeaderParser = {
     val valueParsers: Seq[HeaderValueParser] =
       HeaderParser.ruleNames.map { name ⇒
-        new ModelledHeaderValueParser(name, parser.settings.maxHeaderValueLength, parser.settings.headerValueCacheLimit(name), parser.settings)
+        new ModeledHeaderValueParser(name, parser.settings.maxHeaderValueLength, parser.settings.headerValueCacheLimit(name), parser.settings)
       }(collection.breakOut)
     def insertInGoodOrder(items: Seq[Any])(startIx: Int = 0, endIx: Int = items.size): Unit =
       if (endIx - startIx > 0) {
@@ -477,7 +477,7 @@ private[http] object HttpHeaderParser {
     def cachingEnabled = maxValueCount > 0
   }
 
-  private[parsing] class ModelledHeaderValueParser(headerName: String, maxHeaderValueLength: Int, maxValueCount: Int, settings: HeaderParser.Settings)
+  private[parsing] class ModeledHeaderValueParser(headerName: String, maxHeaderValueLength: Int, maxValueCount: Int, settings: HeaderParser.Settings)
     extends HeaderValueParser(headerName, maxValueCount) {
     def apply(hhp: HttpHeaderParser, input: ByteString, valueStart: Int, onIllegalHeader: ErrorInfo ⇒ Unit): (HttpHeader, Int) = {
       // TODO: optimize by running the header value parser directly on the input ByteString (rather than an extracted String)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -120,8 +120,8 @@ sealed trait BodyPartEntity extends HttpEntity with jm.BodyPartEntity {
   def withContentType(contentType: ContentType): BodyPartEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): BodyPartEntity
 }
 
@@ -134,8 +134,8 @@ sealed trait RequestEntity extends HttpEntity with jm.RequestEntity with Respons
   def withContentType(contentType: ContentType): RequestEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): RequestEntity
 
   def transformDataBytes(transformer: Flow[ByteString, ByteString, Any]): RequestEntity
@@ -150,8 +150,8 @@ sealed trait ResponseEntity extends HttpEntity with jm.ResponseEntity {
   def withContentType(contentType: ContentType): ResponseEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): ResponseEntity
 
   def transformDataBytes(transformer: Flow[ByteString, ByteString, Any]): ResponseEntity
@@ -161,8 +161,8 @@ sealed trait UniversalEntity extends jm.UniversalEntity with MessageEntity with 
   def withContentType(contentType: ContentType): UniversalEntity
 
   /**
-    * See [[HttpEntity#withSizeLimit]].
-    */
+   * See [[HttpEntity#withSizeLimit]].
+   */
   def withSizeLimit(maxBytes: Long): UniversalEntity
 
   def contentLength: Long
@@ -233,8 +233,8 @@ object HttpEntity {
       if (contentType == this.contentType) this else copy(contentType = contentType)
 
     /**
-      * See [[HttpEntity#withSizeLimit]].
-      */
+     * See [[HttpEntity#withSizeLimit]].
+     */
     def withSizeLimit(maxBytes: Long): UniversalEntity =
       if (data.length <= maxBytes) this
       else Default(contentType, data.length, limitableByteSource(Source.single(data))) withSizeLimit maxBytes
@@ -265,8 +265,8 @@ object HttpEntity {
       if (contentType == this.contentType) this else copy(contentType = contentType)
 
     /**
-      * See [[HttpEntity#withSizeLimit]].
-      */
+     * See [[HttpEntity#withSizeLimit]].
+     */
     def withSizeLimit(maxBytes: Long): Default =
       copy(data = data withAttributes Attributes(SizeLimit(maxBytes, Some(contentLength))))
 
@@ -287,8 +287,8 @@ object HttpEntity {
     def dataBytes: Source[ByteString, Any] = data
 
     /**
-      * See [[HttpEntity#withSizeLimit]].
-      */
+     * See [[HttpEntity#withSizeLimit]].
+     */
     def withSizeLimit(maxBytes: Long): Self =
       withData(data withAttributes Attributes(SizeLimit(maxBytes)))
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ModeledCustomHeaderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ModeledCustomHeaderSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.scaladsl.server
+
+import akka.http.scaladsl.model.{ HttpHeader, StatusCodes }
+import akka.http.scaladsl.model.headers._
+
+import scala.concurrent.Future
+import scala.util.{ Success, Failure, Try }
+
+object ModeledCustomHeaderSpec {
+
+  //#modeled-api-key-custom-header
+  object ApiTokenHeader extends ModeledCustomHeaderCompanion[ApiTokenHeader] {
+    override val name = "apiKey"
+    override def parse(value: String) = Try(new ApiTokenHeader(value))
+  }
+  final class ApiTokenHeader(token: String) extends ModeledCustomHeader[ApiTokenHeader] {
+    override val companion = ApiTokenHeader
+    override def value: String = token
+  }
+  //#modeled-api-key-custom-header
+
+  object DifferentHeader extends ModeledCustomHeaderCompanion[DifferentHeader] {
+    override val name = "different"
+    override def parse(value: String) =
+      if (value contains " ") Failure(new Exception("Contains illegal whitespace!"))
+      else Success(new DifferentHeader(value))
+  }
+  final class DifferentHeader(token: String) extends ModeledCustomHeader[DifferentHeader] {
+    override val companion = DifferentHeader
+    override def value = token
+  }
+
+}
+
+class ModeledCustomHeaderSpec extends RoutingSpec {
+  import ModeledCustomHeaderSpec._
+
+  "CustomHeader" should {
+
+    "be able to be extracted using expected syntax" in {
+      //#matching-examples
+      val ApiTokenHeader(t1) = ApiTokenHeader("token")
+      t1 should ===("token")
+
+      val RawHeader(k2, v2) = ApiTokenHeader("token")
+      k2 should ===("apiKey")
+      v2 should ===("token")
+
+      // will match, header keys are case insensitive
+      val ApiTokenHeader(v3) = RawHeader("APIKEY", "token")
+      v3 should ===("token")
+
+      intercept[MatchError] {
+        // won't match, different header name
+        val ApiTokenHeader(v4) = DifferentHeader("token")
+      }
+
+      intercept[MatchError] {
+        // won't match, different header name
+        val RawHeader("something", v5) = DifferentHeader("token")
+      }
+
+      intercept[MatchError] {
+        // won't match, different header name
+        val ApiTokenHeader(v6) = RawHeader("different", "token")
+      }
+      //#matching-examples
+    }
+
+    "be able to match from RawHeader" in {
+
+      //#matching-in-routes
+      def extractFromCustomHeader = headerValuePF {
+        case t @ ApiTokenHeader(token) ⇒ s"extracted> $t"
+        case raw: RawHeader            ⇒ s"raw> $raw"
+      }
+
+      val routes = extractFromCustomHeader { s ⇒
+        complete(s)
+      }
+
+      Get().withHeaders(RawHeader("apiKey", "TheKey")) ~> routes ~> check {
+        status should ===(StatusCodes.OK)
+        responseAs[String] should ===("extracted> apiKey: TheKey")
+      }
+
+      Get().withHeaders(RawHeader("somethingElse", "TheKey")) ~> routes ~> check {
+        status should ===(StatusCodes.OK)
+        responseAs[String] should ===("raw> somethingElse: TheKey")
+      }
+
+      Get().withHeaders(ApiTokenHeader("TheKey")) ~> routes ~> check {
+        status should ===(StatusCodes.OK)
+        responseAs[String] should ===("extracted> apiKey: TheKey")
+      }
+      //#matching-in-routes
+    }
+
+    "fail with useful message when unable to parse" in {
+      val ex = intercept[Exception] {
+        DifferentHeader("Hello world") // illegal " "
+      }
+
+      ex.getMessage should ===("Unable to construct custom header by parsing: 'Hello world'")
+      ex.getCause.getMessage should include("whitespace")
+    }
+  }
+
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -92,9 +92,7 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             |filecontent
             |--12345--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "first part, with a trailing newline\r\n")),
-          Multipart.General.BodyPart.Strict(
-            HttpEntity(`application/octet-stream`, "filecontent"),
-            List(RawHeader("Content-Transfer-Encoding", "binary"))))
+          Multipart.General.BodyPart.Strict(HttpEntity(`application/octet-stream`, "filecontent"), List(RawHeader("Content-Transfer-Encoding", "binary"))))
       }
       "illegal headers" in (
         Unmarshal(HttpEntity(`multipart/form-data` withBoundary "XYZABC",


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/18898

Though I'm not completely happy yet; the problem is about not having "an additional" type, like now, but "one for all custom headers".
The problem is that custom headers are "abused" (well not really, just used in "special cases" by HTTP internally, and making that compile with the companion approach proved to be very tricky (burnt some time on it today).

Would like some initial feedback, and also opinions if we should keep 2 "custom headers" (I could make the bare one be extended by the Modeled one, and we internally keep using the bare; and tell users to use the Modeled one.

// cc @jrudolph @sirthias @rkuhn 
