### PR TITLE
[WIP] #16651 Add formFieldMap, formFieldMultiMap & formFieldSeq Directives

### DIFF
--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFieldMap.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFieldMap.rst
@@ -1,0 +1,29 @@
+.. _-formFieldMap-:
+
+formFieldMap
+============
+
+Signature
+---------
+
+.. includecode2:: /../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
+   :snippet: formFieldMap
+
+Description
+-----------
+Extracts all HTTP form fields at once as a ``Map[String, String]`` mapping form field names to form field values.
+
+If form data contain a field value several times, the map will contain the last one.
+
+See :ref:`-formFields-` for an in-depth description.
+
+Warning
+-------
+Use of this directive can result in performance degradation or even in ``OutOfMemoryError`` s.
+See :ref:`-formFieldSeq-` for details.
+
+Example
+-------
+
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+   :snippet: formFieldMap

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFieldMultiMap.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFieldMultiMap.rst
@@ -1,0 +1,33 @@
+.. _-formFieldMultiMap-:
+
+formFieldMultiMap
+=================
+
+Signature
+---------
+
+.. includecode2:: /../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
+   :snippet: formFieldMultiMap
+
+Description
+-----------
+
+Extracts all HTTP form fields at once as a multi-map of type ``Map[String, List[String]`` mapping
+a form name to a list of all its values.
+
+This directive can be used if form fields can occur several times.
+
+The order of values is *not* specified.
+
+See :ref:`-formFields-` for an in-depth description.
+
+Warning
+-------
+Use of this directive can result in performance degradation or even in ``OutOfMemoryError`` s.
+See :ref:`-formFieldSeq-` for details.
+
+Example
+-------
+
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+   :snippet: formFieldMultiMap

--- a/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFieldSeq.rst
+++ b/akka-docs-dev/rst/scala/http/routing-dsl/directives/form-field-directives/formFieldSeq.rst
@@ -1,0 +1,30 @@
+.. _-formFieldSeq-:
+
+formFieldSeq
+============
+
+Signature
+---------
+
+.. includecode2:: /../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
+   :snippet: formFieldSeq
+
+Description
+-----------
+Extracts all HTTP form fields at once in the original order as (name, value) tuples of type ``(String, String)``.
+
+This directive can be used if the exact order of form fields is important or if parameters can occur several times.
+
+See :ref:`-formFields-` for an in-depth description.
+
+Warning
+-------
+The directive reads all incoming HTT form fields without any configured upper bound.
+It means, that requests with form fields holding significant amount of data (ie. during a file upload)
+can cause performance issues or even an ``OutOfMemoryError`` s.
+
+Example
+-------
+
+.. includecode2:: ../../../../code/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+   :snippet: formFieldSeq

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
@@ -44,5 +44,53 @@ class FormFieldDirectivesExamplesSpec extends RoutingSpec {
       responseAs[String] shouldEqual "Request is missing required form field 'color'"
     }
   }
+  "formFieldMap" in {
+    val route =
+      formFieldMap { fields =>
+        def formFieldString(formField: (String, String)): String =
+          s"""${formField._1} = '${formField._2}'"""
+        complete(s"The form fields are ${fields.map(formFieldString).mkString(", ")}")
+      }
+
+    // tests:
+    Post("/", FormData("color" -> "blue", "count" -> "42")) ~> route ~> check {
+      responseAs[String] shouldEqual "The form fields are color = 'blue', count = '42'"
+    }
+    Post("/", FormData("x" -> "1", "x" -> "5")) ~> route ~> check {
+      responseAs[String] shouldEqual "The form fields are x = '5'"
+    }
+  }
+  "formFieldMultiMap" in {
+    val route =
+      formFieldMultiMap { fields =>
+        complete("There are " +
+          s"form fields ${fields.map(x => x._1 + " -> " + x._2.size).mkString(", ")}")
+      }
+
+    // tests:
+    Post("/", FormData("color" -> "blue", "count" -> "42")) ~> route ~> check {
+      responseAs[String] shouldEqual "There are form fields color -> 1, count -> 1"
+    }
+    Post("/", FormData("x" -> "23", "x" -> "4", "x" -> "89")) ~> route ~> check {
+      responseAs[String] shouldEqual "There are form fields x -> 3"
+    }
+  }
+  "formFieldSeq" in {
+    val route =
+      formFieldSeq { fields =>
+        def formFieldString(formField: (String, String)): String =
+          s"""${formField._1} = '${formField._2}'"""
+        complete(s"The form fields are ${fields.map(formFieldString).mkString(", ")}")
+      }
+
+    // tests:
+    Post("/", FormData("color" -> "blue", "count" -> "42")) ~> route ~> check {
+      responseAs[String] shouldEqual "The form fields are color = 'blue', count = '42'"
+    }
+    Post("/", FormData("x" -> "23", "x" -> "4", "x" -> "89")) ~> route ~> check {
+      responseAs[String] shouldEqual "The form fields are x = '23', x = '4', x = '89'"
+    }
+  }
+
 
 }

--- a/akka-docs/rst/scala/http/routing-dsl/directives/alphabetically.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/alphabetically.rst
@@ -64,7 +64,13 @@ Directive                                   Description
                                             closest :ref:`-handleExceptions-` directive and its ``ExceptionHandler``
 :ref:`-fileUpload-`                         Provides a stream of an uploaded file from a multipart request
 :ref:`-formField-`                          Extracts an HTTP form field from the request
+:ref:`-formFieldMap-`                       Extracts a number of HTTP form field from the request as
+                                            a ``Map[String, String]``
+:ref:`-formFieldMultiMap-`                  Extracts a number of HTTP form field from the request as
+                                            a ``Map[String, List[String]``
 :ref:`-formFields-`                         Extracts a number of HTTP form field from the request
+:ref:`-formFieldSeq-`                       Extracts a number of HTTP form field from the request as
+                                            a ``Seq[(String, String)]``
 :ref:`-get-`                                Rejects all non-GET requests
 :ref:`-getFromBrowseableDirectories-`       Serves the content of the given directories as a file-system browser, i.e.
                                             files are sent and directories served as browseable listings

--- a/akka-docs/rst/scala/http/routing-dsl/directives/form-field-directives/index.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/form-field-directives/index.rst
@@ -8,3 +8,6 @@ FormFieldDirectives
 
    formField
    formFields
+   formFieldSeq
+   formFieldMap
+   formFieldMultiMap

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -162,4 +162,33 @@ class FormFieldDirectivesSpec extends RoutingSpec {
       } ~> check { responseAs[String] === "List(3, 10)" }
     }
   }
+
+  "The 'formFieldMap' directive" should {
+    "extract fields with different keys" in {
+      Post("/", FormData("age" -> "42", "numberA" -> "3", "numberB" -> "5")) ~> {
+        formFieldMap { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "Map(age -> 42, numberA -> 3, numberB -> 5)" }
+    }
+  }
+
+  "The 'formFieldSeq' directive" should {
+    "extract all fields" in {
+      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "5")) ~> {
+        formFieldSeq { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "Vector((age,42), (number,3), (number,5))" }
+    }
+    "produce empty Seq when FormData is empty" in {
+      Post("/", FormData.Empty) ~> {
+        formFieldSeq { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "Vector()" }
+    }
+  }
+
+  "The 'formFieldMultiMap' directive" should {
+    "extract fields with different keys (with duplicates)" in {
+      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "5")) ~> {
+        formFieldMultiMap { echoComplete }
+      } ~> check { responseAs[String] shouldEqual "Map(age -> List(42), number -> List(5, 3))" }
+    }
+  }
 }


### PR DESCRIPTION
This PR includes formFieldMap, formFieldMultiMap and formFieldSeq Directives. Fixes #16651.

The code lacks of Java API implementation and documentation for that API.
@ktoso, Java API is missing many other directives. Should I work on Java from fields directives or it is enough to polish Scala-related stuff?

(This is a continuation of PR #19042)
