### PR TITLE
=doc Fix path to "akka.http.host-connection-pool"

### DIFF
--- a/akka-docs/rst/java/http/client-side/host-level.rst
+++ b/akka-docs/rst/java/http/client-side/host-level.rst
@@ -32,7 +32,7 @@ Configuring a Host Connection Pool
 
 Apart from the connection-level config settings and socket options there are a number of settings that allow you to
 influence the behavior of the connection pool logic itself.
-Check out the ``akka.http.client.host-connection-pool`` section of the Akka HTTP :ref:`akka-http-configuration-java` for
+Check out the ``akka.http.host-connection-pool`` section of the Akka HTTP :ref:`akka-http-configuration-java` for
 more information about which settings are available and what they mean.
 
 Note that, if you request pools with different configurations for the same target host you will get *independent* pools.

--- a/akka-docs/rst/scala/http/client-side/host-level.rst
+++ b/akka-docs/rst/scala/http/client-side/host-level.rst
@@ -32,7 +32,7 @@ Configuring a Host Connection Pool
 
 Apart from the connection-level config settings and socket options there are a number of settings that allow you to
 influence the behavior of the connection pool logic itself.
-Check out the ``akka.http.client.host-connection-pool`` section of the Akka HTTP :ref:`akka-http-configuration` for
+Check out the ``akka.http.host-connection-pool`` section of the Akka HTTP :ref:`akka-http-configuration` for
 more information about which settings are available and what they mean.
 
 Note that, if you request pools with different configurations for the same target host you will get *independent* pools.


### PR DESCRIPTION
The "host-connection-pool" section is not under "client".
