### PR TITLE
#19395: added dedupe graph stage

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDeduplicateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDeduplicateSpec.scala
@@ -1,0 +1,29 @@
+/**
+  * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+  */
+package akka.stream.scaladsl
+
+import akka.stream.testkit._
+import akka.stream.testkit.Utils.assertAllStagesStopped
+import akka.stream.testkit.scaladsl.{ TestSource, TestSink }
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+
+class FlowDeduplicateSpec extends AkkaSpec {
+
+  implicit val materializer = ActorMaterializer()
+
+  "A Deduplicate" must {
+
+    "remove consecutive duplicates" in {
+      val input = List(1, 1, 1, 2, 2, 1, 1, 3)
+      val probe = TestSubscriber.manualProbe[Int]()
+      Source(input).deduplicate.runWith(Sink.fromSubscriber(probe))
+
+      val subscription = probe.expectSubscription()
+      subscription.request(input.size)
+
+      probe.expectNext(1, 2, 1, 3)
+      probe.expectComplete()
+    }
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -43,6 +43,7 @@ private[stream] object Stages {
     val scan = name("scan")
     val fold = name("fold")
     val intersperse = name("intersperse")
+    val deduplicate = name("deduplicate")
     val buffer = name("buffer")
     val conflate = name("conflate")
     val expand = name("expand")

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -281,6 +281,36 @@ final case class Intersperse[T](start: Option[T], inject: T, end: Option[T]) ext
 }
 
 /**
+  * INTERNAL API
+  */
+private[akka] final case class Deduplicate[T](implicit equiv: Equiv[T]) extends GraphStage[FlowShape[T, T]] {
+  private val in = Inlet[T]("Deduplicate.in")
+  private val out = Outlet[T]("Deduplicate.out")
+
+  override def shape: FlowShape[T, T] = FlowShape(in, out)
+  override def initialAttributes = DefaultAttributes.deduplicate
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    var last: T = null.asInstanceOf[T]
+
+    setHandler(in, new InHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        if (equiv.equiv(elem, last)) {
+          last = elem
+          push(out, elem)
+        } else pull(in)
+      }
+    })
+    setHandler(out, new OutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+
+  override def toString = "Deduplicate"
+}
+
+/**
  * INTERNAL API
  */
 private[akka] final case class Grouped[T](n: Int) extends PushPullStage[T, immutable.Seq[T]] {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1352,6 +1352,25 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    */
   def initialDelay(delay: FiniteDuration): Repr[Out] = via(new Timers.DelayInitial[Out](delay))
+  /**
+   *  Filters our consecutive duplicated elements from the stream.
+   *
+   * Examples:
+   *
+   * {{{
+   *   var nums = Source(List(1,1,1,2,2,1,1))
+   *   nums.deduplicate   // 1, 2, 1
+   * }}}
+   *
+   * '''Emits when''' upstream emits element distinct from element emitted previously
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def deduplicate(implicit equiv: Equiv[Out]): Repr[Out] = via(new Deduplicate(equiv))
 
   /**
    * Logs elements flowing through the stream as well as completion and erroring.


### PR DESCRIPTION
## Motivation

As mentioned in #19395 I've seen a missing, but somewhat useful feature of removing consecutive duplicates from the stream of events. This is not same as distinct/unique operation over the standard collections, since this would require potential buffering of the whole stream.

Example:

``` scala
Source(List(1, 1, 2, 2, 2, 1, 1, 1)).dedupe   // 1, 2, 1
```
## Changes

This PR introduces enhancement to akka Flow DSL in form of `dedupe` operation and correlated `Dedupe` graph stage. Correlated specs attached.
