### PR TITLE
GZIPInputStream is not closed at all  at places (for validation)

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -75,8 +75,8 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
   def compress(msg: MessageLite): Array[Byte] = {
     val bos = new ByteArrayOutputStream(BufferSize)
     val zip = new GZIPOutputStream(bos)
-    msg.writeTo(zip)
-    zip.close()
+    try msg.writeTo(zip)
+    finally zip.close()
     bos.toByteArray
   }
 
@@ -92,7 +92,8 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Serializ
         readChunk()
     }
 
-    readChunk()
+    try readChunk()
+    finally in.close()
     out.toByteArray
   }
 

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/protobuf/DistributedPubSubMessageSerializer.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/protobuf/DistributedPubSubMessageSerializer.scala
@@ -67,8 +67,8 @@ class DistributedPubSubMessageSerializer(val system: ExtendedActorSystem) extend
   def compress(msg: MessageLite): Array[Byte] = {
     val bos = new ByteArrayOutputStream(BufferSize)
     val zip = new GZIPOutputStream(bos)
-    msg.writeTo(zip)
-    zip.close()
+    try msg.writeTo(zip)
+    finally zip.close()
     bos.toByteArray
   }
 
@@ -84,7 +84,8 @@ class DistributedPubSubMessageSerializer(val system: ExtendedActorSystem) extend
         readChunk()
     }
 
-    readChunk()
+    try readChunk()
+    finally in.close()
     out.toByteArray
   }
 


### PR DESCRIPTION
which leads to off-heap memory leak with every deserialized message.

GZIPInputStream uses Inflater internally (so also native zlib). Inflater frees up memory only on explicit call to end() or during finalization (finalize() contains only call to end()), so GZIPInputStream should always be explicitly closed.

As native libraries are used a non-scalaish try-finally is used to avoid off-heap memory leak for GZIPInputStream and GZIPOutputStream in case of exceptions.

(cherry picked from commit 35ffc492263a6f758e7f05054ba8264625ae5dae)
