### PR TITLE
Added a Packt video to list of resources

### DIFF
--- a/akka-docs/rst/additional/books.rst
+++ b/akka-docs/rst/additional/books.rst
@@ -1,10 +1,15 @@
 Books
 =====
 
-* `Learning Akka <https://www.packtpub.com/application-development/learning-akka>`_, by Jason Goodwin, PACKT Publishing, ISBN: 9781784393007, December 2015
+* `Learning Akka <https://www.packtpub.com/application-development/learning-akka?utm_source=github&utm_medium=repository&utm_campaign=9781784393007>`_, by Jason Goodwin, PACKT Publishing, ISBN: 9781784393007, December 2015
 * `Akka in Action <http://www.lightbend.com/resources/e-book/akka-in-action>`_, by Raymond Roestenburg and Rob Bakker, Manning Publications Co., ISBN: 9781617291012, estimated in 2016
 * `Reactive Messaging Patterns with the Actor Model <http://www.informit.com/store/reactive-messaging-patterns-with-the-actor-model-applications-9780133846836>`_, by Vaughn Vernon, Addison-Wesley Professional, ISBN: 0133846830, August 2015
 * `Developing an Akka Edge <http://bleedingedgepress.com/our-books/developing-an-akka-edge/>`_, by Thomas Lockney and Raymond Tay, Bleeding Edge Press, ISBN: 9781939902054, April 2014
 * `Effective Akka <http://shop.oreilly.com/product/0636920028789.do>`_, by Jamie Allen, O'Reilly Media, ISBN: 1449360076, August 2013
 * `Akka Concurrency <http://www.artima.com/shop/akka_concurrency>`_, by Derek Wyatt, artima developer, ISBN: 0981531660, May 2013
-* `Akka Essentials <http://www.packtpub.com/akka-java-applications-essentials/book>`_, by Munish K. Gupta, PACKT Publishing, ISBN: 1849518289, October 2012
+* `Akka Essentials <https://www.packtpub.com/application-development/akka-essentials?utm_source=github&utm_medium=repository&utm_campaign=1849518289>`_, by Munish K. Gupta, PACKT Publishing, ISBN: 1849518289, October 2012
+
+Videos
+=====
+
+* `Learning Akka <https://www.packtpub.com/application-development/learning-akka-video?utm_source=github&utm_medium=repository&utm_campaign=9781784391836>`_, by Salma Khater, PACKT Publishing, ISBN: 9781784391836, January 2016


### PR DESCRIPTION
I've added a recently published Packt video to books.rst - might be better if in the long term this is split out into a separate file. For now it's just the one on there, I hope this is okay.
