### PR TITLE
=htc #19159 Adds falback for wildcard charset with decimal priority

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -96,6 +96,11 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
       accept(`text/plain` withCharset `UTF-16`) should reject
     }
 
+    "Accept-Charset: *;q=0.1" test { accept ⇒
+      accept(`text/plain`) should select(`text/plain` withCharset `UTF-8`)
+      accept(`image/gif`) should select(`image/gif`)
+    }
+
     "Accept-Charset: us;q=0.1,*;q=0" test { accept ⇒
       accept(`text/plain`) should select(`text/plain` withCharset `US-ASCII`)
       accept(`text/plain` withCharset `UTF-8`) should reject
@@ -172,3 +177,4 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
     }
   }
 }
+


### PR DESCRIPTION
Ports the PR https://github.com/akka/akka/pull/19135 by @belerophon to the right branch.

I investigated the code, and since @sirthias's recent rewrite of the ContentType models we're all good here, and the change proposed by that PR is not required. I am porting the PR however as the test is good to have.

Please sanity check if I missed something.
