### PR TITLE
LoggerMailbox is calling super after cleanup

### DIFF
--- a/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
+++ b/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
@@ -43,6 +43,5 @@ private[akka] class LoggerMailbox(owner: ActorRef, system: ActorSystem)
         envelope = dequeue
       }
     }
-    super.cleanUp(owner, deadLetters)
   }
 }


### PR DESCRIPTION
LoggerMailbox is calling super after cleanup, once the logger mailbox has been cleanup by sending its messages to `Logging.StandardOutLogger` calling super might just add noise if not worse; it might try to re-log messages to dead letters after logger is dead.
