### PR TITLE
+htp #19311 allow handling a route with Future[RouteResult]

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.server
 
 import scala.collection.immutable
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ Future, ExecutionContext }
 import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
@@ -29,4 +29,9 @@ object RouteResult {
                                                rejectionHandler: RejectionHandler = RejectionHandler.default,
                                                exceptionHandler: ExceptionHandler = null): Flow[HttpRequest, HttpResponse, Unit] =
     Route.handlerFlow(route)
+
+  implicit def routeResult2Route(f: Future[RouteResult]): Route =
+    new StandardRoute {
+      override def apply(ctx: RequestContext): Future[RouteResult] = f
+    }
 }


### PR DESCRIPTION
Resolves #19311

Please have a look @sirthias @jrudolph, does this change make sense to you?
Ticket and gitter discussion explains more, but in short: it's to make handling requests easier with Actors (one example would be people migrating from Spray, where this pattern was popular)
