### PR TITLE
harden cluster.StressSpec, #20095

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -126,6 +126,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
     akka.actor.serialize-creators = off
     akka.actor.provider = akka.cluster.ClusterActorRefProvider
     akka.cluster {
+      failure-detector.acceptable-heartbeat-pause =  5s
       auto-down-unreachable-after = 1s
       publish-stats-interval = 1s
     }


### PR DESCRIPTION
- logs show unexpected unreachable (and downing) during the high
  throughput test
- increasing the failure-detector timeout

I have also verified that the failure should not be related to the change in https://github.com/akka/akka/pull/19897. That code path is not exercised in this part of the test.
