### PR TITLE
sbt projects settings fix: compatible way of passing settings to Project

### DIFF
--- a/akka-samples/akka-sample-cluster-java/build.sbt
+++ b/akka-samples/akka-sample-cluster-java/build.sbt
@@ -4,9 +4,11 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 val akkaVersion = "2.4-SNAPSHOT"
 
 val project = Project(
-  id = "akka-sample-cluster-java",
-  base = file("."),
-  settings = Project.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ Seq(
+    id = "akka-sample-cluster-java",
+    base = file(".")
+  )
+  .settings(SbtMultiJvm.multiJvmSettings: _*)
+  .settings(
     name := "akka-sample-cluster-java",
     version := "2.4-SNAPSHOT",
     scalaVersion := "2.11.7",
@@ -45,4 +47,4 @@ val project = Project(
     },
     licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))
   )
-) configs (MultiJvm)
+  .configs (MultiJvm)

--- a/akka-samples/akka-sample-cluster-scala/build.sbt
+++ b/akka-samples/akka-sample-cluster-scala/build.sbt
@@ -4,9 +4,11 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 val akkaVersion = "2.4-SNAPSHOT"
 
 val project = Project(
-  id = "akka-sample-cluster-scala",
-  base = file("."),
-  settings = Project.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ Seq(
+    id = "akka-sample-cluster-scala",
+    base = file(".")
+  )
+  .settings(SbtMultiJvm.multiJvmSettings: _*)
+  .settings(
     name := "akka-sample-cluster-scala",
     version := "2.4-SNAPSHOT",
     scalaVersion := "2.11.7",
@@ -44,4 +46,4 @@ val project = Project(
     },
     licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))
   )
-) configs (MultiJvm)
+  .configs (MultiJvm)

--- a/akka-samples/akka-sample-distributed-data-java/build.sbt
+++ b/akka-samples/akka-sample-distributed-data-java/build.sbt
@@ -4,9 +4,11 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 val akkaVersion = "2.4-SNAPSHOT"
 
 val project = Project(
-  id = "akka-sample-distributed-data-java",
-  base = file("."),
-  settings = Project.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ Seq(
+    id = "akka-sample-distributed-data-java",
+    base = file(".")
+  )
+  .settings(SbtMultiJvm.multiJvmSettings: _*)
+  .settings(
     name := "akka-sample-distributed-data-java",
     version := "2.4-SNAPSHOT",
     scalaVersion := "2.11.7",
@@ -42,7 +44,7 @@ val project = Project(
     },
     licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))
   )
-) configs (MultiJvm)
+  .configs (MultiJvm)
 
 
 fork in run := true

--- a/akka-samples/akka-sample-distributed-data-scala/build.sbt
+++ b/akka-samples/akka-sample-distributed-data-scala/build.sbt
@@ -4,9 +4,11 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 val akkaVersion = "2.4-SNAPSHOT"
 
 val project = Project(
-  id = "akka-sample-distributed-data-scala",
-  base = file("."),
-  settings = Project.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ Seq(
+    id = "akka-sample-distributed-data-scala",
+    base = file(".")
+  )
+  .settings(SbtMultiJvm.multiJvmSettings: _*)
+  .settings(
     name := "akka-sample-distributed-data-scala",
     version := "2.4-SNAPSHOT",
     scalaVersion := "2.11.7",
@@ -41,7 +43,7 @@ val project = Project(
     },
     licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))
   )
-) configs (MultiJvm)
+  .configs (MultiJvm)
 
 
 fork in run := true

--- a/akka-samples/akka-sample-multi-node-scala/build.sbt
+++ b/akka-samples/akka-sample-multi-node-scala/build.sbt
@@ -4,9 +4,11 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 val akkaVersion = "2.4-SNAPSHOT"
 
 val project = Project(
-  id = "akka-sample-multi-node-scala",
-  base = file("."),
-  settings = Project.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ Seq(
+    id = "akka-sample-multi-node-scala",
+    base = file(".")
+  )
+  .settings(SbtMultiJvm.multiJvmSettings: _*)
+  .settings(
     name := "akka-sample-multi-node-scala",
     version := "2.4-SNAPSHOT",
     scalaVersion := "2.11.7",
@@ -34,4 +36,4 @@ val project = Project(
     },
     licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))
   )
-) configs (MultiJvm)
+  .configs (MultiJvm)


### PR DESCRIPTION
issue: #19887 

I've changed approach of passing settings in following sbt project files:
- project/AkkaBuild.scala
- akka-samples/akka-sample-cluster-java/build.sbt
- akka-samples/akka-sample-cluster-scala/build.sbt
- akka-samples/akka-sample-distributed-data-java/build.sbt
- akka-samples/akka-sample-distributed-data-scala/build.sbt
- akka-samples/akka-sample-multi-node-scala/build.sbt

Main resoans for this PR:
- approach of passing settings by `Project(settings = Seq(...))` semantically differ from `Project().settings(Seq())` - and last one doing it by append setting to project instead of overwriting it completely. Current `Project(settings = Seq(...))` approach may conflict with some sbt plugins, for instance if `ensime-sbt` plugin available in scope sbt throws errors like `Cannot add dependency 'org.scala-lang\#scala-compiler;2.11.7' to configuration 'ensime-internal'"` (see some previous history here: https://github.com/ensime/ensime-sbt/issues/140)
- `Project.defaultSettings` and `Defaults.defaultSettings` is deprecated `(@deprecated("Use Defaults.coreDefaultSettings instead, combined with AutoPlugins.", "0.13.2"))`. And It may conflict with `Project().settings(Seq())` approach of passing project settings.
- as nice benefit we getting ability to use Ensime for Akka development, but it's not only about that it allow us to compile Akka witout `Cannot add dependency 'org.scala-lang'...` errors if ensime-sbt added to `~/.sbt/0.13/plugins.sbt` for working with different projects.

I'm not fully sure that those changes not affect something else, but seems like it works well (`validatePullRequest` passed well on local machine) (hope someone could help me to checking it).
