### PR TITLE
increase timeout for setting up SharedLeveldbStore, #20056

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
@@ -171,7 +171,7 @@ abstract class ClusterShardingCustomShardAllocationSpec(config: ClusterShardingC
 
       runOn(first, second) {
         system.actorSelection(node(first) / "user" / "store") ! Identify(None)
-        val sharedStore = expectMsgType[ActorIdentity].ref.get
+        val sharedStore = expectMsgType[ActorIdentity](10.seconds).ref.get
         SharedLeveldbJournal.setStore(sharedStore, system)
       }
 

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingFailureSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingFailureSpec.scala
@@ -147,7 +147,7 @@ abstract class ClusterShardingFailureSpec(config: ClusterShardingFailureSpecConf
 
       runOn(first, second) {
         system.actorSelection(node(controller) / "user" / "store") ! Identify(None)
-        val sharedStore = expectMsgType[ActorIdentity].ref.get
+        val sharedStore = expectMsgType[ActorIdentity](10.seconds).ref.get
         SharedLeveldbJournal.setStore(sharedStore, system)
       }
 

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingGracefulShutdownSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingGracefulShutdownSpec.scala
@@ -157,7 +157,7 @@ abstract class ClusterShardingGracefulShutdownSpec(config: ClusterShardingGracef
 
       runOn(first, second) {
         system.actorSelection(node(first) / "user" / "store") ! Identify(None)
-        val sharedStore = expectMsgType[ActorIdentity].ref.get
+        val sharedStore = expectMsgType[ActorIdentity](10.seconds).ref.get
         SharedLeveldbJournal.setStore(sharedStore, system)
       }
 

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
@@ -156,7 +156,7 @@ abstract class ClusterShardingLeavingSpec(config: ClusterShardingLeavingSpecConf
       enterBarrier("peristence-started")
 
       system.actorSelection(node(first) / "user" / "store") ! Identify(None)
-      val sharedStore = expectMsgType[ActorIdentity].ref.get
+      val sharedStore = expectMsgType[ActorIdentity](10.seconds).ref.get
       SharedLeveldbJournal.setStore(sharedStore, system)
 
       enterBarrier("after-1")

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
@@ -305,7 +305,7 @@ abstract class ClusterShardingSpec(config: ClusterShardingSpecConfig) extends Mu
 
       runOn(first, second, third, fourth, fifth, sixth) {
         system.actorSelection(node(controller) / "user" / "store") ! Identify(None)
-        val sharedStore = expectMsgType[ActorIdentity].ref.get
+        val sharedStore = expectMsgType[ActorIdentity](10.seconds).ref.get
         SharedLeveldbJournal.setStore(sharedStore, system)
       }
 


### PR DESCRIPTION
- SharedLeveldbStore is opening leveldb in preStart so that might
  sometimes take more than 3 seconds, I guess
- the test looks correct
