### PR TITLE
#19441 convert from Option to Optional in javadsl

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/HttpBasicAuthenticatorExample.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/HttpBasicAuthenticatorExample.java
@@ -3,6 +3,7 @@
  */
 package docs.http.javadsl.server;
 
+import java.util.Optional;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.headers.Host;
 import akka.http.javadsl.server.Handler1;
@@ -27,7 +28,7 @@ public class HttpBasicAuthenticatorExample extends JUnitRouteTest {
 
             private final String hardcodedPassword = "correcthorsebatterystaple";
 
-            public Future<Option<String>> authenticate(BasicCredentials credentials) {
+            public Future<Optional<String>> authenticate(BasicCredentials credentials) {
                 // this is where your actual authentication logic would go
                 if (credentials.available() && // no anonymous access
                     credentials.verify(hardcodedPassword)) {

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/OAuth2AuthenticatorExample.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/OAuth2AuthenticatorExample.java
@@ -3,6 +3,7 @@
  */
 package docs.http.javadsl.server;
 
+import java.util.Optional;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.headers.Host;
 import akka.http.javadsl.model.headers.OAuth2BearerToken;
@@ -31,7 +32,7 @@ public class OAuth2AuthenticatorExample extends JUnitRouteTest {
             private final String hardcodedToken = "token";
 
             @Override
-            public Future<Option<String>> authenticate(OAuth2Credentials credentials) {
+            public Future<Optional<String>> authenticate(OAuth2Credentials credentials) {
                 // this is where your actual authentication logic would go, looking up the user
                 // based on the token or something in that direction
                 if (credentials.available() && // no anonymous access

--- a/akka-docs/rst/java/http/client-side/https-support.rst
+++ b/akka-docs/rst/java/http/client-side/https-support.rst
@@ -9,12 +9,12 @@ Akka HTTP supports TLS encryption on the client-side as well as on the :ref:`ser
 
    Akka HTTP 1.0 does not completely validate certificates when using HTTPS. Please do not treat HTTPS connections
    made with this version as secure. Requests are vulnerable to a Man-In-The-Middle attack via certificate substitution.
-   
-The central vehicle for configuring encryption is the ``HttpsContext``, which can be created using
-the static method ``HttpsContext.create`` which is defined like this:
 
-.. includecode:: /../../akka-http-core/src/main/java/akka/http/javadsl/HttpsContext.java
-   :include: http-context-creation
+The central vehicle for configuring encryption is the ``HttpsConnectionContext``, which can be created using
+the static method ``ConnectionContext.https`` which is defined like this:
+
+.. includecode:: /../../akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+   :include: https-context-creation
 
 In addition to the ``outgoingConnection``, ``newHostConnectionPool`` and ``cachedHostConnectionPool`` methods the
 `akka.http.javadsl.Http`_ extension also defines ``outgoingConnectionTls``, ``newHostConnectionPoolTls`` and

--- a/akka-docs/rst/java/http/server-side/low-level-server-side-api.rst
+++ b/akka-docs/rst/java/http/server-side/low-level-server-side-api.rst
@@ -138,11 +138,11 @@ Server-Side HTTPS Support
 
 Akka HTTP supports TLS encryption on the server-side as well as on the :ref:`client-side <clientSideHTTPS-java>`.
 
-The central vehicle for configuring encryption is the ``HttpsContext``, which can be created using
-the static method ``HttpsContext.create`` which is defined like this:
+The central vehicle for configuring encryption is the ``HttpsConnectionContext``, which can be created using
+the static method ``ConnectionContext.https`` which is defined like this:
 
-.. includecode:: /../../akka-http-core/src/main/java/akka/http/javadsl/HttpsContext.java
-   :include: http-context-creation
+.. includecode:: /../../akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+   :include: https-context-creation
 
 On the server-side the ``bind``, and ``bindAndHandleXXX`` methods of the `akka.http.javadsl.Http`_ extension define an
 optional ``httpsContext`` parameter, which can receive the HTTPS configuration in the form of an ``HttpsContext``

--- a/akka-docs/rst/scala/http/client-side/https-support.rst
+++ b/akka-docs/rst/scala/http/client-side/https-support.rst
@@ -10,10 +10,11 @@ Akka HTTP supports TLS encryption on the client-side as well as on the :ref:`ser
    Akka HTTP 1.0 does not completely validate certificates when using HTTPS. Please do not treat HTTPS connections
    made with this version as secure. Requests are vulnerable to a Man-In-The-Middle attack via certificate substitution.
 
-The central vehicle for configuring encryption is the ``HttpsContext``, which is defined as such:
+The central vehicle for configuring encryption is the ``HttpsConnectionContext``, which can be created using
+the static method ``ConnectionContext.https`` which is defined like this:
 
-.. includecode2:: /../../akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
-   :snippet: https-context-impl
+.. includecode:: /../../akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+   :include: https-context-creation
 
 In addition to the ``outgoingConnection``, ``newHostConnectionPool`` and ``cachedHostConnectionPool`` methods the
 `akka.http.scaladsl.Http`_ extension also defines ``outgoingConnectionTls``, ``newHostConnectionPoolTls`` and

--- a/akka-docs/rst/scala/http/low-level-server-side-api.rst
+++ b/akka-docs/rst/scala/http/low-level-server-side-api.rst
@@ -140,10 +140,11 @@ Server-Side HTTPS Support
 
 Akka HTTP supports TLS encryption on the server-side as well as on the :ref:`client-side <clientSideHTTPS>`.
 
-The central vehicle for configuring encryption is the ``HttpsContext``, which is defined as such:
+The central vehicle for configuring encryption is the ``HttpsConnectionContext``, which can be created using
+the static method ``ConnectionContext.https`` which is defined like this:
 
-.. includecode2:: /../../akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
-   :snippet: https-context-impl
+.. includecode:: /../../akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+   :include: https-context-creation
 
 On the server-side the ``bind``, and ``bindAndHandleXXX`` methods of the `akka.http.scaladsl.Http`_ extension define an
 optional ``httpsContext`` parameter, which can receive the HTTPS configuration in the form of an ``HttpsContext``

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -11,6 +11,7 @@ import akka.stream.io.ClientAuth
 import scala.compat.java8.OptionConverters
 
 object ConnectionContext {
+  //#https-context-creation
   /** Used to serve HTTPS traffic. */
   def https(sslContext: SSLContext): HttpsConnectionContext =
     scaladsl.ConnectionContext.https(sslContext)
@@ -19,6 +20,7 @@ object ConnectionContext {
   def https(sslContext: SSLContext, enabledCipherSuites: Optional[JCollection[String]],
             enabledProtocols: Optional[JCollection[String]], clientAuth: Optional[ClientAuth], sslParameters: Optional[SSLParameters]) =
     scaladsl.ConnectionContext.https(sslContext, sslParameters = OptionConverters.toScala(sslParameters))
+  //#https-context-creation
 
   /** Used to serve HTTP traffic. */
   def noEncryption(): HttpConnectionContext =
@@ -52,4 +54,3 @@ abstract class HttpsConnectionContext extends akka.http.javadsl.ConnectionContex
   /** Java API */
   def getSslParameters: Optional[SSLParameters]
 }
-

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -18,6 +18,7 @@ trait ConnectionContext extends akka.http.javadsl.ConnectionContext {
 }
 
 object ConnectionContext {
+  //#https-context-creation
   def https(sslContext: SSLContext,
             enabledCipherSuites: Option[immutable.Seq[String]] = None,
             enabledProtocols: Option[immutable.Seq[String]] = None,
@@ -25,6 +26,7 @@ object ConnectionContext {
             sslParameters: Option[SSLParameters] = None) = {
     new HttpsConnectionContext(sslContext, enabledCipherSuites, enabledProtocols, clientAuth, sslParameters)
   }
+  //#https-context-creation
 
   def noEncryption() = HttpConnectionContext
 }

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/values/HttpBasicAuthenticationTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/values/HttpBasicAuthenticationTest.java
@@ -4,8 +4,8 @@
 
 package akka.http.javadsl.server.values;
 
+import java.util.Optional;
 import org.junit.Test;
-import scala.Option;
 import scala.concurrent.Future;
 
 import akka.http.javadsl.server.*;
@@ -17,7 +17,7 @@ public class HttpBasicAuthenticationTest extends JUnitRouteTest {
     HttpBasicAuthenticator<String> authenticatedUser =
         new HttpBasicAuthenticator<String>("test-realm") {
             @Override
-            public Future<Option<String>> authenticate(BasicCredentials credentials) {
+            public Future<Optional<String>> authenticate(BasicCredentials credentials) {
                 if (credentials.available() && // no anonymous access
                         credentials.identifier().equals("sina") &&
                         credentials.verify("1234"))
@@ -29,7 +29,7 @@ public class HttpBasicAuthenticationTest extends JUnitRouteTest {
     OAuth2Authenticator<String> authenticatedToken =
         new OAuth2Authenticator<String>("test-realm") {
             @Override
-            public Future<Option<String>> authenticate(OAuth2Credentials credentials) {
+            public Future<Optional<String>> authenticate(OAuth2Credentials credentials) {
                 if (credentials.available() && // no anonymous access
                         credentials.identifier().equals("myToken") &&
                         credentials.verify("myToken"))

--- a/akka-http/src/main/scala/akka/http/impl/server/HeaderImpl.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/HeaderImpl.scala
@@ -4,6 +4,8 @@
 
 package akka.http.impl.server
 
+import java.util.Optional
+
 import akka.http.javadsl.model.HttpHeader
 import akka.http.javadsl.server.RequestVal
 import akka.http.javadsl.server.values.Header
@@ -12,6 +14,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives.BasicDirectives._
 import akka.http.scaladsl.server.directives.RouteDirectives._
 
+import scala.compat.java8.OptionConverters._
 import scala.reflect.ClassTag
 
 /**
@@ -38,9 +41,9 @@ private[http] object HeaderImpl {
           def directive: Directive1[U] = instanceDirective
         }
 
-      def optionalInstance(): RequestVal[Option[U]] =
-        new StandaloneExtractionImpl[Option[U]] {
-          def directive: Directive1[Option[U]] = optionalDirective(uClassTag)
+      def optionalInstance(): RequestVal[Optional[U]] =
+        new StandaloneExtractionImpl[Optional[U]] {
+          def directive: Directive1[Optional[U]] = optionalDirective(uClassTag).map(_.asJava)
         }
 
       def value(): RequestVal[String] =
@@ -48,9 +51,9 @@ private[http] object HeaderImpl {
           def directive: Directive1[String] = instanceDirective.map(_.value)
         }
 
-      def optionalValue(): RequestVal[Option[String]] =
-        new StandaloneExtractionImpl[Option[String]] {
-          def directive: Directive1[Option[String]] = optionalDirective(uClassTag).map(_.map(_.value))
+      def optionalValue(): RequestVal[Optional[String]] =
+        new StandaloneExtractionImpl[Optional[String]] {
+          def directive: Directive1[Optional[String]] = optionalDirective(uClassTag).map(_.map(_.value).asJava)
         }
     }.asInstanceOf[Header[T]] // undeclared covariance
   }

--- a/akka-http/src/main/scala/akka/http/impl/server/RouteImplementation.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/RouteImplementation.scala
@@ -8,10 +8,6 @@ import akka.http.impl.util.JavaMapping
 import akka.http.javadsl.server.values.{ PathMatcher, BasicCredentials, OAuth2Credentials }
 import akka.http.scaladsl.model.StatusCodes.Redirection
 import akka.http.scaladsl.server.util.TupleOps.Join
-
-import scala.language.implicitConversions
-import scala.annotation.tailrec
-import scala.collection.immutable
 import akka.http.javadsl.model.ContentType
 import akka.http.scaladsl.server.directives.{ Credentials, ContentTypeResolver }
 import akka.http.scaladsl.server.directives.FileAndResourceDirectives.DirectoryRenderer
@@ -22,6 +18,11 @@ import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.scaladsl.server
 import akka.http.javadsl.server._
 import RouteStructure._
+
+import scala.annotation.tailrec
+import scala.collection.immutable
+import scala.compat.java8.OptionConverters._
+import scala.language.implicitConversions
 
 /**
  * INTERNAL API
@@ -94,7 +95,7 @@ private[http] object RouteImplementation extends Directives with server.RouteCon
                 }
             }
 
-          authenticator.authenticate(javaCreds)
+          authenticator.authenticate(javaCreds).map(_.asScala)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext)
         }).flatMap { user ⇒
           addExtraction(authenticator.asInstanceOf[RequestVal[Any]], user)
         }
@@ -117,7 +118,7 @@ private[http] object RouteImplementation extends Directives with server.RouteCon
                 }
             }
 
-          authenticator.authenticate(javaCreds)
+          authenticator.authenticate(javaCreds).map(_.asScala)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext)
         }).flatMap { user ⇒
           addExtraction(authenticator.asInstanceOf[RequestVal[Any]], user)
         }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/values/Header.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/values/Header.scala
@@ -4,6 +4,8 @@
 
 package akka.http.javadsl.server.values
 
+import java.util.Optional
+
 import akka.http.impl.server.HeaderImpl
 import akka.http.javadsl.model.HttpHeader
 import akka.http.javadsl.server.RequestVal
@@ -11,27 +13,28 @@ import akka.http.scaladsl.model
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.util.ClassMagnet
 
+import scala.compat.java8.OptionConverters._
 import scala.reflect.{ ClassTag, classTag }
 
 trait Header[T <: HttpHeader] {
   def instance(): RequestVal[T]
-  def optionalInstance(): RequestVal[Option[T]]
+  def optionalInstance(): RequestVal[Optional[T]]
 
   def value(): RequestVal[String]
-  def optionalValue(): RequestVal[Option[String]]
+  def optionalValue(): RequestVal[Optional[String]]
 }
 object Headers {
   import akka.http.scaladsl.server.directives.BasicDirectives._
   import akka.http.scaladsl.server.directives.HeaderDirectives._
 
   def byName(name: String): Header[HttpHeader] =
-    HeaderImpl[HttpHeader](name, _ ⇒ optionalHeaderInstanceByName(name.toLowerCase()), classTag[HttpHeader])
+    HeaderImpl[HttpHeader](name, _ ⇒ optionalHeaderInstanceByName(name.toLowerCase()).map(_.asScala), classTag[HttpHeader])
 
   def byClass[T <: HttpHeader](clazz: Class[T]): Header[T] =
     HeaderImpl[T](clazz.getSimpleName, ct ⇒ optionalHeaderValueByType(ClassMagnet(ct)), ClassTag(clazz))
 
-  private def optionalHeaderInstanceByName(lowercaseName: String): Directive1[Option[model.HttpHeader]] =
+  private def optionalHeaderInstanceByName(lowercaseName: String): Directive1[Optional[model.HttpHeader]] =
     extract(_.request.headers.collectFirst {
       case h @ model.HttpHeader(`lowercaseName`, _) ⇒ h
-    })
+    }.asJava)
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/values/HttpBasicAuthenticator.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/values/HttpBasicAuthenticator.scala
@@ -4,6 +4,8 @@
 
 package akka.http.javadsl.server.values
 
+import java.util.Optional
+
 import akka.http.impl.server.{ ExtractionImplBase, RouteStructure }
 import akka.http.javadsl.server.{ AbstractDirective, RequestVal, Route }
 import akka.http.scaladsl.util.FastFuture
@@ -38,18 +40,18 @@ trait BasicCredentials {
  */
 abstract class HttpBasicAuthenticator[T](val realm: String) extends AbstractDirective with ExtractionImplBase[T] with RequestVal[T] {
   protected[http] implicit def classTag: ClassTag[T] = reflect.classTag[AnyRef].asInstanceOf[ClassTag[T]]
-  def authenticate(credentials: BasicCredentials): Future[Option[T]]
+  def authenticate(credentials: BasicCredentials): Future[Optional[T]]
 
   /**
    * Creates a return value for use in [[authenticate]] that successfully authenticates the requests and provides
    * the given user.
    */
-  def authenticateAs(user: T): Future[Option[T]] = FastFuture.successful(Some(user))
+  def authenticateAs(user: T): Future[Optional[T]] = FastFuture.successful(Optional.of(user))
 
   /**
    * Refuses access for this user.
    */
-  def refuseAccess(): Future[Option[T]] = FastFuture.successful(None)
+  def refuseAccess(): Future[Optional[T]] = FastFuture.successful(Optional.empty[T])
 
   /**
    * INTERNAL API

--- a/akka-http/src/main/scala/akka/http/javadsl/server/values/OAuth2Authenticator.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/values/OAuth2Authenticator.scala
@@ -4,6 +4,8 @@
 
 package akka.http.javadsl.server.values
 
+import java.util.Optional
+
 import akka.http.impl.server.{ ExtractionImplBase, RouteStructure }
 import akka.http.javadsl.server.{ AbstractDirective, RequestVal, Route }
 import akka.http.scaladsl.util.FastFuture
@@ -38,18 +40,18 @@ trait OAuth2Credentials {
  */
 abstract class OAuth2Authenticator[T](val realm: String) extends AbstractDirective with ExtractionImplBase[T] with RequestVal[T] {
   protected[http] implicit def classTag: ClassTag[T] = reflect.classTag[AnyRef].asInstanceOf[ClassTag[T]]
-  def authenticate(credentials: OAuth2Credentials): Future[Option[T]]
+  def authenticate(credentials: OAuth2Credentials): Future[Optional[T]]
 
   /**
    * Creates a return value for use in [[authenticate]] that successfully authenticates the requests and provides
    * the given user.
    */
-  def authenticateAs(user: T): Future[Option[T]] = FastFuture.successful(Some(user))
+  def authenticateAs(user: T): Future[Optional[T]] = FastFuture.successful(Optional.of(user))
 
   /**
    * Refuses access for this user.
    */
-  def refuseAccess(): Future[Option[T]] = FastFuture.successful(None)
+  def refuseAccess(): Future[Optional[T]] = FastFuture.successful(Optional.empty[T])
 
   /**
    * INTERNAL API


### PR DESCRIPTION
Was looking for `Option` in:

```
akka-http-core/src/main/scala/akka/http/javadsl
akka-http-core/src/main/java/akka/http/javadsl
akka-http/src/main/scala/akka/http/javadsl
akka-stream/src/main/scala/akka/stream/javadsl
```

Fixes #19441
