### PR TITLE
#19443: Java Stream support

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -3,12 +3,16 @@
  */
 package akka.stream.scaladsl
 
+import java.util.function.ToIntFunction
+import java.util.stream.Collectors
+
 import akka.stream._
-import akka.stream.testkit.TestPublisher.ManualProbe
 import akka.stream.testkit._
+import akka.testkit.DefaultTimeout
+import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.Future
 
-class SinkSpec extends AkkaSpec {
+class SinkSpec extends AkkaSpec with DefaultTimeout with ScalaFutures {
 
   import GraphDSL.Implicits._
 
@@ -124,6 +128,54 @@ class SinkSpec extends AkkaSpec {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].withAttributes(asyncBoundary).addAttributes(none).named("")
     }
+  }
+
+  "Java collector Sink" must {
+    import scala.compat.java8.FunctionConverters._
+
+    "work in the happy case" in {
+      Source(1 to 100).map(_.toString).runWith(Sink.javaCollector(Collectors.joining(", ")))
+        .futureValue should ===((1 to 100).mkString(", "))
+    }
+
+    "work parallelly in the happy case" in {
+
+      val intIdentity: ToIntFunction[Int] = new ToIntFunction[Int] {
+        override def applyAsInt(value: Int): Int = value
+      }
+
+      Source(1 to 100).runWith(Sink.javaCollectorParallelUnordered(4)(Collectors.summingInt[Int](intIdentity)))
+        .futureValue should ===(5050)
+    }
+
+    "be reusable" in {
+
+    }
+
+    "fail if getting the supplier fails" in {
+
+    }
+
+    "fail if the supplier fails" in {
+
+    }
+
+    "fail if getting the accumulator fails" in {
+
+    }
+
+    "fail if the accumulator fails" in {
+
+    }
+
+    "fail if getting the finisher fails" in {
+
+    }
+
+    "fail if the finisher fails" in {
+
+    }
+
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -186,6 +186,12 @@ object Source {
       override def toString: String = "() => Iterator"
     })
 
+  def fromJavaStream[T, S <: java.util.stream.BaseStream[T, S]](stream: () ⇒ java.util.stream.BaseStream[T, S]): Source[T, Unit] = {
+
+    import scala.collection.JavaConverters._
+    Source.fromIterator(() ⇒ stream().iterator().asScala)
+  }
+
   /**
    * A graph with the shape of a source logically is a source, this method makes
    * it so also in type.


### PR DESCRIPTION
*\* PREVIEW **

Added support for conversion from Stream and using Collectors (also in unordered parallel mode).

Need some feedback on what we would need. (like do we need to expose a blocking Sink.asStream)
