### PR TITLE
=clu #19859 Relaxed constraints on downing old incarnation of rejoining node

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -496,7 +496,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
           // new node will retry join
           logInfo("New incarnation of existing member [{}] is trying to join. " +
             "Existing will be removed from the cluster and then new member will be allowed to join.", m)
-          if (m.status != Down && m.status != Leaving && m.status != Exiting)
+          if (m.status != Down)
             downing(m.address)
         case None ⇒
           // remove the node from the failure detector

--- a/akka-docs/rst/common/cluster.rst
+++ b/akka-docs/rst/common/cluster.rst
@@ -265,7 +265,9 @@ become a part of the cluster). To be able to move forward the state of the
 ``unreachable`` nodes must be changed. It must become ``reachable`` again or marked
 as ``down``. If the node is to join the cluster again the actor system must be
 restarted and go through the joining process again. The cluster can, through the
-leader, also *auto-down* a node after a configured time of unreachability..
+leader, also *auto-down* a node after a configured time of unreachability. If new
+incarnation of unreachable node tries to rejoin the cluster old incarnation will be 
+marked as ``down`` and new incarnation can rejoin the cluster without manual intervention. 
 
 .. note:: If you have *auto-down* enabled and the failure detector triggers, you
    can over time end up with a lot of single node clusters if you don't put


### PR DESCRIPTION
Added information to clustering documentation about this "auto-downing" so it is more explicit - hopefully to right file. 

On my local machine some of the tests from `akka-cluster` module were failing (even w/o any changes) so we will have to see what are results from Jenkins. 
