### PR TITLE
=fix missing param in javadoc example

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -77,7 +77,7 @@ object ActorRef {
  *
  *     } else if (o instanceof Request3) {
  *       Msg msg = ((Request3) o).getMsg();
- *       pipe(ask(other, msg, 5000)).to(getSender());
+ *       pipe(ask(other, msg, 5000), context().dispatcher()).to(getSender());
  *       // the ask call will get a future from other's reply
  *       // when the future is complete, send its value to the original sender
  *


### PR DESCRIPTION
Snippet was missing dispatcher, which is needed for `pipe()`
