### PR TITLE
[Java DSL] Fix type mapping to re-enable Java HTTPS servers

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -165,7 +165,7 @@ private[http] object JavaMapping {
     def toScala(javaObject: J): S = cast[S](javaObject)
   }
 
-  implicit object ConnectionContext extends Inherited[ConnectionContext, akka.http.scaladsl.HttpConnectionContext]
+  implicit object ConnectionContext extends Inherited[ConnectionContext, akka.http.scaladsl.ConnectionContext]
   implicit object HttpConnectionContext extends Inherited[HttpConnectionContext, akka.http.scaladsl.HttpConnectionContext]
   implicit object HttpsConnectionContext extends Inherited[HttpsConnectionContext, akka.http.scaladsl.HttpsConnectionContext]
 


### PR DESCRIPTION
Currently, if a `HttpsConnectionContext` is passed to the Java API `Http.bind()`, it blows up at runtime with

```
java.lang.IllegalArgumentException: Illegal custom subclass of akka.http.scaladsl.HttpConnectionContext. Please use only the provided factories in akka.http.javadsl.model.Http
    at akka.http.impl.util.JavaMapping$.akka$http$impl$util$JavaMapping$$cast(JavaMapping.scala:252)
    at akka.http.impl.util.JavaMapping$Inherited.toScala(JavaMapping.scala:165)
    at akka.http.impl.util.JavaMapping$Implicits$.convertToScala(JavaMapping.scala:74)
    at akka.http.impl.util.JavaMapping$Implicits$$anon$10.asScala(JavaMapping.scala:79)
    at akka.http.javadsl.Http.bindAndHandle(Http.scala:185)
```

That's because `JavaMapping` tries to always cast any `ConnectionContext` to `HttpConnectionContext`. Instead, it should just map the java `ConnectionContext` to the scala `ConnectionContext` base class.

Fixes https://github.com/akka/akka/issues/19657.
