### PR TITLE
handle tick wrap around in LARS, #20424 (for validation)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -466,6 +466,33 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
       }
     }
 
+    "correctly wrap around ticks" in {
+      val numEvents = 40
+      val targetTicks = Int.MaxValue - numEvents + 20
+
+      withScheduler(_startTick = Int.MaxValue - 100) { (sched, driver) ⇒
+        implicit def ec = localEC
+        import driver._
+
+        val start = step / 2
+
+        wakeUp(step * targetTicks)
+        probe.expectMsgType[Long]
+
+        val nums = 0 until numEvents
+        nums foreach (i ⇒ sched.scheduleOnce(start + step * i, testActor, "hello-" + i))
+        expectNoMsg(step)
+        wakeUp(step)
+        expectWait(step)
+
+        nums foreach { i ⇒
+          wakeUp(step)
+          expectMsg("hello-" + i)
+          expectWait(step)
+        }
+      }
+    }
+
     "reliably reject jobs when shutting down" in {
       withScheduler() { (sched, driver) ⇒
         import system.dispatcher
@@ -501,7 +528,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
     def reportFailure(t: Throwable) { t.printStackTrace() }
   }
 
-  def withScheduler(start: Long = 0L, config: Config = ConfigFactory.empty)(thunk: (Scheduler with Closeable, Driver) ⇒ Unit): Unit = {
+  def withScheduler(start: Long = 0L, _startTick: Int = 0, config: Config = ConfigFactory.empty)(thunk: (Scheduler with Closeable, Driver) ⇒ Unit): Unit = {
     import akka.actor.{ LightArrayRevolverScheduler ⇒ LARS }
     val lbq = new AtomicReference[LinkedBlockingQueue[Long]](new LinkedBlockingQueue[Long])
     val prb = TestProbe()
@@ -526,6 +553,8 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
             case _: InterruptedException ⇒ Thread.currentThread.interrupt()
           }
         }
+
+        override protected def startTick: Int = _startTick
       }
     val driver = new Driver {
       def wakeUp(d: FiniteDuration) = lbq.get match {

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -213,6 +213,11 @@ class LightArrayRevolverScheduler(config: Config,
   protected def clock(): Long = System.nanoTime
 
   /**
+   * Replaceable for testing.
+   */
+  protected def startTick: Int = 0
+
+  /**
    * Overridable for tests
    */
   protected def getShutdownTimeout: FiniteDuration = ShutdownTimeout
@@ -336,7 +341,8 @@ class LightArrayRevolverScheduler(config: Config,
 
   @volatile private var timerThread: Thread = threadFactory.newThread(new Runnable {
 
-    var tick = 0
+    var tick = startTick
+    var totalTick: Long = tick // tick count that doesn't wrap around, used for calculating sleep time
     val wheel = Array.fill(WheelSize)(new TaskQueue)
 
     private def clearAll(): immutable.Seq[TimerTask] = {
@@ -397,7 +403,7 @@ class LightArrayRevolverScheduler(config: Config,
 
     @tailrec final def nextTick(): Unit = {
       val time = clock()
-      val sleepTime = start + (tick * tickNanos) - time
+      val sleepTime = start + (totalTick * tickNanos) - time
 
       if (sleepTime > 0) {
         // check the queue before taking a nap
@@ -424,6 +430,7 @@ class LightArrayRevolverScheduler(config: Config,
         wheel(bucket) = putBack
 
         tick += 1
+        totalTick += 1
       }
       stopped.get match {
         case null ⇒ nextTick()


### PR DESCRIPTION
- keep track of total ticks in long

(cherry picked from commit 8d7354076b97d3cd452aadcc595515a7e5cfb14a)
