### PR TITLE
Various streams build improvements

### DIFF
--- a/akka-actor-tests/build.sbt
+++ b/akka-actor-tests/build.sbt
@@ -1,11 +1,6 @@
 import akka.{ AkkaBuild, Dependencies, Formatting }
 
 AkkaBuild.defaultSettings
-
-Formatting.formatSettings
-
-publishArtifact in Compile := false
-
-Dependencies.actorTests
-
 AkkaBuild.dontPublishSettings
+Formatting.formatSettings
+Dependencies.actorTests

--- a/akka-docs/_sphinx/exts/includecode2.py
+++ b/akka-docs/_sphinx/exts/includecode2.py
@@ -43,7 +43,7 @@ class IncludeCode2(Directive):
         encoding = self.options.get('encoding', env.config.source_encoding)
         codec_info = codecs.lookup(encoding)
         try:
-            f = codecs.StreamReaderWriter(open(fn, 'U'),
+            f = codecs.StreamReaderWriter(open(fn, 'Ub'),
                     codec_info[2], codec_info[3], 'strict')
             lines = f.readlines()
             f.close()

--- a/akka-http-core/build.sbt
+++ b/akka-http-core/build.sbt
@@ -2,13 +2,8 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.httpCore
-
 Dependencies.httpCore
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-http-core").value
-
-disablePlugins(Unidoc) // TODO remove me

--- a/akka-http-marshallers-java/akka-http-jackson/build.sbt
+++ b/akka-http-marshallers-java/akka-http-jackson/build.sbt
@@ -2,12 +2,8 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.httpJackson
-
 Dependencies.httpJackson
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-http-jackson").value
-

--- a/akka-http-marshallers-scala/akka-http-spray-json/build.sbt
+++ b/akka-http-marshallers-scala/akka-http-spray-json/build.sbt
@@ -2,11 +2,8 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.httpSprayJson
-
 Dependencies.httpSprayJson
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-http-spray-json").value

--- a/akka-http-marshallers-scala/akka-http-xml/build.sbt
+++ b/akka-http-marshallers-scala/akka-http-xml/build.sbt
@@ -2,11 +2,8 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.httpXml
-
 Dependencies.httpXml
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-http-xml").value

--- a/akka-http-testkit/build.sbt
+++ b/akka-http-testkit/build.sbt
@@ -2,11 +2,10 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.httpTestkit
-
 Dependencies.httpTestkit
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-http-testkit").value
+
+scalacOptions in Compile  += "-language:postfixOps"

--- a/akka-http-tests/build.sbt
+++ b/akka-http-tests/build.sbt
@@ -1,8 +1,13 @@
 import akka._
-import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.dontPublishSettings
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 Dependencies.httpTests
+
+// don't ignore Suites which is the default for the junit-interface
+testOptions += Tests.Argument(TestFrameworks.JUnit, "--ignore-runners=")
+
+scalacOptions in Compile  += "-language:_"
+mainClass in run in Test := Some("akka.http.javadsl.SimpleServerApp")

--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -3,13 +3,11 @@ import com.typesafe.tools.mima.plugin.MimaKeys
 import spray.boilerplate.BoilerplatePlugin._
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.http
-
 Dependencies.http
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-http").value
-
 Boilerplate.settings
+
+scalacOptions in Compile += "-language:_"

--- a/akka-http/src/main/scala/akka/http/impl/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/RequestContextImpl.scala
@@ -40,7 +40,7 @@ private[http] final case class RequestContextImpl(underlying: ScalaRequestContex
     case MarshallerImpl(m) ⇒
       implicit val marshaller = m(underlying.executionContext)
       underlying.complete(value)
-    case _ ⇒ throw new IllegalArgumentException("Unsupported marshaller: $marshaller")
+    case _ ⇒ throw new IllegalArgumentException(s"Unsupported marshaller: $marshaller")
   }
   def complete(response: jm.HttpResponse): RouteResult = underlying.complete(response.asScala)
 

--- a/akka-parsing/build.sbt
+++ b/akka-parsing/build.sbt
@@ -1,22 +1,18 @@
 import akka._
-import akka.ValidatePullRequest._
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
-import com.typesafe.sbt.SbtSite.site
-import com.typesafe.sbt.site.SphinxSupport._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
-enablePlugins(ScaladocNoVerificationOfDiagrams)
-
 AkkaBuild.defaultSettings
-
+AkkaBuild.dontPublishSettings
+AkkaBuild.experimentalSettings
 Formatting.docFormatSettings
-
 site.settings
-
 OSGi.parsing
-
 Dependencies.parsing
 
 unmanagedSourceDirectories in ScalariformKeys.format in Test <<= unmanagedSourceDirectories in Test
+scalacOptions += "-language:_"
 
-AkkaBuild.dontPublishSettings
+// ScalaDoc doesn't like the macros
+sources in doc in Compile := List()
+
+enablePlugins(ScaladocNoVerificationOfDiagrams)

--- a/akka-samples/akka-sample-main-java-lambda/build.sbt
+++ b/akka-samples/akka-sample-main-java-lambda/build.sbt
@@ -1,10 +1,9 @@
 name := "akka-sample-main-java-lambda"
 
-version := "1.0"
+version := "2.4-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT"
 )
-

--- a/akka-samples/akka-sample-main-java-lambda/pom.xml
+++ b/akka-samples/akka-sample-main-java-lambda/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>akka-sample-main-java-lambda</artifactId>
   <groupId>com.typesafe.akka.samples</groupId>
   <name>Akka Main in Java</name>
-  <version>1.0</version>
+  <version>2.4-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/akka-samples/akka-sample-persistence-java-lambda/build.sbt
+++ b/akka-samples/akka-sample-persistence-java-lambda/build.sbt
@@ -1,6 +1,6 @@
 name := "akka-sample-persistence-java-lambda"
 
-version := "1.0"
+version := "2.4-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
@@ -13,4 +13,3 @@ libraryDependencies ++= Seq(
   "org.iq80.leveldb" % "leveldb" % "0.7",
   "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8"
 )
-

--- a/akka-samples/akka-sample-supervision-java-lambda/build.sbt
+++ b/akka-samples/akka-sample-supervision-java-lambda/build.sbt
@@ -1,6 +1,6 @@
 name := "akka-supervision-java-lambda"
 
-version := "1.0"
+version := "2.4-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/akka-samples/akka-sample-supervision-java-lambda/pom.xml
+++ b/akka-samples/akka-sample-supervision-java-lambda/pom.xml
@@ -11,7 +11,7 @@
   <groupId>sample</groupId>
   <artifactId>akka-supervision-java-lambda</artifactId>
   <packaging>jar</packaging>
-  <version>1.0</version>
+  <version>2.4-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/akka-stream-and-http/build.sbt
+++ b/akka-stream-and-http/build.sbt
@@ -1,1 +1,0 @@
-enablePlugins(akka.UnidocRoot, akka.TimeStampede, akka.UnidocWithPrValidation)

--- a/akka-stream-testkit/build.sbt
+++ b/akka-stream-testkit/build.sbt
@@ -2,11 +2,8 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.streamTestkit
-
 Dependencies.streamTestkit
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-stream-testkit").value

--- a/akka-stream-tests-tck/build.sbt
+++ b/akka-stream-tests-tck/build.sbt
@@ -2,7 +2,6 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 Dependencies.streamTestsTck

--- a/akka-stream-tests/build.sbt
+++ b/akka-stream-tests/build.sbt
@@ -2,7 +2,7 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.dontPublishSettings
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 Dependencies.streamTests

--- a/akka-stream/build.sbt
+++ b/akka-stream/build.sbt
@@ -3,13 +3,9 @@ import com.typesafe.tools.mima.plugin.MimaKeys
 import spray.boilerplate.BoilerplatePlugin._
 
 AkkaBuild.defaultSettings
-
+AkkaBuild.experimentalSettings
 Formatting.formatSettings
-
 OSGi.stream
-
 Dependencies.stream
-
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-stream").value
-
 Boilerplate.settings

--- a/akka-typed/build.sbt
+++ b/akka-typed/build.sbt
@@ -2,7 +2,5 @@ import akka.{ AkkaBuild, Formatting, OSGi, Dependencies }
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-
 AkkaBuild.experimentalSettings
-
 Formatting.formatSettings

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -5,7 +5,7 @@ package akka
 
 import sbt._
 import sbtunidoc.Plugin.UnidocKeys._
-import sbtunidoc.Plugin.{ ScalaUnidoc, JavaUnidoc, scalaJavaUnidocSettings, genjavadocExtraSettings, scalaUnidocSettings }
+import sbtunidoc.Plugin.{ ScalaUnidoc, JavaUnidoc, Genjavadoc, scalaJavaUnidocSettings, genjavadocExtraSettings, scalaUnidocSettings }
 import sbt.Keys._
 import sbt.File
 import scala.annotation.tailrec
@@ -120,7 +120,7 @@ object UnidocRoot extends AutoPlugin {
 
   override lazy val projectSettings =
     CliOptions.genjavadocEnabled.ifTrue(scalaJavaUnidocSettings).getOrElse(scalaUnidocSettings) ++
-    settings(Seq(AkkaBuild.samples), Seq(AkkaBuild.remoteTests, AkkaBuild.benchJmh))
+    settings(Seq(AkkaBuild.samples), Seq(AkkaBuild.remoteTests, AkkaBuild.benchJmh, AkkaBuild.parsing, AkkaBuild.protobuf))
 }
 
 /**
@@ -134,7 +134,9 @@ object Unidoc extends AutoPlugin {
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(
     genjavadocExtraSettings ++ Seq(
       scalacOptions in Compile += "-P:genjavadoc:fabricateParams=true",
-      unidocGenjavadocVersion in Global := "0.9"
+      unidocGenjavadocVersion in Global := "0.9",
+      // FIXME: see #18056
+      sources in(Genjavadoc, doc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
     )
   ).getOrElse(Seq.empty)
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9


### PR DESCRIPTION
- remove settings duplication between AkkaBuild and project specific .sbt files
- do not publish test projects
- run akka-http-core tests
- fix lambda sample project versions
- remove obsolete projects (streamAndHttp, httpParent, docsDev)
- exclude parsing project from unidoc
- enable unidoc for http-core #19428
- update to the latest sbt
