### PR TITLE
simplify InHandler in Merge junction: isAvailable(out) implies !pending

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -71,10 +71,10 @@ final class Merge[T] private (val inputPorts: Int, val eagerComplete: Boolean) e
       setHandler(i, new InHandler {
         override def onPush(): Unit = {
           if (isAvailable(out)) {
-            if (!pending) {
-              push(out, grab(i))
-              tryPull(i)
-            }
+            // isAvailable(out) implies !pending
+            // -> grab and push immediately
+            push(out, grab(i))
+            tryPull(i)
           } else pendingQueue.enqueue(i)
         }
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -80,10 +80,10 @@ final class Merge[T] private (val inputPorts: Int, val eagerComplete: Boolean) e
       setHandler(i, new InHandler {
         override def onPush(): Unit = {
           if (isAvailable(out)) {
-            if (!pending) {
-              push(out, grab(i))
-              tryPull(i)
-            }
+            // isAvailable(out) implies !pending
+            // -> grab and push immediately
+            push(out, grab(i))
+            tryPull(i)
           } else enqueue(i)
         }
 


### PR DESCRIPTION
I studied the code of the Merge junction and stumbled across the implementation of the InHandlers. First I thought that the logic is erroneous because after the isAvailable(out) check there was a nested !pending check. In case that the nested !pending check is not satisfied the input would be lost. However, after deep thinking I came to the conclusion that isAvailable(out) always implies !pending. (The OutHandler would immediately push something when it signals availability. This in turn makes the output unavailable again.)
