### PR TITLE
str #19589 backport autoflushing in outputstream sink

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
@@ -13,15 +13,15 @@ import scala.concurrent.Promise
 
 /** INTERNAL API */
 private[akka] object OutputStreamSubscriber {
-  def props(os: OutputStream, completionPromise: Promise[Long], bufSize: Int) = {
+  def props(os: OutputStream, completionPromise: Promise[Long], bufSize: Int, autoFlush: Boolean) = {
     require(bufSize > 0, "buffer size must be > 0")
-    Props(classOf[OutputStreamSubscriber], os, completionPromise, bufSize).withDeploy(Deploy.local)
+    Props(classOf[OutputStreamSubscriber], os, completionPromise, bufSize, autoFlush).withDeploy(Deploy.local)
   }
 
 }
 
 /** INTERNAL API */
-private[akka] class OutputStreamSubscriber(os: OutputStream, bytesWrittenPromise: Promise[Long], bufSize: Int)
+private[akka] class OutputStreamSubscriber(os: OutputStream, bytesWrittenPromise: Promise[Long], bufSize: Int, autoFlush: Boolean)
   extends akka.stream.actor.ActorSubscriber
   with ActorLogging {
 
@@ -35,6 +35,7 @@ private[akka] class OutputStreamSubscriber(os: OutputStream, bytesWrittenPromise
         // blocking write
         os.write(bytes.toArray)
         bytesWritten += bytes.length
+        if (autoFlush) os.flush()
       } catch {
         case ex: Exception ⇒
           bytesWrittenPromise.failure(ex)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
@@ -24,10 +24,25 @@ object StreamConverters {
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    *
+   * If flushing after each write operation is required, user the overload with `autoFlush set to `true`.
+   *
    * @param f A Creator which creates an OutputStream to write to
    */
   def fromOutputStream(f: function.Creator[OutputStream]): javadsl.Sink[ByteString, Future[java.lang.Long]] =
-    new Sink(scaladsl.StreamConverters.fromOutputStream(() ⇒ f.create())).asInstanceOf[javadsl.Sink[ByteString, Future[java.lang.Long]]]
+    fromOutputStream(f, autoFlush = false)
+
+  /**
+   * Sink which writes incoming [[ByteString]]s to an [[OutputStream]] created by the given function.
+   *
+   * Materializes a [[Future]] that will be completed with the size of the file (in bytes) at the streams completion.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   *
+   * @param f A Creator which creates an OutputStream to write to
+   */
+  def fromOutputStream(f: function.Creator[OutputStream], autoFlush: Boolean): javadsl.Sink[ByteString, Future[java.lang.Long]] =
+    new Sink(scaladsl.StreamConverters.fromOutputStream(() ⇒ f.create(), autoFlush)).asInstanceOf[javadsl.Sink[ByteString, Future[java.lang.Long]]]
 
   /**
    * Creates a Sink which when materialized will return an [[java.io.InputStream]] which it is possible

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
@@ -56,11 +56,24 @@ object StreamConverters {
    *
    * Materializes a [[Future]] that will be completed with the size of the file (in bytes) at the streams completion.
    *
+   * If flushing after each write operation is required, user the overload with `autoFlush set to `true`.
+   *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    */
   def fromOutputStream(out: () ⇒ OutputStream): Sink[ByteString, Future[Long]] =
-    new Sink(new OutputStreamSink(out, DefaultAttributes.outputStreamSink, sinkShape("OutputStreamSink")))
+    fromOutputStream(out, autoFlush = false)
+
+  /**
+   * Creates a Sink which writes incoming [[ByteString]]s to an [[OutputStream]] created by the given function.
+   *
+   * Materializes a [[Future]] that will be completed with the size of the file (in bytes) at the streams completion.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   */
+  def fromOutputStream(out: () ⇒ OutputStream, autoFlush: Boolean): Sink[ByteString, Future[Long]] =
+    new Sink(new OutputStreamSink(out, DefaultAttributes.outputStreamSink, sinkShape("OutputStreamSink"), autoFlush))
 
   /**
    * Creates a Sink which when materialized will return an [[InputStream]] which it is possible

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -1335,7 +1335,14 @@ object AkkaBuild extends Build {
     val akkaStream = Seq(
       // Removed internal methods https://github.com/akka/akka/pull/20162/files
       ProblemFilters.exclude[MissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreter.fail"),
-      ProblemFilters.exclude[MissingMethodProblem]("akka.stream.stage.GraphStageLogic.failStage")
+      ProblemFilters.exclude[MissingMethodProblem]("akka.stream.stage.GraphStageLogic.failStage"),
+      
+      ProblemFilters.exclude[FinalClassProblem]("akka.stream.impl.fusing.GraphStages$Breaker"),
+
+      // #19589 auto flushing (params on internal classes changed)
+      ProblemFilters.exclude[MissingMethodProblem]("akka.stream.impl.io.OutputStreamSubscriber.this"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.stream.impl.io.OutputStreamSubscriber.props"),
+      ProblemFilters.exclude[MissingMethodProblem]("akka.stream.impl.io.OutputStreamSink.this")
     )
   }
 


### PR DESCRIPTION
Manual backport of the auto flushing feature added in https://github.com/akka/akka/issues/19589
Just cherry picking is not as trivial since we introduced more things (IOResult etc).
