### PR TITLE
Observable cluster client and its receptionist

### DIFF
--- a/akka-cluster-tools/src/main/resources/reference.conf
+++ b/akka-cluster-tools/src/main/resources/reference.conf
@@ -72,6 +72,20 @@ akka.cluster.client.receptionist {
   # If specified you need to define the settings of the actual dispatcher.
   use-dispatcher = ""
 
+  # How often failure detection heartbeat messages should be received for
+  # each ClusterClient
+  heartbeat-interval = 2s
+
+  # Number of potentially lost/delayed heartbeats that will be
+  # accepted before considering it to be an anomaly.
+  # The ClusterReceptionist is using the akka.remote.DeadlineFailureDetector, which
+  # will trigger if there are no heartbeats within the duration
+  # heartbeat-interval + acceptable-heartbeat-pause, i.e. 15 seconds with
+  # the default settings.
+  acceptable-heartbeat-pause = 13s
+
+  # Failure detection checking interval for checking all ClusterClients
+  failure-detection-interval = 2s
 }
 # //#receptionist-ext-config
 

--- a/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
@@ -4,6 +4,7 @@
 
 package akka.cluster.client;
 
+import akka.actor.*;
 import com.typesafe.config.ConfigFactory;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,12 +12,6 @@ import java.util.Set;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import akka.actor.ActorPath;
-import akka.actor.ActorPaths;
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.UntypedActor;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import org.scalatest.junit.JUnitSuite;
 
@@ -57,10 +52,80 @@ public class ClusterClientTest extends JUnitSuite {
     c.tell(new ClusterClient.Send("/user/serviceA", "hello", true), ActorRef.noSender());
     c.tell(new ClusterClient.SendToAll("/user/serviceB", "hi"), ActorRef.noSender());
     //#client
+
+    system.actorOf(Props.create(ClientListener.class, c));
+    system.actorOf(Props.create(ReceptionistListener.class, ClusterClientReceptionist.get(system).underlying()));
   }
 
   static public class Service extends UntypedActor {
     public void onReceive(Object msg) {
     }
   }
+
+  //#clientEventsListener
+  static public class ClientListener extends UntypedActor {
+    private final ActorRef targetClient;
+    private final Set<ActorPath> contactPoints = new HashSet<>();
+
+    public ClientListener(ActorRef targetClient) {
+      this.targetClient = targetClient;
+    }
+
+    @Override
+    public void preStart() {
+      targetClient.tell(SubscribeContactPoints.getInstance(), sender());
+    }
+
+    @Override
+    public void onReceive(Object message) {
+      if (message instanceof ContactPoints) {
+        ContactPoints msg = (ContactPoints)message;
+        contactPoints.addAll(msg.getContactPoints());
+        // Now do something with an up-to-date "contactPoints"
+      } else if (message instanceof ContactPointAdded) {
+        ContactPointAdded msg = (ContactPointAdded) message;
+        contactPoints.add(msg.contactPoint());
+        // Now do something with an up-to-date "contactPoints"
+      } else if (message instanceof ContactPointRemoved) {
+        ContactPointRemoved msg = (ContactPointRemoved)message;
+        contactPoints.remove(msg.contactPoint());
+        // Now do something with an up-to-date "contactPoints"
+      }
+    }
+  }
+  //#clientEventsListener
+
+  //#receptionistEventsListener
+  static public class ReceptionistListener extends UntypedActor {
+    private final ActorRef targetReceptionist;
+    private final Set<ActorRef> clusterClients = new HashSet<>();
+
+    public ReceptionistListener(ActorRef targetReceptionist) {
+      this.targetReceptionist = targetReceptionist;
+    }
+
+    @Override
+    public void preStart() {
+      targetReceptionist.tell(SubscribeClusterClients.getInstance(), sender());
+    }
+
+    @Override
+    public void onReceive(Object message) {
+      if (message instanceof ClusterClients) {
+        ClusterClients msg = (ClusterClients) message;
+        clusterClients.addAll(msg.getClusterClients());
+        // Now do something with an up-to-date "clusterClients"
+      } else if (message instanceof ClusterClientUp) {
+        ClusterClientUp msg = (ClusterClientUp) message;
+        clusterClients.add(msg.clusterClient());
+        // Now do something with an up-to-date "clusterClients"
+      } else if (message instanceof ClusterClientUnreachable) {
+        ClusterClientUnreachable msg = (ClusterClientUnreachable) message;
+        clusterClients.remove(msg.clusterClient());
+        // Now do something with an up-to-date "clusterClients"
+      }
+    }
+  }
+  //#receptionistEventsListener
+
 }

--- a/akka-docs/rst/java/cluster-client.rst
+++ b/akka-docs/rst/java/cluster-client.rst
@@ -33,6 +33,16 @@ The ``ClusterClientReceptionist`` provides methods for registration of actors th
 should be reachable from the client. Messages are wrapped in ``ClusterClient.Send``,
 ``ClusterClient.SendToAll`` or ``ClusterClient.Publish``.
 
+Both the ``ClusterClient`` and the ``ClusterClientReceptionist`` emit events that can be subscribed to.
+The ``ClusterClient`` sends out notifications in relation to having received a list of contact points
+from the ``ClusterClientReceptionist``. One use of this list might be for the client to record its
+contact points. A client that is restarted could then use this information to supersede any previously
+configured contact points.
+
+The ``ClusterClientReceptionist`` sends out notifications in relation to having received a contact
+from a ``ClusterClient``. This notification enables the server containing the receptionist to become aware of
+what clients are connected.
+
 **1. ClusterClient.Send**
 
 The message will be delivered to one recipient with a matching path, if any such
@@ -111,6 +121,19 @@ It is recommended to load the extension when the actor system is started by defi
 ``akka.extensions`` configuration property::
 
    akka.extensions = ["akka.cluster.client.ClusterClientReceptionist"]
+
+Events
+------
+As mentioned earlier, both the ``ClusterClient`` and ``ClusterClientReceptionist`` emit events that can be subscribed to.
+The following code snippet declares an actor that will receive notifications on contact points (addresses to the available
+receptionists), as they become available. The code illustrates subscribing to the events and receiving the ``ClusterClient``
+initial state.
+
+.. includecode:: ../../../akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java#clientEventsListener
+
+Similarly we can have an actor that behaves in a similar fashion for learning what cluster clients contact a ``ClusterClientReceptionist``:
+
+.. includecode:: ../../../akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java#receptionistEventsListener
 
 Dependencies
 ------------

--- a/akka-docs/rst/scala/cluster-client.rst
+++ b/akka-docs/rst/scala/cluster-client.rst
@@ -33,6 +33,16 @@ The ``ClusterClientReceptionist`` provides methods for registration of actors th
 should be reachable from the client. Messages are wrapped in ``ClusterClient.Send``,
 ``ClusterClient.SendToAll`` or ``ClusterClient.Publish``.
 
+Both the ``ClusterClient`` and the ``ClusterClientReceptionist`` emit events that can be subscribed to.
+The ``ClusterClient`` sends out notifications in relation to having received a list of contact points
+from the ``ClusterClientReceptionist``. One use of this list might be for the client to record its
+contact points. A client that is restarted could then use this information to supersede any previously
+configured contact points.
+
+The ``ClusterClientReceptionist`` sends out notifications in relation to having received contact
+from a ``ClusterClient``. This notification enables the server containing the receptionist to become aware of
+what clients are connected.
+
 **1. ClusterClient.Send**
 
 The message will be delivered to one recipient with a matching path, if any such
@@ -111,6 +121,19 @@ It is recommended to load the extension when the actor system is started by defi
 ``akka.extensions`` configuration property::
 
    akka.extensions = ["akka.cluster.client.ClusterClientReceptionist"]
+
+Events
+------
+As mentioned earlier, both the ``ClusterClient`` and ``ClusterClientReceptionist`` emit events that can be subscribed to.
+The following code snippet declares an actor that will receive notifications on contact points (addresses to the available
+receptionists), as they become available. The code illustrates subscribing to the events and receiving the ``ClusterClient``
+initial state.
+
+.. includecode:: ../../../akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala#clientEventsListener
+
+Similarly we can have an actor that behaves in a similar fashion for learning what cluster clients contact a ``ClusterClientReceptionist``:
+
+.. includecode:: ../../../akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala#receptionistEventsListener
 
 Dependencies
 ------------

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -797,7 +797,12 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[MissingTypesProblem]("akka.stream.extra.Timed$StopTimed"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.extra.Timed#StopTimed.onPush"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.extra.Timed#StopTimed.onUpstreamFinish"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.extra.Timed#StopTimed.onUpstreamFailure")
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.extra.Timed#StopTimed.onUpstreamFailure"),
+
+        // #20462 - now uses a Set instead of a Seq within the private API of the cluster client
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.client.ClusterClient.contacts_="),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.client.ClusterClient.contacts"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.client.ClusterClient.initialContactsSel")
       )
     )
   }


### PR DESCRIPTION
Allows the cluster client and its receptionist to be observable in terms of contact points becoming available and client heartbeats.

Fixes #20446
