### PR TITLE
Workaround for unidoc failing to compile scaladsl.server.Rejection

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.http.scaladsl.server
 
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
@@ -1,0 +1,21 @@
+package akka.http.scaladsl.server
+
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import scala.collection.JavaConverters._
+
+class RejectionSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  "The Transformation Rejection" should {
+
+    "map to and from Java" in {
+      import akka.http.javadsl.{ server ⇒ jserver }
+      val rejections = List(RequestEntityExpectedRejection)
+      val jrejections: java.lang.Iterable[jserver.Rejection] =
+        rejections.map(_.asInstanceOf[jserver.Rejection]).asJava
+      val jresult = TransformationRejection(identity).getTransform.apply(jrejections)
+
+      val result = jresult.asScala.map(r ⇒ r.asInstanceOf[Rejection])
+      result should ===(rejections)
+    }
+  }
+}

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -250,7 +250,8 @@ final case class TransformationRejection(transform: immutable.Seq[Rejection] ⇒
   extends jserver.TransformationRejection with Rejection {
   override def getTransform = new Function[Iterable[jserver.Rejection], Iterable[jserver.Rejection]] {
     override def apply(t: Iterable[jserver.Rejection]): Iterable[jserver.Rejection] =
-      transform(Util.immutableSeq(t).map(x ⇒ x.asScala)).map(_.asJava).asJava // TODO "asJavaDeep" and optimise?
+      // explicit casts is because of unidoc fails compilation on .asScala and .asJava here
+      transform(Util.immutableSeq(t).map(_.asInstanceOf[Rejection])).map(_.asInstanceOf[jserver.Rejection]).asJava // TODO "asJavaDeep" and optimise?
   }
 }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -243,15 +243,15 @@ final case class ValidationRejection(message: String, cause: Option[Throwable] =
  * 3. A TransformationRejection holding a function filtering out the MethodRejection
  *
  * so that in the end the RejectionHandler will only see one rejection (the ValidationRejection), because the
- * MethodRejection added by the get` directive is canceled by the `put` directive (since the HTTP method
+ * MethodRejection added by the `get` directive is canceled by the `put` directive (since the HTTP method
  * did indeed match eventually).
  */
 final case class TransformationRejection(transform: immutable.Seq[Rejection] ⇒ immutable.Seq[Rejection])
   extends jserver.TransformationRejection with Rejection {
   override def getTransform = new Function[Iterable[jserver.Rejection], Iterable[jserver.Rejection]] {
     override def apply(t: Iterable[jserver.Rejection]): Iterable[jserver.Rejection] =
-      // explicit casts is because of unidoc fails compilation on .asScala and .asJava here
-      transform(Util.immutableSeq(t).map(_.asInstanceOf[Rejection])).map(_.asInstanceOf[jserver.Rejection]).asJava // TODO "asJavaDeep" and optimise?
+      // explicit collects instead of implicits is because of unidoc failing compilation on .asScala and .asJava here
+      transform(Util.immutableSeq(t).collect { case r: Rejection ⇒ r }).collect[jserver.Rejection, Seq[jserver.Rejection]] { case j: jserver.Rejection ⇒ j }.asJava // TODO "asJavaDeep" and optimise?
   }
 }
 


### PR DESCRIPTION
Unidoc fails to find implicit conversions somehow. Using explicit casts now.
