### PR TITLE
simplify materialized value computation tree, fixes #20015

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 import akka.NotUsed
 import akka.http.scaladsl.model.RequestEntity
 import akka.stream._
-import akka.stream.impl.StreamLayout.Module
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.impl.{ PublisherSink, SinkModule, SourceModule }
 import akka.stream.scaladsl._
@@ -187,7 +186,7 @@ private[http] object StreamUtils {
     override protected def newInstance(shape: SinkShape[In]): SinkModule[In, Publisher[In]] =
       new OneTimePublisherSink[In](attributes, shape, cell)
 
-    override def withAttributes(attr: Attributes): Module =
+    override def withAttributes(attr: Attributes): OneTimePublisherSink[In] =
       new OneTimePublisherSink[In](attr, amendShape(attr), cell)
   }
   /** A copy of SubscriberSource that allows access to the subscriber through the cell but can only materialized once */
@@ -212,7 +211,7 @@ private[http] object StreamUtils {
 
     override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, Subscriber[Out]] =
       new OneTimeSubscriberSource[Out](attributes, shape, cell)
-    override def withAttributes(attr: Attributes): Module =
+    override def withAttributes(attr: Attributes): OneTimeSubscriberSource[Out] =
       new OneTimeSubscriberSource[Out](attr, amendShape(attr), cell)
   }
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
@@ -4,7 +4,6 @@
 
 package akka.http.javadsl.model;
 
-import akka.http.impl.util.Util;
 import akka.http.javadsl.model.headers.*;
 import akka.japi.Pair;
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/StreamLayoutSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/StreamLayoutSpec.scala
@@ -11,11 +11,9 @@ import akka.stream._
 class StreamLayoutSpec extends AkkaSpec {
   import StreamLayout._
 
-  def testAtomic(inPortCount: Int, outPortCount: Int): Module = new Module {
+  def testAtomic(inPortCount: Int, outPortCount: Int): Module = new AtomicModule {
     override val shape = AmorphousShape(List.fill(inPortCount)(Inlet("")), List.fill(outPortCount)(Outlet("")))
     override def replaceShape(s: Shape): Module = ???
-
-    override def subModules: Set[Module] = Set.empty
 
     override def carbonCopy: Module = ???
 
@@ -174,7 +172,7 @@ class StreamLayoutSpec extends AkkaSpec {
     var publishers = Vector.empty[TestPublisher]
     var subscribers = Vector.empty[TestSubscriber]
 
-    override protected def materializeAtomic(atomic: Module, effectiveAttributes: Attributes,
+    override protected def materializeAtomic(atomic: AtomicModule, effectiveAttributes: Attributes,
                                              matVal: java.util.Map[Module, Any]): Unit = {
       for (inPort ← atomic.inPorts) {
         val subscriber = TestSubscriber(atomic, inPort)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
@@ -12,109 +12,162 @@ import akka.testkit.AkkaSpec
 
 class GraphMatValueSpec extends AkkaSpec {
 
-  val settings = ActorMaterializerSettings(system)
-    .withInputBuffer(initialSize = 2, maxSize = 16)
-
-  implicit val materializer = ActorMaterializer(settings)
-
   import GraphDSL.Implicits._
 
-  "A Graph with materialized value" must {
+  val foldSink = Sink.fold[Int, Int](0)(_ + _)
 
-    val foldSink = Sink.fold[Int, Int](0)(_ + _)
+  "A Graph with materialized value" when {
 
-    "expose the materialized value as source" in {
-      val sub = TestSubscriber.manualProbe[Int]()
-      val f = RunnableGraph.fromGraph(GraphDSL.create(foldSink) { implicit b ⇒
-        fold ⇒
-          Source(1 to 10) ~> fold
-          b.materializedValue.mapAsync(4)(identity) ~> Sink.fromSubscriber(sub)
-          ClosedShape
-      }).run()
+    for (autoFusing ← Seq(true, false)) {
+      val settings = ActorMaterializerSettings(system)
+        .withInputBuffer(initialSize = 2, maxSize = 16)
+        .withAutoFusing(autoFusing)
+      implicit val materializer = ActorMaterializer(settings)
 
-      val r1 = Await.result(f, 3.seconds)
-      sub.expectSubscription().request(1)
-      val r2 = sub.expectNext()
+      s"using autoFusing=$autoFusing" must {
 
-      r1 should ===(r2)
-    }
+        "expose the materialized value as source" in {
+          val sub = TestSubscriber.manualProbe[Int]()
+          val f = RunnableGraph.fromGraph(GraphDSL.create(foldSink) { implicit b ⇒
+            fold ⇒
+              Source(1 to 10) ~> fold
+              b.materializedValue.mapAsync(4)(identity) ~> Sink.fromSubscriber(sub)
+              ClosedShape
+          }).run()
 
-    "expose the materialized value as source multiple times" in {
-      val sub = TestSubscriber.manualProbe[Int]()
+          val r1 = Await.result(f, 3.seconds)
+          sub.expectSubscription().request(1)
+          val r2 = sub.expectNext()
 
-      val f = RunnableGraph.fromGraph(GraphDSL.create(foldSink) { implicit b ⇒
-        fold ⇒
-          val zip = b.add(ZipWith[Int, Int, Int](_ + _))
-          Source(1 to 10) ~> fold
-          b.materializedValue.mapAsync(4)(identity) ~> zip.in0
-          b.materializedValue.mapAsync(4)(identity) ~> zip.in1
+          r1 should ===(r2)
+        }
 
-          zip.out ~> Sink.fromSubscriber(sub)
-          ClosedShape
-      }).run()
+        "expose the materialized value as source multiple times" in {
+          val sub = TestSubscriber.manualProbe[Int]()
 
-      val r1 = Await.result(f, 3.seconds)
-      sub.expectSubscription().request(1)
-      val r2 = sub.expectNext()
+          val f = RunnableGraph.fromGraph(GraphDSL.create(foldSink) { implicit b ⇒
+            fold ⇒
+              val zip = b.add(ZipWith[Int, Int, Int](_ + _))
+              Source(1 to 10) ~> fold
+              b.materializedValue.mapAsync(4)(identity) ~> zip.in0
+              b.materializedValue.mapAsync(4)(identity) ~> zip.in1
 
-      r1 should ===(r2 / 2)
-    }
+              zip.out ~> Sink.fromSubscriber(sub)
+              ClosedShape
+          }).run()
 
-    // Exposes the materialized value as a stream value
-    val foldFeedbackSource: Source[Future[Int], Future[Int]] = Source.fromGraph(GraphDSL.create(foldSink) { implicit b ⇒
-      fold ⇒
-        Source(1 to 10) ~> fold
-        SourceShape(b.materializedValue)
-    })
+          val r1 = Await.result(f, 3.seconds)
+          sub.expectSubscription().request(1)
+          val r2 = sub.expectNext()
 
-    "allow exposing the materialized value as port" in {
-      val (f1, f2) = foldFeedbackSource.mapAsync(4)(identity).map(_ + 100).toMat(Sink.head)(Keep.both).run()
-      Await.result(f1, 3.seconds) should ===(55)
-      Await.result(f2, 3.seconds) should ===(155)
-    }
+          r1 should ===(r2 / 2)
+        }
 
-    "allow exposing the materialized value as port even if wrapped and the final materialized value is Unit" in {
-      val noMatSource: Source[Int, Unit] = foldFeedbackSource.mapAsync(4)(identity).map(_ + 100).mapMaterializedValue((_) ⇒ ())
-      Await.result(noMatSource.runWith(Sink.head), 3.seconds) should ===(155)
-    }
-
-    "work properly with nesting and reusing" in {
-      val compositeSource1 = Source.fromGraph(GraphDSL.create(foldFeedbackSource, foldFeedbackSource)(Keep.both) { implicit b ⇒
-        (s1, s2) ⇒
-          val zip = b.add(ZipWith[Int, Int, Int](_ + _))
-
-          s1.out.mapAsync(4)(identity) ~> zip.in0
-          s2.out.mapAsync(4)(identity).map(_ * 100) ~> zip.in1
-          SourceShape(zip.out)
-      })
-
-      val compositeSource2 = Source.fromGraph(GraphDSL.create(compositeSource1, compositeSource1)(Keep.both) { implicit b ⇒
-        (s1, s2) ⇒
-          val zip = b.add(ZipWith[Int, Int, Int](_ + _))
-          s1.out ~> zip.in0
-          s2.out.map(_ * 10000) ~> zip.in1
-          SourceShape(zip.out)
-      })
-
-      val (((f1, f2), (f3, f4)), result) = compositeSource2.toMat(Sink.head)(Keep.both).run()
-
-      Await.result(result, 3.seconds) should ===(55555555)
-      Await.result(f1, 3.seconds) should ===(55)
-      Await.result(f2, 3.seconds) should ===(55)
-      Await.result(f3, 3.seconds) should ===(55)
-      Await.result(f4, 3.seconds) should ===(55)
-
-    }
-
-    "work also when the source’s module is copied" in {
-      val foldFlow: Flow[Int, Int, Future[Int]] = Flow.fromGraph(GraphDSL.create(Sink.fold[Int, Int](0)(_ + _)) {
-        implicit builder ⇒
+        // Exposes the materialized value as a stream value
+        val foldFeedbackSource: Source[Future[Int], Future[Int]] = Source.fromGraph(GraphDSL.create(foldSink) { implicit b ⇒
           fold ⇒
-            FlowShape(fold.in, builder.materializedValue.mapAsync(4)(identity).outlet)
-      })
+            Source(1 to 10) ~> fold
+            SourceShape(b.materializedValue)
+        })
 
-      Await.result(Source(1 to 10).via(foldFlow).runWith(Sink.head), 3.seconds) should ===(55)
+        "allow exposing the materialized value as port" in {
+          val (f1, f2) = foldFeedbackSource.mapAsync(4)(identity).map(_ + 100).toMat(Sink.head)(Keep.both).run()
+          Await.result(f1, 3.seconds) should ===(55)
+          Await.result(f2, 3.seconds) should ===(155)
+        }
+
+        "allow exposing the materialized value as port even if wrapped and the final materialized value is Unit" in {
+          val noMatSource: Source[Int, Unit] = foldFeedbackSource.mapAsync(4)(identity).map(_ + 100).mapMaterializedValue((_) ⇒ ())
+          Await.result(noMatSource.runWith(Sink.head), 3.seconds) should ===(155)
+        }
+
+        "work properly with nesting and reusing" in {
+          val compositeSource1 = Source.fromGraph(GraphDSL.create(foldFeedbackSource, foldFeedbackSource)(Keep.both) { implicit b ⇒
+            (s1, s2) ⇒
+              val zip = b.add(ZipWith[Int, Int, Int](_ + _))
+
+              s1.out.mapAsync(4)(identity) ~> zip.in0
+              s2.out.mapAsync(4)(identity).map(_ * 100) ~> zip.in1
+              SourceShape(zip.out)
+          })
+
+          val compositeSource2 = Source.fromGraph(GraphDSL.create(compositeSource1, compositeSource1)(Keep.both) { implicit b ⇒
+            (s1, s2) ⇒
+              val zip = b.add(ZipWith[Int, Int, Int](_ + _))
+              s1.out ~> zip.in0
+              s2.out.map(_ * 10000) ~> zip.in1
+              SourceShape(zip.out)
+          })
+
+          val (((f1, f2), (f3, f4)), result) = compositeSource2.toMat(Sink.head)(Keep.both).run()
+
+          Await.result(result, 3.seconds) should ===(55555555)
+          Await.result(f1, 3.seconds) should ===(55)
+          Await.result(f2, 3.seconds) should ===(55)
+          Await.result(f3, 3.seconds) should ===(55)
+          Await.result(f4, 3.seconds) should ===(55)
+
+        }
+
+        "work also when the source’s module is copied" in {
+          val foldFlow: Flow[Int, Int, Future[Int]] = Flow.fromGraph(GraphDSL.create(foldSink) {
+            implicit builder ⇒
+              fold ⇒
+                FlowShape(fold.in, builder.materializedValue.mapAsync(4)(identity).outlet)
+          })
+
+          Await.result(Source(1 to 10).via(foldFlow).runWith(Sink.head), 3.seconds) should ===(55)
+        }
+
+        "work also when the source’s module is copied and the graph is extended before using the matValSrc" in {
+          val foldFlow: Flow[Int, Int, Future[Int]] = Flow.fromGraph(GraphDSL.create(foldSink) {
+            implicit builder ⇒
+              fold ⇒
+                val map = builder.add(Flow[Future[Int]].mapAsync(4)(identity))
+                builder.materializedValue ~> map
+                FlowShape(fold.in, map.outlet)
+          })
+
+          Await.result(Source(1 to 10).via(foldFlow).runWith(Sink.head), 3.seconds) should ===(55)
+        }
+
+        "perform side-effecting transformations even when not used as source" in {
+          var done = false
+          val g = GraphDSL.create() { implicit b ⇒
+            import GraphDSL.Implicits._
+            Source.empty.mapMaterializedValue(_ ⇒ done = true) ~> Sink.ignore
+            ClosedShape
+          }
+          val r = RunnableGraph.fromGraph(GraphDSL.create(Sink.ignore) { implicit b ⇒
+            (s) ⇒
+              b.add(g)
+              Source(1 to 10) ~> s
+              ClosedShape
+          })
+          r.run().futureValue should ===(akka.Done)
+          done should ===(true)
+        }
+
+        "produce NotUsed when not importing materialized value" in {
+          val source = Source.fromGraph(GraphDSL.create() { implicit b ⇒
+            SourceShape(b.materializedValue)
+          })
+          source.runWith(Sink.seq).futureValue should ===(List(akka.NotUsed))
+        }
+
+        "produce NotUsed when starting from Flow.via" in {
+          Source.empty.viaMat(Flow[Int].map(_ * 2))(Keep.right).to(Sink.ignore).run() should ===(akka.NotUsed)
+        }
+
+        "produce NotUsed when starting from Flow.via with transformation" in {
+          var done = false
+          Source.empty.viaMat(
+            Flow[Int].via(Flow[Int].mapMaterializedValue(_ ⇒ done = true)))(Keep.right)
+            .to(Sink.ignore).run() should ===(akka.NotUsed)
+          done should ===(true)
+        }
+
+      }
     }
-
   }
 }

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -61,6 +61,8 @@ trait GraphApply {
 private[stream] object GraphApply {
   final class GraphImpl[S <: Shape, Mat](override val shape: S, private[stream] override val module: StreamLayout.Module)
     extends Graph[S, Mat] {
+    
+    override def toString: String = s"Graph($shape, $module)"
 
     override def withAttributes(attr: Attributes): Graph[S, Mat] =
       new GraphImpl(shape, module.withAttributes(attr))

--- a/akka-stream/src/main/scala/akka/stream/Fusing.scala
+++ b/akka-stream/src/main/scala/akka/stream/Fusing.scala
@@ -31,11 +31,7 @@ object Fusing {
    * implementations based on [[akka.stream.stage.GraphStage]]) and not forbidden
    * via [[akka.stream.Attributes#AsyncBoundary]].
    */
-  def aggressive[S <: Shape, M](g: Graph[S, M]): FusedGraph[S, M] =
-    g match {
-      case fg: FusedGraph[_, _] ⇒ fg
-      case _                    ⇒ Impl.aggressive(g)
-    }
+  def aggressive[S <: Shape, M](g: Graph[S, M]): FusedGraph[S, M] = Impl.aggressive(g)
 
   /**
    * A fused graph of the right shape, containing a [[FusedModule]] which
@@ -46,6 +42,14 @@ object Fusing {
                                                             override val shape: S) extends Graph[S, M] {
     // the @uncheckedVariance look like a compiler bug ... why does it work in Graph but not here?
     override def withAttributes(attr: Attributes) = copy(module = module.withAttributes(attr))
+  }
+
+  object FusedGraph {
+    def unapply[S <: Shape, M](g: Graph[S, M]): Option[(FusedModule, S)] =
+      g.module match {
+        case f: FusedModule => Some((f, g.shape))
+        case _              => None
+      }
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -215,6 +215,8 @@ object ClosedShape extends ClosedShape {
    * Java API: obtain ClosedShape instance
    */
   def getInstance: ClosedShape = this
+
+  override def toString: String = "ClosedShape"
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -11,7 +11,7 @@ import akka.event.Logging
 import akka.dispatch.Dispatchers
 import akka.pattern.ask
 import akka.stream._
-import akka.stream.impl.StreamLayout.Module
+import akka.stream.impl.StreamLayout.{ Module, AtomicModule }
 import akka.stream.impl.fusing.{ ActorGraphInterpreter, GraphModule }
 import akka.stream.impl.io.TLSActor
 import akka.stream.impl.io.TlsModule
@@ -97,7 +97,8 @@ private[akka] case class ActorMaterializerImpl(system: ActorSystem,
         name
       }
 
-      override protected def materializeAtomic(atomic: Module, effectiveAttributes: Attributes, matVal: ju.Map[Module, Any]): Unit = {
+      override protected def materializeAtomic(atomic: AtomicModule, effectiveAttributes: Attributes, matVal: ju.Map[Module, Any]): Unit = {
+        if (MaterializerSession.Debug) println(s"materializing $atomic")
 
         def newMaterializationContext() =
           new MaterializationContext(ActorMaterializerImpl.this, effectiveAttributes, stageName(effectiveAttributes))

--- a/akka-stream/src/main/scala/akka/stream/impl/FlowModule.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FlowModule.scala
@@ -5,11 +5,12 @@ package akka.stream.impl
 
 import akka.stream._
 import akka.stream.impl.StreamLayout.Module
+import akka.event.Logging
 
 /**
  * INTERNAL API
  */
-private[stream] trait FlowModule[In, Out, Mat] extends StreamLayout.Module {
+private[stream] trait FlowModule[In, Out, Mat] extends StreamLayout.AtomicModule {
   override def replaceShape(s: Shape) =
     if (s != shape) throw new UnsupportedOperationException("cannot replace the shape of a FlowModule")
     else this
@@ -18,6 +19,6 @@ private[stream] trait FlowModule[In, Out, Mat] extends StreamLayout.Module {
   val outPort = Outlet[Out]("Flow.out")
   override val shape = new FlowShape(inPort, outPort)
 
-  override def subModules: Set[Module] = Set.empty
+  protected def label: String = Logging.simpleName(this)
+  final override def toString: String = f"$label [${System.identityHashCode(this)}%08x]"
 }
-

--- a/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
@@ -6,29 +6,30 @@ package akka.stream.impl
 import akka.NotUsed
 import akka.actor._
 import akka.stream._
-import akka.stream.impl.StreamLayout.Module
+import akka.stream.impl.StreamLayout.AtomicModule
 import org.reactivestreams._
-
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.Promise
+import akka.event.Logging
 
 /**
  * INTERNAL API
  */
-private[akka] abstract class SourceModule[+Out, +Mat](val shape: SourceShape[Out]) extends Module {
+private[akka] abstract class SourceModule[+Out, +Mat](val shape: SourceShape[Out]) extends AtomicModule {
+
+  protected def label: String = Logging.simpleName(this)
+  final override def toString: String = f"$label [${System.identityHashCode(this)}%08x]"
 
   def create(context: MaterializationContext): (Publisher[Out] @uncheckedVariance, Mat)
 
-  override def replaceShape(s: Shape): Module =
+  override def replaceShape(s: Shape): AtomicModule =
     if (s != shape) throw new UnsupportedOperationException("cannot replace the shape of a Source, you need to wrap it in a Graph for that")
     else this
 
   // This is okay since the only caller of this method is right below.
   protected def newInstance(shape: SourceShape[Out] @uncheckedVariance): SourceModule[Out, Mat]
 
-  override def carbonCopy: Module = newInstance(SourceShape(shape.out.carbonCopy()))
-
-  override def subModules: Set[Module] = Set.empty
+  override def carbonCopy: AtomicModule = newInstance(SourceShape(shape.out.carbonCopy()))
 
   protected def amendShape(attr: Attributes): SourceShape[Out] = {
     val thisN = attributes.nameOrDefault(null)
@@ -52,7 +53,7 @@ private[akka] final class SubscriberSource[Out](val attributes: Attributes, shap
   }
 
   override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, Subscriber[Out]] = new SubscriberSource[Out](attributes, shape)
-  override def withAttributes(attr: Attributes): Module = new SubscriberSource[Out](attr, amendShape(attr))
+  override def withAttributes(attr: Attributes): AtomicModule = new SubscriberSource[Out](attr, amendShape(attr))
 }
 
 /**
@@ -63,22 +64,26 @@ private[akka] final class SubscriberSource[Out](val attributes: Attributes, shap
  * back-pressure upstream.
  */
 private[akka] final class PublisherSource[Out](p: Publisher[Out], val attributes: Attributes, shape: SourceShape[Out]) extends SourceModule[Out, NotUsed](shape) {
+
+  override protected def label: String = s"PublisherSource($p)"
+
   override def create(context: MaterializationContext) = (p, NotUsed)
 
   override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, NotUsed] = new PublisherSource[Out](p, attributes, shape)
-  override def withAttributes(attr: Attributes): Module = new PublisherSource[Out](p, attr, amendShape(attr))
+  override def withAttributes(attr: Attributes): AtomicModule = new PublisherSource[Out](p, attr, amendShape(attr))
 }
 
 /**
  * INTERNAL API
  */
 private[akka] final class MaybeSource[Out](val attributes: Attributes, shape: SourceShape[Out]) extends SourceModule[Out, Promise[Option[Out]]](shape) {
+
   override def create(context: MaterializationContext) = {
     val p = Promise[Option[Out]]()
     new MaybePublisher[Out](p, attributes.nameOrDefault("MaybeSource"))(context.materializer.executionContext) → p
   }
   override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, Promise[Option[Out]]] = new MaybeSource[Out](attributes, shape)
-  override def withAttributes(attr: Attributes): Module = new MaybeSource(attr, amendShape(attr))
+  override def withAttributes(attr: Attributes): AtomicModule = new MaybeSource(attr, amendShape(attr))
 }
 
 /**
@@ -95,7 +100,7 @@ private[akka] final class ActorPublisherSource[Out](props: Props, val attributes
 
   override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, ActorRef] =
     new ActorPublisherSource[Out](props, attributes, shape)
-  override def withAttributes(attr: Attributes): Module = new ActorPublisherSource(props, attr, amendShape(attr))
+  override def withAttributes(attr: Attributes): AtomicModule = new ActorPublisherSource(props, attr, amendShape(attr))
 }
 
 /**
@@ -105,6 +110,8 @@ private[akka] final class ActorRefSource[Out](
   bufferSize: Int, overflowStrategy: OverflowStrategy, val attributes: Attributes, shape: SourceShape[Out])
   extends SourceModule[Out, ActorRef](shape) {
 
+  override protected def label: String = s"ActorRefSource($bufferSize, $overflowStrategy)"
+
   override def create(context: MaterializationContext) = {
     val mat = ActorMaterializer.downcast(context.materializer)
     val ref = mat.actorOf(context, ActorRefSourceActor.props(bufferSize, overflowStrategy, mat.settings))
@@ -113,6 +120,6 @@ private[akka] final class ActorRefSource[Out](
 
   override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, ActorRef] =
     new ActorRefSource[Out](bufferSize, overflowStrategy, attributes, shape)
-  override def withAttributes(attr: Attributes): Module =
+  override def withAttributes(attr: Attributes): AtomicModule =
     new ActorRefSource(bufferSize, overflowStrategy, attr, amendShape(attr))
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -208,6 +208,7 @@ private[stream] object Stages {
 
   final case class GroupBy(maxSubstreams: Int, f: Any ⇒ Any, attributes: Attributes = groupBy) extends StageModule {
     override def withAttributes(attributes: Attributes) = copy(attributes = attributes)
+    override protected def label: String = s"GroupBy($maxSubstreams)"
   }
 
   final case class DirectProcessor(p: () ⇒ (Processor[Any, Any], Any), attributes: Attributes = processor) extends StageModule {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -10,7 +10,7 @@ import akka.event.Logging
 import akka.stream._
 import akka.stream.impl._
 import akka.stream.impl.ReactiveStreamsCompliance._
-import akka.stream.impl.StreamLayout.{ CompositeModule, CopiedModule, Module }
+import akka.stream.impl.StreamLayout.{ CompositeModule, CopiedModule, Module, AtomicModule }
 import akka.stream.impl.fusing.GraphInterpreter.{ DownstreamBoundaryStageLogic, UpstreamBoundaryStageLogic, GraphAssembly }
 import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler }
 import org.reactivestreams.{ Subscriber, Subscription }
@@ -23,9 +23,9 @@ import scala.annotation.tailrec
 /**
  * INTERNAL API
  */
-private[stream] case class GraphModule(assembly: GraphAssembly, shape: Shape, attributes: Attributes,
-                                       matValIDs: Array[Module]) extends Module {
-  override def subModules: Set[Module] = Set.empty
+private[stream] final case class GraphModule(assembly: GraphAssembly, shape: Shape, attributes: Attributes,
+                                             matValIDs: Array[Module]) extends AtomicModule {
+
   override def withAttributes(newAttr: Attributes): Module = copy(attributes = newAttr)
 
   override final def carbonCopy: Module = CopiedModule(shape.deepCopy(), Attributes.none, this)
@@ -34,7 +34,12 @@ private[stream] case class GraphModule(assembly: GraphAssembly, shape: Shape, at
     if (newShape != shape) CompositeModule(this, newShape)
     else this
 
-  override def toString: String = s"GraphModule\n  ${assembly.toString.replace("\n", "\n  ")}\n  shape=$shape, attributes=$attributes"
+  override def toString: String =
+    s"""GraphModule
+       |  ${assembly.toString.replace("\n", "\n  ")}
+       |  shape=$shape, attributes=$attributes
+       |  matVals=
+       |    ${matValIDs.mkString("\n    ")}""".stripMargin
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -191,14 +191,17 @@ private[akka] object GraphInterpreter {
       (inHandlers, outHandlers, logics)
     }
 
-    override def toString: String =
+    override def toString: String = {
+      val stageList = stages.iterator.zip(originalAttributes.iterator).map {
+        case (stage, attr) ⇒ s"${stage.module}    [${attr.attributeList.mkString(", ")}]"
+      }
       "GraphAssembly\n  " +
-        stages.mkString("Stages: [", ",", "]") + "\n  " +
-        originalAttributes.mkString("Attributes: [", ",", "]") + "\n  " +
-        ins.mkString("Inlets: [", ",", "]") + "\n  " +
-        inOwners.mkString("InOwners: [", ",", "]") + "\n  " +
-        outs.mkString("Outlets: [", ",", "]") + "\n  " +
-        outOwners.mkString("OutOwners: [", ",", "]")
+        stageList.mkString("[ ", "\n    ", "\n  ]") + "\n  " +
+        ins.mkString("[", ",", "]") + "\n  " +
+        inOwners.mkString("[", ",", "]") + "\n  " +
+        outs.mkString("[", ",", "]") + "\n  " +
+        outOwners.mkString("[", ",", "]")
+    }
   }
 
   object GraphAssembly {

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
@@ -22,6 +22,8 @@ import scala.concurrent.{ Future, Promise }
 private[akka] final class FileSink(f: File, options: Set[StandardOpenOption], val attributes: Attributes, shape: SinkShape[ByteString])
   extends SinkModule[ByteString, Future[IOResult]](shape) {
 
+  override protected def label: String = s"FileSink($f, $options)"
+
   override def create(context: MaterializationContext) = {
     val materializer = ActorMaterializer.downcast(context.materializer)
     val settings = materializer.effectiveSettings(context.effectiveAttributes)
@@ -68,4 +70,3 @@ private[akka] final class OutputStreamSink(createOutput: () ⇒ OutputStream, va
   override def withAttributes(attr: Attributes): Module =
     new OutputStreamSink(createOutput, attr, amendShape(attr), autoFlush)
 }
-

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
@@ -41,6 +41,8 @@ private[akka] final class FileSource(f: File, chunkSize: Int, val attributes: At
 
   override def withAttributes(attr: Attributes): Module =
     new FileSource(f, chunkSize, attr, amendShape(attr))
+
+  override protected def label: String = s"FileSource($f, $chunkSize)"
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
@@ -28,8 +28,8 @@ private[akka] object InputStreamPublisher {
 
 /** INTERNAL API */
 private[akka] class InputStreamPublisher(is: InputStream, completionPromise: Promise[IOResult], chunkSize: Int)
-    extends akka.stream.actor.ActorPublisher[ByteString]
-    with ActorLogging {
+  extends akka.stream.actor.ActorPublisher[ByteString]
+  with ActorLogging {
 
   // TODO possibly de-duplicate with FilePublisher?
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -140,7 +140,8 @@ private[akka] class InputStreamAdapter(sharedBuffer: BlockingQueue[StreamToAdapt
                 case Failed(ex) ⇒
                   isStageAlive = false
                   throw new IOException(ex)
-                case null ⇒ throw new IOException("Timeout on waiting for new data")
+                case null        ⇒ throw new IOException("Timeout on waiting for new data")
+                case Initialized ⇒ throw new IllegalStateException("message 'Initialized' must come first")
               }
             } catch {
               case ex: InterruptedException ⇒ throw new IOException(ex)
@@ -215,4 +216,3 @@ private[akka] class InputStreamAdapter(sharedBuffer: BlockingQueue[StreamToAdapt
     }
   }
 }
-

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
@@ -3,7 +3,7 @@ package akka.stream.impl.io
 import javax.net.ssl.SSLContext
 
 import akka.stream._
-import akka.stream.impl.StreamLayout.{ CompositeModule, Module }
+import akka.stream.impl.StreamLayout.{ CompositeModule, AtomicModule }
 import akka.stream.TLSProtocol._
 import akka.util.ByteString
 
@@ -15,11 +15,10 @@ private[akka] final case class TlsModule(plainIn: Inlet[SslTlsOutbound], plainOu
                                          shape: Shape, attributes: Attributes,
                                          sslContext: SSLContext,
                                          firstSession: NegotiateNewSession,
-                                         role: TLSRole, closing: TLSClosing, hostInfo: Option[(String, Int)]) extends Module {
-  override def subModules: Set[Module] = Set.empty
+                                         role: TLSRole, closing: TLSClosing, hostInfo: Option[(String, Int)]) extends AtomicModule {
 
-  override def withAttributes(att: Attributes): Module = copy(attributes = att)
-  override def carbonCopy: Module =
+  override def withAttributes(att: Attributes): TlsModule = copy(attributes = att)
+  override def carbonCopy: TlsModule =
     TlsModule(attributes, sslContext, firstSession, role, closing, hostInfo)
 
   override def replaceShape(s: Shape) =
@@ -27,6 +26,8 @@ private[akka] final case class TlsModule(plainIn: Inlet[SslTlsOutbound], plainOu
       shape.requireSamePortsAs(s)
       CompositeModule(this, s)
     } else this
+
+  override def toString: String = f"TlsModule($firstSession, $role, $closing, $hostInfo) [${System.identityHashCode(this)}%08x]"
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -75,6 +75,8 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   override def shape: FlowShape[In, Out] = delegate.shape
   private[stream] def module: StreamLayout.Module = delegate.module
 
+  override def toString: String = delegate.toString
+
   /** Converts this Flow to its Scala DSL counterpart */
   def asScala: scaladsl.Flow[In, Out, Mat] = delegate
 
@@ -119,6 +121,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * flow into the materialized value of the resulting Flow.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def viaMat[T, M, M2](flow: Graph[FlowShape[Out, T], M], combine: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
     new Flow(delegate.viaMat(flow)(combinerToScala(combine)))
@@ -158,6 +163,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * Sink into the materialized value of the resulting Sink.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def toMat[M, M2](sink: Graph[SinkShape[Out], M], combine: function.Function2[Mat, M, M2]): javadsl.Sink[In, M2] =
     new Sink(delegate.toMat(sink)(combinerToScala(combine)))
@@ -189,6 +197,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * Flow into the materialized value of the resulting Flow.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def joinMat[M, M2](flow: Graph[FlowShape[Out, In], M], combine: function.Function2[Mat, M, M2]): javadsl.RunnableGraph[M2] =
     RunnableGraph.fromGraph(delegate.joinMat(flow)(combinerToScala(combine)))
@@ -228,6 +239,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * [[BidiFlow]] into the materialized value of the resulting [[Flow]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def joinMat[I2, O2, Mat2, M](bidi: Graph[BidiShape[Out, O2, I2, In], Mat2], combine: function.Function2[Mat, Mat2, M]): Flow[I2, O2, M] =
     new Flow(delegate.joinMat(bidi)(combinerToScala(combine)))
@@ -1246,6 +1260,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * If this [[Flow]] gets upstream error - no elements from the given [[Source]] will be pulled.
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#concat]]
    */
   def concatMat[T >: Out, M, M2](that: Graph[SourceShape[T], M], matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
@@ -1282,7 +1299,10 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * If the given [[Source]] gets upstream error - no elements from this [[Flow]] will be pulled.
    *
-   * @see [[#prepend]].
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
+   * @see [[#prepend]]
    */
   def prependMat[T >: Out, M, M2](that: Graph[SourceShape[T], M], matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
     new Flow(delegate.prependMat(that)(combinerToScala(matF)))
@@ -1305,6 +1325,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   /**
    * Attaches the given [[Sink]] to this [[Flow]], meaning that elements that passes
    * through will also be sent to the [[Sink]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    *
    * @see [[#alsoTo]]
    */
@@ -1349,7 +1372,10 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * If this [[Flow]] or [[Source]] gets upstream error - stream completes with failure.
    *
-   * @see [[#interleave]].
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
+   * @see [[#interleave]]
    */
   def interleaveMat[T >: Out, M, M2](that: Graph[SourceShape[T], M], segmentSize: Int,
                                      matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
@@ -1389,6 +1415,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * Merge the given [[Source]] to this [[Flow]], taking elements as they arrive from input streams,
    * picking randomly when several elements ready.
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#merge]]
    */
   def mergeMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
@@ -1398,6 +1427,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   /**
    * Merge the given [[Source]] to this [[Flow]], taking elements as they arrive from input streams,
    * picking randomly when several elements ready.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    *
    * @see [[#merge]]
    */
@@ -1431,6 +1463,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * waiting for elements, this merge will block when one of the inputs does not have more elements (and
    * does not complete).
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#mergeSorted]].
    */
   def mergeSortedMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2], comp: Comparator[U],
@@ -1454,12 +1489,15 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   /**
    * Combine the elements of current [[Flow]] and the given [[Source]] into a stream of tuples.
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#zip]]
    */
   def zipMat[T, M, M2](that: Graph[SourceShape[T], M],
                        matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out @uncheckedVariance Pair T, M2] =
     this.viaMat(Flow.fromGraph(GraphDSL.create(that,
-      new function.Function2[GraphDSL.Builder[M], SourceShape[T], FlowShape[Out, Out @ uncheckedVariance Pair T]] {
+      new function.Function2[GraphDSL.Builder[M], SourceShape[T], FlowShape[Out, Out @uncheckedVariance Pair T]] {
         def apply(b: GraphDSL.Builder[M], s: SourceShape[T]): FlowShape[Out, Out @uncheckedVariance Pair T] = {
           val zip: FanInShape2[Out, T, Out Pair T] = b.add(Zip.create[Out, T])
           b.from(s).toInlet(zip.in1)
@@ -1486,6 +1524,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
   /**
    * Put together the elements of current [[Flow]] and the given [[Source]]
    * into a stream of combined elements using a combiner function.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    *
    * @see [[#zipWith]]
    */
@@ -1792,6 +1833,9 @@ object RunnableGraph {
   private final class RunnableGraphAdapter[Mat](runnable: scaladsl.RunnableGraph[Mat]) extends RunnableGraph[Mat] {
     def shape = ClosedShape
     def module = runnable.module
+
+    override def toString: String = runnable.toString
+
     override def mapMaterializedValue[Mat2](f: function.Function[Mat, Mat2]): RunnableGraphAdapter[Mat2] =
       new RunnableGraphAdapter(runnable.mapMaterializedValue(f.apply _))
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -256,6 +256,8 @@ final class Sink[-In, +Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[Sink
   override def shape: SinkShape[In] = delegate.shape
   private[stream] def module: StreamLayout.Module = delegate.module
 
+  override def toString: String = delegate.toString
+
   /** Converts this Sink to its Scala DSL counterpart */
   def asScala: scaladsl.Sink[In, Mat] = delegate
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -323,6 +323,8 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
 
   private[stream] def module: StreamLayout.Module = delegate.module
 
+  override def toString: String = delegate.toString
+
   /** Converts this Java DSL element to its Scala DSL counterpart. */
   def asScala: scaladsl.Source[Out, Mat] = delegate
 
@@ -367,6 +369,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * flow into the materialized value of the resulting Flow.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def viaMat[T, M, M2](flow: Graph[FlowShape[Out, T], M], combine: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
     new Source(delegate.viaMat(flow)(combinerToScala(combine)))
@@ -406,6 +411,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * Sink into the materialized value of the resulting Sink.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def toMat[M, M2](sink: Graph[SinkShape[Out], M], combine: function.Function2[Mat, M, M2]): javadsl.RunnableGraph[M2] =
     RunnableGraph.fromGraph(delegate.toMat(sink)(combinerToScala(combine)))
@@ -470,6 +478,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * If this [[Source]] gets upstream error - no elements from the given [[Source]] will be pulled.
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#concat]].
    */
   def concatMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
@@ -507,6 +518,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * If the given [[Source]] gets upstream error - no elements from this [[Source]] will be pulled.
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#prepend]].
    */
   def prependMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
@@ -531,6 +545,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
   /**
    * Attaches the given [[Sink]] to this [[Flow]], meaning that elements that passes
    * through will also be sent to the [[Sink]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    *
    * @see [[#alsoTo]]
    */
@@ -574,6 +591,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * If one of sources gets upstream error - stream completes with failure.
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#interleave]].
    */
   def interleaveMat[T >: Out, M, M2](that: Graph[SourceShape[T], M], segmentSize: Int,
@@ -598,6 +618,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
   /**
    * Merge the given [[Source]] to the current one, taking elements as they arrive from input streams,
    * picking randomly when several elements ready.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    *
    * @see [[#merge]].
    */
@@ -630,6 +653,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * waiting for elements, this merge will block when one of the inputs does not have more elements (and
    * does not complete).
    *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
    * @see [[#mergeSorted]].
    */
   def mergeSortedMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2], comp: util.Comparator[U],
@@ -652,6 +678,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
 
   /**
    * Combine the elements of current [[Source]] and the given one into a stream of tuples.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    *
    * @see [[#zip]].
    */
@@ -678,6 +707,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
   /**
    * Put together the elements of current [[Source]] and the given one
    * into a stream of combined elements using a combiner function.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    *
    * @see [[#zipWith]].
    */

--- a/akka-stream/src/main/scala/akka/stream/javadsl/package.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/package.scala
@@ -6,6 +6,8 @@ package akka.stream
 package object javadsl {
   def combinerToScala[M1, M2, M](f: akka.japi.function.Function2[M1, M2, M]): (M1, M2) ⇒ M =
     f match {
+      case x if x eq Keep.left   ⇒ scaladsl.Keep.left.asInstanceOf[(M1, M2) ⇒ M]
+      case x if x eq Keep.right  ⇒ scaladsl.Keep.right.asInstanceOf[(M1, M2) ⇒ M]
       case s: Function2[_, _, _] ⇒ s.asInstanceOf[(M1, M2) ⇒ M]
       case other                 ⇒ other.apply _
     }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -30,6 +30,8 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
 
   override val shape: FlowShape[In, Out] = module.shape.asInstanceOf[FlowShape[In, Out]]
 
+  override def toString: String = s"Flow($shape, $module)"
+
   override type Repr[+O] = Flow[In @uncheckedVariance, O, Mat @uncheckedVariance]
   override type ReprMat[+O, +M] = Flow[In @uncheckedVariance, O, M]
 
@@ -42,8 +44,14 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
 
   override def viaMat[T, Mat2, Mat3](flow: Graph[FlowShape[Out, T], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): Flow[In, T, Mat3] =
     if (this.isIdentity) {
-      Flow.fromGraph(flow.asInstanceOf[Graph[FlowShape[In, T], Mat2]])
-        .mapMaterializedValue(combine(NotUsed.asInstanceOf[Mat], _))
+      import Predef.Map.empty
+      import StreamLayout.{ CompositeModule, Ignore, IgnorableMatValComp, Transform, Atomic, Combine }
+      val m = flow.module
+      val mat =
+        if (combine == Keep.left) {
+          if (IgnorableMatValComp(m)) Ignore else Transform(_ => NotUsed, Atomic(m))
+        } else Combine(combine.asInstanceOf[(Any, Any) => Any], Ignore, Atomic(m))
+      new Flow(CompositeModule(Set(m), m.shape, empty, empty, mat, Attributes.none))
     } else {
       val flowCopy = flow.module.carbonCopy
       new Flow(
@@ -86,11 +94,14 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * Sink into the materialized value of the resulting Sink.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def toMat[Mat2, Mat3](sink: Graph[SinkShape[Out], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): Sink[In, Mat3] = {
     if (isIdentity)
       Sink.fromGraph(sink.asInstanceOf[Graph[SinkShape[In], Mat2]])
-        .mapMaterializedValue(combine(().asInstanceOf[Mat], _))
+        .mapMaterializedValue(combine(NotUsed.asInstanceOf[Mat], _))
     else {
       val sinkCopy = sink.module.carbonCopy
       new Sink(
@@ -132,6 +143,9 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * Flow into the materialized value of the resulting Flow.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def joinMat[Mat2, Mat3](flow: Graph[FlowShape[Out, In], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): RunnableGraph[Mat3] = {
     val flowCopy = flow.module.carbonCopy
@@ -176,6 +190,9 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * [[BidiFlow]] into the materialized value of the resulting [[Flow]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def joinMat[I2, O2, Mat2, M](bidi: Graph[BidiShape[Out, O2, I2, In], Mat2])(combine: (Mat, Mat2) ⇒ M): Flow[I2, O2, M] = {
     val copy = bidi.module.carbonCopy
@@ -261,8 +278,6 @@ final class Flow[-In, +Out, +Mat](private[stream] override val module: Module)
 
   /** Converts this Scala DSL element to it's Java DSL counterpart. */
   def asJava: javadsl.Flow[In, Out, Mat] = new javadsl.Flow(this)
-
-  override def toString = s"""Flow(${module})"""
 }
 
 object Flow {
@@ -410,23 +425,23 @@ trait FlowOps[+Out, +Mat] {
   def recover[T >: Out](pf: PartialFunction[Throwable, T]): Repr[T] = andThen(Recover(pf))
 
   /**
-    * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
-    * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
-    * Source may be materialized.
-    *
-    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
-    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
-    *
-    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
-    * from alternative Source
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
-    *
-    * '''Cancels when''' downstream cancels
-    *
-    */
+   * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
+   * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
+   * Source may be materialized.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+   * from alternative Source
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
   def recoverWith[T >: Out](pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =
     via(new RecoverWith(pf))
 
@@ -466,27 +481,27 @@ trait FlowOps[+Out, +Mat] {
   def mapConcat[T](f: Out ⇒ immutable.Iterable[T]): Repr[T] = statefulMapConcat(() => f)
 
   /**
-    * Transform each input element into an `Iterable` of output elements that is
-    * then flattened into the output stream. The transformation is meant to be stateful,
-    * which is enabled by creating the transformation function anew for every materialization —
-    * the returned function will typically close over mutable objects to store state between
-    * invocations. For the stateless variant see [[FlowOps.mapConcat]].
-    *
-    * The returned `Iterable` MUST NOT contain `null` values,
-    * as they are illegal as stream elements - according to the Reactive Streams specification.
-    *
-    * '''Emits when''' the mapping function returns an element or there are still remaining elements
-    * from the previously calculated collection
-    *
-    * '''Backpressures when''' downstream backpressures or there are still remaining elements from the
-    * previously calculated collection
-    *
-    * '''Completes when''' upstream completes and all remaining elements has been emitted
-    *
-    * '''Cancels when''' downstream cancels
-    *
-    * See also [[FlowOps.mapConcat]]
-    */
+   * Transform each input element into an `Iterable` of output elements that is
+   * then flattened into the output stream. The transformation is meant to be stateful,
+   * which is enabled by creating the transformation function anew for every materialization —
+   * the returned function will typically close over mutable objects to store state between
+   * invocations. For the stateless variant see [[FlowOps.mapConcat]].
+   *
+   * The returned `Iterable` MUST NOT contain `null` values,
+   * as they are illegal as stream elements - according to the Reactive Streams specification.
+   *
+   * '''Emits when''' the mapping function returns an element or there are still remaining elements
+   * from the previously calculated collection
+   *
+   * '''Backpressures when''' downstream backpressures or there are still remaining elements from the
+   * previously calculated collection
+   *
+   * '''Completes when''' upstream completes and all remaining elements has been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * See also [[FlowOps.mapConcat]]
+   */
   def statefulMapConcat[T](f: () ⇒ Out ⇒ immutable.Iterable[T]): Repr[T] =
     via(new StatefulMapConcat(f))
 
@@ -1813,6 +1828,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * flow into the materialized value of the resulting Flow.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def viaMat[T, Mat2, Mat3](flow: Graph[FlowShape[Out, T], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): ReprMat[T, Mat3]
 
@@ -1831,6 +1849,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * }}}
    * The `combine` function is used to compose the materialized values of this flow and that
    * Sink into the materialized value of the resulting Sink.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def toMat[Mat2, Mat3](sink: Graph[SinkShape[Out], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): ClosedMat[Mat3]
 
@@ -1838,6 +1859,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
    *
    * @see [[#zip]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def zipMat[U, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(matF: (Mat, Mat2) ⇒ Mat3): ReprMat[(Out, U), Mat3] =
     viaMat(zipGraph(that))(matF)
@@ -1847,6 +1871,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * into a stream of combined elements using a combiner function.
    *
    * @see [[#zipWith]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def zipWithMat[Out2, Out3, Mat2, Mat3](that: Graph[SourceShape[Out2], Mat2])(combine: (Out, Out2) ⇒ Out3)(matF: (Mat, Mat2) ⇒ Mat3): ReprMat[Out3, Mat3] =
     viaMat(zipWithGraph(that)(combine))(matF)
@@ -1856,6 +1883,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * picking randomly when several elements ready.
    *
    * @see [[#merge]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def mergeMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2], eagerComplete: Boolean = false)(matF: (Mat, Mat2) ⇒ Mat3): ReprMat[U, Mat3] =
     viaMat(mergeGraph(that, eagerComplete))(matF)
@@ -1870,6 +1900,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * If it gets error from one of upstreams - stream completes with failure.
    *
    * @see [[#interleave]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def interleaveMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2], request: Int)(matF: (Mat, Mat2) ⇒ Mat3): ReprMat[U, Mat3] =
     viaMat(interleaveGraph(that, request))(matF)
@@ -1882,6 +1915,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * does not complete).
    *
    * @see [[#mergeSorted]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def mergeSortedMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(matF: (Mat, Mat2) ⇒ Mat3)(implicit ord: Ordering[U]): ReprMat[U, Mat3] =
     viaMat(mergeSortedGraph(that))(matF)
@@ -1897,6 +1933,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * If this [[Flow]] gets upstream error - no elements from the given [[Source]] will be pulled.
    *
    * @see [[#concat]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def concatMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(matF: (Mat, Mat2) ⇒ Mat3): ReprMat[U, Mat3] =
     viaMat(concatGraph(that))(matF)
@@ -1912,6 +1951,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * If the given [[Source]] gets upstream error - no elements from this [[Flow]] will be pulled.
    *
    * @see [[#prepend]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def prependMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(matF: (Mat, Mat2) ⇒ Mat3): ReprMat[U, Mat3] =
     viaMat(prependGraph(that))(matF)
@@ -1921,6 +1963,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * through will also be sent to the [[Sink]].
    *
    * @see [[#alsoTo]]
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def alsoToMat[Mat2, Mat3](that: Graph[SinkShape[Out], Mat2])(matF: (Mat, Mat2) ⇒ Mat3): ReprMat[Out, Mat3] =
     viaMat(alsoToGraph(that))(matF)
@@ -1930,6 +1975,9 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * The Future completes with success when received complete message from upstream or cancel
    * from downstream. It fails with the same error when received error message from
    * downstream.
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def watchTermination[Mat2]()(matF: (Mat, Future[Done]) ⇒ Mat2): ReprMat[Out, Mat2] =
     viaMat(GraphStages.terminationWatcher)(matF)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -27,6 +27,8 @@ final class Sink[-In, +Mat](private[stream] override val module: Module)
 
   override val shape: SinkShape[In] = module.shape.asInstanceOf[SinkShape[In]]
 
+  override def toString: String = s"Sink($shape, $module)"
+
   /**
    * Transform this Sink by applying a function to each *incoming* upstream element before
    * it is passed to the [[Sink]]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -38,6 +38,8 @@ final class Source[+Out, +Mat](private[stream] override val module: Module)
 
   override val shape: SourceShape[Out] = module.shape.asInstanceOf[SourceShape[Out]]
 
+  override def toString: String = s"Source($shape, $module)"
+
   override def via[T, Mat2](flow: Graph[FlowShape[Out, T], Mat2]): Repr[T] = viaMat(flow)(Keep.left)
 
   override def viaMat[T, Mat2, Mat3](flow: Graph[FlowShape[Out, T], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): Source[T, Mat3] = {

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -683,7 +683,21 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[FinalClassProblem]("akka.http.scaladsl.marshalling.Marshal$UnacceptableResponseContentTypeException"),
 
         // #20009 internal and shouldn't have been public
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.QueueSource.completion")
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.QueueSource.completion"),
+
+        // #20015 simplify materialized value computation tree
+        ProblemFilters.exclude[FinalMethodProblem]("akka.stream.impl.StreamLayout#AtomicModule.subModules"),
+        ProblemFilters.exclude[FinalMethodProblem]("akka.stream.impl.StreamLayout#AtomicModule.downstreams"),
+        ProblemFilters.exclude[FinalMethodProblem]("akka.stream.impl.StreamLayout#AtomicModule.upstreams"),
+        ProblemFilters.exclude[FinalMethodProblem]("akka.stream.impl.Stages#DirectProcessor.toString"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.impl.MaterializerSession.materializeAtomic"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.impl.MaterializerSession.materializeAtomic"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.stream.impl.Stages$StageModule"),
+        ProblemFilters.exclude[FinalMethodProblem]("akka.stream.impl.Stages#GroupBy.toString"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.stream.impl.FlowModule"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.FlowModule.subModules"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.impl.FlowModule.label"),
+        ProblemFilters.exclude[FinalClassProblem]("akka.stream.impl.fusing.GraphModule")
       )
     )
   }


### PR DESCRIPTION
- also fixes materialized value sources for graphs that import zero or
  one graphs, with and without Fusing

The bulk of this PR is just collateral damage:
- I made the Module trait sealed, allowing only AtomicModules to be created elsewhere
- I added useful toString representations to everything, especially for using the various Debug constants

(The latter was crucial in debugging the issues encountered during this whole endeavor.)
