### PR TITLE
gating should not overwrite quarantine, #20531

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/EndpointRegistrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/EndpointRegistrySpec.scala
@@ -69,7 +69,7 @@ class EndpointRegistrySpec extends AkkaSpec {
       reg.registerWritableEndpoint(address1, None, None, actorA)
       val deadline = Deadline.now
       reg.markAsFailed(actorA, deadline)
-      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline, None)))
       reg.isReadOnly(actorA) should ===(false)
       reg.isWritable(actorA) should ===(false)
     }
@@ -94,7 +94,7 @@ class EndpointRegistrySpec extends AkkaSpec {
       reg.unregisterEndpoint(actorA)
       reg.unregisterEndpoint(actorB)
 
-      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline, None)))
       reg.writableEndpointWithPolicyFor(address2) should ===(Some(Quarantined(42, deadline)))
 
     }
@@ -109,8 +109,8 @@ class EndpointRegistrySpec extends AkkaSpec {
       reg.markAsFailed(actorB, farInTheFuture)
       reg.prune()
 
-      reg.writableEndpointWithPolicyFor(address1) should ===(None)
-      reg.writableEndpointWithPolicyFor(address2) should ===(Some(Gated(farInTheFuture)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(WasGated(None)))
+      reg.writableEndpointWithPolicyFor(address2) should ===(Some(Gated(farInTheFuture, None)))
     }
 
     "be able to register Quarantined policy for an address" in {

--- a/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SystemMessageDeliveryStressTest.scala
@@ -109,7 +109,7 @@ abstract class SystemMessageDeliveryStressTest(msg: String, cfg: String)
   with DefaultTimeout {
   import SystemMessageDeliveryStressTest._
 
-  override def expectedTestDuration: FiniteDuration = 120.seconds
+  override def expectedTestDuration: FiniteDuration = 200.seconds
 
   val systemA = system
   val systemB = ActorSystem("systemB", system.settings.config)

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -869,7 +869,10 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Framing#LengthFieldFramingStage.onPush"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Framing#LengthFieldFramingStage.onUpstreamFinish"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Framing#LengthFieldFramingStage.onPull"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Framing#LengthFieldFramingStage.postStop")
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Framing#LengthFieldFramingStage.postStop"),
+        
+        // #20531 adding refuseUid to Gated
+        FilterAnyProblem("akka.remote.EndpointManager$Gated")
       )
     )
   }


### PR DESCRIPTION
- Reproduced with cluster sample.
  - auto-down=45s
  - node1 and node2 joins
  - suspend node2 (kill -STOP)
  - node1 removes and quarantines node2
  - resume node2 (kill -CONT)
  - node2 receives heartbeat response from node1, which
    is not expected since node2 is supposed to be quarantined
  - the reason is that the quarantine is overwritten by gating
