### PR TITLE
#19533 One2OneBidi should report truncation also if wrapped flow cancels early

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
@@ -6,7 +6,7 @@ package akka.http.impl.engine.client
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import akka.stream.{ FlowShape, ActorMaterializer }
+import akka.stream.{ ActorMaterializerSettings, FlowShape, ActorMaterializer }
 import akka.stream.scaladsl._
 import akka.stream.testkit.AkkaSpec
 import akka.http.scaladsl.{ Http, TestUtils }
@@ -15,7 +15,7 @@ import akka.stream.testkit.Utils
 import org.scalatest.concurrent.ScalaFutures
 
 class HighLevelOutgoingConnectionSpec extends AkkaSpec with ScalaFutures {
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withFuzzing(true))
   implicit val patience = PatienceConfig(1.second)
 
   "The connection-level client implementation" should {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -288,7 +288,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
         val error @ EntityStreamException(info) = probe.expectError()
         info.summary shouldEqual "Illegal chunk termination"
 
-        responses.expectComplete()
+        responses.expectError()
         netOut.expectComplete()
         requestsSub.expectCancellation()
         netInSub.expectCancellation()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/One2OneBidiFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/One2OneBidiFlowSpec.scala
@@ -36,6 +36,11 @@ class One2OneBidiFlowSpec extends AkkaSpec with ConversionCheckedTripleEquals {
       a[One2OneBidiFlow.OutputTruncationException.type] should be thrownBy Await.result(test(f), 1.second)
     }
 
+    "trigger an `OutputTruncationException` if the wrapped stream cancels early" in {
+      val f = One2OneBidiFlow[Int, Int](-1) join Flow[Int].take(2)
+      a[One2OneBidiFlow.OutputTruncationException.type] should be thrownBy Await.result(test(f), 1.second)
+    }
+
     "trigger an `UnexpectedOutputException` if the wrapped stream produces out-of-order elements" in new Test() {
       inIn.sendNext(1)
       inOut.requestNext() should ===(1)


### PR DESCRIPTION
The cause for the test failure was that the terminated connection flow sometimes managed to cancel the One2OneBidi before it consumed the third request. Since all the consumed two requests were served at that point, it didn't report a truncation, although there was potentially one there.

It is impossible to generate 100% correct exceptions in this case, since the cancellation might be in race with an actual completion from the request inputs (i.e. connection cancels after 2 served requests but there are no actual 3rd request, so there is no _real_ truncation). The current implementation always reports a truncation error where there was potentially one.

Fixes #19533
