### PR TITLE
Correct typo in 'Source.from()' function documentation

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -102,7 +102,7 @@ object Source {
    * data.add(1);
    * data.add(2);
    * data.add(3);
-   * Source.fom(data);
+   * Source.from(data);
    * }}}
    *
    * Starts a new `Source` from the given `Iterable`. This is like starting from an


### PR DESCRIPTION
Change-Id: I85f4c6fe5004f24d7b47c7bed15e6c39861b5250
