### PR TITLE
=clu #19274 failure detection of joining/down member status

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -110,25 +110,21 @@ private[cluster] final class ClusterHeartbeatSender extends Actor with ActorLogg
   def active: Actor.Receive = {
     case HeartbeatTick                ⇒ heartbeat()
     case HeartbeatRsp(from)           ⇒ heartbeatRsp(from)
-    case MemberUp(m)                  ⇒ addMember(m)
-    case MemberWeaklyUp(m)            ⇒ addMember(m)
     case MemberRemoved(m, _)          ⇒ removeMember(m)
+    case evt: MemberEvent             ⇒ addMember(evt.member)
     case UnreachableMember(m)         ⇒ unreachableMember(m)
     case ReachableMember(m)           ⇒ reachableMember(m)
-    case _: MemberEvent               ⇒ // not interested in other types of MemberEvent
     case ExpectedFirstHeartbeat(from) ⇒ triggerFirstHeartbeat(from)
   }
 
   def init(snapshot: CurrentClusterState): Unit = {
-    val nodes: Set[UniqueAddress] = snapshot.members.collect {
-      case m if m.status == MemberStatus.Up || m.status == MemberStatus.WeaklyUp ⇒ m.uniqueAddress
-    }(collection.breakOut)
+    val nodes: Set[UniqueAddress] = snapshot.members.map(_.uniqueAddress)
     val unreachable: Set[UniqueAddress] = snapshot.unreachable.map(_.uniqueAddress)
     state = state.init(nodes, unreachable)
   }
 
   def addMember(m: Member): Unit =
-    if (m.uniqueAddress != selfUniqueAddress)
+    if (m.uniqueAddress != selfUniqueAddress && !state.contains(m.uniqueAddress))
       state = state.addMember(m.uniqueAddress)
 
   def removeMember(m: Member): Unit =
@@ -190,6 +186,8 @@ private[cluster] final case class ClusterHeartbeatSenderState(
 
   def init(nodes: Set[UniqueAddress], unreachable: Set[UniqueAddress]): ClusterHeartbeatSenderState =
     copy(ring = ring.copy(nodes = nodes + selfAddress, unreachable = unreachable))
+
+  def contains(node: UniqueAddress): Boolean = ring.nodes(node)
 
   def addMember(node: UniqueAddress): ClusterHeartbeatSenderState =
     membershipChange(ring :+ node)

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode3Spec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode3Spec.scala
@@ -3,48 +3,50 @@
  */
 package akka.cluster
 
-import language.postfixOps
 import scala.collection.immutable
-import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfter
-import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
-import akka.testkit._
 import scala.concurrent.duration._
-import akka.actor.Address
-import akka.actor.ActorSystem
-import akka.actor.Props
+
 import akka.actor.Actor
+import akka.actor.ActorSystem
+import akka.actor.Address
+import akka.actor.Deploy
+import akka.actor.Props
 import akka.actor.RootActorPath
 import akka.cluster.MemberStatus._
-import akka.actor.Deploy
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
 
-object RestartNodeMultiJvmSpec extends MultiNodeConfig {
+object RestartNode3MultiJvmSpec extends MultiNodeConfig {
   val first = role("first")
   val second = role("second")
   val third = role("third")
 
   commonConfig(debugConfig(on = false).
-    withFallback(ConfigFactory.parseString("akka.cluster.auto-down-unreachable-after = 5s")).
+    withFallback(ConfigFactory.parseString("akka.cluster.auto-down-unreachable-after = off")).
     withFallback(MultiNodeClusterSpec.clusterConfig))
+
+  testTransport(on = true)
 }
 
-class RestartNodeMultiJvmNode1 extends RestartNodeSpec
-class RestartNodeMultiJvmNode2 extends RestartNodeSpec
-class RestartNodeMultiJvmNode3 extends RestartNodeSpec
+class RestartNode3MultiJvmNode1 extends RestartNode3Spec
+class RestartNode3MultiJvmNode2 extends RestartNode3Spec
+class RestartNode3MultiJvmNode3 extends RestartNode3Spec
 
-abstract class RestartNodeSpec
-  extends MultiNodeSpec(RestartNodeMultiJvmSpec)
+abstract class RestartNode3Spec
+  extends MultiNodeSpec(RestartNode3MultiJvmSpec)
   with MultiNodeClusterSpec with ImplicitSender {
 
-  import RestartNodeMultiJvmSpec._
+  import RestartNode3MultiJvmSpec._
 
   @volatile var secondUniqueAddress: UniqueAddress = _
 
   // use a separate ActorSystem, to be able to simulate restart
   lazy val secondSystem = ActorSystem(system.name, system.settings.config)
 
-  def seedNodes: immutable.IndexedSeq[Address] = Vector(first, secondUniqueAddress.address, third)
+  def seedNodes: immutable.IndexedSeq[Address] = Vector(first)
 
   lazy val restartedSecondSystem = ActorSystem(system.name,
     ConfigFactory.parseString("akka.remote.netty.tcp.port=" + secondUniqueAddress.address.port.get).
@@ -60,8 +62,10 @@ abstract class RestartNodeSpec
     super.afterAll()
   }
 
+  override def expectedTestDuration = 2.minutes
+
   "Cluster nodes" must {
-    "be able to restart and join again" taggedAs LongRunningTest in within(60 seconds) {
+    "be able to restart and join again when Down before Up" taggedAs LongRunningTest in within(60.seconds) {
       // secondSystem is a separate ActorSystem, to be able to simulate restart
       // we must transfer its address to first
       runOn(first, third) {
@@ -80,22 +84,34 @@ abstract class RestartNodeSpec
         secondUniqueAddress = Cluster(secondSystem).selfUniqueAddress
         List(first, third) foreach { r ⇒
           system.actorSelection(RootActorPath(r) / "user" / "address-receiver") ! secondUniqueAddress
-          expectMsg(5 seconds, "ok")
+          expectMsg(5.seconds, "ok")
         }
       }
       enterBarrier("second-address-transfered")
 
-      // now we can join first, secondSystem, third together
+      // now we can join first, third together
       runOn(first, third) {
         cluster.joinSeedNodes(seedNodes)
-        awaitMembersUp(3)
+        awaitMembersUp(2)
       }
+      enterBarrier("first-third-up")
+
+      // make third unreachable, so that leader can't perform its duties
+      runOn(first) {
+        testConductor.blackhole(first, third, Direction.Both).await
+        val thirdAddress = address(third)
+        awaitAssert(clusterView.unreachableMembers.map(_.address) should ===(Set(thirdAddress)))
+      }
+      enterBarrier("third-unreachable")
+
       runOn(second) {
         Cluster(secondSystem).joinSeedNodes(seedNodes)
         awaitAssert(Cluster(secondSystem).readView.members.size should ===(3))
-        awaitAssert(Cluster(secondSystem).readView.members.map(_.status) should ===(Set(Up)))
+        awaitAssert(Cluster(secondSystem).readView.members.collectFirst {
+          case m if m.address == Cluster(secondSystem).selfAddress ⇒ m.status
+        } should ===(Some(Joining)))
       }
-      enterBarrier("started")
+      enterBarrier("second-joined")
 
       // shutdown secondSystem
       runOn(second) {
@@ -104,6 +120,9 @@ abstract class RestartNodeSpec
       enterBarrier("second-shutdown")
 
       // then immediately start restartedSecondSystem, which has the same address as secondSystem
+      runOn(first) {
+        testConductor.passThrough(first, third, Direction.Both).await
+      }
       runOn(second) {
         Cluster(restartedSecondSystem).joinSeedNodes(seedNodes)
         awaitAssert(Cluster(restartedSecondSystem).readView.members.size should ===(3))


### PR DESCRIPTION
- Failure detection heartbeating was not performed to joining
  nodes, since it was expected that they will become Up first.
- If a joining node is downed before it is changed to Up failure
  detection will not be performed for that node. That resulted in
  the downed node will not be removed from membership, since the
  unreachability signal is used as confirmation that the node is
  actually stopped before removing it.
