### PR TITLE
all #20090 enable running java tests in actor,camel,cluster,persistence

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
@@ -8,8 +8,9 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import akka.japi.Creator;
+import org.scalatest.junit.JUnitSuite;
 
-public class ActorCreationTest {
+public class ActorCreationTest extends JUnitSuite {
 
   @Test
   public void testWrongCreator() {

--- a/akka-actor-tests/src/test/java/akka/actor/InboxJavaAPITest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/InboxJavaAPITest.java
@@ -10,9 +10,10 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.testkit.AkkaSpec;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.FiniteDuration;
 
-public class InboxJavaAPITest {
+public class InboxJavaAPITest extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource("InboxJavaAPITest",

--- a/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
@@ -20,13 +20,14 @@ import akka.testkit.TestProbe;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.Option;
 
 import java.util.Optional;
 
 import static org.junit.Assert.*;
 
-public class JavaAPI {
+public class JavaAPI extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource("JavaAPI",

--- a/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
@@ -7,10 +7,11 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import org.junit.*;
 import akka.testkit.AkkaSpec;
 import com.typesafe.config.ConfigFactory;
+import org.scalatest.junit.JUnitSuite;
 
 import static org.junit.Assert.*;
 
-public class JavaExtension {
+public class JavaExtension extends JUnitSuite {
 
   static class TestExtensionId extends AbstractExtensionId<TestExtension> implements ExtensionIdProvider {
     public final static TestExtensionId TestExtensionProvider = new TestExtensionId();

--- a/akka-actor-tests/src/test/java/akka/actor/StashJavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/StashJavaAPI.java
@@ -5,8 +5,9 @@ import akka.testkit.TestProbe;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 
-public class StashJavaAPI {
+public class StashJavaAPI extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
+++ b/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem;
 
 import akka.japi.*;
 import org.junit.ClassRule;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.Promise;
@@ -22,7 +23,7 @@ import static akka.japi.Util.classTag;
 
 import akka.testkit.AkkaSpec;
 
-public class JavaFutureTests {
+public class JavaFutureTests extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-actor-tests/src/test/java/akka/event/LoggingAdapterTest.java
+++ b/akka-actor-tests/src/test/java/akka/event/LoggingAdapterTest.java
@@ -11,7 +11,9 @@ import static akka.event.Logging.*;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
+import scala.util.control.NoStackTrace;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -21,7 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
 
-public class LoggingAdapterTest {
+public class LoggingAdapterTest extends JUnitSuite {
 
     private static final Config config = ConfigFactory.parseString(
             "akka.loglevel = DEBUG\n" +
@@ -37,7 +39,12 @@ public class LoggingAdapterTest {
             log.error("One arg message: {}", "the arg");
             expectLog(ErrorLevel(), "One arg message: the arg");
 
-            Throwable cause = new IllegalStateException("This state is illegal");
+            Throwable cause = new IllegalStateException("This state is illegal") {
+                @Override
+                public synchronized Throwable fillInStackTrace() {
+                    return this; // no stack trace
+                }
+            };
             log.error(cause, "Two args message: {}, {}", "an arg", "another arg");
             expectLog(ErrorLevel(), "Two args message: an arg, another arg", cause);
 

--- a/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
+++ b/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
@@ -5,11 +5,13 @@ import akka.event.LoggingAdapter;
 import akka.event.NoLogging;
 import akka.serialization.JavaSerializer;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
 import java.util.concurrent.Callable;
 
 import static org.junit.Assert.*;
 
-public class JavaAPITestBase {
+public class JavaAPITestBase extends JUnitSuite {
 
   @Test
   public void shouldCreateSomeString() {

--- a/akka-actor-tests/src/test/java/akka/japi/MatchBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/MatchBuilderTest.java
@@ -9,11 +9,12 @@ import akka.japi.pf.Match;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.MatchError;
 
 import static org.junit.Assert.*;
 
-public class MatchBuilderTest {
+public class MatchBuilderTest extends JUnitSuite {
 
   @Rule
   public ExpectedException exception = ExpectedException.none();

--- a/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
@@ -5,11 +5,13 @@
 package akka.japi.pf;
 
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.PartialFunction;
 
 import static org.junit.Assert.*;
 
-public class PFBuilderTest {
+public class PFBuilderTest extends JUnitSuite {
+
   @Test
   public void pfbuilder_matchAny_should_infer_declared_input_type_for_lambda() {
     PartialFunction<String,Integer> pf = new PFBuilder<String,Integer>()

--- a/akka-actor-tests/src/test/java/akka/pattern/PatternsTest.java
+++ b/akka-actor-tests/src/test/java/akka/pattern/PatternsTest.java
@@ -7,6 +7,7 @@ import akka.testkit.AkkaSpec;
 import akka.testkit.TestProbe;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -17,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
  */
-public class PatternsTest {
+public class PatternsTest extends JUnitSuite {
 
     @ClassRule
     public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource("JavaAPI",

--- a/akka-actor-tests/src/test/java/akka/util/ByteStringTest.java
+++ b/akka-actor-tests/src/test/java/akka/util/ByteStringTest.java
@@ -4,11 +4,13 @@
 package akka.util;
 
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+import org.scalatest.junit.JUnitSuiteLike;
 import scala.concurrent.duration.Duration;
 
 import static junit.framework.TestCase.assertEquals;
 
-public class ByteStringTest {
+public class ByteStringTest extends JUnitSuite {
 
   @Test
   public void testCreation() {
@@ -20,6 +22,7 @@ public class ByteStringTest {
   public void testBuilderCreation() {
     final ByteStringBuilder sb = ByteString.createBuilder();
     sb.append(ByteString.fromString("Hello"));
+    sb.append(ByteString.fromString(" "));
     sb.append(ByteString.fromString("World"));
     assertEquals(ByteString.fromString("Hello World"), sb.result());
   }

--- a/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
+++ b/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
@@ -4,9 +4,10 @@
 package akka.util;
 
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
-public class JavaDuration {
+public class JavaDuration extends JUnitSuite {
 
   @Test
   public void testCreation() {

--- a/akka-camel/src/test/java/akka/camel/ConsumerJavaTest.java
+++ b/akka-camel/src/test/java/akka/camel/ConsumerJavaTest.java
@@ -7,6 +7,7 @@ package akka.camel;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.testkit.AkkaSpec;
 import org.junit.ClassRule;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 import akka.actor.ActorSystem;
@@ -19,7 +20,7 @@ import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.*;
 
-public class ConsumerJavaTest {
+public class ConsumerJavaTest extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-camel/src/test/java/akka/camel/CustomRouteTest.java
+++ b/akka-camel/src/test/java/akka/camel/CustomRouteTest.java
@@ -7,6 +7,7 @@ import akka.camel.javaapi.UntypedProducerActor;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.util.Timeout;
 import org.junit.*;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.Duration;
@@ -19,7 +20,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 
 import java.util.concurrent.TimeUnit;
 
-public class CustomRouteTest {
+public class CustomRouteTest extends JUnitSuite {
 
   @Rule
   public AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-camel/src/test/java/akka/camel/MessageJavaTest.java
+++ b/akka-camel/src/test/java/akka/camel/MessageJavaTest.java
@@ -11,6 +11,7 @@ import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.converter.stream.InputStreamCache;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 
 import java.io.InputStream;
 import java.util.*;
@@ -20,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 /**
  *
  */
-public class MessageJavaTest {
+public class MessageJavaTest extends JUnitSuite {
   private Map<String,Object> empty = new HashMap<String, Object>();
 
   @ClassRule

--- a/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
@@ -18,8 +18,9 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.actor.UntypedActor;
 import akka.testkit.AkkaJUnitActorSystemResource;
+import org.scalatest.junit.JUnitSuite;
 
-public class ClusterClientTest {
+public class ClusterClientTest extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
@@ -17,8 +17,9 @@ import akka.actor.Props;
 import akka.actor.UntypedActor;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
+import org.scalatest.junit.JUnitSuite;
 
-public class DistributedPubSubMediatorTest {
+public class DistributedPubSubMediatorTest extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
@@ -12,6 +12,7 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 import akka.testkit.TestProbe;
 
@@ -21,7 +22,7 @@ import akka.contrib.pattern.ReliableProxy;
 
 //#import
 
-public class ReliableProxyTest {
+public class ReliableProxyTest extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-contrib/src/test/java/akka/contrib/throttle/TimerBasedThrottlerTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/throttle/TimerBasedThrottlerTest.java
@@ -8,6 +8,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
+
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 import com.typesafe.config.ConfigFactory;
 import akka.actor.ActorRef;
@@ -17,7 +19,7 @@ import akka.actor.UntypedActor;
 import akka.contrib.throttle.TimerBasedThrottler;
 import akka.testkit.AkkaJUnitActorSystemResource;
 
-public class TimerBasedThrottlerTest {
+public class TimerBasedThrottlerTest extends JUnitSuite {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource(

--- a/akka-docs/rst/scala/code/docs/stream/QuickStartDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/stream/QuickStartDocSpec.scala
@@ -29,6 +29,8 @@ class QuickStartDocSpec extends WordSpec with BeforeAndAfterAll with ScalaFuture
     system.terminate()
   }
 
+  def println(any: Any) = () // silence printing stuff
+
   "demonstrate Source" in {
     //#create-source
     val source: Source[Int, NotUsed] = Source(1 to 100)

--- a/akka-docs/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -32,8 +32,7 @@ object TwitterStreamQuickstartDocSpec {
   //#model
 
   //#tweet-source
-  val tweets: Source[Tweet, NotUsed]
-  //#tweet-source
+  val tweets: Source[Tweet, NotUsed] //#tweet-source
   = Source(
     Tweet(Author("rolandkuhn"), System.currentTimeMillis, "#akka rocks!") ::
       Tweet(Author("patriknw"), System.currentTimeMillis, "#akka !") ::

--- a/akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java
+++ b/akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import akka.persistence.fsm.PersistentFSM.CurrentState;
 import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
 import static akka.persistence.fsm.AbstractPersistentFSMTest.WebStoreCustomerFSM.UserState;
@@ -40,7 +41,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.matchers.JUnitMatchers.hasItems;
 
-public class AbstractPersistentFSMTest {
+public class AbstractPersistentFSMTest extends JUnitSuite {
     private static Option<String> none = Option.none();
 
     @ClassRule

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/TimeoutsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/TimeoutsSpec.scala
@@ -9,7 +9,7 @@ import akka.Done
 import akka.stream.scaladsl._
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, ClosedShape }
+import akka.stream._
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import akka.testkit.AkkaSpec


### PR DESCRIPTION
Fixes #20090

I made sure this only runs the junit tests once.
For reference: HTTP tests etc were properly extending this class so those were running.

Also fixed silly bug in `ByteStringTest`
