### PR TITLE
Http: HttpEntity stream cancellation

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -4,9 +4,9 @@
 
 package akka.actor.dungeon
 
-import akka.dispatch.sysmsg.{Unwatch, Watch, DeathWatchNotification}
-import akka.event.Logging.{Warning, Debug}
-import akka.actor.{InternalActorRef, Address, Terminated, Actor, ActorRefScope, ActorCell, ActorRef, MinimalActorRef}
+import akka.dispatch.sysmsg.{ Unwatch, Watch, DeathWatchNotification }
+import akka.event.Logging.{ Warning, Debug }
+import akka.actor.{ InternalActorRef, Address, Terminated, Actor, ActorRefScope, ActorCell, ActorRef, MinimalActorRef }
 import akka.event.AddressTerminatedTopic
 
 private[akka] trait DeathWatch { this: ActorCell ⇒

--- a/akka-docs/rst/java/http/client-side/connection-level.rst
+++ b/akka-docs/rst/java/http/client-side/connection-level.rst
@@ -53,6 +53,10 @@ The connection can also be closed by the server.
 An application can actively trigger the closing of the connection by completing the request stream. In this case the
 underlying TCP connection will be closed when the last pending response has been received.
 
+The connection will also be closed if the response entity is cancelled (e.g. by attaching it to ``Sink.cancelled()``)
+or consumed only partially (e.g. by using ``take`` combinator). In order to prevent this behaviour the entity should be
+explicitly drained by attaching it to ``Sink.ignore()``.
+
 
 Timeouts
 --------

--- a/akka-docs/rst/java/http/server-side/low-level-server-side-api.rst
+++ b/akka-docs/rst/java/http/server-side/low-level-server-side-api.rst
@@ -130,6 +130,10 @@ connection. An often times more convenient alternative is to explicitly add a ``
 ``HttpResponse``. This response will then be the last one on the connection and the server will actively close the
 connection when it has been sent out.
 
+Connection will also be closed if request entity has been cancelled (e.g. by attaching it to ``Sink.cancelled()``)
+or consumed only partially (e.g. by using ``take`` combinator). In order to prevent this behaviour entity should be
+explicitly drained by attaching it to ``Sink.ignore()``.
+
 
 .. _serverSideHTTPS-java:
 

--- a/akka-docs/rst/java/stream/migration-guide-2.0-2.4-java.rst
+++ b/akka-docs/rst/java/stream/migration-guide-2.0-2.4-java.rst
@@ -156,3 +156,17 @@ Routing settings parameter name
 and were accessible via ``settings``. We now made it possible to configure the parsers
 settings as well, so ``RoutingSettings`` is now ``routingSettings`` and ``ParserSettings`` is
 now accessible via ``parserSettings``.
+
+Client / server behaviour on cancelled entity
+---------------------------------------------
+
+Previously if request or response were cancelled or consumed only partially
+(e.g. by using ``take`` combinator) the remaining data was silently drained to prevent stalling
+the connection, since there could still be more requests / responses incoming. Now the default
+behaviour is to close the connection in order to prevent using excessive resource usage in case
+of huge entities.
+
+The old behaviour can be achieved by explicitly draining the entity:
+
+   response.entity().getDataBytes().runWith(Sink.ignore())
+

--- a/akka-docs/rst/scala/http/client-side/connection-level.rst
+++ b/akka-docs/rst/scala/http/client-side/connection-level.rst
@@ -55,6 +55,10 @@ The connection can also be closed by the server.
 An application can actively trigger the closing of the connection by completing the request stream. In this case the
 underlying TCP connection will be closed when the last pending response has been received.
 
+The connection will also be closed if the response entity is cancelled (e.g. by attaching it to ``Sink.cancelled``)
+or consumed only partially (e.g. by using ``take`` combinator). In order to prevent this behaviour the entity should be
+explicitly drained by attaching it to ``Sink.ignore``.
+
 
 Timeouts
 --------

--- a/akka-docs/rst/scala/http/low-level-server-side-api.rst
+++ b/akka-docs/rst/scala/http/low-level-server-side-api.rst
@@ -132,6 +132,10 @@ connection. An often times more convenient alternative is to explicitly add a ``
 ``HttpResponse``. This response will then be the last one on the connection and the server will actively close the
 connection when it has been sent out.
 
+Connection will also be closed if request entity has been cancelled (e.g. by attaching it to ``Sink.cancelled``)
+or consumed only partially (e.g. by using ``take`` combinator). In order to prevent this behaviour entity should be
+explicitly drained by attaching it to ``Sink.ignore``.
+
 
 .. _serverSideHTTPS:
 

--- a/akka-docs/rst/scala/stream/migration-guide-2.0-2.4-scala.rst
+++ b/akka-docs/rst/scala/stream/migration-guide-2.0-2.4-scala.rst
@@ -102,6 +102,19 @@ and were accessible via ``settings``. We now made it possible to configure the p
 settings as well, so ``RoutingSettings`` is now ``routingSettings`` and ``ParserSettings`` is
 now accessible via ``parserSettings``.
 
+Client / server behaviour on cancelled entity
+---------------------------------------------
+
+Previously if request or response were cancelled or consumed only partially
+(e.g. by using ``take`` combinator) the remaining data was silently drained to prevent stalling
+the connection, since there could still be more requests / responses incoming. Now the default
+behaviour is to close the connection in order to prevent using excessive resource usage in case
+of huge entities.
+
+The old behaviour can be achieved by explicitly draining the entity:
+
+   response.entity.dataBytes.runWith(Sink.ignore)
+
 Changed Sources / Sinks
 =======================
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -5,7 +5,7 @@
 package akka.http.impl.engine.client
 
 import akka.NotUsed
-import akka.http.scaladsl.settings.ClientConnectionSettings
+import akka.http.scaladsl.settings.{ ClientConnectionSettings, ParserSettings }
 import language.existentials
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
@@ -16,13 +16,13 @@ import akka.stream._
 import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.headers.Host
-import akka.http.scaladsl.model.{ IllegalResponseException, HttpMethod, HttpRequest, HttpResponse }
+import akka.http.scaladsl.model.{ IllegalResponseException, HttpMethod, HttpRequest, HttpResponse, ResponseEntity }
 import akka.http.impl.engine.rendering.{ RequestRenderingContext, HttpRequestRendererFactory }
 import akka.http.impl.engine.parsing._
 import akka.http.impl.util._
 import akka.stream.stage.GraphStage
 import akka.stream.stage.GraphStageLogic
-import akka.stream.stage.InHandler
+import akka.stream.stage.{ InHandler, OutHandler }
 import akka.stream.impl.fusing.SubSource
 
 /**
@@ -69,24 +69,7 @@ private[http] object OutgoingConnectionBlueprint {
     import ParserOutput._
     val responsePrep = Flow[List[ResponseOutput]]
       .mapConcat(conforms)
-      .splitWhen(x ⇒ x.isInstanceOf[MessageStart] || x == MessageEnd)
-      .prefixAndTail(1)
-      .filter {
-        case (Seq(MessageEnd), remaining) ⇒
-          SubSource.kill(remaining)
-          false
-        case (seq, _) ⇒
-          seq.nonEmpty
-      }
-      .map {
-        case (Seq(ResponseStart(statusCode, protocol, headers, createEntity, _)), entityParts) ⇒
-          val entity = createEntity(entityParts) withSizeLimit parserSettings.maxContentLength
-          HttpResponse(statusCode, headers, entity, protocol)
-        case (Seq(MessageStartError(_, info)), tail) ⇒
-          // Tails can be empty, but still need one pull to figure that out -- never drop tails.
-          SubSource.kill(tail)
-          throw IllegalResponseException(info)
-      }.concatSubstreams
+      .via(new ResponsePrep(parserSettings))
 
     val core = BidiFlow.fromGraph(GraphDSL.create() { implicit b ⇒
       import GraphDSL.Implicits._
@@ -147,6 +130,95 @@ private[http] object OutgoingConnectionBlueprint {
   }
 
   import ParserOutput._
+
+  private final class ResponsePrep(parserSettings: ParserSettings)
+    extends GraphStage[FlowShape[ResponseOutput, HttpResponse]] {
+
+    private val in = Inlet[ResponseOutput]("ResponsePrep.in")
+    private val out = Outlet[HttpResponse]("ResponsePrep.out")
+
+    val shape = new FlowShape(in, out)
+
+    override def createLogic(effectiveAttributes: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
+      private var entitySource: SubSourceOutlet[ResponseOutput] = _
+      private def entitySubstreamStarted = entitySource ne null
+      private def idle = this
+
+      def setIdleHandlers(): Unit = {
+        setHandler(in, idle)
+        setHandler(out, idle)
+      }
+
+      def onPush(): Unit = grab(in) match {
+        case ResponseStart(statusCode, protocol, headers, entityCreator, _) ⇒
+          val entity = createEntity(entityCreator) withSizeLimit parserSettings.maxContentLength
+          push(out, HttpResponse(statusCode, headers, entity, protocol))
+
+        case MessageStartError(_, info) ⇒
+          throw IllegalResponseException(info)
+
+        case other ⇒
+          throw new IllegalStateException(s"ResponseStart expected but $other received.")
+      }
+
+      def onPull(): Unit = {
+        if (!entitySubstreamStarted) pull(in)
+      }
+
+      setIdleHandlers()
+
+      private lazy val waitForMessageEnd = new InHandler {
+        def onPush(): Unit = grab(in) match {
+          case MessageEnd ⇒ setHandler(in, idle)
+          case other      ⇒ throw new IllegalStateException(s"MessageEnd expected but $other received.")
+        }
+      }
+
+      private lazy val substreamHandler = new InHandler with OutHandler {
+        override def onPush(): Unit = grab(in) match {
+          case MessageEnd ⇒
+            entitySource.complete()
+            entitySource = null
+            setIdleHandlers()
+
+          case messagePart ⇒
+            entitySource.push(messagePart)
+        }
+
+        override def onPull(): Unit = pull(in)
+
+        override def onUpstreamFinish(): Unit = {
+          entitySource.complete()
+          completeStage()
+        }
+
+        override def onUpstreamFailure(reason: Throwable): Unit = {
+          entitySource.fail(reason)
+          failStage(reason)
+        }
+
+        override def onDownstreamFinish(): Unit = {
+          entitySource.complete()
+          completeStage()
+        }
+      }
+
+      private def createEntity(creator: EntityCreator[ResponseOutput, ResponseEntity]): ResponseEntity = {
+        creator match {
+          case StrictEntityCreator(entity) ⇒
+            pull(in)
+            setHandler(in, waitForMessageEnd)
+            entity
+
+          case StreamedEntityCreator(creator) ⇒
+            entitySource = new SubSourceOutlet[ResponseOutput]("EntitySource")
+            entitySource.setHandler(substreamHandler)
+            setHandler(in, substreamHandler)
+            creator(Source.fromGraph(entitySource.source))
+        }
+      }
+    }
+  }
 
   /**
    * A merge that follows this logic:

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -217,8 +217,11 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
                               log: LoggingAdapter = system.log): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] =
     _outgoingConnection(host, port, localAddress, settings, connectionContext, log)
 
-  private def _outgoingConnection(host: String, port: Int, localAddress: Option[InetSocketAddress],
-                                  settings: ClientConnectionSettings, connectionContext: ConnectionContext,
+  private def _outgoingConnection(host: String,
+                                  port: Int,
+                                  localAddress: Option[InetSocketAddress],
+                                  settings: ClientConnectionSettings,
+                                  connectionContext: ConnectionContext,
                                   log: LoggingAdapter): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {
     val hostHeader = if (port == connectionContext.defaultPort) Host(host) else Host(host, port)
     val layer = clientLayer(hostHeader, settings, log)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -11,6 +11,7 @@ import scala.util.Random
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import org.scalatest.Inside
+import org.scalatest.concurrent.ScalaFutures
 import akka.util.ByteString
 import akka.stream.scaladsl._
 import akka.stream.ActorMaterializer
@@ -322,6 +323,53 @@ class HttpServerSpec extends AkkaSpec(
           send("0\r\n\r\n")
           dataProbe.expectNext(LastChunk)
           dataProbe.expectComplete()
+      }
+    }
+
+    "close the connection if request entity stream has been cancelled" in new TestSetup {
+      // two chunks sent by client
+      send("""POST / HTTP/1.1
+             |Host: example.com
+             |Transfer-Encoding: chunked
+             |
+             |6
+             |abcdef
+             |6
+             |abcdef
+             |0
+             |
+             |""")
+
+      inside(expectRequest()) {
+        case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) ⇒
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          // but only one consumed by server
+          data.take(1).to(Sink.fromSubscriber(dataProbe)).run()
+          val sub = dataProbe.expectSubscription()
+          sub.request(1)
+          dataProbe.expectNext(Chunk(ByteString("abcdef")))
+          dataProbe.expectComplete()
+          // connection closes once requested elements are consumed
+          netIn.expectCancellation()
+      }
+    }
+
+    "proceed to next request once previous request's entity has beed drained" in new TestSetup with ScalaFutures {
+      def twice(action: => Unit): Unit = { action; action }
+
+      twice {
+        send("""POST / HTTP/1.1
+               |Host: example.com
+               |Transfer-Encoding: chunked
+               |
+               |6
+               |abcdef
+               |0
+               |
+               |""")
+
+        val whenComplete = expectRequest().entity.dataBytes.runWith(Sink.ignore)
+        whenComplete.futureValue should be (akka.Done)
       }
     }
 

--- a/akka-stream/src/main/scala/akka/stream/SubstreamCancelStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/SubstreamCancelStrategy.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream
+
+import SubstreamCancelStrategies._
+
+/**
+ * Represents a strategy that decides how to deal with substream events.
+ */
+sealed abstract class SubstreamCancelStrategy
+
+private[akka] object SubstreamCancelStrategies {
+  /**
+   * INTERNAL API
+   */
+  private[akka] final case object Propagate extends SubstreamCancelStrategy
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] final case object Drain extends SubstreamCancelStrategy
+}
+
+object SubstreamCancelStrategy {
+  /**
+   * Cancel the stream of streams if any substream is cancelled.
+   */
+  def propagate: SubstreamCancelStrategy = Propagate
+
+  /**
+   * Drain substream on cancellation in order to prevent stailling of the stream of streams.
+   */
+  def drain: SubstreamCancelStrategy = Drain
+}
+

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -214,14 +214,17 @@ object Split {
   /** Splits after the current element. The current element will be the last element in the current substream. */
   case object SplitAfter extends SplitDecision
 
-  def when[T](p: T ⇒ Boolean): Graph[FlowShape[T, Source[T, NotUsed]], NotUsed] = new Split(Split.SplitBefore, p)
-  def after[T](p: T ⇒ Boolean): Graph[FlowShape[T, Source[T, NotUsed]], NotUsed] = new Split(Split.SplitAfter, p)
+  def when[T](p: T ⇒ Boolean, propagateSubstreamCancel: Boolean = false): Graph[FlowShape[T, Source[T, NotUsed]], NotUsed] =
+    new Split(Split.SplitBefore, p, propagateSubstreamCancel)
+
+  def after[T](p: T ⇒ Boolean, propagateSubstreamCancel: Boolean = false): Graph[FlowShape[T, Source[T, NotUsed]], NotUsed] =
+    new Split(Split.SplitAfter, p, propagateSubstreamCancel)
 }
 
 /**
  * INERNAL API
  */
-final class Split[T](decision: Split.SplitDecision, p: T ⇒ Boolean) extends GraphStage[FlowShape[T, Source[T, NotUsed]]] {
+final class Split[T](decision: Split.SplitDecision, p: T ⇒ Boolean, propagateSubstreamCancel: Boolean) extends GraphStage[FlowShape[T, Source[T, NotUsed]]] {
   val in: Inlet[T] = Inlet("Split.in")
   val out: Outlet[Source[T, NotUsed]] = Outlet("Split.out")
   override val shape: FlowShape[T, Source[T, NotUsed]] = FlowShape(in, out)
@@ -329,8 +332,9 @@ final class Split[T](decision: Split.SplitDecision, p: T ⇒ Boolean) extends Gr
 
       override def onDownstreamFinish(): Unit = {
         substreamCancelled = true
-        if (isClosed(in)) completeStage()
-        else {
+        if (isClosed(in) || propagateSubstreamCancel) {
+          completeStage()
+        } else {
           // Start draining
           if (!hasBeenPulled(in)) pull(in)
         }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1087,12 +1087,23 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * '''Completes when''' upstream completes
    *
-   * '''Cancels when''' downstream cancels and substreams cancel
+   * '''Cancels when''' downstream cancels and substreams cancel on `SubstreamCancelStrategy.drain()`, downstream
+   * cancels or any substream cancels on `SubstreamCancelStrategy.propagate()`
    *
    * See also [[Flow.splitAfter]].
    */
   def splitWhen(p: function.Predicate[Out]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.splitWhen(p.test))
+
+  /**
+   * This operation applies the given predicate to all incoming elements and
+   * emits them to a stream of output streams, always beginning a new one with
+   * the current element if the given predicate returns true for it.
+   *
+   * @see [[#splitWhen]]
+   */
+  def splitWhen(substreamCancelStrategy: SubstreamCancelStrategy)(p: function.Predicate[Out]): SubFlow[In, Out, Mat] =
+    new SubFlow(delegate.splitWhen(substreamCancelStrategy)(p.test))
 
   /**
    * This operation applies the given predicate to all incoming elements and
@@ -1134,12 +1145,23 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * '''Completes when''' upstream completes
    *
-   * '''Cancels when''' downstream cancels and substreams cancel
+   * '''Cancels when''' downstream cancels and substreams cancel on `SubstreamCancelStrategy.drain`, downstream
+   * cancels or any substream cancels on `SubstreamCancelStrategy.propagate`
    *
    * See also [[Flow.splitWhen]].
    */
   def splitAfter[U >: Out](p: function.Predicate[Out]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.splitAfter(p.test))
+
+  /**
+   * This operation applies the given predicate to all incoming elements and
+   * emits them to a stream of output streams. It *ends* the current substream when the
+   * predicate is true.
+   *
+   * @see [[#splitAfter]]
+   */
+  def splitAfter(substreamCancelStrategy: SubstreamCancelStrategy)(p: function.Predicate[Out]): SubFlow[In, Out, Mat] =
+    new SubFlow(delegate.splitAfter(substreamCancelStrategy)(p.test))
 
   /**
    * Transform each input element into a `Source` of output elements that is

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1201,22 +1201,35 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Completes when''' upstream completes
    *
-   * '''Cancels when''' downstream cancels and substreams cancel
+   * '''Cancels when''' downstream cancels and substreams cancel if propagateSubstreamCancel=false, downstream
+   * cancels or any substream cancels if propagateSubstreamCancel=true
    *
    * See also [[FlowOps.splitAfter]].
    */
-  def splitWhen(p: Out ⇒ Boolean): SubFlow[Out, Mat, Repr, Closed] = {
+  def splitWhen(propagateSubstreamCancel: Boolean)(p: Out ⇒ Boolean): SubFlow[Out, Mat, Repr, Closed] = {
     val merge = new SubFlowImpl.MergeBack[Out, Repr] {
       override def apply[T](flow: Flow[Out, T, NotUsed], breadth: Int): Repr[T] =
-        via(Split.when(p))
+        via(Split.when(p, propagateSubstreamCancel))
           .map(_.via(flow))
           .via(new FlattenMerge(breadth))
     }
+
     val finish: (Sink[Out, NotUsed]) ⇒ Closed = s ⇒
-      via(Split.when(p))
+      via(Split.when(p, propagateSubstreamCancel))
         .to(Sink.foreach(_.runWith(s)(GraphInterpreter.currentInterpreter.materializer)))
+
     new SubFlowImpl(Flow[Out], merge, finish)
   }
+
+  /**
+   * This operation applies the given predicate to all incoming elements and
+   * emits them to a stream of output streams, always beginning a new one with
+   * the current element if the given predicate returns true for it.
+   *
+   * @see [[#splitWhen]]
+   */
+  def splitWhen(p: Out ⇒ Boolean): SubFlow[Out, Mat, Repr, Closed] =
+    splitWhen(propagateSubstreamCancel = false)(p)
 
   /**
    * This operation applies the given predicate to all incoming elements and
@@ -1258,22 +1271,33 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Completes when''' upstream completes
    *
-   * '''Cancels when''' downstream cancels and substreams cancel
+   * '''Cancels when''' downstream cancels and substreams cancel if propagateSubstreamCancel=false, downstream
+   * cancels or any substream cancels if propagateSubstreamCancel=true
    *
    * See also [[FlowOps.splitWhen]].
    */
-  def splitAfter(p: Out ⇒ Boolean): SubFlow[Out, Mat, Repr, Closed] = {
+  def splitAfter(propagateSubstreamCancel: Boolean)(p: Out ⇒ Boolean): SubFlow[Out, Mat, Repr, Closed] = {
     val merge = new SubFlowImpl.MergeBack[Out, Repr] {
       override def apply[T](flow: Flow[Out, T, NotUsed], breadth: Int): Repr[T] =
-        via(Split.after(p))
+        via(Split.after(p, propagateSubstreamCancel))
           .map(_.via(flow))
           .via(new FlattenMerge(breadth))
     }
     val finish: (Sink[Out, NotUsed]) ⇒ Closed = s ⇒
-      via(Split.after(p))
+      via(Split.after(p, propagateSubstreamCancel))
         .to(Sink.foreach(_.runWith(s)(GraphInterpreter.currentInterpreter.materializer)))
     new SubFlowImpl(Flow[Out], merge, finish)
   }
+
+  /**
+   * This operation applies the given predicate to all incoming elements and
+   * emits them to a stream of output streams. It *ends* the current substream when the
+   * predicate is true.
+   *
+   * @see [[#splitAfter]]
+   */
+  def splitAfter(p: Out ⇒ Boolean): SubFlow[Out, Mat, Repr, Closed] =
+    splitAfter(propagateSubstreamCancel = false)(p)
 
   /**
    * Transform each input element into a `Source` of output elements that is


### PR DESCRIPTION
Here's an attempt to solve issues #18010 and #18203.

First commit can be treated as a simpler version of the solution, which involves adding `eagerClose` flag to `splitWhen` in order to define how substream cancelation should be treated: by draining the remaining elements in order to prevent stalling (current behaviour) or cancelling the stage altogether.

Second one introduces custom stage instead of `splitWhen/prefixAndTail` pipeline, which would allow to add `eagerClose` flag to `outgoingConnection` without adding flag to `splitWhen`/`splitAt` if this change isn't plausible.

I used https://github.com/akka/akka/commit/ced5aa7ddcac1408e08ed159da9a04fecfad18ed as a reference, however there are some slight changes which will be marked in comments to particular lines.
