### PR TITLE
=rem #19228 make the default TLS version 1.2

### DIFF
--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -298,7 +298,7 @@ An example of setting up the default Netty based SSL driver as default::
         key-store-password = "changeme"
         key-password = "changeme"
         trust-store-password = "changeme"
-        protocol = "TLSv1"
+        protocol = "TLSv1.2"
         random-number-generator = "AES128CounterSecureRNG"
         enabled-algorithms = [TLS_RSA_WITH_AES_128_CBC_SHA]
       }

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -303,7 +303,7 @@ An example of setting up the default Netty based SSL driver as default::
         key-store-password = "changeme"
         key-password = "changeme"
         trust-store-password = "changeme"
-        protocol = "TLSv1"
+        protocol = "TLSv1.2"
         random-number-generator = "AES128CounterSecureRNG"
         enabled-algorithms = [TLS_RSA_WITH_AES_128_CBC_SHA]
       }

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -517,11 +517,9 @@ akka {
         trust-store-password = "changeme"
 
         # Protocol to use for SSL encryption, choose from:
-        # Java 6 & 7:
-        #   'SSLv3', 'TLSv1'
-        # Java 7:
-        #   'TLSv1.1', 'TLSv1.2'
-        protocol = "TLSv1"
+        # TLS 1.2 is available since JDK7, and default since JDK8:
+        # https://blogs.oracle.com/java-platform-group/entry/java_8_will_use_tls
+        protocol = "TLSv1.2"
 
         # Example: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]
         # You need to install the JCE Unlimited Strength Jurisdiction Policy

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -129,7 +129,7 @@ class RemoteConfigSpec extends AkkaSpec(
       sslSettings.SSLKeyPassword should ===(Some("changeme"))
       sslSettings.SSLTrustStore should ===(Some("truststore"))
       sslSettings.SSLTrustStorePassword should ===(Some("changeme"))
-      sslSettings.SSLProtocol should ===(Some("TLSv1"))
+      sslSettings.SSLProtocol should ===(Some("TLSv1.2"))
       sslSettings.SSLEnabledAlgorithms should ===(Set("TLS_RSA_WITH_AES_128_CBC_SHA"))
       sslSettings.SSLRandomNumberGenerator should ===(None)
     }

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -68,7 +68,7 @@ object RemotingSpec {
       key-store-password = "changeme"
       key-password = "changeme"
       trust-store-password = "changeme"
-      protocol = "TLSv1"
+      protocol = "TLSv1.2"
       random-number-generator = "AES128CounterSecureRNG"
       enabled-algorithms = [TLS_RSA_WITH_AES_128_CBC_SHA]
     }

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
@@ -47,7 +47,7 @@ object Configuration {
           key-store-password = "changeme"
           key-password = "changeme"
           trust-store-password = "changeme"
-          protocol = "TLSv1"
+          protocol = "TLSv1.2"
           random-number-generator = "%s"
           enabled-algorithms = [%s]
         }

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978ConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978ConfigSpec.scala
@@ -23,7 +23,7 @@ class Ticket1978ConfigSpec extends AkkaSpec("""
       settings.SSLKeyPassword should ===(Some("changeme"))
       settings.SSLTrustStore should ===(Some("truststore"))
       settings.SSLTrustStorePassword should ===(Some("changeme"))
-      settings.SSLProtocol should ===(Some("TLSv1"))
+      settings.SSLProtocol should ===(Some("TLSv1.2"))
       settings.SSLEnabledAlgorithms should ===(Set("TLS_RSA_WITH_AES_128_CBC_SHA"))
       settings.SSLRandomNumberGenerator should ===(Some("AES128CounterSecureRNG"))
     }


### PR DESCRIPTION
TLS 1.2 should be preferred and we always have it available by virtue of requiring JDK8 for Akka 2.4.x.
See also https://blogs.oracle.com/java-platform-group/entry/java_8_will_use_tls
