### PR TITLE
=act #20447 fix UntypedActorWithStash javadoc

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/UntypedActorWithStash.scala
+++ b/akka-actor/src/main/scala/akka/actor/UntypedActorWithStash.scala
@@ -47,14 +47,14 @@ package akka.actor
 abstract class UntypedActorWithStash extends UntypedActor with Stash
 
 /**
- * Actor base class with `Stash` that enforces an unbounded deque for the actor. The proper mailbox has to be configured
- * manually, and the mailbox should extend the [[akka.dispatch.DequeBasedMessageQueueSemantics]] marker trait.
+ * Actor base class with `Stash` that enforces an unbounded deque for the actor.
  * See [[akka.actor.UntypedActorWithStash]] for details on how `Stash` works.
  */
 abstract class UntypedActorWithUnboundedStash extends UntypedActor with UnboundedStash
 
 /**
- * Actor base class with `Stash` that does not enforce any mailbox type. The mailbox of the actor has to be configured
- * manually. See [[akka.actor.UntypedActorWithStash]] for details on how `Stash` works.
+ * Actor base class with `Stash` that does not enforce any mailbox type. The proper mailbox has to be configured
+ * manually, and the mailbox should extend the [[akka.dispatch.DequeBasedMessageQueueSemantics]] marker trait.
+ * See [[akka.actor.UntypedActorWithStash]] for details on how `Stash` works.
  */
 abstract class UntypedActorWithUnrestrictedStash extends UntypedActor with UnrestrictedStash


### PR DESCRIPTION
Fixes  #20447 

Docs was switched between `UntypedActorWithUnboundedStash` and `UntypedActorWithUnrestrictedStash`
