### PR TITLE
=htc #15799 implement client-side `Expect: 100-continue` support

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
@@ -67,6 +67,7 @@ object WebSocketClientBlueprint {
         // if some is available
         val parser = new HttpResponseParser(settings.parserSettings, HttpHeaderParser(settings.parserSettings)()) {
           var first = true
+          override def handleInformationalResponses = false
           override protected def parseMessage(input: ByteString, offset: Int): StateResult = {
             if (first) {
               first = false
@@ -77,7 +78,7 @@ object WebSocketClientBlueprint {
             }
           }
         }
-        parser.setRequestMethodForNextResponse(HttpMethods.GET)
+        parser.setContextForNextResponse(HttpResponseParser.ResponseContext(HttpMethods.GET, None))
 
         def onPush(elem: ByteString, ctx: Context[ByteString]): SyncDirective = {
           parser.parseBytes(elem) match {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -312,7 +312,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
 
     def newParserStage(requestMethod: HttpMethod = GET) = {
       val parser = new HttpResponseParser(parserSettings, HttpHeaderParser(parserSettings)())
-      parser.setRequestMethodForNextResponse(requestMethod)
+      parser.setContextForNextResponse(HttpResponseParser.ResponseContext(requestMethod, None))
       parser.stage
     }
 


### PR DESCRIPTION
Finally closes #15799 for good.
Sorry for the long delay in getting this done.

This also includes a fix to an oversight that somehow wasn't discovered so far.
The spec requires a response parser to accept and ignore interim 1xx informational responses, which akka-http (and spray) has not been doing up to now.

/cc @jrudolph @2beaucoup 
