### PR TITLE
=act #19216 Fix AbstractNodeQueue value nepotism

### DIFF
--- a/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
@@ -66,7 +66,11 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
     public final T poll() {
         final Node<T> next = pollNode();
         if (next == null) return null;
-        else return next.value;
+        else {
+          T value = next.value;
+          next.value = null;
+          return value;
+        }
     }
     
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Another fix for #19216 

Old nodes that are discarded can pull in the newly written value into the Old Space.
