### PR TITLE
Update akka http and stream version for osgi

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1479,7 +1479,7 @@ object AkkaBuild extends Build {
     )
     def defaultImports = Seq("!sun.misc", akkaImport(), configImport(), scalaImport(), "*")
     def akkaImport(packageName: String = "akka.*") = versionedImport(packageName, "2.3", "2.4")
-    def streamAndHttpImport(packageName: String) = versionedImport(packageName, "1.0", "1.1")
+    def streamAndHttpImport(packageName: String) = versionedImport(packageName, "2.0", "2.1")
     def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.2.0", "1.3.0")
     def protobufImport(packageName: String = "com.google.protobuf.*") = versionedImport(packageName, "2.5.0", "2.6.0")
     def scalaImport(packageName: String = "scala.*") = versionedImport(packageName, s"$scalaEpoch.$scalaMajor", s"$scalaEpoch.${scalaMajor+1}")


### PR DESCRIPTION
The osgi manifests were requiring version 1.0 of the stream and http packages instead of version 2.0
