### PR TITLE
Added text/markdown to MediaType

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
@@ -135,6 +135,7 @@ public final class MediaTypes {
     public static final MediaType.WithOpenCharset TEXT_CSS = akka.http.scaladsl.model.MediaTypes.text$divcss();
     public static final MediaType.WithOpenCharset TEXT_CSV = akka.http.scaladsl.model.MediaTypes.text$divcsv();
     public static final MediaType.WithOpenCharset TEXT_HTML = akka.http.scaladsl.model.MediaTypes.text$divhtml();
+    public static final MediaType.WithOpenCharset TEXT_MARKDOWN = akka.http.scaladsl.model.MediaTypes.text$divmarkdown();
     public static final MediaType.WithOpenCharset TEXT_MCF = akka.http.scaladsl.model.MediaTypes.text$divmcf();
     public static final MediaType.WithOpenCharset TEXT_PLAIN = akka.http.scaladsl.model.MediaTypes.text$divplain();
     public static final MediaType.WithOpenCharset TEXT_RICHTEXT = akka.http.scaladsl.model.MediaTypes.text$divrichtext();

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -425,6 +425,7 @@ object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
   val `text/css`                  = txt("css", "css")
   val `text/csv`                  = txt("csv", "csv")
   val `text/html`                 = txt("html", "htm", "html", "htmls", "htx")
+  val `text/markdown`             = txt("markdown", "md")
   val `text/mcf`                  = txt("mcf", "mcf")
   val `text/plain`                = txt("plain", "conf", "text", "txt", "properties")
   val `text/richtext`             = txt("richtext", "rtf", "rtx")


### PR DESCRIPTION
Hi,

I've added `text/markdown` to `MediaType` with file formats `markdown` and `md`. Please review and merge. This should fix #20126.

I've signed the ICLA.

Thank you,
Venil Noronha
