### PR TITLE
microscopic doc improvement

### DIFF
--- a/akka-docs/rst/scala/code/docs/stream/GraphStageDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/stream/GraphStageDocSpec.scala
@@ -73,7 +73,7 @@ class GraphStageDocSpec extends AkkaSpec {
     val sourceGraph: Graph[SourceShape[Int], NotUsed] = new NumbersSource
 
     // Create a Source from the Graph to access the DSL
-    val mySource: Source[Int, NotUsed] = Source.fromGraph(new NumbersSource)
+    val mySource: Source[Int, NotUsed] = Source.fromGraph(sourceGraph)
 
     // Returns 55
     val result1: Future[Int] = mySource.take(10).runFold(0)(_ + _)


### PR DESCRIPTION
Little things like this make it difficult to ingest the docs:  instead of using the `sourceGraph` that was just instantiated, a `new NumbersSource` is given, confusing the reader as to why `sourceGraph` wasn't used.
