### PR TITLE
!clu #19679 make MemberStatus a sealed class

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -178,9 +178,9 @@ object Member {
 /**
  * Defines the current status of a cluster member node
  *
- * Can be one of: Joining, Up, Leaving, Exiting and Down.
+ * Can be one of: Joining, WeaklyUp, Up, Leaving, Exiting and Down and Removed.
  */
-abstract class MemberStatus
+sealed abstract class MemberStatus
 
 object MemberStatus {
   @SerialVersionUID(1L) case object Joining extends MemberStatus


### PR DESCRIPTION
My assumption is that it the absence of the sealed modifier
was an oversight. Marking it as sealed will avoid exhausitity
warnings from upcoming Scala compiler version in `highestPriorityOf`.
