### PR TITLE
=act #19496 add sender information in LoggingReceive

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -66,7 +66,8 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
           })
         }))
         a ! "hallo"
-        expectMsg(1 second, Logging.Debug("funky", classOf[DummyClassForStringSources], "received unhandled message hallo"))
+        expectMsg(1 second, Logging.Debug("funky", classOf[DummyClassForStringSources],
+          "received unhandled message hallo from " + system.deadLetters))
         expectMsgType[UnhandledMessage](1 second)
       }
     }
@@ -91,7 +92,8 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
         val name = actor.path.toString
         actor ! "buh"
         within(1 second) {
-          expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass, "received handled message buh"))
+          expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass,
+            "received handled message buh from " + self))
           expectMsg("x")
         }
 
@@ -116,7 +118,8 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
         })
         actor ! "buh"
         within(1 second) {
-          expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass, "received handled message buh"))
+          expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass,
+            "received handled message buh from " + self))
           expectMsg("x")
         }
       }

--- a/akka-actor/src/main/scala/akka/event/LoggingReceive.scala
+++ b/akka-actor/src/main/scala/akka/event/LoggingReceive.scala
@@ -54,6 +54,7 @@ class LoggingReceive(source: Option[AnyRef], r: Receive, label: Option[String])(
     if (context.system.eventStream.logLevel >= Logging.DebugLevel) {
       val (str, clazz) = LogSource.fromAnyRef(source getOrElse context.asInstanceOf[ActorCell].actor)
       context.system.eventStream.publish(Debug(str, clazz, "received " + (if (handled) "handled" else "unhandled") + " message " + o
+        + " from " + context.sender()
         + (label match {
           case Some(l) ⇒ " in state " + l
           case _       ⇒ ""


### PR DESCRIPTION
Revives https://github.com/akka/akka/issues/19496
There's basically one way to do it and I thought it made sense to add (had the tab open for some reason with the old PR)
