### PR TITLE
Fixes minor documentation issue

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -799,6 +799,8 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * '''Completes when''' upstream completes
    *
    * '''Cancels when''' downstream cancels and substreams cancel
+    *
+   * See also [[Flow.splitAfter]].
    */
   def splitWhen(p: function.Predicate[Out]): javadsl.Flow[In, Source[Out, Unit], Mat] =
     new Flow(delegate.splitWhen(p.test).map(_.asJava))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -957,6 +957,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels and substreams cancel
    *
+   * See also [[FlowOps.splitAfter]].
    */
   def splitWhen[U >: Out](p: Out ⇒ Boolean): Repr[Source[U, Unit], Mat] =
     deprecatedAndThen(Split.when(p.asInstanceOf[Any ⇒ Boolean]))
@@ -991,7 +992,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels and substreams cancel
    *
-   * See also [[FlowOps.splitAfter]].
+   * See also [[FlowOps.splitWhen]].
    */
   def splitAfter[U >: Out](p: Out ⇒ Boolean): Repr[Source[U, Unit], Mat] =
     deprecatedAndThen(Split.after(p.asInstanceOf[Any ⇒ Boolean]))


### PR DESCRIPTION
FlowOps.splitAfter seeAlso FlowOps.splitAfter seeAlso FlowOps.splitAfter etc.
