### PR TITLE
#18758 Send appropriate events on remote actor system shutdown and quarantine

### DIFF
--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -377,6 +377,9 @@ contains the addresses the remoting listens on.
 
 To be notified  when the remoting subsystem has been shut down, listen to ``RemotingShutdownEvent``.
 
+To be notified when the current system is quarantined by the remote system, listen to ``ThisActorSystemQuarantinedEvent``,
+which includes the addresses of local and remote ActorSystems.
+
 To intercept generic remoting related errors, listen to ``RemotingErrorEvent`` which holds the ``Throwable`` cause.
 
 Remote Security

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -379,6 +379,9 @@ holds the direction of the association (inbound or outbound), the addresses of t
 To be notified  when the remoting subsystem is ready to accept associations, listen to ``RemotingListenEvent`` which
 contains the addresses the remoting listens on.
 
+To be notified when the current system is quarantined by the remote system, listen to ``ThisActorSystemQuarantinedEvent``,
+which includes the addresses of local and remote ActorSystems.
+
 To be notified  when the remoting subsystem has been shut down, listen to ``RemotingShutdownEvent``.
 
 To intercept generic remoting related errors, listen to ``RemotingErrorEvent`` which holds the ``Throwable`` cause.

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
@@ -100,6 +100,7 @@ abstract class RemoteRestartedQuarantinedSpec
       runOn(second) {
         val addr = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
         val firstAddress = node(first).address
+        system.eventStream.subscribe(testActor, classOf[ThisActorSystemQuarantinedEvent])
 
         val (_, ref) = identifyWithUid(first, "subject")
 
@@ -112,6 +113,10 @@ abstract class RemoteRestartedQuarantinedSpec
               ref ! "boo!"
             }
           }
+        }
+
+        expectMsgPF(10 seconds) {
+          case ThisActorSystemQuarantinedEvent(local, remote) ⇒
         }
 
         enterBarrier("still-quarantined")

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -129,8 +129,11 @@ private[remote] final case class ShutDownAssociation(localAddress: Address, remo
 /**
  * INTERNAL API
  */
-@SerialVersionUID(1L)
-private[remote] final case class InvalidAssociation(localAddress: Address, remoteAddress: Address, cause: Throwable)
+@SerialVersionUID(2L)
+private[remote] final case class InvalidAssociation(localAddress: Address,
+                                                    remoteAddress: Address,
+                                                    cause: Throwable,
+                                                    disassociationInfo: Option[DisassociateInfo] = None)
   extends EndpointException("Invalid address: " + remoteAddress, cause) with AssociationProblem
 
 /**
@@ -1000,7 +1003,8 @@ private[remote] class EndpointReader(
         localAddress,
         remoteAddress,
         InvalidAssociationException("The remote system has quarantined this system. No further associations " +
-          "to the remote system are possible until this system is restarted."))
+          "to the remote system are possible until this system is restarted."),
+        Some(AssociationHandle.Quarantined))
   }
 
   private def deliverAndAck(): Unit = {

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -3,6 +3,7 @@
  */
 package akka.remote
 
+import akka.event.Logging.LogLevel
 import akka.event.{ LoggingAdapter, Logging }
 import akka.actor.{ ActorSystem, Address }
 
@@ -85,6 +86,12 @@ final case class QuarantinedEvent(address: Address, uid: Int) extends RemotingLi
     s"Association to [$address] having UID [$uid] is irrecoverably failed. UID is now quarantined and all " +
       "messages to this UID will be delivered to dead letters. Remote actorsystem must be restarted to recover " +
       "from this situation."
+}
+
+@SerialVersionUID(1L)
+final case class ThisActorSystemQuarantinedEvent(localAddress: Address, remoteAddress: Address) extends RemotingLifecycleEvent {
+  override def logLevel: LogLevel = Logging.WarningLevel
+  override val toString: String = s"The remote system ${remoteAddress} has quarantined this system ${localAddress}."
 }
 
 /**

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -591,7 +591,13 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[MissingMethodProblem]("akka.persistence.journal.ReplayFilter.this"),
         ProblemFilters.exclude[MissingMethodProblem]("akka.persistence.journal.AsyncWriteJournal.akka$persistence$journal$AsyncWriteJournal$_setter_$akka$persistence$journal$AsyncWriteJournal$$replayDebugEnabled_="),
         ProblemFilters.exclude[MissingMethodProblem]("akka.persistence.journal.AsyncWriteJournal.akka$persistence$journal$AsyncWriteJournal$$replayDebugEnabled"),
-        ProblemFilters.exclude[MissingMethodProblem]("akka.persistence.journal.ReplayFilter.props")
+        ProblemFilters.exclude[MissingMethodProblem]("akka.persistence.journal.ReplayFilter.props"),
+
+        // report invalid association events #18758
+        ProblemFilters.exclude[MissingTypesProblem]("akka.remote.InvalidAssociation$"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.remote.InvalidAssociation.apply"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.remote.InvalidAssociation.copy"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.remote.InvalidAssociation.this")
       )
     )
   }


### PR DESCRIPTION
Publish appropriate events to the current ActorSystem event stream upon remote ActorSystem shutdown or when current ActorSystem is quarantined by the remote ActorSystem.
