### PR TITLE
+htc,tes #18563 move scripts autobahn jenkins scripts to project

### DIFF
--- a/akka-http-core/src/test/scripts/autobahn-jenkins/step-1-client-tests.sh
+++ b/akka-http-core/src/test/scripts/autobahn-jenkins/step-1-client-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+### CLIENT TESTS ###
+
+CLIENT_CID=autobahn-client.cid
+
+echo "~~~ Docker state before running CLIENT tests ~~~"
+listeners=docker ps | grep '8080->8080' | wc -l
+if [ "$listeners" == "0" ]; then
+  echo "Docker state OK..."
+else
+  for id in $(docker ps -q); do
+    docker kill $id;
+  done
+fi
+
+## RUN CLIENT-SIDE TEST SERVER ##
+# TODO technically should be possible to -v mount the reports instead (unsure on directory though)
+#      this would spare us step-3
+rm -f $CLIENT_CID
+docker run -d --cidfile=$CLIENT_CID \
+           -p 8080:8080 -p 9001:9001 \
+           jrudolph/autobahn-testsuite

--- a/akka-http-core/src/test/scripts/autobahn-jenkins/step-2-run-sbt-client.sh
+++ b/akka-http-core/src/test/scripts/autobahn-jenkins/step-2-run-sbt-client.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+## MOCK, use jenkins to run:
+# 'akka-http-core-experimental/test:run-main akka.http.impl.engine.ws.WSClientAutobahnTest'

--- a/akka-http-core/src/test/scripts/autobahn-jenkins/step-3-download-client-test-results.sh
+++ b/akka-http-core/src/test/scripts/autobahn-jenkins/step-3-download-client-test-results.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# "download" [client] results from docker container
+
+rm -rf localhost\:8080/
+echo "Downloading client results report..."
+wget --recursive --quiet --page-requisites --html-extension \
+     --convert-links --domains localhost --no-parent \
+     --directory-prefix=client/ \
+     http://localhost:8080/cwd/reports/clients/index.html
+
+rm -f client/index.json*
+wget --quiet --directory-prefix=client/ \
+     http://localhost:8080/cwd/reports/clients/index.json

--- a/akka-http-core/src/test/scripts/autobahn-jenkins/step-4-stop-client-tests-server.sh
+++ b/akka-http-core/src/test/scripts/autobahn-jenkins/step-4-stop-client-tests-server.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# STOP TEST SERVER (CLIENT TESTS)
+docker stop $(cat autobahn-client.cid)
+rm -f autobahn-client.cid

--- a/akka-http-core/src/test/scripts/autobahn-jenkins/step-5-server-tests-all.sh
+++ b/akka-http-core/src/test/scripts/autobahn-jenkins/step-5-server-tests-all.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+### SERVER TESTS ###
+
+## RUN AKKA WS-ECHO SERVER ##
+# sadly hardcoded here, we must do much more than just "run sbt", thus running manually
+SBT_JAR=/usr/share/sbt-launcher-packaging/bin/sbt-launch.jar # this jar is "sbt-latest-deb" (from the apt package)
+SBT_OPTS="-Dsbt.ivy.home=/localhome/jenkinsakka/.ivy2 -Dsbt.override.repos=false"
+
+# warning, bash magic – the parens are important, they cause the background process to be executed in a sub shell
+# and only thanks to that, will it not be forced into [Stopped] state, as bash thinks sbt is awaiting on some input
+# and then decides to stop it (instead of keep it running). Keeping it in a sub shell, keeps it running.
+TEST_CLASS=akka.http.impl.engine.ws.WSServerAutobahnTest
+(java $SBT_OPTS -Dakka.ws-mode=sleep -Dakka.ws-host=127.0.0.1 -jar $SBT_JAR "akka-http-core-experimental/test:run-main $TEST_CLASS" | tee output &)
+
+# because of the sub-shell $! is not reported, we need to find the PID some other way:
+SUB_PID=$(jps -mlV | grep $TEST_CLASS | awk '{print $1}') # the PID of JVM
+
+
+## PREPARE TCK ##
+echo "~~~ Docker state before running SERVER tests ~~~"
+listeners=docker ps | grep '8080->8080' | wc -l
+if [ "$listeners" == "0" ]; then
+  echo "Docker state OK..."
+else
+  for id in $(docker ps -q); do
+    docker kill $id;
+  done
+fi
+
+
+## AWAIT ON SERVER INIT ##
+# we need to wait for the server to start (compilation may happen etc, it may take time)
+set +x
+echo "Awaiting server startup before running tests"
+while [ "$(grep 'akka.http.impl.engine.ws.WSServerAutobahnTest' output | wc -l)" == "0" ];
+do
+  sleep 5
+  echo -n '.';
+done
+set -x
+
+# we need to configure the test-client to hit 127.0.0.1 (this works, even from within the container, see below)
+echo '{
+  "outdir": "/tmp/server-report",
+  "servers": [
+    {
+      "agent": "AutobahnPython",
+      "url": "ws://127.0.0.1:9001"
+    }
+  ],
+  "cases": ["*"],
+  "exclude-cases": [],
+  "exclude-agent-cases": {}
+}' > /tmp/fuzzingclient.json
+
+## RUN TESTS ##
+# net=host allows treating localhost in the container as-if the "hosts"
+docker run --net=host \
+           --rm=true \
+           -v /tmp/fuzzingclient.json:/tmp/fuzzingclient.json \
+           -v `pwd`/server-reports:/tmp/server-report \
+           jrudolph/autobahn-testsuite-client
+
+# reports are automatically put to `pwd`/reports, we expose them in jenkins
+
+# okey, time to shut down the server
+kill -9 $SUB_PID

--- a/akka-http-core/src/test/scripts/autobahn-jenkins/step-6-collect-results.sh
+++ b/akka-http-core/src/test/scripts/autobahn-jenkins/step-6-collect-results.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set +x
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# FAIL IF CLIENT TESTS FAILED
+# one is there because of the example column
+client_errors=$(cat client/index.json | grep --ignore-case -n -B1 -A3 '"behavior": "fail' || true) # or true, in order to not fail the build if grep finds no lines
+if [ "$(echo $client_errors | wc -c)" -gt "1" ];
+then
+  echo -e "${RED}[FAILED] WebSocket Client tests failed! See report (you can find it on the left-hand side panel on Jenkins). ${NC}"
+  echo -e "${RED}[FAILED] Client tests report available: https://jenkins.akka.io:8498/job/akka-http-websockets/$BUILD_NUMBER/Autobahn_TCK_%E2%80%93_WebSocket_Client/  ${NC}"
+  echo -e "${RED}[FAILED] Summary:"
+  echo -e "$(cat client/index.json | grep --ignore-case -n -B1 -A3 '"behavior": "fail')"
+  echo -e "${NC}"
+  exit -1
+else
+  echo -e "${GREEN}[PASSED] WebSocket Client tests passed...${NC}"
+fi
+
+
+# FAIL IF SERVER TESTS FAILED
+server_errors=$(cat reports/index.json | grep --ignore-case -n -B1 -A3 '"behavior": "fail' || true) # or true, in order to not fail the build if grep finds no lines
+if [ "$(echo $server_errors | wc -c)" -gt "1" ];
+then
+  echo -e "${RED}[FAILED] WebSocket Server tests failed! See report (you can find it on the left-hand side panel on Jenkins). ${NC}"
+  echo -e "${RED}[FAILED] Server tests report available: https://jenkins.akka.io:8498/job/akka-http-websockets/$BUILD_NUMBER/Autobahn_TCK_%E2%80%93_WebSocket_Server/ ${NC}"
+  echo -e "${RED}[FAILED] Summary:"
+  echo -e "$(cat reports/index.json | grep --ignore-case -n -B1 -A3 '"behavior": "fail')"
+  echo -e "${NC}"
+  exit -1
+else
+  echo -e "${GREEN}[PASSED] WebSocket Server tests passed...${NC}"
+fi
+
+set -x


### PR DESCRIPTION
This resolves #18563 by moving the scripts that make it work, to the repo itself, so it's easier to maintain (than in jenkins in the script windows).
