### PR TITLE
improve codec performance

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
@@ -66,12 +66,12 @@ private[akka] object MessageSerializer {
     envelope.byteBuffer.put(serializer.toBinary(message))
   }
 
-  def deserializeForArtery(system: ExtendedActorSystem, headerBuilder: HeaderBuilder, envelope: EnvelopeBuffer): AnyRef = {
+  def deserializeForArtery(system: ExtendedActorSystem, serialization: Serialization, headerBuilder: HeaderBuilder, envelope: EnvelopeBuffer): AnyRef = {
     // FIXME: Use the buffer directly
     val size = envelope.byteBuffer.limit - envelope.byteBuffer.position
     val bytes = Array.ofDim[Byte](size)
     envelope.byteBuffer.get(bytes)
-    SerializationExtension(system).deserialize(
+    serialization.deserialize(
       bytes,
       Integer.parseInt(headerBuilder.serializer), // FIXME: Use FQCN
       headerBuilder.classManifest).get


### PR DESCRIPTION
Here are a few low hanging performance improvements that I found when profiling. It increases throughput in `MaxThroughputSpec` from around 100,000 msg/s to 300,000 msg/s on my local.
- caching of actor refs in Encoder, Decoder
- dynamicAccess.getClassFor in Serialization is costly,
  so introduced a cache for the class manifests there
