### PR TITLE
toSeq and limit WIP

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -43,5 +43,18 @@ class FlowLimitSpec extends AkkaSpec {
 
       result should be(true)
     }
+
+    "throw a StreamLimitReachedException when n < 0" in {
+      val input = (1 to 6)
+      val n = -1
+
+      val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+      val result = Try(Await.result(future, 300.millis)) match {
+        case Failure(t: StreamLimitReachedException) ⇒ true
+        case _                                       ⇒ false
+      }
+
+      result should be(true)
+    }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -1,11 +1,9 @@
 package akka.stream.scaladsl
 
-import akka.stream.testkit.Utils._
 import akka.stream.{ StreamLimitReachedException, ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit.AkkaSpec
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.util.{ Failure, Try }
 
 class FlowLimitSpec extends AkkaSpec {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -1,14 +1,48 @@
 package akka.stream.scaladsl
 
+import akka.stream.testkit.Utils._
+import akka.stream.{ StreamLimitReachedException, ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit.AkkaSpec
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.{ Failure, Try }
 
-/**
-  * Created by lolski on 11/25/15.
-  */
 class FlowLimitSpec extends AkkaSpec {
-  // Source(size = n).limit(n) == ???
-  "???" must {
+  import system.dispatcher
 
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val mat = ActorMaterializer(settings)
+
+  // Source(size = n).limit(n) == ???
+  "Limit" must {
+    "produce output that is identical to the input when n = input.length" in assertAllStagesStopped {
+      val input = (1 to 6)
+      val n = input.length
+      val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+      val result = Await.result(future, 300.millis)
+      result == input.toSeq
+    }
+  }
+
+  "produce output that is identical to the input when n > input.length" in assertAllStagesStopped {
+    val input = (1 to 6)
+    val n = input.length + 2 // n > input.length
+    val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+    val result = Await.result(future, 300.millis)
+    result == input.toSeq
+  }
+
+  "produce n messages before throwing a StreamLimitReachedException when n < input.size" in {
+    val input = (1 to 6)
+    val n = input.length - 2 // n < input.length
+    val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+    val result = Try(Await.result(future, 300.millis))
+    result match {
+      case Failure(t: StreamLimitReachedException) if t.n == n ⇒ true
+      case _ ⇒ false
+    }
   }
 
   // Source(size = m).limit(n) where m < n == ???

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -8,21 +8,19 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Try }
 
 class FlowLimitSpec extends AkkaSpec {
-  import system.dispatcher
 
   val settings = ActorMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
 
   implicit val mat = ActorMaterializer(settings)
 
-  // Source(size = n).limit(n) == ???
   "Limit" must {
     "produce output that is identical to the input when n = input.length" in assertAllStagesStopped {
       val input = (1 to 6)
       val n = input.length
       val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
       val result = Await.result(future, 300.millis)
-      result == input.toSeq
+      result should be(input.toSeq)
     }
   }
 
@@ -31,22 +29,19 @@ class FlowLimitSpec extends AkkaSpec {
     val n = input.length + 2 // n > input.length
     val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
     val result = Await.result(future, 300.millis)
-    result == input.toSeq
+    result should be(input.toSeq)
   }
 
   "produce n messages before throwing a StreamLimitReachedException when n < input.size" in {
     val input = (1 to 6)
     val n = input.length - 2 // n < input.length
+
     val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
-    val result = Try(Await.result(future, 300.millis))
-    result match {
+    val result = Try(Await.result(future, 300.millis)) match {
       case Failure(t: StreamLimitReachedException) if t.n == n ⇒ true
       case _ ⇒ false
     }
+
+    result should be(true)
   }
-
-  // Source(size = m).limit(n) where m < n == ???
-  // Source(size = m).limit(n) where m > n == ???
-
-  // Source(size = n).limit(n) where one of the element throws an exception
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -32,16 +32,15 @@ class FlowLimitSpec extends AkkaSpec {
     }
 
     "produce n messages before throwing a StreamLimitReachedException when n < input.size" in {
+      // TODO: check if it actually produces n messages
       val input = (1 to 6)
       val n = input.length - 2 // n < input.length
 
       val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
-      val result = Try(Await.result(future, 300.millis)) match {
-        case Failure(t: StreamLimitReachedException) if t.n == n ⇒ true
-        case _ ⇒ false
-      }
 
-      result should be(true)
+      a[StreamLimitReachedException] shouldBe thrownBy {
+        Await.result(future, 300.millis)
+      }
     }
 
     "throw a StreamLimitReachedException when n < 0" in {
@@ -49,12 +48,9 @@ class FlowLimitSpec extends AkkaSpec {
       val n = -1
 
       val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
-      val result = Try(Await.result(future, 300.millis)) match {
-        case Failure(t: StreamLimitReachedException) ⇒ true
-        case _                                       ⇒ false
+      a[StreamLimitReachedException] shouldBe thrownBy {
+        Await.result(future, 300.millis)
       }
-
-      result should be(true)
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -13,6 +13,14 @@ class FlowLimitSpec extends AkkaSpec {
   implicit val mat = ActorMaterializer(settings)
 
   "Limit" must {
+    "produce empty sequence when source is empty and n = 0" in {
+      val input = Range(0, 0, 1)
+      val n = input.length
+      val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.headOption)
+      val result = Await.result(future, 300.millis)
+      result should be(None)
+    }
+
     "produce output that is identical to the input when n = input.length" in {
       val input = (1 to 6)
       val n = input.length

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -1,0 +1,18 @@
+package akka.stream.scaladsl
+
+import akka.stream.testkit.AkkaSpec
+
+/**
+  * Created by lolski on 11/25/15.
+  */
+class FlowLimitSpec extends AkkaSpec {
+  // Source(size = n).limit(n) == ???
+  "???" must {
+
+  }
+
+  // Source(size = m).limit(n) where m < n == ???
+  // Source(size = m).limit(n) where m > n == ???
+
+  // Source(size = n).limit(n) where one of the element throws an exception
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitSpec.scala
@@ -15,33 +15,33 @@ class FlowLimitSpec extends AkkaSpec {
   implicit val mat = ActorMaterializer(settings)
 
   "Limit" must {
-    "produce output that is identical to the input when n = input.length" in assertAllStagesStopped {
+    "produce output that is identical to the input when n = input.length" in {
       val input = (1 to 6)
       val n = input.length
       val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
       val result = Await.result(future, 300.millis)
       result should be(input.toSeq)
     }
-  }
 
-  "produce output that is identical to the input when n > input.length" in assertAllStagesStopped {
-    val input = (1 to 6)
-    val n = input.length + 2 // n > input.length
-    val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
-    val result = Await.result(future, 300.millis)
-    result should be(input.toSeq)
-  }
-
-  "produce n messages before throwing a StreamLimitReachedException when n < input.size" in {
-    val input = (1 to 6)
-    val n = input.length - 2 // n < input.length
-
-    val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
-    val result = Try(Await.result(future, 300.millis)) match {
-      case Failure(t: StreamLimitReachedException) if t.n == n ⇒ true
-      case _ ⇒ false
+    "produce output that is identical to the input when n > input.length" in {
+      val input = (1 to 6)
+      val n = input.length + 2 // n > input.length
+      val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+      val result = Await.result(future, 300.millis)
+      result should be(input.toSeq)
     }
 
-    result should be(true)
+    "produce n messages before throwing a StreamLimitReachedException when n < input.size" in {
+      val input = (1 to 6)
+      val n = input.length - 2 // n < input.length
+
+      val future = Source(input).limit(n).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+      val result = Try(Await.result(future, 300.millis)) match {
+        case Failure(t: StreamLimitReachedException) if t.n == n ⇒ true
+        case _ ⇒ false
+      }
+
+      result should be(true)
+    }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitWeightedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitWeightedSpec.scala
@@ -13,9 +13,18 @@ class FlowLimitWeightedSpec extends AkkaSpec {
   implicit val mat = ActorMaterializer(settings)
 
   "Limit" must {
+    "produce empty sequence regardless of cost when source is empty and n = 0" in {
+      val input = Range(0, 0, 1)
+      val n = input.length
+      def costFn(e: Int): Long = 999999L // set to an arbitrarily big value
+      val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.headOption)
+      val result = Await.result(future, 300.millis)
+      result should be(None)
+    }
+
     "always exhaust a source regardless of n (as long as n > 0) if cost is 0" in {
       val input = (1 to 15)
-      def costFn(e: Int) = 0
+      def costFn(e: Int): Long = 0L
       val n = 1 // must not matter since costFn always evaluates to 0
       val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
       val result = Await.result(future, 300.millis)
@@ -24,7 +33,7 @@ class FlowLimitWeightedSpec extends AkkaSpec {
 
     "exhaust source if n equals to input length and cost is 1" in {
       val input = (1 to 16)
-      def costFn(e: Int) = 1
+      def costFn(e: Int): Long = 1L
       val n = input.length
       val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
       val result = Await.result(future, 300.millis)
@@ -33,7 +42,7 @@ class FlowLimitWeightedSpec extends AkkaSpec {
 
     "exhaust a source if n >= accumulated cost" in {
       val input = List("this", "is", "some", "string")
-      def costFn(e: String) = e.length
+      def costFn(e: String): Long = e.length
       val n = input.flatten.length
       val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
       val result = Await.result(future, 300.millis)
@@ -42,7 +51,7 @@ class FlowLimitWeightedSpec extends AkkaSpec {
 
     "throw a StreamLimitReachedException when n < accumulated cost" in {
       val input = List("this", "is", "some", "string")
-      def costFn(e: String) = e.length
+      def costFn(e: String): Long = e.length
       val n = input.flatten.length - 1
       val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitWeightedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLimitWeightedSpec.scala
@@ -1,0 +1,54 @@
+package akka.stream.scaladsl
+
+import akka.stream.{ StreamLimitReachedException, ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.testkit.AkkaSpec
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class FlowLimitWeightedSpec extends AkkaSpec {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val mat = ActorMaterializer(settings)
+
+  "Limit" must {
+    "always exhaust a source regardless of n (as long as n > 0) if cost is 0" in {
+      val input = (1 to 15)
+      def costFn(e: Int) = 0
+      val n = 1 // must not matter since costFn always evaluates to 0
+      val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+      val result = Await.result(future, 300.millis)
+      result should be(input.toSeq)
+    }
+
+    "exhaust source if n equals to input length and cost is 1" in {
+      val input = (1 to 16)
+      def costFn(e: Int) = 1
+      val n = input.length
+      val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+      val result = Await.result(future, 300.millis)
+      result should be(input.toSeq)
+    }
+
+    "exhaust a source if n >= accumulated cost" in {
+      val input = List("this", "is", "some", "string")
+      def costFn(e: String) = e.length
+      val n = input.flatten.length
+      val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+      val result = Await.result(future, 300.millis)
+      result should be(input.toSeq)
+    }
+
+    "throw a StreamLimitReachedException when n < accumulated cost" in {
+      val input = List("this", "is", "some", "string")
+      def costFn(e: String) = e.length
+      val n = input.flatten.length - 1
+      val future = Source(input).limitWeighted(n)(costFn).grouped(Integer.MAX_VALUE).runWith(Sink.head)
+
+      a[StreamLimitReachedException] shouldBe thrownBy {
+        Await.result(future, 300.millis)
+      }
+    }
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SeqSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SeqSinkSpec.scala
@@ -5,7 +5,7 @@ import akka.stream.testkit.AkkaSpec
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ToSeqSinkSpec extends AkkaSpec {
+class SeqSinkSpec extends AkkaSpec {
 
   val settings = ActorMaterializerSettings(system)
     .withInputBuffer(initialSize = 2, maxSize = 16)
@@ -22,7 +22,7 @@ class ToSeqSinkSpec extends AkkaSpec {
 
     "return an empty Seq[T] from an empty Source" in {
       val input: Seq[Int] = Seq.empty
-      val future = Source(() ⇒ input.iterator).runWith(Sink.seq)
+      val future = Source.fromIterator(() ⇒ input.iterator).runWith(Sink.seq)
       val result = Await.result(future, 300.millis)
       result should be(Seq.empty: Seq[Int])
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
@@ -1,0 +1,8 @@
+package akka.stream.scaladsl
+
+/**
+  * Created by lolski on 11/27/15.
+  */
+class ToSeqSinkSpec {
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
@@ -1,8 +1,23 @@
 package akka.stream.scaladsl
 
-/**
-  * Created by lolski on 11/27/15.
-  */
-class ToSeqSinkSpec {
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.testkit.AkkaSpec
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
+class ToSeqSinkSpec extends AkkaSpec {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val mat = ActorMaterializer(settings)
+
+  "Sink.toSeq" must {
+    "???" in {
+      val input = (1 to 6)
+      val future = Source(input).runWith(Sink.toSeq)
+      val result = Await.result(future, 300.millis)
+      input should be(input.toSeq)
+    }
+  }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
@@ -17,7 +17,14 @@ class ToSeqSinkSpec extends AkkaSpec {
       val input = (1 to 6)
       val future = Source(input).runWith(Sink.toSeq)
       val result = Await.result(future, 300.millis)
-      input should be(input.toSeq)
+      result should be(input.toSeq)
+    }
+
+    "return an empty Seq[T] from an empty Source" in {
+      val input: Seq[Int] = Seq.empty
+      val future = Source(() ⇒ input.iterator).runWith(Sink.toSeq)
+      val result = Await.result(future, 300.millis)
+      result should be(Seq.empty: Seq[Int])
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
@@ -13,7 +13,7 @@ class ToSeqSinkSpec extends AkkaSpec {
   implicit val mat = ActorMaterializer(settings)
 
   "Sink.toSeq" must {
-    "???" in {
+    "return a Seq[T] from a Source" in {
       val input = (1 to 6)
       val future = Source(input).runWith(Sink.toSeq)
       val result = Await.result(future, 300.millis)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ToSeqSinkSpec.scala
@@ -15,14 +15,14 @@ class ToSeqSinkSpec extends AkkaSpec {
   "Sink.toSeq" must {
     "return a Seq[T] from a Source" in {
       val input = (1 to 6)
-      val future = Source(input).runWith(Sink.toSeq)
+      val future = Source(input).runWith(Sink.seq)
       val result = Await.result(future, 300.millis)
       result should be(input.toSeq)
     }
 
     "return an empty Seq[T] from an empty Source" in {
       val input: Seq[Int] = Seq.empty
-      val future = Source(() ⇒ input.iterator).runWith(Sink.toSeq)
+      val future = Source(() ⇒ input.iterator).runWith(Sink.seq)
       val result = Await.result(future, 300.millis)
       result should be(Seq.empty: Seq[Int])
     }

--- a/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
@@ -1,0 +1,5 @@
+package akka.stream
+
+class StreamLimitReachedException(val n: Int, msg: String) extends RuntimeException(msg) {
+  def getLimit = n
+}

--- a/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
@@ -1,3 +1,3 @@
 package akka.stream
 
-class StreamLimitReachedException(val n: Int) extends RuntimeException(s"limit of $n reached")
+class StreamLimitReachedException(val n: Long) extends RuntimeException(s"limit of $n reached")

--- a/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
@@ -1,3 +1,3 @@
 package akka.stream
 
-class StreamLimitReachedException(val n: Int, msg: String) extends RuntimeException(msg)
+class StreamLimitReachedException(val n: Int) extends RuntimeException(s"limit of $n reached")

--- a/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamLimitReachedException.scala
@@ -1,5 +1,3 @@
 package akka.stream
 
-class StreamLimitReachedException(val n: Int, msg: String) extends RuntimeException(msg) {
-  def getLimit = n
-}
+class StreamLimitReachedException(val n: Int, msg: String) extends RuntimeException(msg)

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -156,7 +156,6 @@ private[stream] object Stages {
   }
 
   final case class Limit[T](n: Int, attributes: Attributes = limit) extends SymbolicStage[T, T] {
-    require(n > 0, "n must be greater than 0")
     override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -156,7 +156,6 @@ private[stream] object Stages {
   }
 
   final case class Limit[T](n: Int, attributes: Attributes = limit) extends SymbolicStage[T, T] {
-    require(n >= 0, "n must be greater than or equal to 0")
     override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -159,6 +159,10 @@ private[stream] object Stages {
     override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
   }
 
+  final case class LimitWeighted[T](n: Long, costFn: T ⇒ Long, attributes: Attributes = limit) extends SymbolicStage[T, T] {
+    override def create(attr: Attributes): Stage[T, T] = fusing.LimitWeighted(n, costFn)
+  }
+
   final case class Sliding[T](n: Int, step: Int, attributes: Attributes = sliding) extends SymbolicStage[T, immutable.Seq[T]] {
     require(n > 0, "n must be greater than 0")
     require(step > 0, "step must be greater than 0")

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -35,6 +35,7 @@ private[stream] object Stages {
     val mapAsyncUnordered = name("mapAsyncUnordered")
     val grouped = name("grouped")
     val limit = name("limit")
+    val limitWeighted = name("limitWeighted")
     val sliding = name("sliding")
     val take = name("take")
     val drop = name("drop")
@@ -159,7 +160,7 @@ private[stream] object Stages {
     override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
   }
 
-  final case class LimitWeighted[T](n: Long, costFn: T ⇒ Long, attributes: Attributes = limit) extends SymbolicStage[T, T] {
+  final case class LimitWeighted[T](n: Long, costFn: T ⇒ Long, attributes: Attributes = limitWeighted) extends SymbolicStage[T, T] {
     override def create(attr: Attributes): Stage[T, T] = fusing.LimitWeighted(n, costFn)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -34,6 +34,7 @@ private[stream] object Stages {
     val mapAsync = name("mapAsync")
     val mapAsyncUnordered = name("mapAsyncUnordered")
     val grouped = name("grouped")
+    val limit = name("limit")
     val sliding = name("sliding")
     val take = name("take")
     val drop = name("drop")
@@ -152,6 +153,11 @@ private[stream] object Stages {
   final case class Grouped[T](n: Int, attributes: Attributes = grouped) extends SymbolicStage[T, immutable.Seq[T]] {
     require(n > 0, "n must be greater than 0")
     override def create(attr: Attributes): Stage[T, immutable.Seq[T]] = fusing.Grouped(n)
+  }
+
+  final case class Limit[T](n: Int, attributes: Attributes = limit) extends SymbolicStage[T, T] {
+    require(n > 0, "n must be greater than 0")
+    override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
   }
 
   final case class Sliding[T](n: Int, step: Int, attributes: Attributes = sliding) extends SymbolicStage[T, immutable.Seq[T]] {

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -156,12 +156,8 @@ private[stream] object Stages {
     override def create(attr: Attributes): Stage[T, immutable.Seq[T]] = fusing.Grouped(n)
   }
 
-  final case class Limit[T](n: Long, attributes: Attributes = limit) extends SymbolicStage[T, T] {
-    override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
-  }
-
-  final case class LimitWeighted[T](n: Long, costFn: T ⇒ Long, attributes: Attributes = limitWeighted) extends SymbolicStage[T, T] {
-    override def create(attr: Attributes): Stage[T, T] = fusing.LimitWeighted(n, costFn)
+  final case class LimitWeighted[T](max: Long, weightFn: T ⇒ Long, attributes: Attributes = limitWeighted) extends SymbolicStage[T, T] {
+    override def create(attr: Attributes): Stage[T, T] = fusing.LimitWeighted(max, weightFn)
   }
 
   final case class Sliding[T](n: Int, step: Int, attributes: Attributes = sliding) extends SymbolicStage[T, immutable.Seq[T]] {

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -155,7 +155,7 @@ private[stream] object Stages {
     override def create(attr: Attributes): Stage[T, immutable.Seq[T]] = fusing.Grouped(n)
   }
 
-  final case class Limit[T](n: Int, attributes: Attributes = limit) extends SymbolicStage[T, T] {
+  final case class Limit[T](n: Long, attributes: Attributes = limit) extends SymbolicStage[T, T] {
     override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -156,6 +156,7 @@ private[stream] object Stages {
   }
 
   final case class Limit[T](n: Int, attributes: Attributes = limit) extends SymbolicStage[T, T] {
+    require(n >= 0, "n must be greater than or equal to 0")
     override def create(attr: Attributes): Stage[T, T] = fusing.Limit(n)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -319,7 +319,7 @@ private[akka] final case class Grouped[T](n: Int) extends PushPullStage[T, immut
  * INTERNAL API
  */
 
-private[akka] final case class Limit[T](n: Int) extends PushStage[T, T] {
+private[akka] final case class Limit[T](n: Long) extends PushStage[T, T] {
   private var left = n
 
   override def onPush(elem: T, ctx: Context[T]): SyncDirective = {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -326,7 +326,7 @@ private[akka] final case class Limit[T](n: Int) extends PushStage[T, T] {
     if (left >= 0) ctx.push(elem)
     else {
       if (ctx.isFinishing) ctx.push(elem)
-      else ctx.fail(new StreamLimitReachedException(left, s"limit of $n reached on this stream"))
+      else ctx.fail(new StreamLimitReachedException(n, s"limit of $n reached on this stream"))
     }
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -319,21 +319,6 @@ private[akka] final case class Grouped[T](n: Int) extends PushPullStage[T, immut
  * INTERNAL API
  */
 
-private[akka] final case class Limit[T](n: Long) extends PushStage[T, T] {
-  private var left = n
-
-  override def onPush(elem: T, ctx: Context[T]): SyncDirective = {
-    if (left > 0) {
-      left -= 1
-      ctx.push(elem)
-    } else ctx.fail(new StreamLimitReachedException(n))
-  }
-}
-
-/**
- * INTERNAL API
- */
-
 private[akka] final case class LimitWeighted[T](n: Long, costFn: T ⇒ Long) extends PushStage[T, T] {
   private var left = n
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -323,9 +323,10 @@ private[akka] final case class Limit[T](n: Long) extends PushStage[T, T] {
   private var left = n
 
   override def onPush(elem: T, ctx: Context[T]): SyncDirective = {
-    left -= 1
-    if (left >= 0) ctx.push(elem)
-    else ctx.fail(new StreamLimitReachedException(n))
+    if (left > 0) {
+      left -= 1
+      ctx.push(elem)
+    } else ctx.fail(new StreamLimitReachedException(n))
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -318,16 +318,14 @@ private[akka] final case class Grouped[T](n: Int) extends PushPullStage[T, immut
 /**
  * INTERNAL API
  */
+
 private[akka] final case class Limit[T](n: Int) extends PushStage[T, T] {
   private var left = n
 
   override def onPush(elem: T, ctx: Context[T]): SyncDirective = {
     left -= 1
     if (left >= 0) ctx.push(elem)
-    else {
-      if (ctx.isFinishing) ctx.push(elem)
-      else ctx.fail(new StreamLimitReachedException(n, s"limit of $n reached on this stream"))
-    }
+    else ctx.fail(new StreamLimitReachedException(n))
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -318,7 +318,7 @@ private[akka] final case class Grouped[T](n: Int) extends PushPullStage[T, immut
 /**
  * INTERNAL API
  */
-private[akka] final case class Limit[T](n: Int) extends PushPullStage[T, T] {
+private[akka] final case class Limit[T](n: Int) extends PushStage[T, T] {
   private var left = n
 
   override def onPush(elem: T, ctx: Context[T]): SyncDirective = {
@@ -326,12 +326,8 @@ private[akka] final case class Limit[T](n: Int) extends PushPullStage[T, T] {
     if (left >= 0) ctx.push(elem)
     else {
       if (ctx.isFinishing) ctx.push(elem)
-      else ctx.fail(new Exception("more elements not allowed"))
+      else ctx.fail(new StreamLimitReachedException(left, s"limit of $n reached on this stream"))
     }
-  }
-
-  override def onPull(ctx: Context[T]): SyncDirective = {
-    ctx.pull()
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -333,6 +333,20 @@ private[akka] final case class Limit[T](n: Long) extends PushStage[T, T] {
 /**
  * INTERNAL API
  */
+
+private[akka] final case class LimitWeighted[T](n: Long, costFn: T ⇒ Long) extends PushStage[T, T] {
+  private var left = n
+
+  override def onPush(elem: T, ctx: Context[T]): SyncDirective = {
+    left -= costFn(elem)
+    if (left >= 0) ctx.push(elem)
+    else ctx.fail(new StreamLimitReachedException(n))
+  }
+}
+
+/**
+ * INTERNAL API
+ */
 private[akka] final case class Sliding[T](n: Int, step: Int) extends PushPullStage[T, immutable.Seq[T]] {
   private var buf = Vector.empty[T]
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -318,6 +318,26 @@ private[akka] final case class Grouped[T](n: Int) extends PushPullStage[T, immut
 /**
  * INTERNAL API
  */
+private[akka] final case class Limit[T](n: Int) extends PushPullStage[T, T] {
+  private var left = n
+
+  override def onPush(elem: T, ctx: Context[T]): SyncDirective = {
+    left -= 1
+    if (left >= 0) ctx.push(elem)
+    else {
+      if (ctx.isFinishing) ctx.push(elem)
+      else ctx.fail(new Exception("more elements not allowed"))
+    }
+  }
+
+  override def onPull(ctx: Context[T]): SyncDirective = {
+    ctx.pull()
+  }
+}
+
+/**
+ * INTERNAL API
+ */
 private[akka] final case class Sliding[T](n: Int, step: Int) extends PushPullStage[T, immutable.Seq[T]] {
   private var buf = Vector.empty[T]
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -404,6 +404,11 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
     new Flow(delegate.grouped(n).map(_.asJava)) // TODO optimize to one step
 
   /**
+   * TODO: description
+   */
+  def limit(n: Int): javadsl.Flow[In, Out, Mat] = new Flow(delegate.limit(n))
+
+  /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group
    * possibly smaller than requested due to end-of-stream.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -404,9 +404,55 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
     new Flow(delegate.grouped(n).map(_.asJava)) // TODO optimize to one step
 
   /**
-   * TODO: description
+   * Ensure stream boundedness by limiting the number of elements from upstream.
+   * If the number of incoming elements exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
    */
-  def limit(n: Int): javadsl.Flow[In, Out, Mat] = new Flow(delegate.limit(n))
+  def limit(n: Long): javadsl.Flow[In, Out, Mat] = new Flow(delegate.limit(n))
+
+  /**
+   * Ensure stream boundedness by evaluating the cost of incoming elements
+   * using a cost function. Exactly how many elements will be allowed to travel downstream depends on the
+   * evaluated cost of each element. If the accumulated cost exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def limitWeighted(n: Long)(costFn: function.Function[Out, Long]): javadsl.Flow[In, Out, Mat] = {
+    new Flow(delegate.limitWeighted(n)(costFn.apply))
+  }
 
   /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group
@@ -620,6 +666,8 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * '''Completes when''' predicate returned false or upstream completes
    *
    * '''Cancels when''' predicate returned false or downstream cancels
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]]
    */
   def takeWhile(p: function.Predicate[Out]): javadsl.Flow[In, Out, Mat] = new Flow(delegate.takeWhile(p.test))
 
@@ -669,6 +717,8 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * '''Completes when''' the defined number of elements has been taken or upstream completes
    *
    * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]]
    */
   def take(n: Long): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.take(n))
@@ -689,6 +739,8 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * '''Completes when''' upstream completes or timer fires
    *
    * '''Cancels when''' downstream cancels or timer fires
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]]
    */
   def takeWithin(d: FiniteDuration): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.takeWithin(d))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -136,6 +136,19 @@ object Sink {
       _.map(akka.japi.Option.fromScalaOption)(ExecutionContexts.sameThreadExecutionContext)))
 
   /**
+   * A `Sink` that keeps on collecting incoming elements until upstream terminates.
+   * As upstream may be unbounded, `Flow[T].take` or the stricter ``Flow[T].limit` (and their variants)
+   * may be used to ensure boundedness.
+   * Materializes into a Future` of `Seq[T]` containing all the collected elements.
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def seq[In]: Sink[In, Future[java.util.List[In]]] = {
+    import scala.collection.JavaConverters._
+    new Sink(scaladsl.Sink.seq[In].mapMaterializedValue(fut ⇒ fut.map(sq ⇒ sq.asJava)(ExecutionContexts.sameThreadExecutionContext)))
+  }
+
+  /**
    * Sends the elements of the stream to the given `ActorRef`.
    * If the target actor terminates the stream will be canceled.
    * When the stream is completed successfully the given `onCompleteMessage`

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -812,9 +812,55 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
     new Source(delegate.grouped(n).map(_.asJava))
 
   /**
-   * TODO: description
+   * Ensure stream boundedness by limiting the number of elements from upstream.
+   * If the number of incoming elements exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
    */
   def limit(n: Int): javadsl.Source[Out, Mat] = new Source(delegate.limit(n))
+
+  /**
+   * Ensure stream boundedness by evaluating the cost of incoming elements
+   * using a cost function. Exactly how many elements will be allowed to travel downstream depends on the
+   * evaluated cost of each element. If the accumulated cost exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def limitWeighted(n: Long)(costFn: function.Function[Out, Long]): javadsl.Source[Out, Mat] = {
+    new Source(delegate.limitWeighted(n)(costFn.apply))
+  }
 
   /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -812,6 +812,11 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
     new Source(delegate.grouped(n).map(_.asJava))
 
   /**
+   * TODO: description
+   */
+  def limit(n: Int): javadsl.Source[Out, Mat] = new Source(delegate.limit(n))
+
+  /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group
    * possibly smaller than requested due to end-of-stream.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -266,6 +266,57 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
     new SubFlow(delegate.grouped(n).map(_.asJava)) // TODO optimize to one step
 
   /**
+   * Ensure stream boundedness by limiting the number of elements from upstream.
+   * If the number of incoming elements exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def limit(n: Long): javadsl.SubFlow[In, Out, Mat] = new SubFlow(delegate.limit(n))
+
+  /**
+   * Ensure stream boundedness by evaluating the cost of incoming elements
+   * using a cost function. Exactly how many elements will be allowed to travel downstream depends on the
+   * evaluated cost of each element. If the accumulated cost exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def limitWeighted(n: Long)(costFn: function.Function[Out, Long]): javadsl.SubFlow[In, Out, Mat] = {
+    new SubFlow(delegate.limitWeighted(n)(costFn.apply))
+  }
+
+  /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group
    * possibly smaller than requested due to end-of-stream.
    *
@@ -280,6 +331,7 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    *
    * '''Cancels when''' downstream cancels
    */
+
   def sliding(n: Int, step: Int = 1): SubFlow[In, java.util.List[Out @uncheckedVariance], Mat] =
     new SubFlow(delegate.sliding(n, step).map(_.asJava)) // TODO optimize to one step
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -278,6 +278,58 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    *
    * '''Cancels when''' downstream cancels
    */
+
+  /**
+   * Ensure stream boundedness by limiting the number of elements from upstream.
+   * If the number of incoming elements exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def limit(n: Int): javadsl.SubSource[Out, Mat] = new SubSource(delegate.limit(n))
+
+  /**
+   * Ensure stream boundedness by evaluating the cost of incoming elements
+   * using a cost function. Exactly how many elements will be allowed to travel downstream depends on the
+   * evaluated cost of each element. If the accumulated cost exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def limitWeighted(n: Long)(costFn: function.Function[Out, Long]): javadsl.SubSource[Out, Mat] = {
+    new SubSource(delegate.limitWeighted(n)(costFn.apply))
+  }
+
   def sliding(n: Int, step: Int = 1): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
     new SubSource(delegate.sliding(n, step).map(_.asJava)) // TODO optimize to one step
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -576,7 +576,7 @@ trait FlowOps[+Out, +Mat] {
   /**
    * TODO: description
    */
-  def limit[T](n: Int): Repr[Out, Mat] = andThen(Limit(n))
+  def limit[T](n: Long): Repr[Out, Mat] = andThen(Limit(n))
 
   /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -576,7 +576,7 @@ trait FlowOps[+Out, +Mat] {
   /**
    * TODO: description (Add a see also: take(n))
    */
-  def limit(n: Long): Repr[Out, Mat] = andThen(LimitWeighted(n, { _ ⇒ 1 }))
+  def limit(n: Long): Repr[Out, Mat] = limitWeighted(n)(_ ⇒ 1)
 
   def limitWeighted[T](n: Long)(costFn: Out ⇒ Long): Repr[Out, Mat] = andThen(LimitWeighted(n, costFn))
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -574,6 +574,11 @@ trait FlowOps[+Out, +Mat] {
   def grouped(n: Int): Repr[immutable.Seq[Out]] = andThen(Grouped(n))
 
   /**
+   * TODO: description
+   */
+  def limit[T](n: Int): Repr[Out, Mat] = andThen(Limit(n))
+
+  /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group
    * possibly smaller than requested due to end-of-stream.
    *
@@ -811,8 +816,6 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels or timer fires
    */
   def takeWithin(d: FiniteDuration): Repr[Out] = via(new TakeWithin[Out](d).withAttributes(name("takeWithin")))
-
-  def limit[T](max: Int): Repr[Out, Mat] = ??? // TODO
 
   /**
    * Allows a faster upstream to progress independently of a slower subscriber by conflating elements into a summary

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -576,7 +576,9 @@ trait FlowOps[+Out, +Mat] {
   /**
    * TODO: description (Add a see also: take(n))
    */
-  def limit[T](n: Long): Repr[Out, Mat] = andThen(Limit(n))
+  def limit(n: Long): Repr[Out, Mat] = andThen(LimitWeighted(n, { _ ⇒ 1 }))
+
+  def limitWeighted[T](n: Long)(costFn: Out ⇒ Long): Repr[Out, Mat] = andThen(LimitWeighted(n, costFn))
 
   /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -812,6 +812,8 @@ trait FlowOps[+Out, +Mat] {
    */
   def takeWithin(d: FiniteDuration): Repr[Out] = via(new TakeWithin[Out](d).withAttributes(name("takeWithin")))
 
+  def limit[T](max: Int): Repr[Out, Mat] = ??? // TODO
+
   /**
    * Allows a faster upstream to progress independently of a slower subscriber by conflating elements into a summary
    * until the subscriber is ready to accept them. For example a conflate step might average incoming numbers if the

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -525,6 +525,8 @@ trait FlowOps[+Out, +Mat] {
    * '''Completes when''' predicate returned false or upstream completes
    *
    * '''Cancels when''' predicate returned false or downstream cancels
+   *
+   * See also [[FlowOps.limit]], [[FlowOps.limitWeighted]]
    */
   def takeWhile(p: Out ⇒ Boolean): Repr[Out] = andThen(TakeWhile(p))
 
@@ -574,11 +576,53 @@ trait FlowOps[+Out, +Mat] {
   def grouped(n: Int): Repr[immutable.Seq[Out]] = andThen(Grouped(n))
 
   /**
-   * TODO: description (Add a see also: take(n))
+   * Ensure stream boundedness by limiting the number of elements from upstream.
+   * If the number of incoming elements exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[FlowOps.take]], [[FlowOps.takeWithin]], [[FlowOps.takeWhile]]
    */
-  def limit(n: Long): Repr[Out, Mat] = limitWeighted(n)(_ ⇒ 1)
+  def limit(max: Long): Repr[Out] = limitWeighted(max)(_ ⇒ 1)
 
-  def limitWeighted[T](n: Long)(costFn: Out ⇒ Long): Repr[Out, Mat] = andThen(LimitWeighted(n, costFn))
+  /**
+   * Ensure stream boundedness by evaluating the cost of incoming elements
+   * using a cost function. Exactly how many elements will be allowed to travel downstream depends on the
+   * evaluated cost of each element. If the accumulated cost exceeds max, it will signal
+   * upstream failure `StreamLimitException` downstream.
+   *
+   * Due to input buffering some elements may have been
+   * requested from upstream publishers that will then not be processed downstream
+   * of this step.
+   *
+   * The stream will be completed without producing any elements if `n` is zero
+   * or negative.
+   *
+   * '''Emits when''' the specified number of elements to take has not yet been reached
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' the defined number of elements has been taken or upstream completes
+   *
+   * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[FlowOps.take]], [[FlowOps.takeWithin]], [[FlowOps.takeWhile]]
+   */
+  def limitWeighted[T](max: Long)(costFn: Out ⇒ Long): Repr[Out] = andThen(LimitWeighted(max, costFn))
 
   /**
    * Apply a sliding window over the stream and return the windows as groups of elements, with the last group
@@ -797,6 +841,8 @@ trait FlowOps[+Out, +Mat] {
    * '''Completes when''' the defined number of elements has been taken or upstream completes
    *
    * '''Cancels when''' the defined number of elements has been taken or downstream cancels
+   *
+   * See also [[FlowOps.limit]], [[FlowOps.limitWeighted]]
    */
   def take(n: Long): Repr[Out] = andThen(Take(n))
 
@@ -837,6 +883,8 @@ trait FlowOps[+Out, +Mat] {
    *
    * @param seed Provides the first state for a conflated value using the first unconsumed element as a start
    * @param aggregate Takes the currently aggregated value and the current pending element to produce a new aggregate
+   *
+   * See also [[FlowOps.limit]], [[FlowOps.limitWeighted]]
    */
   def conflate[S](seed: Out ⇒ S)(aggregate: (S, Out) ⇒ S): Repr[S] = andThen(Conflate(seed, aggregate))
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -574,7 +574,7 @@ trait FlowOps[+Out, +Mat] {
   def grouped(n: Int): Repr[immutable.Seq[Out]] = andThen(Grouped(n))
 
   /**
-   * TODO: description
+   * TODO: description (Add a see also: take(n))
    */
   def limit[T](n: Long): Repr[Out, Mat] = andThen(Limit(n))
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -118,8 +118,12 @@ object Sink {
   def lastOption[T]: Sink[T, Future[Option[T]]] = Sink.fromGraph(new LastOptionStage[T]).withAttributes(DefaultAttributes.lastOptionSink)
 
   /**
-   * TODO: document usage
+   * A `Sink` that keeps on collecting incoming elements until upstream terminates.
+   * As upstream may be unbounded, `Flow[T].take` or the stricter ``Flow[T].limit` (and their variants)
+   * may be used to ensure boundedness.
+   * Materializes into a Future` of `Seq[T]` containing all the collected elements.
    *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
    */
   def seq[T]: Sink[T, Future[Seq[T]]] = {
     Flow[T].grouped(Integer.MAX_VALUE).toMat(Sink.headOption)(Keep.right) mapMaterializedValue { e ⇒

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -121,7 +121,7 @@ object Sink {
    * TODO: document usage
    *
    */
-  def toSeq[T]: Sink[T, Future[Seq[T]]] = {
+  def seq[T]: Sink[T, Future[Seq[T]]] = {
     Flow[T].grouped(Integer.MAX_VALUE).toMat(Sink.headOption)(Keep.right) mapMaterializedValue { e ⇒
       e.map(_.getOrElse(Seq.empty[T]))(ExecutionContexts.sameThreadExecutionContext)
     }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -118,6 +118,16 @@ object Sink {
   def lastOption[T]: Sink[T, Future[Option[T]]] = Sink.fromGraph(new LastOptionStage[T]).withAttributes(DefaultAttributes.lastOptionSink)
 
   /**
+   * TODO: document usage
+   *
+   */
+  def toSeq[T]: Sink[T, Future[Seq[T]]] = {
+    Flow[T].grouped(Integer.MAX_VALUE).toMat(Sink.headOption)(Keep.right) mapMaterializedValue { e ⇒
+      e.map(_.getOrElse(Seq.empty[T]))(ExecutionContexts.sameThreadExecutionContext)
+    }
+  }
+
+  /**
    * A `Sink` that materializes into a [[org.reactivestreams.Publisher]].
    *
    * If `fanout` is `true`, the materialized `Publisher` will support multiple `Subscriber`s and


### PR DESCRIPTION
See https://github.com/akka/akka/issues/18921

Two talking points about `toSeq[T]` (I have yet to implement `limit`):
1. `grouped(MAX_INT)` and `Sink.headOption` is used to collect and map the result to `Seq[T]`. An alternative implementation I can think of is to implement a separate stage e.g. `ToSeqStage` if the former approach is "less preferred".
2. I wonder if it is wise to use `ExecutionContexts.sameThreadExecutionContext` as I do here.

This seems like quite a rough, early-stage PR, so feel free to beat the hell out of it.
