### PR TITLE
=doc #16262 temporary disable failing udp multicast doc test

### DIFF
--- a/akka-docs/rst/scala/code/docs/io/ScalaUdpMulticastSpec.scala
+++ b/akka-docs/rst/scala/code/docs/io/ScalaUdpMulticastSpec.scala
@@ -19,6 +19,8 @@ class ScalaUdpMulticastSpec extends TestKit(ActorSystem("ScalaUdpMulticastSpec")
 
   "listener" should {
     "send message back to sink" in {
+      // TODO make this work consistently on all platforms
+      pending
 
       def okInterfaceToUse(iface: NetworkInterface): Boolean = {
         iface.getInetAddresses.exists(_.isInstanceOf[Inet6Address]) &&
@@ -41,6 +43,7 @@ class ScalaUdpMulticastSpec extends TestKit(ActorSystem("ScalaUdpMulticastSpec")
       val listener = system.actorOf(Props(classOf[Listener], iface, group, port, sink))
       expectMsgType[Udp.Bound]
       val sender = system.actorOf(Props(classOf[Sender], iface, group, port, msg))
+      // fails here, so binding succeeds but sending a message does not
       expectMsg(msg)
 
       // unbind


### PR DESCRIPTION
Refs #16262 fails unrelated PRs so often it is not even funny anymore, but I cannot repeat faillure on my machine, so marking as pending in wait to be fixed to work on all platforms to make life easier.
