### PR TITLE
= - Minor cleanups, will get an appropriate commit message soon

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
@@ -46,7 +46,7 @@ object RemoteRestartedQuarantinedSpec extends MultiNodeConfig {
   class Subject extends Actor {
     def receive = {
       case "shutdown" ⇒ context.system.terminate()
-      case "identify" ⇒ sender() ! (AddressUidExtension(context.system).addressUid, self)
+      case "identify" ⇒ sender() ! (AddressUidExtension(context.system).addressUid -> self)
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowModule.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowModule.scala
@@ -11,8 +11,8 @@ import akka.stream.impl.StreamLayout.Module
  */
 private[stream] trait FlowModule[In, Out, Mat] extends StreamLayout.Module {
   override def replaceShape(s: Shape) =
-    if (s == shape) this
-    else throw new UnsupportedOperationException("cannot replace the shape of a FlowModule")
+    if (s != shape) throw new UnsupportedOperationException("cannot replace the shape of a FlowModule")
+    else this
 
   val inPort = Inlet[In]("Flow.in")
   val outPort = Outlet[Out]("Flow.out")

--- a/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
@@ -21,8 +21,8 @@ private[akka] abstract class SourceModule[+Out, +Mat](val shape: SourceShape[Out
   def create(context: MaterializationContext): (Publisher[Out] @uncheckedVariance, Mat)
 
   override def replaceShape(s: Shape): Module =
-    if (s == shape) this
-    else throw new UnsupportedOperationException("cannot replace the shape of a Source, you need to wrap it in a Graph for that")
+    if (s != shape) throw new UnsupportedOperationException("cannot replace the shape of a Source, you need to wrap it in a Graph for that")
+    else this
 
   // This is okay since the only caller of this method is right below.
   protected def newInstance(shape: SourceShape[Out] @uncheckedVariance): SourceModule[Out, Mat]

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -31,8 +31,8 @@ private[akka] abstract class SinkModule[-In, Mat](val shape: SinkShape[In]) exte
   def create(context: MaterializationContext): (Subscriber[In] @uncheckedVariance, Mat)
 
   override def replaceShape(s: Shape): Module =
-    if (s == shape) this
-    else throw new UnsupportedOperationException("cannot replace the shape of a Sink, you need to wrap it in a Graph for that")
+    if (s != shape) throw new UnsupportedOperationException("cannot replace the shape of a Sink, you need to wrap it in a Graph for that")
+    else this
 
   // This is okay since we the only caller of this method is right below.
   protected def newInstance(s: SinkShape[In] @uncheckedVariance): SinkModule[In, Mat]

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -23,6 +23,7 @@ private[stream] object Stages {
 
   object DefaultAttributes {
     val IODispatcher = ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
+    val inputBufferOne = inputBuffer(initial = 1, max = 1)
 
     val fused = name("fused")
     val materializedValueSource = name("matValueSource")
@@ -98,8 +99,8 @@ private[stream] object Stages {
 
     val subscriberSink = name("subscriberSink")
     val cancelledSink = name("cancelledSink")
-    val headSink = name("headSink") and inputBuffer(initial = 1, max = 1)
-    val headOptionSink = name("headOptionSink") and inputBuffer(initial = 1, max = 1)
+    val headSink = name("headSink") and inputBufferOne
+    val headOptionSink = name("headOptionSink") and inputBufferOne
     val lastSink = name("lastSink")
     val lastOptionSink = name("lastOptionSink")
     val seqSink = name("seqSink")

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -31,7 +31,9 @@ private[stream] case class GraphModule(assembly: GraphAssembly, shape: Shape, at
 
   override final def carbonCopy: Module = CopiedModule(shape.deepCopy(), Attributes.none, this)
 
-  override final def replaceShape(newShape: Shape): Module = CompositeModule(this, newShape)
+  override final def replaceShape(newShape: Shape): Module =
+    if (newShape != shape) CompositeModule(this, newShape)
+    else this
 
   override def toString: String = s"GraphModule\n  ${assembly.toString.replace("\n", "\n  ")}\n  shape=$shape, attributes=$attributes"
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -25,13 +25,19 @@ import scala.util.Try
 private[akka] final case class GraphStageModule(shape: Shape,
                                                 attributes: Attributes,
                                                 stage: GraphStageWithMaterializedValue[Shape, Any]) extends Module {
-  def carbonCopy: Module = CopiedModule(shape.deepCopy(), Attributes.none, this)
+  override def carbonCopy: Module = CopiedModule(shape.deepCopy(), Attributes.none, this)
 
-  def replaceShape(s: Shape): Module = CompositeModule(this, s)
+  override def replaceShape(s: Shape): Module =
+    if (s != shape) CompositeModule(this, s)
+    else this
 
-  def subModules: Set[Module] = Set.empty
+  override def subModules: Set[Module] = Set.empty
 
-  def withAttributes(attributes: Attributes): Module = new GraphStageModule(shape, attributes, stage)
+  override def withAttributes(attributes: Attributes): Module =
+    if (attributes ne this.attributes) new GraphStageModule(shape, attributes, stage)
+    else this
+
+  override def toString: String = stage.toString
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/io/SslTls.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/SslTls.scala
@@ -127,9 +127,10 @@ object SslTls {
       TlsModule(attributes, sslContext, firstSession, role, closing, hostInfo)
 
     override def replaceShape(s: Shape) =
-      if (s == shape) this
-      else if (shape.hasSamePortsAs(s)) CompositeModule(this, s)
-      else throw new IllegalArgumentException("trying to replace shape with different ports")
+      if (s != shape) {
+        shape.requireSamePortsAs(s)
+        CompositeModule(this, s)
+      } else this
   }
 
   /**


### PR DESCRIPTION
Do not merge

w.r.t. Module.toString, here's a comparison:

before:

``` scala
scala> Flow[Int].map(_ * 2).filter(_ != 2)
res0: akka.stream.scaladsl.Flow[Int,Int,akka.NotUsed] =
Flow(
 Module: unnamed
 Modules:
   map
   akka.stream.impl.StreamLayout$CopiedModule
 Downstreams:
   map.out -> filter.in
 Upstreams:
   filter.in -> map.out
)
```

after:

``` scala
scala> Flow[Int].map(_ * 2).filter(_ != 2)
res0: akka.stream.scaladsl.Flow[Int,Int,akka.NotUsed] =
Flow(
  Name: unnamed
  Modules:
    map
    filter (copy)
  Downstreams:
    map.out -> filter.in
  Upstreams:
    filter.in -> map.out
)
```
