### PR TITLE
Eliminate doublecopy of byte array

### DIFF
--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -528,7 +528,7 @@ object CompactByteString {
     else {
       val ar = new Array[Byte](bytes.size)
       bytes.copyToArray(ar)
-      CompactByteString(ar)
+      ByteString.ByteString1C(ar)
     }
   }
 


### PR DESCRIPTION
When `CompactByteString` is created from varargs, args are copied to the new byte array in `apply(bytes: Byte*)` method, then this array is passed to `apply(bytes: Array[Byte])` there it's copied again. 

Second copy is unnecessary and may be eliminated by calling `ByteString.ByteString1C` directly. Also, it makes code more consistent, because other apply methods already call it directly on generated byte arrays.
