### PR TITLE
Expire defaults when HTTP-date is not possible to parse (#20362) and  'If-Modified-Since' is more strict (excluding 0 - rfc 7232 3.3).

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -64,7 +64,7 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
   // http://tools.ietf.org/html/rfc7234#section-5.3
   // ******************************************************************************************
 
-  def `expire-date`: Rule1[DateTime] = rule {
+  def `expires-date`: Rule1[DateTime] = rule {
     (`HTTP-date` | zeroOrMore(ANY) ~ push(DateTime.MinValue)) ~ OWS
   }
 
@@ -259,7 +259,7 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
   }
 
   def `expires-av` = rule {
-    ignoreCase("expires=") ~ OWS ~ `expire-date` ~> { (c: HttpCookie, dt: DateTime) ⇒ c.copy(expires = Some(dt)) }
+    ignoreCase("expires=") ~ OWS ~ `expires-date` ~> { (c: HttpCookie, dt: DateTime) ⇒ c.copy(expires = Some(dt)) }
   }
 
   def `max-age-av` = rule {

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -74,7 +74,7 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
   // ******************************************************************************************
 
   def `HTTP-date`: Rule1[DateTime] = rule {
-    (`IMF-fixdate` | `asctime-date`) ~ OWS
+    (`IMF-fixdate` | `asctime-date` | '0' ~ push(DateTime.MinValue)) ~ OWS
   }
 
   def `IMF-fixdate` = rule { // mixture of the spec-ed `IMF-fixdate` and `rfc850-date`

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -61,12 +61,20 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
   def `quoted-cpair` = `quoted-pair`
 
   // ******************************************************************************************
+  // http://tools.ietf.org/html/rfc7234#section-5.3
+  // ******************************************************************************************
+
+  def `expire-date`: Rule1[DateTime] = rule {
+    (`HTTP-date` | zeroOrMore(ANY) ~ push(DateTime.MinValue)) ~ OWS
+  }
+
+  // ******************************************************************************************
   // http://tools.ietf.org/html/rfc7231#section-7.1.1.1
   // but more lenient where we have already seen differing implementations in the field
   // ******************************************************************************************
 
   def `HTTP-date`: Rule1[DateTime] = rule {
-    (`IMF-fixdate` | `asctime-date` | '0' ~ push(DateTime.MinValue)) ~ OWS
+    (`IMF-fixdate` | `asctime-date`) ~ OWS
   }
 
   def `IMF-fixdate` = rule { // mixture of the spec-ed `IMF-fixdate` and `rfc850-date`
@@ -251,7 +259,7 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
   }
 
   def `expires-av` = rule {
-    ignoreCase("expires=") ~ OWS ~ `HTTP-date` ~> { (c: HttpCookie, dt: DateTime) ⇒ c.copy(expires = Some(dt)) }
+    ignoreCase("expires=") ~ OWS ~ `expire-date` ~> { (c: HttpCookie, dt: DateTime) ⇒ c.copy(expires = Some(dt)) }
   }
 
   def `max-age-av` = rule {

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -121,7 +121,7 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
   }
 
   // http://tools.ietf.org/html/rfc7234#section-5.3
-  def `expires` = rule { `expire-date` ~ EOI ~> (Expires(_)) }
+  def `expires` = rule { `expires-date` ~ EOI ~> (Expires(_)) }
 
   // http://tools.ietf.org/html/rfc7230#section-5.4
   // We don't accept scoped IPv6 addresses as they should not appear in the Host header,

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -121,7 +121,7 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
   }
 
   // http://tools.ietf.org/html/rfc7234#section-5.3
-  def `expires` = rule { `HTTP-date` ~ EOI ~> (Expires(_)) }
+  def `expires` = rule { `expire-date` ~ EOI ~> (Expires(_)) }
 
   // http://tools.ietf.org/html/rfc7230#section-5.4
   // We don't accept scoped IPv6 addresses as they should not appear in the Host header,

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -279,6 +279,9 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
     "Expires" in {
       "Expires: Wed, 13 Jul 2011 08:12:31 GMT" =!= Expires(DateTime(2011, 7, 13, 8, 12, 31))
       "Expires: 0" =!= Expires(DateTime.MinValue).renderedTo("Wed, 01 Jan 1800 00:00:00 GMT")
+      "Expires: -1" =!= Expires(DateTime.MinValue).renderedTo("Wed, 01 Jan 1800 00:00:00 GMT")
+      "Expires: " =!= Expires(DateTime.MinValue).renderedTo("Wed, 01 Jan 1800 00:00:00 GMT")
+      "Expires: batman" =!= Expires(DateTime.MinValue).renderedTo("Wed, 01 Jan 1800 00:00:00 GMT")
     }
 
     "Host" in {
@@ -299,7 +302,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
 
     "If-Modified-Since" in {
       "If-Modified-Since: Wed, 13 Jul 2011 08:12:31 GMT" =!= `If-Modified-Since`(DateTime(2011, 7, 13, 8, 12, 31))
-      "If-Modified-Since: 0" =!= `If-Modified-Since`(DateTime.MinValue).renderedTo("Wed, 01 Jan 1800 00:00:00 GMT")
+      "If-Modified-Since: 0" =!= ErrorInfo("Illegal HTTP header 'If-Modified-Since': Invalid input '0', expected IMF-fixdate or asctime-date (line 1, column 1)", "0\n^")
     }
 
     "If-None-Match" in {
@@ -505,9 +508,13 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
         ErrorInfo("Illegal HTTP header 'Set-Cookie': Illegal weekday in date 2014-12-13T00:42:55", "is 'Mon' but should be 'Sat'")
 
       "Set-Cookie: lang=; Expires=xxxx" =!=
+        `Set-Cookie`(HttpCookie("lang", "", expires = Some(DateTime.MinValue)))
+        .renderedTo("lang=; Expires=Wed, 01 Jan 1800 00:00:00 GMT")
+
+      "Set-Cookie: lang=; domain=----" =!=
         ErrorInfo(
-          "Illegal HTTP header 'Set-Cookie': Invalid input 'x', expected OWS or HTTP-date (line 1, column 16)",
-          "lang=; Expires=xxxx\n               ^")
+          "Illegal HTTP header 'Set-Cookie': Invalid input '-', expected OWS or domain-value (line 1, column 15)",
+          "lang=; domain=----\n              ^")
 
       // extra examples from play
       "Set-Cookie: PLAY_FLASH=\"success=found\"; Path=/; HTTPOnly" =!=

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -302,7 +302,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
 
     "If-Modified-Since" in {
       "If-Modified-Since: Wed, 13 Jul 2011 08:12:31 GMT" =!= `If-Modified-Since`(DateTime(2011, 7, 13, 8, 12, 31))
-      "If-Modified-Since: 0" =!= ErrorInfo("Illegal HTTP header 'If-Modified-Since': Invalid input '0', expected IMF-fixdate or asctime-date (line 1, column 1)", "0\n^")
+      "If-Modified-Since: 0" =!= `If-Modified-Since`(DateTime.MinValue).renderedTo("Wed, 01 Jan 1800 00:00:00 GMT")
     }
 
     "If-None-Match" in {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -23,7 +23,7 @@ class HeaderSpec extends FreeSpec with Matchers {
       }
       "failing parse run" in {
         val Left(List(ErrorInfo(summary, detail))) = headers.`Last-Modified`.parseFromValueString("abc")
-        summary shouldEqual "Illegal HTTP header 'Last-Modified': Invalid input 'a', expected IMF-fixdate or asctime-date (line 1, column 1)"
+        summary shouldEqual "Illegal HTTP header 'Last-Modified': Invalid input 'a', expected IMF-fixdate, asctime-date or '0' (line 1, column 1)"
         detail shouldEqual
           """abc
             |^""".stripMarginWithNewline("\n")

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -23,7 +23,7 @@ class HeaderSpec extends FreeSpec with Matchers {
       }
       "failing parse run" in {
         val Left(List(ErrorInfo(summary, detail))) = headers.`Last-Modified`.parseFromValueString("abc")
-        summary shouldEqual "Illegal HTTP header 'Last-Modified': Invalid input 'a', expected IMF-fixdate, asctime-date or '0' (line 1, column 1)"
+        summary shouldEqual "Illegal HTTP header 'Last-Modified': Invalid input 'a', expected IMF-fixdate or asctime-date (line 1, column 1)"
         detail shouldEqual
           """abc
             |^""".stripMarginWithNewline("\n")

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -764,7 +764,10 @@ object MiMa extends AutoPlugin {
         // internal api
         FilterAnyProblemStartingWith("akka.stream.impl"),
         FilterAnyProblemStartingWith("akka.http.impl.engine.parsing.BodyPartParser"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.package.printEvent")
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.package.printEvent"),
+
+        // #20362 - parser private
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.model.parser.CommonRules.expires-date")
       )
     )
   }


### PR DESCRIPTION
> A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired").

and

> A recipient MUST ignore the If-Modified-Since header field if the received field-value is not a valid HTTP-date [...] .
