### PR TITLE
Wip 19014 make stage actor ref location transparent rk

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/FunctionRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FunctionRefSpec.scala
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.actor
+
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import scala.concurrent.duration._
+import akka.testkit.EventFilter
+
+object FunctionRefSpec {
+
+  case class GetForwarder(replyTo: ActorRef)
+  case class DropForwarder(ref: FunctionRef)
+  case class Forwarded(msg: Any, sender: ActorRef)
+
+  class Super extends Actor {
+    def receive = {
+      case GetForwarder(replyTo) ⇒
+        val cell = context.asInstanceOf[ActorCell]
+        val ref = cell.addFunctionRef((sender, msg) ⇒ replyTo ! Forwarded(msg, sender))
+        replyTo ! ref
+      case DropForwarder(ref) ⇒
+        val cell = context.asInstanceOf[ActorCell]
+        cell.removeFunctionRef(ref)
+    }
+  }
+
+  class SupSuper extends Actor {
+    val s = context.actorOf(Props[Super], "super")
+    def receive = {
+      case msg ⇒ s ! msg
+    }
+  }
+
+}
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class FunctionRefSpec extends AkkaSpec with ImplicitSender {
+  import FunctionRefSpec._
+
+  def commonTests(s: ActorRef) = {
+    s ! GetForwarder(testActor)
+    val forwarder = expectMsgType[FunctionRef]
+
+    "forward messages" in {
+      forwarder ! "hello"
+      expectMsg(Forwarded("hello", testActor))
+    }
+
+    "be watchable" in {
+      s ! GetForwarder(testActor)
+      val f = expectMsgType[FunctionRef]
+      watch(f)
+      s ! DropForwarder(f)
+      expectTerminated(f)
+    }
+
+    "be able to watch" in {
+      s ! GetForwarder(testActor)
+      val f = expectMsgType[FunctionRef]
+      forwarder.watch(f)
+      s ! DropForwarder(f)
+      expectMsg(Forwarded(Terminated(f)(true, false), null))
+    }
+
+    "terminate when their parent terminates" in {
+      watch(forwarder)
+      s ! PoisonPill
+      expectTerminated(forwarder)
+    }
+  }
+
+  "A FunctionRef" when {
+
+    "created by a toplevel actor" must {
+      val s = system.actorOf(Props[Super], "super")
+      commonTests(s)
+    }
+
+    "created by a non-toplevel actor" must {
+      val s = system.actorOf(Props[SupSuper], "supsuper")
+      commonTests(s)
+    }
+
+    "not registered" must {
+      "not be found" in {
+        val provider = system.asInstanceOf[ExtendedActorSystem].provider
+        val ref = new FunctionRef(testActor.path / "blabla", provider, system.eventStream, (x, y) ⇒ ())
+        EventFilter[ClassCastException](occurrences = 1) intercept {
+          // needs to be something that fails when the deserialized form is not a FunctionRef
+          // this relies upon serialize-messages during tests
+          testActor ! DropForwarder(ref)
+          expectNoMsg(1.second)
+        }
+      }
+    }
+
+  }
+}

--- a/akka-actor/src/main/java/akka/actor/dungeon/AbstractActorCell.java
+++ b/akka-actor/src/main/java/akka/actor/dungeon/AbstractActorCell.java
@@ -11,12 +11,14 @@ final class AbstractActorCell {
     final static long mailboxOffset;
     final static long childrenOffset;
     final static long nextNameOffset;
+    final static long functionRefsOffset;
 
     static {
         try {
           mailboxOffset = Unsafe.instance.objectFieldOffset(ActorCell.class.getDeclaredField("akka$actor$dungeon$Dispatch$$_mailboxDoNotCallMeDirectly"));
           childrenOffset = Unsafe.instance.objectFieldOffset(ActorCell.class.getDeclaredField("akka$actor$dungeon$Children$$_childrenRefsDoNotCallMeDirectly"));
           nextNameOffset = Unsafe.instance.objectFieldOffset(ActorCell.class.getDeclaredField("akka$actor$dungeon$Children$$_nextNameDoNotCallMeDirectly"));
+          functionRefsOffset = Unsafe.instance.objectFieldOffset(ActorCell.class.getDeclaredField("akka$actor$dungeon$Children$$_functionRefsDoNotCallMeDirectly"));
         } catch(Throwable t){
             throw new ExceptionInInitializerError(t);
         }

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -150,7 +150,10 @@ private[akka] class RepointableActorRef(
           lookup.getChildByName(childName) match {
             case Some(crs: ChildRestartStats) if uid == ActorCell.undefinedUid || uid == crs.uid ⇒
               crs.child.asInstanceOf[InternalActorRef].getChild(name)
-            case _ ⇒ Nobody
+            case _ ⇒ lookup match {
+              case ac: ActorCell ⇒ ac.getFunctionRefOrNobody(childName, uid)
+              case _             ⇒ Nobody
+            }
           }
       }
     } else this

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -12,6 +12,10 @@ import akka.serialization.SerializationExtension
 import akka.util.{ Unsafe, Helpers }
 import akka.serialization.SerializerWithStringManifest
 
+private[akka] object Children {
+  val GetNobody = () ⇒ Nobody
+}
+
 private[akka] trait Children { this: ActorCell ⇒
 
   import ChildrenContainer._
@@ -41,14 +45,57 @@ private[akka] trait Children { this: ActorCell ⇒
   private[akka] def attachChild(props: Props, name: String, systemService: Boolean): ActorRef =
     makeChild(this, props, checkName(name), async = true, systemService = systemService)
 
-  @volatile private var _nextNameDoNotCallMeDirectly = 0L
-  final protected def randomName(): String = {
-    @tailrec def inc(): Long = {
-      val current = Unsafe.instance.getLongVolatile(this, AbstractActorCell.nextNameOffset)
-      if (Unsafe.instance.compareAndSwapLong(this, AbstractActorCell.nextNameOffset, current, current + 1)) current
-      else inc()
+  @volatile private var _functionRefsDoNotCallMeDirectly = Map.empty[String, FunctionRef]
+  private def functionRefs: Map[String, FunctionRef] =
+    Unsafe.instance.getObjectVolatile(this, AbstractActorCell.functionRefsOffset).asInstanceOf[Map[String, FunctionRef]]
+
+  private[akka] def getFunctionRefOrNobody(name: String, uid: Int = ActorCell.undefinedUid): InternalActorRef =
+    functionRefs.getOrElse(name, Children.GetNobody()) match {
+      case f: FunctionRef ⇒
+        if (uid == ActorCell.undefinedUid || f.path.uid == uid) f else Nobody
+      case other ⇒
+        other
     }
-    Helpers.base64(inc())
+
+  private[akka] def addFunctionRef(f: (ActorRef, Any) ⇒ Unit): FunctionRef = {
+    val childPath = new ChildActorPath(self.path, randomName(new java.lang.StringBuilder("$$")), ActorCell.newUid())
+    val ref = new FunctionRef(childPath, provider, system.eventStream, f)
+
+    @tailrec def rec(): Unit = {
+      val old = functionRefs
+      val added = old.updated(childPath.name, ref)
+      if (!Unsafe.instance.compareAndSwapObject(this, AbstractActorCell.functionRefsOffset, old, added)) rec()
+    }
+    rec()
+
+    ref
+  }
+
+  private[akka] def removeFunctionRef(ref: FunctionRef): Unit = {
+    require(ref.path.parent eq self.path, "trying to remove FunctionRef from wrong ActorCell")
+    ref.stop()
+    val name = ref.path.name
+    @tailrec def rec(): Unit = {
+      val old = functionRefs
+      val removed = old - name
+      if (!Unsafe.instance.compareAndSwapObject(this, AbstractActorCell.functionRefsOffset, old, removed)) rec()
+    }
+    rec()
+  }
+
+  protected def stopFunctionRefs(): Unit = {
+    val refs = Unsafe.instance.getAndSetObject(this, AbstractActorCell.functionRefsOffset, Map.empty).asInstanceOf[Map[String, FunctionRef]]
+    refs.valuesIterator.foreach(_.stop())
+  }
+
+  @volatile private var _nextNameDoNotCallMeDirectly = 0L
+  final protected def randomName(sb: java.lang.StringBuilder): String = {
+    val num = Unsafe.instance.getAndAddLong(this, AbstractActorCell.nextNameOffset, 1)
+    Helpers.base64(num, sb)
+  }
+  final protected def randomName(): String = {
+    val num = Unsafe.instance.getAndAddLong(this, AbstractActorCell.nextNameOffset, 1)
+    Helpers.base64(num)
   }
 
   final def stop(actor: ActorRef): Unit = {
@@ -140,14 +187,14 @@ private[akka] trait Children { this: ActorCell ⇒
       // optimization for the non-uid case
       getChildByName(name) match {
         case Some(crs: ChildRestartStats) ⇒ crs.child.asInstanceOf[InternalActorRef]
-        case _                            ⇒ Nobody
+        case _                            ⇒ getFunctionRefOrNobody(name)
       }
     } else {
       val (childName, uid) = ActorCell.splitNameAndUid(name)
       getChildByName(childName) match {
         case Some(crs: ChildRestartStats) if uid == ActorCell.undefinedUid || uid == crs.uid ⇒
           crs.child.asInstanceOf[InternalActorRef]
-        case _ ⇒ Nobody
+        case _ ⇒ getFunctionRefOrNobody(childName, uid)
       }
     }
 

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -211,6 +211,7 @@ private[akka] trait FaultHandling { this: ActorCell ⇒
     catch handleNonFatalOrInterruptedException { e ⇒ publish(Error(e, self.path.toString, clazz(a), e.getMessage)) }
     finally try dispatcher.detach(this)
     finally try parent.sendSystemMessage(DeathWatchNotification(self, existenceConfirmed = true, addressTerminated = false))
+    finally try stopFunctionRefs()
     finally try tellWatchersWeDied()
     finally try unwatchWatchedActors(a) // stay here as we expect an emergency stop from handleInvokeFailure
     finally {

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestKitSpec.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestKitSpec.scala
@@ -22,7 +22,7 @@ class StreamTestKitSpec extends AkkaSpec {
     }
 
     "#toStrict with failing source" in {
-      val msg = intercept[AssertionError] {
+      val error = intercept[AssertionError] {
         Source.fromIterator(() ⇒ new Iterator[Int] {
           var i = 0
           override def hasNext: Boolean = true
@@ -35,10 +35,10 @@ class StreamTestKitSpec extends AkkaSpec {
           }
         }).runWith(TestSink.probe)
           .toStrict(300.millis)
-      }.getMessage
+      }
 
-      msg should include("Boom!")
-      msg should include("List(1, 2)")
+      error.getCause.getMessage should include("Boom!")
+      error.getMessage should include("List(1, 2)")
     }
 
     "#toStrict when subscription was already obtained" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StageActorRefSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StageActorRefSpec.scala
@@ -186,23 +186,23 @@ object StageActorRefSpec {
       val p: Promise[Int] = Promise()
 
       val logic = new GraphStageLogic(shape) {
-        implicit def self = stageActorRef // must be a `def`, we want self to be the sender for our replies
+        implicit def self = stageActor.ref // must be a `def`; we want self to be the sender for our replies
         var sum: Int = 0
 
         override def preStart(): Unit = {
           pull(in)
-          probe ! getStageActorRef(behaviour)
+          probe ! getStageActor(behaviour).ref
         }
 
         def behaviour(m: (ActorRef, Any)): Unit = {
           m match {
             case (sender, Add(n))                ⇒ sum += n
             case (sender, PullNow)               ⇒ pull(in)
-            case (sender, CallInitStageActorRef) ⇒ sender ! getStageActorRef(behaviour)
+            case (sender, CallInitStageActorRef) ⇒ sender ! getStageActor(behaviour).ref
             case (sender, BecomeStringEcho) ⇒
-              getStageActorRef({
+              getStageActor {
                 case (theSender, msg) ⇒ theSender ! msg.toString
-              })
+              }
             case (sender, StopNow) ⇒
               p.trySuccess(sum)
               completeStage()

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -604,6 +604,9 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[MissingMethodProblem]("akka.pattern.BackoffSupervisor.akka$pattern$BackoffSupervisor$$restartCount"),
         ProblemFilters.exclude[MissingMethodProblem]("akka.pattern.BackoffSupervisor.akka$pattern$BackoffSupervisor$$restartCount_="),
         ProblemFilters.exclude[MissingMethodProblem]("akka.pattern.BackoffSupervisor.akka$pattern$BackoffSupervisor$$child")
+      ),
+    "2.4.1" -> Seq(
+        FilterAnyProblem("akka.actor.dungeon.Children")
       )
     )
   }


### PR DESCRIPTION
This new light-weight ActorRef supports running a non-blocking
side-effect upon message send, which is used to dispatch an async
callback to a GraphStageLogic, or it can be used to make the Akka Typed
adapters more efficient. The FunctionRef is registered with its parent,
and it is not user-level API (hence only accessible by downcasting the
ActorContext).

fixes #19014
