### PR TITLE
PFBuilder matchAny should take declared input type I

### DIFF
--- a/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.japi.pf;
+
+import org.junit.Test;
+import scala.PartialFunction;
+
+import static org.junit.Assert.*;
+
+public class PFBuilderTest {
+  @Test
+  public void pfbuilder_matchAny_should_infer_declared_input_type_for_lambda() {
+    PartialFunction<String,Integer> pf = new PFBuilder<String,Integer>()
+      .matchEquals("hello", s -> 1)
+      .matchAny(s -> Integer.valueOf(s))
+      .build();
+      
+    assertTrue(pf.isDefinedAt("hello"));
+    assertTrue(pf.isDefinedAt("42"));
+    assertEquals(42, pf.apply("42").intValue());
+  }
+}

--- a/akka-actor/src/main/java/akka/japi/pf/DeciderBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/DeciderBuilder.java
@@ -65,7 +65,7 @@ public class DeciderBuilder {
    * @param apply      an action to apply to the argument
    * @return           a builder with the case statement added
    */
-  public static PFBuilder<Throwable, Directive> matchAny(FI.Apply<Object, Directive> apply) {
+  public static PFBuilder<Throwable, Directive> matchAny(FI.Apply<Throwable, Directive> apply) {
     return Match.matchAny(apply);
   }
 }

--- a/akka-actor/src/main/java/akka/japi/pf/Match.java
+++ b/akka-actor/src/main/java/akka/japi/pf/Match.java
@@ -70,7 +70,7 @@ public class Match<I, R> extends AbstractMatch<I, R> {
    * @return a builder with the case statement added
    * @see PFBuilder#matchAny(FI.Apply)
    */
-  public static <F, T> PFBuilder<F, T> matchAny(final FI.Apply<Object, T> apply) {
+  public static <F, T> PFBuilder<F, T> matchAny(final FI.Apply<F, T> apply) {
     return new PFBuilder<F, T>().matchAny(apply);
   }
 

--- a/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
@@ -94,8 +94,8 @@ public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
    * @param apply an action to apply to the argument
    * @return a builder with the case statement added
    */
-  public PFBuilder<I, R> matchAny(final FI.Apply<Object, R> apply) {
-    addStatement(new CaseStatement<I, Object, R>(
+  public PFBuilder<I, R> matchAny(final FI.Apply<I, R> apply) {
+    addStatement(new CaseStatement<I, I, R>(
       new FI.Predicate() {
         @Override
         public boolean defined(Object o) {


### PR DESCRIPTION
Currently PFBuilder.matchAny takes a lambda with Object as input argument.
This loses type information for partial functions that are not akka
receive functions, e.g. exception handlers (PF<Exception,RouteResult).
With this change, the fallback handler still has the guaranteed type I
visible on its lambda.

Fixes https://github.com/akka/akka/issues/18996 .
