### PR TITLE
WIP - DON'T MERGE - Set Source.inputStream() default initial and max buffer length to 1

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -324,7 +324,9 @@ object Source {
    * It materializes a [[Future]] containing the number of bytes read from the source file upon completion.
    */
   def inputStream(in: function.Creator[InputStream], chunkSize: Int): javadsl.Source[ByteString, Future[java.lang.Long]] =
-    new Source(scaladsl.Source.inputStream(() ⇒ in.create(), chunkSize)).asInstanceOf[Source[ByteString, Future[java.lang.Long]]]
+    new Source(scaladsl.Source.inputStream(() ⇒ in.create(), chunkSize))
+      .withAttributes(Attributes.inputBuffer(initial = 1, max = 1))
+      .asInstanceOf[Source[ByteString, Future[java.lang.Long]]]
 
   /**
    * Creates a Source from an [[java.io.InputStream]] created by the given function.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -456,6 +456,7 @@ object Source {
    */
   def inputStream(in: () ⇒ InputStream, chunkSize: Int = 8192): Source[ByteString, Future[Long]] =
     new Source(new InputStreamSource(in, chunkSize, DefaultAttributes.inputStreamSource, shape("InputStreamSource")))
+      .withAttributes(Attributes.inputBuffer(initial = 1, max = 1))
 
   /**
    * Creates a Source which when materialized will return an [[OutputStream]] which it is possible


### PR DESCRIPTION
This is provide default behaviour where data flows down from the Source as soon as it's available since the length of the data from InputStream is not known beforehand.

Fixes #19193.
