### PR TITLE
adding getLogger that accepts AbstractActor

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -582,6 +582,16 @@ object Logging {
   }
 
   /**
+    * Obtain LoggingAdapter with MDC support for the given actor.
+    * Don't use it outside its specific Actor as it isn't thread safe
+    */
+  def getLogger(logSource: AbstractActor): DiagnosticLoggingAdapter = {
+    val (str, clazz) = LogSource.fromAnyRef(logSource)
+    val system = logSource.getContext().system.asInstanceOf[ExtendedActorSystem]
+    new BusLogging(system.eventStream, str, clazz, system.logFilter) with DiagnosticLoggingAdapter
+  }
+
+  /**
    * Artificial exception injected into Error events if no Throwable is
    * supplied; used for getting a stack dump of error locations.
    */

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -576,7 +576,7 @@ object Logging {
     * Don't use it outside its specific Actor as it isn't thread safe
     */
   def getLogger(logSource: Actor): DiagnosticLoggingAdapter = {
-    val (str, clazz) = LogSource.fromAnyRef(logSource)
+    val (str, clazz) = LogSource(logSource)
     val system = logSource.context.system.asInstanceOf[ExtendedActorSystem]
     new BusLogging(system.eventStream, str, clazz, system.logFilter) with DiagnosticLoggingAdapter
   }

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -572,20 +572,20 @@ object Logging {
   }
 
   /**
-   * Obtain LoggingAdapter with MDC support for the given actor.
-   * Don't use it outside its specific Actor as it isn't thread safe
-   */
-  def getLogger(logSource: UntypedActor): DiagnosticLoggingAdapter = {
+    * Obtain LoggingAdapter with MDC support for the given actor.
+    * Don't use it outside its specific Actor as it isn't thread safe
+    */
+  def getLogger(logSource: Actor): DiagnosticLoggingAdapter = {
     val (str, clazz) = LogSource.fromAnyRef(logSource)
-    val system = logSource.getContext().system.asInstanceOf[ExtendedActorSystem]
+    val system = logSource.context.system.asInstanceOf[ExtendedActorSystem]
     new BusLogging(system.eventStream, str, clazz, system.logFilter) with DiagnosticLoggingAdapter
   }
 
   /**
-    * Obtain LoggingAdapter with MDC support for the given actor.
-    * Don't use it outside its specific Actor as it isn't thread safe
-    */
-  def getLogger(logSource: AbstractActor): DiagnosticLoggingAdapter = {
+   * Obtain LoggingAdapter with MDC support for the given actor.
+   * Don't use it outside its specific Actor as it isn't thread safe
+   */
+  def getLogger(logSource: UntypedActor): DiagnosticLoggingAdapter = {
     val (str, clazz) = LogSource.fromAnyRef(logSource)
     val system = logSource.getContext().system.asInstanceOf[ExtendedActorSystem]
     new BusLogging(system.eventStream, str, clazz, system.logFilter) with DiagnosticLoggingAdapter

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -575,11 +575,7 @@ object Logging {
     * Obtain LoggingAdapter with MDC support for the given actor.
     * Don't use it outside its specific Actor as it isn't thread safe
     */
-  def getLogger(logSource: Actor): DiagnosticLoggingAdapter = {
-    val (str, clazz) = LogSource(logSource)
-    val system = logSource.context.system.asInstanceOf[ExtendedActorSystem]
-    new BusLogging(system.eventStream, str, clazz, system.logFilter) with DiagnosticLoggingAdapter
-  }
+  def getLogger(logSource: Actor): DiagnosticLoggingAdapter = apply(logSource)
 
   /**
    * Obtain LoggingAdapter with MDC support for the given actor.


### PR DESCRIPTION
PR for https://github.com/akka/akka/issues/18818

I added a new function `getLogger(AbstractActor)` in addition to `getLogger(UntypedActor)`. 

Discussion point: if `Actor` trait declares `getContext: ActorContext`, we should be able to provide a more generic signature `getLogger(Actor)` as opposed to having two `getLogger`s as it is.
