### PR TITLE
=htp stop case class extraction from throwing IllegalArgumentException

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
@@ -119,6 +119,17 @@ class BasicRouteSpecs extends RoutingSpec {
         responseAs[String] shouldEqual "Person(john,38)"
       }
     }
+    "reject if case class requirements fail" in {
+      case class MyValidNumber(i: Int) {
+        require(i > 10)
+      }
+
+      val abcPath = path("abc" / IntNumber).as(MyValidNumber)(echoComplete)
+
+      Get("/abc/5") ~> abcPath ~> check {
+        rejection shouldBe a[ValidationRejection]
+      }
+    }
   }
   "Dynamic execution of inner routes of Directive0" should {
     "re-execute inner routes every time" in {


### PR DESCRIPTION
Hi. I noticed I was getting exceptions when using "as" to extract to a case class in which its requirements failed. This was contrary to the "ValidationRejection" the docs stated would happen.

I made several attempts not to use a nested method (i.e. validatedMap):
1) Passing an implicit tupler to the "as" method changed the API
2) Using a magnet that combined "ConstructFromTuple" and "Tupler" necessitated implicit conversion methods for all Tuples1-22.
3) Calling "val tupler = implicitly[Tupler[A]]"  within the "as" method prevented the compiler from knowing  "Tuple1[A]" and "tupler.Out" was the same thing.

Anyway, this is my first contribution to akka. Let me know if I messed anything up. Thanks!
