### PR TITLE
#19395 : Introduced dedupe graph stage and flow ops method

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDedupeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDedupeSpec.scala
@@ -1,0 +1,32 @@
+/**
+  * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+  */
+package akka.stream.scaladsl
+
+import akka.stream.testkit._
+import akka.stream.testkit.Utils.assertAllStagesStopped
+import akka.stream.testkit.scaladsl.{ TestSource, TestSink }
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+
+class FlowDedupeSpec extends AkkaSpec {
+
+  implicit val materializer = ActorMaterializer()
+
+  "A Dedupe" must {
+
+    "remove consecutive duplicates" in {
+      val input = List(1, 1, 1, 2, 2, 1, 1, 3)
+      val probe = TestSubscriber.manualProbe[Int]()
+      Source(input).dedupe.runWith(Sink.fromSubscriber(probe))
+
+      val subscription = probe.expectSubscription()
+      subscription.request(Long.MaxValue)
+
+      probe.expectNext(1)
+      probe.expectNext(2)
+      probe.expectNext(1)
+      probe.expectNext(3)
+      probe.expectComplete()
+    }
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -43,6 +43,7 @@ private[stream] object Stages {
     val scan = name("scan")
     val fold = name("fold")
     val intersperse = name("intersperse")
+    val dedupe = name("dedupe")
     val buffer = name("buffer")
     val conflate = name("conflate")
     val expand = name("expand")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -752,6 +752,26 @@ trait FlowOps[+Out, +Mat] {
   }
 
   /**
+   * Filters our consecutive duplicated elements from the stream.
+   *
+   * Examples:
+   *
+   * {{{
+   *   var nums = Source(List(1,1,1,2,2,1,1))
+   *   nums.dedupe   // 1, 2, 1
+   * }}}
+   *
+   * '''Emits when''' upstream emits element distinct from element emitted previously
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def dedupe: Repr[Out] = via(new Dedupe())
+
+  /**
    * Intersperses stream with provided element, similar to how [[scala.collection.immutable.List.mkString]]
    * injects a separator between a List's elements.
    *


### PR DESCRIPTION
## Motivation

As mentioned in #19395 I've seen a missing, but somewhat useful feature of removing consecutive duplicates from the stream of events. This is not same as distinct/unique operation over the standard collections, since this would require potential buffering of the whole stream.

Example:

``` scala
Source(List(1, 1, 2, 2, 2, 1, 1, 1)).dedupe   // 1, 2, 1
```
## Changes

This PR introduces enhancement to akka Flow DSL in form of `dedupe` operation and correlated `Dedupe` graph stage. Correlated specs attached.
