### PR TITLE
fix error in distributed pub sub documentation

### DIFF
--- a/akka-docs/rst/java/distributed-pub-sub.rst
+++ b/akka-docs/rst/java/distributed-pub-sub.rst
@@ -169,7 +169,7 @@ and then it takes a while for it to be populated.
 Dependencies
 ------------
 
-To use the Cluster Singleton you must add the following dependency in your project.
+To use Distributed Publish Subscribe you must add the following dependency in your project.
 
 sbt::
 

--- a/akka-docs/rst/scala/distributed-pub-sub.rst
+++ b/akka-docs/rst/scala/distributed-pub-sub.rst
@@ -172,7 +172,7 @@ and then it takes a while for it to be populated.
 Dependencies
 ------------
 
-To use the Cluster Singleton you must add the following dependency in your project.
+To use Distributed Publish Subscribe you must add the following dependency in your project.
 
 sbt::
 


### PR DESCRIPTION
Both cluster-singleton.rst and distributed-pub-sub.rst say "To use the Cluster Singleton you must add the following dependency in your project." in the Dependencies header. This is confusing for distributed-pub-sub.rst because it does not refer to the Cluster Singleton. I changed the reference of "the Cluster Singleton" to "Distributed Publish Subscribe".
