### PR TITLE
Add links to go to Java and Scala contents #15556

### DIFF
--- a/akka-docs/_sphinx/themes/akka/layout.html
+++ b/akka-docs/_sphinx/themes/akka/layout.html
@@ -114,7 +114,7 @@
                 {%- endif %}
               </li>
               <li>
-                <a href="{{ pathto(master_doc) }}">{{ _('Contents') }}</a>
+                <a href="{{ pathto('java.html', 1) }}">Java Contents</a> <span class="divider">|</span> <a href="{{ pathto('scala.html', 1) }}">Scala Contents</a>
               </li>
               <li>
                 {%- if prev %}


### PR DESCRIPTION
This is to fix the issue #15556.
As far as I tested the change with local sbt package-site build, it worked as expected.

Before:
![content-old](https://cloud.githubusercontent.com/assets/7414320/13913603/cd9a461c-ef8b-11e5-9f8b-f966a60aca02.png)

After:
![content-new](https://cloud.githubusercontent.com/assets/7414320/13913604/cfb22c76-ef8b-11e5-9a68-194c209be04d.png)
