### PR TITLE
silence deadletter logging of SubscribeAck

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -149,7 +149,7 @@ object DistributedPubSubMediator {
   object Unsubscribe {
     def apply(topic: String, ref: ActorRef) = new Unsubscribe(topic, ref)
   }
-  @SerialVersionUID(1L) final case class SubscribeAck(subscribe: Subscribe)
+  @SerialVersionUID(1L) final case class SubscribeAck(subscribe: Subscribe) extends DeadLetterSuppression
   @SerialVersionUID(1L) final case class UnsubscribeAck(unsubscribe: Unsubscribe)
   @SerialVersionUID(1L) final case class Publish(topic: String, msg: Any, sendOneMessageToEachGroup: Boolean) extends DistributedPubSubMessage {
     def this(topic: String, msg: Any) = this(topic, msg, sendOneMessageToEachGroup = false)


### PR DESCRIPTION
- since it is normally (practially always) a local
  messages send that will not be rejected you don't
  care about the ack
