### PR TITLE
=str #19299 Performance Flow.flatMapMerge

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/actor/ScheduleBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ScheduleBenchmark.scala
@@ -56,7 +56,7 @@ class ScheduleBenchmark {
   var promise: Promise[Any] = _
 
   @Setup(Level.Iteration)
-  def setup():Unit =  {
+  def setup():Unit = {
     winner = (to * ratio + 1).toInt
     promise = Promise[Any]()
   }

--- a/akka-bench-jmh/src/main/scala/akka/http/HttpBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/http/HttpBenchmark.scala
@@ -53,7 +53,7 @@ class HttpBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit ={
+  def shutdown():Unit = {
     Await.ready(Http().shutdownAllConnectionPools(), 1.second)
     binding.unbind()
     Await.result(system.terminate(), 5.seconds)

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -117,5 +117,4 @@ class MaterializationBenchmark {
 
   @Benchmark
   def graph_with_imported_flow():Unit = graphWithImportedFlow.run()
-
 }

--- a/akka-docs/rst/java/code/docs/stream/GraphStageDocTest.java
+++ b/akka-docs/rst/java/code/docs/stream/GraphStageDocTest.java
@@ -443,23 +443,22 @@ public class GraphStageDocTest extends AbstractJavaTest {
   public void demonstrateAnAsynchronousSideChannel() throws Exception{
 
     // tests:
+    TestSubscriber.Probe<Integer> out = TestSubscriber.probe(system);
+    TestPublisher.Probe<Integer> in = TestPublisher.probe(0, system);
+
     CompletableFuture<Done> switchF = new CompletableFuture<>();
     Graph<FlowShape<Integer, Integer>, NotUsed> killSwitch =
       Flow.fromGraph(new KillSwitch<>(switchF));
 
-    ExecutionContext ec = system.dispatcher();
+    Source.fromPublisher(in).via(killSwitch).to(Sink.fromSubscriber(out)).run(mat);
 
-    CompletionStage<Integer> valueAfterKill = switchF.thenApply(in -> 4);
-
-
-    CompletionStage<Integer> result =
-      Source.from(Arrays.asList(1, 2, 3)).concat(Source.fromCompletionStage(valueAfterKill))
-        .via(killSwitch)
-        .runFold(0, (n, sum) -> n + sum, mat);
+    out.request(1);
+    in.sendNext(1);
+    out.expectNext(1);
 
     switchF.complete(Done.getInstance());
 
-    assertEquals(new Integer(6), result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+    out.expectComplete();
   }
 
 

--- a/akka-docs/rst/scala/code/docs/stream/GraphStageDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/stream/GraphStageDocSpec.scala
@@ -272,7 +272,6 @@ class GraphStageDocSpec extends AkkaSpec {
 
   "Demonstrate an asynchronous side channel" in {
     import system.dispatcher
-
     //#async-side-channel
     // will close upstream in all materializations of the graph stage instance
     // when the future completes

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
@@ -57,7 +57,6 @@ object WSClientAutobahnTest extends App {
     import Console._
     info.flatMap { i ⇒
       val prefix = f"$YELLOW${i.caseInfo.id}%-7s$RESET - $RESET${i.caseInfo.description}$RESET ... "
-      //println(prefix)
 
       status.onComplete {
         case Success((CaseStatus(status), millis)) ⇒

--- a/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
+++ b/akka-persistence/src/main/java/akka/persistence/journal/japi/AsyncWritePlugin.java
@@ -61,7 +61,7 @@ interface AsyncWritePlugin {
    * result `Iterable` for the happy path, i.e. when no messages are rejected.
    *
    * Calls to this method are serialized by the enclosing journal actor. If you spawn
-   * work in asyncronous tasks it is alright that they complete the futures in any order,
+   * work in asynchronous tasks it is alright that they complete the futures in any order,
    * but the actual writes for a specific persistenceId should be serialized to avoid 
    * issues such as events of a later write are visible to consumers (query side, or replay)
    * before the events of an earlier write are visible. This can also be done with

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -212,7 +212,7 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
    * `Future.successful(Nil)` for the happy path, i.e. when no messages are rejected.
    *
    * Calls to this method are serialized by the enclosing journal actor. If you spawn
-   * work in asyncronous tasks it is alright that they complete the futures in any order,
+   * work in asynchronous tasks it is alright that they complete the futures in any order,
    * but the actual writes for a specific persistenceId should be serialized to avoid
    * issues such as events of a later write are visible to consumers (query side, or replay)
    * before the events of an earlier write are visible.

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
@@ -448,7 +448,6 @@ public class SourceTest extends StreamTest {
 
   @Test
   public void mustWorkFromFuture() throws Exception {
-    final JavaTestKit probe = new JavaTestKit(system);
     final Iterable<String> input = Arrays.asList("A", "B", "C");
     CompletionStage<String> future1 = Source.from(input).runWith(Sink.<String>head(), materializer);
     CompletionStage<String> future2 = Source.fromCompletionStage(future1).runWith(Sink.<String>head(), materializer);

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpecKit.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpecKit.scala
@@ -74,7 +74,7 @@ trait GraphInterpreterSpecKit extends AkkaSpec {
         val (inHandlers, outHandlers, logics) =
           assembly.materialize(Attributes.none, assembly.stages.map(_.module), new java.util.HashMap, _ ⇒ ())
         _interpreter = new GraphInterpreter(assembly, NoMaterializer, logger, inHandlers, outHandlers, logics,
-          (_, _, _) ⇒ (), fuzzingMode = false)
+          (_, _, _) ⇒ (), fuzzingMode = false, null)
 
         for ((upstream, i) ← upstreams.zipWithIndex) {
           _interpreter.attachUpstreamBoundary(i, upstream._1)
@@ -92,7 +92,7 @@ trait GraphInterpreterSpecKit extends AkkaSpec {
       val (inHandlers, outHandlers, logics) =
         assembly.materialize(Attributes.none, assembly.stages.map(_.module), new java.util.HashMap, _ ⇒ ())
       _interpreter = new GraphInterpreter(assembly, NoMaterializer, logger, inHandlers, outHandlers, logics,
-        (_, _, _) ⇒ (), fuzzingMode = false)
+        (_, _, _) ⇒ (), fuzzingMode = false, null)
     }
 
     def builder(stages: GraphStageWithMaterializedValue[_ <: Shape, _]*): AssemblyBuilder = new AssemblyBuilder(stages)

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -45,16 +45,21 @@ akka {
       # this may cause an initial runtime overhead, but most of the time fusing is
       # desirable since it reduces the number of Actors that are created.
       auto-fusing = on
-      
+
       # Those stream elements which have explicit buffers (like mapAsync, mapAsyncUnordered,
       # buffer, flatMapMerge, Source.actorRef, Source.queue, etc.) will preallocate a fixed
       # buffer upon stream materialization if the requested buffer size is less than this
       # configuration parameter. The default is very high because failing early is better
       # than failing under load.
       #
-      # Buffers sized larger than this will dynamically grow/shrink and consume more memory 
+      # Buffers sized larger than this will dynamically grow/shrink and consume more memory
       # per element than the fixed size buffers.
       max-fixed-buffer-size = 1000000000
+
+      # Maximum number of sync messages that actor can process for stream to substream communication.
+      # Parameter allows to interrupt synchronous processing to get upsteam/downstream messages.
+      # Allows to accelerate message processing that happening withing same actor but keep system responsive.
+      sync-processing-limit = 1000
 
       debug {
         # Enables the fuzzing mode which increases the chance of race conditions

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/IteratorInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/IteratorInterpreter.scala
@@ -145,7 +145,8 @@ private[akka] class IteratorInterpreter[I, O](val input: Iterator[I], val ops: S
       outHandlers,
       logics,
       (_, _, _) ⇒ throw new UnsupportedOperationException("IteratorInterpreter does not support asynchronous events."),
-      fuzzingMode = false)
+      fuzzingMode = false,
+      null)
     interpreter.attachUpstreamBoundary(0, upstream)
     interpreter.attachDownstreamBoundary(ops.length, downstream)
     interpreter.init(null)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -77,9 +77,7 @@ final class FlattenMerge[T, M](breadth: Int) extends GraphStage[FlowShape[Graph[
             q.enqueue(sinkIn)
           }
         }
-        override def onUpstreamFinish(): Unit = {
-          if (!sinkIn.isAvailable) removeSource(sinkIn)
-        }
+        override def onUpstreamFinish(): Unit = if (!sinkIn.isAvailable) removeSource(sinkIn)
       })
       sinkIn.pull()
       sources += sinkIn
@@ -93,9 +91,8 @@ final class FlattenMerge[T, M](breadth: Int) extends GraphStage[FlowShape[Graph[
       if (activeSources == 0 && isClosed(in)) completeStage()
     }
 
-    override def postStop(): Unit = {
-      sources.foreach(_.cancel())
-    }
+    override def postStop(): Unit = sources.foreach(_.cancel())
+
   }
 
   override def toString: String = s"FlattenMerge($breadth)"

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -11,7 +11,8 @@ import akka.japi.function.{ Effect, Procedure }
 import akka.stream._
 import akka.stream.impl.StreamLayout.Module
 import akka.stream.impl.fusing.{ GraphInterpreter, GraphStageModule, SubSource, SubSink }
-import akka.stream.impl.{ ReactiveStreamsCompliance}
+import akka.stream.impl.ReactiveStreamsCompliance
+import scala.collection.mutable.ArrayBuffer
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration.FiniteDuration
 import akka.stream.actor.ActorSubscriberMessage

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -646,6 +646,10 @@ object MiMa extends AutoPlugin {
       ),
       "2.4.2" -> Seq(
         FilterAnyProblemStartingWith("akka.stream.impl.VirtualProcessor"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.fusing.GraphInterpreter.execute"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreter.this"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreterShell.init"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreterShell.receive"),
         ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.Stages$Drop"),
         ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.impl.MaterializerSession.assignPort"),
         ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.Stages$Drop$"),


### PR DESCRIPTION
Ref: #19299 
This PR creates short circuit for Async Requests that are made within the same ActorGraphInterpreter (has the same actor) by different logics. 
Main use case is when substream exchanges events with main stream and vice-versa
