### PR TITLE
Prepare build for Scala 2.12.0-M3 release

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
     val reactiveStreams = "org.reactivestreams"       % "reactive-streams"             % "1.0.0" // CC0
 
     // ssl-config
-    val sslConfigAkka = "com.typesafe"               %% "ssl-config-akka"              % "0.1.1" // ApacheV2
+    val sslConfigAkka = "com.typesafe"               %% "ssl-config-akka"              % "0.1.3" // ApacheV2
 
     // For akka-http spray-json support
     val sprayJson   = "io.spray"                     %% "spray-json"                   % "1.3.2"       // ApacheV2


### PR DESCRIPTION
By bumping ssl-config to version released also for this version of Scala
