### PR TITLE
Add scheme directive example in javadsl

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.directives;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.headers.Host;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.server.RequestContext;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import java.util.function.Function;
+import akka.http.javadsl.model.Uri;
+import akka.http.javadsl.model.headers.Location;
+
+public class SchemeDirectivesExamplesTest extends JUnitRouteTest {
+
+  @Test
+  public void testScheme() {
+    final Route route = extractScheme((scheme) -> 
+                                      complete(String.format("The scheme is '%s'", scheme)));
+    testRoute(route).run(HttpRequest.GET("https://www.example.com/"))
+      .assertEntity("The scheme is 'https'");
+  }
+
+  @Test
+  public void testRedirection() {
+    final Route route = route(
+      scheme("http", ()->
+        extract((ctx) -> ctx.getRequest().getUri(), (uri)->
+          redirect(uri.scheme("https"), StatusCodes.MOVED_PERMANENTLY)
+        )
+      ),
+      scheme("https", ()->
+        complete("Safe and secure!")
+      )
+    );
+
+    testRoute(route).run(HttpRequest.GET("http://www.example.com/hello"))
+      .assertStatusCode(StatusCodes.MOVED_PERMANENTLY)
+      .assertHeaderExists(Location.create("https://www.example.com/hello"))
+    ;
+
+    testRoute(route).run(HttpRequest.GET("https://www.example.com/hello"))
+      .assertEntity("Safe and secure!");
+  }
+
+}

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -23,14 +23,17 @@ public class SchemeDirectivesExamplesTest extends JUnitRouteTest {
 
   @Test
   public void testScheme() {
+    //#extractScheme
     final Route route = extractScheme((scheme) -> 
                                       complete(String.format("The scheme is '%s'", scheme)));
     testRoute(route).run(HttpRequest.GET("https://www.example.com/"))
       .assertEntity("The scheme is 'https'");
+    //#extractScheme
   }
 
   @Test
   public void testRedirection() {
+    //#scheme
     final Route route = route(
       scheme("http", ()->
         extract((ctx) -> ctx.getRequest().getUri(), (uri)->
@@ -49,6 +52,7 @@ public class SchemeDirectivesExamplesTest extends JUnitRouteTest {
 
     testRoute(route).run(HttpRequest.GET("https://www.example.com/hello"))
       .assertEntity("Safe and secure!");
+    //#scheme
   }
 
 }

--- a/akka-docs/rst/java/http/routing-dsl/directives/scheme-directives/extractScheme.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/scheme-directives/extractScheme.rst
@@ -11,4 +11,5 @@ For rejecting a request if it doesn't match a specified scheme name, see the :re
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java#extractScheme

--- a/akka-docs/rst/java/http/routing-dsl/directives/scheme-directives/scheme.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/scheme-directives/scheme.rst
@@ -18,4 +18,5 @@ For simply extracting the scheme name, see the :ref:`-extractScheme-java-` direc
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java#scheme


### PR DESCRIPTION
Hi,
I translated the scheme example from Scala DSL to Java, following the instructions given in [issue 20466](https://github.com/akka/akka/issues/20466)
