### PR TITLE
[WIP] =htc #19050 reusable http blueprint: attribute injected rem-addr

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.impl.engine.server
+
+import java.net.InetSocketAddress
+
+import akka.stream.Attributes
+
+/**
+ * INTERNAL API
+ * Internally used attributes set in the HTTP pipeline.
+ * May potentially be opened up in the future.
+ */
+private[akka] object HttpAttributes {
+  import Attributes._
+
+  private[akka] final case class RemoteAddress(address: Option[InetSocketAddress]) extends Attribute
+
+  private[akka] def remoteAddress(address: Option[InetSocketAddress]) =
+    Attributes(RemoteAddress(address))
+
+}

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -73,6 +73,16 @@ abstract class SinkStage[In, M](name: String) extends GraphStageWithMaterialized
   override val shape: SinkShape[In] = SinkShape(in)
 }
 
+/**
+ * A FlowStage represents a reusable graph stream processing stage. A FlowStage consists of a [[akka.stream.Shape]] which describes
+ * its input and output ports.
+ */
+abstract class FlowStage[In, Out, M](name: String) extends GraphStageWithMaterializedValue[FlowShape[In, Out], M] {
+  val in: Inlet[In] = Inlet[In](name + ".in")
+  val out: Outlet[Out] = Outlet[Out](name + ".out")
+  override val shape: FlowShape[In, Out] = FlowShape(in, out)
+}
+
 private object TimerMessages {
   final case class Scheduled(timerKey: Any, timerId: Int, repeating: Boolean) extends DeadLetterSuppression
   final case class Timer(id: Int, task: Cancellable)


### PR DESCRIPTION
Moves the remote address injection to Attributes, which allows that part of the HTTP blueprint to become reusable. Need to decide if/how we expose this stage. May be useful enough to include on FlowOps I think actually.

Addresses point two of: https://github.com/akka/akka/issues/19050
