### PR TITLE
first stab at system message delivery, #20323

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/AeronSink.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/AeronSink.scala
@@ -51,7 +51,7 @@ object AeronSink {
 /**
  * @param channel eg. "aeron:udp?endpoint=localhost:40123"
  */
-class AeronSink(channel: String, aeron: Aeron, taskRunner: TaskRunner) extends GraphStage[SinkShape[AeronSink.Bytes]] {
+class AeronSink(channel: String, streamId: Int, aeron: Aeron, taskRunner: TaskRunner) extends GraphStage[SinkShape[AeronSink.Bytes]] {
   import AeronSink._
   import TaskRunner._
 
@@ -62,7 +62,6 @@ class AeronSink(channel: String, aeron: Aeron, taskRunner: TaskRunner) extends G
     new GraphStageLogic(shape) with InHandler {
 
       private val buffer = new UnsafeBuffer(ByteBuffer.allocateDirect(128 * 1024))
-      private val streamId = 10
       private val pub = aeron.addPublication(channel, streamId)
 
       private val spinning = 1000

--- a/akka-remote/src/main/scala/akka/remote/artery/AeronSource.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/AeronSource.scala
@@ -61,7 +61,7 @@ object AeronSource {
 /**
  * @param channel eg. "aeron:udp?endpoint=localhost:40123"
  */
-class AeronSource(channel: String, aeron: Aeron, taskRunner: TaskRunner) extends GraphStage[SourceShape[AeronSource.Bytes]] {
+class AeronSource(channel: String, streamId: Int, aeron: Aeron, taskRunner: TaskRunner) extends GraphStage[SourceShape[AeronSource.Bytes]] {
   import AeronSource._
   import TaskRunner._
 
@@ -71,7 +71,6 @@ class AeronSource(channel: String, aeron: Aeron, taskRunner: TaskRunner) extends
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with OutHandler {
 
-      private val streamId = 10
       private val sub = aeron.addSubscription(channel, streamId)
       private val spinning = 1000
       private val yielding = 0

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -1,0 +1,310 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.util.ArrayDeque
+
+import scala.annotation.tailrec
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import akka.Done
+import akka.actor.ActorRef
+import akka.actor.Address
+import akka.remote.EndpointManager.Send
+import akka.remote.artery.Transport.InboundEnvelope
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.AsyncCallback
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.GraphStageWithMaterializedValue
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import akka.stream.stage.TimerGraphStageLogic
+
+/**
+ * INTERNAL API
+ */
+private[akka] object SystemMessageDelivery {
+  // FIXME serialization of these messages
+  final case class SystemMessageEnvelope(message: AnyRef, seqNo: Long, ackReplyTo: ActorRef)
+  sealed trait SystemMessageReply
+  final case class Ack(seq: Long, from: Address) extends SystemMessageReply
+  final case class Nack(seq: Long, from: Address) extends SystemMessageReply
+
+  private case object ResendTick
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class SystemMessageDelivery(
+  replyJunction: SystemMessageReplyJunction.Junction,
+  resendInterval: FiniteDuration,
+  localAddress: Address,
+  remoteAddress: Address,
+  ackRecipient: ActorRef)
+  extends GraphStage[FlowShape[Send, Send]] {
+
+  import SystemMessageDelivery._
+  import SystemMessageReplyJunction._
+
+  val in: Inlet[Send] = Inlet("SystemMessageDelivery.in")
+  val out: Outlet[Send] = Outlet("SystemMessageDelivery.out")
+  override val shape: FlowShape[Send, Send] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+
+      var registered = false
+      var seqNo = 0L // sequence number for the first message will be 1
+      val unacknowledged = new ArrayDeque[Send]
+      var resending = new ArrayDeque[Send]
+      var resendingFromSeqNo = -1L
+      var stopping = false
+
+      override def preStart(): Unit = {
+        this.schedulePeriodically(ResendTick, resendInterval)
+        def filter(env: InboundEnvelope): Boolean =
+          env.message match {
+            case Ack(_, from) if from == remoteAddress  ⇒ true
+            case Nack(_, from) if from == remoteAddress ⇒ true
+            case _                                      ⇒ false
+          }
+
+        implicit val ec = materializer.executionContext
+        replyJunction.addReplyInterest(filter, ackCallback).foreach {
+          getAsyncCallback[Done] { _ ⇒
+            registered = true
+            if (isAvailable(out))
+              pull(in) // onPull from downstream already called
+          }.invoke
+        }
+
+        replyJunction.stopped.onComplete {
+          getAsyncCallback[Try[Done]] {
+            // FIXME quarantine
+            case Success(_)     ⇒ completeStage()
+            case Failure(cause) ⇒ failStage(cause)
+          }.invoke
+        }
+      }
+
+      override def postStop(): Unit = {
+        replyJunction.removeReplyInterest(ackCallback)
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        if (unacknowledged.isEmpty)
+          super.onUpstreamFinish()
+        else
+          stopping = true
+      }
+
+      override protected def onTimer(timerKey: Any): Unit =
+        timerKey match {
+          case ResendTick ⇒
+            if (resending.isEmpty && !unacknowledged.isEmpty) {
+              resending = unacknowledged.clone()
+              tryResend()
+            }
+        }
+
+      val ackCallback = getAsyncCallback[SystemMessageReply] { reply ⇒
+        reply match {
+          case Ack(n, _) ⇒
+            ack(n)
+          case Nack(n, _) ⇒
+            ack(n)
+            if (n > resendingFromSeqNo)
+              resending = unacknowledged.clone()
+            tryResend()
+        }
+      }
+
+      private def ack(n: Long): Unit = {
+        if (n > seqNo)
+          throw new IllegalArgumentException(s"Unexpected ack $n, when highest sent seqNo is $seqNo")
+        clearUnacknowledged(n)
+      }
+
+      @tailrec private def clearUnacknowledged(ackedSeqNo: Long): Unit = {
+        if (!unacknowledged.isEmpty &&
+          unacknowledged.peek().message.asInstanceOf[SystemMessageEnvelope].seqNo <= ackedSeqNo) {
+          unacknowledged.removeFirst()
+          if (stopping && unacknowledged.isEmpty)
+            completeStage()
+          else
+            clearUnacknowledged(ackedSeqNo)
+        }
+      }
+
+      private def tryResend(): Unit = {
+        if (isAvailable(out) && !resending.isEmpty)
+          push(out, resending.poll())
+      }
+
+      // InHandler
+      override def onPush(): Unit = {
+        grab(in) match {
+          case s @ Send(reply: SystemMessageReply, _, _, _) ⇒
+            // pass through
+            if (isAvailable(out))
+              push(out, s)
+            else {
+              // it's ok to drop the replies, but we can try
+              resending.offer(s)
+            }
+
+          case s @ Send(msg: AnyRef, _, _, _) ⇒
+            seqNo += 1
+            val sendMsg = s.copy(message = SystemMessageEnvelope(msg, seqNo, ackRecipient))
+            // FIXME quarantine if unacknowledged is full
+            unacknowledged.offer(sendMsg)
+            if (resending.isEmpty && isAvailable(out))
+              push(out, sendMsg)
+            else {
+              resending.offer(sendMsg)
+              tryResend()
+            }
+        }
+      }
+
+      // OutHandler
+      override def onPull(): Unit = {
+        if (registered) { // otherwise it will be pulled after replyJunction.addReplyInterest
+          if (resending.isEmpty && !hasBeenPulled(in) && !stopping)
+            pull(in)
+          else
+            tryResend()
+        }
+      }
+
+      setHandlers(in, out, this)
+    }
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class SystemMessageAcker(localAddress: Address) extends GraphStage[FlowShape[InboundEnvelope, InboundEnvelope]] {
+  import SystemMessageDelivery._
+
+  val in: Inlet[InboundEnvelope] = Inlet("SystemMessageAcker.in")
+  val out: Outlet[InboundEnvelope] = Outlet("SystemMessageAcker.out")
+  override val shape: FlowShape[InboundEnvelope, InboundEnvelope] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      var seqNo = 1L
+
+      // InHandler
+      override def onPush(): Unit = {
+        grab(in) match {
+          case env @ InboundEnvelope(_, _, sysEnv @ SystemMessageEnvelope(_, n, ackReplyTo), _) ⇒
+            if (n == seqNo) {
+              ackReplyTo.tell(Ack(n, localAddress), ActorRef.noSender)
+              seqNo += 1
+              val unwrapped = env.copy(message = sysEnv.message)
+              push(out, unwrapped)
+            } else if (n < seqNo) {
+              ackReplyTo.tell(Ack(n, localAddress), ActorRef.noSender)
+              pull(in)
+            } else {
+              ackReplyTo.tell(Nack(seqNo - 1, localAddress), ActorRef.noSender)
+              pull(in)
+            }
+          case env ⇒
+            // messages that don't need acking
+            push(out, env)
+        }
+
+      }
+
+      // OutHandler
+      override def onPull(): Unit = pull(in)
+
+      setHandlers(in, out, this)
+    }
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] object SystemMessageReplyJunction {
+  import SystemMessageDelivery._
+
+  trait Junction {
+    def addReplyInterest(filter: InboundEnvelope ⇒ Boolean, replyCallback: AsyncCallback[SystemMessageReply]): Future[Done]
+    def removeReplyInterest(callback: AsyncCallback[SystemMessageReply]): Unit
+    def stopped: Future[Done]
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+private[akka] class SystemMessageReplyJunction
+  extends GraphStageWithMaterializedValue[FlowShape[InboundEnvelope, InboundEnvelope], SystemMessageReplyJunction.Junction] {
+  import SystemMessageReplyJunction._
+  import SystemMessageDelivery._
+
+  val in: Inlet[InboundEnvelope] = Inlet("SystemMessageReplyJunction.in")
+  val out: Outlet[InboundEnvelope] = Outlet("SystemMessageReplyJunction.out")
+  override val shape: FlowShape[InboundEnvelope, InboundEnvelope] = FlowShape(in, out)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
+    val logic = new GraphStageLogic(shape) with InHandler with OutHandler with Junction {
+
+      private var replyHandlers: Vector[(InboundEnvelope ⇒ Boolean, AsyncCallback[SystemMessageReply])] = Vector.empty
+      private val stoppedPromise = Promise[Done]()
+
+      override def postStop(): Unit = stoppedPromise.success(Done)
+
+      // InHandler
+      override def onPush(): Unit = {
+        grab(in) match {
+          case env @ InboundEnvelope(_, _, reply: SystemMessageReply, _) ⇒
+            replyHandlers.foreach {
+              case (f, callback) ⇒
+                if (f(env))
+                  callback.invoke(reply)
+            }
+            pull(in)
+          case env ⇒
+            push(out, env)
+        }
+      }
+
+      // OutHandler
+      override def onPull(): Unit = pull(in)
+
+      override def addReplyInterest(filter: InboundEnvelope ⇒ Boolean, replyCallback: AsyncCallback[SystemMessageReply]): Future[Done] = {
+        val p = Promise[Done]()
+        getAsyncCallback[Unit](_ ⇒ {
+          replyHandlers :+= (filter -> replyCallback)
+          p.success(Done)
+        }).invoke(())
+        p.future
+      }
+
+      override def removeReplyInterest(callback: AsyncCallback[SystemMessageReply]): Unit = {
+        replyHandlers = replyHandlers.filterNot { case (_, c) ⇒ c == callback }
+      }
+
+      override def stopped: Future[Done] = stoppedPromise.future
+
+      setHandlers(in, out, this)
+    }
+    (logic, logic)
+  }
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.remote.artery
 
 import scala.concurrent.duration._
@@ -6,23 +9,29 @@ import akka.testkit.{ AkkaSpec, ImplicitSender }
 import com.typesafe.config.ConfigFactory
 import RemoteSendConsistencySpec._
 import akka.actor.Actor.Receive
+import akka.testkit.SocketUtil
 
 object RemoteSendConsistencySpec {
 
-  val commonConfig = """
+  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
+
+  val commonConfig = ConfigFactory.parseString(s"""
      akka {
        actor.provider = "akka.remote.RemoteActorRefProvider"
        remote.artery.enabled = on
        remote.artery.hostname = localhost
+       remote.artery.port = $portA
      }
-  """
+  """)
+
+  val configB = ConfigFactory.parseString(s"akka.remote.artery.port = $portB")
+    .withFallback(commonConfig)
 
 }
 
 class RemoteSendConsistencySpec extends AkkaSpec(commonConfig) with ImplicitSender {
 
-  val configB = ConfigFactory.parseString("akka.remote.artery.port = 20201")
-  val systemB = ActorSystem("systemB", configB.withFallback(system.settings.config))
+  val systemB = ActorSystem("systemB", RemoteSendConsistencySpec.configB)
   val addressB = systemB.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
   println(addressB)
   val rootB = RootActorPath(addressB)

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -1,0 +1,282 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.concurrent.forkjoin.ThreadLocalRandom
+
+import akka.Done
+import akka.NotUsed
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.actor.Identify
+import akka.actor.InternalActorRef
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.actor.RootActorPath
+import akka.actor.Stash
+import akka.remote.EndpointManager.Send
+import akka.remote.RemoteActorRef
+import akka.remote.artery.SystemMessageDelivery._
+import akka.remote.artery.Transport.InboundEnvelope
+import akka.stream.ActorMaterializer
+import akka.stream.ActorMaterializerSettings
+import akka.stream.ThrottleMode
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.stream.stage.AsyncCallback
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.testkit.SocketUtil
+import akka.testkit.TestActors
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+
+object SystemMessageDeliverySpec {
+
+  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
+
+  val commonConfig = ConfigFactory.parseString(s"""
+     akka {
+       actor.provider = "akka.remote.RemoteActorRefProvider"
+       remote.artery.enabled = on
+       remote.artery.hostname = localhost
+       remote.artery.port = $portA
+     }
+     akka.actor.serialize-creators = off
+     akka.actor.serialize-messages = off
+  """)
+
+  val configB = ConfigFactory.parseString(s"akka.remote.artery.port = $portB")
+    .withFallback(commonConfig)
+
+  class TestReplyJunction(sendCallbackTo: ActorRef) extends SystemMessageReplyJunction.Junction {
+
+    def addReplyInterest(filter: InboundEnvelope ⇒ Boolean, replyCallback: AsyncCallback[SystemMessageReply]): Future[Done] = {
+      sendCallbackTo ! replyCallback
+      Future.successful(Done)
+    }
+
+    override def removeReplyInterest(callback: AsyncCallback[SystemMessageReply]): Unit = ()
+
+    override def stopped: Future[Done] = Promise[Done]().future
+  }
+
+  def replyConnectorProps(dropRate: Double): Props =
+    Props(new ReplyConnector(dropRate))
+
+  class ReplyConnector(dropRate: Double) extends Actor with Stash {
+    override def receive = {
+      case callback: AsyncCallback[SystemMessageReply] @unchecked ⇒
+        context.become(active(callback))
+        unstashAll()
+      case _ ⇒ stash()
+    }
+
+    def active(callback: AsyncCallback[SystemMessageReply]): Receive = {
+      case reply: SystemMessageReply ⇒
+        if (ThreadLocalRandom.current().nextDouble() >= dropRate)
+          callback.invoke(reply)
+    }
+  }
+
+}
+
+class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.commonConfig) with ImplicitSender {
+  import SystemMessageDeliverySpec._
+
+  val addressA = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+  val systemB = ActorSystem("systemB", configB)
+  val addressB = systemB.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+  val rootB = RootActorPath(addressB)
+  val matSettings = ActorMaterializerSettings(system).withFuzzing(true)
+  implicit val mat = ActorMaterializer(matSettings)(system)
+
+  override def afterTermination(): Unit = shutdown(systemB)
+
+  def setupManualCallback(ackRecipient: ActorRef, resendInterval: FiniteDuration,
+                          dropSeqNumbers: Vector[Long], sendCount: Int): (TestSubscriber.Probe[String], AsyncCallback[SystemMessageReply]) = {
+    val callbackProbe = TestProbe()
+    val replyJunction = new TestReplyJunction(callbackProbe.ref)
+
+    val sink =
+      send(sendCount, resendInterval, replyJunction, ackRecipient)
+        .via(drop(dropSeqNumbers))
+        .via(inbound)
+        .map(_.message.asInstanceOf[String])
+        .runWith(TestSink.probe)
+
+    val callback = callbackProbe.expectMsgType[AsyncCallback[SystemMessageReply]]
+    (sink, callback)
+  }
+
+  def send(sendCount: Int, resendInterval: FiniteDuration, replyJunction: SystemMessageReplyJunction.Junction,
+           ackRecipient: ActorRef): Source[Send, NotUsed] = {
+    val remoteRef = null.asInstanceOf[RemoteActorRef] // not used
+    Source(1 to sendCount)
+      .map(n ⇒ Send("msg-" + n, None, remoteRef, None))
+      .via(new SystemMessageDelivery(replyJunction, resendInterval, addressA, addressB, ackRecipient))
+  }
+
+  def inbound: Flow[Send, InboundEnvelope, NotUsed] = {
+    val recipient = null.asInstanceOf[InternalActorRef] // not used
+    Flow[Send]
+      .map {
+        case Send(sysEnv: SystemMessageEnvelope, _, _, _) ⇒
+          InboundEnvelope(recipient, addressB, sysEnv, None)
+      }
+      .async
+      .via(new SystemMessageAcker(addressB))
+  }
+
+  def drop(dropSeqNumbers: Vector[Long]): Flow[Send, Send, NotUsed] = {
+    Flow[Send]
+      .statefulMapConcat(() ⇒ {
+        var dropping = dropSeqNumbers
+
+        {
+          case s @ Send(SystemMessageEnvelope(_, seqNo, _), _, _, _) ⇒
+            val i = dropping.indexOf(seqNo)
+            if (i >= 0) {
+              dropping = dropping.updated(i, -1L)
+              Nil
+            } else
+              List(s)
+        }
+      })
+  }
+
+  def randomDrop[T](dropRate: Double): Flow[T, T, NotUsed] = Flow[T].mapConcat { elem ⇒
+    if (ThreadLocalRandom.current().nextDouble() < dropRate) Nil
+    else List(elem)
+  }
+
+  "System messages" must {
+
+    "be delivered with real actors" in {
+      val actorOnSystemB = systemB.actorOf(TestActors.echoActorProps, "echo")
+
+      val remoteRef = {
+        system.actorSelection(rootB / "user" / "echo") ! Identify(None)
+        expectMsgType[ActorIdentity].ref.get
+      }
+
+      watch(remoteRef)
+      remoteRef ! PoisonPill
+      expectTerminated(remoteRef)
+    }
+
+    "be resent when some in the middle are lost" in {
+      val ackRecipient = TestProbe()
+      val (sink, replyCallback) =
+        setupManualCallback(ackRecipient.ref, resendInterval = 60.seconds, dropSeqNumbers = Vector(3L, 4L), sendCount = 5)
+
+      sink.request(100)
+      sink.expectNext("msg-1")
+      sink.expectNext("msg-2")
+      ackRecipient.expectMsg(Ack(1L, addressB))
+      ackRecipient.expectMsg(Ack(2L, addressB))
+      // 3 and 4 was dropped
+      ackRecipient.expectMsg(Nack(2L, addressB))
+      sink.expectNoMsg(100.millis) // 3 was dropped
+      replyCallback.invoke(Nack(2L, addressB))
+      // resending 3, 4, 5
+      sink.expectNext("msg-3")
+      ackRecipient.expectMsg(Ack(3L, addressB))
+      sink.expectNext("msg-4")
+      ackRecipient.expectMsg(Ack(4L, addressB))
+      sink.expectNext("msg-5")
+      ackRecipient.expectMsg(Ack(5L, addressB))
+      ackRecipient.expectNoMsg(100.millis)
+      replyCallback.invoke(Ack(5L, addressB))
+      sink.expectComplete()
+    }
+
+    "be resent when first is lost" in {
+      val ackRecipient = TestProbe()
+      val (sink, replyCallback) =
+        setupManualCallback(ackRecipient.ref, resendInterval = 60.seconds, dropSeqNumbers = Vector(1L), sendCount = 3)
+
+      sink.request(100)
+      ackRecipient.expectMsg(Nack(0L, addressB)) // from receiving 2
+      ackRecipient.expectMsg(Nack(0L, addressB)) // from receiving 3
+      sink.expectNoMsg(100.millis) // 1 was dropped
+      replyCallback.invoke(Nack(0L, addressB))
+      replyCallback.invoke(Nack(0L, addressB))
+      // resending 1, 2, 3
+      sink.expectNext("msg-1")
+      ackRecipient.expectMsg(Ack(1L, addressB))
+      sink.expectNext("msg-2")
+      ackRecipient.expectMsg(Ack(2L, addressB))
+      sink.expectNext("msg-3")
+      ackRecipient.expectMsg(Ack(3L, addressB))
+      replyCallback.invoke(Ack(3L, addressB))
+      sink.expectComplete()
+    }
+
+    "be resent when last is lost" in {
+      val ackRecipient = TestProbe()
+      val (sink, replyCallback) =
+        setupManualCallback(ackRecipient.ref, resendInterval = 1.second, dropSeqNumbers = Vector(3L), sendCount = 3)
+
+      sink.request(100)
+      sink.expectNext("msg-1")
+      ackRecipient.expectMsg(Ack(1L, addressB))
+      replyCallback.invoke(Ack(1L, addressB))
+      sink.expectNext("msg-2")
+      ackRecipient.expectMsg(Ack(2L, addressB))
+      replyCallback.invoke(Ack(2L, addressB))
+      sink.expectNoMsg(200.millis) // 3 was dropped
+      // resending 3 due to timeout
+      sink.expectNext("msg-3")
+      ackRecipient.expectMsg(Ack(3L, addressB))
+      replyCallback.invoke(Ack(3L, addressB))
+      sink.expectComplete()
+    }
+
+    "deliver all during stress and random dropping" in {
+      val N = 10000
+      val dropRate = 0.1
+      val replyConnector = system.actorOf(replyConnectorProps(dropRate))
+      val replyJunction = new TestReplyJunction(replyConnector)
+
+      val output =
+        send(N, 1.second, replyJunction, replyConnector)
+          .via(randomDrop(dropRate))
+          .via(inbound)
+          .map(_.message.asInstanceOf[String])
+          .runWith(Sink.seq)
+
+      Await.result(output, 20.seconds) should ===((1 to N).map("msg-" + _).toVector)
+    }
+
+    "deliver all during throttling and random dropping" in {
+      val N = 500
+      val dropRate = 0.1
+      val replyConnector = system.actorOf(replyConnectorProps(dropRate))
+      val replyJunction = new TestReplyJunction(replyConnector)
+
+      val output =
+        send(N, 1.second, replyJunction, replyConnector)
+          .throttle(200, 1.second, 10, ThrottleMode.shaping)
+          .via(randomDrop(dropRate))
+          .via(inbound)
+          .map(_.message.asInstanceOf[String])
+          .runWith(Sink.seq)
+
+      Await.result(output, 20.seconds) should ===((1 to N).map("msg-" + _).toVector)
+    }
+
+  }
+
+}


### PR DESCRIPTION
For discussion.

With this approach incoming system message replies (`Ack`, `Nack`) are received via the ordinary `AeronSource` for the system messages channel/stream and then piped back to the corresponding delivery stage via an async callback.

Here are two sketches of the flow:

![img_3029](https://cloud.githubusercontent.com/assets/336161/15013297/180fa698-11ff-11e6-9488-5a0595b6cf31.JPG)

![img_3030](https://cloud.githubusercontent.com/assets/336161/15013300/1ea0f516-11ff-11e6-93da-114faab39d20.JPG)
