### PR TITLE
=doc correct references to non-existent ShardRegion state messages / return types

### DIFF
--- a/akka-docs/rst/java/cluster-sharding.rst
+++ b/akka-docs/rst/java/cluster-sharding.rst
@@ -360,11 +360,11 @@ Inspecting cluster sharding state
 ---------------------------------
 Two requests to inspect the cluster state are available:
 
-``ClusterShard.getShardRegionStateInstance`` which will return a ``ClusterShard.ShardRegionState`` that contains
+``ShardRegion.getShardRegionStateInstance`` which will return a ``ShardRegion.ShardRegionState`` that contains
 the identifiers of the shards running in a Region and what entities are alive for each of them.
 
-``ClusterShard.getClusterShardingStatsInstance`` which will query all the regions in the cluster and return
-a ``ClusterShard.ClusterShardingStats`` containing the identifiers of the shards running in each region and a count
+``ShardRegion.GetClusterShardingStats`` which will query all the regions in the cluster and return
+a ``ShardRegion.ClusterShardingStats`` containing the identifiers of the shards running in each region and a count
 of entities that are alive in each shard.
 
 The purpose of these messages is testing and monitoring, they are not provided to give access to

--- a/akka-docs/rst/scala/cluster-sharding.rst
+++ b/akka-docs/rst/scala/cluster-sharding.rst
@@ -361,11 +361,11 @@ Inspecting cluster sharding state
 ---------------------------------
 Two requests to inspect the cluster state are available:
 
-``ClusterShard.GetShardRegionState`` which will return a ``ClusterShard.ShardRegionState`` that contains
+``ShardRegion.GetShardRegionState`` which will return a ``ShardRegion.CurrentShardRegionState`` that contains
 the identifiers of the shards running in a Region and what entities are alive for each of them.
 
-``ClusterShard.GetClusterShardingStats`` which will query all the regions in the cluster and return
-a ``ClusterShard.ClusterShardingStats`` containing the identifiers of the shards running in each region and a count
+``ShardRegion.GetClusterShardingStats`` which will query all the regions in the cluster and return
+a ``ShardRegion.ClusterShardingStats`` containing the identifiers of the shards running in each region and a count
 of entities that are alive in each shard.
 
 The purpose of these messages is testing and monitoring, they are not provided to give access to


### PR DESCRIPTION
As mentioned in gitter a few weeks ago:

:point_up: [April 15, 2016 4:20 PM](https://gitter.im/akka/dev?at=571169152c97111664326046)
