### PR TITLE
=act #19614 Fix AbstractBoundedNodeQueue node value nepotism

### DIFF
--- a/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
@@ -129,7 +129,7 @@ public abstract class AbstractBoundedNodeQueue<T> {
     }
 
     public final boolean isEmpty() {
-        return peekNode() == null;
+        return getEnq() == getDeq();
     }
 
     /**
@@ -169,6 +169,7 @@ public abstract class AbstractBoundedNodeQueue<T> {
             if (next != null) {
                 if (casDeq(deq, next)) {
                     deq.value = next.value;
+                    deq.setNext(null);
                     next.value = null;
                     return deq;
                 } // else we retry (concurrent consumers)


### PR DESCRIPTION
1. fix node value nepotism problem
2. break BC for throwing illegal exception when user has already used `AbstractBoundedNodeQueue` with the`BalancePool` in the old version(akka).
3. remove CAS operation on the pollNode method. 

not sure about 2&3, it may be worth from my perspective. The previous discussion can be found here #17267

refs: #19614 

I waiting for use it in 2.4.3, so create this PR :)
