### PR TITLE
Simplify cancellation of TickSource (#20028)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TickSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TickSourceSpec.scala
@@ -101,5 +101,37 @@ class TickSourceSpec extends AkkaSpec {
       c.expectComplete()
     }
 
+    "acknowledge cancellation only once" in assertAllStagesStopped {
+      val c = TestSubscriber.manualProbe[String]()
+      val cancellable = Source.tick(1.second, 500.millis, "tick").to(Sink.fromSubscriber(c)).run()
+      val sub = c.expectSubscription()
+      sub.request(2)
+      c.expectNext("tick")
+      cancellable.cancel() should be(true)
+      cancellable.cancel() should be(false)
+      c.expectComplete()
+    }
+
+    "have isCancelled mirror the cancellation state" in assertAllStagesStopped {
+      val c = TestSubscriber.manualProbe[String]()
+      val cancellable = Source.tick(1.second, 500.millis, "tick").to(Sink.fromSubscriber(c)).run()
+      val sub = c.expectSubscription()
+      sub.request(2)
+      c.expectNext("tick")
+      cancellable.isCancelled should be(false)
+      cancellable.cancel() should be(true)
+      cancellable.isCancelled should be(true)
+      c.expectComplete()
+    }
+
+    "support being cancelled immediately after its materialization" in assertAllStagesStopped {
+      val c = TestSubscriber.manualProbe[String]()
+      val cancellable = Source.tick(1.second, 500.millis, "tick").to(Sink.fromSubscriber(c)).run()
+      cancellable.cancel() should be(true)
+      val sub = c.expectSubscription()
+      sub.request(2)
+      c.expectComplete()
+    }
+
   }
 }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -750,7 +750,11 @@ object MiMa extends AutoPlugin {
 
         // #19828
         ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.persistence.Eventsourced#ProcessingState.onWriteMessageComplete"),
-        ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.persistence.Eventsourced#ProcessingState.onWriteMessageComplete")
+        ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.persistence.Eventsourced#ProcessingState.onWriteMessageComplete"),
+
+        // #20028 Simplify TickSource cancellation
+        ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.fusing.GraphStages$TickSource$TickSourceCancellable"),
+        ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.fusing.GraphStages$TickSource$")
       )
     )
   }


### PR DESCRIPTION
With this fix, the following now works:
- `tickSource.cancel()` returns `true` the first time then `false` afterwards;
- `tickSource.isCancelled()` returns `true` as soon as `tickSource.cancel()` has returned;
- `tickSource` will not emit any tick after `tickSource.cancel()` has returned.
