### PR TITLE
#19517 publish akka parsing

### DIFF
--- a/akka-parsing/build.sbt
+++ b/akka-parsing/build.sbt
@@ -2,7 +2,6 @@ import akka._
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
-AkkaBuild.dontPublishSettings
 AkkaBuild.experimentalSettings
 Formatting.docFormatSettings
 site.settings


### PR DESCRIPTION
This was an oversight. akka-parsing was [being published](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.typesafe.akka%22%20AND%20a%3A%22akka-parsing-experimental_2.11%22) in the original build and should continue being so.

Fixes #19517
