### PR TITLE
Do not verify if scaladoc diagrams have been generated as there is none

### DIFF
--- a/akka-http-marshallers-java/akka-http-jackson/build.sbt
+++ b/akka-http-marshallers-java/akka-http-jackson/build.sbt
@@ -7,3 +7,5 @@ Formatting.formatSettings
 OSGi.httpJackson
 Dependencies.httpJackson
 MimaKeys.previousArtifacts := akkaStreamAndHttpPreviousArtifacts("akka-http-jackson").value
+
+enablePlugins(ScaladocNoVerificationOfDiagrams)


### PR DESCRIPTION
This is valid, as `akka-http-jackson` project has only one object which does not have any inheritance hiearchy.
