### PR TITLE
=doc #20210 fix generation with python 3.5

### DIFF
--- a/akka-docs/_sphinx/exts/includecode.py
+++ b/akka-docs/_sphinx/exts/includecode.py
@@ -114,7 +114,7 @@ class IncludeCode(Directive):
                 "Snippet ({}#{}) not found!".format(filename, section),
                 line=self.lineno
             )]
-        tabcounts = map(lambda l: countwhile(lambda c: c == ' ', l), nonempty)
+        tabcounts = list(map(lambda l: countwhile(lambda c: c == ' ', l), nonempty))
         tabshift = min(tabcounts) if tabcounts else 0
 
         if tabshift > 0:


### PR DESCRIPTION
in python 3.5 map is lazy by default and returns "map object"
tabcounts is an object and not a collection yet in that case.
`if tabcounts` is always true because of above.
`min` evaluates this lazy map and in case of no elements it throws exception.
but it should return 0 as it is defined in `else` case.
simple evaluation before if does the trick.
