### PR TITLE
Benchmark for the flatMapMerge operator

### DIFF
--- a/akka-bench-jmh-dev/src/main/scala/akka/stream/FlatMapMergeBenchmark.scala
+++ b/akka-bench-jmh-dev/src/main/scala/akka/stream/FlatMapMergeBenchmark.scala
@@ -1,0 +1,55 @@
+/**
+  * Copyright (C) 2014 Typesafe Inc. <http://www.typesafe.com>
+  */
+
+package akka.stream
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl._
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scala.concurrent._
+import scala.concurrent.duration.Duration.Inf
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class FlatMapMergeBenchmark {
+  implicit val system = ActorSystem("FlatMapMergeBenchmark")
+  val materializerSettings = ActorMaterializerSettings(system).withDispatcher("akka.test.stream-dispatcher")
+  implicit val materializer = ActorMaterializer(materializerSettings)
+
+  val NumberOfElements = 100000
+
+  @Param(Array("0", "1", "10"))
+  val NumberOfStreams = 0
+
+  var graph: RunnableGraph[Future[Unit]] = _
+
+  def createSource(count: Int): Graph[SourceShape[Int], Unit] = akka.stream.Fusing.aggressive(Source.repeat(1).take(count))
+
+  @Setup
+  def setup() {
+    val source = NumberOfStreams match {
+      // Base line: process NumberOfElements-many elements from a single source without using flatMapMerge
+      case 0 => createSource(NumberOfElements)
+      // Stream merging: process NumberOfElements-many elements from n sources, each producing (NumberOfElements/n)-many elements
+      case n =>
+        val subSource = createSource(NumberOfElements / n)
+        Source.repeat(()).take(n).flatMapMerge(n, _ => subSource)
+    }
+    graph = Source.fromGraph(source).toMat(Sink.ignore)(Keep.right)
+  }
+
+  @TearDown
+  def shutdown() {
+    system.shutdown()
+    system.awaitTermination()
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000) // Note: needs to match NumberOfElements.
+  def flat_map_merge_100k_elements() {
+    Await.result(graph.run(), Inf)
+  }
+}


### PR DESCRIPTION
Add a JMH benchmark for `Flow.flatMapMerge()`.

The benchmark processes 100k elements that – depending on the benchmark parameter `NumberOfStreams` – come from:
- Case `NumberOfStreams`=0: a single source. In this case, `flatMapMerge()` is _not_ used. This is the base line against which the other tests compare.
- Case `NumberOfStreams`>0: the 100k elements come from `NumberOfStreams`-many sources, each of which produces (100k/`NumberOfStreams`)-many elements. The sources are merged together via `flatMapMerge()`.

Notice that in the latter case, the sources are pre-fused to make the comparison as fair as possible.

On my laptop, `sbt 'akka-bench-jmh-dev/run -i 10 -wi 4 -f1 .*FlatMapMergeBenchmark.*'` gives:

```
[info] Benchmark                                           (NumberOfStreams)   Mode  Cnt     Score     Error   Units
[info] FlatMapMergeBenchmark.flat_map_merge_100k_elements                  0  thrpt   10  8455.581 ± 503.256  ops/ms
[info] FlatMapMergeBenchmark.flat_map_merge_100k_elements                  1  thrpt   10   668.567 ±  18.370  ops/ms
[info] FlatMapMergeBenchmark.flat_map_merge_100k_elements                 10  thrpt   10   641.890 ±  14.682  ops/ms
```
