### PR TITLE
+ act #17895 bump the arity of debug,info,error,warning up to 10

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -924,6 +924,36 @@ trait LoggingAdapter {
    * @see [[LoggingAdapter]]
    */
   def error(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = { if (isErrorEnabled) notifyError(cause, format(template, arg1, arg2, arg3, arg4)) }
+  /**
+   * Message template with 5 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any): Unit = { if (isErrorEnabled) notifyError(cause, format(template, arg1, arg2, arg3, arg4, arg5)) }
+  /**
+   * Message template with 6 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any): Unit = { if (isErrorEnabled) notifyError(cause, format(template, arg1, arg2, arg3, arg4, arg5, arg6)) }
+  /**
+   * Message template with 7 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any): Unit = { if (isErrorEnabled) notifyError(cause, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
+  /**
+   * Message template with 8 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any): Unit = { if (isErrorEnabled) notifyError(cause, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
+  /**
+   * Message template with 9 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any): Unit = { if (isErrorEnabled) notifyError(cause, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
+  /**
+   * Message template with 10 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any, arg10: Any): Unit = { if (isErrorEnabled) notifyError(cause, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)) }
 
   /**
    * Log message at error level, without providing the exception that caused the error.
@@ -950,6 +980,36 @@ trait LoggingAdapter {
    * @see [[LoggingAdapter]]
    */
   def error(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = { if (isErrorEnabled) notifyError(format(template, arg1, arg2, arg3, arg4)) }
+  /**
+   * Message template with 5 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any): Unit = { if (isErrorEnabled) notifyError(format(template, arg1, arg2, arg3, arg4, arg5)) }
+  /**
+   * Message template with 6 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any): Unit = { if (isErrorEnabled) notifyError(format(template, arg1, arg2, arg3, arg4, arg5, arg6)) }
+  /**
+   * Message template with 7 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any): Unit = { if (isErrorEnabled) notifyError(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
+  /**
+   * Message template with 8 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any): Unit = { if (isErrorEnabled) notifyError(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
+  /**
+   * Message template with 9 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any): Unit = { if (isErrorEnabled) notifyError(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
+  /**
+   * Message template with 10 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def error(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any, arg10: Any): Unit = { if (isErrorEnabled) notifyError(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)) }
 
   /**
    * Log message at warning level.
@@ -976,6 +1036,36 @@ trait LoggingAdapter {
    * @see [[LoggingAdapter]]
    */
   def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = { if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4)) }
+  /**
+   * Message template with 5 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any): Unit = { if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4, arg5)) }
+  /**
+   * Message template with 6 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any): Unit = { if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4, arg5, arg6)) }
+  /**
+   * Message template with 7 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any): Unit = { if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
+  /**
+   * Message template with 8 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any): Unit = { if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
+  /**
+   * Message template with 9 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any): Unit = { if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
+  /**
+   * Message template with 10 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any, arg10: Any): Unit = { if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)) }
 
   /**
    * Log message at info level.
@@ -1002,6 +1092,36 @@ trait LoggingAdapter {
    * @see [[LoggingAdapter]]
    */
   def info(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = { if (isInfoEnabled) notifyInfo(format(template, arg1, arg2, arg3, arg4)) }
+  /**
+   * Message template with 5 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def info(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any): Unit = { if (isInfoEnabled) notifyInfo(format(template, arg1, arg2, arg3, arg4, arg5)) }
+  /**
+   * Message template with 6 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def info(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any): Unit = { if (isInfoEnabled) notifyInfo(format(template, arg1, arg2, arg3, arg4, arg5, arg6)) }
+  /**
+   * Message template with 7 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def info(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any): Unit = { if (isInfoEnabled) notifyInfo(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
+  /**
+   * Message template with 8 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def info(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any): Unit = { if (isInfoEnabled) notifyInfo(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
+  /**
+   * Message template with 9 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def info(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any): Unit = { if (isInfoEnabled) notifyInfo(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
+  /**
+   * Message template with 10 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def info(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any, arg10: Any): Unit = { if (isInfoEnabled) notifyInfo(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)) }
 
   /**
    * Log message at debug level.
@@ -1028,6 +1148,36 @@ trait LoggingAdapter {
    * @see [[LoggingAdapter]]
    */
   def debug(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = { if (isDebugEnabled) notifyDebug(format(template, arg1, arg2, arg3, arg4)) }
+  /**
+   * Message template with 5 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def debug(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any): Unit = { if (isDebugEnabled) notifyDebug(format(template, arg1, arg2, arg3, arg4, arg5)) }
+  /**
+   * Message template with 6 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def debug(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any): Unit = { if (isDebugEnabled) notifyDebug(format(template, arg1, arg2, arg3, arg4, arg5, arg6)) }
+  /**
+   * Message template with 7 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def debug(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any): Unit = { if (isDebugEnabled) notifyDebug(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
+  /**
+   * Message template with 8 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def debug(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any): Unit = { if (isDebugEnabled) notifyDebug(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
+  /**
+   * Message template with 9 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def debug(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any): Unit = { if (isDebugEnabled) notifyDebug(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
+  /**
+   * Message template with 10 replacement arguments.
+   * @see [[LoggingAdapter]]
+   */
+  def debug(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any, arg10: Any): Unit = { if (isDebugEnabled) notifyDebug(format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)) }
 
   /**
    * Log message at the specified log level.
@@ -1049,6 +1199,30 @@ trait LoggingAdapter {
    * Message template with 4 replacement arguments.
    */
   def log(level: Logging.LogLevel, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = { if (isEnabled(level)) notifyLog(level, format(template, arg1, arg2, arg3, arg4)) }
+  /**
+   * Message template with 5 replacement arguments.
+   */
+  def log(level: Logging.LogLevel, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any): Unit = { if (isEnabled(level)) notifyLog(level, format(template, arg1, arg2, arg3, arg4, arg5)) }
+  /**
+   * Message template with 6 replacement arguments.
+   */
+  def log(level: Logging.LogLevel, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any): Unit = { if (isEnabled(level)) notifyLog(level, format(template, arg1, arg2, arg3, arg4, arg5, arg6)) }
+  /**
+   * Message template with 7 replacement arguments.
+   */
+  def log(level: Logging.LogLevel, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any): Unit = { if (isEnabled(level)) notifyLog(level, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7)) }
+  /**
+   * Message template with 8 replacement arguments.
+   */
+  def log(level: Logging.LogLevel, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any): Unit = { if (isEnabled(level)) notifyLog(level, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)) }
+  /**
+   * Message template with 9 replacement arguments.
+   */
+  def log(level: Logging.LogLevel, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any): Unit = { if (isEnabled(level)) notifyLog(level, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)) }
+  /**
+   * Message template with 10 replacement arguments.
+   */
+  def log(level: Logging.LogLevel, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any, arg7: Any, arg8: Any, arg9: Any, arg10: Any): Unit = { if (isEnabled(level)) notifyLog(level, format(template, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)) }
 
   /**
    * @return true if the specified log level is enabled


### PR DESCRIPTION
cause the first attack by https://github.com/akka/akka/pull/18803 is closed by BC,and I want the feature really,so I open up this one.

only bump the arity up to 10,which is OK I think,so not bump that to more like 22.the more one could comes in later major release.

I think this will not cause any binary compatibility issue,not using the sbt-boilerplate here.
