### PR TITLE
=htp #20601 increase timeout in File touching tests

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -8,6 +8,7 @@ package directives
 import java.io.File
 
 import akka.http.scaladsl.settings.RoutingSettings
+import akka.http.scaladsl.testkit.RouteTestTimeout
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
@@ -22,6 +23,9 @@ import akka.http.scaladsl.TestUtils.writeAllText
 
 class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Inside {
 
+  // operations touch files, can be randomly hit by slowness
+  implicit val routeTestTimeout = RouteTestTimeout(3.seconds) 
+  
   override def testConfigSource = "akka.http.routing.range-coalescing-threshold = 1"
 
   "getFromFile" should {


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/20601
Timing was a bit too aggressive for file system touching things, could rarely fail
