### PR TITLE
+str #19782 Transpose (ZipN) a sources sequence

### DIFF
--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -197,6 +197,22 @@ fromPublisher
 ^^^^^^^^^^^^^
 Integration with Reactive Streams, subscribes to a ``org.reactivestreams.Publisher``.
 
+zipN
+^^^^
+Combine the elements of multiple streams into a stream of sequences.
+
+**emits** when all of the inputs has an element available
+
+**completes** when any upstream completes
+
+zipWithN
+^^^^^^^^
+Combine the elements of multiple streams into a stream of sequences using a combiner function.
+
+**emits** when all of the inputs has an element available
+
+**completes** when any upstream completes
+
 
 
 

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -186,6 +186,22 @@ fromPublisher
 ^^^^^^^^^^^^^
 Integration with Reactive Streams, subscribes to a ``org.reactivestreams.Publisher``.
 
+zipN
+^^^^
+Combine the elements of multiple streams into a stream of sequences.
+
+**emits** when all of the inputs has an element available
+
+**completes** when any upstream completes
+
+zipWithN
+^^^^^^^^
+Combine the elements of multiple streams into a stream of sequences using a combiner function.
+
+**emits** when all of the inputs has an element available
+
+**completes** when any upstream completes
+
 
 
 

--- a/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
@@ -30,6 +30,7 @@ class DslFactoriesConsistencySpec extends WordSpec with Matchers {
     (classOf[scala.collection.immutable.Iterable[_]],   classOf[java.lang.Iterable[_]]) ::
       (classOf[scala.collection.Iterator[_]],           classOf[java.util.Iterator[_]]) ::
       (classOf[scala.collection.Seq[_]],                classOf[java.util.List[_]]) ::
+      (classOf[scala.collection.immutable.Seq[_]],      classOf[java.util.List[_]]) ::
       (classOf[scala.collection.immutable.Set[_]],      classOf[java.util.Set[_]]) ::
       (classOf[Boolean],                                classOf[akka.stream.javadsl.AsPublisher]) ::
       (classOf[scala.Function0[_]],                     classOf[akka.japi.function.Creator[_]]) ::

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipNSpec.scala
@@ -1,0 +1,227 @@
+/**
+ * Copyright (C) 2014-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.testkit._
+import akka.stream.testkit.Utils._
+import akka.stream._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.collection.immutable
+
+class GraphZipNSpec extends TwoStreamsSetup {
+  import GraphDSL.Implicits._
+
+  override type Outputs = immutable.Seq[Int]
+
+  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture(b) {
+    val zipN = b.add(ZipN[Int](2))
+
+    override def left: Inlet[Int] = zipN.in(0)
+    override def right: Inlet[Int] = zipN.in(1)
+    override def out: Outlet[immutable.Seq[Int]] = zipN.out
+  }
+
+  "ZipN" must {
+
+    "work in the happy case" in assertAllStagesStopped {
+      val probe = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+
+      RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
+        val zipN = b.add(ZipN[Int](2))
+
+        Source(1 to 4) ~> zipN.in(0)
+        Source(2 to 5) ~> zipN.in(1)
+
+        zipN.out ~> Sink.fromSubscriber(probe)
+
+        ClosedShape
+      }).run()
+
+      val subscription = probe.expectSubscription()
+
+      subscription.request(2)
+      probe.expectNext(immutable.Seq(1, 2))
+      probe.expectNext(immutable.Seq(2, 3))
+
+      subscription.request(1)
+      probe.expectNext(immutable.Seq(3, 4))
+      subscription.request(1)
+      probe.expectNext(immutable.Seq(4, 5))
+
+      probe.expectComplete()
+    }
+
+    "complete if one side is available but other already completed" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒
+        out ⇒
+          val zipN = b.add(ZipN[Int](2))
+
+          Source.fromPublisher(upstream1) ~> zipN.in(0)
+          Source.fromPublisher(upstream2) ~> zipN.in(1)
+          zipN.out ~> out
+
+          ClosedShape
+      }).run()
+
+      upstream1.sendNext(1)
+      upstream1.sendNext(2)
+      upstream2.sendNext(2)
+      upstream2.sendComplete()
+
+      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.expectComplete()
+      upstream1.expectCancellation()
+    }
+
+    "complete even if no pending demand" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒
+        out ⇒
+          val zipN = b.add(ZipN[Int](2))
+
+          Source.fromPublisher(upstream1) ~> zipN.in(0)
+          Source.fromPublisher(upstream2) ~> zipN.in(1)
+          zipN.out ~> out
+
+          ClosedShape
+      }).run()
+
+      downstream.request(1)
+
+      upstream1.sendNext(1)
+      upstream2.sendNext(2)
+      downstream.expectNext(immutable.Seq(1, 2))
+
+      upstream2.sendComplete()
+      downstream.expectComplete()
+      upstream1.expectCancellation()
+    }
+
+    "complete if both sides complete before requested with elements pending" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒
+        out ⇒
+          val zipN = b.add(ZipN[Int](2))
+
+          Source.fromPublisher(upstream1) ~> zipN.in(0)
+          Source.fromPublisher(upstream2) ~> zipN.in(1)
+          zipN.out ~> out
+
+          ClosedShape
+      }).run()
+
+      upstream1.sendNext(1)
+      upstream2.sendNext(2)
+
+      upstream1.sendComplete()
+      upstream2.sendComplete()
+
+      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.expectComplete()
+    }
+
+    "complete if one side complete before requested with elements pending" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒
+        out ⇒
+          val zipN = b.add(ZipN[Int](2))
+
+          Source.fromPublisher(upstream1) ~> zipN.in(0)
+          Source.fromPublisher(upstream2) ~> zipN.in(1)
+          zipN.out ~> out
+
+          ClosedShape
+      }).run()
+
+      upstream1.sendNext(1)
+      upstream1.sendNext(2)
+      upstream2.sendNext(2)
+
+      upstream1.sendComplete()
+      upstream2.sendComplete()
+
+      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.expectComplete()
+    }
+
+    "complete if one side complete before requested with elements pending 2" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒
+        out ⇒
+          val zipN = b.add(ZipN[Int](2))
+
+          Source.fromPublisher(upstream1) ~> zipN.in(0)
+          Source.fromPublisher(upstream2) ~> zipN.in(1)
+          zipN.out ~> out
+
+          ClosedShape
+      }).run()
+
+      downstream.ensureSubscription()
+
+      upstream1.sendNext(1)
+      upstream1.sendComplete()
+      downstream.expectNoMsg(500.millis)
+
+      upstream2.sendNext(2)
+      upstream2.sendComplete()
+      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.expectComplete()
+    }
+
+    commonTests()
+
+    "work with one immediately completed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(completedPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndComplete()
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), completedPublisher)
+      subscriber2.expectSubscriptionAndComplete()
+    }
+
+    "work with one delayed completed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(soonToCompletePublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndComplete()
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), soonToCompletePublisher)
+      subscriber2.expectSubscriptionAndComplete()
+    }
+
+    "work with one immediately failed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(failedPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndError(TestException)
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), failedPublisher)
+      subscriber2.expectSubscriptionAndError(TestException)
+    }
+
+    "work with one delayed failed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(soonToFailPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndError(TestException)
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), soonToFailPublisher)
+      val subscription2 = subscriber2.expectSubscriptionAndError(TestException)
+    }
+
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithNSpec.scala
@@ -1,0 +1,162 @@
+package akka.stream.scaladsl
+
+import akka.stream.testkit._
+import scala.concurrent.duration._
+import akka.stream._
+import akka.testkit.EventFilter
+import scala.collection.immutable
+
+class GraphZipWithNSpec extends TwoStreamsSetup {
+  import GraphDSL.Implicits._
+
+  override type Outputs = Int
+
+  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture(b) {
+    val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(2))
+    override def left: Inlet[Int] = zip.in(0)
+    override def right: Inlet[Int] = zip.in(1)
+    override def out: Outlet[Int] = zip.out
+  }
+
+  "ZipWithN" must {
+
+    "work in the happy case" in {
+      val probe = TestSubscriber.manualProbe[Outputs]()
+
+      RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
+        val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(2))
+        Source(1 to 4) ~> zip.in(0)
+        Source(10 to 40 by 10) ~> zip.in(1)
+
+        zip.out ~> Sink.fromSubscriber(probe)
+
+        ClosedShape
+      }).run()
+
+      val subscription = probe.expectSubscription()
+
+      subscription.request(2)
+      probe.expectNext(11)
+      probe.expectNext(22)
+
+      subscription.request(1)
+      probe.expectNext(33)
+      subscription.request(1)
+      probe.expectNext(44)
+
+      probe.expectComplete()
+    }
+
+    "work in the sad case" in {
+      val probe = TestSubscriber.manualProbe[Outputs]()
+
+      RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
+        val zip = b.add(ZipWithN((_: immutable.Seq[Int]).foldLeft(1)(_ / _))(2))
+
+        Source(1 to 4) ~> zip.in(0)
+        Source(-2 to 2) ~> zip.in(1)
+
+        zip.out ~> Sink.fromSubscriber(probe)
+
+        ClosedShape
+      }).run()
+
+      val subscription = probe.expectSubscription()
+
+      subscription.request(2)
+      probe.expectNext(1 / 1 / -2)
+      probe.expectNext(1 / 2 / -1)
+
+      EventFilter[ArithmeticException](occurrences = 1).intercept {
+        subscription.request(2)
+      }
+      probe.expectError() match {
+        case a: java.lang.ArithmeticException ⇒ a.getMessage should be("/ by zero")
+      }
+      probe.expectNoMsg(200.millis)
+    }
+
+    commonTests()
+
+    "work with one immediately completed and one nonempty publisher" in {
+      val subscriber1 = setup(completedPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndComplete()
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), completedPublisher)
+      subscriber2.expectSubscriptionAndComplete()
+    }
+
+    "work with one delayed completed and one nonempty publisher" in {
+      val subscriber1 = setup(soonToCompletePublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndComplete()
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), soonToCompletePublisher)
+      subscriber2.expectSubscriptionAndComplete()
+    }
+
+    "work with one immediately failed and one nonempty publisher" in {
+      val subscriber1 = setup(failedPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndError(TestException)
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), failedPublisher)
+      subscriber2.expectSubscriptionAndError(TestException)
+    }
+
+    "work with one delayed failed and one nonempty publisher" in {
+      val subscriber1 = setup(soonToFailPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndError(TestException)
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), soonToFailPublisher)
+      val subscription2 = subscriber2.expectSubscriptionAndError(TestException)
+    }
+
+    "work with 3 inputs" in {
+      val probe = TestSubscriber.manualProbe[Int]()
+
+      RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
+        val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(3))
+
+        Source.single(1) ~> zip.in(0)
+        Source.single(2) ~> zip.in(1)
+        Source.single(3) ~> zip.in(2)
+
+        zip.out ~> Sink.fromSubscriber(probe)
+
+        ClosedShape
+      }).run()
+
+      val subscription = probe.expectSubscription()
+
+      subscription.request(5)
+      probe.expectNext(6)
+
+      probe.expectComplete()
+    }
+
+    "work with 30 inputs" in {
+      val probe = TestSubscriber.manualProbe[Int]()
+
+      RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
+        val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(30))
+
+        (0 to 29).foreach {
+          n ⇒ Source.single(n) ~> zip.in(n)
+        }
+
+        zip.out ~> Sink.fromSubscriber(probe)
+
+        ClosedShape
+      }).run()
+
+      val subscription = probe.expectSubscription()
+
+      subscription.request(1)
+      probe.expectNext((0 to 29).sum)
+
+      probe.expectComplete()
+
+    }
+
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -69,6 +69,8 @@ private[stream] object Stages {
     val broadcast = name("broadcast")
     val balance = name("balance")
     val zip = name("zip")
+    val zipN = name("zipN")
+    val zipWithN = name("zipWithN")
     val unzip = name("unzip")
     val concat = name("concat")
     val repeat = name("repeat")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -244,6 +244,45 @@ object Zip {
 }
 
 /**
+ * Combine the elements of multiple streams into a stream of lists.
+ *
+ * A `ZipN` has a `n` input ports and one `out` port
+ *
+ * '''Emits when''' all of the inputs has an element available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' any upstream completes
+ *
+ * '''Cancels when''' downstream cancels
+ */
+object ZipN {
+  def create[A](n: Int): Graph[UniformFanInShape[A, java.util.List[A]], NotUsed] = {
+    ZipWithN.create(ConstantFun.javaIdentityFunction[java.util.List[A]], n)
+  }
+}
+
+/**
+ * Combine the elements of multiple streams into a stream of lists using a combiner function.
+ *
+ * A `ZipWithN` has a `n` input ports and one `out` port
+ *
+ * '''Emits when''' all of the inputs has an element available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' any upstream completes
+ *
+ * '''Cancels when''' downstream cancels
+ */
+object ZipWithN {
+  def create[A, O](zipper: function.Function[java.util.List[A], O], n: Int): Graph[UniformFanInShape[A, O], NotUsed] = {
+    import scala.collection.JavaConverters._
+    scaladsl.ZipWithN[A, O](seq => zipper.apply(seq.asJava))(n)
+  }
+}
+
+/**
  * Takes a stream of pair elements and splits each pair to two output streams.
  *
  * An `Unzip` has one `in` port and one `left` and one `right` output port.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -272,9 +272,24 @@ object Source {
    */
   def combine[T, U](first: Source[T, _ <: Any], second: Source[T, _ <: Any], rest: java.util.List[Source[T, _ <: Any]],
                     strategy: function.Function[java.lang.Integer, _ <: Graph[UniformFanInShape[T, U], NotUsed]]): Source[U, NotUsed] = {
-    import scala.collection.JavaConverters._
-    val seq = if (rest != null) rest.asScala.map(_.asScala) else Seq()
+    val seq = if (rest != null) Util.immutableSeq(rest).map(_.asScala) else immutable.Seq()
     new Source(scaladsl.Source.combine(first.asScala, second.asScala, seq: _*)(num ⇒ strategy.apply(num)))
+  }
+
+  /**
+   * Combine the elements of multiple streams into a stream of lists.
+   */
+  def zipN[T](sources: java.util.List[Source[T, _ <: Any]]): Source[java.util.List[T], NotUsed] = {
+    val seq = if (sources != null) Util.immutableSeq(sources).map(_.asScala) else immutable.Seq()
+    new Source(scaladsl.Source.zipN(seq).map(_.asJava))
+  }
+
+  /*
+   * Combine the elements of multiple streams into a stream of lists using a combiner function.
+   */
+  def zipWithN[T, O](zipper: function.Function[java.util.List[T], O], sources: java.util.List[Source[T, _ <: Any]]): Source[O, NotUsed] = {
+    val seq = if (sources != null) Util.immutableSeq(sources).map(_.asScala) else immutable.Seq()
+    new Source(scaladsl.Source.zipWithN[T, O](seq => zipper.apply(seq.asJava))(seq))
   }
 
   /**


### PR DESCRIPTION
This is a way of zipping source sequences into a source emitting sequences. I tried to use `ZipWith`, but it is not convenient when you don't know the number of streams you have to zip.

I implemented `Transpose` in the `ZipWith` way, and add the same tests than `GraphZipSpec`.

Please let me know if this PR is unnecessary, and if there is a concise way of resolving my problem.
