### PR TITLE
Add snapshot-store.plugin config to 2.3-2.4 migration docs

### DIFF
--- a/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.3.x-2.4.x.rst
@@ -477,6 +477,13 @@ max-message-batch-size config
 Configuration property ``akka.persistence.journal.max-message-batch-size`` has been moved into the plugin configuration
 section, to allow different values for different journal plugins. See ``reference.conf``.
 
+akka.persistence.snapshot-store.plugin config
+---------------------------------------------
+
+The configuration property ``akka.persistence.snapshot-store.plugin`` now by default is empty. To restore the previous
+setting add ``akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"`` to your application.conf.
+See ``reference.conf``.
+
 PersistentView is deprecated
 ----------------------------
 


### PR DESCRIPTION
In 2.3.x the reference.conf of akka-persistence contained `akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"`, now it's empty. Mentions this in the migration guide.
