### PR TITLE
Fix performance of HTTP server (for strict entities at least)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -6,6 +6,7 @@ package akka.http.impl.engine.rendering
 
 import akka.http.impl.engine.ws.{ FrameEvent, UpgradeToWebsocketResponseHeader }
 import akka.http.scaladsl.model.ws.Message
+import akka.stream.{ Outlet, Inlet, Attributes, FlowShape }
 
 import scala.annotation.tailrec
 import akka.event.LoggingAdapter
@@ -52,170 +53,201 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
   // split out so we can stabilize by overriding in tests
   protected def currentTimeMillis(): Long = System.currentTimeMillis()
 
-  def newRenderer: HttpResponseRenderer = new HttpResponseRenderer
+  def renderer: Flow[ResponseRenderingContext, ResponseRenderingOutput, Unit] = Flow.fromGraph(HttpResponseRenderer)
 
-  final class HttpResponseRenderer extends PushStage[ResponseRenderingContext, Source[ResponseRenderingOutput, Any]] {
+  object HttpResponseRenderer extends GraphStage[FlowShape[ResponseRenderingContext, ResponseRenderingOutput]] {
+    val in = Inlet[ResponseRenderingContext]("in")
+    val out = Outlet[ResponseRenderingOutput]("out")
+    val shape: FlowShape[ResponseRenderingContext, ResponseRenderingOutput] = FlowShape(in, out)
 
-    private[this] var closeMode: CloseMode = DontClose // signals what to do after the current response
-    private[this] def close: Boolean = closeMode != DontClose
-    private[this] def closeIf(cond: Boolean): Unit =
-      if (cond) closeMode = CloseConnection
+    def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) {
+        private[this] var closeMode: CloseMode = DontClose // signals what to do after the current response
+        private[this] def close: Boolean = closeMode != DontClose
+        private[this] def closeIf(cond: Boolean): Unit =
+          if (cond) closeMode = CloseConnection
 
-    // need this for testing
-    private[http] def isComplete = close
+        setHandler(in, new InHandler {
+          def onPush(): Unit =
+            render(grab(in)) match {
+              case Strict(outElement) ⇒
+                push(out, outElement)
+                if (close) completeStage()
+              case Streamed(outStream) ⇒ transfer(outStream)
+            }
 
-    override def onPush(ctx: ResponseRenderingContext, opCtx: Context[Source[ResponseRenderingOutput, Any]]): SyncDirective = {
-      val r = new ByteStringRendering(responseHeaderSizeHint)
-
-      import ctx.response._
-      val noEntity = entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD
-
-      def renderStatusLine(): Unit =
-        protocol match {
-          case `HTTP/1.1` ⇒ if (status eq StatusCodes.OK) r ~~ DefaultStatusLineBytes else r ~~ StatusLineStartBytes ~~ status ~~ CrLf
-          case `HTTP/1.0` ⇒ r ~~ protocol ~~ ' ' ~~ status ~~ CrLf
+          override def onUpstreamFinish(): Unit = closeMode = CloseConnection
+        })
+        val waitForDemandHandler = new OutHandler {
+          def onPull(): Unit = if (close) completeStage() else pull(in)
+        }
+        setHandler(out, waitForDemandHandler)
+        def transfer(outStream: Source[ResponseRenderingOutput, Any]): Unit = {
+          val sinkIn = new SubSinkInlet[ResponseRenderingOutput]("RenderingSink")
+          sinkIn.setHandler(new InHandler {
+            def onPush(): Unit = push(out, sinkIn.grab())
+            override def onUpstreamFinish(): Unit = if (close) completeStage() else setHandler(out, waitForDemandHandler)
+          })
+          setHandler(out, new OutHandler {
+            def onPull(): Unit = sinkIn.pull()
+          })
+          sinkIn.pull()
+          Source.fromGraph(outStream).runWith(sinkIn.sink)(interpreter.subFusingMaterializer)
         }
 
-      def render(h: HttpHeader) = r ~~ h ~~ CrLf
+        def render(ctx: ResponseRenderingContext): StrictOrStreamed = {
+          val r = new ByteStringRendering(responseHeaderSizeHint)
 
-      def mustRenderTransferEncodingChunkedHeader =
-        entity.isChunked && (!entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD) && (ctx.requestProtocol == `HTTP/1.1`)
+          import ctx.response._
+          val noEntity = entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD
 
-      @tailrec def renderHeaders(remaining: List[HttpHeader], alwaysClose: Boolean = false,
-                                 connHeader: Connection = null, serverSeen: Boolean = false,
-                                 transferEncodingSeen: Boolean = false, dateSeen: Boolean = false): Unit =
-        remaining match {
-          case head :: tail ⇒ head match {
-            case x: `Content-Length` ⇒
-              suppressionWarning(log, x, "explicit `Content-Length` header is not allowed. Use the appropriate HttpEntity subtype.")
-              renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
+          def renderStatusLine(): Unit =
+            protocol match {
+              case `HTTP/1.1` ⇒ if (status eq StatusCodes.OK) r ~~ DefaultStatusLineBytes else r ~~ StatusLineStartBytes ~~ status ~~ CrLf
+              case `HTTP/1.0` ⇒ r ~~ protocol ~~ ' ' ~~ status ~~ CrLf
+            }
 
-            case x: `Content-Type` ⇒
-              suppressionWarning(log, x, "explicit `Content-Type` header is not allowed. Set `HttpResponse.entity.contentType` instead.")
-              renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
+          def render(h: HttpHeader) = r ~~ h ~~ CrLf
 
-            case x: Date ⇒
-              render(x)
-              renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen = true)
+          def mustRenderTransferEncodingChunkedHeader =
+            entity.isChunked && (!entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD) && (ctx.requestProtocol == `HTTP/1.1`)
 
-            case x: `Transfer-Encoding` ⇒
-              x.withChunkedPeeled match {
-                case None ⇒
-                  suppressionWarning(log, head)
+          @tailrec def renderHeaders(remaining: List[HttpHeader], alwaysClose: Boolean = false,
+                                     connHeader: Connection = null, serverSeen: Boolean = false,
+                                     transferEncodingSeen: Boolean = false, dateSeen: Boolean = false): Unit =
+            remaining match {
+              case head :: tail ⇒ head match {
+                case x: `Content-Length` ⇒
+                  suppressionWarning(log, x, "explicit `Content-Length` header is not allowed. Use the appropriate HttpEntity subtype.")
                   renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
-                case Some(te) ⇒
-                  // if the user applied some custom transfer-encoding we need to keep the header
-                  render(if (mustRenderTransferEncodingChunkedHeader) te.withChunked else te)
-                  renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen = true, dateSeen)
+
+                case x: `Content-Type` ⇒
+                  suppressionWarning(log, x, "explicit `Content-Type` header is not allowed. Set `HttpResponse.entity.contentType` instead.")
+                  renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
+
+                case x: Date ⇒
+                  render(x)
+                  renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen = true)
+
+                case x: `Transfer-Encoding` ⇒
+                  x.withChunkedPeeled match {
+                    case None ⇒
+                      suppressionWarning(log, head)
+                      renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
+                    case Some(te) ⇒
+                      // if the user applied some custom transfer-encoding we need to keep the header
+                      render(if (mustRenderTransferEncodingChunkedHeader) te.withChunked else te)
+                      renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen = true, dateSeen)
+                  }
+
+                case x: Connection ⇒
+                  val connectionHeader = if (connHeader eq null) x else Connection(x.tokens ++ connHeader.tokens)
+                  renderHeaders(tail, alwaysClose, connectionHeader, serverSeen, transferEncodingSeen, dateSeen)
+
+                case x: Server ⇒
+                  render(x)
+                  renderHeaders(tail, alwaysClose, connHeader, serverSeen = true, transferEncodingSeen, dateSeen)
+
+                case x: CustomHeader ⇒
+                  if (!x.suppressRendering) render(x)
+                  renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
+
+                case x: RawHeader if (x is "content-type") || (x is "content-length") || (x is "transfer-encoding") ||
+                  (x is "date") || (x is "server") || (x is "connection") ⇒
+                  suppressionWarning(log, x, "illegal RawHeader")
+                  renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
+
+                case x ⇒
+                  render(x)
+                  renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
               }
 
-            case x: Connection ⇒
-              val connectionHeader = if (connHeader eq null) x else Connection(x.tokens ++ connHeader.tokens)
-              renderHeaders(tail, alwaysClose, connectionHeader, serverSeen, transferEncodingSeen, dateSeen)
+              case Nil ⇒
+                if (!serverSeen) renderDefaultServerHeader(r)
+                if (!dateSeen) r ~~ dateHeader
 
-            case x: Server ⇒
-              render(x)
-              renderHeaders(tail, alwaysClose, connHeader, serverSeen = true, transferEncodingSeen, dateSeen)
+                // Do we close the connection after this response?
+                closeIf {
+                  // if we are prohibited to keep-alive by the spec
+                  alwaysClose ||
+                    // if the client wants to close and we don't override
+                    (ctx.closeRequested && ((connHeader eq null) || !connHeader.hasKeepAlive)) ||
+                    // if the application wants to close explicitly
+                    (protocol match {
+                      case `HTTP/1.1` ⇒ (connHeader ne null) && connHeader.hasClose
+                      case `HTTP/1.0` ⇒ if (connHeader eq null) ctx.requestProtocol == `HTTP/1.1` else !connHeader.hasKeepAlive
+                    })
+                }
 
-            case x: CustomHeader ⇒
-              if (!x.suppressRendering) render(x)
-              renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
+                // Do we render an explicit Connection header?
+                val renderConnectionHeader =
+                  protocol == `HTTP/1.0` && !close || protocol == `HTTP/1.1` && close || // if we don't follow the default behavior
+                    close != ctx.closeRequested || // if we override the client's closing request
+                    protocol != ctx.requestProtocol // if we reply with a mismatching protocol (let's be very explicit in this case)
 
-            case x: RawHeader if (x is "content-type") || (x is "content-length") || (x is "transfer-encoding") ||
-              (x is "date") || (x is "server") || (x is "connection") ⇒
-              suppressionWarning(log, x, "illegal RawHeader")
-              renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
-
-            case x ⇒
-              render(x)
-              renderHeaders(tail, alwaysClose, connHeader, serverSeen, transferEncodingSeen, dateSeen)
-          }
-
-          case Nil ⇒
-            if (!serverSeen) renderDefaultServerHeader(r)
-            if (!dateSeen) r ~~ dateHeader
-
-            // Do we close the connection after this response?
-            closeIf {
-              // if we are prohibited to keep-alive by the spec
-              alwaysClose ||
-                // if the client wants to close and we don't override
-                (ctx.closeRequested && ((connHeader eq null) || !connHeader.hasKeepAlive)) ||
-                // if the application wants to close explicitly
-                (protocol match {
-                  case `HTTP/1.1` ⇒ (connHeader ne null) && connHeader.hasClose
-                  case `HTTP/1.0` ⇒ if (connHeader eq null) ctx.requestProtocol == `HTTP/1.1` else !connHeader.hasKeepAlive
-                })
+                if (renderConnectionHeader)
+                  r ~~ Connection ~~ (if (close) CloseBytes else KeepAliveBytes) ~~ CrLf
+                else if (connHeader != null && connHeader.hasUpgrade) {
+                  r ~~ connHeader ~~ CrLf
+                  headers
+                    .collectFirst { case u: UpgradeToWebsocketResponseHeader ⇒ u }
+                    .foreach { header ⇒ closeMode = SwitchToWebsocket(header.handler) }
+                }
+                if (mustRenderTransferEncodingChunkedHeader && !transferEncodingSeen)
+                  r ~~ `Transfer-Encoding` ~~ ChunkedBytes ~~ CrLf
             }
 
-            // Do we render an explicit Connection header?
-            val renderConnectionHeader =
-              protocol == `HTTP/1.0` && !close || protocol == `HTTP/1.1` && close || // if we don't follow the default behavior
-                close != ctx.closeRequested || // if we override the client's closing request
-                protocol != ctx.requestProtocol // if we reply with a mismatching protocol (let's be very explicit in this case)
+          def renderContentLengthHeader(contentLength: Long) =
+            if (status.allowsEntity) r ~~ `Content-Length` ~~ contentLength ~~ CrLf else r
 
-            if (renderConnectionHeader)
-              r ~~ Connection ~~ (if (close) CloseBytes else KeepAliveBytes) ~~ CrLf
-            else if (connHeader != null && connHeader.hasUpgrade) {
-              r ~~ connHeader ~~ CrLf
-              headers
-                .collectFirst { case u: UpgradeToWebsocketResponseHeader ⇒ u }
-                .foreach { header ⇒ closeMode = SwitchToWebsocket(header.handler) }
+          def byteStrings(entityBytes: ⇒ Source[ByteString, Any]): Source[ResponseRenderingOutput, Any] =
+            renderByteStrings(r, entityBytes, skipEntity = noEntity).map(ResponseRenderingOutput.HttpData(_))
+
+          def completeResponseRendering(entity: ResponseEntity): StrictOrStreamed =
+            entity match {
+              case HttpEntity.Strict(_, data) ⇒
+                renderHeaders(headers.toList)
+                renderEntityContentType(r, entity)
+                renderContentLengthHeader(data.length) ~~ CrLf
+
+                if (!noEntity) r ~~ data
+
+                Strict {
+                  closeMode match {
+                    case SwitchToWebsocket(handler) ⇒ ResponseRenderingOutput.SwitchToWebsocket(r.get, handler)
+                    case _                          ⇒ ResponseRenderingOutput.HttpData(r.get)
+                  }
+                }
+
+              case HttpEntity.Default(_, contentLength, data) ⇒
+                renderHeaders(headers.toList)
+                renderEntityContentType(r, entity)
+                renderContentLengthHeader(contentLength) ~~ CrLf
+                Streamed(byteStrings(data.via(CheckContentLengthTransformer.flow(contentLength))))
+
+              case HttpEntity.CloseDelimited(_, data) ⇒
+                renderHeaders(headers.toList, alwaysClose = ctx.requestMethod != HttpMethods.HEAD)
+                renderEntityContentType(r, entity) ~~ CrLf
+                Streamed(byteStrings(data))
+
+              case HttpEntity.Chunked(contentType, chunks) ⇒
+                if (ctx.requestProtocol == `HTTP/1.0`)
+                  completeResponseRendering(HttpEntity.CloseDelimited(contentType, chunks.map(_.data)))
+                else {
+                  renderHeaders(headers.toList)
+                  renderEntityContentType(r, entity) ~~ CrLf
+                  Streamed(byteStrings(chunks.via(ChunkTransformer.flow)))
+                }
             }
-            if (mustRenderTransferEncodingChunkedHeader && !transferEncodingSeen)
-              r ~~ `Transfer-Encoding` ~~ ChunkedBytes ~~ CrLf
+
+          renderStatusLine()
+          completeResponseRendering(entity)
         }
+      }
 
-      def renderContentLengthHeader(contentLength: Long) =
-        if (status.allowsEntity) r ~~ `Content-Length` ~~ contentLength ~~ CrLf else r
-
-      def byteStrings(entityBytes: ⇒ Source[ByteString, Any]): Source[ResponseRenderingOutput, Any] =
-        renderByteStrings(r, entityBytes, skipEntity = noEntity).map(ResponseRenderingOutput.HttpData(_))
-
-      def completeResponseRendering(entity: ResponseEntity): Source[ResponseRenderingOutput, Any] =
-        entity match {
-          case HttpEntity.Strict(_, data) ⇒
-            renderHeaders(headers.toList)
-            renderEntityContentType(r, entity)
-            renderContentLengthHeader(data.length) ~~ CrLf
-
-            if (!noEntity) r ~~ data
-
-            Source.single {
-              closeMode match {
-                case SwitchToWebsocket(handler) ⇒ ResponseRenderingOutput.SwitchToWebsocket(r.get, handler)
-                case _                          ⇒ ResponseRenderingOutput.HttpData(r.get)
-              }
-            }
-
-          case HttpEntity.Default(_, contentLength, data) ⇒
-            renderHeaders(headers.toList)
-            renderEntityContentType(r, entity)
-            renderContentLengthHeader(contentLength) ~~ CrLf
-            byteStrings(data.via(CheckContentLengthTransformer.flow(contentLength)))
-
-          case HttpEntity.CloseDelimited(_, data) ⇒
-            renderHeaders(headers.toList, alwaysClose = ctx.requestMethod != HttpMethods.HEAD)
-            renderEntityContentType(r, entity) ~~ CrLf
-            byteStrings(data)
-
-          case HttpEntity.Chunked(contentType, chunks) ⇒
-            if (ctx.requestProtocol == `HTTP/1.0`)
-              completeResponseRendering(HttpEntity.CloseDelimited(contentType, chunks.map(_.data)))
-            else {
-              renderHeaders(headers.toList)
-              renderEntityContentType(r, entity) ~~ CrLf
-              byteStrings(chunks.via(ChunkTransformer.flow))
-            }
-        }
-
-      renderStatusLine()
-      val result = completeResponseRendering(entity)
-      if (close)
-        opCtx.pushAndFinish(result)
-      else
-        opCtx.push(result)
-    }
+    sealed trait StrictOrStreamed
+    case class Strict(bytes: ResponseRenderingOutput) extends StrictOrStreamed
+    case class Streamed(source: Source[ResponseRenderingOutput, Any]) extends StrictOrStreamed
   }
 
   sealed trait CloseMode

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -73,46 +73,56 @@ private[http] object HttpServerBluePrint {
     BidiFlow.fromGraph(new ControllerStage(settings, log)).reversed
 
   def requestPreparation(settings: ServerSettings): BidiFlow[HttpResponse, HttpResponse, RequestOutput, HttpRequest, Unit] =
-    BidiFlow.fromFlows(Flow[HttpResponse],
-      Flow[RequestOutput]
-        .splitWhen(x ⇒ x.isInstanceOf[MessageStart] || x == MessageEnd)
-        .prefixAndTail(1)
-        .map(p ⇒ p._1.head -> p._2)
-        .concatSubstreams
-        .via(requestStartOrRunIgnore(settings)))
+    BidiFlow.fromFlows(Flow[HttpResponse], new PrepareRequests(settings))
 
-  def requestStartOrRunIgnore(settings: ServerSettings): Flow[(ParserOutput.RequestOutput, Source[ParserOutput.RequestOutput, Unit]), HttpRequest, Unit] =
-    Flow.fromGraph(new GraphStage[FlowShape[(RequestOutput, Source[RequestOutput, Unit]), HttpRequest]] {
-      val in = Inlet[(RequestOutput, Source[RequestOutput, Unit])]("RequestStartThenRunIgnore.in")
-      val out = Outlet[HttpRequest]("RequestStartThenRunIgnore.out")
-      override val shape: FlowShape[(RequestOutput, Source[RequestOutput, Unit]), HttpRequest] = FlowShape.of(in, out)
+  final class PrepareRequests(settings: ServerSettings) extends GraphStage[FlowShape[RequestOutput, HttpRequest]] {
+    val in = Inlet[RequestOutput]("RequestStartThenRunIgnore.in")
+    val out = Outlet[HttpRequest]("RequestStartThenRunIgnore.out")
+    override val shape: FlowShape[RequestOutput, HttpRequest] = FlowShape.of(in, out)
 
-      override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) {
-        val remoteAddress = inheritedAttributes.get[HttpAttributes.RemoteAddress].flatMap(_.address)
+    override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) {
+      val remoteAddress = inheritedAttributes.get[HttpAttributes.RemoteAddress].flatMap(_.address)
 
-        setHandler(in, new InHandler {
-          override def onPush(): Unit = grab(in) match {
-            case (RequestStart(method, uri, protocol, hdrs, createEntity, _, _), entityParts) ⇒
-              val effectiveMethod = if (method == HttpMethods.HEAD && settings.transparentHeadRequests) HttpMethods.GET else method
-              val effectiveHeaders =
-                if (settings.remoteAddressHeader && remoteAddress.isDefined)
-                  headers.`Remote-Address`(RemoteAddress(remoteAddress.get)) +: hdrs
-                else hdrs
+      val idle = new InHandler {
+        def onPush(): Unit = grab(in) match {
+          case RequestStart(method, uri, protocol, hdrs, entityCreator, _, _) ⇒
+            val effectiveMethod = if (method == HttpMethods.HEAD && settings.transparentHeadRequests) HttpMethods.GET else method
+            val effectiveHeaders =
+              if (settings.remoteAddressHeader && remoteAddress.isDefined)
+                headers.`Remote-Address`(RemoteAddress(remoteAddress.get)) +: hdrs
+              else hdrs
 
-              val entity = createEntity(entityParts) withSizeLimit settings.parserSettings.maxContentLength
-              push(out, HttpRequest(effectiveMethod, uri, effectiveHeaders, entity, protocol))
-
-            case (wat, src) ⇒
-              SubSource.kill(src)
-              pull(in)
-          }
-        })
-
-        setHandler(out, new OutHandler {
-          override def onPull(): Unit = pull(in)
-        })
+            val entity = createEntity(entityCreator) withSizeLimit settings.parserSettings.maxContentLength
+            push(out, HttpRequest(effectiveMethod, uri, effectiveHeaders, entity, protocol))
+        }
       }
-    })
+      setHandler(in, idle)
+
+      def createEntity(creator: EntityCreator[RequestOutput, RequestEntity]): RequestEntity =
+        creator match {
+          case StrictEntityCreator(entity) ⇒ entity
+          case StreamedEntityCreator(creator) ⇒
+            val entitySource = new SubSourceOutlet[RequestOutput]("EntitySource")
+            entitySource.setHandler(new OutHandler {
+              def onPull(): Unit = pull(in)
+            })
+            setHandler(in, new InHandler {
+              def onPush(): Unit = grab(in) match {
+                case MessageEnd ⇒
+                  entitySource.complete()
+                  setHandler(in, idle)
+                case x ⇒ entitySource.push(x)
+              }
+              override def onUpstreamFinish(): Unit = completeStage()
+            })
+            creator(Source.fromGraph(entitySource.source))
+        }
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit = pull(in)
+      })
+    }
+  }
 
   def parsing(settings: ServerSettings, log: LoggingAdapter): Flow[ByteString, RequestOutput, Unit] = {
     import settings._

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -166,8 +166,7 @@ private[http] object HttpServerBluePrint {
     }
 
     Flow[ResponseRenderingContext]
-      .via(Flow[ResponseRenderingContext].transform(() ⇒ responseRendererFactory.newRenderer).named("renderer"))
-      .flatMapConcat(ConstantFun.scalaIdentityFunction)
+      .via(responseRendererFactory.renderer.named("renderer"))
       .via(Flow[ResponseRenderingOutput].transform(() ⇒ errorHandling(errorHandler)).named("errorLogger"))
   }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -393,7 +393,7 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll wit
         private val HttpRequest(POST, uri, List(Accept(Seq(MediaRanges.`*/*`)), Host(_, _), `User-Agent`(_)),
           Chunked(`chunkedContentType`, chunkStream), HttpProtocols.`HTTP/1.1`) = serverIn.expectNext()
         uri shouldEqual Uri(s"http://$hostname:$port/chunked")
-        Await.result(chunkStream.grouped(4).runWith(Sink.head), 100.millis) shouldEqual chunks
+        Await.result(chunkStream.grouped(5).runWith(Sink.head), 100.millis) shouldEqual chunks
 
         val serverOutSub = serverOut.expectSubscription()
         serverOutSub.expectRequest()

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -315,7 +315,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   /**
    * INTERNAL API
    */
-  private[stream] def interpreter: GraphInterpreter =
+  private[akka] def interpreter: GraphInterpreter =
     if (_interpreter == null)
       throw new IllegalStateException("not yet initialized: only setHandler is allowed in GraphStageLogic constructor")
     else _interpreter


### PR DESCRIPTION
i.e. only for Strict entities where we can now completely get rid of per-request materialization.

This includes a fix for #19240 and also the corresponding issue on the rendering side.

This is just a quick try which makes a few tests fail probably because some boundary conditions need to be fixed properly.

With this patch performance is up to ~ 90k RPS (from 15k without the patch) on my machine.

/cc @sirthias 
