### PR TITLE
make FlowOps.reprFlatten safe and precise

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/SubFlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SubFlowImpl.scala
@@ -5,7 +5,6 @@ package akka.stream.impl
 
 import akka.stream._
 import akka.stream.scaladsl._
-
 import language.higherKinds
 
 object SubFlowImpl {
@@ -37,5 +36,4 @@ class SubFlowImpl[In, Out, Mat, F[+_], C](val subFlow: Flow[In, Out, Unit],
   override def mergeSubstreamsWithParallelism(breadth: Int): F[Out] = mergeBackFunction(subFlow, breadth)
 
   def to[M](sink: Graph[SinkShape[Out], M]): C = finishFunction(subFlow.to(sink))
-
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -922,10 +922,9 @@ object GraphDSL extends GraphApply {
 
       def to[Mat2](sink: Graph[SinkShape[Out], Mat2]): Closed =
         super.~>(sink)(b)
-
     }
 
-    private class DisabledPortOps[Out, Mat](msg: String) extends PortOpsImpl[Out](null, null) {
+    private class DisabledPortOps[Out](msg: String) extends PortOpsImpl[Out](null, null) {
       override def importAndGetPort(b: Builder[_]): Outlet[Out] = throw new IllegalArgumentException(msg)
 
       override def via[T, Mat2](flow: Graph[FlowShape[Out, T], Mat2]): Repr[T] =


### PR DESCRIPTION
Finally I figured out how to teach scalac that `FlowOps#Repr` is some kind of “my-type”. This implementation removes some casts and actually requires FlowOps subtypes to adhere to the contract.
