### PR TITLE
Buffer and header parsing support

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
@@ -7,8 +7,8 @@ package akka.remote
 import akka.remote.WireFormats._
 import akka.protobuf.ByteString
 import akka.actor.ExtendedActorSystem
-import akka.serialization.SerializationExtension
-import akka.serialization.SerializerWithStringManifest
+import akka.remote.artery.{ EnvelopeBuffer, HeaderBuilder }
+import akka.serialization.{ Serialization, SerializationExtension, SerializerWithStringManifest }
 
 /**
  * INTERNAL API
@@ -46,5 +46,34 @@ private[akka] object MessageSerializer {
           builder.setMessageManifest(ByteString.copyFromUtf8(message.getClass.getName))
     }
     builder.build
+  }
+
+  def serializeForArtery(serialization: Serialization, message: AnyRef, headerBuilder: HeaderBuilder, envelope: EnvelopeBuffer): Unit = {
+    val serializer = serialization.findSerializerFor(message)
+
+    // FIXME: This should be a FQCN instead
+    headerBuilder.serializer = serializer.identifier.toString
+    serializer match {
+      case ser2: SerializerWithStringManifest ⇒
+        val manifest = ser2.manifest(message)
+        headerBuilder.classManifest = manifest
+      case _ ⇒
+        headerBuilder.classManifest = message.getClass.getName
+    }
+
+    envelope.writeHeader(headerBuilder)
+    // FIXME: This should directly write to the buffer instead
+    envelope.byteBuffer.put(serializer.toBinary(message))
+  }
+
+  def deserializeForArtery(system: ExtendedActorSystem, headerBuilder: HeaderBuilder, envelope: EnvelopeBuffer): AnyRef = {
+    // FIXME: Use the buffer directly
+    val size = envelope.byteBuffer.limit - envelope.byteBuffer.position
+    val bytes = Array.ofDim[Byte](size)
+    envelope.byteBuffer.get(bytes)
+    SerializationExtension(system).deserialize(
+      bytes,
+      Integer.parseInt(headerBuilder.serializer), // FIXME: Use FQCN
+      headerBuilder.classManifest).get
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
@@ -1,0 +1,316 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.remote.artery
+
+import java.lang.reflect.Field
+import java.nio.charset.Charset
+import java.nio.{ ByteBuffer, ByteOrder }
+
+import org.agrona.concurrent.{ ManyToManyConcurrentArrayQueue, UnsafeBuffer }
+import sun.misc.Cleaner
+
+import scala.util.control.NonFatal
+
+/**
+ * INTERNAL API
+ */
+private[remote] class OutOfBuffersException extends RuntimeException("Out of usable ByteBuffers")
+
+/**
+ * INTERNAL API
+ */
+private[remote] class EnvelopeBufferPool(maximumPayload: Int, maximumBuffers: Int) {
+  private val availableBuffers = new ManyToManyConcurrentArrayQueue[EnvelopeBuffer](maximumBuffers)
+
+  def acquire(): EnvelopeBuffer = {
+    val buf = availableBuffers.poll()
+    if (buf ne null) {
+      buf.byteBuffer.clear()
+      buf
+    } else {
+      val newBuf = new EnvelopeBuffer(ByteBuffer.allocateDirect(maximumPayload))
+      newBuf.byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+      newBuf
+    }
+  }
+
+  def release(buffer: EnvelopeBuffer) = if (!availableBuffers.offer(buffer)) buffer.tryForceDrop()
+
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] object EnvelopeBuffer {
+
+  val TagTypeMask = 0xFF000000
+  val TagValueMask = 0x0000FFFF
+
+  val VersionOffset = 0
+  val UidOffset = 4
+  val SenderActorRefTagOffset = 8
+  val RecipientActorRefTagOffset = 12
+  val SerializerTagOffset = 16
+  val ClassManifestTagOffset = 24
+
+  val LiteralsSectionOffset = 32
+
+  val UsAscii = Charset.forName("US-ASCII")
+
+  val DeadLettersCode = 0
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] trait LiteralCompressionTable {
+
+  def compressActorRef(ref: String): Int
+  def decompressActorRef(idx: Int): String
+
+  def compressSerializer(serializer: String): Int
+  def decompressSerializer(idx: Int): String
+
+  def compressClassManifest(manifest: String): Int
+  def decompressClassManifest(idx: Int): String
+
+}
+
+object HeaderBuilder {
+  def apply(compressionTable: LiteralCompressionTable): HeaderBuilder = new HeaderBuilderImpl(compressionTable)
+}
+
+/**
+ * INTERNAL API
+ */
+sealed trait HeaderBuilder {
+  def version_=(v: Int): Unit
+  def version: Int
+
+  def uid_=(u: Int): Unit
+  def uid: Int
+
+  def senderActorRef_=(ref: String): Unit
+  def senderActorRef: String
+
+  def setNoSender(): Unit
+
+  def recipientActorRef_=(ref: String): Unit
+  def recipientActorRef: String
+
+  def serializer_=(serializer: String): Unit
+  def serializer: String
+
+  def classManifest_=(manifest: String): Unit
+  def classManifest: String
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] final class HeaderBuilderImpl(val compressionTable: LiteralCompressionTable) extends HeaderBuilder {
+  var version: Int = _
+  var uid: Int = _
+
+  // Fields only available for EnvelopeBuffer
+  var _senderActorRef: String = null
+  var _senderActorRefIdx: Int = -1
+  var _recipientActorRef: String = null
+  var _recipientActorRefIdx: Int = -1
+
+  var _serializer: String = null
+  var _serializerIdx: Int = -1
+  var _classManifest: String = null
+  var _classManifestIdx: Int = -1
+
+  def senderActorRef_=(ref: String): Unit = {
+    _senderActorRef = ref
+    _senderActorRefIdx = compressionTable.compressActorRef(ref)
+  }
+
+  def setNoSender(): Unit = {
+    _senderActorRef = null
+    _senderActorRefIdx = EnvelopeBuffer.DeadLettersCode
+  }
+
+  def senderActorRef: String = {
+    if (_senderActorRef ne null) _senderActorRef
+    else {
+      _senderActorRef = compressionTable.decompressActorRef(_senderActorRefIdx)
+      _senderActorRef
+    }
+  }
+
+  def recipientActorRef_=(ref: String): Unit = {
+    _recipientActorRef = ref
+    _recipientActorRefIdx = compressionTable.compressActorRef(ref)
+  }
+
+  def recipientActorRef: String = {
+    if (_recipientActorRef ne null) _recipientActorRef
+    else {
+      _recipientActorRef = compressionTable.decompressActorRef(_recipientActorRefIdx)
+      _recipientActorRef
+    }
+  }
+
+  override def serializer_=(serializer: String): Unit = {
+    _serializer = serializer
+    _serializerIdx = compressionTable.compressSerializer(serializer)
+  }
+
+  override def serializer: String = {
+    if (_serializer ne null) _serializer
+    else {
+      _serializer = compressionTable.decompressSerializer(_serializerIdx)
+      _serializer
+    }
+  }
+
+  override def classManifest_=(manifest: String): Unit = {
+    _classManifest = manifest
+    _classManifestIdx = compressionTable.compressClassManifest(manifest)
+  }
+
+  override def classManifest: String = {
+    if (_classManifest ne null) _classManifest
+    else {
+      _classManifest = compressionTable.decompressClassManifest(_classManifestIdx)
+      _classManifest
+    }
+  }
+
+  override def toString = s"HeaderBuilderImpl($version, $uid, ${_senderActorRef}, ${_senderActorRefIdx}, ${_recipientActorRef}, ${_recipientActorRefIdx}, ${_serializer}, ${_serializerIdx}, ${_classManifest}, ${_classManifestIdx})"
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
+  import EnvelopeBuffer._
+  val aeronBuffer = new UnsafeBuffer(byteBuffer)
+
+  private val cleanerField: Field = try {
+    val cleaner = byteBuffer.getClass.getDeclaredField("cleaner")
+    cleaner.setAccessible(true)
+    cleaner
+  } catch {
+    case NonFatal(_) ⇒ null
+  }
+
+  def tryForceDrop(): Unit = {
+    if (cleanerField ne null) cleanerField.get(byteBuffer) match {
+      case cleaner: Cleaner ⇒ cleaner.clean()
+      case _                ⇒
+    }
+  }
+
+  def writeHeader(h: HeaderBuilder): Unit = {
+    val header = h.asInstanceOf[HeaderBuilderImpl]
+    byteBuffer.clear()
+
+    // Write fixed length parts
+    byteBuffer.putInt(header.version)
+    byteBuffer.putInt(header.uid)
+
+    // Write compressable, variable-length parts always to the actual position of the buffer
+    // Write tag values explicitly in their proper offset
+    byteBuffer.position(LiteralsSectionOffset)
+
+    // Serialize sender
+    if (header._senderActorRefIdx != -1)
+      byteBuffer.putInt(SenderActorRefTagOffset, header._senderActorRefIdx | TagTypeMask)
+    else
+      writeLiteral(SenderActorRefTagOffset, header._senderActorRef)
+
+    // Serialize recipient
+    if (header._recipientActorRefIdx != -1)
+      byteBuffer.putInt(RecipientActorRefTagOffset, header._recipientActorRefIdx | TagTypeMask)
+    else
+      writeLiteral(RecipientActorRefTagOffset, header._recipientActorRef)
+
+    // Serialize serializer
+    if (header._serializerIdx != -1)
+      byteBuffer.putInt(SerializerTagOffset, header._serializerIdx | TagTypeMask)
+    else
+      writeLiteral(SerializerTagOffset, header._serializer)
+
+    // Serialize class manifest
+    if (header._classManifestIdx != -1)
+      byteBuffer.putInt(ClassManifestTagOffset, header._classManifestIdx | TagTypeMask)
+    else
+      writeLiteral(ClassManifestTagOffset, header._classManifest)
+  }
+
+  def parseHeader(h: HeaderBuilder): Unit = {
+    val header = h.asInstanceOf[HeaderBuilderImpl]
+
+    // Read fixed length parts
+    header.version = byteBuffer.getInt
+    header.uid = byteBuffer.getInt
+
+    // Read compressable, variable-length parts always from the actual position of the buffer
+    // Read tag values explicitly from their proper offset
+    byteBuffer.position(LiteralsSectionOffset)
+
+    // Deserialize sender
+    val senderTag = byteBuffer.getInt(SenderActorRefTagOffset)
+    if ((senderTag & TagTypeMask) != 0) {
+      val idx = senderTag & TagValueMask
+      header._senderActorRef = null
+      header._senderActorRefIdx = idx
+    } else {
+      header._senderActorRef = readLiteral()
+    }
+
+    // Deserialize recipient
+    val recipientTag = byteBuffer.getInt(RecipientActorRefTagOffset)
+    if ((recipientTag & TagTypeMask) != 0) {
+      val idx = recipientTag & TagValueMask
+      header._recipientActorRef = null
+      header._recipientActorRefIdx = idx
+    } else {
+      header._recipientActorRef = readLiteral()
+    }
+
+    // Deserialize serializer
+    val serializerTag = byteBuffer.getInt(SerializerTagOffset)
+    if ((serializerTag & TagTypeMask) != 0) {
+      val idx = serializerTag & TagValueMask
+      header._serializer = null
+      header._serializerIdx = idx
+    } else {
+      header._serializer = readLiteral()
+    }
+
+    // Deserialize class manifest
+    val classManifestTag = byteBuffer.getInt(ClassManifestTagOffset)
+    if ((classManifestTag & TagTypeMask) != 0) {
+      val idx = classManifestTag & TagValueMask
+      header._classManifest = null
+      header._classManifestIdx = idx
+    } else {
+      header._classManifest = readLiteral()
+    }
+  }
+
+  private def readLiteral(): String = {
+    val length = byteBuffer.getShort
+    val bytes = Array.ofDim[Byte](length)
+    byteBuffer.get(bytes)
+    new String(bytes, UsAscii)
+  }
+
+  private def writeLiteral(tagOffset: Int, literal: String): Unit = {
+    if (literal.length > 65535)
+      throw new IllegalArgumentException("Literals longer than 65535 cannot be encoded in the envelope")
+
+    val literalBytes = literal.getBytes(UsAscii)
+    byteBuffer.putInt(tagOffset, byteBuffer.position())
+    byteBuffer.putShort(literalBytes.length.toShort)
+    byteBuffer.put(literalBytes)
+  }
+
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -1,0 +1,103 @@
+package akka.remote.artery
+
+import akka.actor.{ ActorRef, InternalActorRef }
+import akka.remote.EndpointManager.Send
+import akka.remote.{ MessageSerializer, UniqueAddress }
+import akka.serialization.{ Serialization, SerializationExtension }
+import akka.stream._
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+
+// TODO: Long UID
+class Encoder(
+  transport: ArteryTransport,
+  compressionTable: LiteralCompressionTable)
+  extends GraphStage[FlowShape[Send, EnvelopeBuffer]] {
+
+  val in: Inlet[Send] = Inlet("Artery.Encoder.in")
+  val out: Outlet[EnvelopeBuffer] = Outlet("Artery.Encoder.out")
+  val shape: FlowShape[Send, EnvelopeBuffer] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      private val pool = transport.envelopePool
+      private val headerBuilder = HeaderBuilder(compressionTable)
+      headerBuilder.version = ArteryTransport.Version
+      headerBuilder.uid = transport.localAddress.uid
+      private val localAddress = transport.localAddress.address
+      private val serialization = SerializationExtension(transport.system)
+
+      override def onPush(): Unit = {
+        val send = grab(in)
+        val envelope = pool.acquire()
+
+        headerBuilder.recipientActorRef = send.recipient.path.toSerializationFormat
+        send.senderOption match {
+          case Some(sender) ⇒
+            headerBuilder.senderActorRef = sender.path.toSerializationFormatWithAddress(localAddress)
+          case None ⇒
+            //headerBuilder.setNoSender()
+            headerBuilder.senderActorRef = transport.system.deadLetters.path.toSerializationFormatWithAddress(localAddress)
+        }
+
+        // FIXME: Thunk allocation
+        Serialization.currentTransportInformation.withValue(Serialization.Information(localAddress, transport.system)) {
+          MessageSerializer.serializeForArtery(serialization, send.message.asInstanceOf[AnyRef], headerBuilder, envelope)
+        }
+
+        //println(s"${headerBuilder.senderActorRef} --> ${headerBuilder.recipientActorRef} ${headerBuilder.classManifest}")
+
+        envelope.byteBuffer.flip()
+        push(out, envelope)
+      }
+
+      override def onPull(): Unit = pull(in)
+
+      setHandlers(in, out, this)
+    }
+}
+
+class Decoder(
+  transport: ArteryTransport,
+  compressionTable: LiteralCompressionTable) extends GraphStage[FlowShape[EnvelopeBuffer, InboundEnvelope]] {
+  val in: Inlet[EnvelopeBuffer] = Inlet("Artery.Decoder.in")
+  val out: Outlet[InboundEnvelope] = Outlet("Artery.Decoder.out")
+  val shape: FlowShape[EnvelopeBuffer, InboundEnvelope] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      private val pool = transport.envelopePool
+      private val localAddress = transport.localAddress.address
+      private val provider = transport.provider
+      private val headerBuilder = HeaderBuilder(compressionTable)
+
+      override def onPush(): Unit = {
+        val envelope = grab(in)
+        envelope.parseHeader(headerBuilder)
+
+        //println(s"${headerBuilder.recipientActorRef} <-- ${headerBuilder.senderActorRef} ${headerBuilder.classManifest}")
+
+        // FIXME: Instead of using Strings, the headerBuilder should automatically return cached ActorRef instances
+        // in case of compression is enabled
+        // FIXME: Is localAddress really needed?
+        val recipient: InternalActorRef =
+          provider.resolveActorRefWithLocalAddress(headerBuilder.recipientActorRef, localAddress)
+        val sender: ActorRef =
+          provider.resolveActorRefWithLocalAddress(headerBuilder.senderActorRef, localAddress)
+
+        val decoded = InboundEnvelope(
+          recipient,
+          localAddress, // FIXME: Is this needed anymore? What should we do here?
+          MessageSerializer.deserializeForArtery(transport.system, headerBuilder, envelope),
+          Some(sender), // FIXME: No need for an option, decode simply to deadLetters instead
+          UniqueAddress(sender.path.address, headerBuilder.uid))
+
+        pool.release(envelope)
+        push(out, decoded)
+      }
+
+      override def onPull(): Unit = pull(in)
+
+      setHandlers(in, out, this)
+    }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/Compression.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Compression.scala
@@ -1,0 +1,23 @@
+package akka.remote.artery
+
+import akka.actor.ActorSystem
+
+/**
+ * INTERNAL API
+ */
+// FIXME: Dummy compression table, needs to be replaced by the real deal
+// Currently disables all compression
+private[remote] class Compression(system: ActorSystem) extends LiteralCompressionTable {
+  // FIXME: Of course it is foolish to store this as String, but this is a stub
+  val deadLettersString = system.deadLetters.path.toSerializationFormat
+
+  override def compressActorRef(ref: String): Int = -1
+  override def decompressActorRef(idx: Int): String = ???
+
+  override def compressSerializer(serializer: String): Int = -1
+  override def decompressSerializer(idx: Int): String = ???
+
+  override def compressClassManifest(manifest: String): Int = -1
+  override def decompressClassManifest(idx: Int): String = ???
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
@@ -1,0 +1,169 @@
+package akka.remote.artery
+
+import java.nio.{ ByteBuffer, ByteOrder }
+
+import akka.testkit.AkkaSpec
+import akka.util.ByteString
+
+class EnvelopeBufferSpec extends AkkaSpec {
+
+  object TestCompressor extends LiteralCompressionTable {
+    val refToIdx = Map(
+      "compressable0" -> 0,
+      "compressable1" -> 1,
+      "reallylongcompressablestring" -> 2)
+    val idxToRef = refToIdx.map(_.swap)
+
+    val serializerToIdx = Map(
+      "serializer0" -> 0,
+      "serializer1" -> 1)
+    val idxToSer = serializerToIdx.map(_.swap)
+
+    val manifestToIdx = Map(
+      "manifest0" -> 0,
+      "manifest1" -> 1)
+    val idxToManifest = manifestToIdx.map(_.swap)
+
+    override def compressActorRef(ref: String): Int = refToIdx.getOrElse(ref, -1)
+    override def decompressActorRef(idx: Int): String = idxToRef(idx)
+    override def compressSerializer(serializer: String): Int = serializerToIdx.getOrElse(serializer, -1)
+    override def decompressSerializer(idx: Int): String = idxToSer(idx)
+    override def compressClassManifest(manifest: String): Int = manifestToIdx.getOrElse(manifest, -1)
+    override def decompressClassManifest(idx: Int): String = idxToManifest(idx)
+  }
+
+  "EnvelopeBuffer" must {
+    val headerIn = HeaderBuilder(TestCompressor)
+    val headerOut = HeaderBuilder(TestCompressor)
+
+    val byteBuffer = ByteBuffer.allocate(1024).order(ByteOrder.LITTLE_ENDIAN)
+    val envelope = new EnvelopeBuffer(byteBuffer)
+
+    "be able to encode and decode headers with compressed literals" in {
+      headerIn.version = 1
+      headerIn.uid = 42
+      headerIn.senderActorRef = "compressable0"
+      headerIn.recipientActorRef = "compressable1"
+      headerIn.serializer = "serializer0"
+      headerIn.classManifest = "manifest1"
+
+      envelope.writeHeader(headerIn)
+      envelope.byteBuffer.position() should ===(EnvelopeBuffer.LiteralsSectionOffset) // Fully compressed header
+
+      envelope.byteBuffer.flip()
+      envelope.parseHeader(headerOut)
+
+      headerOut.version should ===(1)
+      headerOut.uid should ===(42)
+      headerOut.senderActorRef should ===("compressable0")
+      headerOut.recipientActorRef should ===("compressable1")
+      headerOut.serializer should ===("serializer0")
+      headerOut.classManifest should ===("manifest1")
+    }
+
+    "be able to encode and decode headers with uncompressed literals" in {
+      headerIn.version = 1
+      headerIn.uid = 42
+      headerIn.senderActorRef = "uncompressable0"
+      headerIn.recipientActorRef = "uncompressable11"
+      headerIn.serializer = "uncompressable222"
+      headerIn.classManifest = "uncompressable3333"
+
+      val expectedHeaderLength =
+        EnvelopeBuffer.LiteralsSectionOffset + // Constant header part
+          2 + headerIn.senderActorRef.length + // Length field + literal
+          2 + headerIn.recipientActorRef.length + // Length field + literal
+          2 + headerIn.serializer.length + // Length field + literal
+          2 + headerIn.classManifest.length // Length field + literal
+
+      envelope.writeHeader(headerIn)
+      envelope.byteBuffer.position() should ===(expectedHeaderLength)
+
+      envelope.byteBuffer.flip()
+      envelope.parseHeader(headerOut)
+
+      headerOut.version should ===(1)
+      headerOut.uid should ===(42)
+      headerOut.senderActorRef should ===("uncompressable0")
+      headerOut.recipientActorRef should ===("uncompressable11")
+      headerOut.serializer should ===("uncompressable222")
+      headerOut.classManifest should ===("uncompressable3333")
+    }
+
+    "be able to encode and decode headers with mixed literals" in {
+      headerIn.version = 1
+      headerIn.uid = 42
+      headerIn.senderActorRef = "reallylongcompressablestring"
+      headerIn.recipientActorRef = "uncompressable1"
+      headerIn.serializer = "longuncompressedserializer"
+      headerIn.classManifest = "manifest1"
+
+      envelope.writeHeader(headerIn)
+      envelope.byteBuffer.position() should ===(
+        EnvelopeBuffer.LiteralsSectionOffset +
+          2 + headerIn.recipientActorRef.length +
+          2 + headerIn.serializer.length)
+
+      envelope.byteBuffer.flip()
+      envelope.parseHeader(headerOut)
+
+      headerOut.version should ===(1)
+      headerOut.uid should ===(42)
+      headerOut.senderActorRef should ===("reallylongcompressablestring")
+      headerOut.recipientActorRef should ===("uncompressable1")
+      headerOut.serializer should ===("longuncompressedserializer")
+      headerOut.classManifest should ===("manifest1")
+
+      headerIn.version = 3
+      headerIn.uid = Int.MinValue
+      headerIn.senderActorRef = "uncompressable0"
+      headerIn.recipientActorRef = "reallylongcompressablestring"
+      headerIn.serializer = "serializer0"
+      headerIn.classManifest = "longlonglongliteralmanifest"
+
+      envelope.writeHeader(headerIn)
+      envelope.byteBuffer.position() should ===(
+        EnvelopeBuffer.LiteralsSectionOffset +
+          2 + headerIn.senderActorRef.length +
+          2 + headerIn.classManifest.length)
+
+      envelope.byteBuffer.flip()
+      envelope.parseHeader(headerOut)
+
+      headerOut.version should ===(3)
+      headerOut.uid should ===(Int.MinValue)
+      headerOut.senderActorRef should ===("uncompressable0")
+      headerOut.recipientActorRef should ===("reallylongcompressablestring")
+      headerOut.serializer should ===("serializer0")
+      headerOut.classManifest should ===("longlonglongliteralmanifest")
+    }
+
+    "be able to encode and decode headers with mixed literals and payload" in {
+      val payload = ByteString("Hello Artery!")
+
+      headerIn.version = 1
+      headerIn.uid = 42
+      headerIn.senderActorRef = "reallylongcompressablestring"
+      headerIn.recipientActorRef = "uncompressable1"
+      headerIn.serializer = "serializer1"
+      headerIn.classManifest = "manifest1"
+
+      envelope.writeHeader(headerIn)
+      envelope.byteBuffer.put(payload.toByteBuffer)
+      envelope.byteBuffer.flip()
+
+      envelope.parseHeader(headerOut)
+
+      headerOut.version should ===(1)
+      headerOut.uid should ===(42)
+      headerOut.senderActorRef should ===("reallylongcompressablestring")
+      headerOut.recipientActorRef should ===("uncompressable1")
+      headerOut.serializer should ===("serializer1")
+      headerOut.classManifest should ===("manifest1")
+
+      ByteString.fromByteBuffer(envelope.byteBuffer) should ===(payload)
+    }
+
+  }
+
+}


### PR DESCRIPTION
First stab at an efficient, ByteBuffer based, envelope codec that is allocation-free for compressed literals.

Not all fields are there, and we need to do something about origin address.
