### PR TITLE
http: Fix spinlock race condition in PoolGateway

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
@@ -19,8 +19,7 @@ private object PoolGateway {
 
   sealed trait State
   final case class Running(interfaceActorRef: ActorRef,
-                           shutdownStartedPromise: Promise[Done],
-                           shutdownStartedHandled: Future[Done],
+                           _onShutdownStarted: () => Unit,
                            shutdownCompletedPromise: Promise[Done]) extends State
   final case class IsShutdown(shutdownCompleted: Future[Done]) extends State
   final case class NewIncarnation(gatewayFuture: Future[PoolGateway]) extends State
@@ -40,9 +39,8 @@ private object PoolGateway {
  * get reused will automatically forward requests directed at them to the latest pool incarnation from the cache.
  */
 private[http] class PoolGateway(hcps: HostConnectionPoolSetup,
-                                _shutdownStartedPromise: Promise[Done], // constructor arg only
-                                _shutdownStartedHandled: Future[Done])( // constructor arg only
-                                  implicit system: ActorSystem, fm: Materializer) {
+                                _onShutdownStarted: () => Unit)(// constructor arg only
+                                                                implicit system: ActorSystem, fm: Materializer) {
   import PoolGateway._
   import fm.executionContext
 
@@ -50,14 +48,14 @@ private[http] class PoolGateway(hcps: HostConnectionPoolSetup,
     val shutdownCompletedPromise = Promise[Done]()
     val props = Props(new PoolInterfaceActor(hcps, shutdownCompletedPromise, this)).withDeploy(Deploy.local)
     val ref = system.actorOf(props, PoolInterfaceActor.name.next())
-    new AtomicReference[State](Running(ref, _shutdownStartedPromise, _shutdownStartedHandled, shutdownCompletedPromise))
+    new AtomicReference[State](Running(ref, _onShutdownStarted, shutdownCompletedPromise))
   }
 
   def currentState: Any = state.get() // enables test access
 
   def apply(request: HttpRequest, previousIncarnation: PoolGateway = null): Future[HttpResponse] =
     state.get match {
-      case Running(ref, _, _, _) ⇒
+      case Running(ref, _, _) ⇒
         val responsePromise = Promise[HttpResponse]()
         ref ! PoolInterfaceActor.PoolRequest(request, responsePromise)
         responsePromise.future
@@ -80,11 +78,11 @@ private[http] class PoolGateway(hcps: HostConnectionPoolSetup,
   // triggers a shutdown of the current pool, even if it is already a later incarnation
   @tailrec final def shutdown(): Future[Done] =
     state.get match {
-      case x @ Running(ref, shutdownStartedPromise, shutdownStartedHandled, shutdownCompletedPromise) ⇒
+      case x @ Running(ref, onShutdownStarted, shutdownCompletedPromise) ⇒
         if (state.compareAndSet(x, IsShutdown(shutdownCompletedPromise.future))) {
-          shutdownStartedPromise.success(Done) // trigger cache removal
+          onShutdownStarted() // trigger cache removal
           ref ! PoolInterfaceActor.Shutdown
-          shutdownStartedHandled.flatMap(_ ⇒ shutdownCompletedPromise.future)
+          shutdownCompletedPromise.future
         } else shutdown() // CAS loop (not a spinlock)
 
       case IsShutdown(x)                    ⇒ x

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -321,7 +321,8 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    */
   private[akka] def newHostConnectionPool[T](setup: HostConnectionPoolSetup)(
     implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
-    val gatewayFuture = FastFuture.successful(new PoolGateway(setup, Promise()))
+    val shutdownStartedPromise = Promise[Done]()
+    val gatewayFuture = FastFuture.successful(new PoolGateway(setup, shutdownStartedPromise, shutdownStartedPromise.future))
     gatewayClientFlow(setup, gatewayFuture)
   }
 
@@ -568,8 +569,9 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
     hostPoolCache.putIfAbsent(setup, gatewayPromise.future) match {
       case null ⇒ // only one thread can get here at a time
         val whenShuttingDown = Promise[Done]()
+        val whenShuttingDownCompleted = Promise[Done]()
         val gateway =
-          try new PoolGateway(setup, whenShuttingDown)
+          try new PoolGateway(setup, whenShuttingDown, whenShuttingDownCompleted.future)
           catch {
             case NonFatal(e) ⇒
               hostPoolCache.remove(setup)
@@ -579,7 +581,10 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
         val fastFuture = FastFuture.successful(gateway)
         hostPoolCache.put(setup, fastFuture) // optimize subsequent gateway accesses
         gatewayPromise.success(gateway) // satisfy everyone who got a hold of our promise while we were starting up
-        whenShuttingDown.future.onComplete(_ ⇒ hostPoolCache.remove(setup, fastFuture))(fm.executionContext)
+        whenShuttingDown.future.onComplete { _ ⇒
+          hostPoolCache.remove(setup, fastFuture)
+          whenShuttingDownCompleted.success(Done)
+        }(fm.executionContext)
         fastFuture
 
       case future ⇒ future // return cached instance

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -208,8 +208,9 @@ class ConnectionPoolSpec extends AkkaSpec("""
     "automatically shutdown after configured timeout periods" in new TestSetup() {
       val (_, _, _, hcp) = cachedHostConnectionPool[Int](idleTimeout = 1.second)
       val gateway = Await.result(hcp.gatewayFuture, 500.millis)
-      val PoolGateway.Running(_, shutdownStartedPromise, shutdownCompletedPromise) = gateway.currentState
+      val PoolGateway.Running(_, shutdownStartedPromise, shutdownStartedHandled, shutdownCompletedPromise) = gateway.currentState
       shutdownStartedPromise.isCompleted shouldEqual false
+      shutdownStartedHandled.isCompleted shouldEqual false
       shutdownCompletedPromise.isCompleted shouldEqual false
       Await.result(shutdownStartedPromise.future, 1500.millis) // verify shutdown start (after idle)
       Await.result(shutdownCompletedPromise.future, 1500.millis) // verify shutdown completed
@@ -219,7 +220,7 @@ class ConnectionPoolSpec extends AkkaSpec("""
       val (requestIn, responseOut, responseOutSub, hcp) = cachedHostConnectionPool[Int](idleTimeout = 1.second)
 
       val gateway = Await.result(hcp.gatewayFuture, 500.millis)
-      val PoolGateway.Running(_, _, shutdownCompletedPromise) = gateway.currentState
+      val PoolGateway.Running(_, _, _, shutdownCompletedPromise) = gateway.currentState
       Await.result(shutdownCompletedPromise.future, 1500.millis) // verify shutdown completed
 
       requestIn.sendNext(HttpRequest(uri = "/") -> 42)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -208,19 +208,17 @@ class ConnectionPoolSpec extends AkkaSpec("""
     "automatically shutdown after configured timeout periods" in new TestSetup() {
       val (_, _, _, hcp) = cachedHostConnectionPool[Int](idleTimeout = 1.second)
       val gateway = Await.result(hcp.gatewayFuture, 500.millis)
-      val PoolGateway.Running(_, shutdownStartedPromise, shutdownStartedHandled, shutdownCompletedPromise) = gateway.currentState
-      shutdownStartedPromise.isCompleted shouldEqual false
-      shutdownStartedHandled.isCompleted shouldEqual false
+      val PoolGateway.Running(_, preShutdownHook, shutdownCompletedPromise) = gateway.currentState
       shutdownCompletedPromise.isCompleted shouldEqual false
-      Await.result(shutdownStartedPromise.future, 1500.millis) // verify shutdown start (after idle)
       Await.result(shutdownCompletedPromise.future, 1500.millis) // verify shutdown completed
+      Http().hostPoolCache shouldNot contain(hcp.setup) // verify shutdown hook executed (after idle)
     }
 
     "transparently restart after idle shutdown" in new TestSetup() {
       val (requestIn, responseOut, responseOutSub, hcp) = cachedHostConnectionPool[Int](idleTimeout = 1.second)
 
       val gateway = Await.result(hcp.gatewayFuture, 500.millis)
-      val PoolGateway.Running(_, _, _, shutdownCompletedPromise) = gateway.currentState
+      val PoolGateway.Running(_, _, shutdownCompletedPromise) = gateway.currentState
       Await.result(shutdownCompletedPromise.future, 1500.millis) // verify shutdown completed
 
       requestIn.sendNext(HttpRequest(uri = "/") -> 42)


### PR DESCRIPTION
Removes the race condition between the side effects needed from "shutdown started" and "shutdown completed" by waiting for the shutdown started `Promise` to eventually callback the `shutdownStartedHandled` `Future`.

Usages of the `PoolGateway` that do not need special handling / side effects can use the `shutdownStartedPromise.future` as the `shutdownStartedHandled` argument, as shown in https://github.com/akka/akka/compare/master...nkvoll:fix-spinlock-race-condition-in-akka-http-client-connection-pool?expand=1#diff-57c314af9e0369f72b0f60ff1fa56f0aR574

Attempts to address: https://github.com/akka/akka/issues/20071.
