### PR TITLE
Add Flow.foldMerge

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldMergeSpec.scala
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.testkit.TestPublisher
+import akka.stream.ActorMaterializer
+import akka.testkit.AkkaSpec
+import org.scalatest.exceptions.TestFailedException
+
+import scala.concurrent._
+
+class FlowFoldMergeSpec extends AkkaSpec {
+  implicit val materializer = ActorMaterializer()
+  import system.dispatcher
+
+  def src10(i: Int) = Source(i until (i + 10))
+  def blocked = Source.fromFuture(Promise[Int].future)
+
+  val toSeq = Sink.seq[Int]
+  val toSet: Sink[Int, Future[Set[Int]]] = toSeq.mapMaterializedValue(_.map(_.toSet))
+
+  "A FoldMerge" must {
+
+    "work in the nominal case" in {
+      Source(List(0, 10, 20, 30))
+        .foldMerge[Int, Int](Hub.empty)((id, hub) ⇒ hub + (id -> src10(id)))
+        .runWith(toSet)
+        .futureValue should ===((0 until 40).toSet)
+    }
+
+    "not be held back by one slow stream" in {
+      Source(List(0, 10, -1, 20, 30))
+        .foldMerge[Int, Int](Hub.empty) { (id, hub) ⇒
+          if (id < 0) hub + (id -> blocked) else hub + (id -> src10(id))
+        }.take(40)
+        .runWith(toSet)
+        .futureValue should ===((0 until 40).toSet)
+    }
+
+    "propagate early failure from main stream" in {
+      val ex = new Exception("buh")
+      intercept[TestFailedException] {
+        Source.failed[Int](ex)
+          .foldMerge[Int, Int](Hub.empty)((id, hub) ⇒ hub + (id -> src10(id)))
+          .runWith(Sink.head)
+          .futureValue
+      }.cause.get should ===(ex)
+    }
+
+    "propagate late failure from main stream" in {
+      val ex = new Exception("buh")
+      intercept[TestFailedException] {
+        (Source(List(1, 2)) ++ Source.failed[Int](ex))
+          .foldMerge[Int, Int](Hub.empty)((id, hub) ⇒ hub + (id -> blocked))
+          .runWith(Sink.head)
+          .futureValue
+      }.cause.get should ===(ex)
+    }
+
+    "allow removing sub streams" in {
+      val sourceProbe, p1, p2, p3 = TestPublisher.probe[Int]()
+      val sources = Map(
+        1 -> Source.fromPublisher(p1),
+        2 -> Source.fromPublisher(p2),
+        3 -> Source.fromPublisher(p3))
+
+      val result = Source.fromPublisher(sourceProbe).foldMerge[Int, Int](Hub.empty) { (id, hub) ⇒
+        if (id < 0) hub - (-id)
+        else hub + (id -> sources(id))
+      }.runWith(toSet)
+
+      sourceProbe.sendNext(1)
+      p1.sendNext(10)
+      sourceProbe.sendNext(2)
+      p2.sendNext(20)
+      p1.sendNext(11)
+      p2.sendNext(21)
+      sourceProbe.sendNext(-1)
+      p1.expectCancellation()
+      sourceProbe.sendNext(3)
+      p3.sendNext(30)
+      p2.sendNext(22)
+      sourceProbe.sendNext(-3)
+      p3.expectCancellation()
+      sourceProbe.sendComplete()
+      p2.sendNext(23)
+      p2.sendComplete()
+
+      result
+        .futureValue should ===(Set(10, 11, 20, 21, 22, 23, 30))
+    }
+
+    // Other tests needed: Initial sources in hub, exception in fold method, failures in substreams
+
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -65,6 +65,7 @@ private[stream] object Stages {
     val merge = name("merge")
     val mergePreferred = name("mergePreferred")
     val flattenMerge = name("flattenMerge")
+    val foldMerge = name("foldMerge")
     val recoverWith = name("recoverWith")
     val broadcast = name("broadcast")
     val balance = name("balance")

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -8,6 +8,7 @@ import akka.NotUsed
 import akka.stream._
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl.SubscriptionTimeoutException
+import akka.stream.scaladsl.Hub.HubImpl
 import akka.stream.stage._
 import akka.stream.scaladsl._
 import akka.stream.actor.ActorSubscriberMessage
@@ -96,6 +97,100 @@ final class FlattenMerge[T, M](breadth: Int) extends GraphStage[FlowShape[Graph[
   }
 
   override def toString: String = s"FlattenMerge($breadth)"
+}
+
+/**
+ * INTERNAL API
+ */
+final class FoldMerge[Id, In, Out](initial: Hub[Id, Out], f: (In, Hub[Id, Out]) ⇒ Hub[Id, Out]) extends GraphStage[FlowShape[In, Out]] {
+  private val in = Inlet[In]("fold.in")
+  private val out = Outlet[Out]("fold.out")
+
+  override def initialAttributes = DefaultAttributes.foldMerge
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(attr: Attributes) = new GraphStageLogic(shape) {
+
+    var sources = immutable.Map.empty[Id, SubSinkInlet[Out]]
+    def activeSources = sources.size
+
+    var q: immutable.Queue[Id] = _
+
+    override def preStart(): Unit = {
+      q = immutable.Queue.empty
+      initial.asInstanceOf[HubImpl[Id, Out]].newSources.foreach((addSource _).tupled)
+    }
+
+    def pushOut(): Unit = {
+      val (srcId, newQ) = q.dequeue
+      q = newQ
+      val src = sources(srcId)
+      push(out, src.grab())
+      if (!src.isClosed) src.pull()
+      else removeSource(srcId)
+    }
+
+    setHandler(in, new InHandler {
+      override def onPush(): Unit = {
+        val inElement = grab(in)
+        val hub = f(inElement, new Hub.HubImpl[Id, Out](sources.keySet, immutable.Map.empty)).asInstanceOf[Hub.HubImpl[Id, Out]]
+        // The sources to remove are all the sources not in the current source ids and are in the new sources
+        // (if there is a new source, it replaces the existing the source with that id)
+        sources.keySet.foreach { id ⇒
+          if (!hub.sourceIds.contains(id) || hub.newSources.contains(id)) {
+            removeSource(id)
+          }
+        }
+        hub.newSources.foreach((addSource _).tupled)
+
+        tryPull(in)
+      }
+      override def onUpstreamFinish(): Unit = if (activeSources == 0) completeStage()
+    })
+
+    setHandler(out, new OutHandler {
+      override def onPull(): Unit = {
+        pull(in)
+        setHandler(out, outHandler)
+      }
+    })
+
+    val outHandler = new OutHandler {
+      // could be unavailable due to async input having been executed before this notification
+      override def onPull(): Unit = if (q.nonEmpty && isAvailable(out)) pushOut()
+    }
+
+    def addSource(id: Id, source: Graph[SourceShape[Out], _]): Unit = {
+      val sinkIn = new SubSinkInlet[Out]("FoldMergeSink")
+      sinkIn.setHandler(new InHandler {
+        override def onPush(): Unit = {
+          if (isAvailable(out)) {
+            push(out, sinkIn.grab())
+            sinkIn.pull()
+          } else {
+            q = q.enqueue(id)
+          }
+        }
+        override def onUpstreamFinish(): Unit = if (!sinkIn.isAvailable) removeSource(id)
+      })
+      sinkIn.pull()
+      sources += id -> sinkIn
+      Source.fromGraph(source).runWith(sinkIn.sink)(interpreter.subFusingMaterializer)
+    }
+
+    def removeSource(id: Id): Unit = {
+      val toRemove = sources(id)
+      if (!toRemove.isClosed) toRemove.cancel()
+      sources -= id
+      q = q.filterNot(_ == id)
+      if (activeSources == 0 && isClosed(in)) completeStage()
+    }
+
+    override def postStop(): Unit = sources.values.foreach(_.cancel())
+
+  }
+
+  override def toString: String = s"FoldMerge"
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1378,6 +1378,20 @@ trait FlowOps[+Out, +Mat] {
   def flatMapMerge[T, M](breadth: Int, f: Out ⇒ Graph[SourceShape[T], M]): Repr[T] = map(f).via(new FlattenMerge[T, M](breadth))
 
   /**
+    * Fold each element into a `Hub` of merged `Source`'s, that can be added to
+    * and removed from dynamically each time an element is received.
+    *
+    * '''Emits when''' a currently consumed substream has an element available
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes and all consumed substreams complete
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def foldMerge[Id, T](initial: Hub[Id, T])(f: (Out, Hub[Id, T]) => Hub[Id, T]): Repr[T] = via(new FoldMerge[Id, Out, T](initial, f))
+
+  /**
    * If the first element has not passed through this stage before the provided timeout, the stream is failed
    * with a [[scala.concurrent.TimeoutException]].
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
@@ -1,0 +1,30 @@
+package akka.stream.scaladsl
+
+import akka.stream.{ SourceShape, Graph }
+
+import scala.collection.{ immutable, GenTraversableOnce }
+
+sealed trait Hub[Id, Out] {
+  def sourceIds: Set[Id]
+  def +(source: (Id, Graph[SourceShape[Out], _])): Hub[Id, Out]
+  def ++(sources: GenTraversableOnce[(Id, Graph[SourceShape[Out], _])]): Hub[Id, Out]
+  def -(sourceId: Id): Hub[Id, Out]
+  def --(sourceIds: GenTraversableOnce[Id]): Hub[Id, Out]
+}
+
+object Hub {
+
+  /**
+   * INTERNAL API
+   */
+  private[stream] class HubImpl[Id, Out](val currentSourceIds: Set[Id], val newSources: immutable.Map[Id, Graph[SourceShape[Out], _]]) extends Hub[Id, Out] {
+    override def sourceIds: Set[Id] = currentSourceIds ++ newSources.keySet
+    override def +(source: (Id, Graph[SourceShape[Out], _])): Hub[Id, Out] = new HubImpl(currentSourceIds + source._1, newSources + source)
+    override def ++(sources: GenTraversableOnce[(Id, Graph[SourceShape[Out], _])]): Hub[Id, Out] = new HubImpl(currentSourceIds ++ sources.toTraversable.map(_._1), newSources ++ sources)
+    override def -(sourceId: Id): Hub[Id, Out] = new HubImpl(currentSourceIds - sourceId, newSources - sourceId)
+    override def --(sourceIds: GenTraversableOnce[Id]): Hub[Id, Out] = new HubImpl(currentSourceIds -- sourceIds, newSources -- sourceIds)
+  }
+
+  def empty[Id, Out]: Hub[Id, Out] = new HubImpl(Set.empty, immutable.Map.empty)
+  def apply[Id, Out](sources: immutable.Map[Id, Source[Out, _]]): Hub[Id, Out] = new HubImpl(sources.keySet, sources)
+}


### PR DESCRIPTION
- This is an example of the type of interface I think would be really useful for using a hub.
- I don't expect it to be merged, certainly not in its current form, it's missing Java API, documentation, and tests are not very comprehensive. But it's also probably a good idea to generalise it, in particular, flattenMerge shares a lot in common with this, and there's probably a lower level public API that could also work with dynamic Sinks similar to GraphStage that could be offered that this could be implemented in.
- My purpose for submitting this is to demonstrate one aspect of the feature set that I think should be there.  My intended use case for this API looks something like this, imagine you have a websocket that serves real time points of interest based on what area of a map users are viewing, the points of interest are published via pubsub, with topics being the id of discrete regions of the globe, and the viewing area is mapped to a list of region ids.  So every time the user scrolls on the map, a new viewing area is sent, and this updates the subscriptions.  This could be implemented using `foldMerge` like so:

``` scala
val pubSub: PubSub[PointOfInterest] = ...
val webSocket: Flow[ViewingArea, PointOfInterest, _] =
  Flow[ViewingArea].foldMerge[RegionId, PointOfInterest](Hub.empty) { (area, hub) =>
    val regions: Seq[RegionId] = calculateRegions(area)
    val unsubscribeRegions = hub.activeSourceIds.filterNot(regions.contains)
    val subscribeRegions = regions.filterNot(hub.activeSourceIds.contains)
    val subscribeRegionSources =
      subscribeRegions.map(regionId => regionId -> pubSub.subscribe(regionId))
    hub ++ subscribeRegionSources -- unsubscribeRegions
  }
```
