### PR TITLE
handshake and quarantine, #20313

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/HandshakeRestartReceiverSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/HandshakeRestartReceiverSpec.scala
@@ -3,21 +3,18 @@
  */
 package akka.remote.artery
 
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit.NANOSECONDS
+import scala.concurrent.Await
 import scala.concurrent.duration._
+
 import akka.actor._
-import akka.remote.RemoteActorRefProvider
+import akka.remote.AddressUidExtension
+import akka.remote.RARP
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
 import akka.remote.testkit.STMultiNodeSpec
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
-import java.net.InetAddress
-import scala.concurrent.Await
-import akka.remote.RARP
-import akka.remote.AddressUidExtension
 
 object HandshakeRestartReceiverSpec extends MultiNodeConfig {
   val first = role("first")
@@ -77,7 +74,7 @@ abstract class HandshakeRestartReceiverSpec
 
         val secondAddress = node(second).address
         val secondAssociation = RARP(system).provider.transport.asInstanceOf[ArteryTransport].association(secondAddress)
-        val secondUniqueRemoteAddress = Await.result(secondAssociation.uniqueRemoteAddress, 3.seconds)
+        val secondUniqueRemoteAddress = Await.result(secondAssociation.associationState.uniqueRemoteAddress, 3.seconds)
         secondUniqueRemoteAddress.address should ===(secondAddress)
         secondUniqueRemoteAddress.uid should ===(secondUid)
 
@@ -93,7 +90,10 @@ abstract class HandshakeRestartReceiverSpec
         }
         val (secondUid2, subject2) = identifyWithUid(secondRootPath, "subject2")
         secondUid2 should !==(secondUid)
-        // FIXME verify that UID in association was replaced (not implemented yet)
+        val secondUniqueRemoteAddress2 = Await.result(secondAssociation.associationState.uniqueRemoteAddress, 3.seconds)
+        secondUniqueRemoteAddress2.uid should ===(secondUid2)
+        secondUniqueRemoteAddress2.address should ===(secondAddress)
+        secondUniqueRemoteAddress2 should !==(secondUniqueRemoteAddress)
 
         subject2 ! "shutdown"
       }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/PiercingShouldKeepQuarantineSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/PiercingShouldKeepQuarantineSpec.scala
@@ -25,24 +25,6 @@ object PiercingShouldKeepQuarantineSpec extends MultiNodeConfig {
       akka.remote.artery.enabled = on
                               """)))
 
-  def aeronPort(roleName: RoleName): Int =
-    roleName match {
-      case `first`  ⇒ 20561 // TODO yeah, we should have support for dynamic port assignment
-      case `second` ⇒ 20562
-    }
-
-  nodeConfig(first) {
-    ConfigFactory.parseString(s"""
-      akka.remote.artery.port = ${aeronPort(first)}
-      """)
-  }
-
-  nodeConfig(second) {
-    ConfigFactory.parseString(s"""
-      akka.remote.artery.port = ${aeronPort(second)}
-      """)
-  }
-
   class Subject extends Actor {
     def receive = {
       case "getuid" ⇒ sender() ! AddressUidExtension(context.system).addressUid

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/PiercingShouldKeepQuarantineSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/PiercingShouldKeepQuarantineSpec.scala
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+import com.typesafe.config.ConfigFactory
+import akka.actor._
+import akka.testkit._
+import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec, STMultiNodeSpec }
+import akka.remote.testconductor.RoleName
+import akka.remote.AddressUidExtension
+import akka.remote.RARP
+
+object PiercingShouldKeepQuarantineSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+
+  commonConfig(debugConfig(on = false).withFallback(
+    ConfigFactory.parseString("""
+      #akka.loglevel = INFO
+      #akka.remote.log-remote-lifecycle-events = INFO
+      akka.remote.retry-gate-closed-for = 0.5s
+
+      akka.remote.artery.enabled = on
+                              """)))
+
+  def aeronPort(roleName: RoleName): Int =
+    roleName match {
+      case `first`  ⇒ 20561 // TODO yeah, we should have support for dynamic port assignment
+      case `second` ⇒ 20562
+    }
+
+  nodeConfig(first) {
+    ConfigFactory.parseString(s"""
+      akka.remote.artery.port = ${aeronPort(first)}
+      """)
+  }
+
+  nodeConfig(second) {
+    ConfigFactory.parseString(s"""
+      akka.remote.artery.port = ${aeronPort(second)}
+      """)
+  }
+
+  class Subject extends Actor {
+    def receive = {
+      case "getuid" ⇒ sender() ! AddressUidExtension(context.system).addressUid
+    }
+  }
+
+}
+
+class PiercingShouldKeepQuarantineSpecMultiJvmNode1 extends PiercingShouldKeepQuarantineSpec
+class PiercingShouldKeepQuarantineSpecMultiJvmNode2 extends PiercingShouldKeepQuarantineSpec
+
+abstract class PiercingShouldKeepQuarantineSpec extends MultiNodeSpec(PiercingShouldKeepQuarantineSpec)
+  with STMultiNodeSpec
+  with ImplicitSender {
+
+  import PiercingShouldKeepQuarantineSpec._
+
+  override def initialParticipants = roles.size
+
+  "While probing through the quarantine remoting" must {
+
+    "not lose existing quarantine marker" taggedAs LongRunningTest in {
+      runOn(first) {
+        enterBarrier("actors-started")
+
+        // Communicate with second system
+        system.actorSelection(node(second) / "user" / "subject") ! "getuid"
+        val uid = expectMsgType[Int](10.seconds)
+        enterBarrier("actor-identified")
+
+        // Manually Quarantine the other system
+        RARP(system).provider.transport.quarantine(node(second).address, Some(uid))
+
+        // Quarantining is not immediate
+        Thread.sleep(1000)
+
+        // Quarantine is up -- Should not be able to communicate with remote system any more
+        for (_ ← 1 to 4) {
+          system.actorSelection(node(second) / "user" / "subject") ! "getuid"
+          expectNoMsg(2.seconds)
+        }
+
+        enterBarrier("quarantine-intact")
+
+      }
+
+      runOn(second) {
+        system.actorOf(Props[Subject], "subject")
+        enterBarrier("actors-started")
+        enterBarrier("actor-identified")
+        enterBarrier("quarantine-intact")
+      }
+
+    }
+
+  }
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteQuarantinePiercingSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteQuarantinePiercingSpec.scala
@@ -31,24 +31,6 @@ object RemoteQuarantinePiercingSpec extends MultiNodeConfig {
       akka.remote.artery.enabled = on
                               """)))
 
-  def aeronPort(roleName: RoleName): Int =
-    roleName match {
-      case `first`  ⇒ 20551 // TODO yeah, we should have support for dynamic port assignment
-      case `second` ⇒ 20552
-    }
-
-  nodeConfig(first) {
-    ConfigFactory.parseString(s"""
-      akka.remote.artery.port = ${aeronPort(first)}
-      """)
-  }
-
-  nodeConfig(second) {
-    ConfigFactory.parseString(s"""
-      akka.remote.artery.port = ${aeronPort(second)}
-      """)
-  }
-
   class Subject extends Actor {
     def receive = {
       case "shutdown" ⇒ context.system.terminate()

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteQuarantinePiercingSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteQuarantinePiercingSpec.scala
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import language.postfixOps
+import scala.concurrent.duration._
+import com.typesafe.config.ConfigFactory
+import akka.actor._
+import akka.remote.testconductor.RoleName
+import akka.remote.transport.ThrottlerTransportAdapter.{ ForceDisassociate, Direction }
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.STMultiNodeSpec
+import akka.testkit._
+import akka.actor.ActorIdentity
+import akka.remote.testconductor.RoleName
+import akka.actor.Identify
+import scala.concurrent.Await
+import akka.remote.AddressUidExtension
+import akka.remote.RARP
+
+object RemoteQuarantinePiercingSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+
+  commonConfig(debugConfig(on = false).withFallback(
+    ConfigFactory.parseString("""
+      akka.loglevel = INFO
+      akka.remote.log-remote-lifecycle-events = INFO
+      akka.remote.artery.enabled = on
+                              """)))
+
+  def aeronPort(roleName: RoleName): Int =
+    roleName match {
+      case `first`  ⇒ 20551 // TODO yeah, we should have support for dynamic port assignment
+      case `second` ⇒ 20552
+    }
+
+  nodeConfig(first) {
+    ConfigFactory.parseString(s"""
+      akka.remote.artery.port = ${aeronPort(first)}
+      """)
+  }
+
+  nodeConfig(second) {
+    ConfigFactory.parseString(s"""
+      akka.remote.artery.port = ${aeronPort(second)}
+      """)
+  }
+
+  class Subject extends Actor {
+    def receive = {
+      case "shutdown" ⇒ context.system.terminate()
+      case "identify" ⇒ sender() ! (AddressUidExtension(context.system).addressUid -> self)
+    }
+  }
+
+}
+
+class RemoteQuarantinePiercingSpecMultiJvmNode1 extends RemoteQuarantinePiercingSpec
+class RemoteQuarantinePiercingSpecMultiJvmNode2 extends RemoteQuarantinePiercingSpec
+
+abstract class RemoteQuarantinePiercingSpec extends MultiNodeSpec(RemoteQuarantinePiercingSpec)
+  with STMultiNodeSpec
+  with ImplicitSender {
+
+  import RemoteQuarantinePiercingSpec._
+
+  override def initialParticipants = roles.size
+
+  def identifyWithUid(role: RoleName, actorName: String, timeout: FiniteDuration = remainingOrDefault): (Int, ActorRef) = {
+    within(timeout) {
+      system.actorSelection(node(role) / "user" / actorName) ! "identify"
+      expectMsgType[(Int, ActorRef)]
+    }
+  }
+
+  "RemoteNodeShutdownAndComesBack" must {
+
+    "allow piercing through the quarantine when remote UID is new" taggedAs LongRunningTest in {
+      runOn(first) {
+        val secondAddress = node(second).address
+        enterBarrier("actors-started")
+
+        // Acquire ActorRef from first system
+        val (uidFirst, subjectFirst) = identifyWithUid(second, "subject", 5.seconds)
+        enterBarrier("actor-identified")
+
+        // Manually Quarantine the other system
+        RARP(system).provider.transport.quarantine(node(second).address, Some(uidFirst))
+
+        // Quarantine is up -- Cannot communicate with remote system any more
+        system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! "identify"
+        expectNoMsg(2.seconds)
+
+        // Shut down the other system -- which results in restart (see runOn(second))
+        Await.result(testConductor.shutdown(second), 30.seconds)
+
+        // Now wait until second system becomes alive again
+        within(30.seconds) {
+          // retry because the Subject actor might not be started yet
+          awaitAssert {
+            system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! "identify"
+            val (uidSecond, subjectSecond) = expectMsgType[(Int, ActorRef)](1.second)
+            uidSecond should not be (uidFirst)
+            subjectSecond should not be (subjectFirst)
+          }
+        }
+
+        // If we got here the Quarantine was successfully pierced since it is configured to last 1 day
+
+        system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! "shutdown"
+
+      }
+
+      runOn(second) {
+        val addr = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+        system.actorOf(Props[Subject], "subject")
+        enterBarrier("actors-started")
+
+        enterBarrier("actor-identified")
+
+        Await.ready(system.whenTerminated, 30.seconds)
+
+        val freshSystem = ActorSystem(system.name, ConfigFactory.parseString(s"""
+              akka.remote.artery.port = ${addr.port.get}
+              """).withFallback(system.settings.config))
+        freshSystem.actorOf(Props[Subject], "subject")
+
+        Await.ready(freshSystem.whenTerminated, 30.seconds)
+      }
+
+    }
+
+  }
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteRestartedQuarantinedSpec.scala
@@ -1,0 +1,169 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import akka.remote.transport.AssociationHandle
+import language.postfixOps
+import scala.concurrent.duration._
+import com.typesafe.config.ConfigFactory
+import akka.actor._
+import akka.remote.testconductor.RoleName
+import akka.remote.transport.ThrottlerTransportAdapter.{ ForceDisassociateExplicitly, ForceDisassociate, Direction }
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.STMultiNodeSpec
+import akka.testkit._
+import akka.actor.ActorIdentity
+import akka.remote.testconductor.RoleName
+import akka.actor.Identify
+import scala.concurrent.Await
+import akka.remote.AddressUidExtension
+import akka.remote.RARP
+import akka.remote.ThisActorSystemQuarantinedEvent
+
+object RemoteRestartedQuarantinedSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+
+  commonConfig(debugConfig(on = false).withFallback(
+    ConfigFactory.parseString("""
+      akka.loglevel = WARNING
+      akka.remote.log-remote-lifecycle-events = WARNING
+
+      # Keep it long, we don't want reconnects
+      akka.remote.retry-gate-closed-for  = 1 s
+
+      # Important, otherwise it is very racy to get a non-writing endpoint: the only way to do it if the two nodes
+      # associate to each other at the same time. Setting this will ensure that the right scenario happens.
+      akka.remote.use-passive-connections = off
+
+      # TODO should not be needed, but see TODO at the end of the test
+      akka.remote.transport-failure-detector.heartbeat-interval = 1 s
+      akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 10 s
+
+      akka.remote.artery.enabled = on
+                              """)))
+
+  def aeronPort(roleName: RoleName): Int =
+    roleName match {
+      case `first`  ⇒ 20541 // TODO yeah, we should have support for dynamic port assignment
+      case `second` ⇒ 20542
+    }
+
+  nodeConfig(first) {
+    ConfigFactory.parseString(s"""
+      akka.remote.artery.port = ${aeronPort(first)}
+      """)
+  }
+
+  nodeConfig(second) {
+    ConfigFactory.parseString(s"""
+      akka.remote.artery.port = ${aeronPort(second)}
+      """)
+  }
+
+  class Subject extends Actor {
+    def receive = {
+      case "shutdown" ⇒ context.system.terminate()
+      case "identify" ⇒ sender() ! (AddressUidExtension(context.system).addressUid -> self)
+    }
+  }
+
+}
+
+class RemoteRestartedQuarantinedSpecMultiJvmNode1 extends RemoteRestartedQuarantinedSpec
+class RemoteRestartedQuarantinedSpecMultiJvmNode2 extends RemoteRestartedQuarantinedSpec
+
+abstract class RemoteRestartedQuarantinedSpec
+  extends MultiNodeSpec(RemoteRestartedQuarantinedSpec)
+  with STMultiNodeSpec with ImplicitSender {
+
+  import RemoteRestartedQuarantinedSpec._
+
+  override def initialParticipants = 2
+
+  def identifyWithUid(role: RoleName, actorName: String, timeout: FiniteDuration = remainingOrDefault): (Int, ActorRef) = {
+    within(timeout) {
+      system.actorSelection(node(role) / "user" / actorName) ! "identify"
+      expectMsgType[(Int, ActorRef)]
+    }
+  }
+
+  "A restarted quarantined system" must {
+
+    "should not crash the other system (#17213)" taggedAs LongRunningTest in {
+
+      system.actorOf(Props[Subject], "subject")
+      enterBarrier("subject-started")
+
+      runOn(first) {
+        val secondAddress = node(second).address
+
+        val (uid, ref) = identifyWithUid(second, "subject", 5.seconds)
+
+        enterBarrier("before-quarantined")
+        RARP(system).provider.transport.quarantine(node(second).address, Some(uid))
+
+        enterBarrier("quarantined")
+        enterBarrier("still-quarantined")
+
+        testConductor.shutdown(second).await
+
+        within(30.seconds) {
+          awaitAssert {
+            system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! Identify("subject")
+            expectMsgType[ActorIdentity](1.second).ref.get
+          }
+        }
+
+        system.actorSelection(RootActorPath(secondAddress) / "user" / "subject") ! "shutdown"
+      }
+
+      runOn(second) {
+        val addr = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+        val firstAddress = node(first).address
+        system.eventStream.subscribe(testActor, classOf[ThisActorSystemQuarantinedEvent])
+
+        val (firstUid, ref) = identifyWithUid(first, "subject", 5.seconds)
+
+        enterBarrier("before-quarantined")
+        enterBarrier("quarantined")
+
+        expectMsgPF(10 seconds) {
+          case ThisActorSystemQuarantinedEvent(local, remote) ⇒
+        }
+
+        // check that we quarantine back
+        val firstAssociation = RARP(system).provider.transport.asInstanceOf[ArteryTransport].association(firstAddress)
+        awaitAssert {
+          firstAssociation.associationState.isQuarantined(firstUid)
+          firstAssociation.associationState.isQuarantined()
+        }
+
+        enterBarrier("still-quarantined")
+
+        Await.result(system.whenTerminated, 10.seconds)
+
+        val freshSystem = ActorSystem(system.name, ConfigFactory.parseString(s"""
+              akka.remote.artery.port = ${addr.port.get}
+              """).withFallback(system.settings.config))
+
+        val probe = TestProbe()(freshSystem)
+
+        freshSystem.actorSelection(RootActorPath(firstAddress) / "user" / "subject").tell(Identify("subject"), probe.ref)
+        // TODO sometimes it takes long time until the new connection is established,
+        //      It seems like there must first be a transport failure detector timeout, that triggers
+        //      "No response from remote. Handshake timed out or transport failure detector triggered".
+        probe.expectMsgType[ActorIdentity](30.second).ref should not be (None)
+
+        // Now the other system will be able to pass, too
+        freshSystem.actorOf(Props[Subject], "subject")
+
+        Await.ready(freshSystem.whenTerminated, 10.seconds)
+      }
+
+    }
+
+  }
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteRestartedQuarantinedSpec.scala
@@ -45,24 +45,6 @@ object RemoteRestartedQuarantinedSpec extends MultiNodeConfig {
       akka.remote.artery.enabled = on
                               """)))
 
-  def aeronPort(roleName: RoleName): Int =
-    roleName match {
-      case `first`  ⇒ 20541 // TODO yeah, we should have support for dynamic port assignment
-      case `second` ⇒ 20542
-    }
-
-  nodeConfig(first) {
-    ConfigFactory.parseString(s"""
-      akka.remote.artery.port = ${aeronPort(first)}
-      """)
-  }
-
-  nodeConfig(second) {
-    ConfigFactory.parseString(s"""
-      akka.remote.artery.port = ${aeronPort(second)}
-      """)
-  }
-
   class Subject extends Actor {
     def receive = {
       case "shutdown" ⇒ context.system.terminate()

--- a/akka-remote/src/main/java/akka/remote/artery/AbstractAssociation.java
+++ b/akka-remote/src/main/java/akka/remote/artery/AbstractAssociation.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery;
+
+import akka.util.Unsafe;
+
+class AbstractAssociation {
+    protected final static long sharedStateOffset;
+
+    static {
+        try {
+            sharedStateOffset = Unsafe.instance.objectFieldOffset(Association.class.getDeclaredField("_sharedStateDoNotCallMeDirectly"));
+        } catch(Throwable t){
+            throw new ExceptionInInitializerError(t);
+        }
+    }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -3,18 +3,24 @@
  */
 package akka.remote.artery
 
+import java.io.File
 import java.nio.ByteOrder
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.{ Function ⇒ JFunction }
 
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
 import akka.Done
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.actor.Address
 import akka.actor.ExtendedActorSystem
 import akka.actor.InternalActorRef
+import akka.actor.Props
 import akka.event.Logging
 import akka.event.LoggingAdapter
 import akka.remote.AddressUidExtension
@@ -23,8 +29,10 @@ import akka.remote.MessageSerializer
 import akka.remote.RemoteActorRef
 import akka.remote.RemoteActorRefProvider
 import akka.remote.RemoteTransport
+import akka.remote.SeqNo
 import akka.remote.UniqueAddress
 import akka.remote.artery.InboundControlJunction.ControlMessageSubject
+import akka.remote.artery.OutboundControlJunction.OutboundControlIngress
 import akka.remote.transport.AkkaPduCodec
 import akka.remote.transport.AkkaPduProtobufCodec
 import akka.serialization.Serialization
@@ -60,7 +68,8 @@ private[akka] final case class InboundEnvelope(
   recipient: InternalActorRef,
   recipientAddress: Address,
   message: AnyRef,
-  senderOption: Option[ActorRef])
+  senderOption: Option[ActorRef],
+  originAddress: UniqueAddress)
 
 /**
  * INTERNAL API
@@ -75,7 +84,7 @@ private[akka] trait InboundContext {
 
   /**
    * An inbound stage can send control message, e.g. a reply, to the origin
-   * address with this method.
+   * address with this method. It will be sent over the control sub-channel.
    */
   def sendControl(to: Address, message: ControlMessage): Unit
 
@@ -83,6 +92,26 @@ private[akka] trait InboundContext {
    * Lookup the outbound association for a given address.
    */
   def association(remoteAddress: Address): OutboundContext
+}
+
+final class AssociationState(
+  val incarnation: Int,
+  val uniqueRemoteAddressPromise: Promise[UniqueAddress]) {
+
+  /**
+   * Full outbound address with UID for this association.
+   * Completed when by the handshake.
+   */
+  def uniqueRemoteAddress: Future[UniqueAddress] = uniqueRemoteAddressPromise.future
+
+  override def toString(): String = {
+    val a = uniqueRemoteAddressPromise.future.value match {
+      case Some(Success(a)) ⇒ a
+      case Some(Failure(e)) ⇒ s"Failure(${e.getMessage})"
+      case None             ⇒ "unknown"
+    }
+    s"AssociationState($incarnation, $a)"
+  }
 }
 
 /**
@@ -101,17 +130,15 @@ private[akka] trait OutboundContext {
    */
   def remoteAddress: Address
 
-  /**
-   * Full outbound address with UID for this association.
-   * Completed when by the handshake.
-   */
-  def uniqueRemoteAddress: Future[UniqueAddress]
+  def associationState: AssociationState
+
+  def completeHandshake(peer: UniqueAddress): Unit
 
   /**
-   * Set the outbound address with UID when the
-   * handshake is completed.
+   * An inbound stage can send control message, e.g. a HandshakeReq, to the remote
+   * address of this association. It will be sent over the control sub-channel.
    */
-  def completeRemoteAddress(a: UniqueAddress): Unit
+  def sendControl(message: ControlMessage): Unit
 
   /**
    * An outbound stage can listen to control messages
@@ -139,7 +166,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   @volatile private[this] var driver: MediaDriver = _
   @volatile private[this] var aeron: Aeron = _
 
-  override val log: LoggingAdapter = Logging(system.eventStream, getClass.getName)
+  override val log: LoggingAdapter = Logging(system, getClass.getName)
   override def defaultAddress: Address = localAddress.address
   override def addresses: Set[Address] = Set(defaultAddress)
   override def localAddressForRemote(remote: Address): Address = defaultAddress
@@ -280,9 +307,8 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     }
   }
 
-  override def quarantine(remoteAddress: Address, uid: Option[Int]): Unit = {
-    ???
-  }
+  override def quarantine(remoteAddress: Address, uid: Option[Int]): Unit =
+    association(remoteAddress).quarantine(uid)
 
   def outbound(outboundContext: OutboundContext): Sink[Send, Any] = {
     Flow.fromGraph(killSwitch.flow[Send])
@@ -302,6 +328,9 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       .to(new AeronSink(outboundChannel(outboundContext.remoteAddress), controlStreamId, aeron, taskRunner))
   }
 
+  // FIXME hack until real envelopes, encoding originAddress in sender :)
+  private val dummySender = system.systemActorOf(Props.empty, "dummy")
+
   // TODO: Try out parallelized serialization (mapAsync) for performance
   val encoder: Flow[Send, ByteString, NotUsed] = Flow[Send].map { sendEnvelope ⇒
     val pdu: ByteString = codec.constructMessage(
@@ -310,8 +339,8 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       Serialization.currentTransportInformation.withValue(Serialization.Information(localAddress.address, system)) {
         MessageSerializer.serialize(system, sendEnvelope.message.asInstanceOf[AnyRef])
       },
-      sendEnvelope.senderOption,
-      seqOption = None, // FIXME: Acknowledgements will be handled differently I just reused the old codec
+      if (sendEnvelope.senderOption.isDefined) sendEnvelope.senderOption else Some(dummySender), // FIXME: hack until real envelopes
+      seqOption = Some(SeqNo(localAddress.uid)), // FIXME: hack until real envelopes
       ackOption = None)
 
     // TODO: Drop unserializable messages
@@ -337,14 +366,15 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
         m.recipient,
         m.recipientAddress,
         MessageSerializer.deserialize(system, m.serializedMessage),
-        m.senderOption)
+        if (m.senderOption.get.path.name == "dummy") None else m.senderOption, // FIXME hack until real envelopes
+        UniqueAddress(m.senderOption.get.path.address, m.seq.rawValue.toInt)) // FIXME hack until real envelopes
     }
 
   val inboundFlow: Flow[ByteString, ByteString, NotUsed] = {
     Flow.fromSinkAndSource(
       decoder
         .via(deserializer)
-        .via(new InboundHandshake(this))
+        .via(new InboundHandshake(this, inControlStream = false))
         .to(messageDispatcherSink),
       Source.maybe[ByteString].via(killSwitch.flow))
   }
@@ -353,9 +383,9 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     Flow.fromSinkAndSourceMat(
       decoder
         .via(deserializer)
-        .via(new InboundHandshake(this))
-        .via(new SystemMessageAcker(this))
+        .via(new InboundHandshake(this, inControlStream = true))
         .viaMat(new InboundControlJunction)(Keep.right)
+        .via(new SystemMessageAcker(this))
         .to(messageDispatcherSink),
       Source.maybe[ByteString].via(killSwitch.flow))((a, b) ⇒ a)
   }

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -265,6 +265,8 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     messageDispatcher = new MessageDispatcher(system, provider)
 
     runInboundStreams()
+
+    log.info("Remoting started; listening on address: {}", defaultAddress)
   }
 
   private def startMediaDriver(): Unit = {

--- a/akka-remote/src/main/scala/akka/remote/artery/Control.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Control.scala
@@ -4,10 +4,8 @@
 package akka.remote.artery
 
 import java.util.ArrayDeque
-
 import scala.concurrent.Future
 import scala.concurrent.Promise
-
 import akka.Done
 import akka.remote.EndpointManager.Send
 import akka.stream.Attributes
@@ -19,17 +17,24 @@ import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.GraphStageWithMaterializedValue
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
+import akka.remote.UniqueAddress
 
 /**
- * Marker trait for reply messages
+ * INTERNAL API: Marker trait for reply messages
  */
-trait Reply extends ControlMessage
+private[akka] trait Reply extends ControlMessage
 
 /**
+ * INTERNAL API
  * Marker trait for control messages that can be sent via the system message sub-channel
  * but don't need full reliable delivery. E.g. `HandshakeReq` and `Reply`.
  */
-trait ControlMessage
+private[akka] trait ControlMessage
+
+/**
+ * INTERNAL API
+ */
+private[akka] final case class Quarantined(from: UniqueAddress, to: UniqueAddress) extends ControlMessage // FIXME serialization
 
 /**
  * INTERNAL API

--- a/akka-remote/src/main/scala/akka/remote/artery/Control.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Control.scala
@@ -3,20 +3,22 @@
  */
 package akka.remote.artery
 
+import java.util.ArrayDeque
+
 import scala.concurrent.Future
 import scala.concurrent.Promise
+
 import akka.Done
+import akka.remote.EndpointManager.Send
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
 import akka.stream.Outlet
+import akka.stream.stage.CallbackWrapper
 import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.GraphStageWithMaterializedValue
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
-import akka.remote.EndpointManager.Send
-import java.util.ArrayDeque
-import akka.stream.stage.CallbackWrapper
 
 /**
  * Marker trait for reply messages
@@ -97,7 +99,7 @@ private[akka] class InboundControlJunction
       // InHandler
       override def onPush(): Unit = {
         grab(in) match {
-          case env @ InboundEnvelope(_, _, _: ControlMessage, _) ⇒
+          case env @ InboundEnvelope(_, _, _: ControlMessage, _, _) ⇒
             observers.foreach(_.notify(env))
             pull(in)
           case env ⇒

--- a/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
@@ -159,7 +159,7 @@ private[akka] class InboundHandshake(inboundContext: InboundContext, inControlSt
       private def isKnownOrigin(originAddress: UniqueAddress): Boolean = {
         // FIXME these association lookups are probably too costly for each message, need local cache or something
         val associationState = inboundContext.association(originAddress.address).associationState
-        associationState.uniqueRemoteAddress.value match {
+        associationState.uniqueRemoteAddressValue() match {
           case Some(Success(a)) if a.uid == originAddress.uid ⇒ true
           case x ⇒ false
         }

--- a/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+
+/**
+ * INTERNAL API
+ */
+private[akka] class InboundQuarantineCheck(inboundContext: InboundContext) extends GraphStage[FlowShape[InboundEnvelope, InboundEnvelope]] {
+  val in: Inlet[InboundEnvelope] = Inlet("InboundQuarantineCheck.in")
+  val out: Outlet[InboundEnvelope] = Outlet("InboundQuarantineCheck.out")
+  override val shape: FlowShape[InboundEnvelope, InboundEnvelope] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      // InHandler
+      override def onPush(): Unit = {
+        val env = grab(in)
+        val association = inboundContext.association(env.originAddress.address)
+        if (association.associationState.isQuarantined(env.originAddress.uid)) {
+          inboundContext.sendControl(env.originAddress.address,
+            Quarantined(inboundContext.localAddress, env.originAddress))
+          pull(in)
+        } else
+          push(out, env)
+      }
+
+      // OutHandler
+      override def onPull(): Unit = pull(in)
+
+      setHandlers(in, out, this)
+    }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
@@ -25,7 +25,7 @@ private[akka] class MessageDispatcher(
   provider: RemoteActorRefProvider) {
 
   private val remoteDaemon = provider.remoteDaemon
-  private val log = Logging(system.eventStream, getClass.getName)
+  private val log = Logging(system, getClass.getName)
 
   def dispatch(recipient: InternalActorRef,
                recipientAddress: Address,

--- a/akka-remote/src/main/scala/akka/remote/artery/RestartCounter.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/RestartCounter.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration.Deadline
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration.FiniteDuration
+import scala.annotation.tailrec
+
+/**
+ * INTERNAL API
+ */
+private[akka] object RestartCounter {
+  final case class State(count: Int, deadline: Deadline)
+}
+
+/**
+ * INTERNAL API: Thread safe "restarts with duration" counter
+ */
+private[akka] class RestartCounter(maxRestarts: Int, restartTimeout: FiniteDuration) {
+  import RestartCounter._
+
+  private val state = new AtomicReference[State](State(0, Deadline.now + restartTimeout))
+
+  /**
+   * Current number of restarts.
+   */
+  def count(): Int = state.get.count
+
+  /**
+   * Increment the restart counter, or reset the counter to 1 if the
+   * `restartTimeout` has elapsed. The latter also resets the timeout.
+   * @return `true` if number of restarts, including this one, is less
+   *         than or equal to `maxRestarts`
+   */
+  @tailrec final def restart(): Boolean = {
+    val s = state.get
+
+    val newState =
+      if (s.deadline.hasTimeLeft())
+        s.copy(count = s.count + 1)
+      else
+        State(1, Deadline.now + restartTimeout)
+
+    if (state.compareAndSet(s, newState))
+      newState.count <= maxRestarts
+    else
+      restart() // recur
+  }
+
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -199,7 +199,7 @@ private[akka] class SystemMessageAcker(inboundContext: InboundContext) extends G
       // InHandler
       override def onPush(): Unit = {
         grab(in) match {
-          case env @ InboundEnvelope(_, _, sysEnv @ SystemMessageEnvelope(_, n, ackReplyTo), _) ⇒
+          case env @ InboundEnvelope(_, _, sysEnv @ SystemMessageEnvelope(_, n, ackReplyTo), _, _) ⇒
             if (n == seqNo) {
               inboundContext.sendControl(ackReplyTo.address, Ack(n, localAddress))
               seqNo += 1

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
@@ -13,14 +13,15 @@ import com.typesafe.config.ConfigFactory
 
 object HandshakeFailureSpec {
 
-  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
+  // need the port before systemB is started
+  val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
 
   val commonConfig = ConfigFactory.parseString(s"""
      akka {
        actor.provider = "akka.remote.RemoteActorRefProvider"
        remote.artery.enabled = on
        remote.artery.hostname = localhost
-       remote.artery.port = $portA
+       remote.artery.port = 0
        remote.handshake-timeout = 2s
      }
   """)
@@ -47,7 +48,6 @@ class HandshakeFailureSpec extends AkkaSpec(HandshakeFailureSpec.commonConfig) w
 
       within(10.seconds) {
         awaitAssert {
-          println(s"# identify $sel") // FIXME
           sel ! "hello2"
           expectMsg(1.second, "hello2")
         }

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+
+import akka.actor.{ ActorIdentity, ActorSystem, Identify }
+import akka.testkit.{ AkkaSpec, ImplicitSender }
+import akka.testkit.SocketUtil
+import akka.testkit.TestActors
+import com.typesafe.config.ConfigFactory
+
+object HandshakeFailureSpec {
+
+  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
+
+  val commonConfig = ConfigFactory.parseString(s"""
+     akka {
+       actor.provider = "akka.remote.RemoteActorRefProvider"
+       remote.artery.enabled = on
+       remote.artery.hostname = localhost
+       remote.artery.port = $portA
+       remote.handshake-timeout = 2s
+     }
+  """)
+
+  val configB = ConfigFactory.parseString(s"akka.remote.artery.port = $portB")
+    .withFallback(commonConfig)
+
+}
+
+class HandshakeFailureSpec extends AkkaSpec(HandshakeFailureSpec.commonConfig) with ImplicitSender {
+  import HandshakeFailureSpec._
+
+  var systemB: ActorSystem = null
+
+  "Artery handshake" must {
+
+    "allow for timeout and later connect" in {
+      def sel = system.actorSelection(s"akka.artery://systemB@localhost:$portB/user/echo")
+      sel ! "hello"
+      expectNoMsg(3.seconds) // longer than handshake-timeout
+
+      systemB = ActorSystem("systemB", HandshakeFailureSpec.configB)
+      systemB.actorOf(TestActors.echoActorProps, "echo")
+
+      within(10.seconds) {
+        awaitAssert {
+          println(s"# identify $sel") // FIXME
+          sel ! "hello2"
+          expectMsg(1.second, "hello2")
+        }
+      }
+
+      sel ! Identify(None)
+      val remoteRef = expectMsgType[ActorIdentity].ref.get
+
+      remoteRef ! "ping"
+      expectMsg("ping")
+    }
+
+  }
+
+  override def afterTermination(): Unit =
+    if (systemB != null) shutdown(systemB)
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
@@ -13,14 +13,15 @@ import com.typesafe.config.ConfigFactory
 
 object HandshakeRetrySpec {
 
-  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
+  // need the port before systemB is started
+  val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
 
   val commonConfig = ConfigFactory.parseString(s"""
      akka {
        actor.provider = "akka.remote.RemoteActorRefProvider"
        remote.artery.enabled = on
        remote.artery.hostname = localhost
-       remote.artery.port = $portA
+       remote.artery.port = 0
        remote.handshake-timeout = 10s
      }
   """)

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+
+import akka.actor.{ ActorIdentity, ActorSystem, Identify }
+import akka.testkit.{ AkkaSpec, ImplicitSender }
+import akka.testkit.SocketUtil
+import akka.testkit.TestActors
+import com.typesafe.config.ConfigFactory
+
+object HandshakeRetrySpec {
+
+  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
+
+  val commonConfig = ConfigFactory.parseString(s"""
+     akka {
+       actor.provider = "akka.remote.RemoteActorRefProvider"
+       remote.artery.enabled = on
+       remote.artery.hostname = localhost
+       remote.artery.port = $portA
+       remote.handshake-timeout = 10s
+     }
+  """)
+
+  val configB = ConfigFactory.parseString(s"akka.remote.artery.port = $portB")
+    .withFallback(commonConfig)
+
+}
+
+class HandshakeRetrySpec extends AkkaSpec(HandshakeRetrySpec.commonConfig) with ImplicitSender {
+  import HandshakeRetrySpec._
+
+  var systemB: ActorSystem = null
+
+  "Artery handshake" must {
+
+    "be retried during handshake-timeout (no message loss)" in {
+      def sel = system.actorSelection(s"akka.artery://systemB@localhost:$portB/user/echo")
+      sel ! "hello"
+      expectNoMsg(1.second)
+
+      systemB = ActorSystem("systemB", HandshakeRetrySpec.configB)
+      systemB.actorOf(TestActors.echoActorProps, "echo")
+
+      expectMsg("hello")
+
+      sel ! Identify(None)
+      val remoteRef = expectMsgType[ActorIdentity].ref.get
+
+      remoteRef ! "ping"
+      expectMsg("ping")
+    }
+
+  }
+
+  override def afterTermination(): Unit =
+    if (systemB != null) shutdown(systemB)
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
@@ -42,9 +42,9 @@ class InboundControlJunctionSpec extends AkkaSpec with ImplicitSender {
       val recipient = null.asInstanceOf[InternalActorRef] // not used
 
       val ((upstream, controlSubject), downstream) = TestSource.probe[AnyRef]
-        .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, None))
+        .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, None, addressA))
         .viaMat(new InboundControlJunction)(Keep.both)
-        .map { case InboundEnvelope(_, _, msg, _) ⇒ msg }
+        .map { case InboundEnvelope(_, _, msg, _, _) ⇒ msg }
         .toMat(TestSink.probe[Any])(Keep.both)
         .run()
 

--- a/akka-remote/src/test/scala/akka/remote/artery/InboundHandshakeSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/InboundHandshakeSpec.scala
@@ -52,7 +52,7 @@ class InboundHandshakeSpec extends AkkaSpec with ImplicitSender {
 
     "send HandshakeRsp as reply to HandshakeReq" in {
       val replyProbe = TestProbe()
-      val inboundContext = new ManualReplyInboundContext(replyProbe.ref, addressB, new TestControlMessageSubject)
+      val inboundContext = new TestInboundContext(addressB, controlProbe = Some(replyProbe.ref))
       val (upstream, downstream) = setupStream(inboundContext)
 
       downstream.request(10)
@@ -77,9 +77,9 @@ class InboundHandshakeSpec extends AkkaSpec with ImplicitSender {
       downstream.cancel()
     }
 
-    "send HandshakeReq as when receiving message from unknown (receiving system restarted)" in {
+    "send HandshakeReq when receiving message from unknown (receiving system restarted)" in {
       val replyProbe = TestProbe()
-      val inboundContext = new ManualReplyInboundContext(replyProbe.ref, addressB, new TestControlMessageSubject)
+      val inboundContext = new TestInboundContext(addressB, controlProbe = Some(replyProbe.ref))
       val (upstream, downstream) = setupStream(inboundContext)
 
       downstream.request(10)

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
@@ -7,31 +7,24 @@ import scala.concurrent.duration._
 import akka.actor.{ Actor, ActorIdentity, ActorSystem, Deploy, ExtendedActorSystem, Identify, Props, RootActorPath }
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 import com.typesafe.config.ConfigFactory
-import RemoteSendConsistencySpec._
 import akka.actor.Actor.Receive
-import akka.testkit.SocketUtil
 
 object RemoteSendConsistencySpec {
 
-  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
-
-  val commonConfig = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString(s"""
      akka {
        actor.provider = "akka.remote.RemoteActorRefProvider"
        remote.artery.enabled = on
        remote.artery.hostname = localhost
-       remote.artery.port = $portA
+       remote.artery.port = 0
      }
   """)
 
-  val configB = ConfigFactory.parseString(s"akka.remote.artery.port = $portB")
-    .withFallback(commonConfig)
-
 }
 
-class RemoteSendConsistencySpec extends AkkaSpec(commonConfig) with ImplicitSender {
+class RemoteSendConsistencySpec extends AkkaSpec(RemoteSendConsistencySpec.config) with ImplicitSender {
 
-  val systemB = ActorSystem("systemB", RemoteSendConsistencySpec.configB)
+  val systemB = ActorSystem("systemB", system.settings.config)
   val addressB = systemB.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
   println(addressB)
   val rootB = RootActorPath(addressB)

--- a/akka-remote/src/test/scala/akka/remote/artery/RestartCounterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RestartCounterSpec.scala
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class RestartCounterSpec extends WordSpec with Matchers {
+
+  "RestartCounter" must {
+
+    "count max restarts within duration" in {
+      val counter = new RestartCounter(3, 3.seconds)
+      counter.restart() should ===(true)
+      counter.restart() should ===(true)
+      counter.restart() should ===(true)
+      counter.restart() should ===(false)
+      counter.count() should ===(4)
+    }
+
+    "allow sporadic restarts" in {
+      val counter = new RestartCounter(3, 10.millis)
+      for (_ ← 1 to 10) {
+        counter.restart() should ===(true)
+        Thread.sleep(20)
+      }
+    }
+
+    "reset count after timeout" in {
+      val counter = new RestartCounter(3, 500.millis)
+      counter.restart()
+      counter.restart()
+      counter.count() should ===(2)
+      Thread.sleep(600)
+      counter.restart()
+      counter.count() should ===(1)
+    }
+  }
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -30,37 +30,32 @@ import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
-import akka.testkit.SocketUtil
 import akka.testkit.TestActors
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 
 object SystemMessageDeliverySpec {
 
-  val Seq(portA, portB) = SocketUtil.temporaryServerAddresses(2, "localhost", udp = true).map(_.getPort)
-
-  val commonConfig = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString(s"""
      akka {
        actor.provider = "akka.remote.RemoteActorRefProvider"
        remote.artery.enabled = on
        remote.artery.hostname = localhost
-       remote.artery.port = $portA
+       remote.artery.port = 0
      }
      akka.actor.serialize-creators = off
      akka.actor.serialize-messages = off
   """)
 
-  val configB = ConfigFactory.parseString(s"akka.remote.artery.port = $portB")
-    .withFallback(commonConfig)
 }
 
-class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.commonConfig) with ImplicitSender {
+class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.config) with ImplicitSender {
   import SystemMessageDeliverySpec._
 
   val addressA = UniqueAddress(
     system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress,
     AddressUidExtension(system).addressUid)
-  val systemB = ActorSystem("systemB", configB)
+  val systemB = ActorSystem("systemB", system.settings.config)
   val addressB = UniqueAddress(
     systemB.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress,
     AddressUidExtension(systemB).addressUid)

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -74,7 +74,7 @@ class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.commo
     val remoteRef = null.asInstanceOf[RemoteActorRef] // not used
     Source(1 to sendCount)
       .map(n ⇒ Send("msg-" + n, None, remoteRef, None))
-      .via(new SystemMessageDelivery(outboundContext, resendInterval))
+      .via(new SystemMessageDelivery(outboundContext, resendInterval, maxBufferSize = 1000))
   }
 
   private def inbound(inboundContext: InboundContext): Flow[Send, InboundEnvelope, NotUsed] = {

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -10,9 +10,7 @@ import scala.concurrent.duration._
 
 import akka.NotUsed
 import akka.actor.ActorIdentity
-import akka.actor.ActorRef
 import akka.actor.ActorSystem
-import akka.actor.Address
 import akka.actor.ExtendedActorSystem
 import akka.actor.Identify
 import akka.actor.InternalActorRef
@@ -84,7 +82,7 @@ class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.commo
     Flow[Send]
       .map {
         case Send(sysEnv: SystemMessageEnvelope, _, _, _) ⇒
-          InboundEnvelope(recipient, addressB.address, sysEnv, None)
+          InboundEnvelope(recipient, addressB.address, sysEnv, None, addressA)
       }
       .async
       .via(new SystemMessageAcker(inboundContext))

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -3,35 +3,39 @@
  */
 package akka.remote.artery
 
-import akka.remote.UniqueAddress
-import akka.actor.Address
-import scala.concurrent.Future
-import akka.remote.artery.InboundControlJunction.ControlMessageSubject
-import akka.remote.RemoteActorRef
-import scala.concurrent.Promise
-import akka.Done
-import akka.remote.artery.InboundControlJunction.ControlMessageObserver
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ThreadLocalRandom
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Success
+
+import akka.Done
 import akka.actor.ActorRef
+import akka.actor.Address
+import akka.remote.RemoteActorRef
+import akka.remote.UniqueAddress
+import akka.remote.artery.InboundControlJunction.ControlMessageObserver
+import akka.remote.artery.InboundControlJunction.ControlMessageSubject
 
 private[akka] class TestInboundContext(
   override val localAddress: UniqueAddress,
   val controlSubject: TestControlMessageSubject = new TestControlMessageSubject,
-  replyDropRate: Double = 0.0) extends InboundContext {
+  val controlProbe: Option[ActorRef] = None,
+  val replyDropRate: Double = 0.0) extends InboundContext {
 
   private val associations = new ConcurrentHashMap[Address, OutboundContext]
 
-  def sendControl(to: Address, message: ControlMessage) = {
+  override def sendControl(to: Address, message: ControlMessage) = {
     if (ThreadLocalRandom.current().nextDouble() >= replyDropRate)
-      controlSubject.sendControl(InboundEnvelope(null, to, message, None))
+      association(to).sendControl(message)
   }
 
-  def association(remoteAddress: Address): OutboundContext =
+  override def association(remoteAddress: Address): OutboundContext =
     associations.get(remoteAddress) match {
       case null ⇒
-        val a = new TestOutboundContext(localAddress, remoteAddress, controlSubject)
+        val a = createAssociation(remoteAddress)
         associations.putIfAbsent(remoteAddress, a) match {
           case null     ⇒ a
           case existing ⇒ existing
@@ -40,20 +44,38 @@ private[akka] class TestInboundContext(
     }
 
   protected def createAssociation(remoteAddress: Address): OutboundContext =
-    new TestOutboundContext(localAddress, remoteAddress, controlSubject)
+    new TestOutboundContext(localAddress, remoteAddress, controlSubject, controlProbe)
 }
 
 private[akka] class TestOutboundContext(
   override val localAddress: UniqueAddress,
   override val remoteAddress: Address,
-  override val controlSubject: TestControlMessageSubject) extends OutboundContext {
+  override val controlSubject: TestControlMessageSubject,
+  val controlProbe: Option[ActorRef] = None) extends OutboundContext {
 
-  private val _uniqueRemoteAddress = Promise[UniqueAddress]()
-  def uniqueRemoteAddress: Future[UniqueAddress] = _uniqueRemoteAddress.future
-  def completeRemoteAddress(a: UniqueAddress): Unit = _uniqueRemoteAddress.trySuccess(a)
+  // access to this is synchronized (it's a test utility)
+  private var _associationState = new AssociationState(1, Promise())
+
+  override def associationState: AssociationState = synchronized {
+    _associationState
+  }
+
+  override def completeHandshake(peer: UniqueAddress): Unit = synchronized {
+    _associationState.uniqueRemoteAddressPromise.trySuccess(peer)
+    _associationState.uniqueRemoteAddress.value match {
+      case Some(Success(`peer`)) ⇒ // our value
+      case _ ⇒
+        _associationState = new AssociationState(incarnation = _associationState.incarnation + 1, Promise.successful(peer))
+    }
+  }
+
+  override def sendControl(message: ControlMessage) = {
+    controlProbe.foreach(_ ! message)
+    controlSubject.sendControl(InboundEnvelope(null, remoteAddress, message, None, localAddress))
+  }
 
   // FIXME we should be able to Send without a recipient ActorRef
-  def dummyRecipient: RemoteActorRef = null
+  override def dummyRecipient: RemoteActorRef = null
 
 }
 


### PR DESCRIPTION
- handle UID incarnations, shared association state that can be swapped
  for new handshakes
- detect that message comes from unknown origin and then initiate new
  handshake (handled by InboundHandshake stage)
- simplify the OutboundHandshake stage
  - doesn't have to listen for HandshakeRsp replies, it can just listen
    to when the uniqueRemoteAddress future is completed, InboundHandshake
    stage completes the handshake when it receives HandshakeRsp
  - send the HandshakeReq via the control message ingress, instead of
    pushing it downstreams, than also means that HandshakeReq is only sent
    on the control stream, which is good
- make control message ingress buffer bounded

This is what the streams look like now: 
![artery_stages3](https://cloud.githubusercontent.com/assets/336161/15248401/51cf7454-191a-11e6-82e9-847319679f53.png)
