### PR TITLE
add Twitter Chill to list of External Akka Serializers

### DIFF
--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -220,3 +220,6 @@ External Akka Serializers
 
 
 `Akka-kryo by Roman Levenstein <https://github.com/romix/akka-kryo-serialization>`_
+
+
+`Twitter Chill Scala extensions for Kryo <https://github.com/twitter/chill>`

--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -222,4 +222,4 @@ External Akka Serializers
 `Akka-kryo by Roman Levenstein <https://github.com/romix/akka-kryo-serialization>`_
 
 
-`Twitter Chill Scala extensions for Kryo <https://github.com/twitter/chill>`
+`Twitter Chill Scala extensions for Kryo (based on Akka Version 2.3.x but due to backwards compatibility of the Serializer Interface this extension also works with 2.4.x) <https://github.com/twitter/chill>`_

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -212,4 +212,4 @@ External Akka Serializers
 `Akka-kryo by Roman Levenstein <https://github.com/romix/akka-kryo-serialization>`_
 
 
-`Twitter Chill Scala extensions for Kryo <https://github.com/twitter/chill>`_
+`Twitter Chill Scala extensions for Kryo (based on Akka Version 2.3.x but due to backwards compatibility of the Serializer Interface this extension also works with 2.4.x) <https://github.com/twitter/chill>`_

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -210,3 +210,6 @@ External Akka Serializers
 
 
 `Akka-kryo by Roman Levenstein <https://github.com/romix/akka-kryo-serialization>`_
+
+
+`Twitter Chill Scala extensions for Kryo <https://github.com/twitter/chill>`_


### PR DESCRIPTION
We were running in quite some trouble when using the Akka-kryo Serialization Extension by Roman Levenstein. https://github.com/romix/akka-kryo-serialization/issues/75

Twitters Scala extensions for Kryo `Chill` seems to be much more stable, so i would suggest to add it to the list of External Akka Serializers
