### PR TITLE
=htp add explicit type annotations to public implicits where still missing

### DIFF
--- a/akka-http/src/main/boilerplate/akka/http/scaladsl/server/util/ApplyConverterInstances.scala.template
+++ b/akka-http/src/main/boilerplate/akka/http/scaladsl/server/util/ApplyConverterInstances.scala.template
@@ -7,7 +7,7 @@ package akka.http.scaladsl.server.util
 import akka.http.scaladsl.server.Route
 
 private[util] abstract class ApplyConverterInstances {
-  [#implicit def hac1[[#T1#]] = new ApplyConverter[Tuple1[[#T1#]]] {
+  [#implicit def hac1[[#T1#]]: ApplyConverter[Tuple1[[#T1#]]] { type In = ([#T1#]) ⇒ Route } = new ApplyConverter[Tuple1[[#T1#]]] {
     type In = ([#T1#]) ⇒ Route
     def apply(fn: In): (Tuple1[[#T1#]]) ⇒ Route = {
       case Tuple1([#t1#]) ⇒ fn([#t1#])

--- a/akka-http/src/main/scala/akka/http/impl/server/HeaderImpl.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/HeaderImpl.scala
@@ -24,7 +24,7 @@ private[http] object HeaderImpl {
     type U = T with scaladsl.model.HttpHeader
 
     // cast is safe because creation of javadsl.model.HttpHeader that are not <: scaladsl.model.HttpHeader is forbidden
-    implicit def uClassTag = tClassTag.asInstanceOf[ClassTag[U]]
+    implicit def uClassTag: ClassTag[U] = tClassTag.asInstanceOf[ClassTag[U]]
 
     new Header[U] {
       val instanceDirective: Directive1[U] =

--- a/akka-http/src/main/scala/akka/http/scaladsl/client/TransformerPipelineSupport.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/client/TransformerPipelineSupport.scala
@@ -35,14 +35,14 @@ trait TransformerAux[A, B, AA, BB, R] {
 }
 
 object TransformerAux {
-  implicit def aux1[A, B, C] = new TransformerAux[A, B, B, C, C] {
+  implicit def aux1[A, B, C]: TransformerAux[A, B, B, C, C] = new TransformerAux[A, B, B, C, C] {
     def apply(f: A ⇒ B, g: B ⇒ C): A ⇒ C = f andThen g
   }
-  implicit def aux2[A, B, C](implicit ec: ExecutionContext) =
+  implicit def aux2[A, B, C](implicit ec: ExecutionContext): TransformerAux[A, Future[B], B, C, Future[C]] =
     new TransformerAux[A, Future[B], B, C, Future[C]] {
       def apply(f: A ⇒ Future[B], g: B ⇒ C): A ⇒ Future[C] = f(_).map(g)
     }
-  implicit def aux3[A, B, C](implicit ec: ExecutionContext) =
+  implicit def aux3[A, B, C](implicit ec: ExecutionContext): TransformerAux[A, Future[B], B, Future[C], Future[C]] =
     new TransformerAux[A, Future[B], B, Future[C], Future[C]] {
       def apply(f: A ⇒ Future[B], g: B ⇒ Future[C]): A ⇒ Future[C] = f(_).flatMap(g)
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
@@ -68,14 +68,14 @@ object StrictForm {
       def unmarshalPart(value: Multipart.FormData.BodyPart.Strict)(implicit ec: ExecutionContext, mat: Materializer): Future[T]
     }
     object FieldUnmarshaller extends LowPrioImplicits {
-      implicit def fromBoth[T](implicit fsu: FromStringUnmarshaller[T], feu: FromEntityUnmarshaller[T]) =
+      implicit def fromBoth[T](implicit fsu: FromStringUnmarshaller[T], feu: FromEntityUnmarshaller[T]): FieldUnmarshaller[T] =
         new FieldUnmarshaller[T] {
           def unmarshalString(value: String)(implicit ec: ExecutionContext, mat: Materializer) = fsu(value)
           def unmarshalPart(value: Multipart.FormData.BodyPart.Strict)(implicit ec: ExecutionContext, mat: Materializer) = feu(value.entity)
         }
     }
     sealed abstract class LowPrioImplicits {
-      implicit def fromFSU[T](implicit fsu: FromStringUnmarshaller[T]) =
+      implicit def fromFSU[T](implicit fsu: FromStringUnmarshaller[T]): FieldUnmarshaller[T] =
         new FieldUnmarshaller[T] {
           def unmarshalString(value: String)(implicit ec: ExecutionContext, mat: Materializer) = fsu(value)
           def unmarshalPart(value: Multipart.FormData.BodyPart.Strict)(implicit ec: ExecutionContext, mat: Materializer) = {
@@ -83,7 +83,7 @@ object StrictForm {
             fsu(value.entity.data.decodeString(charsetName))
           }
         }
-      implicit def fromFEU[T](implicit feu: FromEntityUnmarshaller[T]) =
+      implicit def fromFEU[T](implicit feu: FromEntityUnmarshaller[T]): FieldUnmarshaller[T] =
         new FieldUnmarshaller[T] {
           def unmarshalString(value: String)(implicit ec: ExecutionContext, mat: Materializer) = feu(HttpEntity(value))
           def unmarshalPart(value: Multipart.FormData.BodyPart.Strict)(implicit ec: ExecutionContext, mat: Materializer) = feu(value.entity)

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ContentTypeOverrider.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ContentTypeOverrider.scala
@@ -18,18 +18,21 @@ object ContentTypeOverrider {
       value.withContentType(newContentType).asInstanceOf[T] // can't be expressed in types
   }
 
-  implicit def forHeadersAndEntity[T <: HttpEntity] = new ContentTypeOverrider[(immutable.Seq[HttpHeader], T)] {
-    def apply(value: (immutable.Seq[HttpHeader], T), newContentType: ContentType) =
-      value._1 -> value._2.withContentType(newContentType).asInstanceOf[T]
-  }
+  implicit def forHeadersAndEntity[T <: HttpEntity]: ContentTypeOverrider[(immutable.Seq[HttpHeader], T)] =
+    new ContentTypeOverrider[(immutable.Seq[HttpHeader], T)] {
+      def apply(value: (immutable.Seq[HttpHeader], T), newContentType: ContentType) =
+        value._1 -> value._2.withContentType(newContentType).asInstanceOf[T]
+    }
 
-  implicit val forResponse = new ContentTypeOverrider[HttpResponse] {
-    def apply(value: HttpResponse, newContentType: ContentType) =
-      value.mapEntity(forEntity(_: ResponseEntity, newContentType))
-  }
+  implicit val forResponse: ContentTypeOverrider[HttpResponse] =
+    new ContentTypeOverrider[HttpResponse] {
+      def apply(value: HttpResponse, newContentType: ContentType) =
+        value.mapEntity(forEntity(_: ResponseEntity, newContentType))
+    }
 
-  implicit val forRequest = new ContentTypeOverrider[HttpRequest] {
-    def apply(value: HttpRequest, newContentType: ContentType) =
-      value.mapEntity(forEntity(_: RequestEntity, newContentType))
-  }
+  implicit val forRequest: ContentTypeOverrider[HttpRequest] =
+    new ContentTypeOverrider[HttpRequest] {
+      def apply(value: HttpRequest, newContentType: ContentType) =
+        value.mapEntity(forEntity(_: RequestEntity, newContentType))
+    }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/EmptyValue.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/EmptyValue.scala
@@ -10,7 +10,12 @@ import akka.http.scaladsl.model._
 class EmptyValue[+T] private (val emptyValue: T)
 
 object EmptyValue {
-  implicit def emptyEntity = new EmptyValue[UniversalEntity](HttpEntity.Empty)
-  implicit val emptyHeadersAndEntity = new EmptyValue[(immutable.Seq[HttpHeader], UniversalEntity)](Nil -> HttpEntity.Empty)
-  implicit val emptyResponse = new EmptyValue[HttpResponse](HttpResponse(entity = emptyEntity.emptyValue))
+  implicit def emptyEntity: EmptyValue[UniversalEntity] =
+    new EmptyValue[UniversalEntity](HttpEntity.Empty)
+
+  implicit val emptyHeadersAndEntity: EmptyValue[(immutable.Seq[HttpHeader], UniversalEntity)] =
+    new EmptyValue[(immutable.Seq[HttpHeader], UniversalEntity)](Nil -> HttpEntity.Empty)
+
+  implicit val emptyResponse: EmptyValue[HttpResponse] =
+    new EmptyValue[HttpResponse](HttpResponse(entity = emptyEntity.emptyValue))
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
@@ -165,13 +165,13 @@ object ConjunctionMagnet {
         }(Tuple.yes) // we know that join will only ever produce tuples
     }
 
-  implicit def fromStandardRoute[L](route: StandardRoute) =
+  implicit def fromStandardRoute[L](route: StandardRoute): ConjunctionMagnet[L] { type Out = StandardRoute } =
     new ConjunctionMagnet[L] {
       type Out = StandardRoute
       def apply(underlying: Directive[L]) = StandardRoute(underlying.tapply(_ ⇒ route))
     }
 
-  implicit def fromRouteGenerator[T, R <: Route](generator: T ⇒ R) =
+  implicit def fromRouteGenerator[T, R <: Route](generator: T ⇒ R): ConjunctionMagnet[Unit] { type Out = RouteGenerator[T] } =
     new ConjunctionMagnet[Unit] {
       type Out = RouteGenerator[T]
       def apply(underlying: Directive0) = value ⇒ underlying.tapply(_ ⇒ generator(value))

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.util.FastFuture._
 
 trait RouteConcatenation {
 
-  implicit def enhanceRouteWithConcatenation(route: Route) =
+  implicit def enhanceRouteWithConcatenation(route: Route): RouteConcatenation.RouteWithConcatenation =
     new RouteConcatenation.RouteWithConcatenation(route: Route)
 }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RoutingSettings.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RoutingSettings.scala
@@ -27,6 +27,6 @@ object RoutingSettings extends SettingsCompanion[RoutingSettings]("akka.http.rou
     c getIntBytes "decode-max-bytes-per-chunk",
     c getString "file-io-dispatcher")
 
-  implicit def default(implicit refFactory: ActorRefFactory) =
+  implicit def default(implicit refFactory: ActorRefFactory): RoutingSettings =
     apply(actorSystem)
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/StandardRoute.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/StandardRoute.scala
@@ -23,5 +23,6 @@ object StandardRoute {
    * Converts the StandardRoute into a directive that never passes the request to its inner route
    * (and always returns its underlying route).
    */
-  implicit def toDirective[L: Tuple](route: StandardRoute) = Directive[L] { _ ⇒ route }
+  implicit def toDirective[L: Tuple](route: StandardRoute): Directive[L] =
+    Directive[L] { _ ⇒ route }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DebuggingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DebuggingDirectives.scala
@@ -50,25 +50,25 @@ object DebuggingDirectives extends DebuggingDirectives
 case class LoggingMagnet[T](f: LoggingAdapter ⇒ T) // # logging-magnet
 
 object LoggingMagnet {
-  implicit def forMessageFromMarker[T](marker: String) = // # message-magnets
+  implicit def forMessageFromMarker[T](marker: String): LoggingMagnet[T ⇒ Unit] = // # message-magnets
     forMessageFromMarkerAndLevel[T](marker -> DebugLevel)
 
-  implicit def forMessageFromMarkerAndLevel[T](markerAndLevel: (String, LogLevel)) = // # message-magnets
+  implicit def forMessageFromMarkerAndLevel[T](markerAndLevel: (String, LogLevel)): LoggingMagnet[T ⇒ Unit] = // # message-magnets
     forMessageFromFullShow[T] {
       val (marker, level) = markerAndLevel
       Message ⇒ LogEntry(Message, marker, level)
     }
 
-  implicit def forMessageFromShow[T](show: T ⇒ String) = // # message-magnets
+  implicit def forMessageFromShow[T](show: T ⇒ String): LoggingMagnet[T ⇒ Unit] = // # message-magnets
     forMessageFromFullShow[T](msg ⇒ LogEntry(show(msg), DebugLevel))
 
   implicit def forMessageFromFullShow[T](show: T ⇒ LogEntry): LoggingMagnet[T ⇒ Unit] = // # message-magnets
     LoggingMagnet(log ⇒ show(_).logTo(log))
 
-  implicit def forRequestResponseFromMarker(marker: String) = // # request-response-magnets
+  implicit def forRequestResponseFromMarker(marker: String): LoggingMagnet[HttpRequest ⇒ RouteResult ⇒ Unit] = // # request-response-magnets
     forRequestResponseFromMarkerAndLevel(marker -> DebugLevel)
 
-  implicit def forRequestResponseFromMarkerAndLevel(markerAndLevel: (String, LogLevel)) = // # request-response-magnets
+  implicit def forRequestResponseFromMarkerAndLevel(markerAndLevel: (String, LogLevel)): LoggingMagnet[HttpRequest ⇒ RouteResult ⇒ Unit] = // # request-response-magnets
     forRequestResponseFromFullShow {
       val (marker, level) = markerAndLevel
       request ⇒ response ⇒ Some(

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -255,7 +255,7 @@ object ContentTypeResolver {
    * The default way of resolving a filename to a ContentType is by looking up the file extension in the
    * registry of all defined media-types. By default all non-binary file content is assumed to be UTF-8 encoded.
    */
-  implicit val Default = withDefaultCharset(HttpCharsets.`UTF-8`)
+  implicit val Default: ContentTypeResolver = withDefaultCharset(HttpCharsets.`UTF-8`)
 
   def withDefaultCharset(charset: HttpCharset): ContentTypeResolver =
     new ContentTypeResolver {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala
@@ -53,7 +53,7 @@ trait OnSuccessMagnet {
 }
 
 object OnSuccessMagnet {
-  implicit def apply[T](future: ⇒ Future[T])(implicit tupler: Tupler[T]) =
+  implicit def apply[T](future: ⇒ Future[T])(implicit tupler: Tupler[T]): OnSuccessMagnet { type Out = tupler.Out } =
     new OnSuccessMagnet {
       type Out = tupler.Out
       val directive = Directive[tupler.Out] { inner ⇒ ctx ⇒
@@ -68,7 +68,7 @@ trait CompleteOrRecoverWithMagnet {
 }
 
 object CompleteOrRecoverWithMagnet {
-  implicit def apply[T](future: ⇒ Future[T])(implicit m: ToResponseMarshaller[T]) =
+  implicit def apply[T](future: ⇒ Future[T])(implicit m: ToResponseMarshaller[T]): CompleteOrRecoverWithMagnet =
     new CompleteOrRecoverWithMagnet {
       val directive = Directive[Tuple1[Throwable]] { inner ⇒ ctx ⇒
         import ctx.executionContext

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -35,7 +35,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    * If matched the value extracted by the PathMatcher is extracted on the directive level.
    */
   def rawPathPrefix[L](pm: PathMatcher[L]): Directive[L] = {
-    implicit def LIsTuple = pm.ev
+    implicit val LIsTuple = pm.ev
     extract(ctx ⇒ pm(ctx.unmatchedPath)).flatMap {
       case Matched(rest, values) ⇒ tprovide(values) & mapRequestContext(_ withUnmatchedPath rest)
       case Unmatched             ⇒ reject
@@ -54,7 +54,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    * actually "consumed".
    */
   def rawPathPrefixTest[L](pm: PathMatcher[L]): Directive[L] = {
-    implicit def LIsTuple = pm.ev
+    implicit val LIsTuple = pm.ev
     extract(ctx ⇒ pm(ctx.unmatchedPath)).flatMap {
       case Matched(_, values) ⇒ tprovide(values)
       case Unmatched          ⇒ reject
@@ -68,7 +68,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    * order, i.e. `pathSuffix("baz" / "bar")` would match `/foo/bar/baz`!
    */
   def pathSuffix[L](pm: PathMatcher[L]): Directive[L] = {
-    implicit def LIsTuple = pm.ev
+    implicit val LIsTuple = pm.ev
     extract(ctx ⇒ pm(ctx.unmatchedPath.reverse)).flatMap {
       case Matched(rest, values) ⇒ tprovide(values) & mapRequestContext(_.withUnmatchedPath(rest.reverse))
       case Unmatched             ⇒ reject
@@ -83,7 +83,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    * order, i.e. `pathSuffixTest("baz" / "bar")` would match `/foo/bar/baz`!
    */
   def pathSuffixTest[L](pm: PathMatcher[L]): Directive[L] = {
-    implicit def LIsTuple = pm.ev
+    implicit val LIsTuple = pm.ev
     extract(ctx ⇒ pm(ctx.unmatchedPath.reverse)).flatMap {
       case Matched(_, values) ⇒ tprovide(values)
       case Unmatched          ⇒ reject

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/ClassMagnet.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/ClassMagnet.scala
@@ -19,7 +19,7 @@ trait ClassMagnet[T] {
 }
 object ClassMagnet {
   implicit def fromClass[T](c: Class[T]): ClassMagnet[T] = ClassMagnet(ClassTag(c))
-  implicit def fromUnit[T](u: Unit)(implicit tag: ClassTag[T]) = ClassMagnet(tag)
+  implicit def fromUnit[T](u: Unit)(implicit tag: ClassTag[T]): ClassMagnet[T] = ClassMagnet(tag)
 
   def apply[T](implicit tag: ClassTag[T]): ClassMagnet[T] =
     new ClassMagnet[T] {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tupler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tupler.scala
@@ -15,7 +15,7 @@ trait Tupler[T] {
 }
 
 object Tupler extends LowerPriorityTupler {
-  implicit def forTuple[T: Tuple] =
+  implicit def forTuple[T: Tuple]: Tupler[T] { type Out = T } =
     new Tupler[T] {
       type Out = T
       def OutIsTuple = implicitly[Tuple[Out]]
@@ -24,7 +24,7 @@ object Tupler extends LowerPriorityTupler {
 }
 
 private[server] abstract class LowerPriorityTupler {
-  implicit def forAnyRef[T] =
+  implicit def forAnyRef[T]: Tupler[T] { type Out = Tuple1[T] } =
     new Tupler[T] {
       type Out = Tuple1[T]
       def OutIsTuple = implicitly[Tuple[Out]]


### PR DESCRIPTION
For some reason I'm still having implicit resolution troubles with the `formFieldDirectives`.
So I temporarily added [wartremover](https://github.com/puffnfresh/wartremover) to identify all the remaining implicits that don't carry an explicit type annotation.

There were quite a few, which this PR fixes.
Even with it doesn't immediately fix any known problems it might prevent us from more future issues.

/cc @jrudolph
