### PR TITLE
Revert "!htc fix multipart model (java6 had trouble)"

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
@@ -69,7 +69,7 @@ public interface Multipart {
      * Basic model for multipart content as defined by http://tools.ietf.org/html/rfc2046.
      */
     interface General extends Multipart {
-        Source<? extends Multipart.General.BodyPart, Object> getGeneralParts();
+        Source<? extends Multipart.General.BodyPart, Object> getParts();
 
         Future<Multipart.General.Strict> toStrict(long timeoutMillis, Materializer materializer);
 
@@ -92,7 +92,7 @@ public interface Multipart {
      * All parts must have distinct names. (This is not verified!)
      */
     interface FormData extends Multipart {
-        Source<? extends Multipart.FormData.BodyPart, Object> getFormDataParts();
+        Source<? extends Multipart.FormData.BodyPart, Object> getParts();
 
         Future<Multipart.FormData.Strict> toStrict(long timeoutMillis, Materializer materializer);
 
@@ -120,7 +120,7 @@ public interface Multipart {
      * https://tools.ietf.org/html/rfc7233#section-5.4.1 and https://tools.ietf.org/html/rfc7233#appendix-A
      */
     interface ByteRanges extends Multipart {
-        Source<? extends Multipart.ByteRanges.BodyPart, Object> getByteRangeParts();
+        Source<? extends Multipart.ByteRanges.BodyPart, Object> getParts();
 
         Future<Multipart.ByteRanges.Strict> toStrict(long timeoutMillis, Materializer materializer);
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -5,6 +5,7 @@
 package akka.http.scaladsl.model
 
 import java.io.File
+import scala.collection.immutable.VectorBuilder
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 import scala.collection.immutable
@@ -202,13 +203,8 @@ object Multipart {
       strictify(parts)(_.toStrict(timeout)).fast.map(General.Strict(mediaType, _))
     }
 
-    // TODO: bring back once JDK7+, overload resolution in JDK6 freaks out with getParts overriding with more specific generic param
-    //    /** Java API */
-    //    override def getParts: JSource[_ <: jm.Multipart.General.BodyPart, AnyRef] =
-    //      super.getParts.asInstanceOf[JSource[_ <: jm.Multipart.General.BodyPart, AnyRef]]
-
     /** Java API */
-    override def getGeneralParts: JSource[_ <: jm.Multipart.General.BodyPart, AnyRef] =
+    override def getParts: JSource[_ <: jm.Multipart.General.BodyPart, AnyRef] =
       super.getParts.asInstanceOf[JSource[_ <: jm.Multipart.General.BodyPart, AnyRef]]
 
     /** Java API */
@@ -220,8 +216,8 @@ object Multipart {
 
     def apply(_mediaType: MediaType.Multipart, _parts: Source[Multipart.General.BodyPart, Any]): Multipart.General =
       new Multipart.General {
-        override def mediaType = _mediaType
-        override def parts = _parts
+        def mediaType = _mediaType
+        def parts = _parts
         override def toString = s"General($mediaType, $parts)"
       }
 
@@ -233,7 +229,7 @@ object Multipart {
      */
     case class Strict(mediaType: MediaType.Multipart, strictParts: immutable.Seq[Multipart.General.BodyPart.Strict])
       extends Multipart.General with Multipart.Strict with jm.Multipart.General.Strict {
-      override def parts: Source[Multipart.General.BodyPart.Strict, Any] = Source(strictParts)
+      def parts: Source[Multipart.General.BodyPart.Strict, Any] = Source(strictParts)
       override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer) = FastFuture.successful(this)
       override def productPrefix = "General.Strict"
 
@@ -250,7 +246,7 @@ object Multipart {
      * Body part of the [[General]] model.
      */
     sealed abstract class BodyPart extends Multipart.BodyPart with jm.Multipart.General.BodyPart {
-      override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[Multipart.General.BodyPart.Strict] = {
+      def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[Multipart.General.BodyPart.Strict] = {
         import fm.executionContext
         entity.toStrict(timeout).map(BodyPart.Strict(_, headers))
       }
@@ -309,9 +305,9 @@ object Multipart {
    * All parts must have distinct names. (This is not verified!)
    */
   sealed abstract class FormData extends Multipart with jm.Multipart.FormData {
-    override def mediaType = MediaTypes.`multipart/form-data`
+    def mediaType = MediaTypes.`multipart/form-data`
 
-    override def parts: Source[Multipart.FormData.BodyPart, Any]
+    def parts: Source[Multipart.FormData.BodyPart, Any]
 
     def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[Multipart.FormData.Strict] = {
       import fm.executionContext
@@ -337,8 +333,6 @@ object Multipart {
     def apply(_parts: Source[Multipart.FormData.BodyPart, Any]): Multipart.FormData =
       new Multipart.FormData {
         def parts = _parts
-        override def getFormDataParts: JSource[jm.Multipart.FormData.BodyPart, AnyRef] =
-          parts.asJava.asInstanceOf[JSource[_ <: jm.Multipart.FormData.BodyPart, AnyRef]]
         override def toString = s"FormData($parts)"
       }
 
@@ -356,9 +350,7 @@ object Multipart {
      */
     case class Strict(strictParts: immutable.Seq[Multipart.FormData.BodyPart.Strict])
       extends FormData with Multipart.Strict with jm.Multipart.FormData.Strict {
-      override def parts: Source[Multipart.FormData.BodyPart.Strict, Any] = Source(strictParts)
-      override def getFormDataParts: JSource[jm.Multipart.FormData.BodyPart, AnyRef] =
-        parts.asJava.asInstanceOf[JSource[_ <: jm.Multipart.FormData.BodyPart, AnyRef]]
+      def parts: Source[Multipart.FormData.BodyPart.Strict, Any] = Source(strictParts)
       override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer) = FastFuture.successful(this)
       override def productPrefix = "FormData.Strict"
 
@@ -369,7 +361,6 @@ object Multipart {
       /** Java API */
       override def getStrictParts: java.lang.Iterable[jm.Multipart.FormData.BodyPart.Strict] =
         super.getStrictParts.asInstanceOf[java.lang.Iterable[jm.Multipart.FormData.BodyPart.Strict]]
-
     }
 
     /**
@@ -484,9 +475,7 @@ object Multipart {
 
     def apply(_parts: Source[Multipart.ByteRanges.BodyPart, Any]): Multipart.ByteRanges =
       new Multipart.ByteRanges {
-        override def parts = _parts
-        override def getByteRangeParts: JSource[jm.Multipart.ByteRanges.BodyPart, AnyRef] =
-          parts.asJava.asInstanceOf[JSource[jm.Multipart.ByteRanges.BodyPart, AnyRef]]
+        def parts = _parts
         override def toString = s"ByteRanges($parts)"
       }
 
@@ -495,7 +484,7 @@ object Multipart {
      */
     case class Strict(strictParts: immutable.Seq[Multipart.ByteRanges.BodyPart.Strict])
       extends Multipart.ByteRanges with Multipart.Strict with jm.Multipart.ByteRanges.Strict {
-      override def parts: Source[Multipart.ByteRanges.BodyPart.Strict, Any] = Source(strictParts)
+      def parts: Source[Multipart.ByteRanges.BodyPart.Strict, Any] = Source(strictParts)
       override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer) = FastFuture.successful(this)
       override def productPrefix = "ByteRanges.Strict"
 
@@ -506,9 +495,6 @@ object Multipart {
       /** Java API */
       override def getStrictParts: java.lang.Iterable[jm.Multipart.ByteRanges.BodyPart.Strict] =
         super.getStrictParts.asInstanceOf[java.lang.Iterable[jm.Multipart.ByteRanges.BodyPart.Strict]]
-
-      override def getByteRangeParts: JSource[jm.Multipart.ByteRanges.BodyPart, AnyRef] =
-        parts.asJava.asInstanceOf[JSource[jm.Multipart.ByteRanges.BodyPart.Strict, AnyRef]]
     }
 
     /**

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
@@ -95,8 +95,7 @@ public class TcpTest extends StreamTest {
           } catch (BindFailedException e) {
             // expected
           } catch (Exception e) {
-            // throw new AssertionError("failed", e); // TODO: bring back once we're JDK7+
-            throw new RuntimeException("failed", e);
+            throw new AssertionError("failed", e);
           }
           return null;
         }


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/19251

Since the upcoming HTTP release is aiming to use Java 8, we can revert this change.
See the above issue for details.

Reverts akka/akka#19250
