### PR TITLE
=htc add test to verify URI against a very long path

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -609,5 +609,11 @@ class UriSpec extends WordSpec with Matchers {
       Uri("http://example.com/foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString === "/foo/bar?query=1"
       Uri("http://example.com//foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString === "//foo/bar?query=1"
     }
+
+    "survive parsing a URI with thousands of path segments" in {
+      val slashes = "/a/" * 2000
+      val uri = Uri(s"http://foo.bar/$slashes")
+      uri.toString // was reported to throw StackOverflowException in Spray's URI
+    }
   }
 }


### PR DESCRIPTION
Was reported in Spray gitter channel, spray's URI throws an StackOverflowException for such URI.
Adding the test to make our URI survives it (it does), and that it stays this way.
