### PR TITLE
=doc #18972 fix typo in docs on oauth2

### DIFF
--- a/akka-docs-dev/rst/java/http/routing-dsl/request-vals/oauth2-authenticator.rst
+++ b/akka-docs-dev/rst/java/http/routing-dsl/request-vals/oauth2-authenticator.rst
@@ -12,7 +12,7 @@ about OAuth 2 Bearer Token see `RFC6750`_.
 
 .. _RFC6750: https://tools.ietf.org/html/rfc6750
 
-To use it you subclass ``OAutht2Authenticator`` and implement the ``authenticate`` method
+To use it you subclass ``OAuth2Authenticator`` and implement the ``authenticate`` method
 to provide your own logic which verifies the OAuth2 credentials. When verification is done
 the request can either be refused by returning the return value of ``refuseAccess()`` or completed
 with an object that is application specific by returning the return value of ``authenticateAs(T)``.


### PR DESCRIPTION
Resolves typo from https://github.com/akka/akka/pull/18972#discussion_r45414443
