### PR TITLE
[WIP] [act] Allow PFBuilder cases without type and only predicate

### DIFF
--- a/akka-actor-tests/src/test/java/akka/japi/MatchBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/MatchBuilderTest.java
@@ -4,15 +4,17 @@
 
 package akka.japi;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.scalatest.junit.JUnitSuite;
+
+import scala.MatchError;
 import akka.japi.pf.FI;
 import akka.japi.pf.Match;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
-import scala.MatchError;
-
-import static org.junit.Assert.*;
 
 public class MatchBuilderTest extends JUnitSuite {
 
@@ -21,7 +23,9 @@ public class MatchBuilderTest extends JUnitSuite {
 
   @Test
   public void shouldPassBasicMatchTest() {
-    Match<Object, Double> pf = Match.create(Match.match(Integer.class, new FI.Apply<Integer, Double>() {
+    
+      
+    Match<Object, Double> pf = Match.create(Match.<Object,Double>newBuilder().match(Integer.class, new FI.Apply<Integer, Double>() {
       @Override
       public Double apply(Integer integer) {
         return integer * 10.0;
@@ -51,7 +55,7 @@ public class MatchBuilderTest extends JUnitSuite {
 
   @Test
   public void shouldHandleMatchOnGenericClass() {
-    Match<Object, String> pf = Match.create(Match.match(GenericClass.class, new FI.Apply<GenericClass<String>, String>() {
+    Match<Object, String> pf = Match.create(Match.match(new FI.Apply<GenericClass<String>, String>() {
       @Override
       public String apply(GenericClass<String> stringGenericClass) {
         return stringGenericClass.val;
@@ -64,7 +68,7 @@ public class MatchBuilderTest extends JUnitSuite {
 
   @Test
   public void shouldHandleMatchWithPredicateOnGenericClass() {
-    Match<Object, String> pf = Match.create(Match.match(GenericClass.class, new FI.TypedPredicate<GenericClass<String>>() {
+    Match<Object, String> pf = Match.create(Match.<Object,String>newBuilder().match(new FI.TypedPredicate<GenericClass<String>>() {
       @Override
       public boolean defined(GenericClass<String> genericClass) {
         return !genericClass.val.isEmpty();

--- a/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
@@ -4,11 +4,14 @@
 
 package akka.japi.pf;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
-import scala.PartialFunction;
 
-import static org.junit.Assert.*;
+import scala.PartialFunction;
 
 public class PFBuilderTest extends JUnitSuite {
 
@@ -22,5 +25,57 @@ public class PFBuilderTest extends JUnitSuite {
     assertTrue(pf.isDefinedAt("hello"));
     assertTrue(pf.isDefinedAt("42"));
     assertEquals(42, pf.apply("42").intValue());
+  }
+  
+  interface TestInner {
+      public boolean exists();
+  }
+  
+  @Test
+  public void typed_pfbuilder_can_match_with_only_predicate_argument() {
+    PartialFunction<String,Integer> pf = Match
+      .match(String::isEmpty, emptyString -> 42)
+      .build();
+    
+    assertTrue(pf.isDefinedAt(""));
+    assertEquals(42, pf.apply("").intValue());
+    assertFalse(pf.isDefinedAt("42"));
+  }
+  
+  @Test
+  public void typed_pfbuilder_can_match_with_anonymous_inner_class() {
+    PartialFunction<Object,Integer> pf = new PFBuilder<Object,Integer>()
+      .match(TestInner::exists, obj -> 42)
+      .build();
+    
+    assertFalse(pf.isDefinedAt(new TestInner() {
+        @Override
+        public boolean exists() {
+            return false;
+        }
+    }));
+    assertTrue(pf.isDefinedAt(new TestInner() {
+        @Override
+        public boolean exists() {
+            return true;
+        }
+    }));
+    assertEquals(42, pf.apply(new TestInner() {
+        @Override
+        public boolean exists() {
+            return true;
+        }
+    }).intValue());
+  }
+  
+  @Test
+  public void typed_pfbuilder_can_match_with_only_predicate_argument_of_subclass() {
+    PartialFunction<Number,Integer> pf = new PFBuilder<Number,Integer>()
+      .match((Integer i) -> i == 0, n -> 42)
+      .build();
+    
+    assertFalse(pf.isDefinedAt(1.0f));
+    assertTrue(pf.isDefinedAt(0));
+    assertEquals(42, pf.apply(0).intValue());
   }
 }

--- a/akka-actor/src/main/java/akka/japi/pf/AbstractMatch.java
+++ b/akka-actor/src/main/java/akka/japi/pf/AbstractMatch.java
@@ -10,17 +10,17 @@ import scala.PartialFunction;
  * Version of {@link scala.PartialFunction} that can be built during
  * runtime from Java.
  *
- * @param <I> the input type, that this PartialFunction will be applied to
- * @param <R> the return type, that the results of the application will have
+ * @param <A> the input type, that this PartialFunction will be applied to
+ * @param <B> the return type, that the results of the application will have
  *
  * This is an EXPERIMENTAL feature and is subject to change until it has received more real world testing.
  */
-class AbstractMatch<I, R> {
+class AbstractMatch<A, B> {
 
-  protected final PartialFunction<I, R> statements;
+  protected final PartialFunction<A, B> statements;
 
-  AbstractMatch(PartialFunction<I, R> statements) {
-    PartialFunction<I, R> empty = CaseStatement.empty();
+  AbstractMatch(PartialFunction<A, B> statements) {
+    PartialFunction<A, B> empty = CaseStatement.empty();
     if (statements == null)
       this.statements = empty;
     else
@@ -32,7 +32,7 @@ class AbstractMatch<I, R> {
    *
    * @return  a partial function representation ot his {@link Match}
    */
-  public PartialFunction<I, R> asPF() {
+  public PartialFunction<A, B> asPF() {
     return statements;
   }
 }

--- a/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
@@ -4,15 +4,16 @@
 
 package akka.japi.pf;
 
+
 /**
  * A builder for {@link scala.PartialFunction}.
  *
- * @param <I> the input type, that this PartialFunction will be applied to
- * @param <R> the return type, that the results of the application will have
+ * @param <A> the input type, that this PartialFunction will be applied to
+ * @param <B> the return type, that the results of the application will have
  *
  * This is an EXPERIMENTAL feature and is subject to change until it has received more real world testing.
  */
-public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
+public final class PFBuilder<A, B> extends AbstractPFBuilder<A, B> {
 
   /**
    * Create a PFBuilder.
@@ -27,17 +28,10 @@ public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
    * @param apply an action to apply to the argument if the type matches
    * @return a builder with the case statement added
    */
-  @SuppressWarnings("unchecked")
-  public <P> PFBuilder<I, R> match(final Class<? extends P> type, FI.Apply<? extends P, R> apply) {
-
-    FI.Predicate predicate = new FI.Predicate() {
-      @Override
-      public boolean defined(Object o) {
-        return type.isInstance(o);
-      }
-    };
-
-    addStatement(new CaseStatement<I, P, R>(predicate, (FI.Apply<P, R>) apply));
+  public <P extends A> PFBuilder<A, B> match(
+          Class<P> type, 
+          FI.Apply<? super P, ? extends B> apply) {
+    addStatement(type::isInstance, i -> apply.apply(type.cast(i)));
     return this;
   }
 
@@ -49,23 +43,47 @@ public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
    * @param apply     an action to apply to the argument if the type matches and the predicate returns true
    * @return a builder with the case statement added
    */
-  @SuppressWarnings("unchecked")
-  public <P> PFBuilder<I, R> match(final Class<? extends P> type,
-                                   final FI.TypedPredicate<? extends P> predicate,
-                                   final FI.Apply<? extends P, R> apply) {
-    FI.Predicate fiPredicate = new FI.Predicate() {
-      @Override
-      public boolean defined(Object o) {
-        if (!type.isInstance(o))
-          return false;
-        else {
-          @SuppressWarnings("unchecked")
-          P p = (P) o;
-          return ((FI.TypedPredicate<P>) predicate).defined(p);
-        }
-      }
-    };
-    addStatement(new CaseStatement<I, P, R>(fiPredicate, (FI.Apply<P, R>) apply));
+  public <P extends A> PFBuilder<A, B> match(
+          Class<P> type,
+          FI.TypedPredicate<? super P> predicate,
+          FI.Apply<? super P, ? extends B> apply) {
+    addStatement(i -> type.isInstance(i) && predicate.defined(type.cast(i)), i -> apply.apply(type.cast(i)));
+    return this;
+  }
+
+  /**
+   * Add a new case statement to this builder.
+   *
+   * This variant will at runtime check the type of [predicate], using reflection to infer the actual
+   * type argument, and only allow instances of that type to reach the predicate. This only works one-level,
+   * e.g. for a TypedPredicate<List<String>> we can only filter that instances of List go in, not what's
+   * in the list. This is because although generics are preserved for the method's type signature, they're
+   * not available for actual object instances passed into the method.
+   * 
+   * @param predicate a predicate that will be evaluated on the argument if the type matches
+   * @param apply     an action to apply to the argument if the type matches and the predicate returns true
+   * @return a builder with the case statement added
+   */
+  public <P extends A> PFBuilder<A, B> match(
+          FI.TypedPredicate<P> predicate,
+          FI.Apply<P, ? extends B> apply) {
+    
+    @SuppressWarnings("unchecked")
+    Class<P> type = (Class<P>) Reflect.resolveLambdaArgumentType(predicate, 0);
+      
+    addStatement(i -> type.isInstance(i) && predicate.defined(type.cast(i)), i -> apply.apply(type.cast(i)));
+    return this;
+  }
+
+/**
+   * Add a new case statement to this builder.
+   *
+   * @param object the object to compare equals with
+   * @param apply  an action to apply to the argument if the object compares equal
+   * @return a builder with the case statement added
+   */
+  public PFBuilder<A, B> matchEquals(A object, FI.Apply<? super A, ? extends B> apply) {
+    addStatement(object::equals, apply::apply);
     return this;
   }
 
@@ -73,18 +91,15 @@ public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
    * Add a new case statement to this builder.
    *
    * @param object the object to compare equals with
+   * @param predicate a predicate that will be evaluated on the argument if the object compares equal
    * @param apply  an action to apply to the argument if the object compares equal
    * @return a builder with the case statement added
    */
-  public <P> PFBuilder<I, R> matchEquals(final P object,
-                                         final FI.Apply<P, R> apply) {
-    addStatement(new CaseStatement<I, P, R>(
-      new FI.Predicate() {
-        @Override
-        public boolean defined(Object o) {
-          return object.equals(o);
-        }
-      }, apply));
+  public PFBuilder<A, B> matchEquals(
+          A object, 
+          FI.TypedPredicate<? super A> predicate, 
+          FI.Apply<? super A, ? extends B> apply) {
+    addStatement(a -> object.equals(a) && predicate.defined(a), apply::apply);
     return this;
   }
 
@@ -94,14 +109,8 @@ public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
    * @param apply an action to apply to the argument
    * @return a builder with the case statement added
    */
-  public PFBuilder<I, R> matchAny(final FI.Apply<I, R> apply) {
-    addStatement(new CaseStatement<I, I, R>(
-      new FI.Predicate() {
-        @Override
-        public boolean defined(Object o) {
-          return true;
-        }
-      }, apply));
+  public PFBuilder<A, B> matchAny(final FI.Apply<? super A, ? extends  B> apply) {
+    addStatement(i -> true, apply::apply);
     return this;
   }
 }

--- a/akka-actor/src/main/java/akka/japi/pf/ReceiveBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/ReceiveBuilder.java
@@ -43,7 +43,8 @@ public class ReceiveBuilder {
    * @param apply an action to apply to the argument if the type matches
    * @return a builder with the case statement added
    */
-  public static <P> UnitPFBuilder<Object> match(final Class<? extends P> type, FI.UnitApply<? extends P> apply) {
+  public static <P> UnitPFBuilder<Object> match(Class<P> type,
+                                                FI.UnitApply<? super P> apply) {
     return UnitMatch.match(type, apply);
   }
 
@@ -55,34 +56,56 @@ public class ReceiveBuilder {
    * @param apply     an action to apply to the argument if the type matches and the predicate returns true
    * @return a builder with the case statement added
    */
-  public static <P> UnitPFBuilder<Object> match(final Class<? extends P> type,
-                                                FI.TypedPredicate<? extends P> predicate,
-                                                FI.UnitApply<? extends P> apply) {
+  public static <P> UnitPFBuilder<Object> match(Class<P> type,
+                                                FI.TypedPredicate<? super P> predicate,
+                                                FI.UnitApply<? super P> apply) {
     return UnitMatch.match(type, predicate, apply);
   }
 
   /**
    * Return a new {@link UnitPFBuilder} with a case statement added.
    *
+   * @param predicate a predicate that will be evaluated on the argument if the type matches
+   * @param apply     an action to apply to the argument if the type matches and the predicate returns true
+   * @return a builder with the case statement added
+   */
+  public static UnitPFBuilder<Object> match(FI.TypedPredicate<Object> predicate,
+                                            FI.UnitApply<Object> apply) {
+    return UnitMatch.match(predicate, apply);
+  }
+  
+  /**
+   * Return a new {@link UnitPFBuilder} with a case statement added.
+   *
+   * Note: This can't be safely generic in P, since some object.equals(a) does not imply that [a] is an instance of
+   * the same type that [object] was compile-time.
+   * If you want that safety, use UnitMatch.matchEquals directly (to get a UnitPFBuilder<T>), or use 
+   * the matchEquals variant that takes a Class argument as well.
+   * 
    * @param object the object to compare equals with
    * @param apply  an action to apply to the argument if the object compares equal
    * @return a builder with the case statement added
    */
-  public static <P> UnitPFBuilder<Object> matchEquals(P object, FI.UnitApply<P> apply) {
+  public static UnitPFBuilder<Object> matchEquals(Object object, FI.UnitApply<Object> apply) {
     return UnitMatch.matchEquals(object, apply);
   }
 
   /**
    * Return a new {@link UnitPFBuilder} with a case statement added.
    *
+   * Note: This can't be safely generic in P, since some object.equals(a) does not imply that [a] is an instance of
+   * the same type that [object] was compile-time.
+   * If you want that safety, use UnitMatch.matchEquals directly (to get a UnitPFBuilder<T>), or use 
+   * the matchEquals variant that takes a Class argument as well.
+   * 
    * @param object    the object to compare equals with
    * @param predicate a predicate that will be evaluated on the argument if the object compares equal
    * @param apply     an action to apply to the argument if the object compares equal
    * @return a builder with the case statement added
    */
-  public static <P> UnitPFBuilder<Object> matchEquals(P object,
-                                                      FI.TypedPredicate<P> predicate,
-                                                      FI.UnitApply<P> apply) {
+  public static UnitPFBuilder<Object> matchEquals(Object object, 
+                                                  FI.TypedPredicate<Object> predicate, 
+                                                  FI.UnitApply<Object> apply) {
     return UnitMatch.matchEquals(object, predicate, apply);
   }
 

--- a/akka-actor/src/main/java/akka/japi/pf/Reflect.java
+++ b/akka-actor/src/main/java/akka/japi/pf/Reflect.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.japi.pf;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+import sun.reflect.ConstantPool;
+
+/**
+ * INTERNAL API
+ */
+public class Reflect {
+    private static final Method getConstantPoolMethod;
+
+    static {
+        try {
+            getConstantPoolMethod = Class.class.getDeclaredMethod("getConstantPool");
+            getConstantPoolMethod.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Couldn't find the 'getConstantPool' method - are you using the SUN JVM?",
+                                       e);
+        }
+    }
+
+    /**
+     * Resolve the generic argument types of a lamb instance (even though types are not reified in Java)<br/>
+     * Example: If a class/method is handed a Function&lt;Foo, Bar> then resolveGenericLambdaArgumentType for argument 0 (the only argument) will return String.class:
+     * <pre>
+     * Function&lt;String, Boolean> myStrToBoolFunc = strArg -> true;
+     * assertThat(Reflect.resolveGenericLambdaArgumentType(myStrToBoolFunc, 0), equalTo(String.class));
+     * </pre>
+     * Example of a lambda with multiple arguments:
+     * <pre>
+     * BiConsumer&lt;Integer, Long> biConsumer = (i, l) -> {};
+     * assertThat(Reflect.resolveGenericLambdaArgumentType(biConsumer, 0), equalTo(Integer.class));
+     * assertThat(Reflect.resolveGenericLambdaArgumentType(biConsumer, 1), equalTo(Long.class));
+     * </pre>
+     */
+    public static Class<?> resolveLambdaArgumentType(Object object, int argumentIndex) {
+        Objects.requireNonNull(object,
+                               "object");
+        if (argumentIndex < 0) {
+            throw new IllegalArgumentException("ArgumentIndex must be >= 0");
+        }
+
+        Type genericInterface = object.getClass()
+                                      .getGenericInterfaces()[0];
+        if (genericInterface instanceof ParameterizedType) {
+            Type type = ((ParameterizedType) genericInterface).getActualTypeArguments()[argumentIndex];
+            if (type instanceof ParameterizedType) {
+                return (Class<?>) ((ParameterizedType)type).getRawType();
+            } else {
+                return (Class<?>) type;                
+            }
+        }
+        else {
+            String[] methodRef = resolveMethodRef(object, "Failed to resolve generic type arguments for " + object + " of type " + genericInterface.toString());
+            try {
+                if (methodRef[1].startsWith("lambda")) {
+                    // This is an inline lambda expression, e.g. (String s) -> s.isEmpty()
+                    String argumentType = jdk.internal.org.objectweb.asm.Type.getArgumentTypes(methodRef[2])[argumentIndex].getClassName();
+                    return Class.forName(argumentType);                    
+                } else {
+                    // This was a function reference literal, e.g. String::isEmpty. 
+                    // methodRef[0] will have a resource syntax, e.g. "java/lang/String"
+                    return object.getClass().getClassLoader().loadClass(methodRef[0].replaceAll("/", "."));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to resolve generic type arguments for " + object + " of type " + genericInterface
+                    .toString(),
+                                           e);
+            }
+        }
+    }
+
+    /**
+     * Resolve the generic return type of an lambda instance (even though types are not reified in Java)<br/>
+     * Example: If a class/method is handed a Function&lt;Foo, Bar> then resolveGenericLambdaReturnType will return Boolean.class:
+     * <pre>
+     * Function&lt;String, Boolean> myStrToBoolFunc = strArg -> true;
+     * assertThat(Reflect.resolveGenericLambdaReturnType(myStrToBoolFunc), equalTo(Boolean.class));
+     * </pre>
+     */
+    public static Class<?> resolveLambdaReturnType(Object object) {
+        Objects.requireNonNull(object,
+                               "object");
+        String[] methodRef = resolveMethodRef(object, "Failed to resolve generic return type for " + object + " of type " + object.getClass()
+                                                                                                                                  .toString());
+
+        try {
+            String returnType = jdk.internal.org.objectweb.asm.Type.getReturnType(methodRef[2])
+                                                                   .getClassName();
+            return Class.forName(returnType);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to resolve generic return type for " + object + " of type " + object.getClass()
+                                                                                                                   .toString(),
+                                       e);
+        }
+    }
+
+    private static String[] resolveMethodRef(Object object, String message) {
+        ConstantPool constantPool = getConstantPool(object, message);
+
+        int at = 15;
+        String[] methodRef = null;
+        // Try and resolve the methodRef, but stop if advancing the at doesn't turn out a result
+        while (methodRef == null && at < 100) {
+            try {
+                // This is pretty slow and somewhat idiotic, but works and gives us reified generics in Java 8
+                methodRef = constantPool.getMemberRefInfoAt(at);
+            } catch (IllegalArgumentException e) {
+                // For every generic argument the index forward
+                at += 1;
+            }
+        }
+        if (methodRef == null) {
+            throw new RuntimeException(message);
+        }
+        return methodRef;
+    }
+
+    private static ConstantPool getConstantPool(Object object, String message) {
+        try {
+            return (ConstantPool) getConstantPoolMethod.invoke(object.getClass());
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(message, e);
+        }
+    }
+}

--- a/akka-actor/src/main/java/akka/japi/pf/UnitMatch.java
+++ b/akka-actor/src/main/java/akka/japi/pf/UnitMatch.java
@@ -14,11 +14,11 @@ import scala.runtime.BoxedUnit;
  * This is a specialized version of {@link UnitMatch} to map java
  * void methods to {@link scala.runtime.BoxedUnit}.
  *
- * @param <I> the input type, that this PartialFunction will be applied to
+ * @param <A> the input type, that this PartialFunction will be applied to
  *
  * This is an EXPERIMENTAL feature and is subject to change until it has received more real world testing.
  */
-public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
+public class UnitMatch<A> extends AbstractMatch<A, BoxedUnit> {
 
   /**
    * Convenience function to create a {@link UnitPFBuilder} with the first
@@ -29,8 +29,10 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * @return a builder with the case statement added
    * @see UnitPFBuilder#match(Class, FI.UnitApply)
    */
-  public static <F, P> UnitPFBuilder<F> match(final Class<? extends P> type, FI.UnitApply<? extends P> apply) {
-    return new UnitPFBuilder<F>().match(type, apply);
+  public static <A, P extends A> UnitPFBuilder<A> match(
+          Class<P> type,
+          FI.UnitApply<? super P> apply) {
+    return new UnitPFBuilder<A>().match(type, apply);
   }
 
   /**
@@ -43,12 +45,29 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * @return a builder with the case statement added
    * @see UnitPFBuilder#match(Class, FI.TypedPredicate, FI.UnitApply)
    */
-  public static <F, P> UnitPFBuilder<F> match(final Class<? extends P> type,
-                                              final FI.TypedPredicate<? extends P> predicate,
-                                              final FI.UnitApply<? extends P> apply) {
-    return new UnitPFBuilder<F>().match(type, predicate, apply);
+  public static <A, P extends A> UnitPFBuilder<A> match(
+          Class<P> type,
+          FI.TypedPredicate<? super P> predicate,
+          FI.UnitApply<? super P> apply) {
+    return new UnitPFBuilder<A>().match(type, predicate, apply);
   }
 
+  /**
+   * Convenience function to create a {@link UnitPFBuilder} with the first
+   * case statement added.
+   *
+   * @param predicate a predicate that will be evaluated on the argument if the type matches
+   * @param apply     an action to apply to the argument if the predicate matches
+   * @return a builder with the case statement added
+   * @see UnitPFBuilder#match(FI.TypedPredicate, FI.UnitApply)
+   */
+  public static <A> UnitPFBuilder<A> match(
+          FI.TypedPredicate<? super A> predicate,
+          FI.UnitApply<? super A> apply) {
+    return new UnitPFBuilder<A>().match(predicate, apply);
+  }
+  
+  
   /**
    * Convenience function to create a {@link UnitPFBuilder} with the first
    * case statement added.
@@ -58,9 +77,8 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * @return a builder with the case statement added
    * @see UnitPFBuilder#matchEquals(Object, FI.UnitApply)
    */
-  public static <F, P> UnitPFBuilder<F> matchEquals(final P object,
-                                                    final FI.UnitApply<P> apply) {
-    return new UnitPFBuilder<F>().matchEquals(object, apply);
+  public static <A> UnitPFBuilder<A> matchEquals(A object, FI.UnitApply<? super A> apply) {
+    return new UnitPFBuilder<A>().matchEquals(object, apply);
   }
 
   /**
@@ -73,10 +91,11 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * @return a builder with the case statement added
    * @see UnitPFBuilder#matchEquals(Object, FI.UnitApply)
    */
-  public static <F, P> UnitPFBuilder<F> matchEquals(final P object,
-                                                    final FI.TypedPredicate<P> predicate,
-                                                    final FI.UnitApply<P> apply) {
-    return new UnitPFBuilder<F>().matchEquals(object, predicate, apply);
+  public static <A> UnitPFBuilder<A> matchEquals(
+          A object, 
+          FI.TypedPredicate<? super A> predicate, 
+          FI.UnitApply<? super A> apply) {
+    return new UnitPFBuilder<A>().matchEquals(object, predicate, apply);
   }
 
   /**
@@ -87,8 +106,8 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * @return a builder with the case statement added
    * @see UnitPFBuilder#matchAny(FI.UnitApply)
    */
-  public static <F> UnitPFBuilder<F> matchAny(final FI.UnitApply<Object> apply) {
-    return new UnitPFBuilder<F>().matchAny(apply);
+  public static <A> UnitPFBuilder<A> matchAny(final FI.UnitApply<? super A> apply) {
+    return new UnitPFBuilder<A>().matchAny(apply);
   }
 
   /**
@@ -97,11 +116,11 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * @param builder a builder representing the partial function
    * @return a {@link UnitMatch} that can be reused
    */
-  public static <F> UnitMatch<F> create(UnitPFBuilder<F> builder) {
-    return new UnitMatch<F>(builder.build());
+  public static <A> UnitMatch<A> create(UnitPFBuilder<A> builder) {
+    return new UnitMatch<A>(builder.build());
   }
 
-  private UnitMatch(PartialFunction<I, BoxedUnit> statements) {
+  private UnitMatch(PartialFunction<A, BoxedUnit> statements) {
     super(statements);
   }
 
@@ -117,7 +136,7 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * @param i the argument to apply the match to
    * @throws scala.MatchError if there is no match
    */
-  public void match(I i) throws MatchError {
+  public void match(A i) throws MatchError {
     statements.apply(i);
   }
 }

--- a/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
+++ b/akka-actor/src/main/scala/akka/japi/pf/CaseStatements.scala
@@ -10,18 +10,10 @@ private[pf] object CaseStatement {
   def empty[F, T](): PartialFunction[F, T] = PartialFunction.empty
 }
 
-private[pf] class CaseStatement[-F, +P, T](predicate: Predicate, apply: Apply[P, T])
-  extends PartialFunction[F, T] {
+private[pf] class CaseStatement[-A, +B](predicate: FI.TypedPredicate[_ >: A], apply: FI.Apply[_ >: A, _ <: B])
+  extends PartialFunction[A, B] {
 
-  override def isDefinedAt(o: F) = predicate.defined(o)
+  override def isDefinedAt(a: A): Boolean = predicate.defined(a)
 
-  override def apply(o: F) = apply.apply(o.asInstanceOf[P])
-}
-
-private[pf] class UnitCaseStatement[F, P](predicate: Predicate, apply: UnitApply[P])
-  extends PartialFunction[F, Unit] {
-
-  override def isDefinedAt(o: F) = predicate.defined(o)
-
-  override def apply(o: F) = apply.apply(o.asInstanceOf[P])
+  override def apply(a: A): B = apply.apply(a)
 }


### PR DESCRIPTION
This is especially useful when you have a typed `PFBuilder`, e.g.
`PFBuilder<Event,Void>` and you just want to say:

```
b.match(Event::isMyType, evt -> doStuff())
```

@ktoso follow-up of https://github.com/ktoso/akka/pull/9 against master (to separate it from the Java HTTP DSL effort), and not changing `ReceiveBuilder`. It should be safe to also update `UnitPFBuilder` though.
