### PR TITLE
=doc #19840 Introduction docs for HTTP

### DIFF
--- a/akka-docs/rst/scala/http/common/json-support.rst
+++ b/akka-docs/rst/scala/http/common/json-support.rst
@@ -1,3 +1,5 @@
+.. _akka-http-spray-json:
+
 JSON Support
 ============
 

--- a/akka-docs/rst/scala/http/common/xml-support.rst
+++ b/akka-docs/rst/scala/http/common/xml-support.rst
@@ -1,3 +1,5 @@
+.. _akka-http-xml-marshalling:
+
 XML Support
 ===========
 


### PR DESCRIPTION
Refs #19840 

I have only introduced more than one new example, re-using existing ones, I think the problem is more about discoverability and docs navigation than lack of docs, so I hope this intro-page helps with that.

I think Java will have to wait until the new Java API is in place.
