### PR TITLE
=act #19016 use the BackoffSupervisor as sender for parent msg

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
@@ -148,8 +148,8 @@ object BackoffSupervisor {
  * message to this actor and it will reply with [[akka.pattern.BackoffSupervisor.CurrentChild]]
  * containing the `ActorRef` of the current child, if any.
  *
- * The `BackoffSupervisor` forwards all messages from the child to the parent of the
- * `BackoffSupervisor`.
+ * The `BackoffSupervisor`delegates all messages from the child to the parent of the
+ * `BackoffSupervisor`, with the supervisor as sender.
  *
  * The `BackoffSupervisor` forwards all other messages to the child, if it is currently running.
  *
@@ -211,7 +211,8 @@ final class BackoffSupervisor(
       sender() ! CurrentChild(child)
 
     case msg if child.contains(sender()) ⇒
-      context.parent.forward(msg)
+      // use the BackoffSupervisor as sender
+      context.parent ! msg
 
     case msg ⇒ child match {
       case Some(c) ⇒ c.forward(msg)

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/TransparentExponentialBackoffSupervisor.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/TransparentExponentialBackoffSupervisor.scala
@@ -195,7 +195,8 @@ class TransparentExponentialBackoffSupervisor(
       log.debug(s"Terminating, because child [$childRef] terminated itself")
       stop(self)
     case msg if sender() == childRef ⇒
-      parent.forward(msg)
+      // use the supervisor as sender
+      context.parent ! msg
     case msg ⇒
       childRef.forward(msg)
   }


### PR DESCRIPTION
Intermediate fix for using BackoffSupervisor with sharding passivation. I'm short of time and therefore no tests. WIll not close the ticket until tests are added or another solution implemented.

Nevertheless this is more correct than the previous forward, since the child ref should not really be exposed to the outside when using BackoffSupervisor.

As far as I can see this should at least work with Cluster Sharding passivation when using PoisonPill as stop message.
