### PR TITLE
!str #19336 make FlowOpsMat#Repr more narrow

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1634,6 +1634,7 @@ trait FlowOps[+Out, +Mat] {
  */
 trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
 
+  type Repr[+O] <: FlowOpsMat[O, Mat]
   type ReprMat[+O, +M] <: FlowOpsMat[O, M]
   type ClosedMat[+M] <: Graph[_, M]
 


### PR DESCRIPTION
Rational for this change is explained in the referenced issue, https://github.com/akka/akka/issues/19336
