### PR TITLE
+doc #19844 rel links to "current" on each page

### DIFF
--- a/akka-docs/_sphinx/themes/akka/layout.html
+++ b/akka-docs/_sphinx/themes/akka/layout.html
@@ -23,7 +23,9 @@
 {% block relbar2 %}{% endblock %}
 
 {% block extrahead %}
-  <!-- Akka release version-->
+    <!-- Hint to search engines that the "canonical" page is under "current", which will boost it appearing in search results -->
+    <link rel="canonical" href="http://akka.io/docs/akka/current/{{ pagename }}.html" />
+
   {%- if include_analytics %}
     <!--Google Analytics-->
     <script type="text/javascript">


### PR DESCRIPTION
A bit of sphinx hackery but made it work.

Appears as 

```
    <link rel="canonical" href="http://akka.io/docs/akka/current/general/terminology.html" />
```

Resolves https://github.com/akka/akka/issues/19844
