### PR TITLE
Agolubev #18565 termination notification combinator

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.actor.Status.Failure
+import akka.pattern.pipe
+import akka.stream._
+import akka.stream.testkit.AkkaSpec
+import akka.stream.testkit.Utils._
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+
+import scala.util.control.NoStackTrace
+
+class FlowWatchTerminationSpec extends AkkaSpec {
+
+  val settings = ActorMaterializerSettings(system)
+
+  implicit val materializer = ActorMaterializer(settings)
+  implicit val ec = system.dispatcher
+
+  "A WatchTermination" must {
+
+    "complete future when stream is completed" in assertAllStagesStopped {
+      val (future, p) = Source(1 to 4).watchTermination()(Keep.right).toMat(TestSink.probe[Int])(Keep.both).run()
+      p.request(4).expectNext(1, 2, 3, 4)
+      future.pipeTo(testActor)
+      expectMsg(())
+      p.expectComplete()
+    }
+
+    "complete future when stream is cancelled from downstream" in assertAllStagesStopped {
+      val (future, p) = Source(1 to 4).watchTermination()(Keep.right).toMat(TestSink.probe[Int])(Keep.both).run()
+      p.request(3).expectNext(1, 2, 3).cancel()
+      future.pipeTo(testActor)
+      expectMsg(())
+    }
+
+    "fail future when stream is failed" in assertAllStagesStopped {
+      val ex = new RuntimeException("Stream failed.") with NoStackTrace
+      val (p, future) = TestSource.probe[Int].watchTermination()(Keep.both).to(Sink.ignore).run()
+      p.sendNext(1)
+      future.pipeTo(testActor)
+      p.sendError(ex)
+      expectMsg(Failure(ex))
+    }
+
+    "complete the future for an empty stream" in assertAllStagesStopped {
+      val (future, p) = Source.empty[Int].watchTermination()(Keep.right).toMat(TestSink.probe[Int])(Keep.both).run()
+      p.request(1)
+      future.pipeTo(testActor)
+      expectMsg(())
+    }
+
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1459,6 +1459,15 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   def detach: javadsl.Flow[In, Out, Mat] = new Flow(delegate.detach)
 
   /**
+    * Materializes to `Future[Unit]` that completes on getting termination message.
+    * The Future completes with success when received complete message from upstream or cancel
+    * from downstream. It fails with the same error when received error message from
+    * downstream.
+    */
+  def watchTermination[M]()(matF: function.Function2[Mat, Future[Unit], M]): javadsl.Flow[In, Out, M] =
+    new Flow(delegate.watchTermination()(combinerToScala(matF)))
+
+  /**
    * Delays the initial element by the specified duration.
    *
    * '''Emits when''' upstream emits an element if the initial delay already elapsed

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1459,13 +1459,24 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   def detach: javadsl.Flow[In, Out, Mat] = new Flow(delegate.detach)
 
   /**
-    * Materializes to `Future[Unit]` that completes on getting termination message.
-    * The Future completes with success when received complete message from upstream or cancel
-    * from downstream. It fails with the same error when received error message from
-    * downstream.
-    */
-  def watchTermination[M]()(matF: function.Function2[Mat, Future[Unit], M]): javadsl.Flow[In, Out, M] =
-    new Flow(delegate.watchTermination()(combinerToScala(matF)))
+   * Materializes to `Future[Unit]` that completes on getting termination message.
+   * The Future completes with success when received complete message from upstream or cancel
+   * from downstream. It fails with the same error when received error message from
+   * downstream.
+   *
+   * Taking `Future` as materialization value for resulting `Flow`. In other words it's combine
+   * materialize values with Keep.right
+   */
+  def watchTermination[M](): javadsl.Flow[In, Out, Future[Unit]] =
+    new Flow(delegate.watchTermination())
+  /**
+   * Materializes to `Future[Unit]` that completes on getting termination message.
+   * The Future completes with success when received complete message from upstream or cancel
+   * from downstream. It fails with the same error when received error message from
+   * downstream.
+   */
+  def watchTerminationMat[M]()(matF: function.Function2[Mat, Future[Unit], M]): javadsl.Flow[In, Out, M] =
+    new Flow(delegate.watchTerminationMat()(combinerToScala(matF)))
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -11,7 +11,7 @@ import akka.event.LoggingAdapter
 import akka.japi.{ Pair, Util, function }
 import akka.stream.Attributes._
 import akka.stream._
-import akka.stream.impl.fusing.Delay
+import akka.stream.impl.fusing.{ GraphStages, Delay }
 import akka.stream.impl.{ ConstantFun, StreamLayout }
 import akka.stream.stage.Stage
 import akka.util.ByteString
@@ -1625,6 +1625,15 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * '''Cancels when''' downstream cancels
    */
   def detach: javadsl.Source[Out, Mat] = new Source(delegate.detach)
+
+  /**
+    * Materializes to `Future[Unit]` that completes on getting termination message.
+    * The Future completes with success when received complete message from upstream or cancel
+    * from downstream. It fails with the same error when received error message from
+    * downstream.
+    */
+  def watchTermination[M]()(matF: function.Function2[Mat, Future[Unit], M]): javadsl.Source[Out, M] =
+    new Source(delegate.watchTermination()(combinerToScala(matF)))
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1627,13 +1627,25 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
   def detach: javadsl.Source[Out, Mat] = new Source(delegate.detach)
 
   /**
-    * Materializes to `Future[Unit]` that completes on getting termination message.
-    * The Future completes with success when received complete message from upstream or cancel
-    * from downstream. It fails with the same error when received error message from
-    * downstream.
-    */
-  def watchTermination[M]()(matF: function.Function2[Mat, Future[Unit], M]): javadsl.Source[Out, M] =
-    new Source(delegate.watchTermination()(combinerToScala(matF)))
+   * Materializes to `Future[Unit]` that completes on getting termination message.
+   * The Future completes with success when received complete message from upstream or cancel
+   * from downstream. It fails with the same error when received error message from
+   * downstream.
+   *
+   * Taking `Future` as materialization value for resulting `Source`. In other words it's combine
+   * materialize values with Keep.right
+   */
+  def watchTermination[M](): javadsl.Source[Out, Future[Unit]] =
+    new Source(delegate.watchTermination())
+
+  /**
+   * Materializes to `Future[Unit]` that completes on getting termination message.
+   * The Future completes with success when received complete message from upstream or cancel
+   * from downstream. It fails with the same error when received error message from
+   * downstream.
+   */
+  def watchTerminationMat[M]()(matF: function.Function2[Mat, Future[Unit], M]): javadsl.Source[Out, M] =
+    new Source(delegate.watchTerminationMat()(combinerToScala(matF)))
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1790,8 +1790,20 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * The Future completes with success when received complete message from upstream or cancel
    * from downstream. It fails with the same error when received error message from
    * downstream.
+   *
+   * Taking `Future` as materialization value for resulting `Flow`. In other words it's combine
+   * materialize values with Keep.right
    */
-  def watchTermination[Mat2]()(matF: (Mat, Future[Unit]) ⇒ Mat2): ReprMat[Out, Mat2] =
+  def watchTermination(): ReprMat[Out, Future[Unit]] =
+    viaMat(GraphStages.terminationWatcher)(Keep.right)
+
+  /**
+   * Materializes to `Future[Unit]` that completes on getting termination message.
+   * The Future completes with success when received complete message from upstream or cancel
+   * from downstream. It fails with the same error when received error message from
+   * downstream.
+   */
+  def watchTerminationMat[Mat2]()(matF: (Mat, Future[Unit]) ⇒ Mat2): ReprMat[Out, Mat2] =
     viaMat(GraphStages.terminationWatcher)(matF)
 
   /**


### PR DESCRIPTION
Ref #18565
Two commits are here. 
- First is about having `def watchTermination[M](combine: [Mat, Future[Unit]] => M): Repr[Out, M]`
- Second is having watchTermination (with Keep.right) and watchTerminationMat (with combine function). I know  that default is Keep.left but with second approach it's more elegant (and still can us Mat version if we need both Mat values).
- watch termination from previous stage and cancellation from next stage
