### PR TITLE
=doc fix reference to outdated methods

### DIFF
--- a/akka-docs-dev/rst/java/stream-composition.rst
+++ b/akka-docs-dev/rst/java/stream-composition.rst
@@ -48,7 +48,7 @@ hiding them behind a *shape* that looks like a :class:`Source`, :class:`Flow`, e
 |
 
 One interesting example above is a :class:`Flow` which is composed of a disconnected :class:`Sink` and :class:`Source`.
-This can be achieved by using the ``wrap()`` constructor method on :class:`Flow` which takes the two parts as
+This can be achieved by using the ``fromSinkAndSource()`` constructor method on :class:`Flow` which takes the two parts as
 parameters.
 
 The example :class:`BidiFlow` demonstrates that internally a module can be of arbitrary complexity, and the exposed
@@ -175,7 +175,7 @@ Since our partial graph has the right shape, it can be already used in the simpl
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/CompositionDocTest.java#partial-use
 
 It is not possible to use it as a :class:`Flow` yet, though (i.e. we cannot call ``.filter()`` on it), but :class:`Flow`
-has a ``wrap()`` method that just adds the DSL to a :class:`FlowShape`. There are similar methods on :class:`Source`,
+has a ``fromGraph()`` method that just adds the DSL to a :class:`FlowShape`. There are similar methods on :class:`Source`,
 :class:`Sink` and :class:`BidiShape`, so it is easy to get back to the simpler DSL if a graph has the right shape.
 For convenience, it is also possible to skip the partial graph creation, and use one of the convenience creator methods.
 To demonstrate this, we will create the following graph:

--- a/akka-docs-dev/rst/java/stream-customize.rst
+++ b/akka-docs-dev/rst/java/stream-customize.rst
@@ -54,7 +54,7 @@ To illustrate these concepts we create a small :class:`PushPullStage` that imple
 
 |
 
-Map calls ``ctx.push()`` from the ``onPush()`` handler and it also calls ``ctx.pull()`` form the ``onPull``
+Map calls ``ctx.push()`` from the ``onPush()`` handler and it also calls ``ctx.pull()`` from the ``onPull``
 handler resulting in the conceptual wiring above, and fully expressed in code below:
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/FlowStagesDocTest.java#one-to-one
@@ -127,13 +127,13 @@ Completion handling
 Completion handling usually (but not exclusively) comes into the picture when processing stages need to emit a few
 more elements after their upstream source has been completed. We have seen an example of this in our ``Duplicator`` class
 where the last element needs to be doubled even after the upstream neighbor stage has been completed. Since the
-``onUpstreamFinish()`` handler expects a :class:`TerminationDirective` as the return type we are only allowed to call
+``onUpstreamFinish()`` handler expects a :class:`TerminationDirective` as the return type, we are only allowed to call
 ``ctx.finish()``, ``ctx.fail()`` or ``ctx.absorbTermination()``. Since the first two of these available methods will
 immediately terminate, our only option is ``absorbTermination()``. It is also clear from the return type of
 ``onUpstreamFinish`` that we cannot call ``ctx.push()`` but we need to emit elements somehow! The trick is that after
 calling ``absorbTermination()`` the ``onPull()`` handler will be called eventually, and at the same time
 ``ctx.isFinishing`` will return true, indicating that ``ctx.pull()`` cannot be called anymore. Now we are free to
-emit additional elementss and call ``ctx.finish()`` or ``ctx.pushAndFinish()`` eventually to finish processing.
+emit additional elements and call ``ctx.finish()`` or ``ctx.pushAndFinish()`` eventually to finish processing.
 
 The reason for this slightly complex termination sequence is that the underlying ``onComplete`` signal of
 Reactive Streams may arrive without any pending demand, i.e. without respecting backpressure. This means that

--- a/akka-docs-dev/rst/java/stream-rate.rst
+++ b/akka-docs-dev/rst/java/stream-rate.rst
@@ -26,7 +26,7 @@ Running the above example, one of the possible outputs looks like this:
 
 Note that the order is *not* ``A:1, B:1, C:1, A:2, B:2, C:2,`` which would correspond to a synchronous execution model
 where an element completely flows through the processing pipeline before the next element enters the flow. The next
-element is processed by a stage as soon as it is emitted the previous one.
+element is processed by a stage as soon as it emitted the previous one.
 
 While pipelining in general increases throughput, in practice there is a cost of passing an element through the
 asynchronous (and therefore thread crossing) boundary which is significant. To amortize this cost Akka Streams uses
@@ -143,7 +143,7 @@ Understanding conflate
 
 When a fast producer can not be informed to slow down by backpressure or some other signal, conflate might be useful to combine elements from a producer until a demand signal comes from a consumer.
 
-Below is an example snippet that summarizes fast stream of elements to a standart deviation, mean and count of elements that have arrived  while the stats have been calculated.
+Below is an example snippet that summarizes fast stream of elements to a standard deviation, mean and count of elements that have arrived  while the stats have been calculated.
 
 .. includecode:: ../../../akka-samples/akka-docs-java-lambda/src/test/java/docs/stream/RateTransformationDocTest.java#conflate-summarize
 

--- a/akka-docs-dev/rst/scala/stream-composition.rst
+++ b/akka-docs-dev/rst/scala/stream-composition.rst
@@ -48,7 +48,7 @@ hiding them behind a *shape* that looks like a :class:`Source`, :class:`Flow`, e
 |
 
 One interesting example above is a :class:`Flow` which is composed of a disconnected :class:`Sink` and :class:`Source`.
-This can be achieved by using the ``wrap()`` constructor method on :class:`Flow` which takes the two parts as
+This can be achieved by using the `` fromSinkAndSource()`` constructor method on :class:`Flow` which takes the two parts as
 parameters.
 
 The example :class:`BidiFlow` demonstrates that internally a module can be of arbitrary complexity, and the exposed
@@ -176,7 +176,7 @@ Since our partial graph has the right shape, it can be already used in the simpl
 .. includecode:: code/docs/stream/CompositionDocSpec.scala#partial-use
 
 It is not possible to use it as a :class:`Flow` yet, though (i.e. we cannot call ``.filter()`` on it), but :class:`Flow`
-has a ``wrap()`` method that just adds the DSL to a :class:`FlowShape`. There are similar methods on :class:`Source`,
+has a ``fromGraph()`` method that just adds the DSL to a :class:`FlowShape`. There are similar methods on :class:`Source`,
 :class:`Sink` and :class:`BidiShape`, so it is easy to get back to the simpler DSL if a graph has the right shape.
 For convenience, it is also possible to skip the partial graph creation, and use one of the convenience creator methods.
 To demonstrate this, we will create the following graph:

--- a/akka-docs-dev/rst/scala/stream-customize.rst
+++ b/akka-docs-dev/rst/scala/stream-customize.rst
@@ -54,7 +54,7 @@ To illustrate these concepts we create a small :class:`PushPullStage` that imple
 
 |
 
-Map calls ``ctx.push()`` from the ``onPush()`` handler and it also calls ``ctx.pull()`` form the ``onPull``
+Map calls ``ctx.push()`` from the ``onPush()`` handler and it also calls ``ctx.pull()`` from the ``onPull``
 handler resulting in the conceptual wiring above, and fully expressed in code below:
 
 .. includecode:: code/docs/stream/FlowStagesSpec.scala#one-to-one
@@ -128,13 +128,13 @@ Completion handling
 Completion handling usually (but not exclusively) comes into the picture when processing stages need to emit a few
 more elements after their upstream source has been completed. We have seen an example of this in our ``Duplicator`` class
 where the last element needs to be doubled even after the upstream neighbor stage has been completed. Since the
-``onUpstreamFinish()`` handler expects a :class:`TerminationDirective` as the return type we are only allowed to call
+``onUpstreamFinish()`` handler expects a :class:`TerminationDirective` as the return type, we are only allowed to call
 ``ctx.finish()``, ``ctx.fail()`` or ``ctx.absorbTermination()``. Since the first two of these available methods will
 immediately terminate, our only option is ``absorbTermination()``. It is also clear from the return type of
 ``onUpstreamFinish`` that we cannot call ``ctx.push()`` but we need to emit elements somehow! The trick is that after
 calling ``absorbTermination()`` the ``onPull()`` handler will be called eventually, and at the same time
 ``ctx.isFinishing`` will return true, indicating that ``ctx.pull()`` cannot be called anymore. Now we are free to
-emit additional elementss and call ``ctx.finish()`` or ``ctx.pushAndFinish()`` eventually to finish processing.
+emit additional elements and call ``ctx.finish()`` or ``ctx.pushAndFinish()`` eventually to finish processing.
 
 The reason for this slightly complex termination sequence is that the underlying ``onComplete`` signal of
 Reactive Streams may arrive without any pending demand, i.e. without respecting backpressure. This means that

--- a/akka-docs-dev/rst/scala/stream-rate.rst
+++ b/akka-docs-dev/rst/scala/stream-rate.rst
@@ -26,7 +26,7 @@ Running the above example, one of the possible outputs looks like this:
 
 Note that the order is *not* ``A:1, B:1, C:1, A:2, B:2, C:2,`` which would correspond to a synchronous execution model
 where an element completely flows through the processing pipeline before the next element enters the flow. The next
-element is processed by a stage as soon as it is emitted the previous one.
+element is processed by a stage as soon as it emitted the previous one.
 
 While pipelining in general increases throughput, in practice there is a cost of passing an element through the
 asynchronous (and therefore thread crossing) boundary which is significant. To amortize this cost Akka Streams uses
@@ -143,7 +143,7 @@ Understanding conflate
 
 When a fast producer can not be informed to slow down by backpressure or some other signal, conflate might be useful to combine elements from a producer until a demand signal comes from a consumer.
 
-Below is an example snippet that summarizes fast stream of elements to a standart deviation, mean and count of elements that have arrived  while the stats have been calculated.
+Below is an example snippet that summarizes fast stream of elements to a standard deviation, mean and count of elements that have arrived  while the stats have been calculated.
 
 .. includecode:: code/docs/stream/RateTransformationDocSpec.scala#conflate-summarize
 


### PR DESCRIPTION
Akka Streams documentation refers to the removed `wrap` constructors when it shouldn't and there's a couple of other typos.
