### PR TITLE
Include Future Directives Examples for Java.

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.directives;
+
+import java.util.concurrent.CompletableFuture;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.server.Marshaller;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import akka.http.scaladsl.model.StatusCodes;
+import akka.japi.pf.PFBuilder;
+import org.junit.Test;
+
+import static akka.http.javadsl.server.PathMatchers.*;
+import static scala.compat.java8.JFunction.func;
+
+public class FutureDirectivesExamplesTest extends JUnitRouteTest {
+
+  @Test
+  public void testOnComplete() {
+    //#onComplete
+    // import static scala.compat.java8.JFunction.func;
+    // import static akka.http.javadsl.server.PathMatchers.*;
+
+    final Route route = path(segment("divide").slash(integerSegment()).slash(integerSegment()),
+      (a, b) -> onComplete(
+        () -> CompletableFuture.supplyAsync(() -> a / b),
+        maybeResult -> maybeResult
+          .map(func(result -> complete("The result was " + result)))
+          .recover(new PFBuilder<Throwable, Route>()
+            .matchAny(ex -> complete(StatusCodes.InternalServerError(),
+              "An error occurred: " + ex.getMessage())
+            )
+            .build())
+          .get()
+      )
+    );
+
+    testRoute(route).run(HttpRequest.GET("/divide/10/2"))
+      .assertEntity("The result was 5");
+
+    testRoute(route).run(HttpRequest.GET("/divide/10/0"))
+      .assertStatusCode(StatusCodes.InternalServerError())
+      .assertEntity("An error occurred: / by zero");
+    //#onComplete
+  }
+
+  @Test
+  public void testOnSuccess() {
+    //#onSuccess
+    final Route route = path("success", () ->
+      onSuccess(() -> CompletableFuture.supplyAsync(() -> "Ok"),
+        extraction -> complete(extraction)
+      )
+    ).orElse(path("failure", () ->
+      onSuccess(() -> CompletableFuture.supplyAsync(() -> {
+          throw new RuntimeException();
+        }),
+        extraction -> complete("never reaches here"))
+    ));
+
+    testRoute(route).run(HttpRequest.GET("/success"))
+      .assertEntity("Ok");
+
+    testRoute(route).run(HttpRequest.GET("/failure"))
+      .assertStatusCode(StatusCodes.InternalServerError())
+      .assertEntity("There was an internal server error.");
+    //#onSuccess
+  }
+
+  @Test
+  public void testCompleteOrRecoverWith() {
+    //#completeOrRecoverWith
+    final Route route = path("success", () ->
+      completeOrRecoverWith(
+        () -> CompletableFuture.supplyAsync(() -> "Ok"),
+        Marshaller.stringToEntity(),
+        extraction -> failWith(extraction) // not executed
+      )
+    ).orElse(path("failure", () ->
+      completeOrRecoverWith(
+        () -> CompletableFuture.supplyAsync(() -> {
+          throw new RuntimeException();
+        }),
+        Marshaller.stringToEntity(),
+        extraction -> failWith(extraction))
+    ));
+
+    testRoute(route).run(HttpRequest.GET("/success"))
+      .assertEntity("Ok");
+
+    testRoute(route).run(HttpRequest.GET("/failure"))
+      .assertStatusCode(StatusCodes.InternalServerError())
+      .assertEntity("There was an internal server error.");
+    //#completeOrRecoverWith
+  }
+
+}

--- a/akka-docs/rst/java/http/routing-dsl/directives/future-directives/completeOrRecoverWith.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/future-directives/completeOrRecoverWith.rst
@@ -15,4 +15,4 @@ To handle the successful case manually as well, use the :ref:`-onComplete-java-`
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java#completeOrRecoverWith

--- a/akka-docs/rst/java/http/routing-dsl/directives/future-directives/onComplete.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/future-directives/onComplete.rst
@@ -15,4 +15,4 @@ To complete with a successful result automatically and just handle the failure r
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java#onComplete

--- a/akka-docs/rst/java/http/routing-dsl/directives/future-directives/onSuccess.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/future-directives/onSuccess.rst
@@ -14,4 +14,4 @@ To handle the ``Failure`` case manually as well, use :ref:`-onComplete-java-`, i
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java#onSuccess

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -24,8 +24,8 @@ import akka.http.scaladsl.TestUtils.writeAllText
 class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Inside {
 
   // operations touch files, can be randomly hit by slowness
-  implicit val routeTestTimeout = RouteTestTimeout(3.seconds) 
-  
+  implicit val routeTestTimeout = RouteTestTimeout(3.seconds)
+
   override def testConfigSource = "akka.http.routing.range-coalescing-threshold = 1"
 
   "getFromFile" should {


### PR DESCRIPTION
This PR addresses the following directives for #20466
- future-with-directives/onComplete.rst
- future-with-directives/onSuccess.rst
- future-with-directives/completeOrRecoverWith.rst

`onComplete` directive passes an Scala `Try` to the inner route. The lack of pattern matching in Java makes pretty complex the handling of that `Try`. I had to use `func` from `scala-java8-compat`, that's why I've included the package import commented out. In order to create a Partial Function I've used `PFBuilder` from `akka.japi.pf` package. That class is marked as _EXPERIMENTAL_, so I'm not sure if this is the intended way of consuming the result of `onSuccess` in Java.

That example gets really deep nested. As it needs to fit in the box generated by Sphinx I had to break the lines with not the best readability. 

As my previous PR, the code here has been indented with tabs. It will be reformatted whenever the Java formatter will be ready.
