### PR TITLE
!htc WIP #19956 removing case classes from HttpMessages

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/http/HttpMessageMatchingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/http/HttpMessageMatchingBenchmark.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http
+
+import akka.http.scaladsl.model._
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+/**
+ * Benchmark used to verify move to name-based extraction does not hurt preformance.
+ * It does not allocate an Option thus it should be more optimal actually.
+ */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class HttpMessageMatchingBenchmark {
+
+  val req = HttpRequest()
+  val res = HttpResponse()
+
+  @Benchmark
+  def res_matching: HttpResponse = {
+    res match {
+      case r @ HttpResponse(status, headers, entity, protocol) => r
+    }
+  }
+
+  @Benchmark
+  def req_matching: HttpRequest = {
+    req match {
+      case r @ HttpRequest(method, uri, headers, entity, protocol) => r
+    }
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
@@ -28,8 +28,8 @@ private[akka] object InputStreamPublisher {
 
 /** INTERNAL API */
 private[akka] class InputStreamPublisher(is: InputStream, completionPromise: Promise[IOResult], chunkSize: Int)
-    extends akka.stream.actor.ActorPublisher[ByteString]
-    with ActorLogging {
+  extends akka.stream.actor.ActorPublisher[ByteString]
+  with ActorLogging {
 
   // TODO possibly de-duplicate with FilePublisher?
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -532,6 +532,47 @@ object AkkaBuild extends Build {
      javacOptions in doc ++= Seq("-Xdoclint:none")
    )
 
+  def akkaPreviousArtifacts(id: String): Def.Initialize[Set[sbt.ModuleID]] = Def.setting {
+    if (enableMiMa) {
+      val versions = {
+        val akka23Versions = Seq("2.3.11", "2.3.12", "2.3.13", "2.3.14")
+        val akka24Versions = Seq("2.4.0", "2.4.1", "2.4.2")
+        val akka24NewArtifacts = Seq(
+          "akka-cluster-sharding",
+          "akka-cluster-tools",
+          "akka-cluster-metrics",
+          "akka-persistence",
+          "akka-distributed-data-experimental",
+          "akka-persistence-query-experimental"
+        )
+        scalaBinaryVersion.value match {
+          case "2.11" if !akka24NewArtifacts.contains(id) => akka23Versions ++ akka24Versions
+          case _ => akka24Versions // Only Akka 2.4.x for scala > than 2.11
+        }
+      }
+
+      // check against all binary compatible artifacts
+      versions.map(organization.value %% id % _).toSet
+    }
+    else Set.empty
+  }
+
+  def akkaStreamAndHttpPreviousArtifacts(id: String): Def.Initialize[Set[sbt.ModuleID]] = Def.setting {
+    if (enableMiMa) {
+      val versions = {
+          val akka24Versions = Seq("2.4.2")
+          val akka24NewArtifacts = Seq(
+            "akka-http-core"
+          )
+
+          akka24Versions
+        }
+
+        // check against all binary compatible artifacts
+        versions.map(organization.value %% id % _).toSet
+    } else Set.empty
+  }
+
   def loadSystemProperties(fileName: String): Unit = {
     import scala.collection.JavaConverters._
     val file = new File(fileName)

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -675,6 +675,33 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.RequestEntity.withoutSizeLimit"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.UniversalEntity.withoutSizeLimit"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ResponseEntity.withoutSizeLimit"),
+        // #19956 Remove exposed case classes in HTTP model
+        ProblemFilters.exclude[MissingTypesProblem]("akka.http.scaladsl.model.HttpRequest$"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.model.HttpRequest.unapply"), // returned Option[HttpRequest], now returns HttpRequest – no Option allocations!
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.<init>$default$1"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.<init>$default$2"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.<init>$default$3"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.<init>$default$4"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.<init>$default$5"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.http.scaladsl.model.HttpResponse"), // was a case class (Serializable, Product, Equals)
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.productElement"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.productArity"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.canEqual"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.productIterator"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.productPrefix"),
+
+        ProblemFilters.exclude[MissingTypesProblem]("akka.http.scaladsl.model.HttpRequest"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.productElement"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.productArity"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.canEqual"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.productIterator"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpRequest.productPrefix"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.http.scaladsl.model.HttpResponse$"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.model.HttpResponse.unapply"), // returned Option[HttpRequest], now returns HttpRequest – no Option allocations!
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.<init>$default$1"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.<init>$default$2"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.<init>$default$3"),
+        ProblemFilters.exclude[MissingMethodProblem]("akka.http.scaladsl.model.HttpResponse.<init>$default$4"),
 
         // #20014 should have been final always
         ProblemFilters.exclude[FinalClassProblem]("akka.http.scaladsl.model.EntityStreamSizeException"),


### PR DESCRIPTION
Moved HttpRequest and HttpResponse to name based extraction.
Did not notice provable performance improvements, however there is one less allocation involved when matching now – i.e. the Option is not allocated in unapply.

It's somewhat debatable how far we should push this, as well as if we need more tooling – manually doing this to all classes is quite some work (100+ classes). Note that source breaking changes we'll most likely won't be able to do anyway and these types are strongly geared towards matching on them.

Eventually to resolve #19956
