### PR TITLE
harden ActorLeakSpec, #20221

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
@@ -27,7 +27,7 @@ object ActorsLeakSpec {
       | akka.remote.transport-failure-detector.heartbeat-interval = 1 s
       | akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 3 s
       | akka.remote.quarantine-after-silence = 3 s
-      | akka.test.filter-leeway = 10 s
+      | akka.test.filter-leeway = 12 s
       |
       |""".stripMargin)
 


### PR DESCRIPTION
- on local it took 8 seconds for the expected
  TimeoutException to occur in the last
  EventFilter[TimeoutException](occurrences = 1).intercept {}
  Therefore I assume that the 10 seconds timeout was too short
