### PR TITLE
=str #19781 Use overriden `InputBuffer` attribute

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeoutException
 
 import akka.actor.ActorSystem
 import akka.stream._
+import akka.stream.Attributes.inputBuffer
 import akka.stream.impl.StreamSupervisor.Children
 import akka.stream.impl.io.InputStreamSinkStage
 import akka.stream.impl.{ ActorMaterializerImpl, StreamSupervisor }
@@ -217,6 +218,19 @@ class InputStreamSinkSpec extends AkkaSpec(UnboundedMailboxConfig) {
       inputStream.read() should ===(-1)
 
       inputStream.close()
+    }
+  }
+
+  "fail to materialize with zero sized input buffer" in {
+    an[IllegalArgumentException] shouldBe thrownBy {
+      Source.single(byteString)
+        .runWith(StreamConverters.asInputStream(timeout).withAttributes(inputBuffer(0, 0)))
+      /*
+       With Source.single we test the code path in which the sink
+       itself throws an exception when being materialized. If
+       Source.empty is used, the same exception is thrown by
+       Materializer.
+       */
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSinkSpec.scala
@@ -5,6 +5,7 @@ package akka.stream.scaladsl
 
 import akka.actor.{ Actor, ActorRef, Props }
 import akka.stream.ActorMaterializer
+import akka.stream.Attributes.inputBuffer
 import akka.stream.testkit.Utils._
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl._
@@ -128,6 +129,16 @@ class ActorRefBackpressureSinkSpec extends AkkaSpec with ScalaFutures with Conve
         fw ! TriggerAckMessage
       }
       expectMsg(completeMessage)
+    }
+
+    "fail to materialize with zero sized input buffer" in {
+      val fw = createActor(classOf[Fw])
+      an[IllegalArgumentException] shouldBe thrownBy {
+        val badSink = Sink
+          .actorRefWithAck(fw, initMessage, ackMessage, completeMessage)
+          .withAttributes(inputBuffer(0, 0))
+        Source.single(()).runWith(badSink)
+      }
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
@@ -5,6 +5,7 @@ package akka.stream.scaladsl
 
 import akka.actor.Status
 import akka.pattern.pipe
+import akka.stream.Attributes.inputBuffer
 import akka.stream.{ OverflowStrategy, ActorMaterializer }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.{ AkkaSpec, _ }
@@ -129,5 +130,10 @@ class QueueSinkSpec extends AkkaSpec with ScalaFutures {
 
     }
 
+    "fail to materialize with zero sized input buffer" in {
+      an[IllegalArgumentException] shouldBe thrownBy {
+        Source.single(()).runWith(Sink.queue().withAttributes(inputBuffer(0, 0)))
+      }
+    }
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -289,13 +289,14 @@ final private[stream] class QueueSink[T]() extends GraphStageWithMaterializedVal
   type Requested[E] = Promise[Option[E]]
 
   val in = Inlet[T]("queueSink.in")
+  override def initialAttributes = DefaultAttributes.queueSink
   override val shape: SinkShape[T] = SinkShape.of(in)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
     val stageLogic = new GraphStageLogic(shape) with CallbackWrapper[Requested[T]] {
       type Received[E] = Try[Option[E]]
 
-      val maxBuffer = module.attributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+      val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
       require(maxBuffer > 0, "Buffer size must be greater than 0")
 
       var buffer: Buffer[Received[T]] = _

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -107,6 +107,7 @@ private[stream] object Stages {
     val fanoutPublisherSink = name("fanoutPublisherSink")
     val ignoreSink = name("ignoreSink")
     val actorRefSink = name("actorRefSink")
+    val actorRefWithAck = name("actorRefWithAckSink")
     val actorSubscriberSink = name("actorSubscriberSink")
     val queueSink = name("queueSink")
     val outputStreamSink = name("outputStreamSink") and IODispatcher

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.{ BlockingQueue, LinkedBlockingQueue }
 
 import akka.stream.{ Outlet, SourceShape, Attributes }
 import akka.stream.Attributes.InputBuffer
+import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl.io.OutputStreamSourceStage._
 import akka.stream.stage._
 import akka.util.ByteString
@@ -34,13 +35,13 @@ private[stream] object OutputStreamSourceStage {
 
 final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration) extends GraphStageWithMaterializedValue[SourceShape[ByteString], OutputStream] {
   val out = Outlet[ByteString]("OutputStreamSource.out")
+  override def initialAttributes = DefaultAttributes.outputStreamSource
   override val shape: SourceShape[ByteString] = SourceShape.of(out)
 
-  // has to be in this order as module depends on shape
-  val maxBuffer = module.attributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
-  require(maxBuffer > 0, "Buffer size must be greater than 0")
-
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, OutputStream) = {
+    val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+    require(maxBuffer > 0, "Buffer size must be greater than 0")
+
     val dataQueue = new LinkedBlockingQueue[ByteString](maxBuffer)
     val downstreamStatus = new AtomicReference[DownstreamStatus](Ok)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -340,6 +340,6 @@ object Sink {
    * @see [[akka.stream.SinkQueue]]
    */
   def queue[T](): Sink[T, SinkQueue[T]] =
-    Sink.fromGraph(new QueueSink().withAttributes(DefaultAttributes.queueSink))
+    Sink.fromGraph(new QueueSink())
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
@@ -51,7 +51,7 @@ object StreamConverters {
    * @param writeTimeout the max time the write operation on the materialized OutputStream should block, defaults to 5 seconds
    */
   def asOutputStream(writeTimeout: FiniteDuration = 5.seconds): Source[ByteString, OutputStream] =
-    Source.fromGraph(new OutputStreamSourceStage(writeTimeout)).withAttributes(DefaultAttributes.outputStreamSource)
+    Source.fromGraph(new OutputStreamSourceStage(writeTimeout))
 
   /**
    * Creates a Sink which writes incoming [[ByteString]]s to an [[OutputStream]] created by the given function.
@@ -78,6 +78,6 @@ object StreamConverters {
    * @param readTimeout the max time the read operation on the materialized InputStream should block
    */
   def asInputStream(readTimeout: FiniteDuration = 5.seconds): Sink[ByteString, InputStream] =
-    Sink.fromGraph(new InputStreamSinkStage(readTimeout)).withAttributes(DefaultAttributes.inputStreamSink)
+    Sink.fromGraph(new InputStreamSinkStage(readTimeout))
 
 }


### PR DESCRIPTION
- Sink.{queue, actorRefWithAck} and StreamConverters.{asInputStream,
  asOutputStream} now use overriden/inherited `InputBuffer` attribute
- They now use their default attributes as initial attributes.
