### PR TITLE
!htc fix multipart model (java6 had trouble)

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
@@ -69,7 +69,7 @@ public interface Multipart {
      * Basic model for multipart content as defined by http://tools.ietf.org/html/rfc2046.
      */
     interface General extends Multipart {
-        Source<? extends Multipart.General.BodyPart, Object> getParts();
+        Source<? extends Multipart.General.BodyPart, Object> getGeneralParts();
 
         Future<Multipart.General.Strict> toStrict(long timeoutMillis, Materializer materializer);
 
@@ -92,7 +92,7 @@ public interface Multipart {
      * All parts must have distinct names. (This is not verified!)
      */
     interface FormData extends Multipart {
-        Source<? extends Multipart.FormData.BodyPart, Object> getParts();
+        Source<? extends Multipart.FormData.BodyPart, Object> getFormDataParts();
 
         Future<Multipart.FormData.Strict> toStrict(long timeoutMillis, Materializer materializer);
 
@@ -120,7 +120,7 @@ public interface Multipart {
      * https://tools.ietf.org/html/rfc7233#section-5.4.1 and https://tools.ietf.org/html/rfc7233#appendix-A
      */
     interface ByteRanges extends Multipart {
-        Source<? extends Multipart.ByteRanges.BodyPart, Object> getParts();
+        Source<? extends Multipart.ByteRanges.BodyPart, Object> getByteRangeParts();
 
         Future<Multipart.ByteRanges.Strict> toStrict(long timeoutMillis, Materializer materializer);
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.server.directives
 
 import java.io.{ FileInputStream, File }
-import java.nio.charset.StandardCharsets
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.{ MissingFormFieldRejection, RoutingSpec }
 import akka.util.ByteString
@@ -145,7 +144,7 @@ class FileUploadDirectivesSpec extends RoutingSpec {
     try {
       val buffer = new Array[Byte](1024)
       in.read(buffer)
-      new String(buffer, StandardCharsets.UTF_8)
+      new String(buffer, "UTF-8")
     } finally {
       in.close()
     }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
@@ -95,7 +95,8 @@ public class TcpTest extends StreamTest {
           } catch (BindFailedException e) {
             // expected
           } catch (Exception e) {
-            throw new AssertionError("failed", e);
+            // throw new AssertionError("failed", e); // TODO: bring back once we're JDK7+
+            throw new RuntimeException("failed", e);
           }
           return null;
         }


### PR DESCRIPTION
Got stuck releasing today since Java6 had trouble figuring out these overloads:

```
     interface ByteRanges extends Multipart {
>>>        Source<? extends Multipart.ByteRanges.BodyPart, Object> getParts();  

         interface Strict extends Multipart.ByteRanges, Multipart.Strict {               
>>>             Source<Multipart.ByteRanges.BodyPart.Strict, Object> getParts();    
```
