### PR TITLE
=str remove unneeded test marker

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -510,7 +510,7 @@ class TcpSpec extends AkkaSpec(
       Await.result(total, 3.seconds) should ===(1000)
     }
 
-    "xoxoxo shut down properly even if some accepted connection Flows have not been subscribed to" in assertAllStagesStopped {
+    "shut down properly even if some accepted connection Flows have not been subscribed to" in assertAllStagesStopped {
       val address = temporaryServerAddress()
       val firstClientConnected = Promise[Unit]()
       val takeTwoAndDropSecond = Flow[IncomingConnection].map(conn ⇒ {


### PR DESCRIPTION
Remove the xoxo marker (which we used to run only this test) when debugging it.
