### PR TITLE
=doc clarify akka.actor.Status.Success usage with Source.actorRef

### DIFF
--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -141,7 +141,8 @@ elements or failing the stream, the strategy is chosen by the user.
 
 **emits** when there is demand and there are messages in the buffer or a message is sent to the actorref
 
-**completes** when the ``ActorRef`` is sent ``akka.actor.Status.Success`` or ``PoisonPill``
+**completes** when the ``ActorRef`` is sent a ``new akka.actor.Status.Success`` (whose content will be ignored) or
+by sending ``akka.actor.PoisonPill``
 
 combine
 ^^^^^^^

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -139,7 +139,8 @@ elements or failing the stream, the strategy is chosen by the user.
 
 **emits** when there is demand and there are messages in the buffer or a message is sent to the actorref
 
-**completes** when the actorref is sent ``akka.actor.Status.Success`` or ``PoisonPill``
+**completes** when the `ActorRef` is sent a ``akka.actor.Status.Success(...)`` (whose content will be ignored) or by
+sending ``akka.actor.PoisonPill``
 
 combine
 ^^^^^^^


### PR DESCRIPTION
Related to https://github.com/akka/akka/issues/20421, and continuing the effort from 34d51dcd001a3917bda3272751195e9f0e863b02
