### PR TITLE
-htp #19577 replace overloads of bind with HttpConnect

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -42,7 +42,7 @@ trait RouterConfig extends Serializable {
 
   /**
    * Create the actual router, responsible for routing messages to routees.
- *
+   *
    * @param system the ActorSystem this router belongs to
    */
   def createRouter(system: ActorSystem): Router

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/HttpServerExampleDocTest.java
@@ -6,6 +6,8 @@ package docs.http.javadsl.server;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
+import akka.dispatch.OnFailure;
+import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.IncomingConnection;
 import akka.http.javadsl.ServerBinding;
@@ -38,7 +40,7 @@ public class HttpServerExampleDocTest {
         Materializer materializer = ActorMaterializer.create(system);
 
         Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-            Http.get(system).bind("localhost", 8080, materializer);
+            Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
 
         CompletionStage<ServerBinding> serverBindingFuture =
             serverSource.to(Sink.foreach(connection -> {
@@ -56,7 +58,7 @@ public class HttpServerExampleDocTest {
         Materializer materializer = ActorMaterializer.create(system);
 
         Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-            Http.get(system).bind("localhost", 80, materializer);
+            Http.get(system).bind(ConnectHttp.toHost("localhost", 80), materializer);
 
         CompletionStage<ServerBinding> serverBindingFuture =
             serverSource.to(Sink.foreach(connection -> {
@@ -78,7 +80,7 @@ public class HttpServerExampleDocTest {
         Materializer materializer = ActorMaterializer.create(system);
 
         Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-            Http.get(system).bind("localhost", 8080, materializer);
+            Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
 
         Flow<IncomingConnection, IncomingConnection, NotUsed> failureDetection =
             Flow.of(IncomingConnection.class).watchTermination((notUsed, termination) -> {
@@ -108,7 +110,7 @@ public class HttpServerExampleDocTest {
         Materializer materializer = ActorMaterializer.create(system);
 
         Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-            Http.get(system).bind("localhost", 8080, materializer);
+            Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
 
         Flow<HttpRequest, HttpRequest, NotUsed> failureDetection =
             Flow.of(HttpRequest.class)
@@ -151,7 +153,7 @@ public class HttpServerExampleDocTest {
             final Materializer materializer = ActorMaterializer.create(system);
 
             Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-                    Http.get(system).bind("localhost", 8080, materializer);
+                    Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
 
             //#request-handler
             final Function<HttpRequest, HttpResponse> requestHandler =

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/WebSocketCoreExample.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/WebSocketCoreExample.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import akka.NotUsed;
+import akka.http.javadsl.ConnectHttp;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
@@ -57,7 +58,7 @@ public class WebSocketCoreExample {
                         public HttpResponse apply(HttpRequest request) throws Exception {
                             return handleRequest(request);
                         }
-                    }, "localhost", 8080, materializer);
+                    }, ConnectHttp.toHost("localhost", 8080), materializer);
 
             // will throw if binding fails
             serverBindingFuture.toCompletableFuture().get(1, TimeUnit.SECONDS);

--- a/akka-docs/rst/scala/stream/migration-guide-2.0-2.4-scala.rst
+++ b/akka-docs/rst/scala/stream/migration-guide-2.0-2.4-scala.rst
@@ -170,3 +170,22 @@ how the word is spelled in the spec and some other places of Akka HTTP.
 
 Methods and classes using the word WebSocket now consistently use it as ``WebSocket``, so updating is as simple as
 find-and-replacing the lower-case ``s`` to an upper-case ``S`` wherever the word WebSocket appeared.
+
+Java DSL for Http binding and connections changed
+-------------------------------------------------
+
+In order to minimise the number of needed overloads for each method defined on the ``Http`` extension
+a new mini-DSL has been introduced for connecting to hosts given a hostname, port and optional ``ConnectionContext``.
+
+The availability of the connection context (if it's set to ``HttpsConnectionContext``) makes the server be bound
+as an HTTPS server, and for outgoing connections those settings are used instead of the default ones if provided.
+
+Was::
+
+    http.cachedHostConnectionPool(toHost("akka.io"), materializer());
+    http.cachedHostConnectionPool("akka.io", 80, httpsConnectionContext, materializer()); // does not work anymore
+
+Replace with::
+
+    http.cachedHostConnectionPool(toHostHttps("akka.io", 8081), materializer());
+    http.cachedHostConnectionPool(toHostHttps("akka.io", 8081).withCustomHttpsContext(httpsContext), materializer());

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
@@ -17,6 +17,12 @@ abstract class ConnectHttp {
 
   final def effectiveHttpsConnectionContext(fallbackContext: HttpsConnectionContext): HttpsConnectionContext =
     connectionContext.orElse(fallbackContext)
+
+  final def effectiveConnectionContext(fallbackContext: ConnectionContext): ConnectionContext =
+    if (connectionContext.isPresent) connectionContext.get()
+    else fallbackContext
+
+  override def toString = s"ConnectHttp($host,$port,$isHttps,$connectionContext)"
 }
 
 object ConnectHttp {
@@ -35,7 +41,8 @@ object ConnectHttp {
 
   def toHost(host: String, port: Int): ConnectHttp = {
     require(port > 0, "port must be > 0")
-    toHost(Uri.create(host).port(port))
+    val start = if (host.startsWith("http://") || host.startsWith("https://")) host else s"http://$host"
+    toHost(Uri.create(start).port(port))
   }
 
   /**
@@ -59,7 +66,8 @@ object ConnectHttp {
   @throws(classOf[IllegalArgumentException])
   def toHostHttps(host: String, port: Int): ConnectWithHttps = {
     require(port > 0, "port must be > 0")
-    toHostHttps(Uri.create(host).port(port).host.address)
+    val start = if (host.startsWith("https://")) host else s"https://$host"
+    toHostHttps(Uri.create(s"$start").port(port))
   }
 
   private def effectivePort(uri: Uri): Int = {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -896,7 +896,7 @@ final case class `WWW-Authenticate`(challenges: immutable.Seq[HttpChallenge]) ex
 }
 
 // http://en.wikipedia.org/wiki/X-Forwarded-For
-object `X-Forwarded-For` extends ModeledCompanion[`X-Forwarded-For`] {  
+object `X-Forwarded-For` extends ModeledCompanion[`X-Forwarded-For`] {
   def apply(first: RemoteAddress, more: RemoteAddress*): `X-Forwarded-For` = apply(immutable.Seq(first +: more: _*))
   implicit val addressesRenderer = Renderer.defaultSeqRenderer[RemoteAddress] // cache
 }
@@ -911,9 +911,9 @@ final case class `X-Forwarded-For`(addresses: immutable.Seq[RemoteAddress]) exte
   def getAddresses: Iterable[jm.RemoteAddress] = addresses.asJava
 }
 
-object `X-Real-Ip` extends ModeledCompanion[`X-Real-Ip`]   
-final case class `X-Real-Ip`(address:RemoteAddress) extends jm.headers.XRealIp 
+object `X-Real-Ip` extends ModeledCompanion[`X-Real-Ip`]
+final case class `X-Real-Ip`(address: RemoteAddress) extends jm.headers.XRealIp
   with RequestHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ address
-  protected def companion = `X-Real-Ip`  
+  protected def companion = `X-Real-Ip`
 }

--- a/akka-http-tests/src/test/java/akka/http/javadsl/client/HttpAPIsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/client/HttpAPIsTest.java
@@ -36,22 +36,22 @@ public class HttpAPIsTest extends JUnitRouteTest {
     ConnectionPoolSettings conSettings = null;
     LoggingAdapter log = null;
 
-    http.bind("127.0.0.1", 8080, materializer());
-    http.bind("127.0.0.1", 8080, connectionContext, materializer());
-    http.bind("127.0.0.1", 8080, httpContext, materializer());
-    http.bind("127.0.0.1", 8080, httpsContext, materializer());
+    http.bind(toHost("127.0.0.1", 8080), materializer());
+    http.bind(toHost("127.0.0.1", 8080), materializer());
+    http.bind(toHostHttps("127.0.0.1", 8080), materializer());
 
     final Flow<HttpRequest, HttpResponse, ?> handler = null;
-    http.bindAndHandle(handler, "127.0.0.1", 8080, materializer());
-    http.bindAndHandle(handler, "127.0.0.1", 8080, httpsContext, materializer());
+    http.bindAndHandle(handler, toHost("127.0.0.1", 8080), materializer());
+    http.bindAndHandle(handler, toHost("127.0.0.1", 8080), materializer());
+    http.bindAndHandle(handler, toHostHttps("127.0.0.1", 8080).withCustomHttpsContext(httpsContext), materializer());
 
     final Function<HttpRequest, CompletionStage<HttpResponse>> handler1 = null;
-    http.bindAndHandleAsync(handler1, "127.0.0.1", 8080, materializer());
-    http.bindAndHandleAsync(handler1, "127.0.0.1", 8080, httpsContext, materializer());
+    http.bindAndHandleAsync(handler1, toHost("127.0.0.1", 8080), materializer());
+    http.bindAndHandleAsync(handler1, toHostHttps("127.0.0.1", 8080), materializer());
 
     final Function<HttpRequest, HttpResponse> handler2 = null;
-    http.bindAndHandleSync(handler2, "127.0.0.1", 8080, materializer());
-    http.bindAndHandleSync(handler2, "127.0.0.1", 8080, httpsContext, materializer());
+    http.bindAndHandleSync(handler2, toHost("127.0.0.1", 8080), materializer());
+    http.bindAndHandleSync(handler2, toHostHttps("127.0.0.1", 8080), materializer());
 
     final HttpRequest handler3 = null;
     http.singleRequest(handler3, materializer());

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -363,12 +363,12 @@ object StreamLayout {
   }
 
   final case class CompositeModule(
-      override val subModules: Set[Module],
-      override val shape: Shape,
-      override val downstreams: Map[OutPort, InPort],
-      override val upstreams: Map[InPort, OutPort],
-      override val materializedValueComputation: MaterializedValueNode,
-      override val attributes: Attributes) extends Module {
+    override val subModules: Set[Module],
+    override val shape: Shape,
+    override val downstreams: Map[OutPort, InPort],
+    override val upstreams: Map[InPort, OutPort],
+    override val materializedValueComputation: MaterializedValueNode,
+    override val attributes: Attributes) extends Module {
 
     override def replaceShape(s: Shape): Module =
       if (s != shape) {
@@ -395,13 +395,13 @@ object StreamLayout {
   }
 
   final case class FusedModule(
-      override val subModules: Set[Module],
-      override val shape: Shape,
-      override val downstreams: Map[OutPort, InPort],
-      override val upstreams: Map[InPort, OutPort],
-      override val materializedValueComputation: MaterializedValueNode,
-      override val attributes: Attributes,
-      info: Fusing.StructuralInfo) extends Module {
+    override val subModules: Set[Module],
+    override val shape: Shape,
+    override val downstreams: Map[OutPort, InPort],
+    override val upstreams: Map[InPort, OutPort],
+    override val materializedValueComputation: MaterializedValueNode,
+    override val attributes: Attributes,
+    info: Fusing.StructuralInfo) extends Module {
 
     override def isFused: Boolean = true
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -347,7 +347,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * @see [[#mapAsyncUnordered]]
    */
   def mapAsync[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): javadsl.Flow[In, T, Mat] =
-    new Flow(delegate.mapAsync(parallelism)(x => f(x).toScala))
+    new Flow(delegate.mapAsync(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Transform this stream by applying the given function to each of the elements
@@ -379,7 +379,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * @see [[#mapAsync]]
    */
   def mapAsyncUnordered[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): javadsl.Flow[In, T, Mat] =
-    new Flow(delegate.mapAsyncUnordered(parallelism)(x => f(x).toScala))
+    new Flow(delegate.mapAsyncUnordered(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Only pass on those elements that satisfy the given predicate.
@@ -1461,7 +1461,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   def zipMat[T, M, M2](that: Graph[SourceShape[T], M],
                        matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out @uncheckedVariance Pair T, M2] =
     this.viaMat(Flow.fromGraph(GraphDSL.create(that,
-      new function.Function2[GraphDSL.Builder[M], SourceShape[T], FlowShape[Out, Out @uncheckedVariance Pair T]] {
+      new function.Function2[GraphDSL.Builder[M], SourceShape[T], FlowShape[Out, Out @ uncheckedVariance Pair T]] {
         def apply(b: GraphDSL.Builder[M], s: SourceShape[T]): FlowShape[Out, Out @uncheckedVariance Pair T] = {
           val zip: FanInShape2[Out, T, Out Pair T] = b.add(Zip.create[Out, T])
           b.from(s).toInlet(zip.in1)
@@ -1638,7 +1638,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * downstream.
    */
   def watchTermination[M]()(matF: function.Function2[Mat, CompletionStage[Done], M]): javadsl.Flow[In, Out, M] =
-    new Flow(delegate.watchTermination()((left, right) => matF(left, right.toJava)))
+    new Flow(delegate.watchTermination()((left, right) ⇒ matF(left, right.toJava)))
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -838,7 +838,7 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * @see [[#mapAsyncUnordered]]
    */
   def mapAsync[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): javadsl.Source[T, Mat] =
-    new Source(delegate.mapAsync(parallelism)(x => f(x).toScala))
+    new Source(delegate.mapAsync(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Transform this stream by applying the given function to each of the elements
@@ -870,7 +870,7 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * @see [[#mapAsync]]
    */
   def mapAsyncUnordered[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): javadsl.Source[T, Mat] =
-    new Source(delegate.mapAsyncUnordered(parallelism)(x => f(x).toScala))
+    new Source(delegate.mapAsyncUnordered(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Only pass on those elements that satisfy the given predicate.
@@ -1777,7 +1777,7 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * downstream.
    */
   def watchTermination[M]()(matF: function.Function2[Mat, CompletionStage[Done], M]): javadsl.Source[Out, M] =
-    new Source(delegate.watchTermination()((left, right) => matF(left, right.toJava)))
+    new Source(delegate.watchTermination()((left, right) ⇒ matF(left, right.toJava)))
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -201,7 +201,7 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    * @see [[#mapAsyncUnordered]]
    */
   def mapAsync[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): SubFlow[In, T, Mat] =
-    new SubFlow(delegate.mapAsync(parallelism)(x => f(x).toScala))
+    new SubFlow(delegate.mapAsync(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Transform this stream by applying the given function to each of the elements
@@ -233,7 +233,7 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    * @see [[#mapAsync]]
    */
   def mapAsyncUnordered[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): SubFlow[In, T, Mat] =
-    new SubFlow(delegate.mapAsyncUnordered(parallelism)(x => f(x).toScala))
+    new SubFlow(delegate.mapAsyncUnordered(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Only pass on those elements that satisfy the given predicate.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -199,7 +199,7 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    * @see [[#mapAsyncUnordered]]
    */
   def mapAsync[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): SubSource[T, Mat] =
-    new SubSource(delegate.mapAsync(parallelism)(x => f(x).toScala))
+    new SubSource(delegate.mapAsync(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Transform this stream by applying the given function to each of the elements
@@ -231,7 +231,7 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    * @see [[#mapAsync]]
    */
   def mapAsyncUnordered[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): SubSource[T, Mat] =
-    new SubSource(delegate.mapAsyncUnordered(parallelism)(x => f(x).toScala))
+    new SubSource(delegate.mapAsyncUnordered(parallelism)(x ⇒ f(x).toScala))
 
   /**
    * Only pass on those elements that satisfy the given predicate.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1009,7 +1009,7 @@ object GraphDSL extends GraphApply {
     }
 
     private class PortOpsImpl[+Out](override val outlet: Outlet[Out @uncheckedVariance], b: Builder[_])
-        extends PortOps[Out] {
+      extends PortOps[Out] {
 
       override def withAttributes(attr: Attributes): Repr[Out] = throw settingAttrNotSupported
       override def addAttributes(attr: Attributes): Repr[Out] = throw settingAttrNotSupported


### PR DESCRIPTION
This was the missing piece to resolve https://github.com/akka/akka/issues/19577 completely.
It simply replaces the overloads that explicitly take the ConnectionContext (possibly HttpsConnectionContext) by using HttpConnect everywhere, which carries along an ConnectionContext – when it's Https, it binds as an HTTPS server.
