### PR TITLE
Fix comment for safe-shutdown-example-bad

### DIFF
--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -392,7 +392,6 @@ object PersistenceDocSpec {
     // order of received messages:
     // a
     //   # b arrives at mailbox, stashing;        internal-stash = [b]
-    //   # PoisonPill arrives at mailbox, stashing; internal-stash = [b, Shutdown]
     // PoisonPill is an AutoReceivedMessage, is handled automatically
     // !! stop !!
     // Actor is stopped without handling `b` nor the `a` handler!


### PR DESCRIPTION
The `PoisonPill` of course isn't stashed, probably a copy-paste-remnant of the 'good' example.
