### PR TITLE
Wip experimental udp transport

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/driver/FlowAndLossControl.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/driver/FlowAndLossControl.scala
@@ -1,0 +1,245 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.remote.artery.driver
+
+import akka.NotUsed
+import akka.stream.impl.FixedSizeBuffer
+import akka.stream.scaladsl.BidiFlow
+import akka.stream.{ Attributes, BidiShape, Inlet, Outlet }
+import akka.stream.stage._
+import akka.util.ByteString
+
+import scala.concurrent.duration._
+
+/**
+ * INTERNAL API
+ */
+private[remote] object FlowAndLossControl {
+  val WindowSize = 16
+  val BufferMask = WindowSize - 1
+  val AckWaterMark = WindowSize >> 1
+  val DATA: Byte = 0
+  val ACK: Byte = 1
+
+  val AckTimer = "AckTimer"
+  val AckPeriod = 10.millis
+
+  def apply(frameBuffer: FrameBuffer): BidiFlow[ByteString, Frame, Frame, ByteString, NotUsed] = {
+    BidiFlow.fromGraph(new FlowAndLossControlStage(frameBuffer))
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] final class FlowAndLossControlStage(sndFramePool: FrameBuffer) extends GraphStage[BidiShape[ByteString, Frame, Frame, ByteString]] {
+  import FlowAndLossControl._
+
+  val fromApp: Inlet[ByteString] = Inlet("FlowControl.fromApp")
+  val toApp: Outlet[ByteString] = Outlet("FlowControl.toApp")
+  val fromNet: Inlet[Frame] = Inlet("FlowControl.fromNet")
+  val toNet: Outlet[Frame] = Outlet("FlowControl.toNet")
+  override val shape: BidiShape[ByteString, Frame, Frame, ByteString] = BidiShape(fromApp, toNet, fromNet, toApp)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
+    private[this] var nextUnusedOutboundSeq = 0L // TODO: Randomize
+    private[this] var highestAckedOutboundSeq = -1L
+    private[this] var nextOutboundSeqToSend = 0L
+    private[this] var accumulateAckRoundsLeft = AckWaterMark
+
+    private[this] val outboundBuf = Array.ofDim[Frame](WindowSize)
+    private[this] val pendingHoles = FixedSizeBuffer[Long](WindowSize) // FIXME would be nice to specialize to Long!
+
+    private[this] var nextContiguousInboundSeq = 0L
+    private[this] var highestSeenInboundSeq = 0L
+    private[this] var highestDeliveredInboundSeq = -1L
+    private[this] val inboundBuf = Array.ofDim[ByteString](WindowSize)
+
+    private[this] var pendingAck: Frame = sndFramePool.aquire()
+
+    override def preStart(): Unit = {
+      pull(fromNet)
+      pull(fromApp)
+    }
+
+    private def slot(seq: Long): Int = (seq & BufferMask).toInt
+
+    private def sendBufferDepleted: Boolean = (nextUnusedOutboundSeq - highestAckedOutboundSeq) == WindowSize + 1
+    private def sendWindowAvailable: Boolean = nextOutboundSeqToSend < nextUnusedOutboundSeq
+
+    private def deliverNext(): Unit = {
+      val nextSend = outboundBuf(slot(nextOutboundSeqToSend))
+      if (nextSend ne null) {
+        push(toNet, nextSend)
+        nextOutboundSeqToSend += 1
+      }
+    }
+
+    private def trySendAck(): Boolean = {
+      if (accumulateAckRoundsLeft <= 0) {
+        calculateAckNack()
+        push(toNet, pendingAck)
+        pendingAck = sndFramePool.aquire()
+        accumulateAckRoundsLeft = AckWaterMark
+        true
+      } else false
+    }
+
+    override protected def onTimer(timerKey: Any): Unit = {
+      accumulateAckRoundsLeft = 0
+      trySendAck()
+    }
+
+    private[this] val outboundHandler = new InHandler with OutHandler {
+
+      override def onPush(): Unit = {
+        val frame = sndFramePool.aquire()
+        val payload = grab(fromApp)
+        val seq = nextUnusedOutboundSeq
+        nextUnusedOutboundSeq += 1
+
+        // Add frame
+        // FIXME: Needs alignment, no need to read from non-aligned addresses
+        frame.buffer.put(DATA)
+        frame.buffer.putLong(seq)
+        // FIXME: Explicit length information, while not necessary for the usual use-case, can be very useful
+        // for crypto where emitting fixed size frames is preferred!
+
+        // Add payload
+        frame.writeByteString(payload)
+        outboundBuf(slot(seq)) = frame
+
+        if (isAvailable(toNet)) {
+          push(toNet, frame)
+          nextOutboundSeqToSend = seq + 1
+        }
+
+        if (!sendBufferDepleted) pull(fromApp)
+      }
+
+      override def onPull(): Unit = {
+        if (!trySendAck()) {
+          if (!pendingHoles.isEmpty) {
+            // Resend nacked Frames first before sending new ones
+            val resendSeq = pendingHoles.dequeue()
+            push(toNet, outboundBuf(slot(resendSeq)))
+          } else if (sendWindowAvailable) {
+            deliverNext()
+          }
+        }
+
+      }
+
+      override def onUpstreamFinish(): Unit = ()
+    }
+
+    private[this] val inboundHandler = new InHandler with OutHandler {
+      override def onPush(): Unit = {
+        val frame = grab(fromNet)
+        frame.buffer.flip()
+        val tag = frame.buffer.get()
+        val seq = frame.buffer.getLong()
+        tag match {
+          case DATA ⇒ processData(seq, frame.toByteString)
+          case ACK  ⇒ processAck(seq, frame)
+        }
+        frame.release()
+      }
+
+      override def onPull(): Unit = {
+        val toDeliver = highestDeliveredInboundSeq + 1
+        val next = inboundBuf(slot(toDeliver))
+        if (next ne null) {
+          accumulateAckRoundsLeft -= 1
+          if (isAvailable(toNet)) trySendAck()
+          inboundBuf(slot(toDeliver)) = null
+          push(toApp, next)
+          highestDeliveredInboundSeq = toDeliver
+        } else {
+          // Reader is blocked, schedule ACKs
+          schedulePeriodically(AckTimer, AckPeriod)
+        }
+      }
+
+      override def onUpstreamFinish(): Unit = ()
+    }
+
+    private def processAck(seq: Long, frame: Frame): Unit = {
+      val previousHighestAckedSeq = highestAckedOutboundSeq
+      highestAckedOutboundSeq = seq
+      var nacks = frame.buffer.getInt() // Get number of nacks
+      while (nacks > 0) {
+        val nack = frame.buffer.getLong
+        pendingHoles.enqueue(nack)
+        highestAckedOutboundSeq = math.min(highestAckedOutboundSeq, nack - 1)
+        nacks -= 1
+      }
+
+      if (isAvailable(toNet) && pendingHoles.nonEmpty) {
+        val resendSeq = pendingHoles.dequeue()
+        push(toNet, outboundBuf(slot(resendSeq)))
+      }
+
+      // Count the number of Frames that have been gaplessly delivered
+      var toFlush = previousHighestAckedSeq + 1
+      while (toFlush <= highestAckedOutboundSeq) {
+        outboundBuf(slot(toFlush)).release()
+        outboundBuf(slot(toFlush)) = null
+        toFlush += 1
+      }
+
+      // Unblock application if space was freed
+      if (!sendBufferDepleted && !hasBeenPulled(fromApp) && !isClosed(fromApp)) pull(fromApp)
+      if (sendWindowAvailable && isAvailable(fromNet)) deliverNext()
+      pull(fromNet)
+    }
+
+    private def processData(seq: Long, payload: ByteString): Unit = {
+
+      if (seq >= nextContiguousInboundSeq && seq <= highestDeliveredInboundSeq + WindowSize) {
+        highestSeenInboundSeq = math.max(seq, highestSeenInboundSeq)
+        inboundBuf(slot(seq)) = payload
+        if (seq == nextContiguousInboundSeq) {
+          val endOfWindow = highestSeenInboundSeq + 1
+          do nextContiguousInboundSeq += 1
+          while ((inboundBuf(slot(nextContiguousInboundSeq)) ne null) &&
+            nextContiguousInboundSeq < endOfWindow)
+        }
+      }
+
+      if (highestDeliveredInboundSeq == seq - 1 && isAvailable(toApp)) {
+        inboundBuf(slot(seq)) = null
+        accumulateAckRoundsLeft -= 1
+        if (isAvailable(toNet)) trySendAck()
+        highestDeliveredInboundSeq = seq
+        push(toApp, payload)
+        // Unblocked app, ACK can be descheduled
+        cancelTimer(AckTimer)
+      }
+
+      pull(fromNet)
+    }
+
+    private def calculateAckNack(): Unit = {
+      pendingAck.buffer.put(ACK)
+      pendingAck.buffer.putLong(highestDeliveredInboundSeq)
+      pendingAck.buffer.putInt(0) // Placeholder for ACK count
+      var scan = nextContiguousInboundSeq
+      var nacks = 0
+      while (scan < highestSeenInboundSeq) {
+        if (inboundBuf(slot(scan)) eq null) {
+          nacks += 1
+          pendingAck.buffer.putLong(scan)
+        }
+        scan += 1
+      }
+      pendingAck.buffer.putInt(9, nacks)
+    }
+
+    setHandlers(fromApp, toNet, outboundHandler)
+    setHandlers(fromNet, toApp, inboundHandler)
+
+  }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/driver/FrameBuffer.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/driver/FrameBuffer.scala
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.remote.artery.driver
+
+import java.nio.ByteBuffer
+
+import akka.io.DirectByteBufferPool
+import akka.util.ByteString
+
+/**
+ * INTERNAL API
+ */
+private[remote] object FrameBuffer {
+  val FrameSize = 16
+  val BufferSizeInFrames = 32
+  val BufferSize = FrameSize * BufferSizeInFrames
+  val BufferSizeMask = BufferSizeInFrames - 1
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] final class FrameBuffer(val pool: DirectByteBufferPool) {
+  import FrameBuffer._
+
+  val buffer: ByteBuffer = pool.acquire()
+  private var lastAllocation = 0
+  private val frames: Array[Frame] = Array.tabulate(BufferSizeInFrames)(new Frame(this, _))
+  private val allocated: Array[Boolean] = Array.ofDim(BufferSizeInFrames)
+
+  def aquire(): Frame = {
+    val wraparound = lastAllocation
+    lastAllocation = (lastAllocation + 1) & BufferSizeMask
+    while (allocated(lastAllocation) && lastAllocation != wraparound) lastAllocation = (lastAllocation + 1) & BufferSizeMask
+    if (lastAllocation == wraparound) null
+    else {
+      allocated(lastAllocation) = true
+      frames(lastAllocation)
+    }
+  }
+
+  def release(frame: Frame): Unit = {
+    allocated(frame.id) = false
+  }
+
+  def close(): Unit = {
+    pool.release(buffer)
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] final class Frame(val owner: FrameBuffer, val id: Int) {
+  import FrameBuffer._
+
+  val buffer = {
+    owner.buffer.position(id * FrameSize)
+    owner.buffer.limit(id * FrameSize + FrameSize)
+    owner.buffer.slice()
+  }
+
+  def release(): Unit = owner.release(this)
+
+  def toByteString: ByteString = {
+    ByteString.fromByteBuffer(buffer)
+  }
+
+  def putByteString(bs: ByteString): Unit = {
+    buffer.clear()
+    buffer.put(bs.toByteBuffer) // FIXME: toByteBuffer copies
+  }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/driver/FrameBuffer.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/driver/FrameBuffer.scala
@@ -21,6 +21,8 @@ private[remote] object FrameBuffer {
 
 /**
  * INTERNAL API
+ *
+ * This class is not thread safe, it must be owned by a stage.
  */
 private[remote] final class FrameBuffer(val pool: DirectByteBufferPool) {
   import FrameBuffer._

--- a/akka-remote/src/main/scala/akka/remote/artery/driver/UdpDriver.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/driver/UdpDriver.scala
@@ -1,0 +1,229 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.remote.artery.driver
+
+import java.net.{ InetSocketAddress, StandardSocketOptions }
+import java.nio.ByteBuffer
+import java.nio.channels.DatagramChannel
+import java.util
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.dispatch.AbstractNodeQueue
+import akka.io.DirectByteBufferPool
+import akka.stream.stage.AsyncCallback
+import org.agrona.concurrent.{ BackoffIdleStrategy, OneToOneConcurrentArrayQueue }
+
+import scala.util.control.Breaks._
+
+/**
+ * INTERNAL API
+ */
+private[remote] object UdpDriver {
+
+  val Debug = true
+  val SendQueueSize = 128
+  val RcvQueueSize = 128
+
+  sealed trait Command
+  case object Shutdown extends Command
+  final case class Register(
+    registrationCallback: AsyncCallback[Registration],
+    wakeupCallback: AsyncCallback[Unit],
+    remoteAddress: InetSocketAddress) extends Command
+  final case class Deregister(registration: Registration) extends Command
+
+  final class CommandQueue extends AbstractNodeQueue[Command]
+
+  val ignoreWakeup = new AsyncCallback[Unit] {
+    override def invoke(t: Unit): Unit = if (Debug) println("Ignored wakeup")
+  }
+
+  final class Registration(val owner: UdpDriver, val remoteAddress: InetSocketAddress) {
+    val rcvBuffer = new FrameBuffer(owner.bufferPool)
+    val sendQueue = new OneToOneConcurrentArrayQueue[Frame](SendQueueSize)
+    val rcvQueue = new OneToOneConcurrentArrayQueue[Frame](RcvQueueSize)
+    val readWeakupNeeded = new AtomicBoolean(false)
+
+    private var wakeupCallback: AsyncCallback[Unit] = ignoreWakeup
+
+    def setWakeupCallback(cb: AsyncCallback[Unit]): Unit = {
+      // ignoreWakeup is only the initial behavior
+      if (cb ne ignoreWakeup) wakeupCallback = cb
+    }
+
+    def deregister(): Unit = owner.command(Deregister(this))
+
+    def enqueueForWrite(frame: Frame): Unit = {
+      sendQueue.offer(frame)
+    }
+
+    def enqueueRead(frame: Frame): Unit = {
+      // Drop if overloaded
+      if (!rcvQueue.offer(frame)) rcvBuffer.release(frame)
+    }
+
+    def readWakeUp(): Unit = {
+      readWeakupNeeded.set(false)
+      wakeupCallback.invoke(())
+    }
+  }
+
+  val MaxIterationsUntilProcessCommand = 32
+
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] final class UdpDriver(listenAddress: InetSocketAddress) extends Runnable {
+  import UdpDriver._
+
+  val bufferPool = new DirectByteBufferPool(FrameBuffer.BufferSize, 128) // TODO: Proper maximum buffer count
+
+  private[this] val queue = new CommandQueue
+  private[this] var channel: DatagramChannel = _
+  private[this] val backoff: BackoffIdleStrategy = new BackoffIdleStrategy(
+    128, // maxSpins
+    128, // maxYields
+    128, // minParkPeriodNs
+    65536 // maxParkPeriodNs
+    )
+
+  private[this] var wasIoAction = false
+  private[this] val registrations = new util.ArrayList[Registration]()
+  private[this] val addressToRegistration = new util.HashMap[InetSocketAddress, Registration]()
+  private[this] val dispatchBuffer = ByteBuffer.allocateDirect(FrameBuffer.FrameSize)
+
+  def start(): Unit = {
+    val thread = new Thread(this)
+    thread.setDaemon(true)
+    thread.start()
+  }
+  def stop(): Unit = {
+    command(Shutdown)
+  }
+
+  def command(cmd: Command): Unit = {
+    queue.add(cmd)
+  }
+
+  override def run(): Unit = {
+    try {
+      preStart()
+      mainLoop()
+    } finally {
+      // FIXME: add error reporting
+      postStop()
+    }
+  }
+
+  private def preStart(): Unit = {
+    channel = DatagramChannel.open()
+    channel.configureBlocking(false)
+    //channel.setOption(StandardSocketOptions.SO_REUSEADDR, true)
+    channel.bind(new InetSocketAddress(listenAddress.getPort))
+  }
+
+  private def postStop(): Unit = {
+    channel.close()
+    // TODO: Deallocate buffer pool, have no public API for that
+  }
+
+  private def mainLoop(): Unit = {
+    breakable {
+      while (true) {
+        val cmd = queue.poll()
+        if (cmd ne null) processCommand(cmd)
+        var ioIterations = MaxIterationsUntilProcessCommand
+        do {
+          if (Debug) println("iterations " + ioIterations)
+          ioIterations -= 1
+          wasIoAction = false
+          receive()
+          scanAndSend()
+        } while (wasIoAction && ioIterations > 0)
+        //backoff.idle()
+        if (Debug) Thread.sleep(500)
+      }
+    }
+  }
+
+  private def processCommand(cmd: Command): Unit = {
+    if (Debug) println("process command " + cmd)
+    backoff.reset()
+    cmd match {
+      case Shutdown ⇒ break()
+      case Register(callback, wakeupCallback, remoteAddress) ⇒
+        callback.invoke(registrationForAddress(remoteAddress, wakeupCallback))
+
+      case Deregister(registration) ⇒
+        registrations.remove(registrations.indexOf(registration))
+        addressToRegistration.remove(registration.remoteAddress)
+    }
+  }
+
+  private def registrationForAddress(remoteAddress: InetSocketAddress, cb: AsyncCallback[Unit]): Registration = {
+    val existingRegistration = addressToRegistration.get(remoteAddress)
+
+    if (existingRegistration eq null) {
+      val registration = new Registration(this, remoteAddress)
+      registrations.add(registration)
+      addressToRegistration.put(remoteAddress, registration)
+      registration.setWakeupCallback(cb)
+      registration
+    } else {
+      existingRegistration.setWakeupCallback(cb)
+      existingRegistration
+    }
+  }
+
+  private def receive(): Unit = {
+    if (Debug) println("receiving")
+    val address = channel.receive(dispatchBuffer).asInstanceOf[InetSocketAddress]
+    if (address ne null) {
+      println("received " + address)
+      backoff.reset()
+      wasIoAction = true
+      val registration = registrationForAddress(address, ignoreWakeup)
+      val frame = registration.rcvBuffer.aquire()
+      // Drop if we have no space in the FrameBuffer
+      if (frame ne null) {
+        dispatchBuffer.flip()
+        frame.buffer.clear()
+        frame.buffer.put(dispatchBuffer)
+        dispatchBuffer.clear()
+        registration.rcvQueue.offer(frame)
+      }
+    }
+  }
+
+  private def scanAndSend(): Unit = {
+    if (Debug) println("scanAndSend")
+    val registrationsItr = registrations.iterator()
+    while (registrationsItr.hasNext) {
+      val registration = registrationsItr.next()
+      if (registration.readWeakupNeeded.get() && !registration.rcvQueue.isEmpty) {
+        if (Debug) println("wake up registration")
+        registration.readWakeUp()
+      }
+      val queue = registration.sendQueue
+      var frame = queue.peek()
+      while (frame ne null) {
+        if (Debug) println("Attempt to write")
+        frame.buffer.flip()
+        if (channel.send(frame.buffer, registration.remoteAddress) > 0) {
+          if (Debug) println("written")
+          queue.poll()
+          backoff.reset()
+          wasIoAction = true
+          frame = queue.peek()
+        } else {
+          // FIXME: Uncomsumed frame must be un-flipped
+          frame = null // Exit write loop
+        }
+      }
+    }
+  }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/driver/UdpDriver.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/driver/UdpDriver.scala
@@ -192,7 +192,7 @@ private[remote] final class UdpDriver(listenAddress: InetSocketAddress) extends 
       backoff.reset()
       wasIoAction = true
       val registration = registrationForAddress(address, ignoreWakeup)
-      val frame = registration.rcvBuffer.aquire()
+      val frame = registration.rcvBuffer.acquire()
       // Drop if we have no space in the FrameBuffer
       if (frame ne null) {
         dispatchBuffer.flip()
@@ -230,6 +230,7 @@ private[remote] final class UdpDriver(listenAddress: InetSocketAddress) extends 
           if (channel.send(frame.buffer, registration.remoteAddress) > 0) {
             if (Debug) println("written")
             queue.poll()
+            if (frame.driverReleases) frame.release()
             backoff.reset()
             wasIoAction = true
             frame = queue.peek()

--- a/akka-remote/src/main/scala/akka/remote/artery/driver/UdpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/driver/UdpTransport.scala
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.remote.artery.driver
+
+import java.net.InetSocketAddress
+
+import akka.NotUsed
+import akka.remote.artery.driver.UdpDriver.Registration
+import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import akka.stream.scaladsl.Flow
+import akka.stream.stage._
+
+/**
+ * INTERNAL API
+ */
+private[remote] class UdpTransport(driver: UdpDriver) {
+
+  def forRemoteAddress(address: InetSocketAddress): Flow[Frame, Frame, NotUsed] = {
+    Flow.fromGraph(new UdpTransportFlow(driver, address))
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] class UdpTransportFlow(val driver: UdpDriver, val remoteAddress: InetSocketAddress)
+  extends GraphStage[FlowShape[Frame, Frame]] {
+
+  val in: Inlet[Frame] = Inlet[Frame]("UdpTransport.write")
+  val out: Outlet[Frame] = Outlet[Frame]("UdpTransport.read")
+  override val shape: FlowShape[Frame, Frame] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+
+    private var registration: UdpDriver.Registration = _
+
+    override def preStart(): Unit = {
+      driver.command(UdpDriver.Register(
+        getAsyncCallback(onRegistered),
+        getAsyncCallback(_ ⇒ onWakeUp()),
+        remoteAddress))
+    }
+
+    override def postStop(): Unit = {
+      if (registration ne null) registration.deregister()
+    }
+
+    private def onRegistered(registration: Registration): Unit = {
+      this.registration = registration
+      pull(in)
+      onWakeUp()
+    }
+
+    private def onWakeUp(): Unit = {
+      if (UdpDriver.Debug) println("woken up")
+      if (isAvailable(out)) onPull()
+    }
+
+    override def onPush(): Unit = {
+      // Might drop, but higher level flow control should prevent this
+      registration.sendQueue.offer(grab(in))
+    }
+
+    override def onPull(): Unit = {
+      if (registration ne null) {
+        val frame = registration.rcvQueue.poll()
+        if (frame ne null) push(out, frame)
+        else registration.readWeakupNeeded.set(true)
+      }
+    }
+
+    setHandlers(in, out, this)
+  }
+
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/driver/UdpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/driver/UdpTransport.scala
@@ -62,7 +62,12 @@ private[remote] class UdpTransportFlow(val driver: UdpDriver, val remoteAddress:
     override def onPush(): Unit = {
       // Might drop, but higher level flow control should prevent this
       registration.sendQueue.offer(grab(in))
+      pull(in)
     }
+
+    override def onUpstreamFinish(): Unit = ()
+
+    override def onDownstreamFinish(): Unit = ()
 
     override def onPull(): Unit = {
       if (registration ne null) {

--- a/akka-remote/src/test/scala/akka/remote/artery/driver/FlowAndLossControlSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/driver/FlowAndLossControlSpec.scala
@@ -1,0 +1,80 @@
+package akka.remote.artery.driver
+
+import java.util.concurrent.ThreadLocalRandom
+
+import akka.NotUsed
+import akka.io.DirectByteBufferPool
+import akka.stream.{ ActorMaterializer, OverflowStrategy }
+import akka.stream.scaladsl._
+import akka.testkit.AkkaSpec
+import akka.util.ByteString
+
+class FlowAndLossControlSpec extends AkkaSpec {
+
+  implicit val mat = ActorMaterializer()
+
+  val DropRate = 0.1
+
+  val droppyFlow = Flow[Frame].mapConcat { frame ⇒
+    if (ThreadLocalRandom.current().nextDouble() < DropRate) {
+      frame.release()
+      Nil
+    } else List(frame)
+  }
+
+  val pool = new DirectByteBufferPool(FrameBuffer.BufferSize, 2)
+  val frameBuffer = new FrameBuffer(pool)
+
+  "Flow and loss control" must {
+
+    // FIXME: Stage completion
+    // FXIME: Longer chains
+
+    "work looped back to self" in {
+      val Count = 1000
+      val testData = List.tabulate(Count)(i ⇒ ByteString.fromArray(Array.fill[Byte](i + 1)(i.toByte)))
+
+      val flow: Flow[ByteString, ByteString, NotUsed] =
+        FlowAndLossControl(frameBuffer) join Flow[Frame]
+
+      Source(testData).via(flow).take(Count).runWith(Sink.seq).futureValue should ===(testData)
+    }
+
+    "work looped through a counter-pair" in {
+      val Count = 1000
+      val testData = List.tabulate(Count)(i ⇒ ByteString.fromArray(Array.fill[Byte](i + 1)(i.toByte)))
+
+      val flow: Flow[ByteString, ByteString, NotUsed] =
+        FlowAndLossControl(frameBuffer) atop FlowAndLossControl(frameBuffer).reversed join Flow[ByteString]
+
+      Source(testData).via(flow).take(Count).runWith(Sink.seq).futureValue should ===(testData)
+    }
+
+    "work on a lossy channel, looped back to self" in {
+      val Count = 1000
+      val testData = List.tabulate(Count)(i ⇒ ByteString.fromArray(Array.fill[Byte](i + 1)(i.toByte)))
+
+      val flow: Flow[ByteString, ByteString, NotUsed] =
+        FlowAndLossControl(frameBuffer) join droppyFlow
+
+      Source(testData).via(flow).take(Count).runWith(Sink.seq).futureValue should ===(testData)
+    }
+
+    //    "work on a lossy channel looped through a counter-pair" in {
+    //      val Count = 100
+    //      val testData = List.tabulate(Count)(i ⇒ ByteString.fromInts(i))
+    //
+    //      val lossyBidi = BidiFlow.fromFlows(droppyFlow, droppyFlow)
+    //
+    //      val flow: Flow[ByteString, ByteString, NotUsed] =
+    //        FlowAndLossControl(frameBuffer) atop lossyBidi atop FlowAndLossControl(frameBuffer).reversed join Flow[ByteString]
+    //
+    //      Source(testData).via(flow).take(Count).map { bs ⇒
+    //        println("GOT " + bs(0))
+    //        bs
+    //      }.runWith(Sink.seq).futureValue should ===(testData)
+    //    }
+
+  }
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/driver/UdpDriverSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/driver/UdpDriverSpec.scala
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.remote.artery.driver
+
+import java.net.InetSocketAddress
+
+import akka.NotUsed
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
+import akka.testkit.AkkaSpec
+import akka.util.ByteString
+
+import scala.concurrent.Promise
+
+class UdpDriverSpec extends AkkaSpec {
+  implicit val mat = ActorMaterializer()
+  val address1 = new InetSocketAddress("localhost", 8000)
+  val address2 = new InetSocketAddress("localhost", 8001)
+
+  val driver1 = new UdpDriver(address1)
+  val driver2 = new UdpDriver(address2)
+  driver1.start()
+  println("starting 2")
+  driver2.start()
+
+  val transport1 = new UdpTransport(driver1)
+  val transport2 = new UdpTransport(driver2)
+
+  val sink: Sink[Frame, NotUsed] = transport1.forRemoteAddress(address2).to(Sink.ignore)
+  val source: Source[Frame, Any] = Source.maybe[Frame].via(transport2.forRemoteAddress(address1))
+
+  val frameBuffer = new FrameBuffer(driver1.bufferPool)
+
+  "Udp transport" must {
+
+    "work in the happy case" in {
+      val frame = frameBuffer.aquire()
+      frame.putByteString(ByteString("Hello"))
+
+      val result = source.take(1).map { frame ⇒
+        frame.buffer.flip()
+        val bs = frame.toByteString
+        frame.release()
+        println("GOT " + bs)
+        bs
+      }.runWith(Sink.seq)
+
+      Source.single(frame).runWith(sink)
+
+      result.futureValue should ===(List(ByteString("Hello")))
+
+    }
+
+  }
+
+  override def afterTermination(): Unit = {
+    driver1.stop()
+    driver2.stop()
+  }
+}


### PR DESCRIPTION
**DO NOT MERGE**

This is just a PoC, not production quality at all, missing tests, shortcuts, whatnot. Does not need a detailed review, purpose is to inspire brainstorming.

Basic items here:
- Udp based, spinning-thread driver to send/receive UDP stuff
- SPSC based communication from Flow representing transport and between driver spinning thread
- Allocation free design using preallocated Frames (slices into DirectBuffer), exploiting backpressure/boundedness
- Transparent plug-in into existing Flow (does not matter who sends first, they will share the same underlying Registration)
- Flow control and message redelivery (still buggy)

What I couldn't finish in this PoC
- handshake, UID management/quarantine
- fragmenting/defragmenting 
- subchannels

Basically this is just a bunch of ideas, many of these can be used with Aeron as well (I used plain UDP here but the style is similar).
