### PR TITLE
Fix link to SBT installation instructions

### DIFF
--- a/akka-docs/rst/intro/getting-started.rst
+++ b/akka-docs/rst/intro/getting-started.rst
@@ -142,7 +142,7 @@ project.
 
 Summary of the essential parts for using Akka with SBT:
 
-SBT installation instructions on `https://github.com/harrah/xsbt/wiki/Setup <https://github.com/harrah/xsbt/wiki/Setup>`_
+SBT installation instructions on `http://www.scala-sbt.org/release/tutorial/Setup.html <http://www.scala-sbt.org/release/tutorial/Setup.html>`_
 
 ``build.sbt`` file:
 


### PR DESCRIPTION
https://github.com/harrah/xsbt/wiki/Setup defunct, documentation moved to www.scala-sbt.org. Replaced the link with the best match I could find.
