### PR TITLE
The great reformatting

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorCreationPerfSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorCreationPerfSpec.scala
@@ -100,7 +100,7 @@ object ActorCreationPerfSpec {
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ActorCreationPerfSpec extends AkkaSpec("akka.actor.serialize-messages = off") with ImplicitSender
-  with MetricsKit with BeforeAndAfterAll {
+    with MetricsKit with BeforeAndAfterAll {
 
   import ActorCreationPerfSpec._
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -102,7 +102,8 @@ class ActorLifeCycleSpec extends AkkaSpec("akka.actor.serialize-messages=off") w
 
     "not invoke preRestart and postRestart when never restarted using OneForOneStrategy" in {
       val id = newUuid().toString
-      val supervisor = system.actorOf(Props(classOf[Supervisor],
+      val supervisor = system.actorOf(Props(
+        classOf[Supervisor],
         OneForOneStrategy(maxNrOfRetries = 3)(List(classOf[Exception]))))
       val gen = new AtomicInteger(0)
       val props = Props(classOf[LifeCycleTestActor], testActor, id, gen)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
@@ -250,14 +250,14 @@ class ActorLookupSpec extends AkkaSpec with DefaultTimeout {
         val lookname = looker.path.elements.mkString("", "/", "/")
         for (
           (l, r) ← Seq(
-            LookupString("a/b/c") -> empty(lookname + "a/b/c"),
-            LookupString("") -> system.deadLetters,
-            LookupString("akka://all-systems/Nobody") -> system.deadLetters,
-            LookupPath(system / "hallo") -> empty("user/hallo"),
-            LookupPath(looker.path child "hallo") -> empty(lookname + "hallo"), // test Java API
-            LookupPath(looker.path descendant Seq("a", "b").asJava) -> empty(lookname + "a/b"), // test Java API
-            LookupElems(Seq()) -> system.deadLetters,
-            LookupElems(Seq("a")) -> empty(lookname + "a"))
+            LookupString("a/b/c") → empty(lookname + "a/b/c"),
+            LookupString("") → system.deadLetters,
+            LookupString("akka://all-systems/Nobody") → system.deadLetters,
+            LookupPath(system / "hallo") → empty("user/hallo"),
+            LookupPath(looker.path child "hallo") → empty(lookname + "hallo"), // test Java API
+            LookupPath(looker.path descendant Seq("a", "b").asJava) → empty(lookname + "a/b"), // test Java API
+            LookupElems(Seq()) → system.deadLetters,
+            LookupElems(Seq("a")) → empty(lookname + "a"))
         ) checkOne(looker, l, r)
       }
       for (looker ← all) check(looker)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
@@ -208,9 +208,10 @@ object ActorMailboxSpec {
 
   trait MCBoundedMessageQueueSemantics extends MessageQueue with MultipleConsumerSemantics
   final case class MCBoundedMailbox(val capacity: Int, val pushTimeOut: FiniteDuration)
-    extends MailboxType with ProducesMessageQueue[MCBoundedMessageQueueSemantics] {
+      extends MailboxType with ProducesMessageQueue[MCBoundedMessageQueueSemantics] {
 
-    def this(settings: ActorSystem.Settings, config: Config) = this(config.getInt("mailbox-capacity"),
+    def this(settings: ActorSystem.Settings, config: Config) = this(
+      config.getInt("mailbox-capacity"),
       config.getNanosDuration("mailbox-push-timeout-time"))
 
     final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
@@ -241,23 +242,29 @@ class ActorMailboxSpec(conf: Config) extends AkkaSpec(conf) with DefaultTimeout 
     }
 
     "get an unbounded deque message queue when it is only configured on the props" in {
-      checkMailboxQueue(Props[QueueReportingActor].withMailbox("akka.actor.mailbox.unbounded-deque-based"),
+      checkMailboxQueue(
+        Props[QueueReportingActor].withMailbox("akka.actor.mailbox.unbounded-deque-based"),
         "default-override-from-props", UnboundedDeqMailboxTypes)
     }
 
     "get an bounded message queue when it's only configured with RequiresMailbox" in {
-      checkMailboxQueue(Props[BoundedQueueReportingActor],
+      checkMailboxQueue(
+        Props[BoundedQueueReportingActor],
         "default-override-from-trait", BoundedMailboxTypes)
     }
 
     "get an unbounded deque message queue when it's only mixed with Stash" in {
-      checkMailboxQueue(Props[StashQueueReportingActor],
+      checkMailboxQueue(
+        Props[StashQueueReportingActor],
         "default-override-from-stash", UnboundedDeqMailboxTypes)
-      checkMailboxQueue(Props(new StashQueueReportingActor),
+      checkMailboxQueue(
+        Props(new StashQueueReportingActor),
         "default-override-from-stash2", UnboundedDeqMailboxTypes)
-      checkMailboxQueue(Props(classOf[StashQueueReportingActorWithParams], 17, "hello"),
+      checkMailboxQueue(
+        Props(classOf[StashQueueReportingActorWithParams], 17, "hello"),
         "default-override-from-stash3", UnboundedDeqMailboxTypes)
-      checkMailboxQueue(Props(new StashQueueReportingActorWithParams(17, "hello")),
+      checkMailboxQueue(
+        Props(new StashQueueReportingActorWithParams(17, "hello")),
         "default-override-from-stash4", UnboundedDeqMailboxTypes)
     }
 
@@ -278,12 +285,14 @@ class ActorMailboxSpec(conf: Config) extends AkkaSpec(conf) with DefaultTimeout 
     }
 
     "get an bounded control aware message queue when it's only configured with RequiresMailbox" in {
-      checkMailboxQueue(Props[BoundedControlAwareQueueReportingActor],
+      checkMailboxQueue(
+        Props[BoundedControlAwareQueueReportingActor],
         "default-override-from-trait-bounded-control-aware", BoundedControlAwareMailboxTypes)
     }
 
     "get an unbounded control aware message queue when it's only configured with RequiresMailbox" in {
-      checkMailboxQueue(Props[UnboundedControlAwareQueueReportingActor],
+      checkMailboxQueue(
+        Props[UnboundedControlAwareQueueReportingActor],
         "default-override-from-trait-unbounded-control-aware", UnboundedControlAwareMailboxTypes)
     }
 
@@ -317,7 +326,8 @@ class ActorMailboxSpec(conf: Config) extends AkkaSpec(conf) with DefaultTimeout 
     }
 
     "get an unbounded message queue overriding configuration on the props" in {
-      checkMailboxQueue(Props[QueueReportingActor].withMailbox("akka.actor.mailbox.unbounded-deque-based"),
+      checkMailboxQueue(
+        Props[QueueReportingActor].withMailbox("akka.actor.mailbox.unbounded-deque-based"),
         "bounded-unbounded-override-props", UnboundedMailboxTypes)
     }
 
@@ -401,17 +411,20 @@ class ActorMailboxSpec(conf: Config) extends AkkaSpec(conf) with DefaultTimeout 
     }
 
     "get an unbounded message queue with a balancing dispatcher" in {
-      checkMailboxQueue(Props[QueueReportingActor].withDispatcher("balancing-dispatcher"),
+      checkMailboxQueue(
+        Props[QueueReportingActor].withDispatcher("balancing-dispatcher"),
         "unbounded-balancing", UnboundedMailboxTypes)
     }
 
     "get a bounded message queue with a balancing bounded dispatcher" in {
-      checkMailboxQueue(Props[QueueReportingActor].withDispatcher("balancing-bounded-dispatcher"),
+      checkMailboxQueue(
+        Props[QueueReportingActor].withDispatcher("balancing-bounded-dispatcher"),
         "bounded-balancing", BoundedMailboxTypes)
     }
 
     "get a bounded message queue with a requiring balancing bounded dispatcher" in {
-      checkMailboxQueue(Props[QueueReportingActor].withDispatcher("requiring-balancing-bounded-dispatcher"),
+      checkMailboxQueue(
+        Props[QueueReportingActor].withDispatcher("requiring-balancing-bounded-dispatcher"),
         "requiring-bounded-balancing", BoundedMailboxTypes)
     }
   }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
@@ -66,7 +66,8 @@ class ActorSelectionSpec extends AkkaSpec("akka.loglevel=DEBUG") with DefaultTim
     asked.correlationId should ===(selection)
 
     implicit val ec = system.dispatcher
-    val resolved = Await.result(selection.resolveOne(timeout.duration).mapTo[ActorRef] recover { case _ ⇒ null },
+    val resolved = Await.result(
+      selection.resolveOne(timeout.duration).mapTo[ActorRef] recover { case _ ⇒ null },
       timeout.duration)
     Option(resolved) should ===(result)
 
@@ -249,11 +250,11 @@ class ActorSelectionSpec extends AkkaSpec("akka.loglevel=DEBUG") with DefaultTim
         val lookname = looker.path.elements.mkString("", "/", "/")
         for (
           (l, r) ← Seq(
-            SelectString("a/b/c") -> None,
-            SelectString("akka://all-systems/Nobody") -> None,
-            SelectPath(system / "hallo") -> None,
-            SelectPath(looker.path child "hallo") -> None, // test Java API
-            SelectPath(looker.path descendant Seq("a", "b").asJava) -> None) // test Java API
+            SelectString("a/b/c") → None,
+            SelectString("akka://all-systems/Nobody") → None,
+            SelectPath(system / "hallo") → None,
+            SelectPath(looker.path child "hallo") → None, // test Java API
+            SelectPath(looker.path descendant Seq("a", "b").asJava) → None) // test Java API
         ) checkOne(looker, l, r)
       }
       for (looker ← all) check(looker)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -319,7 +319,8 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
     }
 
     "allow configuration of guardian supervisor strategy" in {
-      implicit val system = ActorSystem("Stop",
+      implicit val system = ActorSystem(
+        "Stop",
         ConfigFactory.parseString("akka.actor.guardian-supervisor-strategy=akka.actor.StoppingSupervisorStrategy")
           .withFallback(AkkaSpec.testConf))
       val a = system.actorOf(Props(new Actor {
@@ -339,7 +340,8 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
     }
 
     "shut down when /user escalates" in {
-      implicit val system = ActorSystem("Stop",
+      implicit val system = ActorSystem(
+        "Stop",
         ConfigFactory.parseString("akka.actor.guardian-supervisor-strategy=\"akka.actor.ActorSystemSpec$Strategy\"")
           .withFallback(AkkaSpec.testConf))
       val a = system.actorOf(Props(new Actor {

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
@@ -71,7 +71,7 @@ object FSMActorSpec {
     }
 
     onTransition {
-      case Locked -> Open ⇒ transitionLatch.open
+      case Locked → Open ⇒ transitionLatch.open
     }
 
     // verify that old-style does still compile
@@ -99,7 +99,7 @@ object FSMActorSpec {
 }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" -> true)) with ImplicitSender {
+class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" → true)) with ImplicitSender {
   import FSMActorSpec._
 
   val timeout = Timeout(2 seconds)
@@ -223,7 +223,7 @@ class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" -> true)) with Im
           case Event("stop", _) ⇒ stop()
         }
         onTransition {
-          case "not-started" -> "started" ⇒
+          case "not-started" → "started" ⇒
             for (timerName ← timerNames) setTimer(timerName, (), 10 seconds, false)
         }
         onTermination {
@@ -251,8 +251,8 @@ class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" -> true)) with Im
 
     "log events and transitions if asked to do so" in {
       import scala.collection.JavaConverters._
-      val config = ConfigFactory.parseMap(Map("akka.loglevel" -> "DEBUG", "akka.actor.serialize-messages" -> "off",
-        "akka.actor.debug.fsm" -> true).asJava).withFallback(system.settings.config)
+      val config = ConfigFactory.parseMap(Map("akka.loglevel" → "DEBUG", "akka.actor.serialize-messages" → "off",
+        "akka.actor.debug.fsm" → true).asJava).withFallback(system.settings.config)
       val fsmEventSystem = ActorSystem("fsmEvent", config)
       try {
         new TestKit(fsmEventSystem) {

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
@@ -130,7 +130,8 @@ class FSMTimingSpec extends AkkaSpec with ImplicitSender {
     }
 
     "notify unhandled messages" taggedAs TimingTest in {
-      filterEvents(EventFilter.warning("unhandled event Tick in state TestUnhandled", source = fsm.path.toString, occurrences = 1),
+      filterEvents(
+        EventFilter.warning("unhandled event Tick in state TestUnhandled", source = fsm.path.toString, occurrences = 1),
         EventFilter.warning("unhandled event Unhandled(test) in state TestUnhandled", source = fsm.path.toString, occurrences = 1)) {
           fsm ! TestUnhandled
           within(3 second) {
@@ -209,7 +210,7 @@ object FSMTimingSpec {
         goto(Initial)
     }
     onTransition {
-      case Initial -> TestSingleTimerResubmit ⇒ setTimer("blah", Tick, 500.millis.dilated)
+      case Initial → TestSingleTimerResubmit ⇒ setTimer("blah", Tick, 500.millis.dilated)
     }
     when(TestSingleTimerResubmit) {
       case Event(Tick, _) ⇒

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -20,7 +20,7 @@ object FSMTransitionSpec {
       case Event("stay", _) ⇒ stay()
       case Event(_, _)      ⇒ goto(0)
     }
-    onTransition { case from -> to ⇒ target ! (from -> to) }
+    onTransition { case from → to ⇒ target ! (from → to) }
 
     initialize()
   }
@@ -50,8 +50,11 @@ object FSMTransitionSpec {
       case _ ⇒ goto(1)
     }
     onTransition {
+      // format: OFF
+      // make sure normal arrow matches too
       case 0 -> 1 ⇒ target ! ((stateData, nextStateData))
-      case 1 -> 1 ⇒ target ! ((stateData, nextStateData))
+      // format: OFF
+      case 1 → 1 ⇒ target ! ((stateData, nextStateData))
     }
   }
 
@@ -70,11 +73,11 @@ class FSMTransitionSpec extends AkkaSpec with ImplicitSender {
 
     "not trigger onTransition for stay" in {
       val fsm = system.actorOf(Props(new SendAnyTransitionFSM(testActor)))
-      expectMsg(0 -> 0) // caused by initialize(), OK.
+      expectMsg(0 → 0) // caused by initialize(), OK.
       fsm ! "stay" // no transition event
       expectNoMsg(500.millis)
       fsm ! "goto" // goto(current state)
-      expectMsg(0 -> 0)
+      expectMsg(0 → 0)
     }
 
     "notify listeners" in {
@@ -151,7 +154,7 @@ class FSMTransitionSpec extends AkkaSpec with ImplicitSender {
           case Event("switch", _) ⇒ goto(1) using sender()
         }
         onTransition {
-          case x -> y ⇒ nextStateData ! (x -> y)
+          case x → y ⇒ nextStateData ! (x → y)
         }
         when(1) {
           case Event("test", _) ⇒

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -61,7 +61,7 @@ object SupervisorHierarchySpec {
   final case class Event(msg: Any, identity: Long) { val time: Long = System.nanoTime }
   final case class ErrorLog(msg: String, log: Vector[Event])
   final case class Failure(directive: Directive, stop: Boolean, depth: Int, var failPre: Int, var failPost: Int, val failConstr: Int, stopKids: Int)
-    extends RuntimeException("Failure") with NoStackTrace {
+      extends RuntimeException("Failure") with NoStackTrace {
     override def toString = productPrefix + productIterator.mkString("(", ",", ")")
   }
   final case class Dump(level: Int)
@@ -76,10 +76,11 @@ object SupervisorHierarchySpec {
   """)
 
   class MyDispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-    extends DispatcherConfigurator(config, prerequisites) {
+      extends DispatcherConfigurator(config, prerequisites) {
 
     private val instance: MessageDispatcher =
-      new Dispatcher(this,
+      new Dispatcher(
+        this,
         config.getString("id"),
         config.getInt("throughput"),
         config.getNanosDuration("throughput-deadline-time"),
@@ -467,7 +468,7 @@ object SupervisorHierarchySpec {
     }
 
     onTransition {
-      case Init -> Stress ⇒
+      case Init → Stress ⇒
         self ! Work
         idleChildren = children
         activeChildren = children
@@ -532,7 +533,7 @@ object SupervisorHierarchySpec {
     }
 
     onTransition {
-      case Stress -> Finishing ⇒ ignoreFailConstr = true
+      case Stress → Finishing ⇒ ignoreFailConstr = true
     }
 
     when(Finishing) {
@@ -546,7 +547,7 @@ object SupervisorHierarchySpec {
     }
 
     onTransition {
-      case _ -> LastPing ⇒
+      case _ → LastPing ⇒
         idleChildren foreach (_ ! "ping")
         pingChildren ++= idleChildren
         idleChildren = Vector.empty
@@ -563,7 +564,7 @@ object SupervisorHierarchySpec {
     }
 
     onTransition {
-      case _ -> Stopping ⇒
+      case _ → Stopping ⇒
         ignoreNotResumedLogs = false
         hierarchy ! PingOfDeath
     }
@@ -596,7 +597,7 @@ object SupervisorHierarchySpec {
           stop
         }
       case Event(StateTimeout, _) ⇒
-        errors :+= self -> ErrorLog("timeout while Stopping", Vector.empty)
+        errors :+= self → ErrorLog("timeout while Stopping", Vector.empty)
         println(system.asInstanceOf[ActorSystemImpl].printTree)
         getErrors(hierarchy, 10)
         printErrors()
@@ -604,7 +605,7 @@ object SupervisorHierarchySpec {
         testActor ! "timeout in Stopping"
         stop
       case Event(e: ErrorLog, _) ⇒
-        errors :+= sender() -> e
+        errors :+= sender() → e
         goto(Failed)
     }
 
@@ -630,7 +631,7 @@ object SupervisorHierarchySpec {
     when(Failed, stateTimeout = 5.seconds.dilated) {
       case Event(e: ErrorLog, _) ⇒
         if (!e.msg.startsWith("not resumed") || !ignoreNotResumedLogs)
-          errors :+= sender() -> e
+          errors :+= sender() → e
         stay
       case Event(Terminated(r), _) if r == hierarchy ⇒
         printErrors()
@@ -650,8 +651,8 @@ object SupervisorHierarchySpec {
       target match {
         case l: LocalActorRef ⇒
           l.underlying.actor match {
-            case h: Hierarchy ⇒ errors :+= target -> ErrorLog("forced", h.log)
-            case _            ⇒ errors :+= target -> ErrorLog("fetched", stateCache.get(target.path).log)
+            case h: Hierarchy ⇒ errors :+= target → ErrorLog("forced", h.log)
+            case _            ⇒ errors :+= target → ErrorLog("fetched", stateCache.get(target.path).log)
           }
           if (depth > 0) {
             l.underlying.children foreach (getErrors(_, depth - 1))
@@ -663,8 +664,8 @@ object SupervisorHierarchySpec {
       target match {
         case l: LocalActorRef ⇒
           l.underlying.actor match {
-            case h: Hierarchy ⇒ errors :+= target -> ErrorLog("forced", h.log)
-            case _            ⇒ errors :+= target -> ErrorLog("fetched", stateCache.get(target.path).log)
+            case h: Hierarchy ⇒ errors :+= target → ErrorLog("forced", h.log)
+            case _            ⇒ errors :+= target → ErrorLog("fetched", stateCache.get(target.path).log)
           }
           if (target != hierarchy) getErrorsUp(l.getParent)
       }
@@ -693,7 +694,7 @@ object SupervisorHierarchySpec {
       case Event(e: ErrorLog, _) ⇒
         if (e.msg.startsWith("not resumed")) stay
         else {
-          errors :+= sender() -> e
+          errors :+= sender() → e
           // don’t stop the hierarchy, that is going to happen all by itself and in the right order
           goto(Failed)
         }

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
@@ -59,7 +59,7 @@ class SupervisorMiscSpec extends AkkaSpec(SupervisorMiscSpec.config) with Defaul
 
         countDownLatch.await(10, TimeUnit.SECONDS)
 
-        Seq("actor1" -> actor1, "actor2" -> actor2, "actor3" -> actor3, "actor4" -> actor4) map {
+        Seq("actor1" → actor1, "actor2" → actor2, "actor3" → actor3, "actor4" → actor4) map {
           case (id, ref) ⇒ (id, ref ? "status")
         } foreach {
           case (id, f) ⇒ (id, Await.result(f, timeout.duration)) should ===((id, "OK"))

--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -204,7 +204,7 @@ object TypedActorSpec {
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
-  with BeforeAndAfterEach with BeforeAndAfterAll with DefaultTimeout {
+    with BeforeAndAfterEach with BeforeAndAfterAll with DefaultTimeout {
 
   import akka.actor.TypedActorSpec._
 
@@ -515,7 +515,7 @@ class TypedActorSpec extends AkkaSpec(TypedActorSpec.config)
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class TypedActorRouterSpec extends AkkaSpec(TypedActorSpec.config)
-  with BeforeAndAfterEach with BeforeAndAfterAll with DefaultTimeout {
+    with BeforeAndAfterEach with BeforeAndAfterAll with DefaultTimeout {
 
   import akka.actor.TypedActorSpec._
 

--- a/akka-actor-tests/src/test/scala/akka/actor/UidClashTest.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/UidClashTest.scala
@@ -16,9 +16,10 @@ object UidClashTest {
 
   @volatile var oldActor: ActorRef = _
 
-  private[akka] class EvilCollidingActorRef(override val provider: ActorRefProvider,
-                                            override val path: ActorPath,
-                                            val eventStream: EventStream) extends MinimalActorRef {
+  private[akka] class EvilCollidingActorRef(
+    override val provider: ActorRefProvider,
+      override val path: ActorPath,
+      val eventStream: EventStream) extends MinimalActorRef {
 
     //Ignore everything
     override def isTerminated: Boolean = true

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -218,7 +218,8 @@ object ActorModelSpec {
       await(deadline)(stats.restarts.get() == restarts)
     } catch {
       case e: Throwable ⇒
-        system.eventStream.publish(Error(e,
+        system.eventStream.publish(Error(
+          e,
           Option(dispatcher).toString,
           (Option(dispatcher) getOrElse this).getClass,
           "actual: " + stats + ", required: InterceptorStats(susp=" + suspensions +
@@ -524,12 +525,13 @@ object DispatcherModelSpec {
   }
 
   class MessageDispatcherInterceptorConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-    extends MessageDispatcherConfigurator(config, prerequisites) {
+      extends MessageDispatcherConfigurator(config, prerequisites) {
 
     import akka.util.Helpers.ConfigOps
 
     private val instance: MessageDispatcher =
-      new Dispatcher(this,
+      new Dispatcher(
+        this,
         config.getString("id"),
         config.getInt("throughput"),
         config.getNanosDuration("throughput-deadline-time"),
@@ -598,12 +600,13 @@ object BalancingDispatcherModelSpec {
   }
 
   class BalancingMessageDispatcherInterceptorConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-    extends BalancingDispatcherConfigurator(config, prerequisites) {
+      extends BalancingDispatcherConfigurator(config, prerequisites) {
 
     import akka.util.Helpers.ConfigOps
 
     override protected def create(mailboxType: MailboxType): BalancingDispatcher =
-      new BalancingDispatcher(this,
+      new BalancingDispatcher(
+        this,
         config.getString("id"),
         config.getInt("throughput"),
         config.getNanosDuration("throughput-deadline-time"),

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
@@ -69,7 +69,7 @@ object DispatchersSpec {
   }
 
   class OneShotMailboxType(settings: ActorSystem.Settings, config: Config)
-    extends MailboxType with ProducesMessageQueue[DoublingMailbox] {
+      extends MailboxType with ProducesMessageQueue[DoublingMailbox] {
     val created = new AtomicBoolean(false)
     override def create(owner: Option[ActorRef], system: Option[ActorSystem]) =
       if (created.compareAndSet(false, true)) {
@@ -105,15 +105,15 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
   def ofType[T <: MessageDispatcher: ClassTag]: (MessageDispatcher) ⇒ Boolean = _.getClass == implicitly[ClassTag[T]].runtimeClass
 
   def typesAndValidators: Map[String, (MessageDispatcher) ⇒ Boolean] = Map(
-    "PinnedDispatcher" -> ofType[PinnedDispatcher],
-    "Dispatcher" -> ofType[Dispatcher])
+    "PinnedDispatcher" → ofType[PinnedDispatcher],
+    "Dispatcher" → ofType[Dispatcher])
 
   def validTypes = typesAndValidators.keys.toList
 
   val defaultDispatcherConfig = settings.config.getConfig("akka.actor.default-dispatcher")
 
   lazy val allDispatchers: Map[String, MessageDispatcher] = {
-    validTypes.map(t ⇒ (t, from(ConfigFactory.parseMap(Map(tipe -> t, id -> t).asJava).
+    validTypes.map(t ⇒ (t, from(ConfigFactory.parseMap(Map(tipe → t, id → t).asJava).
       withFallback(defaultDispatcherConfig)))).toMap
   }
 
@@ -151,7 +151,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
 
     "throw ConfigurationException if type does not exist" in {
       intercept[ConfigurationException] {
-        from(ConfigFactory.parseMap(Map(tipe -> "typedoesntexist", id -> "invalid-dispatcher").asJava).
+        from(ConfigFactory.parseMap(Map(tipe → "typedoesntexist", id → "invalid-dispatcher").asJava).
           withFallback(defaultDispatcherConfig))
       }
     }

--- a/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
@@ -126,55 +126,57 @@ abstract class MailboxSpec extends AkkaSpec with BeforeAndAfterAll with BeforeAn
     q.hasMessages should ===(false)
   }
 
-  def testEnqueueDequeue(config: MailboxType,
-                         enqueueN: Int = 10000,
-                         dequeueN: Int = 10000,
-                         parallel: Boolean = true): Unit = within(10 seconds) {
+  def testEnqueueDequeue(
+    config: MailboxType,
+    enqueueN: Int = 10000,
+    dequeueN: Int = 10000,
+    parallel: Boolean = true): Unit = within(10 seconds) {
     val q = factory(config)
     ensureInitialMailboxState(config, q)
 
-    EventFilter.warning(pattern = ".*received dead letter from Actor.*MailboxSpec/deadLetters.*",
+    EventFilter.warning(
+      pattern = ".*received dead letter from Actor.*MailboxSpec/deadLetters.*",
       occurrences = (enqueueN - dequeueN)) intercept {
 
-        def createProducer(fromNum: Int, toNum: Int): Future[Vector[Envelope]] = spawn {
-          val messages = Vector() ++ (for (i ← fromNum to toNum) yield createMessageInvocation(i))
-          for (i ← messages) q.enqueue(testActor, i)
-          messages
-        }
-
-        val producers = {
-          val step = 500
-          val ps = for (i ← (1 to enqueueN by step).toList) yield createProducer(i, Math.min(enqueueN, i + step - 1))
-
-          if (parallel == false)
-            ps foreach { Await.ready(_, remainingOrDefault) }
-
-          ps
-        }
-
-        def createConsumer: Future[Vector[Envelope]] = spawn {
-          var r = Vector[Envelope]()
-
-          while (producers.exists(_.isCompleted == false) || q.hasMessages)
-            Option(q.dequeue) foreach { message ⇒ r = r :+ message }
-
-          r
-        }
-
-        val consumers = List.fill(maxConsumers)(createConsumer)
-
-        val ps = producers.map(Await.result(_, remainingOrDefault))
-        val cs = consumers.map(Await.result(_, remainingOrDefault))
-
-        ps.map(_.size).sum should ===(enqueueN) //Must have produced 1000 messages
-        cs.map(_.size).sum should ===(dequeueN) //Must have consumed all produced messages
-        //No message is allowed to be consumed by more than one consumer
-        cs.flatten.distinct.size should ===(dequeueN)
-        //All consumed messages should have been produced
-        (cs.flatten diff ps.flatten).size should ===(0)
-        //The ones that were produced and not consumed
-        (ps.flatten diff cs.flatten).size should ===(enqueueN - dequeueN)
+      def createProducer(fromNum: Int, toNum: Int): Future[Vector[Envelope]] = spawn {
+        val messages = Vector() ++ (for (i ← fromNum to toNum) yield createMessageInvocation(i))
+        for (i ← messages) q.enqueue(testActor, i)
+        messages
       }
+
+      val producers = {
+        val step = 500
+        val ps = for (i ← (1 to enqueueN by step).toList) yield createProducer(i, Math.min(enqueueN, i + step - 1))
+
+        if (parallel == false)
+          ps foreach { Await.ready(_, remainingOrDefault) }
+
+        ps
+      }
+
+      def createConsumer: Future[Vector[Envelope]] = spawn {
+        var r = Vector[Envelope]()
+
+        while (producers.exists(_.isCompleted == false) || q.hasMessages)
+          Option(q.dequeue) foreach { message ⇒ r = r :+ message }
+
+        r
+      }
+
+      val consumers = List.fill(maxConsumers)(createConsumer)
+
+      val ps = producers.map(Await.result(_, remainingOrDefault))
+      val cs = consumers.map(Await.result(_, remainingOrDefault))
+
+      ps.map(_.size).sum should ===(enqueueN) //Must have produced 1000 messages
+      cs.map(_.size).sum should ===(dequeueN) //Must have consumed all produced messages
+      //No message is allowed to be consumed by more than one consumer
+      cs.flatten.distinct.size should ===(dequeueN)
+      //All consumed messages should have been produced
+      (cs.flatten diff ps.flatten).size should ===(0)
+      //The ones that were produced and not consumed
+      (ps.flatten diff cs.flatten).size should ===(enqueueN - dequeueN)
+    }
   }
 }
 

--- a/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
@@ -10,8 +10,8 @@ import org.scalatest.BeforeAndAfterEach
 import akka.testkit._
 import scala.concurrent.duration._
 
-import akka.actor.{ Props, Actor, ActorRef, ActorSystem, PoisonPill}
-import akka.japi.{ Procedure}
+import akka.actor.{ Props, Actor, ActorRef, ActorSystem, PoisonPill }
+import akka.japi.{ Procedure }
 import com.typesafe.config.{ Config, ConfigFactory }
 
 object EventBusSpec {
@@ -144,7 +144,7 @@ abstract class EventBusSpec(busName: String, conf: Config = ConfigFactory.empty(
 
 object ActorEventBusSpec {
   class MyActorEventBus(protected val system: ActorSystem) extends ActorEventBus
-    with ManagedActorClassification with ActorClassifier {
+      with ManagedActorClassification with ActorClassifier {
 
     type Event = Notification
 

--- a/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
@@ -117,10 +117,10 @@ object LoggerSpec {
 
     override def mdc(currentMessage: Any): MDC = {
       reqId += 1
-      val always = Map("requestId" -> reqId)
+      val always = Map("requestId" → reqId)
       val cmim = "Current Message in MDC"
       val perMessage = currentMessage match {
-        case `cmim` ⇒ Map[String, Any]("currentMsg" -> cmim, "currentMsgLength" -> cmim.length)
+        case `cmim` ⇒ Map[String, Any]("currentMsg" → cmim, "currentMsgLength" → cmim.length)
         case _      ⇒ Map()
       }
       always ++ perMessage

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -29,9 +29,9 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
     akka.loglevel=DEBUG
     akka.actor.serialize-messages = off # debug noise from serialization
     """).withFallback(AkkaSpec.testConf)
-  val appLogging = ActorSystem("logging", ConfigFactory.parseMap(Map("akka.actor.debug.receive" -> true).asJava).withFallback(config))
-  val appAuto = ActorSystem("autoreceive", ConfigFactory.parseMap(Map("akka.actor.debug.autoreceive" -> true).asJava).withFallback(config))
-  val appLifecycle = ActorSystem("lifecycle", ConfigFactory.parseMap(Map("akka.actor.debug.lifecycle" -> true).asJava).withFallback(config))
+  val appLogging = ActorSystem("logging", ConfigFactory.parseMap(Map("akka.actor.debug.receive" → true).asJava).withFallback(config))
+  val appAuto = ActorSystem("autoreceive", ConfigFactory.parseMap(Map("akka.actor.debug.autoreceive" → true).asJava).withFallback(config))
+  val appLifecycle = ActorSystem("lifecycle", ConfigFactory.parseMap(Map("akka.actor.debug.lifecycle" → true).asJava).withFallback(config))
 
   val filter = TestEvent.Mute(EventFilter.custom {
     case _: Logging.Debug ⇒ true

--- a/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
@@ -13,7 +13,7 @@ class CapacityLimitSpec extends AkkaSpec("""
     akka.io.tcp.max-channels = 4
     akka.actor.serialize-creators = on
     """)
-  with TcpIntegrationSpecSupport {
+    with TcpIntegrationSpecSupport {
 
   "The TCP transport implementation" should {
 

--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -887,10 +887,11 @@ class TcpConnectionSpec extends AkkaSpec("""
 
     def setServerSocketOptions() = ()
 
-    def createConnectionActor(serverAddress: InetSocketAddress = serverAddress,
-                              options: immutable.Seq[SocketOption] = Nil,
-                              timeout: Option[FiniteDuration] = None,
-                              pullMode: Boolean = false): TestActorRef[TcpOutgoingConnection] = {
+    def createConnectionActor(
+      serverAddress: InetSocketAddress = serverAddress,
+      options: immutable.Seq[SocketOption] = Nil,
+      timeout: Option[FiniteDuration] = None,
+      pullMode: Boolean = false): TestActorRef[TcpOutgoingConnection] = {
       val ref = createConnectionActorWithoutRegistration(serverAddress, options, timeout, pullMode)
       ref ! newChannelRegistration
       ref
@@ -902,10 +903,11 @@ class TcpConnectionSpec extends AkkaSpec("""
         def disableInterest(op: Int): Unit = interestCallReceiver.ref ! -op
       }
 
-    def createConnectionActorWithoutRegistration(serverAddress: InetSocketAddress = serverAddress,
-                                                 options: immutable.Seq[SocketOption] = Nil,
-                                                 timeout: Option[FiniteDuration] = None,
-                                                 pullMode: Boolean = false): TestActorRef[TcpOutgoingConnection] =
+    def createConnectionActorWithoutRegistration(
+      serverAddress: InetSocketAddress = serverAddress,
+      options: immutable.Seq[SocketOption] = Nil,
+      timeout: Option[FiniteDuration] = None,
+      pullMode: Boolean = false): TestActorRef[TcpOutgoingConnection] =
       TestActorRef(
         new TcpOutgoingConnection(Tcp(system), this, userHandler.ref,
           Connect(serverAddress, options = options, timeout = timeout, pullMode = pullMode)) {
@@ -934,7 +936,7 @@ class TcpConnectionSpec extends AkkaSpec("""
     keepOpenOnPeerClosed: Boolean = false,
     useResumeWriting: Boolean = true,
     pullMode: Boolean = false)
-    extends UnacceptedConnectionTest(pullMode) {
+      extends UnacceptedConnectionTest(pullMode) {
 
     // lazy init since potential exceptions should not be triggered in the constructor but during execution of `run`
     lazy val serverSideChannel = acceptServerSideConnection(localServerChannel)
@@ -1016,7 +1018,7 @@ class TcpConnectionSpec extends AkkaSpec("""
      * Tries to simultaneously act on client and server side to read from the server all pending data from the client.
      */
     @tailrec final def pullFromServerSide(remaining: Int, remainingTries: Int = 1000,
-                                          into: ByteBuffer = defaultbuffer): Unit =
+      into: ByteBuffer = defaultbuffer): Unit =
       if (remainingTries <= 0)
         throw new AssertionError("Pulling took too many loops,  remaining data: " + remaining)
       else if (remaining > 0) {
@@ -1075,7 +1077,7 @@ class TcpConnectionSpec extends AkkaSpec("""
       }
 
     val interestsNames =
-      Seq(OP_ACCEPT -> "accepting", OP_CONNECT -> "connecting", OP_READ -> "reading", OP_WRITE -> "writing")
+      Seq(OP_ACCEPT → "accepting", OP_CONNECT → "connecting", OP_READ → "reading", OP_WRITE → "writing")
     def interestsDesc(interests: Int): String =
       interestsNames.filter(i ⇒ (i._1 & interests) != 0).map(_._2).mkString(", ")
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -213,7 +213,7 @@ class AskSpec extends AkkaSpec {
 
       val act = system.actorOf(Props(new Actor {
         def receive = {
-          case msg ⇒ p.ref ! sender() -> msg
+          case msg ⇒ p.ref ! sender() → msg
         }
       }))
 

--- a/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
@@ -44,9 +44,10 @@ object MetricsBasedResizerSpec {
 
     var msgs: Set[TestLatch] = Set()
 
-    def mockSend(await: Boolean,
-                 l: TestLatch = TestLatch(),
-                 routeeIdx: Int = Random.nextInt(routees.length)): Latches = {
+    def mockSend(
+      await: Boolean,
+      l: TestLatch = TestLatch(),
+      routeeIdx: Int = Random.nextInt(routees.length)): Latches = {
       val target = routees(routeeIdx)
       val first = TestLatch()
       val latches = Latches(first, l)

--- a/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
@@ -51,7 +51,7 @@ class RandomSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
       val counter = new AtomicInteger
       var replies = Map.empty[Int, Int]
       for (i ← 0 until connectionCount) {
-        replies = replies + (i -> 0)
+        replies = replies + (i → 0)
       }
 
       val actor = system.actorOf(RandomPool(connectionCount).props(routeeProps =
@@ -66,7 +66,7 @@ class RandomSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
       for (i ← 0 until iterationCount) {
         for (k ← 0 until connectionCount) {
           val id = Await.result((actor ? "hit").mapTo[Int], timeout.duration)
-          replies = replies + (id -> (replies(id) + 1))
+          replies = replies + (id → (replies(id) + 1))
         }
       }
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RoundRobinSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoundRobinSpec.scala
@@ -65,7 +65,7 @@ class RoundRobinSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
       for (_ ← 1 to iterationCount; _ ← 1 to connectionCount) {
         val id = Await.result((actor ? "hit").mapTo[Int], timeout.duration)
-        replies = replies + (id -> (replies(id) + 1))
+        replies = replies + (id → (replies(id) + 1))
       }
 
       counter.get should ===(connectionCount)
@@ -139,7 +139,7 @@ class RoundRobinSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
       for (_ ← 1 to iterationCount; _ ← 1 to connectionCount) {
         val id = Await.result((actor ? "hit").mapTo[String], timeout.duration)
-        replies = replies + (id -> (replies(id) + 1))
+        replies = replies + (id → (replies(id) + 1))
       }
 
       actor ! akka.routing.Broadcast("end")
@@ -185,7 +185,7 @@ class RoundRobinSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
       for (_ ← 1 to iterationCount; _ ← 1 to connectionCount) {
         val id = Await.result((actor ? "hit").mapTo[String], timeout.duration)
-        replies = replies + (id -> (replies(id) + 1))
+        replies = replies + (id → (replies(id) + 1))
       }
 
       watch(actor)

--- a/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
@@ -10,7 +10,7 @@ import akka.testkit.{ TestLatch, ImplicitSender, DefaultTimeout, AkkaSpec }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class SmallestMailboxSpec extends AkkaSpec("akka.actor.serialize-messages = off")
-  with DefaultTimeout with ImplicitSender {
+    with DefaultTimeout with ImplicitSender {
 
   "smallest mailbox pool" must {
 

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -327,7 +327,8 @@ class SerializationCompatibilitySpec extends AkkaSpec(SerializationTests.mostlyR
 
     "be preserved for the Create SystemMessage" in {
       // Using null as the cause to avoid a large serialized message and JDK differences
-      verify(Create(Some(null)),
+      verify(
+        Create(Some(null)),
         if (scala.util.Properties.versionNumberString.startsWith("2.10.")) {
           "aced00057372001b616b6b612e64697370617463682e7379736d73672e4372656174650000000000" +
             "0000010200014c00076661696c75726574000e4c7363616c612f4f7074696f6e3b78707372000a73" +
@@ -341,53 +342,62 @@ class SerializationCompatibilitySpec extends AkkaSpec(SerializationTests.mostlyR
         })
     }
     "be preserved for the Recreate SystemMessage" in {
-      verify(Recreate(null),
+      verify(
+        Recreate(null),
         "aced00057372001d616b6b612e64697370617463682e7379736d73672e5265637265617465000000" +
           "00000000010200014c000563617573657400154c6a6176612f6c616e672f5468726f7761626c653b" +
           "787070")
     }
     "be preserved for the Suspend SystemMessage" in {
-      verify(Suspend(),
+      verify(
+        Suspend(),
         "aced00057372001c616b6b612e64697370617463682e7379736d73672e53757370656e6400000000" +
           "000000010200007870")
     }
     "be preserved for the Resume SystemMessage" in {
-      verify(Resume(null),
+      verify(
+        Resume(null),
         "aced00057372001b616b6b612e64697370617463682e7379736d73672e526573756d650000000000" +
           "0000010200014c000f63617573656442794661696c7572657400154c6a6176612f6c616e672f5468" +
           "726f7761626c653b787070")
     }
     "be preserved for the Terminate SystemMessage" in {
-      verify(Terminate(),
+      verify(
+        Terminate(),
         "aced00057372001e616b6b612e64697370617463682e7379736d73672e5465726d696e6174650000" +
           "0000000000010200007870")
     }
     "be preserved for the Supervise SystemMessage" in {
-      verify(Supervise(null, true),
+      verify(
+        Supervise(null, true),
         "aced00057372001e616b6b612e64697370617463682e7379736d73672e5375706572766973650000" +
           "0000000000010200025a00056173796e634c00056368696c647400154c616b6b612f6163746f722f" +
           "4163746f725265663b78700170")
     }
     "be preserved for the Watch SystemMessage" in {
-      verify(Watch(null, null),
+      verify(
+        Watch(null, null),
         "aced00057372001a616b6b612e64697370617463682e7379736d73672e5761746368000000000000" +
           "00010200024c00077761746368656574001d4c616b6b612f6163746f722f496e7465726e616c4163" +
           "746f725265663b4c00077761746368657271007e000178707070")
     }
     "be preserved for the Unwatch SystemMessage" in {
-      verify(Unwatch(null, null),
+      verify(
+        Unwatch(null, null),
         "aced00057372001c616b6b612e64697370617463682e7379736d73672e556e776174636800000000" +
           "000000010200024c0007776174636865657400154c616b6b612f6163746f722f4163746f72526566" +
           "3b4c00077761746368657271007e000178707070")
     }
     "be preserved for the NoMessage SystemMessage" in {
-      verify(NoMessage,
+      verify(
+        NoMessage,
         "aced00057372001f616b6b612e64697370617463682e7379736d73672e4e6f4d6573736167652400" +
           "000000000000010200007870")
     }
     "be preserved for the Failed SystemMessage" in {
       // Using null as the cause to avoid a large serialized message and JDK differences
-      verify(Failed(null, cause = null, uid = 0),
+      verify(
+        Failed(null, cause = null, uid = 0),
         "aced00057372001b616b6b612e64697370617463682e7379736d73672e4661696c65640000000000" +
           "0000010200034900037569644c000563617573657400154c6a6176612f6c616e672f5468726f7761" +
           "626c653b4c00056368696c647400154c616b6b612f6163746f722f4163746f725265663b78700000" +

--- a/akka-actor-tests/src/test/scala/akka/testkit/CallingThreadDispatcherModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/testkit/CallingThreadDispatcherModelSpec.scala
@@ -28,7 +28,7 @@ object CallingThreadDispatcherModelSpec {
   }
 
   class CallingThreadDispatcherInterceptorConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-    extends MessageDispatcherConfigurator(config, prerequisites) {
+      extends MessageDispatcherConfigurator(config, prerequisites) {
 
     private val instance: MessageDispatcher =
       new CallingThreadDispatcher(this) with MessageDispatcherInterceptor {

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -121,7 +121,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
     val (bsAIt, bsBIt) = (a.iterator, b.iterator)
     val (vecAIt, vecBIt) = (Vector(a: _*).iterator.buffered, Vector(b: _*).iterator.buffered)
     (body(bsAIt, bsBIt) == body(vecAIt, vecBIt)) &&
-      (!strict || (bsAIt.toSeq -> bsBIt.toSeq) == (vecAIt.toSeq -> vecBIt.toSeq))
+      (!strict || (bsAIt.toSeq → bsBIt.toSeq) == (vecAIt.toSeq → vecBIt.toSeq))
   }
 
   def likeVecBld(body: Builder[Byte, _] ⇒ Unit): Boolean = {

--- a/akka-actor-tests/src/test/scala/akka/util/PrettyDurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/PrettyDurationSpec.scala
@@ -15,16 +15,16 @@ class PrettyDurationSpec extends FlatSpec with Matchers {
   import scala.concurrent.duration._
 
   val cases: Seq[(Duration, String)] =
-    9.nanos -> "9.000 ns" ::
-      95.nanos -> "95.00 ns" ::
-      999.nanos -> "999.0 ns" ::
-      1000.nanos -> "1.000 μs" ::
-      9500.nanos -> "9.500 μs" ::
-      9500.micros -> "9.500 ms" ::
-      9500.millis -> "9.500 s" ::
-      95.seconds -> "1.583 min" ::
-      95.minutes -> "1.583 h" ::
-      95.hours -> "3.958 d" ::
+    9.nanos → "9.000 ns" ::
+      95.nanos → "95.00 ns" ::
+      999.nanos → "999.0 ns" ::
+      1000.nanos → "1.000 μs" ::
+      9500.nanos → "9.500 μs" ::
+      9500.micros → "9.500 ms" ::
+      9500.millis → "9.500 s" ::
+      95.seconds → "1.583 min" ::
+      95.minutes → "1.583 h" ::
+      95.hours → "3.958 d" ::
       Nil
 
   cases foreach {

--- a/akka-actor/src/main/scala/akka/actor/AbstractFSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractFSM.scala
@@ -66,9 +66,10 @@ abstract class AbstractFSM[S, D] extends FSM[S, D] {
    * @param stateTimeout default state timeout for this state
    * @param stateFunctionBuilder partial function builder describing response to input
    */
-  final def when(stateName: S,
-                 stateTimeout: FiniteDuration,
-                 stateFunctionBuilder: FSMStateFunctionBuilder[S, D]): Unit =
+  final def when(
+    stateName: S,
+    stateTimeout: FiniteDuration,
+    stateFunctionBuilder: FSMStateFunctionBuilder[S, D]): Unit =
     when(stateName, stateTimeout)(stateFunctionBuilder.build())
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -97,7 +97,7 @@ final case class ActorIdentity(correlationId: Any, ref: Option[ActorRef]) {
 final case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
   @BeanProperty val existenceConfirmed: Boolean,
   @BeanProperty val addressTerminated: Boolean)
-  extends AutoReceivedMessage with PossiblyHarmful with DeadLetterSuppression
+    extends AutoReceivedMessage with PossiblyHarmful with DeadLetterSuppression
 
 /**
  * INTERNAL API
@@ -164,7 +164,7 @@ final case class InvalidActorNameException(message: String) extends AkkaExceptio
  */
 @SerialVersionUID(1L)
 class ActorInitializationException protected (actor: ActorRef, message: String, cause: Throwable)
-  extends AkkaException(ActorInitializationException.enrichedMessage(actor, message), cause) {
+    extends AkkaException(ActorInitializationException.enrichedMessage(actor, message), cause) {
   def getActor: ActorRef = actor
 }
 object ActorInitializationException {
@@ -189,7 +189,8 @@ object ActorInitializationException {
  */
 @SerialVersionUID(1L)
 final case class PreRestartException private[akka] (actor: ActorRef, cause: Throwable, originalCause: Throwable, messageOption: Option[Any])
-  extends ActorInitializationException(actor,
+  extends ActorInitializationException(
+    actor,
     "exception in preRestart(" +
       (if (originalCause == null) "null" else originalCause.getClass) + ", " +
       (messageOption match { case Some(m: AnyRef) ⇒ m.getClass; case _ ⇒ "None" }) +
@@ -205,7 +206,8 @@ final case class PreRestartException private[akka] (actor: ActorRef, cause: Thro
  */
 @SerialVersionUID(1L)
 final case class PostRestartException private[akka] (actor: ActorRef, cause: Throwable, originalCause: Throwable)
-  extends ActorInitializationException(actor,
+  extends ActorInitializationException(
+    actor,
     "exception post restart (" + (if (originalCause == null) "null" else originalCause.getClass) + ")", cause)
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -377,12 +377,12 @@ private[akka] class ActorCell(
   final val props: Props, // Must be final so that it can be properly cleared in clearActorCellFields
   val dispatcher: MessageDispatcher,
   val parent: InternalActorRef)
-  extends UntypedActorContext with AbstractActorContext with Cell
-  with dungeon.ReceiveTimeout
-  with dungeon.Children
-  with dungeon.Dispatch
-  with dungeon.DeathWatch
-  with dungeon.FaultHandling {
+    extends UntypedActorContext with AbstractActorContext with Cell
+    with dungeon.ReceiveTimeout
+    with dungeon.Children
+    with dungeon.Dispatch
+    with dungeon.DeathWatch
+    with dungeon.FaultHandling {
 
   import ActorCell._
 
@@ -598,7 +598,8 @@ private[akka] class ActorCell(
       case NonFatal(e) ⇒
         clearOutActorIfNonNull()
         e match {
-          case i: InstantiationException ⇒ throw ActorInitializationException(self,
+          case i: InstantiationException ⇒ throw ActorInitializationException(
+            self,
             """exception during creation, this problem is likely to occur because the class of the Actor you tried to create is either,
                a non-static inner class (in which case make it a static inner class or use Props(new ...) or Props( new Creator ... )
                or is missing an appropriate, reachable no-args constructor.

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -254,7 +254,8 @@ sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
  */
 @SerialVersionUID(1L)
 final case class RootActorPath(address: Address, name: String = "/") extends ActorPath {
-  require(name.length == 1 || name.indexOf('/', 1) == -1,
+  require(
+    name.length == 1 || name.indexOf('/', 1) == -1,
     "/ may only exist at the beginning of the root actors name, " +
       "it is a path separator and is not legal in ActorPath names: [%s]" format name)
   require(name.indexOf('#') == -1, "# is a fragment separator and is not legal in ActorPath names: [%s]" format name)

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -308,7 +308,7 @@ private[akka] class LocalActorRef private[akka] (
   _mailboxType: MailboxType,
   _supervisor: InternalActorRef,
   override val path: ActorPath)
-  extends ActorRefWithCell with LocalRef {
+    extends ActorRefWithCell with LocalRef {
 
   /*
    * Safe publication of this class’s fields is guaranteed by mailbox.setActor()
@@ -518,9 +518,10 @@ private[akka] object DeadLetterActorRef {
  *
  * INTERNAL API
  */
-private[akka] class EmptyLocalActorRef(override val provider: ActorRefProvider,
-                                       override val path: ActorPath,
-                                       val eventStream: EventStream) extends MinimalActorRef {
+private[akka] class EmptyLocalActorRef(
+  override val provider: ActorRefProvider,
+    override val path: ActorPath,
+    val eventStream: EventStream) extends MinimalActorRef {
 
   @deprecated("Use context.watch(actor) and receive Terminated(actor)", "2.2")
   override private[akka] def isTerminated = true
@@ -570,9 +571,10 @@ private[akka] class EmptyLocalActorRef(override val provider: ActorRefProvider,
  *
  * INTERNAL API
  */
-private[akka] class DeadLetterActorRef(_provider: ActorRefProvider,
-                                       _path: ActorPath,
-                                       _eventStream: EventStream) extends EmptyLocalActorRef(_provider, _path, _eventStream) {
+private[akka] class DeadLetterActorRef(
+  _provider: ActorRefProvider,
+    _path: ActorPath,
+    _eventStream: EventStream) extends EmptyLocalActorRef(_provider, _path, _eventStream) {
 
   override def !(message: Any)(implicit sender: ActorRef = this): Unit = message match {
     case null                ⇒ throw new InvalidMessageException("Message is null")
@@ -601,10 +603,10 @@ private[akka] class DeadLetterActorRef(_provider: ActorRefProvider,
  * INTERNAL API
  */
 private[akka] class VirtualPathContainer(
-  override val provider: ActorRefProvider,
-  override val path: ActorPath,
-  override val getParent: InternalActorRef,
-  val log: LoggingAdapter) extends MinimalActorRef {
+    override val provider: ActorRefProvider,
+    override val path: ActorPath,
+    override val getParent: InternalActorRef,
+    val log: LoggingAdapter) extends MinimalActorRef {
 
   private val children = new ConcurrentHashMap[String, InternalActorRef]
 
@@ -705,10 +707,11 @@ private[akka] class VirtualPathContainer(
  * When using the watch() feature you must ensure that upon reception of the
  * Terminated message the watched actorRef is unwatch()ed.
  */
-private[akka] final class FunctionRef(override val path: ActorPath,
-                                      override val provider: ActorRefProvider,
-                                      val eventStream: EventStream,
-                                      f: (ActorRef, Any) ⇒ Unit) extends MinimalActorRef {
+private[akka] final class FunctionRef(
+  override val path: ActorPath,
+    override val provider: ActorRefProvider,
+    val eventStream: EventStream,
+    f: (ActorRef, Any) ⇒ Unit) extends MinimalActorRef {
 
   override def !(message: Any)(implicit sender: ActorRef = Actor.noSender): Unit = {
     f(sender, message)

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -407,7 +407,7 @@ private[akka] object LocalActorRefProvider {
    * Root and user guardian
    */
   private class Guardian(override val supervisorStrategy: SupervisorStrategy) extends Actor
-    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+      with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
     def receive = {
       case Terminated(_)    ⇒ context.stop(self)
@@ -422,7 +422,7 @@ private[akka] object LocalActorRefProvider {
    * System guardian
    */
   private class SystemGuardian(override val supervisorStrategy: SupervisorStrategy, val guardian: ActorRef)
-    extends Actor with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+      extends Actor with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
     import SystemGuardian._
 
     var terminationHooks = Set.empty[ActorRef]
@@ -481,14 +481,16 @@ private[akka] class LocalActorRefProvider private[akka] (
   val dynamicAccess: DynamicAccess,
   override val deployer: Deployer,
   _deadLetters: Option[ActorPath ⇒ InternalActorRef])
-  extends ActorRefProvider {
+    extends ActorRefProvider {
 
   // this is the constructor needed for reflectively instantiating the provider
-  def this(_systemName: String,
-           settings: ActorSystem.Settings,
-           eventStream: EventStream,
-           dynamicAccess: DynamicAccess) =
-    this(_systemName,
+  def this(
+    _systemName: String,
+    settings: ActorSystem.Settings,
+    eventStream: EventStream,
+    dynamicAccess: DynamicAccess) =
+    this(
+      _systemName,
       settings,
       eventStream,
       dynamicAccess,
@@ -729,7 +731,7 @@ private[akka] class LocalActorRefProvider private[akka] (
     }
 
   def actorOf(system: ActorSystemImpl, props: Props, supervisor: InternalActorRef, path: ActorPath,
-              systemService: Boolean, deploy: Option[Deploy], lookupDeploy: Boolean, async: Boolean): InternalActorRef = {
+    systemService: Boolean, deploy: Option[Deploy], lookupDeploy: Boolean, async: Boolean): InternalActorRef = {
     props.deploy.routerConfig match {
       case NoRouter ⇒
         if (settings.DebugRouterMisconfiguration) {
@@ -776,7 +778,8 @@ private[akka] class LocalActorRefProvider private[akka] (
         if (!system.dispatchers.hasDispatcher(r.routerDispatcher))
           throw new ConfigurationException(s"Dispatcher [${p.dispatcher}] not configured for router of $path")
 
-        val routerProps = Props(p.deploy.copy(dispatcher = p.routerConfig.routerDispatcher),
+        val routerProps = Props(
+          p.deploy.copy(dispatcher = p.routerConfig.routerDispatcher),
           classOf[RoutedActorCell.RouterActorCreator], Vector(p.routerConfig))
         val routeeProps = p.withRouter(NoRouter)
 

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -218,7 +218,8 @@ object ActorSelection {
                   if (matchingChildren.isEmpty && !sel.wildcardFanOut)
                     emptyRef.tell(sel, sender)
                   else {
-                    val m = sel.copy(elements = iter.toVector,
+                    val m = sel.copy(
+                      elements = iter.toVector,
                       wildcardFanOut = sel.wildcardFanOut || matchingChildren.size > 1)
                     matchingChildren.foreach(c ⇒ deliverSelection(c.asInstanceOf[InternalActorRef], sender, m))
                   }
@@ -256,7 +257,7 @@ private[akka] final case class ActorSelectionMessage(
   msg: Any,
   elements: immutable.Iterable[SelectionPathElement],
   wildcardFanOut: Boolean)
-  extends AutoReceivedMessage with PossiblyHarmful {
+    extends AutoReceivedMessage with PossiblyHarmful {
 
   def identifyRequest: Option[Identify] = msg match {
     case x: Identify ⇒ Some(x)

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -523,11 +523,11 @@ abstract class ExtendedActorSystem extends ActorSystem {
 }
 
 private[akka] class ActorSystemImpl(
-  val name: String,
-  applicationConfig: Config,
-  classLoader: ClassLoader,
-  defaultExecutionContext: Option[ExecutionContext],
-  val guardianProps: Option[Props]) extends ExtendedActorSystem {
+    val name: String,
+    applicationConfig: Config,
+    classLoader: ClassLoader,
+    defaultExecutionContext: Option[ExecutionContext],
+    val guardianProps: Option[Props]) extends ExtendedActorSystem {
 
   if (!name.matches("""^[a-zA-Z0-9][a-zA-Z0-9-_]*$"""))
     throw new IllegalArgumentException(
@@ -611,7 +611,7 @@ private[akka] class ActorSystemImpl(
   eventStream.startStdoutLogger(settings)
 
   val logFilter: LoggingFilter = {
-    val arguments = Vector(classOf[Settings] -> settings, classOf[EventStream] -> eventStream)
+    val arguments = Vector(classOf[Settings] → settings, classOf[EventStream] → eventStream)
     dynamicAccess.createInstanceFor[LoggingFilter](LoggingFilter, arguments).get
   }
 
@@ -621,10 +621,10 @@ private[akka] class ActorSystemImpl(
 
   val provider: ActorRefProvider = try {
     val arguments = Vector(
-      classOf[String] -> name,
-      classOf[Settings] -> settings,
-      classOf[EventStream] -> eventStream,
-      classOf[DynamicAccess] -> dynamicAccess)
+      classOf[String] → name,
+      classOf[Settings] → settings,
+      classOf[EventStream] → eventStream,
+      classOf[DynamicAccess] → dynamicAccess)
 
     dynamicAccess.createInstanceFor[ActorRefProvider](ProviderClass, arguments).get
   } catch {
@@ -716,9 +716,9 @@ private[akka] class ActorSystemImpl(
    */
   protected def createScheduler(): Scheduler =
     dynamicAccess.createInstanceFor[Scheduler](settings.SchedulerClass, immutable.Seq(
-      classOf[Config] -> settings.config,
-      classOf[LoggingAdapter] -> log,
-      classOf[ThreadFactory] -> threadFactory.withName(threadFactory.name + "-scheduler"))).get
+      classOf[Config] → settings.config,
+      classOf[LoggingAdapter] → log,
+      classOf[ThreadFactory] → threadFactory.withName(threadFactory.name + "-scheduler"))).get
   //#create-scheduler
 
   /*

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -35,12 +35,12 @@ object Deploy {
  */
 @SerialVersionUID(2L)
 final case class Deploy(
-  path: String = "",
-  config: Config = ConfigFactory.empty,
-  routerConfig: RouterConfig = NoRouter,
-  scope: Scope = NoScopeGiven,
-  dispatcher: String = Deploy.NoDispatcherGiven,
-  mailbox: String = Deploy.NoMailboxGiven) {
+    path: String = "",
+    config: Config = ConfigFactory.empty,
+    routerConfig: RouterConfig = NoRouter,
+    scope: Scope = NoScopeGiven,
+    dispatcher: String = Deploy.NoDispatcherGiven,
+    mailbox: String = Deploy.NoMailboxGiven) {
 
   /**
    * Java API to create a Deploy with the given RouterConfig
@@ -137,7 +137,7 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
   protected val default = config.getConfig("default")
   val routerTypeMapping: Map[String, String] =
     settings.config.getConfig("akka.actor.router.type-mapping").root.unwrapped.asScala.collect {
-      case (key, value: String) ⇒ (key -> value)
+      case (key, value: String) ⇒ (key → value)
     }.toMap
 
   config.root.asScala flatMap {
@@ -198,8 +198,8 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
             s"[${args(0)._1.getName}] and optional [${args(1)._1.getName}] parameter", cause)
 
       // first try with Config param, and then with Config and DynamicAccess parameters
-      val args1 = List(classOf[Config] -> deployment2)
-      val args2 = List(classOf[Config] -> deployment2, classOf[DynamicAccess] -> dynamicAccess)
+      val args1 = List(classOf[Config] → deployment2)
+      val args2 = List(classOf[Config] → deployment2, classOf[DynamicAccess] → dynamicAccess)
       dynamicAccess.createInstanceFor[RouterConfig](fqn, args1).recover({
         case e @ (_: IllegalArgumentException | _: ConfigException) ⇒ throw e
         case e: NoSuchMethodException ⇒

--- a/akka-actor/src/main/scala/akka/actor/Extension.scala
+++ b/akka-actor/src/main/scala/akka/actor/Extension.scala
@@ -150,5 +150,5 @@ abstract class ExtensionKey[T <: Extension](implicit m: ClassTag[T]) extends Ext
   def this(clazz: Class[T]) = this()(ClassTag(clazz))
 
   override def lookup(): ExtensionId[T] = this
-  def createExtension(system: ExtendedActorSystem): T = system.dynamicAccess.createInstanceFor[T](m.runtimeClass, List(classOf[ExtendedActorSystem] -> system)).get
+  def createExtension(system: ExtendedActorSystem): T = system.dynamicAccess.createInstanceFor[T](m.runtimeClass, List(classOf[ExtendedActorSystem] → system)).get
 }

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -315,6 +315,10 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
   val Event: FSM.Event.type = FSM.Event
   val StopEvent: FSM.StopEvent.type = FSM.StopEvent
 
+  object → {
+    def unapply[Z](in: (Z, Z)) = Some(in)
+  }
+
   /**
    * This extractor is just convenience for matching a (S, S) pair, including a
    * reminder what the new state is.

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -30,7 +30,7 @@ private[akka] case object ChildNameReserved extends ChildStats
  * and is used for SupervisorStrategies to know how to deal with problems that occur for the children.
  */
 final case class ChildRestartStats(child: ActorRef, var maxNrOfRetriesCount: Int = 0, var restartTimeWindowStartNanos: Long = 0L)
-  extends ChildStats {
+    extends ChildStats {
 
   def uid: Int = child.path.uid
 
@@ -383,7 +383,7 @@ case class AllForOneStrategy(
   maxNrOfRetries: Int = -1,
   withinTimeRange: Duration = Duration.Inf,
   override val loggingEnabled: Boolean = true)(val decider: SupervisorStrategy.Decider)
-  extends SupervisorStrategy {
+    extends SupervisorStrategy {
 
   import SupervisorStrategy._
 
@@ -461,7 +461,7 @@ case class OneForOneStrategy(
   maxNrOfRetries: Int = -1,
   withinTimeRange: Duration = Duration.Inf,
   override val loggingEnabled: Boolean = true)(val decider: SupervisorStrategy.Decider)
-  extends SupervisorStrategy {
+    extends SupervisorStrategy {
 
   /**
    * Java API

--- a/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
@@ -34,10 +34,11 @@ import akka.dispatch.AbstractNodeQueue
  * scheduled possibly one tick later than they could be (if checking that
  * “now() + delay &lt;= nextTick” were done).
  */
-class LightArrayRevolverScheduler(config: Config,
-                                  log: LoggingAdapter,
-                                  threadFactory: ThreadFactory)
-  extends Scheduler with Closeable {
+class LightArrayRevolverScheduler(
+  config: Config,
+  log: LoggingAdapter,
+  threadFactory: ThreadFactory)
+    extends Scheduler with Closeable {
 
   import Helpers.Requiring
   import Helpers.ConfigOps
@@ -83,9 +84,10 @@ class LightArrayRevolverScheduler(config: Config,
     }
   }
 
-  override def schedule(initialDelay: FiniteDuration,
-                        delay: FiniteDuration,
-                        runnable: Runnable)(implicit executor: ExecutionContext): Cancellable = {
+  override def schedule(
+    initialDelay: FiniteDuration,
+    delay: FiniteDuration,
+    runnable: Runnable)(implicit executor: ExecutionContext): Cancellable = {
     checkMaxDelay(roundUp(delay).toNanos)
     val preparedEC = executor.prepare()
     try new AtomicReference[Cancellable](InitialRepeatMarker) with Cancellable { self ⇒
@@ -215,7 +217,7 @@ class LightArrayRevolverScheduler(config: Config,
               time - start + // calculate the nanos since timer start
               (ticks * tickNanos) + // adding the desired delay
               tickNanos - 1 // rounding up
-              ) / tickNanos).toInt // and converting to slot number
+            ) / tickNanos).toInt // and converting to slot number
             // tick is an Int that will wrap around, but toInt of futureTick gives us modulo operations
             // and the difference (offset) will be correct in any case
             val offset = futureTick - tick
@@ -306,7 +308,7 @@ object LightArrayRevolverScheduler {
    * INTERNAL API
    */
   protected[actor] class TaskHolder(@volatile var task: Runnable, var ticks: Int, executionContext: ExecutionContext)
-    extends TimerTask {
+      extends TimerTask {
 
     @tailrec
     private final def extractTask(replaceWith: Runnable): Runnable =

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -30,7 +30,7 @@ private[akka] class RepointableActorRef(
   val mailboxType: MailboxType,
   val supervisor: InternalActorRef,
   val path: ActorPath)
-  extends ActorRefWithCell with RepointableRef {
+    extends ActorRefWithCell with RepointableRef {
 
   import AbstractActorRef.{ cellOffset, lookupOffset }
 
@@ -176,10 +176,11 @@ private[akka] class RepointableActorRef(
   protected def writeReplace(): AnyRef = SerializedActorRef(this)
 }
 
-private[akka] class UnstartedCell(val systemImpl: ActorSystemImpl,
-                                  val self: RepointableActorRef,
-                                  val props: Props,
-                                  val supervisor: InternalActorRef) extends Cell {
+private[akka] class UnstartedCell(
+  val systemImpl: ActorSystemImpl,
+    val self: RepointableActorRef,
+    val props: Props,
+    val supervisor: InternalActorRef) extends Cell {
 
   /*
    * This lock protects all accesses to this cell’s queues. It also ensures

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -44,8 +44,9 @@ trait Scheduler {
     initialDelay: FiniteDuration,
     interval: FiniteDuration,
     receiver: ActorRef,
-    message: Any)(implicit executor: ExecutionContext,
-                  sender: ActorRef = Actor.noSender): Cancellable =
+    message: Any)(implicit
+    executor: ExecutionContext,
+    sender: ActorRef = Actor.noSender): Cancellable =
     schedule(initialDelay, interval, new Runnable {
       def run = {
         receiver ! message
@@ -72,7 +73,8 @@ trait Scheduler {
   final def schedule(
     initialDelay: FiniteDuration,
     interval: FiniteDuration)(f: ⇒ Unit)(
-      implicit executor: ExecutionContext): Cancellable =
+    implicit
+    executor: ExecutionContext): Cancellable =
     schedule(initialDelay, interval, new Runnable { override def run = f })
 
   /**
@@ -105,8 +107,9 @@ trait Scheduler {
   final def scheduleOnce(
     delay: FiniteDuration,
     receiver: ActorRef,
-    message: Any)(implicit executor: ExecutionContext,
-                  sender: ActorRef = Actor.noSender): Cancellable =
+    message: Any)(implicit
+    executor: ExecutionContext,
+    sender: ActorRef = Actor.noSender): Cancellable =
     scheduleOnce(delay, new Runnable {
       override def run = receiver ! message
     })
@@ -118,7 +121,8 @@ trait Scheduler {
    * Scala API
    */
   final def scheduleOnce(delay: FiniteDuration)(f: ⇒ Unit)(
-    implicit executor: ExecutionContext): Cancellable =
+    implicit
+    executor: ExecutionContext): Cancellable =
     scheduleOnce(delay, new Runnable { override def run = f })
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -522,12 +522,12 @@ object TypedProps {
  */
 @SerialVersionUID(1L)
 final case class TypedProps[T <: AnyRef] protected[TypedProps] (
-  interfaces: immutable.Seq[Class[_]],
-  creator: () ⇒ T,
-  dispatcher: String = TypedProps.defaultDispatcherId,
-  deploy: Deploy = Props.defaultDeploy,
-  timeout: Option[Timeout] = TypedProps.defaultTimeout,
-  loader: Option[ClassLoader] = TypedProps.defaultLoader) {
+    interfaces: immutable.Seq[Class[_]],
+    creator: () ⇒ T,
+    dispatcher: String = TypedProps.defaultDispatcherId,
+    deploy: Deploy = Props.defaultDeploy,
+    timeout: Option[Timeout] = TypedProps.defaultTimeout,
+    loader: Option[ClassLoader] = TypedProps.defaultLoader) {
 
   /**
    * Uses the supplied class as the factory for the TypedActor implementation,
@@ -536,7 +536,8 @@ final case class TypedProps[T <: AnyRef] protected[TypedProps] (
    * appended in the sequence of interfaces.
    */
   def this(implementation: Class[T]) =
-    this(interfaces = TypedProps.extractInterfaces(implementation),
+    this(
+      interfaces = TypedProps.extractInterfaces(implementation),
       creator = instantiator(implementation))
 
   /**
@@ -546,7 +547,8 @@ final case class TypedProps[T <: AnyRef] protected[TypedProps] (
    * appended in the sequence of interfaces.
    */
   def this(interface: Class[_ >: T], implementation: Creator[T]) =
-    this(interfaces = TypedProps.extractInterfaces(interface),
+    this(
+      interfaces = TypedProps.extractInterfaces(interface),
       creator = implementation.create _)
 
   /**
@@ -556,7 +558,8 @@ final case class TypedProps[T <: AnyRef] protected[TypedProps] (
    * appended in the sequence of interfaces.
    */
   def this(interface: Class[_ >: T], implementation: Class[T]) =
-    this(interfaces = TypedProps.extractInterfaces(interface),
+    this(
+      interfaces = TypedProps.extractInterfaces(interface),
       creator = instantiator(implementation))
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
@@ -156,7 +156,7 @@ private[akka] object ChildrenContainer {
    * the reason was “Terminating”.
    */
   final case class TerminatingChildrenContainer(c: immutable.TreeMap[String, ChildStats], toDie: Set[ActorRef], reason: SuspendReason)
-    extends ChildrenContainer {
+      extends ChildrenContainer {
 
     override def add(name: String, stats: ChildRestartStats): ChildrenContainer = copy(c.updated(name, stats))
 

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
@@ -62,7 +62,8 @@ private[akka] trait Dispatch { this: ActorCell ⇒
         if (req isInstance mbox.messageQueue) Create(None)
         else {
           val gotType = if (mbox.messageQueue == null) "null" else mbox.messageQueue.getClass.getName
-          Create(Some(ActorInitializationException(self,
+          Create(Some(ActorInitializationException(
+            self,
             s"Actor [$self] requires mailbox type [$req] got [$gotType]")))
         }
       case _ ⇒ Create(None)

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -322,8 +322,8 @@ abstract class MessageDispatcherConfigurator(_config: Config, val prerequisites:
       case "thread-pool-executor"           ⇒ new ThreadPoolExecutorConfigurator(config.getConfig("thread-pool-executor"), prerequisites)
       case fqcn ⇒
         val args = List(
-          classOf[Config] -> config,
-          classOf[DispatcherPrerequisites] -> prerequisites)
+          classOf[Config] → config,
+          classOf[DispatcherPrerequisites] → prerequisites)
         prerequisites.dynamicAccess.createInstanceFor[ExecutorServiceConfigurator](fqcn, args).recover({
           case exception ⇒ throw new IllegalArgumentException(
             ("""Cannot instantiate ExecutorServiceConfigurator ("executor = [%s]"), defined in [%s],
@@ -377,14 +377,16 @@ object ForkJoinExecutorConfigurator {
   /**
    * INTERNAL AKKA USAGE ONLY
    */
-  final class AkkaForkJoinPool(parallelism: Int,
-                               threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
-                               unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
-                               asyncMode: Boolean)
-    extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode) with LoadMetrics {
-    def this(parallelism: Int,
-             threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
-             unhandledExceptionHandler: Thread.UncaughtExceptionHandler) = this(parallelism, threadFactory, unhandledExceptionHandler, asyncMode = true)
+  final class AkkaForkJoinPool(
+    parallelism: Int,
+    threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+    unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
+    asyncMode: Boolean)
+      extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode) with LoadMetrics {
+    def this(
+      parallelism: Int,
+      threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+      unhandledExceptionHandler: Thread.UncaughtExceptionHandler) = this(parallelism, threadFactory, unhandledExceptionHandler, asyncMode = true)
 
     override def execute(r: Runnable): Unit =
       if (r ne null)
@@ -425,9 +427,10 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
     case x ⇒ throw new IllegalStateException("The prerequisites for the ForkJoinExecutorConfigurator is a ForkJoinPool.ForkJoinWorkerThreadFactory!")
   }
 
-  class ForkJoinExecutorServiceFactory(val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
-                                       val parallelism: Int,
-                                       val asyncMode: Boolean) extends ExecutorServiceFactory {
+  class ForkJoinExecutorServiceFactory(
+    val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+      val parallelism: Int,
+      val asyncMode: Boolean) extends ExecutorServiceFactory {
     def this(threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory, parallelism: Int) = this(threadFactory, parallelism, asyncMode = true)
     def createExecutorService: ExecutorService = new AkkaForkJoinPool(parallelism, threadFactory, MonitorableThreadFactory.doNothing, asyncMode)
   }

--- a/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
@@ -38,7 +38,7 @@ class BalancingDispatcher(
   _executorServiceFactoryProvider: ExecutorServiceFactoryProvider,
   _shutdownTimeout: FiniteDuration,
   attemptTeamWork: Boolean)
-  extends Dispatcher(_configurator, _id, throughput, throughputDeadlineTime, _executorServiceFactoryProvider, _shutdownTimeout) {
+    extends Dispatcher(_configurator, _id, throughput, throughputDeadlineTime, _executorServiceFactoryProvider, _shutdownTimeout) {
 
   /**
    * INTERNAL API
@@ -54,7 +54,7 @@ class BalancingDispatcher(
   private[akka] val messageQueue: MessageQueue = _mailboxType.create(None, None)
 
   private class SharingMailbox(val system: ActorSystemImpl, _messageQueue: MessageQueue)
-    extends Mailbox(_messageQueue) with DefaultSystemMessageQueue {
+      extends Mailbox(_messageQueue) with DefaultSystemMessageQueue {
     override def cleanUp(): Unit = {
       val dlq = mailboxes.deadLetterMailbox
       //Don't call the original implementation of this since it scraps all messages, and we don't want to do that

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -32,7 +32,7 @@ class Dispatcher(
   val throughputDeadlineTime: Duration,
   executorServiceFactoryProvider: ExecutorServiceFactoryProvider,
   val shutdownTimeout: FiniteDuration)
-  extends MessageDispatcher(_configurator) {
+    extends MessageDispatcher(_configurator) {
 
   import configurator.prerequisites._
 

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -135,13 +135,13 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
     def simpleName = id.substring(id.lastIndexOf('.') + 1)
     idConfig(id)
       .withFallback(appConfig)
-      .withFallback(ConfigFactory.parseMap(Map("name" -> simpleName).asJava))
+      .withFallback(ConfigFactory.parseMap(Map("name" → simpleName).asJava))
       .withFallback(defaultDispatcherConfig)
   }
 
   private def idConfig(id: String): Config = {
     import scala.collection.JavaConverters._
-    ConfigFactory.parseMap(Map("id" -> id).asJava)
+    ConfigFactory.parseMap(Map("id" → id).asJava)
   }
 
   /**
@@ -180,7 +180,7 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
           classOf[BalancingDispatcherConfigurator].getName)
       case "PinnedDispatcher" ⇒ new PinnedDispatcherConfigurator(cfg, prerequisites)
       case fqn ⇒
-        val args = List(classOf[Config] -> cfg, classOf[DispatcherPrerequisites] -> prerequisites)
+        val args = List(classOf[Config] → cfg, classOf[DispatcherPrerequisites] → prerequisites)
         prerequisites.dynamicAccess.createInstanceFor[MessageDispatcherConfigurator](fqn, args).recover({
           case exception ⇒
             throw new ConfigurationException(
@@ -199,7 +199,7 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
  * of the `dispatcher()` method.
  */
 class DispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-  extends MessageDispatcherConfigurator(config, prerequisites) {
+    extends MessageDispatcherConfigurator(config, prerequisites) {
 
   private val instance = new Dispatcher(
     this,
@@ -232,7 +232,7 @@ private[akka] object BalancingDispatcherConfigurator {
  * of the `dispatcher()` method.
  */
 class BalancingDispatcherConfigurator(_config: Config, _prerequisites: DispatcherPrerequisites)
-  extends MessageDispatcherConfigurator(BalancingDispatcherConfigurator.amendConfig(_config), _prerequisites) {
+    extends MessageDispatcherConfigurator(BalancingDispatcherConfigurator.amendConfig(_config), _prerequisites) {
 
   private val instance = {
     val mailboxes = prerequisites.mailboxes
@@ -282,13 +282,14 @@ class BalancingDispatcherConfigurator(_config: Config, _prerequisites: Dispatche
  * of the `dispatcher()` method.
  */
 class PinnedDispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-  extends MessageDispatcherConfigurator(config, prerequisites) {
+    extends MessageDispatcherConfigurator(config, prerequisites) {
 
   private val threadPoolConfig: ThreadPoolConfig = configureExecutor() match {
     case e: ThreadPoolExecutorConfigurator ⇒ e.threadPoolConfig
     case other ⇒
       prerequisites.eventStream.publish(
-        Warning("PinnedDispatcherConfigurator",
+        Warning(
+          "PinnedDispatcherConfigurator",
           this.getClass,
           "PinnedDispatcher [%s] not configured to use ThreadPoolExecutor, falling back to default config.".format(
             config.getString("id"))))

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -9,7 +9,7 @@ import akka.japi.{ Function ⇒ JFunc, Option ⇒ JOption, Procedure }
 import scala.concurrent.{ Future, Promise, ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService }
 import java.lang.{ Iterable ⇒ JIterable }
 import java.util.{ LinkedList ⇒ JLinkedList }
-import java.util.concurrent.{ Executor, ExecutorService, Callable}
+import java.util.concurrent.{ Executor, ExecutorService, Callable }
 import scala.util.{ Try, Success, Failure }
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -657,7 +657,8 @@ final case class BoundedMailbox(val capacity: Int, override val pushTimeOut: Fin
     extends MailboxType with ProducesMessageQueue[BoundedMailbox.MessageQueue]
     with ProducesPushTimeoutSemanticsMailbox {
 
-  def this(settings: ActorSystem.Settings, config: Config) = this(config.getInt("mailbox-capacity"),
+  def this(settings: ActorSystem.Settings, config: Config) = this(
+    config.getInt("mailbox-capacity"),
     config.getNanosDuration("mailbox-push-timeout-time"))
 
   if (capacity < 0) throw new IllegalArgumentException("The capacity for BoundedMailbox can not be negative")
@@ -782,7 +783,8 @@ case class BoundedDequeBasedMailbox( final val capacity: Int, override final val
     extends MailboxType with ProducesMessageQueue[BoundedDequeBasedMailbox.MessageQueue]
     with ProducesPushTimeoutSemanticsMailbox {
 
-  def this(settings: ActorSystem.Settings, config: Config) = this(config.getInt("mailbox-capacity"),
+  def this(settings: ActorSystem.Settings, config: Config) = this(
+    config.getInt("mailbox-capacity"),
     config.getNanosDuration("mailbox-push-timeout-time"))
 
   if (capacity < 0) throw new IllegalArgumentException("The capacity for BoundedDequeBasedMailbox can not be negative")
@@ -858,7 +860,8 @@ object UnboundedControlAwareMailbox {
 final case class BoundedControlAwareMailbox(capacity: Int, override final val pushTimeOut: FiniteDuration) extends MailboxType
     with ProducesMessageQueue[BoundedControlAwareMailbox.MessageQueue]
     with ProducesPushTimeoutSemanticsMailbox {
-  def this(settings: ActorSystem.Settings, config: Config) = this(config.getInt("mailbox-capacity"),
+  def this(settings: ActorSystem.Settings, config: Config) = this(
+    config.getInt("mailbox-capacity"),
     config.getNanosDuration("mailbox-push-timeout-time"))
 
   def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue = new BoundedControlAwareMailbox.MessageQueue(capacity, pushTimeOut)

--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -23,10 +23,10 @@ object Mailboxes {
 }
 
 private[akka] class Mailboxes(
-  val settings: ActorSystem.Settings,
-  val eventStream: EventStream,
-  dynamicAccess: DynamicAccess,
-  deadLetters: ActorRef) {
+    val settings: ActorSystem.Settings,
+    val eventStream: EventStream,
+    dynamicAccess: DynamicAccess,
+    deadLetters: ActorRef) {
 
   import Mailboxes._
 
@@ -187,7 +187,7 @@ private[akka] class Mailboxes(
             val mailboxType = conf.getString("mailbox-type") match {
               case "" ⇒ throw new ConfigurationException(s"The setting mailbox-type, defined in [$id] is empty")
               case fqcn ⇒
-                val args = List(classOf[ActorSystem.Settings] -> settings, classOf[Config] -> conf)
+                val args = List(classOf[ActorSystem.Settings] → settings, classOf[Config] → conf)
                 dynamicAccess.createInstanceFor[MailboxType](fqcn, args).recover({
                   case exception ⇒
                     throw new IllegalArgumentException(
@@ -228,7 +228,7 @@ private[akka] class Mailboxes(
   //INTERNAL API
   private def config(id: String): Config = {
     import scala.collection.JavaConverters._
-    ConfigFactory.parseMap(Map("id" -> id).asJava)
+    ConfigFactory.parseMap(Map("id" → id).asJava)
       .withFallback(settings.config.getConfig(id))
       .withFallback(defaultMailboxConfig)
   }

--- a/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
@@ -20,12 +20,13 @@ class PinnedDispatcher(
   _id: String,
   _shutdownTimeout: FiniteDuration,
   _threadPoolConfig: ThreadPoolConfig)
-  extends Dispatcher(_configurator,
-    _id,
-    Int.MaxValue,
-    Duration.Zero,
-    _threadPoolConfig.copy(corePoolSize = 1, maxPoolSize = 1),
-    _shutdownTimeout) {
+    extends Dispatcher(
+      _configurator,
+      _id,
+      Int.MaxValue,
+      Duration.Zero,
+      _threadPoolConfig.copy(corePoolSize = 1, maxPoolSize = 1),
+      _shutdownTimeout) {
 
   @volatile
   private var owner: ActorCell = _actor

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -65,13 +65,14 @@ trait ExecutorServiceFactoryProvider {
 /**
  * A small configuration DSL to create ThreadPoolExecutors that can be provided as an ExecutorServiceFactoryProvider to Dispatcher
  */
-final case class ThreadPoolConfig(allowCorePoolTimeout: Boolean = ThreadPoolConfig.defaultAllowCoreThreadTimeout,
-                                  corePoolSize: Int = ThreadPoolConfig.defaultCorePoolSize,
-                                  maxPoolSize: Int = ThreadPoolConfig.defaultMaxPoolSize,
-                                  threadTimeout: Duration = ThreadPoolConfig.defaultTimeout,
-                                  queueFactory: ThreadPoolConfig.QueueFactory = ThreadPoolConfig.linkedBlockingQueue(),
-                                  rejectionPolicy: RejectedExecutionHandler = ThreadPoolConfig.defaultRejectionPolicy)
-  extends ExecutorServiceFactoryProvider {
+final case class ThreadPoolConfig(
+  allowCorePoolTimeout: Boolean = ThreadPoolConfig.defaultAllowCoreThreadTimeout,
+  corePoolSize: Int = ThreadPoolConfig.defaultCorePoolSize,
+  maxPoolSize: Int = ThreadPoolConfig.defaultMaxPoolSize,
+  threadTimeout: Duration = ThreadPoolConfig.defaultTimeout,
+  queueFactory: ThreadPoolConfig.QueueFactory = ThreadPoolConfig.linkedBlockingQueue(),
+  rejectionPolicy: RejectedExecutionHandler = ThreadPoolConfig.defaultRejectionPolicy)
+    extends ExecutorServiceFactoryProvider {
   class ThreadPoolExecutorServiceFactory(val threadFactory: ThreadFactory) extends ExecutorServiceFactory {
     def createExecutorService: ExecutorService = {
       val service: ThreadPoolExecutor = new ThreadPoolExecutor(
@@ -173,12 +174,13 @@ object MonitorableThreadFactory {
   }
 }
 
-final case class MonitorableThreadFactory(name: String,
-                                          daemonic: Boolean,
-                                          contextClassLoader: Option[ClassLoader],
-                                          exceptionHandler: Thread.UncaughtExceptionHandler = MonitorableThreadFactory.doNothing,
-                                          protected val counter: AtomicLong = new AtomicLong)
-  extends ThreadFactory with ForkJoinPool.ForkJoinWorkerThreadFactory {
+final case class MonitorableThreadFactory(
+  name: String,
+  daemonic: Boolean,
+  contextClassLoader: Option[ClassLoader],
+  exceptionHandler: Thread.UncaughtExceptionHandler = MonitorableThreadFactory.doNothing,
+  protected val counter: AtomicLong = new AtomicLong)
+    extends ThreadFactory with ForkJoinPool.ForkJoinWorkerThreadFactory {
 
   def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
     val t = wire(new MonitorableThreadFactory.AkkaForkJoinWorkerThread(pool))

--- a/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
+++ b/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
@@ -17,7 +17,7 @@ trait LoggerMessageQueueSemantics
  * INTERNAL API
  */
 private[akka] class LoggerMailboxType(settings: ActorSystem.Settings, config: Config) extends MailboxType
-  with ProducesMessageQueue[LoggerMailbox] {
+    with ProducesMessageQueue[LoggerMailbox] {
 
   override def create(owner: Option[ActorRef], system: Option[ActorSystem]) = (owner, system) match {
     case (Some(o), Some(s)) ⇒ new LoggerMailbox(o, s)
@@ -29,7 +29,7 @@ private[akka] class LoggerMailboxType(settings: ActorSystem.Settings, config: Co
  * INTERNAL API
  */
 private[akka] class LoggerMailbox(owner: ActorRef, system: ActorSystem)
-  extends UnboundedMailbox.MessageQueue with LoggerMessageQueueSemantics {
+    extends UnboundedMailbox.MessageQueue with LoggerMessageQueueSemantics {
 
   override def cleanUp(owner: ActorRef, deadLetters: MessageQueue): Unit = {
     if (hasMessages) {

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -1196,7 +1196,7 @@ trait DiagnosticLoggingAdapter extends LoggingAdapter {
  * [[akka.event.LoggingAdapter]] that publishes [[akka.event.Logging.LogEvent]] to event stream.
  */
 class BusLogging(val bus: LoggingBus, val logSource: String, val logClass: Class[_], loggingFilter: LoggingFilter)
-  extends LoggingAdapter {
+    extends LoggingAdapter {
 
   // For backwards compatibility, and when LoggingAdapter is created without direct
   // association to an ActorSystem

--- a/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
+++ b/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
@@ -95,7 +95,7 @@ private[io] object SelectionHandler {
   private[io] final val connectionSupervisorStrategy: SupervisorStrategy =
     new OneForOneStrategy()(SupervisorStrategy.stoppingStrategy.decider) {
       override def logFailure(context: ActorContext, child: ActorRef, cause: Throwable,
-                              decision: SupervisorStrategy.Directive): Unit =
+        decision: SupervisorStrategy.Directive): Unit =
         if (cause.isInstanceOf[DeathPactException]) {
           try context.system.eventStream.publish {
             Logging.Debug(child.path.toString, getClass, "Closed after handler termination")
@@ -223,7 +223,7 @@ private[io] object SelectionHandler {
 }
 
 private[io] class SelectionHandler(settings: SelectionHandlerSettings) extends Actor with ActorLogging
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import SelectionHandler._
   import settings._
 
@@ -254,7 +254,7 @@ private[io] class SelectionHandler(settings: SelectionHandlerSettings) extends A
     }
     new OneForOneStrategy()(stoppingDecider) {
       override def logFailure(context: ActorContext, child: ActorRef, cause: Throwable,
-                              decision: SupervisorStrategy.Directive): Unit =
+        decision: SupervisorStrategy.Directive): Unit =
         try {
           val logMessage = cause match {
             case e: ActorInitializationException if (e.getCause ne null) && (e.getCause.getMessage ne null) ⇒ e.getCause.getMessage

--- a/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
+++ b/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
@@ -58,7 +58,7 @@ object SimpleDnsCache {
 
       new Cache(
         queue + new ExpiryEntry(answer.name, until),
-        cache + (answer.name -> CacheEntry(answer, until)),
+        cache + (answer.name → CacheEntry(answer, until)),
         clock)
     }
 

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -110,11 +110,12 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * @param localAddress optionally specifies a specific address to bind to
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  final case class Connect(remoteAddress: InetSocketAddress,
-                           localAddress: Option[InetSocketAddress] = None,
-                           options: immutable.Traversable[SocketOption] = Nil,
-                           timeout: Option[FiniteDuration] = None,
-                           pullMode: Boolean = false) extends Command
+  final case class Connect(
+    remoteAddress: InetSocketAddress,
+    localAddress: Option[InetSocketAddress] = None,
+    options: immutable.Traversable[SocketOption] = Nil,
+    timeout: Option[FiniteDuration] = None,
+    pullMode: Boolean = false) extends Command
 
   /**
    * The Bind message is send to the TCP manager actor, which is obtained via
@@ -135,11 +136,12 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    *
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  final case class Bind(handler: ActorRef,
-                        localAddress: InetSocketAddress,
-                        backlog: Int = 100,
-                        options: immutable.Traversable[SocketOption] = Nil,
-                        pullMode: Boolean = false) extends Command
+  final case class Bind(
+    handler: ActorRef,
+    localAddress: InetSocketAddress,
+    backlog: Int = 100,
+    options: immutable.Traversable[SocketOption] = Nil,
+    pullMode: Boolean = false) extends Command
 
   /**
    * This message must be sent to a TCP connection actor after receiving the
@@ -357,7 +359,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * respective write has been written completely.
    */
   final case class CompoundWrite(override val head: SimpleWriteCommand, tailCommand: WriteCommand) extends WriteCommand
-    with immutable.Iterable[SimpleWriteCommand] {
+      with immutable.Iterable[SimpleWriteCommand] {
 
     def iterator: Iterator[SimpleWriteCommand] =
       new Iterator[SimpleWriteCommand] {
@@ -624,11 +626,12 @@ object TcpMessage {
    * @param timeout is the desired connection timeout, `null` means "no timeout"
    * @param pullMode enables pull based reading from the connection
    */
-  def connect(remoteAddress: InetSocketAddress,
-              localAddress: InetSocketAddress,
-              options: JIterable[SocketOption],
-              timeout: FiniteDuration,
-              pullMode: Boolean): Command = Connect(remoteAddress, Option(localAddress), options, Option(timeout), pullMode)
+  def connect(
+    remoteAddress: InetSocketAddress,
+    localAddress: InetSocketAddress,
+    options: JIterable[SocketOption],
+    timeout: FiniteDuration,
+    pullMode: Boolean): Command = Connect(remoteAddress, Option(localAddress), options, Option(timeout), pullMode)
 
   /**
    * Connect to the given `remoteAddress` without binding to a local address and without
@@ -658,17 +661,19 @@ object TcpMessage {
    * @param pullMode enables pull based accepting and of connections and pull
    *                 based reading from the accepted connections.
    */
-  def bind(handler: ActorRef,
-           endpoint: InetSocketAddress,
-           backlog: Int,
-           options: JIterable[SocketOption],
-           pullMode: Boolean): Command = Bind(handler, endpoint, backlog, options, pullMode)
+  def bind(
+    handler: ActorRef,
+    endpoint: InetSocketAddress,
+    backlog: Int,
+    options: JIterable[SocketOption],
+    pullMode: Boolean): Command = Bind(handler, endpoint, backlog, options, pullMode)
   /**
    * Open a listening socket without specifying options.
    */
-  def bind(handler: ActorRef,
-           endpoint: InetSocketAddress,
-           backlog: Int): Command = Bind(handler, endpoint, backlog, Nil)
+  def bind(
+    handler: ActorRef,
+    endpoint: InetSocketAddress,
+    backlog: Int): Command = Bind(handler, endpoint, backlog, Nil)
 
   /**
    * This message must be sent to a TCP connection actor after receiving the

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -26,7 +26,7 @@ import akka.dispatch.{ UnboundedMessageQueueSemantics, RequiresMessageQueue }
  * INTERNAL API
  */
 private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketChannel, val pullMode: Boolean)
-  extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
   import tcp.Settings._
   import tcp.bufferPool
@@ -106,7 +106,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
 
   /** connection is closing but a write has to be finished first */
   def closingWithPendingWrite(info: ConnectionInfo, closeCommander: Option[ActorRef],
-                              closedEvent: ConnectionClosed): Receive = {
+    closedEvent: ConnectionClosed): Receive = {
     case SuspendReading  ⇒ suspendReading(info)
     case ResumeReading   ⇒ resumeReading(info)
     case ChannelReadable ⇒ doRead(info, closeCommander)
@@ -189,7 +189,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
 
   /** used in subclasses to start the common machinery above once a channel is connected */
   def completeConnect(registration: ChannelRegistration, commander: ActorRef,
-                      options: immutable.Traversable[SocketOption]): Unit = {
+    options: immutable.Traversable[SocketOption]): Unit = {
     // Turn off Nagle's algorithm by default
     try channel.socket.setTcpNoDelay(true) catch {
       case e: SocketException ⇒
@@ -267,7 +267,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
     else PeerClosed
 
   def handleClose(info: ConnectionInfo, closeCommander: Option[ActorRef],
-                  closedEvent: ConnectionClosed): Unit = closedEvent match {
+    closedEvent: ConnectionClosed): Unit = closedEvent match {
     case Aborted ⇒
       if (TraceLogging) log.debug("Got Abort command. RESETing connection.")
       doCloseConnection(info.handler, closeCommander, closedEvent)
@@ -386,11 +386,11 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   }
 
   class PendingBufferWrite(
-    val commander: ActorRef,
-    remainingData: ByteString,
-    ack: Any,
-    buffer: ByteBuffer,
-    tail: WriteCommand) extends PendingWrite {
+      val commander: ActorRef,
+      remainingData: ByteString,
+      ack: Any,
+      buffer: ByteBuffer,
+      tail: WriteCommand) extends PendingWrite {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
       @tailrec def writeToChannel(data: ByteString): PendingWrite = {
@@ -424,16 +424,16 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   }
 
   def PendingWriteFile(commander: ActorRef, filePath: String, offset: Long, count: Long, ack: Event,
-                       tail: WriteCommand): PendingWriteFile =
+    tail: WriteCommand): PendingWriteFile =
     new PendingWriteFile(commander, new FileInputStream(filePath).getChannel, offset, count, ack, tail)
 
   class PendingWriteFile(
-    val commander: ActorRef,
-    fileChannel: FileChannel,
-    offset: Long,
-    remaining: Long,
-    ack: Event,
-    tail: WriteCommand) extends PendingWrite with Runnable {
+      val commander: ActorRef,
+      fileChannel: FileChannel,
+      offset: Long,
+      remaining: Long,
+      ack: Event,
+      tail: WriteCommand) extends PendingWrite with Runnable {
 
     def doWrite(info: ConnectionInfo): PendingWrite = {
       tcp.fileIoDispatcher.execute(this)
@@ -479,10 +479,11 @@ private[io] object TcpConnection {
   /**
    * Groups required connection-related data that are only available once the connection has been fully established.
    */
-  final case class ConnectionInfo(registration: ChannelRegistration,
-                                  handler: ActorRef,
-                                  keepOpenOnPeerClosed: Boolean,
-                                  useResumeWriting: Boolean)
+  final case class ConnectionInfo(
+    registration: ChannelRegistration,
+    handler: ActorRef,
+    keepOpenOnPeerClosed: Boolean,
+    useResumeWriting: Boolean)
 
   // INTERNAL MESSAGES
 

--- a/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
@@ -15,13 +15,14 @@ import akka.io.Inet.SocketOption
  *
  * INTERNAL API
  */
-private[io] class TcpIncomingConnection(_tcp: TcpExt,
-                                        _channel: SocketChannel,
-                                        registry: ChannelRegistry,
-                                        bindHandler: ActorRef,
-                                        options: immutable.Traversable[SocketOption],
-                                        readThrottling: Boolean)
-  extends TcpConnection(_tcp, _channel, readThrottling) {
+private[io] class TcpIncomingConnection(
+  _tcp: TcpExt,
+  _channel: SocketChannel,
+  registry: ChannelRegistry,
+  bindHandler: ActorRef,
+  options: immutable.Traversable[SocketOption],
+  readThrottling: Boolean)
+    extends TcpConnection(_tcp, _channel, readThrottling) {
 
   signDeathPact(bindHandler)
 

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -29,12 +29,13 @@ private[io] object TcpListener {
 /**
  * INTERNAL API
  */
-private[io] class TcpListener(selectorRouter: ActorRef,
-                              tcp: TcpExt,
-                              channelRegistry: ChannelRegistry,
-                              bindCommander: ActorRef,
-                              bind: Bind)
-  extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+private[io] class TcpListener(
+  selectorRouter: ActorRef,
+  tcp: TcpExt,
+  channelRegistry: ChannelRegistry,
+  bindCommander: ActorRef,
+  bind: Bind)
+    extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
   import TcpListener._
   import tcp.Settings._

--- a/akka-actor/src/main/scala/akka/io/TcpManager.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpManager.scala
@@ -45,7 +45,7 @@ import akka.actor.{ ActorLogging, Props }
  *
  */
 private[io] class TcpManager(tcp: TcpExt)
-  extends SelectionHandler.SelectorBasedManager(tcp.Settings, tcp.Settings.NrOfSelectors) with ActorLogging {
+    extends SelectionHandler.SelectorBasedManager(tcp.Settings, tcp.Settings.NrOfSelectors) with ActorLogging {
 
   def receive = workerForCommandHandler {
     case c: Connect ⇒

--- a/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -19,11 +19,12 @@ import akka.io.Tcp._
  *
  * INTERNAL API
  */
-private[io] class TcpOutgoingConnection(_tcp: TcpExt,
-                                        channelRegistry: ChannelRegistry,
-                                        commander: ActorRef,
-                                        connect: Connect)
-  extends TcpConnection(_tcp, SocketChannel.open().configureBlocking(false).asInstanceOf[SocketChannel], connect.pullMode) {
+private[io] class TcpOutgoingConnection(
+  _tcp: TcpExt,
+  channelRegistry: ChannelRegistry,
+  commander: ActorRef,
+  connect: Connect)
+    extends TcpConnection(_tcp, SocketChannel.open().configureBlocking(false).asInstanceOf[SocketChannel], connect.pullMode) {
 
   import context._
   import connect._

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -92,9 +92,10 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    * The listener actor for the newly bound port will reply with a [[Bound]]
    * message, or the manager will reply with a [[CommandFailed]] message.
    */
-  final case class Bind(handler: ActorRef,
-                        localAddress: InetSocketAddress,
-                        options: immutable.Traversable[SocketOption] = Nil) extends Command
+  final case class Bind(
+    handler: ActorRef,
+    localAddress: InetSocketAddress,
+    options: immutable.Traversable[SocketOption] = Nil) extends Command
 
   /**
    * Send this message to the listener actor that previously sent a [[Bound]]

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -84,10 +84,11 @@ object UdpConnected extends ExtensionId[UdpConnectedExt] with ExtensionIdProvide
    * which is restricted to sending to and receiving from the given `remoteAddress`.
    * All received datagrams will be sent to the designated `handler` actor.
    */
-  final case class Connect(handler: ActorRef,
-                           remoteAddress: InetSocketAddress,
-                           localAddress: Option[InetSocketAddress] = None,
-                           options: immutable.Traversable[SocketOption] = Nil) extends Command
+  final case class Connect(
+    handler: ActorRef,
+    remoteAddress: InetSocketAddress,
+    localAddress: Option[InetSocketAddress] = None,
+    options: immutable.Traversable[SocketOption] = Nil) extends Command
 
   /**
    * Send this message to a connection actor (which had previously sent the
@@ -176,21 +177,24 @@ object UdpConnectedMessage {
    * which is restricted to sending to and receiving from the given `remoteAddress`.
    * All received datagrams will be sent to the designated `handler` actor.
    */
-  def connect(handler: ActorRef,
-              remoteAddress: InetSocketAddress,
-              localAddress: InetSocketAddress,
-              options: JIterable[SocketOption]): Command = Connect(handler, remoteAddress, Some(localAddress), options)
+  def connect(
+    handler: ActorRef,
+    remoteAddress: InetSocketAddress,
+    localAddress: InetSocketAddress,
+    options: JIterable[SocketOption]): Command = Connect(handler, remoteAddress, Some(localAddress), options)
   /**
    * Connect without specifying the `localAddress`.
    */
-  def connect(handler: ActorRef,
-              remoteAddress: InetSocketAddress,
-              options: JIterable[SocketOption]): Command = Connect(handler, remoteAddress, None, options)
+  def connect(
+    handler: ActorRef,
+    remoteAddress: InetSocketAddress,
+    options: JIterable[SocketOption]): Command = Connect(handler, remoteAddress, None, options)
   /**
    * Connect without specifying the `localAddress` or `options`.
    */
-  def connect(handler: ActorRef,
-              remoteAddress: InetSocketAddress): Command = Connect(handler, remoteAddress, None, Nil)
+  def connect(
+    handler: ActorRef,
+    remoteAddress: InetSocketAddress): Command = Connect(handler, remoteAddress, None, Nil)
 
   /**
    * This message is understood by the connection actors to send data to their

--- a/akka-actor/src/main/scala/akka/io/UdpConnectedManager.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnectedManager.scala
@@ -10,7 +10,7 @@ import akka.io.UdpConnected.Connect
  * INTERNAL API
  */
 private[io] class UdpConnectedManager(udpConn: UdpConnectedExt)
-  extends SelectionHandler.SelectorBasedManager(udpConn.settings, udpConn.settings.NrOfSelectors) {
+    extends SelectionHandler.SelectorBasedManager(udpConn.settings, udpConn.settings.NrOfSelectors) {
 
   def receive = workerForCommandHandler {
     case c: Connect ⇒

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -18,11 +18,12 @@ import akka.io.UdpConnected._
 /**
  * INTERNAL API
  */
-private[io] class UdpConnection(udpConn: UdpConnectedExt,
-                                channelRegistry: ChannelRegistry,
-                                commander: ActorRef,
-                                connect: Connect)
-  extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+private[io] class UdpConnection(
+  udpConn: UdpConnectedExt,
+  channelRegistry: ChannelRegistry,
+  commander: ActorRef,
+  connect: Connect)
+    extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
   import connect._
   import udpConn._
@@ -153,7 +154,8 @@ private[io] class UdpConnection(udpConn: UdpConnectedExt,
       thunk
     } catch {
       case NonFatal(e) ⇒
-        log.debug("Failure while connecting UDP channel to remote address [{}] local address [{}]: {}",
+        log.debug(
+          "Failure while connecting UDP channel to remote address [{}] local address [{}]: {}",
           remoteAddress, localAddress.getOrElse("undefined"), e)
         commander ! CommandFailed(connect)
         context.stop(self)

--- a/akka-actor/src/main/scala/akka/io/UdpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpListener.scala
@@ -18,11 +18,12 @@ import akka.io.Udp._
 /**
  * INTERNAL API
  */
-private[io] class UdpListener(val udp: UdpExt,
-                              channelRegistry: ChannelRegistry,
-                              bindCommander: ActorRef,
-                              bind: Bind)
-  extends Actor with ActorLogging with WithUdpSend with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+private[io] class UdpListener(
+  val udp: UdpExt,
+  channelRegistry: ChannelRegistry,
+  bindCommander: ActorRef,
+  bind: Bind)
+    extends Actor with ActorLogging with WithUdpSend with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
   import udp.bufferPool
   import udp.settings._

--- a/akka-actor/src/main/scala/akka/io/UdpSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpSender.scala
@@ -14,11 +14,12 @@ import akka.actor._
 /**
  * INTERNAL API
  */
-private[io] class UdpSender(val udp: UdpExt,
-                            channelRegistry: ChannelRegistry,
-                            commander: ActorRef,
-                            options: immutable.Traversable[SocketOption])
-  extends Actor with ActorLogging with WithUdpSend with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+private[io] class UdpSender(
+  val udp: UdpExt,
+  channelRegistry: ChannelRegistry,
+  commander: ActorRef,
+  options: immutable.Traversable[SocketOption])
+    extends Actor with ActorLogging with WithUdpSend with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
   val channel = {
     val datagramChannel = DatagramChannel.open

--- a/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
+++ b/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
@@ -51,7 +51,8 @@ private[io] trait WithUdpSend {
             } catch {
               case NonFatal(e) ⇒
                 sender() ! CommandFailed(send)
-                log.debug("Failure while sending UDP datagram to remote address [{}]: {}",
+                log.debug(
+                  "Failure while sending UDP datagram to remote address [{}]: {}",
                   send.target, e)
                 retriedSend = false
                 pendingSend = null

--- a/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
+++ b/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
@@ -11,7 +11,7 @@ private[pf] object CaseStatement {
 }
 
 private[pf] class CaseStatement[-F, +P, T](predicate: Predicate, apply: Apply[P, T])
-  extends PartialFunction[F, T] {
+    extends PartialFunction[F, T] {
 
   override def isDefinedAt(o: F) = predicate.defined(o)
 
@@ -19,7 +19,7 @@ private[pf] class CaseStatement[-F, +P, T](predicate: Predicate, apply: Apply[P,
 }
 
 private[pf] class UnitCaseStatement[F, P](predicate: Predicate, apply: UnitApply[P])
-  extends PartialFunction[F, Unit] {
+    extends PartialFunction[F, Unit] {
 
   override def isDefinedAt(o: F) = predicate.defined(o)
 

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -434,7 +434,7 @@ final class ExplicitlyAskableActorSelection(val actorSel: ActorSelection) extend
  * INTERNAL API
  */
 private[akka] final class PromiseActorRef private (val provider: ActorRefProvider, val result: Promise[Any], _mcn: String)
-  extends MinimalActorRef {
+    extends MinimalActorRef {
   import AbstractPromiseActorRef.{ stateOffset, watchedByOffset }
   import PromiseActorRef._
 

--- a/akka-actor/src/main/scala/akka/pattern/BackoffOnRestartSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffOnRestartSupervisor.scala
@@ -22,8 +22,8 @@ private class BackoffOnRestartSupervisor(
   val reset: BackoffReset,
   randomFactor: Double,
   strategy: OneForOneStrategy)
-  extends Actor with HandleBackoff
-  with ActorLogging {
+    extends Actor with HandleBackoff
+    with ActorLogging {
 
   import context._
   import BackoffSupervisor._

--- a/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
@@ -183,14 +183,14 @@ trait BackoffOptions {
 }
 
 private final case class BackoffOptionsImpl(
-  backoffType: BackoffType = RestartImpliesFailure,
-  childProps: Props,
-  childName: String,
-  minBackoff: FiniteDuration,
-  maxBackoff: FiniteDuration,
-  randomFactor: Double,
-  reset: Option[BackoffReset] = None,
-  supervisorStrategy: OneForOneStrategy = OneForOneStrategy()(SupervisorStrategy.defaultStrategy.decider)) extends BackoffOptions {
+    backoffType: BackoffType = RestartImpliesFailure,
+    childProps: Props,
+    childName: String,
+    minBackoff: FiniteDuration,
+    maxBackoff: FiniteDuration,
+    randomFactor: Double,
+    reset: Option[BackoffReset] = None,
+    supervisorStrategy: OneForOneStrategy = OneForOneStrategy()(SupervisorStrategy.defaultStrategy.decider)) extends BackoffOptions {
 
   val backoffReset = reset.getOrElse(AutoReset(minBackoff))
 

--- a/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
@@ -172,7 +172,7 @@ final class BackoffSupervisor(
   val reset: BackoffReset,
   randomFactor: Double,
   strategy: SupervisorStrategy)
-  extends Actor with HandleBackoff {
+    extends Actor with HandleBackoff {
 
   import BackoffSupervisor._
   import context.dispatcher

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -516,4 +516,4 @@ class CircuitBreaker(scheduler: Scheduler, maxFailures: Int, callTimeout: Finite
 class CircuitBreakerOpenException(
   val remainingDuration: FiniteDuration,
   message: String = "Circuit Breaker is open; calls are failing fast")
-  extends AkkaException(message) with NoStackTrace
+    extends AkkaException(message) with NoStackTrace

--- a/akka-actor/src/main/scala/akka/pattern/PromiseRef.scala
+++ b/akka-actor/src/main/scala/akka/pattern/PromiseRef.scala
@@ -136,7 +136,7 @@ object FutureRef {
 }
 
 private[akka] class PromiseRefImpl[T](val ref: ActorRef, val promise: Promise[T])
-  extends PromiseRef[T] with FutureRef[T] {
+    extends PromiseRef[T] with FutureRef[T] {
   def toFutureRef: FutureRef[T] = this
 }
 

--- a/akka-actor/src/main/scala/akka/routing/Balancing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Balancing.scala
@@ -69,7 +69,7 @@ final case class BalancingPool(
   override val nrOfInstances: Int,
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
-  extends Pool {
+    extends Pool {
 
   def this(config: Config) =
     this(nrOfInstances = config.getInt("nr-of-instances"))
@@ -112,12 +112,14 @@ final case class BalancingPool(
       // dispatcher of this pool
       val deployDispatcherConfigPath = s"akka.actor.deployment.$deployPath.pool-dispatcher"
       val systemConfig = context.system.settings.config
-      val dispatcherConfig = context.system.dispatchers.config(dispatcherId,
+      val dispatcherConfig = context.system.dispatchers.config(
+        dispatcherId,
         // use the user defined 'pool-dispatcher' config as fallback, if any
         if (systemConfig.hasPath(deployDispatcherConfigPath)) systemConfig.getConfig(deployDispatcherConfigPath)
         else ConfigFactory.empty)
 
-      dispatchers.registerConfigurator(dispatcherId, new BalancingDispatcherConfigurator(dispatcherConfig,
+      dispatchers.registerConfigurator(dispatcherId, new BalancingDispatcherConfigurator(
+        dispatcherConfig,
         dispatchers.prerequisites))
     }
 

--- a/akka-actor/src/main/scala/akka/routing/Broadcast.scala
+++ b/akka-actor/src/main/scala/akka/routing/Broadcast.scala
@@ -60,7 +60,7 @@ final case class BroadcastPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool with PoolOverrideUnsetConfig[BroadcastPool] {
+    extends Pool with PoolOverrideUnsetConfig[BroadcastPool] {
 
   def this(config: Config) =
     this(
@@ -120,7 +120,7 @@ final case class BroadcastPool(
 final case class BroadcastGroup(
   override val paths: immutable.Iterable[String],
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
-  extends Group {
+    extends Group {
 
   def this(config: Config) =
     this(paths = immutableSeq(config.getStringList("routees.paths")))

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHash.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHash.scala
@@ -39,7 +39,8 @@ class ConsistentHash[T: ClassTag] private (nodes: immutable.SortedMap[Int, T], v
    */
   def :+(node: T): ConsistentHash[T] = {
     val nodeHash = hashFor(node.toString)
-    new ConsistentHash(nodes ++ ((1 to virtualNodesFactor) map { r ⇒ (concatenateNodeHash(nodeHash, r) -> node) }),
+    new ConsistentHash(
+      nodes ++ ((1 to virtualNodesFactor) map { r ⇒ (concatenateNodeHash(nodeHash, r) → node) }),
       virtualNodesFactor)
   }
 
@@ -57,7 +58,8 @@ class ConsistentHash[T: ClassTag] private (nodes: immutable.SortedMap[Int, T], v
    */
   def :-(node: T): ConsistentHash[T] = {
     val nodeHash = hashFor(node.toString)
-    new ConsistentHash(nodes -- ((1 to virtualNodesFactor) map { r ⇒ concatenateNodeHash(nodeHash, r) }),
+    new ConsistentHash(
+      nodes -- ((1 to virtualNodesFactor) map { r ⇒ concatenateNodeHash(nodeHash, r) }),
       virtualNodesFactor)
   }
 
@@ -110,12 +112,13 @@ class ConsistentHash[T: ClassTag] private (nodes: immutable.SortedMap[Int, T], v
 
 object ConsistentHash {
   def apply[T: ClassTag](nodes: Iterable[T], virtualNodesFactor: Int): ConsistentHash[T] = {
-    new ConsistentHash(immutable.SortedMap.empty[Int, T] ++
+    new ConsistentHash(
+      immutable.SortedMap.empty[Int, T] ++
       (for {
         node ← nodes
         nodeHash = hashFor(node.toString)
         vnode ← 1 to virtualNodesFactor
-      } yield (concatenateNodeHash(nodeHash, vnode) -> node)),
+      } yield (concatenateNodeHash(nodeHash, vnode) → node)),
       virtualNodesFactor)
   }
 

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -49,7 +49,7 @@ object ConsistentHashingRouter {
    */
   @SerialVersionUID(1L)
   final case class ConsistentHashableEnvelope(message: Any, hashKey: Any)
-    extends ConsistentHashable with RouterEnvelope {
+      extends ConsistentHashable with RouterEnvelope {
     override def consistentHashKey: Any = hashKey
   }
 
@@ -138,7 +138,7 @@ final case class ConsistentHashingRoutingLogic(
   system: ActorSystem,
   virtualNodesFactor: Int = 0,
   hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping)
-  extends RoutingLogic {
+    extends RoutingLogic {
 
   import ConsistentHashingRouter._
 
@@ -210,7 +210,8 @@ final case class ConsistentHashingRoutingLogic(
         case _ if hashMapping.isDefinedAt(message) ⇒ target(hashMapping(message))
         case hashable: ConsistentHashable          ⇒ target(hashable.consistentHashKey)
         case other ⇒
-          log.warning("Message [{}] must be handled by hashMapping, or implement [{}] or be wrapped in [{}]",
+          log.warning(
+            "Message [{}] must be handled by hashMapping, or implement [{}] or be wrapped in [{}]",
             message.getClass.getName, classOf[ConsistentHashable].getName,
             classOf[ConsistentHashableEnvelope].getName)
           NoRoutee
@@ -264,7 +265,7 @@ final case class ConsistentHashingPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool with PoolOverrideUnsetConfig[ConsistentHashingPool] {
+    extends Pool with PoolOverrideUnsetConfig[ConsistentHashingPool] {
 
   def this(config: Config) =
     this(
@@ -349,7 +350,7 @@ final case class ConsistentHashingGroup(
   val virtualNodesFactor: Int = 0,
   val hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
-  extends Group {
+    extends Group {
 
   def this(config: Config) =
     this(paths = immutableSeq(config.getStringList("routees.paths")))

--- a/akka-actor/src/main/scala/akka/routing/OptimalSizeExploringResizer.scala
+++ b/akka-actor/src/main/scala/akka/routing/OptimalSizeExploringResizer.scala
@@ -115,16 +115,16 @@ case object OptimalSizeExploringResizer {
  */
 @SerialVersionUID(1L)
 case class DefaultOptimalSizeExploringResizer(
-  lowerBound: PoolSize = 1,
-  upperBound: PoolSize = 30,
-  chanceOfScalingDownWhenFull: Double = 0.2,
-  actionInterval: Duration = 5.seconds,
-  numOfAdjacentSizesToConsiderDuringOptimization: Int = 16,
-  exploreStepSize: Double = 0.1,
-  downsizeRatio: Double = 0.8,
-  downsizeAfterUnderutilizedFor: Duration = 72.hours,
-  explorationProbability: Double = 0.4,
-  weightOfLatestMetric: Double = 0.5) extends OptimalSizeExploringResizer {
+    lowerBound: PoolSize = 1,
+    upperBound: PoolSize = 30,
+    chanceOfScalingDownWhenFull: Double = 0.2,
+    actionInterval: Duration = 5.seconds,
+    numOfAdjacentSizesToConsiderDuringOptimization: Int = 16,
+    exploreStepSize: Double = 0.1,
+    downsizeRatio: Double = 0.8,
+    downsizeAfterUnderutilizedFor: Duration = 72.hours,
+    explorationProbability: Double = 0.4,
+    weightOfLatestMetric: Double = 0.5) extends OptimalSizeExploringResizer {
   /**
    * Leave package accessible for testing purpose
    */

--- a/akka-actor/src/main/scala/akka/routing/Random.scala
+++ b/akka-actor/src/main/scala/akka/routing/Random.scala
@@ -61,7 +61,7 @@ final case class RandomPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool with PoolOverrideUnsetConfig[RandomPool] {
+    extends Pool with PoolOverrideUnsetConfig[RandomPool] {
 
   def this(config: Config) =
     this(
@@ -121,7 +121,7 @@ final case class RandomPool(
 final case class RandomGroup(
   override val paths: immutable.Iterable[String],
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
-  extends Group {
+    extends Group {
 
   def this(config: Config) =
     this(paths = immutableSeq(config.getStringList("routees.paths")))

--- a/akka-actor/src/main/scala/akka/routing/Resizer.scala
+++ b/akka-actor/src/main/scala/akka/routing/Resizer.scala
@@ -126,13 +126,13 @@ case object DefaultResizer {
  */
 @SerialVersionUID(1L)
 case class DefaultResizer(
-  val lowerBound: Int = 1,
-  val upperBound: Int = 10,
-  val pressureThreshold: Int = 1,
-  val rampupRate: Double = 0.2,
-  val backoffThreshold: Double = 0.3,
-  val backoffRate: Double = 0.1,
-  val messagesPerResize: Int = 10) extends Resizer {
+    val lowerBound: Int = 1,
+    val upperBound: Int = 10,
+    val pressureThreshold: Int = 1,
+    val rampupRate: Double = 0.2,
+    val backoffThreshold: Double = 0.3,
+    val backoffRate: Double = 0.1,
+    val messagesPerResize: Int = 10) extends Resizer {
 
   /**
    * Java API constructor for default values except bounds.
@@ -253,7 +253,7 @@ private[akka] final class ResizablePoolCell(
   _routeeProps: Props,
   _supervisor: InternalActorRef,
   val pool: Pool)
-  extends RoutedActorCell(_system, _ref, _routerProps, _routerDispatcher, _routeeProps, _supervisor) {
+    extends RoutedActorCell(_system, _ref, _routerProps, _routerDispatcher, _routeeProps, _supervisor) {
 
   require(pool.resizer.isDefined, "RouterConfig must be a Pool with defined resizer")
   val resizer = pool.resizer.get
@@ -314,7 +314,7 @@ private[akka] object ResizablePoolActor {
  * INTERNAL API
  */
 private[akka] class ResizablePoolActor(supervisorStrategy: SupervisorStrategy)
-  extends RouterPoolActor(supervisorStrategy) {
+    extends RouterPoolActor(supervisorStrategy) {
   import ResizablePoolActor._
 
   val resizerCell = context match {

--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -69,10 +69,11 @@ final case class RoundRobinPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool with PoolOverrideUnsetConfig[RoundRobinPool] {
+    extends Pool with PoolOverrideUnsetConfig[RoundRobinPool] {
 
   def this(config: Config) =
-    this(nrOfInstances = config.getInt("nr-of-instances"),
+    this(
+      nrOfInstances = config.getInt("nr-of-instances"),
       resizer = Resizer.fromConfig(config),
       usePoolDispatcher = config.hasPath("pool-dispatcher"))
 
@@ -129,7 +130,7 @@ final case class RoundRobinPool(
 final case class RoundRobinGroup(
   override val paths: immutable.Iterable[String],
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
-  extends Group {
+    extends Group {
 
   def this(config: Config) =
     this(paths = immutableSeq(config.getStringList("routees.paths")))

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
@@ -41,7 +41,7 @@ private[akka] class RoutedActorCell(
   _routerDispatcher: MessageDispatcher,
   val routeeProps: Props,
   _supervisor: InternalActorRef)
-  extends ActorCell(_system, _ref, _routerProps, _routerDispatcher, _supervisor) {
+    extends ActorCell(_system, _ref, _routerProps, _routerDispatcher, _supervisor) {
 
   private[akka] val routerConfig = _routerProps.routerConfig
 
@@ -154,8 +154,9 @@ private[akka] class RouterActor extends Actor {
   }
 
   val routingLogicController: Option[ActorRef] = cell.routerConfig.routingLogicController(
-    cell.router.logic).map(props ⇒ context.actorOf(props.withDispatcher(context.props.dispatcher),
-      name = "routingLogicController"))
+    cell.router.logic).map(props ⇒ context.actorOf(
+    props.withDispatcher(context.props.dispatcher),
+    name = "routingLogicController"))
 
   def receive = {
     case GetRoutees ⇒

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorRef.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorRef.scala
@@ -29,7 +29,7 @@ private[akka] class RoutedActorRef(
   _routeeProps: Props,
   _supervisor: InternalActorRef,
   _path: ActorPath)
-  extends RepointableActorRef(_system, _routerProps, _routerDispatcher, _routerMailbox, _supervisor, _path) {
+    extends RepointableActorRef(_system, _routerProps, _routerDispatcher, _routerMailbox, _supervisor, _path) {
 
   // verify that a BalancingDispatcher is not used with a Router
   if (_routerProps.routerConfig != NoRouter && _routerDispatcher.isInstanceOf[BalancingDispatcher]) {

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -3,7 +3,6 @@
  */
 package akka.routing
 
-
 import scala.collection.immutable
 import akka.ConfigurationException
 import akka.actor.ActorContext
@@ -297,9 +296,10 @@ case object FromConfig extends FromConfig {
  * (defaults to default-dispatcher).
  */
 @SerialVersionUID(1L)
-class FromConfig(override val resizer: Option[Resizer],
-                 override val supervisorStrategy: SupervisorStrategy,
-                 override val routerDispatcher: String) extends Pool {
+class FromConfig(
+  override val resizer: Option[Resizer],
+    override val supervisorStrategy: SupervisorStrategy,
+    override val routerDispatcher: String) extends Pool {
 
   def this() = this(None, Pool.defaultSupervisorStrategy, Dispatchers.DefaultDispatcherId)
 

--- a/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
+++ b/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
@@ -38,7 +38,7 @@ final case class ScatterGatherFirstCompletedRoutingLogic(within: FiniteDuration)
  */
 @SerialVersionUID(1L)
 private[akka] final case class ScatterGatherFirstCompletedRoutees(
-  routees: immutable.IndexedSeq[Routee], within: FiniteDuration) extends Routee {
+    routees: immutable.IndexedSeq[Routee], within: FiniteDuration) extends Routee {
 
   override def send(message: Any, sender: ActorRef): Unit =
     if (routees.isEmpty) {
@@ -101,7 +101,7 @@ final case class ScatterGatherFirstCompletedPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool with PoolOverrideUnsetConfig[ScatterGatherFirstCompletedPool] {
+    extends Pool with PoolOverrideUnsetConfig[ScatterGatherFirstCompletedPool] {
 
   def this(config: Config) =
     this(
@@ -168,7 +168,7 @@ final case class ScatterGatherFirstCompletedGroup(
   override val paths: immutable.Iterable[String],
   within: FiniteDuration,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
-  extends Group {
+    extends Group {
 
   def this(config: Config) =
     this(

--- a/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
+++ b/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
@@ -45,11 +45,12 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
   // 4. An ActorRef with unknown mailbox size that isn't processing anything
   // 5. An ActorRef with a known mailbox size
   // 6. An ActorRef without any messages
-  @tailrec private def selectNext(targets: immutable.IndexedSeq[Routee],
-                                  proposedTarget: Routee = NoRoutee,
-                                  currentScore: Long = Long.MaxValue,
-                                  at: Int = 0,
-                                  deep: Boolean = false): Routee = {
+  @tailrec private def selectNext(
+    targets: immutable.IndexedSeq[Routee],
+    proposedTarget: Routee = NoRoutee,
+    currentScore: Long = Long.MaxValue,
+    at: Int = 0,
+    deep: Boolean = false): Routee = {
     if (targets.isEmpty)
       NoRoutee
     else if (at >= targets.size) {
@@ -176,7 +177,7 @@ final case class SmallestMailboxPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool with PoolOverrideUnsetConfig[SmallestMailboxPool] {
+    extends Pool with PoolOverrideUnsetConfig[SmallestMailboxPool] {
 
   def this(config: Config) =
     this(

--- a/akka-actor/src/main/scala/akka/routing/TailChopping.scala
+++ b/akka-actor/src/main/scala/akka/routing/TailChopping.scala
@@ -45,7 +45,7 @@ import scala.util.Random
  */
 @SerialVersionUID(1L)
 final case class TailChoppingRoutingLogic(scheduler: Scheduler, within: FiniteDuration,
-                                          interval: FiniteDuration, context: ExecutionContext) extends RoutingLogic {
+    interval: FiniteDuration, context: ExecutionContext) extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee = {
     if (routees.isEmpty) NoRoutee
     else TailChoppingRoutees(scheduler, routees, within, interval)(context)
@@ -57,8 +57,8 @@ final case class TailChoppingRoutingLogic(scheduler: Scheduler, within: FiniteDu
  */
 @SerialVersionUID(1L)
 private[akka] final case class TailChoppingRoutees(
-  scheduler: Scheduler, routees: immutable.IndexedSeq[Routee],
-  within: FiniteDuration, interval: FiniteDuration)(implicit ec: ExecutionContext) extends Routee {
+    scheduler: Scheduler, routees: immutable.IndexedSeq[Routee],
+    within: FiniteDuration, interval: FiniteDuration)(implicit ec: ExecutionContext) extends Routee {
 
   override def send(message: Any, sender: ActorRef): Unit = {
     implicit val timeout = Timeout(within)
@@ -147,7 +147,7 @@ final case class TailChoppingPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool with PoolOverrideUnsetConfig[TailChoppingPool] {
+    extends Pool with PoolOverrideUnsetConfig[TailChoppingPool] {
 
   def this(config: Config) =
     this(
@@ -227,10 +227,10 @@ final case class TailChoppingPool(
  *   router management messages
  */
 final case class TailChoppingGroup(
-  override val paths: immutable.Iterable[String],
-  within: FiniteDuration,
-  interval: FiniteDuration,
-  override val routerDispatcher: String = Dispatchers.DefaultDispatcherId) extends Group {
+    override val paths: immutable.Iterable[String],
+    within: FiniteDuration,
+    interval: FiniteDuration,
+    override val routerDispatcher: String = Dispatchers.DefaultDispatcherId) extends Group {
 
   def this(config: Config) =
     this(

--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -35,7 +35,7 @@ object Serialization {
 
     private final def configToMap(path: String): Map[String, String] = {
       import scala.collection.JavaConverters._
-      config.getConfig(path).root.unwrapped.asScala.toMap map { case (k, v) ⇒ (k -> v.toString) }
+      config.getConfig(path).root.unwrapped.asScala.toMap map { case (k, v) ⇒ (k → v.toString) }
     }
   }
 
@@ -194,7 +194,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    * loading is performed by the system’s [[akka.actor.DynamicAccess]].
    */
   def serializerOf(serializerFQN: String): Try[Serializer] =
-    system.dynamicAccess.createInstanceFor[Serializer](serializerFQN, List(classOf[ExtendedActorSystem] -> system)) recoverWith {
+    system.dynamicAccess.createInstanceFor[Serializer](serializerFQN, List(classOf[ExtendedActorSystem] → system)) recoverWith {
       case _: NoSuchMethodException ⇒ system.dynamicAccess.createInstanceFor[Serializer](serializerFQN, Nil)
     }
 
@@ -203,7 +203,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    * By default always contains the following mapping: "java" -> akka.serialization.JavaSerializer
    */
   private val serializers: Map[String, Serializer] =
-    for ((k: String, v: String) ← settings.Serializers) yield k -> serializerOf(v).get
+    for ((k: String, v: String) ← settings.Serializers) yield k → serializerOf(v).get
 
   /**
    *  bindings is a Seq of tuple representing the mapping from Class to Serializer.
@@ -244,7 +244,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    * Maps from a Serializer Identity (Int) to a Serializer instance (optimization)
    */
   val serializerByIdentity: Map[Int, Serializer] =
-    Map(NullSerializer.identifier -> NullSerializer) ++ serializers map { case (_, v) ⇒ (v.identifier, v) }
+    Map(NullSerializer.identifier → NullSerializer) ++ serializers map { case (_, v) ⇒ (v.identifier, v) }
 
   private val isJavaSerializationWarningEnabled = settings.config.getBoolean("akka.actor.warn-about-java-serializer-usage")
 

--- a/akka-actor/src/main/scala/akka/util/BoundedBlockingQueue.scala
+++ b/akka-actor/src/main/scala/akka/util/BoundedBlockingQueue.scala
@@ -15,7 +15,7 @@ import annotation.tailrec
  * @param backing - the backing Queue
  */
 class BoundedBlockingQueue[E <: AnyRef](
-  val maxCapacity: Int, private val backing: Queue[E]) extends AbstractQueue[E] with BlockingQueue[E] {
+    val maxCapacity: Int, private val backing: Queue[E]) extends AbstractQueue[E] with BlockingQueue[E] {
 
   backing match {
     case null ⇒ throw new IllegalArgumentException("Backing Queue may not be null")

--- a/akka-actor/src/main/scala/akka/util/BoxedType.scala
+++ b/akka-actor/src/main/scala/akka/util/BoxedType.scala
@@ -7,15 +7,15 @@ object BoxedType {
   import java.{ lang ⇒ jl }
 
   private val toBoxed = Map[Class[_], Class[_]](
-    classOf[Boolean] -> classOf[jl.Boolean],
-    classOf[Byte] -> classOf[jl.Byte],
-    classOf[Char] -> classOf[jl.Character],
-    classOf[Short] -> classOf[jl.Short],
-    classOf[Int] -> classOf[jl.Integer],
-    classOf[Long] -> classOf[jl.Long],
-    classOf[Float] -> classOf[jl.Float],
-    classOf[Double] -> classOf[jl.Double],
-    classOf[Unit] -> classOf[scala.runtime.BoxedUnit])
+    classOf[Boolean] → classOf[jl.Boolean],
+    classOf[Byte] → classOf[jl.Byte],
+    classOf[Char] → classOf[jl.Character],
+    classOf[Short] → classOf[jl.Short],
+    classOf[Int] → classOf[jl.Integer],
+    classOf[Long] → classOf[jl.Long],
+    classOf[Float] → classOf[jl.Float],
+    classOf[Double] → classOf[jl.Double],
+    classOf[Unit] → classOf[scala.runtime.BoxedUnit])
 
   final def apply(c: Class[_]): Class[_] = if (c.isPrimitive) toBoxed(c) else c
 }

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -357,7 +357,7 @@ object ByteString {
 
   private[akka] object Companion {
     private val companionMap = Seq(ByteString1, ByteString1C, ByteStrings).
-      map(x ⇒ x.SerializationIdentity -> x).toMap.
+      map(x ⇒ x.SerializationIdentity → x).toMap.
       withDefault(x ⇒ throw new IllegalArgumentException("Invalid serialization id " + x))
 
     def apply(from: Byte): Companion = companionMap(from)

--- a/akka-actor/src/main/scala/akka/util/LineNumbers.scala
+++ b/akka-actor/src/main/scala/akka/util/LineNumbers.scala
@@ -187,7 +187,7 @@ object LineNumbers {
     val cl = c.getClassLoader
     val r = cl.getResourceAsStream(resource)
     if (debug) println(s"LNB:     resource '$resource' resolved to stream $r")
-    Option(r).map(_ -> None)
+    Option(r).map(_ → None)
   }
 
   private def getStreamForLambda(l: AnyRef): Option[(InputStream, Some[String])] =
@@ -269,7 +269,7 @@ object LineNumbers {
     val count = d.readUnsignedShort()
     if (debug) println(s"LNB: reading $count methods")
     if (c.contains("Code") && c.contains("LineNumberTable")) {
-      (1 to count).map(_ ⇒ readMethod(d, c("Code"), c("LineNumberTable"), filter)).flatten.foldLeft(Int.MaxValue -> 0) {
+      (1 to count).map(_ ⇒ readMethod(d, c("Code"), c("LineNumberTable"), filter)).flatten.foldLeft(Int.MaxValue → 0) {
         case ((low, high), (start, end)) ⇒ (Math.min(low, start), Math.max(high, end))
       } match {
         case (Int.MaxValue, 0) ⇒ None
@@ -282,10 +282,11 @@ object LineNumbers {
     }
   }
 
-  private def readMethod(d: DataInputStream,
-                         codeTag: Int,
-                         lineNumberTableTag: Int,
-                         filter: Option[String])(implicit c: Constants): Option[(Int, Int)] = {
+  private def readMethod(
+    d: DataInputStream,
+    codeTag: Int,
+    lineNumberTableTag: Int,
+    filter: Option[String])(implicit c: Constants): Option[(Int, Int)] = {
     skip(d, 2) // access flags
     val name = d.readUnsignedShort() // name
     skip(d, 2) // signature
@@ -315,7 +316,7 @@ object LineNumbers {
                     skip(d, 2) // start PC
                     d.readUnsignedShort() // finally: the line number
                   }
-                Some(lines.min -> lines.max)
+                Some(lines.min → lines.max)
               }
             }
           if (debug) println(s"LNB:     nested attributes yielded: $possibleLines")

--- a/akka-actor/src/main/scala/akka/util/SerializedSuspendableExecutionContext.scala
+++ b/akka-actor/src/main/scala/akka/util/SerializedSuspendableExecutionContext.scala
@@ -31,7 +31,7 @@ private[akka] object SerializedSuspendableExecutionContext {
  * @param context the underlying context which will be used to actually execute the submitted tasks
  */
 private[akka] final class SerializedSuspendableExecutionContext(throughput: Int)(val context: ExecutionContext)
-  extends AbstractNodeQueue[Runnable] with Runnable with ExecutionContext {
+    extends AbstractNodeQueue[Runnable] with Runnable with ExecutionContext {
   import SerializedSuspendableExecutionContext._
   require(throughput > 0, s"SerializedSuspendableExecutionContext.throughput must be greater than 0 but was $throughput")
 

--- a/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
+++ b/akka-actor/src/main/scala/akka/util/SubclassifiedIndex.scala
@@ -127,7 +127,7 @@ private[akka] class SubclassifiedIndex[K, V] private (protected var values: Set[
     if (!found) {
       val v = values + value
       val n = new Nonroot(root, key, v)
-      integrate(n) ++ n.innerAddValue(key, value) :+ (key -> v)
+      integrate(n) ++ n.innerAddValue(key, value) :+ (key → v)
     } else ch
   }
 

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorCreationBenchmark.scala
@@ -34,7 +34,7 @@ class ActorCreationBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
   }

--- a/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
@@ -28,7 +28,7 @@ class ForkJoinActorBenchmark {
   implicit var system: ActorSystem = _
 
   @Setup(Level.Trial)
-  def setup():Unit = {
+  def setup(): Unit = {
     system = ActorSystem("ForkJoinActorBenchmark", ConfigFactory.parseString(
       s"""| akka {
         |   log-dead-letters = off
@@ -44,11 +44,12 @@ class ForkJoinActorBenchmark {
         |     }
         |   }
         | }
-      """.stripMargin))
+      """.stripMargin
+    ))
   }
 
   @TearDown(Level.Trial)
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
   }
@@ -56,7 +57,7 @@ class ForkJoinActorBenchmark {
   @Benchmark
   @Measurement(timeUnit = TimeUnit.MILLISECONDS)
   @OperationsPerInvocation(messages)
-  def pingPong():Unit = {
+  def pingPong(): Unit = {
     val ping = system.actorOf(Props[ForkJoinActorBenchmark.PingPong])
     val pong = system.actorOf(Props[ForkJoinActorBenchmark.PingPong])
 
@@ -72,7 +73,7 @@ class ForkJoinActorBenchmark {
   @Benchmark
   @Measurement(timeUnit = TimeUnit.MILLISECONDS)
   @OperationsPerInvocation(messages)
-  def floodPipe():Unit = {
+  def floodPipe(): Unit = {
 
     val end = system.actorOf(Props(classOf[ForkJoinActorBenchmark.Pipe], None))
     val middle = system.actorOf(Props(classOf[ForkJoinActorBenchmark.Pipe], Some(end)))

--- a/akka-bench-jmh/src/main/scala/akka/actor/RouterPoolCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/RouterPoolCreationBenchmark.scala
@@ -26,7 +26,7 @@ class RouterPoolCreationBenchmark {
   var size = 0
 
   @TearDown(Level.Trial)
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
   }

--- a/akka-bench-jmh/src/main/scala/akka/actor/ScheduleBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ScheduleBenchmark.scala
@@ -56,13 +56,13 @@ class ScheduleBenchmark {
   var promise: Promise[Any] = _
 
   @Setup(Level.Iteration)
-  def setup():Unit = {
+  def setup(): Unit = {
     winner = (to * ratio + 1).toInt
     promise = Promise[Any]()
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
   }
@@ -70,7 +70,7 @@ class ScheduleBenchmark {
   def op(idx: Int) = if (idx == winner) promise.trySuccess(idx) else idx
 
   @Benchmark
-  def oneSchedule():Unit = {
+  def oneSchedule(): Unit = {
     val aIdx = new AtomicInteger(1)
     val tryWithNext = scheduler.schedule(0.millis, interval) {
       val idx = aIdx.getAndIncrement
@@ -84,7 +84,7 @@ class ScheduleBenchmark {
   }
 
   @Benchmark
-  def multipleScheduleOnce():Unit = {
+  def multipleScheduleOnce(): Unit = {
     val tryWithNext = (1 to to).foldLeft(0.millis -> List[Cancellable]()) {
       case ((interv, c), idx) ⇒
         (interv + interval, scheduler.scheduleOnce(interv) {

--- a/akka-bench-jmh/src/main/scala/akka/actor/StashCreationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/StashCreationBenchmark.scala
@@ -35,7 +35,7 @@ class StashCreationBenchmark {
   val probe = TestProbe()
 
   @TearDown(Level.Trial)
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
   }

--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetMergeBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetMergeBenchmark.scala
@@ -48,7 +48,7 @@ class ORSetMergeBenchmark {
   var elem2: String = _
 
   @Setup(Level.Trial)
-  def setup():Unit = {
+  def setup(): Unit = {
     set1 = (1 to set1Size).foldLeft(ORSet.empty[String])((s, n) => s.add(nextNode(), "elem" + n))
     addFromSameNode = set1.add(nodeA, "elem" + set1Size + 1).merge(set1)
     addFromOtherNode = set1.add(nodeB, "elem" + set1Size + 1).merge(set1)

--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
@@ -45,7 +45,7 @@ class VersionVectorBenchmark {
   var dot1: VersionVector = _
 
   @Setup(Level.Trial)
-  def setup():Unit = {
+  def setup(): Unit = {
     vv1 = (1 to size).foldLeft(VersionVector.empty)((vv, n) => vv + nextNode())
     vv2 = vv1 + nextNode()
     vv3 = vv1 + nextNode()

--- a/akka-bench-jmh/src/main/scala/akka/dispatch/CachingConfigBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/dispatch/CachingConfigBenchmark.scala
@@ -21,7 +21,7 @@ class CachingConfigBenchmark {
   val deepConfig = ConfigFactory.parseString(deepConfigString)
   val deepCaching = new CachingConfig(deepConfig)
 
-  @Benchmark def deep_config  = deepConfig.hasPath(deepKey)
+  @Benchmark def deep_config = deepConfig.hasPath(deepKey)
   @Benchmark def deep_caching = deepCaching.hasPath(deepKey)
 
 }

--- a/akka-bench-jmh/src/main/scala/akka/dispatch/NodeQueueBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/dispatch/NodeQueueBenchmark.scala
@@ -42,7 +42,7 @@ mailbox {
   val ref = sys.actorOf(Props(new Actor {
     def receive = {
       case Stop => sender() ! Stop
-      case _    =>
+      case _ =>
     }
   }).withDispatcher("dispatcher").withMailbox("mailbox"), "receiver")
 

--- a/akka-bench-jmh/src/main/scala/akka/http/HttpBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/http/HttpBenchmark.scala
@@ -28,7 +28,8 @@ class HttpBenchmark {
     """
       akka {
         loglevel = "ERROR"
-      }""".stripMargin).withFallback(ConfigFactory.load())
+      }""".stripMargin
+  ).withFallback(ConfigFactory.load())
 
   implicit val system = ActorSystem("HttpBenchmark", config)
   implicit val materializer = ActorMaterializer()
@@ -38,7 +39,7 @@ class HttpBenchmark {
   var pool: Flow[(HttpRequest, Int), (Try[HttpResponse], Int), _] = _
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     val route = {
       path("test") {
         get {
@@ -53,21 +54,21 @@ class HttpBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     Await.ready(Http().shutdownAllConnectionPools(), 1.second)
     binding.unbind()
     Await.result(system.terminate(), 5.seconds)
   }
 
   @Benchmark
-  def single_request():Unit = {
+  def single_request(): Unit = {
     import system.dispatcher
     val response = Await.result(Http().singleRequest(request), 1.second)
     Await.result(Unmarshal(response.entity).to[String], 1.second)
   }
 
   @Benchmark
-  def single_request_pool():Unit = {
+  def single_request_pool(): Unit = {
     import system.dispatcher
     val (response, id) = Await.result(Source.single(HttpRequest(uri = "/test") -> 42).via(pool).runWith(Sink.head), 1.second)
     Await.result(Unmarshal(response.get.entity).to[String], 1.second)

--- a/akka-bench-jmh/src/main/scala/akka/persistence/LevelDbBatchingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/LevelDbBatchingBenchmark.scala
@@ -45,7 +45,7 @@ class LevelDbBatchingBenchmark {
   val batch_200 = List.fill(200) { AtomicWrite(PersistentRepr("data", 12, "pa")) }
 
   @Setup(Level.Trial)
-  def setup():Unit = {
+  def setup(): Unit = {
     sys = ActorSystem("sys")
     deleteStorage(sys)
     SharedLeveldbJournal.setStore(store, sys)
@@ -55,7 +55,7 @@ class LevelDbBatchingBenchmark {
   }
 
   @TearDown(Level.Trial)
-  def tearDown():Unit = {
+  def tearDown(): Unit = {
     store ! PoisonPill
     Thread.sleep(500)
 
@@ -66,7 +66,7 @@ class LevelDbBatchingBenchmark {
   @Benchmark
   @Measurement(timeUnit = TimeUnit.MICROSECONDS)
   @OperationsPerInvocation(1)
-  def write_1():Unit = {
+  def write_1(): Unit = {
     probe.send(store, WriteMessages(batch_1))
     probe.expectMsgType[Any]
   }
@@ -74,7 +74,7 @@ class LevelDbBatchingBenchmark {
   @Benchmark
   @Measurement(timeUnit = TimeUnit.MICROSECONDS)
   @OperationsPerInvocation(10)
-  def writeBatch_10():Unit = {
+  def writeBatch_10(): Unit = {
     probe.send(store, WriteMessages(batch_10))
     probe.expectMsgType[Any]
   }
@@ -82,7 +82,7 @@ class LevelDbBatchingBenchmark {
   @Benchmark
   @Measurement(timeUnit = TimeUnit.MICROSECONDS)
   @OperationsPerInvocation(100)
-  def writeBatch_100():Unit = {
+  def writeBatch_100(): Unit = {
     probe.send(store, WriteMessages(batch_100))
     probe.expectMsgType[Any]
   }
@@ -90,7 +90,7 @@ class LevelDbBatchingBenchmark {
   @Benchmark
   @Measurement(timeUnit = TimeUnit.MICROSECONDS)
   @OperationsPerInvocation(200)
-  def writeBatch_200():Unit = {
+  def writeBatch_200(): Unit = {
     probe.send(store, WriteMessages(batch_200))
     probe.expectMsgType[Any]
   }
@@ -101,7 +101,8 @@ class LevelDbBatchingBenchmark {
     val storageLocations = List(
       "akka.persistence.journal.leveldb.dir",
       "akka.persistence.journal.leveldb-shared.store.dir",
-      "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(sys.settings.config.getString(s)))
+      "akka.persistence.snapshot-store.local.dir"
+    ).map(s ⇒ new File(sys.settings.config.getString(s)))
 
     storageLocations.foreach(FileUtils.deleteDirectory)
   }

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistenceActorDeferBenchmark.scala
@@ -32,7 +32,8 @@ class PersistentActorDeferBenchmark {
   lazy val storageLocations = List(
     "akka.persistence.journal.leveldb.dir",
     "akka.persistence.journal.leveldb-shared.store.dir",
-    "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
+    "akka.persistence.snapshot-store.local.dir"
+  ).map(s ⇒ new File(system.settings.config.getString(s)))
 
   var system: ActorSystem = _
 
@@ -43,7 +44,7 @@ class PersistentActorDeferBenchmark {
   val data10k = (1 to 10000).toArray
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     system = ActorSystem("test", config)
 
     probe = TestProbe()(system)
@@ -54,7 +55,7 @@ class PersistentActorDeferBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
 
@@ -63,7 +64,7 @@ class PersistentActorDeferBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def tell_persistAsync_defer_persistAsync_reply():Unit = {
+  def tell_persistAsync_defer_persistAsync_reply(): Unit = {
     for (i <- data10k) persistAsync_defer.tell(i, probe.ref)
 
     probe.expectMsg(data10k.last)
@@ -71,7 +72,7 @@ class PersistentActorDeferBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def tell_persistAsync_defer_persistAsync_replyASAP():Unit = {
+  def tell_persistAsync_defer_persistAsync_replyASAP(): Unit = {
     for (i <- data10k) persistAsync_defer_replyASAP.tell(i, probe.ref)
 
     probe.expectMsg(data10k.last)

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorBenchmark.scala
@@ -21,7 +21,8 @@ class PersistentActorThroughputBenchmark {
   lazy val storageLocations = List(
     "akka.persistence.journal.leveldb.dir",
     "akka.persistence.journal.leveldb-shared.store.dir",
-    "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
+    "akka.persistence.snapshot-store.local.dir"
+  ).map(s ⇒ new File(system.settings.config.getString(s)))
 
   var system: ActorSystem = _
 
@@ -35,7 +36,7 @@ class PersistentActorThroughputBenchmark {
   val data10k = (1 to 10000).toArray
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     system = ActorSystem("test", config)
 
     probe = TestProbe()(system)
@@ -52,7 +53,7 @@ class PersistentActorThroughputBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
 
@@ -61,7 +62,7 @@ class PersistentActorThroughputBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def actor_normalActor_reply_baseline():Unit = {
+  def actor_normalActor_reply_baseline(): Unit = {
     for (i <- data10k) actor.tell(i, probe.ref)
 
     probe.expectMsg(data10k.last)
@@ -69,7 +70,7 @@ class PersistentActorThroughputBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def persistentActor_persist_reply():Unit = {
+  def persistentActor_persist_reply(): Unit = {
     for (i <- data10k) persistPersistentActor.tell(i, probe.ref)
 
     probe.expectMsg(Evt(data10k.last))
@@ -77,7 +78,7 @@ class PersistentActorThroughputBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def persistentActor_persistAsync_reply():Unit = {
+  def persistentActor_persistAsync_reply(): Unit = {
     for (i <- data10k) persistAsync1PersistentActor.tell(i, probe.ref)
 
     probe.expectMsg(Evt(data10k.last))
@@ -85,7 +86,7 @@ class PersistentActorThroughputBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def persistentActor_noPersist_reply():Unit = {
+  def persistentActor_noPersist_reply(): Unit = {
     for (i <- data10k) noPersistPersistentActor.tell(i, probe.ref)
 
     probe.expectMsg(Evt(data10k.last))
@@ -93,7 +94,7 @@ class PersistentActorThroughputBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def persistentActor_persistAsync_replyRightOnCommandReceive():Unit = {
+  def persistentActor_persistAsync_replyRightOnCommandReceive(): Unit = {
     for (i <- data10k) persistAsyncQuickReplyPersistentActor.tell(i, probe.ref)
 
     probe.expectMsg(Evt(data10k.last))

--- a/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorWithAtLeastOnceDeliveryBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/persistence/PersistentActorWithAtLeastOnceDeliveryBenchmark.scala
@@ -22,7 +22,8 @@ class PersistentActorWithAtLeastOnceDeliveryBenchmark {
   lazy val storageLocations = List(
     "akka.persistence.journal.leveldb.dir",
     "akka.persistence.journal.leveldb-shared.store.dir",
-    "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
+    "akka.persistence.snapshot-store.local.dir"
+  ).map(s ⇒ new File(system.settings.config.getString(s)))
 
   var system: ActorSystem = _
 
@@ -36,7 +37,7 @@ class PersistentActorWithAtLeastOnceDeliveryBenchmark {
   val dataCount = 10000
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     system = ActorSystem("PersistentActorWithAtLeastOnceDeliveryBenchmark", config)
 
     probe = TestProbe()(system)
@@ -51,7 +52,7 @@ class PersistentActorWithAtLeastOnceDeliveryBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     system.terminate()
     Await.ready(system.whenTerminated, 15.seconds)
 
@@ -60,7 +61,7 @@ class PersistentActorWithAtLeastOnceDeliveryBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def persistentActor_persistAsync_with_AtLeastOnceDelivery():Unit = {
+  def persistentActor_persistAsync_with_AtLeastOnceDelivery(): Unit = {
     for (i <- 1 to dataCount)
       persistAsyncPersistentActorWithAtLeastOnceDelivery.tell(i, probe.ref)
     probe.expectMsg(20.seconds, Evt(dataCount))
@@ -68,7 +69,7 @@ class PersistentActorWithAtLeastOnceDeliveryBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def persistentActor_persist_with_AtLeastOnceDelivery():Unit = {
+  def persistentActor_persist_with_AtLeastOnceDelivery(): Unit = {
     for (i <- 1 to dataCount)
       persistPersistentActorWithAtLeastOnceDelivery.tell(i, probe.ref)
     probe.expectMsg(2.minutes, Evt(dataCount))
@@ -76,7 +77,7 @@ class PersistentActorWithAtLeastOnceDeliveryBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(10000)
-  def persistentActor_noPersist_with_AtLeastOnceDelivery():Unit = {
+  def persistentActor_noPersist_with_AtLeastOnceDelivery(): Unit = {
     for (i <- 1 to dataCount)
       noPersistPersistentActorWithAtLeastOnceDelivery.tell(i, probe.ref)
     probe.expectMsg(20.seconds, Evt(dataCount))

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlatMapMergeBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlatMapMergeBenchmark.scala
@@ -4,7 +4,7 @@
 
 package akka.stream
 
-import akka.{Done, NotUsed}
+import akka.{ Done, NotUsed }
 import akka.actor.ActorSystem
 import akka.stream.scaladsl._
 import java.util.concurrent.TimeUnit
@@ -30,7 +30,7 @@ class FlatMapMergeBenchmark {
   def createSource(count: Int): Graph[SourceShape[Int], NotUsed] = akka.stream.Fusing.aggressive(Source.repeat(1).take(count))
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     val source = NumberOfStreams match {
       // Base line: process NumberOfElements-many elements from a single source without using flatMapMerge
       case 0 => createSource(NumberOfElements)
@@ -43,13 +43,13 @@ class FlatMapMergeBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     Await.result(system.terminate(), 5.seconds)
   }
 
   @Benchmark
   @OperationsPerInvocation(100000) // Note: needs to match NumberOfElements.
-  def flat_map_merge_100k_elements():Unit = {
+  def flat_map_merge_100k_elements(): Unit = {
     Await.result(graph.run(), Duration.Inf)
   }
 }

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -47,7 +47,8 @@ class FlowMapBenchmark {
             type = akka.testkit.CallingThreadDispatcherConfigurator
           }
         }
-      }""".stripMargin).withFallback(ConfigFactory.load())
+      }""".stripMargin
+  ).withFallback(ConfigFactory.load())
 
   implicit val system = ActorSystem("test", config)
 
@@ -69,7 +70,7 @@ class FlowMapBenchmark {
   var numberOfMapOps = 0
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     val settings = ActorMaterializerSettings(system)
       .withInputBuffer(initialInputBufferSize, initialInputBufferSize)
 
@@ -111,13 +112,13 @@ class FlowMapBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     Await.result(system.terminate(), 5.seconds)
   }
 
   @Benchmark
   @OperationsPerInvocation(100000)
-  def flow_map_100k_elements():Unit = {
+  def flow_map_100k_elements(): Unit = {
     val lock = new Lock() // todo rethink what is the most lightweight way to await for a streams completion
     lock.acquire()
 

--- a/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
@@ -16,22 +16,22 @@ class GraphBuilderBenchmark {
   var complexity = 0
 
   @Benchmark
-  def flow_with_map():Unit = {
+  def flow_with_map(): Unit = {
     MaterializationBenchmark.flowWithMapBuilder(complexity)
   }
 
   @Benchmark
-  def graph_with_junctions():Unit ={
+  def graph_with_junctions(): Unit = {
     MaterializationBenchmark.graphWithJunctionsBuilder(complexity)
   }
 
   @Benchmark
-  def graph_with_nested_imports():Unit = {
+  def graph_with_nested_imports(): Unit = {
     MaterializationBenchmark.graphWithNestedImportsBuilder(complexity)
   }
 
   @Benchmark
-  def graph_with_imported_flow():Unit = {
+  def graph_with_imported_flow(): Unit = {
     MaterializationBenchmark.graphWithImportedFlowBuilder(complexity)
   }
 }

--- a/akka-bench-jmh/src/main/scala/akka/stream/InterpreterBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/InterpreterBenchmark.scala
@@ -1,12 +1,11 @@
 package akka.stream
 
 import akka.event._
-import akka.stream.impl.fusing.{ GraphInterpreterSpecKit, GraphStages}
+import akka.stream.impl.fusing.{ GraphInterpreterSpecKit, GraphStages }
 import akka.stream.impl.fusing.GraphStages
 import akka.stream.impl.fusing.GraphInterpreter.{ DownstreamBoundaryStageLogic, UpstreamBoundaryStageLogic }
 import akka.stream.stage._
 import org.openjdk.jmh.annotations._
-
 
 import java.util.concurrent.TimeUnit
 
@@ -24,7 +23,7 @@ class InterpreterBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(100000)
-  def graph_interpreter_100k_elements():Unit = {
+  def graph_interpreter_100k_elements(): Unit = {
     new GraphInterpreterSpecKit {
       new TestSetup {
         val identities = Vector.fill(numberOfIds)(GraphStages.identity[Int])

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -43,33 +43,30 @@ object MaterializationBenchmark {
   val graphWithNestedImportsBuilder = (numOfNestedGraphs: Int) => {
     var flow: Graph[FlowShape[Unit, Unit], NotUsed] = Flow[Unit].map(identity)
     for (_ <- 1 to numOfNestedGraphs) {
-      flow = GraphDSL.create(flow) { b ⇒
-        flow ⇒
-          FlowShape(flow.in, flow.out)
+      flow = GraphDSL.create(flow) { b ⇒ flow ⇒
+        FlowShape(flow.in, flow.out)
       }
     }
 
-    RunnableGraph.fromGraph(GraphDSL.create(flow) { implicit b ⇒
-      flow ⇒
-        import GraphDSL.Implicits._
-        Source.single(()) ~> flow ~> Sink.ignore
-        ClosedShape
+    RunnableGraph.fromGraph(GraphDSL.create(flow) { implicit b ⇒ flow ⇒
+      import GraphDSL.Implicits._
+      Source.single(()) ~> flow ~> Sink.ignore
+      ClosedShape
     })
   }
 
   val graphWithImportedFlowBuilder = (numOfFlows: Int) =>
-    RunnableGraph.fromGraph(GraphDSL.create(Source.single(())) { implicit b ⇒
-      source ⇒
-        import GraphDSL.Implicits._
-        val flow = Flow[Unit].map(identity)
-        var out: Outlet[Unit] = source.out
-        for (i <- 0 until numOfFlows) {
-          val flowShape = b.add(flow)
-          out ~> flowShape
-          out = flowShape.outlet
-        }
-        out ~> Sink.ignore
-        ClosedShape
+    RunnableGraph.fromGraph(GraphDSL.create(Source.single(())) { implicit b ⇒ source ⇒
+      import GraphDSL.Implicits._
+      val flow = Flow[Unit].map(identity)
+      var out: Outlet[Unit] = source.out
+      for (i <- 0 until numOfFlows) {
+        val flowShape = b.add(flow)
+        out ~> flowShape
+        out = flowShape.outlet
+      }
+      out ~> Sink.ignore
+      ClosedShape
     })
 }
 
@@ -91,7 +88,7 @@ class MaterializationBenchmark {
   var complexity = 0
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     flowWithMap = flowWithMapBuilder(complexity)
     graphWithJunctions = graphWithJunctionsBuilder(complexity)
     graphWithNestedImports = graphWithNestedImportsBuilder(complexity)
@@ -99,22 +96,19 @@ class MaterializationBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     Await.result(system.terminate(), 5.seconds)
   }
 
   @Benchmark
-  def flow_with_map():Unit = flowWithMap.run()
-
-
-  @Benchmark
-  def graph_with_junctions():Unit = graphWithJunctions.run()
-
+  def flow_with_map(): Unit = flowWithMap.run()
 
   @Benchmark
-  def graph_with_nested_imports():Unit = graphWithNestedImports.run()
-
+  def graph_with_junctions(): Unit = graphWithJunctions.run()
 
   @Benchmark
-  def graph_with_imported_flow():Unit = graphWithImportedFlow.run()
+  def graph_with_nested_imports(): Unit = graphWithNestedImports.run()
+
+  @Benchmark
+  def graph_with_imported_flow(): Unit = graphWithImportedFlow.run()
 }

--- a/akka-bench-jmh/src/main/scala/akka/stream/io/FileSourcesBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/io/FileSourcesBenchmark.scala
@@ -50,7 +50,7 @@ class FileSourcesBenchmark {
   var ioSourceLinesIterator: Source[ByteString, NotUsed] = _
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     fileChannelSource = FileIO.fromFile(file, bufSize)
     fileInputStreamSource = StreamConverters.fromInputStream(() ⇒ new FileInputStream(file), bufSize)
     ioSourceLinesIterator = Source.fromIterator(() ⇒ scala.io.Source.fromFile(file).getLines()).map(ByteString(_))
@@ -62,26 +62,26 @@ class FileSourcesBenchmark {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     Await.result(system.terminate(), Duration.Inf)
   }
 
   @Benchmark
-  def fileChannel():Unit = {
+  def fileChannel(): Unit = {
     val h = fileChannelSource.to(Sink.ignore).run()
 
     Await.result(h, 30.seconds)
   }
 
   @Benchmark
-  def fileChannel_noReadAhead():Unit = {
+  def fileChannel_noReadAhead(): Unit = {
     val h = fileChannelSource.withAttributes(Attributes.inputBuffer(1, 1)).to(Sink.ignore).run()
 
     Await.result(h, 30.seconds)
   }
 
   @Benchmark
-  def inputStream():Unit = {
+  def inputStream(): Unit = {
     val h = fileInputStreamSource.to(Sink.ignore).run()
 
     Await.result(h, 30.seconds)
@@ -93,7 +93,7 @@ class FileSourcesBenchmark {
    * FileSourcesBenchmark.naive_ioSourceLinesIterator  avgt   20  7067.944 ± 1341.847  ms/op
    */
   @Benchmark
-  def naive_ioSourceLinesIterator():Unit = {
+  def naive_ioSourceLinesIterator(): Unit = {
     val p = Promise[Done]()
     ioSourceLinesIterator.to(Sink.onComplete(p.complete(_))).run()
 

--- a/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
+++ b/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
@@ -288,6 +288,6 @@ case object Ack {
  * message or Exchange.getOut message, depending on the exchange pattern.
  */
 class AkkaCamelException private[akka] (cause: Throwable, val headers: Map[String, Any])
-  extends AkkaException(cause.getMessage, cause) {
+    extends AkkaException(cause.getMessage, cause) {
   def this(cause: Throwable) = this(cause, Map.empty)
 }

--- a/akka-camel/src/main/scala/akka/camel/internal/CamelSupervisor.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/CamelSupervisor.scala
@@ -98,7 +98,7 @@ private[camel] class Registry(activationTracker: ActorRef) extends Actor with Ca
 
   class RegistryLogStrategy()(_decider: SupervisorStrategy.Decider) extends OneForOneStrategy()(_decider) {
     override def logFailure(context: ActorContext, child: ActorRef, cause: Throwable,
-                            decision: SupervisorStrategy.Directive): Unit =
+      decision: SupervisorStrategy.Directive): Unit =
       cause match {
         case _: ActorActivationException | _: ActorDeActivationException ⇒
           try context.system.eventStream.publish {
@@ -163,7 +163,7 @@ private[camel] class ProducerRegistrar(activationTracker: ActorRef) extends Acto
         try {
           val endpoint = camelContext.getEndpoint(endpointUri)
           val processor = new SendProcessor(endpoint)
-          camelObjects = camelObjects.updated(producer, endpoint -> processor)
+          camelObjects = camelObjects.updated(producer, endpoint → processor)
           // if this throws, the supervisor stops the producer and de-registers it on termination
           processor.start()
           producer ! CamelProducerObjects(endpoint, processor)

--- a/akka-camel/src/main/scala/akka/camel/internal/component/ActorComponent.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/component/ActorComponent.scala
@@ -49,10 +49,11 @@ private[camel] class ActorComponent(camel: Camel, system: ActorSystem) extends D
  * <code>[actorPath]?[options]%s</code>,
  * where <code>[actorPath]</code> refers to the actor path to the actor.
  */
-private[camel] class ActorEndpoint(uri: String,
-                                   comp: ActorComponent,
-                                   val path: ActorEndpointPath,
-                                   val camel: Camel) extends DefaultEndpoint(uri, comp) with ActorEndpointConfig {
+private[camel] class ActorEndpoint(
+  uri: String,
+    comp: ActorComponent,
+    val path: ActorEndpointPath,
+    val camel: Camel) extends DefaultEndpoint(uri, comp) with ActorEndpointConfig {
 
   /**
    * The ActorEndpoint only supports receiving messages from Camel.
@@ -174,7 +175,7 @@ private[camel] class ActorProducer(val endpoint: ActorEndpoint, camel: Camel) ex
     path.findActorIn(camel.system) getOrElse (throw new ActorNotRegisteredException(path.actorPath))
 
   private[this] def messageFor(exchange: CamelExchangeAdapter) =
-    exchange.toRequestMessage(Map(CamelMessage.MessageExchangeId -> exchange.getExchangeId))
+    exchange.toRequestMessage(Map(CamelMessage.MessageExchangeId → exchange.getExchangeId))
 }
 
 /**

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
@@ -153,13 +153,15 @@ private[metrics] class ClusterMetricsCollector extends Actor with ActorLogging {
   /**
    * Start periodic gossip to random nodes in cluster
    */
-  val gossipTask = scheduler.schedule(PeriodicTasksInitialDelay max CollectorGossipInterval,
+  val gossipTask = scheduler.schedule(
+    PeriodicTasksInitialDelay max CollectorGossipInterval,
     CollectorGossipInterval, self, GossipTick)
 
   /**
    * Start periodic metrics collection
    */
-  val sampleTask = scheduler.schedule(PeriodicTasksInitialDelay max CollectorSampleInterval,
+  val sampleTask = scheduler.schedule(
+    PeriodicTasksInitialDelay max CollectorSampleInterval,
     CollectorSampleInterval, self, MetricsTick)
 
   override def preStart(): Unit = {

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsExtension.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsExtension.scala
@@ -44,7 +44,7 @@ class ClusterMetricsExtension(system: ExtendedActorSystem) extends Extension {
    * Supervision strategy.
    */
   private[metrics] val strategy = system.dynamicAccess.createInstanceFor[SupervisorStrategy](
-    SupervisorStrategyProvider, immutable.Seq(classOf[Config] -> SupervisorStrategyConfiguration))
+    SupervisorStrategyProvider, immutable.Seq(classOf[Config] → SupervisorStrategyConfiguration))
     .getOrElse {
       val log: LoggingAdapter = Logging(system, getClass.getName)
       log.error(s"Configured strategy provider ${SupervisorStrategyProvider} failed to load, using default ${classOf[ClusterMetricsStrategy].getName}.")

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
@@ -21,7 +21,7 @@ import scala.util.Try
  */
 @SerialVersionUID(1L)
 final case class Metric private[metrics] (name: String, value: Number, average: Option[EWMA])
-  extends MetricNumericConverter {
+    extends MetricNumericConverter {
 
   require(defined(value), s"Invalid Metric [$name] value [$value]")
 
@@ -207,12 +207,12 @@ object StandardMetrics {
    */
   @SerialVersionUID(1L)
   final case class Cpu(
-    address: Address,
-    timestamp: Long,
-    systemLoadAverage: Option[Double],
-    cpuCombined: Option[Double],
-    cpuStolen: Option[Double],
-    processors: Int) {
+      address: Address,
+      timestamp: Long,
+      systemLoadAverage: Option[Double],
+      cpuCombined: Option[Double],
+      cpuStolen: Option[Double],
+      processors: Int) {
 
     cpuCombined match {
       case Some(x) ⇒ require(0.0 <= x && x <= 1.0, s"cpuCombined must be between [0.0 - 1.0], was [$x]")

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/MetricsCollector.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/MetricsCollector.scala
@@ -60,7 +60,7 @@ private[metrics] object MetricsCollector {
     def create(provider: String) = TryNative {
       log.debug(s"Trying ${provider}.")
       system.asInstanceOf[ExtendedActorSystem].dynamicAccess
-        .createInstanceFor[MetricsCollector](provider, List(classOf[ActorSystem] -> system)).get
+        .createInstanceFor[MetricsCollector](provider, List(classOf[ActorSystem] → system)).get
     }
 
     val collector = if (useCustom)
@@ -86,7 +86,8 @@ class JmxMetricsCollector(address: Address, decayFactor: Double) extends Metrics
   import StandardMetrics._
 
   private def this(address: Address, settings: ClusterMetricsSettings) =
-    this(address,
+    this(
+      address,
       EWMA.alpha(settings.CollectorMovingAverageHalfLife, settings.CollectorSampleInterval))
 
   /**
@@ -187,13 +188,14 @@ class JmxMetricsCollector(address: Address, decayFactor: Double) extends Metrics
  * @param sigar the org.hyperic.Sigar instance
  */
 class SigarMetricsCollector(address: Address, decayFactor: Double, sigar: SigarProxy)
-  extends JmxMetricsCollector(address, decayFactor) {
+    extends JmxMetricsCollector(address, decayFactor) {
 
   import StandardMetrics._
   import org.hyperic.sigar.CpuPerc
 
   def this(address: Address, settings: ClusterMetricsSettings, sigar: SigarProxy) =
-    this(address,
+    this(
+      address,
       EWMA.alpha(settings.CollectorMovingAverageHalfLife, settings.CollectorSampleInterval),
       sigar)
 

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/protobuf/MessageSerializer.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/protobuf/MessageSerializer.scala
@@ -177,7 +177,8 @@ class MessageSerializer(val system: ExtendedActorSystem) extends SerializerWithS
         case NumberType.Float_VALUE   ⇒ jl.Float.intBitsToFloat(number.getValue32)
         case NumberType.Integer_VALUE ⇒ number.getValue32
         case NumberType.Serialized_VALUE ⇒
-          val in = new ClassLoaderObjectInputStream(system.dynamicAccess.classLoader,
+          val in = new ClassLoaderObjectInputStream(
+            system.dynamicAccess.classLoader,
             new ByteArrayInputStream(number.getSerialized.toByteArray))
           val obj = in.readObject
           in.close()

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -167,7 +167,8 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
   }
 
   private[akka] def requireClusterRole(role: Option[String]): Unit =
-    require(role.forall(cluster.selfRoles.contains),
+    require(
+      role.forall(cluster.selfRoles.contains),
       s"This cluster member [${cluster.selfAddress}] doesn't have the role [$role]")
 
   /**
@@ -274,9 +275,9 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
 
     start(typeName, entityProps, settings,
       extractEntityId = {
-        case msg if messageExtractor.entityId(msg) ne null ⇒
-          (messageExtractor.entityId(msg), messageExtractor.entityMessage(msg))
-      },
+      case msg if messageExtractor.entityId(msg) ne null ⇒
+        (messageExtractor.entityId(msg), messageExtractor.entityMessage(msg))
+    },
       extractShardId = msg ⇒ messageExtractor.shardId(msg),
       allocationStrategy = allocationStrategy,
       handOffStopMessage = handOffStopMessage)
@@ -369,9 +370,9 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
 
     startProxy(typeName, Option(role.orElse(null)),
       extractEntityId = {
-        case msg if messageExtractor.entityId(msg) ne null ⇒
-          (messageExtractor.entityId(msg), messageExtractor.entityMessage(msg))
-      },
+      case msg if messageExtractor.entityId(msg) ne null ⇒
+        (messageExtractor.entityId(msg), messageExtractor.entityMessage(msg))
+    },
       extractShardId = msg ⇒ messageExtractor.shardId(msg))
 
   }
@@ -394,12 +395,12 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
 private[akka] object ClusterShardingGuardian {
   import ShardCoordinator.ShardAllocationStrategy
   final case class Start(typeName: String, entityProps: Props, settings: ClusterShardingSettings,
-                         extractEntityId: ShardRegion.ExtractEntityId, extractShardId: ShardRegion.ExtractShardId,
-                         allocationStrategy: ShardAllocationStrategy, handOffStopMessage: Any)
-    extends NoSerializationVerificationNeeded
+    extractEntityId: ShardRegion.ExtractEntityId, extractShardId: ShardRegion.ExtractShardId,
+    allocationStrategy: ShardAllocationStrategy, handOffStopMessage: Any)
+      extends NoSerializationVerificationNeeded
   final case class StartProxy(typeName: String, settings: ClusterShardingSettings,
-                              extractEntityId: ShardRegion.ExtractEntityId, extractShardId: ShardRegion.ExtractShardId)
-    extends NoSerializationVerificationNeeded
+    extractEntityId: ShardRegion.ExtractEntityId, extractShardId: ShardRegion.ExtractShardId)
+      extends NoSerializationVerificationNeeded
   final case class Started(shardRegion: ActorRef) extends NoSerializationVerificationNeeded
 }
 
@@ -443,14 +444,16 @@ private[akka] class ClusterShardingGuardian extends Actor {
             randomFactor = 0.2).withDeploy(Deploy.local)
           val singletonSettings = settings.coordinatorSingletonSettings
             .withSingletonName("singleton").withRole(role)
-          context.actorOf(ClusterSingletonManager.props(
+          context.actorOf(
+            ClusterSingletonManager.props(
             singletonProps,
             terminationMessage = PoisonPill,
             singletonSettings).withDispatcher(context.props.dispatcher),
             name = cName)
         }
 
-        context.actorOf(ShardRegion.props(
+        context.actorOf(
+          ShardRegion.props(
           typeName = typeName,
           entityProps = entityProps,
           settings = settings,
@@ -467,7 +470,8 @@ private[akka] class ClusterShardingGuardian extends Actor {
       val cName = coordinatorSingletonManagerName(encName)
       val cPath = coordinatorPath(encName)
       val shardRegion = context.child(encName).getOrElse {
-        context.actorOf(ShardRegion.proxyProps(
+        context.actorOf(
+          ShardRegion.proxyProps(
           typeName = typeName,
           settings = settings,
           coordinatorPath = cPath,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -102,15 +102,16 @@ object ClusterShardingSettings {
  * @param tuningParameters additional tuning parameters, see descriptions in reference.conf
  */
 final class ClusterShardingSettings(
-  val role: Option[String],
-  val rememberEntities: Boolean,
-  val journalPluginId: String,
-  val snapshotPluginId: String,
-  val stateStoreMode: String,
-  val tuningParameters: ClusterShardingSettings.TuningParameters,
-  val coordinatorSingletonSettings: ClusterSingletonManagerSettings) extends NoSerializationVerificationNeeded {
+    val role: Option[String],
+    val rememberEntities: Boolean,
+    val journalPluginId: String,
+    val snapshotPluginId: String,
+    val stateStoreMode: String,
+    val tuningParameters: ClusterShardingSettings.TuningParameters,
+    val coordinatorSingletonSettings: ClusterSingletonManagerSettings) extends NoSerializationVerificationNeeded {
 
-  require(stateStoreMode == "persistence" || stateStoreMode == "ddata",
+  require(
+    stateStoreMode == "persistence" || stateStoreMode == "ddata",
     s"Unknown 'state-store-mode' [$stateStoreMode], valid values are 'persistence' or 'ddata'")
 
   def withRole(role: String): ClusterShardingSettings = copy(role = ClusterShardingSettings.roleOption(role))
@@ -136,13 +137,14 @@ final class ClusterShardingSettings(
   def withCoordinatorSingletonSettings(coordinatorSingletonSettings: ClusterSingletonManagerSettings): ClusterShardingSettings =
     copy(coordinatorSingletonSettings = coordinatorSingletonSettings)
 
-  private def copy(role: Option[String] = role,
-                   rememberEntities: Boolean = rememberEntities,
-                   journalPluginId: String = journalPluginId,
-                   snapshotPluginId: String = snapshotPluginId,
-                   stateStoreMode: String = stateStoreMode,
-                   tuningParameters: ClusterShardingSettings.TuningParameters = tuningParameters,
-                   coordinatorSingletonSettings: ClusterSingletonManagerSettings = coordinatorSingletonSettings): ClusterShardingSettings =
+  private def copy(
+    role: Option[String] = role,
+    rememberEntities: Boolean = rememberEntities,
+    journalPluginId: String = journalPluginId,
+    snapshotPluginId: String = snapshotPluginId,
+    stateStoreMode: String = stateStoreMode,
+    tuningParameters: ClusterShardingSettings.TuningParameters = tuningParameters,
+    coordinatorSingletonSettings: ClusterSingletonManagerSettings = coordinatorSingletonSettings): ClusterShardingSettings =
     new ClusterShardingSettings(
       role,
       rememberEntities,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/RemoveInternalClusterShardingData.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/RemoveInternalClusterShardingData.scala
@@ -81,7 +81,7 @@ object RemoveInternalClusterShardingData {
    * [[RemoveInternalClusterShardingData$ RemoveInternalClusterShardingData companion object]]
    */
   def remove(system: ActorSystem, journalPluginId: String, typeNames: Set[String],
-             terminateSystem: Boolean, remove2dot3Data: Boolean): Future[Unit] = {
+    terminateSystem: Boolean, remove2dot3Data: Boolean): Future[Unit] = {
 
     val resolvedJournalPluginId =
       if (journalPluginId == "") system.settings.config.getString("akka.persistence.journal.plugin")
@@ -92,7 +92,8 @@ object RemoveInternalClusterShardingData {
     }
 
     val completion = Promise[Unit]()
-    system.actorOf(props(journalPluginId, typeNames, completion, remove2dot3Data),
+    system.actorOf(
+      props(journalPluginId, typeNames, completion, remove2dot3Data),
       name = "removeInternalClusterShardingData")
     completion.future
   }
@@ -122,7 +123,7 @@ object RemoveInternalClusterShardingData {
    */
   private[akka] class RemoveOnePersistenceId(
     override val journalPluginId: String, override val persistenceId: String, replyTo: ActorRef)
-    extends PersistentActor {
+      extends PersistentActor {
 
     import RemoveInternalClusterShardingData.RemoveOnePersistenceId._
 
@@ -180,8 +181,8 @@ object RemoveInternalClusterShardingData {
  * @see [[RemoveInternalClusterShardingData$ RemoveInternalClusterShardingData companion object]]
  */
 class RemoveInternalClusterShardingData(journalPluginId: String, typeNames: Set[String], completion: Promise[Unit],
-                                        remove2dot3Data: Boolean) extends Actor
-  with ActorLogging {
+  remove2dot3Data: Boolean) extends Actor
+    with ActorLogging {
   import RemoveInternalClusterShardingData._
   import RemoveOnePersistenceId.Result
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -80,13 +80,14 @@ private[akka] object Shard {
    * If `settings.rememberEntities` is enabled the `PersistentShard`
    * subclass is used, otherwise `Shard`.
    */
-  def props(typeName: String,
-            shardId: ShardRegion.ShardId,
-            entityProps: Props,
-            settings: ClusterShardingSettings,
-            extractEntityId: ShardRegion.ExtractEntityId,
-            extractShardId: ShardRegion.ExtractShardId,
-            handOffStopMessage: Any): Props = {
+  def props(
+    typeName: String,
+    shardId: ShardRegion.ShardId,
+    entityProps: Props,
+    settings: ClusterShardingSettings,
+    extractEntityId: ShardRegion.ExtractEntityId,
+    extractShardId: ShardRegion.ExtractShardId,
+    handOffStopMessage: Any): Props = {
     if (settings.rememberEntities)
       Props(new PersistentShard(typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage))
         .withDeploy(Deploy.local)
@@ -105,13 +106,13 @@ private[akka] object Shard {
  * @see [[ClusterSharding$ ClusterSharding extension]]
  */
 private[akka] class Shard(
-  typeName: String,
-  shardId: ShardRegion.ShardId,
-  entityProps: Props,
-  settings: ClusterShardingSettings,
-  extractEntityId: ShardRegion.ExtractEntityId,
-  extractShardId: ShardRegion.ExtractShardId,
-  handOffStopMessage: Any) extends Actor with ActorLogging {
+    typeName: String,
+    shardId: ShardRegion.ShardId,
+    entityProps: Props,
+    settings: ClusterShardingSettings,
+    extractEntityId: ShardRegion.ExtractEntityId,
+    extractShardId: ShardRegion.ExtractShardId,
+    handOffStopMessage: Any) extends Actor with ActorLogging {
 
   import ShardRegion.{ handOffStopperProps, EntityId, Msg, Passivate, ShardInitialized }
   import ShardCoordinator.Internal.{ HandOff, ShardStopped }
@@ -309,7 +310,7 @@ private[akka] class PersistentShard(
   extractShardId: ShardRegion.ExtractShardId,
   handOffStopMessage: Any) extends Shard(
   typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage)
-  with PersistentActor with ActorLogging {
+    with PersistentActor with ActorLogging {
 
   import ShardRegion.{ EntityId, Msg }
   import Shard.{ State, RestartEntity, EntityStopped, EntityStarted }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -304,7 +304,7 @@ object ShardRegion {
    * them have terminated it replies with `ShardStopped`.
    */
   private[akka] class HandOffStopper(shard: String, replyTo: ActorRef, entities: Set[ActorRef], stopMessage: Any)
-    extends Actor {
+      extends Actor {
     import ShardCoordinator.Internal.ShardStopped
 
     entities.foreach { a ⇒
@@ -337,13 +337,13 @@ object ShardRegion {
  * @see [[ClusterSharding$ ClusterSharding extension]]
  */
 class ShardRegion(
-  typeName: String,
-  entityProps: Option[Props],
-  settings: ClusterShardingSettings,
-  coordinatorPath: String,
-  extractEntityId: ShardRegion.ExtractEntityId,
-  extractShardId: ShardRegion.ExtractShardId,
-  handOffStopMessage: Any) extends Actor with ActorLogging {
+    typeName: String,
+    entityProps: Option[Props],
+    settings: ClusterShardingSettings,
+    coordinatorPath: String,
+    extractEntityId: ShardRegion.ExtractEntityId,
+    extractShardId: ShardRegion.ExtractShardId,
+    handOffStopMessage: Any) extends Actor with ActorLogging {
 
   import ShardCoordinator.Internal._
   import ShardRegion._
@@ -609,7 +609,8 @@ class ShardRegion(
   def register(): Unit = {
     coordinatorSelection.foreach(_ ! registrationMessage)
     if (shardBuffers.nonEmpty && retryCount >= 5)
-      log.warning("Trying to register to coordinator at [{}], but no acknowledgement. Total [{}] buffered messages.",
+      log.warning(
+        "Trying to register to coordinator at [{}], but no acknowledgement. Total [{}] buffered messages.",
         coordinatorSelection, totalBufferSize)
   }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializer.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializer.scala
@@ -26,7 +26,7 @@ import akka.protobuf.MessageLite
  * INTERNAL API: Protobuf serializer of ClusterSharding messages.
  */
 private[akka] class ClusterShardingMessageSerializer(val system: ExtendedActorSystem)
-  extends SerializerWithStringManifest with BaseSerializer {
+    extends SerializerWithStringManifest with BaseSerializer {
   import ShardCoordinator.Internal._
   import Shard.{ GetShardStats, ShardStats }
   import Shard.{ State ⇒ EntityState, EntityStarted, EntityStopped }
@@ -64,33 +64,33 @@ private[akka] class ClusterShardingMessageSerializer(val system: ExtendedActorSy
   private val ShardStatsManifest = "DB"
 
   private val fromBinaryMap = collection.immutable.HashMap[String, Array[Byte] ⇒ AnyRef](
-    EntityStateManifest -> entityStateFromBinary,
-    EntityStartedManifest -> entityStartedFromBinary,
-    EntityStoppedManifest -> entityStoppedFromBinary,
+    EntityStateManifest → entityStateFromBinary,
+    EntityStartedManifest → entityStartedFromBinary,
+    EntityStoppedManifest → entityStoppedFromBinary,
 
-    CoordinatorStateManifest -> coordinatorStateFromBinary,
-    ShardRegionRegisteredManifest -> { bytes ⇒ ShardRegionRegistered(actorRefMessageFromBinary(bytes)) },
-    ShardRegionProxyRegisteredManifest -> { bytes ⇒ ShardRegionProxyRegistered(actorRefMessageFromBinary(bytes)) },
-    ShardRegionTerminatedManifest -> { bytes ⇒ ShardRegionTerminated(actorRefMessageFromBinary(bytes)) },
-    ShardRegionProxyTerminatedManifest -> { bytes ⇒ ShardRegionProxyTerminated(actorRefMessageFromBinary(bytes)) },
-    ShardHomeAllocatedManifest -> shardHomeAllocatedFromBinary,
-    ShardHomeDeallocatedManifest -> { bytes ⇒ ShardHomeDeallocated(shardIdMessageFromBinary(bytes)) },
+    CoordinatorStateManifest → coordinatorStateFromBinary,
+    ShardRegionRegisteredManifest → { bytes ⇒ ShardRegionRegistered(actorRefMessageFromBinary(bytes)) },
+    ShardRegionProxyRegisteredManifest → { bytes ⇒ ShardRegionProxyRegistered(actorRefMessageFromBinary(bytes)) },
+    ShardRegionTerminatedManifest → { bytes ⇒ ShardRegionTerminated(actorRefMessageFromBinary(bytes)) },
+    ShardRegionProxyTerminatedManifest → { bytes ⇒ ShardRegionProxyTerminated(actorRefMessageFromBinary(bytes)) },
+    ShardHomeAllocatedManifest → shardHomeAllocatedFromBinary,
+    ShardHomeDeallocatedManifest → { bytes ⇒ ShardHomeDeallocated(shardIdMessageFromBinary(bytes)) },
 
-    RegisterManifest -> { bytes ⇒ Register(actorRefMessageFromBinary(bytes)) },
-    RegisterProxyManifest -> { bytes ⇒ RegisterProxy(actorRefMessageFromBinary(bytes)) },
-    RegisterAckManifest -> { bytes ⇒ RegisterAck(actorRefMessageFromBinary(bytes)) },
-    GetShardHomeManifest -> { bytes ⇒ GetShardHome(shardIdMessageFromBinary(bytes)) },
-    ShardHomeManifest -> shardHomeFromBinary,
-    HostShardManifest -> { bytes ⇒ HostShard(shardIdMessageFromBinary(bytes)) },
-    ShardStartedManifest -> { bytes ⇒ ShardStarted(shardIdMessageFromBinary(bytes)) },
-    BeginHandOffManifest -> { bytes ⇒ BeginHandOff(shardIdMessageFromBinary(bytes)) },
-    BeginHandOffAckManifest -> { bytes ⇒ BeginHandOffAck(shardIdMessageFromBinary(bytes)) },
-    HandOffManifest -> { bytes ⇒ HandOff(shardIdMessageFromBinary(bytes)) },
-    ShardStoppedManifest -> { bytes ⇒ ShardStopped(shardIdMessageFromBinary(bytes)) },
-    GracefulShutdownReqManifest -> { bytes ⇒ GracefulShutdownReq(actorRefMessageFromBinary(bytes)) },
+    RegisterManifest → { bytes ⇒ Register(actorRefMessageFromBinary(bytes)) },
+    RegisterProxyManifest → { bytes ⇒ RegisterProxy(actorRefMessageFromBinary(bytes)) },
+    RegisterAckManifest → { bytes ⇒ RegisterAck(actorRefMessageFromBinary(bytes)) },
+    GetShardHomeManifest → { bytes ⇒ GetShardHome(shardIdMessageFromBinary(bytes)) },
+    ShardHomeManifest → shardHomeFromBinary,
+    HostShardManifest → { bytes ⇒ HostShard(shardIdMessageFromBinary(bytes)) },
+    ShardStartedManifest → { bytes ⇒ ShardStarted(shardIdMessageFromBinary(bytes)) },
+    BeginHandOffManifest → { bytes ⇒ BeginHandOff(shardIdMessageFromBinary(bytes)) },
+    BeginHandOffAckManifest → { bytes ⇒ BeginHandOffAck(shardIdMessageFromBinary(bytes)) },
+    HandOffManifest → { bytes ⇒ HandOff(shardIdMessageFromBinary(bytes)) },
+    ShardStoppedManifest → { bytes ⇒ ShardStopped(shardIdMessageFromBinary(bytes)) },
+    GracefulShutdownReqManifest → { bytes ⇒ GracefulShutdownReq(actorRefMessageFromBinary(bytes)) },
 
-    GetShardStatsManifest -> { bytes ⇒ GetShardStats },
-    ShardStatsManifest -> { bytes ⇒ shardStatsFromBinary(bytes) })
+    GetShardStatsManifest → { bytes ⇒ GetShardStats },
+    ShardStatsManifest → { bytes ⇒ shardStatsFromBinary(bytes) })
 
   override def manifest(obj: AnyRef): String = obj match {
     case _: EntityState                ⇒ EntityStateManifest
@@ -194,11 +194,11 @@ private[akka] class ClusterShardingMessageSerializer(val system: ExtendedActorSy
   private def coordinatorStateFromProto(state: sm.CoordinatorState): State = {
     val shards: Map[String, ActorRef] =
       state.getShardsList.asScala.toVector.map { entry ⇒
-        entry.getShardId -> resolveActorRef(entry.getRegionRef)
+        entry.getShardId → resolveActorRef(entry.getRegionRef)
       }(breakOut)
 
     val regionsZero: Map[ActorRef, Vector[String]] =
-      state.getRegionsList.asScala.toVector.map(resolveActorRef(_) -> Vector.empty[String])(breakOut)
+      state.getRegionsList.asScala.toVector.map(resolveActorRef(_) → Vector.empty[String])(breakOut)
     val regions: Map[ActorRef, Vector[String]] =
       shards.foldLeft(regionsZero) { case (acc, (shardId, regionRef)) ⇒ acc.updated(regionRef, acc(regionRef) :+ shardId) }
 

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -105,13 +105,13 @@ object ClusterClientSettings {
  *   external service registry
  */
 final class ClusterClientSettings(
-  val initialContacts: Set[ActorPath],
-  val establishingGetContactsInterval: FiniteDuration,
-  val refreshContactsInterval: FiniteDuration,
-  val heartbeatInterval: FiniteDuration,
-  val acceptableHeartbeatPause: FiniteDuration,
-  val bufferSize: Int,
-  val reconnectTimeout: Option[FiniteDuration]) extends NoSerializationVerificationNeeded {
+    val initialContacts: Set[ActorPath],
+    val establishingGetContactsInterval: FiniteDuration,
+    val refreshContactsInterval: FiniteDuration,
+    val heartbeatInterval: FiniteDuration,
+    val acceptableHeartbeatPause: FiniteDuration,
+    val bufferSize: Int,
+    val reconnectTimeout: Option[FiniteDuration]) extends NoSerializationVerificationNeeded {
 
   require(bufferSize >= 0 && bufferSize <= 10000, "bufferSize must be >= 0 and <= 10000")
 
@@ -504,9 +504,9 @@ object ClusterReceptionistSettings {
  *   client will be stopped after this time of inactivity.
  */
 final class ClusterReceptionistSettings(
-  val role: Option[String],
-  val numberOfContacts: Int,
-  val responseTunnelReceiveTimeout: FiniteDuration) extends NoSerializationVerificationNeeded {
+    val role: Option[String],
+    val numberOfContacts: Int,
+    val responseTunnelReceiveTimeout: FiniteDuration) extends NoSerializationVerificationNeeded {
 
   def withRole(role: String): ClusterReceptionistSettings = copy(role = ClusterReceptionistSettings.roleOption(role))
 
@@ -597,7 +597,7 @@ object ClusterReceptionist {
  *
  */
 final class ClusterReceptionist(pubSubMediator: ActorRef, settings: ClusterReceptionistSettings)
-  extends Actor with ActorLogging {
+    extends Actor with ActorLogging {
 
   import DistributedPubSubMediator.{ Send, SendToAll, Publish }
 
@@ -608,7 +608,8 @@ final class ClusterReceptionist(pubSubMediator: ActorRef, settings: ClusterRecep
   val verboseHeartbeat = cluster.settings.Debug.VerboseHeartbeatLogging
   import cluster.selfAddress
 
-  require(role.forall(cluster.selfRoles.contains),
+  require(
+    role.forall(cluster.selfRoles.contains),
     s"This cluster member [${selfAddress}] doesn't have the role [$role]")
 
   var nodes: immutable.SortedSet[Address] = {

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializer.scala
@@ -15,7 +15,7 @@ import akka.cluster.client.protobuf.msg.{ ClusterClientMessages ⇒ cm }
  * INTERNAL API: Serializer of ClusterClient messages.
  */
 private[akka] class ClusterClientMessageSerializer(val system: ExtendedActorSystem)
-  extends SerializerWithStringManifest with BaseSerializer {
+    extends SerializerWithStringManifest with BaseSerializer {
   import ClusterReceptionist.Internal._
 
   private lazy val serialization = SerializationExtension(system)
@@ -28,10 +28,10 @@ private[akka] class ClusterClientMessageSerializer(val system: ExtendedActorSyst
   private val emptyByteArray = Array.empty[Byte]
 
   private val fromBinaryMap = collection.immutable.HashMap[String, Array[Byte] ⇒ AnyRef](
-    ContactsManifest -> contactsFromBinary,
-    GetContactsManifest -> { _ ⇒ GetContacts },
-    HeartbeatManifest -> { _ ⇒ Heartbeat },
-    HeartbeatRspManifest -> { _ ⇒ HeartbeatRsp })
+    ContactsManifest → contactsFromBinary,
+    GetContactsManifest → { _ ⇒ GetContacts },
+    HeartbeatManifest → { _ ⇒ Heartbeat },
+    HeartbeatRspManifest → { _ ⇒ HeartbeatRsp })
 
   override def manifest(obj: AnyRef): String = obj match {
     case _: Contacts  ⇒ ContactsManifest

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -83,13 +83,14 @@ object DistributedPubSubSettings {
  *   the registries. Next chunk will be transferred in next round of gossip.
  */
 final class DistributedPubSubSettings(
-  val role: Option[String],
-  val routingLogic: RoutingLogic,
-  val gossipInterval: FiniteDuration,
-  val removedTimeToLive: FiniteDuration,
-  val maxDeltaElements: Int) extends NoSerializationVerificationNeeded {
+    val role: Option[String],
+    val routingLogic: RoutingLogic,
+    val gossipInterval: FiniteDuration,
+    val removedTimeToLive: FiniteDuration,
+    val maxDeltaElements: Int) extends NoSerializationVerificationNeeded {
 
-  require(!routingLogic.isInstanceOf[ConsistentHashingRoutingLogic],
+  require(
+    !routingLogic.isInstanceOf[ConsistentHashingRoutingLogic],
     "'ConsistentHashingRoutingLogic' can't be used by the pub-sub mediator")
 
   def withRole(role: String): DistributedPubSubSettings = copy(role = DistributedPubSubSettings.roleOption(role))
@@ -108,11 +109,12 @@ final class DistributedPubSubSettings(
   def withMaxDeltaElements(maxDeltaElements: Int): DistributedPubSubSettings =
     copy(maxDeltaElements = maxDeltaElements)
 
-  private def copy(role: Option[String] = role,
-                   routingLogic: RoutingLogic = routingLogic,
-                   gossipInterval: FiniteDuration = gossipInterval,
-                   removedTimeToLive: FiniteDuration = removedTimeToLive,
-                   maxDeltaElements: Int = maxDeltaElements): DistributedPubSubSettings =
+  private def copy(
+    role: Option[String] = role,
+    routingLogic: RoutingLogic = routingLogic,
+    gossipInterval: FiniteDuration = gossipInterval,
+    removedTimeToLive: FiniteDuration = removedTimeToLive,
+    maxDeltaElements: Int = maxDeltaElements): DistributedPubSubSettings =
     new DistributedPubSubSettings(role, routingLogic, gossipInterval, removedTimeToLive, maxDeltaElements)
 }
 
@@ -477,13 +479,15 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
   import DistributedPubSubMediator.Internal._
   import settings._
 
-  require(!routingLogic.isInstanceOf[ConsistentHashingRoutingLogic],
+  require(
+    !routingLogic.isInstanceOf[ConsistentHashingRoutingLogic],
     "'consistent-hashing' routing logic can't be used by the pub-sub mediator")
 
   val cluster = Cluster(context.system)
   import cluster.selfAddress
 
-  require(role.forall(cluster.selfRoles.contains),
+  require(
+    role.forall(cluster.selfRoles.contains),
     s"This cluster member [${selfAddress}] doesn't have the role [$role]")
 
   val removedTimeToLiveMillis = removedTimeToLive.toMillis
@@ -627,7 +631,7 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
           if (nodes(b.owner)) {
             val myBucket = registry(b.owner)
             if (b.version > myBucket.version) {
-              registry += (b.owner -> myBucket.copy(version = b.version, content = myBucket.content ++ b.content))
+              registry += (b.owner → myBucket.copy(version = b.version, content = myBucket.content ++ b.content))
             }
           }
         }
@@ -710,8 +714,9 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
   def put(key: String, valueOption: Option[ActorRef]): Unit = {
     val bucket = registry(selfAddress)
     val v = nextVersion()
-    registry += (selfAddress -> bucket.copy(version = v,
-      content = bucket.content + (key -> ValueHolder(v, valueOption))))
+    registry += (selfAddress → bucket.copy(
+      version = v,
+      content = bucket.content + (key → ValueHolder(v, valueOption))))
   }
 
   def getCurrentTopics(): Set[String] = {
@@ -734,11 +739,11 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
 
   def mkKey(path: ActorPath): String = Internal.mkKey(path)
 
-  def myVersions: Map[Address, Long] = registry.map { case (owner, bucket) ⇒ (owner -> bucket.version) }
+  def myVersions: Map[Address, Long] = registry.map { case (owner, bucket) ⇒ (owner → bucket.version) }
 
   def collectDelta(otherVersions: Map[Address, Long]): immutable.Iterable[Bucket] = {
     // missing entries are represented by version 0
-    val filledOtherVersions = myVersions.map { case (k, _) ⇒ k -> 0L } ++ otherVersions
+    val filledOtherVersions = myVersions.map { case (k, _) ⇒ k → 0L } ++ otherVersions
     var count = 0
     filledOtherVersions.collect {
       case (owner, v) if registry(owner).version > v && count < maxDeltaElements ⇒
@@ -782,7 +787,7 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
           case (key, ValueHolder(version, None)) if (bucket.version - version > removedTimeToLiveMillis) ⇒ key
         }
         if (oldRemoved.nonEmpty)
-          registry += owner -> bucket.copy(content = bucket.content -- oldRemoved)
+          registry += owner → bucket.copy(content = bucket.content -- oldRemoved)
     }
   }
 

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/PerGroupingBuffer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/PerGroupingBuffer.scala
@@ -44,5 +44,5 @@ private[pubsub] trait PerGroupingBuffer {
     }
   }
 
-  def initializeGrouping(grouping: String): Unit = buffers += grouping -> Vector.empty
+  def initializeGrouping(grouping: String): Unit = buffers += grouping → Vector.empty
 }

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
@@ -26,7 +26,7 @@ import akka.serialization.SerializerWithStringManifest
  * INTERNAL API: Protobuf serializer of DistributedPubSubMediator messages.
  */
 private[akka] class DistributedPubSubMessageSerializer(val system: ExtendedActorSystem)
-  extends SerializerWithStringManifest with BaseSerializer {
+    extends SerializerWithStringManifest with BaseSerializer {
 
   private lazy val serialization = SerializationExtension(system)
 
@@ -39,11 +39,11 @@ private[akka] class DistributedPubSubMessageSerializer(val system: ExtendedActor
   private val PublishManifest = "E"
 
   private val fromBinaryMap = collection.immutable.HashMap[String, Array[Byte] ⇒ AnyRef](
-    StatusManifest -> statusFromBinary,
-    DeltaManifest -> deltaFromBinary,
-    SendManifest -> sendFromBinary,
-    SendToAllManifest -> sendToAllFromBinary,
-    PublishManifest -> publishFromBinary)
+    StatusManifest → statusFromBinary,
+    DeltaManifest → deltaFromBinary,
+    SendManifest → sendFromBinary,
+    SendToAllManifest → sendToAllFromBinary,
+    PublishManifest → publishFromBinary)
 
   override def manifest(obj: AnyRef): String = obj match {
     case _: Status    ⇒ StatusManifest
@@ -122,7 +122,7 @@ private[akka] class DistributedPubSubMessageSerializer(val system: ExtendedActor
 
   private def statusFromProto(status: dm.Status): Status =
     Status(status.getVersionsList.asScala.map(v ⇒
-      addressFromProto(v.getAddress) -> v.getTimestamp)(breakOut))
+      addressFromProto(v.getAddress) → v.getTimestamp)(breakOut))
 
   private def deltaToProto(delta: Delta): dm.Delta = {
     val buckets = delta.buckets.map { b ⇒
@@ -148,7 +148,7 @@ private[akka] class DistributedPubSubMessageSerializer(val system: ExtendedActor
   private def deltaFromProto(delta: dm.Delta): Delta =
     Delta(delta.getBucketsList.asScala.toVector.map { b ⇒
       val content: TreeMap[String, ValueHolder] = b.getContentList.asScala.map { entry ⇒
-        entry.getKey -> ValueHolder(entry.getVersion, if (entry.hasRef) Some(resolveActorRef(entry.getRef)) else None)
+        entry.getKey → ValueHolder(entry.getVersion, if (entry.hasRef) Some(resolveActorRef(entry.getRef)) else None)
       }(breakOut)
       Bucket(addressFromProto(b.getOwner), b.getVersion, content)
     })

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonProxy.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonProxy.scala
@@ -69,10 +69,10 @@ object ClusterSingletonProxySettings {
  *   immediately if the location of the singleton is unknown.
  */
 final class ClusterSingletonProxySettings(
-  val singletonName: String,
-  val role: Option[String],
-  val singletonIdentificationInterval: FiniteDuration,
-  val bufferSize: Int) extends NoSerializationVerificationNeeded {
+    val singletonName: String,
+    val role: Option[String],
+    val singletonIdentificationInterval: FiniteDuration,
+    val bufferSize: Int) extends NoSerializationVerificationNeeded {
 
   require(bufferSize >= 0 && bufferSize <= 10000, "bufferSize must be >= 0 and <= 10000")
 
@@ -88,10 +88,11 @@ final class ClusterSingletonProxySettings(
   def withBufferSize(bufferSize: Int): ClusterSingletonProxySettings =
     copy(bufferSize = bufferSize)
 
-  private def copy(singletonName: String = singletonName,
-                   role: Option[String] = role,
-                   singletonIdentificationInterval: FiniteDuration = singletonIdentificationInterval,
-                   bufferSize: Int = bufferSize): ClusterSingletonProxySettings =
+  private def copy(
+    singletonName: String = singletonName,
+    role: Option[String] = role,
+    singletonIdentificationInterval: FiniteDuration = singletonIdentificationInterval,
+    bufferSize: Int = bufferSize): ClusterSingletonProxySettings =
     new ClusterSingletonProxySettings(singletonName, role, singletonIdentificationInterval, bufferSize)
 }
 
@@ -252,7 +253,8 @@ final class ClusterSingletonProxy(singletonManagerPath: String, settings: Cluste
       singleton match {
         case Some(s) ⇒
           if (log.isDebugEnabled)
-            log.debug("Forwarding message of type [{}] to current singleton instance at [{}]: {}",
+            log.debug(
+              "Forwarding message of type [{}] to current singleton instance at [{}]: {}",
               Logging.simpleName(msg.getClass.getName), s.path)
           s forward msg
         case None ⇒

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/protobuf/ClusterSingletonMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/protobuf/ClusterSingletonMessageSerializer.scala
@@ -18,7 +18,7 @@ import akka.serialization.SerializerWithStringManifest
  * the ClusterSingleton we want to make protobuf representations of them.
  */
 private[akka] class ClusterSingletonMessageSerializer(val system: ExtendedActorSystem)
-  extends SerializerWithStringManifest with BaseSerializer {
+    extends SerializerWithStringManifest with BaseSerializer {
 
   private lazy val serialization = SerializationExtension(system)
 
@@ -30,10 +30,10 @@ private[akka] class ClusterSingletonMessageSerializer(val system: ExtendedActorS
   private val emptyByteArray = Array.empty[Byte]
 
   private val fromBinaryMap = collection.immutable.HashMap[String, Array[Byte] ⇒ AnyRef](
-    HandOverToMeManifest -> { _ ⇒ HandOverToMe },
-    HandOverInProgressManifest -> { _ ⇒ HandOverInProgress },
-    HandOverDoneManifest -> { _ ⇒ HandOverDone },
-    TakeOverFromMeManifest -> { _ ⇒ TakeOverFromMe })
+    HandOverToMeManifest → { _ ⇒ HandOverToMe },
+    HandOverInProgressManifest → { _ ⇒ HandOverInProgress },
+    HandOverDoneManifest → { _ ⇒ HandOverDone },
+    TakeOverFromMeManifest → { _ ⇒ TakeOverFromMe })
 
   override def manifest(obj: AnyRef): String = obj match {
     case HandOverToMe       ⇒ HandOverToMeManifest

--- a/akka-cluster/src/main/scala/akka/cluster/AutoDown.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/AutoDown.scala
@@ -34,7 +34,7 @@ private[cluster] object AutoDown {
  * able to unit test the logic without running cluster.
  */
 private[cluster] class AutoDown(autoDownUnreachableAfter: FiniteDuration)
-  extends AutoDownBase(autoDownUnreachableAfter) {
+    extends AutoDownBase(autoDownUnreachableAfter) {
 
   val cluster = Cluster(context.system)
   import cluster.InfoLogger._
@@ -125,7 +125,7 @@ private[cluster] abstract class AutoDownBase(autoDownUnreachableAfter: FiniteDur
       downOrAddPending(node)
     } else {
       val task = scheduler.scheduleOnce(autoDownUnreachableAfter, self, UnreachableTimeout(node))
-      scheduledUnreachable += (node -> task)
+      scheduledUnreachable += (node → task)
     }
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -111,7 +111,8 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    */
   private[cluster] val scheduler: Scheduler = {
     if (system.scheduler.maxFrequency < 1.second / SchedulerTickDuration) {
-      logInfo("Using a dedicated scheduler for cluster. Default scheduler can be used if configured " +
+      logInfo(
+        "Using a dedicated scheduler for cluster. Default scheduler can be used if configured " +
         "with 'akka.scheduler.tick-duration' [{} ms] <=  'akka.cluster.scheduler.tick-duration' [{} ms].",
         (1000 / system.scheduler.maxFrequency).toInt, SchedulerTickDuration.toMillis)
 
@@ -123,9 +124,9 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         case tf                           ⇒ tf
       }
       system.dynamicAccess.createInstanceFor[Scheduler](system.settings.SchedulerClass, immutable.Seq(
-        classOf[Config] -> cfg,
-        classOf[LoggingAdapter] -> log,
-        classOf[ThreadFactory] -> threadFactory)).get
+        classOf[Config] → cfg,
+        classOf[LoggingAdapter] → log,
+        classOf[ThreadFactory] → threadFactory)).get
     } else {
       // delegate to system.scheduler, but don't close over system
       val systemScheduler = system.scheduler
@@ -135,11 +136,12 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         override def maxFrequency: Double = systemScheduler.maxFrequency
 
         override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration,
-                              runnable: Runnable)(implicit executor: ExecutionContext): Cancellable =
+          runnable: Runnable)(implicit executor: ExecutionContext): Cancellable =
           systemScheduler.schedule(initialDelay, interval, runnable)
 
-        override def scheduleOnce(delay: FiniteDuration,
-                                  runnable: Runnable)(implicit executor: ExecutionContext): Cancellable =
+        override def scheduleOnce(
+          delay: FiniteDuration,
+          runnable: Runnable)(implicit executor: ExecutionContext): Cancellable =
           systemScheduler.scheduleOnce(delay, runnable)
       }
     }
@@ -224,7 +226,8 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    */
   @varargs def subscribe(subscriber: ActorRef, initialStateMode: SubscriptionInitialStateMode, to: Class[_]*): Unit = {
     require(to.length > 0, "at least one `ClusterDomainEvent` class is required")
-    require(to.forall(classOf[ClusterDomainEvent].isAssignableFrom),
+    require(
+      to.forall(classOf[ClusterDomainEvent].isAssignableFrom),
       s"subscribe to `akka.cluster.ClusterEvent.ClusterDomainEvent` or subclasses, was [${to.map(_.getName).mkString(", ")}]")
     clusterCore ! InternalClusterAction.Subscribe(subscriber, initialStateMode, to.toSet)
   }

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -153,7 +153,7 @@ private[cluster] object InternalClusterAction {
  * Supervisor managing the different Cluster daemons.
  */
 private[cluster] final class ClusterDaemon(settings: ClusterSettings) extends Actor with ActorLogging
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import InternalClusterAction._
   // Important - don't use Cluster(context.system) in constructor because that would
   // cause deadlock. The Cluster extension is currently being created and is waiting
@@ -195,7 +195,7 @@ private[cluster] final class ClusterDaemon(settings: ClusterSettings) extends Ac
  * would be obsolete. Shutdown the member if any those actors crashed.
  */
 private[cluster] final class ClusterCoreSupervisor extends Actor with ActorLogging
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import InternalClusterAction._
 
   // Important - don't use Cluster(context.system) in constructor because that would
@@ -235,7 +235,7 @@ private[cluster] final class ClusterCoreSupervisor extends Actor with ActorLoggi
  * INTERNAL API.
  */
 private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with ActorLogging
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import InternalClusterAction._
 
   val cluster = Cluster(context.system)
@@ -272,15 +272,18 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
   import context.dispatcher
 
   // start periodic gossip to random nodes in cluster
-  val gossipTask = scheduler.schedule(PeriodicTasksInitialDelay.max(GossipInterval),
+  val gossipTask = scheduler.schedule(
+    PeriodicTasksInitialDelay.max(GossipInterval),
     GossipInterval, self, GossipTick)
 
   // start periodic cluster failure detector reaping (moving nodes condemned by the failure detector to unreachable list)
-  val failureDetectorReaperTask = scheduler.schedule(PeriodicTasksInitialDelay.max(UnreachableNodesReaperInterval),
+  val failureDetectorReaperTask = scheduler.schedule(
+    PeriodicTasksInitialDelay.max(UnreachableNodesReaperInterval),
     UnreachableNodesReaperInterval, self, ReapUnreachableTick)
 
   // start periodic leader action management (only applies for the current leader)
-  val leaderActionsTask = scheduler.schedule(PeriodicTasksInitialDelay.max(LeaderActionsInterval),
+  val leaderActionsTask = scheduler.schedule(
+    PeriodicTasksInitialDelay.max(LeaderActionsInterval),
     LeaderActionsInterval, self, LeaderActionsTick)
 
   // start periodic publish of current stats
@@ -373,7 +376,8 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
     case ClusterUserAction.JoinTo(address) ⇒
       logInfo("Trying to join [{}] when already part of a cluster, ignoring", address)
     case JoinSeedNodes(seedNodes) ⇒
-      logInfo("Trying to join seed nodes [{}] when already part of a cluster, ignoring",
+      logInfo(
+        "Trying to join seed nodes [{}] when already part of a cluster, ignoring",
         seedNodes.mkString(", "))
   }
 
@@ -429,10 +433,12 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
    */
   def join(address: Address): Unit = {
     if (address.protocol != selfAddress.protocol)
-      log.warning("Trying to join member with wrong protocol, but was ignored, expected [{}] but was [{}]",
+      log.warning(
+        "Trying to join member with wrong protocol, but was ignored, expected [{}] but was [{}]",
         selfAddress.protocol, address.protocol)
     else if (address.system != selfAddress.system)
-      log.warning("Trying to join member with wrong ActorSystem name, but was ignored, expected [{}] but was [{}]",
+      log.warning(
+        "Trying to join member with wrong ActorSystem name, but was ignored, expected [{}] but was [{}]",
         selfAddress.system, address.system)
     else {
       require(latestGossip.members.isEmpty, "Join can only be done from empty state")
@@ -472,10 +478,12 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
   def joining(node: UniqueAddress, roles: Set[String]): Unit = {
     val selfStatus = latestGossip.member(selfUniqueAddress).status
     if (node.address.protocol != selfAddress.protocol)
-      log.warning("Member with wrong protocol tried to join, but was ignored, expected [{}] but was [{}]",
+      log.warning(
+        "Member with wrong protocol tried to join, but was ignored, expected [{}] but was [{}]",
         selfAddress.protocol, node.address.protocol)
     else if (node.address.system != selfAddress.system)
-      log.warning("Member with wrong ActorSystem name tried to join, but was ignored, expected [{}] but was [{}]",
+      log.warning(
+        "Member with wrong ActorSystem name tried to join, but was ignored, expected [{}] but was [{}]",
         selfAddress.system, node.address.system)
     else if (Gossip.removeUnreachableWithMemberStatus.contains(selfStatus))
       logInfo("Trying to join [{}] to [{}] member, ignoring. Use a member that is Up instead.", node, selfStatus)
@@ -609,7 +617,8 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
       val newOverview = localGossip.overview copy (reachability = newReachability)
       val newGossip = localGossip copy (overview = newOverview)
       updateLatestGossip(newGossip)
-      log.warning("Cluster Node [{}] - Marking node as TERMINATED [{}], due to quarantine",
+      log.warning(
+        "Cluster Node [{}] - Marking node as TERMINATED [{}], due to quarantine",
         selfAddress, node.address)
       publish(latestGossip)
       downing(node.address)
@@ -836,7 +845,8 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
 
         leaderActionCounter += 1
         if (leaderActionCounter == firstNotice || leaderActionCounter % periodicNotice == 0)
-          logInfo("Leader can currently not perform its duties, reachability status: [{}], member status: [{}]",
+          logInfo(
+            "Leader can currently not perform its duties, reachability status: [{}], member status: [{}]",
             latestGossip.reachabilityExcludingDownedObservers,
             latestGossip.members.map(m ⇒
               s"${m.address} ${m.status} seen=${latestGossip.seenByNode(m.uniqueAddress)}").mkString(", "))
@@ -1043,7 +1053,8 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
           if (nonExiting.nonEmpty)
             log.warning("Cluster Node [{}] - Marking node(s) as UNREACHABLE [{}]", selfAddress, nonExiting.mkString(", "))
           if (exiting.nonEmpty)
-            logInfo("Marking exiting node(s) as UNREACHABLE [{}]. This is expected and they will be removed.",
+            logInfo(
+              "Marking exiting node(s) as UNREACHABLE [{}]. This is expected and they will be removed.",
               exiting.mkString(", "))
           if (newlyDetectedReachableMembers.nonEmpty)
             logInfo("Marking node(s) as REACHABLE [{}]", newlyDetectedReachableMembers.mkString(", "))
@@ -1289,11 +1300,11 @@ private[cluster] class OnMemberStatusChangedListener(callback: Runnable, status:
  */
 @SerialVersionUID(1L)
 private[cluster] final case class GossipStats(
-  receivedGossipCount: Long = 0L,
-  mergeCount: Long = 0L,
-  sameCount: Long = 0L,
-  newerCount: Long = 0L,
-  olderCount: Long = 0L) {
+    receivedGossipCount: Long = 0L,
+    mergeCount: Long = 0L,
+    sameCount: Long = 0L,
+    newerCount: Long = 0L,
+    olderCount: Long = 0L) {
 
   def incrementMergeCount(): GossipStats =
     copy(mergeCount = mergeCount + 1, receivedGossipCount = receivedGossipCount + 1)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -56,11 +56,11 @@ object ClusterEvent {
    * Current snapshot state of the cluster. Sent to new subscriber.
    */
   final case class CurrentClusterState(
-    members: immutable.SortedSet[Member] = immutable.SortedSet.empty,
-    unreachable: Set[Member] = Set.empty,
-    seenBy: Set[Address] = Set.empty,
-    leader: Option[Address] = None,
-    roleLeaderMap: Map[String, Option[Address]] = Map.empty) {
+      members: immutable.SortedSet[Member] = immutable.SortedSet.empty,
+      unreachable: Set[Member] = Set.empty,
+      seenBy: Set[Address] = Set.empty,
+      leader: Option[Address] = None,
+      roleLeaderMap: Map[String, Option[Address]] = Map.empty) {
 
     /**
      * Java API: get current member list.
@@ -355,7 +355,7 @@ object ClusterEvent {
  * domain events to event bus.
  */
 private[cluster] final class ClusterDomainEventPublisher extends Actor with ActorLogging
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import InternalClusterAction._
 
   val selfUniqueAddress = Cluster(context.system).selfUniqueAddress
@@ -395,7 +395,7 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
       unreachable = unreachable,
       seenBy = latestGossip.seenBy.map(_.address),
       leader = latestGossip.leader(selfUniqueAddress).map(_.address),
-      roleLeaderMap = latestGossip.allRoles.map(r ⇒ r -> latestGossip.roleLeader(r, selfUniqueAddress)
+      roleLeaderMap = latestGossip.allRoles.map(r ⇒ r → latestGossip.roleLeader(r, selfUniqueAddress)
         .map(_.address))(collection.breakOut))
     receiver ! state
   }

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -76,7 +76,8 @@ private[cluster] final class ClusterHeartbeatSender extends Actor with ActorLogg
     failureDetector)
 
   // start periodic heartbeat to other nodes in cluster
-  val heartbeatTask = scheduler.schedule(PeriodicTasksInitialDelay max HeartbeatInterval,
+  val heartbeatTask = scheduler.schedule(
+    PeriodicTasksInitialDelay max HeartbeatInterval,
     HeartbeatInterval, self, HeartbeatTick)
 
   override def preStart(): Unit = {
@@ -173,9 +174,9 @@ private[cluster] final class ClusterHeartbeatSender extends Actor with ActorLogg
  * It is immutable, but it updates the failureDetector.
  */
 private[cluster] final case class ClusterHeartbeatSenderState(
-  ring: HeartbeatNodeRing,
-  oldReceiversNowUnreachable: Set[UniqueAddress],
-  failureDetector: FailureDetectorRegistry[Address]) {
+    ring: HeartbeatNodeRing,
+    oldReceiversNowUnreachable: Set[UniqueAddress],
+    failureDetector: FailureDetectorRegistry[Address]) {
 
   val activeReceivers: Set[UniqueAddress] = ring.myReceivers union oldReceiversNowUnreachable
 
@@ -241,10 +242,10 @@ private[cluster] final case class ClusterHeartbeatSenderState(
  * It is immutable, i.e. the methods return new instances.
  */
 private[cluster] final case class HeartbeatNodeRing(
-  selfAddress: UniqueAddress,
-  nodes: Set[UniqueAddress],
-  unreachable: Set[UniqueAddress],
-  monitoredByNrOfMembers: Int) {
+    selfAddress: UniqueAddress,
+    nodes: Set[UniqueAddress],
+    unreachable: Set[UniqueAddress],
+    monitoredByNrOfMembers: Int) {
 
   require(nodes contains selfAddress, s"nodes [${nodes.mkString(", ")}] must contain selfAddress [${selfAddress}]")
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterMetricsCollector.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterMetricsCollector.scala
@@ -69,13 +69,15 @@ private[cluster] class ClusterMetricsCollector(publisher: ActorRef) extends Acto
   /**
    * Start periodic gossip to random nodes in cluster
    */
-  val gossipTask = scheduler.schedule(PeriodicTasksInitialDelay max MetricsGossipInterval,
+  val gossipTask = scheduler.schedule(
+    PeriodicTasksInitialDelay max MetricsGossipInterval,
     MetricsGossipInterval, self, GossipTick)
 
   /**
    * Start periodic metrics collection
    */
-  val metricsTask = scheduler.schedule(PeriodicTasksInitialDelay max MetricsInterval,
+  val metricsTask = scheduler.schedule(
+    PeriodicTasksInitialDelay max MetricsInterval,
     MetricsInterval, self, MetricsTick)
 
   override def preStart(): Unit = {
@@ -309,7 +311,7 @@ private[cluster] final case class EWMA(value: Double, alpha: Double) {
 @SerialVersionUID(1L)
 @deprecated("Superseded by akka.cluster.metrics (in akka-cluster-metrics jar)", "2.4")
 final case class Metric private[cluster] (name: String, value: Number, private[cluster] val average: Option[EWMA])
-  extends MetricNumericConverter {
+    extends MetricNumericConverter {
 
   require(defined(value), s"Invalid Metric [$name] value [$value]")
 
@@ -535,11 +537,11 @@ object StandardMetrics {
    */
   @SerialVersionUID(1L)
   final case class Cpu(
-    address: Address,
-    timestamp: Long,
-    systemLoadAverage: Option[Double],
-    cpuCombined: Option[Double],
-    processors: Int) {
+      address: Address,
+      timestamp: Long,
+      systemLoadAverage: Option[Double],
+      cpuCombined: Option[Double],
+      processors: Int) {
 
     cpuCombined match {
       case Some(x) ⇒ require(0.0 <= x && x <= 1.0, s"cpuCombined must be between [0.0 - 1.0], was [$x]")
@@ -607,7 +609,8 @@ class JmxMetricsCollector(address: Address, decayFactor: Double) extends Metrics
   import StandardMetrics._
 
   private def this(cluster: Cluster) =
-    this(cluster.selfAddress,
+    this(
+      cluster.selfAddress,
       EWMA.alpha(cluster.settings.MetricsMovingAverageHalfLife, cluster.settings.MetricsInterval))
 
   /**
@@ -705,12 +708,13 @@ class JmxMetricsCollector(address: Address, decayFactor: Double) extends Metrics
  */
 @deprecated("Superseded by akka.cluster.metrics (in akka-cluster-metrics jar)", "2.4")
 class SigarMetricsCollector(address: Address, decayFactor: Double, sigar: AnyRef)
-  extends JmxMetricsCollector(address, decayFactor) {
+    extends JmxMetricsCollector(address, decayFactor) {
 
   import StandardMetrics._
 
   private def this(cluster: Cluster) =
-    this(cluster.selfAddress,
+    this(
+      cluster.selfAddress,
       EWMA.alpha(cluster.settings.MetricsMovingAverageHalfLife, cluster.settings.MetricsInterval),
       cluster.system.dynamicAccess.createInstanceFor[AnyRef]("org.hyperic.sigar.Sigar", Nil).get)
 
@@ -804,7 +808,7 @@ private[cluster] object MetricsCollector {
       }
 
     } else {
-      system.dynamicAccess.createInstanceFor[MetricsCollector](fqcn, List(classOf[ActorSystem] -> system)).
+      system.dynamicAccess.createInstanceFor[MetricsCollector](fqcn, List(classOf[ActorSystem] → system)).
         recover {
           case e ⇒ throw new ConfigurationException("Could not create custom metrics collector [" + fqcn + "] due to:" + e.toString)
         }.get

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
@@ -69,12 +69,13 @@ private[akka] class ClusterReadView(cluster: Cluster) extends Closeable {
             val newUnreachable =
               if (_state.unreachable.contains(event.member)) _state.unreachable - event.member + event.member
               else _state.unreachable
-            _state = _state.copy(members = _state.members - event.member + event.member,
+            _state = _state.copy(
+              members = _state.members - event.member + event.member,
               unreachable = newUnreachable)
           case LeaderChanged(leader) ⇒
             _state = _state.copy(leader = leader)
           case RoleLeaderChanged(role, leader) ⇒
-            _state = _state.copy(roleLeaderMap = _state.roleLeaderMap + (role -> leader))
+            _state = _state.copy(roleLeaderMap = _state.roleLeaderMap + (role → leader))
           case stats: CurrentInternalStats  ⇒ _latestStats = stats
           case ClusterMetricsChanged(nodes) ⇒ _clusterMetrics = nodes
           case ClusterShuttingDown          ⇒

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -45,11 +45,11 @@ private[cluster] class ClusterRemoteWatcher(
   heartbeatInterval: FiniteDuration,
   unreachableReaperInterval: FiniteDuration,
   heartbeatExpectedResponseAfter: FiniteDuration)
-  extends RemoteWatcher(
-    failureDetector,
-    heartbeatInterval,
-    unreachableReaperInterval,
-    heartbeatExpectedResponseAfter) {
+    extends RemoteWatcher(
+      failureDetector,
+      heartbeatInterval,
+      unreachableReaperInterval,
+      heartbeatExpectedResponseAfter) {
 
   val cluster = Cluster(context.system)
   import cluster.selfAddress

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -83,7 +83,7 @@ final class ClusterSettings(val config: Config, val systemName: String) {
   val MinNrOfMembersOfRole: Map[String, Int] = {
     import scala.collection.JavaConverters._
     cc.getConfig("role").root.asScala.collect {
-      case (key, value: ConfigObject) ⇒ (key -> value.toConfig.getInt("min-nr-of-members"))
+      case (key, value: ConfigObject) ⇒ (key → value.toConfig.getInt("min-nr-of-members"))
     }.toMap
   }
   val JmxEnabled: Boolean = cc.getBoolean("jmx.enabled")

--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -60,9 +60,9 @@ private[cluster] object Gossip {
  */
 @SerialVersionUID(1L)
 private[cluster] final case class Gossip(
-  members: immutable.SortedSet[Member], // sorted set of members with their status, sorted by address
-  overview: GossipOverview = GossipOverview(),
-  version: VectorClock = VectorClock()) { // vector clock version
+    members: immutable.SortedSet[Member], // sorted set of members with their status, sorted by address
+    overview: GossipOverview = GossipOverview(),
+    version: VectorClock = VectorClock()) { // vector clock version
 
   if (Cluster.isAssertInvariantsEnabled) assertInvariants()
 
@@ -84,7 +84,7 @@ private[cluster] final case class Gossip(
   }
 
   @transient private lazy val membersMap: Map[UniqueAddress, Member] =
-    members.map(m ⇒ m.uniqueAddress -> m)(collection.breakOut)
+    members.map(m ⇒ m.uniqueAddress → m)(collection.breakOut)
 
   /**
    * Increments the version for this 'Node'.
@@ -142,7 +142,8 @@ private[cluster] final case class Gossip(
     val mergedMembers = Gossip.emptyMembers union Member.pickHighestPriority(this.members, that.members)
 
     // 3. merge reachability table by picking records with highest version
-    val mergedReachability = this.overview.reachability.merge(mergedMembers.map(_.uniqueAddress),
+    val mergedReachability = this.overview.reachability.merge(
+      mergedMembers.map(_.uniqueAddress),
       that.overview.reachability)
 
     // 4. Nobody can have seen this new gossip yet
@@ -200,7 +201,8 @@ private[cluster] final case class Gossip(
   def isSingletonCluster: Boolean = members.size == 1
 
   def member(node: UniqueAddress): Member = {
-    membersMap.getOrElse(node,
+    membersMap.getOrElse(
+      node,
       Member.removed(node)) // placeholder for removed member
   }
 
@@ -227,8 +229,8 @@ private[cluster] final case class Gossip(
  */
 @SerialVersionUID(1L)
 private[cluster] final case class GossipOverview(
-  seen: Set[UniqueAddress] = Set.empty,
-  reachability: Reachability = Reachability.empty) {
+    seen: Set[UniqueAddress] = Set.empty,
+    reachability: Reachability = Reachability.empty) {
 
   override def toString =
     s"GossipOverview(reachability = [$reachability], seen = [${seen.mkString(", ")}])"
@@ -252,11 +254,11 @@ object GossipEnvelope {
  */
 @SerialVersionUID(2L)
 private[cluster] class GossipEnvelope private (
-  val from: UniqueAddress,
-  val to: UniqueAddress,
-  @volatile var g: Gossip,
-  serDeadline: Deadline,
-  @transient @volatile var ser: () ⇒ Gossip) extends ClusterMessage {
+    val from: UniqueAddress,
+    val to: UniqueAddress,
+    @volatile var g: Gossip,
+    serDeadline: Deadline,
+    @transient @volatile var ser: () ⇒ Gossip) extends ClusterMessage {
 
   def gossip: Gossip = {
     deserialize()

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -15,10 +15,10 @@ import MemberStatus._
  */
 @SerialVersionUID(1L)
 class Member private[cluster] (
-  val uniqueAddress: UniqueAddress,
-  private[cluster] val upNumber: Int, // INTERNAL API
-  val status: MemberStatus,
-  val roles: Set[String]) extends Serializable {
+    val uniqueAddress: UniqueAddress,
+    private[cluster] val upNumber: Int, // INTERNAL API
+    val status: MemberStatus,
+    val roles: Set[String]) extends Serializable {
 
   def address: Address = uniqueAddress.address
 
@@ -53,7 +53,8 @@ class Member private[cluster] (
     val oldStatus = this.status
     if (status == oldStatus) this
     else {
-      require(allowedTransitions(oldStatus)(status),
+      require(
+        allowedTransitions(oldStatus)(status),
         s"Invalid member status transition [ ${this} -> ${status}]")
       new Member(uniqueAddress, upNumber, status, roles)
     }
@@ -233,13 +234,13 @@ object MemberStatus {
    */
   private[cluster] val allowedTransitions: Map[MemberStatus, Set[MemberStatus]] =
     Map(
-      Joining -> Set(WeaklyUp, Up, Down, Removed),
-      WeaklyUp -> Set(Up, Down, Removed),
-      Up -> Set(Leaving, Down, Removed),
-      Leaving -> Set(Exiting, Down, Removed),
-      Down -> Set(Removed),
-      Exiting -> Set(Removed, Down),
-      Removed -> Set.empty[MemberStatus])
+      Joining → Set(WeaklyUp, Up, Down, Removed),
+      WeaklyUp → Set(Up, Down, Removed),
+      Up → Set(Leaving, Down, Removed),
+      Leaving → Set(Exiting, Down, Removed),
+      Down → Set(Removed),
+      Exiting → Set(Removed, Down),
+      Removed → Set.empty[MemberStatus])
 }
 
 /**

--- a/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
@@ -47,8 +47,8 @@ private[cluster] object Reachability {
  */
 @SerialVersionUID(1L)
 private[cluster] class Reachability private (
-  val records: immutable.IndexedSeq[Reachability.Record],
-  val versions: Map[UniqueAddress, Long]) extends Serializable {
+    val records: immutable.IndexedSeq[Reachability.Record],
+    val versions: Map[UniqueAddress, Long]) extends Serializable {
 
   import Reachability._
 
@@ -67,10 +67,10 @@ private[cluster] class Reachability private (
 
         records foreach { r ⇒
           val m = mapBuilder.get(r.observer) match {
-            case None    ⇒ Map(r.subject -> r)
+            case None    ⇒ Map(r.subject → r)
             case Some(m) ⇒ m.updated(r.subject, r)
           }
-          mapBuilder += (r.observer -> m)
+          mapBuilder += (r.observer → m)
 
           if (r.status == Unreachable) unreachableBuilder += r.subject
           else if (r.status == Terminated) terminatedBuilder += r.subject
@@ -167,7 +167,7 @@ private[cluster] class Reachability private (
       }
 
       if (observerVersion2 > observerVersion1)
-        newVersions += (observer -> observerVersion2)
+        newVersions += (observer → observerVersion2)
     }
 
     newVersions = newVersions.filterNot { case (k, _) ⇒ !allowed(k) }
@@ -242,7 +242,7 @@ private[cluster] class Reachability private (
       case (subject, records) if records.exists(_.status == Unreachable) ⇒
         val observers: Set[UniqueAddress] =
           records.collect { case r if r.status == Unreachable ⇒ r.observer }(breakOut)
-        (subject -> observers)
+        (subject → observers)
     }
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
@@ -67,7 +67,7 @@ private[cluster] object VectorClock {
  */
 @SerialVersionUID(1L)
 final case class VectorClock(
-  versions: TreeMap[VectorClock.Node, Long] = TreeMap.empty[VectorClock.Node, Long]) {
+    versions: TreeMap[VectorClock.Node, Long] = TreeMap.empty[VectorClock.Node, Long]) {
 
   import VectorClock._
 

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -37,27 +37,28 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
   private lazy val GossipTimeToLive = Cluster(system).settings.GossipTimeToLive
 
   private val fromBinaryMap = collection.immutable.HashMap[Class[_ <: ClusterMessage], Array[Byte] ⇒ AnyRef](
-    classOf[InternalClusterAction.Join] -> {
+    classOf[InternalClusterAction.Join] → {
       case bytes ⇒
         val m = cm.Join.parseFrom(bytes)
-        InternalClusterAction.Join(uniqueAddressFromProto(m.getNode),
+        InternalClusterAction.Join(
+          uniqueAddressFromProto(m.getNode),
           Set.empty[String] ++ m.getRolesList.asScala)
     },
-    classOf[InternalClusterAction.Welcome] -> {
+    classOf[InternalClusterAction.Welcome] → {
       case bytes ⇒
         val m = cm.Welcome.parseFrom(decompress(bytes))
         InternalClusterAction.Welcome(uniqueAddressFromProto(m.getFrom), gossipFromProto(m.getGossip))
     },
-    classOf[ClusterUserAction.Leave] -> (bytes ⇒ ClusterUserAction.Leave(addressFromBinary(bytes))),
-    classOf[ClusterUserAction.Down] -> (bytes ⇒ ClusterUserAction.Down(addressFromBinary(bytes))),
-    InternalClusterAction.InitJoin.getClass -> (_ ⇒ InternalClusterAction.InitJoin),
-    classOf[InternalClusterAction.InitJoinAck] -> (bytes ⇒ InternalClusterAction.InitJoinAck(addressFromBinary(bytes))),
-    classOf[InternalClusterAction.InitJoinNack] -> (bytes ⇒ InternalClusterAction.InitJoinNack(addressFromBinary(bytes))),
-    classOf[ClusterHeartbeatSender.Heartbeat] -> (bytes ⇒ ClusterHeartbeatSender.Heartbeat(addressFromBinary(bytes))),
-    classOf[ClusterHeartbeatSender.HeartbeatRsp] -> (bytes ⇒ ClusterHeartbeatSender.HeartbeatRsp(uniqueAddressFromBinary(bytes))),
-    classOf[GossipStatus] -> gossipStatusFromBinary,
-    classOf[GossipEnvelope] -> gossipEnvelopeFromBinary,
-    classOf[MetricsGossipEnvelope] -> metricsGossipEnvelopeFromBinary)
+    classOf[ClusterUserAction.Leave] → (bytes ⇒ ClusterUserAction.Leave(addressFromBinary(bytes))),
+    classOf[ClusterUserAction.Down] → (bytes ⇒ ClusterUserAction.Down(addressFromBinary(bytes))),
+    InternalClusterAction.InitJoin.getClass → (_ ⇒ InternalClusterAction.InitJoin),
+    classOf[InternalClusterAction.InitJoinAck] → (bytes ⇒ InternalClusterAction.InitJoinAck(addressFromBinary(bytes))),
+    classOf[InternalClusterAction.InitJoinNack] → (bytes ⇒ InternalClusterAction.InitJoinNack(addressFromBinary(bytes))),
+    classOf[ClusterHeartbeatSender.Heartbeat] → (bytes ⇒ ClusterHeartbeatSender.Heartbeat(addressFromBinary(bytes))),
+    classOf[ClusterHeartbeatSender.HeartbeatRsp] → (bytes ⇒ ClusterHeartbeatSender.HeartbeatRsp(uniqueAddressFromBinary(bytes))),
+    classOf[GossipStatus] → gossipStatusFromBinary,
+    classOf[GossipEnvelope] → gossipEnvelopeFromBinary,
+    classOf[MetricsGossipEnvelope] → metricsGossipEnvelopeFromBinary)
 
   def includeManifest: Boolean = true
 
@@ -164,20 +165,20 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
     UniqueAddress(addressFromProto(uniqueAddress.getAddress), uniqueAddress.getUid)
 
   private val memberStatusToInt = scala.collection.immutable.HashMap[MemberStatus, Int](
-    MemberStatus.Joining -> cm.MemberStatus.Joining_VALUE,
-    MemberStatus.Up -> cm.MemberStatus.Up_VALUE,
-    MemberStatus.Leaving -> cm.MemberStatus.Leaving_VALUE,
-    MemberStatus.Exiting -> cm.MemberStatus.Exiting_VALUE,
-    MemberStatus.Down -> cm.MemberStatus.Down_VALUE,
-    MemberStatus.Removed -> cm.MemberStatus.Removed_VALUE,
-    MemberStatus.WeaklyUp -> cm.MemberStatus.WeaklyUp_VALUE)
+    MemberStatus.Joining → cm.MemberStatus.Joining_VALUE,
+    MemberStatus.Up → cm.MemberStatus.Up_VALUE,
+    MemberStatus.Leaving → cm.MemberStatus.Leaving_VALUE,
+    MemberStatus.Exiting → cm.MemberStatus.Exiting_VALUE,
+    MemberStatus.Down → cm.MemberStatus.Down_VALUE,
+    MemberStatus.Removed → cm.MemberStatus.Removed_VALUE,
+    MemberStatus.WeaklyUp → cm.MemberStatus.WeaklyUp_VALUE)
 
   private val memberStatusFromInt = memberStatusToInt.map { case (a, b) ⇒ (b, a) }
 
   private val reachabilityStatusToInt = scala.collection.immutable.HashMap[Reachability.ReachabilityStatus, Int](
-    Reachability.Reachable -> cm.ReachabilityStatus.Reachable_VALUE,
-    Reachability.Unreachable -> cm.ReachabilityStatus.Unreachable_VALUE,
-    Reachability.Terminated -> cm.ReachabilityStatus.Terminated_VALUE)
+    Reachability.Reachable → cm.ReachabilityStatus.Reachable_VALUE,
+    Reachability.Unreachable → cm.ReachabilityStatus.Unreachable_VALUE,
+    Reachability.Terminated → cm.ReachabilityStatus.Terminated_VALUE)
 
   private val reachabilityStatusFromInt = reachabilityStatusToInt.map { case (a, b) ⇒ (b, a) }
 
@@ -310,7 +311,8 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
   }
 
   private def gossipStatusFromProto(status: cm.GossipStatus): GossipStatus =
-    GossipStatus(uniqueAddressFromProto(status.getFrom), vectorClockFromProto(status.getVersion,
+    GossipStatus(uniqueAddressFromProto(status.getFrom), vectorClockFromProto(
+      status.getVersion,
       status.getAllHashesList.asScala.toVector))
 
   private def metricsGossipEnvelopeToProto(envelope: MetricsGossipEnvelope): cm.MetricsGossipEnvelope = {
@@ -381,7 +383,8 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
         case NumberType.Float_VALUE   ⇒ jl.Float.intBitsToFloat(number.getValue32)
         case NumberType.Integer_VALUE ⇒ number.getValue32
         case NumberType.Serialized_VALUE ⇒
-          val in = new ClassLoaderObjectInputStream(system.dynamicAccess.classLoader,
+          val in = new ClassLoaderObjectInputStream(
+            system.dynamicAccess.classLoader,
             new ByteArrayInputStream(number.getSerialized.toByteArray))
           val obj = in.readObject
           in.close()

--- a/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/AdaptiveLoadBalancing.scala
@@ -44,7 +44,7 @@ import akka.routing._
  */
 @deprecated("Superseded by akka.cluster.metrics (in akka-cluster-metrics jar)", "2.4")
 final case class AdaptiveLoadBalancingRoutingLogic(system: ActorSystem, metricsSelector: MetricsSelector = MixMetricsSelector)
-  extends RoutingLogic with NoSerializationVerificationNeeded {
+    extends RoutingLogic with NoSerializationVerificationNeeded {
 
   private val cluster = Cluster(system)
 
@@ -136,10 +136,11 @@ final case class AdaptiveLoadBalancingPool(
   override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
   override val usePoolDispatcher: Boolean = false)
-  extends Pool {
+    extends Pool {
 
   def this(config: Config, dynamicAccess: DynamicAccess) =
-    this(nrOfInstances = ClusterRouterSettingsBase.getMaxTotalNrOfInstances(config),
+    this(
+      nrOfInstances = ClusterRouterSettingsBase.getMaxTotalNrOfInstances(config),
       metricsSelector = MetricsSelector.fromConfig(config, dynamicAccess),
       usePoolDispatcher = config.hasPath("pool-dispatcher"))
 
@@ -159,7 +160,8 @@ final case class AdaptiveLoadBalancingPool(
     new Router(AdaptiveLoadBalancingRoutingLogic(system, metricsSelector))
 
   override def routingLogicController(routingLogic: RoutingLogic): Option[Props] =
-    Some(Props(classOf[AdaptiveLoadBalancingMetricsListener],
+    Some(Props(
+      classOf[AdaptiveLoadBalancingMetricsListener],
       routingLogic.asInstanceOf[AdaptiveLoadBalancingRoutingLogic]))
 
   /**
@@ -215,10 +217,11 @@ final case class AdaptiveLoadBalancingGroup(
   metricsSelector: MetricsSelector = MixMetricsSelector,
   override val paths: immutable.Iterable[String] = Nil,
   override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
-  extends Group {
+    extends Group {
 
   def this(config: Config, dynamicAccess: DynamicAccess) =
-    this(metricsSelector = MetricsSelector.fromConfig(config, dynamicAccess),
+    this(
+      metricsSelector = MetricsSelector.fromConfig(config, dynamicAccess),
       paths = immutableSeq(config.getStringList("routees.paths")))
 
   /**
@@ -228,8 +231,9 @@ final case class AdaptiveLoadBalancingGroup(
    * @param routeesPaths string representation of the actor paths of the routees, messages are
    *   sent with [[akka.actor.ActorSelection]] to these paths
    */
-  def this(metricsSelector: MetricsSelector,
-           routeesPaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeesPaths))
+  def this(
+    metricsSelector: MetricsSelector,
+    routeesPaths: java.lang.Iterable[String]) = this(paths = immutableSeq(routeesPaths))
 
   override def paths(system: ActorSystem): immutable.Iterable[String] = this.paths
 
@@ -237,7 +241,8 @@ final case class AdaptiveLoadBalancingGroup(
     new Router(AdaptiveLoadBalancingRoutingLogic(system, metricsSelector))
 
   override def routingLogicController(routingLogic: RoutingLogic): Option[Props] =
-    Some(Props(classOf[AdaptiveLoadBalancingMetricsListener],
+    Some(Props(
+      classOf[AdaptiveLoadBalancingMetricsListener],
       routingLogic.asInstanceOf[AdaptiveLoadBalancingRoutingLogic]))
 
   /**
@@ -342,7 +347,7 @@ object MixMetricsSelector extends MixMetricsSelectorBase(
 @deprecated("Superseded by akka.cluster.metrics (in akka-cluster-metrics jar)", "2.4")
 final case class MixMetricsSelector(
   selectors: immutable.IndexedSeq[CapacityMetricsSelector])
-  extends MixMetricsSelectorBase(selectors)
+    extends MixMetricsSelectorBase(selectors)
 
 /**
  * Base class for MetricsSelector that combines other selectors and aggregates their capacity.
@@ -350,7 +355,7 @@ final case class MixMetricsSelector(
 @SerialVersionUID(1L)
 @deprecated("Superseded by akka.cluster.metrics (in akka-cluster-metrics jar)", "2.4")
 abstract class MixMetricsSelectorBase(selectors: immutable.IndexedSeq[CapacityMetricsSelector])
-  extends CapacityMetricsSelector {
+    extends CapacityMetricsSelector {
 
   /**
    * Java API: construct a mix-selector from a sequence of selectors
@@ -363,9 +368,9 @@ abstract class MixMetricsSelectorBase(selectors: immutable.IndexedSeq[CapacityMe
     combined.foldLeft(Map.empty[Address, (Double, Int)].withDefaultValue((0.0, 0))) {
       case (acc, (address, capacity)) ⇒
         val (sum, count) = acc(address)
-        acc + (address -> ((sum + capacity, count + 1)))
+        acc + (address → ((sum + capacity, count + 1)))
     }.map {
-      case (addr, (sum, count)) ⇒ (addr -> sum / count)
+      case (addr, (sum, count)) ⇒ (addr → sum / count)
     }
   }
 
@@ -380,7 +385,7 @@ object MetricsSelector {
       case "cpu"  ⇒ CpuMetricsSelector
       case "load" ⇒ SystemLoadAverageMetricsSelector
       case fqn ⇒
-        val args = List(classOf[Config] -> config)
+        val args = List(classOf[Config] → config)
         dynamicAccess.createInstanceFor[MetricsSelector](fqn, args).recover({
           case exception ⇒ throw new IllegalArgumentException(
             (s"Cannot instantiate metrics-selector [$fqn], " +
@@ -430,7 +435,7 @@ abstract class CapacityMetricsSelector extends MetricsSelector {
       val (_, min) = capacity.minBy { case (_, c) ⇒ c }
       // lowest usable capacity is 1% (>= 0.5% will be rounded to weight 1), also avoids div by zero
       val divisor = math.max(0.01, min)
-      capacity map { case (addr, c) ⇒ (addr -> math.round((c) / divisor).toInt) }
+      capacity map { case (addr, c) ⇒ (addr → math.round((c) / divisor).toInt) }
     }
   }
 
@@ -512,7 +517,7 @@ private[cluster] class WeightedRoutees(routees: immutable.IndexedSeq[Routee], se
  * subscribe to ClusterMetricsChanged and update routing logic
  */
 private[akka] class AdaptiveLoadBalancingMetricsListener(routingLogic: AdaptiveLoadBalancingRoutingLogic)
-  extends Actor {
+    extends Actor {
 
   val cluster = Cluster(context.system)
 

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -43,10 +43,10 @@ object ClusterRouterGroupSettings {
  */
 @SerialVersionUID(1L)
 final case class ClusterRouterGroupSettings(
-  totalInstances: Int,
-  routeesPaths: immutable.Seq[String],
-  allowLocalRoutees: Boolean,
-  useRole: Option[String]) extends ClusterRouterSettingsBase {
+    totalInstances: Int,
+    routeesPaths: immutable.Seq[String],
+    allowLocalRoutees: Boolean,
+    useRole: Option[String]) extends ClusterRouterSettingsBase {
 
   /**
    * Java API
@@ -82,10 +82,10 @@ object ClusterRouterPoolSettings {
  */
 @SerialVersionUID(1L)
 final case class ClusterRouterPoolSettings(
-  totalInstances: Int,
-  maxInstancesPerNode: Int,
-  allowLocalRoutees: Boolean,
-  useRole: Option[String]) extends ClusterRouterSettingsBase {
+    totalInstances: Int,
+    maxInstancesPerNode: Int,
+    allowLocalRoutees: Boolean,
+    useRole: Option[String]) extends ClusterRouterSettingsBase {
 
   /**
    * Java API
@@ -242,7 +242,7 @@ private[akka] trait ClusterRouterConfigBase extends RouterConfig {
  */
 private[akka] class ClusterRouterPoolActor(
   supervisorStrategy: SupervisorStrategy, val settings: ClusterRouterPoolSettings)
-  extends RouterPoolActor(supervisorStrategy) with ClusterRouterActor {
+    extends RouterPoolActor(supervisorStrategy) with ClusterRouterActor {
 
   override def receive = clusterReceive orElse super.receive
 
@@ -276,9 +276,9 @@ private[akka] class ClusterRouterPoolActor(
     } else {
       // find the node with least routees
       val numberOfRouteesPerNode: Map[Address, Int] =
-        currentRoutees.foldLeft(currentNodes.map(_ -> 0).toMap.withDefaultValue(0)) { (acc, x) ⇒
+        currentRoutees.foldLeft(currentNodes.map(_ → 0).toMap.withDefaultValue(0)) { (acc, x) ⇒
           val address = fullAddress(x)
-          acc + (address -> (acc(address) + 1))
+          acc + (address → (acc(address) + 1))
         }
 
       val (address, count) = numberOfRouteesPerNode.minBy(_._2)
@@ -292,7 +292,7 @@ private[akka] class ClusterRouterPoolActor(
  * INTERNAL API
  */
 private[akka] class ClusterRouterGroupActor(val settings: ClusterRouterGroupSettings)
-  extends RouterActor with ClusterRouterActor {
+    extends RouterActor with ClusterRouterActor {
 
   val group = cell.routerConfig match {
     case x: Group ⇒ x
@@ -304,7 +304,7 @@ private[akka] class ClusterRouterGroupActor(val settings: ClusterRouterGroupSett
 
   var usedRouteePaths: Map[Address, Set[String]] =
     if (settings.allowLocalRoutees)
-      Map(cluster.selfAddress -> settings.routeesPaths.toSet)
+      Map(cluster.selfAddress → settings.routeesPaths.toSet)
     else
       Map.empty
 

--- a/akka-contrib/src/main/scala/akka/contrib/mailbox/PeekMailbox.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/mailbox/PeekMailbox.scala
@@ -53,7 +53,7 @@ class PeekMailboxType(settings: ActorSystem.Settings, config: Config) extends Ma
 }
 
 class PeekMailbox(owner: ActorRef, system: ActorSystem, maxRetries: Int)
-  extends UnboundedQueueBasedMessageQueue {
+    extends UnboundedQueueBasedMessageQueue {
   final val queue = new ConcurrentLinkedQueue[Envelope]()
 
   /*

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -16,7 +16,7 @@ object ReliableProxy {
    * constructor.
    */
   def props(targetPath: ActorPath, retryAfter: FiniteDuration, reconnectAfter: Option[FiniteDuration],
-            maxReconnects: Option[Int]): Props = {
+    maxReconnects: Option[Int]): Props = {
     Props(new ReliableProxy(targetPath, retryAfter, reconnectAfter, maxReconnects))
   }
 
@@ -25,7 +25,7 @@ object ReliableProxy {
    * constructor.
    */
   def props(targetPath: ActorPath, retryAfter: FiniteDuration, reconnectAfter: FiniteDuration,
-            maxReconnects: Int): Props = {
+    maxReconnects: Int): Props = {
     props(targetPath, retryAfter, Option(reconnectAfter), if (maxReconnects > 0) Some(maxReconnects) else None)
   }
 
@@ -225,8 +225,8 @@ import ReliableProxy._
  *   target actor. Use `None` for no limit. If `reconnectAfter` is `None` this value is ignored.
  */
 class ReliableProxy(targetPath: ActorPath, retryAfter: FiniteDuration,
-                    reconnectAfter: Option[FiniteDuration], maxConnectAttempts: Option[Int])
-  extends Actor with LoggingFSM[State, Vector[Message]] with ReliableProxyDebugLogging {
+  reconnectAfter: Option[FiniteDuration], maxConnectAttempts: Option[Int])
+    extends Actor with LoggingFSM[State, Vector[Message]] with ReliableProxyDebugLogging {
 
   var tunnel: ActorRef = _
   var currentSerial: Int = 0
@@ -284,9 +284,9 @@ class ReliableProxy(targetPath: ActorPath, retryAfter: FiniteDuration,
   }
 
   onTransition {
-    case _ -> Active     ⇒ scheduleTick()
-    case Active -> Idle  ⇒ cancelTimer(resendTimer)
-    case _ -> Connecting ⇒ scheduleReconnectTick()
+    case _ → Active     ⇒ scheduleTick()
+    case Active → Idle  ⇒ cancelTimer(resendTimer)
+    case _ → Connecting ⇒ scheduleReconnectTick()
   }
 
   when(Active) {

--- a/akka-contrib/src/main/scala/akka/contrib/throttle/TimerBasedThrottler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/throttle/TimerBasedThrottler.scala
@@ -109,9 +109,10 @@ private[throttle] object TimerBasedThrottler {
   final case class Message(message: Any, sender: ActorRef)
 
   // The data of the FSM
-  final case class Data(target: Option[ActorRef],
-                        callsLeftInThisPeriod: Int,
-                        queue: Q[Message])
+  final case class Data(
+    target: Option[ActorRef],
+    callsLeftInThisPeriod: Int,
+    queue: Q[Message])
 }
 
 /**
@@ -277,8 +278,8 @@ class TimerBasedThrottler(var rate: Rate) extends Actor with FSM[State, Data] {
   }
 
   onTransition {
-    case Idle -> Active ⇒ startTimer(rate)
-    case Active -> Idle ⇒ stopTimer()
+    case Idle → Active ⇒ startTimer(rate)
+    case Active → Idle ⇒ stopTimer()
   }
 
   initialize()

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
@@ -40,7 +40,7 @@ object GCounter {
 @SerialVersionUID(1L)
 final class GCounter private[akka] (
   private[akka] val state: Map[UniqueAddress, BigInt] = Map.empty)
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning with FastMerge {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning with FastMerge {
 
   import GCounter.Zero
 
@@ -83,8 +83,8 @@ final class GCounter private[akka] (
     else state.get(key) match {
       case Some(v) ⇒
         val tot = v + delta
-        assignAncestor(new GCounter(state + (key -> tot)))
-      case None ⇒ assignAncestor(new GCounter(state + (key -> delta)))
+        assignAncestor(new GCounter(state + (key → tot)))
+      case None ⇒ assignAncestor(new GCounter(state + (key → delta)))
     }
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
@@ -39,7 +39,7 @@ object LWWMap {
 @SerialVersionUID(1L)
 final class LWWMap[A] private[akka] (
   private[akka] val underlying: ORMap[LWWRegister[A]])
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
   import LWWRegister.{ Clock, defaultClock }
 
   type T = LWWMap[A]
@@ -47,7 +47,7 @@ final class LWWMap[A] private[akka] (
   /**
    * Scala API: All entries of the map.
    */
-  def entries: Map[String, A] = underlying.entries.map { case (k, r) ⇒ k -> r.value }
+  def entries: Map[String, A] = underlying.entries.map { case (k, r) ⇒ k → r.value }
 
   /**
    * Java API: All entries of the map.

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
@@ -95,7 +95,7 @@ final class LWWRegister[A] private[akka] (
   private[akka] val node: UniqueAddress,
   val value: A,
   val timestamp: Long)
-  extends ReplicatedData with ReplicatedDataSerialization {
+    extends ReplicatedData with ReplicatedDataSerialization {
   import LWWRegister.{ Clock, defaultClock }
 
   type T = LWWRegister[A]

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
@@ -35,7 +35,7 @@ object ORMap {
 final class ORMap[A <: ReplicatedData] private[akka] (
   private[akka] val keys: ORSet[String],
   private[akka] val values: Map[String, A])
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
 
   type T = ORMap[A]
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
@@ -41,7 +41,7 @@ object ORMultiMap {
  */
 @SerialVersionUID(1L)
 final class ORMultiMap[A] private[akka] (private[akka] val underlying: ORMap[ORSet[A]])
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
 
   override type T = ORMultiMap[A]
 
@@ -52,7 +52,7 @@ final class ORMultiMap[A] private[akka] (private[akka] val underlying: ORMap[ORS
    * Scala API: All entries of a multimap where keys are strings and values are sets.
    */
   def entries: Map[String, Set[A]] =
-    underlying.entries.map { case (k, v) ⇒ k -> v.elements }
+    underlying.entries.map { case (k, v) ⇒ k → v.elements }
 
   /**
    * Java API: All entries of a multimap where keys are strings and values are sets.

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
@@ -150,11 +150,11 @@ object ORSet {
    * @see [[ORSet#merge]]
    */
   private[akka] def mergeDisjointKeys[A](keys: Set[A], elementsMap: Map[A, ORSet.Dot], vvector: VersionVector,
-                                         accumulator: Map[A, ORSet.Dot]): Map[A, ORSet.Dot] =
+    accumulator: Map[A, ORSet.Dot]): Map[A, ORSet.Dot] =
     mergeDisjointKeys(keys.iterator, elementsMap, vvector, accumulator)
 
   private def mergeDisjointKeys[A](keys: Iterator[A], elementsMap: Map[A, ORSet.Dot], vvector: VersionVector,
-                                   accumulator: Map[A, ORSet.Dot]): Map[A, ORSet.Dot] = {
+    accumulator: Map[A, ORSet.Dot]): Map[A, ORSet.Dot] = {
     keys.foldLeft(accumulator) {
       case (acc, k) ⇒
         val dots = elementsMap(k)
@@ -202,7 +202,7 @@ object ORSet {
 final class ORSet[A] private[akka] (
   private[akka] val elementsMap: Map[A, ORSet.Dot],
   private[akka] val vvector: VersionVector)
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning with FastMerge {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning with FastMerge {
 
   type T = ORSet[A]
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounter.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounter.scala
@@ -39,7 +39,7 @@ object PNCounter {
 @SerialVersionUID(1L)
 final class PNCounter private[akka] (
   private[akka] val increments: GCounter, private[akka] val decrements: GCounter)
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
 
   type T = PNCounter
 
@@ -90,18 +90,21 @@ final class PNCounter private[akka] (
     else this
 
   override def merge(that: PNCounter): PNCounter =
-    copy(increments = that.increments.merge(this.increments),
+    copy(
+      increments = that.increments.merge(this.increments),
       decrements = that.decrements.merge(this.decrements))
 
   override def needPruningFrom(removedNode: UniqueAddress): Boolean =
     increments.needPruningFrom(removedNode) || decrements.needPruningFrom(removedNode)
 
   override def prune(removedNode: UniqueAddress, collapseInto: UniqueAddress): PNCounter =
-    copy(increments = increments.prune(removedNode, collapseInto),
+    copy(
+      increments = increments.prune(removedNode, collapseInto),
       decrements = decrements.prune(removedNode, collapseInto))
 
   override def pruningCleanup(removedNode: UniqueAddress): PNCounter =
-    copy(increments = increments.pruningCleanup(removedNode),
+    copy(
+      increments = increments.pruningCleanup(removedNode),
       decrements = decrements.pruningCleanup(removedNode))
 
   private def copy(increments: GCounter = this.increments, decrements: GCounter = this.decrements): PNCounter =

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
@@ -29,17 +29,17 @@ object PNCounterMap {
 @SerialVersionUID(1L)
 final class PNCounterMap private[akka] (
   private[akka] val underlying: ORMap[PNCounter])
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
 
   type T = PNCounterMap
 
   /** Scala API */
-  def entries: Map[String, BigInt] = underlying.entries.map { case (k, c) ⇒ k -> c.value }
+  def entries: Map[String, BigInt] = underlying.entries.map { case (k, c) ⇒ k → c.value }
 
   /** Java API */
   def getEntries: java.util.Map[String, BigInteger] = {
     import scala.collection.JavaConverters._
-    underlying.entries.map { case (k, c) ⇒ k -> c.value.bigInteger }.asJava
+    underlying.entries.map { case (k, c) ⇒ k → c.value.bigInteger }.asJava
   }
 
   /**

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/VersionVector.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/VersionVector.scala
@@ -96,7 +96,7 @@ object VersionVector {
  */
 @SerialVersionUID(1L)
 sealed abstract class VersionVector
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
+    extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
 
   type T = VersionVector
 
@@ -262,7 +262,7 @@ final case class OneVersionVector private[akka] (node: UniqueAddress, version: L
   private[akka] override def increment(n: UniqueAddress): VersionVector = {
     val v = Timestamp.counter.getAndIncrement()
     if (n == node) copy(version = v)
-    else ManyVersionVector(TreeMap(node -> version, n -> v))
+    else ManyVersionVector(TreeMap(node → version, n → v))
   }
 
   /** INTERNAL API */
@@ -282,7 +282,7 @@ final case class OneVersionVector private[akka] (node: UniqueAddress, version: L
     that match {
       case OneVersionVector(n2, v2) ⇒
         if (node == n2) if (version >= v2) this else OneVersionVector(n2, v2)
-        else ManyVersionVector(TreeMap(node -> version, n2 -> v2))
+        else ManyVersionVector(TreeMap(node → version, n2 → v2))
       case ManyVersionVector(vs2) ⇒
         val v2 = vs2.getOrElse(node, Timestamp.Zero)
         val mergedVersions =

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -26,7 +26,7 @@ import akka.cluster.UniqueAddress
  * Protobuf serializer of ReplicatedData.
  */
 class ReplicatedDataSerializer(val system: ExtendedActorSystem)
-  extends SerializerWithStringManifest with SerializationSupport with BaseSerializer {
+    extends SerializerWithStringManifest with SerializationSupport with BaseSerializer {
 
   private val DeletedDataManifest = "A"
   private val GSetManifest = "B"
@@ -52,29 +52,29 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   private val VersionVectorManifest = "L"
 
   private val fromBinaryMap = collection.immutable.HashMap[String, Array[Byte] ⇒ AnyRef](
-    GSetManifest -> gsetFromBinary,
-    ORSetManifest -> orsetFromBinary,
-    FlagManifest -> flagFromBinary,
-    LWWRegisterManifest -> lwwRegisterFromBinary,
-    GCounterManifest -> gcounterFromBinary,
-    PNCounterManifest -> pncounterFromBinary,
-    ORMapManifest -> ormapFromBinary,
-    LWWMapManifest -> lwwmapFromBinary,
-    PNCounterMapManifest -> pncountermapFromBinary,
-    ORMultiMapManifest -> multimapFromBinary,
-    DeletedDataManifest -> (_ ⇒ DeletedData),
-    VersionVectorManifest -> versionVectorFromBinary,
+    GSetManifest → gsetFromBinary,
+    ORSetManifest → orsetFromBinary,
+    FlagManifest → flagFromBinary,
+    LWWRegisterManifest → lwwRegisterFromBinary,
+    GCounterManifest → gcounterFromBinary,
+    PNCounterManifest → pncounterFromBinary,
+    ORMapManifest → ormapFromBinary,
+    LWWMapManifest → lwwmapFromBinary,
+    PNCounterMapManifest → pncountermapFromBinary,
+    ORMultiMapManifest → multimapFromBinary,
+    DeletedDataManifest → (_ ⇒ DeletedData),
+    VersionVectorManifest → versionVectorFromBinary,
 
-    GSetKeyManifest -> (bytes ⇒ GSetKey(keyIdFromBinary(bytes))),
-    ORSetKeyManifest -> (bytes ⇒ ORSetKey(keyIdFromBinary(bytes))),
-    FlagKeyManifest -> (bytes ⇒ FlagKey(keyIdFromBinary(bytes))),
-    LWWRegisterKeyManifest -> (bytes ⇒ LWWRegisterKey(keyIdFromBinary(bytes))),
-    GCounterKeyManifest -> (bytes ⇒ GCounterKey(keyIdFromBinary(bytes))),
-    PNCounterKeyManifest -> (bytes ⇒ PNCounterKey(keyIdFromBinary(bytes))),
-    ORMapKeyManifest -> (bytes ⇒ ORMapKey(keyIdFromBinary(bytes))),
-    LWWMapKeyManifest -> (bytes ⇒ LWWMapKey(keyIdFromBinary(bytes))),
-    PNCounterMapKeyManifest -> (bytes ⇒ PNCounterMapKey(keyIdFromBinary(bytes))),
-    ORMultiMapKeyManifest -> (bytes ⇒ ORMultiMapKey(keyIdFromBinary(bytes))))
+    GSetKeyManifest → (bytes ⇒ GSetKey(keyIdFromBinary(bytes))),
+    ORSetKeyManifest → (bytes ⇒ ORSetKey(keyIdFromBinary(bytes))),
+    FlagKeyManifest → (bytes ⇒ FlagKey(keyIdFromBinary(bytes))),
+    LWWRegisterKeyManifest → (bytes ⇒ LWWRegisterKey(keyIdFromBinary(bytes))),
+    GCounterKeyManifest → (bytes ⇒ GCounterKey(keyIdFromBinary(bytes))),
+    PNCounterKeyManifest → (bytes ⇒ PNCounterKey(keyIdFromBinary(bytes))),
+    ORMapKeyManifest → (bytes ⇒ ORMapKey(keyIdFromBinary(bytes))),
+    LWWMapKeyManifest → (bytes ⇒ LWWMapKey(keyIdFromBinary(bytes))),
+    PNCounterMapKeyManifest → (bytes ⇒ PNCounterMapKey(keyIdFromBinary(bytes))),
+    ORMultiMapKeyManifest → (bytes ⇒ ORMultiMapKey(keyIdFromBinary(bytes))))
 
   override def manifest(obj: AnyRef): String = obj match {
     case _: ORSet[_]          ⇒ ORSetManifest
@@ -284,7 +284,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def gcounterFromProto(gcounter: rd.GCounter): GCounter = {
     new GCounter(state = gcounter.getEntriesList.asScala.map(entry ⇒
-      uniqueAddressFromProto(entry.getNode) -> BigInt(entry.getValue.toByteArray))(breakOut))
+      uniqueAddressFromProto(entry.getNode) → BigInt(entry.getValue.toByteArray))(breakOut))
   }
 
   def pncounterToProto(pncounter: PNCounter): rd.PNCounter =
@@ -322,7 +322,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
       VersionVector(uniqueAddressFromProto(entries.get(0).getNode), entries.get(0).getVersion)
     else {
       val versions: TreeMap[UniqueAddress, Long] = versionVector.getEntriesList.asScala.map(entry ⇒
-        uniqueAddressFromProto(entry.getNode) -> entry.getVersion)(breakOut)
+        uniqueAddressFromProto(entry.getNode) → entry.getVersion)(breakOut)
       VersionVector(versions)
     }
   }
@@ -341,7 +341,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def ormapFromProto(ormap: rd.ORMap): ORMap[ReplicatedData] = {
     val entries = ormap.getEntriesList.asScala.map(entry ⇒
-      entry.getKey -> otherMessageFromProto(entry.getValue).asInstanceOf[ReplicatedData]).toMap
+      entry.getKey → otherMessageFromProto(entry.getValue).asInstanceOf[ReplicatedData]).toMap
     new ORMap(
       keys = orsetFromProto(ormap.getKeys).asInstanceOf[ORSet[String]],
       entries)
@@ -361,7 +361,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def lwwmapFromProto(lwwmap: rd.LWWMap): LWWMap[Any] = {
     val entries = lwwmap.getEntriesList.asScala.map(entry ⇒
-      entry.getKey -> lwwRegisterFromProto(entry.getValue)).toMap
+      entry.getKey → lwwRegisterFromProto(entry.getValue)).toMap
     new LWWMap(new ORMap(
       keys = orsetFromProto(lwwmap.getKeys).asInstanceOf[ORSet[String]],
       entries))
@@ -381,7 +381,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def pncountermapFromProto(pncountermap: rd.PNCounterMap): PNCounterMap = {
     val entries = pncountermap.getEntriesList.asScala.map(entry ⇒
-      entry.getKey -> pncounterFromProto(entry.getValue)).toMap
+      entry.getKey → pncounterFromProto(entry.getValue)).toMap
     new PNCounterMap(new ORMap(
       keys = orsetFromProto(pncountermap.getKeys).asInstanceOf[ORSet[String]],
       entries))
@@ -401,7 +401,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def multimapFromProto(multimap: rd.ORMultiMap): ORMultiMap[Any] = {
     val entries = multimap.getEntriesList.asScala.map(entry ⇒
-      entry.getKey -> orsetFromProto(entry.getValue)).toMap
+      entry.getKey → orsetFromProto(entry.getValue)).toMap
     new ORMultiMap(new ORMap(
       keys = orsetFromProto(multimap.getKeys).asInstanceOf[ORSet[String]],
       entries))

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
@@ -139,7 +139,7 @@ private[akka] object ReplicatorMessageSerializer {
  * Protobuf serializer of ReplicatorMessage messages.
  */
 class ReplicatorMessageSerializer(val system: ExtendedActorSystem)
-  extends SerializerWithStringManifest with SerializationSupport with BaseSerializer {
+    extends SerializerWithStringManifest with SerializationSupport with BaseSerializer {
   import ReplicatorMessageSerializer.SmallCache
 
   private val cacheTimeToLive = system.settings.config.getDuration(
@@ -169,20 +169,20 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem)
   val GossipManifest = "N"
 
   private val fromBinaryMap = collection.immutable.HashMap[String, Array[Byte] ⇒ AnyRef](
-    GetManifest -> getFromBinary,
-    GetSuccessManifest -> getSuccessFromBinary,
-    NotFoundManifest -> notFoundFromBinary,
-    GetFailureManifest -> getFailureFromBinary,
-    SubscribeManifest -> subscribeFromBinary,
-    UnsubscribeManifest -> unsubscribeFromBinary,
-    ChangedManifest -> changedFromBinary,
-    DataEnvelopeManifest -> dataEnvelopeFromBinary,
-    WriteManifest -> writeFromBinary,
-    WriteAckManifest -> (_ ⇒ WriteAck),
-    ReadManifest -> readFromBinary,
-    ReadResultManifest -> readResultFromBinary,
-    StatusManifest -> statusFromBinary,
-    GossipManifest -> gossipFromBinary)
+    GetManifest → getFromBinary,
+    GetSuccessManifest → getSuccessFromBinary,
+    NotFoundManifest → notFoundFromBinary,
+    GetFailureManifest → getFailureFromBinary,
+    SubscribeManifest → subscribeFromBinary,
+    UnsubscribeManifest → unsubscribeFromBinary,
+    ChangedManifest → changedFromBinary,
+    DataEnvelopeManifest → dataEnvelopeFromBinary,
+    WriteManifest → writeFromBinary,
+    WriteAckManifest → (_ ⇒ WriteAck),
+    ReadManifest → readFromBinary,
+    ReadResultManifest → readResultFromBinary,
+    StatusManifest → statusFromBinary,
+    GossipManifest → gossipFromBinary)
 
   override def manifest(obj: AnyRef): String = obj match {
     case _: DataEnvelope   ⇒ DataEnvelopeManifest
@@ -243,8 +243,9 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem)
 
   private def statusFromBinary(bytes: Array[Byte]): Status = {
     val status = dm.Status.parseFrom(bytes)
-    Status(status.getEntriesList.asScala.map(e ⇒
-      e.getKey -> AkkaByteString(e.getDigest.toByteArray()))(breakOut),
+    Status(
+      status.getEntriesList.asScala.map(e ⇒
+      e.getKey → AkkaByteString(e.getDigest.toByteArray()))(breakOut),
       status.getChunk, status.getTotChunks)
   }
 
@@ -261,8 +262,9 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem)
 
   private def gossipFromBinary(bytes: Array[Byte]): Gossip = {
     val gossip = dm.Gossip.parseFrom(decompress(bytes))
-    Gossip(gossip.getEntriesList.asScala.map(e ⇒
-      e.getKey -> dataEnvelopeFromProto(e.getEnvelope))(breakOut),
+    Gossip(
+      gossip.getEntriesList.asScala.map(e ⇒
+      e.getKey → dataEnvelopeFromProto(e.getEnvelope))(breakOut),
       sendBack = gossip.getSendBack)
   }
 
@@ -408,7 +410,7 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem)
           else PruningState.PruningInitialized(pruningEntry.getSeenList.asScala.map(addressFromProto)(breakOut))
         val state = PruningState(uniqueAddressFromProto(pruningEntry.getOwnerAddress), phase)
         val removed = uniqueAddressFromProto(pruningEntry.getRemovedAddress)
-        removed -> state
+        removed → state
       }(breakOut)
     val data = otherMessageFromProto(dataEnvelope.getData).asInstanceOf[ReplicatedData]
     DataEnvelope(data, pruning)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -50,9 +50,10 @@ private[http] object OutgoingConnectionBlueprint {
                                   |  Merge     |<------------------------------------------ V
                                   +------------+
   */
-  def apply(hostHeader: headers.Host,
-            settings: ClientConnectionSettings,
-            log: LoggingAdapter): Http.ClientLayer = {
+  def apply(
+    hostHeader: headers.Host,
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter): Http.ClientLayer = {
     import settings._
 
     val core = BidiFlow.fromGraph(GraphDSL.create() { implicit b ⇒
@@ -157,7 +158,7 @@ private[http] object OutgoingConnectionBlueprint {
    * of downstream until end of chunks has been reached.
    */
   private[client] final class PrepareResponse(parserSettings: ParserSettings)
-    extends GraphStage[FlowShape[ResponseOutput, HttpResponse]] {
+      extends GraphStage[FlowShape[ResponseOutput, HttpResponse]] {
 
     private val in = Inlet[ResponseOutput]("PrepareResponse.in")
     private val out = Outlet[HttpResponse]("PrepareResponse.out")
@@ -279,7 +280,7 @@ private[http] object OutgoingConnectionBlueprint {
    * 3. Go back to 1.
    */
   private class ResponseParsingMerge(rootParser: HttpResponseParser)
-    extends GraphStage[FanInShape2[SessionBytes, BypassData, List[ResponseOutput]]] {
+      extends GraphStage[FanInShape2[SessionBytes, BypassData, List[ResponseOutput]]] {
     private val dataInput = Inlet[SessionBytes]("data")
     private val bypassInput = Inlet[BypassData]("request")
     private val out = Outlet[List[ResponseOutput]]("out")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
@@ -21,9 +21,9 @@ private object PoolConductor {
   import PoolSlot.{ RawSlotEvent, SlotEvent }
 
   case class Ports(
-    requestIn: Inlet[RequestContext],
-    slotEventIn: Inlet[RawSlotEvent],
-    slotOuts: immutable.Seq[Outlet[RequestContext]]) extends Shape {
+      requestIn: Inlet[RequestContext],
+      slotEventIn: Inlet[RawSlotEvent],
+      slotOuts: immutable.Seq[Outlet[RequestContext]]) extends Shape {
 
     override val inlets = requestIn :: slotEventIn :: Nil
     override def outlets = slotOuts
@@ -106,7 +106,7 @@ private object PoolConductor {
   private object Busy extends Busy(1)
 
   private class SlotSelector(slotCount: Int, pipeliningLimit: Int, log: LoggingAdapter)
-    extends GraphStage[FanInShape2[RequestContext, SlotEvent, SwitchCommand]] {
+      extends GraphStage[FanInShape2[RequestContext, SlotEvent, SwitchCommand]] {
 
     private val ctxIn = Inlet[RequestContext]("requestContext")
     private val slotIn = Inlet[SlotEvent]("slotEvents")
@@ -194,7 +194,7 @@ private object PoolConductor {
       @tailrec def bestSlot(ix: Int = 0, bestIx: Int = -1, bestState: SlotState = Busy): Int =
         if (ix < slotStates.length) {
           val pl = pipeliningLimit
-          slotStates(ix) -> bestState match {
+          slotStates(ix) → bestState match {
             case (Idle, _)                           ⇒ ix
             case (Unconnected, Loaded(_) | Busy)     ⇒ bestSlot(ix + 1, ix, Unconnected)
             case (x @ Loaded(a), Loaded(b)) if a < b ⇒ bestSlot(ix + 1, ix, x)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
@@ -68,9 +68,11 @@ private object PoolFlow {
     - Simple merge of the Connection Slots' outputs
 
   */
-  def apply(connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]],
-            remoteAddress: InetSocketAddress, settings: ConnectionPoolSettings, log: LoggingAdapter)(
-              implicit system: ActorSystem, fm: Materializer): Flow[RequestContext, ResponseContext, NotUsed] =
+  def apply(
+    connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]],
+    remoteAddress: InetSocketAddress, settings: ConnectionPoolSettings, log: LoggingAdapter)(
+    implicit
+    system: ActorSystem, fm: Materializer): Flow[RequestContext, ResponseContext, NotUsed] =
     Flow.fromGraph(GraphDSL.create[FlowShape[RequestContext, ResponseContext]]() { implicit b ⇒
       import settings._
       import GraphDSL.Implicits._

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
@@ -18,9 +18,10 @@ import akka.stream.Materializer
 private object PoolGateway {
 
   sealed trait State
-  final case class Running(interfaceActorRef: ActorRef,
-                           shutdownStartedPromise: Promise[Done],
-                           shutdownCompletedPromise: Promise[Done]) extends State
+  final case class Running(
+    interfaceActorRef: ActorRef,
+    shutdownStartedPromise: Promise[Done],
+    shutdownCompletedPromise: Promise[Done]) extends State
   final case class IsShutdown(shutdownCompleted: Future[Done]) extends State
   final case class NewIncarnation(gatewayFuture: Future[PoolGateway]) extends State
 }
@@ -38,9 +39,11 @@ private object PoolGateway {
  * Removal of cache entries for terminated pools is also supported, because old gateway references that
  * get reused will automatically forward requests directed at them to the latest pool incarnation from the cache.
  */
-private[http] class PoolGateway(hcps: HostConnectionPoolSetup,
-                                _shutdownStartedPromise: Promise[Done])( // constructor arg only
-                                  implicit system: ActorSystem, fm: Materializer) {
+private[http] class PoolGateway(
+  hcps: HostConnectionPoolSetup,
+    _shutdownStartedPromise: Promise[Done])( // constructor arg only
+    implicit
+    system: ActorSystem, fm: Materializer) {
   import PoolGateway._
   import fm.executionContext
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
@@ -46,10 +46,11 @@ private object PoolInterfaceActor {
  *   To the inside (i.e. the running connection pool flow) the gateway actor acts as request source
  *   (ActorPublisher) and response sink (ActorSubscriber).
  */
-private class PoolInterfaceActor(hcps: HostConnectionPoolSetup,
-                                 shutdownCompletedPromise: Promise[Done],
-                                 gateway: PoolGateway)(implicit fm: Materializer)
-  extends ActorSubscriber with ActorPublisher[RequestContext] with ActorLogging {
+private class PoolInterfaceActor(
+  hcps: HostConnectionPoolSetup,
+  shutdownCompletedPromise: Promise[Done],
+  gateway: PoolGateway)(implicit fm: Materializer)
+    extends ActorSubscriber with ActorPublisher[RequestContext] with ActorLogging {
   import PoolInterfaceActor._
 
   private[this] val inputBuffer = Buffer[PoolRequest](hcps.setup.settings.maxOpenRequests, fm)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
@@ -50,9 +50,10 @@ private object PoolSlot {
                                                                                                  v
    */
   def apply(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any],
-            remoteAddress: InetSocketAddress, // TODO: remove after #16168 is cleared
-            settings: ConnectionPoolSettings)(implicit system: ActorSystem,
-                                              fm: Materializer): Graph[FanOutShape2[RequestContext, ResponseContext, RawSlotEvent], Any] =
+    remoteAddress: InetSocketAddress, // TODO: remove after #16168 is cleared
+    settings: ConnectionPoolSettings)(implicit
+    system: ActorSystem,
+    fm: Materializer): Graph[FanOutShape2[RequestContext, ResponseContext, RawSlotEvent], Any] =
     GraphDSL.create() { implicit b ⇒
       import GraphDSL.Implicits._
 
@@ -60,7 +61,8 @@ private object PoolSlot {
       val name = slotProcessorActorName.next()
       val slotProcessor = b.add {
         Flow.fromProcessor { () ⇒
-          val actor = system.actorOf(Props(new SlotProcessor(slotIx, connectionFlow, settings)).withDeploy(Deploy.local),
+          val actor = system.actorOf(
+            Props(new SlotProcessor(slotIx, connectionFlow, settings)).withDeploy(Deploy.local),
             name)
           ActorProcessor[RequestContext, List[ProcessorOut]](actor)
         }.mapConcat(conforms)
@@ -69,7 +71,8 @@ private object PoolSlot {
 
       slotProcessor ~> split.in
 
-      new FanOutShape2(slotProcessor.in,
+      new FanOutShape2(
+        slotProcessor.in,
         split.out(0).collect { case ResponseDelivery(r) ⇒ r }.outlet,
         split.out(1).collect { case r: RawSlotEvent ⇒ r }.outlet)
     }
@@ -87,8 +90,8 @@ private object PoolSlot {
    * shutting down completely).
    */
   private class SlotProcessor(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any],
-                              settings: ConnectionPoolSettings)(implicit fm: Materializer)
-    extends ActorSubscriber with ActorPublisher[List[ProcessorOut]] with ActorLogging {
+    settings: ConnectionPoolSettings)(implicit fm: Materializer)
+      extends ActorSubscriber with ActorPublisher[List[ProcessorOut]] with ActorLogging {
     var exposedPublisher: akka.stream.impl.ActorPublisher[Any] = _
     var inflightRequests = immutable.Queue.empty[RequestContext]
     val runnableGraph = Source.actorPublisher[HttpRequest](Props(new FlowInportActor(self)).withDeploy(Deploy.local))
@@ -131,7 +134,7 @@ private object PoolSlot {
     }
 
     def waitingForDemandFromConnection(connInport: ActorRef, connOutport: ActorRef,
-                                       firstRequest: RequestContext): Receive = {
+      firstRequest: RequestContext): Receive = {
       case ev @ (Request(_) | Cancel)     ⇒ connOutport ! ev
       case ev @ (OnComplete | OnError(_)) ⇒ connInport ! ev
       case OnNext(x)                      ⇒ throw new IllegalStateException("Unrequested RequestContext: " + x)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -59,15 +59,15 @@ import akka.http.impl.model.parser.CharacterClasses._
  * cannot hold more then 255 items, so this array has a fixed size of 255.
  */
 private[engine] final class HttpHeaderParser private (
-  val settings: HttpHeaderParser.Settings,
-  onIllegalHeader: ErrorInfo ⇒ Unit,
-  private[this] var nodes: Array[Char] = new Array(512), // initial size, can grow as needed
-  private[this] var nodeCount: Int = 0,
-  private[this] var branchData: Array[Short] = new Array(254 * 3),
-  private[this] var branchDataCount: Int = 0,
-  private[this] var values: Array[AnyRef] = new Array(255), // fixed size of 255
-  private[this] var valueCount: Int = 0,
-  private[this] var trieIsPrivate: Boolean = false) { // signals the trie data can be mutated w/o having to copy first
+    val settings: HttpHeaderParser.Settings,
+    onIllegalHeader: ErrorInfo ⇒ Unit,
+    private[this] var nodes: Array[Char] = new Array(512), // initial size, can grow as needed
+    private[this] var nodeCount: Int = 0,
+    private[this] var branchData: Array[Short] = new Array(254 * 3),
+    private[this] var branchDataCount: Int = 0,
+    private[this] var values: Array[AnyRef] = new Array(255), // fixed size of 255
+    private[this] var valueCount: Int = 0,
+    private[this] var trieIsPrivate: Boolean = false) { // signals the trie data can be mutated w/o having to copy first
 
   // TODO: evaluate whether switching to a value-class-based approach allows us to improve code readability without sacrificing performance
 
@@ -300,7 +300,7 @@ private[engine] final class HttpHeaderParser private (
         val prefixedLines = lines.zipWithIndex map {
           case (line, ix) ⇒ (if (ix < mainIx) p1 else if (ix > mainIx) p3 else p2) :: line
         }
-        prefixedLines -> mainIx
+        prefixedLines → mainIx
       }
       def branchLines(dataIx: Int, p1: String, p2: String, p3: String) = branchData(dataIx) match {
         case 0         ⇒ Seq.empty
@@ -315,9 +315,9 @@ private[engine] final class HttpHeaderParser private (
             case ValueBranch(_, valueParser, branchRootNodeIx, _) ⇒
               val pad = " " * (valueParser.headerName.length + 3)
               recurseAndPrefixLines(branchRootNodeIx, pad, "(" + valueParser.headerName + ")-", pad)
-            case vp: HeaderValueParser ⇒ Seq(" (" :: vp.headerName :: ")" :: Nil) -> 0
-            case value: RawHeader      ⇒ Seq(" *" :: value.toString :: Nil) -> 0
-            case value                 ⇒ Seq(" " :: value.toString :: Nil) -> 0
+            case vp: HeaderValueParser ⇒ Seq(" (" :: vp.headerName :: ")" :: Nil) → 0
+            case value: RawHeader      ⇒ Seq(" *" :: value.toString :: Nil) → 0
+            case value                 ⇒ Seq(" " :: value.toString :: Nil) → 0
           }
           case nodeChar ⇒
             val rix = rowIx(msb)
@@ -350,7 +350,7 @@ private[engine] final class HttpHeaderParser private (
       node >>> 8 match {
         case 0 ⇒ build(nodeIx + 1)
         case msb if (node & 0xFF) == 0 ⇒ values(msb - 1) match {
-          case ValueBranch(_, parser, _, count) ⇒ Map(parser.headerName -> count)
+          case ValueBranch(_, parser, _, count) ⇒ Map(parser.headerName → count)
           case _                                ⇒ Map.empty
         }
         case msb ⇒
@@ -470,7 +470,7 @@ private[http] object HttpHeaderParser {
   }
 
   private[parsing] class ModeledHeaderValueParser(headerName: String, maxHeaderValueLength: Int, maxValueCount: Int, settings: HeaderParser.Settings)
-    extends HeaderValueParser(headerName, maxValueCount) {
+      extends HeaderValueParser(headerName, maxValueCount) {
     def apply(hhp: HttpHeaderParser, input: ByteString, valueStart: Int, onIllegalHeader: ErrorInfo ⇒ Unit): (HttpHeader, Int) = {
       // TODO: optimize by running the header value parser directly on the input ByteString (rather than an extracted String)
       val (headerValue, endIx) = scanHeaderValue(hhp, input, valueStart, valueStart + maxHeaderValueLength + 2)()
@@ -481,15 +481,15 @@ private[http] object HttpHeaderParser {
           onIllegalHeader(error.withSummaryPrepended(s"Illegal '$headerName' header"))
           RawHeader(headerName, trimmedHeaderValue)
       }
-      header -> endIx
+      header → endIx
     }
   }
 
   private[parsing] class RawHeaderValueParser(headerName: String, maxHeaderValueLength: Int, maxValueCount: Int)
-    extends HeaderValueParser(headerName, maxValueCount) {
+      extends HeaderValueParser(headerName, maxValueCount) {
     def apply(hhp: HttpHeaderParser, input: ByteString, valueStart: Int, onIllegalHeader: ErrorInfo ⇒ Unit): (HttpHeader, Int) = {
       val (headerValue, endIx) = scanHeaderValue(hhp, input, valueStart, valueStart + maxHeaderValueLength + 2)()
-      RawHeader(headerName, headerValue.trim) -> endIx
+      RawHeader(headerName, headerValue.trim) → endIx
     }
   }
 
@@ -503,7 +503,7 @@ private[http] object HttpHeaderParser {
     else fail(s"HTTP header name exceeds the configured limit of ${limit - start - 1} characters")
 
   @tailrec private def scanHeaderValue(hhp: HttpHeaderParser, input: ByteString, start: Int,
-                                       limit: Int)(sb: JStringBuilder = null, ix: Int = start): (String, Int) = {
+    limit: Int)(sb: JStringBuilder = null, ix: Int = start): (String, Int) = {
     def appended(c: Char) = (if (sb != null) sb else new JStringBuilder(asciiString(input, start, ix))).append(c)
     def appended2(c: Int) = if ((c >> 16) != 0) appended(c.toChar).append((c >> 16).toChar) else appended(c.toChar)
     if (ix < limit)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -23,8 +23,9 @@ import ParserOutput._
 /**
  * INTERNAL API
  */
-private[http] abstract class HttpMessageParser[Output >: MessageOutput <: ParserOutput](val settings: ParserSettings,
-                                                                                        val headerParser: HttpHeaderParser) { self ⇒
+private[http] abstract class HttpMessageParser[Output >: MessageOutput <: ParserOutput](
+  val settings: ParserSettings,
+    val headerParser: HttpHeaderParser) { self ⇒
   import HttpMessageParser._
   import settings._
 
@@ -120,10 +121,10 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
   def badProtocol: Nothing
 
   @tailrec final def parseHeaderLines(input: ByteString, lineStart: Int, headers: ListBuffer[HttpHeader] = initialHeaderBuffer,
-                                      headerCount: Int = 0, ch: Option[Connection] = None,
-                                      clh: Option[`Content-Length`] = None, cth: Option[`Content-Type`] = None,
-                                      teh: Option[`Transfer-Encoding`] = None, e100c: Boolean = false,
-                                      hh: Boolean = false): StateResult =
+    headerCount: Int = 0, ch: Option[Connection] = None,
+    clh: Option[`Content-Length`] = None, cth: Option[`Content-Type`] = None,
+    teh: Option[`Transfer-Encoding`] = None, e100c: Boolean = false,
+    hh: Boolean = false): StateResult =
     if (headerCount < maxHeaderCount) {
       var lineEnd = 0
       val resultHeader =
@@ -171,16 +172,17 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
 
   // work-around for compiler complaining about non-tail-recursion if we inline this method
   def parseHeaderLinesAux(headers: ListBuffer[HttpHeader], headerCount: Int, ch: Option[Connection],
-                          clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
-                          e100c: Boolean, hh: Boolean)(input: ByteString, lineStart: Int): StateResult =
+    clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
+    e100c: Boolean, hh: Boolean)(input: ByteString, lineStart: Int): StateResult =
     parseHeaderLines(input, lineStart, headers, headerCount, ch, clh, cth, teh, e100c, hh)
 
   def parseEntity(headers: List[HttpHeader], protocol: HttpProtocol, input: ByteString, bodyStart: Int,
-                  clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
-                  expect100continue: Boolean, hostHeaderPresent: Boolean, closeAfterResponseCompletion: Boolean): StateResult
+    clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
+    expect100continue: Boolean, hostHeaderPresent: Boolean, closeAfterResponseCompletion: Boolean): StateResult
 
-  def parseFixedLengthBody(remainingBodyBytes: Long,
-                           isLastMessage: Boolean)(input: ByteString, bodyStart: Int): StateResult = {
+  def parseFixedLengthBody(
+    remainingBodyBytes: Long,
+    isLastMessage: Boolean)(input: ByteString, bodyStart: Int): StateResult = {
     val remainingInputBytes = input.length - bodyStart
     if (remainingInputBytes > 0) {
       if (remainingInputBytes < remainingBodyBytes) {
@@ -199,7 +201,7 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
 
   def parseChunk(input: ByteString, offset: Int, isLastMessage: Boolean, totalBytesRead: Long): StateResult = {
     @tailrec def parseTrailer(extension: String, lineStart: Int, headers: List[HttpHeader] = Nil,
-                              headerCount: Int = 0): StateResult = {
+      headerCount: Int = 0): StateResult = {
       var errorInfo: ErrorInfo = null
       val lineEnd =
         try headerParser.parseHeaderLine(input, lineStart)()
@@ -318,7 +320,7 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
     StrictEntityCreator(if (cth.isDefined) HttpEntity.empty(cth.get.contentType) else HttpEntity.Empty)
 
   def strictEntity(cth: Option[`Content-Type`], input: ByteString, bodyStart: Int,
-                   contentLength: Int) =
+    contentLength: Int) =
     StrictEntityCreator(HttpEntity.Strict(contentType(cth), input.slice(bodyStart, bodyStart + contentLength)))
 
   def defaultEntity[A <: ParserOutput](cth: Option[`Content-Type`], contentLength: Long) =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
@@ -18,10 +18,11 @@ import ParserOutput._
 /**
  * INTERNAL API
  */
-private[http] class HttpRequestParser(_settings: ParserSettings,
-                                      rawRequestUriHeader: Boolean,
-                                      _headerParser: HttpHeaderParser)
-  extends HttpMessageParser[RequestOutput](_settings, _headerParser) {
+private[http] class HttpRequestParser(
+  _settings: ParserSettings,
+  rawRequestUriHeader: Boolean,
+  _headerParser: HttpHeaderParser)
+    extends HttpMessageParser[RequestOutput](_settings, _headerParser) {
   import HttpMessageParser._
   import settings._
 
@@ -54,7 +55,8 @@ private[http] class HttpRequestParser(_settings: ParserSettings,
             }
           case c ⇒ parseCustomMethod(ix + 1, sb.append(c))
         }
-      } else throw new ParsingException(BadRequest,
+      } else throw new ParsingException(
+        BadRequest,
         ErrorInfo("Unsupported HTTP method", s"HTTP method too long (started with '${sb.toString}'). " +
           "Increase `akka.http.server.parsing.max-method-length` to support HTTP methods with more characters."))
 
@@ -93,7 +95,8 @@ private[http] class HttpRequestParser(_settings: ParserSettings,
       if (ix == input.length) throw NotEnoughDataException
       else if (CharacterClasses.WSPCRLF(input(ix).toChar)) ix
       else if (ix < uriEndLimit) findUriEnd(ix + 1)
-      else throw new ParsingException(RequestUriTooLong,
+      else throw new ParsingException(
+        RequestUriTooLong,
         s"URI length exceeds the configured limit of $maxUriLength characters")
 
     val uriEnd = findUriEnd()
@@ -110,11 +113,12 @@ private[http] class HttpRequestParser(_settings: ParserSettings,
 
   // http://tools.ietf.org/html/rfc7230#section-3.3
   def parseEntity(headers: List[HttpHeader], protocol: HttpProtocol, input: ByteString, bodyStart: Int,
-                  clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
-                  expect100continue: Boolean, hostHeaderPresent: Boolean, closeAfterResponseCompletion: Boolean): StateResult =
+    clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
+    expect100continue: Boolean, hostHeaderPresent: Boolean, closeAfterResponseCompletion: Boolean): StateResult =
     if (hostHeaderPresent || protocol == HttpProtocols.`HTTP/1.0`) {
-      def emitRequestStart(createEntity: EntityCreator[RequestOutput, RequestEntity],
-                           headers: List[HttpHeader] = headers) = {
+      def emitRequestStart(
+        createEntity: EntityCreator[RequestOutput, RequestEntity],
+        headers: List[HttpHeader] = headers) = {
         val allHeaders0 =
           if (rawRequestUriHeader) `Raw-Request-URI`(new String(uriBytes, HttpCharsets.`US-ASCII`.nioCharset)) :: headers
           else headers

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -18,7 +18,7 @@ import ParserOutput._
  * INTERNAL API
  */
 private[http] class HttpResponseParser(_settings: ParserSettings, _headerParser: HttpHeaderParser)
-  extends HttpMessageParser[ResponseOutput](_settings, _headerParser) {
+    extends HttpMessageParser[ResponseOutput](_settings, _headerParser) {
   import HttpResponseParser._
   import HttpMessageParser._
   import settings._
@@ -85,11 +85,12 @@ private[http] class HttpResponseParser(_settings: ParserSettings, _headerParser:
 
   // http://tools.ietf.org/html/rfc7230#section-3.3
   def parseEntity(headers: List[HttpHeader], protocol: HttpProtocol, input: ByteString, bodyStart: Int,
-                  clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
-                  expect100continue: Boolean, hostHeaderPresent: Boolean, closeAfterResponseCompletion: Boolean): StateResult = {
+    clh: Option[`Content-Length`], cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`],
+    expect100continue: Boolean, hostHeaderPresent: Boolean, closeAfterResponseCompletion: Boolean): StateResult = {
 
-    def emitResponseStart(createEntity: EntityCreator[ResponseOutput, ResponseEntity],
-                          headers: List[HttpHeader] = headers) = {
+    def emitResponseStart(
+      createEntity: EntityCreator[ResponseOutput, ResponseEntity],
+      headers: List[HttpHeader] = headers) = {
       val close =
         contextForCurrentResponse.get.oneHundredContinueTrigger match {
           case None ⇒ closeAfterResponseCompletion
@@ -175,8 +176,9 @@ private[http] object HttpResponseParser {
    *                                  a promise whose completion either triggers the sending of the (suspended)
    *                                  request entity or the closing of the connection (for error completion)
    */
-  private[http] final case class ResponseContext(requestMethod: HttpMethod,
-                                                 oneHundredContinueTrigger: Option[Promise[Unit]])
+  private[http] final case class ResponseContext(
+    requestMethod: HttpMethod,
+    oneHundredContinueTrigger: Option[Promise[Unit]])
 
   private[http] object OneHundredContinueError
     extends RuntimeException("Received error response for request with `Expect: 100-continue` header")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/ParserOutput.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/ParserOutput.scala
@@ -73,7 +73,7 @@ private[http] object ParserOutput {
     }
   }
   final case class StreamedEntityCreator[-A <: ParserOutput, +B >: HttpEntity.Strict <: HttpEntity](creator: Source[A, NotUsed] ⇒ B)
-    extends EntityCreator[A, B] {
+      extends EntityCreator[A, B] {
     def apply(parts: Source[A, NotUsed]) = creator(parts)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
@@ -38,7 +38,7 @@ package object parsing {
   }
 
   private[http] def logParsingError(info: ErrorInfo, log: LoggingAdapter,
-                                    setting: ParserSettings.ErrorLoggingVerbosity): Unit =
+    setting: ParserSettings.ErrorLoggingVerbosity): Unit =
     setting match {
       case ParserSettings.ErrorLoggingVerbosity.Off    ⇒ // nothing to do
       case ParserSettings.ErrorLoggingVerbosity.Simple ⇒ log.warning(info.summary)
@@ -51,8 +51,9 @@ package parsing {
   /**
    * INTERNAL API
    */
-  private[parsing] class ParsingException(val status: StatusCode,
-                                          val info: ErrorInfo) extends RuntimeException(info.formatPretty) {
+  private[parsing] class ParsingException(
+    val status: StatusCode,
+      val info: ErrorInfo) extends RuntimeException(info.formatPretty) {
     def this(status: StatusCode, summary: String = "") =
       this(status, ErrorInfo(if (summary.isEmpty) status.defaultMessage else summary))
     def this(summary: String) =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -25,10 +25,11 @@ import scala.concurrent.forkjoin.ThreadLocalRandom
  */
 private[http] object BodyPartRenderer {
 
-  def streamed(boundary: String,
-               nioCharset: Charset,
-               partHeadersSizeHint: Int,
-               log: LoggingAdapter): PushPullStage[Multipart.BodyPart, Source[ChunkStreamPart, Any]] =
+  def streamed(
+    boundary: String,
+    nioCharset: Charset,
+    partHeadersSizeHint: Int,
+    log: LoggingAdapter): PushPullStage[Multipart.BodyPart, Source[ChunkStreamPart, Any]] =
     new PushPullStage[Multipart.BodyPart, Source[ChunkStreamPart, Any]] {
       var firstBoundaryRendered = false
 
@@ -75,7 +76,7 @@ private[http] object BodyPartRenderer {
     }
 
   def strict(parts: immutable.Seq[Multipart.BodyPart.Strict], boundary: String, nioCharset: Charset,
-             partHeadersSizeHint: Int, log: LoggingAdapter): ByteString = {
+    partHeadersSizeHint: Int, log: LoggingAdapter): ByteString = {
     val r = new CustomCharsetByteStringRendering(nioCharset, partHeadersSizeHint)
     if (parts.nonEmpty) {
       for (part ← parts) {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -22,9 +22,10 @@ import headers._
 /**
  * INTERNAL API
  */
-private[http] class HttpRequestRendererFactory(userAgentHeader: Option[headers.`User-Agent`],
-                                               requestHeaderSizeHint: Int,
-                                               log: LoggingAdapter) {
+private[http] class HttpRequestRendererFactory(
+  userAgentHeader: Option[headers.`User-Agent`],
+    requestHeaderSizeHint: Int,
+    log: LoggingAdapter) {
   import HttpRequestRendererFactory.RequestRenderingOutput
 
   def renderToSource(ctx: RequestRenderingContext): Source[ByteString, Any] = render(ctx).byteStream
@@ -47,7 +48,7 @@ private[http] class HttpRequestRendererFactory(userAgentHeader: Option[headers.`
     def render(h: HttpHeader) = r ~~ h ~~ CrLf
 
     @tailrec def renderHeaders(remaining: List[HttpHeader], hostHeaderSeen: Boolean = false,
-                               userAgentSeen: Boolean = false, transferEncodingSeen: Boolean = false): Unit =
+      userAgentSeen: Boolean = false, transferEncodingSeen: Boolean = false): Unit =
       remaining match {
         case head :: tail ⇒ head match {
           case x: `Content-Length` ⇒

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -23,9 +23,10 @@ import headers._
 /**
  * INTERNAL API
  */
-private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Server],
-                                                responseHeaderSizeHint: Int,
-                                                log: LoggingAdapter) {
+private[http] class HttpResponseRendererFactory(
+  serverHeader: Option[headers.Server],
+    responseHeaderSizeHint: Int,
+    log: LoggingAdapter) {
 
   private val renderDefaultServerHeader: Rendering ⇒ Unit =
     serverHeader match {
@@ -46,7 +47,7 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
       val r = new ByteArrayRendering(48)
       DateTime(now).renderRfc1123DateTimeString(r ~~ headers.Date) ~~ CrLf
       cachedBytes = r.get
-      cachedDateHeader = cachedSeconds -> cachedBytes
+      cachedDateHeader = cachedSeconds → cachedBytes
     }
     cachedBytes
   }
@@ -127,8 +128,8 @@ private[http] class HttpResponseRendererFactory(serverHeader: Option[headers.Ser
             entity.isChunked && (!entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD) && (ctx.requestProtocol == `HTTP/1.1`)
 
           @tailrec def renderHeaders(remaining: List[HttpHeader], alwaysClose: Boolean = false,
-                                     connHeader: Connection = null, serverSeen: Boolean = false,
-                                     transferEncodingSeen: Boolean = false, dateSeen: Boolean = false): Unit =
+            connHeader: Connection = null, serverSeen: Boolean = false,
+            transferEncodingSeen: Boolean = false, dateSeen: Boolean = false): Unit =
             remaining match {
               case head :: tail ⇒ head match {
                 case x: `Content-Length` ⇒

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
@@ -32,11 +32,10 @@ private object RenderSupport {
   val defaultLastChunkBytes: ByteString = renderChunk(HttpEntity.LastChunk)
 
   def CancelSecond[T, Mat](first: Source[T, Mat], second: Source[T, Any]): Source[T, Mat] = {
-    Source.fromGraph(GraphDSL.create(first) { implicit b ⇒
-      frst ⇒
-        import GraphDSL.Implicits._
-        second ~> Sink.cancelled
-        SourceShape(frst.out)
+    Source.fromGraph(GraphDSL.create(first) { implicit b ⇒ frst ⇒
+      import GraphDSL.Implicits._
+      second ~> Sink.cancelled
+      SourceShape(frst.out)
     })
   }
 
@@ -45,7 +44,7 @@ private object RenderSupport {
     else r
 
   def renderByteStrings(r: ByteStringRendering, entityBytes: ⇒ Source[ByteString, Any],
-                        skipEntity: Boolean = false): Source[ByteString, Any] = {
+    skipEntity: Boolean = false): Source[ByteString, Any] = {
     val messageStart = Source.single(r.get)
     val messageBytes =
       if (!skipEntity) (messageStart ++ entityBytes).mapMaterializedValue(_ ⇒ ())
@@ -129,6 +128,6 @@ private object RenderSupport {
   }
 
   def suppressionWarning(log: LoggingAdapter, h: HttpHeader,
-                         msg: String = "the akka-http-core layer sets this header automatically!"): Unit =
+    msg: String = "the akka-http-core layer sets this header automatically!"): Unit =
     log.warning("Explicitly set HTTP header '{}' is ignored, {}", h, msg)
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEvent.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEvent.scala
@@ -41,26 +41,28 @@ private[http] final case class FrameData(data: ByteString, lastPart: Boolean) ex
 }
 
 /** Model of the frame header */
-private[http] final case class FrameHeader(opcode: Protocol.Opcode,
-                                           mask: Option[Int],
-                                           length: Long,
-                                           fin: Boolean,
-                                           rsv1: Boolean = false,
-                                           rsv2: Boolean = false,
-                                           rsv3: Boolean = false)
+private[http] final case class FrameHeader(
+  opcode: Protocol.Opcode,
+  mask: Option[Int],
+  length: Long,
+  fin: Boolean,
+  rsv1: Boolean = false,
+  rsv2: Boolean = false,
+  rsv3: Boolean = false)
 
 private[http] object FrameEvent {
-  def empty(opcode: Protocol.Opcode,
-            fin: Boolean,
-            rsv1: Boolean = false,
-            rsv2: Boolean = false,
-            rsv3: Boolean = false): FrameStart =
+  def empty(
+    opcode: Protocol.Opcode,
+    fin: Boolean,
+    rsv1: Boolean = false,
+    rsv2: Boolean = false,
+    rsv3: Boolean = false): FrameStart =
     fullFrame(opcode, None, ByteString.empty, fin, rsv1, rsv2, rsv3)
   def fullFrame(opcode: Protocol.Opcode, mask: Option[Int], data: ByteString,
-                fin: Boolean,
-                rsv1: Boolean = false,
-                rsv2: Boolean = false,
-                rsv3: Boolean = false): FrameStart =
+    fin: Boolean,
+    rsv1: Boolean = false,
+    rsv2: Boolean = false,
+    rsv3: Boolean = false): FrameStart =
     FrameStart(FrameHeader(opcode, mask, data.length, fin, rsv1, rsv2, rsv3), data)
   val emptyLastContinuationFrame: FrameStart =
     empty(Protocol.Opcode.Continuation, fin = true)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventParser.scala
@@ -73,7 +73,8 @@ private[http] object FrameEventParser extends ByteStringParser[FrameEvent] {
 
         def isFlagSet(mask: Int): Boolean = (flags & mask) != 0
         val header =
-          FrameHeader(Opcode.forCode(op.toByte),
+          FrameHeader(
+            Opcode.forCode(op.toByte),
             mask,
             length,
             fin = isFlagSet(FIN_MASK),

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Handshake.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Handshake.scala
@@ -92,7 +92,8 @@ private[http] object Handshake {
           def requestedProtocols: Seq[String] = clientSupportedSubprotocols
 
           def handle(handler: Either[Graph[FlowShape[FrameEvent, FrameEvent], Any], Graph[FlowShape[Message, Message], Any]], subprotocol: Option[String]): HttpResponse = {
-            require(subprotocol.forall(chosen ⇒ clientSupportedSubprotocols.contains(chosen)),
+            require(
+              subprotocol.forall(chosen ⇒ clientSupportedSubprotocols.contains(chosen)),
               s"Tried to choose invalid subprotocol '$subprotocol' which wasn't offered by the client: [${requestedProtocols.mkString(", ")}]")
             buildResponse(key.get, handler, subprotocol)
           }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
@@ -26,10 +26,11 @@ private[http] object WebSocket {
   /**
    * A stack of all the higher WS layers between raw frames and the user API.
    */
-  def stack(serverSide: Boolean,
-            maskingRandomFactory: () ⇒ Random,
-            closeTimeout: FiniteDuration = 3.seconds,
-            log: LoggingAdapter): BidiFlow[FrameEvent, Message, Message, FrameEvent, NotUsed] =
+  def stack(
+    serverSide: Boolean,
+    maskingRandomFactory: () ⇒ Random,
+    closeTimeout: FiniteDuration = 3.seconds,
+    log: LoggingAdapter): BidiFlow[FrameEvent, Message, Message, FrameEvent, NotUsed] =
     masking(serverSide, maskingRandomFactory) atop
       frameHandling(serverSide, closeTimeout, log) atop
       messageAPI(serverSide, closeTimeout)
@@ -50,9 +51,10 @@ private[http] object WebSocket {
    * The layer that implements all low-level frame handling, like handling control frames, collecting messages
    * from frames, decoding text messages, close handling, etc.
    */
-  def frameHandling(serverSide: Boolean = true,
-                    closeTimeout: FiniteDuration,
-                    log: LoggingAdapter): BidiFlow[FrameEventOrError, FrameHandler.Output, FrameOutHandler.Input, FrameStart, NotUsed] =
+  def frameHandling(
+    serverSide: Boolean = true,
+    closeTimeout: FiniteDuration,
+    log: LoggingAdapter): BidiFlow[FrameEventOrError, FrameHandler.Output, FrameOutHandler.Input, FrameStart, NotUsed] =
     BidiFlow.fromFlows(
       FrameHandler.create(server = serverSide),
       FrameOutHandler.create(serverSide, closeTimeout, log))
@@ -67,7 +69,7 @@ private[http] object WebSocket {
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with InHandler with OutHandler {
       var inMessage = false
-      override def onPush():Unit = grab(in) match {
+      override def onPush(): Unit = grab(in) match {
         case PeerClosed(code, reason) ⇒
           if (code.exists(Protocol.CloseCodes.isError)) failStage(new PeerClosedConnectionException(code.get, reason))
           else if (inMessage) failStage(new ProtocolException(s"Truncated message, peer closed connection in the middle of message."))
@@ -77,8 +79,8 @@ private[http] object WebSocket {
           else failStage(new IllegalStateException("Regular close from FrameHandler is unexpected"))
         case x: MessageDataPart ⇒
           inMessage = !x.last
-          push(out,x)
-        case x ⇒ push(out,x)
+          push(out, x)
+        case x ⇒ push(out, x)
       }
       override def onPull(): Unit = pull(in)
       setHandlers(in, out, this)
@@ -88,8 +90,9 @@ private[http] object WebSocket {
   /**
    * The layer that provides the high-level user facing API on top of frame handling.
    */
-  def messageAPI(serverSide: Boolean,
-                 closeTimeout: FiniteDuration): BidiFlow[FrameHandler.Output, Message, Message, FrameOutHandler.Input, NotUsed] = {
+  def messageAPI(
+    serverSide: Boolean,
+    closeTimeout: FiniteDuration): BidiFlow[FrameHandler.Output, Message, Message, FrameOutHandler.Input, NotUsed] = {
     /* Collects user-level API messages from MessageDataParts */
     val collectMessage: Flow[MessageDataPart, Message, NotUsed] =
       Flow[MessageDataPart]

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
@@ -33,9 +33,10 @@ object WebSocketClientBlueprint {
   /**
    * Returns a WebSocketClientLayer that can be materialized once.
    */
-  def apply(request: WebSocketRequest,
-            settings: ClientConnectionSettings,
-            log: LoggingAdapter): Http.WebSocketClientLayer =
+  def apply(
+    request: WebSocketRequest,
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter): Http.WebSocketClientLayer =
     (simpleTls.atopMat(handshake(request, settings, log))(Keep.right) atop
       WebSocket.framing atop
       WebSocket.stack(serverSide = false, maskingRandomFactory = settings.websocketRandomFactory, log = log)).reversed
@@ -44,9 +45,10 @@ object WebSocketClientBlueprint {
    * A bidi flow that injects and inspects the WS handshake and then goes out of the way. This BidiFlow
    * can only be materialized once.
    */
-  def handshake(request: WebSocketRequest,
-                settings: ClientConnectionSettings,
-                log: LoggingAdapter): BidiFlow[ByteString, ByteString, ByteString, ByteString, Future[WebSocketUpgradeResponse]] = {
+  def handshake(
+    request: WebSocketRequest,
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter): BidiFlow[ByteString, ByteString, ByteString, ByteString, Future[WebSocketUpgradeResponse]] = {
     import request._
     val result = Promise[WebSocketUpgradeResponse]()
 

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonActions.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonActions.scala
@@ -13,7 +13,7 @@ private[parser] trait CommonActions {
   type StringMapBuilder = scala.collection.mutable.Builder[(String, String), Map[String, String]]
 
   def getMediaType(mainType: String, subType: String, charsetDefined: Boolean,
-                   params: Map[String, String]): MediaType = {
+    params: Map[String, String]): MediaType = {
     val subLower = subType.toRootLowerCase
     mainType.toRootLowerCase match {
       case "multipart" ⇒ subLower match {

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -172,8 +172,8 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
 
   def `challenge-or-credentials`: Rule2[String, Seq[(String, String)]] = rule {
     `auth-scheme` ~ (
-      oneOrMore(`auth-param` ~> (_ -> _)).separatedBy(listSep)
-      | `token68` ~> (x ⇒ ("" -> x) :: Nil)
+      oneOrMore(`auth-param` ~> (_ → _)).separatedBy(listSep)
+      | `token68` ~> (x ⇒ ("" → x) :: Nil)
       | push(Nil))
   }
 
@@ -389,7 +389,7 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
     token ~ zeroOrMore(ws(';') ~ `transfer-parameter`) ~> (_.toMap) ~> (TransferEncodings.Extension(_, _))
   }
 
-  def `transfer-parameter` = rule { token ~ ws('=') ~ word ~> (_ -> _) }
+  def `transfer-parameter` = rule { token ~ ws('=') ~ word ~> (_ → _) }
 
   // ******************************************************************************************
   //                                    helpers

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentDispositionHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentDispositionHeader.scala
@@ -22,7 +22,7 @@ private[parser] trait ContentDispositionHeader { this: Parser with CommonRules w
 
   def `disp-ext-type` = rule { token }
 
-  def `disposition-parm` = rule { (`filename-parm` | `disp-ext-parm`) ~> (_ -> _) }
+  def `disposition-parm` = rule { (`filename-parm` | `disp-ext-parm`) ~> (_ → _) }
 
   def `filename-parm` = rule(
     ignoreCase("filename") ~ OWS ~ ws('=') ~ push("filename") ~ word

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
@@ -15,11 +15,12 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
     `media-type` ~ EOI ~> ((main, sub, params) ⇒ headers.`Content-Type`(contentType(main, sub, params)))
   }
 
-  @tailrec private def contentType(main: String,
-                                   sub: String,
-                                   params: Seq[(String, String)],
-                                   charset: Option[HttpCharset] = None,
-                                   builder: StringMapBuilder = null): ContentType =
+  @tailrec private def contentType(
+    main: String,
+    sub: String,
+    params: Seq[(String, String)],
+    charset: Option[HttpCharset] = None,
+    builder: StringMapBuilder = null): ContentType =
     params match {
       case Nil ⇒
         val parameters = if (builder eq null) Map.empty[String, String] else builder.result()

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -17,20 +17,20 @@ import akka.http.scaladsl.model._
  * INTERNAL API.
  */
 private[http] class HeaderParser(val input: ParserInput, settings: HeaderParser.Settings = HeaderParser.DefaultSettings) extends Parser with DynamicRuleHandler[HeaderParser, HttpHeader :: HNil]
-  with CommonRules
-  with AcceptCharsetHeader
-  with AcceptEncodingHeader
-  with AcceptHeader
-  with AcceptLanguageHeader
-  with CacheControlHeader
-  with ContentDispositionHeader
-  with ContentTypeHeader
-  with CommonActions
-  with IpAddressParsing
-  with LinkHeader
-  with SimpleHeaders
-  with StringBuilding
-  with WebSocketHeaders {
+    with CommonRules
+    with AcceptCharsetHeader
+    with AcceptEncodingHeader
+    with AcceptHeader
+    with AcceptLanguageHeader
+    with CacheControlHeader
+    with ContentDispositionHeader
+    with ContentTypeHeader
+    with CommonActions
+    with IpAddressParsing
+    with LinkHeader
+    with SimpleHeaders
+    with StringBuilding
+    with WebSocketHeaders {
   import CharacterClasses._
 
   // http://www.rfc-editor.org/errata_search.php?rfc=7230 errata id 4189
@@ -93,7 +93,8 @@ private[http] object HeaderParser {
     dispatch(parser, headerName) match {
       case r @ Right(_) if parser.cursor == v.length ⇒ r
       case r @ Right(_) ⇒
-        Left(ErrorInfo("Header parsing error",
+        Left(ErrorInfo(
+          "Header parsing error",
           s"Rule for $headerName accepted trailing garbage. Is the parser missing a trailing EOI?"))
       case Left(e) ⇒ Left(e.copy(summary = e.summary.filterNot(_ == EOI), detail = e.detail.filterNot(_ == EOI)))
     }
@@ -162,8 +163,9 @@ private[http] object HeaderParser {
     def uriParsingMode: Uri.ParsingMode
     def cookieParsingMode: ParserSettings.CookieParsingMode
   }
-  def Settings(uriParsingMode: Uri.ParsingMode = Uri.ParsingMode.Relaxed,
-               cookieParsingMode: ParserSettings.CookieParsingMode = ParserSettings.CookieParsingMode.RFC6265): Settings = {
+  def Settings(
+    uriParsingMode: Uri.ParsingMode = Uri.ParsingMode.Relaxed,
+    cookieParsingMode: ParserSettings.CookieParsingMode = ParserSettings.CookieParsingMode.RFC6265): Settings = {
     val _uriParsingMode = uriParsingMode
     val _cookieParsingMode = cookieParsingMode
 

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
@@ -66,8 +66,8 @@ private[parser] trait LinkHeader { this: Parser with CommonRules with CommonActi
 
   // filter out subsequent `rel`, `media`, `title`, `type` and `type*` params
   @tailrec private def sanitize(params: Seq[LinkParam], result: Seq[LinkParam] = Nil, seenRel: Boolean = false,
-                                seenMedia: Boolean = false, seenTitle: Boolean = false, seenTitleS: Boolean = false,
-                                seenType: Boolean = false): Seq[LinkParam] =
+    seenMedia: Boolean = false, seenTitle: Boolean = false, seenTitleS: Boolean = false,
+    seenType: Boolean = false): Seq[LinkParam] =
     params match {
       case Seq((x: LinkParams.rel), tail @ _*)      ⇒ sanitize(tail, if (seenRel) result else result :+ x, seenRel = true, seenMedia, seenTitle, seenTitleS, seenType)
       case Seq((x: LinkParams.media), tail @ _*)    ⇒ sanitize(tail, if (seenMedia) result else result :+ x, seenRel, seenMedia = true, seenTitle, seenTitleS, seenType)

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -25,7 +25,7 @@ private[akka] final case class ClientConnectionSettingsImpl(
   websocketRandomFactory: () ⇒ Random,
   socketOptions: immutable.Seq[SocketOption],
   parserSettings: ParserSettings)
-  extends akka.http.scaladsl.settings.ClientConnectionSettings {
+    extends akka.http.scaladsl.settings.ClientConnectionSettings {
 
   require(connectingTimeout >= Duration.Zero, "connectingTimeout must be >= 0")
   require(requestHeaderSizeHint > 0, "request-size-hint must be > 0")

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -18,7 +18,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   val pipeliningLimit: Int,
   val idleTimeout: Duration,
   val connectionSettings: ClientConnectionSettings)
-  extends ConnectionPoolSettings {
+    extends ConnectionPoolSettings {
 
   require(maxConnections > 0, "max-connections must be > 0")
   require(maxRetries >= 0, "max-retries must be >= 0")

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -30,7 +30,7 @@ private[akka] final case class ParserSettingsImpl(
   includeTlsSessionInfoHeader: Boolean,
   customMethods: String ⇒ Option[HttpMethod],
   customStatusCodes: Int ⇒ Option[StatusCode])
-  extends akka.http.scaladsl.settings.ParserSettings {
+    extends akka.http.scaladsl.settings.ParserSettings {
 
   require(maxUriLength > 0, "max-uri-length must be > 0")
   require(maxMethodLength > 0, "max-method-length must be > 0")
@@ -74,7 +74,7 @@ object ParserSettingsImpl extends SettingsCompanion[ParserSettingsImpl]("akka.ht
       CookieParsingMode(c getString "cookie-parsing-mode"),
       c getBoolean "illegal-header-warnings",
       ErrorLoggingVerbosity(c getString "error-logging-verbosity"),
-      cacheConfig.entrySet.asScala.map(kvp ⇒ kvp.getKey -> cacheConfig.getInt(kvp.getKey))(collection.breakOut),
+      cacheConfig.entrySet.asScala.map(kvp ⇒ kvp.getKey → cacheConfig.getInt(kvp.getKey))(collection.breakOut),
       c getBoolean "tls-session-info-header",
       noCustomMethods,
       noCustomStatusCodes)

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
@@ -9,13 +9,13 @@ import com.typesafe.config.Config
 
 /** INTERNAL API */
 final case class RoutingSettingsImpl(
-  verboseErrorMessages: Boolean,
-  fileGetConditional: Boolean,
-  renderVanityFooter: Boolean,
-  rangeCountLimit: Int,
-  rangeCoalescingThreshold: Long,
-  decodeMaxBytesPerChunk: Int,
-  fileIODispatcher: String) extends akka.http.scaladsl.settings.RoutingSettings {
+    verboseErrorMessages: Boolean,
+    fileGetConditional: Boolean,
+    renderVanityFooter: Boolean,
+    rangeCountLimit: Int,
+    rangeCoalescingThreshold: Long,
+    decodeMaxBytesPerChunk: Int,
+    fileIODispatcher: String) extends akka.http.scaladsl.settings.RoutingSettings {
 
   override def productPrefix = "RoutingSettings"
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -25,20 +25,20 @@ import akka.http.scaladsl.model.headers.{ Host, Server }
 
 /** INTERNAL API */
 private[akka] final case class ServerSettingsImpl(
-  serverHeader: Option[Server],
-  timeouts: ServerSettings.Timeouts,
-  maxConnections: Int,
-  pipeliningLimit: Int,
-  remoteAddressHeader: Boolean,
-  rawRequestUriHeader: Boolean,
-  transparentHeadRequests: Boolean,
-  verboseErrorMessages: Boolean,
-  responseHeaderSizeHint: Int,
-  backlog: Int,
-  socketOptions: immutable.Seq[SocketOption],
-  defaultHostHeader: Host,
-  websocketRandomFactory: () ⇒ Random,
-  parserSettings: ParserSettings) extends ServerSettings {
+    serverHeader: Option[Server],
+    timeouts: ServerSettings.Timeouts,
+    maxConnections: Int,
+    pipeliningLimit: Int,
+    remoteAddressHeader: Boolean,
+    rawRequestUriHeader: Boolean,
+    transparentHeadRequests: Boolean,
+    verboseErrorMessages: Boolean,
+    responseHeaderSizeHint: Int,
+    backlog: Int,
+    socketOptions: immutable.Seq[SocketOption],
+    defaultHostHeader: Host,
+    websocketRandomFactory: () ⇒ Random,
+    parserSettings: ParserSettings) extends ServerSettings {
 
   require(0 < maxConnections, "max-connections must be > 0")
   require(0 < pipeliningLimit && pipeliningLimit <= 1024, "pipelining-limit must be > 0 and <= 1024")
@@ -53,9 +53,9 @@ object ServerSettingsImpl extends SettingsCompanion[ServerSettingsImpl]("akka.ht
 
   /** INTERNAL API */
   final case class Timeouts(
-    idleTimeout: Duration,
-    requestTimeout: Duration,
-    bindTimeout: FiniteDuration) extends ServerSettings.Timeouts {
+      idleTimeout: Duration,
+      requestTimeout: Duration,
+      bindTimeout: FiniteDuration) extends ServerSettings.Timeouts {
     require(idleTimeout > Duration.Zero, "idleTimeout must be infinite or > 0")
     require(requestTimeout > Duration.Zero, "requestTimeout must be infinite or > 0")
     require(bindTimeout > Duration.Zero, "bindTimeout must be > 0")

--- a/akka-http-core/src/main/scala/akka/http/impl/util/SettingsCompanion.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/SettingsCompanion.scala
@@ -54,6 +54,6 @@ private[http] object SettingsCompanion {
     val localHostName =
       try new InetSocketAddress(InetAddress.getLocalHost, 80).getHostString
       catch { case NonFatal(_) ⇒ "" }
-    ConfigFactory.parseMap(Map("akka.http.hostname" -> localHostName).asJava)
+    ConfigFactory.parseMap(Map("akka.http.hostname" → localHostName).asJava)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -81,7 +81,7 @@ private[http] object StreamUtils {
         setHandlers(in, out, this)
       }
     }
-    source.via(transformer) -> promise.future
+    source.via(transformer) → promise.future
   }
 
   def sliceBytesTransformer(start: Long, length: Long): Flow[ByteString, ByteString, NotUsed] = {

--- a/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
@@ -125,7 +125,7 @@ package util {
   }
 
   private[http] class ToStrict(timeout: FiniteDuration, contentType: ContentType)
-    extends GraphStage[FlowShape[ByteString, HttpEntity.Strict]] {
+      extends GraphStage[FlowShape[ByteString, HttpEntity.Strict]] {
 
     val in = Inlet[ByteString]("in")
     val out = Outlet[HttpEntity.Strict]("out")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
@@ -102,7 +102,7 @@ final class ConnectHttpImpl(val host: String, val port: Int) extends ConnectHttp
 }
 
 final class ConnectHttpsImpl(val host: String, val port: Int, val context: Optional[HttpsConnectionContext] = Optional.empty())
-  extends ConnectWithHttps {
+    extends ConnectWithHttps {
 
   override def isHttps: Boolean = true
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -18,7 +18,7 @@ object ConnectionContext {
 
   /** Used to serve HTTPS traffic. */
   def https(sslContext: SSLContext, enabledCipherSuites: Optional[JCollection[String]],
-            enabledProtocols: Optional[JCollection[String]], clientAuth: Optional[TLSClientAuth], sslParameters: Optional[SSLParameters]) =
+    enabledProtocols: Optional[JCollection[String]], clientAuth: Optional[TLSClientAuth], sslParameters: Optional[SSLParameters]) =
     scaladsl.ConnectionContext.https(sslContext, sslParameters = OptionConverters.toScala(sslParameters))
   //#https-context-creation
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -54,8 +54,9 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * Constructs a server layer stage using the given [[akka.http.javadsl.settings.ServerSettings]]. The returned [[BidiFlow]] isn't reusable and
    * can only be materialized once.
    */
-  def serverLayer(settings: ServerSettings,
-                  materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+  def serverLayer(
+    settings: ServerSettings,
+    materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
     adaptServerLayer(delegate.serverLayer(settings.asScala)(materializer))
 
   /**
@@ -63,9 +64,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * can only be materialized once. The `remoteAddress`, if provided, will be added as a header to each [[HttpRequest]]
    * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
    */
-  def serverLayer(settings: ServerSettings,
-                  remoteAddress: Optional[InetSocketAddress],
-                  materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+  def serverLayer(
+    settings: ServerSettings,
+    remoteAddress: Optional[InetSocketAddress],
+    materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
     adaptServerLayer(delegate.serverLayer(settings.asScala, remoteAddress.asScala)(materializer))
 
   /**
@@ -73,10 +75,11 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * can only be materialized once. The remoteAddress, if provided, will be added as a header to each [[HttpRequest]]
    * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
    */
-  def serverLayer(settings: ServerSettings,
-                  remoteAddress: Optional[InetSocketAddress],
-                  log: LoggingAdapter,
-                  materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+  def serverLayer(
+    settings: ServerSettings,
+    remoteAddress: Optional[InetSocketAddress],
+    log: LoggingAdapter,
+    materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
     adaptServerLayer(delegate.serverLayer(settings.asScala, remoteAddress.asScala, log)(materializer))
 
   /**
@@ -116,9 +119,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bind(connect: ConnectHttp,
-           settings: ServerSettings,
-           materializer: Materializer): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
+  def bind(
+    connect: ConnectHttp,
+    settings: ServerSettings,
+    materializer: Materializer): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     new Source(delegate.bind(connect.host, connect.port, settings = settings.asScala, connectionContext = connectionContext)(materializer)
       .map(new IncomingConnection(_))
@@ -140,10 +144,11 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bind(connect: ConnectHttp,
-           settings: ServerSettings,
-           log: LoggingAdapter,
-           materializer: Materializer): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
+  def bind(
+    connect: ConnectHttp,
+    settings: ServerSettings,
+    log: LoggingAdapter,
+    materializer: Materializer): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     new Source(delegate.bind(connect.host, connect.port, connectionContext, settings.asScala, log)(materializer)
       .map(new IncomingConnection(_))
@@ -160,11 +165,13 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bindAndHandle(handler: Flow[HttpRequest, HttpResponse, _],
-                    connect: ConnectHttp,
-                    materializer: Materializer): CompletionStage[ServerBinding] = {
+  def bindAndHandle(
+    handler: Flow[HttpRequest, HttpResponse, _],
+    connect: ConnectHttp,
+    materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
-    delegate.bindAndHandle(handler.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
+    delegate.bindAndHandle(
+      handler.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
       connect.host, connect.port, connectionContext)(materializer)
       .map(new ServerBinding(_))(ec).toJava
   }
@@ -179,13 +186,15 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bindAndHandle(handler: Flow[HttpRequest, HttpResponse, _],
-                    connect: ConnectHttp,
-                    settings: ServerSettings,
-                    log: LoggingAdapter,
-                    materializer: Materializer): CompletionStage[ServerBinding] = {
+  def bindAndHandle(
+    handler: Flow[HttpRequest, HttpResponse, _],
+    connect: ConnectHttp,
+    settings: ServerSettings,
+    log: LoggingAdapter,
+    materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
-    delegate.bindAndHandle(handler.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
+    delegate.bindAndHandle(
+      handler.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
       connect.host, connect.port, connectionContext, settings.asScala, log)(materializer)
       .map(new ServerBinding(_))(ec).toJava
   }
@@ -200,9 +209,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bindAndHandleSync(handler: Function[HttpRequest, HttpResponse],
-                        connect: ConnectHttp,
-                        materializer: Materializer): CompletionStage[ServerBinding] = {
+  def bindAndHandleSync(
+    handler: Function[HttpRequest, HttpResponse],
+    connect: ConnectHttp,
+    materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     delegate.bindAndHandleSync(handler.apply(_).asScala, connect.host, connect.port, connectionContext)(materializer)
       .map(new ServerBinding(_))(ec).toJava
@@ -218,13 +228,15 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bindAndHandleSync(handler: Function[HttpRequest, HttpResponse],
-                        connect: ConnectHttp,
-                        settings: ServerSettings,
-                        log: LoggingAdapter,
-                        materializer: Materializer): CompletionStage[ServerBinding] = {
+  def bindAndHandleSync(
+    handler: Function[HttpRequest, HttpResponse],
+    connect: ConnectHttp,
+    settings: ServerSettings,
+    log: LoggingAdapter,
+    materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
-    delegate.bindAndHandleSync(handler.apply(_).asScala,
+    delegate.bindAndHandleSync(
+      handler.apply(_).asScala,
       connect.host, connect.port, connectionContext, settings.asScala, log)(materializer)
       .map(new ServerBinding(_))(ec).toJava
   }
@@ -239,9 +251,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bindAndHandleAsync(handler: Function[HttpRequest, CompletionStage[HttpResponse]],
-                         connect: ConnectHttp,
-                         materializer: Materializer): CompletionStage[ServerBinding] = {
+  def bindAndHandleAsync(
+    handler: Function[HttpRequest, CompletionStage[HttpResponse]],
+    connect: ConnectHttp,
+    materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
     delegate.bindAndHandleAsync(handler.apply(_).toScala, connect.host, connect.port, connectionContext)(materializer)
       .map(new ServerBinding(_))(ec).toJava
@@ -257,13 +270,15 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    */
-  def bindAndHandleAsync(handler: Function[HttpRequest, CompletionStage[HttpResponse]],
-                         connect: ConnectHttp,
-                         settings: ServerSettings,
-                         parallelism: Int, log: LoggingAdapter,
-                         materializer: Materializer): CompletionStage[ServerBinding] = {
+  def bindAndHandleAsync(
+    handler: Function[HttpRequest, CompletionStage[HttpResponse]],
+    connect: ConnectHttp,
+    settings: ServerSettings,
+    parallelism: Int, log: LoggingAdapter,
+    materializer: Materializer): CompletionStage[ServerBinding] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
-    delegate.bindAndHandleAsync(handler.apply(_).toScala,
+    delegate.bindAndHandleAsync(
+      handler.apply(_).toScala,
       connect.host, connect.port, connectionContext, settings.asScala, parallelism, log)(materializer)
       .map(new ServerBinding(_))(ec).toJava
   }
@@ -277,16 +292,18 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
   /**
    * Constructs a client layer stage using the given [[akka.http.javadsl.settings.ClientConnectionSettings]].
    */
-  def clientLayer(hostHeader: headers.Host,
-                  settings: ClientConnectionSettings): BidiFlow[HttpRequest, SslTlsOutbound, SslTlsInbound, HttpResponse, NotUsed] =
+  def clientLayer(
+    hostHeader: headers.Host,
+    settings: ClientConnectionSettings): BidiFlow[HttpRequest, SslTlsOutbound, SslTlsInbound, HttpResponse, NotUsed] =
     adaptClientLayer(delegate.clientLayer(JavaMapping.toScala(hostHeader), settings.asScala))
 
   /**
    * Constructs a client layer stage using the given [[ClientConnectionSettings]].
    */
-  def clientLayer(hostHeader: headers.Host,
-                  settings: ClientConnectionSettings,
-                  log: LoggingAdapter): BidiFlow[HttpRequest, SslTlsOutbound, SslTlsInbound, HttpResponse, NotUsed] =
+  def clientLayer(
+    hostHeader: headers.Host,
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter): BidiFlow[HttpRequest, SslTlsOutbound, SslTlsInbound, HttpResponse, NotUsed] =
     adaptClientLayer(delegate.clientLayer(JavaMapping.toScala(hostHeader), settings.asScala, log))
 
   /**
@@ -314,10 +331,11 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * Creates a [[Flow]] representing a prospective HTTP client connection to the given endpoint.
    * Every materialization of the produced flow will attempt to establish a new outgoing connection.
    */
-  def outgoingConnection(to: ConnectHttp,
-                         localAddress: Optional[InetSocketAddress],
-                         settings: ClientConnectionSettings,
-                         log: LoggingAdapter): Flow[HttpRequest, HttpResponse, CompletionStage[OutgoingConnection]] =
+  def outgoingConnection(
+    to: ConnectHttp,
+    localAddress: Optional[InetSocketAddress],
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter): Flow[HttpRequest, HttpResponse, CompletionStage[OutgoingConnection]] =
     adaptOutgoingFlow {
       if (to.isHttps)
         delegate.outgoingConnectionHttps(to.host, to.port, to.effectiveConnectionContext(defaultClientHttpsContext).asInstanceOf[HttpsConnectionContext].asScala, localAddress.asScala, settings.asScala, log)
@@ -364,9 +382,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * The given [[ConnectionContext]] will be used for encryption on the connection.
    */
-  def newHostConnectionPool[T](to: ConnectHttp,
-                               settings: ConnectionPoolSettings,
-                               log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], HostConnectionPool] =
+  def newHostConnectionPool[T](
+    to: ConnectHttp,
+    settings: ConnectionPoolSettings,
+    log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], HostConnectionPool] =
     adaptTupleFlow {
       to.effectiveHttpsConnectionContext(defaultClientHttpsContext) match {
         case https: HttpsConnectionContext ⇒
@@ -423,9 +442,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * The given [[ConnectionContext]] will be used for encryption on the connection.
    */
-  def cachedHostConnectionPool[T](to: ConnectHttp,
-                                  settings: ConnectionPoolSettings,
-                                  log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], HostConnectionPool] =
+  def cachedHostConnectionPool[T](
+    to: ConnectHttp,
+    settings: ConnectionPoolSettings,
+    log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], HostConnectionPool] =
     adaptTupleFlow(delegate.cachedHostConnectionPoolHttps[T](to.host, to.port, to.effectiveHttpsConnectionContext(defaultClientHttpsContext).asScala, settings.asScala, log)(materializer)
       .mapMaterializedValue(_.toJava))
 
@@ -459,9 +479,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * In order to allow for easy response-to-request association the flow takes in a custom, opaque context
    * object of type `T` from the application which is emitted together with the corresponding response.
    */
-  def superPool[T](settings: ConnectionPoolSettings,
-                   connectionContext: HttpsConnectionContext,
-                   log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
+  def superPool[T](
+    settings: ConnectionPoolSettings,
+    connectionContext: HttpsConnectionContext,
+    log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
     adaptTupleFlow(delegate.superPool[T](connectionContext.asScala, settings.asScala, log)(materializer))
 
   /**
@@ -479,8 +500,9 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * In order to allow for easy response-to-request association the flow takes in a custom, opaque context
    * object of type `T` from the application which is emitted together with the corresponding response.
    */
-  def superPool[T](settings: ConnectionPoolSettings,
-                   log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
+  def superPool[T](
+    settings: ConnectionPoolSettings,
+    log: LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
     adaptTupleFlow(delegate.superPool[T](defaultClientHttpsContext.asScala, settings.asScala, log)(materializer))
 
   /**
@@ -516,10 +538,11 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * Note that the request must have either an absolute URI or a valid `Host` header, otherwise
    * the future will be completed with an error.
    */
-  def singleRequest(request: HttpRequest,
-                    connectionContext: HttpsConnectionContext,
-                    settings: ConnectionPoolSettings,
-                    log: LoggingAdapter, materializer: Materializer): CompletionStage[HttpResponse] =
+  def singleRequest(
+    request: HttpRequest,
+    connectionContext: HttpsConnectionContext,
+    settings: ConnectionPoolSettings,
+    log: LoggingAdapter, materializer: Materializer): CompletionStage[HttpResponse] =
     delegate.singleRequest(request.asScala, connectionContext.asScala, settings.asScala, log)(materializer).toJava
 
   /**
@@ -536,8 +559,9 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * The layer is not reusable and must only be materialized once.
    */
-  def webSocketClientLayer(request: WebSocketRequest,
-                           settings: ClientConnectionSettings): BidiFlow[Message, SslTlsOutbound, SslTlsInbound, Message, CompletionStage[WebSocketUpgradeResponse]] =
+  def webSocketClientLayer(
+    request: WebSocketRequest,
+    settings: ClientConnectionSettings): BidiFlow[Message, SslTlsOutbound, SslTlsInbound, Message, CompletionStage[WebSocketUpgradeResponse]] =
     adaptWsBidiFlow(delegate.webSocketClientLayer(request.asScala, settings.asScala))
 
   /**
@@ -546,9 +570,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * The layer is not reusable and must only be materialized once.
    */
-  def webSocketClientLayer(request: WebSocketRequest,
-                           settings: ClientConnectionSettings,
-                           log: LoggingAdapter): BidiFlow[Message, SslTlsOutbound, SslTlsInbound, Message, CompletionStage[WebSocketUpgradeResponse]] =
+  def webSocketClientLayer(
+    request: WebSocketRequest,
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter): BidiFlow[Message, SslTlsOutbound, SslTlsInbound, Message, CompletionStage[WebSocketUpgradeResponse]] =
     adaptWsBidiFlow(delegate.webSocketClientLayer(request.asScala, settings.asScala, log))
 
   /**
@@ -566,11 +591,12 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * The layer is not reusable and must only be materialized once.
    */
-  def webSocketClientFlow(request: WebSocketRequest,
-                          connectionContext: ConnectionContext,
-                          localAddress: Optional[InetSocketAddress],
-                          settings: ClientConnectionSettings,
-                          log: LoggingAdapter): Flow[Message, Message, CompletionStage[WebSocketUpgradeResponse]] =
+  def webSocketClientFlow(
+    request: WebSocketRequest,
+    connectionContext: ConnectionContext,
+    localAddress: Optional[InetSocketAddress],
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter): Flow[Message, Message, CompletionStage[WebSocketUpgradeResponse]] =
     adaptWsFlow {
       delegate.webSocketClientFlow(request.asScala, connectionContext.asScala, localAddress.asScala, settings.asScala, log)
     }
@@ -581,9 +607,10 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * The [[defaultClientHttpsContext]] is used to configure TLS for the connection.
    */
-  def singleWebSocketRequest[T](request: WebSocketRequest,
-                                clientFlow: Flow[Message, Message, T],
-                                materializer: Materializer): Pair[CompletionStage[WebSocketUpgradeResponse], T] =
+  def singleWebSocketRequest[T](
+    request: WebSocketRequest,
+    clientFlow: Flow[Message, Message, T],
+    materializer: Materializer): Pair[CompletionStage[WebSocketUpgradeResponse], T] =
     adaptWsResultTuple {
       delegate.singleWebSocketRequest(
         request.asScala,
@@ -596,10 +623,11 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * The [[defaultClientHttpsContext]] is used to configure TLS for the connection.
    */
-  def singleWebSocketRequest[T](request: WebSocketRequest,
-                                clientFlow: Flow[Message, Message, T],
-                                connectionContext: ConnectionContext,
-                                materializer: Materializer): Pair[CompletionStage[WebSocketUpgradeResponse], T] =
+  def singleWebSocketRequest[T](
+    request: WebSocketRequest,
+    clientFlow: Flow[Message, Message, T],
+    connectionContext: ConnectionContext,
+    materializer: Materializer): Pair[CompletionStage[WebSocketUpgradeResponse], T] =
     adaptWsResultTuple {
       delegate.singleWebSocketRequest(
         request.asScala,
@@ -611,13 +639,14 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * Runs a single WebSocket conversation given a Uri and a flow that represents the client side of the
    * WebSocket conversation.
    */
-  def singleWebSocketRequest[T](request: WebSocketRequest,
-                                clientFlow: Flow[Message, Message, T],
-                                connectionContext: ConnectionContext,
-                                localAddress: Optional[InetSocketAddress],
-                                settings: ClientConnectionSettings,
-                                log: LoggingAdapter,
-                                materializer: Materializer): Pair[CompletionStage[WebSocketUpgradeResponse], T] =
+  def singleWebSocketRequest[T](
+    request: WebSocketRequest,
+    clientFlow: Flow[Message, Message, T],
+    connectionContext: ConnectionContext,
+    localAddress: Optional[InetSocketAddress],
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter,
+    materializer: Materializer): Pair[CompletionStage[WebSocketUpgradeResponse], T] =
     adaptWsResultTuple {
       delegate.singleWebSocketRequest(
         request.asScala,

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
@@ -60,12 +60,12 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
 
   @varargs
   def withCustomMethods(methods: HttpMethod*): ParserSettings = {
-    val map = methods.map(m ⇒ m.name -> m.asScala).toMap
+    val map = methods.map(m ⇒ m.name → m.asScala).toMap
     self.copy(customMethods = map.get)
   }
   @varargs
   def withCustomStatusCodes(codes: StatusCode*): ParserSettings = {
-    val map = codes.map(c ⇒ c.intValue -> c.asScala).toMap
+    val map = codes.map(c ⇒ c.intValue → c.asScala).toMap
     self.copy(customStatusCodes = map.get)
   }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -20,11 +20,12 @@ trait ConnectionContext extends akka.http.javadsl.ConnectionContext {
 
 object ConnectionContext {
   //#https-context-creation
-  def https(sslContext: SSLContext,
-            enabledCipherSuites: Option[immutable.Seq[String]] = None,
-            enabledProtocols: Option[immutable.Seq[String]] = None,
-            clientAuth: Option[TLSClientAuth] = None,
-            sslParameters: Option[SSLParameters] = None) = {
+  def https(
+    sslContext: SSLContext,
+    enabledCipherSuites: Option[immutable.Seq[String]] = None,
+    enabledProtocols: Option[immutable.Seq[String]] = None,
+    clientAuth: Option[TLSClientAuth] = None,
+    sslParameters: Option[SSLParameters] = None) = {
     new HttpsConnectionContext(sslContext, enabledCipherSuites, enabledProtocols, clientAuth, sslParameters)
   }
   //#https-context-creation
@@ -38,7 +39,7 @@ final class HttpsConnectionContext(
   val enabledProtocols: Option[immutable.Seq[String]] = None,
   val clientAuth: Option[TLSClientAuth] = None,
   val sslParameters: Option[SSLParameters] = None)
-  extends akka.http.javadsl.HttpsConnectionContext with ConnectionContext {
+    extends akka.http.javadsl.HttpsConnectionContext with ConnectionContext {
 
   def firstSession = NegotiateNewSession(enabledCipherSuites, enabledProtocols, clientAuth, sslParameters)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -36,7 +36,7 @@ import scala.util.control.NonFatal
 import scala.compat.java8.FutureConverters._
 
 class HttpExt(private val config: Config)(implicit val system: ActorSystem) extends akka.actor.Extension
-  with DefaultSSLContextCreation {
+    with DefaultSSLContextCreation {
 
   import Http._
 
@@ -75,9 +75,9 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * use the `akka.http.server` config section or pass in a [[akka.http.scaladsl.settings.ServerSettings]] explicitly.
    */
   def bind(interface: String, port: Int = DefaultPortForProtocol,
-           connectionContext: ConnectionContext = defaultServerHttpContext,
-           settings: ServerSettings = ServerSettings(system),
-           log: LoggingAdapter = system.log)(implicit fm: Materializer): Source[IncomingConnection, Future[ServerBinding]] = {
+    connectionContext: ConnectionContext = defaultServerHttpContext,
+    settings: ServerSettings = ServerSettings(system),
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Source[IncomingConnection, Future[ServerBinding]] = {
     val effectivePort = if (port >= 0) port else connectionContext.defaultPort
     val tlsStage = sslTlsStage(connectionContext, Server)
     val connections: Source[Tcp.IncomingConnection, Future[Tcp.ServerBinding]] =
@@ -102,11 +102,12 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * To configure additional settings for a server started using this method,
    * use the `akka.http.server` config section or pass in a [[akka.http.scaladsl.settings.ServerSettings]] explicitly.
    */
-  def bindAndHandle(handler: Flow[HttpRequest, HttpResponse, Any],
-                    interface: String, port: Int = DefaultPortForProtocol,
-                    connectionContext: ConnectionContext = defaultServerHttpContext,
-                    settings: ServerSettings = ServerSettings(system),
-                    log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[ServerBinding] = {
+  def bindAndHandle(
+    handler: Flow[HttpRequest, HttpResponse, Any],
+    interface: String, port: Int = DefaultPortForProtocol,
+    connectionContext: ConnectionContext = defaultServerHttpContext,
+    settings: ServerSettings = ServerSettings(system),
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[ServerBinding] = {
     def handleOneConnection(incomingConnection: IncomingConnection): Future[Unit] =
       try
         incomingConnection.flow
@@ -143,11 +144,12 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * To configure additional settings for a server started using this method,
    * use the `akka.http.server` config section or pass in a [[akka.http.scaladsl.settings.ServerSettings]] explicitly.
    */
-  def bindAndHandleSync(handler: HttpRequest ⇒ HttpResponse,
-                        interface: String, port: Int = DefaultPortForProtocol,
-                        connectionContext: ConnectionContext = defaultServerHttpContext,
-                        settings: ServerSettings = ServerSettings(system),
-                        log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[ServerBinding] =
+  def bindAndHandleSync(
+    handler: HttpRequest ⇒ HttpResponse,
+    interface: String, port: Int = DefaultPortForProtocol,
+    connectionContext: ConnectionContext = defaultServerHttpContext,
+    settings: ServerSettings = ServerSettings(system),
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[ServerBinding] =
     bindAndHandle(Flow[HttpRequest].map(handler), interface, port, connectionContext, settings, log)
 
   /**
@@ -160,12 +162,13 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * To configure additional settings for a server started using this method,
    * use the `akka.http.server` config section or pass in a [[akka.http.scaladsl.settings.ServerSettings]] explicitly.
    */
-  def bindAndHandleAsync(handler: HttpRequest ⇒ Future[HttpResponse],
-                         interface: String, port: Int = DefaultPortForProtocol,
-                         connectionContext: ConnectionContext = defaultServerHttpContext,
-                         settings: ServerSettings = ServerSettings(system),
-                         parallelism: Int = 1,
-                         log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[ServerBinding] =
+  def bindAndHandleAsync(
+    handler: HttpRequest ⇒ Future[HttpResponse],
+    interface: String, port: Int = DefaultPortForProtocol,
+    connectionContext: ConnectionContext = defaultServerHttpContext,
+    settings: ServerSettings = ServerSettings(system),
+    parallelism: Int = 1,
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[ServerBinding] =
     bindAndHandle(Flow[HttpRequest].mapAsync(parallelism)(handler), interface, port, connectionContext, settings, log)
 
   type ServerLayer = Http.ServerLayer
@@ -183,9 +186,10 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * can only be materialized once. The `remoteAddress`, if provided, will be added as a header to each [[akka.http.scaladsl.model.HttpRequest]]
    * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
    */
-  def serverLayer(settings: ServerSettings,
-                  remoteAddress: Option[InetSocketAddress] = None,
-                  log: LoggingAdapter = system.log)(implicit mat: Materializer): ServerLayer =
+  def serverLayer(
+    settings: ServerSettings,
+    remoteAddress: Option[InetSocketAddress] = None,
+    log: LoggingAdapter = system.log)(implicit mat: Materializer): ServerLayer =
     HttpServerBluePrint(settings, remoteAddress, log)
 
   // ** CLIENT ** //
@@ -198,9 +202,9 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * use the `akka.http.client` config section or pass in a [[akka.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
    */
   def outgoingConnection(host: String, port: Int = 80,
-                         localAddress: Option[InetSocketAddress] = None,
-                         settings: ClientConnectionSettings = ClientConnectionSettings(system),
-                         log: LoggingAdapter = system.log): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] =
+    localAddress: Option[InetSocketAddress] = None,
+    settings: ClientConnectionSettings = ClientConnectionSettings(system),
+    log: LoggingAdapter = system.log): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] =
     _outgoingConnection(host, port, localAddress, settings, ConnectionContext.noEncryption(), log)
 
   /**
@@ -213,27 +217,28 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * use the `akka.http.client` config section or pass in a [[akka.http.scaladsl.settings.ClientConnectionSettings]] explicitly.
    */
   def outgoingConnectionHttps(host: String, port: Int = 443,
-                              connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
-                              localAddress: Option[InetSocketAddress] = None,
-                              settings: ClientConnectionSettings = ClientConnectionSettings(system),
-                              log: LoggingAdapter = system.log): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] =
+    connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
+    localAddress: Option[InetSocketAddress] = None,
+    settings: ClientConnectionSettings = ClientConnectionSettings(system),
+    log: LoggingAdapter = system.log): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] =
     _outgoingConnection(host, port, localAddress, settings, connectionContext, log)
 
-  private def _outgoingConnection(host: String,
-                                  port: Int,
-                                  localAddress: Option[InetSocketAddress],
-                                  settings: ClientConnectionSettings,
-                                  connectionContext: ConnectionContext,
-                                  log: LoggingAdapter): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {
+  private def _outgoingConnection(
+    host: String,
+    port: Int,
+    localAddress: Option[InetSocketAddress],
+    settings: ClientConnectionSettings,
+    connectionContext: ConnectionContext,
+    log: LoggingAdapter): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {
     val hostHeader = if (port == connectionContext.defaultPort) Host(host) else Host(host, port)
     val layer = clientLayer(hostHeader, settings, log)
     layer.joinMat(_outgoingTlsConnectionLayer(host, port, localAddress, settings, connectionContext, log))(Keep.right)
   }
 
   private def _outgoingTlsConnectionLayer(host: String, port: Int, localAddress: Option[InetSocketAddress],
-                                          settings: ClientConnectionSettings, connectionContext: ConnectionContext,
-                                          log: LoggingAdapter): Flow[SslTlsOutbound, SslTlsInbound, Future[OutgoingConnection]] = {
-    val tlsStage = sslTlsStage(connectionContext, Client, Some(host -> port))
+    settings: ClientConnectionSettings, connectionContext: ConnectionContext,
+    log: LoggingAdapter): Flow[SslTlsOutbound, SslTlsInbound, Future[OutgoingConnection]] = {
+    val tlsStage = sslTlsStage(connectionContext, Client, Some(host → port))
     val transportFlow = Tcp().outgoingConnection(new InetSocketAddress(host, port), localAddress,
       settings.socketOptions, halfClose = true, settings.connectingTimeout, settings.idleTimeout)
 
@@ -255,9 +260,10 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
   /**
    * Constructs a [[akka.http.scaladsl.Http.ClientLayer]] stage using the given [[akka.http.scaladsl.settings.ClientConnectionSettings]].
    */
-  def clientLayer(hostHeader: Host,
-                  settings: ClientConnectionSettings,
-                  log: LoggingAdapter = system.log): ClientLayer =
+  def clientLayer(
+    hostHeader: Host,
+    settings: ClientConnectionSettings,
+    log: LoggingAdapter = system.log): ClientLayer =
     OutgoingConnectionBlueprint(hostHeader, settings, log)
 
   // ** CONNECTION POOL ** //
@@ -280,8 +286,8 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def newHostConnectionPool[T](host: String, port: Int = 80,
-                               settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
-                               log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
+    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
     val cps = ConnectionPoolSetup(settings, ConnectionContext.noEncryption(), log)
     newHostConnectionPool(HostConnectionPoolSetup(host, port, cps))
   }
@@ -296,9 +302,9 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def newHostConnectionPoolHttps[T](host: String, port: Int = 443,
-                                    connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
-                                    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
-                                    log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
+    connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
+    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
     val cps = ConnectionPoolSetup(settings, connectionContext, log)
     newHostConnectionPool(HostConnectionPoolSetup(host, port, cps))
   }
@@ -320,7 +326,8 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * object of type `T` from the application which is emitted together with the corresponding response.
    */
   private[akka] def newHostConnectionPool[T](setup: HostConnectionPoolSetup)(
-    implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
+    implicit
+    fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
     val gatewayFuture = FastFuture.successful(new PoolGateway(setup, Promise()))
     gatewayClientFlow(setup, gatewayFuture)
   }
@@ -346,8 +353,8 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def cachedHostConnectionPool[T](host: String, port: Int = 80,
-                                  settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
-                                  log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
+    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
     val cps = ConnectionPoolSetup(settings, ConnectionContext.noEncryption(), log)
     val setup = HostConnectionPoolSetup(host, port, cps)
     cachedHostConnectionPool(setup)
@@ -363,9 +370,9 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
   def cachedHostConnectionPoolHttps[T](host: String, port: Int = 443,
-                                       connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
-                                       settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
-                                       log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
+    connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
+    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
     val cps = ConnectionPoolSetup(settings, connectionContext, log)
     val setup = HostConnectionPoolSetup(host, port, cps)
     cachedHostConnectionPool(setup)
@@ -389,7 +396,8 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * object of type `T` from the application which is emitted together with the corresponding response.
    */
   private def cachedHostConnectionPool[T](setup: HostConnectionPoolSetup)(
-    implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] =
+    implicit
+    fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] =
     gatewayClientFlow(setup, cachedGateway(setup))
 
   /**
@@ -409,10 +417,11 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * To configure additional settings for the pool (and requests made using it),
    * use the `akka.http.host-connection-pool` config section or pass in a [[ConnectionPoolSettings]] explicitly.
    */
-  def superPool[T](connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
-                   settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
-                   log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed] =
-    clientFlow[T](settings) { request ⇒ request -> cachedGateway(request, settings, connectionContext, log) }
+  def superPool[T](
+    connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
+    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed] =
+    clientFlow[T](settings) { request ⇒ request → cachedGateway(request, settings, connectionContext, log) }
 
   /**
    * Fires a single [[akka.http.scaladsl.model.HttpRequest]] across the (cached) host connection pool for the request's
@@ -423,10 +432,11 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    *
    * Note that the request must have an absolute URI, otherwise the future will be completed with an error.
    */
-  def singleRequest(request: HttpRequest,
-                    connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
-                    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
-                    log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[HttpResponse] =
+  def singleRequest(
+    request: HttpRequest,
+    connectionContext: HttpsConnectionContext = defaultClientHttpsContext,
+    settings: ConnectionPoolSettings = defaultConnectionPoolSettings,
+    log: LoggingAdapter = system.log)(implicit fm: Materializer): Future[HttpResponse] =
     try {
       val gatewayFuture = cachedGateway(request, settings, connectionContext, log)
       gatewayFuture.flatMap(_(request))(fm.executionContext)
@@ -440,9 +450,10 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    *
    * The layer is not reusable and must only be materialized once.
    */
-  def webSocketClientLayer(request: WebSocketRequest,
-                           settings: ClientConnectionSettings = ClientConnectionSettings(system),
-                           log: LoggingAdapter = system.log): Http.WebSocketClientLayer =
+  def webSocketClientLayer(
+    request: WebSocketRequest,
+    settings: ClientConnectionSettings = ClientConnectionSettings(system),
+    log: LoggingAdapter = system.log): Http.WebSocketClientLayer =
     WebSocketClientBlueprint(request, settings, log)
 
   /**
@@ -450,11 +461,12 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    *
    * The layer is not reusable and must only be materialized once.
    */
-  def webSocketClientFlow(request: WebSocketRequest,
-                          connectionContext: ConnectionContext = defaultClientHttpsContext,
-                          localAddress: Option[InetSocketAddress] = None,
-                          settings: ClientConnectionSettings = ClientConnectionSettings(system),
-                          log: LoggingAdapter = system.log): Flow[Message, Message, Future[WebSocketUpgradeResponse]] = {
+  def webSocketClientFlow(
+    request: WebSocketRequest,
+    connectionContext: ConnectionContext = defaultClientHttpsContext,
+    localAddress: Option[InetSocketAddress] = None,
+    settings: ClientConnectionSettings = ClientConnectionSettings(system),
+    log: LoggingAdapter = system.log): Flow[Message, Message, Future[WebSocketUpgradeResponse]] = {
     import request.uri
     require(uri.isAbsolute, s"WebSocket request URI must be absolute but was '$uri'")
 
@@ -477,12 +489,13 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
    * Runs a single WebSocket conversation given a Uri and a flow that represents the client side of the
    * WebSocket conversation.
    */
-  def singleWebSocketRequest[T](request: WebSocketRequest,
-                                clientFlow: Flow[Message, Message, T],
-                                connectionContext: ConnectionContext = defaultClientHttpsContext,
-                                localAddress: Option[InetSocketAddress] = None,
-                                settings: ClientConnectionSettings = ClientConnectionSettings(system),
-                                log: LoggingAdapter = system.log)(implicit mat: Materializer): (Future[WebSocketUpgradeResponse], T) =
+  def singleWebSocketRequest[T](
+    request: WebSocketRequest,
+    clientFlow: Flow[Message, Message, T],
+    connectionContext: ConnectionContext = defaultClientHttpsContext,
+    localAddress: Option[InetSocketAddress] = None,
+    settings: ClientConnectionSettings = ClientConnectionSettings(system),
+    log: LoggingAdapter = system.log)(implicit mat: Materializer): (Future[WebSocketUpgradeResponse], T) =
     webSocketClientFlow(request, connectionContext, localAddress, settings, log)
       .joinMat(clientFlow)(Keep.both).run()
 
@@ -548,9 +561,10 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
   // every ActorSystem maintains its own connection pools
   private[http] val hostPoolCache = new ConcurrentHashMap[HostConnectionPoolSetup, Future[PoolGateway]]
 
-  private def cachedGateway(request: HttpRequest,
-                            settings: ConnectionPoolSettings, connectionContext: ConnectionContext,
-                            log: LoggingAdapter)(implicit fm: Materializer): Future[PoolGateway] =
+  private def cachedGateway(
+    request: HttpRequest,
+    settings: ConnectionPoolSettings, connectionContext: ConnectionContext,
+    log: LoggingAdapter)(implicit fm: Materializer): Future[PoolGateway] =
     if (request.uri.scheme.nonEmpty && request.uri.authority.nonEmpty) {
       val httpsCtx = if (request.uri.scheme.equalsIgnoreCase("https")) connectionContext else ConnectionContext.noEncryption()
       val setup = ConnectionPoolSetup(settings, httpsCtx, log)
@@ -586,14 +600,17 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
     }
   }
 
-  private def gatewayClientFlow[T](hcps: HostConnectionPoolSetup,
-                                   gatewayFuture: Future[PoolGateway])(
-                                     implicit fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] =
-    clientFlow[T](hcps.setup.settings)(_ -> gatewayFuture)
+  private def gatewayClientFlow[T](
+    hcps: HostConnectionPoolSetup,
+    gatewayFuture: Future[PoolGateway])(
+    implicit
+    fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] =
+    clientFlow[T](hcps.setup.settings)(_ → gatewayFuture)
       .mapMaterializedValue(_ ⇒ HostConnectionPool(hcps)(gatewayFuture))
 
   private def clientFlow[T](settings: ConnectionPoolSettings)(f: HttpRequest ⇒ (HttpRequest, Future[PoolGateway]))(
-    implicit system: ActorSystem, fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed] = {
+    implicit
+    system: ActorSystem, fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed] = {
     // a connection pool can never have more than pipeliningLimit * maxConnections requests in flight at any point
     val parallelism = settings.pipeliningLimit * settings.maxConnections
     Flow[(HttpRequest, T)].mapAsyncUnordered(parallelism) {
@@ -602,7 +619,7 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
         val result = Promise[(Try[HttpResponse], T)]() // TODO: simplify to `transformWith` when on Scala 2.12
         gatewayFuture
           .flatMap(_(effectiveRequest))(fm.executionContext)
-          .onComplete(responseTry ⇒ result.success(responseTry -> userContext))(fm.executionContext)
+          .onComplete(responseTry ⇒ result.success(responseTry → userContext))(fm.executionContext)
         result.future
     }
   }
@@ -684,9 +701,9 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
    * Represents one accepted incoming HTTP connection.
    */
   final case class IncomingConnection(
-    localAddress: InetSocketAddress,
-    remoteAddress: InetSocketAddress,
-    flow: Flow[HttpResponse, HttpRequest, NotUsed]) {
+      localAddress: InetSocketAddress,
+      remoteAddress: InetSocketAddress,
+      flow: Flow[HttpResponse, HttpRequest, NotUsed]) {
 
     /**
      * Handles the connection with the given flow, which is materialized exactly once
@@ -717,7 +734,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
    * Represents a connection pool to a specific target host and pool configuration.
    */
   final case class HostConnectionPool private[http] (setup: HostConnectionPoolSetup)(
-    private[http] val gatewayFuture: Future[PoolGateway]) { // enable test access
+      private[http] val gatewayFuture: Future[PoolGateway]) { // enable test access
 
     /**
      * Asynchronously triggers the shutdown of the host connection pool.

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -65,12 +65,12 @@ object ContentType {
   }
 
   final case class WithFixedCharset(val mediaType: MediaType.WithFixedCharset)
-    extends jm.ContentType.WithFixedCharset with NonBinary {
+      extends jm.ContentType.WithFixedCharset with NonBinary {
     def charset = mediaType.charset
   }
 
   final case class WithCharset(val mediaType: MediaType.WithOpenCharset, val charset: HttpCharset)
-    extends jm.ContentType.WithCharset with NonBinary {
+      extends jm.ContentType.WithCharset with NonBinary {
 
     private[http] override def render[R <: Rendering](r: R): r.type =
       super.render(r) ~~ ContentType.`; charset=` ~~ charset

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/DateTime.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/DateTime.scala
@@ -11,15 +11,16 @@ import akka.http.impl.util._
  * Does not support TimeZones, all DateTime values are always GMT based.
  * Note that this implementation discards milliseconds (i.e. rounds down to full seconds).
  */
-final case class DateTime private (year: Int, // the year
-                                   month: Int, // the month of the year. January is 1.
-                                   day: Int, // the day of the month. The first day is 1.
-                                   hour: Int, // the hour of the day. The first hour is 0.
-                                   minute: Int, // the minute of the hour. The first minute is 0.
-                                   second: Int, // the second of the minute. The first second is 0.
-                                   weekday: Int, // the day of the week. Sunday is 0.
-                                   clicks: Long, // milliseconds since January 1, 1970, 00:00:00 GMT
-                                   isLeapYear: Boolean) extends akka.http.javadsl.model.DateTime with Ordered[DateTime] with Renderable {
+final case class DateTime private (
+  year: Int, // the year
+    month: Int, // the month of the year. January is 1.
+    day: Int, // the day of the month. The first day is 1.
+    hour: Int, // the hour of the day. The first hour is 0.
+    minute: Int, // the minute of the hour. The first minute is 0.
+    second: Int, // the second of the minute. The first second is 0.
+    weekday: Int, // the day of the week. Sunday is 0.
+    clicks: Long, // milliseconds since January 1, 1970, 00:00:00 GMT
+    isLeapYear: Boolean) extends akka.http.javadsl.model.DateTime with Ordered[DateTime] with Renderable {
   /**
    * The day of the week as a 3 letter abbreviation:
    * `Sun`, `Mon`, `Tue`, `Wed`, `Thu`, `Fri` or `Sat`
@@ -161,7 +162,8 @@ object DateTime {
    * Note that this implementation discards milliseconds (i.e. rounds down to full seconds).
    */
   def apply(clicks: Long): DateTime = {
-    require(DateTime.MinValue.clicks <= clicks && clicks <= DateTime.MaxValue.clicks,
+    require(
+      DateTime.MinValue.clicks <= clicks && clicks <= DateTime.MaxValue.clicks,
       "DateTime value must be >= " + DateTime.MinValue + " and <= " + DateTime.MaxValue)
 
     // based on a fast RFC1123 implementation (C) 2000 by Tim Kientzle <kientzle@acm.org>

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpCharset.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpCharset.scala
@@ -49,7 +49,7 @@ object HttpCharsetRange {
 }
 
 final case class HttpCharset private[http] (override val value: String)(val aliases: immutable.Seq[String])
-  extends jm.HttpCharset with SingletonValueRenderable with WithQValue[HttpCharsetRange] {
+    extends jm.HttpCharset with SingletonValueRenderable with WithQValue[HttpCharsetRange] {
   @transient private[this] var _nioCharset: Try[Charset] = HttpCharset.findNioCharset(value)
 
   /** Returns the Charset for this charset if available or throws an exception otherwise */

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -10,12 +10,12 @@ import akka.http.impl.model.JavaInitialization
 
 import language.implicitConversions
 import java.io.File
-import java.lang.{ Iterable ⇒ JIterable}
+import java.lang.{ Iterable ⇒ JIterable }
 import scala.util.control.NonFatal
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.collection.immutable
-import akka.util.{Unsafe, ByteString}
+import akka.util.{ Unsafe, ByteString }
 import akka.stream.scaladsl._
 import akka.stream.stage._
 import akka.stream._
@@ -227,7 +227,7 @@ object HttpEntity {
    * The model for the entity of a "regular" unchunked HTTP message with known, fixed data.
    */
   final case class Strict(contentType: ContentType, data: ByteString)
-    extends jm.HttpEntity.Strict with UniversalEntity {
+      extends jm.HttpEntity.Strict with UniversalEntity {
 
     override def contentLength: Long = data.length
 
@@ -284,10 +284,11 @@ object HttpEntity {
   /**
    * The model for the entity of a "regular" unchunked HTTP message with a known non-zero length.
    */
-  final case class Default(contentType: ContentType,
-                           contentLength: Long,
-                           data: Source[ByteString, Any])
-    extends jm.HttpEntity.Default with UniversalEntity {
+  final case class Default(
+    contentType: ContentType,
+    contentLength: Long,
+    data: Source[ByteString, Any])
+      extends jm.HttpEntity.Default with UniversalEntity {
     require(contentLength > 0, "contentLength must be positive (use `HttpEntity.empty(contentType)` for empty entities)")
     def isKnownEmpty = false
     override def isDefault: Boolean = true
@@ -346,7 +347,7 @@ object HttpEntity {
    * Note that this type of HttpEntity can only be used for HttpResponses.
    */
   final case class CloseDelimited(contentType: ContentType, data: Source[ByteString, Any])
-    extends jm.HttpEntity.CloseDelimited with ResponseEntity with HttpEntity.WithoutKnownLength {
+      extends jm.HttpEntity.CloseDelimited with ResponseEntity with HttpEntity.WithoutKnownLength {
     type Self = HttpEntity.CloseDelimited
 
     override def isCloseDelimited: Boolean = true
@@ -363,7 +364,7 @@ object HttpEntity {
    * Note that this type of HttpEntity can only be used for BodyParts.
    */
   final case class IndefiniteLength(contentType: ContentType, data: Source[ByteString, Any])
-    extends jm.HttpEntity.IndefiniteLength with BodyPartEntity with HttpEntity.WithoutKnownLength {
+      extends jm.HttpEntity.IndefiniteLength with BodyPartEntity with HttpEntity.WithoutKnownLength {
     type Self = HttpEntity.IndefiniteLength
 
     override def isIndefiniteLength: Boolean = true
@@ -379,7 +380,7 @@ object HttpEntity {
    * The model for the entity of a chunked HTTP message (with `Transfer-Encoding: chunked`).
    */
   final case class Chunked(contentType: ContentType, chunks: Source[ChunkStreamPart, Any])
-    extends jm.HttpEntity.Chunked with MessageEntity {
+      extends jm.HttpEntity.Chunked with MessageEntity {
 
     override def isKnownEmpty = chunks eq Source.empty
     override def contentLengthOption: Option[Long] = None
@@ -535,18 +536,18 @@ object HttpEntity {
    */
   private[http] def captureTermination[T <: HttpEntity](entity: T): (T, Future[Unit]) =
     entity match {
-      case x: HttpEntity.Strict ⇒ x.asInstanceOf[T] -> FastFuture.successful(())
+      case x: HttpEntity.Strict ⇒ x.asInstanceOf[T] → FastFuture.successful(())
       case x: HttpEntity.Default ⇒
         val (newData, whenCompleted) = StreamUtils.captureTermination(x.data)
-        x.copy(data = newData).asInstanceOf[T] -> whenCompleted
+        x.copy(data = newData).asInstanceOf[T] → whenCompleted
       case x: HttpEntity.Chunked ⇒
         val (newChunks, whenCompleted) = StreamUtils.captureTermination(x.chunks)
-        x.copy(chunks = newChunks).asInstanceOf[T] -> whenCompleted
+        x.copy(chunks = newChunks).asInstanceOf[T] → whenCompleted
       case x: HttpEntity.CloseDelimited ⇒
         val (newData, whenCompleted) = StreamUtils.captureTermination(x.data)
-        x.copy(data = newData).asInstanceOf[T] -> whenCompleted
+        x.copy(data = newData).asInstanceOf[T] → whenCompleted
       case x: HttpEntity.IndefiniteLength ⇒
         val (newData, whenCompleted) = StreamUtils.captureTermination(x.data)
-        x.copy(data = newData).asInstanceOf[T] -> whenCompleted
+        x.copy(data = newData).asInstanceOf[T] → whenCompleted
     }
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable
 import scala.reflect.{ classTag, ClassTag }
 import akka.parboiled2.CharUtils
 import akka.stream.Materializer
-import akka.util.{HashCode, ByteString}
+import akka.util.{ HashCode, ByteString }
 import akka.http.impl.util._
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.util.FastFuture._
@@ -135,16 +135,17 @@ object HttpMessage {
  * The immutable model HTTP request model.
  */
 final class HttpRequest(
-    val method: HttpMethod,
-    val uri: Uri,
-    val headers: immutable.Seq[HttpHeader],
-    val entity: RequestEntity,
-    val protocol: HttpProtocol)
-  extends jm.HttpRequest with HttpMessage {
+  val method: HttpMethod,
+  val uri: Uri,
+  val headers: immutable.Seq[HttpHeader],
+  val entity: RequestEntity,
+  val protocol: HttpProtocol)
+    extends jm.HttpRequest with HttpMessage {
 
   HttpRequest.verifyUri(uri)
   require(entity.isKnownEmpty || method.isEntityAccepted, s"Requests with method '${method.value}' must have an empty entity")
-  require(protocol != HttpProtocols.`HTTP/1.0` || !entity.isInstanceOf[HttpEntity.Chunked],
+  require(
+    protocol != HttpProtocols.`HTTP/1.0` || !entity.isInstanceOf[HttpEntity.Chunked],
     "HTTP/1.0 requests must not have a chunked entity")
 
   type Self = HttpRequest
@@ -202,13 +203,12 @@ final class HttpRequest(
 
   /* Manual Case Class things, to easen bin-compat */
 
-  def copy(method: HttpMethod = method,
-           uri: Uri = uri,
-           headers: immutable.Seq[HttpHeader] = headers,
-           entity: RequestEntity = entity,
-           protocol: HttpProtocol = protocol) = new HttpRequest(method, uri, headers, entity, protocol)
-
-
+  def copy(
+    method: HttpMethod = method,
+    uri: Uri = uri,
+    headers: immutable.Seq[HttpHeader] = headers,
+    entity: RequestEntity = entity,
+    protocol: HttpProtocol = protocol) = new HttpRequest(method, uri, headers, entity, protocol)
 
   override def hashCode(): Int = {
     var result = HashCode.SEED
@@ -221,13 +221,13 @@ final class HttpRequest(
   }
 
   override def equals(obj: scala.Any): Boolean = obj match {
-    case HttpRequest(_method, _uri, _headers, _entity, _protocol) =>
+    case HttpRequest(_method, _uri, _headers, _entity, _protocol) ⇒
       method == _method &&
         uri == _uri &&
         headers == _headers &&
         entity == _entity &&
         protocol == _protocol
-    case _ => false
+    case _ ⇒ false
   }
 
   override def toString = s"""HttpRequest(${_1},${_2},${_3},${_4},${_5})"""
@@ -263,7 +263,8 @@ object HttpRequest {
     } else // http://tools.ietf.org/html/rfc7230#section-5.4
     if (hostHeader.isEmpty || uri.authority.isEmpty && hostHeader.get.isEmpty ||
       hostHeader.get.host.equalsIgnoreCase(uri.authority.host) && hostHeader.get.port == uri.authority.port) uri
-    else throw IllegalUriException(s"'Host' header value of request to `$uri` doesn't match request target authority",
+    else throw IllegalUriException(
+      s"'Host' header value of request to `$uri` doesn't match request target authority",
       s"Host header: $hostHeader\nrequest target authority: ${uri.authority}")
   }
 
@@ -285,11 +286,12 @@ object HttpRequest {
 
   /* Manual Case Class things, to easen bin-compat */
 
-  def apply(method: HttpMethod = HttpMethods.GET,
-            uri: Uri = Uri./,
-            headers: immutable.Seq[HttpHeader] = Nil,
-            entity: RequestEntity = HttpEntity.Empty,
-            protocol: HttpProtocol = HttpProtocols.`HTTP/1.1`) = new HttpRequest(method, uri, headers, entity, protocol)
+  def apply(
+    method: HttpMethod = HttpMethods.GET,
+    uri: Uri = Uri./,
+    headers: immutable.Seq[HttpHeader] = Nil,
+    entity: RequestEntity = HttpEntity.Empty,
+    protocol: HttpProtocol = HttpProtocols.`HTTP/1.1`) = new HttpRequest(method, uri, headers, entity, protocol)
 
   def unapply(any: HttpRequest) = new OptHttpRequest(any)
 }
@@ -298,14 +300,15 @@ object HttpRequest {
  * The immutable HTTP response model.
  */
 final class HttpResponse(
-    val status: StatusCode,
-    val headers: immutable.Seq[HttpHeader],
-    val entity: ResponseEntity,
-    val protocol: HttpProtocol)
-  extends jm.HttpResponse with HttpMessage {
+  val status: StatusCode,
+  val headers: immutable.Seq[HttpHeader],
+  val entity: ResponseEntity,
+  val protocol: HttpProtocol)
+    extends jm.HttpResponse with HttpMessage {
 
   require(entity.isKnownEmpty || status.allowsEntity, "Responses with this status code must have an empty entity")
-  require(protocol == HttpProtocols.`HTTP/1.1` || !entity.isInstanceOf[HttpEntity.Chunked],
+  require(
+    protocol == HttpProtocols.`HTTP/1.1` || !entity.isInstanceOf[HttpEntity.Chunked],
     "HTTP/1.0 responses must not have a chunked entity")
 
   type Self = HttpResponse
@@ -331,19 +334,19 @@ final class HttpResponse(
 
   /* Manual Case Class things, to easen bin-compat */
 
-  def copy(status: StatusCode = status,
-           headers: immutable.Seq[HttpHeader] = headers,
-           entity: ResponseEntity = entity,
-           protocol: HttpProtocol = protocol) = new HttpResponse(status, headers, entity, protocol)
-
+  def copy(
+    status: StatusCode = status,
+    headers: immutable.Seq[HttpHeader] = headers,
+    entity: ResponseEntity = entity,
+    protocol: HttpProtocol = protocol) = new HttpResponse(status, headers, entity, protocol)
 
   override def equals(obj: scala.Any): Boolean = obj match {
-    case HttpResponse(_status, _headers, _entity, _protocol) =>
+    case HttpResponse(_status, _headers, _entity, _protocol) ⇒
       status == _status &&
         headers == _headers &&
         entity == _entity &&
         protocol == _protocol
-    case _ => false
+    case _ ⇒ false
   }
 
   override def hashCode: Int = {
@@ -368,10 +371,11 @@ final class HttpResponse(
 object HttpResponse {
   /* Manual Case Class things, to easen bin-compat */
 
-  def apply(status: StatusCode = StatusCodes.OK,
-            headers: immutable.Seq[HttpHeader] = Nil,
-            entity: ResponseEntity = HttpEntity.Empty,
-            protocol: HttpProtocol = HttpProtocols.`HTTP/1.1`) = new HttpResponse(status, headers, entity, protocol)
+  def apply(
+    status: StatusCode = StatusCodes.OK,
+    headers: immutable.Seq[HttpHeader] = Nil,
+    entity: ResponseEntity = HttpEntity.Empty,
+    protocol: HttpProtocol = HttpProtocols.`HTTP/1.1`) = new HttpResponse(status, headers, entity, protocol)
 
   def unapply(any: HttpResponse): OptHttpResponse = new OptHttpResponse(any)
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMethod.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMethod.scala
@@ -29,10 +29,11 @@ object RequestEntityAcceptance {
  * @param isIdempotent true if requests can be safely (& automatically) repeated
  * @param requestEntityAcceptance Expected if meaning of request entities is properly defined
  */
-final case class HttpMethod private[http] (override val value: String,
-                                           isSafe: Boolean,
-                                           isIdempotent: Boolean,
-                                           requestEntityAcceptance: RequestEntityAcceptance) extends jm.HttpMethod with SingletonValueRenderable {
+final case class HttpMethod private[http] (
+  override val value: String,
+    isSafe: Boolean,
+    isIdempotent: Boolean,
+    requestEntityAcceptance: RequestEntityAcceptance) extends jm.HttpMethod with SingletonValueRenderable {
   override def isEntityAccepted: Boolean = requestEntityAcceptance.isEntityAccepted
   override def toString: String = s"HttpMethod($value)"
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
@@ -50,12 +50,12 @@ sealed abstract class MediaRange extends jm.MediaRange with Renderable with With
 object MediaRange {
   private[http] def splitOffQValue(params: Map[String, String], defaultQ: Float = 1.0f): (Map[String, String], Float) =
     params.get("q") match {
-      case Some(x) ⇒ (params - "q") -> (try x.toFloat catch { case _: NumberFormatException ⇒ 1.0f })
-      case None    ⇒ params -> defaultQ
+      case Some(x) ⇒ (params - "q") → (try x.toFloat catch { case _: NumberFormatException ⇒ 1.0f })
+      case None    ⇒ params → defaultQ
     }
 
   private final case class Custom(mainType: String, params: Map[String, String], qValue: Float)
-    extends MediaRange with ValueRenderable {
+      extends MediaRange with ValueRenderable {
     require(0.0f <= qValue && qValue <= 1.0f, "qValue must be >= 0 and <= 1.0")
     def matches(mediaType: MediaType) = mainType == "*" || mediaType.mainType == mainType
     def withParams(params: Map[String, String]) = custom(mainType, params, qValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -74,7 +74,7 @@ object MediaType {
     }
 
   def applicationWithFixedCharset(subType: String, charset: HttpCharset,
-                                  fileExtensions: String*): WithFixedCharset =
+    fileExtensions: String*): WithFixedCharset =
     new WithFixedCharset("application/" + subType, "application", subType, charset, fileExtensions.toList) {
       override def isApplication = true
     }
@@ -110,7 +110,7 @@ object MediaType {
     }
 
   def customBinary(mainType: String, subType: String, comp: Compressibility, fileExtensions: List[String] = Nil,
-                   params: Map[String, String] = Map.empty, allowArbitrarySubtypes: Boolean = false): Binary = {
+    params: Map[String, String] = Map.empty, allowArbitrarySubtypes: Boolean = false): Binary = {
     require(mainType != "multipart", "Cannot create a MediaType.Multipart here, use `customMultipart` instead!")
     require(allowArbitrarySubtypes || subType != "*", "Cannot create a MediaRange here, use `MediaRange.custom` instead!")
     val _params = params
@@ -126,8 +126,8 @@ object MediaType {
   }
 
   def customWithFixedCharset(mainType: String, subType: String, charset: HttpCharset, fileExtensions: List[String] = Nil,
-                             params: Map[String, String] = Map.empty,
-                             allowArbitrarySubtypes: Boolean = false): WithFixedCharset = {
+    params: Map[String, String] = Map.empty,
+    allowArbitrarySubtypes: Boolean = false): WithFixedCharset = {
     require(mainType != "multipart", "Cannot create a MediaType.Multipart here, use `customMultipart` instead!")
     require(allowArbitrarySubtypes || subType != "*", "Cannot create a MediaRange here, use `MediaRange.custom` instead!")
     val _params = params
@@ -143,8 +143,8 @@ object MediaType {
   }
 
   def customWithOpenCharset(mainType: String, subType: String, fileExtensions: List[String] = Nil,
-                            params: Map[String, String] = Map.empty,
-                            allowArbitrarySubtypes: Boolean = false): WithOpenCharset = {
+    params: Map[String, String] = Map.empty,
+    allowArbitrarySubtypes: Boolean = false): WithOpenCharset = {
     require(mainType != "multipart", "Cannot create a MediaType.Multipart here, use `customMultipart` instead!")
     require(allowArbitrarySubtypes || subType != "*", "Cannot create a MediaRange here, use `MediaRange.custom` instead!")
     val _params = params
@@ -165,7 +165,7 @@ object MediaType {
   }
 
   def custom(value: String, binary: Boolean, comp: Compressibility = Compressible,
-             fileExtensions: List[String] = Nil): MediaType = {
+    fileExtensions: List[String] = Nil): MediaType = {
     val parts = value.split('/')
     require(parts.length == 2, s"`$value` is not a valid media-type. It must consist of two parts separated by '/'.")
     if (binary) customBinary(parts(0), parts(1), comp, fileExtensions)
@@ -190,7 +190,7 @@ object MediaType {
   }
 
   sealed abstract class Binary(val value: String, val mainType: String, val subType: String, val comp: Compressibility,
-                               val fileExtensions: List[String]) extends MediaType with jm.MediaType.Binary {
+      val fileExtensions: List[String]) extends MediaType with jm.MediaType.Binary {
     def binary = true
     def params: Map[String, String] = Map.empty
     def withParams(params: Map[String, String]): Binary with MediaType =
@@ -212,8 +212,8 @@ object MediaType {
   }
 
   sealed abstract class WithFixedCharset(val value: String, val mainType: String, val subType: String,
-                                         val charset: HttpCharset, val fileExtensions: List[String])
-    extends NonBinary with jm.MediaType.WithFixedCharset {
+    val charset: HttpCharset, val fileExtensions: List[String])
+      extends NonBinary with jm.MediaType.WithFixedCharset {
     def params: Map[String, String] = Map.empty
     def withParams(params: Map[String, String]): WithFixedCharset with MediaType =
       customWithFixedCharset(mainType, subType, charset, fileExtensions, params)
@@ -234,14 +234,14 @@ object MediaType {
   }
 
   sealed abstract class NonMultipartWithOpenCharset(val value: String, val mainType: String, val subType: String,
-                                                    val fileExtensions: List[String]) extends WithOpenCharset {
+      val fileExtensions: List[String]) extends WithOpenCharset {
     def params: Map[String, String] = Map.empty
     def withParams(params: Map[String, String]): WithOpenCharset with MediaType =
       customWithOpenCharset(mainType, subType, fileExtensions, params)
   }
 
   final class Multipart(val subType: String, val params: Map[String, String])
-    extends WithOpenCharset with jm.MediaType.Multipart {
+      extends WithOpenCharset with jm.MediaType.Multipart {
     val value = renderValue(mainType, subType, params)
     override def mainType = "multipart"
     override def isMultipart = true
@@ -274,7 +274,7 @@ object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
 
   private def register[T <: MediaType](mediaType: T): T = {
     registerFileExtensions(mediaType)
-    register(mediaType.mainType.toRootLowerCase -> mediaType.subType.toRootLowerCase, mediaType)
+    register(mediaType.mainType.toRootLowerCase → mediaType.subType.toRootLowerCase, mediaType)
   }
 
   import MediaType._  

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -56,8 +56,9 @@ sealed trait Multipart extends jm.Multipart {
   /**
    * Creates a [[akka.http.scaladsl.model.MessageEntity]] from this multipart object.
    */
-  def toEntity(charset: HttpCharset = HttpCharsets.`UTF-8`,
-               boundary: String = BodyPartRenderer.randomBoundary())(implicit log: LoggingAdapter = NoLogging): MessageEntity = {
+  def toEntity(
+    charset: HttpCharset = HttpCharsets.`UTF-8`,
+    boundary: String = BodyPartRenderer.randomBoundary())(implicit log: LoggingAdapter = NoLogging): MessageEntity = {
     val chunks =
       parts
         .transform(() ⇒ BodyPartRenderer.streamed(boundary, charset.nioCharset, partHeadersSizeHint = 128, log))
@@ -224,13 +225,13 @@ object Multipart {
       }
 
     def unapply(value: Multipart.General): Option[(MediaType.Multipart, Source[Multipart.General.BodyPart, Any])] =
-      Some(value.mediaType -> value.parts)
+      Some(value.mediaType → value.parts)
 
     /**
      * Strict [[General]] multipart content.
      */
     case class Strict(mediaType: MediaType.Multipart, strictParts: immutable.Seq[Multipart.General.BodyPart.Strict])
-      extends Multipart.General with Multipart.Strict with jm.Multipart.General.Strict {
+        extends Multipart.General with Multipart.Strict with jm.Multipart.General.Strict {
       def parts: Source[Multipart.General.BodyPart.Strict, Any] = Source(strictParts)
       override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer) = FastFuture.successful(this)
       override def productPrefix = "General.Strict"
@@ -284,13 +285,13 @@ object Multipart {
           override def toString = s"General.BodyPart($entity, $headers)"
         }
 
-      def unapply(value: BodyPart): Option[(BodyPartEntity, immutable.Seq[HttpHeader])] = Some(value.entity -> value.headers)
+      def unapply(value: BodyPart): Option[(BodyPartEntity, immutable.Seq[HttpHeader])] = Some(value.entity → value.headers)
 
       /**
        * Strict [[General.BodyPart]].
        */
       case class Strict(entity: HttpEntity.Strict, headers: immutable.Seq[HttpHeader] = Nil)
-        extends BodyPart with Multipart.BodyPart.Strict with jm.Multipart.General.BodyPart.Strict {
+          extends BodyPart with Multipart.BodyPart.Strict with jm.Multipart.General.BodyPart.Strict {
         override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[Multipart.General.BodyPart.Strict] =
           FastFuture.successful(this)
         override def toFormDataBodyPart: Try[Multipart.FormData.BodyPart.Strict] =
@@ -351,7 +352,7 @@ object Multipart {
      * Strict [[FormData]].
      */
     case class Strict(strictParts: immutable.Seq[Multipart.FormData.BodyPart.Strict])
-      extends FormData with Multipart.Strict with jm.Multipart.FormData.Strict {
+        extends FormData with Multipart.Strict with jm.Multipart.FormData.Strict {
       def parts: Source[Multipart.FormData.BodyPart.Strict, Any] = Source(strictParts)
       override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer) = FastFuture.successful(this)
       override def productPrefix = "FormData.Strict"
@@ -419,8 +420,8 @@ object Multipart {
     }
     object BodyPart {
       def apply(_name: String, _entity: BodyPartEntity,
-                _additionalDispositionParams: Map[String, String] = Map.empty,
-                _additionalHeaders: immutable.Seq[HttpHeader] = Nil): Multipart.FormData.BodyPart =
+        _additionalDispositionParams: Map[String, String] = Map.empty,
+        _additionalHeaders: immutable.Seq[HttpHeader] = Nil): Multipart.FormData.BodyPart =
         new Multipart.FormData.BodyPart {
           def name = _name
           def additionalDispositionParams = _additionalDispositionParams
@@ -433,7 +434,7 @@ object Multipart {
        * Creates a BodyPart backed by a File that will be streamed using a FileSource.
        */
       def fromFile(name: String, contentType: ContentType, file: File, chunkSize: Int = -1): BodyPart =
-        BodyPart(name, HttpEntity(contentType, file, chunkSize), Map("filename" -> file.getName))
+        BodyPart(name, HttpEntity(contentType, file, chunkSize), Map("filename" → file.getName))
 
       def unapply(value: BodyPart): Option[(String, BodyPartEntity, Map[String, String], immutable.Seq[HttpHeader])] =
         Some((value.name, value.entity, value.additionalDispositionParams, value.additionalHeaders))
@@ -442,9 +443,9 @@ object Multipart {
        * Strict [[FormData.BodyPart]].
        */
       case class Strict(name: String, entity: HttpEntity.Strict,
-                        additionalDispositionParams: Map[String, String] = Map.empty,
-                        additionalHeaders: immutable.Seq[HttpHeader] = Nil)
-        extends Multipart.FormData.BodyPart with Multipart.BodyPart.Strict with jm.Multipart.FormData.BodyPart.Strict {
+        additionalDispositionParams: Map[String, String] = Map.empty,
+        additionalHeaders: immutable.Seq[HttpHeader] = Nil)
+          extends Multipart.FormData.BodyPart with Multipart.BodyPart.Strict with jm.Multipart.FormData.BodyPart.Strict {
         override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[Multipart.FormData.BodyPart.Strict] =
           FastFuture.successful(this)
         override def productPrefix = "FormData.BodyPart.Strict"
@@ -485,7 +486,7 @@ object Multipart {
      * Strict [[ByteRanges]].
      */
     case class Strict(strictParts: immutable.Seq[Multipart.ByteRanges.BodyPart.Strict])
-      extends Multipart.ByteRanges with Multipart.Strict with jm.Multipart.ByteRanges.Strict {
+        extends Multipart.ByteRanges with Multipart.Strict with jm.Multipart.ByteRanges.Strict {
       def parts: Source[Multipart.ByteRanges.BodyPart.Strict, Any] = Source(strictParts)
       override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer) = FastFuture.successful(this)
       override def productPrefix = "ByteRanges.Strict"
@@ -549,7 +550,7 @@ object Multipart {
     }
     object BodyPart {
       def apply(_contentRange: ContentRange, _entity: BodyPartEntity, _rangeUnit: RangeUnit = RangeUnits.Bytes,
-                _additionalHeaders: immutable.Seq[HttpHeader] = Nil): Multipart.ByteRanges.BodyPart =
+        _additionalHeaders: immutable.Seq[HttpHeader] = Nil): Multipart.ByteRanges.BodyPart =
         new Multipart.ByteRanges.BodyPart {
           def contentRange = _contentRange
           def entity = _entity
@@ -565,8 +566,8 @@ object Multipart {
        * Strict [[ByteRanges.BodyPart]].
        */
       case class Strict(contentRange: ContentRange, entity: HttpEntity.Strict, rangeUnit: RangeUnit = RangeUnits.Bytes,
-                        additionalHeaders: immutable.Seq[HttpHeader] = Nil)
-        extends Multipart.ByteRanges.BodyPart with Multipart.BodyPart.Strict with jm.Multipart.ByteRanges.BodyPart.Strict {
+        additionalHeaders: immutable.Seq[HttpHeader] = Nil)
+          extends Multipart.ByteRanges.BodyPart with Multipart.BodyPart.Strict with jm.Multipart.ByteRanges.BodyPart.Strict {
         override def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[Multipart.ByteRanges.BodyPart.Strict] =
           FastFuture.successful(this)
         override def productPrefix = "ByteRanges.BodyPart.Strict"

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -23,7 +23,7 @@ import Uri._
  * All members of this class represent the *decoded* URI elements (i.e. without percent-encoding).
  */
 sealed abstract case class Uri(scheme: String, authority: Authority, path: Path, rawQueryString: Option[String],
-                               fragment: Option[String]) {
+    fragment: Option[String]) {
 
   def isAbsolute: Boolean = !isRelative
   def isRelative: Boolean = scheme.isEmpty
@@ -55,7 +55,7 @@ sealed abstract case class Uri(scheme: String, authority: Authority, path: Path,
    * Returns a copy of this Uri with the given components.
    */
   def copy(scheme: String = scheme, authority: Authority = authority, path: Path = path,
-           rawQueryString: Option[String] = rawQueryString, fragment: Option[String] = fragment): Uri =
+    rawQueryString: Option[String] = rawQueryString, fragment: Option[String] = fragment): Uri =
     Uri(scheme, authority, path, rawQueryString, fragment)
 
   /**
@@ -135,7 +135,7 @@ sealed abstract case class Uri(scheme: String, authority: Authority, path: Path,
    * http://tools.ietf.org/html/rfc7230#section-5.5
    */
   def toEffectiveHttpRequestUri(hostHeaderHost: Host, hostHeaderPort: Int, securedConnection: Boolean = false,
-                                defaultAuthority: Authority = Authority.Empty): Uri =
+    defaultAuthority: Authority = Authority.Empty): Uri =
     effectiveHttpRequestUri(scheme, authority.host, authority.port, path, rawQueryString, fragment, securedConnection,
       hostHeaderHost, hostHeaderPort, defaultAuthority)
 
@@ -215,7 +215,7 @@ object Uri {
    * http://tools.ietf.org/html/rfc3986 the method throws an `IllegalUriException`.
    */
   def apply(scheme: String = "", authority: Authority = Authority.Empty, path: Path = Path.Empty,
-            queryString: Option[String] = None, fragment: Option[String] = None): Uri = {
+    queryString: Option[String] = None, fragment: Option[String] = None): Uri = {
     val p = verifyPath(path, scheme, authority.host)
     create(
       scheme = normalizeScheme(scheme),
@@ -232,8 +232,8 @@ object Uri {
    * http://tools.ietf.org/html/rfc3986 the method throws an `IllegalUriException`.
    */
   def from(scheme: String = "", userinfo: String = "", host: String = "", port: Int = 0, path: String = "",
-           queryString: Option[String] = None, fragment: Option[String] = None,
-           mode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): Uri =
+    queryString: Option[String] = None, fragment: Option[String] = None,
+    mode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): Uri =
     apply(scheme, Authority(Host(host, UTF8, mode), normalizePort(port, scheme), userinfo), Path(path), queryString, fragment)
 
   /**
@@ -254,7 +254,7 @@ object Uri {
    * If the given string is not a valid URI the method throws an `IllegalUriException`.
    */
   def parseAndResolve(string: ParserInput, base: Uri, charset: Charset = UTF8,
-                      mode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): Uri =
+    mode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): Uri =
     new UriParser(string, charset, mode).parseAndResolveUriReference(base)
 
   /**
@@ -264,7 +264,7 @@ object Uri {
    * If the given string is not a valid URI the method throws an `IllegalUriException`.
    */
   def parseHttpRequestTarget(requestTarget: ParserInput, charset: Charset = UTF8,
-                             mode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): Uri =
+    mode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): Uri =
     new UriParser(requestTarget, charset, mode).parseHttpRequestTarget()
 
   /**
@@ -285,8 +285,8 @@ object Uri {
    * http://tools.ietf.org/html/rfc7230#section-5.5.
    */
   def effectiveHttpRequestUri(scheme: String, host: Host, port: Int, path: Path, query: Option[String], fragment: Option[String],
-                              securedConnection: Boolean, hostHeaderHost: Host, hostHeaderPort: Int,
-                              defaultAuthority: Authority = Authority.Empty): Uri = {
+    securedConnection: Boolean, hostHeaderHost: Host, hostHeaderPort: Int,
+    defaultAuthority: Authority = Authority.Empty): Uri = {
     var _scheme = scheme
     var _host = host
     var _port = port
@@ -595,9 +595,9 @@ object Uri {
   }
 
   private val defaultPorts: Map[String, Int] =
-    Map("ftp" -> 21, "ssh" -> 22, "telnet" -> 23, "smtp" -> 25, "domain" -> 53, "tftp" -> 69, "http" -> 80, "ws" -> 80,
-      "pop3" -> 110, "nntp" -> 119, "imap" -> 143, "snmp" -> 161, "ldap" -> 389, "https" -> 443, "wss" -> 443, "imaps" -> 993,
-      "nfs" -> 2049).withDefaultValue(-1)
+    Map("ftp" → 21, "ssh" → 22, "telnet" → 23, "smtp" → 25, "domain" → 53, "tftp" → 69, "http" → 80, "ws" → 80,
+      "pop3" → 110, "nntp" → 119, "imap" → 143, "snmp" → 161, "ldap" → 389, "https" → 443, "wss" → 443, "imaps" → 993,
+      "nfs" → 2049).withDefaultValue(-1)
 
   sealed trait ParsingMode extends akka.http.javadsl.model.Uri.ParsingMode
   object ParsingMode {
@@ -614,7 +614,7 @@ object Uri {
 
   // http://tools.ietf.org/html/rfc3986#section-5.2.2
   private[http] def resolve(scheme: String, userinfo: String, host: Host, port: Int, path: Path, query: Option[String],
-                            fragment: Option[String], base: Uri): Uri = {
+    fragment: Option[String], base: Uri): Uri = {
     require(base.isAbsolute, "Resolution base Uri must be absolute")
     if (scheme.isEmpty)
       if (host.isEmpty)
@@ -727,9 +727,9 @@ object Uri {
         case Slash(Segment("..", tail)) ⇒ process(
           input = if (tail.isEmpty) Path./ else tail,
           output =
-            if (output.startsWithSegment)
-              if (output.tail.startsWithSlash) output.tail.tail else tail
-            else output)
+          if (output.startsWithSegment)
+            if (output.tail.startsWithSlash) output.tail.tail else tail
+          else output)
         case Segment("." | "..", tail) ⇒ process(tail, output)
         case Slash(tail)               ⇒ process(tail, Slash(output))
         case Segment(string, tail)     ⇒ process(tail, string :: output)
@@ -741,11 +741,11 @@ object Uri {
   private[http] def fail(summary: String, detail: String = "") = throw IllegalUriException(summary, detail)
 
   private[http] def create(scheme: String, userinfo: String, host: Host, port: Int, path: Path, queryString: Option[String],
-                           fragment: Option[String]): Uri =
+    fragment: Option[String]): Uri =
     create(scheme, Authority(host, normalizePort(port, scheme), userinfo), path, queryString, fragment)
 
   private[http] def create(scheme: String, authority: Authority, path: Path, queryString: Option[String],
-                           fragment: Option[String]): Uri =
+    fragment: Option[String]): Uri =
     if (path.isEmpty && scheme.isEmpty && authority.isEmpty && queryString.isEmpty && fragment.isEmpty) Empty
     else new Uri(scheme, authority, path, queryString, fragment) { def isEmpty = false }
 }
@@ -825,7 +825,7 @@ object UriRendering {
     }
 
   def renderQuery[R <: Rendering](r: R, query: Query, charset: Charset,
-                                  keep: CharPredicate = `strict-query-char-np`): r.type = {
+    keep: CharPredicate = `strict-query-char-np`): r.type = {
     def enc(s: String): Unit = encode(r, s, charset, keep, replaceSpaces = true)
     @tailrec def append(q: Query): r.type =
       q match {
@@ -841,7 +841,7 @@ object UriRendering {
   }
 
   private[http] def encode(r: Rendering, string: String, charset: Charset, keep: CharPredicate,
-                           replaceSpaces: Boolean = false): r.type = {
+    replaceSpaces: Boolean = false): r.type = {
     val asciiCompatible = isAsciiCompatible(charset)
     @tailrec def rec(ix: Int): r.type = {
       def appendEncoded(byte: Byte): Unit = r ~~ '%' ~~ CharUtils.upperHexDigit(byte >>> 4) ~~ CharUtils.upperHexDigit(byte)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
@@ -18,7 +18,7 @@ object CacheDirective {
   sealed trait ResponseDirective extends CacheDirective
 
   final case class CustomCacheDirective(name: String, content: Option[String])
-    extends RequestDirective with ResponseDirective with ValueRenderable {
+      extends RequestDirective with ResponseDirective with ValueRenderable {
     def render[R <: Rendering](r: R): r.type = content match {
       case Some(s) ⇒ r ~~ name ~~ '=' ~~# s
       case None    ⇒ r ~~ name

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpChallenge.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpChallenge.scala
@@ -10,7 +10,7 @@ import akka.http.impl.util._
 import akka.http.impl.util.JavaMapping.Implicits._
 
 final case class HttpChallenge(scheme: String, realm: String,
-                               params: Map[String, String] = Map.empty) extends jm.headers.HttpChallenge with ValueRenderable {
+    params: Map[String, String] = Map.empty) extends jm.headers.HttpChallenge with ValueRenderable {
 
   def render[R <: Rendering](r: R): r.type = {
     r ~~ scheme ~~ " realm=" ~~#! realm

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCookie.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCookie.scala
@@ -17,8 +17,8 @@ import scala.compat.java8.OptionConverters._
 // see http://tools.ietf.org/html/rfc6265
 // sealed abstract to prevent generation of default apply method in companion
 sealed abstract case class HttpCookiePair private (
-  name: String,
-  value: String) extends jm.headers.HttpCookiePair with ToStringRenderable {
+    name: String,
+    value: String) extends jm.headers.HttpCookiePair with ToStringRenderable {
 
   def render[R <: Rendering](r: R): r.type = r ~~ name ~~ '=' ~~ value
   def toCookie: HttpCookie = HttpCookie.fromPair(this)
@@ -50,15 +50,15 @@ object HttpCookiePair {
 
 // see http://tools.ietf.org/html/rfc6265
 final case class HttpCookie(
-  name: String,
-  value: String,
-  expires: Option[DateTime] = None,
-  maxAge: Option[Long] = None,
-  domain: Option[String] = None,
-  path: Option[String] = None,
-  secure: Boolean = false,
-  httpOnly: Boolean = false,
-  extension: Option[String] = None) extends jm.headers.HttpCookie with ToStringRenderable {
+    name: String,
+    value: String,
+    expires: Option[DateTime] = None,
+    maxAge: Option[Long] = None,
+    domain: Option[String] = None,
+    path: Option[String] = None,
+    secure: Boolean = false,
+    httpOnly: Boolean = false,
+    extension: Option[String] = None) extends jm.headers.HttpCookie with ToStringRenderable {
 
   /** Returns the name/value pair for this cookie, to be used in [[Cookie]] headers. */
   def pair: HttpCookiePair = HttpCookiePair(name, value)
@@ -111,14 +111,15 @@ final case class HttpCookie(
 }
 
 object HttpCookie {
-  def fromPair(pair: HttpCookiePair,
-               expires: Option[DateTime] = None,
-               maxAge: Option[Long] = None,
-               domain: Option[String] = None,
-               path: Option[String] = None,
-               secure: Boolean = false,
-               httpOnly: Boolean = false,
-               extension: Option[String] = None): HttpCookie =
+  def fromPair(
+    pair: HttpCookiePair,
+    expires: Option[DateTime] = None,
+    maxAge: Option[Long] = None,
+    domain: Option[String] = None,
+    path: Option[String] = None,
+    secure: Boolean = false,
+    httpOnly: Boolean = false,
+    extension: Option[String] = None): HttpCookie =
     HttpCookie(pair.name, pair.value, expires, maxAge, domain, path, secure, httpOnly, extension)
 
   import akka.http.impl.model.parser.CharacterClasses._

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
@@ -51,7 +51,7 @@ final case class OAuth2BearerToken(token: String) extends jm.headers.OAuth2Beare
 }
 
 final case class GenericHttpCredentials(scheme: String, token: String,
-                                        params: Map[String, String] = Map.empty) extends HttpCredentials {
+    params: Map[String, String] = Map.empty) extends HttpCredentials {
   def render[R <: Rendering](r: R): r.type = {
     r ~~ scheme
     if (!token.isEmpty) r ~~ ' ' ~~ token

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LanguageRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LanguageRange.scala
@@ -61,7 +61,7 @@ object LanguageRange {
 }
 
 final case class Language(primaryTag: String, subTags: immutable.Seq[String])
-  extends jm.headers.Language with ValueRenderable with WithQValue[LanguageRange] {
+    extends jm.headers.Language with ValueRenderable with WithQValue[LanguageRange] {
   def withQValue(qValue: Float) = LanguageRange(this, qValue.toFloat)
   def render[R <: Rendering](r: R): r.type = {
     r ~~ primaryTag

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -126,7 +126,7 @@ object `Accept-Charset` extends ModeledCompanion[`Accept-Charset`] {
   implicit val charsetRangesRenderer = Renderer.defaultSeqRenderer[HttpCharsetRange] // cache
 }
 final case class `Accept-Charset`(charsetRanges: immutable.Seq[HttpCharsetRange]) extends jm.headers.AcceptCharset
-  with RequestHeader {
+    with RequestHeader {
   require(charsetRanges.nonEmpty, "charsetRanges must not be empty")
   import `Accept-Charset`.charsetRangesRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ charsetRanges
@@ -142,7 +142,7 @@ object `Accept-Encoding` extends ModeledCompanion[`Accept-Encoding`] {
   implicit val encodingsRenderer = Renderer.defaultSeqRenderer[HttpEncodingRange] // cache
 }
 final case class `Accept-Encoding`(encodings: immutable.Seq[HttpEncodingRange]) extends jm.headers.AcceptEncoding
-  with RequestHeader {
+    with RequestHeader {
   import `Accept-Encoding`.encodingsRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ encodings
   protected def companion = `Accept-Encoding`
@@ -157,7 +157,7 @@ object `Accept-Language` extends ModeledCompanion[`Accept-Language`] {
   implicit val languagesRenderer = Renderer.defaultSeqRenderer[LanguageRange] // cache
 }
 final case class `Accept-Language`(languages: immutable.Seq[LanguageRange]) extends jm.headers.AcceptLanguage
-  with RequestHeader {
+    with RequestHeader {
   require(languages.nonEmpty, "languages must not be empty")
   import `Accept-Language`.languagesRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ languages
@@ -173,7 +173,7 @@ object `Accept-Ranges` extends ModeledCompanion[`Accept-Ranges`] {
   implicit val rangeUnitsRenderer = Renderer.defaultSeqRenderer[RangeUnit] // cache
 }
 final case class `Accept-Ranges`(rangeUnits: immutable.Seq[RangeUnit]) extends jm.headers.AcceptRanges
-  with ResponseHeader {
+    with ResponseHeader {
   import `Accept-Ranges`.rangeUnitsRenderer
   def renderValue[R <: Rendering](r: R): r.type = if (rangeUnits.isEmpty) r ~~ "none" else r ~~ rangeUnits
   protected def companion = `Accept-Ranges`
@@ -185,7 +185,7 @@ final case class `Accept-Ranges`(rangeUnits: immutable.Seq[RangeUnit]) extends j
 // http://www.w3.org/TR/cors/#access-control-allow-credentials-response-header
 object `Access-Control-Allow-Credentials` extends ModeledCompanion[`Access-Control-Allow-Credentials`]
 final case class `Access-Control-Allow-Credentials`(allow: Boolean)
-  extends jm.headers.AccessControlAllowCredentials with ResponseHeader {
+    extends jm.headers.AccessControlAllowCredentials with ResponseHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ allow.toString
   protected def companion = `Access-Control-Allow-Credentials`
 }
@@ -196,7 +196,7 @@ object `Access-Control-Allow-Headers` extends ModeledCompanion[`Access-Control-A
   implicit val headersRenderer = Renderer.defaultSeqRenderer[String] // cache
 }
 final case class `Access-Control-Allow-Headers`(headers: immutable.Seq[String])
-  extends jm.headers.AccessControlAllowHeaders with ResponseHeader {
+    extends jm.headers.AccessControlAllowHeaders with ResponseHeader {
   import `Access-Control-Allow-Headers`.headersRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ headers
   protected def companion = `Access-Control-Allow-Headers`
@@ -211,7 +211,7 @@ object `Access-Control-Allow-Methods` extends ModeledCompanion[`Access-Control-A
   implicit val methodsRenderer = Renderer.defaultSeqRenderer[HttpMethod] // cache
 }
 final case class `Access-Control-Allow-Methods`(methods: immutable.Seq[HttpMethod])
-  extends jm.headers.AccessControlAllowMethods with ResponseHeader {
+    extends jm.headers.AccessControlAllowMethods with ResponseHeader {
   import `Access-Control-Allow-Methods`.methodsRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ methods
   protected def companion = `Access-Control-Allow-Methods`
@@ -236,7 +236,7 @@ object `Access-Control-Allow-Origin` extends ModeledCompanion[`Access-Control-Al
   def forRange(range: HttpOriginRange) = new `Access-Control-Allow-Origin`(range)
 }
 final case class `Access-Control-Allow-Origin` private (range: HttpOriginRange)
-  extends jm.headers.AccessControlAllowOrigin with ResponseHeader {
+    extends jm.headers.AccessControlAllowOrigin with ResponseHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ range
   protected def companion = `Access-Control-Allow-Origin`
 }
@@ -247,7 +247,7 @@ object `Access-Control-Expose-Headers` extends ModeledCompanion[`Access-Control-
   implicit val headersRenderer = Renderer.defaultSeqRenderer[String] // cache
 }
 final case class `Access-Control-Expose-Headers`(headers: immutable.Seq[String])
-  extends jm.headers.AccessControlExposeHeaders with ResponseHeader {
+    extends jm.headers.AccessControlExposeHeaders with ResponseHeader {
   import `Access-Control-Expose-Headers`.headersRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ headers
   protected def companion = `Access-Control-Expose-Headers`
@@ -259,7 +259,7 @@ final case class `Access-Control-Expose-Headers`(headers: immutable.Seq[String])
 // http://www.w3.org/TR/cors/#access-control-max-age-response-header
 object `Access-Control-Max-Age` extends ModeledCompanion[`Access-Control-Max-Age`]
 final case class `Access-Control-Max-Age`(deltaSeconds: Long) extends jm.headers.AccessControlMaxAge
-  with ResponseHeader {
+    with ResponseHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ deltaSeconds
   protected def companion = `Access-Control-Max-Age`
 }
@@ -270,7 +270,7 @@ object `Access-Control-Request-Headers` extends ModeledCompanion[`Access-Control
   implicit val headersRenderer = Renderer.defaultSeqRenderer[String] // cache
 }
 final case class `Access-Control-Request-Headers`(headers: immutable.Seq[String])
-  extends jm.headers.AccessControlRequestHeaders with RequestHeader {
+    extends jm.headers.AccessControlRequestHeaders with RequestHeader {
   import `Access-Control-Request-Headers`.headersRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ headers
   protected def companion = `Access-Control-Request-Headers`
@@ -282,7 +282,7 @@ final case class `Access-Control-Request-Headers`(headers: immutable.Seq[String]
 // http://www.w3.org/TR/cors/#access-control-request-method-request-header
 object `Access-Control-Request-Method` extends ModeledCompanion[`Access-Control-Request-Method`]
 final case class `Access-Control-Request-Method`(method: HttpMethod) extends jm.headers.AccessControlRequestMethod
-  with RequestHeader {
+    with RequestHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ method
   protected def companion = `Access-Control-Request-Method`
 }
@@ -321,7 +321,7 @@ object `Cache-Control` extends ModeledCompanion[`Cache-Control`] {
   implicit val directivesRenderer = Renderer.defaultSeqRenderer[CacheDirective] // cache
 }
 final case class `Cache-Control`(directives: immutable.Seq[CacheDirective]) extends jm.headers.CacheControl
-  with RequestResponseHeader {
+    with RequestResponseHeader {
   require(directives.nonEmpty, "directives must not be empty")
   import `Cache-Control`.directivesRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ directives
@@ -369,7 +369,7 @@ final case class `Content-Length` private[http] (length: Long) extends RequestRe
 // http://tools.ietf.org/html/rfc6266
 object `Content-Disposition` extends ModeledCompanion[`Content-Disposition`]
 final case class `Content-Disposition`(dispositionType: ContentDispositionType, params: Map[String, String] = Map.empty)
-  extends jm.headers.ContentDisposition with RequestResponseHeader {
+    extends jm.headers.ContentDisposition with RequestResponseHeader {
   def renderValue[R <: Rendering](r: R): r.type = {
     r ~~ dispositionType
     params foreach { case (k, v) ⇒ r ~~ "; " ~~ k ~~ '=' ~~# v }
@@ -387,7 +387,7 @@ object `Content-Encoding` extends ModeledCompanion[`Content-Encoding`] {
   implicit val encodingsRenderer = Renderer.defaultSeqRenderer[HttpEncoding] // cache
 }
 final case class `Content-Encoding`(encodings: immutable.Seq[HttpEncoding]) extends jm.headers.ContentEncoding
-  with RequestResponseHeader {
+    with RequestResponseHeader {
   require(encodings.nonEmpty, "encodings must not be empty")
   import `Content-Encoding`.encodingsRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ encodings
@@ -402,7 +402,7 @@ object `Content-Range` extends ModeledCompanion[`Content-Range`] {
   def apply(byteContentRange: ByteContentRange): `Content-Range` = apply(RangeUnits.Bytes, byteContentRange)
 }
 final case class `Content-Range`(rangeUnit: RangeUnit, contentRange: ContentRange) extends jm.headers.ContentRange
-  with ResponseHeader {
+    with ResponseHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ rangeUnit ~~ ' ' ~~ contentRange
   protected def companion = `Content-Range`
 }
@@ -414,7 +414,7 @@ object `Content-Type` extends ModeledCompanion[`Content-Type`]
  * in HttpMessage.header. To access the Content-Type, see subclasses of HttpEntity.
  */
 final case class `Content-Type` private[http] (contentType: ContentType) extends jm.headers.ContentType
-  with RequestResponseHeader {
+    with RequestResponseHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ contentType
   protected def companion = `Content-Type`
 }
@@ -598,7 +598,7 @@ object `Proxy-Authenticate` extends ModeledCompanion[`Proxy-Authenticate`] {
   implicit val challengesRenderer = Renderer.defaultSeqRenderer[HttpChallenge] // cache
 }
 final case class `Proxy-Authenticate`(challenges: immutable.Seq[HttpChallenge]) extends jm.headers.ProxyAuthenticate
-  with ResponseHeader {
+    with ResponseHeader {
   require(challenges.nonEmpty, "challenges must not be empty")
   import `Proxy-Authenticate`.challengesRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ challenges
@@ -611,7 +611,7 @@ final case class `Proxy-Authenticate`(challenges: immutable.Seq[HttpChallenge]) 
 // http://tools.ietf.org/html/rfc7235#section-4.4
 object `Proxy-Authorization` extends ModeledCompanion[`Proxy-Authorization`]
 final case class `Proxy-Authorization`(credentials: HttpCredentials) extends jm.headers.ProxyAuthorization
-  with RequestHeader {
+    with RequestHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ credentials
   protected def companion = `Proxy-Authorization`
 }
@@ -623,7 +623,7 @@ object Range extends ModeledCompanion[Range] {
   implicit val rangesRenderer = Renderer.defaultSeqRenderer[ByteRange] // cache
 }
 final case class Range(rangeUnit: RangeUnit, ranges: immutable.Seq[ByteRange]) extends jm.headers.Range
-  with RequestHeader {
+    with RequestHeader {
   require(ranges.nonEmpty, "ranges must not be empty")
   import Range.rangesRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ rangeUnit ~~ '=' ~~ ranges
@@ -641,7 +641,7 @@ final case class RawHeader(name: String, value: String) extends jm.headers.RawHe
 }
 object RawHeader {
   def unapply[H <: HttpHeader](customHeader: H): Option[(String, String)] =
-    Some(customHeader.name -> customHeader.value)
+    Some(customHeader.name → customHeader.value)
 }
 
 object `Raw-Request-URI` extends ModeledCompanion[`Raw-Request-URI`]
@@ -706,7 +706,7 @@ private[http] object `Sec-WebSocket-Extensions` extends ModeledCompanion[`Sec-We
  * INTERNAL API
  */
 private[http] final case class `Sec-WebSocket-Extensions`(extensions: immutable.Seq[WebSocketExtension])
-  extends ResponseHeader {
+    extends ResponseHeader {
   require(extensions.nonEmpty, "Sec-WebSocket-Extensions.extensions must not be empty")
   import `Sec-WebSocket-Extensions`.extensionsRenderer
   protected[http] def renderValue[R <: Rendering](r: R): r.type = r ~~ extensions
@@ -749,7 +749,7 @@ private[http] object `Sec-WebSocket-Protocol` extends ModeledCompanion[`Sec-WebS
  * INTERNAL API
  */
 private[http] final case class `Sec-WebSocket-Protocol`(protocols: immutable.Seq[String])
-  extends RequestResponseHeader {
+    extends RequestResponseHeader {
   require(protocols.nonEmpty, "Sec-WebSocket-Protocol.protocols must not be empty")
   import `Sec-WebSocket-Protocol`.protocolsRenderer
   protected[http] def renderValue[R <: Rendering](r: R): r.type = r ~~ protocols
@@ -767,7 +767,7 @@ private[http] object `Sec-WebSocket-Version` extends ModeledCompanion[`Sec-WebSo
  * INTERNAL API
  */
 private[http] final case class `Sec-WebSocket-Version`(versions: immutable.Seq[Int])
-  extends RequestResponseHeader {
+    extends RequestResponseHeader {
   require(versions.nonEmpty, "Sec-WebSocket-Version.versions must not be empty")
   require(versions.forall(v ⇒ v >= 0 && v <= 255), s"Sec-WebSocket-Version.versions must be in the range 0 <= version <= 255 but were $versions")
   import `Sec-WebSocket-Version`.versionsRenderer
@@ -814,7 +814,7 @@ final case class `Set-Cookie`(cookie: HttpCookie) extends jm.headers.SetCookie w
 
 object `Timeout-Access` extends ModeledCompanion[`Timeout-Access`]
 final case class `Timeout-Access`(timeoutAccess: akka.http.scaladsl.TimeoutAccess)
-  extends jm.headers.TimeoutAccess with SyntheticHeader {
+    extends jm.headers.TimeoutAccess with SyntheticHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ timeoutAccess.toString
   protected def companion = `Timeout-Access`
 }
@@ -831,7 +831,7 @@ final case class `Timeout-Access`(timeoutAccess: akka.http.scaladsl.TimeoutAcces
  */
 object `Tls-Session-Info` extends ModeledCompanion[`Tls-Session-Info`]
 final case class `Tls-Session-Info`(session: SSLSession) extends jm.headers.TlsSessionInfo with SyntheticHeader
-  with ScalaSessionAPI {
+    with ScalaSessionAPI {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ session.toString
   protected def companion = `Tls-Session-Info`
 
@@ -845,7 +845,7 @@ object `Transfer-Encoding` extends ModeledCompanion[`Transfer-Encoding`] {
   implicit val encodingsRenderer = Renderer.defaultSeqRenderer[TransferEncoding] // cache
 }
 final case class `Transfer-Encoding`(encodings: immutable.Seq[TransferEncoding]) extends jm.headers.TransferEncoding
-  with RequestResponseHeader {
+    with RequestResponseHeader {
   require(encodings.nonEmpty, "encodings must not be empty")
   import `Transfer-Encoding`.encodingsRenderer
   def isChunked: Boolean = encodings.last == TransferEncodings.chunked
@@ -900,7 +900,7 @@ object `WWW-Authenticate` extends ModeledCompanion[`WWW-Authenticate`] {
   implicit val challengesRenderer = Renderer.defaultSeqRenderer[HttpChallenge] // cache
 }
 final case class `WWW-Authenticate`(challenges: immutable.Seq[HttpChallenge]) extends jm.headers.WWWAuthenticate
-  with ResponseHeader {
+    with ResponseHeader {
   require(challenges.nonEmpty, "challenges must not be empty")
   import `WWW-Authenticate`.challengesRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ challenges
@@ -916,7 +916,7 @@ object `X-Forwarded-For` extends ModeledCompanion[`X-Forwarded-For`] {
   implicit val addressesRenderer = Renderer.defaultSeqRenderer[RemoteAddress] // cache
 }
 final case class `X-Forwarded-For`(addresses: immutable.Seq[RemoteAddress]) extends jm.headers.XForwardedFor
-  with RequestHeader {
+    with RequestHeader {
   require(addresses.nonEmpty, "addresses must not be empty")
   import `X-Forwarded-For`.addressesRenderer
   def renderValue[R <: Rendering](r: R): r.type = r ~~ addresses
@@ -928,7 +928,7 @@ final case class `X-Forwarded-For`(addresses: immutable.Seq[RemoteAddress]) exte
 
 object `X-Real-Ip` extends ModeledCompanion[`X-Real-Ip`]
 final case class `X-Real-Ip`(address: RemoteAddress) extends jm.headers.XRealIp
-  with RequestHeader {
+    with RequestHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ address
   protected def companion = `X-Real-Ip`
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
@@ -34,8 +34,9 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
    *
    * Optionally, a subprotocol out of the ones requested by the client can be chosen.
    */
-  def handleMessages(handlerFlow: Graph[FlowShape[Message, Message], Any],
-                     subprotocol: Option[String] = None): HttpResponse
+  def handleMessages(
+    handlerFlow: Graph[FlowShape[Message, Message], Any],
+    subprotocol: Option[String] = None): HttpResponse
 
   /**
    * The high-level interface to create a WebSocket server based on "messages".
@@ -47,9 +48,10 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
    *
    * Optionally, a subprotocol out of the ones requested by the client can be chosen.
    */
-  def handleMessagesWithSinkSource(inSink: Graph[SinkShape[Message], Any],
-                                   outSource: Graph[SourceShape[Message], Any],
-                                   subprotocol: Option[String] = None): HttpResponse =
+  def handleMessagesWithSinkSource(
+    inSink: Graph[SinkShape[Message], Any],
+    outSource: Graph[SourceShape[Message], Any],
+    subprotocol: Option[String] = None): HttpResponse =
     handleMessages(scaladsl.Flow.fromSinkAndSource(inSink, outSource), subprotocol)
 
   import scala.collection.JavaConverters._
@@ -80,9 +82,10 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
   /**
    * Java API
    */
-  def handleMessagesWith(inSink: Graph[SinkShape[jm.ws.Message], _ <: Any],
-                         outSource: Graph[SourceShape[jm.ws.Message], _ <: Any],
-                         subprotocol: String): HttpResponse =
+  def handleMessagesWith(
+    inSink: Graph[SinkShape[jm.ws.Message], _ <: Any],
+    outSource: Graph[SourceShape[jm.ws.Message], _ <: Any],
+    subprotocol: String): HttpResponse =
     handleMessages(createScalaFlow(inSink, outSource), subprotocol = Some(subprotocol))
 
   private[this] def createScalaFlow(inSink: Graph[SinkShape[jm.ws.Message], _ <: Any], outSource: Graph[SourceShape[jm.ws.Message], _ <: Any]): Graph[FlowShape[Message, Message], NotUsed] =

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -83,11 +83,11 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   def withErrorLoggingVerbosity(newValue: ParserSettings.ErrorLoggingVerbosity): ParserSettings = self.copy(errorLoggingVerbosity = newValue)
   def withHeaderValueCacheLimits(newValue: Map[String, Int]): ParserSettings = self.copy(headerValueCacheLimits = newValue)
   def withCustomMethods(methods: HttpMethod*): ParserSettings = {
-    val map = methods.map(m ⇒ m.name -> m).toMap
+    val map = methods.map(m ⇒ m.name → m).toMap
     self.copy(customMethods = map.get)
   }
   def withCustomStatusCodes(codes: StatusCode*): ParserSettings = {
-    val map = codes.map(c ⇒ c.intValue -> c).toMap
+    val map = codes.map(c ⇒ c.intValue → c).toMap
     self.copy(customStatusCodes = map.get)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/util/FastFuture.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/util/FastFuture.scala
@@ -80,9 +80,9 @@ object FastFuture {
     def isCompleted = true
     def result(atMost: Duration)(implicit permit: CanAwait) = a
     def ready(atMost: Duration)(implicit permit: CanAwait) = this
-    def transform[S](f: scala.util.Try[A] => scala.util.Try[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
+    def transform[S](f: scala.util.Try[A] ⇒ scala.util.Try[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
       FastFuture(f(Success(a)))
-    def transformWith[S](f: scala.util.Try[A] => scala.concurrent.Future[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
+    def transformWith[S](f: scala.util.Try[A] ⇒ scala.concurrent.Future[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
       new FastFuture(this).transformWith(f)
   }
   private case class ErrorFuture(error: Throwable) extends Future[Nothing] {
@@ -91,9 +91,9 @@ object FastFuture {
     def isCompleted = true
     def result(atMost: Duration)(implicit permit: CanAwait) = throw error
     def ready(atMost: Duration)(implicit permit: CanAwait) = this
-    def transform[S](f: scala.util.Try[Nothing] => scala.util.Try[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
+    def transform[S](f: scala.util.Try[Nothing] ⇒ scala.util.Try[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
       FastFuture(f(Failure(error)))
-    def transformWith[S](f: scala.util.Try[Nothing] => scala.concurrent.Future[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
+    def transformWith[S](f: scala.util.Try[Nothing] ⇒ scala.concurrent.Future[S])(implicit executor: scala.concurrent.ExecutionContext): scala.concurrent.Future[S] =
       new FastFuture(this).transformWith(f)
   }
 

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestResponse.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestResponse.scala
@@ -146,7 +146,8 @@ abstract class TestResponse(_response: HttpResponse, awaitAtMost: FiniteDuration
     val lowercased = name.toRootLowerCase
     val headers = response.headers.filter(_.is(lowercased))
     if (headers.isEmpty) fail(s"Expected `$name` header was missing.")
-    else assertTrue(headers.exists(_.value == value),
+    else assertTrue(
+      headers.exists(_.value == value),
       s"`$name` header was found but had the wrong value. Found headers: ${headers.mkString(", ")}")
 
     this

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -139,14 +139,15 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
       type Out = HttpRequest
       def apply(request: HttpRequest, f: HttpRequest ⇒ HttpRequest) = f(request)
     }
-    implicit def injectIntoRoute(implicit timeout: RouteTestTimeout,
-                                 defaultHostInfo: DefaultHostInfo,
-                                 routingSettings: RoutingSettings,
-                                 executionContext: ExecutionContext,
-                                 materializer: Materializer,
-                                 routingLog: RoutingLog,
-                                 rejectionHandler: RejectionHandler = RejectionHandler.default,
-                                 exceptionHandler: ExceptionHandler = null) =
+    implicit def injectIntoRoute(implicit
+      timeout: RouteTestTimeout,
+      defaultHostInfo: DefaultHostInfo,
+      routingSettings: RoutingSettings,
+      executionContext: ExecutionContext,
+      materializer: Materializer,
+      routingLog: RoutingLog,
+      rejectionHandler: RejectionHandler = RejectionHandler.default,
+      exceptionHandler: ExceptionHandler = null) =
       new TildeArrow[RequestContext, Future[RouteResult]] {
         type Out = RouteTestResult
         def apply(request: HttpRequest, route: Route): Out = {

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSTestRequestBuilding.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSTestRequestBuilding.scala
@@ -20,10 +20,11 @@ trait WSTestRequestBuilding { self: RouteTest ⇒
 
         def handleMessages(handlerFlow: Graph[FlowShape[Message, Message], Any], subprotocol: Option[String]): HttpResponse = {
           clientSideHandler.join(handlerFlow).run()
-          HttpResponse(StatusCodes.SwitchingProtocols,
+          HttpResponse(
+            StatusCodes.SwitchingProtocols,
             headers =
-              Upgrade(UpgradeProtocol("websocket") :: Nil) ::
-                subprotocol.map(p ⇒ `Sec-WebSocket-Protocol`(p :: Nil)).toList)
+            Upgrade(UpgradeProtocol("websocket") :: Nil) ::
+              subprotocol.map(p ⇒ `Sec-WebSocket-Protocol`(p :: Nil)).toList)
         }
       })
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
@@ -18,7 +18,7 @@ class FormDataSpec extends AkkaSpec {
   implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
-  val formData = FormData(Map("surname" -> "Smith", "age" -> "42"))
+  val formData = FormData(Map("surname" → "Smith", "age" → "42"))
 
   "The FormData infrastructure" should {
     "properly round-trip the fields of www-urlencoded forms" in {
@@ -27,10 +27,10 @@ class FormDataSpec extends AkkaSpec {
     }
 
     "properly marshal www-urlencoded forms containing special chars" in {
-      Marshal(FormData(Map("name" -> "Smith&Wesson"))).to[HttpEntity]
+      Marshal(FormData(Map("name" → "Smith&Wesson"))).to[HttpEntity]
         .flatMap(Unmarshal(_).to[String]).futureValue shouldEqual "name=Smith%26Wesson"
 
-      Marshal(FormData(Map("name" -> "Smith+Wesson; hopefully!"))).to[HttpEntity]
+      Marshal(FormData(Map("name" → "Smith+Wesson; hopefully!"))).to[HttpEntity]
         .flatMap(Unmarshal(_).to[String]).futureValue shouldEqual "name=Smith%2BWesson%3B+hopefully%21"
     }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationGivenResponseCodeSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationGivenResponseCodeSpec.scala
@@ -15,9 +15,9 @@ class ContentNegotiationGivenResponseCodeSpec extends RoutingSpec {
     pathPrefix(Segment) { mode ⇒
       complete {
         mode match {
-          case "200-text" ⇒ OK -> "ok"
-          case "201-text" ⇒ Created -> "created"
-          case "400-text" ⇒ BadRequest -> "bad-request"
+          case "200-text" ⇒ OK → "ok"
+          case "201-text" ⇒ Created → "created"
+          case "400-text" ⇒ BadRequest → "bad-request"
         }
       }
     }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -107,7 +107,8 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
     }
 
     "Accept-Charset: UTF-8, *;q=0.8, us;q=0.1" test { accept ⇒
-      accept(`text/plain` withCharset `US-ASCII`,
+      accept(
+        `text/plain` withCharset `US-ASCII`,
         `text/plain` withCharset `ISO-8859-1`) should select(`text/plain` withCharset `ISO-8859-1`)
     }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -34,7 +34,7 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
       marshal("Ha“llo".toCharArray) shouldEqual HttpEntity("Ha“llo")
     }
     "FormDataMarshaller should marshal FormData instances to application/x-www-form-urlencoded content" in {
-      marshal(FormData(Map("name" -> "Bob", "pass" -> "hällo", "admin" -> ""))) shouldEqual
+      marshal(FormData(Map("name" → "Bob", "pass" → "hällo", "admin" → ""))) shouldEqual
         HttpEntity(`application/x-www-form-urlencoded` withCharset `UTF-8`, "name=Bob&pass=h%C3%A4llo&admin=")
     }
   }
@@ -65,7 +65,7 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
       "one non-empty part" in {
         marshal(Multipart.General(`multipart/alternative`, Multipart.General.BodyPart.Strict(
           entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
-          headers = `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" -> "email")) :: Nil))) shouldEqual
+          headers = `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" → "email")) :: Nil))) shouldEqual
           HttpEntity(
             contentType = `multipart/alternative` withBoundary randomBoundary withCharset `UTF-8`,
             string = s"""--$randomBoundary
@@ -76,7 +76,8 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
                         |--$randomBoundary--""".stripMarginWithNewline("\r\n"))
       }
       "two different parts" in {
-        marshal(Multipart.General(`multipart/related`,
+        marshal(Multipart.General(
+          `multipart/related`,
           Multipart.General.BodyPart.Strict(HttpEntity(`text/plain` withCharset `US-ASCII`, "first part, with a trailing linebreak\r\n")),
           Multipart.General.BodyPart.Strict(
             HttpEntity(`application/octet-stream`, ByteString("filecontent")),
@@ -100,8 +101,8 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
     "multipartFormDataMarshaller should correctly marshal 'multipart/form-data' content with" - {
       "two fields" in {
         marshal(Multipart.FormData(ListMap(
-          "surname" -> HttpEntity("Mike"),
-          "age" -> marshal(<int>42</int>)))) shouldEqual
+          "surname" → HttpEntity("Mike"),
+          "age" → marshal(<int>42</int>)))) shouldEqual
           HttpEntity(
             contentType = `multipart/form-data` withBoundary randomBoundary withCharset `UTF-8`,
             string = s"""--$randomBoundary
@@ -120,9 +121,9 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
       "two fields having a custom `Content-Disposition`" in {
         marshal(Multipart.FormData(Source(List(
           Multipart.FormData.BodyPart("attachment[0]", HttpEntity(`text/csv` withCharset `UTF-8`, "name,age\r\n\"John Doe\",20\r\n"),
-            Map("filename" -> "attachment.csv")),
+            Map("filename" → "attachment.csv")),
           Multipart.FormData.BodyPart("attachment[1]", HttpEntity("naice!".getBytes),
-            Map("filename" -> "attachment2.csv"), List(RawHeader("Content-Transfer-Encoding", "binary"))))))) shouldEqual
+            Map("filename" → "attachment2.csv"), List(RawHeader("Content-Transfer-Encoding", "binary"))))))) shouldEqual
           HttpEntity(
             contentType = `multipart/form-data` withBoundary randomBoundary withCharset `UTF-8`,
             string = s"""--$randomBoundary

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -52,7 +52,8 @@ class DontLeakActorsOnFailingConnectionSpecs extends WordSpecLike with Matchers 
             val children = probe.expectMsgType[StreamSupervisor.Children].children.filter { c ⇒
               c.path.toString contains name
             }
-            assert(children.isEmpty,
+            assert(
+              children.isEmpty,
               s"expected no StreamSupervisor children, but got [${children.mkString(", ")}]")
           }
         }
@@ -67,7 +68,7 @@ class DontLeakActorsOnFailingConnectionSpecs extends WordSpecLike with Matchers 
         val reqsCount = 100
         val clientFlow = Http().superPool[Int]()
         val (_, _, port) = TestUtils.temporaryServerHostnameAndPort()
-        val source = Source(1 to reqsCount).map(i ⇒ HttpRequest(uri = Uri(s"http://127.0.0.1:$port/test/$i")) -> i)
+        val source = Source(1 to reqsCount).map(i ⇒ HttpRequest(uri = Uri(s"http://127.0.0.1:$port/test/$i")) → i)
 
         val countDown = new CountDownLatch(reqsCount)
         val sink = Sink.foreach[(Try[HttpResponse], Int)] {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
@@ -16,8 +16,8 @@ import scala.concurrent.Await
 
 /** INTERNAL API - not (yet?) ready for public consuption */
 private[akka] trait IntegrationRoutingSpec extends WordSpecLike with Matchers with BeforeAndAfterAll
-  with Directives with RequestBuilding
-  with ScalaFutures with IntegrationPatience {
+    with Directives with RequestBuilding
+    with ScalaFutures with IntegrationPatience {
 
   implicit val system = ActorSystem(AkkaSpec.getCallerName(getClass))
   implicit val mat = ActorMaterializer()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -33,7 +33,8 @@ object TestServer extends App {
   val bindingFuture = Http().bindAndHandle({
     get {
       path("") {
-        withRequestTimeout(1.milli, _ ⇒ HttpResponse(StatusCodes.EnhanceYourCalm,
+        withRequestTimeout(1.milli, _ ⇒ HttpResponse(
+          StatusCodes.EnhanceYourCalm,
           entity = "Unable to serve response within time limit, please enchance your calm.")) {
           Thread.sleep(1000)
           complete(index)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CookieDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CookieDirectivesSpec.scala
@@ -15,7 +15,7 @@ class CookieDirectivesSpec extends RoutingSpec {
 
   "The 'cookie' directive" should {
     "extract the respectively named cookie" in {
-      Get() ~> addHeader(Cookie("fancy" -> "pants")) ~> {
+      Get() ~> addHeader(Cookie("fancy" → "pants")) ~> {
         cookie("fancy") { echoComplete }
       } ~> check { responseAs[String] shouldEqual "fancy=pants" }
     }
@@ -25,7 +25,7 @@ class CookieDirectivesSpec extends RoutingSpec {
       } ~> check { rejection shouldEqual MissingCookieRejection("fancy") }
     }
     "properly pass through inner rejections" in {
-      Get() ~> addHeader(Cookie("fancy" -> "pants")) ~> {
+      Get() ~> addHeader(Cookie("fancy" → "pants")) ~> {
         cookie("fancy") { c ⇒ reject(ValidationRejection("Dont like " + c.value)) }
       } ~> check { rejection shouldEqual ValidationRejection("Dont like pants") }
     }
@@ -56,7 +56,7 @@ class CookieDirectivesSpec extends RoutingSpec {
 
   "The 'optionalCookie' directive" should {
     "produce a `Some(cookie)` extraction if the cookie is present" in {
-      Get() ~> Cookie("abc" -> "123") ~> {
+      Get() ~> Cookie("abc" → "123") ~> {
         optionalCookie("abc") { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Some(abc=123)" }
     }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -21,7 +21,7 @@ class FileUploadDirectivesSpec extends RoutingSpec {
         Multipart.FormData(Multipart.FormData.BodyPart.Strict(
           "fieldName",
           HttpEntity(ContentTypes.`text/xml(UTF-8)`, xml),
-          Map("filename" -> "age.xml")))
+          Map("filename" → "age.xml")))
 
       @volatile var file: Option[File] = None
 
@@ -71,7 +71,7 @@ class FileUploadDirectivesSpec extends RoutingSpec {
         Multipart.FormData(Multipart.FormData.BodyPart.Strict(
           "field1",
           HttpEntity(ContentTypes.`text/plain(UTF-8)`, str1),
-          Map("filename" -> "data1.txt")))
+          Map("filename" → "data1.txt")))
 
       Post("/", multipartForm) ~> route ~> check {
         status shouldEqual StatusCodes.OK
@@ -92,11 +92,11 @@ class FileUploadDirectivesSpec extends RoutingSpec {
           Multipart.FormData.BodyPart.Strict(
             "field1",
             HttpEntity(ContentTypes.`text/plain(UTF-8)`, str1),
-            Map("filename" -> "data1.txt")),
+            Map("filename" → "data1.txt")),
           Multipart.FormData.BodyPart.Strict(
             "field1",
             HttpEntity(ContentTypes.`text/plain(UTF-8)`, str2),
-            Map("filename" -> "data2.txt")))
+            Map("filename" → "data2.txt")))
 
       Post("/", multipartForm) ~> route ~> check {
         status shouldEqual StatusCodes.OK
@@ -129,7 +129,7 @@ class FileUploadDirectivesSpec extends RoutingSpec {
         Multipart.FormData(Multipart.FormData.BodyPart.Strict(
           "field1",
           HttpEntity(ContentTypes.`text/plain(UTF-8)`, str1),
-          Map("filename" -> "data1.txt")))
+          Map("filename" → "data1.txt")))
 
       Post("/", multipartForm) ~> route ~> check {
         rejection === MissingFormFieldRejection("missing")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -19,24 +19,24 @@ class FormFieldDirectivesSpec extends RoutingSpec {
     ScalaXmlSupport.nodeSeqUnmarshaller(`text/xml`, `text/html`, `text/plain`)
 
   val nodeSeq: xml.NodeSeq = <b>yes</b>
-  val urlEncodedForm = FormData(Map("firstName" -> "Mike", "age" -> "42"))
-  val urlEncodedFormWithVip = FormData(Map("firstName" -> "Mike", "age" -> "42", "VIP" -> "true", "super" -> "<b>no</b>"))
+  val urlEncodedForm = FormData(Map("firstName" → "Mike", "age" → "42"))
+  val urlEncodedFormWithVip = FormData(Map("firstName" → "Mike", "age" → "42", "VIP" → "true", "super" → "<b>no</b>"))
   val multipartForm = Multipart.FormData {
     Map(
-      "firstName" -> HttpEntity("Mike"),
-      "age" -> HttpEntity(ContentTypes.`text/xml(UTF-8)`, "<int>42</int>"),
-      "VIPBoolean" -> HttpEntity("true"))
+      "firstName" → HttpEntity("Mike"),
+      "age" → HttpEntity(ContentTypes.`text/xml(UTF-8)`, "<int>42</int>"),
+      "VIPBoolean" → HttpEntity("true"))
   }
   val multipartFormWithTextHtml = Multipart.FormData {
     Map(
-      "firstName" -> HttpEntity("Mike"),
-      "age" -> HttpEntity(ContentTypes.`text/xml(UTF-8)`, "<int>42</int>"),
-      "VIP" -> HttpEntity(ContentTypes.`text/html(UTF-8)`, "<b>yes</b>"),
-      "super" -> HttpEntity("no"))
+      "firstName" → HttpEntity("Mike"),
+      "age" → HttpEntity(ContentTypes.`text/xml(UTF-8)`, "<int>42</int>"),
+      "VIP" → HttpEntity(ContentTypes.`text/html(UTF-8)`, "<b>yes</b>"),
+      "super" → HttpEntity("no"))
   }
   val multipartFormWithFile = Multipart.FormData(
     Multipart.FormData.BodyPart.Strict("file", HttpEntity(ContentTypes.`text/xml(UTF-8)`, "<int>42</int>"),
-      Map("filename" -> "age.xml")))
+      Map("filename" → "age.xml")))
 
   "The 'formFields' extraction directive" should {
     "properly extract the value of www-urlencoded form fields" in {
@@ -142,22 +142,22 @@ class FormFieldDirectivesSpec extends RoutingSpec {
 
   "The 'formField' repeated directive" should {
     "extract an empty Iterable when the parameter is absent" in {
-      Post("/", FormData("age" -> "42")) ~> {
+      Post("/", FormData("age" → "42")) ~> {
         formField('hobby.*) { echoComplete }
       } ~> check { responseAs[String] === "List()" }
     }
     "extract all occurrences into an Iterable when parameter is present" in {
-      Post("/", FormData("age" -> "42", "hobby" -> "cooking", "hobby" -> "reading")) ~> {
+      Post("/", FormData("age" → "42", "hobby" → "cooking", "hobby" → "reading")) ~> {
         formField('hobby.*) { echoComplete }
       } ~> check { responseAs[String] === "List(cooking, reading)" }
     }
     "extract as Iterable[Int]" in {
-      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "5")) ~> {
+      Post("/", FormData("age" → "42", "number" → "3", "number" → "5")) ~> {
         formField('number.as[Int].*) { echoComplete }
       } ~> check { responseAs[String] === "List(3, 5)" }
     }
     "extract as Iterable[Int] with an explicit deserializer" in {
-      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "A")) ~> {
+      Post("/", FormData("age" → "42", "number" → "3", "number" → "A")) ~> {
         formField('number.as(HexInt).*) { echoComplete }
       } ~> check { responseAs[String] === "List(3, 10)" }
     }
@@ -165,7 +165,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
 
   "The 'formFieldMap' directive" should {
     "extract fields with different keys" in {
-      Post("/", FormData("age" -> "42", "numberA" -> "3", "numberB" -> "5")) ~> {
+      Post("/", FormData("age" → "42", "numberA" → "3", "numberB" → "5")) ~> {
         formFieldMap { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Map(age -> 42, numberA -> 3, numberB -> 5)" }
     }
@@ -173,7 +173,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
 
   "The 'formFieldSeq' directive" should {
     "extract all fields" in {
-      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "5")) ~> {
+      Post("/", FormData("age" → "42", "number" → "3", "number" → "5")) ~> {
         formFieldSeq { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Vector((age,42), (number,3), (number,5))" }
     }
@@ -186,7 +186,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
 
   "The 'formFieldMultiMap' directive" should {
     "extract fields with different keys (with duplicates)" in {
-      Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "5")) ~> {
+      Post("/", FormData("age" → "42", "number" → "3", "number" → "5")) ~> {
         formFieldMultiMap { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Map(age -> List(42), number -> List(5, 3))" }
     }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -103,7 +103,7 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
   }
 
   "pathPrefix(Map(\"red\" -> 1, \"green\" -> 2, \"blue\" -> 3))" should {
-    val test = testFor(pathPrefix(Map("red" -> 1, "green" -> 2, "blue" -> 3)) { echoCaptureAndUnmatchedPath })
+    val test = testFor(pathPrefix(Map("red" → 1, "green" → 2, "blue" → 3)) { echoCaptureAndUnmatchedPath })
     "accept [/green]" in test("2:")
     "accept [/redsea]" in test("1:sea")
     "reject [/black]" in test()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -78,7 +78,7 @@ class RouteDirectivesSpec extends FreeSpec with GenericRoutingSpec {
                 case AlreadyRegistered ⇒
                   import spray.json.DefaultJsonProtocol._
                   import SprayJsonSupport._
-                  StatusCodes.BadRequest -> Map("error" -> "User already Registered")
+                  StatusCodes.BadRequest → Map("error" → "User already Registered")
               }
             }
           }
@@ -119,7 +119,8 @@ class RouteDirectivesSpec extends FreeSpec with GenericRoutingSpec {
       } ~> check {
         response shouldEqual HttpResponse(
           status = 302,
-          entity = HttpEntity(ContentTypes.`text/html(UTF-8)`,
+          entity = HttpEntity(
+            ContentTypes.`text/html(UTF-8)`,
             "The requested resource temporarily resides under <a href=\"/foo\">this URI</a>."),
           headers = Location("/foo") :: Nil)
       }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
@@ -31,7 +31,8 @@ class TimeoutDirectivesSpec extends IntegrationRoutingSpec {
   }
 
   "allow mapping the response" in {
-    val timeoutResponse = HttpResponse(StatusCodes.EnhanceYourCalm,
+    val timeoutResponse = HttpResponse(
+      StatusCodes.EnhanceYourCalm,
       entity = "Unable to serve response within time limit, please enchance your calm.")
 
     val route =

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -29,13 +29,15 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
 
     "multipartGeneralUnmarshaller should correctly unmarshal 'multipart/*' content with" - {
       "an empty part" in {
-        Unmarshal(HttpEntity(`multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
           """--XYZABC
             |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/plain(UTF-8)`)))
       }
       "two empty parts" in {
-        Unmarshal(HttpEntity(`multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
           """--XYZABC
             |--XYZABC
             |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
@@ -43,7 +45,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/plain(UTF-8)`)))
       }
       "a part without entity and missing header separation CRLF" in {
-        Unmarshal(HttpEntity(`multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
           """--XYZABC
             |Content-type: text/xml
             |Age: 12
@@ -51,7 +54,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/xml(UTF-8)`), List(Age(12))))
       }
       "an implicitly typed part (without headers) (Strict)" in {
-        Unmarshal(HttpEntity(`multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
           """--XYZABC
             |
             |Perfectly fine part content.
@@ -69,7 +73,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Perfectly fine part content.")))
       }
       "one non-empty form-data part" in {
-        Unmarshal(HttpEntity(`multipart/form-data` withBoundary "-" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/form-data` withBoundary "-" withCharset `UTF-8`,
           """---
             |Content-type: text/plain; charset=UTF8
             |content-disposition: form-data; name="email"
@@ -78,10 +83,11 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             |-----""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(
             HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
-            List(`Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" -> "email")))))
+            List(`Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" → "email")))))
       }
       "two different parts" in {
-        Unmarshal(HttpEntity(`multipart/mixed` withBoundary "12345" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "12345" withCharset `UTF-8`,
           """--12345
             |
             |first part, with a trailing newline
@@ -93,11 +99,13 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             |filecontent
             |--12345--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "first part, with a trailing newline\r\n")),
-          Multipart.General.BodyPart.Strict(HttpEntity(`application/octet-stream`, ByteString("filecontent")),
+          Multipart.General.BodyPart.Strict(
+            HttpEntity(`application/octet-stream`, ByteString("filecontent")),
             List(RawHeader("Content-Transfer-Encoding", "binary"))))
       }
       "illegal headers" in (
-        Unmarshal(HttpEntity(`multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
           """--XYZABC
             |Date: unknown
             |content-disposition: form-data; name=email
@@ -106,10 +114,12 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(
             HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
-            List(RawHeader("date", "unknown"),
-              `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" -> "email"))))))
+            List(
+              RawHeader("date", "unknown"),
+              `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" → "email"))))))
       "a full example (Strict)" in {
-        Unmarshal(HttpEntity(`multipart/mixed` withBoundary "12345" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "12345" withCharset `UTF-8`,
           """preamble and
             |more preamble
             |--12345
@@ -145,7 +155,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             Multipart.General.BodyPart.Strict(HttpEntity(`application/octet-stream`, ByteString("second part, explicitly typed"))))
       }
       "a boundary with spaces" in {
-        Unmarshal(HttpEntity(`multipart/mixed` withBoundary "simple boundary" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "simple boundary" withCharset `UTF-8`,
           """--simple boundary
             |--simple boundary--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/plain(UTF-8)`)))
@@ -158,13 +169,15 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual "Unexpected end of multipart entity"
       }
       "an entity without initial boundary" in {
-        Await.result(Unmarshal(HttpEntity(`multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+        Await.result(Unmarshal(HttpEntity(
+          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
           """this is
             |just preamble text""".stripMarginWithNewline("\r\n")))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual "Unexpected end of multipart entity"
       }
       "a stray boundary" in {
-        Await.result(Unmarshal(HttpEntity(`multipart/form-data` withBoundary "ABC" withCharset `UTF-8`,
+        Await.result(Unmarshal(HttpEntity(
+          `multipart/form-data` withBoundary "ABC" withCharset `UTF-8`,
           """--ABC
             |Content-type: text/plain; charset=UTF8
             |--ABCContent-type: application/json
@@ -173,7 +186,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual "Illegal multipart boundary in message content"
       }
       "duplicate Content-Type header" in {
-        Await.result(Unmarshal(HttpEntity(`multipart/form-data` withBoundary "-" withCharset `UTF-8`,
+        Await.result(Unmarshal(HttpEntity(
+          `multipart/form-data` withBoundary "-" withCharset `UTF-8`,
           """---
             |Content-type: text/plain; charset=UTF8
             |Content-type: application/json
@@ -185,7 +199,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
           "multipart part must not contain more than one Content-Type header"
       }
       "a missing header-separating CRLF (in Strict entity)" in {
-        Await.result(Unmarshal(HttpEntity(`multipart/form-data` withBoundary "-" withCharset `UTF-8`,
+        Await.result(Unmarshal(HttpEntity(
+          `multipart/form-data` withBoundary "-" withCharset `UTF-8`,
           """---
             |not good here
             |-----""".stripMarginWithNewline("\r\n")))
@@ -207,19 +222,20 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
       "a boundary with a trailing space" in {
         Await.result(
           Unmarshal(HttpEntity(`multipart/mixed` withBoundary "simple boundary " withCharset `UTF-8`, ByteString.empty))
-            .to[Multipart.General].failed, 1.second).getMessage shouldEqual
+          .to[Multipart.General].failed, 1.second).getMessage shouldEqual
           "requirement failed: 'boundary' parameter of multipart Content-Type must not end with a space char"
       }
       "a boundary with an illegal character" in {
         Await.result(
           Unmarshal(HttpEntity(`multipart/mixed` withBoundary "simple&boundary" withCharset `UTF-8`, ByteString.empty))
-            .to[Multipart.General].failed, 1.second).getMessage shouldEqual
+          .to[Multipart.General].failed, 1.second).getMessage shouldEqual
           "requirement failed: 'boundary' parameter of multipart Content-Type contains illegal character '&'"
       }
     }
 
     "multipartByteRangesUnmarshaller should correctly unmarshal multipart/byteranges content with two different parts" in {
-      Unmarshal(HttpEntity(`multipart/byteranges` withBoundary "12345" withCharset `UTF-8`,
+      Unmarshal(HttpEntity(
+        `multipart/byteranges` withBoundary "12345" withCharset `UTF-8`,
         """--12345
           |Content-Range: bytes 0-2/26
           |Content-Type: text/plain
@@ -237,7 +253,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
 
     "multipartFormDataUnmarshaller should correctly unmarshal 'multipart/form-data' content" - {
       "with one element and no explicit content-type" in {
-        Unmarshal(HttpEntity(`multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
           """--XYZABC
             |content-disposition: form-data; name=email
             |
@@ -246,7 +263,8 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
           Multipart.FormData.BodyPart.Strict("email", HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com")))
       }
       "with one element" in {
-        Unmarshal(HttpEntity(`multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
+        Unmarshal(HttpEntity(
+          `multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
           """--XYZABC
             |content-disposition: form-data; name=email
             |Content-Type: application/octet-stream
@@ -284,7 +302,7 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
             })
         }.to[Multipart.FormData].flatMap(_.toStrict(1.second)) should haveParts(
           Multipart.FormData.BodyPart.Strict("email", HttpEntity(`application/octet-stream`, ByteString("test@there.com"))),
-          Multipart.FormData.BodyPart.Strict("userfile", HttpEntity(`application/pdf`, ByteString("filecontent")), Map("filename" -> "test€.dat"),
+          Multipart.FormData.BodyPart.Strict("userfile", HttpEntity(`application/pdf`, ByteString("filecontent")), Map("filename" → "test€.dat"),
             List(
               RawHeader("Content-Transfer-Encoding", "binary"),
               RawHeader("Content-Additional-1", "anything"),

--- a/akka-http/src/main/scala/akka/http/impl/server/FormFieldImpl.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/FormFieldImpl.scala
@@ -20,8 +20,9 @@ import scala.compat.java8.OptionConverters._
  * INTERNAL API
  */
 private[http] class FormFieldImpl[T, U](receptacle: NameReceptacle[T])(
-  implicit fu: FromStrictFormFieldUnmarshaller[T], tTag: ClassTag[U], conv: T ⇒ U)
-  extends StandaloneExtractionImpl[U] with FormField[U] {
+  implicit
+  fu: FromStrictFormFieldUnmarshaller[T], tTag: ClassTag[U], conv: T ⇒ U)
+    extends StandaloneExtractionImpl[U] with FormField[U] {
   import Directives._
 
   def directive: Directive1[U] =

--- a/akka-http/src/main/scala/akka/http/impl/server/ParameterImpl.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/ParameterImpl.scala
@@ -22,8 +22,9 @@ import scala.compat.java8.OptionConverters._
  * INTERNAL API
  */
 private[http] class ParameterImpl[T, U](receptacle: NameReceptacle[T])(
-  implicit fu: FromStringUnmarshaller[T], tTag: ClassTag[U], conv: T ⇒ U)
-  extends StandaloneExtractionImpl[U] with Parameter[U] {
+  implicit
+  fu: FromStringUnmarshaller[T], tTag: ClassTag[U], conv: T ⇒ U)
+    extends StandaloneExtractionImpl[U] with Parameter[U] {
 
   import ParameterDirectives._
   def directive: Directive1[U] = parameter(receptacle).map(conv)

--- a/akka-http/src/main/scala/akka/http/impl/server/PathMatcherImpl.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/PathMatcherImpl.scala
@@ -17,6 +17,6 @@ import scala.compat.java8.OptionConverters
  * INTERNAL API
  */
 private[http] class PathMatcherImpl[T: ClassTag](val matcher: ScalaPathMatcher[Tuple1[T]])
-  extends ExtractionImpl[T] with PathMatcher[T] {
+    extends ExtractionImpl[T] with PathMatcher[T] {
   def optional: PathMatcher[Optional[T]] = new PathMatcherImpl[Optional[T]](matcher.?.map(OptionConverters.toJava))
 }

--- a/akka-http/src/main/scala/akka/http/impl/server/RouteImplementation.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/RouteImplementation.scala
@@ -180,9 +180,10 @@ private[http] object RouteImplementation extends Directives with server.RouteCon
       case p: Product     ⇒ extractExecutionContext { implicit ec ⇒ complete((500, s"Not implemented: ${p.productPrefix}")) }
     }
   }
-  def pathMatcherDirective[T](matchers: immutable.Seq[PathMatcher[_]],
-                              directive: PathMatcher1[T] ⇒ Directive1[T] // this type is too specific and only a placeholder for a proper polymorphic function
-                              ): Directive0 = {
+  def pathMatcherDirective[T](
+    matchers: immutable.Seq[PathMatcher[_]],
+    directive: PathMatcher1[T] ⇒ Directive1[T] // this type is too specific and only a placeholder for a proper polymorphic function
+  ): Directive0 = {
     // Concatenating PathMatchers is a bit complicated as we don't want to build up a tuple
     // but something which we can later split all the separate values and add them to the
     // ExtractionMap.
@@ -197,7 +198,7 @@ private[http] object RouteImplementation extends Directives with server.RouteCon
         Tuple1(prefix._1 ++ suffix._1)
     }
     def toScala(matcher: PathMatcher[_]): ScalaPathMatcher[ValMap] =
-      matcher.asInstanceOf[PathMatcherImpl[_]].matcher.transform(_.map(v ⇒ Tuple1(Map(matcher -> v._1))))
+      matcher.asInstanceOf[PathMatcherImpl[_]].matcher.transform(_.map(v ⇒ Tuple1(Map(matcher → v._1))))
     def addExtractions(valMap: T): Directive0 = transformExtractionMap(_.addAll(valMap.asInstanceOf[Map[RequestVal[_], Any]]))
     val reduced: ScalaPathMatcher[ValMap] = matchers.map(toScala).reduce(_.~(_)(AddToMapJoin))
     directive(reduced.asInstanceOf[PathMatcher1[T]]).flatMap(addExtractions)

--- a/akka-http/src/main/scala/akka/http/javadsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/HttpApp.scala
@@ -14,8 +14,8 @@ import java.util.concurrent.CompletionStage
  * to start the server on the specified interface.
  */
 abstract class HttpApp
-  extends AllDirectives
-  with HttpServiceBase {
+    extends AllDirectives
+    with HttpServiceBase {
   def createRoute(): Route
 
   /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
@@ -50,7 +50,7 @@ abstract class RejectionHandler {
    * Signals that the request was rejected because a query parameter could not be interpreted.
    */
   def handleMalformedQueryParamRejection(ctx: RequestContext, parameterName: String, errorMsg: String,
-                                         cause: Throwable): RouteResult = passRejection()
+    cause: Throwable): RouteResult = passRejection()
 
   /**
    * Callback called to handle rejection created by form field filters.
@@ -63,7 +63,7 @@ abstract class RejectionHandler {
    * Signals that the request was rejected because a form field could not be interpreted.
    */
   def handleMalformedFormFieldRejection(ctx: RequestContext, fieldName: String, errorMsg: String,
-                                        cause: Throwable): RouteResult = passRejection()
+    cause: Throwable): RouteResult = passRejection()
 
   /**
    * Callback called to handle rejection created by header directives.
@@ -76,7 +76,7 @@ abstract class RejectionHandler {
    * Signals that the request was rejected because a header value is malformed.
    */
   def handleMalformedHeaderRejection(ctx: RequestContext, headerName: String, errorMsg: String,
-                                     cause: Throwable): RouteResult = passRejection()
+    cause: Throwable): RouteResult = passRejection()
 
   /**
    * Callback called to handle rejection created by unmarshallers.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
@@ -169,7 +169,7 @@ abstract class BasicDirectives extends BasicDirectivesBase {
       /** Makes sure both RouteResult and Future[RouteResult] are acceptable result types. */
       def adaptResult(method: Method): (RequestContext, AnyRef) ⇒ RouteResult =
         if (returnsFuture(method)) (ctx, v) ⇒ ctx.completeWith(v.asInstanceOf[Future[RouteResult]].toJava)
-        else if (returnsCompletionStage(method)) (ctx, v) => ctx.completeWith(v.asInstanceOf[CompletionStage[RouteResult]])
+        else if (returnsCompletionStage(method)) (ctx, v) ⇒ ctx.completeWith(v.asInstanceOf[CompletionStage[RouteResult]])
         else (_, v) ⇒ v.asInstanceOf[RouteResult]
 
       val IdentityAdaptor: (RequestContext, Seq[Any]) ⇒ Seq[Any] = (_, ps) ⇒ ps

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/MiscDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/MiscDirectives.scala
@@ -36,11 +36,12 @@ abstract class MiscDirectives extends MethodDirectives {
    * route is rejected with a [[akka.http.scaladsl.server.ValidationRejection]].
    */
   @varargs
-  def validate[T1, T2](value1: RequestVal[T1],
-                       value2: RequestVal[T2],
-                       check: Function2[T1, T2, JBoolean],
-                       errorMsg: String,
-                       innerRoute: Route, moreInnerRoutes: Route*): Route =
+  def validate[T1, T2](
+    value1: RequestVal[T1],
+    value2: RequestVal[T2],
+    check: Function2[T1, T2, JBoolean],
+    errorMsg: String,
+    innerRoute: Route, moreInnerRoutes: Route*): Route =
     new DynamicDirectiveRoute2[T1, T2](value1, value2)(innerRoute, moreInnerRoutes.toList) {
       def createDirective(t1: T1, t2: T2): Directive = Directives.custom(Validated(check.apply(t1, t2), errorMsg))
     }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/values/PathMatchers.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/values/PathMatchers.scala
@@ -51,7 +51,7 @@ object PathMatchers {
    * Creates a PathMatcher that consumes (a prefix of) the first path segment
    * (if the path begins with a segment) and extracts a given value.
    */
-  def segment(name: String): PathMatcher[String] = matcher(_ ⇒ name -> name)
+  def segment(name: String): PathMatcher[String] = matcher(_ ⇒ name → name)
 
   /**
    * A PathMatcher that efficiently matches a number of digits and extracts their (non-negative) Int value.

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
@@ -7,7 +7,7 @@ package akka.http.scaladsl.coding
 import akka.NotUsed
 import akka.http.scaladsl.model._
 import akka.stream.{ FlowShape, Materializer }
-import akka.stream.stage.{ GraphStage}
+import akka.stream.stage.{ GraphStage }
 import akka.util.ByteString
 import headers.HttpEncoding
 import akka.stream.scaladsl.{ Sink, Source, Flow }

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
@@ -103,7 +103,7 @@ class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefaul
 }
 
 abstract class DeflateDecompressorBase(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault)
-  extends ByteStringParser[ByteString] {
+    extends ByteStringParser[ByteString] {
 
   abstract class DecompressorParsingLogic extends ParsingLogic {
     val inflater: Inflater

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
@@ -125,5 +125,5 @@ private[http] object GzipDecompressor {
     0, // MTIME 4
     0, // XFL
     0 // OS
-    )
+  )
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/NoCoding.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/NoCoding.scala
@@ -7,7 +7,7 @@ package akka.http.scaladsl.coding
 import akka.http.scaladsl.model._
 import akka.http.impl.util.StreamUtils
 import akka.stream.FlowShape
-import akka.stream.stage.{ GraphStage}
+import akka.stream.stage.{ GraphStage }
 import akka.util.ByteString
 import headers.HttpEncodings
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
@@ -91,38 +91,38 @@ object StrictForm {
     }
   }
 
-  implicit def unmarshaller(implicit formDataUM: FromEntityUnmarshaller[FormData],
-                            multipartUM: FromEntityUnmarshaller[Multipart.FormData]): FromEntityUnmarshaller[StrictForm] =
-    Unmarshaller.withMaterializer { implicit ec ⇒
-      implicit fm ⇒
-        entity ⇒
+  implicit def unmarshaller(implicit
+    formDataUM: FromEntityUnmarshaller[FormData],
+    multipartUM: FromEntityUnmarshaller[Multipart.FormData]): FromEntityUnmarshaller[StrictForm] =
+    Unmarshaller.withMaterializer { implicit ec ⇒ implicit fm ⇒
+      entity ⇒
 
-          def tryUnmarshalToQueryForm: Future[StrictForm] =
-            for (formData ← formDataUM(entity).fast) yield {
-              new StrictForm {
-                val fields = formData.fields.map { case (name, value) ⇒ name -> Field.FromString(value) }(collection.breakOut)
-              }
+        def tryUnmarshalToQueryForm: Future[StrictForm] =
+          for (formData ← formDataUM(entity).fast) yield {
+            new StrictForm {
+              val fields = formData.fields.map { case (name, value) ⇒ name → Field.FromString(value) }(collection.breakOut)
             }
-
-          def tryUnmarshalToMultipartForm: Future[StrictForm] =
-            for {
-              multiPartFD ← multipartUM(entity).fast
-              strictMultiPartFD ← multiPartFD.toStrict(10.seconds).fast // TODO: make timeout configurable
-            } yield {
-              new StrictForm {
-                val fields = strictMultiPartFD.strictParts.map {
-                  case x: Multipart.FormData.BodyPart.Strict ⇒ x.name -> Field.FromPart(x)
-                }(collection.breakOut)
-              }
-            }
-
-          tryUnmarshalToQueryForm.fast.recoverWith {
-            case Unmarshaller.UnsupportedContentTypeException(supported1) ⇒
-              tryUnmarshalToMultipartForm.fast.recoverWith {
-                case Unmarshaller.UnsupportedContentTypeException(supported2) ⇒
-                  FastFuture.failed(Unmarshaller.UnsupportedContentTypeException(supported1 ++ supported2))
-              }
           }
+
+        def tryUnmarshalToMultipartForm: Future[StrictForm] =
+          for {
+            multiPartFD ← multipartUM(entity).fast
+            strictMultiPartFD ← multiPartFD.toStrict(10.seconds).fast // TODO: make timeout configurable
+          } yield {
+            new StrictForm {
+              val fields = strictMultiPartFD.strictParts.map {
+                case x: Multipart.FormData.BodyPart.Strict ⇒ x.name → Field.FromPart(x)
+              }(collection.breakOut)
+            }
+          }
+
+        tryUnmarshalToQueryForm.fast.recoverWith {
+          case Unmarshaller.UnsupportedContentTypeException(supported1) ⇒
+            tryUnmarshalToMultipartForm.fast.recoverWith {
+              case Unmarshaller.UnsupportedContentTypeException(supported2) ⇒
+                FastFuture.failed(Unmarshaller.UnsupportedContentTypeException(supported1 ++ supported2))
+            }
+        }
     }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ContentTypeOverrider.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ContentTypeOverrider.scala
@@ -21,7 +21,7 @@ object ContentTypeOverrider {
   implicit def forHeadersAndEntity[T <: HttpEntity]: ContentTypeOverrider[(immutable.Seq[HttpHeader], T)] =
     new ContentTypeOverrider[(immutable.Seq[HttpHeader], T)] {
       def apply(value: (immutable.Seq[HttpHeader], T), newContentType: ContentType) =
-        value._1 -> value._2.withContentType(newContentType).asInstanceOf[T]
+        value._1 → value._2.withContentType(newContentType).asInstanceOf[T]
     }
 
   implicit val forResponse: ContentTypeOverrider[HttpResponse] =

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/EmptyValue.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/EmptyValue.scala
@@ -14,7 +14,7 @@ object EmptyValue {
     new EmptyValue[UniversalEntity](HttpEntity.Empty)
 
   implicit val emptyHeadersAndEntity: EmptyValue[(immutable.Seq[HttpHeader], UniversalEntity)] =
-    new EmptyValue[(immutable.Seq[HttpHeader], UniversalEntity)](Nil -> HttpEntity.Empty)
+    new EmptyValue[(immutable.Seq[HttpHeader], UniversalEntity)](Nil → HttpEntity.Empty)
 
   implicit val emptyResponse: EmptyValue[HttpResponse] =
     new EmptyValue[HttpResponse](HttpResponse(entity = emptyEntity.emptyValue))

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
@@ -35,36 +35,35 @@ sealed abstract class Marshaller[-A, +B] {
    * If the wrapping is illegal the [[scala.concurrent.Future]] produced by the resulting marshaller will contain a [[RuntimeException]].
    */
   def wrapWithEC[C, D >: B](newMediaType: MediaType)(f: ExecutionContext ⇒ C ⇒ A)(implicit cto: ContentTypeOverrider[D]): Marshaller[C, D] =
-    Marshaller { implicit ec ⇒
-      value ⇒
-        import Marshalling._
-        this(f(ec)(value)).fast map {
-          _ map {
-            (_, newMediaType) match {
-              case (WithFixedContentType(_, marshal), newMT: MediaType.Binary) ⇒
-                WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
-              case (WithFixedContentType(oldCT: ContentType.Binary, marshal), newMT: MediaType.WithFixedCharset) ⇒
-                WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
-              case (WithFixedContentType(oldCT: ContentType.NonBinary, marshal), newMT: MediaType.WithFixedCharset) if oldCT.charset == newMT.charset ⇒
-                WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
-              case (WithFixedContentType(oldCT: ContentType.NonBinary, marshal), newMT: MediaType.WithOpenCharset) ⇒
-                val newCT = newMT withCharset oldCT.charset
-                WithFixedContentType(newCT, () ⇒ cto(marshal(), newCT))
+    Marshaller { implicit ec ⇒ value ⇒
+      import Marshalling._
+      this(f(ec)(value)).fast map {
+        _ map {
+          (_, newMediaType) match {
+            case (WithFixedContentType(_, marshal), newMT: MediaType.Binary) ⇒
+              WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
+            case (WithFixedContentType(oldCT: ContentType.Binary, marshal), newMT: MediaType.WithFixedCharset) ⇒
+              WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
+            case (WithFixedContentType(oldCT: ContentType.NonBinary, marshal), newMT: MediaType.WithFixedCharset) if oldCT.charset == newMT.charset ⇒
+              WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
+            case (WithFixedContentType(oldCT: ContentType.NonBinary, marshal), newMT: MediaType.WithOpenCharset) ⇒
+              val newCT = newMT withCharset oldCT.charset
+              WithFixedContentType(newCT, () ⇒ cto(marshal(), newCT))
 
-              case (WithOpenCharset(oldMT, marshal), newMT: MediaType.WithOpenCharset) ⇒
-                WithOpenCharset(newMT, cs ⇒ cto(marshal(cs), newMT withCharset cs))
-              case (WithOpenCharset(oldMT, marshal), newMT: MediaType.WithFixedCharset) ⇒
-                WithFixedContentType(newMT, () ⇒ cto(marshal(newMT.charset), newMT))
+            case (WithOpenCharset(oldMT, marshal), newMT: MediaType.WithOpenCharset) ⇒
+              WithOpenCharset(newMT, cs ⇒ cto(marshal(cs), newMT withCharset cs))
+            case (WithOpenCharset(oldMT, marshal), newMT: MediaType.WithFixedCharset) ⇒
+              WithFixedContentType(newMT, () ⇒ cto(marshal(newMT.charset), newMT))
 
-              case (Opaque(marshal), newMT: MediaType.Binary) ⇒
-                WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
-              case (Opaque(marshal), newMT: MediaType.WithFixedCharset) ⇒
-                WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
+            case (Opaque(marshal), newMT: MediaType.Binary) ⇒
+              WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
+            case (Opaque(marshal), newMT: MediaType.WithFixedCharset) ⇒
+              WithFixedContentType(newMT, () ⇒ cto(marshal(), newMT))
 
-              case x ⇒ sys.error(s"Illegal marshaller wrapping. Marshalling `$x` cannot be wrapped with MediaType `$newMediaType`")
-            }
+            case x ⇒ sys.error(s"Illegal marshaller wrapping. Marshalling `$x` cannot be wrapped with MediaType `$newMediaType`")
           }
         }
+      }
     }
 
   def compose[C](f: C ⇒ A): Marshaller[C, B] =
@@ -76,10 +75,10 @@ sealed abstract class Marshaller[-A, +B] {
 
 //# marshaller-creation
 object Marshaller
-  extends GenericMarshallers
-  with PredefinedToEntityMarshallers
-  with PredefinedToResponseMarshallers
-  with PredefinedToRequestMarshallers {
+    extends GenericMarshallers
+    with PredefinedToEntityMarshallers
+    with PredefinedToResponseMarshallers
+    with PredefinedToRequestMarshallers {
 
   /**
    * Creates a [[Marshaller]] from the given function.
@@ -151,16 +150,18 @@ object Marshalling {
   /**
    * A Marshalling to a specific [[akka.http.scaladsl.model.ContentType]].
    */
-  final case class WithFixedContentType[A](contentType: ContentType,
-                                           marshal: () ⇒ A) extends Marshalling[A] {
+  final case class WithFixedContentType[A](
+    contentType: ContentType,
+      marshal: () ⇒ A) extends Marshalling[A] {
     def map[B](f: A ⇒ B): WithFixedContentType[B] = copy(marshal = () ⇒ f(marshal()))
   }
 
   /**
    * A Marshalling to a specific [[akka.http.scaladsl.model.MediaType]] with a flexible charset.
    */
-  final case class WithOpenCharset[A](mediaType: MediaType.WithOpenCharset,
-                                      marshal: HttpCharset ⇒ A) extends Marshalling[A] {
+  final case class WithOpenCharset[A](
+    mediaType: MediaType.WithOpenCharset,
+      marshal: HttpCharset ⇒ A) extends Marshalling[A] {
     def map[B](f: A ⇒ B): WithOpenCharset[B] = copy(marshal = cs ⇒ f(marshal(cs)))
   }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
@@ -15,9 +15,11 @@ trait PredefinedToResponseMarshallers extends LowPriorityToResponseMarshallerImp
 
   private type TRM[T] = ToResponseMarshaller[T] // brevity alias
 
-  def fromToEntityMarshaller[T](status: StatusCode = StatusCodes.OK,
-                                headers: immutable.Seq[HttpHeader] = Nil)(
-                                  implicit m: ToEntityMarshaller[T]): ToResponseMarshaller[T] =
+  def fromToEntityMarshaller[T](
+    status: StatusCode = StatusCodes.OK,
+    headers: immutable.Seq[HttpHeader] = Nil)(
+    implicit
+    m: ToEntityMarshaller[T]): ToResponseMarshaller[T] =
     fromStatusCodeAndHeadersAndValue compose (t ⇒ (status, headers, t))
 
   implicit val fromResponse: TRM[HttpResponse] = Marshaller.opaque(ConstantFun.scalaIdentityFunction)
@@ -30,8 +32,9 @@ trait PredefinedToResponseMarshallers extends LowPriorityToResponseMarshallerImp
   implicit def fromStatusCodeAndValue[S, T](implicit sConv: S ⇒ StatusCode, mt: ToEntityMarshaller[T]): TRM[(S, T)] =
     fromStatusCodeAndHeadersAndValue[T] compose { case (status, value) ⇒ (sConv(status), Nil, value) }
 
-  implicit def fromStatusCodeConvertibleAndHeadersAndT[S, T](implicit sConv: S ⇒ StatusCode,
-                                                             mt: ToEntityMarshaller[T]): TRM[(S, immutable.Seq[HttpHeader], T)] =
+  implicit def fromStatusCodeConvertibleAndHeadersAndT[S, T](implicit
+    sConv: S ⇒ StatusCode,
+    mt: ToEntityMarshaller[T]): TRM[(S, immutable.Seq[HttpHeader], T)] =
     fromStatusCodeAndHeadersAndValue[T] compose { case (status, headers, value) ⇒ (sConv(status), headers, value) }
 
   implicit def fromStatusCodeAndHeadersAndValue[T](implicit mt: ToEntityMarshaller[T]): TRM[(StatusCode, immutable.Seq[HttpHeader], T)] =

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
@@ -44,12 +44,11 @@ abstract class Directive[L](implicit val ev: Tuple[L]) {
   def as[A](constructor: ConstructFromTuple[L, A]): Directive1[A] = {
     def validatedMap[R](f: L ⇒ R)(implicit tupler: Tupler[R]): Directive[tupler.Out] =
       Directive[tupler.Out] { inner ⇒
-        tapply { values ⇒
-          ctx ⇒
-            try inner(tupler(f(values)))(ctx)
-            catch {
-              case e: IllegalArgumentException ⇒ ctx.reject(ValidationRejection(e.getMessage.nullAsEmpty, Some(e)))
-            }
+        tapply { values ⇒ ctx ⇒
+          try inner(tupler(f(values)))(ctx)
+          catch {
+            case e: IllegalArgumentException ⇒ ctx.reject(ValidationRejection(e.getMessage.nullAsEmpty, Some(e)))
+          }
         }
       }(tupler.OutIsTuple)
 
@@ -88,14 +87,13 @@ abstract class Directive[L](implicit val ev: Tuple[L]) {
    * **before the inner route was applied**.
    */
   def recover[R >: L: Tuple](recovery: immutable.Seq[Rejection] ⇒ Directive[R]): Directive[R] =
-    Directive[R] { inner ⇒
-      ctx ⇒
-        import ctx.executionContext
-        @volatile var rejectedFromInnerRoute = false
-        tapply({ list ⇒ c ⇒ rejectedFromInnerRoute = true; inner(list)(c) })(ctx).fast.flatMap {
-          case RouteResult.Rejected(rejections) if !rejectedFromInnerRoute ⇒ recovery(rejections).tapply(inner)(ctx)
-          case x ⇒ FastFuture.successful(x)
-        }
+    Directive[R] { inner ⇒ ctx ⇒
+      import ctx.executionContext
+      @volatile var rejectedFromInnerRoute = false
+      tapply({ list ⇒ c ⇒ rejectedFromInnerRoute = true; inner(list)(c) })(ctx).fast.flatMap {
+        case RouteResult.Rejected(rejections) if !rejectedFromInnerRoute ⇒ recovery(rejections).tapply(inner)(ctx)
+        case x ⇒ FastFuture.successful(x)
+      }
     }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -40,7 +40,8 @@ object ExceptionHandler {
   def default(settings: RoutingSettings): ExceptionHandler =
     apply(knownToBeSealed = true) {
       case IllegalRequestException(info, status) ⇒ ctx ⇒ {
-        ctx.log.warning("Illegal request {}\n\t{}\n\tCompleting with '{}' response",
+        ctx.log.warning(
+          "Illegal request {}\n\t{}\n\tCompleting with '{}' response",
           ctx.request, info.formatPretty, status)
         ctx.complete((status, info.format(settings.verboseErrorMessages)))
       }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
@@ -415,7 +415,7 @@ trait PathMatchers {
    * @group pathmatcher
    */
   abstract class NumberMatcher[@specialized(Int, Long) T](max: T, base: T)(implicit x: Integral[T])
-    extends PathMatcher1[T] {
+      extends PathMatcher1[T] {
 
     import x._ // import implicit conversions for numeric operators
     val minusOne = x.zero - x.one

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -38,7 +38,7 @@ case class MissingQueryParamRejection(parameterName: String) extends Rejection
  * Signals that the request was rejected because a query parameter could not be interpreted.
  */
 case class MalformedQueryParamRejection(parameterName: String, errorMsg: String,
-                                        cause: Option[Throwable] = None) extends Rejection
+  cause: Option[Throwable] = None) extends Rejection
 
 /**
  * Rejection created by form field filters.
@@ -51,7 +51,7 @@ case class MissingFormFieldRejection(fieldName: String) extends Rejection
  * Signals that the request was rejected because a form field could not be interpreted.
  */
 case class MalformedFormFieldRejection(fieldName: String, errorMsg: String,
-                                       cause: Option[Throwable] = None) extends Rejection
+  cause: Option[Throwable] = None) extends Rejection
 
 /**
  * Rejection created by header directives.
@@ -64,7 +64,7 @@ case class MissingHeaderRejection(headerName: String) extends Rejection
  * Signals that the request was rejected because a header value is malformed.
  */
 case class MalformedHeaderRejection(headerName: String, errorMsg: String,
-                                    cause: Option[Throwable] = None) extends Rejection
+  cause: Option[Throwable] = None) extends Rejection
 
 /**
  * Rejection created by unmarshallers.
@@ -129,8 +129,9 @@ object UnacceptedResponseEncodingRejection {
  * Signals that the request was rejected because the user could not be authenticated. The reason for the rejection is
  * specified in the cause.
  */
-case class AuthenticationFailedRejection(cause: AuthenticationFailedRejection.Cause,
-                                         challenge: HttpChallenge) extends Rejection
+case class AuthenticationFailedRejection(
+  cause: AuthenticationFailedRejection.Cause,
+  challenge: HttpChallenge) extends Rejection
 
 object AuthenticationFailedRejection {
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -83,14 +83,15 @@ object RejectionHandler {
   private sealed abstract class Handler
   private final case class CaseHandler(pf: PartialFunction[Rejection, Route]) extends Handler
   private final case class TypeHandler[T <: Rejection](
-    runtimeClass: Class[_], f: immutable.Seq[T] ⇒ Route) extends Handler with PartialFunction[Rejection, T] {
+      runtimeClass: Class[_], f: immutable.Seq[T] ⇒ Route) extends Handler with PartialFunction[Rejection, T] {
     def isDefinedAt(rejection: Rejection) = runtimeClass isInstance rejection
     def apply(rejection: Rejection) = rejection.asInstanceOf[T]
   }
 
-  private class BuiltRejectionHandler(val cases: Vector[Handler],
-                                      val notFound: Option[Route],
-                                      val isDefault: Boolean) extends RejectionHandler {
+  private class BuiltRejectionHandler(
+    val cases: Vector[Handler],
+      val notFound: Option[Route],
+      val isDefault: Boolean) extends RejectionHandler {
     def apply(rejections: immutable.Seq[Rejection]): Option[Route] =
       if (rejections.nonEmpty) {
         @tailrec def rec(ix: Int): Option[Route] =
@@ -120,7 +121,7 @@ object RejectionHandler {
         complete((BadRequest, "Uri scheme not allowed, supported schemes: " + schemes))
       }
       .handleAll[MethodRejection] { rejections ⇒
-        val (methods, names) = rejections.map(r ⇒ r.supported -> r.supported.name).unzip
+        val (methods, names) = rejections.map(r ⇒ r.supported → r.supported.name).unzip
         complete((MethodNotAllowed, List(Allow(methods)), "HTTP method not allowed, supported methods: " + names.mkString(", ")))
       }
       .handle {
@@ -207,7 +208,8 @@ object RejectionHandler {
       .handle { case ExpectedWebSocketRequestRejection ⇒ complete((BadRequest, "Expected WebSocket Upgrade request")) }
       .handleAll[UnsupportedWebSocketSubprotocolRejection] { rejections ⇒
         val supported = rejections.map(_.supportedProtocol)
-        complete(HttpResponse(BadRequest,
+        complete(HttpResponse(
+          BadRequest,
           entity = s"None of the websocket subprotocols offered in the request are supported. Supported are ${supported.map("'" + _ + "'").mkString(",")}.",
           headers = `Sec-WebSocket-Protocol`(supported) :: Nil))
       }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
@@ -17,13 +17,13 @@ import akka.http.scaladsl.util.FastFuture._
  * INTERNAL API
  */
 private[http] class RequestContextImpl(
-  val request: HttpRequest,
-  val unmatchedPath: Uri.Path,
-  val executionContext: ExecutionContextExecutor,
-  val materializer: Materializer,
-  val log: LoggingAdapter,
-  val settings: RoutingSettings,
-  val parserSettings: ParserSettings) extends RequestContext {
+    val request: HttpRequest,
+    val unmatchedPath: Uri.Path,
+    val executionContext: ExecutionContextExecutor,
+    val materializer: Materializer,
+    val log: LoggingAdapter,
+    val settings: RoutingSettings,
+    val parserSettings: ParserSettings) extends RequestContext {
 
   def this(request: HttpRequest, log: LoggingAdapter, settings: RoutingSettings, parserSettings: ParserSettings)(implicit ec: ExecutionContextExecutor, materializer: Materializer) =
     this(request, request.uri.path, ec, materializer, log, settings, parserSettings)
@@ -97,12 +97,13 @@ private[http] class RequestContextImpl(
       case _ ⇒ Future.successful(RouteResult.Rejected(UnacceptedResponseContentTypeRejection(supported) :: Nil))
     }
 
-  private def copy(request: HttpRequest = request,
-                   unmatchedPath: Uri.Path = unmatchedPath,
-                   executionContext: ExecutionContextExecutor = executionContext,
-                   materializer: Materializer = materializer,
-                   log: LoggingAdapter = log,
-                   routingSettings: RoutingSettings = settings,
-                   parserSettings: ParserSettings = parserSettings) =
+  private def copy(
+    request: HttpRequest = request,
+    unmatchedPath: Uri.Path = unmatchedPath,
+    executionContext: ExecutionContextExecutor = executionContext,
+    materializer: Materializer = materializer,
+    log: LoggingAdapter = log,
+    routingSettings: RoutingSettings = settings,
+    parserSettings: ParserSettings = parserSettings) =
     new RequestContextImpl(request, unmatchedPath, executionContext, materializer, log, routingSettings, parserSettings)
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -23,10 +23,11 @@ object Route {
   /**
    * "Seals" a route by wrapping it with exception handling and rejection conversion.
    */
-  def seal(route: Route)(implicit routingSettings: RoutingSettings,
-                         parserSettings: ParserSettings = null,
-                         rejectionHandler: RejectionHandler = RejectionHandler.default,
-                         exceptionHandler: ExceptionHandler = null): Route = {
+  def seal(route: Route)(implicit
+    routingSettings: RoutingSettings,
+    parserSettings: ParserSettings = null,
+    rejectionHandler: RejectionHandler = RejectionHandler.default,
+    exceptionHandler: ExceptionHandler = null): Route = {
     import directives.ExecutionDirectives._
     handleExceptions(ExceptionHandler.seal(exceptionHandler)) {
       handleRejections(rejectionHandler.seal) {
@@ -40,25 +41,27 @@ object Route {
    *
    * This conversion is also implicitly available through [[RouteResult#route2HandlerFlow]].
    */
-  def handlerFlow(route: Route)(implicit routingSettings: RoutingSettings,
-                                parserSettings: ParserSettings,
-                                materializer: Materializer,
-                                routingLog: RoutingLog,
-                                executionContext: ExecutionContextExecutor = null,
-                                rejectionHandler: RejectionHandler = RejectionHandler.default,
-                                exceptionHandler: ExceptionHandler = null): Flow[HttpRequest, HttpResponse, NotUsed] =
+  def handlerFlow(route: Route)(implicit
+    routingSettings: RoutingSettings,
+    parserSettings: ParserSettings,
+    materializer: Materializer,
+    routingLog: RoutingLog,
+    executionContext: ExecutionContextExecutor = null,
+    rejectionHandler: RejectionHandler = RejectionHandler.default,
+    exceptionHandler: ExceptionHandler = null): Flow[HttpRequest, HttpResponse, NotUsed] =
     Flow[HttpRequest].mapAsync(1)(asyncHandler(route))
 
   /**
    * Turns a `Route` into an async handler function.
    */
-  def asyncHandler(route: Route)(implicit routingSettings: RoutingSettings,
-                                 parserSettings: ParserSettings,
-                                 materializer: Materializer,
-                                 routingLog: RoutingLog,
-                                 executionContext: ExecutionContextExecutor = null,
-                                 rejectionHandler: RejectionHandler = RejectionHandler.default,
-                                 exceptionHandler: ExceptionHandler = null): HttpRequest ⇒ Future[HttpResponse] = {
+  def asyncHandler(route: Route)(implicit
+    routingSettings: RoutingSettings,
+    parserSettings: ParserSettings,
+    materializer: Materializer,
+    routingLog: RoutingLog,
+    executionContext: ExecutionContextExecutor = null,
+    rejectionHandler: RejectionHandler = RejectionHandler.default,
+    exceptionHandler: ExceptionHandler = null): HttpRequest ⇒ Future[HttpResponse] = {
     val effectiveEC = if (executionContext ne null) executionContext else materializer.executionContext
 
     {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -24,12 +24,13 @@ object RouteResult {
   final case class Complete(response: HttpResponse) extends RouteResult
   final case class Rejected(rejections: immutable.Seq[Rejection]) extends RouteResult
 
-  implicit def route2HandlerFlow(route: Route)(implicit routingSettings: RoutingSettings,
-                                               parserSettings: ParserSettings,
-                                               materializer: Materializer,
-                                               routingLog: RoutingLog,
-                                               executionContext: ExecutionContext = null,
-                                               rejectionHandler: RejectionHandler = RejectionHandler.default,
-                                               exceptionHandler: ExceptionHandler = null): Flow[HttpRequest, HttpResponse, NotUsed] =
+  implicit def route2HandlerFlow(route: Route)(implicit
+    routingSettings: RoutingSettings,
+    parserSettings: ParserSettings,
+    materializer: Materializer,
+    routingLog: RoutingLog,
+    executionContext: ExecutionContext = null,
+    rejectionHandler: RejectionHandler = RejectionHandler.default,
+    exceptionHandler: ExceptionHandler = null): Flow[HttpRequest, HttpResponse, NotUsed] =
     Route.handlerFlow(route)
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DebuggingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DebuggingDirectives.scala
@@ -61,7 +61,7 @@ case class LoggingMagnet[T](f: LoggingAdapter ⇒ T) // # logging-magnet
 
 object LoggingMagnet {
   implicit def forMessageFromMarker[T](marker: String): LoggingMagnet[T ⇒ Unit] = // # message-magnets
-    forMessageFromMarkerAndLevel[T](marker -> DebugLevel)
+    forMessageFromMarkerAndLevel[T](marker → DebugLevel)
 
   implicit def forMessageFromMarkerAndLevel[T](markerAndLevel: (String, LogLevel)): LoggingMagnet[T ⇒ Unit] = // # message-magnets
     forMessageFromFullShow[T] {
@@ -76,7 +76,7 @@ object LoggingMagnet {
     LoggingMagnet(log ⇒ show(_).logTo(log))
 
   implicit def forRequestResponseFromMarker(marker: String): LoggingMagnet[HttpRequest ⇒ RouteResult ⇒ Unit] = // # request-response-magnets
-    forRequestResponseFromMarkerAndLevel(marker -> DebugLevel)
+    forRequestResponseFromMarkerAndLevel(marker → DebugLevel)
 
   implicit def forRequestResponseFromMarkerAndLevel(markerAndLevel: (String, LogLevel)): LoggingMagnet[HttpRequest ⇒ RouteResult ⇒ Unit] = // # request-response-magnets
     forRequestResponseFromFullShow {
@@ -86,10 +86,9 @@ object LoggingMagnet {
     }
 
   implicit def forRequestResponseFromFullShow(show: HttpRequest ⇒ RouteResult ⇒ Option[LogEntry]): LoggingMagnet[HttpRequest ⇒ RouteResult ⇒ Unit] = // # request-response-magnets
-    LoggingMagnet { log ⇒
-      request ⇒
-        val showResult = show(request)
-        result ⇒ showResult(result).foreach(_.logTo(log))
+    LoggingMagnet { log ⇒ request ⇒
+      val showResult = show(request)
+      result ⇒ showResult(result).foreach(_.logTo(log))
     }
 }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala
@@ -25,15 +25,14 @@ trait ExecutionDirectives {
    * @group execution
    */
   def handleExceptions(handler: ExceptionHandler): Directive0 =
-    Directive { innerRouteBuilder ⇒
-      ctx ⇒
-        import ctx.executionContext
-        def handleException: PartialFunction[Throwable, Future[RouteResult]] =
-          handler andThen (_(ctx.withAcceptAll))
-        try innerRouteBuilder(())(ctx).fast.recoverWith(handleException)
-        catch {
-          case NonFatal(e) ⇒ handleException.applyOrElse[Throwable, Future[RouteResult]](e, throw _)
-        }
+    Directive { innerRouteBuilder ⇒ ctx ⇒
+      import ctx.executionContext
+      def handleException: PartialFunction[Throwable, Future[RouteResult]] =
+        handler andThen (_(ctx.withAcceptAll))
+      try innerRouteBuilder(())(ctx).fast.recoverWith(handleException)
+      catch {
+        case NonFatal(e) ⇒ handleException.applyOrElse[Throwable, Future[RouteResult]](e, throw _)
+      }
     }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -332,39 +332,38 @@ object DirectoryListing {
       |""".stripMarginWithNewline("\n") split '$'
 
   def directoryMarshaller(renderVanityFooter: Boolean): ToEntityMarshaller[DirectoryListing] =
-    Marshaller.StringMarshaller.wrapWithEC(MediaTypes.`text/html`) { implicit ec ⇒
-      listing ⇒
-        val DirectoryListing(path, isRoot, files) = listing
-        val filesAndNames = files.map(file ⇒ file -> file.getName).sortBy(_._2)
-        val deduped = filesAndNames.zipWithIndex.flatMap {
-          case (fan @ (file, name), ix) ⇒
-            if (ix == 0 || filesAndNames(ix - 1)._2 != name) Some(fan) else None
-        }
-        val (directoryFilesAndNames, fileFilesAndNames) = deduped.partition(_._1.isDirectory)
-        def maxNameLength(seq: Seq[(File, String)]) = if (seq.isEmpty) 0 else seq.map(_._2.length).max
-        val maxNameLen = math.max(maxNameLength(directoryFilesAndNames) + 1, maxNameLength(fileFilesAndNames))
-        val sb = new java.lang.StringBuilder
-        sb.append(html(0)).append(path).append(html(1)).append(path).append(html(2))
-        if (!isRoot) {
-          val secondToLastSlash = path.lastIndexOf('/', path.lastIndexOf('/', path.length - 1) - 1)
-          sb.append("<a href=\"%s/\">../</a>\n" format path.substring(0, secondToLastSlash))
-        }
-        def lastModified(file: File) = DateTime(file.lastModified).toIsoLikeDateTimeString
-        def start(name: String) =
-          sb.append("<a href=\"").append(path + name).append("\">").append(name).append("</a>")
-            .append(" " * (maxNameLen - name.length))
-        def renderDirectory(file: File, name: String) =
-          start(name + '/').append("        ").append(lastModified(file)).append('\n')
-        def renderFile(file: File, name: String) = {
-          val size = akka.http.impl.util.humanReadableByteCount(file.length, si = true)
-          start(name).append("        ").append(lastModified(file))
-          sb.append("                ".substring(size.length)).append(size).append('\n')
-        }
-        for ((file, name) ← directoryFilesAndNames) renderDirectory(file, name)
-        for ((file, name) ← fileFilesAndNames) renderFile(file, name)
-        if (isRoot && files.isEmpty) sb.append("(no files)\n")
-        sb.append(html(3))
-        if (renderVanityFooter) sb.append(html(4)).append(DateTime.now.toIsoLikeDateTimeString).append(html(5))
-        sb.append(html(6)).toString
+    Marshaller.StringMarshaller.wrapWithEC(MediaTypes.`text/html`) { implicit ec ⇒ listing ⇒
+      val DirectoryListing(path, isRoot, files) = listing
+      val filesAndNames = files.map(file ⇒ file → file.getName).sortBy(_._2)
+      val deduped = filesAndNames.zipWithIndex.flatMap {
+        case (fan @ (file, name), ix) ⇒
+          if (ix == 0 || filesAndNames(ix - 1)._2 != name) Some(fan) else None
+      }
+      val (directoryFilesAndNames, fileFilesAndNames) = deduped.partition(_._1.isDirectory)
+      def maxNameLength(seq: Seq[(File, String)]) = if (seq.isEmpty) 0 else seq.map(_._2.length).max
+      val maxNameLen = math.max(maxNameLength(directoryFilesAndNames) + 1, maxNameLength(fileFilesAndNames))
+      val sb = new java.lang.StringBuilder
+      sb.append(html(0)).append(path).append(html(1)).append(path).append(html(2))
+      if (!isRoot) {
+        val secondToLastSlash = path.lastIndexOf('/', path.lastIndexOf('/', path.length - 1) - 1)
+        sb.append("<a href=\"%s/\">../</a>\n" format path.substring(0, secondToLastSlash))
+      }
+      def lastModified(file: File) = DateTime(file.lastModified).toIsoLikeDateTimeString
+      def start(name: String) =
+        sb.append("<a href=\"").append(path + name).append("\">").append(name).append("</a>")
+          .append(" " * (maxNameLen - name.length))
+      def renderDirectory(file: File, name: String) =
+        start(name + '/').append("        ").append(lastModified(file)).append('\n')
+      def renderFile(file: File, name: String) = {
+        val size = akka.http.impl.util.humanReadableByteCount(file.length, si = true)
+        start(name).append("        ").append(lastModified(file))
+        sb.append("                ".substring(size.length)).append(size).append('\n')
+      }
+      for ((file, name) ← directoryFilesAndNames) renderDirectory(file, name)
+      for ((file, name) ← fileFilesAndNames) renderFile(file, name)
+      if (isRoot && files.isEmpty) sb.append("(no files)\n")
+      sb.append(html(3))
+      if (renderVanityFooter) sb.append(html(4)).append(DateTime.now.toIsoLikeDateTimeString).append(html(5))
+      sb.append(html(6)).toString
     }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
@@ -174,7 +174,7 @@ object FormFieldDirectives extends FormFieldDirectives {
     //////////////////// required formField support ////////////////////
 
     private def requiredFilter[T](fieldName: String, fu: Unmarshaller[Option[StrictForm.Field], T],
-                                  requiredValue: Any)(implicit sfu: SFU): Directive0 =
+      requiredValue: Any)(implicit sfu: SFU): Directive0 =
       extract(fieldOfForm(fieldName, fu)).flatMap {
         onComplete(_).flatMap {
           case Success(value) if value == requiredValue ⇒ pass

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -6,12 +6,12 @@ package akka.http.scaladsl.server
 package directives
 
 import akka.http.javadsl.model.headers.CustomHeader
-import akka.http.scaladsl.model.headers.{ModeledCustomHeaderCompanion, ModeledCustomHeader, RawHeader}
+import akka.http.scaladsl.model.headers.{ ModeledCustomHeaderCompanion, ModeledCustomHeader, RawHeader }
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
-import akka.http.javadsl.{ model => jm }
+import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.server.util.ClassMagnet
 import akka.http.scaladsl.model._
 import akka.http.impl.util._
@@ -161,13 +161,12 @@ object HeaderMagnet extends LowPriorityHeaderMagnetImplicits {
    * If possible we want to apply the special logic for [[ModeledCustomHeader]] to extract custom headers by type,
    * otherwise the default `fromUnit` is good enough (for headers that the parser emits in the right type already).
    */
-  implicit def fromUnitForModeledCustomHeader[T <: ModeledCustomHeader[T], H <: ModeledCustomHeaderCompanion[T]]
-    (u: Unit)(implicit tag: ClassTag[T], companion: ModeledCustomHeaderCompanion[T]): HeaderMagnet[T] =
+  implicit def fromUnitForModeledCustomHeader[T <: ModeledCustomHeader[T], H <: ModeledCustomHeaderCompanion[T]](u: Unit)(implicit tag: ClassTag[T], companion: ModeledCustomHeaderCompanion[T]): HeaderMagnet[T] =
     new HeaderMagnet[T] {
       override def runtimeClass = tag.runtimeClass.asInstanceOf[Class[T]]
       override def classTag = tag
       override def extractPF = {
-        case h if h.is(companion.lowercaseName) => companion.apply(h.toString)
+        case h if h.is(companion.lowercaseName) ⇒ companion.apply(h.toString)
       }
     }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.util.FastFuture._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.AuthenticationFailedRejection.{ CredentialsRejected, CredentialsMissing }
 
-import scala.util.{Try, Success}
+import scala.util.{ Try, Success }
 
 /**
  * Provides directives for securing an inner route using the standard Http authentication headers [[`WWW-Authenticate`]]
@@ -220,7 +220,7 @@ trait SecurityDirectives {
    * @group security
    */
   def authorize(check: RequestContext ⇒ Boolean): Directive0 =
-    authorizeAsync(ctx => Future.successful(check(ctx)))
+    authorizeAsync(ctx ⇒ Future.successful(check(ctx)))
 
   /**
    * Asynchronous version of [[authorize]].
@@ -230,7 +230,7 @@ trait SecurityDirectives {
    * @group security
    */
   def authorizeAsync(check: ⇒ Future[Boolean]): Directive0 =
-    authorizeAsync(ctx => check)
+    authorizeAsync(ctx ⇒ check)
 
   /**
    * Asynchronous version of [[authorize]].
@@ -241,10 +241,10 @@ trait SecurityDirectives {
    */
   def authorizeAsync(check: RequestContext ⇒ Future[Boolean]): Directive0 =
     extractExecutionContext.flatMap { implicit ec ⇒
-      extract(check).flatMap[Unit] { fa =>
+      extract(check).flatMap[Unit] { fa ⇒
         onComplete(fa).flatMap {
-          case Success(true) => pass
-          case _ => reject(AuthorizationFailedRejection)
+          case Success(true) ⇒ pass
+          case _             ⇒ reject(AuthorizationFailedRejection)
         }
       }
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala
@@ -57,17 +57,16 @@ trait TimeoutDirectives {
    * @group timeout
    */
   def withRequestTimeout(timeout: Duration, handler: Option[HttpRequest ⇒ HttpResponse]): Directive0 =
-    Directive { inner ⇒
-      ctx ⇒
-        ctx.request.header[`Timeout-Access`] match {
-          case Some(t) ⇒
-            handler match {
-              case Some(h) ⇒ t.timeoutAccess.update(timeout, h)
-              case _       ⇒ t.timeoutAccess.updateTimeout(timeout)
-            }
-          case _ ⇒ ctx.log.warning("withRequestTimeout was used in route however no request-timeout is set!")
-        }
-        inner()(ctx)
+    Directive { inner ⇒ ctx ⇒
+      ctx.request.header[`Timeout-Access`] match {
+        case Some(t) ⇒
+          handler match {
+            case Some(h) ⇒ t.timeoutAccess.update(timeout, h)
+            case _       ⇒ t.timeoutAccess.updateTimeout(timeout)
+          }
+        case _ ⇒ ctx.log.warning("withRequestTimeout was used in route however no request-timeout is set!")
+      }
+      inner()(ctx)
     }
 
   /**
@@ -80,13 +79,12 @@ trait TimeoutDirectives {
    * @group timeout
    */
   def withRequestTimeoutResponse(handler: HttpRequest ⇒ HttpResponse): Directive0 =
-    Directive { inner ⇒
-      ctx ⇒
-        ctx.request.header[`Timeout-Access`] match {
-          case Some(t) ⇒ t.timeoutAccess.updateHandler(handler)
-          case _       ⇒ ctx.log.warning("withRequestTimeoutResponse was used in route however no request-timeout is set!")
-        }
-        inner()(ctx)
+    Directive { inner ⇒ ctx ⇒
+      ctx.request.header[`Timeout-Access`] match {
+        case Some(t) ⇒ t.timeoutAccess.updateHandler(handler)
+        case _       ⇒ ctx.log.warning("withRequestTimeoutResponse was used in route however no request-timeout is set!")
+      }
+      inner()(ctx)
     }
 
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
@@ -10,7 +10,7 @@ import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
 import akka.util.ByteString
 import akka.event.{ NoLogging, LoggingAdapter }
-import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.stream.{ ActorMaterializer, OverflowStrategy }
 import akka.stream.impl.fusing.IteratorInterpreter
 import akka.stream.scaladsl._
 import akka.http.impl.engine.parsing.BodyPartParser
@@ -67,7 +67,7 @@ trait MultipartUnmarshallers {
     createStreamed: (MediaType.Multipart, Source[BP, Any]) ⇒ T,
     createStrictBodyPart: (HttpEntity.Strict, List[HttpHeader]) ⇒ BPS,
     createStrict: (MediaType.Multipart, immutable.Seq[BPS]) ⇒ T)(implicit log: LoggingAdapter = NoLogging, parserSettings: ParserSettings = null): FromEntityUnmarshaller[T] =
-    Unmarshaller.withMaterializer { implicit ec ⇒ mat =>
+    Unmarshaller.withMaterializer { implicit ec ⇒ mat ⇒
       entity ⇒
         if (entity.contentType.mediaType.isMultipart && mediaRange.matches(entity.contentType.mediaType)) {
           entity.contentType.mediaType.params.get("boundary") match {

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
@@ -40,9 +40,8 @@ trait PredefinedFromStringUnmarshallers {
   implicit def CsvSeq[T](implicit unmarshaller: Unmarshaller[String, T]): Unmarshaller[String, immutable.Seq[T]] =
     Unmarshaller.strict[String, immutable.Seq[String]] { string ⇒
       string.split(",").toList
-    } flatMap { implicit ec ⇒
-      implicit mat ⇒ strings ⇒
-        FastFuture.sequence(strings.map(unmarshaller(_)))
+    } flatMap { implicit ec ⇒ implicit mat ⇒ strings ⇒
+      FastFuture.sequence(strings.map(unmarshaller(_)))
     }
 
   val HexByte: Unmarshaller[String, Byte] =

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
@@ -33,9 +33,9 @@ trait Unmarshaller[-A, B] {
 }
 
 object Unmarshaller
-  extends GenericUnmarshallers
-  with PredefinedFromEntityUnmarshallers
-  with PredefinedFromStringUnmarshallers {
+    extends GenericUnmarshallers
+    with PredefinedFromEntityUnmarshallers
+    with PredefinedFromStringUnmarshallers {
 
   // format: OFF
 
@@ -101,18 +101,18 @@ object Unmarshaller
      * an IllegalStateException will be thrown!
      */
     def forContentTypes(ranges: ContentTypeRange*): FromEntityUnmarshaller[A] =
-      Unmarshaller.withMaterializer { implicit ec ⇒
-        implicit mat ⇒
-          entity ⇒
-            if (entity.contentType == ContentTypes.NoContentType || ranges.exists(_ matches entity.contentType)) {
-              underlying(entity).fast.recover[A](barkAtUnsupportedContentTypeException(ranges, entity.contentType))
-            } else FastFuture.failed(UnsupportedContentTypeException(ranges: _*))
+      Unmarshaller.withMaterializer { implicit ec ⇒ implicit mat ⇒
+        entity ⇒
+          if (entity.contentType == ContentTypes.NoContentType || ranges.exists(_ matches entity.contentType)) {
+            underlying(entity).fast.recover[A](barkAtUnsupportedContentTypeException(ranges, entity.contentType))
+          } else FastFuture.failed(UnsupportedContentTypeException(ranges: _*))
       }
 
     // TODO: move back into the [[EnhancedFromEntityUnmarshaller]] value class after the upgrade to Scala 2.11,
     // Scala 2.10 suffers from this bug: https://issues.scala-lang.org/browse/SI-8018
-    private def barkAtUnsupportedContentTypeException(ranges: Seq[ContentTypeRange],
-                                                      newContentType: ContentType): PartialFunction[Throwable, Nothing] = {
+    private def barkAtUnsupportedContentTypeException(
+      ranges: Seq[ContentTypeRange],
+      newContentType: ContentType): PartialFunction[Throwable, Nothing] = {
       case UnsupportedContentTypeException(supported) ⇒ throw new IllegalStateException(
         s"Illegal use of `unmarshaller.forContentTypes($ranges)`: $newContentType is not supported by underlying marshaller!")
     }

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -431,7 +431,7 @@ private[akka] class Controller(private var initialParticipants: Int, controllerP
         }
         fsm ! ToClient(BarrierResult("initial startup", false))
       } else {
-        nodes += name -> c
+        nodes += name → c
         if (initialParticipants <= 0) fsm ! ToClient(Done)
         else if (nodes.size == initialParticipants) {
           for (NodeInfo(_, _, client) ← nodes.values) client ! ToClient(Done)
@@ -451,7 +451,7 @@ private[akka] class Controller(private var initialParticipants: Int, controllerP
         case _: FailBarrier  ⇒ barrier forward op
         case GetAddress(node) ⇒
           if (nodes contains node) sender() ! ToClient(AddressReply(node, nodes(node).addr))
-          else addrInterest += node -> ((addrInterest get node getOrElse Set()) + sender())
+          else addrInterest += node → ((addrInterest get node getOrElse Set()) + sender())
         case _: Done ⇒ //FIXME what should happen?
       }
     case op: CommandOp ⇒
@@ -567,8 +567,8 @@ private[akka] class BarrierCoordinator extends Actor with LoggingFSM[BarrierCoor
   }
 
   onTransition {
-    case Idle -> Waiting ⇒ setTimer("Timeout", StateTimeout, nextStateData.deadline.timeLeft, false)
-    case Waiting -> Idle ⇒ cancelTimer("Timeout")
+    case Idle → Waiting ⇒ setTimer("Timeout", StateTimeout, nextStateData.deadline.timeLeft, false)
+    case Waiting → Idle ⇒ cancelTimer("Timeout")
   }
 
   when(Waiting) {

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/DataTypes.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/DataTypes.scala
@@ -133,7 +133,8 @@ private[akka] class MsgDecoder extends OneToOneDecoder {
           case BarrierOp.Succeeded ⇒ BarrierResult(barrier.getName, true)
           case BarrierOp.Failed    ⇒ BarrierResult(barrier.getName, false)
           case BarrierOp.Fail      ⇒ FailBarrier(barrier.getName)
-          case BarrierOp.Enter ⇒ EnterBarrier(barrier.getName,
+          case BarrierOp.Enter ⇒ EnterBarrier(
+            barrier.getName,
             if (barrier.hasTimeout) Option(Duration.fromNanos(barrier.getTimeout)) else None)
         }
       } else if (w.hasFailure) {

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -143,7 +143,7 @@ private[akka] object ClientFSM {
  * INTERNAL API.
  */
 private[akka] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress) extends Actor
-  with LoggingFSM[ClientFSM.State, ClientFSM.Data] with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    with LoggingFSM[ClientFSM.State, ClientFSM.Data] with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import ClientFSM._
 
   val settings = TestConductor().Settings
@@ -192,8 +192,8 @@ private[akka] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress)
     case Event(ToServer(msg), d @ Data(Some(channel), None)) ⇒
       channel.write(msg)
       val token = msg match {
-        case EnterBarrier(barrier, timeout) ⇒ Some(barrier -> sender())
-        case GetAddress(node)               ⇒ Some(node.name -> sender())
+        case EnterBarrier(barrier, timeout) ⇒ Some(barrier → sender())
+        case GetAddress(node)               ⇒ Some(node.name → sender())
         case _                              ⇒ None
       }
       stay using d.copy(runningOp = token)
@@ -281,7 +281,7 @@ private[akka] class PlayerHandler(
   fsm: ActorRef,
   log: LoggingAdapter,
   scheduler: Scheduler)(implicit executor: ExecutionContext)
-  extends SimpleChannelUpstreamHandler {
+    extends SimpleChannelUpstreamHandler {
 
   import ClientFSM._
 

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -41,7 +41,7 @@ abstract class MultiNodeConfig {
    */
   def nodeConfig(roles: RoleName*)(configs: Config*): Unit = {
     val c = configs.reduceLeft(_ withFallback _)
-    _nodeConf ++= roles map { _ -> c }
+    _nodeConf ++= roles map { _ → c }
   }
 
   /**
@@ -78,7 +78,7 @@ abstract class MultiNodeConfig {
   }
 
   def deployOn(role: RoleName, deployment: String): Unit =
-    _deployments += role -> ((_deployments get role getOrElse Vector()) :+ deployment)
+    _deployments += role → ((_deployments get role getOrElse Vector()) :+ deployment)
 
   def deployOnAll(deployment: String): Unit = _allDeploy :+= deployment
 
@@ -195,9 +195,9 @@ object MultiNodeSpec {
   require(selfIndex >= 0 && selfIndex < maxNodes, "multinode.index is out of bounds: " + selfIndex)
 
   private[testkit] val nodeConfig = mapToConfig(Map(
-    "akka.actor.provider" -> "akka.remote.RemoteActorRefProvider",
-    "akka.remote.netty.tcp.hostname" -> selfName,
-    "akka.remote.netty.tcp.port" -> selfPort))
+    "akka.actor.provider" → "akka.remote.RemoteActorRefProvider",
+    "akka.remote.netty.tcp.hostname" → selfName,
+    "akka.remote.netty.tcp.port" → selfPort))
 
   private[testkit] val baseConfig: Config = ConfigFactory.parseString("""
       akka {
@@ -241,7 +241,7 @@ object MultiNodeSpec {
  * val is fine.
  */
 abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles: immutable.Seq[RoleName], deployments: RoleName ⇒ Seq[String])
-  extends TestKit(_system) with MultiNodeSpecCallbacks {
+    extends TestKit(_system) with MultiNodeSpecCallbacks {
 
   import MultiNodeSpec._
 

--- a/akka-parsing/build.sbt
+++ b/akka-parsing/build.sbt
@@ -1,4 +1,5 @@
 import akka._
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 AkkaBuild.defaultSettings
 Formatting.docFormatSettings

--- a/akka-parsing/src/main/scala/akka/parboiled2/ErrorFormatter.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/ErrorFormatter.scala
@@ -34,13 +34,14 @@ import java.lang.{ StringBuilder ⇒ JStringBuilder }
  *                   Set to a value < 0 to disable tab expansion.
  * @param traceCutOff the maximum number of (trailing) characters shown for a rule trace
  */
-class ErrorFormatter(showExpected: Boolean = true,
-                     showPosition: Boolean = true,
-                     showLine: Boolean = true,
-                     showTraces: Boolean = false,
-                     showFrameStartOffset: Boolean = true,
-                     expandTabs: Int = -1,
-                     traceCutOff: Int = 120) {
+class ErrorFormatter(
+  showExpected: Boolean = true,
+    showPosition: Boolean = true,
+    showLine: Boolean = true,
+    showTraces: Boolean = false,
+    showFrameStartOffset: Boolean = true,
+    expandTabs: Int = -1,
+    traceCutOff: Int = 120) {
 
   /**
    * Formats the given [[ParseError]] into a String using the settings configured for this formatter instance.
@@ -200,7 +201,7 @@ class ErrorFormatter(showExpected: Boolean = true,
     val dontSep: String ⇒ JStringBuilder = _ ⇒ sb
     def render(names: List[String], sep: String = "") = if (names.nonEmpty) names.reverse.mkString("", ":", sep) else ""
     @tailrec def rec(remainingPrefix: List[RuleTrace.NonTerminal], names: List[String],
-                     sep: String ⇒ JStringBuilder): JStringBuilder =
+      sep: String ⇒ JStringBuilder): JStringBuilder =
       remainingPrefix match {
         case NonTerminal(Named(name), _) :: tail ⇒
           rec(tail, name :: names, sep)
@@ -225,8 +226,9 @@ class ErrorFormatter(showExpected: Boolean = true,
   /**
    * Formats the head element of a [[RuleTrace]] into a String.
    */
-  def formatNonTerminal(nonTerminal: RuleTrace.NonTerminal,
-                        showFrameStartOffset: Boolean = showFrameStartOffset): String = {
+  def formatNonTerminal(
+    nonTerminal: RuleTrace.NonTerminal,
+    showFrameStartOffset: Boolean = showFrameStartOffset): String = {
     import RuleTrace._
     import CharUtils.escape
     val keyString = nonTerminal.key match {

--- a/akka-parsing/src/main/scala/akka/parboiled2/ParseError.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/ParseError.scala
@@ -19,9 +19,10 @@ package akka.parboiled2
 import scala.annotation.tailrec
 import scala.collection.immutable
 
-case class ParseError(position: Position,
-                      principalPosition: Position,
-                      traces: immutable.Seq[RuleTrace]) extends RuntimeException {
+case class ParseError(
+  position: Position,
+    principalPosition: Position,
+    traces: immutable.Seq[RuleTrace]) extends RuntimeException {
   require(principalPosition.index >= position.index, "principalPosition must be > position")
   def format(parser: Parser): String = format(parser.input)
   def format(parser: Parser, formatter: ErrorFormatter): String = format(parser.input, formatter)

--- a/akka-parsing/src/main/scala/akka/parboiled2/Parser.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/Parser.scala
@@ -23,8 +23,9 @@ import scala.util.control.{ NonFatal, NoStackTrace }
 import akka.shapeless._
 import akka.parboiled2.support._
 
-abstract class Parser(initialValueStackSize: Int = 16,
-                      maxValueStackSize: Int = 1024) extends RuleDSL {
+abstract class Parser(
+  initialValueStackSize: Int = 16,
+    maxValueStackSize: Int = 1024) extends RuleDSL {
   import Parser._
 
   require(maxValueStackSize <= 65536, "`maxValueStackSize` > 2^16 is not supported") // due to current snapshot design
@@ -591,9 +592,9 @@ object Parser {
   // that we are in when mismatching at the principal error index
   // or -1 if no atomic rule fails with a mismatch at the principal error index
   private class EstablishingReportedErrorIndex(
-    private var _principalErrorIndex: Int,
-    var currentAtomicStart: Int = Int.MinValue,
-    var maxAtomicErrorStart: Int = Int.MinValue) extends ErrorAnalysisPhase {
+      private var _principalErrorIndex: Int,
+      var currentAtomicStart: Int = Int.MinValue,
+      var maxAtomicErrorStart: Int = Int.MinValue) extends ErrorAnalysisPhase {
     def reportedErrorIndex = if (maxAtomicErrorStart >= 0) maxAtomicErrorStart else _principalErrorIndex
     def applyOffset(offset: Int) = {
       _principalErrorIndex -= offset
@@ -605,9 +606,9 @@ object Parser {
   // determine whether the reported error location can only be reached via quiet rules
   // in which case we need to report them even though they are marked as "quiet"
   private class DetermineReportQuiet(
-    private var _minErrorIndex: Int, // the smallest index at which a mismatch triggers a StartTracingException
-    var inQuiet: Boolean = false // are we currently in a quiet rule?
-    ) extends ErrorAnalysisPhase {
+      private var _minErrorIndex: Int, // the smallest index at which a mismatch triggers a StartTracingException
+      var inQuiet: Boolean = false // are we currently in a quiet rule?
+  ) extends ErrorAnalysisPhase {
     def minErrorIndex = _minErrorIndex
     def applyOffset(offset: Int) = _minErrorIndex -= offset
   }
@@ -615,11 +616,11 @@ object Parser {
   // collect the traces of all mismatches happening at an index >= minErrorIndex (the reported error index)
   // by throwing a StartTracingException which gets turned into a TracingBubbleException by the terminal rule
   private class CollectingRuleTraces(
-    var minErrorIndex: Int, // the smallest index at which a mismatch triggers a StartTracingException
-    val reportQuiet: Boolean, // do we need to trace mismatches from quiet rules?
-    val traceNr: Int = 0, // the zero-based index number of the RuleTrace we are currently building
-    var errorMismatches: Int = 0 // the number of times we have already seen a mismatch at >= minErrorIndex
-    ) extends ErrorAnalysisPhase {
+      var minErrorIndex: Int, // the smallest index at which a mismatch triggers a StartTracingException
+      val reportQuiet: Boolean, // do we need to trace mismatches from quiet rules?
+      val traceNr: Int = 0, // the zero-based index number of the RuleTrace we are currently building
+      var errorMismatches: Int = 0 // the number of times we have already seen a mismatch at >= minErrorIndex
+  ) extends ErrorAnalysisPhase {
     def applyOffset(offset: Int) = minErrorIndex -= offset
   }
 }

--- a/akka-parsing/src/main/scala/akka/parboiled2/Rule.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/Rule.scala
@@ -46,16 +46,18 @@ sealed class Rule[-I <: HList, +O <: HList] extends RuleX {
    *   Rule[A, B:C] ~ Rule[D:B:C, E:F] = Rule[D:A, E:F]
    */
   @compileTimeOnly("Calls to `~` must be inside `rule` macro")
-  def ~[I2 <: HList, O2 <: HList](that: Rule[I2, O2])(implicit i: TailSwitch[I2, O @uncheckedVariance, I @uncheckedVariance],
-                                                      o: TailSwitch[O @uncheckedVariance, I2, O2]): Rule[i.Out, o.Out] = `n/a`
+  def ~[I2 <: HList, O2 <: HList](that: Rule[I2, O2])(implicit
+    i: TailSwitch[I2, O @uncheckedVariance, I @uncheckedVariance],
+    o: TailSwitch[O @uncheckedVariance, I2, O2]): Rule[i.Out, o.Out] = `n/a`
 
   /**
    * Same as `~` but with "cut" semantics, meaning that the parser will never backtrack across this boundary.
    * If the rule being concatenated doesn't match a parse error will be triggered immediately.
    */
   @compileTimeOnly("Calls to `~!~` must be inside `rule` macro")
-  def ~!~[I2 <: HList, O2 <: HList](that: Rule[I2, O2])(implicit i: TailSwitch[I2, O @uncheckedVariance, I @uncheckedVariance],
-                                                        o: TailSwitch[O @uncheckedVariance, I2, O2]): Rule[i.Out, o.Out] = `n/a`
+  def ~!~[I2 <: HList, O2 <: HList](that: Rule[I2, O2])(implicit
+    i: TailSwitch[I2, O @uncheckedVariance, I @uncheckedVariance],
+    o: TailSwitch[O @uncheckedVariance, I2, O2]): Rule[i.Out, o.Out] = `n/a`
 
   /**
    * Combines this rule with the given other one in a way that the resulting rule matches if this rule matches

--- a/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
@@ -397,13 +397,13 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
           if (i <= 0) c.abort(base.pos, "`x` in `x.times` must be positive")
           else if (i == 1) rule
           else Times(rule, q"val min, max = $n", collector, separator)
-        case x@(Ident(_) | Select(_, _)) ⇒ Times(rule, q"val min = $n; val max = min", collector, separator)
-        case _ ⇒ c.abort(n.pos, "Invalid int base expression for `.times(...)`: " + n)
+        case x @ (Ident(_) | Select(_, _)) ⇒ Times(rule, q"val min = $n; val max = min", collector, separator)
+        case _                             ⇒ c.abort(n.pos, "Invalid int base expression for `.times(...)`: " + n)
       }
       case q"$a.this.range2NTimes($r)" ⇒ r match {
-        case q"scala.Predef.intWrapper($mn).to($mx)" ⇒ handleRange(mn, mx, r) // Scala 2.12
+        case q"scala.Predef.intWrapper($mn).to($mx)"      ⇒ handleRange(mn, mx, r) // Scala 2.12
         case q"scala.this.Predef.intWrapper($mn).to($mx)" ⇒ handleRange(mn, mx, r) // Scala 2.11
-        case x@(Ident(_) | Select(_, _)) ⇒
+        case x @ (Ident(_) | Select(_, _)) ⇒
           Times(rule, q"val r = $r; val min = r.start; val max = r.end", collector, separator)
         case _ ⇒ c.abort(r.pos, "Invalid range base expression for `.times(...)`: " + r)
       }

--- a/akka-parsing/src/main/scala/akka/shapeless/hlists.scala
+++ b/akka-parsing/src/main/scala/akka/shapeless/hlists.scala
@@ -16,7 +16,6 @@
 
 package akka.shapeless
 
-
 /**
  * `HList` ADT base trait.
  *

--- a/akka-parsing/src/main/scala/akka/shapeless/ops/hlists.scala
+++ b/akka-parsing/src/main/scala/akka/shapeless/ops/hlists.scala
@@ -17,7 +17,6 @@
 package akka.shapeless
 package ops
 
-
 object hlist {
   /**
    * Type class witnessing that this `HList` is composite and providing access to head and tail.

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/PersistenceQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/PersistenceQuery.scala
@@ -26,7 +26,7 @@ object PersistenceQuery extends ExtensionId[PersistenceQuery] with ExtensionIdPr
   /** INTERNAL API. */
   private[persistence] case class PluginHolder(
     scaladslPlugin: scaladsl.ReadJournal, javadslPlugin: akka.persistence.query.javadsl.ReadJournal)
-    extends Extension
+      extends Extension
 
 }
 
@@ -71,7 +71,8 @@ class PersistenceQuery(system: ExtendedActorSystem) extends Extension {
   }
 
   private def createPlugin(configPath: String): ReadJournalProvider = {
-    require(!isEmpty(configPath) && system.settings.config.hasPath(configPath),
+    require(
+      !isEmpty(configPath) && system.settings.config.hasPath(configPath),
       s"'reference.conf' is missing persistence read journal plugin config path: '${configPath}'")
     val pluginConfig = system.settings.config.getConfig(configPath)
     val pluginClassName = pluginConfig.getString("class")

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentEventsByPersistenceIdQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentEventsByPersistenceIdQuery.scala
@@ -19,6 +19,6 @@ trait CurrentEventsByPersistenceIdQuery extends ReadJournal {
    * not included in the event stream.
    */
   def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
-                                   toSequenceNr: Long): Source[EventEnvelope, NotUsed]
+    toSequenceNr: Long): Source[EventEnvelope, NotUsed]
 
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByPersistenceIdQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByPersistenceIdQuery.scala
@@ -26,6 +26,6 @@ trait EventsByPersistenceIdQuery extends ReadJournal {
    * stored events is provided by [[CurrentEventsByPersistenceIdQuery#currentEventsByPersistenceId]].
    */
   def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
-                            toSequenceNr: Long): Source[EventEnvelope, NotUsed]
+    toSequenceNr: Long): Source[EventEnvelope, NotUsed]
 
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/AllPersistenceIdsPublisher.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/AllPersistenceIdsPublisher.scala
@@ -27,7 +27,7 @@ private[akka] object AllPersistenceIdsPublisher {
  * INTERNAL API
  */
 private[akka] class AllPersistenceIdsPublisher(liveQuery: Boolean, maxBufSize: Int, writeJournalPluginId: String)
-  extends ActorPublisher[String] with DeliveryBuffer[String] with ActorLogging {
+    extends ActorPublisher[String] with DeliveryBuffer[String] with ActorLogging {
 
   val journal: ActorRef = Persistence(context.system).journalFor(writeJournalPluginId)
 

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/EventsByPersistenceIdPublisher.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/EventsByPersistenceIdPublisher.scala
@@ -20,7 +20,7 @@ import akka.persistence.query.EventEnvelope
  */
 private[akka] object EventsByPersistenceIdPublisher {
   def props(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, refreshInterval: Option[FiniteDuration],
-            maxBufSize: Int, writeJournalPluginId: String): Props = {
+    maxBufSize: Int, writeJournalPluginId: String): Props = {
     refreshInterval match {
       case Some(interval) ⇒
         Props(new LiveEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, interval,
@@ -43,7 +43,7 @@ private[akka] object EventsByPersistenceIdPublisher {
 private[akka] abstract class AbstractEventsByPersistenceIdPublisher(
   val persistenceId: String, val fromSequenceNr: Long,
   val maxBufSize: Int, val writeJournalPluginId: String)
-  extends ActorPublisher[EventEnvelope] with DeliveryBuffer[EventEnvelope] with ActorLogging {
+    extends ActorPublisher[EventEnvelope] with DeliveryBuffer[EventEnvelope] with ActorLogging {
   import EventsByPersistenceIdPublisher._
 
   val journal: ActorRef = Persistence(context.system).journalFor(writeJournalPluginId)
@@ -124,8 +124,8 @@ private[akka] class LiveEventsByPersistenceIdPublisher(
   persistenceId: String, fromSequenceNr: Long, override val toSequenceNr: Long,
   refreshInterval: FiniteDuration,
   maxBufSize: Int, writeJournalPluginId: String)
-  extends AbstractEventsByPersistenceIdPublisher(
-    persistenceId, fromSequenceNr, maxBufSize, writeJournalPluginId) {
+    extends AbstractEventsByPersistenceIdPublisher(
+      persistenceId, fromSequenceNr, maxBufSize, writeJournalPluginId) {
   import EventsByPersistenceIdPublisher._
 
   val tickTask =
@@ -160,8 +160,8 @@ private[akka] class LiveEventsByPersistenceIdPublisher(
 private[akka] class CurrentEventsByPersistenceIdPublisher(
   persistenceId: String, fromSequenceNr: Long, var toSeqNr: Long,
   maxBufSize: Int, writeJournalPluginId: String)
-  extends AbstractEventsByPersistenceIdPublisher(
-    persistenceId, fromSequenceNr, maxBufSize, writeJournalPluginId) {
+    extends AbstractEventsByPersistenceIdPublisher(
+      persistenceId, fromSequenceNr, maxBufSize, writeJournalPluginId) {
   import EventsByPersistenceIdPublisher._
 
   override def toSequenceNr: Long = toSeqNr

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/EventsByTagPublisher.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/EventsByTagPublisher.scala
@@ -22,7 +22,7 @@ import akka.persistence.journal.leveldb.LeveldbJournal.ReplayedTaggedMessage
  */
 private[akka] object EventsByTagPublisher {
   def props(tag: String, fromOffset: Long, toOffset: Long, refreshInterval: Option[FiniteDuration],
-            maxBufSize: Int, writeJournalPluginId: String): Props = {
+    maxBufSize: Int, writeJournalPluginId: String): Props = {
     refreshInterval match {
       case Some(interval) ⇒
         Props(new LiveEventsByTagPublisher(tag, fromOffset, toOffset, interval,
@@ -45,7 +45,7 @@ private[akka] object EventsByTagPublisher {
 private[akka] abstract class AbstractEventsByTagPublisher(
   val tag: String, val fromOffset: Long,
   val maxBufSize: Int, val writeJournalPluginId: String)
-  extends ActorPublisher[EventEnvelope] with DeliveryBuffer[EventEnvelope] with ActorLogging {
+    extends ActorPublisher[EventEnvelope] with DeliveryBuffer[EventEnvelope] with ActorLogging {
   import EventsByTagPublisher._
 
   val journal: ActorRef = Persistence(context.system).journalFor(writeJournalPluginId)
@@ -126,8 +126,8 @@ private[akka] class LiveEventsByTagPublisher(
   tag: String, fromOffset: Long, override val toOffset: Long,
   refreshInterval: FiniteDuration,
   maxBufSize: Int, writeJournalPluginId: String)
-  extends AbstractEventsByTagPublisher(
-    tag, fromOffset, maxBufSize, writeJournalPluginId) {
+    extends AbstractEventsByTagPublisher(
+      tag, fromOffset, maxBufSize, writeJournalPluginId) {
   import EventsByTagPublisher._
 
   val tickTask =
@@ -162,8 +162,8 @@ private[akka] class LiveEventsByTagPublisher(
 private[akka] class CurrentEventsByTagPublisher(
   tag: String, fromOffset: Long, var _toOffset: Long,
   maxBufSize: Int, writeJournalPluginId: String)
-  extends AbstractEventsByTagPublisher(
-    tag, fromOffset, maxBufSize, writeJournalPluginId) {
+    extends AbstractEventsByTagPublisher(
+      tag, fromOffset, maxBufSize, writeJournalPluginId) {
   import EventsByTagPublisher._
 
   override def toOffset: Long = _toOffset

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
@@ -26,13 +26,13 @@ import akka.stream.javadsl.Source
  *
  */
 class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal)
-  extends ReadJournal
-  with AllPersistenceIdsQuery
-  with CurrentPersistenceIdsQuery
-  with EventsByPersistenceIdQuery
-  with CurrentEventsByPersistenceIdQuery
-  with EventsByTagQuery
-  with CurrentEventsByTagQuery {
+    extends ReadJournal
+    with AllPersistenceIdsQuery
+    with CurrentPersistenceIdsQuery
+    with EventsByPersistenceIdQuery
+    with CurrentEventsByPersistenceIdQuery
+    with EventsByTagQuery
+    with CurrentEventsByTagQuery {
 
   /**
    * `allPersistenceIds` is used for retrieving all `persistenceIds` of all
@@ -90,7 +90,7 @@ class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.lev
    * backend journal.
    */
   override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
-                                     toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+    toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**
@@ -99,7 +99,7 @@ class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.lev
    * stored after the query is completed are not included in the event stream.
    */
   override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
-                                            toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+    toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
@@ -36,12 +36,12 @@ import com.typesafe.config.Config
  * for the default [[LeveldbReadJournal#Identifier]]. See `reference.conf`.
  */
 class LeveldbReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal
-  with AllPersistenceIdsQuery
-  with CurrentPersistenceIdsQuery
-  with EventsByPersistenceIdQuery
-  with CurrentEventsByPersistenceIdQuery
-  with EventsByTagQuery
-  with CurrentEventsByTagQuery {
+    with AllPersistenceIdsQuery
+    with CurrentPersistenceIdsQuery
+    with EventsByPersistenceIdQuery
+    with CurrentEventsByPersistenceIdQuery
+    with EventsByTagQuery
+    with CurrentEventsByTagQuery {
 
   private val serialization = SerializationExtension(system)
   private val refreshInterval = Some(config.getDuration("refresh-interval", MILLISECONDS).millis)
@@ -112,7 +112,7 @@ class LeveldbReadJournal(system: ExtendedActorSystem, config: Config) extends Re
    * backend journal.
    */
   override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long = 0L,
-                                     toSequenceNr: Long = Long.MaxValue): Source[EventEnvelope, NotUsed] = {
+    toSequenceNr: Long = Long.MaxValue): Source[EventEnvelope, NotUsed] = {
     Source.actorPublisher[EventEnvelope](EventsByPersistenceIdPublisher.props(persistenceId, fromSequenceNr, toSequenceNr,
       refreshInterval, maxBufSize, writeJournalPluginId)).mapMaterializedValue(_ ⇒ NotUsed)
       .named("eventsByPersistenceId-" + persistenceId)
@@ -124,7 +124,7 @@ class LeveldbReadJournal(system: ExtendedActorSystem, config: Config) extends Re
    * stored after the query is completed are not included in the event stream.
    */
   override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long = 0L,
-                                            toSequenceNr: Long = Long.MaxValue): Source[EventEnvelope, NotUsed] = {
+    toSequenceNr: Long = Long.MaxValue): Source[EventEnvelope, NotUsed] = {
     Source.actorPublisher[EventEnvelope](EventsByPersistenceIdPublisher.props(persistenceId, fromSequenceNr, toSequenceNr,
       None, maxBufSize, writeJournalPluginId)).mapMaterializedValue(_ ⇒ NotUsed)
       .named("currentEventsByPersistenceId-" + persistenceId)

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentEventsByPersistenceIdQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentEventsByPersistenceIdQuery.scala
@@ -19,6 +19,6 @@ trait CurrentEventsByPersistenceIdQuery extends ReadJournal {
    * not included in the event stream.
    */
   def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
-                                   toSequenceNr: Long): Source[EventEnvelope, NotUsed]
+    toSequenceNr: Long): Source[EventEnvelope, NotUsed]
 
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByPersistenceIdQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByPersistenceIdQuery.scala
@@ -26,6 +26,6 @@ trait EventsByPersistenceIdQuery extends ReadJournal {
    * stored events is provided by [[CurrentEventsByPersistenceIdQuery#currentEventsByPersistenceId]].
    */
   def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
-                            toSequenceNr: Long): Source[EventEnvelope, NotUsed]
+    toSequenceNr: Long): Source[EventEnvelope, NotUsed]
 
 }

--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.Config
 
 object JournalPerfSpec {
   class BenchActor(override val persistenceId: String, replyTo: ActorRef, replyAfter: Int) extends PersistentActor
-    with ActorLogging {
+      with ActorLogging {
 
     var counter = 0
 

--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala
@@ -35,7 +35,7 @@ object JournalSpec {
  * @see [[akka.persistence.japi.journal.JavaJournalPerfSpec]]
  */
 abstract class JournalSpec(config: Config) extends PluginSpec(config) with MayVerb
-  with OptionalTests with JournalCapabilityFlags {
+    with OptionalTests with JournalCapabilityFlags {
 
   implicit lazy val system: ActorSystem = ActorSystem("JournalSpec", config.withFallback(JournalSpec.config))
 

--- a/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
@@ -29,7 +29,7 @@ object SnapshotStoreSpec {
  * @see [[akka.persistence.japi.snapshot.JavaSnapshotStoreSpec]]
  */
 abstract class SnapshotStoreSpec(config: Config) extends PluginSpec(config)
-  with OptionalTests with SnapshotStoreCapabilityFlags {
+    with OptionalTests with SnapshotStoreCapabilityFlags {
   implicit lazy val system = ActorSystem("SnapshotStoreSpec", config.withFallback(SnapshotStoreSpec.config))
 
   private var senderProbe: TestProbe = _

--- a/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
@@ -20,7 +20,7 @@ object AtLeastOnceDelivery {
    */
   @SerialVersionUID(1L)
   case class AtLeastOnceDeliverySnapshot(currentDeliveryId: Long, unconfirmedDeliveries: immutable.Seq[UnconfirmedDelivery])
-    extends Message {
+      extends Message {
 
     /**
      * Java API
@@ -308,7 +308,8 @@ trait AtLeastOnceDeliveryLike extends Eventsourced {
    * as a blob in your custom snapshot.
    */
   def getDeliverySnapshot: AtLeastOnceDeliverySnapshot =
-    AtLeastOnceDeliverySnapshot(deliverySequenceNr,
+    AtLeastOnceDeliverySnapshot(
+      deliverySequenceNr,
       unconfirmed.map { case (deliveryId, d) ⇒ UnconfirmedDelivery(deliveryId, d.destination, d.message) }(breakOut))
 
   /**
@@ -319,7 +320,7 @@ trait AtLeastOnceDeliveryLike extends Eventsourced {
     deliverySequenceNr = snapshot.currentDeliveryId
     val now = System.nanoTime()
     unconfirmed = snapshot.unconfirmedDeliveries.map(d ⇒
-      d.deliveryId -> Delivery(d.destination, d.message, now, 0))(breakOut)
+      d.deliveryId → Delivery(d.destination, d.message, now, 0))(breakOut)
   }
 
   /**

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -145,7 +145,8 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
    * @param event the event that was to be persisted
    */
   protected def onPersistRejected(cause: Throwable, event: Any, seqNr: Long): Unit = {
-    log.warning("Rejected to persist event type [{}] with sequence number [{}] for persistenceId [{}] due to [{}].",
+    log.warning(
+      "Rejected to persist event type [{}] with sequence number [{}] for persistenceId [{}] due to [{}].",
       event.getClass.getName, seqNr, persistenceId, cause.getMessage)
   }
 
@@ -229,7 +230,8 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
       case DeleteSnapshotsFailure(c, e) ⇒
         log.warning("Failed to deleteSnapshots given criteria [{}] due to: [{}: {}]", c, e.getClass.getCanonicalName, e.getMessage)
       case DeleteMessagesFailure(e, toSequenceNr) ⇒
-        log.warning("Failed to deleteMessages toSequenceNr [{}] for persistenceId [{}] due to [{}: {}].",
+        log.warning(
+          "Failed to deleteMessages toSequenceNr [{}] for persistenceId [{}] due to [{}: {}].",
           toSequenceNr, persistenceId, e.getClass.getCanonicalName, e.getMessage)
       case m ⇒ super.unhandled(m)
     }

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -102,7 +102,7 @@ private[persistence] object JournalProtocol {
    * @param persistentActor requesting persistent actor.
    */
   final case class ReplayMessages(fromSequenceNr: Long, toSequenceNr: Long, max: Long,
-                                  persistenceId: String, persistentActor: ActorRef) extends Request
+    persistenceId: String, persistentActor: ActorRef) extends Request
 
   /**
    * Reply message to a [[ReplayMessages]] request. A separate reply is sent to the requestor for each

--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -305,7 +305,8 @@ class Persistence(val system: ExtendedActorSystem) extends Extension {
 
   private class PluginHolderExtensionId(configPath: String, fallbackPath: String) extends ExtensionId[PluginHolder] {
     override def createExtension(system: ExtendedActorSystem): PluginHolder = {
-      require(!isEmpty(configPath) && system.settings.config.hasPath(configPath),
+      require(
+        !isEmpty(configPath) && system.settings.config.hasPath(configPath),
         s"'reference.conf' is missing persistence plugin config path: '$configPath'")
       val config: Config = system.settings.config.getConfig(configPath)
         .withFallback(system.settings.config.getConfig(fallbackPath))

--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -42,7 +42,8 @@ final case class AtomicWrite(payload: immutable.Seq[PersistentRepr]) extends Per
     case l: List[PersistentRepr]   ⇒ l.tail.nonEmpty // avoids calling .size
     case v: Vector[PersistentRepr] ⇒ v.size > 1
     case _                         ⇒ true // some other collection type, let's just check
-  }) require(payload.forall(_.persistenceId == payload.head.persistenceId),
+  }) require(
+    payload.forall(_.persistenceId == payload.head.persistenceId),
     "AtomicWrite must contain messages for the same persistenceId, " +
       s"yet different persistenceIds found: ${payload.map(_.persistenceId).toSet}")
 
@@ -157,13 +158,13 @@ object PersistentRepr {
  * INTERNAL API.
  */
 private[persistence] final case class PersistentImpl(
-  override val payload: Any,
-  override val sequenceNr: Long,
-  override val persistenceId: String,
-  override val manifest: String,
-  override val deleted: Boolean,
-  override val sender: ActorRef,
-  override val writerUuid: String) extends PersistentRepr with NoSerializationVerificationNeeded {
+    override val payload: Any,
+    override val sequenceNr: Long,
+    override val persistenceId: String,
+    override val manifest: String,
+    override val deleted: Boolean,
+    override val sender: ActorRef,
+    override val writerUuid: String) extends PersistentRepr with NoSerializationVerificationNeeded {
 
   def withPayload(payload: Any): PersistentRepr =
     copy(payload = payload)

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentView.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentView.scala
@@ -82,8 +82,8 @@ private[akka] object PersistentView {
  */
 @deprecated("use Persistence Query instead", "2.4")
 trait PersistentView extends Actor with Snapshotter with Stash with StashFactory
-  with PersistenceIdentity with PersistenceRecovery
-  with ActorLogging {
+    with PersistenceIdentity with PersistenceRecovery
+    with ActorLogging {
   import PersistentView._
   import JournalProtocol._
   import SnapshotProtocol.LoadSnapshotResult

--- a/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
@@ -106,10 +106,10 @@ final case class SnapshotOffer(metadata: SnapshotMetadata, snapshot: Any)
  */
 @SerialVersionUID(1L)
 final case class SnapshotSelectionCriteria(
-  maxSequenceNr: Long = Long.MaxValue,
-  maxTimestamp: Long = Long.MaxValue,
-  minSequenceNr: Long = 0L,
-  minTimestamp: Long = 0L) {
+    maxSequenceNr: Long = Long.MaxValue,
+    maxTimestamp: Long = Long.MaxValue,
+    minSequenceNr: Long = 0L,
+    minTimestamp: Long = 0L) {
 
   /**
    * INTERNAL API.
@@ -146,7 +146,7 @@ object SnapshotSelectionCriteria {
    * Java API.
    */
   def create(maxSequenceNr: Long, maxTimestamp: Long,
-             minSequenceNr: Long, minTimestamp: Long) =
+    minSequenceNr: Long, minTimestamp: Long) =
     SnapshotSelectionCriteria(maxSequenceNr, maxTimestamp, minSequenceNr, minTimestamp)
 
   /**

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -214,7 +214,7 @@ object PersistentFSM {
    */
   // FIXME: what about the cancellable?
   private[persistence] final case class Timer(name: String, msg: Any, repeat: Boolean, generation: Int)(context: ActorContext)
-    extends NoSerializationVerificationNeeded {
+      extends NoSerializationVerificationNeeded {
     private var ref: Option[Cancellable] = _
     private val scheduler = context.system.scheduler
     private implicit val executionContext = context.dispatcher
@@ -235,7 +235,7 @@ object PersistentFSM {
    * This extractor is just convenience for matching a (S, S) pair, including a
    * reminder what the new state is.
    */
-  object -> {
+  object → {
     def unapply[S](in: (S, S)) = Some(in)
   }
 
@@ -251,13 +251,13 @@ object PersistentFSM {
    * to be executed after FSM moves to the new state (also triggered when staying in the same state)
    */
   final case class State[S, D, E](
-    stateName: S,
-    stateData: D,
-    timeout: Option[FiniteDuration] = None,
-    stopReason: Option[Reason] = None,
-    replies: List[Any] = Nil,
-    domainEvents: Seq[E] = Nil,
-    afterTransitionDo: D ⇒ Unit = { _: D ⇒ })(private[akka] val notifies: Boolean = true) {
+      stateName: S,
+      stateData: D,
+      timeout: Option[FiniteDuration] = None,
+      stopReason: Option[Reason] = None,
+      replies: List[Any] = Nil,
+      domainEvents: Seq[E] = Nil,
+      afterTransitionDo: D ⇒ Unit = { _: D ⇒ })(private[akka] val notifies: Boolean = true) {
 
     /**
      * Copy object and update values if needed.

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncRecovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncRecovery.scala
@@ -45,7 +45,7 @@ trait AsyncRecovery {
    * @see [[AsyncWriteJournal]]
    */
   def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long,
-                          max: Long)(recoveryCallback: PersistentRepr ⇒ Unit): Future[Unit]
+    max: Long)(recoveryCallback: PersistentRepr ⇒ Unit): Future[Unit]
 
   /**
    * Plugin API: asynchronously reads the highest stored sequence number for the

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -280,7 +280,7 @@ private[persistence] object AsyncWriteJournal {
         delivered = d.snr
         d.target.tell(d.msg, d.sender)
       } else {
-        delayed += (d.snr -> d)
+        delayed += (d.snr → d)
       }
       val ro = delayed.remove(delivered + 1)
       if (ro.isDefined) resequence(ro.get)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
@@ -20,9 +20,9 @@ import scala.util.Try
  * `EventAdapters` serves as a per-journal collection of bound event adapters.
  */
 class EventAdapters(
-  map: ConcurrentHashMap[Class[_], EventAdapter],
-  bindings: immutable.Seq[(Class[_], EventAdapter)],
-  log: LoggingAdapter) {
+    map: ConcurrentHashMap[Class[_], EventAdapter],
+    bindings: immutable.Seq[(Class[_], EventAdapter)],
+    log: LoggingAdapter) {
 
   /**
    * Finds the "most specific" matching adapter for the given class (i.e. it may return an adapter that can work on a
@@ -79,12 +79,13 @@ private[akka] object EventAdapters {
     for {
       (fqn, boundToAdapters) ← adapterBindings
       boundAdapter ← boundToAdapters
-    } require(adapterNames(boundAdapter.toString),
+    } require(
+      adapterNames(boundAdapter.toString),
       s"$fqn was bound to undefined event-adapter: $boundAdapter (bindings: ${boundToAdapters.mkString("[", ", ", "]")}, known adapters: ${adapters.keys.mkString})")
 
     // A Map of handler from alias to implementation (i.e. class implementing akka.serialization.Serializer)
     // For example this defines a handler named 'country': `"country" -> com.example.comain.CountryTagsAdapter`
-    val handlers = for ((k: String, v: String) ← adapters) yield k -> instantiateAdapter(v, system).get
+    val handlers = for ((k: String, v: String) ← adapters) yield k → instantiateAdapter(v, system).get
 
     // bindings is a Seq of tuple representing the mapping from Class to handler.
     // It is primarily ordered by the most specific classes first, and secondly in the configured order.
@@ -131,7 +132,7 @@ private[akka] object EventAdapters {
    * loading is performed by the system’s [[akka.actor.DynamicAccess]].
    */
   private def instantiate[T: ClassTag](fqn: FQN, system: ExtendedActorSystem): Try[T] =
-    system.dynamicAccess.createInstanceFor[T](fqn, List(classOf[ExtendedActorSystem] -> system)) recoverWith {
+    system.dynamicAccess.createInstanceFor[T](fqn, List(classOf[ExtendedActorSystem] → system)) recoverWith {
       case _: NoSuchMethodException ⇒ system.dynamicAccess.createInstanceFor[T](fqn, Nil)
     }
 
@@ -151,7 +152,7 @@ private[akka] object EventAdapters {
   private final def configToMap(config: Config, path: String): Map[String, String] = {
     import scala.collection.JavaConverters._
     if (config.hasPath(path)) {
-      config.getConfig(path).root.unwrapped.asScala.toMap map { case (k, v) ⇒ k -> v.toString }
+      config.getConfig(path).root.unwrapped.asScala.toMap map { case (k, v) ⇒ k → v.toString }
     } else Map.empty
   }
 
@@ -159,8 +160,8 @@ private[akka] object EventAdapters {
     import scala.collection.JavaConverters._
     if (config.hasPath(path)) {
       config.getConfig(path).root.unwrapped.asScala.toMap map {
-        case (k, v: util.ArrayList[_]) if v.isInstanceOf[util.ArrayList[_]] ⇒ k -> v.asScala.map(_.toString).toList
-        case (k, v) ⇒ k -> List(v.toString)
+        case (k, v: util.ArrayList[_]) if v.isInstanceOf[util.ArrayList[_]] ⇒ k → v.asScala.map(_.toString).toList
+        case (k, v) ⇒ k → List(v.toString)
       }
     } else Map.empty
   }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/ReplayFilter.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/ReplayFilter.scala
@@ -48,14 +48,14 @@ private[akka] object ReplayFilter {
  * INTERNAL API
  */
 private[akka] class ReplayFilter(persistentActor: ActorRef, mode: ReplayFilter.Mode,
-                                 windowSize: Int, maxOldWriters: Int, debugEnabled: Boolean)
-  extends Actor with ActorLogging {
+  windowSize: Int, maxOldWriters: Int, debugEnabled: Boolean)
+    extends Actor with ActorLogging {
   import JournalProtocol._
   import ReplayFilter.{ Warn, Fail, RepairByDiscardOld, Disabled }
 
   // for binary compatibility
   def this(persistentActor: ActorRef, mode: ReplayFilter.Mode,
-           windowSize: Int, maxOldWriters: Int) = this(persistentActor, mode, windowSize, maxOldWriters, debugEnabled = false)
+    windowSize: Int, maxOldWriters: Int) = this(persistentActor, mode, windowSize, maxOldWriters, debugEnabled = false)
 
   val buffer = new LinkedList[ReplayedMessage]()
   val oldWriters = LinkedHashSet.empty[String]

--- a/akka-persistence/src/main/scala/akka/persistence/journal/inmem/InmemJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/inmem/InmemJournal.scala
@@ -54,17 +54,17 @@ private[persistence] trait InmemMessages {
   var messages = Map.empty[String, Vector[PersistentRepr]]
 
   def add(p: PersistentRepr): Unit = messages = messages + (messages.get(p.persistenceId) match {
-    case Some(ms) ⇒ p.persistenceId -> (ms :+ p)
-    case None     ⇒ p.persistenceId -> Vector(p)
+    case Some(ms) ⇒ p.persistenceId → (ms :+ p)
+    case None     ⇒ p.persistenceId → Vector(p)
   })
 
   def update(pid: String, snr: Long)(f: PersistentRepr ⇒ PersistentRepr): Unit = messages = messages.get(pid) match {
-    case Some(ms) ⇒ messages + (pid -> ms.map(sp ⇒ if (sp.sequenceNr == snr) f(sp) else sp))
+    case Some(ms) ⇒ messages + (pid → ms.map(sp ⇒ if (sp.sequenceNr == snr) f(sp) else sp))
     case None     ⇒ messages
   }
 
   def delete(pid: String, snr: Long): Unit = messages = messages.get(pid) match {
-    case Some(ms) ⇒ messages + (pid -> ms.filterNot(_.sequenceNr == snr))
+    case Some(ms) ⇒ messages + (pid → ms.filterNot(_.sequenceNr == snr))
     case None     ⇒ messages
   }
 

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbIdMapping.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbIdMapping.scala
@@ -55,13 +55,13 @@ private[persistence] trait LeveldbIdMapping extends Actor { this: LeveldbStore �
       val nextKey = keyFromBytes(nextEntry.getKey)
       if (!isMappingKey(nextKey)) pathMap else {
         val nextVal = new String(nextEntry.getValue, UTF_8)
-        readIdMap(pathMap + (nextVal -> nextKey.mappingId), iter)
+        readIdMap(pathMap + (nextVal → nextKey.mappingId), iter)
       }
     }
   }
 
   private def writeIdMapping(id: String, numericId: Int): Int = {
-    idMap = idMap + (id -> numericId)
+    idMap = idMap + (id → numericId)
     leveldb.put(keyToBytes(mappingKey(numericId)), id.getBytes(UTF_8))
     newPersistenceIdAdded(id)
     numericId

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
@@ -94,7 +94,7 @@ private[persistence] object LeveldbJournal {
   final case class TaggedEventAppended(tag: String) extends DeadLetterSuppression
 
   final case class ReplayTaggedMessages(fromSequenceNr: Long, toSequenceNr: Long, max: Long,
-                                        tag: String, replyTo: ActorRef) extends SubscriptionCommand
+    tag: String, replyTo: ActorRef) extends SubscriptionCommand
   final case class ReplayedTaggedMessage(persistent: PersistentRepr, tag: String, offset: Long)
     extends DeadLetterSuppression with NoSerializationVerificationNeeded
 }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
@@ -64,7 +64,8 @@ private[persistence] trait LeveldbStore extends Actor with WriteJournalBase with
             if (tags.nonEmpty && hasTagSubscribers)
               allTags = allTags union tags
 
-            require(!p2.persistenceId.startsWith(tagPersistenceIdPrefix),
+            require(
+              !p2.persistenceId.startsWith(tagPersistenceIdPrefix),
               s"persistenceId [${p.persistenceId}] must not start with $tagPersistenceIdPrefix")
             addToMessageBatch(p2, tags, batch)
           }

--- a/akka-remote/src/main/scala/akka/remote/AckedDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/AckedDelivery.scala
@@ -88,10 +88,10 @@ class ResendUnfulfillableException
  *               will be not stored but rejected with [[java.lang.IllegalArgumentException]]
  */
 final case class AckedSendBuffer[T <: HasSequenceNumber](
-  capacity: Int,
-  nonAcked: IndexedSeq[T] = Vector.empty[T],
-  nacked: IndexedSeq[T] = Vector.empty[T],
-  maxSeq: SeqNo = SeqNo(-1)) {
+    capacity: Int,
+    nonAcked: IndexedSeq[T] = Vector.empty[T],
+    nacked: IndexedSeq[T] = Vector.empty[T],
+    maxSeq: SeqNo = SeqNo(-1)) {
 
   /**
    * Processes an incoming acknowledgement and returns a new buffer with only unacknowledged elements remaining.
@@ -137,9 +137,9 @@ final case class AckedSendBuffer[T <: HasSequenceNumber](
  * @param buf Buffer of messages that are waiting for delivery
  */
 final case class AckedReceiveBuffer[T <: HasSequenceNumber](
-  lastDelivered: SeqNo = SeqNo(-1),
-  cumulativeAck: SeqNo = SeqNo(-1),
-  buf: SortedSet[T] = TreeSet.empty[T])(implicit val seqOrdering: Ordering[T]) {
+    lastDelivered: SeqNo = SeqNo(-1),
+    cumulativeAck: SeqNo = SeqNo(-1),
+    buf: SortedSet[T] = TreeSet.empty[T])(implicit val seqOrdering: Ordering[T]) {
 
   import SeqNo.ord.max
 

--- a/akka-remote/src/main/scala/akka/remote/DeadlineFailureDetector.scala
+++ b/akka-remote/src/main/scala/akka/remote/DeadlineFailureDetector.scala
@@ -27,9 +27,10 @@ import akka.util.Helpers.ConfigOps
  *   purposes. It is only used for measuring intervals (duration).
  */
 class DeadlineFailureDetector(
-  val acceptableHeartbeatPause: FiniteDuration,
-  val heartbeatInterval: FiniteDuration)(
-    implicit clock: Clock) extends FailureDetector {
+    val acceptableHeartbeatPause: FiniteDuration,
+    val heartbeatInterval: FiniteDuration)(
+    implicit
+    clock: Clock) extends FailureDetector {
 
   /**
    * Constructor that reads parameters from config.

--- a/akka-remote/src/main/scala/akka/remote/DefaultFailureDetectorRegistry.scala
+++ b/akka-remote/src/main/scala/akka/remote/DefaultFailureDetectorRegistry.scala
@@ -48,7 +48,7 @@ class DefaultFailureDetectorRegistry[A](detectorFactory: () ⇒ FailureDetector)
             case None ⇒
               val newDetector: FailureDetector = detectorFactory()
               newDetector.heartbeat()
-              resourceToFailureDetector.set(oldTable + (resource -> newDetector))
+              resourceToFailureDetector.set(oldTable + (resource → newDetector))
           }
         } finally failureDetectorCreationLock.unlock()
     }

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -32,25 +32,28 @@ import scala.concurrent.Future
  * INTERNAL API
  */
 private[remote] trait InboundMessageDispatcher {
-  def dispatch(recipient: InternalActorRef,
-               recipientAddress: Address,
-               serializedMessage: SerializedMessage,
-               senderOption: Option[ActorRef]): Unit
+  def dispatch(
+    recipient: InternalActorRef,
+    recipientAddress: Address,
+    serializedMessage: SerializedMessage,
+    senderOption: Option[ActorRef]): Unit
 }
 
 /**
  * INTERNAL API
  */
-private[remote] class DefaultMessageDispatcher(private val system: ExtendedActorSystem,
-                                               private val provider: RemoteActorRefProvider,
-                                               private val log: LoggingAdapter) extends InboundMessageDispatcher {
+private[remote] class DefaultMessageDispatcher(
+  private val system: ExtendedActorSystem,
+    private val provider: RemoteActorRefProvider,
+    private val log: LoggingAdapter) extends InboundMessageDispatcher {
 
   private val remoteDaemon = provider.remoteDaemon
 
-  override def dispatch(recipient: InternalActorRef,
-                        recipientAddress: Address,
-                        serializedMessage: SerializedMessage,
-                        senderOption: Option[ActorRef]): Unit = {
+  override def dispatch(
+    recipient: InternalActorRef,
+    recipientAddress: Address,
+    serializedMessage: SerializedMessage,
+    senderOption: Option[ActorRef]): Unit = {
 
     import provider.remoteSettings._
 
@@ -76,7 +79,8 @@ private[remote] class DefaultMessageDispatcher(private val system: ExtendedActor
           case sel: ActorSelectionMessage ⇒
             if (UntrustedMode && (!TrustedSelectionPaths.contains(sel.elements.mkString("/", "/", "")) ||
               sel.msg.isInstanceOf[PossiblyHarmful] || l != provider.rootGuardian))
-              log.debug("operating in UntrustedMode, dropping inbound actor selection to [{}], " +
+              log.debug(
+                "operating in UntrustedMode, dropping inbound actor selection to [{}], " +
                 "allow it by adding the path to 'akka.remote.trusted-selection-paths' configuration",
                 sel.elements.mkString("/", "/", ""))
             else
@@ -94,10 +98,12 @@ private[remote] class DefaultMessageDispatcher(private val system: ExtendedActor
           // if it was originally addressed to us but is in fact remote from our point of view (i.e. remote-deployed)
           r.!(payload)(sender)
         else
-          log.error("dropping message [{}] for non-local recipient [{}] arriving at [{}] inbound addresses are [{}]",
+          log.error(
+            "dropping message [{}] for non-local recipient [{}] arriving at [{}] inbound addresses are [{}]",
             payloadClass, r, recipientAddress, provider.transport.addresses.mkString(", "))
 
-      case r ⇒ log.error("dropping message [{}] for unknown recipient [{}] arriving at [{}] inbound addresses are [{}]",
+      case r ⇒ log.error(
+        "dropping message [{}] for unknown recipient [{}] arriving at [{}] inbound addresses are [{}]",
         payloadClass, r, recipientAddress, provider.transport.addresses.mkString(", "))
 
     }
@@ -129,11 +135,12 @@ private[remote] final case class ShutDownAssociation(localAddress: Address, remo
  * INTERNAL API
  */
 @SerialVersionUID(2L)
-private[remote] final case class InvalidAssociation(localAddress: Address,
-                                                    remoteAddress: Address,
-                                                    cause: Throwable,
-                                                    disassociationInfo: Option[DisassociateInfo] = None)
-  extends EndpointException("Invalid address: " + remoteAddress, cause) with AssociationProblem
+private[remote] final case class InvalidAssociation(
+  localAddress: Address,
+  remoteAddress: Address,
+  cause: Throwable,
+  disassociationInfo: Option[DisassociateInfo] = None)
+    extends EndpointException("Invalid address: " + remoteAddress, cause) with AssociationProblem
 
 /**
  * INTERNAL API
@@ -189,14 +196,14 @@ private[remote] object ReliableDeliverySupervisor {
  * INTERNAL API
  */
 private[remote] class ReliableDeliverySupervisor(
-  handleOrActive: Option[AkkaProtocolHandle],
-  val localAddress: Address,
-  val remoteAddress: Address,
-  val refuseUid: Option[Int],
-  val transport: AkkaProtocolTransport,
-  val settings: RemoteSettings,
-  val codec: AkkaPduCodec,
-  val receiveBuffers: ConcurrentHashMap[Link, ResendState]) extends Actor with ActorLogging {
+    handleOrActive: Option[AkkaProtocolHandle],
+    val localAddress: Address,
+    val remoteAddress: Address,
+    val refuseUid: Option[Int],
+    val transport: AkkaProtocolTransport,
+    val settings: RemoteSettings,
+    val codec: AkkaPduCodec,
+    val receiveBuffers: ConcurrentHashMap[Link, ResendState]) extends Actor with ActorLogging {
   import ReliableDeliverySupervisor._
   import context.dispatcher
 
@@ -209,7 +216,8 @@ private[remote] class ReliableDeliverySupervisor(
     case e @ (_: AssociationProblem) ⇒ Escalate
     case NonFatal(e) ⇒
       val causedBy = if (e.getCause == null) "" else s"Caused by: [${e.getCause.getMessage}]"
-      log.warning("Association with remote system [{}] has failed, address is now gated for [{}] ms. Reason: [{}] {}",
+      log.warning(
+        "Association with remote system [{}] has failed, address is now gated for [{}] ms. Reason: [{}] {}",
         remoteAddress, settings.RetryGateClosedFor.toMillis, e.getMessage, causedBy)
       uidConfirmed = false // Need confirmation of UID again
       if (bufferWasInUse) {
@@ -437,11 +445,11 @@ private[remote] class ReliableDeliverySupervisor(
  * INTERNAL API
  */
 private[remote] abstract class EndpointActor(
-  val localAddress: Address,
-  val remoteAddress: Address,
-  val transport: Transport,
-  val settings: RemoteSettings,
-  val codec: AkkaPduCodec) extends Actor with ActorLogging {
+    val localAddress: Address,
+    val remoteAddress: Address,
+    val transport: Transport,
+    val settings: RemoteSettings,
+    val codec: AkkaPduCodec) extends Actor with ActorLogging {
 
   def inbound: Boolean
 
@@ -517,7 +525,7 @@ private[remote] class EndpointWriter(
   codec: AkkaPduCodec,
   val receiveBuffers: ConcurrentHashMap[Link, ResendState],
   val reliableDeliverySupervisor: Option[ActorRef])
-  extends EndpointActor(localAddress, remoteAddress, transport, settings, codec) {
+    extends EndpointActor(localAddress, remoteAddress, transport, settings, codec) {
 
   import EndpointWriter._
   import context.dispatcher
@@ -704,7 +712,8 @@ private[remote] class EndpointWriter(
       if (size > settings.LogBufferSizeExceeding) {
         val now = System.nanoTime()
         if (now - largeBufferLogTimestamp >= LogBufferSizeInterval) {
-          log.warning("[{}] buffered messages in EndpointWriter for [{}]. " +
+          log.warning(
+            "[{}] buffered messages in EndpointWriter for [{}]. " +
             "You should probably implement flow control to avoid flooding the remote connection.",
             size, remoteAddress)
           largeBufferLogTimestamp = now
@@ -907,16 +916,16 @@ private[remote] object EndpointReader {
  * INTERNAL API
  */
 private[remote] class EndpointReader(
-  localAddress: Address,
-  remoteAddress: Address,
-  transport: Transport,
-  settings: RemoteSettings,
-  codec: AkkaPduCodec,
-  msgDispatch: InboundMessageDispatcher,
-  val inbound: Boolean,
-  val uid: Int,
-  val reliableDeliverySupervisor: Option[ActorRef],
-  val receiveBuffers: ConcurrentHashMap[Link, ResendState]) extends EndpointActor(localAddress, remoteAddress, transport, settings, codec) {
+    localAddress: Address,
+    remoteAddress: Address,
+    transport: Transport,
+    settings: RemoteSettings,
+    codec: AkkaPduCodec,
+    msgDispatch: InboundMessageDispatcher,
+    val inbound: Boolean,
+    val uid: Int,
+    val reliableDeliverySupervisor: Option[ActorRef],
+    val receiveBuffers: ConcurrentHashMap[Link, ResendState]) extends EndpointActor(localAddress, remoteAddress, transport, settings, codec) {
 
   import EndpointWriter.{ OutboundAck, StopReading, StoppedReading }
 
@@ -972,7 +981,8 @@ private[remote] class EndpointReader(
       }
 
     case InboundPayload(oversized) ⇒
-      log.error(new OversizedPayloadException(s"Discarding oversized payload received: " +
+      log.error(
+        new OversizedPayloadException(s"Discarding oversized payload received: " +
         s"max allowed size [${transport.maximumPayloadBytes}] bytes, actual size [${oversized.size}] bytes."),
         "Transient error while reading from association (association remains live)")
 

--- a/akka-remote/src/main/scala/akka/remote/FailureDetectorRegistry.scala
+++ b/akka-remote/src/main/scala/akka/remote/FailureDetectorRegistry.scala
@@ -67,11 +67,11 @@ private[akka] object FailureDetectorLoader {
   def load(fqcn: String, config: Config, system: ActorSystem): FailureDetector = {
     system.asInstanceOf[ExtendedActorSystem].dynamicAccess.createInstanceFor[FailureDetector](
       fqcn, List(
-        classOf[Config] -> config,
-        classOf[EventStream] -> system.eventStream)).recover({
-        case e ⇒ throw new ConfigurationException(
-          s"Could not create custom failure detector [$fqcn] due to: ${e.toString}", e)
-      }).get
+      classOf[Config] → config,
+      classOf[EventStream] → system.eventStream)).recover({
+      case e ⇒ throw new ConfigurationException(
+        s"Could not create custom failure detector [$fqcn] due to: ${e.toString}", e)
+    }).get
   }
 
   /**

--- a/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
+++ b/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
@@ -54,12 +54,13 @@ import akka.util.Helpers.ConfigOps
  *   purposes. It is only used for measuring intervals (duration).
  */
 class PhiAccrualFailureDetector(
-  val threshold: Double,
-  val maxSampleSize: Int,
-  val minStdDeviation: FiniteDuration,
-  val acceptableHeartbeatPause: FiniteDuration,
-  val firstHeartbeatEstimate: FiniteDuration)(
-    implicit clock: Clock) extends FailureDetector {
+    val threshold: Double,
+    val maxSampleSize: Int,
+    val minStdDeviation: FiniteDuration,
+    val acceptableHeartbeatPause: FiniteDuration,
+    val firstHeartbeatEstimate: FiniteDuration)(
+    implicit
+    clock: Clock) extends FailureDetector {
 
   /**
    * Constructor that reads parameters from config.
@@ -203,10 +204,10 @@ private[akka] object HeartbeatHistory {
  * for empty HeartbeatHistory, i.e. throws ArithmeticException.
  */
 private[akka] final case class HeartbeatHistory private (
-  maxSampleSize: Int,
-  intervals: immutable.IndexedSeq[Long],
-  intervalSum: Long,
-  squaredIntervalSum: Long) {
+    maxSampleSize: Int,
+    intervals: immutable.IndexedSeq[Long],
+    intervalSum: Long,
+    squaredIntervalSum: Long) {
 
   // Heartbeat histories are created trough the firstHeartbeat variable of the PhiAccrualFailureDetector
   // which always have intervals.size > 0.

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -33,7 +33,7 @@ private[akka] object RemoteActorRefProvider {
   case object Finished extends TerminatorState
 
   private class RemotingTerminator(systemGuardian: ActorRef) extends Actor with FSM[TerminatorState, Option[Internals]]
-    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+      with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
     import context.dispatcher
 
     startWith(Uninitialized, None)
@@ -79,9 +79,10 @@ private[akka] object RemoteActorRefProvider {
    * and handled as dead letters to the original (remote) destination. Without this special case, DeathWatch related
    * functionality breaks, like the special handling of Watch messages arriving to dead letters.
    */
-  private class RemoteDeadLetterActorRef(_provider: ActorRefProvider,
-                                         _path: ActorPath,
-                                         _eventStream: EventStream) extends DeadLetterActorRef(_provider, _path, _eventStream) {
+  private class RemoteDeadLetterActorRef(
+    _provider: ActorRefProvider,
+      _path: ActorPath,
+      _eventStream: EventStream) extends DeadLetterActorRef(_provider, _path, _eventStream) {
     import EndpointManager.Send
 
     override def !(message: Any)(implicit sender: ActorRef): Unit = message match {
@@ -109,10 +110,10 @@ private[akka] object RemoteActorRefProvider {
  *
  */
 private[akka] class RemoteActorRefProvider(
-  val systemName: String,
-  val settings: ActorSystem.Settings,
-  val eventStream: EventStream,
-  val dynamicAccess: DynamicAccess) extends ActorRefProvider {
+    val systemName: String,
+    val settings: ActorSystem.Settings,
+    val eventStream: EventStream,
+    val dynamicAccess: DynamicAccess) extends ActorRefProvider {
   import RemoteActorRefProvider._
 
   val remoteSettings: RemoteSettings = new RemoteSettings(settings.config)
@@ -168,16 +169,16 @@ private[akka] class RemoteActorRefProvider(
 
     val internals = Internals(
       remoteDaemon = {
-        val d = new RemoteSystemDaemon(
-          system,
-          local.rootPath / "remote",
-          rootGuardian,
-          remotingTerminator,
-          log,
-          untrustedMode = remoteSettings.UntrustedMode)
-        local.registerExtraNames(Map(("remote", d)))
-        d
-      },
+      val d = new RemoteSystemDaemon(
+        system,
+        local.rootPath / "remote",
+        rootGuardian,
+        remotingTerminator,
+        log,
+        untrustedMode = remoteSettings.UntrustedMode)
+      local.registerExtraNames(Map(("remote", d)))
+      d
+    },
       serialization = SerializationExtension(system),
       transport = new Remoting(system, this))
 
@@ -217,7 +218,7 @@ private[akka] class RemoteActorRefProvider(
     system.systemActorOf(remoteSettings.configureDispatcher(Props[RemoteDeploymentWatcher]), "remote-deployment-watcher")
 
   def actorOf(system: ActorSystemImpl, props: Props, supervisor: InternalActorRef, path: ActorPath,
-              systemService: Boolean, deploy: Option[Deploy], lookupDeploy: Boolean, async: Boolean): InternalActorRef =
+    systemService: Boolean, deploy: Option[Deploy], lookupDeploy: Boolean, async: Boolean): InternalActorRef =
     if (systemService) local.actorOf(system, props, supervisor, path, systemService, deploy, lookupDeploy, async)
     else {
 
@@ -446,7 +447,7 @@ private[akka] class RemoteActorRef private[akka] (
   val getParent: InternalActorRef,
   props: Option[Props],
   deploy: Option[Deploy])
-  extends InternalActorRef with RemoteRef {
+    extends InternalActorRef with RemoteRef {
 
   def getChild(name: Iterator[String]): InternalActorRef = {
     val s = name.toStream

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -48,7 +48,7 @@ private[akka] class RemoteSystemDaemon(
   terminator: ActorRef,
   _log: LoggingAdapter,
   val untrustedMode: Boolean)
-  extends VirtualPathContainer(system.provider, _path, _parent, _log) {
+    extends VirtualPathContainer(system.provider, _path, _parent, _log) {
 
   import akka.actor.SystemGuardian._
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteDeploymentWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDeploymentWatcher.scala
@@ -30,7 +30,7 @@ private[akka] class RemoteDeploymentWatcher extends Actor with RequiresMessageQu
 
   def receive = {
     case WatchRemote(a, supervisor: InternalActorRef) ⇒
-      supervisors += (a -> supervisor)
+      supervisors += (a → supervisor)
       context.watch(a)
 
     case t @ Terminated(a) if supervisors isDefinedAt a ⇒

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -96,7 +96,8 @@ final class RemoteSettings(val config: Config) {
   } requiring (_ > Duration.Zero, "quarantine-after-silence must be > 0")
 
   val QuarantineDuration: FiniteDuration = {
-    config.getMillisDuration("akka.remote.prune-quarantine-marker-after").requiring(_ > Duration.Zero,
+    config.getMillisDuration("akka.remote.prune-quarantine-marker-after").requiring(
+      _ > Duration.Zero,
       "prune-quarantine-marker-after must be > 0 ms")
   }
 
@@ -118,7 +119,8 @@ final class RemoteSettings(val config: Config) {
 
   val Transports: immutable.Seq[(String, immutable.Seq[String], Config)] = transportNames.map { name ⇒
     val transportConfig = transportConfigFor(name)
-    (transportConfig.getString("transport-class"),
+    (
+      transportConfig.getString("transport-class"),
       immutableSeq(transportConfig.getStringList("applied-adapters")).reverse,
       transportConfig)
   }

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -44,8 +44,9 @@ private[akka] object RemoteWatcher {
     lazy val empty: Stats = counts(0, 0)
     def counts(watching: Int, watchingNodes: Int): Stats = Stats(watching, watchingNodes)(Set.empty, Set.empty)
   }
-  final case class Stats(watching: Int, watchingNodes: Int)(val watchingRefs: Set[(ActorRef, ActorRef)],
-                                                            val watchingAddresses: Set[Address]) {
+  final case class Stats(watching: Int, watchingNodes: Int)(
+    val watchingRefs: Set[(ActorRef, ActorRef)],
+      val watchingAddresses: Set[Address]) {
     override def toString: String = {
       def formatWatchingRefs: String =
         watchingRefs.map(x ⇒ x._2.path.name + " -> " + x._1.path.name).mkString("[", ", ", "]")
@@ -82,7 +83,7 @@ private[akka] class RemoteWatcher(
   heartbeatInterval: FiniteDuration,
   unreachableReaperInterval: FiniteDuration,
   heartbeatExpectedResponseAfter: FiniteDuration)
-  extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    extends Actor with ActorLogging with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
   import RemoteWatcher._
   import context.dispatcher

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -29,7 +29,7 @@ final case class AssociatedEvent(
   localAddress: Address,
   remoteAddress: Address,
   inbound: Boolean)
-  extends AssociationEvent {
+    extends AssociationEvent {
 
   protected override def eventName: String = "Associated"
   override def logLevel: Logging.LogLevel = Logging.DebugLevel
@@ -41,18 +41,18 @@ final case class DisassociatedEvent(
   localAddress: Address,
   remoteAddress: Address,
   inbound: Boolean)
-  extends AssociationEvent {
+    extends AssociationEvent {
   protected override def eventName: String = "Disassociated"
   override def logLevel: Logging.LogLevel = Logging.DebugLevel
 }
 
 @SerialVersionUID(1L)
 final case class AssociationErrorEvent(
-  cause: Throwable,
-  localAddress: Address,
-  remoteAddress: Address,
-  inbound: Boolean,
-  logLevel: Logging.LogLevel) extends AssociationEvent {
+    cause: Throwable,
+    localAddress: Address,
+    remoteAddress: Address,
+    inbound: Boolean,
+    logLevel: Logging.LogLevel) extends AssociationEvent {
   protected override def eventName: String = "AssociationError"
   override def toString: String = s"${super.toString}: Error [${cause.getMessage}] [${Logging.stackTraceFor(cause)}]"
   def getCause: Throwable = cause

--- a/akka-remote/src/main/scala/akka/remote/security/provider/InternetSeedGenerator.scala
+++ b/akka-remote/src/main/scala/akka/remote/security/provider/InternetSeedGenerator.scala
@@ -36,7 +36,8 @@ object InternetSeedGenerator {
   private final val Instance: InternetSeedGenerator = new InternetSeedGenerator
   /**Delegate generators. */
   private final val Generators: immutable.Seq[SeedGenerator] =
-    List(new RandomDotOrgSeedGenerator, // first try the Internet seed generator
+    List(
+      new RandomDotOrgSeedGenerator, // first try the Internet seed generator
       new SecureRandomSeedGenerator) // this is last because it always works
 }
 

--- a/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
@@ -27,7 +27,7 @@ class TransportAdapters(system: ExtendedActorSystem) extends Extension {
   val settings = RARP(system).provider.remoteSettings
 
   private val adaptersTable: Map[String, TransportAdapterProvider] = for ((name, fqn) ← settings.Adapters) yield {
-    name -> system.dynamicAccess.createInstanceFor[TransportAdapterProvider](fqn, immutable.Seq.empty).recover({
+    name → system.dynamicAccess.createInstanceFor[TransportAdapterProvider](fqn, immutable.Seq.empty).recover({
       case e ⇒ throw new IllegalArgumentException(s"Cannot instantiate transport adapter [${fqn}]", e)
     }).get
   }
@@ -64,12 +64,13 @@ trait SchemeAugmenter {
  * An adapter that wraps a transport and provides interception
  */
 abstract class AbstractTransportAdapter(protected val wrappedTransport: Transport)(implicit val ec: ExecutionContext)
-  extends Transport with SchemeAugmenter {
+    extends Transport with SchemeAugmenter {
 
   protected def maximumOverhead: Int
 
-  protected def interceptListen(listenAddress: Address,
-                                listenerFuture: Future[AssociationEventListener]): Future[AssociationEventListener]
+  protected def interceptListen(
+    listenAddress: Address,
+    listenerFuture: Future[AssociationEventListener]): Future[AssociationEventListener]
 
   protected def interceptAssociate(remoteAddress: Address, statusPromise: Promise[AssociationHandle]): Unit
 
@@ -116,14 +117,16 @@ abstract class AbstractTransportAdapter(protected val wrappedTransport: Transpor
 
 }
 
-abstract class AbstractTransportAdapterHandle(val originalLocalAddress: Address,
-                                              val originalRemoteAddress: Address,
-                                              val wrappedHandle: AssociationHandle,
-                                              val addedSchemeIdentifier: String) extends AssociationHandle
-  with SchemeAugmenter {
+abstract class AbstractTransportAdapterHandle(
+  val originalLocalAddress: Address,
+  val originalRemoteAddress: Address,
+  val wrappedHandle: AssociationHandle,
+  val addedSchemeIdentifier: String) extends AssociationHandle
+    with SchemeAugmenter {
 
   def this(wrappedHandle: AssociationHandle, addedSchemeIdentifier: String) =
-    this(wrappedHandle.localAddress,
+    this(
+      wrappedHandle.localAddress,
       wrappedHandle.remoteAddress,
       wrappedHandle,
       addedSchemeIdentifier)
@@ -138,8 +141,9 @@ object ActorTransportAdapter {
 
   final case class ListenerRegistered(listener: AssociationEventListener) extends TransportOperation
   final case class AssociateUnderlying(remoteAddress: Address, statusPromise: Promise[AssociationHandle]) extends TransportOperation
-  final case class ListenUnderlying(listenAddress: Address,
-                                    upstreamListener: Future[AssociationEventListener]) extends TransportOperation
+  final case class ListenUnderlying(
+    listenAddress: Address,
+    upstreamListener: Future[AssociationEventListener]) extends TransportOperation
   final case class DisassociateUnderlying(info: DisassociateInfo = AssociationHandle.Unknown)
     extends TransportOperation with DeadLetterSuppression
 
@@ -147,7 +151,7 @@ object ActorTransportAdapter {
 }
 
 abstract class ActorTransportAdapter(wrappedTransport: Transport, system: ActorSystem)
-  extends AbstractTransportAdapter(wrappedTransport)(system.dispatcher) {
+    extends AbstractTransportAdapter(wrappedTransport)(system.dispatcher) {
 
   import ActorTransportAdapter._
 
@@ -159,8 +163,9 @@ abstract class ActorTransportAdapter(wrappedTransport: Transport, system: ActorS
   private def registerManager(): Future[ActorRef] =
     (system.actorSelection("/system/transports") ? RegisterTransportActor(managerProps, managerName)).mapTo[ActorRef]
 
-  override def interceptListen(listenAddress: Address,
-                               listenerPromise: Future[AssociationEventListener]): Future[AssociationEventListener] = {
+  override def interceptListen(
+    listenAddress: Address,
+    listenerPromise: Future[AssociationEventListener]): Future[AssociationEventListener] = {
     registerManager().map { mgr ⇒
       // Side effecting: storing the manager instance in volatile var
       // This is done only once: during the initialization of the protocol stack. The variable manager is not read
@@ -182,7 +187,7 @@ abstract class ActorTransportAdapter(wrappedTransport: Transport, system: ActorS
 }
 
 abstract class ActorTransportAdapterManager extends Actor
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import ActorTransportAdapter.{ ListenUnderlying, ListenerRegistered }
 
   private var delayedEvents = immutable.Queue.empty[Any]

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
@@ -34,11 +34,12 @@ private[remote] object AkkaPduCodec {
   case object Heartbeat extends AkkaPdu
   final case class Payload(bytes: ByteString) extends AkkaPdu
 
-  final case class Message(recipient: InternalActorRef,
-                           recipientAddress: Address,
-                           serializedMessage: SerializedMessage,
-                           senderOption: Option[ActorRef],
-                           seqOption: Option[SeqNo]) extends HasSequenceNumber {
+  final case class Message(
+    recipient: InternalActorRef,
+      recipientAddress: Address,
+      serializedMessage: SerializedMessage,
+      senderOption: Option[ActorRef],
+      seqOption: Option[SeqNo]) extends HasSequenceNumber {
 
     def reliableDeliveryEnabled = seqOption.isDefined
 

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -51,7 +51,8 @@ private[remote] class AkkaProtocolSettings(config: Config) {
     else if (enabledTransports.contains("akka.remote.netty.ssl"))
       config.getMillisDuration("akka.remote.netty.ssl.connection-timeout")
     else
-      config.getMillisDuration("akka.remote.handshake-timeout").requiring(_ > Duration.Zero,
+      config.getMillisDuration("akka.remote.handshake-timeout").requiring(
+        _ > Duration.Zero,
         "handshake-timeout must be > 0")
   }
 }
@@ -93,10 +94,10 @@ final case class HandshakeInfo(origin: Address, uid: Int, cookie: Option[String]
  *   the codec that will be used to encode/decode Akka PDUs
  */
 private[remote] class AkkaProtocolTransport(
-  wrappedTransport: Transport,
-  private val system: ActorSystem,
-  private val settings: AkkaProtocolSettings,
-  private val codec: AkkaPduCodec) extends ActorTransportAdapter(wrappedTransport, system) {
+    wrappedTransport: Transport,
+    private val system: ActorSystem,
+    private val settings: AkkaProtocolSettings,
+    private val codec: AkkaPduCodec) extends ActorTransportAdapter(wrappedTransport, system) {
 
   override val addedSchemeIdentifier: String = AkkaScheme
 
@@ -123,7 +124,7 @@ private[remote] class AkkaProtocolTransport(
 private[transport] class AkkaProtocolManager(
   private val wrappedTransport: Transport,
   private val settings: AkkaProtocolSettings)
-  extends ActorTransportAdapterManager {
+    extends ActorTransportAdapterManager {
 
   // The AkkaProtocolTransport does not handle the recovery of associations, this task is implemented in the
   // remoting itself. Hence the strategy Stop.
@@ -188,7 +189,7 @@ private[remote] class AkkaProtocolHandle(
   val handshakeInfo: HandshakeInfo,
   private val stateActor: ActorRef,
   private val codec: AkkaPduCodec)
-  extends AbstractTransportAdapterHandle(_localAddress, _remoteAddress, _wrappedHandle, AkkaScheme) {
+    extends AbstractTransportAdapterHandle(_localAddress, _remoteAddress, _wrappedHandle, AkkaScheme) {
 
   override def write(payload: ByteString): Boolean = wrappedHandle.write(codec.constructPayload(payload))
 
@@ -247,8 +248,8 @@ private[transport] object ProtocolStateActor {
 
   // Both transports are associated, but the handler for the handle has not yet been provided
   final case class AssociatedWaitHandler(handleListener: Future[HandleEventListener], wrappedHandle: AssociationHandle,
-                                         queue: immutable.Queue[ByteString])
-    extends ProtocolStateData
+    queue: immutable.Queue[ByteString])
+      extends ProtocolStateData
 
   final case class ListenerReady(listener: HandleEventListener, wrappedHandle: AssociationHandle)
     extends ProtocolStateData
@@ -279,37 +280,40 @@ private[transport] object ProtocolStateActor {
       failureDetector).withDeploy(Deploy.local)
 }
 
-private[transport] class ProtocolStateActor(initialData: InitialProtocolStateData,
-                                            private val localHandshakeInfo: HandshakeInfo,
-                                            private val refuseUid: Option[Int],
-                                            private val settings: AkkaProtocolSettings,
-                                            private val codec: AkkaPduCodec,
-                                            private val failureDetector: FailureDetector)
-  extends Actor with FSM[AssociationState, ProtocolStateData]
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+private[transport] class ProtocolStateActor(
+  initialData: InitialProtocolStateData,
+  private val localHandshakeInfo: HandshakeInfo,
+  private val refuseUid: Option[Int],
+  private val settings: AkkaProtocolSettings,
+  private val codec: AkkaPduCodec,
+  private val failureDetector: FailureDetector)
+    extends Actor with FSM[AssociationState, ProtocolStateData]
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
 
   import ProtocolStateActor._
   import context.dispatcher
 
   // Outbound case
-  def this(handshakeInfo: HandshakeInfo,
-           remoteAddress: Address,
-           statusPromise: Promise[AssociationHandle],
-           transport: Transport,
-           settings: AkkaProtocolSettings,
-           codec: AkkaPduCodec,
-           failureDetector: FailureDetector,
-           refuseUid: Option[Int]) = {
+  def this(
+    handshakeInfo: HandshakeInfo,
+    remoteAddress: Address,
+    statusPromise: Promise[AssociationHandle],
+    transport: Transport,
+    settings: AkkaProtocolSettings,
+    codec: AkkaPduCodec,
+    failureDetector: FailureDetector,
+    refuseUid: Option[Int]) = {
     this(OutboundUnassociated(remoteAddress, statusPromise, transport), handshakeInfo, refuseUid, settings, codec, failureDetector)
   }
 
   // Inbound case
-  def this(handshakeInfo: HandshakeInfo,
-           wrappedHandle: AssociationHandle,
-           associationListener: AssociationEventListener,
-           settings: AkkaProtocolSettings,
-           codec: AkkaPduCodec,
-           failureDetector: FailureDetector) = {
+  def this(
+    handshakeInfo: HandshakeInfo,
+    wrappedHandle: AssociationHandle,
+    associationListener: AssociationEventListener,
+    settings: AkkaProtocolSettings,
+    codec: AkkaPduCodec,
+    failureDetector: FailureDetector) = {
     this(InboundUnassociated(associationListener, wrappedHandle), handshakeInfo, refuseUid = None, settings, codec, failureDetector)
   }
 
@@ -413,7 +417,8 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
               immutable.Queue.empty)
           } else {
             if (log.isDebugEnabled)
-              log.warning(s"Association attempt with mismatching cookie from [{}]. Expected [{}] but received [{}].",
+              log.warning(
+                s"Association attempt with mismatching cookie from [{}]. Expected [{}] but received [{}].",
                 info.origin, localHandshakeInfo.cookie.getOrElse(""), info.cookie.getOrElse(""))
             else
               log.warning(s"Association attempt with mismatching cookie from [{}].", info.origin)
@@ -581,9 +586,10 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
   private def listenForListenerRegistration(readHandlerPromise: Promise[HandleEventListener]): Unit =
     readHandlerPromise.future.map { HandleListenerRegistered(_) } pipeTo self
 
-  private def notifyOutboundHandler(wrappedHandle: AssociationHandle,
-                                    handshakeInfo: HandshakeInfo,
-                                    statusPromise: Promise[AssociationHandle]): Future[HandleEventListener] = {
+  private def notifyOutboundHandler(
+    wrappedHandle: AssociationHandle,
+    handshakeInfo: HandshakeInfo,
+    statusPromise: Promise[AssociationHandle]): Future[HandleEventListener] = {
     val readHandlerPromise = Promise[HandleEventListener]()
     listenForListenerRegistration(readHandlerPromise)
 
@@ -599,9 +605,10 @@ private[transport] class ProtocolStateActor(initialData: InitialProtocolStateDat
     readHandlerPromise.future
   }
 
-  private def notifyInboundHandler(wrappedHandle: AssociationHandle,
-                                   handshakeInfo: HandshakeInfo,
-                                   associationListener: AssociationEventListener): Future[HandleEventListener] = {
+  private def notifyInboundHandler(
+    wrappedHandle: AssociationHandle,
+    handshakeInfo: HandshakeInfo,
+    associationListener: AssociationEventListener): Future[HandleEventListener] = {
     val readHandlerPromise = Promise[HandleEventListener]()
     listenForListenerRegistration(readHandlerPromise)
 

--- a/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
@@ -53,7 +53,7 @@ private[remote] object FailureInjectorTransportAdapter {
  * INTERNAL API
  */
 private[remote] class FailureInjectorTransportAdapter(wrappedTransport: Transport, val extendedSystem: ExtendedActorSystem)
-  extends AbstractTransportAdapter(wrappedTransport)(extendedSystem.dispatcher) with AssociationEventListener {
+    extends AbstractTransportAdapter(wrappedTransport)(extendedSystem.dispatcher) with AssociationEventListener {
 
   private def rng = ThreadLocalRandom.current()
   private val log = Logging(extendedSystem, getClass.getName)
@@ -77,8 +77,9 @@ private[remote] class FailureInjectorTransportAdapter(wrappedTransport: Transpor
     case _ ⇒ wrappedTransport.managementCommand(cmd)
   }
 
-  protected def interceptListen(listenAddress: Address,
-                                listenerFuture: Future[AssociationEventListener]): Future[AssociationEventListener] = {
+  protected def interceptListen(
+    listenAddress: Address,
+    listenerFuture: Future[AssociationEventListener]): Future[AssociationEventListener] = {
     log.warning("FailureInjectorTransport is active on this system. Gremlins might munch your packets.")
     listenerFuture.onSuccess {
       // Side effecting: As this class is not an actor, the only way to safely modify state is through volatile vars.
@@ -140,10 +141,11 @@ private[remote] class FailureInjectorTransportAdapter(wrappedTransport: Transpor
 /**
  * INTERNAL API
  */
-private[remote] final case class FailureInjectorHandle(_wrappedHandle: AssociationHandle,
-                                                       private val gremlinAdapter: FailureInjectorTransportAdapter)
-  extends AbstractTransportAdapterHandle(_wrappedHandle, FailureInjectorSchemeIdentifier)
-  with HandleEventListener {
+private[remote] final case class FailureInjectorHandle(
+  _wrappedHandle: AssociationHandle,
+  private val gremlinAdapter: FailureInjectorTransportAdapter)
+    extends AbstractTransportAdapterHandle(_wrappedHandle, FailureInjectorSchemeIdentifier)
+    with HandleEventListener {
   import gremlinAdapter.extendedSystem.dispatcher
 
   @volatile private var upstreamListener: HandleEventListener = null

--- a/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
@@ -24,10 +24,10 @@ import scala.concurrent.ExecutionContext.Implicits.global
  * production systems.
  */
 class TestTransport(
-  val localAddress: Address,
-  final val registry: AssociationRegistry,
-  val maximumPayloadBytes: Int = 32000,
-  val schemeIdentifier: String = "test") extends Transport {
+    val localAddress: Address,
+    final val registry: AssociationRegistry,
+    val maximumPayloadBytes: Int = 32000,
+    val schemeIdentifier: String = "test") extends Transport {
 
   def this(system: ExtendedActorSystem, conf: Config) = {
     this(
@@ -141,12 +141,12 @@ class TestTransport(
    */
   val writeBehavior = new SwitchableLoggedBehavior[(TestAssociationHandle, ByteString), Boolean](
     defaultBehavior = {
-      defaultWrite _
-    },
+    defaultWrite _
+  },
     logCallback = {
-      case (handle, payload) ⇒
-        registry.logActivity(WriteAttempt(handle.localAddress, handle.remoteAddress, payload))
-    })
+    case (handle, payload) ⇒
+      registry.logActivity(WriteAttempt(handle.localAddress, handle.remoteAddress, payload))
+  })
 
   /**
    * The [[akka.remote.transport.TestTransport.SwitchableLoggedBehavior]] for the disassociate() method on handles. All
@@ -154,12 +154,12 @@ class TestTransport(
    */
   val disassociateBehavior = new SwitchableLoggedBehavior[TestAssociationHandle, Unit](
     defaultBehavior = {
-      defaultDisassociate _
-    },
+    defaultDisassociate _
+  },
     logCallback = {
-      (handle) ⇒
-        registry.logActivity(DisassociateAttempt(handle.localAddress, handle.remoteAddress))
-    })
+    (handle) ⇒
+      registry.logActivity(DisassociateAttempt(handle.localAddress, handle.remoteAddress))
+  })
 
   private[akka] def write(handle: TestAssociationHandle, payload: ByteString): Boolean =
     Await.result(writeBehavior((handle, payload)), 3.seconds)
@@ -299,8 +299,9 @@ object TestTransport {
      * @param listenerPair pair of listeners in initiator, receiver order.
      * @return
      */
-    def remoteListenerRelativeTo(handle: TestAssociationHandle,
-                                 listenerPair: (HandleEventListener, HandleEventListener)): HandleEventListener = {
+    def remoteListenerRelativeTo(
+      handle: TestAssociationHandle,
+      listenerPair: (HandleEventListener, HandleEventListener)): HandleEventListener = {
       listenerPair match {
         case (initiator, receiver) ⇒ if (handle.inbound) initiator else receiver
       }
@@ -448,10 +449,10 @@ object AssociationRegistry {
 }
 
 final case class TestAssociationHandle(
-  localAddress: Address,
-  remoteAddress: Address,
-  transport: TestTransport,
-  inbound: Boolean) extends AssociationHandle {
+    localAddress: Address,
+    remoteAddress: Address,
+    transport: TestTransport,
+    inbound: Boolean) extends AssociationHandle {
 
   @volatile var writable = true
 

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -97,7 +97,7 @@ object ThrottlerTransportAdapter {
 
   @SerialVersionUID(1L)
   final case class TokenBucket(capacity: Int, tokensPerSecond: Double, nanoTimeOfLastSend: Long, availableTokens: Int)
-    extends ThrottleMode {
+      extends ThrottleMode {
 
     private def isAvailable(nanoTimeOfSend: Long, tokens: Int): Boolean =
       if ((tokens > capacity && availableTokens > 0)) {
@@ -232,7 +232,7 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport) extends A
       val inMode = getInboundMode(naked)
       wrappedHandle.outboundThrottleMode.set(getOutboundMode(naked))
       wrappedHandle.readHandlerPromise.future map { ListenerAndMode(_, inMode) } pipeTo wrappedHandle.throttlerActor
-      handleTable ::= naked -> wrappedHandle
+      handleTable ::= naked → wrappedHandle
       statusPromise.success(wrappedHandle)
     case SetThrottle(address, direction, mode) ⇒
       val naked = nakedAddress(address)
@@ -259,7 +259,7 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport) extends A
 
     case Checkin(origin, handle) ⇒
       val naked: Address = nakedAddress(origin)
-      handleTable ::= naked -> handle
+      handleTable ::= naked → handle
       setMode(naked, handle)
 
   }
@@ -364,8 +364,8 @@ private[transport] class ThrottledAssociation(
   val associationHandler: AssociationEventListener,
   val originalHandle: AssociationHandle,
   val inbound: Boolean)
-  extends Actor with LoggingFSM[ThrottledAssociation.ThrottlerState, ThrottledAssociation.ThrottlerData]
-  with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
+    extends Actor with LoggingFSM[ThrottledAssociation.ThrottlerState, ThrottledAssociation.ThrottlerData]
+    with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import ThrottledAssociation._
   import context.dispatcher
 
@@ -521,7 +521,7 @@ private[transport] class ThrottledAssociation(
  * INTERNAL API
  */
 private[transport] final case class ThrottlerHandle(_wrappedHandle: AssociationHandle, throttlerActor: ActorRef)
-  extends AbstractTransportAdapterHandle(_wrappedHandle, SchemeIdentifier) {
+    extends AbstractTransportAdapterHandle(_wrappedHandle, SchemeIdentifier) {
 
   private[transport] val outboundThrottleMode = new AtomicReference[ThrottleMode](Unthrottled)
 

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -167,10 +167,11 @@ private[netty] trait CommonHandlers extends NettyHelpers {
 
   protected def createHandle(channel: Channel, localAddress: Address, remoteAddress: Address): AssociationHandle
 
-  protected def registerListener(channel: Channel,
-                                 listener: HandleEventListener,
-                                 msg: ChannelBuffer,
-                                 remoteSocketAddress: InetSocketAddress): Unit
+  protected def registerListener(
+    channel: Channel,
+    listener: HandleEventListener,
+    msg: ChannelBuffer,
+    remoteSocketAddress: InetSocketAddress): Unit
 
   final protected def init(channel: Channel, remoteSocketAddress: SocketAddress, remoteAddress: Address, msg: ChannelBuffer)(
     op: (AssociationHandle ⇒ Any)): Unit = {
@@ -193,9 +194,10 @@ private[netty] trait CommonHandlers extends NettyHelpers {
 /**
  * INTERNAL API
  */
-private[netty] abstract class ServerHandler(protected final val transport: NettyTransport,
-                                            private final val associationListenerFuture: Future[AssociationEventListener])
-  extends NettyServerHelpers with CommonHandlers {
+private[netty] abstract class ServerHandler(
+  protected final val transport: NettyTransport,
+  private final val associationListenerFuture: Future[AssociationEventListener])
+    extends NettyServerHelpers with CommonHandlers {
 
   import transport.executionContext
 
@@ -205,7 +207,7 @@ private[netty] abstract class ServerHandler(protected final val transport: Netty
       case listener: AssociationEventListener ⇒
         val remoteAddress = NettyTransport.addressFromSocketAddress(remoteSocketAddress, transport.schemeIdentifier,
           transport.system.name, hostName = None, port = None).getOrElse(
-            throw new NettyTransportException(s"Unknown inbound remote address type [${remoteSocketAddress.getClass.getName}]"))
+          throw new NettyTransportException(s"Unknown inbound remote address type [${remoteSocketAddress.getClass.getName}]"))
         init(channel, remoteSocketAddress, remoteAddress, msg) { listener notify InboundAssociation(_) }
     }
   }
@@ -216,7 +218,7 @@ private[netty] abstract class ServerHandler(protected final val transport: Netty
  * INTERNAL API
  */
 private[netty] abstract class ClientHandler(protected final val transport: NettyTransport, remoteAddress: Address)
-  extends NettyClientHelpers with CommonHandlers {
+    extends NettyClientHelpers with CommonHandlers {
   final protected val statusPromise = Promise[AssociationHandle]()
   def statusFuture = statusPromise.future
 
@@ -243,7 +245,7 @@ private[transport] object NettyTransport {
   val uniqueIdCounter = new AtomicInteger(0)
 
   def addressFromSocketAddress(addr: SocketAddress, schemeIdentifier: String, systemName: String,
-                               hostName: Option[String], port: Option[Int]): Option[Address] = addr match {
+    hostName: Option[String], port: Option[Int]): Option[Address] = addr match {
     case sa: InetSocketAddress ⇒ Some(Address(schemeIdentifier, systemName,
       hostName.getOrElse(sa.getHostString), port.getOrElse(sa.getPort)))
     case _ ⇒ None
@@ -251,7 +253,7 @@ private[transport] object NettyTransport {
 
   // Need to do like this for binary compatibility reasons
   def addressFromSocketAddress(addr: SocketAddress, schemeIdentifier: String, systemName: String,
-                               hostName: Option[String]): Option[Address] =
+    hostName: Option[String]): Option[Address] =
     addressFromSocketAddress(addr, schemeIdentifier, systemName, hostName, port = None)
 }
 

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
@@ -28,10 +28,11 @@ private[remote] trait TcpHandlers extends CommonHandlers {
 
   import ChannelLocalActor._
 
-  override def registerListener(channel: Channel,
-                                listener: HandleEventListener,
-                                msg: ChannelBuffer,
-                                remoteSocketAddress: InetSocketAddress): Unit = ChannelLocalActor.set(channel, Some(listener))
+  override def registerListener(
+    channel: Channel,
+    listener: HandleEventListener,
+    msg: ChannelBuffer,
+    remoteSocketAddress: InetSocketAddress): Unit = ChannelLocalActor.set(channel, Some(listener))
 
   override def createHandle(channel: Channel, localAddress: Address, remoteAddress: Address): AssociationHandle =
     new TcpAssociationHandle(localAddress, remoteAddress, transport, channel)
@@ -54,7 +55,7 @@ private[remote] trait TcpHandlers extends CommonHandlers {
  * INTERNAL API
  */
 private[remote] class TcpServerHandler(_transport: NettyTransport, _associationListenerFuture: Future[AssociationEventListener])
-  extends ServerHandler(_transport, _associationListenerFuture) with TcpHandlers {
+    extends ServerHandler(_transport, _associationListenerFuture) with TcpHandlers {
 
   override def onConnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit =
     initInbound(e.getChannel, e.getChannel.getRemoteAddress, null)
@@ -65,7 +66,7 @@ private[remote] class TcpServerHandler(_transport: NettyTransport, _associationL
  * INTERNAL API
  */
 private[remote] class TcpClientHandler(_transport: NettyTransport, remoteAddress: Address)
-  extends ClientHandler(_transport, remoteAddress) with TcpHandlers {
+    extends ClientHandler(_transport, remoteAddress) with TcpHandlers {
 
   override def onConnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit =
     initOutbound(e.getChannel, e.getChannel.getRemoteAddress, null)
@@ -75,11 +76,12 @@ private[remote] class TcpClientHandler(_transport: NettyTransport, remoteAddress
 /**
  * INTERNAL API
  */
-private[remote] class TcpAssociationHandle(val localAddress: Address,
-                                           val remoteAddress: Address,
-                                           val transport: NettyTransport,
-                                           private val channel: Channel)
-  extends AssociationHandle {
+private[remote] class TcpAssociationHandle(
+  val localAddress: Address,
+  val remoteAddress: Address,
+  val transport: NettyTransport,
+  private val channel: Channel)
+    extends AssociationHandle {
   import transport.executionContext
 
   override val readHandlerPromise: Promise[HandleEventListener] = Promise()

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/UdpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/UdpSupport.scala
@@ -21,10 +21,11 @@ private[remote] trait UdpHandlers extends CommonHandlers {
   override def createHandle(channel: Channel, localAddress: Address, remoteAddress: Address): AssociationHandle =
     new UdpAssociationHandle(localAddress, remoteAddress, channel, transport)
 
-  override def registerListener(channel: Channel,
-                                listener: HandleEventListener,
-                                msg: ChannelBuffer,
-                                remoteSocketAddress: InetSocketAddress): Unit = {
+  override def registerListener(
+    channel: Channel,
+    listener: HandleEventListener,
+    msg: ChannelBuffer,
+    remoteSocketAddress: InetSocketAddress): Unit = {
     transport.udpConnectionTable.putIfAbsent(remoteSocketAddress, listener) match {
       case null ⇒ listener notify InboundPayload(ByteString(msg.array()))
       case oldReader ⇒
@@ -53,7 +54,7 @@ private[remote] trait UdpHandlers extends CommonHandlers {
  * INTERNAL API
  */
 private[remote] class UdpServerHandler(_transport: NettyTransport, _associationListenerFuture: Future[AssociationEventListener])
-  extends ServerHandler(_transport, _associationListenerFuture) with UdpHandlers {
+    extends ServerHandler(_transport, _associationListenerFuture) with UdpHandlers {
 
   override def initUdp(channel: Channel, remoteSocketAddress: SocketAddress, msg: ChannelBuffer): Unit =
     initInbound(channel, remoteSocketAddress, msg)
@@ -63,7 +64,7 @@ private[remote] class UdpServerHandler(_transport: NettyTransport, _associationL
  * INTERNAL API
  */
 private[remote] class UdpClientHandler(_transport: NettyTransport, remoteAddress: Address)
-  extends ClientHandler(_transport, remoteAddress) with UdpHandlers {
+    extends ClientHandler(_transport, remoteAddress) with UdpHandlers {
 
   override def initUdp(channel: Channel, remoteSocketAddress: SocketAddress, msg: ChannelBuffer): Unit =
     initOutbound(channel, remoteSocketAddress, msg)
@@ -72,10 +73,11 @@ private[remote] class UdpClientHandler(_transport: NettyTransport, remoteAddress
 /**
  * INTERNAL API
  */
-private[remote] class UdpAssociationHandle(val localAddress: Address,
-                                           val remoteAddress: Address,
-                                           private val channel: Channel,
-                                           private val transport: NettyTransport) extends AssociationHandle {
+private[remote] class UdpAssociationHandle(
+  val localAddress: Address,
+    val remoteAddress: Address,
+    private val channel: Channel,
+    private val transport: NettyTransport) extends AssociationHandle {
 
   override val readHandlerPromise: Promise[HandleEventListener] = Promise()
 

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/TestGraphStage.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/TestGraphStage.scala
@@ -16,13 +16,15 @@ object GraphStageMessages {
 }
 
 object TestSinkStage {
-  def apply[T, M](stageUnderTest: GraphStageWithMaterializedValue[SinkShape[T], M],
-                  probe: TestProbe) = new TestSinkStage(stageUnderTest, probe)
+  def apply[T, M](
+    stageUnderTest: GraphStageWithMaterializedValue[SinkShape[T], M],
+    probe: TestProbe) = new TestSinkStage(stageUnderTest, probe)
 }
 
-private[testkit] class TestSinkStage[T, M](stageUnderTest: GraphStageWithMaterializedValue[SinkShape[T], M],
-                                           probe: TestProbe)
-  extends GraphStageWithMaterializedValue[SinkShape[T], M] {
+private[testkit] class TestSinkStage[T, M](
+  stageUnderTest: GraphStageWithMaterializedValue[SinkShape[T], M],
+  probe: TestProbe)
+    extends GraphStageWithMaterializedValue[SinkShape[T], M] {
 
   val in = Inlet[T]("testSinkStage.in")
   override val shape: SinkShape[T] = SinkShape.of(in)
@@ -51,13 +53,15 @@ private[testkit] class TestSinkStage[T, M](stageUnderTest: GraphStageWithMateria
 }
 
 object TestSourceStage {
-  def apply[T, M](stageUnderTest: GraphStageWithMaterializedValue[SourceShape[T], M],
-                  probe: TestProbe) = Source.fromGraph(new TestSourceStage(stageUnderTest, probe))
+  def apply[T, M](
+    stageUnderTest: GraphStageWithMaterializedValue[SourceShape[T], M],
+    probe: TestProbe) = Source.fromGraph(new TestSourceStage(stageUnderTest, probe))
 }
 
-private[testkit] class TestSourceStage[T, M](stageUnderTest: GraphStageWithMaterializedValue[SourceShape[T], M],
-                                             probe: TestProbe)
-  extends GraphStageWithMaterializedValue[SourceShape[T], M] {
+private[testkit] class TestSourceStage[T, M](
+  stageUnderTest: GraphStageWithMaterializedValue[SourceShape[T], M],
+  probe: TestProbe)
+    extends GraphStageWithMaterializedValue[SourceShape[T], M] {
 
   val out = Outlet[T]("testSourceStage.out")
   override val shape: SourceShape[T] = SourceShape.of(out)

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -276,28 +276,29 @@ object ActorMaterializerSettings {
  * Please refer to the `withX` methods for descriptions of the individual settings.
  */
 final class ActorMaterializerSettings private (
-  val initialInputBufferSize: Int,
-  val maxInputBufferSize: Int,
-  val dispatcher: String,
-  val supervisionDecider: Supervision.Decider,
-  val subscriptionTimeoutSettings: StreamSubscriptionTimeoutSettings,
-  val debugLogging: Boolean,
-  val outputBurstLimit: Int,
-  val fuzzingMode: Boolean,
-  val autoFusing: Boolean,
-  val maxFixedBufferSize: Int,
-  val syncProcessingLimit: Int) {
+    val initialInputBufferSize: Int,
+    val maxInputBufferSize: Int,
+    val dispatcher: String,
+    val supervisionDecider: Supervision.Decider,
+    val subscriptionTimeoutSettings: StreamSubscriptionTimeoutSettings,
+    val debugLogging: Boolean,
+    val outputBurstLimit: Int,
+    val fuzzingMode: Boolean,
+    val autoFusing: Boolean,
+    val maxFixedBufferSize: Int,
+    val syncProcessingLimit: Int) {
 
-  def this(initialInputBufferSize: Int,
-           maxInputBufferSize: Int,
-           dispatcher: String,
-           supervisionDecider: Supervision.Decider,
-           subscriptionTimeoutSettings: StreamSubscriptionTimeoutSettings,
-           debugLogging: Boolean,
-           outputBurstLimit: Int,
-           fuzzingMode: Boolean,
-           autoFusing: Boolean,
-           maxFixedBufferSize: Int) {
+  def this(
+    initialInputBufferSize: Int,
+    maxInputBufferSize: Int,
+    dispatcher: String,
+    supervisionDecider: Supervision.Decider,
+    subscriptionTimeoutSettings: StreamSubscriptionTimeoutSettings,
+    debugLogging: Boolean,
+    outputBurstLimit: Int,
+    fuzzingMode: Boolean,
+    autoFusing: Boolean,
+    maxFixedBufferSize: Int) {
     this(initialInputBufferSize, maxInputBufferSize, dispatcher, supervisionDecider, subscriptionTimeoutSettings, debugLogging,
       outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize, defaultMaxFixedBufferSize)
   }

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -65,16 +65,14 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    */
   def getAttribute[T <: Attribute](c: Class[T]): Optional[T] =
     Optional.ofNullable(attributeList.foldLeft(
-      null.asInstanceOf[T]
-    )(
-      (acc, attr) ⇒ if (c.isInstance(attr)) c.cast(attr) else acc)
-    )
+      null.asInstanceOf[T])(
+      (acc, attr) ⇒ if (c.isInstance(attr)) c.cast(attr) else acc))
 
   /**
    * Java API: Get the first (least specific) attribute of a given `Class` or subclass thereof.
    */
   def getFirstAttribute[T <: Attribute](c: Class[T]): Optional[T] =
-    attributeList.collectFirst { case attr if c.isInstance(attr) => c cast attr }.asJava
+    attributeList.collectFirst { case attr if c.isInstance(attr) ⇒ c cast attr }.asJava
 
   /**
    * Scala API: get all attributes of a given type (or subtypes thereof).
@@ -105,7 +103,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    */
   def get[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-    attributeList.reverseIterator.collectFirst[T] { case attr if c.isInstance(attr) => c.cast(attr) }
+    attributeList.reverseIterator.collectFirst[T] { case attr if c.isInstance(attr) ⇒ c.cast(attr) }
   }
 
   /**
@@ -113,7 +111,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    */
   def getFirst[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-    attributeList.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }
+    attributeList.collectFirst { case attr if c.isInstance(attr) ⇒ c.cast(attr) }
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/Fusing.scala
+++ b/akka-stream/src/main/scala/akka/stream/Fusing.scala
@@ -38,8 +38,9 @@ object Fusing {
    * holds more information on the operation structure of the contained stream
    * topology for convenient graph traversal.
    */
-  case class FusedGraph[+S <: Shape @uncheckedVariance, +M](override val module: FusedModule,
-                                                            override val shape: S) extends Graph[S, M] {
+  case class FusedGraph[+S <: Shape @uncheckedVariance, +M](
+    override val module: FusedModule,
+      override val shape: S) extends Graph[S, M] {
     // the @uncheckedVariance look like a compiler bug ... why does it work in Graph but not here?
     override def withAttributes(attr: Attributes) = copy(module = module.withAttributes(attr))
   }
@@ -47,8 +48,8 @@ object Fusing {
   object FusedGraph {
     def unapply[S <: Shape, M](g: Graph[S, M]): Option[(FusedModule, S)] =
       g.module match {
-        case f: FusedModule => Some((f, g.shape))
-        case _              => None
+        case f: FusedModule ⇒ Some((f, g.shape))
+        case _              ⇒ None
       }
   }
 
@@ -59,10 +60,11 @@ object Fusing {
    * the wirings in a more accessible form, allowing traversal from port to upstream
    * or downstream port and from there to the owning module (or graph vertex).
    */
-  final case class StructuralInfo(upstreams: immutable.Map[InPort, OutPort],
-                                  downstreams: immutable.Map[OutPort, InPort],
-                                  inOwners: immutable.Map[InPort, Module],
-                                  outOwners: immutable.Map[OutPort, Module],
-                                  allModules: Set[Module])
+  final case class StructuralInfo(
+    upstreams: immutable.Map[InPort, OutPort],
+    downstreams: immutable.Map[OutPort, InPort],
+    inOwners: immutable.Map[InPort, Module],
+    outOwners: immutable.Map[OutPort, Module],
+    allModules: Set[Module])
 
 }

--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -306,10 +306,11 @@ object SinkShape {
  *        +------+
  * }}}
  */
-final case class BidiShape[-In1, +Out1, -In2, +Out2](in1: Inlet[In1 @uncheckedVariance],
-                                                     out1: Outlet[Out1 @uncheckedVariance],
-                                                     in2: Inlet[In2 @uncheckedVariance],
-                                                     out2: Outlet[Out2 @uncheckedVariance]) extends Shape {
+final case class BidiShape[-In1, +Out1, -In2, +Out2](
+  in1: Inlet[In1 @uncheckedVariance],
+    out1: Outlet[Out1 @uncheckedVariance],
+    in2: Inlet[In2 @uncheckedVariance],
+    out2: Outlet[Out2 @uncheckedVariance]) extends Shape {
   //#implementation-details-elided
   override val inlets: immutable.Seq[Inlet[_]] = List(in1, in2)
   override val outlets: immutable.Seq[Outlet[_]] = List(out1, out2)
@@ -335,10 +336,11 @@ object BidiShape {
     BidiShape(top.in, top.out, bottom.in, bottom.out)
 
   /** Java API */
-  def of[In1, Out1, In2, Out2](in1: Inlet[In1 @uncheckedVariance],
-                               out1: Outlet[Out1 @uncheckedVariance],
-                               in2: Inlet[In2 @uncheckedVariance],
-                               out2: Outlet[Out2 @uncheckedVariance]): BidiShape[In1, Out1, In2, Out2] =
+  def of[In1, Out1, In2, Out2](
+    in1: Inlet[In1 @uncheckedVariance],
+    out1: Outlet[Out1 @uncheckedVariance],
+    in2: Inlet[In2 @uncheckedVariance],
+    out2: Outlet[Out2 @uncheckedVariance]): BidiShape[In1, Out1, In2, Out2] =
     BidiShape(in1, out1, in2, out2)
 
 }

--- a/akka-stream/src/main/scala/akka/stream/SslTlsOptions.scala
+++ b/akka-stream/src/main/scala/akka/stream/SslTlsOptions.scala
@@ -189,10 +189,10 @@ object TLSProtocol {
    * switches off client authentication.
    */
   case class NegotiateNewSession(
-    enabledCipherSuites: Option[immutable.Seq[String]],
-    enabledProtocols: Option[immutable.Seq[String]],
-    clientAuth: Option[TLSClientAuth],
-    sslParameters: Option[SSLParameters]) extends SslTlsOutbound {
+      enabledCipherSuites: Option[immutable.Seq[String]],
+      enabledProtocols: Option[immutable.Seq[String]],
+      clientAuth: Option[TLSClientAuth],
+      sslParameters: Option[SSLParameters]) extends SslTlsOutbound {
 
     /**
      * Java API: Make a copy of this message with the given `enabledCipherSuites`.

--- a/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
@@ -287,7 +287,8 @@ trait ActorPublisher[T] extends Actor {
           tryOnComplete(sub)
         case Active | Canceled ⇒
           tryOnSubscribe(sub, CancelledSubscription)
-          tryOnError(sub,
+          tryOnError(
+            sub,
             if (subscriber == sub) ReactiveStreamsCompliance.canNotSubscribeTheSameSubscriberMultipleTimesException
             else ReactiveStreamsCompliance.canNotSubscribeTheSameSubscriberMultipleTimesException)
       }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -26,12 +26,13 @@ import akka.stream.impl.fusing.GraphInterpreterShell
 /**
  * INTERNAL API
  */
-private[akka] case class ActorMaterializerImpl(system: ActorSystem,
-                                               override val settings: ActorMaterializerSettings,
-                                               dispatchers: Dispatchers,
-                                               supervisor: ActorRef,
-                                               haveShutDown: AtomicBoolean,
-                                               flowNames: SeqActorName) extends ActorMaterializer {
+private[akka] case class ActorMaterializerImpl(
+  system: ActorSystem,
+    override val settings: ActorMaterializerSettings,
+    dispatchers: Dispatchers,
+    supervisor: ActorRef,
+    haveShutDown: AtomicBoolean,
+    flowNames: SeqActorName) extends ActorMaterializer {
   import akka.stream.impl.Stages._
   private val _logger = Logging.getLogger(system, this)
   override def logger = _logger
@@ -78,8 +79,9 @@ private[akka] case class ActorMaterializerImpl(system: ActorSystem,
   override def materialize[Mat](_runnableGraph: Graph[ClosedShape, Mat]): Mat =
     materialize(_runnableGraph, null)
 
-  private[stream] def materialize[Mat](_runnableGraph: Graph[ClosedShape, Mat],
-                                       subflowFuser: GraphInterpreterShell ⇒ ActorRef): Mat = {
+  private[stream] def materialize[Mat](
+    _runnableGraph: Graph[ClosedShape, Mat],
+    subflowFuser: GraphInterpreterShell ⇒ ActorRef): Mat = {
     val runnableGraph =
       if (settings.autoFusing) Fusing.aggressive(_runnableGraph)
       else _runnableGraph
@@ -143,7 +145,8 @@ private[akka] case class ActorMaterializerImpl(system: ActorSystem,
 
           case stage: GraphStageModule ⇒
             val graph =
-              GraphModule(GraphAssembly(stage.shape.inlets, stage.shape.outlets, stage.stage),
+              GraphModule(
+                GraphAssembly(stage.shape.inlets, stage.shape.outlets, stage.stage),
                 stage.shape, stage.attributes, Array(stage))
             matGraph(graph, effectiveAttributes, matVal)
         }
@@ -176,14 +179,15 @@ private[akka] case class ActorMaterializerImpl(system: ActorSystem,
       }
 
       // FIXME: Remove this, only stream-of-stream ops need it
-      private def processorFor(op: StageModule,
-                               effectiveAttributes: Attributes,
-                               effectiveSettings: ActorMaterializerSettings): (Processor[Any, Any], Any) = op match {
+      private def processorFor(
+        op: StageModule,
+        effectiveAttributes: Attributes,
+        effectiveSettings: ActorMaterializerSettings): (Processor[Any, Any], Any) = op match {
         case DirectProcessor(processorFactory, _) ⇒ processorFactory()
         case _ ⇒
           val (opprops, mat) = ActorProcessorFactory.props(ActorMaterializerImpl.this, op, effectiveAttributes)
           ActorProcessorFactory[Any, Any](
-            actorOf(opprops, stageName(effectiveAttributes), effectiveSettings.dispatcher)) -> mat
+            actorOf(opprops, stageName(effectiveAttributes), effectiveSettings.dispatcher)) → mat
       }
     }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -27,7 +27,7 @@ private[akka] object ActorProcessor {
  * INTERNAL API
  */
 private[akka] class ActorProcessor[I, O](impl: ActorRef) extends ActorPublisher[O](impl)
-  with Processor[I, O] {
+    with Processor[I, O] {
   override def onSubscribe(s: Subscription): Unit = {
     ReactiveStreamsCompliance.requireNonNullSubscription(s)
     impl ! OnSubscribe(s)
@@ -247,9 +247,9 @@ private[akka] class SimpleOutputs(val actor: ActorRef, val pump: Pump) extends D
  * INTERNAL API
  */
 private[akka] abstract class ActorProcessorImpl(val settings: ActorMaterializerSettings)
-  extends Actor
-  with ActorLogging
-  with Pump {
+    extends Actor
+    with ActorLogging
+    with Pump {
 
   protected val primaryInputs: Inputs = new BatchingInputBuffer(settings.initialInputBufferSize, this) {
     override def inputOnError(e: Throwable): Unit = ActorProcessorImpl.this.onError(e)

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
@@ -15,10 +15,10 @@ import akka.stream.stage._
  * INTERNAL API
  */
 private[akka] class ActorRefBackpressureSinkStage[In](ref: ActorRef, onInitMessage: Any,
-                                                      ackMessage: Any,
-                                                      onCompleteMessage: Any,
-                                                      onFailureMessage: (Throwable) ⇒ Any)
-  extends GraphStage[SinkShape[In]] {
+  ackMessage: Any,
+  onCompleteMessage: Any,
+  onFailureMessage: (Throwable) ⇒ Any)
+    extends GraphStage[SinkShape[In]] {
   val in: Inlet[In] = Inlet[In]("ActorRefBackpressureSink.in")
   override def initialAttributes = DefaultAttributes.actorRefWithAck
   override val shape: SinkShape[In] = SinkShape(in)

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorRefSourceActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorRefSourceActor.scala
@@ -25,7 +25,7 @@ private[akka] object ActorRefSourceActor {
  * INTERNAL API
  */
 private[akka] class ActorRefSourceActor(bufferSize: Int, overflowStrategy: OverflowStrategy, maxFixedBufferSize: Int)
-  extends akka.stream.actor.ActorPublisher[Any] with ActorLogging {
+    extends akka.stream.actor.ActorPublisher[Any] with ActorLogging {
   import akka.stream.actor.ActorPublisherMessage._
 
   // when bufferSize is 0 there the buffer is not used

--- a/akka-stream/src/main/scala/akka/stream/impl/CompletedPublishers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/CompletedPublishers.scala
@@ -46,8 +46,8 @@ private[akka] final case class ErrorPublisher(t: Throwable, name: String) extend
  * INTERNAL API
  */
 private[akka] final case class MaybePublisher[T](
-  promise: Promise[Option[T]],
-  name: String)(implicit ec: ExecutionContext) extends Publisher[T] {
+    promise: Promise[Option[T]],
+    name: String)(implicit ec: ExecutionContext) extends Publisher[T] {
   import ReactiveStreamsCompliance._
 
   private[this] class MaybeSubscription(subscriber: Subscriber[_ >: T]) extends Subscription {

--- a/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FanoutProcessor.scala
@@ -7,12 +7,13 @@ import org.reactivestreams.Subscriber
 /**
  * INTERNAL API
  */
-private[akka] abstract class FanoutOutputs(val maxBufferSize: Int,
-                                           val initialBufferSize: Int,
-                                           self: ActorRef,
-                                           val pump: Pump)
-  extends DefaultOutputTransferStates
-  with SubscriberManagement[Any] {
+private[akka] abstract class FanoutOutputs(
+  val maxBufferSize: Int,
+  val initialBufferSize: Int,
+  self: ActorRef,
+  val pump: Pump)
+    extends DefaultOutputTransferStates
+    with SubscriberManagement[Any] {
 
   override type S = ActorSubscriptionWithCursor[_ >: Any]
   override def createSubscription(subscriber: Subscriber[_ >: Any]): S =
@@ -99,7 +100,7 @@ private[akka] object FanoutProcessorImpl {
  * INTERNAL API
  */
 private[akka] class FanoutProcessorImpl(_settings: ActorMaterializerSettings)
-  extends ActorProcessorImpl(_settings) {
+    extends ActorProcessorImpl(_settings) {
 
   override val primaryOutputs: FanoutOutputs =
     new FanoutOutputs(settings.maxInputBufferSize, settings.initialInputBufferSize, self, this) {

--- a/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/GroupByProcessorImpl.scala
@@ -23,7 +23,7 @@ private[akka] object GroupByProcessorImpl {
  * INTERNAL API
  */
 private[akka] class GroupByProcessorImpl(settings: ActorMaterializerSettings, val maxSubstreams: Int, val keyFor: Any ⇒ Any)
-  extends MultiStreamOutputProcessor(settings) {
+    extends MultiStreamOutputProcessor(settings) {
 
   import MultiStreamOutputProcessor._
   import GroupByProcessorImpl.Drop

--- a/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
@@ -108,7 +108,7 @@ private[akka] final class ActorPublisherSource[Out](props: Props, val attributes
  */
 private[akka] final class ActorRefSource[Out](
   bufferSize: Int, overflowStrategy: OverflowStrategy, val attributes: Attributes, shape: SourceShape[Out])
-  extends SourceModule[Out, ActorRef](shape) {
+    extends SourceModule[Out, ActorRef](shape) {
 
   override protected def label: String = s"ActorRefSource($bufferSize, $overflowStrategy)"
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ResizableMultiReaderRingBuffer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ResizableMultiReaderRingBuffer.scala
@@ -13,12 +13,15 @@ import ResizableMultiReaderRingBuffer._
  * Contrary to many other ring buffer implementations this one does not automatically overwrite the oldest
  * elements, rather, if full, the buffer tries to grow and rejects further writes if max capacity is reached.
  */
-private[akka] class ResizableMultiReaderRingBuffer[T](initialSize: Int, // constructor param, not field
-                                                      maxSize: Int, // constructor param, not field
-                                                      val cursors: Cursors) {
-  require(Integer.lowestOneBit(maxSize) == maxSize && 0 < maxSize && maxSize <= Int.MaxValue / 2,
+private[akka] class ResizableMultiReaderRingBuffer[T](
+  initialSize: Int, // constructor param, not field
+    maxSize: Int, // constructor param, not field
+    val cursors: Cursors) {
+  require(
+    Integer.lowestOneBit(maxSize) == maxSize && 0 < maxSize && maxSize <= Int.MaxValue / 2,
     "maxSize must be a power of 2 that is > 0 and < Int.MaxValue/2")
-  require(Integer.lowestOneBit(initialSize) == initialSize && 0 < initialSize && initialSize <= maxSize,
+  require(
+    Integer.lowestOneBit(initialSize) == initialSize && 0 < initialSize && initialSize <= maxSize,
     "initialSize must be a power of 2 that is > 0 and <= maxSize")
 
   private[this] val maxSizeBit = Integer.numberOfTrailingZeros(maxSize)

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -87,7 +87,7 @@ private[akka] class PublisherSink[In](val attributes: Attributes, shape: SinkSha
 private[akka] final class FanoutPublisherSink[In](
   val attributes: Attributes,
   shape: SinkShape[In])
-  extends SinkModule[In, Publisher[In]](shape) {
+    extends SinkModule[In, Publisher[In]](shape) {
 
   override def create(context: MaterializationContext): (Subscriber[In], Publisher[In]) = {
     val actorMaterializer = ActorMaterializer.downcast(context.materializer)
@@ -164,13 +164,14 @@ private[akka] final class ActorSubscriberSink[In](props: Props, val attributes: 
  * INTERNAL API
  */
 private[akka] final class ActorRefSink[In](ref: ActorRef, onCompleteMessage: Any,
-                                           val attributes: Attributes,
-                                           shape: SinkShape[In]) extends SinkModule[In, NotUsed](shape) {
+    val attributes: Attributes,
+    shape: SinkShape[In]) extends SinkModule[In, NotUsed](shape) {
 
   override def create(context: MaterializationContext) = {
     val actorMaterializer = ActorMaterializer.downcast(context.materializer)
     val effectiveSettings = actorMaterializer.effectiveSettings(context.effectiveAttributes)
-    val subscriberRef = actorMaterializer.actorOf(context,
+    val subscriberRef = actorMaterializer.actorOf(
+      context,
       ActorRefSinkActor.props(ref, effectiveSettings.maxInputBufferSize, onCompleteMessage))
     (akka.stream.actor.ActorSubscriber[In](subscriberRef), NotUsed)
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
@@ -195,9 +195,10 @@ private[akka] final class SourceQueueAdapter[T](delegate: SourceQueueWithComplet
 /**
  * INTERNAL API
  */
-private[stream] final class UnfoldResourceSource[T, S](create: () ⇒ S,
-                                                       readData: (S) ⇒ Option[T],
-                                                       close: (S) ⇒ Unit) extends GraphStage[SourceShape[T]] {
+private[stream] final class UnfoldResourceSource[T, S](
+  create: () ⇒ S,
+    readData: (S) ⇒ Option[T],
+    close: (S) ⇒ Unit) extends GraphStage[SourceShape[T]] {
   val out = Outlet[T]("UnfoldResourceSource.out")
   override val shape = SourceShape(out)
   override def initialAttributes: Attributes = DefaultAttributes.unfoldResourceSource
@@ -251,9 +252,10 @@ private[stream] final class UnfoldResourceSource[T, S](create: () ⇒ S,
   override def toString = "UnfoldResourceSource"
 }
 
-private[stream] final class UnfoldResourceSourceAsync[T, S](create: () ⇒ Future[S],
-                                                            readData: (S) ⇒ Future[Option[T]],
-                                                            close: (S) ⇒ Future[Done]) extends GraphStage[SourceShape[T]] {
+private[stream] final class UnfoldResourceSourceAsync[T, S](
+  create: () ⇒ Future[S],
+    readData: (S) ⇒ Future[Option[T]],
+    close: (S) ⇒ Future[Done]) extends GraphStage[SourceShape[T]] {
   val out = Outlet[T]("UnfoldResourceSourceAsync.out")
   override val shape = SourceShape(out)
   override def initialAttributes: Attributes = DefaultAttributes.unfoldResourceSourceAsync

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -129,9 +129,9 @@ private[stream] object Stages {
    * Stage that is backed by a GraphStage but can be symbolically introspected
    */
   case class SymbolicGraphStage[-In, +Out, Ext](symbolicStage: SymbolicStage[In, Out])
-    extends PushPullGraphStage[In, Out, Ext](
-      symbolicStage.create,
-      symbolicStage.attributes) {
+      extends PushPullGraphStage[In, Out, Ext](
+        symbolicStage.create,
+        symbolicStage.attributes) {
   }
 
   sealed trait SymbolicStage[-In, +Out] {

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -201,10 +201,12 @@ object StreamLayout {
     final def wire(from: OutPort, to: InPort): Module = {
       if (Debug) validate(this)
 
-      require(outPorts(from),
+      require(
+        outPorts(from),
         if (downstreams.contains(from)) s"The output port [$from] is already connected"
         else s"The output port [$from] is not part of the underlying graph.")
-      require(inPorts(to),
+      require(
+        inPorts(to),
         if (upstreams.contains(to)) s"The input port [$to] is already connected"
         else s"The input port [$to] is not part of the underlying graph.")
 
@@ -360,9 +362,10 @@ object StreamLayout {
     override def materializedValueComputation: MaterializedValueNode = Ignore
   }
 
-  final case class CopiedModule(override val shape: Shape,
-                                override val attributes: Attributes,
-                                copyOf: Module) extends Module {
+  final case class CopiedModule(
+    override val shape: Shape,
+      override val attributes: Attributes,
+      copyOf: Module) extends Module {
     override val subModules: Set[Module] = Set(copyOf)
 
     override def withAttributes(attr: Attributes): Module =
@@ -529,14 +532,14 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
   override def subscribe(s: Subscriber[_ >: T]): Unit = {
     @tailrec def rec(sub: Subscriber[Any]): Unit =
       get() match {
-        case null => if (!compareAndSet(null, s)) rec(sub)
-        case subscription: Subscription =>
+        case null ⇒ if (!compareAndSet(null, s)) rec(sub)
+        case subscription: Subscription ⇒
           if (compareAndSet(subscription, Both(sub))) establishSubscription(sub, subscription)
           else rec(sub)
-        case pub: Publisher[_] =>
+        case pub: Publisher[_] ⇒
           if (compareAndSet(pub, Inert)) pub.subscribe(sub)
           else rec(sub)
-        case _ =>
+        case _ ⇒
           rejectAdditionalSubscriber(sub, "VirtualProcessor")
       }
 
@@ -550,19 +553,19 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
   override final def onSubscribe(s: Subscription): Unit = {
     @tailrec def rec(obj: AnyRef): Unit =
       get() match {
-        case null => if (!compareAndSet(null, obj)) rec(obj)
-        case subscriber: Subscriber[_] =>
+        case null ⇒ if (!compareAndSet(null, obj)) rec(obj)
+        case subscriber: Subscriber[_] ⇒
           obj match {
-            case subscription: Subscription =>
+            case subscription: Subscription ⇒
               if (compareAndSet(subscriber, Both.create(subscriber))) establishSubscription(subscriber, subscription)
               else rec(obj)
-            case pub: Publisher[_] =>
+            case pub: Publisher[_] ⇒
               getAndSet(Inert) match {
-                case Inert => // nothing to be done
-                case _     => pub.subscribe(subscriber.asInstanceOf[Subscriber[Any]])
+                case Inert ⇒ // nothing to be done
+                case _     ⇒ pub.subscribe(subscriber.asInstanceOf[Subscriber[Any]])
               }
           }
-        case _ =>
+        case _ ⇒
           // spec violation
           tryCancel(s)
       }
@@ -578,7 +581,7 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
     val wrapped = new WrappedSubscription(subscription)
     try subscriber.onSubscribe(wrapped)
     catch {
-      case NonFatal(ex) =>
+      case NonFatal(ex) ⇒
         set(Inert)
         tryCancel(subscription)
         tryOnError(subscriber, ex)
@@ -593,22 +596,22 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
      */
     @tailrec def rec(ex: Throwable): Unit =
       get() match {
-        case null =>
+        case null ⇒
           if (!compareAndSet(null, ErrorPublisher(ex, "failed-VirtualProcessor"))) rec(ex)
           else if (t == null) throw ex
-        case s: Subscription =>
+        case s: Subscription ⇒
           if (!compareAndSet(s, ErrorPublisher(ex, "failed-VirtualProcessor"))) rec(ex)
           else if (t == null) throw ex
-        case Both(s) =>
+        case Both(s) ⇒
           set(Inert)
           try tryOnError(s, ex)
           finally if (t == null) throw ex // must throw NPE, rule 2:13
-        case s: Subscriber[_] => // spec violation
+        case s: Subscriber[_] ⇒ // spec violation
           getAndSet(Inert) match {
-            case Inert => // nothing to be done
-            case _     => ErrorPublisher(ex, "failed-VirtualProcessor").subscribe(s)
+            case Inert ⇒ // nothing to be done
+            case _     ⇒ ErrorPublisher(ex, "failed-VirtualProcessor").subscribe(s)
           }
-        case _ => // spec violation or cancellation race, but nothing we can do
+        case _ ⇒ // spec violation or cancellation race, but nothing we can do
       }
 
     val ex = if (t == null) exceptionMustNotBeNullException else t
@@ -617,15 +620,15 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
 
   @tailrec override final def onComplete(): Unit =
     get() match {
-      case null            => if (!compareAndSet(null, EmptyPublisher)) onComplete()
-      case s: Subscription => if (!compareAndSet(s, EmptyPublisher)) onComplete()
-      case Both(s) =>
+      case null            ⇒ if (!compareAndSet(null, EmptyPublisher)) onComplete()
+      case s: Subscription ⇒ if (!compareAndSet(s, EmptyPublisher)) onComplete()
+      case Both(s) ⇒
         set(Inert)
         tryOnComplete(s)
-      case s: Subscriber[_] => // spec violation
+      case s: Subscriber[_] ⇒ // spec violation
         set(Inert)
         EmptyPublisher.subscribe(s)
-      case _ => // spec violation or cancellation race, but nothing we can do
+      case _ ⇒ // spec violation or cancellation race, but nothing we can do
     }
 
   override def onNext(t: T): Unit =
@@ -633,32 +636,32 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
       val ex = elementMustNotBeNullException
       @tailrec def rec(): Unit =
         get() match {
-          case x @ (null | _: Subscription) => if (!compareAndSet(x, ErrorPublisher(ex, "failed-VirtualProcessor"))) rec()
-          case s: Subscriber[_]             => try s.onError(ex) catch { case NonFatal(_) => } finally set(Inert)
-          case Both(s)                      => try s.onError(ex) catch { case NonFatal(_) => } finally set(Inert)
-          case _                            => // spec violation or cancellation race, but nothing we can do
+          case x @ (null | _: Subscription) ⇒ if (!compareAndSet(x, ErrorPublisher(ex, "failed-VirtualProcessor"))) rec()
+          case s: Subscriber[_]             ⇒ try s.onError(ex) catch { case NonFatal(_) ⇒ } finally set(Inert)
+          case Both(s)                      ⇒ try s.onError(ex) catch { case NonFatal(_) ⇒ } finally set(Inert)
+          case _                            ⇒ // spec violation or cancellation race, but nothing we can do
         }
       rec()
       throw ex // must throw NPE, rule 2:13
     } else {
       @tailrec def rec(): Unit =
         get() match {
-          case Both(s) =>
+          case Both(s) ⇒
             try s.onNext(t)
             catch {
-              case NonFatal(e) =>
+              case NonFatal(e) ⇒
                 set(Inert)
                 throw new IllegalStateException("Subscriber threw exception, this is in violation of rule 2:13", e)
             }
-          case s: Subscriber[_] => // spec violation
+          case s: Subscriber[_] ⇒ // spec violation
             val ex = new IllegalStateException(noDemand)
             getAndSet(Inert) match {
-              case Inert => // nothing to be done
-              case _     => ErrorPublisher(ex, "failed-VirtualProcessor").subscribe(s)
+              case Inert ⇒ // nothing to be done
+              case _     ⇒ ErrorPublisher(ex, "failed-VirtualProcessor").subscribe(s)
             }
             throw ex
-          case Inert | _: Publisher[_] => // nothing to be done
-          case other =>
+          case Inert | _: Publisher[_] ⇒ // nothing to be done
+          case other ⇒
             val pub = ErrorPublisher(new IllegalStateException(noDemand), "failed-VirtualPublisher")
             if (!compareAndSet(other, pub)) rec()
             else throw pub.t
@@ -673,9 +676,9 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
       if (n < 1) {
         tryCancel(real)
         getAndSet(Inert) match {
-          case Both(s) => rejectDueToNonPositiveDemand(s)
-          case Inert   => // another failure has won the race
-          case _       => // this cannot possibly happen, but signaling errors is impossible at this point
+          case Both(s) ⇒ rejectDueToNonPositiveDemand(s)
+          case Inert   ⇒ // another failure has won the race
+          case _       ⇒ // this cannot possibly happen, but signaling errors is impossible at this point
         }
       } else real.request(n)
     }
@@ -712,12 +715,12 @@ private[impl] class VirtualPublisher[T] extends AtomicReference[AnyRef] with Pub
     requireNonNullSubscriber(subscriber)
     @tailrec def rec(): Unit = {
       get() match {
-        case null => if (!compareAndSet(null, subscriber)) rec()
-        case pub: Publisher[_] =>
+        case null ⇒ if (!compareAndSet(null, subscriber)) rec()
+        case pub: Publisher[_] ⇒
           if (compareAndSet(pub, Inert.subscriber)) {
             pub.asInstanceOf[Publisher[T]].subscribe(subscriber)
           } else rec()
-        case _: Subscriber[_] => rejectAdditionalSubscriber(subscriber, "Sink.asPublisher(fanout = false)")
+        case _: Subscriber[_] ⇒ rejectAdditionalSubscriber(subscriber, "Sink.asPublisher(fanout = false)")
       }
     }
     rec() // return value is boolean only to make the expressions above compile
@@ -725,11 +728,11 @@ private[impl] class VirtualPublisher[T] extends AtomicReference[AnyRef] with Pub
 
   @tailrec final def registerPublisher(pub: Publisher[_]): Unit =
     get() match {
-      case null => if (!compareAndSet(null, pub)) registerPublisher(pub)
-      case sub: Subscriber[r] =>
+      case null ⇒ if (!compareAndSet(null, pub)) registerPublisher(pub)
+      case sub: Subscriber[r] ⇒
         set(Inert.subscriber)
         pub.asInstanceOf[Publisher[r]].subscribe(sub)
-      case _ => throw new IllegalStateException("internal error")
+      case _ ⇒ throw new IllegalStateException("internal error")
     }
 }
 
@@ -858,14 +861,14 @@ private[stream] abstract class MaterializerSession(val topLevel: StreamLayout.Mo
           exitScope(copied)
         case composite @ (_: CompositeModule | _: FusedModule) ⇒
           materializedValues.put(composite, materializeComposite(composite, subEffectiveAttributes))
-        case EmptyModule => // nothing to do or say
+        case EmptyModule ⇒ // nothing to do or say
       }
     }
 
     if (MaterializerSession.Debug) {
       println(f"resolving module [${System.identityHashCode(module)}%08x] computation ${module.materializedValueComputation}")
       println(s"  matValSrc = $matValSrc")
-      println(s"  matVals =\n    ${materializedValues.asScala.map(p ⇒ "%08x".format(System.identityHashCode(p._1)) -> p._2).mkString("\n    ")}")
+      println(s"  matVals =\n    ${materializedValues.asScala.map(p ⇒ "%08x".format(System.identityHashCode(p._1)) → p._2).mkString("\n    ")}")
     }
 
     val ret = resolveMaterialized(module.materializedValueComputation, materializedValues, 2)
@@ -924,8 +927,8 @@ private[stream] abstract class MaterializerSession(val topLevel: StreamLayout.Mo
 
   private def doSubscribe(publisher: Publisher[_ <: Any], subscriberOrVirtual: AnyRef): Unit =
     subscriberOrVirtual match {
-      case s: Subscriber[_]       => publisher.subscribe(s.asInstanceOf[Subscriber[Any]])
-      case v: VirtualPublisher[_] => v.registerPublisher(publisher)
+      case s: Subscriber[_]       ⇒ publisher.subscribe(s.asInstanceOf[Subscriber[Any]])
+      case v: VirtualPublisher[_] ⇒ v.registerPublisher(publisher)
     }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamOfStreamProcessors.scala
@@ -36,7 +36,7 @@ private[akka] object MultiStreamOutputProcessor {
   }
 
   class SubstreamOutput(val key: SubstreamKey, actor: ActorRef, pump: Pump, subscriptionTimeout: Cancellable)
-    extends SimpleOutputs(actor, pump) with Publisher[Any] {
+      extends SimpleOutputs(actor, pump) with Publisher[Any] {
     import ReactiveStreamsCompliance._
 
     import SubstreamOutput._

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamSubscriptionTimeout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamSubscriptionTimeout.scala
@@ -89,7 +89,8 @@ private[akka] trait StreamSubscriptionTimeoutSupport {
   }
 
   private def warn(target: Publisher[_], timeout: FiniteDuration): Unit = {
-    log.warning("Timed out {} detected (after {} ms)! You should investigate if you either cancel or consume all {} instances",
+    log.warning(
+      "Timed out {} detected (after {} ms)! You should investigate if you either cancel or consume all {} instances",
       target, timeout.toMillis, target.getClass.getCanonicalName)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/SubFlowImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SubFlowImpl.scala
@@ -14,10 +14,11 @@ object SubFlowImpl {
   }
 }
 
-class SubFlowImpl[In, Out, Mat, F[+_], C](val subFlow: Flow[In, Out, NotUsed],
-                                          mergeBackFunction: SubFlowImpl.MergeBack[In, F],
-                                          finishFunction: Sink[In, NotUsed] ⇒ C)
-  extends SubFlow[Out, Mat, F, C] {
+class SubFlowImpl[In, Out, Mat, F[+_], C](
+  val subFlow: Flow[In, Out, NotUsed],
+  mergeBackFunction: SubFlowImpl.MergeBack[In, F],
+  finishFunction: Sink[In, NotUsed] ⇒ C)
+    extends SubFlow[Out, Mat, F, C] {
 
   override def deprecatedAndThen[U](op: Stages.StageModule): SubFlow[U, Mat, F, C] =
     new SubFlowImpl[In, U, Mat, F, C](subFlow.deprecatedAndThen(op), mergeBackFunction, finishFunction)

--- a/akka-stream/src/main/scala/akka/stream/impl/Throttle.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Throttle.scala
@@ -14,12 +14,13 @@ import scala.concurrent.duration.{ FiniteDuration, _ }
 /**
  * INTERNAL API
  */
-private[stream] class Throttle[T](cost: Int,
-                                  per: FiniteDuration,
-                                  maximumBurst: Int,
-                                  costCalculation: (T) ⇒ Int,
-                                  mode: ThrottleMode)
-  extends SimpleLinearGraphStage[T] {
+private[stream] class Throttle[T](
+  cost: Int,
+  per: FiniteDuration,
+  maximumBurst: Int,
+  costCalculation: (T) ⇒ Int,
+  mode: ThrottleMode)
+    extends SimpleLinearGraphStage[T] {
   require(cost > 0, "cost must be > 0")
   require(per.toNanos > 0, "per time must be > 0")
   require(!(mode == ThrottleMode.Enforcing && maximumBurst < 0), "maximumBurst must be > 0 in Enforcing mode")

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -24,7 +24,7 @@ import scala.annotation.tailrec
  * INTERNAL API
  */
 private[stream] final case class GraphModule(assembly: GraphAssembly, shape: Shape, attributes: Attributes,
-                                             matValIDs: Array[Module]) extends AtomicModule {
+    matValIDs: Array[Module]) extends AtomicModule {
 
   override def withAttributes(newAttr: Attributes): Module = copy(attributes = newAttr)
 
@@ -308,13 +308,13 @@ private[stream] object ActorGraphInterpreter {
  * INTERNAL API
  */
 private[stream] final class GraphInterpreterShell(
-  assembly: GraphAssembly,
-  inHandlers: Array[InHandler],
-  outHandlers: Array[OutHandler],
-  logics: Array[GraphStageLogic],
-  shape: Shape,
-  settings: ActorMaterializerSettings,
-  val mat: ActorMaterializerImpl) {
+    assembly: GraphAssembly,
+    inHandlers: Array[InHandler],
+    outHandlers: Array[OutHandler],
+    logics: Array[GraphStageLogic],
+    shape: Shape,
+    settings: ActorMaterializerSettings,
+    val mat: ActorMaterializerImpl) {
 
   import ActorGraphInterpreter._
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Fusing.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Fusing.scala
@@ -30,7 +30,7 @@ private[stream] object Fusing {
   def aggressive[S <: Shape, M](g: Graph[S, M]): FusedGraph[S, M] =
     g match {
       case fg: FusedGraph[_, _]      ⇒ fg
-      case FusedGraph(module, shape) => FusedGraph(module, shape)
+      case FusedGraph(module, shape) ⇒ FusedGraph(module, shape)
       case _                         ⇒ doAggressive(g)
     }
 
@@ -160,7 +160,7 @@ private[stream] object Fusing {
         }
 
         pos += 1
-      case _ => throw new IllegalArgumentException("unexpected module structure")
+      case _ ⇒ throw new IllegalArgumentException("unexpected module structure")
     }
 
     val outsB2 = new Array[Outlet[_]](insB2.size)
@@ -186,7 +186,7 @@ private[stream] object Fusing {
             }
         }
         pos += 1
-      case _ => throw new IllegalArgumentException("unexpected module structure")
+      case _ ⇒ throw new IllegalArgumentException("unexpected module structure")
     }
 
     /*
@@ -217,8 +217,8 @@ private[stream] object Fusing {
 
     // FIXME attributes should contain some naming info and async boundary where needed
     val firstModule = group.iterator.next() match {
-      case c: CopiedModule => c
-      case _               => throw new IllegalArgumentException("unexpected module structure")
+      case c: CopiedModule ⇒ c
+      case _               ⇒ throw new IllegalArgumentException("unexpected module structure")
     }
     val async = if (isAsync(firstModule)) Attributes(AsyncBoundary) else Attributes.none
     val disp = dispatcher(firstModule) match {
@@ -253,11 +253,12 @@ private[stream] object Fusing {
    * correspondence is then used during materialization to trigger these sources
    * when “their” node has received its value.
    */
-  private def descend(m: Module,
-                      inheritedAttributes: Attributes,
-                      struct: BuildStructuralInfo,
-                      openGroup: ju.Set[Module],
-                      indent: Int): List[(Module, MaterializedValueNode)] = {
+  private def descend(
+    m: Module,
+    inheritedAttributes: Attributes,
+    struct: BuildStructuralInfo,
+    openGroup: ju.Set[Module],
+    indent: Int): List[(Module, MaterializedValueNode)] = {
     def log(msg: String): Unit = println("  " * indent + msg)
     val async = m match {
       case _: GraphStageModule ⇒ m.attributes.contains(AsyncBoundary)
@@ -327,7 +328,7 @@ private[stream] object Fusing {
               struct.registerInternals(newShape, indent)
 
               copy
-            case _ => throw new IllegalArgumentException("unexpected module structure")
+            case _ ⇒ throw new IllegalArgumentException("unexpected module structure")
           }
           val newgm = gm.copy(shape = oldShape.copyFromPorts(oldIns.toList, oldOuts.toList), matValIDs = newids)
           // make sure to add all the port mappings from old GraphModule Shape to new shape
@@ -336,14 +337,14 @@ private[stream] object Fusing {
           var result = List.empty[(Module, MaterializedValueNode)]
           var i = 0
           while (i < mvids.length) {
-            result ::= mvids(i) -> Atomic(newids(i))
+            result ::= mvids(i) → Atomic(newids(i))
             i += 1
           }
-          result ::= m -> Atomic(newgm)
+          result ::= m → Atomic(newgm)
           result
         case _ ⇒
           if (Debug) log(s"atomic module $m")
-          List(m -> struct.addModule(m, localGroup, inheritedAttributes, indent))
+          List(m → struct.addModule(m, localGroup, inheritedAttributes, indent))
       }
     } else {
       val attributes = inheritedAttributes and m.attributes
@@ -351,7 +352,7 @@ private[stream] object Fusing {
         case CopiedModule(shape, _, copyOf) ⇒
           val ret =
             descend(copyOf, attributes, struct, localGroup, indent + 1) match {
-              case xs @ (_, mat) :: _ ⇒ (m -> mat) :: xs
+              case xs @ (_, mat) :: _ ⇒ (m → mat) :: xs
               case _                  ⇒ throw new IllegalArgumentException("cannot happen")
             }
           struct.rewire(copyOf.shape, shape, indent)
@@ -390,7 +391,7 @@ private[stream] object Fusing {
             val ms = c.copyOf.asInstanceOf[GraphStageModule].stage.asInstanceOf[MaterializedValueSource[Any]]
             val mapped = ms.computation match {
               case Atomic(sub) ⇒ subMat(sub)
-              case Ignore      => Ignore
+              case Ignore      ⇒ Ignore
               case other       ⇒ matNodeMapping.get(other)
             }
             if (Debug) log(s"materialized value source: ${c.copyOf} -> $mapped")
@@ -400,7 +401,7 @@ private[stream] object Fusing {
             struct.replace(c, replacement, localGroup)
           }
           // the result for each level is the materialized value computation
-          List(m -> newMat)
+          List(m → newMat)
       }
     }
   }
@@ -418,7 +419,7 @@ private[stream] object Fusing {
    * descend().
    */
   private def rewriteMat(subMat: Predef.Map[Module, MaterializedValueNode], mat: MaterializedValueNode,
-                         mapping: ju.Map[MaterializedValueNode, MaterializedValueNode]): MaterializedValueNode =
+    mapping: ju.Map[MaterializedValueNode, MaterializedValueNode]): MaterializedValueNode =
     mat match {
       case Atomic(sub) ⇒
         val ret = subMat(sub)
@@ -616,7 +617,7 @@ private[stream] object Fusing {
      * Add a module to the given group, performing normalization (i.e. giving it a unique port identity).
      */
     def addModule(m: Module, group: ju.Set[Module], inheritedAttributes: Attributes, indent: Int,
-                  _oldShape: Shape = null): Atomic = {
+      _oldShape: Shape = null): Atomic = {
       val copy =
         if (_oldShape == null) CopiedModule(m.shape.deepCopy(), inheritedAttributes, realModule(m))
         else m

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -99,12 +99,13 @@ private[akka] object GraphInterpreter {
    * corresponding segments of these arrays matches the exact same order of the ports in the [[Shape]].
    *
    */
-  final class GraphAssembly(val stages: Array[GraphStageWithMaterializedValue[Shape, Any]],
-                            val originalAttributes: Array[Attributes],
-                            val ins: Array[Inlet[_]],
-                            val inOwners: Array[Int],
-                            val outs: Array[Outlet[_]],
-                            val outOwners: Array[Int]) {
+  final class GraphAssembly(
+    val stages: Array[GraphStageWithMaterializedValue[Shape, Any]],
+      val originalAttributes: Array[Attributes],
+      val ins: Array[Inlet[_]],
+      val inOwners: Array[Int],
+      val outs: Array[Outlet[_]],
+      val outOwners: Array[Int]) {
     require(ins.length == inOwners.length && inOwners.length == outs.length && outs.length == outOwners.length)
 
     def connectionCount: Int = ins.length
@@ -119,10 +120,11 @@ private[akka] object GraphInterpreter {
      *  - array of the logics
      *  - materialized value
      */
-    def materialize(inheritedAttributes: Attributes,
-                    copiedModules: Array[Module],
-                    matVal: ju.Map[Module, Any],
-                    register: MaterializedValueSource[Any] ⇒ Unit): (Array[InHandler], Array[OutHandler], Array[GraphStageLogic]) = {
+    def materialize(
+      inheritedAttributes: Attributes,
+      copiedModules: Array[Module],
+      matVal: ju.Map[Module, Any],
+      register: MaterializedValueSource[Any] ⇒ Unit): (Array[InHandler], Array[OutHandler], Array[GraphStageLogic]) = {
       val logics = Array.ofDim[GraphStageLogic](stages.length)
 
       var i = 0
@@ -208,9 +210,10 @@ private[akka] object GraphInterpreter {
     /**
      * INTERNAL API
      */
-    final def apply(inlets: immutable.Seq[Inlet[_]],
-                    outlets: immutable.Seq[Outlet[_]],
-                    stages: GraphStageWithMaterializedValue[Shape, _]*): GraphAssembly = {
+    final def apply(
+      inlets: immutable.Seq[Inlet[_]],
+      outlets: immutable.Seq[Outlet[_]],
+      stages: GraphStageWithMaterializedValue[Shape, _]*): GraphAssembly = {
       // add the contents of an iterator to an array starting at idx
       @tailrec def add[T](i: Iterator[T], a: Array[T], idx: Int): Array[T] =
         if (i.hasNext) {
@@ -344,15 +347,15 @@ private[akka] object GraphInterpreter {
  * edge of a balance is pulled, dissolving the original cycle).
  */
 private[stream] final class GraphInterpreter(
-  private val assembly: GraphInterpreter.GraphAssembly,
-  val materializer: Materializer,
-  val log: LoggingAdapter,
-  val inHandlers: Array[InHandler], // Lookup table for the InHandler of a connection
-  val outHandlers: Array[OutHandler], // Lookup table for the outHandler of the connection
-  val logics: Array[GraphStageLogic], // Array of stage logics
-  val onAsyncInput: (GraphStageLogic, Any, (Any) ⇒ Unit) ⇒ Unit,
-  val fuzzingMode: Boolean,
-  val context: ActorRef) {
+    private val assembly: GraphInterpreter.GraphAssembly,
+    val materializer: Materializer,
+    val log: LoggingAdapter,
+    val inHandlers: Array[InHandler], // Lookup table for the InHandler of a connection
+    val outHandlers: Array[OutHandler], // Lookup table for the outHandler of the connection
+    val logics: Array[GraphStageLogic], // Array of stage logics
+    val onAsyncInput: (GraphStageLogic, Any, (Any) ⇒ Unit) ⇒ Unit,
+    val fuzzingMode: Boolean,
+    val context: ActorRef) {
   import GraphInterpreter._
 
   // Maintains additional information for events, basically elements in-flight, or failure.

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -25,9 +25,10 @@ import scala.util.Try
 /**
  * INTERNAL API
  */
-private[akka] final case class GraphStageModule(shape: Shape,
-                                                attributes: Attributes,
-                                                stage: GraphStageWithMaterializedValue[Shape, Any]) extends AtomicModule {
+private[akka] final case class GraphStageModule(
+  shape: Shape,
+    attributes: Attributes,
+    stage: GraphStageWithMaterializedValue[Shape, Any]) extends AtomicModule {
   override def carbonCopy: Module = CopiedModule(shape.deepCopy(), Attributes.none, this)
 
   override def replaceShape(s: Shape): Module =
@@ -221,7 +222,7 @@ object GraphStages {
   }
 
   final class TickSource[T](initialDelay: FiniteDuration, interval: FiniteDuration, tick: T)
-    extends GraphStageWithMaterializedValue[SourceShape[T], Cancellable] {
+      extends GraphStageWithMaterializedValue[SourceShape[T], Cancellable] {
     override val shape = SourceShape(Outlet[T]("TickSource.out"))
     val out = shape.out
     override def initialAttributes: Attributes = DefaultAttributes.tickSource

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -482,22 +482,22 @@ private[akka] final case class Buffer[T](size: Int, overflowStrategy: OverflowSt
         if (buffer.isFull) buffer.dropHead()
         buffer.enqueue(elem)
         ctx.pull()
-        case DropTail ⇒ (ctx, elem) ⇒
+      case DropTail ⇒ (ctx, elem) ⇒
         if (buffer.isFull) buffer.dropTail()
         buffer.enqueue(elem)
         ctx.pull()
-        case DropBuffer ⇒ (ctx, elem) ⇒
+      case DropBuffer ⇒ (ctx, elem) ⇒
         if (buffer.isFull) buffer.clear()
         buffer.enqueue(elem)
         ctx.pull()
-        case DropNew ⇒ (ctx, elem) ⇒
+      case DropNew ⇒ (ctx, elem) ⇒
         if (!buffer.isFull) buffer.enqueue(elem)
         ctx.pull()
-        case Backpressure ⇒ (ctx, elem) ⇒
+      case Backpressure ⇒ (ctx, elem) ⇒
         buffer.enqueue(elem)
         if (buffer.isFull) ctx.holdUpstream()
         else ctx.pull()
-        case Fail ⇒ (ctx, elem) ⇒
+      case Fail ⇒ (ctx, elem) ⇒
         if (buffer.isFull) ctx.fail(new BufferOverflowException(s"Buffer overflow (max capacity was: $size)!"))
         else {
           buffer.enqueue(elem)
@@ -520,7 +520,7 @@ private[akka] final case class Completed[T]() extends PushPullStage[T, T] {
  * INTERNAL API
  */
 private[akka] final case class Batch[In, Out](max: Long, costFn: In ⇒ Long, seed: In ⇒ Out, aggregate: (Out, In) ⇒ Out)
-  extends GraphStage[FlowShape[In, Out]] {
+    extends GraphStage[FlowShape[In, Out]] {
 
   val in = Inlet[In]("Batch.in")
   val out = Outlet[Out]("Batch.out")
@@ -715,7 +715,7 @@ private[akka] object MapAsync {
  * INTERNAL API
  */
 private[akka] final case class MapAsync[In, Out](parallelism: Int, f: In ⇒ Future[Out])
-  extends GraphStage[FlowShape[In, Out]] {
+    extends GraphStage[FlowShape[In, Out]] {
 
   import MapAsync._
 
@@ -779,7 +779,7 @@ private[akka] final case class MapAsync[In, Out](parallelism: Int, f: In ⇒ Fut
  * INTERNAL API
  */
 private[akka] final case class MapAsyncUnordered[In, Out](parallelism: Int, f: In ⇒ Future[Out])
-  extends GraphStage[FlowShape[In, Out]] {
+    extends GraphStage[FlowShape[In, Out]] {
 
   private val in = Inlet[In]("MapAsyncUnordered.in")
   private val out = Outlet[Out]("MapAsyncUnordered.out")
@@ -848,8 +848,8 @@ private[akka] final case class MapAsyncUnordered[In, Out](parallelism: Int, f: I
  * INTERNAL API
  */
 private[akka] final case class Log[T](name: String, extract: T ⇒ Any,
-                                      logAdapter: Option[LoggingAdapter],
-                                      decider: Supervision.Decider) extends PushStage[T, T] {
+    logAdapter: Option[LoggingAdapter],
+    decider: Supervision.Decider) extends PushStage[T, T] {
 
   import Log._
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -396,7 +396,7 @@ object SubSink {
  * INTERNAL API
  */
 final class SubSink[T](name: String, externalCallback: ActorSubscriberMessage ⇒ Unit)
-  extends GraphStage[SinkShape[T]] {
+    extends GraphStage[SinkShape[T]] {
   import SubSink._
 
   private val in = Inlet[T]("SubSink.in")
@@ -482,7 +482,7 @@ object SubSource {
  * INTERNAL API
  */
 final class SubSource[T](name: String, private[fusing] val externalCallback: AsyncCallback[SubSink.Command])
-  extends GraphStage[SourceShape[T]] {
+    extends GraphStage[SourceShape[T]] {
   import SubSink._
 
   val out: Outlet[T] = Outlet("SubSource.out")

--- a/akka-stream/src/main/scala/akka/stream/impl/io/ByteStringParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/ByteStringParser.scala
@@ -82,9 +82,10 @@ private[akka] object ByteStringParser {
    * @param acceptUpstreamFinish - if true - stream will complete when received `onUpstreamFinish`, if "false"
    *                             - onTruncation will be called
    */
-  case class ParseResult[+T](result: Option[T],
-                             nextStep: ParseStep[T],
-                             acceptUpstreamFinish: Boolean = true)
+  case class ParseResult[+T](
+    result: Option[T],
+    nextStep: ParseStep[T],
+    acceptUpstreamFinish: Boolean = true)
 
   trait ParseStep[+T] {
     /**

--- a/akka-stream/src/main/scala/akka/stream/impl/io/FilePublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/FilePublisher.scala
@@ -36,7 +36,7 @@ private[akka] object FilePublisher {
 
 /** INTERNAL API */
 private[akka] final class FilePublisher(f: File, completionPromise: Promise[IOResult], chunkSize: Int, initialBuffer: Int, maxBuffer: Int)
-  extends akka.stream.actor.ActorPublisher[ByteString] with ActorLogging {
+    extends akka.stream.actor.ActorPublisher[ByteString] with ActorLogging {
   import FilePublisher._
 
   var eofReachedAtOffset = Long.MinValue

--- a/akka-stream/src/main/scala/akka/stream/impl/io/FileSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/FileSubscriber.scala
@@ -27,8 +27,8 @@ private[akka] object FileSubscriber {
 
 /** INTERNAL API */
 private[akka] class FileSubscriber(f: File, completionPromise: Promise[IOResult], bufSize: Int, openOptions: Set[StandardOpenOption])
-  extends akka.stream.actor.ActorSubscriber
-  with ActorLogging {
+    extends akka.stream.actor.ActorSubscriber
+    with ActorLogging {
 
   override protected val requestStrategy = WatermarkRequestStrategy(highWatermark = bufSize)
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ Future, Promise }
  * (creating it before hand if necessary).
  */
 private[akka] final class FileSink(f: File, options: Set[StandardOpenOption], val attributes: Attributes, shape: SinkShape[ByteString])
-  extends SinkModule[ByteString, Future[IOResult]](shape) {
+    extends SinkModule[ByteString, Future[IOResult]](shape) {
 
   override protected def label: String = s"FileSink($f, $options)"
 
@@ -49,7 +49,7 @@ private[akka] final class FileSink(f: File, options: Set[StandardOpenOption], va
  * (creating it before hand if necessary).
  */
 private[akka] final class OutputStreamSink(createOutput: () ⇒ OutputStream, val attributes: Attributes, shape: SinkShape[ByteString], autoFlush: Boolean)
-  extends SinkModule[ByteString, Future[IOResult]](shape) {
+    extends SinkModule[ByteString, Future[IOResult]](shape) {
 
   override def create(context: MaterializationContext) = {
     val materializer = ActorMaterializer.downcast(context.materializer)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ Future, Promise }
  * Creates simple synchronous (Java 6 compatible) Source backed by the given file.
  */
 private[akka] final class FileSource(f: File, chunkSize: Int, val attributes: Attributes, shape: SourceShape[ByteString])
-  extends SourceModule[ByteString, Future[IOResult]](shape) {
+    extends SourceModule[ByteString, Future[IOResult]](shape) {
   require(chunkSize > 0, "chunkSize must be greater than 0")
   override def create(context: MaterializationContext) = {
     // FIXME rewrite to be based on GraphStage rather than dangerous downcasts
@@ -50,7 +50,7 @@ private[akka] final class FileSource(f: File, chunkSize: Int, val attributes: At
  * Source backed by the given input stream.
  */
 private[akka] final class InputStreamSource(createInputStream: () ⇒ InputStream, chunkSize: Int, val attributes: Attributes, shape: SourceShape[ByteString])
-  extends SourceModule[ByteString, Future[IOResult]](shape) {
+    extends SourceModule[ByteString, Future[IOResult]](shape) {
   override def create(context: MaterializationContext) = {
     val materializer = ActorMaterializer.downcast(context.materializer)
     val ioResultPromise = Promise[IOResult]()

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamPublisher.scala
@@ -28,8 +28,8 @@ private[akka] object InputStreamPublisher {
 
 /** INTERNAL API */
 private[akka] class InputStreamPublisher(is: InputStream, completionPromise: Promise[IOResult], chunkSize: Int)
-  extends akka.stream.actor.ActorPublisher[ByteString]
-  with ActorLogging {
+    extends akka.stream.actor.ActorPublisher[ByteString]
+    with ActorLogging {
 
   // TODO possibly de-duplicate with FilePublisher?
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -90,10 +90,11 @@ final private[stream] class InputStreamSinkStage(readTimeout: FiniteDuration) ex
  * INTERNAL API
  * InputStreamAdapter that interacts with InputStreamSinkStage
  */
-private[akka] class InputStreamAdapter(sharedBuffer: BlockingQueue[StreamToAdapterMessage],
-                                       sendToStage: (AdapterToStageMessage) ⇒ Unit,
-                                       readTimeout: FiniteDuration)
-  extends InputStream {
+private[akka] class InputStreamAdapter(
+  sharedBuffer: BlockingQueue[StreamToAdapterMessage],
+  sendToStage: (AdapterToStageMessage) ⇒ Unit,
+  readTimeout: FiniteDuration)
+    extends InputStream {
 
   var isInitialized = false
   var isActive = true
@@ -171,7 +172,7 @@ private[akka] class InputStreamAdapter(sharedBuffer: BlockingQueue[StreamToAdapt
 
   @tailrec
   private[this] def getData(arr: Array[Byte], begin: Int, length: Int,
-                            gotBytes: Int): Int = {
+    gotBytes: Int): Int = {
     grabDataChunk() match {
       case Some(data) ⇒
         val size = data.size

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
@@ -121,11 +121,12 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
   }
 }
 
-private[akka] class OutputStreamAdapter(dataQueue: BlockingQueue[ByteString],
-                                        downstreamStatus: AtomicReference[DownstreamStatus],
-                                        sendToStage: (AdapterToStageMessage) ⇒ Future[Unit],
-                                        writeTimeout: FiniteDuration)
-  extends OutputStream {
+private[akka] class OutputStreamAdapter(
+  dataQueue: BlockingQueue[ByteString],
+  downstreamStatus: AtomicReference[DownstreamStatus],
+  sendToStage: (AdapterToStageMessage) ⇒ Future[Unit],
+  writeTimeout: FiniteDuration)
+    extends OutputStream {
 
   var isActive = true
   var isPublisherAlive = true

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSubscriber.scala
@@ -25,8 +25,8 @@ private[akka] object OutputStreamSubscriber {
 
 /** INTERNAL API */
 private[akka] class OutputStreamSubscriber(os: OutputStream, completionPromise: Promise[IOResult], bufSize: Int, autoFlush: Boolean)
-  extends akka.stream.actor.ActorSubscriber
-  with ActorLogging {
+    extends akka.stream.actor.ActorSubscriber
+    with ActorLogging {
 
   override protected val requestStrategy = WatermarkRequestStrategy(highWatermark = bufSize)
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -25,13 +25,14 @@ import akka.stream.TLSProtocol._
  */
 private[akka] object TLSActor {
 
-  def props(settings: ActorMaterializerSettings,
-            sslContext: SSLContext,
-            firstSession: NegotiateNewSession,
-            role: TLSRole,
-            closing: TLSClosing,
-            hostInfo: Option[(String, Int)],
-            tracing: Boolean = false): Props =
+  def props(
+    settings: ActorMaterializerSettings,
+    sslContext: SSLContext,
+    firstSession: NegotiateNewSession,
+    role: TLSRole,
+    closing: TLSClosing,
+    hostInfo: Option[(String, Int)],
+    tracing: Boolean = false): Props =
     Props(new TLSActor(settings, sslContext, firstSession, role, closing, hostInfo, tracing)).withDeploy(Deploy.local)
 
   final val TransportIn = 0
@@ -44,11 +45,12 @@ private[akka] object TLSActor {
 /**
  * INTERNAL API.
  */
-private[akka] class TLSActor(settings: ActorMaterializerSettings,
-                             sslContext: SSLContext,
-                             firstSession: NegotiateNewSession, role: TLSRole, closing: TLSClosing,
-                             hostInfo: Option[(String, Int)], tracing: Boolean)
-  extends Actor with ActorLogging with Pump {
+private[akka] class TLSActor(
+  settings: ActorMaterializerSettings,
+  sslContext: SSLContext,
+  firstSession: NegotiateNewSession, role: TLSRole, closing: TLSClosing,
+  hostInfo: Option[(String, Int)], tracing: Boolean)
+    extends Actor with ActorLogging with Pump {
 
   import TLSActor._
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -26,14 +26,15 @@ import scala.concurrent.{ Future, Promise }
 /**
  * INTERNAL API
  */
-private[stream] class ConnectionSourceStage(val tcpManager: ActorRef,
-                                            val endpoint: InetSocketAddress,
-                                            val backlog: Int,
-                                            val options: immutable.Traversable[SocketOption],
-                                            val halfClose: Boolean,
-                                            val idleTimeout: Duration,
-                                            val bindShutdownTimeout: FiniteDuration)
-  extends GraphStageWithMaterializedValue[SourceShape[StreamTcp.IncomingConnection], Future[StreamTcp.ServerBinding]] {
+private[stream] class ConnectionSourceStage(
+  val tcpManager: ActorRef,
+  val endpoint: InetSocketAddress,
+  val backlog: Int,
+  val options: immutable.Traversable[SocketOption],
+  val halfClose: Boolean,
+  val idleTimeout: Duration,
+  val bindShutdownTimeout: FiniteDuration)
+    extends GraphStageWithMaterializedValue[SourceShape[StreamTcp.IncomingConnection], Future[StreamTcp.ServerBinding]] {
   import ConnectionSourceStage._
 
   val out: Outlet[StreamTcp.IncomingConnection] = Outlet("IncomingConnections.out")
@@ -267,7 +268,8 @@ private[stream] object TcpConnectionStage {
       override def onUpstreamFailure(ex: Throwable): Unit = {
         if (connection != null) {
           if (interpreter.log.isDebugEnabled) {
-            interpreter.log.debug("Aborting tcp connection because of upstream failure: {}\n{}",
+            interpreter.log.debug(
+              "Aborting tcp connection because of upstream failure: {}\n{}",
               ex.getMessage,
               ex.getStackTrace.mkString("\n"))
           }
@@ -289,7 +291,7 @@ private[stream] object TcpConnectionStage {
  * INTERNAL API
  */
 private[stream] class IncomingConnectionStage(connection: ActorRef, remoteAddress: InetSocketAddress, halfClose: Boolean)
-  extends GraphStage[FlowShape[ByteString, ByteString]] {
+    extends GraphStage[FlowShape[ByteString, ByteString]] {
   import TcpConnectionStage._
 
   private val hasBeenCreated = new AtomicBoolean(false)
@@ -312,14 +314,15 @@ private[stream] class IncomingConnectionStage(connection: ActorRef, remoteAddres
 /**
  * INTERNAL API
  */
-private[stream] class OutgoingConnectionStage(manager: ActorRef,
-                                              remoteAddress: InetSocketAddress,
-                                              localAddress: Option[InetSocketAddress] = None,
-                                              options: immutable.Traversable[SocketOption] = Nil,
-                                              halfClose: Boolean = true,
-                                              connectTimeout: Duration = Duration.Inf)
+private[stream] class OutgoingConnectionStage(
+  manager: ActorRef,
+  remoteAddress: InetSocketAddress,
+  localAddress: Option[InetSocketAddress] = None,
+  options: immutable.Traversable[SocketOption] = Nil,
+  halfClose: Boolean = true,
+  connectTimeout: Duration = Duration.Inf)
 
-  extends GraphStageWithMaterializedValue[FlowShape[ByteString, ByteString], Future[StreamTcp.OutgoingConnection]] {
+    extends GraphStageWithMaterializedValue[FlowShape[ByteString, ByteString], Future[StreamTcp.OutgoingConnection]] {
   import TcpConnectionStage._
 
   val bytesIn: Inlet[ByteString] = Inlet("IncomingTCP.in")

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
@@ -11,11 +11,11 @@ import akka.util.ByteString
  * INTERNAL API.
  */
 private[akka] final case class TlsModule(plainIn: Inlet[SslTlsOutbound], plainOut: Outlet[SslTlsInbound],
-                                         cipherIn: Inlet[ByteString], cipherOut: Outlet[ByteString],
-                                         shape: Shape, attributes: Attributes,
-                                         sslContext: SSLContext,
-                                         firstSession: NegotiateNewSession,
-                                         role: TLSRole, closing: TLSClosing, hostInfo: Option[(String, Int)]) extends AtomicModule {
+    cipherIn: Inlet[ByteString], cipherOut: Outlet[ByteString],
+    shape: Shape, attributes: Attributes,
+    sslContext: SSLContext,
+    firstSession: NegotiateNewSession,
+    role: TLSRole, closing: TLSClosing, hostInfo: Option[(String, Int)]) extends AtomicModule {
 
   override def withAttributes(att: Attributes): TlsModule = copy(attributes = att)
   override def carbonCopy: TlsModule =

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -6,7 +6,7 @@ package akka.stream.javadsl
 import akka.{ NotUsed, Done }
 import akka.event.LoggingAdapter
 import akka.japi.{ function, Pair }
-import akka.stream.impl.{ConstantFun, StreamLayout}
+import akka.stream.impl.{ ConstantFun, StreamLayout }
 import akka.stream._
 import akka.stream.stage.Stage
 import org.reactivestreams.Processor
@@ -1331,8 +1331,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * @see [[#alsoTo]]
    */
-  def alsoToMat[M2, M3](that: Graph[SinkShape[Out], M2],
-                        matF: function.Function2[Mat, M2, M3]): javadsl.Flow[In, Out, M3] =
+  def alsoToMat[M2, M3](
+    that: Graph[SinkShape[Out], M2],
+    matF: function.Function2[Mat, M2, M3]): javadsl.Flow[In, Out, M3] =
     new Flow(delegate.alsoToMat(that)(combinerToScala(matF)))
 
   /**
@@ -1378,7 +1379,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * @see [[#interleave]]
    */
   def interleaveMat[T >: Out, M, M2](that: Graph[SourceShape[T], M], segmentSize: Int,
-                                     matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
+    matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
     new Flow(delegate.interleaveMat(that, segmentSize)(combinerToScala(matF)))
 
   /**
@@ -1420,8 +1421,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * @see [[#merge]]
    */
-  def mergeMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
-                                matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
+  def mergeMat[T >: Out, M, M2](
+    that: Graph[SourceShape[T], M],
+    matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, T, M2] =
     mergeMat(that, matF, eagerComplete = false)
 
   /**
@@ -1433,9 +1435,10 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * @see [[#merge]]
    */
-  def mergeMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
-                                matF: function.Function2[Mat, M, M2],
-                                eagerComplete: Boolean): javadsl.Flow[In, T, M2] =
+  def mergeMat[T >: Out, M, M2](
+    that: Graph[SourceShape[T], M],
+    matF: function.Function2[Mat, M, M2],
+    eagerComplete: Boolean): javadsl.Flow[In, T, M2] =
     new Flow(delegate.mergeMat(that)(combinerToScala(matF)))
 
   /**
@@ -1469,7 +1472,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * @see [[#mergeSorted]].
    */
   def mergeSortedMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2], comp: Comparator[U],
-                                           matF: function.Function2[Mat, Mat2, Mat3]): javadsl.Flow[In, U, Mat3] =
+    matF: function.Function2[Mat, Mat2, Mat3]): javadsl.Flow[In, U, Mat3] =
     new Flow(delegate.mergeSortedMat(that)(combinerToScala(matF))(Ordering.comparatorToOrdering(comp)))
 
   /**
@@ -1494,9 +1497,11 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * @see [[#zip]]
    */
-  def zipMat[T, M, M2](that: Graph[SourceShape[T], M],
-                       matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out @uncheckedVariance Pair T, M2] =
-    this.viaMat(Flow.fromGraph(GraphDSL.create(that,
+  def zipMat[T, M, M2](
+    that: Graph[SourceShape[T], M],
+    matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out @uncheckedVariance Pair T, M2] =
+    this.viaMat(Flow.fromGraph(GraphDSL.create(
+      that,
       new function.Function2[GraphDSL.Builder[M], SourceShape[T], FlowShape[Out, Out @uncheckedVariance Pair T]] {
         def apply(b: GraphDSL.Builder[M], s: SourceShape[T]): FlowShape[Out, Out @uncheckedVariance Pair T] = {
           val zip: FanInShape2[Out, T, Out Pair T] = b.add(Zip.create[Out, T])
@@ -1517,8 +1522,9 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWith[Out2, Out3](that: Graph[SourceShape[Out2], _],
-                          combine: function.Function2[Out, Out2, Out3]): javadsl.Flow[In, Out3, Mat] =
+  def zipWith[Out2, Out3](
+    that: Graph[SourceShape[Out2], _],
+    combine: function.Function2[Out, Out2, Out3]): javadsl.Flow[In, Out3, Mat] =
     new Flow(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
   /**
@@ -1530,9 +1536,10 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * @see [[#zipWith]]
    */
-  def zipWithMat[Out2, Out3, M, M2](that: Graph[SourceShape[Out2], M],
-                                    combine: function.Function2[Out, Out2, Out3],
-                                    matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out3, M2] =
+  def zipWithMat[Out2, Out3, M, M2](
+    that: Graph[SourceShape[Out2], M],
+    combine: function.Function2[Out, Out2, Out3],
+    matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out3, M2] =
     new Flow(delegate.zipWithMat[Out2, Out3, M, M2](that)(combinerToScala(combine))(combinerToScala(matF)))
 
   /**
@@ -1630,7 +1637,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * '''Cancels when''' downstream cancels
    */
   def throttle(elements: Int, per: FiniteDuration, maximumBurst: Int,
-               mode: ThrottleMode): javadsl.Flow[In, Out, Mat] =
+    mode: ThrottleMode): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.throttle(elements, per, maximumBurst, mode))
 
   /**
@@ -1660,7 +1667,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * '''Cancels when''' downstream cancels
    */
   def throttle(cost: Int, per: FiniteDuration, maximumBurst: Int,
-               costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.Flow[In, Out, Mat] =
+    costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.throttle(cost, per, maximumBurst, costCalculation.apply, mode))
 
   /**
@@ -1687,11 +1694,11 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
     new Flow(delegate.watchTermination()((left, right) ⇒ matF(left, right.toJava)))
 
   /**
-    * Materializes to `FlowMonitor[Out]` that allows monitoring of the the current flow. All events are propagated
-    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
-    * event, and may therefor affect performance.
-    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
-    */
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   */
   def monitor[M]()(combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Flow[In, Out, M] =
     new Flow(delegate.monitor()(combinerToScala(combine)))
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
@@ -66,9 +66,10 @@ object Framing {
    *                           this Flow will fail the stream. This length *includes* the header (i.e the offset and
    *                           the length of the size field)
    */
-  def lengthField(fieldLength: Int,
-                  fieldOffset: Int,
-                  maximumFrameLength: Int): Flow[ByteString, ByteString, NotUsed] =
+  def lengthField(
+    fieldLength: Int,
+    fieldOffset: Int,
+    maximumFrameLength: Int): Flow[ByteString, ByteString, NotUsed] =
     scaladsl.Framing.lengthField(fieldLength, fieldOffset, maximumFrameLength).asJava
 
   /**
@@ -85,10 +86,11 @@ object Framing {
    *                           the length of the size field)
    * @param byteOrder The ''ByteOrder'' to be used when decoding the field
    */
-  def lengthField(fieldLength: Int,
-                  fieldOffset: Int,
-                  maximumFrameLength: Int,
-                  byteOrder: ByteOrder): Flow[ByteString, ByteString, NotUsed] =
+  def lengthField(
+    fieldLength: Int,
+    fieldOffset: Int,
+    maximumFrameLength: Int,
+    byteOrder: ByteOrder): Flow[ByteString, ByteString, NotUsed] =
     scaladsl.Framing.lengthField(fieldLength, fieldOffset, maximumFrameLength, byteOrder).asJava
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -193,7 +193,7 @@ object Sink {
    * message will be sent to the destination actor.
    */
   def actorRefWithAck[In](ref: ActorRef, onInitMessage: Any, ackMessage: Any, onCompleteMessage: Any,
-                          onFailureMessage: function.Function[Throwable, Any]): Sink[In, NotUsed] =
+    onFailureMessage: function.Function[Throwable, Any]): Sink[In, NotUsed] =
     new Sink(scaladsl.Sink.actorRefWithAck[In](ref, onInitMessage, ackMessage, onCompleteMessage, onFailureMessage.apply))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -268,7 +268,7 @@ object Source {
    * Combines several sources with fan-in strategy like `Merge` or `Concat` and returns `Source`.
    */
   def combine[T, U](first: Source[T, _ <: Any], second: Source[T, _ <: Any], rest: java.util.List[Source[T, _ <: Any]],
-                    strategy: function.Function[java.lang.Integer, _ <: Graph[UniformFanInShape[T, U], NotUsed]]): Source[U, NotUsed] = {
+    strategy: function.Function[java.lang.Integer, _ <: Graph[UniformFanInShape[T, U], NotUsed]]): Source[U, NotUsed] = {
     import scala.collection.JavaConverters._
     val seq = if (rest != null) rest.asScala.map(_.asScala) else Seq()
     new Source(scaladsl.Source.combine(first.asScala, second.asScala, seq: _*)(num ⇒ strategy.apply(num)))
@@ -307,61 +307,65 @@ object Source {
     new Source(scaladsl.Source.queue[T](bufferSize, overflowStrategy).mapMaterializedValue(new SourceQueueAdapter(_)))
 
   /**
-    * Start a new `Source` from some resource which can be opened, read and closed.
-    * Interaction with resource happens in a blocking way.
-    *
-    * Example:
-    * {{{
-    * Source.unfoldResource(
-    *   () -> new BufferedReader(new FileReader("...")),
-    *   reader -> reader.readLine(),
-    *   reader -> reader.close())
-    * }}}
-    *
-    * You can use the supervision strategy to handle exceptions for `read` function. All exceptions thrown by `create`
-    * or `close` will fail the stream.
-    *
-    * `Restart` supervision strategy will close and create blocking IO again. Default strategy is `Stop` which means
-    * that stream will be terminated on error in `read` function by default.
-    *
-    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
-    * set it for a given Source by using [[ActorAttributes]].
-    *
-    * @param create - function that is called on stream start and creates/opens resource.
-    * @param read - function that reads data from opened resource. It is called each time backpressure signal
-    *             is received. Stream calls close and completes when `read` returns None.
-    * @param close - function that closes resource
-    */
-  def unfoldResource[T, S](create: function.Creator[S],
-                     read: function.Function[S, Optional[T]],
-                     close: function.Procedure[S]): javadsl.Source[T, NotUsed] =
-    new Source(scaladsl.Source.unfoldResource[T,S](create.create,
+   * Start a new `Source` from some resource which can be opened, read and closed.
+   * Interaction with resource happens in a blocking way.
+   *
+   * Example:
+   * {{{
+   * Source.unfoldResource(
+   *   () -> new BufferedReader(new FileReader("...")),
+   *   reader -> reader.readLine(),
+   *   reader -> reader.close())
+   * }}}
+   *
+   * You can use the supervision strategy to handle exceptions for `read` function. All exceptions thrown by `create`
+   * or `close` will fail the stream.
+   *
+   * `Restart` supervision strategy will close and create blocking IO again. Default strategy is `Stop` which means
+   * that stream will be terminated on error in `read` function by default.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   *
+   * @param create - function that is called on stream start and creates/opens resource.
+   * @param read - function that reads data from opened resource. It is called each time backpressure signal
+   *             is received. Stream calls close and completes when `read` returns None.
+   * @param close - function that closes resource
+   */
+  def unfoldResource[T, S](
+    create: function.Creator[S],
+    read: function.Function[S, Optional[T]],
+    close: function.Procedure[S]): javadsl.Source[T, NotUsed] =
+    new Source(scaladsl.Source.unfoldResource[T, S](
+      create.create,
       (s: S) ⇒ read.apply(s).asScala, close.apply))
 
   /**
-    * Start a new `Source` from some resource which can be opened, read and closed.
-    * It's similar to `unfoldResource` but takes functions that return `CopletionStage` instead of plain values.
-    *
-    * You can use the supervision strategy to handle exceptions for `read` function or failures of produced `Futures`.
-    * All exceptions thrown by `create` or `close` as well as fails of returned futures will fail the stream.
-    *
-    * `Restart` supervision strategy will close and create resource. Default strategy is `Stop` which means
-    * that stream will be terminated on error in `read` function (or future) by default.
-    *
-    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
-    * set it for a given Source by using [[ActorAttributes]].
-    *
-    * @param create - function that is called on stream start and creates/opens resource.
-    * @param read - function that reads data from opened resource. It is called each time backpressure signal
-    *             is received. Stream calls close and completes when `CompletionStage` from read function returns None.
-    * @param close - function that closes resource
-    */
-  def unfoldResourceAsync[T, S](create: function.Creator[CompletionStage[S]],
+   * Start a new `Source` from some resource which can be opened, read and closed.
+   * It's similar to `unfoldResource` but takes functions that return `CopletionStage` instead of plain values.
+   *
+   * You can use the supervision strategy to handle exceptions for `read` function or failures of produced `Futures`.
+   * All exceptions thrown by `create` or `close` as well as fails of returned futures will fail the stream.
+   *
+   * `Restart` supervision strategy will close and create resource. Default strategy is `Stop` which means
+   * that stream will be terminated on error in `read` function (or future) by default.
+   *
+   * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
+   * set it for a given Source by using [[ActorAttributes]].
+   *
+   * @param create - function that is called on stream start and creates/opens resource.
+   * @param read - function that reads data from opened resource. It is called each time backpressure signal
+   *             is received. Stream calls close and completes when `CompletionStage` from read function returns None.
+   * @param close - function that closes resource
+   */
+  def unfoldResourceAsync[T, S](
+    create: function.Creator[CompletionStage[S]],
     read: function.Function[S, CompletionStage[Optional[T]]],
     close: function.Function[S, CompletionStage[Done]]): javadsl.Source[T, NotUsed] =
-  new Source(scaladsl.Source.unfoldResourceAsync[T,S](() ⇒ create.create().toScala,
-    (s: S) ⇒ read.apply(s).toScala.map(_.asScala)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext),
-    (s: S) ⇒ close.apply(s).toScala))
+    new Source(scaladsl.Source.unfoldResourceAsync[T, S](
+      () ⇒ create.create().toScala,
+      (s: S) ⇒ read.apply(s).toScala.map(_.asScala)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext),
+      (s: S) ⇒ close.apply(s).toScala))
 }
 
 /**
@@ -538,8 +542,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * @see [[#concat]].
    */
-  def concatMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
-                                 matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
+  def concatMat[T >: Out, M, M2](
+    that: Graph[SourceShape[T], M],
+    matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
     new Source(delegate.concatMat(that)(combinerToScala(matF)))
 
   /**
@@ -578,8 +583,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * @see [[#prepend]].
    */
-  def prependMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
-                                  matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
+  def prependMat[T >: Out, M, M2](
+    that: Graph[SourceShape[T], M],
+    matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
     new Source(delegate.prependMat(that)(combinerToScala(matF)))
 
   /**
@@ -606,8 +612,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * @see [[#alsoTo]]
    */
-  def alsoToMat[M2, M3](that: Graph[SinkShape[Out], M2],
-                        matF: function.Function2[Mat, M2, M3]): javadsl.Source[Out, M3] =
+  def alsoToMat[M2, M3](
+    that: Graph[SinkShape[Out], M2],
+    matF: function.Function2[Mat, M2, M3]): javadsl.Source[Out, M3] =
     new Source(delegate.alsoToMat(that)(combinerToScala(matF)))
 
   /**
@@ -652,7 +659,7 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * @see [[#interleave]].
    */
   def interleaveMat[T >: Out, M, M2](that: Graph[SourceShape[T], M], segmentSize: Int,
-                                     matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
+    matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
     new Source(delegate.interleaveMat(that, segmentSize)(combinerToScala(matF)))
 
   /**
@@ -679,8 +686,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * @see [[#merge]].
    */
-  def mergeMat[T >: Out, M, M2](that: Graph[SourceShape[T], M],
-                                matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
+  def mergeMat[T >: Out, M, M2](
+    that: Graph[SourceShape[T], M],
+    matF: function.Function2[Mat, M, M2]): javadsl.Source[T, M2] =
     new Source(delegate.mergeMat(that)(combinerToScala(matF)))
 
   /**
@@ -714,7 +722,7 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * @see [[#mergeSorted]].
    */
   def mergeSortedMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2], comp: util.Comparator[U],
-                                           matF: function.Function2[Mat, Mat2, Mat3]): javadsl.Source[U, Mat3] =
+    matF: function.Function2[Mat, Mat2, Mat3]): javadsl.Source[U, Mat3] =
     new Source(delegate.mergeSortedMat(that)(combinerToScala(matF))(Ordering.comparatorToOrdering(comp)))
 
   /**
@@ -739,8 +747,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * @see [[#zip]].
    */
-  def zipMat[T, M, M2](that: Graph[SourceShape[T], M],
-                       matF: function.Function2[Mat, M, M2]): javadsl.Source[Out @uncheckedVariance Pair T, M2] =
+  def zipMat[T, M, M2](
+    that: Graph[SourceShape[T], M],
+    matF: function.Function2[Mat, M, M2]): javadsl.Source[Out @uncheckedVariance Pair T, M2] =
     this.viaMat(Flow.create[Out].zipMat(that, Keep.right[NotUsed, M]), matF)
 
   /**
@@ -755,8 +764,9 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWith[Out2, Out3](that: Graph[SourceShape[Out2], _],
-                          combine: function.Function2[Out, Out2, Out3]): javadsl.Source[Out3, Mat] =
+  def zipWith[Out2, Out3](
+    that: Graph[SourceShape[Out2], _],
+    combine: function.Function2[Out, Out2, Out3]): javadsl.Source[Out3, Mat] =
     new Source(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
   /**
@@ -768,9 +778,10 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * @see [[#zipWith]].
    */
-  def zipWithMat[Out2, Out3, M, M2](that: Graph[SourceShape[Out2], M],
-                                    combine: function.Function2[Out, Out2, Out3],
-                                    matF: function.Function2[Mat, M, M2]): javadsl.Source[Out3, M2] =
+  def zipWithMat[Out2, Out3, M, M2](
+    that: Graph[SourceShape[Out2], M],
+    combine: function.Function2[Out, Out2, Out3],
+    matF: function.Function2[Mat, M, M2]): javadsl.Source[Out3, M2] =
     new Source(delegate.zipWithMat[Out2, Out3, M, M2](that)(combinerToScala(combine))(combinerToScala(matF)))
 
   /**
@@ -1813,7 +1824,7 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * '''Cancels when''' downstream cancels
    */
   def throttle(elements: Int, per: FiniteDuration, maximumBurst: Int,
-               mode: ThrottleMode): javadsl.Source[Out, Mat] =
+    mode: ThrottleMode): javadsl.Source[Out, Mat] =
     new Source(delegate.throttle(elements, per, maximumBurst, mode))
 
   /**
@@ -1843,7 +1854,7 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * '''Cancels when''' downstream cancels
    */
   def throttle(cost: Int, per: FiniteDuration, maximumBurst: Int,
-               costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.Source[Out, Mat] =
+    costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.Source[Out, Mat] =
     new Source(delegate.throttle(cost, per, maximumBurst, costCalculation.apply _, mode))
 
   /**
@@ -1870,11 +1881,11 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
     new Source(delegate.watchTermination()((left, right) ⇒ matF(left, right.toJava)))
 
   /**
-    * Materializes to `FlowMonitor[Out]` that allows monitoring of the the current flow. All events are propagated
-    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
-    * event, and may therefor affect performance.
-    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
-    */
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   */
   def monitor[M]()(combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Source[Out, M] =
     new Source(delegate.monitor()(combinerToScala(combine)))
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1040,8 +1040,9 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWith[Out2, Out3](that: Graph[SourceShape[Out2], _],
-                          combine: function.Function2[Out, Out2, Out3]): SubFlow[In, Out3, Mat] =
+  def zipWith[Out2, Out3](
+    that: Graph[SourceShape[Out2], _],
+    combine: function.Function2[Out, Out2, Out3]): SubFlow[In, Out3, Mat] =
     new SubFlow(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
   /**
@@ -1132,7 +1133,7 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    * '''Cancels when''' downstream cancels
    */
   def throttle(elements: Int, per: FiniteDuration, maximumBurst: Int,
-               mode: ThrottleMode): javadsl.SubFlow[In, Out, Mat] =
+    mode: ThrottleMode): javadsl.SubFlow[In, Out, Mat] =
     new SubFlow(delegate.throttle(elements, per, maximumBurst, mode))
 
   /**
@@ -1169,7 +1170,7 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    * '''Cancels when''' downstream cancels
    */
   def throttle(cost: Int, per: FiniteDuration, maximumBurst: Int,
-               costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.SubFlow[In, Out, Mat] =
+    costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.SubFlow[In, Out, Mat] =
     new SubFlow(delegate.throttle(cost, per, maximumBurst, costCalculation.apply, mode))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1039,8 +1039,9 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWith[Out2, Out3](that: Graph[SourceShape[Out2], _],
-                          combine: function.Function2[Out, Out2, Out3]): SubSource[Out3, Mat] =
+  def zipWith[Out2, Out3](
+    that: Graph[SourceShape[Out2], _],
+    combine: function.Function2[Out, Out2, Out3]): SubSource[Out3, Mat] =
     new SubSource(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
   /**
@@ -1131,7 +1132,7 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    * '''Cancels when''' downstream cancels
    */
   def throttle(elements: Int, per: FiniteDuration, maximumBurst: Int,
-               mode: ThrottleMode): javadsl.SubSource[Out, Mat] =
+    mode: ThrottleMode): javadsl.SubSource[Out, Mat] =
     new SubSource(delegate.throttle(elements, per, maximumBurst, mode))
 
   /**
@@ -1161,7 +1162,7 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    * '''Cancels when''' downstream cancels
    */
   def throttle(cost: Int, per: FiniteDuration, maximumBurst: Int,
-               costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.SubSource[Out, Mat] =
+    costCalculation: function.Function[Out, Integer], mode: ThrottleMode): javadsl.SubSource[Out, Mat] =
     new SubSource(delegate.throttle(cost, per, maximumBurst, costCalculation.apply _, mode))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -120,12 +120,13 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *                  independently whether the client is still attempting to write. This setting is recommended
    *                  for servers, and therefore it is the default setting.
    */
-  def bind(interface: String,
-           port: Int,
-           backlog: Int,
-           options: JIterable[SocketOption],
-           halfClose: Boolean,
-           idleTimeout: Duration): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+  def bind(
+    interface: String,
+    port: Int,
+    backlog: Int,
+    options: JIterable[SocketOption],
+    halfClose: Boolean,
+    idleTimeout: Duration): Source[IncomingConnection, CompletionStage[ServerBinding]] =
     Source.fromGraph(delegate.bind(interface, port, backlog, immutableSeq(options), halfClose, idleTimeout)
       .map(new IncomingConnection(_))
       .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
@@ -159,12 +160,13 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *                  If set to false, the connection will immediately closed once the client closes its write side,
    *                  independently whether the server is still attempting to write.
    */
-  def outgoingConnection(remoteAddress: InetSocketAddress,
-                         localAddress: Optional[InetSocketAddress],
-                         options: JIterable[SocketOption],
-                         halfClose: Boolean,
-                         connectTimeout: Duration,
-                         idleTimeout: Duration): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
+  def outgoingConnection(
+    remoteAddress: InetSocketAddress,
+    localAddress: Optional[InetSocketAddress],
+    options: JIterable[SocketOption],
+    halfClose: Boolean,
+    connectTimeout: Duration,
+    idleTimeout: Duration): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
     Flow.fromGraph(delegate.outgoingConnection(remoteAddress, localAddress.asScala, immutableSeq(options), halfClose, connectTimeout, idleTimeout)
       .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava))
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -194,8 +194,7 @@ object BidiFlow {
   def fromFlowsMat[I1, O1, I2, O2, M1, M2, M](
     flow1: Graph[FlowShape[I1, O1], M1],
     flow2: Graph[FlowShape[I2, O2], M2])(combine: (M1, M2) ⇒ M): BidiFlow[I1, O1, I2, O2, M] =
-    fromGraph(GraphDSL.create(flow1, flow2)(combine) {
-      implicit b ⇒ (f1, f2) ⇒ BidiShape(f1.in, f1.out, f2.in, f2.out)
+    fromGraph(GraphDSL.create(flow1, flow2)(combine) { implicit b ⇒ (f1, f2) ⇒ BidiShape(f1.in, f1.out, f2.in, f2.out)
     })
 
   /**
@@ -216,8 +215,9 @@ object BidiFlow {
    * }}}
    *
    */
-  def fromFlows[I1, O1, I2, O2, M1, M2](flow1: Graph[FlowShape[I1, O1], M1],
-                                        flow2: Graph[FlowShape[I2, O2], M2]): BidiFlow[I1, O1, I2, O2, NotUsed] =
+  def fromFlows[I1, O1, I2, O2, M1, M2](
+    flow1: Graph[FlowShape[I1, O1], M1],
+    flow2: Graph[FlowShape[I2, O2], M2]): BidiFlow[I1, O1, I2, O2, NotUsed] =
     fromFlowsMat(flow1, flow2)(Keep.none)
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -46,10 +46,11 @@ object Framing {
    *                           the length of the size field)
    * @param byteOrder The ''ByteOrder'' to be used when decoding the field
    */
-  def lengthField(fieldLength: Int,
-                  fieldOffset: Int = 0,
-                  maximumFrameLength: Int,
-                  byteOrder: ByteOrder = ByteOrder.LITTLE_ENDIAN): Flow[ByteString, ByteString, NotUsed] = {
+  def lengthField(
+    fieldLength: Int,
+    fieldOffset: Int = 0,
+    maximumFrameLength: Int,
+    byteOrder: ByteOrder = ByteOrder.LITTLE_ENDIAN): Flow[ByteString, ByteString, NotUsed] = {
     require(fieldLength >= 1 && fieldLength <= 4, "Length field length must be 1, 2, 3 or 4.")
     Flow[ByteString].transform(() ⇒ new LengthFieldFramingStage(fieldLength, fieldOffset, maximumFrameLength, byteOrder))
       .named("lengthFieldFraming")
@@ -126,7 +127,7 @@ object Framing {
   }
 
   private class DelimiterFramingStage(val separatorBytes: ByteString, val maximumLineBytes: Int, val allowTruncation: Boolean)
-    extends PushPullStage[ByteString, ByteString] {
+      extends PushPullStage[ByteString, ByteString] {
     private val firstSeparatorByte = separatorBytes.head
     private var buffer = ByteString.empty
     private var nextPossibleMatch = 0
@@ -188,10 +189,10 @@ object Framing {
   }
 
   private final class LengthFieldFramingStage(
-    val lengthFieldLength: Int,
-    val lengthFieldOffset: Int,
-    val maximumFrameLength: Int,
-    val byteOrder: ByteOrder) extends PushPullStage[ByteString, ByteString] {
+      val lengthFieldLength: Int,
+      val lengthFieldOffset: Int,
+      val maximumFrameLength: Int,
+      val byteOrder: ByteOrder) extends PushPullStage[ByteString, ByteString] {
     private var buffer = ByteString.empty
     private var frameSize = Int.MaxValue
     private val minimumChunkSize = lengthFieldOffset + lengthFieldLength

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -23,7 +23,7 @@ import scala.util.{ Failure, Success, Try }
  * Can be used as a `Subscriber`
  */
 final class Sink[-In, +Mat](private[stream] override val module: Module)
-  extends Graph[SinkShape[In], Mat] {
+    extends Graph[SinkShape[In], Mat] {
 
   override val shape: SinkShape[In] = module.shape.asInstanceOf[SinkShape[In]]
 
@@ -307,7 +307,7 @@ object Sink {
    * function will be sent to the destination actor.
    */
   def actorRefWithAck[T](ref: ActorRef, onInitMessage: Any, ackMessage: Any, onCompleteMessage: Any,
-                         onFailureMessage: (Throwable) ⇒ Any = Status.Failure): Sink[T, NotUsed] =
+    onFailureMessage: (Throwable) ⇒ Any = Status.Failure): Sink[T, NotUsed] =
     Sink.fromGraph(new ActorRefBackpressureSinkStage(ref, onInitMessage, ackMessage, onCompleteMessage, onFailureMessage))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -28,7 +28,7 @@ import scala.compat.java8.FutureConverters._
  * a Reactive Streams `Publisher` (at least conceptually).
  */
 final class Source[+Out, +Mat](private[stream] override val module: Module)
-  extends FlowOpsMat[Out, Mat] with Graph[SourceShape[Out], Mat] {
+    extends FlowOpsMat[Out, Mat] with Graph[SourceShape[Out], Mat] {
 
   override type Repr[+O] = Source[O, Mat @uncheckedVariance]
   override type ReprMat[+O, +M] = Source[O, M]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
@@ -63,7 +63,7 @@ object TLS {
    * configured using [[SSLParameters.setEndpointIdentificationAlgorithm]].
    */
   def apply(sslContext: SSLContext, firstSession: NegotiateNewSession, role: TLSRole,
-            closing: TLSClosing = IgnoreComplete, hostInfo: Option[(String, Int)] = None): scaladsl.BidiFlow[SslTlsOutbound, ByteString, ByteString, SslTlsInbound, NotUsed] =
+    closing: TLSClosing = IgnoreComplete, hostInfo: Option[(String, Int)] = None): scaladsl.BidiFlow[SslTlsOutbound, ByteString, ByteString, SslTlsInbound, NotUsed] =
     new scaladsl.BidiFlow(TlsModule(Attributes.none, sslContext, firstSession, role, closing, hostInfo))
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -31,9 +31,9 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
    * Represents an accepted incoming TCP connection.
    */
   final case class IncomingConnection(
-    localAddress: InetSocketAddress,
-    remoteAddress: InetSocketAddress,
-    flow: Flow[ByteString, ByteString, NotUsed]) {
+      localAddress: InetSocketAddress,
+      remoteAddress: InetSocketAddress,
+      flow: Flow[ByteString, ByteString, NotUsed]) {
 
     /**
      * Handles the connection using the given flow, which is materialized exactly once and the respective
@@ -87,12 +87,13 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *                  independently whether the client is still attempting to write. This setting is recommended
    *                  for servers, and therefore it is the default setting.
    */
-  def bind(interface: String,
-           port: Int,
-           backlog: Int = 100,
-           options: immutable.Traversable[SocketOption] = Nil,
-           halfClose: Boolean = false,
-           idleTimeout: Duration = Duration.Inf): Source[IncomingConnection, Future[ServerBinding]] =
+  def bind(
+    interface: String,
+    port: Int,
+    backlog: Int = 100,
+    options: immutable.Traversable[SocketOption] = Nil,
+    halfClose: Boolean = false,
+    idleTimeout: Duration = Duration.Inf): Source[IncomingConnection, Future[ServerBinding]] =
     Source.fromGraph(new ConnectionSourceStage(
       IO(IoTcp)(system),
       new InetSocketAddress(interface, port),
@@ -154,12 +155,13 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *                  If set to false, the connection will immediately closed once the client closes its write side,
    *                  independently whether the server is still attempting to write.
    */
-  def outgoingConnection(remoteAddress: InetSocketAddress,
-                         localAddress: Option[InetSocketAddress] = None,
-                         options: immutable.Traversable[SocketOption] = Nil,
-                         halfClose: Boolean = true,
-                         connectTimeout: Duration = Duration.Inf,
-                         idleTimeout: Duration = Duration.Inf): Flow[ByteString, ByteString, Future[OutgoingConnection]] = {
+  def outgoingConnection(
+    remoteAddress: InetSocketAddress,
+    localAddress: Option[InetSocketAddress] = None,
+    options: immutable.Traversable[SocketOption] = Nil,
+    halfClose: Boolean = true,
+    connectTimeout: Duration = Duration.Inf,
+    idleTimeout: Duration = Duration.Inf): Flow[ByteString, ByteString, Future[OutgoingConnection]] = {
 
     val tcpFlow = Flow.fromGraph(new OutgoingConnectionStage(
       IO(IoTcp)(system),

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -123,9 +123,10 @@ object GraphStageLogic {
   /**
    * Minimal actor to work with other actors and watch them in a synchronous ways
    */
-  final class StageActor(materializer: ActorMaterializer,
-                         getAsyncCallback: StageActorRef.Receive ⇒ AsyncCallback[(ActorRef, Any)],
-                         initialReceive: StageActorRef.Receive) {
+  final class StageActor(
+    materializer: ActorMaterializer,
+      getAsyncCallback: StageActorRef.Receive ⇒ AsyncCallback[(ActorRef, Any)],
+      initialReceive: StageActorRef.Receive) {
 
     private val callback = getAsyncCallback(internalReceive)
     private def cell = materializer.supervisor match {
@@ -537,8 +538,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
             pos += 1
             if (pos == n) andThen(result)
           },
-          () ⇒ onClose(result.take(pos)))
-        )
+          () ⇒ onClose(result.take(pos))))
       } else andThen(result)
     }
 
@@ -794,7 +794,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   }
 
   private class EmittingSingle[T](_out: Outlet[T], elem: T, _previous: OutHandler, _andThen: () ⇒ Unit)
-    extends Emitting(_out, _previous, _andThen) {
+      extends Emitting(_out, _previous, _andThen) {
 
     override def onPull(): Unit = {
       push(out, elem)
@@ -803,7 +803,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   }
 
   private class EmittingIterator[T](_out: Outlet[T], elems: Iterator[T], _previous: OutHandler, _andThen: () ⇒ Unit)
-    extends Emitting(_out, _previous, _andThen) {
+      extends Emitting(_out, _previous, _andThen) {
 
     override def onPull(): Unit = {
       push(out, elems.next())
@@ -824,8 +824,8 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    * `doPull` instructs to perform one initial pull on the `from` port.
    */
   final protected def passAlong[Out, In <: Out](from: Inlet[In], to: Outlet[Out],
-                                                doFinish: Boolean = true, doFail: Boolean = true,
-                                                doPull: Boolean = false): Unit = {
+    doFinish: Boolean = true, doFail: Boolean = true,
+    doPull: Boolean = false): Unit = {
     class PassAlongHandler extends InHandler with (() ⇒ Unit) {
       override def apply(): Unit = tryPull(from)
       override def onPush(): Unit = {

--- a/akka-stream/src/main/scala/akka/stream/stage/Stage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/Stage.scala
@@ -40,7 +40,7 @@ private[stream] object AbstractStage {
     private val shape: FlowShape[In, Out],
     val attributes: Attributes,
     val stage: AbstractStage[In, Out, Directive, Directive, Context[Out], LifecycleContext])
-    extends GraphStageLogic(shape) with DetachedContext[Out] {
+      extends GraphStageLogic(shape) with DetachedContext[Out] {
 
     final override def materializer: Materializer = interpreter.materializer
 
@@ -165,7 +165,7 @@ private[stream] object AbstractStage {
   class PushPullGraphStageWithMaterializedValue[-In, +Out, Ext, +Mat](
     val factory: (Attributes) ⇒ (Stage[In, Out], Mat),
     stageAttributes: Attributes)
-    extends GraphStageWithMaterializedValue[FlowShape[In, Out], Mat] {
+      extends GraphStageWithMaterializedValue[FlowShape[In, Out], Mat] {
 
     val name = stageAttributes.nameOrDefault()
     override def initialAttributes = stageAttributes
@@ -370,7 +370,7 @@ abstract class PushStage[In, Out] extends PushPullStage[In, Out] {
  */
 @deprecated("Please use GraphStage instead.", "2.4.2")
 abstract class DetachedStage[In, Out]
-  extends AbstractStage[In, Out, UpstreamDirective, DownstreamDirective, DetachedContext[Out], LifecycleContext] {
+    extends AbstractStage[In, Out, UpstreamDirective, DownstreamDirective, DetachedContext[Out], LifecycleContext] {
   private[stream] override def isDetached = true
 
   /**

--- a/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
@@ -52,16 +52,16 @@ private[testkit] class CallingThreadDispatcherQueues extends Extension {
     queues = (Map.newBuilder[CallingThreadMailbox, Set[WeakReference[MessageQueue]]] /: queues) {
       case (m, (k, v)) ⇒
         val nv = v filter (_.get ne null)
-        if (nv.isEmpty) m else m += (k -> nv)
+        if (nv.isEmpty) m else m += (k → nv)
     }.result
   }
 
   protected[akka] def registerQueue(mbox: CallingThreadMailbox, q: MessageQueue): Unit = synchronized {
     if (queues contains mbox) {
       val newSet = queues(mbox) + new WeakReference(q)
-      queues += mbox -> newSet
+      queues += mbox → newSet
     } else {
-      queues += mbox -> Set(new WeakReference(q))
+      queues += mbox → Set(new WeakReference(q))
     }
     val now = System.nanoTime
     if (now - lastGC > 1000000000l) {
@@ -298,7 +298,7 @@ class CallingThreadDispatcher(_configurator: MessageDispatcherConfigurator) exte
 }
 
 class CallingThreadDispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-  extends MessageDispatcherConfigurator(config, prerequisites) {
+    extends MessageDispatcherConfigurator(config, prerequisites) {
 
   private val instance = new CallingThreadDispatcher(this)
 
@@ -306,7 +306,7 @@ class CallingThreadDispatcherConfigurator(config: Config, prerequisites: Dispatc
 }
 
 class CallingThreadMailbox(_receiver: akka.actor.Cell, val mailboxType: MailboxType)
-  extends Mailbox(null) with DefaultSystemMessageQueue {
+    extends Mailbox(null) with DefaultSystemMessageQueue {
 
   val system = _receiver.system
   val self = _receiver.self

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -95,7 +95,8 @@ abstract class EventFilter(occurrences: Int) {
    * `occurrences` parameter specifies.
    */
   def assertDone(max: Duration): Unit =
-    assert(awaitDone(max),
+    assert(
+      awaitDone(max),
       if (todo > 0) s"$todo messages outstanding on $this"
       else s"received ${-todo} excess messages on $this")
 
@@ -199,7 +200,8 @@ object EventFilter {
    * source filter).''
    */
   def warning(message: String = null, source: String = null, start: String = "", pattern: String = null, occurrences: Int = Int.MaxValue): EventFilter =
-    WarningFilter(Option(source),
+    WarningFilter(
+      Option(source),
       if (message ne null) Left(message) else Option(pattern) map (new Regex(_)) toRight start,
       message ne null)(occurrences)
 
@@ -218,7 +220,8 @@ object EventFilter {
    * source filter).''
    */
   def info(message: String = null, source: String = null, start: String = "", pattern: String = null, occurrences: Int = Int.MaxValue): EventFilter =
-    InfoFilter(Option(source),
+    InfoFilter(
+      Option(source),
       if (message ne null) Left(message) else Option(pattern) map (new Regex(_)) toRight start,
       message ne null)(occurrences)
 
@@ -237,7 +240,8 @@ object EventFilter {
    * source filter).''
    */
   def debug(message: String = null, source: String = null, start: String = "", pattern: String = null, occurrences: Int = Int.MaxValue): EventFilter =
-    DebugFilter(Option(source),
+    DebugFilter(
+      Option(source),
       if (message ne null) Left(message) else Option(pattern) map (new Regex(_)) toRight start,
       message ne null)(occurrences)
 
@@ -271,10 +275,10 @@ object EventFilter {
  * If you want to match all Error events, the most efficient is to use <code>Left("")</code>.
  */
 final case class ErrorFilter(
-  throwable: Class[_],
-  override val source: Option[String],
-  override val message: Either[String, Regex],
-  override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
+    throwable: Class[_],
+    override val source: Option[String],
+    override val message: Either[String, Regex],
+    override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
 
   def matches(event: LogEvent) = {
     event match {
@@ -323,9 +327,9 @@ final case class ErrorFilter(
  * If you want to match all Warning events, the most efficient is to use <code>Left("")</code>.
  */
 final case class WarningFilter(
-  override val source: Option[String],
-  override val message: Either[String, Regex],
-  override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
+    override val source: Option[String],
+    override val message: Either[String, Regex],
+    override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
 
   def matches(event: LogEvent) = {
     event match {
@@ -350,7 +354,8 @@ final case class WarningFilter(
    *   whether the event’s message must match the given message string or pattern completely
    */
   def this(source: String, message: String, pattern: Boolean, complete: Boolean, occurrences: Int) =
-    this(Option(source),
+    this(
+      Option(source),
       if (message eq null) Left("")
       else if (pattern) Right(new Regex(message))
       else Left(message),
@@ -366,9 +371,9 @@ final case class WarningFilter(
  * If you want to match all Info events, the most efficient is to use <code>Left("")</code>.
  */
 final case class InfoFilter(
-  override val source: Option[String],
-  override val message: Either[String, Regex],
-  override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
+    override val source: Option[String],
+    override val message: Either[String, Regex],
+    override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
 
   def matches(event: LogEvent) = {
     event match {
@@ -393,7 +398,8 @@ final case class InfoFilter(
    *   whether the event’s message must match the given message string or pattern completely
    */
   def this(source: String, message: String, pattern: Boolean, complete: Boolean, occurrences: Int) =
-    this(Option(source),
+    this(
+      Option(source),
       if (message eq null) Left("")
       else if (pattern) Right(new Regex(message))
       else Left(message),
@@ -409,9 +415,9 @@ final case class InfoFilter(
  * If you want to match all Debug events, the most efficient is to use <code>Left("")</code>.
  */
 final case class DebugFilter(
-  override val source: Option[String],
-  override val message: Either[String, Regex],
-  override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
+    override val source: Option[String],
+    override val message: Either[String, Regex],
+    override val complete: Boolean)(occurrences: Int) extends EventFilter(occurrences) {
 
   def matches(event: LogEvent) = {
     event match {
@@ -436,7 +442,8 @@ final case class DebugFilter(
    *   whether the event’s message must match the given message string or pattern completely
    */
   def this(source: String, message: String, pattern: Boolean, complete: Boolean, occurrences: Int) =
-    this(Option(source),
+    this(
+      Option(source),
       if (message eq null) Left("")
       else if (pattern) Right(new Regex(message))
       else Left(message),

--- a/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestFSMRef.scala
@@ -37,7 +37,7 @@ class TestFSMRef[S, D, T <: Actor](
   props: Props,
   supervisor: ActorRef,
   name: String)(implicit ev: T <:< FSM[S, D])
-  extends TestActorRef[T](system, props, supervisor, name) {
+    extends TestActorRef[T](system, props, supervisor, name) {
 
   private def fsm: T = underlyingActor
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -123,7 +123,8 @@ trait TestKitBase {
    */
   val testActor: ActorRef = {
     val impl = system.asInstanceOf[ExtendedActorSystem]
-    val ref = impl.systemActorOf(TestActor.props(queue)
+    val ref = impl.systemActorOf(
+      TestActor.props(queue)
       .withDispatcher(CallingThreadDispatcher.Id),
       "%s-%d".format(testActorName, TestKit.testActorId.incrementAndGet))
     awaitCond(ref match {
@@ -499,8 +500,9 @@ trait TestKitBase {
   def expectMsgAllOf[T](max: FiniteDuration, obj: T*): immutable.Seq[T] = expectMsgAllOf_internal(max.dilated, obj: _*)
 
   private def checkMissingAndUnexpected(missing: Seq[Any], unexpected: Seq[Any],
-                                        missingMessage: String, unexpectedMessage: String): Unit = {
-    assert(missing.isEmpty && unexpected.isEmpty,
+    missingMessage: String, unexpectedMessage: String): Unit = {
+    assert(
+      missing.isEmpty && unexpected.isEmpty,
       (if (missing.isEmpty) "" else missing.mkString(missingMessage + " [", ", ", "] ")) +
         (if (unexpected.isEmpty) "" else unexpected.mkString(unexpectedMessage + " [", ", ", "]")))
   }
@@ -679,9 +681,10 @@ trait TestKitBase {
    *
    * If verifySystemShutdown is true, then an exception will be thrown on failure.
    */
-  def shutdown(actorSystem: ActorSystem = system,
-               duration: Duration = 5.seconds.dilated.min(10.seconds),
-               verifySystemShutdown: Boolean = false) {
+  def shutdown(
+    actorSystem: ActorSystem = system,
+    duration: Duration = 5.seconds.dilated.min(10.seconds),
+    verifySystemShutdown: Boolean = false) {
     TestKit.shutdownActorSystem(actorSystem, duration, verifySystemShutdown)
   }
 
@@ -771,9 +774,10 @@ object TestKit {
    *
    * If verifySystemShutdown is true, then an exception will be thrown on failure.
    */
-  def shutdownActorSystem(actorSystem: ActorSystem,
-                          duration: Duration = 10.seconds,
-                          verifySystemShutdown: Boolean = false): Unit = {
+  def shutdownActorSystem(
+    actorSystem: ActorSystem,
+    duration: Duration = 10.seconds,
+    verifySystemShutdown: Boolean = false): Unit = {
     actorSystem.terminate()
     try Await.ready(actorSystem.whenTerminated, duration) catch {
       case _: TimeoutException ⇒

--- a/akka-testkit/src/main/scala/akka/testkit/package.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/package.scala
@@ -3,7 +3,6 @@
  */
 package akka
 
-
 import akka.actor.ActorSystem
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.reflect.ClassTag

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -60,7 +60,8 @@ abstract class AkkaSpec(_system: ActorSystem)
 
   implicit val patience = PatienceConfig(testKitSettings.DefaultTimeout.duration)
 
-  def this(config: Config) = this(ActorSystem(AkkaSpec.getCallerName(getClass),
+  def this(config: Config) = this(ActorSystem(
+    AkkaSpec.getCallerName(getClass),
     ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
 
   def this(s: String) = this(ConfigFactory.parseString(s))

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
@@ -35,8 +35,8 @@ class AkkaSpecSpec extends WordSpec with Matchers {
       // verbose config just for demonstration purposes, please leave in in case of debugging
       import scala.collection.JavaConverters._
       val conf = Map(
-        "akka.actor.debug.lifecycle" -> true, "akka.actor.debug.event-stream" -> true,
-        "akka.loglevel" -> "DEBUG", "akka.stdout-loglevel" -> "DEBUG")
+        "akka.actor.debug.lifecycle" → true, "akka.actor.debug.event-stream" → true,
+        "akka.loglevel" → "DEBUG", "akka.stdout-loglevel" → "DEBUG")
       val system = ActorSystem("AkkaSpec1", ConfigFactory.parseMap(conf.asJava).withFallback(AkkaSpec.testConf))
       var refs = Seq.empty[ActorRef]
       val spec = new AkkaSpec(system) { refs = Seq(testActor, system.actorOf(Props.empty, "name")) }

--- a/akka-testkit/src/test/scala/akka/testkit/Coroner.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/Coroner.scala
@@ -37,7 +37,7 @@ object Coroner {
   }
 
   private class WatchHandleImpl(startAndStopDuration: FiniteDuration)
-    extends WatchHandle {
+      extends WatchHandle {
     val cancelPromise = Promise[Boolean]
     val startedLatch = new CountDownLatch(1)
     val finishedLatch = new CountDownLatch(1)
@@ -77,8 +77,8 @@ object Coroner {
    * and stop.
    */
   def watch(duration: FiniteDuration, reportTitle: String, out: PrintStream,
-            startAndStopDuration: FiniteDuration = defaultStartAndStopDuration,
-            displayThreadCounts: Boolean = false): WatchHandle = {
+    startAndStopDuration: FiniteDuration = defaultStartAndStopDuration,
+    displayThreadCounts: Boolean = false): WatchHandle = {
 
     val watchedHandle = new WatchHandleImpl(startAndStopDuration)
 

--- a/akka-testkit/src/test/scala/akka/testkit/DefaultTimeoutSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/DefaultTimeoutSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class DefaultTimeoutSpec
-  extends WordSpec with Matchers with BeforeAndAfterAll with TestKitBase with DefaultTimeout {
+    extends WordSpec with Matchers with BeforeAndAfterAll with TestKitBase with DefaultTimeout {
 
   implicit lazy val system = ActorSystem("AkkaCustomSpec")
 

--- a/akka-testkit/src/test/scala/akka/testkit/ImplicitSenderSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/ImplicitSenderSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ImplicitSenderSpec
-  extends WordSpec with Matchers with BeforeAndAfterAll with TestKitBase with ImplicitSender {
+    extends WordSpec with Matchers with BeforeAndAfterAll with TestKitBase with ImplicitSender {
 
   implicit lazy val system = ActorSystem("AkkaCustomSpec")
 

--- a/akka-testkit/src/test/scala/akka/testkit/TestTimeSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestTimeSpec.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 import org.scalatest.exceptions.TestFailedException
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class TestTimeSpec extends AkkaSpec(Map("akka.test.timefactor" -> 2.0)) {
+class TestTimeSpec extends AkkaSpec(Map("akka.test.timefactor" → 2.0)) {
 
   "A TestKit" must {
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/FileDescriptorMetricSet.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/FileDescriptorMetricSet.scala
@@ -18,15 +18,15 @@ private[akka] class FileDescriptorMetricSet(os: OperatingSystemMXBean = Manageme
   override def getMetrics: util.Map[String, Metric] = {
     Map[String, Metric](
 
-      name("file-descriptors", "open") -> new Gauge[Long] {
+      name("file-descriptors", "open") → new Gauge[Long] {
         override def getValue: Long = invoke("getOpenFileDescriptorCount")
       },
 
-      name("file-descriptors", "max") -> new Gauge[Long] {
+      name("file-descriptors", "max") → new Gauge[Long] {
         override def getValue: Long = invoke("getMaxFileDescriptorCount")
       },
 
-      name("file-descriptors", "ratio") -> new FileDescriptorRatioGauge(os)).asJava
+      name("file-descriptors", "ratio") → new FileDescriptorRatioGauge(os)).asJava
   }
 
   private def invoke(name: String): Long = {

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/HdrHistogram.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/HdrHistogram.scala
@@ -19,7 +19,7 @@ private[akka] class HdrHistogram(
   highestTrackableValue: Long,
   numberOfSignificantValueDigits: Int,
   val unit: String = "")
-  extends Metric {
+    extends Metric {
 
   private val hist = new hdr.Histogram(highestTrackableValue, numberOfSignificantValueDigits)
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
@@ -208,7 +208,7 @@ trait AkkaMetricRegistry {
     for {
       (key, metric) ← getMetrics.asScala
       if clazz.isInstance(metric)
-    } yield key -> metric.asInstanceOf[T]
+    } yield key → metric.asInstanceOf[T]
 }
 
 private[akka] class MetricsKitSettings(config: Config) {

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitOps.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitOps.scala
@@ -91,6 +91,6 @@ private[metrics] trait MetricsPrefix extends MetricSet {
   abstract override def getMetrics: util.Map[String, Metric] = {
     // does not have to be fast, is only called once during registering registry
     import collection.JavaConverters._
-    (super.getMetrics.asScala.map { case (k, v) ⇒ (prefix / k).toString -> v }).asJava
+    (super.getMetrics.asScala.map { case (k, v) ⇒ (prefix / k).toString → v }).asJava
   }
 }

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest._
 import com.typesafe.config.ConfigFactory
 
 class MetricsKitSpec extends WordSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll
-  with MetricsKit {
+    with MetricsKit {
 
   import scala.concurrent.duration._
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
@@ -17,7 +17,7 @@ class AkkaConsoleReporter(
   registry: AkkaMetricRegistry,
   verbose: Boolean,
   output: PrintStream = System.out)
-  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-console-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
+    extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-console-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
 
   private final val ConsoleWidth = 80
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaGraphiteReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaGraphiteReporter.scala
@@ -19,7 +19,7 @@ class AkkaGraphiteReporter(
   prefix: String,
   graphite: GraphiteClient,
   verbose: Boolean = false)
-  extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-graphite-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
+    extends ScheduledReporter(registry.asInstanceOf[MetricRegistry], "akka-graphite-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.NANOSECONDS) {
 
   // todo get rid of ScheduledReporter (would mean removing codahale metrics)?
 

--- a/akka-typed/src/main/scala/akka/typed/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/ActorContext.scala
@@ -155,8 +155,8 @@ trait ActorContext[T] {
  * See [[EffectfulActorContext]] for more advanced uses.
  */
 class StubbedActorContext[T](
-  val name: String,
-  override val props: Props[T])(
+    val name: String,
+    override val props: Props[T])(
     override implicit val system: ActorSystem[Nothing]) extends ActorContext[T] {
 
   val inbox = Inbox.sync[T](name)
@@ -169,7 +169,7 @@ class StubbedActorContext[T](
   override def child(name: String): Option[ActorRef[Nothing]] = _children get name map (_.ref)
   override def spawnAnonymous[U](props: Props[U]): ActorRef[U] = {
     val i = Inbox.sync[U](childName.next())
-    _children += i.ref.untypedRef.path.name -> i
+    _children += i.ref.untypedRef.path.name → i
     i.ref
   }
   override def spawn[U](props: Props[U], name: String): ActorRef[U] =
@@ -177,12 +177,12 @@ class StubbedActorContext[T](
       case Some(_) ⇒ throw new untyped.InvalidActorNameException(s"actor name $name is already taken")
       case None ⇒
         val i = Inbox.sync[U](name)
-        _children += name -> i
+        _children += name → i
         i.ref
     }
   override def actorOf(props: untyped.Props): untyped.ActorRef = {
     val i = Inbox.sync[Any](childName.next())
-    _children += i.ref.untypedRef.path.name -> i
+    _children += i.ref.untypedRef.path.name → i
     i.ref.untypedRef
   }
   override def actorOf(props: untyped.Props, name: String): untyped.ActorRef =
@@ -190,7 +190,7 @@ class StubbedActorContext[T](
       case Some(_) ⇒ throw new untyped.InvalidActorNameException(s"actor name $name is already taken")
       case None ⇒
         val i = Inbox.sync[Any](name)
-        _children += name -> i
+        _children += name → i
         i.ref.untypedRef
     }
   override def stop(child: ActorRef[Nothing]): Boolean = {

--- a/akka-typed/src/main/scala/akka/typed/ActorSystem.scala
+++ b/akka-typed/src/main/scala/akka/typed/ActorSystem.scala
@@ -120,16 +120,16 @@ abstract class ActorSystem[-T](_name: String) extends ActorRef[T] { this: ScalaA
 
 object ActorSystem {
   private class Impl[T](_name: String, _config: Config, _cl: ClassLoader, _ec: Option[ExecutionContext], _p: Props[T])
-    extends ActorSystem[T](_name) with ScalaActorRef[T] {
+      extends ActorSystem[T](_name) with ScalaActorRef[T] {
     override private[akka] val untyped: ExtendedActorSystem = new ActorSystemImpl(_name, _config, _cl, _ec, Some(Props.untyped(_p))).start()
   }
 
   private class Wrapper(val untyped: ExtendedActorSystem) extends ActorSystem[Nothing](untyped.name) with ScalaActorRef[Nothing]
 
   def apply[T](name: String, guardianProps: Props[T],
-               config: Option[Config] = None,
-               classLoader: Option[ClassLoader] = None,
-               executionContext: Option[ExecutionContext] = None): ActorSystem[T] = {
+    config: Option[Config] = None,
+    classLoader: Option[ClassLoader] = None,
+    executionContext: Option[ExecutionContext] = None): ActorSystem[T] = {
     val cl = classLoader.getOrElse(akka.actor.ActorSystem.findClassLoader())
     val appConfig = config.getOrElse(ConfigFactory.load(cl))
     new Impl(name, appConfig, cl, executionContext, guardianProps)

--- a/akka-typed/src/main/scala/akka/typed/Ask.scala
+++ b/akka-typed/src/main/scala/akka/typed/Ask.scala
@@ -37,11 +37,13 @@ object AskPattern {
   private class PromiseRef[U](actorRef: ActorRef[_], timeout: Timeout) {
     val (ref: ActorRef[U], future: Future[U], promiseRef: PromiseActorRef) = actorRef.untypedRef match {
       case ref: InternalActorRef if ref.isTerminated ⇒
-        (ActorRef[U](ref.provider.deadLetters),
+        (
+          ActorRef[U](ref.provider.deadLetters),
           Future.failed[U](new AskTimeoutException(s"Recipient[$actorRef] had already been terminated.")))
       case ref: InternalActorRef ⇒
         if (timeout.duration.length <= 0)
-          (ActorRef[U](ref.provider.deadLetters),
+          (
+            ActorRef[U](ref.provider.deadLetters),
             Future.failed[U](new IllegalArgumentException(s"Timeout length must not be negative, question not sent to [$actorRef]")))
         else {
           val a = PromiseActorRef(ref.provider, timeout, actorRef, "unknown")

--- a/akka-typed/src/main/scala/akka/typed/Behavior.scala
+++ b/akka-typed/src/main/scala/akka/typed/Behavior.scala
@@ -3,7 +3,6 @@
  */
 package akka.typed
 
-
 /**
  * The behavior of an actor defines how it reacts to the messages that it
  * receives. The message may either be of the type that the Actor declares

--- a/akka-typed/src/main/scala/akka/typed/Effects.scala
+++ b/akka-typed/src/main/scala/akka/typed/Effects.scala
@@ -31,7 +31,7 @@ object Effect {
  * on it and otherwise stubs them out like a [[StubbedActorContext]].
  */
 class EffectfulActorContext[T](_name: String, _props: Props[T], _system: ActorSystem[Nothing])
-  extends StubbedActorContext[T](_name, _props)(_system) {
+    extends StubbedActorContext[T](_name, _props)(_system) {
   import akka.{ actor ⇒ a }
   import Effect._
 

--- a/project/Formatting.scala
+++ b/project/Formatting.scala
@@ -8,32 +8,34 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
+import scalariform.formatter.preferences._
+
 object Formatting {
   lazy val formatSettings = SbtScalariform.scalariformSettings ++ Seq(
-    ScalariformKeys.preferences in Compile  := formattingPreferences,
-    ScalariformKeys.preferences in Test     := formattingPreferences,
-    ScalariformKeys.preferences in MultiJvm := formattingPreferences
+    ScalariformKeys.preferences in Compile  := configureFormatting(ScalariformKeys.preferences.value),
+    ScalariformKeys.preferences in Test     := configureFormatting(ScalariformKeys.preferences.value),
+    ScalariformKeys.preferences in MultiJvm := configureFormatting(ScalariformKeys.preferences.value)
   )
 
   lazy val docFormatSettings = SbtScalariform.scalariformSettings ++ Seq(
-    ScalariformKeys.preferences in Compile  := docFormattingPreferences,
-    ScalariformKeys.preferences in Test     := docFormattingPreferences,
-    ScalariformKeys.preferences in MultiJvm := docFormattingPreferences
+    ScalariformKeys.preferences in Compile  := configureFormattingInDocs(ScalariformKeys.preferences.value),
+    ScalariformKeys.preferences in Test     := configureFormattingInDocs(ScalariformKeys.preferences.value),
+    ScalariformKeys.preferences in MultiJvm := configureFormattingInDocs(ScalariformKeys.preferences.value)
   )
 
-  def formattingPreferences = {
-    import scalariform.formatter.preferences._
-    FormattingPreferences()
+  def configureFormatting(prefs: IFormattingPreferences) =
+    prefs
       .setPreference(RewriteArrowSymbols, true)
-      .setPreference(AlignParameters, true)
+      .setPreference(AlignParameters, false)
       .setPreference(AlignSingleLineCaseStatements, true)
-  }
+      .setPreference(SpacesAroundMultiImports, true)
+      .setPreference(DanglingCloseParenthesis, Prevent)
 
-  def docFormattingPreferences = {
-    import scalariform.formatter.preferences._
-    FormattingPreferences()
+  def configureFormattingInDocs(prefs: IFormattingPreferences) =
+    prefs
       .setPreference(RewriteArrowSymbols, false)
-      .setPreference(AlignParameters, true)
+      .setPreference(AlignParameters, false)
       .setPreference(AlignSingleLineCaseStatements, true)
-  }
+      .setPreference(SpacesAroundMultiImports, true)
+      .setPreference(DanglingCloseParenthesis, Prevent)
 }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -157,6 +157,9 @@ object MiMa extends AutoPlugin {
       ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.Gossip.leader"),
       ProblemFilters.exclude[MissingMethodProblem]("akka.cluster.Gossip.roleLeader"),
 
+      // added → alias in FSM
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.FSM.→"),
+
       // copied everything above from release-2.3 branch
 
       // final case classes

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,8 @@ resolvers += "Bintray Jcenter" at "https://jcenter.bintray.com/"
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.8")
 //#sbt-multi-jvm
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.8"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
 
@@ -35,7 +36,7 @@ libraryDependencies += "com.timgroup" % "java-statsd-client" % "2.0.0"
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")
 
 // for advanced PR validation features
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
 libraryDependencies += "org.kohsuke" % "github-api" % "1.68"
 


### PR DESCRIPTION
Thanks to the the efforts by @bwmcadams and @jrudolph in #19746 and https://github.com/akka/akka/pull/19936
I was able to update to latest published scalariform (sadly not the `0.2.0` - as it won't be released anyway it seems until 1.0 hits – https://github.com/scala-ide/scalariform/issues/223)

I tried to keep the formatting rules similar to what we had (and as @jrudolph found), still a bit of reformatting going on. No errors are printed while formatting AFAICS.

Note that the -> rewriting will eventually be hidden under a flag as generally speaking it is not always safe: https://github.com/scala-ide/scalariform/issues/209 I made it work for our FSM though – by adding object only, which works around the problem found in https://github.com/akka/akka/pull/19746#discussion_r58512702 (no setter is generated - that's what was blocking that other PR)
