### PR TITLE
Generate version files

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -27,8 +27,8 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
       {
         import config._
 
-        getString("akka.version") should ===("2.4-SNAPSHOT")
-        settings.ConfigVersion should ===("2.4-SNAPSHOT")
+        getString("akka.version") should ===(ActorSystem.Version)
+        settings.ConfigVersion should ===(ActorSystem.Version)
 
         getBoolean("akka.daemonic") should ===(false)
 

--- a/akka-actor/build.sbt
+++ b/akka-actor/build.sbt
@@ -1,4 +1,4 @@
-import akka.{ AkkaBuild, Formatting, OSGi, Dependencies }
+import akka.{ AkkaBuild, Formatting, OSGi, Dependencies, Version }
 import com.typesafe.tools.mima.plugin.MimaKeys
 
 AkkaBuild.defaultSettings
@@ -12,3 +12,5 @@ Dependencies.actor
 MimaKeys.previousArtifacts := akkaPreviousArtifacts("akka-actor").value
 
 spray.boilerplate.BoilerplatePlugin.Boilerplate.settings
+
+Version.versionSettings

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -5,10 +5,10 @@
 # This is the reference config file that contains all the default settings.
 # Make your edits/overrides in your application.conf.
 
-akka {
-  # Akka version, checked against the runtime version of Akka.
-  version = "2.4-SNAPSHOT"
+# Akka version, checked against the runtime version of Akka. Loaded from generated conf file.
+include "version"
 
+akka {
   # Home directory of Akka, modules in the deploy directory will be loaded
   home = ""
 

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -25,7 +25,7 @@ import java.util.Locale
 
 object ActorSystem {
 
-  val Version: String = "2.4-SNAPSHOT"
+  val Version: String = akka.Version.current // generated file
 
   val EnvHome: Option[String] = System.getenv("AKKA_HOME") match {
     case null | "" | "." ⇒ None

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,0 +1,31 @@
+package akka
+
+import sbt._
+import sbt.Keys._
+
+/**
+ * Generate version.conf and akka/Version.scala files based on the version setting.
+ */
+object Version {
+
+  def versionSettings: Seq[Setting[_]] = inConfig(Compile)(Seq(
+    resourceGenerators <+= generateVersion(resourceManaged, _ / "version.conf",
+      """|akka.version = "%s"
+         |"""),
+    sourceGenerators <+= generateVersion(sourceManaged, _ / "akka" / "Version.scala",
+      """|package akka
+         |
+         |object Version {
+         |  val current: String = "%s"
+         |}
+         |""")
+  ))
+
+  def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {
+    val file = locate(dir.value)
+    val content = template.stripMargin.format(version.value)
+    if (!file.exists || IO.read(file) != content) IO.write(file, content)
+    Seq(file)
+  }
+
+}


### PR DESCRIPTION
This means that `ActorSystem.Version` and `akka.version` in config can be set dynamically from sbt using the version setting (without the find-replace in the release script) and work with dbuild.
