### PR TITLE
Agolubev #17967 sink.actor ref with acking 2

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSinkSpec.scala
@@ -50,7 +50,7 @@ class ActorRefBackpressureSinkSpec extends AkkaSpec {
   def createActor[T](c: Class[T]) =
     system.actorOf(Props(c, testActor).withDispatcher("akka.test.stream-dispatcher"))
 
-  "An ActorRefSink" must {
+  "An ActorRefBackpressureSink" must {
 
     "send the elements to the ActorRef" in assertAllStagesStopped {
       val fw = createActor(classOf[Fw])


### PR DESCRIPTION
This is after merge fix of #17967 that removes redundant async calls. 
It is continuation of #18773
