### PR TITLE
initiate new handshake after restart of receiving system, #20568

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/HandshakeRestartReceiverSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/HandshakeRestartReceiverSpec.scala
@@ -91,7 +91,6 @@ abstract class HandshakeRestartReceiverSpec
         val (secondUid2, subject2) = identifyWithUid(secondRootPath, "subject2")
         secondUid2 should !==(secondUid)
         val secondUniqueRemoteAddress2 = Await.result(secondAssociation.associationState.uniqueRemoteAddress, 3.seconds)
-        println(s"# ${secondAssociation.associationState} secondUid $secondUid $secondUid2") // FIXME
         secondUniqueRemoteAddress2.uid should ===(secondUid2)
         secondUniqueRemoteAddress2.address should ===(secondAddress)
         secondUniqueRemoteAddress2 should !==(secondUniqueRemoteAddress)

--- a/akka-remote/src/main/scala/akka/remote/AddressUidExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/AddressUidExtension.scala
@@ -25,5 +25,12 @@ object AddressUidExtension extends ExtensionId[AddressUidExtension] with Extensi
 }
 
 class AddressUidExtension(val system: ExtendedActorSystem) extends Extension {
-  val addressUid: Int = ThreadLocalRandom.current.nextInt()
+  val longAddressUid: Long = {
+    // FIXME we should use a long here, but then we need to change in Cluster and RemoteWatcher also
+    //ThreadLocalRandom.current.nextLong()
+    ThreadLocalRandom.current.nextInt()
+  }
+
+  @deprecated("Use longAddressUid instead", "2.4.x")
+  val addressUid: Int = longAddressUid.toInt
 }

--- a/akka-remote/src/main/scala/akka/remote/UniqueAddress.scala
+++ b/akka-remote/src/main/scala/akka/remote/UniqueAddress.scala
@@ -6,12 +6,15 @@ package akka.remote
 import akka.actor.Address
 
 @SerialVersionUID(1L)
-final case class UniqueAddress(address: Address, uid: Int) extends Ordered[UniqueAddress] {
-  override def hashCode = uid
+final case class UniqueAddress(address: Address, uid: Long) extends Ordered[UniqueAddress] {
+  override def hashCode = java.lang.Long.hashCode(uid)
 
   def compare(that: UniqueAddress): Int = {
     val result = Address.addressOrdering.compare(this.address, that.address)
     if (result == 0) if (this.uid < that.uid) -1 else if (this.uid == that.uid) 0 else 1
     else result
   }
+
+  override def toString(): String =
+    address + "#" + uid
 }

--- a/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
@@ -48,14 +48,14 @@ private[remote] object EnvelopeBuffer {
   val TagTypeMask = 0xFF000000
   val TagValueMask = 0x0000FFFF
 
-  val VersionOffset = 0
-  val UidOffset = 4
-  val SerializerOffset = 8
-  val SenderActorRefTagOffset = 12
-  val RecipientActorRefTagOffset = 16
-  val ClassManifestTagOffset = 20
+  val VersionOffset = 0 // Int
+  val UidOffset = 4 // Long
+  val SerializerOffset = 12 // Int
+  val SenderActorRefTagOffset = 16 // Int
+  val RecipientActorRefTagOffset = 20 // Int
+  val ClassManifestTagOffset = 24 // Int
 
-  val LiteralsSectionOffset = 32
+  val LiteralsSectionOffset = 28
 
   val UsAscii = Charset.forName("US-ASCII")
 
@@ -86,8 +86,8 @@ sealed trait HeaderBuilder {
   def version_=(v: Int): Unit
   def version: Int
 
-  def uid_=(u: Int): Unit
-  def uid: Int
+  def uid_=(u: Long): Unit
+  def uid: Long
 
   def senderActorRef_=(ref: String): Unit
   def senderActorRef: String
@@ -109,7 +109,7 @@ sealed trait HeaderBuilder {
  */
 private[remote] final class HeaderBuilderImpl(val compressionTable: LiteralCompressionTable) extends HeaderBuilder {
   var version: Int = _
-  var uid: Int = _
+  var uid: Long = _
 
   // Fields only available for EnvelopeBuffer
   var _senderActorRef: String = null
@@ -203,7 +203,7 @@ private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
 
     // Write fixed length parts
     byteBuffer.putInt(header.version)
-    byteBuffer.putInt(header.uid)
+    byteBuffer.putLong(header.uid)
     byteBuffer.putInt(header.serializer)
 
     // Write compressable, variable-length parts always to the actual position of the buffer
@@ -234,7 +234,7 @@ private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
 
     // Read fixed length parts
     header.version = byteBuffer.getInt
-    header.uid = byteBuffer.getInt
+    header.uid = byteBuffer.getLong
     header.serializer = byteBuffer.getInt
 
     // Read compressable, variable-length parts always from the actual position of the buffer

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -167,7 +167,7 @@ class Decoder(
             localAddress, // FIXME: Is this needed anymore? What should we do here?
             deserializedMessage,
             senderOption, // FIXME: No need for an option, decode simply to deadLetters instead
-            UniqueAddress(senderOption.get.path.address, headerBuilder.uid)) // FIXME see issue #20568
+            headerBuilder.uid)
 
           push(out, decoded)
         } catch {

--- a/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
@@ -111,7 +111,7 @@ class EnvelopeBufferSpec extends AkkaSpec {
       headerOut.manifest should ===("manifest1")
 
       headerIn.version = 3
-      headerIn.uid = Int.MinValue
+      headerIn.uid = Long.MinValue
       headerIn.serializer = -1
       headerIn.senderActorRef = "uncompressable0"
       headerIn.recipientActorRef = "reallylongcompressablestring"
@@ -127,7 +127,7 @@ class EnvelopeBufferSpec extends AkkaSpec {
       envelope.parseHeader(headerOut)
 
       headerOut.version should ===(3)
-      headerOut.uid should ===(Int.MinValue)
+      headerOut.uid should ===(Long.MinValue)
       headerOut.serializer should ===(-1)
       headerOut.senderActorRef should ===("uncompressable0")
       headerOut.recipientActorRef should ===("reallylongcompressablestring")

--- a/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
@@ -42,7 +42,7 @@ class InboundControlJunctionSpec extends AkkaSpec with ImplicitSender {
       val recipient = null.asInstanceOf[InternalActorRef] // not used
 
       val ((upstream, controlSubject), downstream) = TestSource.probe[AnyRef]
-        .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, None, addressA))
+        .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, None, addressA.uid))
         .viaMat(new InboundControlJunction)(Keep.both)
         .map { case InboundEnvelope(_, _, msg, _, _) ⇒ msg }
         .toMat(TestSink.probe[Any])(Keep.both)

--- a/akka-remote/src/test/scala/akka/remote/artery/LargeMessagesStreamSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LargeMessagesStreamSpec.scala
@@ -57,19 +57,19 @@ class LargeMessagesStreamSpec extends WordSpec with ShouldMatchers with ScalaFut
         val senderProbeB = TestProbe()(systemB)
 
         // start actor and make sure it is up and running
-        val large = systemB.actorOf(Props(new EchoSize), "regular")
-        large.tell(Ping(), senderProbeB.ref)
+        val regular = systemB.actorOf(Props(new EchoSize), "regular")
+        regular.tell(Ping(), senderProbeB.ref)
         senderProbeB.expectMsg(Pong(0))
 
         // communicate with it from the other system
         val addressB = systemB.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
         val rootB = RootActorPath(addressB)
-        val largeRemote = awaitResolve(systemA.actorSelection(rootB / "user" / "regular"))
-        largeRemote.tell(Ping(), senderProbeA.ref)
+        val regularRemote = awaitResolve(systemA.actorSelection(rootB / "user" / "regular"))
+        regularRemote.tell(Ping(), senderProbeA.ref)
         senderProbeA.expectMsg(Pong(0))
 
         // flag should be cached now
-        largeRemote.asInstanceOf[RemoteActorRef].cachedLargeMessageDestinationFlag should ===(RegularDestination)
+        regularRemote.asInstanceOf[RemoteActorRef].cachedLargeMessageDestinationFlag should ===(RegularDestination)
 
       } finally {
         TestKit.shutdownActorSystem(systemA)

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundHandshakeSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundHandshakeSpec.scala
@@ -31,12 +31,15 @@ class OutboundHandshakeSpec extends AkkaSpec with ImplicitSender {
   val addressA = UniqueAddress(Address("artery", "sysA", "hostA", 1001), 1)
   val addressB = UniqueAddress(Address("artery", "sysB", "hostB", 1002), 2)
 
-  private def setupStream(outboundContext: OutboundContext, timeout: FiniteDuration = 5.seconds,
-                          retryInterval: FiniteDuration = 10.seconds): (TestPublisher.Probe[String], TestSubscriber.Probe[Any]) = {
+  private def setupStream(
+    outboundContext: OutboundContext, timeout: FiniteDuration = 5.seconds,
+    retryInterval: FiniteDuration = 10.seconds,
+    injectHandshakeInterval: FiniteDuration = 10.seconds): (TestPublisher.Probe[String], TestSubscriber.Probe[Any]) = {
+
     val destination = null.asInstanceOf[RemoteActorRef] // not used
     TestSource.probe[String]
       .map(msg ⇒ Send(msg, None, destination, None))
-      .via(new OutboundHandshake(outboundContext, timeout, retryInterval))
+      .via(new OutboundHandshake(outboundContext, timeout, retryInterval, injectHandshakeInterval))
       .map { case Send(msg, _, _, _) ⇒ msg }
       .toMat(TestSink.probe[Any])(Keep.both)
       .run()
@@ -44,13 +47,25 @@ class OutboundHandshakeSpec extends AkkaSpec with ImplicitSender {
 
   "OutboundHandshake stage" must {
     "send HandshakeReq when first pulled" in {
-      val controlProbe = TestProbe()
-      val inboundContext = new TestInboundContext(localAddress = addressA, controlProbe = Some(controlProbe.ref))
+      val inboundContext = new TestInboundContext(localAddress = addressA)
       val outboundContext = inboundContext.association(addressB.address)
       val (upstream, downstream) = setupStream(outboundContext)
 
       downstream.request(10)
-      controlProbe.expectMsg(HandshakeReq(addressA))
+      downstream.expectNext(HandshakeReq(addressA))
+      downstream.cancel()
+    }
+
+    "send HandshakeReq also when uniqueRemoteAddress future completed at startup" in {
+      val inboundContext = new TestInboundContext(localAddress = addressA)
+      val outboundContext = inboundContext.association(addressB.address)
+      inboundContext.completeHandshake(addressB)
+      val (upstream, downstream) = setupStream(outboundContext)
+
+      upstream.sendNext("msg1")
+      downstream.request(10)
+      downstream.expectNext(HandshakeReq(addressA))
+      downstream.expectNext("msg1")
       downstream.cancel()
     }
 
@@ -60,37 +75,60 @@ class OutboundHandshakeSpec extends AkkaSpec with ImplicitSender {
       val (upstream, downstream) = setupStream(outboundContext, timeout = 200.millis)
 
       downstream.request(1)
+      downstream.expectNext(HandshakeReq(addressA))
       downstream.expectError().getClass should be(classOf[HandshakeTimeoutException])
     }
 
     "retry HandshakeReq" in {
-      val controlProbe = TestProbe()
-      val inboundContext = new TestInboundContext(localAddress = addressA, controlProbe = Some(controlProbe.ref))
+      val inboundContext = new TestInboundContext(localAddress = addressA)
       val outboundContext = inboundContext.association(addressB.address)
       val (upstream, downstream) = setupStream(outboundContext, retryInterval = 100.millis)
 
       downstream.request(10)
-      controlProbe.expectMsg(HandshakeReq(addressA))
-      controlProbe.expectMsg(HandshakeReq(addressA))
-      controlProbe.expectMsg(HandshakeReq(addressA))
+      downstream.expectNext(HandshakeReq(addressA))
+      downstream.expectNext(HandshakeReq(addressA))
+      downstream.expectNext(HandshakeReq(addressA))
       downstream.cancel()
     }
 
     "not deliver messages from upstream until handshake completed" in {
-      val controlProbe = TestProbe()
-      val inboundContext = new TestInboundContext(localAddress = addressA, controlProbe = Some(controlProbe.ref))
+      val inboundContext = new TestInboundContext(localAddress = addressA)
       val outboundContext = inboundContext.association(addressB.address)
       val (upstream, downstream) = setupStream(outboundContext)
 
       downstream.request(10)
-      controlProbe.expectMsg(HandshakeReq(addressA))
+      downstream.expectNext(HandshakeReq(addressA))
       upstream.sendNext("msg1")
       downstream.expectNoMsg(200.millis)
       // InboundHandshake stage will complete the handshake when receiving HandshakeRsp
-      inboundContext.association(addressB.address).completeHandshake(addressB)
+      inboundContext.completeHandshake(addressB)
       downstream.expectNext("msg1")
       upstream.sendNext("msg2")
       downstream.expectNext("msg2")
+      downstream.cancel()
+    }
+
+    "inject HandshakeReq" in {
+      val inboundContext = new TestInboundContext(localAddress = addressA)
+      val outboundContext = inboundContext.association(addressB.address)
+      val (upstream, downstream) = setupStream(outboundContext, injectHandshakeInterval = 500.millis)
+
+      downstream.request(10)
+      upstream.sendNext("msg1")
+      downstream.expectNext(HandshakeReq(addressA))
+      inboundContext.completeHandshake(addressB)
+      downstream.expectNext("msg1")
+
+      downstream.expectNoMsg(600.millis)
+      upstream.sendNext("msg2")
+      upstream.sendNext("msg3")
+      upstream.sendNext("msg4")
+      downstream.expectNext(HandshakeReq(addressA))
+      downstream.expectNext("msg2")
+      downstream.expectNext("msg3")
+      downstream.expectNext("msg4")
+      downstream.expectNoMsg(600.millis)
+
       downstream.cancel()
     }
 

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -77,7 +77,7 @@ class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.confi
     Flow[Send]
       .map {
         case Send(sysEnv: SystemMessageEnvelope, _, _, _) ⇒
-          InboundEnvelope(recipient, addressB.address, sysEnv, None, addressA)
+          InboundEnvelope(recipient, addressB.address, sysEnv, None, addressA.uid)
       }
       .async
       .via(new SystemMessageAcker(inboundContext))


### PR DESCRIPTION
- we don't want to include the full origin address in each message,
  only the UID
- that means that the restarted receiving system can't initate a
  new handshake immediately when it sees message from unknown origin
- instead we inject HandshakeReq from the sending system once in a while
  (1 per second) which will trigger the new handshake
- any messages that arrives before the HandshakeReq are dropped, but
  that is fine since the system was just restarted anyway
- note that the injected handshake is only done for active connections,
  when a message is sent
- also changed the UID to a Long, but there are more places in old remoting
  that must be changed before we actually can use a Long value
