### PR TITLE
#19824 Unhandled akka.actor.Status.Failure in RemoteActorRefProvider in state WaitTransportShutdown

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -4,6 +4,7 @@
 
 package akka.remote
 
+import akka.Done
 import akka.actor._
 import akka.dispatch.sysmsg._
 import akka.event.{ Logging, LoggingAdapter, EventStream }
@@ -59,8 +60,13 @@ private[akka] object RemoteActorRefProvider {
     }
 
     when(WaitTransportShutdown) {
-      case Event((), _) ⇒
+      case Event(Done, _) ⇒
         log.info("Remoting shut down.")
+        systemGuardian ! TerminationHookDone
+        stop()
+
+      case Event(Status.Failure(ex), _) ⇒
+        log.error(ex, "Remoting shut down with error")
         systemGuardian ! TerminationHookDone
         stop()
     }

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -5,6 +5,7 @@
 package akka.remote
 
 import akka.AkkaException
+import akka.Done
 import akka.actor._
 import akka.event.{ LoggingAdapter }
 import scala.collection.immutable
@@ -39,7 +40,7 @@ private[akka] abstract class RemoteTransport(val system: ExtendedActorSystem, va
   /**
    * Shuts down the remoting
    */
-  def shutdown(): Future[Unit]
+  def shutdown(): Future[Done]
 
   /**
    * Address to be used in RootActorPath of refs generated for this transport.

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -3,6 +3,7 @@
  */
 package akka.remote
 
+import akka.Done
 import akka.actor.SupervisorStrategy._
 import akka.actor._
 import akka.event.{ Logging, LoggingAdapter }
@@ -135,7 +136,7 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
   private def notifyError(msg: String, cause: Throwable): Unit =
     eventPublisher.notifyListeners(RemotingErrorEvent(new RemoteTransportException(msg, cause)))
 
-  override def shutdown(): Future[Unit] = {
+  override def shutdown(): Future[Done] = {
     endpointManager match {
       case Some(manager) ⇒
         implicit val timeout = ShutdownTimeout
@@ -156,10 +157,10 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
           case Failure(e) ⇒
             notifyError("Failure during shutdown of remoting.", e)
             finalize()
-        } map { _ ⇒ () } // RARP needs only type Unit, not a boolean
+        } map { _ ⇒ Done } // RARP needs only akka.Done, not a boolean
       case None ⇒
         log.warning("Remoting is not running. Ignoring shutdown attempt.")
-        Future successful (())
+        Future successful Done
     }
   }
 


### PR DESCRIPTION
Fixes #19824 

When RARP is being shutdown, it pipes result of the shutdown of transport to self.

remote's shutdown is using `ask` pattern, so it can produce `Status.Failure`, which is not handled in RARP's state `WaitTransportShutdown`.
For fixing it added matching for `Status.Failure` and changed `RemoteTransport`'s shutdown signature to use `akka.Done`, which looks more consistent with other shutdown's and `akka.Done` is more verbose than previously used `Unit`.
