### PR TITLE
=htc,doc more docs on EntityStreamSizeException

### DIFF
--- a/akka-docs-dev/rst/scala/http/common/http-model.rst
+++ b/akka-docs-dev/rst/scala/http/common/http-model.rst
@@ -166,6 +166,7 @@ them. This check makes sure that the total entity size is less than or equal to 
 However, a single global limit for all requests (or responses) is often too inflexible for applications that need to
 allow large limits for *some* requests (or responses) but want to clamp down on all messages not belonging into that
 group.
+
 In order to give you maximum flexibility in defining entity size limits according to your needs the ``HttpEntity``
 features a ``withSizeLimit`` method, which lets you adjust the globally configured maximum size for this particular
 entity, be it to increase or decrease any previously set value.
@@ -173,7 +174,7 @@ This means that your application will receive all requests (or responses) from t
 ``Content-Length`` exceeds the configured limit (because you might want to increase the limit yourself).
 Only when the actual data stream ``Source`` contained in the entity is materialized will the boundary checks be
 actually applied. In case the length verification fails the respective stream will be terminated with an
-``EntityStreamException`` either directly at materialization time (if the ``Content-Length`` is known) or whenever more
+:class:`EntityStreamSizeException` either directly at materialization time (if the ``Content-Length`` is known) or whenever more
 data bytes than allowed have been read.
 
 When called on ``Strict`` entities the ``withSizeLimit`` method will return the entity itself if the length is within

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
@@ -72,8 +72,19 @@ object EntityStreamException {
   def apply(summary: String, detail: String = ""): EntityStreamException = apply(ErrorInfo(summary, detail))
 }
 
+/**
+ * This exception is thrown when the size of the HTTP Entity exceeds the configured limit.
+ * It is possible to configure the limit using configuration options `akka.http.parsing.max-content-length`
+ * or specifically for the server or client side by setting `akka.http.[server|client].parsing.max-content-length`.
+ *
+ * The limit can also be configured in code, by calling [[HttpEntity#withSizeLimit]]
+ * on the entity before materializing its `dataBytes` stream.
+ */
 case class EntityStreamSizeException(limit: Long, actualSize: Option[Long] = None) extends RuntimeException {
-  override def toString = s"EntityStreamSizeException($limit, $actualSize)"
+  override def toString =
+    s"EntityStreamSizeException: actual entity size ($actualSize) exceeded content length limit ($limit bytes)! " +
+      s"You can configure this by setting `akka.http.[server|client].parsing.max-content-length` or calling `HttpEntity.withSizeLimit` " +
+      s"before materializing the dataBytes stream."
 }
 
 case class RequestTimeoutException(request: HttpRequest, message: String) extends RuntimeException(message)


### PR DESCRIPTION
This exception is something newcomers will run into quite early, when trying a file upload or something else when trying to stream some data (i.e. large entity), so it must be very clearly documented both in scaladoc and exception message as well I'd argue.
