### PR TITLE
=doc #19355 fix typo in docs

### DIFF
--- a/akka-docs/rst/scala/futures.rst
+++ b/akka-docs/rst/scala/futures.rst
@@ -128,7 +128,7 @@ but if 2 or more ``Future``\s are involved ``map`` will not allow you to combine
 .. includecode:: code/docs/future/FutureDocSpec.scala
    :include: flat-map
 
-Composing futures using nested combinators it can sometimes become quite complicated and hard read, in these cases using Scala's
+Composing futures using nested combinators it can sometimes become quite complicated and hard to read, in these cases using Scala's
 'for comprehensions' usually yields more readable code. See next section for examples.
 
 If you need to do conditional propagation, you can use ``filter``:


### PR DESCRIPTION
Changes
"complicated and hard read" -> "complicated and hard to read"
