### PR TITLE
Unicode alias from → to -> in FSM

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -51,7 +51,8 @@ object FSMTransitionSpec {
     }
     onTransition {
       case 0 -> 1 ⇒ target ! ((stateData, nextStateData))
-      case 1 -> 1 ⇒ target ! ((stateData, nextStateData))
+      // Verify the unicode alias of -> works correctly in onTransition
+      case 1 → 1  ⇒ target ! ((stateData, nextStateData))
     }
   }
 

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -115,6 +115,13 @@ object FSM {
   }
 
   /**
+   * Convenience Unicode alias for the (S, S) pair to ->
+   */
+  object → {
+    def unapply[S](in: (S, S)) = Some(in)
+  }
+
+  /**
    * Log Entry of the [[akka.actor.LoggingFSM]], can be obtained by calling `getLog`.
    */
   final case class LogEntry[S, D](stateName: S, stateData: D, event: Any)
@@ -320,6 +327,11 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
    * reminder what the new state is.
    */
   val -> = FSM.->
+
+  /**
+   * Unicode alias for ->, matches a (S, S) pair
+   */
+  val → = FSM.->
 
   /**
    * This case object is received in case of a state timeout.


### PR DESCRIPTION
- Some editors and code reformatters allow you to or automatically do
  reformatting from -> to →, which breaks FSM code in onTransition.
  This allows usage of → in onTransition.
