### PR TITLE
harden LoggingReceiveSpec, #20027

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -91,19 +91,15 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
 
         val name = actor.path.toString
         actor ! "buh"
-        within(1 second) {
-          expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass,
-            "received handled message buh from " + self))
-          expectMsg("x")
-        }
+        expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass,
+          "received handled message buh from " + self))
+        expectMsg("x")
 
         actor ! "becomenull"
 
-        within(500 millis) {
-          actor ! "bah"
-          expectMsgPF() {
-            case UnhandledMessage("bah", testActor, `actor`) ⇒ true
-          }
+        actor ! "bah"
+        expectMsgPF() {
+          case UnhandledMessage("bah", testActor, `actor`) ⇒ true
         }
       }
     }
@@ -117,11 +113,9 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
           })
         })
         actor ! "buh"
-        within(1 second) {
-          expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass,
-            "received handled message buh from " + self))
-          expectMsg("x")
-        }
+        expectMsg(Logging.Debug(actor.path.toString, actor.underlyingActor.getClass,
+          "received handled message buh from " + self))
+        expectMsg("x")
       }
     }
 
@@ -139,10 +133,11 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
         })
         val name = actor.path.toString
         actor ! PoisonPill
-        expectMsgPF() {
+        fishForMessage(hint = "received AutoReceiveMessage Envelope(PoisonPill") {
           case Logging.Debug(`name`, _, msg: String) if msg startsWith "received AutoReceiveMessage Envelope(PoisonPill" ⇒ true
+          case _ ⇒ false
         }
-        awaitCond(actor.isTerminated, 100 millis)
+        awaitCond(actor.isTerminated)
       }
     }
 
@@ -182,12 +177,13 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
           supervisor watch actor
           fishForMessage(hint = "now watched by") {
             case Logging.Debug(`aname`, `sclass`, msg: String) if msg.startsWith("now watched by") ⇒ true
-            case _ ⇒ false
+            case m ⇒ false
           }
 
           supervisor unwatch actor
-          expectMsgPF(hint = "no longer watched by") {
-            case Logging.Debug(`aname`, `sclass`, msg: String) if msg.startsWith("no longer watched by") ⇒
+          fishForMessage(hint = "no longer watched by") {
+            case Logging.Debug(`aname`, `sclass`, msg: String) if msg.startsWith("no longer watched by") ⇒ true
+            case _ ⇒ false
           }
         }
       }


### PR DESCRIPTION
- the Debug message was spilled over from previous watch,
  replaced with fishForMessage
- also cleaned up some within limits
