### PR TITLE
-doc remove unnecessary Loading div

### DIFF
--- a/akka-docs/_sphinx/themes/akka/layout.html
+++ b/akka-docs/_sphinx/themes/akka/layout.html
@@ -131,7 +131,6 @@
         <div class="row">
           {%- if include_analytics %}
           <div class="span9">
-            <div id="cse">Loading</div>
           </div>
           {%- endif -%}
           <div class="span9">


### PR DESCRIPTION
Was used by google search, which we now dont use anymore
