### PR TITLE
Deprecate InvalidAbsorbTermination In favour of GraphStage

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
@@ -550,6 +550,8 @@ class InterpreterSpec extends AkkaSpec with GraphInterpreterSpecKit {
 
     }
 
+    //#20386
+    @deprecated("Usage of PushPullStage is deprecated, please use GraphStage instead", "2.4.5")
     class InvalidAbsorbTermination extends PushPullStage[Int, Int] {
       override def onPull(ctx: Context[Int]): SyncDirective = ctx.pull()
       override def onPush(elem: Int, ctx: Context[Int]): SyncDirective = ctx.push(elem)


### PR DESCRIPTION
Refs #20288

According to the [Replacement Guideline](http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0.4/scala/migration-guide-1.0-2.x-scala.html#AsyncStage_has_been_replaced_by_GraphStage),  `ctx.absorbTermination()` should be replaced by 
`if (isAvailable(shape.outlet)) <call the onPull() handler>`

If I understood it correctly, it means [this condition](https://github.com/akka/akka/blob/65a9e0a0f9372d2e2ecb945c8a9dae129a438f77/akka-stream/src/main/scala/akka/stream/stage/Stage.scala#L123L130), which InvalidAbsorbTermination was checking, is no longer relevant?
