### PR TITLE
lazy usage of defaultAddress in ConsistentHashingRouter, #20263 (for validation)

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -165,7 +165,17 @@ final case class ConsistentHashingRoutingLogic(
   def this(system: ActorSystem) =
     this(system, virtualNodesFactor = 0, hashMapping = ConsistentHashingRouter.emptyConsistentHashMapping)
 
-  private val selfAddress = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+  private lazy val selfAddress = {
+    // Important that this is lazy, because consistent hashing routing pool is used by SimpleDnsManager
+    // that can be activated early, before the transport defaultAddress is set in the startup.
+    // See issue #20263.
+    // If defaultAddress is not available the message will not be routed, but new attempt
+    // is performed for next message.
+    val a = ConsistentHashingRoutingLogic.defaultAddress(system)
+    if (a == null)
+      throw new IllegalStateException("defaultAddress not available yet")
+    a
+  }
   val vnodes =
     if (virtualNodesFactor == 0) system.settings.DefaultVirtualNodesFactor
     else virtualNodesFactor
@@ -217,7 +227,6 @@ final case class ConsistentHashingRoutingLogic(
         }
       } catch {
         case NonFatal(e) ⇒
-          // serialization failed
           log.warning("Couldn't route message with consistent hash key [{}] due to [{}]", hashData, e.getMessage)
           NoRoutee
       }


### PR DESCRIPTION
- because consistent hashing routing pool is used by SimpleDnsManager
  and that can be activated early, before the transport defaultAddress
  is set in the startup

(cherry picked from commit 78505ccddb77562a0a8bf6c4b8dee3365c367d55)

Not sure how important it is to backport this to 2.3.x, but since the previous fix for the SimpleDnsManager was backported we can backport this also.
