### PR TITLE
Adding javadsl.model.MediaType.Compressibility

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
@@ -6,7 +6,6 @@ package akka.http.javadsl.model;
 
 import akka.http.impl.util.Util;
 import akka.http.scaladsl.model.MediaTypes$;
-
 import java.util.Optional;
 
 /**
@@ -187,9 +186,22 @@ public final class MediaTypes {
     public static final MediaType.Binary VIDEO_X_SGI_MOVIE = akka.http.scaladsl.model.MediaTypes.video$divx$minussgi$minusmovie();
     public static final MediaType.Binary VIDEO_WEBM = akka.http.scaladsl.model.MediaTypes.video$divwebm();
 
+    public static final MediaType.Compressibility COMPRESSIBLE = akka.http.scaladsl.model.MediaType.Compressible$.MODULE$;
+    public static final MediaType.Compressibility NOT_COMPRESSIBLE = akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
+    public static final MediaType.Compressibility GZIPPED = akka.http.scaladsl.model.MediaType.Gzipped$.MODULE$;
+
     public static MediaType.Binary applicationBinary(String subType, boolean compressible, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
+
+        scala.collection.immutable.List<String> fileEx =
+                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+
+        return akka.http.scaladsl.model.MediaType.applicationBinary(subType, comp, fileEx);
+    }
+
+    public static MediaType.Binary applicationBinary(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
+         akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
         scala.collection.immutable.List<String> fileEx =
                 scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
@@ -223,6 +235,15 @@ public final class MediaTypes {
         return akka.http.scaladsl.model.MediaType.audio(subType, comp, fileEx);
     }
 
+    public static MediaType.Binary audio(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
+        akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
+
+        scala.collection.immutable.List<String> fileEx =
+                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+
+        return akka.http.scaladsl.model.MediaType.audio(subType, comp, fileEx);
+    }
+
     public static MediaType.Binary image(String subType, boolean compressible, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
@@ -233,9 +254,27 @@ public final class MediaTypes {
         return akka.http.scaladsl.model.MediaType.image(subType, comp, fileEx);
     }
 
+    public static MediaType.Binary image(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
+        akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
+
+        scala.collection.immutable.List<String> fileEx =
+                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+
+        return akka.http.scaladsl.model.MediaType.image(subType, comp, fileEx);
+    }
+
     public static MediaType.Binary message(String subType, boolean compressible, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
+
+        scala.collection.immutable.List<String> fileEx =
+                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+
+        return akka.http.scaladsl.model.MediaType.message(subType, comp, fileEx);
+    }
+
+    public static MediaType.Binary message(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
+        akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
         scala.collection.immutable.List<String> fileEx =
                 scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
@@ -260,11 +299,31 @@ public final class MediaTypes {
         return akka.http.scaladsl.model.MediaType.video(subType, comp, fileEx);
     }
 
+    public static MediaType.Binary video(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
+        akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
+
+        scala.collection.immutable.List<String> fileEx =
+                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+
+        return akka.http.scaladsl.model.MediaType.video(subType, comp, fileEx);
+    }
+
     // arguments have been reordered due to varargs having to be the last argument
     // should we create multiple overloads of this function?
     public static MediaType.Binary customBinary(String mainType, String subType, boolean compressible, java.util.Map<String, String> params, boolean allowArbitrarySubtypes, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
+
+        scala.collection.immutable.List<String> fileEx =
+                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+
+        scala.collection.immutable.Map<String, String> p = Util.convertMapToScala(params);
+
+        return akka.http.scaladsl.model.MediaType.customBinary(mainType, subType, comp, fileEx, p, allowArbitrarySubtypes);
+    }
+
+    public static MediaType.Binary customBinary(String mainType, String subType, MediaType.Compressibility compressibility, java.util.Map<String, String> params, boolean allowArbitrarySubtypes, String... fileExtensions) {
+        akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
         scala.collection.immutable.List<String> fileEx =
                 scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
@@ -306,8 +365,15 @@ public final class MediaTypes {
     public static MediaType custom(String value, boolean binary, boolean compressible) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
-        return akka.http.scaladsl.model.MediaType.custom(value, binary, comp , 
-            akka.http.scaladsl.model.MediaType.custom$default$4());
+        return akka.http.scaladsl.model.MediaType.custom(value, binary, comp ,
+                akka.http.scaladsl.model.MediaType.custom$default$4());
+    }
+
+    public static MediaType custom(String value, boolean binary, MediaType.Compressibility compressibility) {
+        akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
+
+        return akka.http.scaladsl.model.MediaType.custom(value, binary, comp ,
+                akka.http.scaladsl.model.MediaType.custom$default$4());
     }
 
     /**

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
@@ -194,8 +194,7 @@ public final class MediaTypes {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.applicationBinary(subType, comp, fileEx);
     }
@@ -203,8 +202,7 @@ public final class MediaTypes {
     public static MediaType.Binary applicationBinary(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
          akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.applicationBinary(subType, comp, fileEx);
     }
@@ -212,15 +210,13 @@ public final class MediaTypes {
     public static MediaType.WithFixedCharset applicationWithFixedCharset(String subType, HttpCharset charset, String... fileExtensions) {
         akka.http.scaladsl.model.HttpCharset cs = (akka.http.scaladsl.model.HttpCharset) charset;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.applicationWithFixedCharset(subType, cs, fileEx);
     }
 
     public static MediaType.WithOpenCharset applicationWithOpenCharset(String subType, String... fileExtensions) {
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.applicationWithOpenCharset(subType, fileEx);
     }
@@ -229,8 +225,7 @@ public final class MediaTypes {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.audio(subType, comp, fileEx);
     }
@@ -238,8 +233,7 @@ public final class MediaTypes {
     public static MediaType.Binary audio(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.audio(subType, comp, fileEx);
     }
@@ -248,8 +242,7 @@ public final class MediaTypes {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.image(subType, comp, fileEx);
     }
@@ -257,8 +250,7 @@ public final class MediaTypes {
     public static MediaType.Binary image(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.image(subType, comp, fileEx);
     }
@@ -267,8 +259,7 @@ public final class MediaTypes {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.message(subType, comp, fileEx);
     }
@@ -276,15 +267,13 @@ public final class MediaTypes {
     public static MediaType.Binary message(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.message(subType, comp, fileEx);
     }
 
     public static MediaType.WithOpenCharset text(String subType, String... fileExtensions) {
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.text(subType, fileEx);
     }
@@ -293,8 +282,7 @@ public final class MediaTypes {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.video(subType, comp, fileEx);
     }
@@ -302,8 +290,7 @@ public final class MediaTypes {
     public static MediaType.Binary video(String subType, MediaType.Compressibility compressibility, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.Seq<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions));
 
         return akka.http.scaladsl.model.MediaType.video(subType, comp, fileEx);
     }
@@ -314,8 +301,7 @@ public final class MediaTypes {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.List<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions)).toList();
 
         scala.collection.immutable.Map<String, String> p = Util.convertMapToScala(params);
 
@@ -325,8 +311,7 @@ public final class MediaTypes {
     public static MediaType.Binary customBinary(String mainType, String subType, MediaType.Compressibility compressibility, java.util.Map<String, String> params, boolean allowArbitrarySubtypes, String... fileExtensions) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = (akka.http.scaladsl.model.MediaType.Compressibility) compressibility;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.List<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions)).toList();
 
         scala.collection.immutable.Map<String, String> p = Util.convertMapToScala(params);
 
@@ -336,8 +321,7 @@ public final class MediaTypes {
     public static MediaType.WithFixedCharset customWithFixedCharset(String mainType, String subType, HttpCharset charset, java.util.Map<String, String> params, boolean allowArbitrarySubtypes, String... fileExtensions) {
         akka.http.scaladsl.model.HttpCharset cs = (akka.http.scaladsl.model.HttpCharset) charset;
 
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.List<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions)).toList();
 
         scala.collection.immutable.Map<String, String> p = Util.convertMapToScala(params);
 
@@ -345,8 +329,7 @@ public final class MediaTypes {
     }
 
     public static MediaType.WithOpenCharset customWithOpenCharset(String mainType, String subType, java.util.Map<String, String> params, boolean allowArbitrarySubtypes, String... fileExtensions) {
-        scala.collection.immutable.List<String> fileEx =
-                scala.collection.JavaConversions.asScalaBuffer(java.util.Arrays.asList(fileExtensions)).toList();
+        scala.collection.immutable.List<String> fileEx = akka.japi.Util.<String>immutableSeq(java.util.Arrays.asList(fileExtensions)).toList();
 
         scala.collection.immutable.Map<String, String> p = Util.convertMapToScala(params);
 
@@ -365,6 +348,7 @@ public final class MediaTypes {
     public static MediaType custom(String value, boolean binary, boolean compressible) {
         akka.http.scaladsl.model.MediaType.Compressibility comp = compressible ?
                 akka.http.scaladsl.model.MediaType.Compressible$.MODULE$ : akka.http.scaladsl.model.MediaType.NotCompressible$.MODULE$;
+
         return akka.http.scaladsl.model.MediaType.custom(value, binary, comp ,
                 akka.http.scaladsl.model.MediaType.custom$default$4());
     }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
@@ -30,6 +30,9 @@ object MediaType {
   trait Multipart extends WithOpenCharset {
   }
 
+  trait Compressibility {
+    def compressible: Boolean
+  }
 }
 
 trait MediaType {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -251,7 +251,7 @@ object MediaType {
       withParams(if (boundary.isEmpty) params - "boundary" else params.updated("boundary", boundary))
   }
 
-  sealed abstract class Compressibility(val compressible: Boolean)
+  sealed class Compressibility(val compressible: Boolean) extends jm.MediaType.Compressibility
   case object Compressible extends Compressibility(compressible = true)
   case object NotCompressible extends Compressibility(compressible = false)
   case object Gzipped extends Compressibility(compressible = false)


### PR DESCRIPTION
PR for https://github.com/akka/akka/issues/20199
1. Most of the `bool compressible` counterparts are kept since I assume they are important for binary compatibility.
2. List conversion codes are replaced with the method within `akka.japi.Util` 
