### PR TITLE
=doc #19955 separate-section-persistence-eager-init

### DIFF
--- a/akka-docs/rst/java/lambda-persistence.rst
+++ b/akka-docs/rst/java/lambda-persistence.rst
@@ -814,6 +814,9 @@ Plugin development requires the following imports:
 
 .. includecode:: code/docs/persistence/LambdaPersistencePluginDocTest.java#plugin-imports
 
+Eager initialization of persistence plugin
+------------------------------------------
+
 By default, persistence plugins are started on-demand, as they are used. In some case, however, it might be beneficial
 to start a certain plugin eagerly. In order to do that, you should first add the ``akka.persistence.Persistence``
 under the ``akka.extensions`` key. Then, specify the IDs of plugins you wish to start automatically under

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -765,6 +765,9 @@ Plugin development requires the following imports:
 
 .. includecode:: code/docs/persistence/PersistencePluginDocTest.java#plugin-imports
 
+Eager initialization of persistence plugin
+------------------------------------------
+
 By default, persistence plugins are started on-demand, as they are used. In some case, however, it might be beneficial
 to start a certain plugin eagerly. In order to do that, you should first add the ``akka.persistence.Persistence``
 under the ``akka.extensions`` key. Then, specify the IDs of plugins you wish to start automatically under

--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -161,7 +161,7 @@ Emit each integer in a range, with an option to take bigger steps than 1.
 **completes** when the end of the range has been reached
 
 unfoldResource
-^^^^^
+^^^^^^^^^^^^^^
 Wrap any resource that can be opened, queried for next element (in a blocking way) and closed using three distinct functions into a source.
 
 **emits** when there is demand and read method returns value
@@ -169,7 +169,7 @@ Wrap any resource that can be opened, queried for next element (in a blocking wa
 **completes** when read function returns ``None``
 
 unfoldAsyncResource
-^^^^^
+^^^^^^^^^^^^^^^^^^^
 Wrap any resource that can be opened, queried for next element and closed using three distinct functions into a source.
 Functions return ``CompletionStage`` result to achieve asynchronous processing
 

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -823,6 +823,9 @@ Plugin development requires the following imports:
 
 .. includecode:: code/docs/persistence/PersistencePluginDocSpec.scala#plugin-imports
 
+Eager initialization of persistence plugin
+------------------------------------------
+
 By default, persistence plugins are started on-demand, as they are used. In some case, however, it might be beneficial
 to start a certain plugin eagerly. In order to do that, you should first add the ``akka.persistence.Persistence``
 under the ``akka.extensions`` key. Then, specify the IDs of plugins you wish to start automatically under

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -150,7 +150,7 @@ Combine several sources, using a given strategy such as merge or concat, into on
 **completes** when all sources has completed
 
 unfoldResource
-^^^^^
+^^^^^^^^^^^^^^
 Wrap any resource that can be opened, queried for next element (in a blocking way) and closed using three distinct functions into a source.
 
 **emits** when there is demand and read function returns value
@@ -158,7 +158,7 @@ Wrap any resource that can be opened, queried for next element (in a blocking wa
 **completes** when read function returns ``None``
 
 unfoldAsyncResource
-^^^^^
+^^^^^^^^^^^^^^^^^^^
 Wrap any resource that can be opened, queried for next element (in a blocking way) and closed using three distinct functions into a source.
 Functions return ``Future`` to achieve asynchronous processing
 


### PR DESCRIPTION
should fix #19955

also fix of a warning displayed during doc generation that section marker is shorter than title.
