### PR TITLE
backport ClusterClientSpec fixes, #18741

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,6 @@ tm.out
 worker*.log
 *-shim.sbt
 test-output
+.cache-main
+.cache-tests
 

--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterClientSpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ClusterClientSpec.scala
@@ -36,6 +36,8 @@ object ClusterClientSpec extends MultiNodeConfig {
     akka.contrib.cluster.client.heartbeat-interval = 1s
     akka.contrib.cluster.client.acceptable-heartbeat-pause = 3s
     akka.test.filter-leeway = 10s
+    # number-of-contacts must be >= 4 because we shutdown all but one in the end
+    akka.contrib.cluster.receptionist.number-of-contacts = 4
     """))
 
   testTransport(on = true)


### PR DESCRIPTION
- backport of #17735

There might be something more, but let's start with this one. The only reason I backport this is annoying when it fails for pr validation of release-2.3 branch. 
