### PR TITLE
PFBuilder matchAny should take declared input type I, not Object

### DIFF
--- a/akka-actor-tests/src/test/java/akka/japi/PFBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/PFBuilderTest.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.japi;
+
+import org.junit.Test;
+import scala.PartialFunction;
+
+import static org.junit.Assert.*;
+
+public class MatchBuilderTest {
+  @Test
+  public void pfbuilder_matchAny_should_infer_declared_input_type_for_lambda() {
+    PartialFunction<String,Integer> pf = new PFBuilder<String,Integer>()
+      .matchEquals("hello", () -> 1)
+      .matchAny(s -> Integer.valueOf(s))
+      .build();
+      
+    assertTrue(pf.isDefinedAt("hello"));
+    assertTrue(pf.isDefinedAt("42"));
+    assertEquals(42, pf.apply("42"));
+  }
+}

--- a/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
@@ -89,11 +89,11 @@ public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
    * @param apply  an action to apply to the argument
    * @return       a builder with the case statement added
    */
-  public PFBuilder<I, R> matchAny(final FI.Apply<Object, R> apply) {
-    addStatement(new CaseStatement<I, Object, R>(
+  public PFBuilder<I, R> matchAny(final FI.Apply<I, R> apply) {
+    addStatement(new CaseStatement<I, I, R>(
       new FI.Predicate() {
         @Override
-        public boolean defined(Object o) {
+        public boolean defined(I o) {
           return true;
         }
       }, apply));


### PR DESCRIPTION
Currently PFBuilder.matchAny takes a lambda with Object as input argument.
This loses type information for partial functions that are not akka
receive functions, e.g. exception handlers (PF<Exception,RouteResult).
With this change, the fallback handler still has the guaranteed type I
visible on its lambda.
