### PR TITLE
Improve documentation and configuration API when using together: sharding and distibuted data

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -129,6 +129,9 @@ final class ClusterShardingSettings(
   def withTuningParameters(tuningParameters: ClusterShardingSettings.TuningParameters): ClusterShardingSettings =
     copy(tuningParameters = tuningParameters)
 
+  def withStateStoreMode(stateStoreMode: String): ClusterShardingSettings =
+    copy(stateStoreMode = stateStoreMode)
+
   /**
    * The `role` of the `ClusterSingletonManagerSettings` is not used. The `role` of the
    * coordinator singleton will be the same as the `role` of `ClusterShardingSettings`.

--- a/akka-docs/rst/java/cluster-sharding.rst
+++ b/akka-docs/rst/java/cluster-sharding.rst
@@ -202,7 +202,8 @@ you use this mode. It is possible to remove ``akka-persistence`` dependency from
 is not used in user code and ``remember-entities`` is ``off``.
 Using it together with ``Remember Entities`` shards will be recreated after rebalancing, however will
 not be recreated after a clean cluster start as the Sharding Coordinator state is empty after a clean cluster
-start when using ddata mode.
+start when using ddata mode. When ``Remember Entities`` is ``on`` Sharding Region always keeps data usig persistence,
+no matter how ``State Store Mode`` is set.
 
 .. warning::
 

--- a/akka-docs/rst/java/cluster-sharding.rst
+++ b/akka-docs/rst/java/cluster-sharding.rst
@@ -200,6 +200,8 @@ on all nodes::
 You must explicitly add the ``akka-distributed-data-experimental`` dependency to your build if
 you use this mode. It is possible to remove ``akka-persistence`` dependency from a project if it
 is not used in user code and ``remember-entities`` is ``off``.
+Using it together with ``Remember Entities`` shards will be recreated after rebalancing, however will
+not be recreated after a clean cluster start - as data source is empty.
 
 .. warning::
 

--- a/akka-docs/rst/java/cluster-sharding.rst
+++ b/akka-docs/rst/java/cluster-sharding.rst
@@ -201,7 +201,8 @@ You must explicitly add the ``akka-distributed-data-experimental`` dependency to
 you use this mode. It is possible to remove ``akka-persistence`` dependency from a project if it
 is not used in user code and ``remember-entities`` is ``off``.
 Using it together with ``Remember Entities`` shards will be recreated after rebalancing, however will
-not be recreated after a clean cluster start - as data source is empty.
+not be recreated after a clean cluster start as the Sharding Coordinator state is empty after a clean cluster
+start when using ddata mode.
 
 .. warning::
 

--- a/akka-docs/rst/scala/cluster-sharding.rst
+++ b/akka-docs/rst/scala/cluster-sharding.rst
@@ -204,7 +204,8 @@ You must explicitly add the ``akka-distributed-data-experimental`` dependency to
 you use this mode. It is possible to remove ``akka-persistence`` dependency from a project if it
 is not used in user code and ``remember-entities`` is ``off``.
 Using it together with ``Remember Entities`` shards will be recreated after rebalancing, however will
-not be recreated after a clean cluster start - as data source is empty.
+not be recreated after a clean cluster start as the Sharding Coordinator state is empty after a clean cluster
+start when using ddata mode.
 
 .. warning::
 

--- a/akka-docs/rst/scala/cluster-sharding.rst
+++ b/akka-docs/rst/scala/cluster-sharding.rst
@@ -203,6 +203,8 @@ on all nodes::
 You must explicitly add the ``akka-distributed-data-experimental`` dependency to your build if
 you use this mode. It is possible to remove ``akka-persistence`` dependency from a project if it
 is not used in user code and ``remember-entities`` is ``off``.
+Using it together with ``Remember Entities`` shards will be recreated after rebalancing, however will
+not be recreated after a clean cluster start - as data source is empty.
 
 .. warning::
 

--- a/akka-docs/rst/scala/cluster-sharding.rst
+++ b/akka-docs/rst/scala/cluster-sharding.rst
@@ -205,7 +205,8 @@ you use this mode. It is possible to remove ``akka-persistence`` dependency from
 is not used in user code and ``remember-entities`` is ``off``.
 Using it together with ``Remember Entities`` shards will be recreated after rebalancing, however will
 not be recreated after a clean cluster start as the Sharding Coordinator state is empty after a clean cluster
-start when using ddata mode.
+start when using ddata mode. When ``Remember Entities`` is ``on`` Sharding Region always keeps data usig persistence,
+no matter how ``State Store Mode`` is set.
 
 .. warning::
 


### PR DESCRIPTION
It's hard to configure stateStoreMode per each shard in Java as one setter is missing.
Additionally it's worth to document that both features when used together have some drawbacks (shards are not recreated after clean start, only after rebalance)
