### PR TITLE
#19681 MalformedRequestContentRejection cause traceability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ The Akka build includes a special task called `validatePullRequest` which invest
 then running tests only on those projects.
 
 For example changing something in `akka-http-core` would cause tests to be run in all projects which depend on it
-(e.g. `akka-http-core-tests`, `akka-http-marshallers-*`, `akka-docs` etc.).
+(e.g. `akka-http-tests`, `akka-http-marshallers-*`, `akka-docs` etc.).
 
 To use the task simply type, and the output should include entries like shown below:
 

--- a/akka-http/src/main/scala/akka/http/impl/server/RejectionHandlerWrapper.scala
+++ b/akka-http/src/main/scala/akka/http/impl/server/RejectionHandlerWrapper.scala
@@ -48,7 +48,7 @@ private[http] class RejectionHandlerWrapper(javaHandler: server.RejectionHandler
         case TooManyRangesRejection(maxRanges) ⇒
           handleTooManyRangesRejection(ctx, maxRanges)
         case MalformedRequestContentRejection(message, cause) ⇒
-          handleMalformedRequestContentRejection(ctx, message, cause.orNull)
+          handleMalformedRequestContentRejection(ctx, message, cause)
         case RequestEntityExpectedRejection ⇒
           handleRequestEntityExpectedRejection(ctx)
         case UnacceptedResponseContentTypeRejection(supported) ⇒

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -99,7 +99,7 @@ case class TooManyRangesRejection(maxRanges: Int) extends Rejection
  * Note that semantic issues with the request content (e.g. because some parameter was out of range)
  * will usually trigger a `ValidationRejection` instead.
  */
-case class MalformedRequestContentRejection(message: String, cause: Option[Throwable] = None) extends Rejection
+case class MalformedRequestContentRejection(message: String, cause: Throwable) extends Rejection
 
 /**
  * Rejection created by unmarshallers.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala
@@ -33,10 +33,11 @@ trait MarshallingDirectives {
       import ctx.materializer
       onComplete(um(ctx.request)) flatMap {
         case Success(value) ⇒ provide(value)
+        case Failure(RejectionError(r)) ⇒ reject(r)
         case Failure(Unmarshaller.NoContentException) ⇒ reject(RequestEntityExpectedRejection)
         case Failure(Unmarshaller.UnsupportedContentTypeException(x)) ⇒ reject(UnsupportedRequestContentTypeRejection(x))
         case Failure(x: IllegalArgumentException) ⇒ reject(ValidationRejection(x.getMessage.nullAsEmpty, Some(x)))
-        case Failure(x) ⇒ reject(MalformedRequestContentRejection(x.getMessage.nullAsEmpty, Option(x.getCause)))
+        case Failure(x) ⇒ reject(MalformedRequestContentRejection(x.getMessage.nullAsEmpty, x))
       }
     } & cancelRejections(RequestEntityExpectedRejection.getClass, classOf[UnsupportedRequestContentTypeRejection])
 


### PR DESCRIPTION
- improved cause tracking for MalformedRequestContentRejection
- unwrapping RejectionErrors when unmarshalling
- amended old project name in CONTRIBUTING.md
