### PR TITLE
+doc more visible note on connection pool shutdown

### DIFF
--- a/akka-docs/rst/java/http/client-side/host-level.rst
+++ b/akka-docs/rst/java/http/client-side/host-level.rst
@@ -144,6 +144,11 @@ It's also possible to trigger the immediate termination of *all* connection pool
 time by calling ``Http.get(system).shutdownAllConnectionPools()``. This call too produces a ``CompletionStage<Done>`` which is fulfilled when
 all pools have terminated.
 
+.. note::
+  When encoutering unexpected ``akka.stream.AbruptTerminationException`` exceptions during ``ActorSystem`` **shutdown**
+  please make sure that active connections are shut down before shutting down the entire system, this can be done by
+  calling the ``Http.get(system).shutdownAllConnectionPools()`` method, and only once its CompletionStage completes,
+  shutting down the actor system.
 
 Example
 -------

--- a/akka-docs/rst/scala/http/client-side/host-level.rst
+++ b/akka-docs/rst/scala/http/client-side/host-level.rst
@@ -143,6 +143,11 @@ It's also possible to trigger the immediate termination of *all* connection pool
 time by calling ``Http().shutdownAllConnectionPools()``. This call too produces a ``Future[Unit]`` which is fulfilled when
 all pools have terminated.
 
+.. note::
+  When encoutering unexpected ``akka.stream.AbruptTerminationException`` exceptions during ``ActorSystem`` **shutdown**
+  please make sure that active connections are shut down before shutting down the entire system, this can be done by
+  calling the ``Http().shutdownAllConnectionPools()`` method, and only once its Future completes, shutting down the actor system.
+
 
 Example
 -------


### PR DESCRIPTION
This should help a bit in people noticing this, also makes it googlable by `AbruptTerminationException`
