### PR TITLE
=act #19901 Include actor path in ActorInitializationException message

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorRefSpec.scala
@@ -254,6 +254,17 @@ class ActorRefSpec extends AkkaSpec with DefaultTimeout {
       }
     }
 
+    "insert its path in a ActorInitializationException" in {
+      EventFilter[ActorInitializationException](occurrences = 1, pattern = "/user/failingActor:") intercept {
+        intercept[java.lang.IllegalStateException] {
+          wrap(result ⇒
+            system.actorOf(Props(promiseIntercept({
+              throw new IllegalStateException
+            })(result)), "failingActor"))
+        }
+      }
+    }
+
     "be serializable using Java Serialization on local node" in {
       val a = system.actorOf(Props[InnerActor])
       val esys = system.asInstanceOf[ExtendedActorSystem]

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -164,10 +164,12 @@ final case class InvalidActorNameException(message: String) extends AkkaExceptio
  */
 @SerialVersionUID(1L)
 class ActorInitializationException protected (actor: ActorRef, message: String, cause: Throwable)
-  extends AkkaException(message, cause) {
+  extends AkkaException(ActorInitializationException.enrichedMessage(actor, message), cause) {
   def getActor: ActorRef = actor
 }
 object ActorInitializationException {
+  private def enrichedMessage(actor: ActorRef, message: String) =
+    if (actor == null) message else s"${actor.path}: $message"
   private[akka] def apply(actor: ActorRef, message: String, cause: Throwable = null): ActorInitializationException =
     new ActorInitializationException(actor, message, cause)
   private[akka] def apply(message: String): ActorInitializationException = new ActorInitializationException(null, message, null)


### PR DESCRIPTION
The full name of the actor is used as there are no other references to the ActorSystem in the exception message.
