### PR TITLE
#20564 Fix compose method of EmptyModule to be able to Keep.left or right

### DIFF
--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -26,7 +26,7 @@ trait GraphApply {
    */
   def create[S <: Shape, Mat](g1: Graph[Shape, Mat])(buildBlock: GraphDSL.Builder[Mat] ⇒ (g1.Shape) ⇒ S): Graph[S, Mat] = {
     val builder = new GraphDSL.Builder
-    val s1 = builder.add(g1)
+    val s1 = builder.add(g1, Keep.right)
     val s = buildBlock(builder)(s1)
     val mod = builder.module.replaceShape(s)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -913,7 +913,7 @@ object GraphDSL extends GraphApply {
     def add[S <: Shape](graph: Graph[S, _]): S = {
       if (StreamLayout.Debug) StreamLayout.validate(graph.module)
       val copy = graph.module.carbonCopy
-      moduleInProgress = moduleInProgress.compose(copy)
+      moduleInProgress = moduleInProgress.compose(copy, Keep.left)
       graph.shape.copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
     }
 
@@ -926,7 +926,7 @@ object GraphDSL extends GraphApply {
     private[stream] def add[S <: Shape, A](graph: Graph[S, _], transform: (A) ⇒ Any): S = {
       if (StreamLayout.Debug) StreamLayout.validate(graph.module)
       val copy = graph.module.carbonCopy
-      moduleInProgress = moduleInProgress.compose(copy.transformMaterializedValue(transform.asInstanceOf[Any ⇒ Any]))
+      moduleInProgress = moduleInProgress.compose(copy.transformMaterializedValue(transform.asInstanceOf[Any ⇒ Any]), Keep.right)
       graph.shape.copyFromPorts(copy.shape.inlets, copy.shape.outlets).asInstanceOf[S]
     }
 


### PR DESCRIPTION
... and use the proper version from the GraphDSL depending on whether materialized value must be altered on an import or not.

Fixes #20564
