### PR TITLE
show Aeron stats in tests

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
@@ -108,13 +108,8 @@ abstract class AeronStreamLatencySpec
   }
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
-  def reporter(name: String): RateReporter = {
-    val r = new RateReporter(SECONDS.toNanos(1), new RateReporter.Reporter {
-      override def onReport(messagesPerSec: Double, bytesPerSec: Double, totalMessages: Long, totalBytes: Long): Unit = {
-        println(name + ": %.03g msgs/sec, %.03g bytes/sec, totals %d messages %d MB".format(
-          messagesPerSec, bytesPerSec, totalMessages, totalBytes / (1024 * 1024)))
-      }
-    })
+  def reporter(name: String): TestRateReporter = {
+    val r = new TestRateReporter(name)
     reporterExecutor.execute(r)
     r
   }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
@@ -114,13 +114,8 @@ abstract class AeronStreamMaxThroughputSpec
   }
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
-  def reporter(name: String): RateReporter = {
-    val r = new RateReporter(SECONDS.toNanos(1), new RateReporter.Reporter {
-      override def onReport(messagesPerSec: Double, bytesPerSec: Double, totalMessages: Long, totalBytes: Long): Unit = {
-        println(name + ": %.03g msgs/sec, %.03g bytes/sec, totals %d messages %d MB".format(
-          messagesPerSec, bytesPerSec, totalMessages, totalBytes / (1024 * 1024)))
-      }
-    })
+  def reporter(name: String): TestRateReporter = {
+    val r = new TestRateReporter(name)
     reporterExecutor.execute(r)
     r
   }
@@ -139,7 +134,7 @@ abstract class AeronStreamMaxThroughputSpec
     val d = (System.nanoTime - startTime).nanos.toMillis
     val throughput = 1000.0 * total / d
     println(f"=== AeronStreamMaxThroughput $testName: " +
-      f"${throughput}%.03g msg/s, ${throughput * payloadSize}%.03g bytes/s, " +
+      f"${throughput}%,.0f msg/s, ${throughput * payloadSize}%,.0f bytes/s, " +
       s"payload size $payloadSize, " +
       s"$d ms to deliver $total messages")
     plot = plot.add(testName, throughput * payloadSize / 1024 / 1024)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
@@ -179,13 +179,8 @@ abstract class LatencySpec
   }
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
-  def reporter(name: String): RateReporter = {
-    val r = new RateReporter(SECONDS.toNanos(1), new RateReporter.Reporter {
-      override def onReport(messagesPerSec: Double, bytesPerSec: Double, totalMessages: Long, totalBytes: Long): Unit = {
-        println(name + ": %.03g msgs/sec, %.03g bytes/sec, totals %d messages %d MB".format(
-          messagesPerSec, bytesPerSec, totalMessages, totalBytes / (1024 * 1024)))
-      }
-    })
+  def reporter(name: String): TestRateReporter = {
+    val r = new TestRateReporter(name)
     reporterExecutor.execute(r)
     r
   }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
@@ -129,8 +129,8 @@ object MaxThroughputSpec extends MultiNodeConfig {
         val throughput = (totalReceived * 1000.0 / took)
         println(
           s"=== MaxThroughput ${self.path.name}: " +
-            f"throughput ${throughput}%.03g msg/s, " +
-            f"${throughput * payloadSize}%.03g bytes/s, " +
+            f"throughput ${throughput}%,.0f msg/s, " +
+            f"${throughput * payloadSize}%,.0f bytes/s, " +
             s"dropped ${totalMessages - totalReceived}, " +
             s"max round-trip $maxRoundTripMillis ms, " +
             s"burst size $burstSize, " +
@@ -187,13 +187,8 @@ abstract class MaxThroughputSpec
   def remoteSettings = system.asInstanceOf[ExtendedActorSystem].provider.asInstanceOf[RemoteActorRefProvider].remoteSettings
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
-  def reporter(name: String): RateReporter = {
-    val r = new RateReporter(SECONDS.toNanos(1), new RateReporter.Reporter {
-      override def onReport(messagesPerSec: Double, bytesPerSec: Double, totalMessages: Long, totalBytes: Long): Unit = {
-        println(name + ": %.03g msgs/sec, %.03g bytes/sec, totals %d messages %d MB".format(
-          messagesPerSec, bytesPerSec, totalMessages, totalBytes / (1024 * 1024)))
-      }
-    })
+  def reporter(name: String): TestRateReporter = {
+    val r = new TestRateReporter(name)
     reporterExecutor.execute(r)
     r
   }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/TestRateReporter.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/TestRateReporter.scala
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.Executors
+
+class TestRateReporter(name: String) extends RateReporter(SECONDS.toNanos(1),
+  new RateReporter.Reporter {
+    override def onReport(messagesPerSec: Double, bytesPerSec: Double, totalMessages: Long, totalBytes: Long): Unit = {
+      println(name +
+        f": ${messagesPerSec}%,.0f msgs/sec, ${bytesPerSec}%,.0f bytes/sec, " +
+        f"totals ${totalMessages}%,d messages ${totalBytes / (1024 * 1024)}%,d MB")
+    }
+  }) {
+
+}

--- a/akka-remote/src/test/java/akka/remote/artery/AeronStat.java
+++ b/akka-remote/src/test/java/akka/remote/artery/AeronStat.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2014 - 2016 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package akka.remote.artery;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.MappedByteBuffer;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import io.aeron.CncFileDescriptor;
+import io.aeron.CommonContext;
+import org.agrona.DirectBuffer;
+import org.agrona.IoUtil;
+import org.agrona.concurrent.status.CountersReader;
+import org.agrona.concurrent.SigInt;
+
+import static io.aeron.CncFileDescriptor.*;
+import static io.aeron.driver.status.StreamPositionCounter.*;
+import static io.aeron.driver.status.PublisherLimit.PUBLISHER_LIMIT_TYPE_ID;
+import static io.aeron.driver.status.SubscriberPos.SUBSCRIBER_POSITION_TYPE_ID;
+import static io.aeron.driver.status.SystemCounterDescriptor.SYSTEM_COUNTER_TYPE_ID;
+
+/**
+ * Tool for printing out Aeron counters. A command-and-control (cnc) file is maintained by media driver
+ * in shared memory. This application reads the the cnc file and prints the counters. Layout of the cnc file is
+ * described in {@link CncFileDescriptor}.
+ *
+ * This tool accepts filters on the command line, e.g. for connections only see example below:
+ *
+ * <code>
+ *     java -cp aeron-samples/build/libs/samples.jar io.aeron.samples.AeronStat type=[1-4] identity=12345
+ * </code>
+ */
+public class AeronStat
+{
+    /**
+     * Types of the counters.
+     * <ul>
+     *     <li>0: System Counters</li>
+     *     <li>1 - 4: Stream Positions</li>
+     * </ul>
+     */
+    private static final String COUNTER_TYPE_ID = "type";
+
+    /**
+     * The identity of each counter that can either be the system counter id or registration id for positions.
+     */
+    private static final String COUNTER_IDENTITY = "identity";
+
+    /**
+     * Session id filter to be used for position counters.
+     */
+    private static final String COUNTER_SESSION_ID = "session";
+
+    /**
+     * Stream id filter to be used for position counters.
+     */
+    private static final String COUNTER_STREAM_ID = "stream";
+
+    /**
+     * Channel filter to be used for position counters.
+     */
+    private static final String COUNTER_CHANNEL = "channel";
+
+    private static final int ONE_SECOND = 1_000;
+
+    private final CountersReader counters;
+    private final Pattern typeFilter;
+    private final Pattern identityFilter;
+    private final Pattern sessionFilter;
+    private final Pattern streamFilter;
+    private final Pattern channelFilter;
+
+    public AeronStat(
+        final CountersReader counters,
+        final Pattern typeFilter,
+        final Pattern identityFilter,
+        final Pattern sessionFilter,
+        final Pattern streamFilter,
+        final Pattern channelFilter)
+    {
+        this.counters = counters;
+        this.typeFilter = typeFilter;
+        this.identityFilter = identityFilter;
+        this.sessionFilter = sessionFilter;
+        this.streamFilter = streamFilter;
+        this.channelFilter = channelFilter;
+    }
+
+    public AeronStat(final CountersReader counters)
+    {
+        this.counters = counters;
+        this.typeFilter = null;
+        this.identityFilter = null;
+        this.sessionFilter = null;
+        this.streamFilter = null;
+        this.channelFilter = null;
+    }
+
+    public static CountersReader mapCounters() 
+    {
+      return mapCounters(CommonContext.newDefaultCncFile()); 
+    }
+    
+    public static CountersReader mapCounters(final File cncFile)
+    {
+        System.out.println("Command `n Control file " + cncFile);
+
+        final MappedByteBuffer cncByteBuffer = IoUtil.mapExistingFile(cncFile, "cnc");
+        final DirectBuffer cncMetaData = createMetaDataBuffer(cncByteBuffer);
+        final int cncVersion = cncMetaData.getInt(cncVersionOffset(0));
+
+        if (CncFileDescriptor.CNC_VERSION != cncVersion)
+        {
+            throw new IllegalStateException("CnC version not supported: file version=" + cncVersion);
+        }
+
+        return new CountersReader(
+            createCountersMetaDataBuffer(cncByteBuffer, cncMetaData),
+            createCountersValuesBuffer(cncByteBuffer, cncMetaData));
+    }
+
+    public static void main(final String[] args) throws Exception
+    {
+        Pattern typeFilter = null;
+        Pattern identityFilter = null;
+        Pattern sessionFilter = null;
+        Pattern streamFilter = null;
+        Pattern channelFilter = null;
+
+        if (0 != args.length)
+        {
+            checkForHelp(args);
+
+            for (final String arg : args)
+            {
+                final int equalsIndex = arg.indexOf('=');
+                if (-1 == equalsIndex)
+                {
+                    System.out.println("Arguments must be in name=pattern format: Invalid '" + arg + "'");
+                    return;
+                }
+
+                final String argName = arg.substring(0, equalsIndex);
+                final String argValue = arg.substring(equalsIndex + 1);
+
+                switch (argName)
+                {
+                    case COUNTER_TYPE_ID:
+                        typeFilter = Pattern.compile(argValue);
+                        break;
+
+                    case COUNTER_IDENTITY:
+                        identityFilter = Pattern.compile(argValue);
+                        break;
+
+                    case COUNTER_SESSION_ID:
+                        sessionFilter = Pattern.compile(argValue);
+                        break;
+
+                    case COUNTER_STREAM_ID:
+                        streamFilter = Pattern.compile(argValue);
+                        break;
+
+                    case COUNTER_CHANNEL:
+                        channelFilter = Pattern.compile(argValue);
+                        break;
+
+                    default:
+                        System.out.println("Unrecognised argument: '" + arg + "'");
+                        return;
+                }
+            }
+        }
+
+        final AeronStat aeronStat = new AeronStat(
+            mapCounters(), typeFilter, identityFilter, sessionFilter, streamFilter, channelFilter);
+        final AtomicBoolean running = new AtomicBoolean(true);
+        SigInt.register(() -> running.set(false));
+
+        while (running.get())
+        {
+            System.out.print("\033[H\033[2J");
+
+            System.out.format("%1$tH:%1$tM:%1$tS - Aeron Stat%n", new Date());
+            System.out.println("=========================");
+
+            aeronStat.print(System.out);
+            System.out.println("--");
+
+            Thread.sleep(ONE_SECOND);
+        }
+    }
+
+    public void print(final PrintStream out)
+    {
+        counters.forEach(
+            (counterId, typeId, keyBuffer, label) ->
+            {
+                if (filter(typeId, keyBuffer))
+                {
+                    final long value = counters.getCounterValue(counterId);
+                    out.format("%3d: %,20d - %s%n", counterId, value, label);
+                }
+            });
+    }
+
+    private static void checkForHelp(final String[] args)
+    {
+        for (final String arg : args)
+        {
+            if ("-?".equals(arg) || "-h".equals(arg) || "-help".equals(arg))
+            {
+                System.out.println(
+                    "Usage: [-Daeron.dir=<directory containing CnC file>] AeronStat%n" +
+                        "\tfilter by optional regex patterns:%n" +
+                        "\t[type=<pattern>]%n" +
+                        "\t[identity=<pattern>]%n" +
+                        "\t[sessionId=<pattern>]%n" +
+                        "\t[streamId=<pattern>]%n" +
+                        "\t[channel=<pattern>]%n");
+
+                System.exit(0);
+            }
+        }
+    }
+
+    private boolean filter(final int typeId, final DirectBuffer keyBuffer)
+    {
+        if (!match(typeFilter, () -> Integer.toString(typeId)))
+        {
+            return false;
+        }
+
+        if (SYSTEM_COUNTER_TYPE_ID == typeId && !match(identityFilter, () -> Integer.toString(keyBuffer.getInt(0))))
+        {
+            return false;
+        }
+        else if (typeId >= PUBLISHER_LIMIT_TYPE_ID && typeId <= SUBSCRIBER_POSITION_TYPE_ID)
+        {
+            if (!match(identityFilter, () -> Long.toString(keyBuffer.getLong(REGISTRATION_ID_OFFSET))) ||
+                !match(sessionFilter, () -> Integer.toString(keyBuffer.getInt(SESSION_ID_OFFSET))) ||
+                !match(streamFilter, () -> Integer.toString(keyBuffer.getInt(STREAM_ID_OFFSET))) ||
+                !match(channelFilter, () -> keyBuffer.getStringUtf8(CHANNEL_OFFSET)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean match(final Pattern pattern, final Supplier<String> supplier)
+    {
+        return null == pattern || pattern.matcher(supplier.get()).find();
+    }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,8 +67,8 @@ object Dependencies {
     // For Java 8 Conversions
     val java8Compat = "org.scala-lang.modules"       %% "scala-java8-compat"           % "0.7.0"       // Scala License
     
-    val aeronDriver = "io.aeron"                      % "aeron-driver"                 % "0.9.5"       // ApacheV2
-    val aeronClient = "io.aeron"                      % "aeron-client"                 % "0.9.5"       // ApacheV2
+    val aeronDriver = "io.aeron"                      % "aeron-driver"                 % "0.9.7"       // ApacheV2
+    val aeronClient = "io.aeron"                      % "aeron-client"                 % "0.9.7"       // ApacheV2
 
     object Docs {
       val sprayJson   = "io.spray"                   %%  "spray-json"                  % "1.3.2"             % "test"


### PR DESCRIPTION
Show the Aeron stats counters. Can be useful when tuning/debugging.

Also updated to Aeron 0.9.7 and change the number format to more readable `650,342 msgs/sec`

The counters look like:

```
[JVM-2] receiver stats:
[JVM-2]   0:                    0 - Bytes Sent
[JVM-2]   1:          331,120,696 - Bytes received
[JVM-2]   2:                    0 - Failed offers to ReceiverProxy
[JVM-2]   3:                    0 - Failed offers to SenderProxy
[JVM-2]   4:                    0 - Failed offers to DriverConductorProxy
[JVM-2]   5:                   52 - NAKs sent
[JVM-2]   6:                    0 - NAKs received
[JVM-2]   7:                6,365 - Status Messages sent
[JVM-2]   8:                    0 - Status Messages received
[JVM-2]   9:                    0 - Heartbeats sent
[JVM-2]  10:                   10 - Heartbeats received
[JVM-2]  11:                    0 - Retransmits sent
[JVM-2]  12:                    0 - Flow control under runs
[JVM-2]  13:                    0 - Flow control over runs
[JVM-2]  14:                    0 - Invalid packets
[JVM-2]  15:                    0 - Errors
[JVM-2]  16:                    0 - Data Packet short sends
[JVM-2]  17:                    0 - Setup Message short sends
[JVM-2]  18:                    0 - Status Message short sends
[JVM-2]  19:                    0 - NAK Message short sends
[JVM-2]  20:                    4 - Client keep-alives
[JVM-2]  21:                    0 - Sender flow control limits applied
[JVM-2]  22:                    0 - Unblocked Publications
[JVM-2]  23:                    0 - Unblocked Control Commands
[JVM-2]  24:                    0 - Possible TTL Asymmetry
[JVM-2]  25:          100,764,016 - Rcv-hwm: 9 -771653916 10 aeron:udp?endpoint=localhost:20512
[JVM-2]  26:          128,000,896 - Rcv-hwm: 2 -771653918 10 aeron:udp?endpoint=localhost:20512
[JVM-2]  27:          102,406,144 - Rcv-hwm: 5 -771653917 10 aeron:udp?endpoint=localhost:20512
[JVM-2]  29:          128,000,896 - Rcv-hwm: 6 -771653918 10 aeron:udp?endpoint=localhost:20512
[JVM-2]  31:          128,000,896 - Rcv-hwm: 10 -771653918 10 aeron:udp?endpoint=localhost:20512
[JVM-2]  33:          102,406,144 - Rcv-hwm: 11 -771653917 10 aeron:udp?endpoint=localhost:20512
```
