### PR TITLE
#19767 Exclude meta-projects from unidoc tasks

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -120,7 +120,7 @@ object UnidocRoot extends AutoPlugin {
 
   override lazy val projectSettings =
     CliOptions.genjavadocEnabled.ifTrue(scalaJavaUnidocSettings).getOrElse(scalaUnidocSettings) ++
-    settings(Seq(AkkaBuild.samples), Seq(AkkaBuild.remoteTests, AkkaBuild.benchJmh, AkkaBuild.parsing, AkkaBuild.protobuf))
+    settings(Seq(AkkaBuild.samples), Seq(AkkaBuild.remoteTests, AkkaBuild.benchJmh, AkkaBuild.parsing, AkkaBuild.protobuf, AkkaBuild.osgiDiningHakkersSampleMavenTest, AkkaBuild.akkaScalaNightly))
 }
 
 /**

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -19,7 +19,7 @@ object Release {
     commands ++= Seq(buildReleaseCommand, uploadReleaseCommand)
   )
 
-  def buildReleaseCommand = Command.command("build-release") { state =>
+  def buildReleaseCommand = Command.command("buildRelease") { state =>
     val extracted = Project.extract(state)
     val release = extracted.get(releaseDirectory)
     val dist = extracted.get(Dist.distDirectory)
@@ -50,7 +50,7 @@ object Release {
     state5
   }
 
-  def uploadReleaseCommand = Command.command("upload-release") { state =>
+  def uploadReleaseCommand = Command.command("uploadRelease") { state =>
     val extracted = Project.extract(state)
     val (state1, _) = extracted.runTask(S3.upload, state)
     state1

--- a/project/scripts/release
+++ b/project/scripts/release
@@ -20,7 +20,7 @@
 #
 # 1.2) Check that signing works
 #      From inside sbt do the following
-#        sbt> publish-local-signed
+#        sbt> publishLocalSigned
 #      It should should ask you for your pass phrase, and create .asc files for
 #      all artifacts
 #
@@ -300,13 +300,13 @@ if [ ! $dry_run ]; then
 else
   RELEASE_OPT="-Dakka.genjavadoc.enabled=true"
 fi
-try sbt $RELEASE_OPT +build-release
+try sbt $RELEASE_OPT +buildRelease
 echolog "Successfully created local release"
 
 # check binary compatibility for dry run
 if [ ! $no_mima ] && [ $dry_run ]; then
   echodry "Running migration manager report..."
-  sbt mima-report-binary-issues
+  sbt mimaReportBinaryIssues
   echodry "Finished migration manager report"
 fi
 
@@ -358,10 +358,10 @@ echolog "Pushing ${release_dir} to ${publish_path} ..."
 if [ $dry_run ]; then
   echodry "Not actually pushing to server. Command:"
   echodry "  rsync -rlpvz --chmod=Dg+ws,Fg+w --exclude ${release_dir}/downloads ${release_dir}/ ${publish_path}/"
-  echodry "  sbt upload-release"
+  echodry "  sbt uploadRelease"
 else
   important rsync -rlpvz --chmod=Dg+ws,Fg+w --exclude ${release_dir}/downloads ${release_dir}/ ${publish_path}/
-  important sbt upload-release
+  important sbt uploadRelease
 fi
 
 echolog "Updating http://doc.akka.io/docs/versions.json [from $script_dir/../../akka-docs/versions.json]..."


### PR DESCRIPTION
`publishM2` was invoked by `unidoc` task. The fix is to add OSGi integration test project to unidoc scope filter.

Also changed release task and command names to follow the current sbt naming conventions.

Fixes #19767.
