### PR TITLE
+htc add `text/csv(UTF-8)` ContentType

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -105,6 +105,7 @@ object ContentTypes {
   val `text/plain(UTF-8)` = MediaTypes.`text/plain` withCharset HttpCharsets.`UTF-8`
   val `text/html(UTF-8)` = MediaTypes.`text/html` withCharset HttpCharsets.`UTF-8`
   val `text/xml(UTF-8)` = MediaTypes.`text/xml` withCharset HttpCharsets.`UTF-8`
+  val `text/csv(UTF-8)` = MediaTypes.`text/csv` withCharset HttpCharsets.`UTF-8`
 
   // used for explicitly suppressing the rendering of Content-Type headers on requests and responses
   val NoContentType = ContentType(MediaTypes.NoMediaType)


### PR DESCRIPTION
"CSV files considered the ultimate integration pattern" :wink:

Adding the ContentType here is useful when someone wants to render a raw response which we know is a csv (i.e. fed from a file)
