### PR TITLE
=htc #18993 HttpConnectionPool constructor made private as it leaks i…

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -712,7 +712,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
   /**
    * Represents a connection pool to a specific target host and pool configuration.
    */
-  final case class HostConnectionPool(setup: HostConnectionPoolSetup)(
+  final case class HostConnectionPool private[http] (setup: HostConnectionPoolSetup)(
     private[http] val gatewayFuture: Future[PoolGateway]) { // enable test access
 
     /**


### PR DESCRIPTION
…mpl type and is not meant to be constructed outside of akka-http.

Refs #18993
