### PR TITLE
=doc fixed part of scaladoc warnings

### DIFF
--- a/akka-actor/src/main/scala/akka/event/EventBus.scala
+++ b/akka-actor/src/main/scala/akka/event/EventBus.scala
@@ -255,7 +255,7 @@ trait ScanningClassification { self: EventBus ⇒
 /**
  * Maps ActorRefs to ActorRefs to form an EventBus where ActorRefs can listen to other ActorRefs.
  *
- * All subscribers will be watched by an [[akka.event.ActorClassificationUnsubscriber]] and unsubscribed when they terminate.
+ * All subscribers will be watched by an `akka.event.ActorClassificationUnsubscriber` and unsubscribed when they terminate.
  * The unsubscriber actor will not be stopped automatically, and if you want to stop using the bus you should stop it yourself.
  */
 trait ManagedActorClassification { this: ActorEventBus with ActorClassifier ⇒

--- a/akka-actor/src/main/scala/akka/routing/Resizer.scala
+++ b/akka-actor/src/main/scala/akka/routing/Resizer.scala
@@ -96,20 +96,9 @@ case object DefaultResizer {
 /**
  * Implementation of [[Resizer]] that adjust the [[Pool]] based on specified
  * thresholds.
- */
-@SerialVersionUID(1L)
-case class DefaultResizer(
-  /**
-   * The fewest number of routees the router should ever have.
-   */
-  val lowerBound: Int = 1,
-  /**
- * The most number of routees the router should ever have.
- * Must be greater than or equal to `lowerBound`.
- */
-  val upperBound: Int = 10,
-  /**
- * Threshold to evaluate if routee is considered to be busy (under pressure).
+ * @param lowerBound The fewest number of routees the router should ever have.
+ * @param upperBound The most number of routees the router should ever have. Must be greater than or equal to `lowerBound`.
+ * @param pressureThreshold Threshold to evaluate if routee is considered to be busy (under pressure).
  * Implementation depends on this value (default is 1).
  * <ul>
  * <li> 0:   number of routees currently processing a message.</li>
@@ -119,35 +108,30 @@ case class DefaultResizer(
  *           messages in their mailbox. Note that estimating mailbox size of
  *           default UnboundedMailbox is O(N) operation.</li>
  * </ul>
- */
-  val pressureThreshold: Int = 1,
-  /**
- * Percentage to increase capacity whenever all routees are busy.
+ * @param rampupRate  Percentage to increase capacity whenever all routees are busy.
  * For example, 0.2 would increase 20% (rounded up), i.e. if current
  * capacity is 6 it will request an increase of 2 more routees.
- */
-  val rampupRate: Double = 0.2,
-  /**
- * Minimum fraction of busy routees before backing off.
+ * @param backoffThreshold Minimum fraction of busy routees before backing off.
  * For example, if this is 0.3, then we'll remove some routees only when
  * less than 30% of routees are busy, i.e. if current capacity is 10 and
  * 3 are busy then the capacity is unchanged, but if 2 or less are busy
  * the capacity is decreased.
- *
  * Use 0.0 or negative to avoid removal of routees.
- */
-  val backoffThreshold: Double = 0.3,
-  /**
- * Fraction of routees to be removed when the resizer reaches the
+ * @param backoffRate  Fraction of routees to be removed when the resizer reaches the
  * backoffThreshold.
  * For example, 0.1 would decrease 10% (rounded up), i.e. if current
  * capacity is 9 it will request an decrease of 1 routee.
- */
-  val backoffRate: Double = 0.1,
-  /**
- * Number of messages between resize operation.
+ * @param messagesPerResize Number of messages between resize operation.
  * Use 1 to resize before each message.
  */
+@SerialVersionUID(1L)
+case class DefaultResizer(
+  val lowerBound: Int = 1,
+  val upperBound: Int = 10,
+  val pressureThreshold: Int = 1,
+  val rampupRate: Double = 0.2,
+  val backoffThreshold: Double = 0.3,
+  val backoffRate: Double = 0.1,
   val messagesPerResize: Int = 10) extends Resizer {
 
   /**

--- a/akka-actor/src/main/scala/akka/serialization/Serializer.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serializer.scala
@@ -25,7 +25,7 @@ import scala.util.DynamicVariable
  * load classes using reflection.</li>
  * </ul>
  *
- * <b>Be sure to always use the [[akka.actor.DynamicAccess]] for loading classes!</b> This is necessary to
+ * <b>Be sure to always use the </b>[[akka.actor.DynamicAccess]]<b> for loading classes!</b> This is necessary to
  * avoid strange match errors and inequalities which arise from different class loaders loading
  * the same class.
  */
@@ -72,7 +72,7 @@ trait Serializer {
  * that the class can be moved/removed and the serializer can still deserialize old data by matching
  * on the `String`. This is especially useful for Akka Persistence.
  *
- * The manifest string can also encode a version number that can be used in [[#fromBinary]] to
+ * The manifest string can also encode a version number that can be used in `fromBinary` to
  * deserialize in different ways to migrate old data to new domain objects.
  *
  * If the data was originally serialized with [[Serializer]] and in a later version of the
@@ -91,7 +91,7 @@ trait Serializer {
  * load classes using reflection.</li>
  * </ul>
  *
- * <b>Be sure to always use the [[akka.actor.DynamicAccess]] for loading classes!</b> This is necessary to
+ * <b>Be sure to always use the </b>[[akka.actor.DynamicAccess]]<b> for loading classes!</b> This is necessary to
  * avoid strange match errors and inequalities which arise from different class loaders loading
  * the same class.
  */
@@ -141,6 +141,7 @@ trait BaseSerializer extends Serializer {
    *  Actor system which is required by most serializer implementations.
    */
   def system: ExtendedActorSystem
+
   /**
    * Configuration namespace of serialization identifiers in the `reference.conf`.
    *
@@ -150,10 +151,11 @@ trait BaseSerializer extends Serializer {
    * and `ID` is globally unique serializer identifier number.
    */
   final val SerializationIdentifiers = "akka.actor.serialization-identifiers"
+
   /**
    * Globally unique serialization identifier configured in the `reference.conf`.
    *
-   * See [[Serializer#identifier()]].
+   * See [[Serializer#identifier]].
    */
   override val identifier: Int = identifierFromConfig
 


### PR DESCRIPTION
I have fixed few scaladoc warnings (that appear after running `sbt doc` command locally).

Some of those warnings were appearing only when running `sbt doc` locally, and were not appearing on jenkins (but scaladoc was generated incorrectly)
