### PR TITLE
Use an Actor-System wide materializer for cached gateways (#20032)

### DIFF
--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -735,7 +735,10 @@ object MiMa extends AutoPlugin {
 
         // #19828
         ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.persistence.Eventsourced#ProcessingState.onWriteMessageComplete"),
-        ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.persistence.Eventsourced#ProcessingState.onWriteMessageComplete")
+        ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.persistence.Eventsourced#ProcessingState.onWriteMessageComplete"),
+
+        // #20032 use an actorsystem-wide materializer for cached gateways
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.HttpExt.cachedGateway")
       )
     )
   }


### PR DESCRIPTION
The materializer lifespan must not be shorter than the one of the cache it is used in. 
