### PR TITLE
=str #19623 fix for SubSource pushing twice (backport)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphSubSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphSubSourceSpec.scala
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.ActorMaterializer
+import akka.stream.actor.ActorPublisherMessage
+import akka.stream.impl.fusing.{ SubSink, SubSource }
+import akka.stream.stage.AsyncCallback
+import akka.stream.testkit.{ AkkaSpec, TestSubscriber }
+import akka.testkit.TestProbe
+
+class GraphSubSourceSpec extends AkkaSpec {
+
+  implicit val materializer = ActorMaterializer()
+
+  "The SubSource graph stage" should {
+
+    "not fail with cannot push twice exception if elements are pushed before initialized" in {
+      // covering akka/akka#19623
+      val callback = new AsyncCallback[ActorPublisherMessage] {
+        override def invoke(t: ActorPublisherMessage): Unit = {}
+      }
+      val subsource = new SubSource[String]("subsource", callback)
+
+      val source = Source.fromGraph(subsource)
+      val probe = TestSubscriber.manualProbe[String]()
+      source.to(Sink.fromSubscriber(probe)).run()
+      val sub = probe.expectSubscription()
+
+      // push before there is demand
+      subsource.pushSubstream("one")
+      // this causes a cannot push twice exception before bug is fixed
+      subsource.pushSubstream("two")
+
+      sub.request(1)
+      probe.expectNext("one")
+      sub.request(1)
+      probe.expectNext("two")
+
+      sub.cancel()
+    }
+
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -514,7 +514,7 @@ final class SubSource[T](name: String, private[fusing] val externalCallback: Asy
       val ourOwnCallback = getAsyncCallback[ActorSubscriberMessage] {
         case OnComplete   ⇒ completeStage()
         case OnError(ex)  ⇒ failStage(ex)
-        case OnNext(elem) ⇒ push(out, elem.asInstanceOf[T])
+        case OnNext(elem) ⇒ emit(out, elem.asInstanceOf[T])
       }
       setCB(ourOwnCallback)
     }


### PR DESCRIPTION
(cherry picked from commit e749d77)
