### PR TITLE
Include Respond Directives Examples for Java.

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package docs.http.javadsl.server.directives;
 
 import java.util.List;
@@ -19,7 +23,7 @@ public class RespondWithDirectivesExamplesTest extends JUnitRouteTest {
         final Route route = path("foo", () ->
                 respondWithHeader(RawHeader.create("Funky-Muppet", "gonzo"), () ->
                         complete("beep")));
-        
+
         testRoute(route).run(HttpRequest.GET("/foo"))
                 .assertHeaderExists("Funky-Muppet", "gonzo")
                 .assertEntity("beep");

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java
@@ -1,0 +1,131 @@
+package docs.http.javadsl.server.directives;
+
+import java.util.List;
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.headers.HttpOrigin;
+import akka.http.javadsl.model.headers.Origin;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+public class RespondWithDirectivesExamplesTest extends JUnitRouteTest {
+
+    @Test
+    public void testRespondWithHeader() {
+        //#respondWithHeader
+        final Route route = path("foo", () ->
+                respondWithHeader(RawHeader.create("Funky-Muppet", "gonzo"), () ->
+                        complete("beep")));
+        
+        testRoute(route).run(HttpRequest.GET("/foo"))
+                .assertHeaderExists("Funky-Muppet", "gonzo")
+                .assertEntity("beep");
+        //#respondWithHeader
+    }
+
+    @Test
+    public void testRespondWithDefaultHeader() {
+        //#respondWithDefaultHeader
+        //custom headers
+        final RawHeader blippy = RawHeader.create("X-Fish-Name", "Blippy");
+        final RawHeader elTonno = RawHeader.create("X-Fish-Name", "El Tonno");
+
+        // format: OFF
+        // by default always include the Blippy header,
+        // unless a more specific X-Fish-Name is given by the inner route
+        final Route route =
+                respondWithDefaultHeader(blippy, () ->                      // blippy
+                        respondWithHeader(elTonno, () ->                    // / el tonno
+                                path("el-tonno", () ->                      // | /
+                                        complete("¡Ay blippy!")             // | |- el tonno
+                                ).orElse(                                   // | |
+                                        path("los-tonnos", () ->            // | |
+                                                complete("¡Ay ay blippy!")  // | |- el tonno
+                                        )                                   // | |
+                                )                                           // | |
+                        ).orElse(                                           // | x
+                                complete("Blip!")                           // |- blippy
+                        )                                                   // x
+                );
+        //format: ON
+
+        testRoute(route).run(HttpRequest.GET("/"))
+                .assertHeaderExists("X-Fish-Name", "Blippy")
+                .assertEntity("Blip!");
+
+        testRoute(route).run(HttpRequest.GET("/el-tonno"))
+                .assertHeaderExists("X-Fish-Name", "El Tonno")
+                .assertEntity("¡Ay blippy!");
+
+        testRoute(route).run(HttpRequest.GET("/los-tonnos"))
+                .assertHeaderExists("X-Fish-Name", "El Tonno")
+                .assertEntity("¡Ay ay blippy!");
+        //#respondWithDefaultHeader
+    }
+
+    @Test
+    public void respondWithHeaders() {
+        //#respondWithHeaders
+        final HttpHeader gonzo = RawHeader.create("Funky-Muppet", "gonzo");
+        final HttpHeader akka = Origin.create(HttpOrigin.parse("http://akka.io"));
+
+        final Route route = path("foo", () ->
+                respondWithHeaders(Lists.newArrayList(gonzo, akka), () ->
+                        complete("beep")
+                )
+        );
+
+        testRoute(route).run(HttpRequest.GET("/foo"))
+                .assertHeaderExists("Funky-Muppet", "gonzo")
+                .assertHeaderExists("Origin", "http://akka.io")
+                .assertEntity("beep");
+
+        //#respondWithHeaders
+    }
+
+    @Test
+    public void testRespondWithDefaultHeaders() {
+        //#respondWithDefaultHeaders
+        //custom headers
+        final RawHeader blippy = RawHeader.create("X-Fish-Name", "Blippy");
+        final HttpHeader akka = Origin.create(HttpOrigin.parse("http://akka.io"));
+        final List<HttpHeader> defaultHeaders = Lists.newArrayList(blippy, akka);
+        final RawHeader elTonno = RawHeader.create("X-Fish-Name", "El Tonno");
+
+        // format: OFF
+        // by default always include the Blippy and Akka headers,
+        // unless a more specific X-Fish-Name is given by the inner route
+        final Route route =
+                respondWithDefaultHeaders(defaultHeaders, () ->            // blippy and akka
+                        respondWithHeader(elTonno, () ->                   // / el tonno
+                                path("el-tonno", () ->                     // | /
+                                        complete("¡Ay blippy!")            // | |- el tonno
+                                ).orElse(                                  // | |
+                                        path("los-tonnos", () ->           // | |
+                                                complete("¡Ay ay blippy!") // | |- el tonno
+                                        )                                  // | |
+                                )                                          // | |
+                        ).orElse(                                          // | x
+                                complete("Blip!")                          // |- blippy and akka
+                        )                                                  // x
+                );
+        //format: ON
+
+        testRoute(route).run(HttpRequest.GET("/"))
+                .assertHeaderExists("X-Fish-Name", "Blippy")
+                .assertHeaderExists("Origin", "http://akka.io")
+                .assertEntity("Blip!");
+
+        testRoute(route).run(HttpRequest.GET("/el-tonno"))
+                .assertHeaderExists("X-Fish-Name", "El Tonno")
+                .assertEntity("¡Ay blippy!");
+
+        testRoute(route).run(HttpRequest.GET("/los-tonnos"))
+                .assertHeaderExists("X-Fish-Name", "El Tonno")
+                .assertEntity("¡Ay ay blippy!");
+        //#respondWithDefaultHeaders
+    }
+}

--- a/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeader.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeader.rst
@@ -18,4 +18,4 @@ See also :ref:`-respondWithDefaultHeaders-java-`  if you'd like to add more than
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java#respondWithDefaultHeader

--- a/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeaders.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeaders.rst
@@ -30,6 +30,6 @@ is shown in the example below, however it allows including multiple default head
 
 The semantics remain the same however, as explained by the following example:
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java#respondWithDefaultHeaders
 
 See the :ref:`-respondWithDefaultHeader-java-` directive for an example with only one header.

--- a/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithHeader.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithHeader.rst
@@ -14,4 +14,4 @@ See also :ref:`-respondWithHeaders-java-` if you'd like to add more than one hea
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java#respondWithHeader

--- a/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithHeaders.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/respond-with-directives/respondWithHeaders.rst
@@ -15,4 +15,4 @@ See also :ref:`-respondWithHeader-java-` if you'd like to add just a single head
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java#respondWithHeaders

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/SprayJsonCompactMarshalSpec.scala
@@ -5,7 +5,7 @@ package docs.http.scaladsl
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.server.Directives
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
 
@@ -22,7 +22,7 @@ class SprayJsonCompactMarshalSpec extends WordSpec with Matchers {
     }
 
     // use it wherever json (un)marshalling is needed
-    class MyJsonService extends Directives with CompactJsonFormatSupport{
+    class MyJsonService extends Directives with CompactJsonFormatSupport {
 
       // format: OFF
       val route =


### PR DESCRIPTION
This PR addresses the following directives for #20466 
- respond-with-directives/respondWithDefaultHeader.rst
- respond-with-directives/respondWithDefaultHeaders.rst
- respond-with-directives/respondWithHeader.rst
- respond-with-directives/respondWithHeaders.rst
