### PR TITLE
=htc,str #19256 InputStreamPublisher could emit without pending demnd

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -91,7 +91,7 @@ trait FileAndResourceDirectives {
                   complete {
                     HttpEntity.Default(contentType, length,
                       StreamConverters.fromInputStream(() ⇒ url.openStream())
-                        .withAttributes(ActorAttributes.dispatcher(settings.fileIODispatcher)))
+                        .withAttributes(ActorAttributes.dispatcher(settings.fileIODispatcher))) // TODO is this needed? It already uses `val inputStreamSource = name("inputStreamSource") and IODispatcher`
                   }
                 }
               } else complete(HttpEntity.Empty)

--- a/akka-stream-tck/src/test/scala/akka/stream/tck/InputStreamSourceTest.scala
+++ b/akka-stream-tck/src/test/scala/akka/stream/tck/InputStreamSourceTest.scala
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.tck
+
+import java.io.InputStream
+
+import akka.stream.ActorAttributes
+import akka.stream.scaladsl.{ Sink, StreamConverters }
+import akka.util.ByteString
+import org.reactivestreams.Publisher
+
+class InputStreamSourceTest extends AkkaPublisherVerification[ByteString] {
+
+  def createPublisher(elements: Long): Publisher[ByteString] = {
+    StreamConverters.fromInputStream(() ⇒ new InputStream {
+      @volatile var num = 0
+      override def read(): Int = {
+        num += 1
+        num
+      }
+    }).withAttributes(ActorAttributes.dispatcher("akka.test.stream-dispatcher"))
+      .take(elements)
+      .runWith(Sink.asPublisher(false))
+  }
+}
+

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
@@ -50,7 +50,7 @@ private[akka] class InputStreamPublisher(is: InputStream, bytesReadPromise: Prom
       if (totalDemand > 0) self ! Continue
     }
 
-  def readAndEmit() = try {
+  def readAndEmit(): Unit = if (totalDemand > 0) try {
     // blocking read
     val readBytes = is.read(arr)
 


### PR DESCRIPTION
Fixes the bug found in https://github.com/akka/akka/issues/19256

This breaks HTTP for serving resources.
We need to decide when to roll an 2.0.1 as this breaks existing apps...

// I think I'll also want to look at https://github.com/typesafehub/ssl-config/issues/22 before rolling 2.0.1. Anything else?
