### PR TITLE
=htp #19397,#19842 fix content negotiation for non 2xx and Accept handling

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
@@ -239,6 +239,12 @@ private object PoolSlot {
   }
 
   final class UnexpectedDisconnectException(msg: String, cause: Throwable) extends RuntimeException(msg, cause) {
+    def this(msg: String) {
+      this(msg, null)
+    }
+  }
+
+  final class UnexpectedDisconnectException(msg: String, cause: Throwable) extends RuntimeException(msg, cause) {
     def this(msg: String) = this(msg, null)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
@@ -239,12 +239,6 @@ private object PoolSlot {
   }
 
   final class UnexpectedDisconnectException(msg: String, cause: Throwable) extends RuntimeException(msg, cause) {
-    def this(msg: String) {
-      this(msg, null)
-    }
-  }
-
-  final class UnexpectedDisconnectException(msg: String, cause: Throwable) extends RuntimeException(msg, cause) {
     def this(msg: String) = this(msg, null)
   }
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationGivenResponseCodeSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationGivenResponseCodeSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.http.scaladsl.marshalling
+
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.model.{ ContentTypes, MediaRanges }
+import akka.http.scaladsl.server.{ Route, RoutingSpec }
+
+class ContentNegotiationGivenResponseCodeSpec extends RoutingSpec {
+
+  val routes = {
+    pathPrefix(Segment) { mode ⇒
+      complete {
+        mode match {
+          case "200-text" ⇒ OK -> "ok"
+          case "201-text" ⇒ Created -> "created"
+          case "400-text" ⇒ BadRequest -> "bad-request"
+        }
+      }
+    }
+  }
+
+  "Return NotAcceptable for" should {
+    "200 OK response, when entity not available in Accept-ed MediaRange" in {
+      val request = Post("/200-text").addHeader(Accept(MediaRanges.`application/*`))
+
+      request ~> Route.seal(routes) ~> check {
+        status should ===(NotAcceptable)
+        entityAs[String] should include("text/plain")
+      }
+    }
+
+    "201 Created response, when entity not available in Accept-ed MediaRange" in {
+      val request = Post("/201-text").addHeader(Accept(MediaRanges.`application/*`))
+      request ~> Route.seal(routes) ~> check {
+        status should ===(NotAcceptable)
+        entityAs[String] should include("text/plain")
+      }
+    }
+  }
+
+  "Allow not explicitly Accept-ed content type to be returned if response code is non-2xx" should {
+    "400 BadRequest response, when entity not available in Accept-ed MediaRange" in {
+      val request = Post("/400-text").addHeader(Accept(MediaRanges.`application/*`))
+      request ~> Route.seal(routes) ~> check {
+        status should ===(BadRequest)
+        contentType should ===(ContentTypes.`text/plain(UTF-8)`)
+        entityAs[String] should include("bad-request")
+      }
+    }
+  }
+
+}

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshal.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshal.scala
@@ -9,11 +9,13 @@ import akka.http.scaladsl.server.ContentNegotiator
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.util.FastFuture._
 
+import scala.util.control.NoStackTrace
+
 object Marshal {
   def apply[T](value: T): Marshal[T] = new Marshal(value)
 
-  case class UnacceptableResponseContentTypeException(supported: Set[ContentNegotiator.Alternative])
-    extends RuntimeException
+  final case class UnacceptableResponseContentTypeException(supported: Set[ContentNegotiator.Alternative])
+    extends RuntimeException with NoStackTrace
 }
 
 class Marshal[A](val value: A) {

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -677,7 +677,10 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ResponseEntity.withoutSizeLimit"),
 
         // #20014 should have been final always
-        ProblemFilters.exclude[FinalClassProblem]("akka.http.scaladsl.model.EntityStreamSizeException")
+        ProblemFilters.exclude[FinalClassProblem]("akka.http.scaladsl.model.EntityStreamSizeException"),
+
+        // #19849 content negotiation fixes
+        ProblemFilters.exclude[FinalClassProblem]("akka.http.scaladsl.marshalling.Marshal$UnacceptableResponseContentTypeException")
       )
     )
   }


### PR DESCRIPTION
The added test replicates the behaviour as shown in the example in #19842

The general thing is that we need to retry at the right point, with trimming the Accept headers from the request. Some logic for this was already implemented, just not applied in the right spot from what I found.

Resolves #19397 
Resolves #19842

Please review if you have a moment to spare @jrudolph :)
