### PR TITLE
19678 add variadic concat route combinator

### DIFF
--- a/akka-docs/rst/scala/http/routing-dsl/directives/index.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/index.rst
@@ -139,7 +139,7 @@ Composing Directives
 --------------------
 
 .. note:: Gotcha: forgetting the ``~`` (tilde) character in between directives can often result in perfectly valid
-  Scala code that compiles but lead to your composed directive only containing the up to where ``~`` is missing.
+  Scala code that compiles but lead to your composed directive only containing the up to where ``~`` is missing. Alternatively, you might choose to use the ``concat`` combinator. ``concat(a, b, c)`` is the same as ``a ~ b ~ c``.
 
 As you have seen from the examples presented so far the "normal" way of composing directives is nesting.
 Let's take a look at this concrete example:

--- a/akka-docs/rst/scala/http/routing-dsl/directives/index.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/index.rst
@@ -138,8 +138,8 @@ transformations, both (or either) on the request and on the response side.
 Composing Directives
 --------------------
 
-.. note:: Gotcha: forgetting the ``~`` (tilde) character in between directives can often result in perfectly valid
-  Scala code that compiles but lead to your composed directive only containing the up to where ``~`` is missing. Alternatively, you might choose to use the ``concat`` combinator. ``concat(a, b, c)`` is the same as ``a ~ b ~ c``.
+.. note:: Gotcha: forgetting the ``~`` (tilde) character in between directives can result in perfectly valid
+  Scala code that compiles but does not work as expected. What would be intended as a single expression would actually be multiple expressions, and only the final one would be used as the result of the parent directive. Alternatively, you might choose to use the ``concat`` combinator. ``concat(a, b, c)`` is the same as ``a ~ b ~ c``.
 
 As you have seen from the examples presented so far the "normal" way of composing directives is nesting.
 Let's take a look at this concrete example:

--- a/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
@@ -4,7 +4,7 @@
 package akka.http.impl.util
 
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.{ Sink, Source }
 import akka.testkit.AkkaSpec
 
 import scala.concurrent.Await
@@ -33,7 +33,6 @@ class StreamUtilsSpec extends AkkaSpec {
 
         Await.ready(whenCompleted, 3.seconds).value shouldBe Some(Failure(ex))
       }
-
 
       "downstream cancels" in {
         val (newSource, whenCompleted) = StreamUtils.captureTermination(Source(List(1, 2, 3)))

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
@@ -4,6 +4,7 @@
 
 package akka.http.scaladsl.server
 
+import akka.http.scaladsl.server.Directives.reject
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
 
@@ -18,6 +19,17 @@ trait RouteConcatenation {
    */
   implicit def enhanceRouteWithConcatenation(route: Route): RouteConcatenation.RouteWithConcatenation =
     new RouteConcatenation.RouteWithConcatenation(route: Route)
+
+  /**
+   * Tries the supplied routes in sequence, returning the result of the first route that doesn't reject the request.
+   * This is an alternative to direct usage of the infix ~ operator. The ~ can be prone to programmer error, because if
+   * it is omitted, the program will still be syntactically correct, but will not actually attempt to match multiple
+   * routes, as intended.
+   *
+   * @param routes subroutes to concatenate
+   * @return the concatenated route
+   */
+  def concat(routes: Route*): Route = routes.foldLeft[Route](reject)(_ ~ _)
 }
 
 object RouteConcatenation extends RouteConcatenation {


### PR DESCRIPTION
Refs #19678. Cc @ktoso 

I added the bare minimum documentation, because I'm not sure what is preferred from a standpoint of recommendation. At the least, I felt it was worth mentioning as part of the warning about `~`, but I'd be glad to do something more thorough, if there's a consensus that `concat` would be the safer option for the docs to recommend. Or I'd be glad to mention it as an alternative in more places. Whatever works!
