### PR TITLE
=htc make basic credentials token method return correct token

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
@@ -27,9 +27,9 @@ final case class BasicHttpCredentials(username: String, password: String) extend
   }
   def render[R <: Rendering](r: R): r.type = r ~~ "Basic " ~~ cookie
 
-  def scheme: String = "Basic"
-  def token = cookie.toString
-  def params = Map.empty
+  override def scheme: String = "Basic"
+  override def token: String = String.valueOf(cookie)
+  override def params: Map[String, String] = Map.empty
 }
 
 object BasicHttpCredentials {
@@ -46,8 +46,8 @@ object BasicHttpCredentials {
 final case class OAuth2BearerToken(token: String) extends jm.headers.OAuth2BearerToken {
   def render[R <: Rendering](r: R): r.type = r ~~ "Bearer " ~~ token
 
-  def scheme: String = "Bearer"
-  def params: Map[String, String] = Map.empty
+  override def scheme: String = "Bearer"
+  override def params: Map[String, String] = Map.empty
 }
 
 final case class GenericHttpCredentials(scheme: String, token: String,

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -128,6 +128,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
     }
 
     "Authorization" in {
+      BasicHttpCredentials("Aladdin", "open sesame").token shouldEqual "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
       "Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" =!=
         Authorization(BasicHttpCredentials("Aladdin", "open sesame"))
       "Authorization: bAsIc QWxhZGRpbjpvcGVuIHNlc2FtZQ==" =!=


### PR DESCRIPTION
"cookie" is an array of bytes. Calling "toString" on that returns an identity hash instead of the actual token.

Apologies for not adding an accompanying test, wasn't too sure on where/how to do it. Somewhere in here perhaps?: https://github.com/akka/akka/blob/10d3af14785970ba584e15effa4b7472fc1f39d5/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
