### PR TITLE
Add "Philosophy" section to Akka HTTP intro, to explain what Akka HTTP is not

### DIFF
--- a/akka-docs/rst/scala/http/introduction.rst
+++ b/akka-docs/rst/scala/http/introduction.rst
@@ -12,7 +12,7 @@ it done with a low-level API, which offers more flexibility but might require yo
 
 Phylosophy
 ---------------
-Since its inception in early 2011 sprays development has been driven with a clear focus on providing tools for building integration layers rather than application cores. As such it regards itself as a suite of libraries rather than a framework.
+Akka HTTP has been driven with a clear focus on providing tools for building integration layers rather than application cores. As such it regards itself as a suite of libraries rather than a framework.
 
 A framework, as we’d like to think of the term, gives you a “frame”, in which you build your application. It comes with a lot of decisions already pre-made and provides a foundation including support structures that lets you get started and deliver results quickly. In a way a framework is like a skeleton onto which you put the “flesh” of your application in order to have it come alive. As such frameworks work best if you choose them before you start application development and try to stick to the frameworks “way of doing things” as you go along.
 
@@ -20,7 +20,7 @@ For example, if you are building a browser-facing web application it makes sense
 
 However, if your application is not primarily a web application because its core is not browser-interaction but some specialized maybe complex business service and you are merely trying to connect it to the world via a REST/HTTP interface a web-framework might not be what you need. In this case the application architecture should be dictated by what makes sense for the core not the interface layer. Also, you probably won’t benefit from the possibly existing browser-specific framework components like view templating, asset management, JavaScript- and CSS generation/manipulation/minification, localization support, AJAX support, etc.
 
-spray was designed specifically as “not-a-framework”, not because we don’t like frameworks, but for use cases where a framework is not the right choice. spray is made for building integration layers based on HTTP and as such tries to “stay on the sidelines”. Therefore you normally don’t build your application “on top of” spray, but you build your application on top of whatever makes sense and use spray merely for the HTTP integration needs.
+Akka HTTP was designed specifically as “not-a-framework”, not because we don’t like frameworks, but for use cases where a framework is not the right choice. Akka HTTP is made for building integration layers based on HTTP and as such tries to “stay on the sidelines”. Therefore you normally don’t build your application “on top of” Akka HTTP, but you build your application on top of whatever makes sense and use Akka HTTP merely for the HTTP integration needs.
 
 Using Akka HTTP
 ---------------

--- a/akka-docs/rst/scala/http/introduction.rst
+++ b/akka-docs/rst/scala/http/introduction.rst
@@ -10,6 +10,18 @@ You get to pick the API level of abstraction that is most suitable for your appl
 This means that, if you have trouble achieving something using a high-level API, there's a good chance that you can get
 it done with a low-level API, which offers more flexibility but might require you to write more application code.
 
+Phylosophy
+---------------
+Since its inception in early 2011 sprays development has been driven with a clear focus on providing tools for building integration layers rather than application cores. As such it regards itself as a suite of libraries rather than a framework.
+
+A framework, as we’d like to think of the term, gives you a “frame”, in which you build your application. It comes with a lot of decisions already pre-made and provides a foundation including support structures that lets you get started and deliver results quickly. In a way a framework is like a skeleton onto which you put the “flesh” of your application in order to have it come alive. As such frameworks work best if you choose them before you start application development and try to stick to the frameworks “way of doing things” as you go along.
+
+For example, if you are building a browser-facing web application it makes sense to choose a web framework and build your application on top of it because the “core” of the application is the interaction of a browser with your code on the web-server. The framework makers have chosen one “proven” way of designing such applications and let you “fill in the blanks” of a more or less flexible “application-template”. Being able to rely on best-practice architecture like this can be a great asset for getting things done quickly.
+
+However, if your application is not primarily a web application because its core is not browser-interaction but some specialized maybe complex business service and you are merely trying to connect it to the world via a REST/HTTP interface a web-framework might not be what you need. In this case the application architecture should be dictated by what makes sense for the core not the interface layer. Also, you probably won’t benefit from the possibly existing browser-specific framework components like view templating, asset management, JavaScript- and CSS generation/manipulation/minification, localization support, AJAX support, etc.
+
+spray was designed specifically as “not-a-framework”, not because we don’t like frameworks, but for use cases where a framework is not the right choice. spray is made for building integration layers based on HTTP and as such tries to “stay on the sidelines”. Therefore you normally don’t build your application “on top of” spray, but you build your application on top of whatever makes sense and use spray merely for the HTTP integration needs.
+
 Using Akka HTTP
 ---------------
 Akka HTTP is provided in separate jar files, to use it make sure to include the following dependencies::

--- a/akka-docs/rst/scala/http/introduction.rst
+++ b/akka-docs/rst/scala/http/introduction.rst
@@ -10,7 +10,7 @@ You get to pick the API level of abstraction that is most suitable for your appl
 This means that, if you have trouble achieving something using a high-level API, there's a good chance that you can get
 it done with a low-level API, which offers more flexibility but might require you to write more application code.
 
-Phylosophy
+Philosophy
 ---------------
 Akka HTTP has been driven with a clear focus on providing tools for building integration layers rather than application cores. As such it regards itself as a suite of libraries rather than a framework.
 


### PR DESCRIPTION
Refs #19898

Just ported [What is Spray](http://spray.io/introduction/what-is-spray/) -> Phylosophy, and then replaced "Spray" with "Akka HTTP". 

[Diff from Spray's doc.](https://github.com/richard-imaoka/akka/commit/435e3ce78c12736fcac4709956de20e3cce39a27)

Looking at YouTube's [Akka HTTP — The What, Why and How](https://www.youtube.com/watch?v=y_slPbktLr0#t=8m03s), should we probably mention major [improvements](https://www.youtube.com/watch?v=y_slPbktLr0#t=11m11s) too? That's sidetracked from the original purpose of the issue #19898 though.
