### PR TITLE
=htc #16821 support UTF-8 characters in field values

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -42,7 +42,7 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
 
   def qdtext = rule { `qdtext-base` | `obs-text` }
 
-  def `obs-text` = rule { "\u0080" - "\u00FF" }
+  def `obs-text` = rule { "\u0080" - "\uFFFE" }
 
   def `quoted-pair` = rule { '\\' ~ (`quotable-base` | `obs-text`) ~ appendSB() }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -589,9 +589,10 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       parse("Foo", "ba\u0000r") shouldEqual ParsingResult.Error(ErrorInfo(
         "Illegal HTTP header value: Invalid input '\\u0000', expected field-value-char, FWS or 'EOI' (line 1, column 3)",
         "ba\u0000r\n  ^"))
-      parse("Flood-Resistant-Hammerdrill", "árvíztűrő ütvefúrógép") shouldEqual ParsingResult.Error(ErrorInfo(
-        "Illegal HTTP header value: Invalid input 'ű', expected field-value-char, FWS or 'EOI' (line 1, column 7)",
-        "árvíztűrő ütvefúrógép\n      ^"))
+    }
+    "allow UTF8 characters in RawHeaders" in {
+      parse("Flood-Resistant-Hammerdrill", "árvíztűrő ütvefúrógép") shouldEqual
+        ParsingResult.Ok(RawHeader("Flood-Resistant-Hammerdrill", "árvíztűrő ütvefúrógép"), Nil)
     }
     "compress value whitespace into single spaces and trim" in {
       parse("Foo", " b  a \tr\t") shouldEqual ParsingResult.Ok(RawHeader("Foo", "b a r"), Nil)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -261,7 +261,7 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
                     |Content-Dispo""".stripMarginWithNewline("\r\n")
                 },
                 ByteString {
-                  """sition: form-data; name="userfile"; filename="test.dat"
+                  """sition: form-data; name="userfile"; filename="test€.dat"
                     |Content-Type: application/pdf
                     |Content-Transfer-Encoding: binary
                     |Content-Additional-1: anything
@@ -273,7 +273,7 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             })
         }.to[Multipart.FormData].flatMap(_.toStrict(1.second)) should haveParts(
           Multipart.FormData.BodyPart.Strict("email", HttpEntity(`application/octet-stream`, ByteString("test@there.com"))),
-          Multipart.FormData.BodyPart.Strict("userfile", HttpEntity(`application/pdf`, ByteString("filecontent")), Map("filename" -> "test.dat"),
+          Multipart.FormData.BodyPart.Strict("userfile", HttpEntity(`application/pdf`, ByteString("filecontent")), Map("filename" -> "test€.dat"),
             List(
               RawHeader("Content-Transfer-Encoding", "binary"),
               RawHeader("Content-Additional-1", "anything"),


### PR DESCRIPTION
This alone seems to fix the immediate issue that we cannot parse UTF8 encoded filenames in `form-data/multipart`. The question is whether this change is not too broad (i.e. what other parsing rules are impacted) and e.g. whether we should guard against consuming half surrogate pairs in the parser.

The other issue is that we still cannot configure a specific charset to do header parsing and so we cannot introduce a configurable charset for multipart parsing as suggested in #16821. On the other hand, UTF8 should be common enough today that with this simple change we may already enable 90% of the use cases. If you control both the page containing the form and the backend receiving the data it should be no problem at all as you can make sure that the HTML page is encoded with UTF8.

Fixes #16821.

/cc @sirthias 
