### PR TITLE
Added test to check if charset is set on application/json content type

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -156,6 +156,24 @@ class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll
               |
               |""", close = false)
       }
+
+      "add charset to application/json" in new TestSetup() {
+
+        ResponseRenderingContext(
+          requestMethod = HttpMethods.HEAD,
+          response = HttpResponse(
+            headers = List(Age(30)),
+            entity = HttpEntity.Default(ContentTypes.`application/json`, 100, Source.empty))) should renderTo(
+            """HTTP/1.1 200 OK
+            |Age: 30
+            |Server: akka-http/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Content-Type: application/json ; charset=UTF-8
+            |Content-Length: 100
+            |
+            |""", close = false)
+
+      }
     }
 
     "a response with a Strict body," - {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -156,24 +156,6 @@ class ResponseRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll
               |
               |""", close = false)
       }
-
-      "add charset to application/json" in new TestSetup() {
-
-        ResponseRenderingContext(
-          requestMethod = HttpMethods.HEAD,
-          response = HttpResponse(
-            headers = List(Age(30)),
-            entity = HttpEntity.Default(ContentTypes.`application/json`, 100, Source.empty))) should renderTo(
-            """HTTP/1.1 200 OK
-            |Age: 30
-            |Server: akka-http/1.0.0
-            |Date: Thu, 25 Aug 2011 09:10:29 GMT
-            |Content-Type: application/json ; charset=UTF-8
-            |Content-Length: 100
-            |
-            |""", close = false)
-
-      }
     }
 
     "a response with a Strict body," - {

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -194,6 +194,8 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
     "Content-Type" in {
       "Content-Type: application/pdf" =!=
         `Content-Type`(`application/pdf`)
+      "Content-Type: application/json" =!=
+        `Content-Type`(`application/json`)
       "Content-Type: text/plain; charset=utf8" =!=
         `Content-Type`(ContentType(`text/plain`, `UTF-8`)).renderedTo("text/plain; charset=UTF-8")
       "Content-Type: text/xml2; version=3; charset=windows-1252" =!=


### PR DESCRIPTION
I looks like part of the problem is with that application/json is WithFIxedCharset 
Firstly `application/json` can have utf-16 and utf-32 charsets and secondly I cannot force charsets. 
