### PR TITLE
=act #19466 add failing test for `ByteString`

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -16,6 +16,7 @@ import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.prop.Checkers
 
+import scala.collection.{ immutable, mutable }
 import scala.collection.mutable.Builder
 
 class ByteStringSpec extends WordSpec with Matchers with Checkers {
@@ -616,6 +617,11 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
           a.nonEmpty
         }
       }
+    }
+    "return the correct class from Builder.result" in {
+      val builder = ByteString().genericBuilder[String]
+      builder += "foo"
+      builder.result.getClass should equal(classOf[ByteString])
     }
   }
 }


### PR DESCRIPTION
This obviously needs a fix before it can be committed. Please also see romix/akka-kryo-serialization#69 for more background here and a workaround that @luben very kindly solved and put together. :+1: 
