### PR TITLE
#19344 Made BackoffSupervisorSpec more robust

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/BackoffSupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/BackoffSupervisorSpec.scala
@@ -133,8 +133,11 @@ class BackoffSupervisorSpec extends AkkaSpec with ImplicitSender {
           watch(c1)
           c1 ! "boom"
           expectTerminated(c1)
-          supervisor ! BackoffSupervisor.GetRestartCount
-          expectMsg(BackoffSupervisor.RestartCount(1))
+
+          awaitAssert {
+            supervisor ! BackoffSupervisor.GetRestartCount
+            expectMsg(BackoffSupervisor.RestartCount(1))
+          }
 
           awaitAssert {
             supervisor ! BackoffSupervisor.GetCurrentChild


### PR DESCRIPTION
I think there is a race with the `GetRestartCount` and the generated `Terminated` at the parent caused by the `DeathWatchNotification` received for the child, but I am not 100% sure. The modification won't make the situation worse though, so let's give it a try.

Fixes #19344 
