### PR TITLE
=str #19469 More verbose logging of stage and tcp errors

### DIFF
--- a/akka-stream-tests/src/test/resources/reference.conf
+++ b/akka-stream-tests/src/test/resources/reference.conf
@@ -5,6 +5,7 @@ akka {
     serialize-messages = on
     default-dispatcher.throughput = 1 // Amplify the effects of fuzzing
   }
+  akka.actor.warn-about-java-serializer-usage = false
 
   stream.materializer.debug.fuzzing-mode = on
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -252,7 +252,7 @@ class ActorGraphInterpreterSpec extends AkkaSpec {
         }
       }
 
-      EventFilter[IllegalArgumentException](message = "Error after stage was closed.", occurrences = 1).intercept {
+      EventFilter[IllegalArgumentException](pattern = "Error in stage.*", occurrences = 1).intercept {
         Await.result(Source.fromGraph(failyStage).runWith(Sink.ignore), 3.seconds)
       }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -102,7 +102,7 @@ object GraphStages {
   private val _detacher = new Detacher[Any]
   def detacher[T]: GraphStage[FlowShape[T, T]] = _detacher.asInstanceOf[GraphStage[FlowShape[T, T]]]
 
-  final class Breaker(callback: Breaker.Operation ⇒ Unit) {
+  class Breaker(callback: Breaker.Operation ⇒ Unit) {
     import Breaker._
     def complete(): Unit = callback(Complete)
     def fail(ex: Throwable): Unit = callback(Fail(ex))

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -268,8 +268,14 @@ private[stream] object TcpConnectionStage {
       }
 
       override def onUpstreamFailure(ex: Throwable): Unit = {
-        if (connection != null) connection ! Abort
-        else failStage(ex)
+        if (connection != null) {
+          if (interpreter.log.isDebugEnabled) {
+            interpreter.log.debug("Aborting tcp connection because of upstream failure: {}\n{}",
+              ex.getMessage,
+              ex.getStackTrace.mkString("\n"))
+          }
+          connection ! Abort
+        } else failStage(ex)
       }
     })
 

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -532,7 +532,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   /**
    * Signals failure through the given port.
    */
-  final protected def fail[T](out: Outlet[T], ex: Throwable): Unit = interpreter.fail(conn(out), ex, isInternal = false)
+  final protected def fail[T](out: Outlet[T], ex: Throwable): Unit = interpreter.fail(conn(out), ex)
 
   /**
    * Automatically invokes [[cancel()]] or [[complete()]] on all the input or output ports that have been called,
@@ -556,21 +556,13 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    * Automatically invokes [[cancel()]] or [[fail()]] on all the input or output ports that have been called,
    * then stops the stage, then [[postStop()]] is called.
    */
-  final def failStage(ex: Throwable): Unit = failStage(ex, isInternal = false)
-
-  /**
-   * INTERNAL API
-   *
-   * Used to signal errors caught by the interpreter itself. This method logs failures if the stage has been
-   * already closed if ``isInternal`` is set to true.
-   */
-  private[stream] final def failStage(ex: Throwable, isInternal: Boolean): Unit = {
+  final def failStage(ex: Throwable): Unit = {
     var i = 0
     while (i < portToConn.length) {
       if (i < inCount)
         interpreter.cancel(portToConn(i))
       else
-        interpreter.fail(portToConn(i), ex, isInternal)
+        interpreter.fail(portToConn(i), ex)
       i += 1
     }
     setKeepGoing(false)

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1332,7 +1332,11 @@ object AkkaBuild extends Build {
       ProblemFilters.exclude[MissingMethodProblem]("akka.remote.ReliableDeliverySupervisor#GotUid.apply")
     )
 
-    val akkaStream = Seq()
+    val akkaStream = Seq(
+      // Removed internal methods https://github.com/akka/akka/pull/20162/files
+      ProblemFilters.exclude[MissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreter.fail"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.stream.stage.GraphStageLogic.failStage")
+    )
   }
 
   lazy val mimaSettings = mimaDefaultSettings ++ Seq(


### PR DESCRIPTION
- Logs all exceptions thrown in GraphStages at error level
- Logs any exception leading to an abort of a tcp connection at debug level
  (cherry picked from commit 2ed7911)
