### PR TITLE
inject outgoing control messages at lower level

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -23,7 +23,7 @@ import akka.remote.RemoteActorRef
 import akka.remote.RemoteActorRefProvider
 import akka.remote.RemoteTransport
 import akka.remote.UniqueAddress
-import akka.remote.artery.InboundReplyJunction.ReplySubject
+import akka.remote.artery.InboundControlJunction.ControlMessageSubject
 import akka.remote.transport.AkkaPduCodec
 import akka.remote.transport.AkkaPduProtobufCodec
 import akka.serialization.Serialization
@@ -47,7 +47,7 @@ import io.aeron.exceptions.ConductorServiceTimeoutException
 import org.agrona.ErrorHandler
 import org.agrona.IoUtil
 import java.io.File
-import akka.remote.artery.OutboundReplyJunction.OutboundReplyIngress
+import akka.remote.artery.OutboundControlJunction.OutboundControlIngress
 
 /**
  * INTERNAL API
@@ -70,10 +70,10 @@ private[akka] trait InboundContext {
   def localAddress: UniqueAddress
 
   /**
-   * An inbound stage can send reply message to the origin
+   * An inbound stage can send control message, e.g. a reply, to the origin
    * address with this method.
    */
-  def sendReply(to: Address, message: ControlMessage): Unit // FIXME rename to sendControl
+  def sendControl(to: Address, message: ControlMessage): Unit
 
   /**
    * Lookup the outbound association for a given address.
@@ -110,10 +110,10 @@ private[akka] trait OutboundContext {
   def completeRemoteAddress(a: UniqueAddress): Unit
 
   /**
-   * An outbound stage can listen to reply messages
+   * An outbound stage can listen to control messages
    * via this observer subject.
    */
-  def replySubject: ReplySubject // FIXME rename to controlSubject
+  def controlSubject: ControlMessageSubject
 
   // FIXME we should be able to Send without a recipient ActorRef
   def dummyRecipient: RemoteActorRef
@@ -130,7 +130,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   @volatile private[this] var _localAddress: UniqueAddress = _
   override def localAddress: UniqueAddress = _localAddress
   @volatile private[this] var materializer: Materializer = _
-  @volatile private[this] var replySubject: ReplySubject = _
+  @volatile private[this] var controlSubject: ControlMessageSubject = _
   @volatile private[this] var messageDispatcher: MessageDispatcher = _
   @volatile private[this] var driver: MediaDriver = _
   @volatile private[this] var aeron: Aeron = _
@@ -147,7 +147,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   // TODO support port 0
   private def inboundChannel = s"aeron:udp?endpoint=${localAddress.address.host.get}:${localAddress.address.port.get}"
   private def outboundChannel(a: Address) = s"aeron:udp?endpoint=${a.host.get}:${a.port.get}"
-  private val systemMessageStreamId = 1 // FIXME rename to controlStreamId
+  private val controlStreamId = 1
   private val ordinaryStreamId = 3
   private val taskRunner = new TaskRunner(system)
 
@@ -215,10 +215,10 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   }
 
   private def runInboundFlows(): Unit = {
-    replySubject = Source.fromGraph(new AeronSource(inboundChannel, systemMessageStreamId, aeron, taskRunner))
+    controlSubject = Source.fromGraph(new AeronSource(inboundChannel, controlStreamId, aeron, taskRunner))
       .async // FIXME measure
       .map(ByteString.apply) // TODO we should use ByteString all the way
-      .viaMat(inboundSystemMessageFlow)(Keep.right)
+      .viaMat(inboundControlFlow)(Keep.right)
       .to(Sink.ignore)
       .run()(materializer)
 
@@ -242,8 +242,8 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   }
 
   // InboundContext
-  override def sendReply(to: Address, message: ControlMessage) =
-    association(to).outboundReplyIngress.sendControlMessage(message)
+  override def sendControl(to: Address, message: ControlMessage) =
+    association(to).outboundControlIngress.sendControlMessage(message)
 
   override def send(message: Any, senderOption: Option[ActorRef], recipient: RemoteActorRef): Unit = {
     val cached = recipient.cachedAssociation
@@ -262,7 +262,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     else {
       associations.computeIfAbsent(remoteAddress, new JFunction[Address, Association] {
         override def apply(remoteAddress: Address): Association = {
-          val newAssociation = new Association(ArteryTransport.this, materializer, remoteAddress, replySubject)
+          val newAssociation = new Association(ArteryTransport.this, materializer, remoteAddress, controlSubject)
           newAssociation.associate() // This is a bit costly for this blocking method :(
           newAssociation
         }
@@ -282,14 +282,14 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       .to(new AeronSink(outboundChannel(outboundContext.remoteAddress), ordinaryStreamId, aeron, taskRunner))
   }
 
-  def outboundSystemMessage(outboundContext: OutboundContext): Sink[Send, OutboundReplyIngress] = {
+  def outboundControl(outboundContext: OutboundContext): Sink[Send, OutboundControlIngress] = {
     Flow.fromGraph(killSwitch.flow[Send])
       .via(new OutboundHandshake(outboundContext))
       .via(new SystemMessageDelivery(outboundContext, systemMessageResendInterval))
-      .viaMat(new OutboundReplyJunction(outboundContext))(Keep.right)
+      .viaMat(new OutboundControlJunction(outboundContext))(Keep.right)
       .via(encoder)
       .map(_.toArray) // TODO we should use ByteString all the way
-      .to(new AeronSink(outboundChannel(outboundContext.remoteAddress), systemMessageStreamId, aeron, taskRunner))
+      .to(new AeronSink(outboundChannel(outboundContext.remoteAddress), controlStreamId, aeron, taskRunner))
   }
 
   // TODO: Try out parallelized serialization (mapAsync) for performance
@@ -339,14 +339,13 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       Source.maybe[ByteString].via(killSwitch.flow))
   }
 
-  // FIXME rename to controlFlow
-  val inboundSystemMessageFlow: Flow[ByteString, ByteString, ReplySubject] = {
+  val inboundControlFlow: Flow[ByteString, ByteString, ControlMessageSubject] = {
     Flow.fromSinkAndSourceMat(
       decoder
         .via(deserializer)
         .via(new InboundHandshake(this))
         .via(new SystemMessageAcker(this))
-        .viaMat(new InboundReplyJunction)(Keep.right)
+        .viaMat(new InboundControlJunction)(Keep.right)
         .to(messageDispatcherSink),
       Source.maybe[ByteString].via(killSwitch.flow))((a, b) ⇒ a)
   }

--- a/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 import akka.Done
 import akka.remote.EndpointManager.Send
 import akka.remote.UniqueAddress
-import akka.remote.artery.ReplyJunction.ReplyObserver
+import akka.remote.artery.InboundReplyJunction.ReplyObserver
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -14,7 +14,7 @@ import scala.util.Try
 import akka.Done
 import akka.remote.EndpointManager.Send
 import akka.remote.UniqueAddress
-import akka.remote.artery.ReplyJunction.ReplyObserver
+import akka.remote.artery.InboundReplyJunction.ReplyObserver
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
@@ -151,15 +151,6 @@ private[akka] class SystemMessageDelivery(
       // InHandler
       override def onPush(): Unit = {
         grab(in) match {
-          case s @ Send(reply: ControlMessage, _, _, _) ⇒
-            // pass through
-            if (isAvailable(out))
-              push(out, s)
-            else {
-              // it's ok to drop the replies, but we can try
-              resending.offer(s)
-            }
-
           case s @ Send(msg: AnyRef, _, _, _) ⇒
             seqNo += 1
             val sendMsg = s.copy(message = SystemMessageEnvelope(msg, seqNo, localAddress))

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -6,11 +6,11 @@ package akka.remote.artery
 import akka.remote.UniqueAddress
 import akka.actor.Address
 import scala.concurrent.Future
-import akka.remote.artery.ReplyJunction.ReplySubject
+import akka.remote.artery.InboundReplyJunction.ReplySubject
 import akka.remote.RemoteActorRef
 import scala.concurrent.Promise
 import akka.Done
-import akka.remote.artery.ReplyJunction.ReplyObserver
+import akka.remote.artery.InboundReplyJunction.ReplyObserver
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ThreadLocalRandom

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -6,31 +6,31 @@ package akka.remote.artery
 import akka.remote.UniqueAddress
 import akka.actor.Address
 import scala.concurrent.Future
-import akka.remote.artery.InboundReplyJunction.ReplySubject
+import akka.remote.artery.InboundControlJunction.ControlMessageSubject
 import akka.remote.RemoteActorRef
 import scala.concurrent.Promise
 import akka.Done
-import akka.remote.artery.InboundReplyJunction.ReplyObserver
+import akka.remote.artery.InboundControlJunction.ControlMessageObserver
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ThreadLocalRandom
 
 private[akka] class TestInboundContext(
   override val localAddress: UniqueAddress,
-  val replySubject: TestReplySubject = new TestReplySubject,
+  val controlSubject: TestControlMessageSubject = new TestControlMessageSubject,
   replyDropRate: Double = 0.0) extends InboundContext {
 
   private val associations = new ConcurrentHashMap[Address, OutboundContext]
 
-  def sendReply(to: Address, message: ControlMessage) = {
+  def sendControl(to: Address, message: ControlMessage) = {
     if (ThreadLocalRandom.current().nextDouble() >= replyDropRate)
-      replySubject.sendReply(InboundEnvelope(null, to, message, None))
+      controlSubject.sendControl(InboundEnvelope(null, to, message, None))
   }
 
   def association(remoteAddress: Address): OutboundContext =
     associations.get(remoteAddress) match {
       case null ⇒
-        val a = new TestOutboundContext(localAddress, remoteAddress, replySubject)
+        val a = new TestOutboundContext(localAddress, remoteAddress, controlSubject)
         associations.putIfAbsent(remoteAddress, a) match {
           case null     ⇒ a
           case existing ⇒ existing
@@ -39,13 +39,13 @@ private[akka] class TestInboundContext(
     }
 
   protected def createAssociation(remoteAddress: Address): OutboundContext =
-    new TestOutboundContext(localAddress, remoteAddress, replySubject)
+    new TestOutboundContext(localAddress, remoteAddress, controlSubject)
 }
 
 private[akka] class TestOutboundContext(
   override val localAddress: UniqueAddress,
   override val remoteAddress: Address,
-  override val replySubject: TestReplySubject) extends OutboundContext {
+  override val controlSubject: TestControlMessageSubject) extends OutboundContext {
 
   private val _uniqueRemoteAddress = Promise[UniqueAddress]()
   def uniqueRemoteAddress: Future[UniqueAddress] = _uniqueRemoteAddress.future
@@ -56,24 +56,24 @@ private[akka] class TestOutboundContext(
 
 }
 
-private[akka] class TestReplySubject extends ReplySubject {
+private[akka] class TestControlMessageSubject extends ControlMessageSubject {
 
-  private var replyObservers = new CopyOnWriteArrayList[ReplyObserver]
+  private var observers = new CopyOnWriteArrayList[ControlMessageObserver]
 
-  override def attach(observer: ReplyObserver): Future[Done] = {
-    replyObservers.add(observer)
+  override def attach(observer: ControlMessageObserver): Future[Done] = {
+    observers.add(observer)
     Future.successful(Done)
   }
 
-  override def detach(observer: ReplyObserver): Unit = {
-    replyObservers.remove(observer)
+  override def detach(observer: ControlMessageObserver): Unit = {
+    observers.remove(observer)
   }
 
   override def stopped: Future[Done] = Promise[Done]().future
 
-  def sendReply(env: InboundEnvelope): Unit = {
-    val iter = replyObservers.iterator()
+  def sendControl(env: InboundEnvelope): Unit = {
+    val iter = observers.iterator()
     while (iter.hasNext())
-      iter.next().reply(env)
+      iter.next().notify(env)
   }
 }


### PR DESCRIPTION
- instead of sending the the control messages (e.g. handshake reply,
  sys msg ack) via the normal message send ingress point they are
  now injected via side channel and will therefore not go through
  higher level stages such as handshake and system message delivery

I also want to rename all `Reply` things to `Control` or `ControlMessage`, but will do that in a separate commit to make it easier to see the diff.
