### PR TITLE
20514 - HTTP: Document how a type is marshalled into json

### DIFF
--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -14,10 +14,10 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
     import spray.json._
 
     // domain model
-    final case class Item(name: String, id: Long)
-    object Item extends DefaultJsonProtocol with SprayJsonSupport {
+    final case class CompactPrintedItem(name: String, id: Long)
+    object CompactPrintedItem extends DefaultJsonProtocol with SprayJsonSupport {
       implicit val printer = CompactPrinter
-      implicit val itemFormat = jsonFormat2(Item.apply)
+      implicit val itemFormat = jsonFormat2(CompactPrintedItem.apply)
     }
 
     // use it wherever json (un)marshalling is needed
@@ -29,7 +29,7 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
           pathSingleSlash {
             complete {
               // should complete with spray.json.JsValue = {"name":"Akka","id":42}
-              Item("thing", 42) // will render as JSON
+              CompactPrintedItem("thing", 42) // will render as JSON
             }
           }
         }

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package docs.http.scaladsl
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import org.scalatest.{Matchers, WordSpec}
+
+class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
+
+  "spray-json example" in {
+    //#example
+    import spray.json._
+
+    // domain model
+    final case class Item(name: String, id: Long)
+    object Item extends DefaultJsonProtocol with SprayJsonSupport {
+      implicit val printer = CompactPrinter
+      implicit val itemFormat = jsonFormat2(Item.apply)
+    }
+
+    Item("Akka", 6).toJson
+    // yields res0: spray.json.JsValue = {"name":"Akka","age":25}
+  }
+}

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -28,8 +28,8 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
         get {
           pathSingleSlash {
             complete {
-              // should complete with spray.json.JsValue = {"name":"Akka","id":42}
-              CompactPrintedItem("thing", 42) // will render as JSON
+              // should complete with spray.json.JsValue = {"name":"akka","id":42}
+              CompactPrintedItem("akka", 42) // will render as JSON
             }
           }
         }

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -22,6 +22,7 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
 
     // use it wherever json (un)marshalling is needed
     class MyJsonService extends Directives {
+      import CompactPrintedItem._
 
       // format: OFF
       val route =

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -15,14 +15,14 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
 
     // domain model
     final case class CompactPrintedItem(name: String, id: Long)
-    object CompactPrintedItem extends DefaultJsonProtocol with SprayJsonSupport {
+
+    trait CompactJsonFormatSupport extends DefaultJsonProtocol with SprayJsonSupport {
       implicit val printer = CompactPrinter
-      implicit val compactPrintedItemFormat = jsonFormat2(CompactPrintedItem.apply)
+      implicit val compactPrintedItemFormat = jsonFormat2(CompactPrintedItem)
     }
 
     // use it wherever json (un)marshalling is needed
-    class MyJsonService extends Directives {
-      import CompactPrintedItem._
+    class MyJsonService extends Directives with CompactJsonFormatSupport{
 
       // format: OFF
       val route =

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -4,6 +4,7 @@
 package docs.http.scaladsl
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.server.Directives
 import org.scalatest.{Matchers, WordSpec}
 
 class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
@@ -19,7 +20,21 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
       implicit val itemFormat = jsonFormat2(Item.apply)
     }
 
-    Item("Akka", 6).toJson
-    // yields res0: spray.json.JsValue = {"name":"Akka","age":25}
+    // use it wherever json (un)marshalling is needed
+    class MyJsonService extends Directives {
+
+      // format: OFF
+      val route =
+        get {
+          pathSingleSlash {
+            complete {
+              // should complete with spray.json.JsValue = {"name":"Akka","id":42}
+              Item("thing", 42) // will render as JSON
+            }
+          }
+        }
+      // format: ON
+      //#
+    }
   }
 }

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -17,7 +17,7 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
     final case class CompactPrintedItem(name: String, id: Long)
     object CompactPrintedItem extends DefaultJsonProtocol with SprayJsonSupport {
       implicit val printer = CompactPrinter
-      implicit val itemFormat = jsonFormat2(CompactPrintedItem.apply)
+      implicit val compactPrintedItemFormat = jsonFormat2(CompactPrintedItem.apply)
     }
 
     // use it wherever json (un)marshalling is needed

--- a/akka-docs/rst/scala/http/common/json-support.rst
+++ b/akka-docs/rst/scala/http/common/json-support.rst
@@ -38,6 +38,9 @@ Once you have done this (un)marshalling between JSON and your type ``T`` should 
    ``implicit def sprayJsonMarshallerConverter[T](writer: RootJsonWriter[T])(implicit printer: JsonPrinter = PrettyPrinter): ToEntityMarshaller[T]``.
    Alternately to marshal your types to compact printed json, bring a ``CompactPrinter`` in scope to perform implicit conversion.
 
+.. includecode:: ../../code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+   :include: example
+
 To learn more about how spray-json works please refer to its `documentation <https://github.com/spray/spray-json>`_.
 
 

--- a/akka-docs/rst/scala/http/common/json-support.rst
+++ b/akka-docs/rst/scala/http/common/json-support.rst
@@ -34,6 +34,10 @@ Once you have done this (un)marshalling between JSON and your type ``T`` should 
 .. includecode:: ../../code/docs/http/scaladsl/SprayJsonExampleSpec.scala
   :include: example
 
+4. By default, spray-json marshals your types to pretty printed json by implicit conversion using PrettyPrinter, as defined in
+   ``implicit def sprayJsonMarshallerConverter[T](writer: RootJsonWriter[T])(implicit printer: JsonPrinter = PrettyPrinter): ToEntityMarshaller[T]``.
+   Alternately to marshal your types to compact printed json, bring a ``CompactPrinter`` in scope to perform implicit conversion.
+
 To learn more about how spray-json works please refer to its `documentation <https://github.com/spray/spray-json>`_.
 
 


### PR DESCRIPTION
The type is marshalled into pretty printed json by default. Improve the documentation to elaborate how to bring compact printer into scope.
