### PR TITLE
add JMH benchmark for encoder decoder stage

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/BenchTestSource.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/BenchTestSource.scala
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import akka.stream.Attributes
+import akka.stream.Outlet
+import akka.stream.SourceShape
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.OutHandler
+
+/**
+ * Emits integers from 1 to the given `elementCount`. The `java.lang.Integer`
+ * objects are allocated in the constructor of the stage, so it should be created
+ * before the benchmark is started.
+ */
+class BenchTestSource(elementCount: Int) extends GraphStage[SourceShape[java.lang.Integer]] {
+
+  private val elements = Array.ofDim[java.lang.Integer](elementCount)
+  (1 to elementCount).map(n => elements(n - 1) = n)
+
+  val out: Outlet[java.lang.Integer] = Outlet("BenchTestSource")
+  override val shape: SourceShape[java.lang.Integer] = SourceShape(out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with OutHandler {
+
+      var n = 0
+
+      override def onPull(): Unit = {
+        n += 1
+        if (n > elementCount)
+          complete(out)
+        else
+          push(out, elements(n - 1))
+      }
+
+      setHandler(out, this)
+    }
+}
+
+class BenchTestSourceSameElement[T](elements: Int, elem: T) extends GraphStage[SourceShape[T]] {
+
+  val out: Outlet[T] = Outlet("BenchTestSourceSameElement")
+  override val shape: SourceShape[T] = SourceShape(out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with OutHandler {
+
+      var n = 0
+
+      override def onPull(): Unit = {
+        n += 1
+        if (n > elements)
+          complete(out)
+        else
+          push(out, elem)
+      }
+
+      setHandler(out, this)
+    }
+}

--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.actor.InternalActorRef
+import akka.actor.Props
+import akka.actor.RootActorPath
+import akka.remote.AddressUidExtension
+import akka.remote.EndpointManager.Send
+import akka.remote.RARP
+import akka.remote.RemoteActorRef
+import akka.remote.UniqueAddress
+import akka.stream.ActorMaterializer
+import akka.stream.ActorMaterializerSettings
+import akka.stream.scaladsl._
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(2)
+@Warmup(iterations = 4)
+@Measurement(iterations = 5)
+class CodecBenchmark {
+
+  val config = ConfigFactory.parseString(
+    """
+    akka {
+       loglevel = WARNING
+       actor.provider = "akka.remote.RemoteActorRefProvider"
+       remote.artery.enabled = on
+       remote.artery.hostname = localhost
+       remote.artery.port = 0
+     }
+    """)
+
+  implicit val system = ActorSystem("CodecBenchmark", config)
+  val systemB = ActorSystem("systemB", system.settings.config)
+
+  val envelopePool = new EnvelopeBufferPool(ArteryTransport.MaximumFrameSize, ArteryTransport.MaximumPooledBuffers)
+  val compression = new Compression(system)
+  val headerIn = HeaderBuilder(compression)
+  val envelopeTemplateBuffer = ByteBuffer.allocate(ArteryTransport.MaximumFrameSize).order(ByteOrder.LITTLE_ENDIAN)
+
+  val uniqueLocalAddress = UniqueAddress(system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress,
+    AddressUidExtension(system).addressUid)
+  val payload = Array.ofDim[Byte](1000)
+
+  private var materializer: ActorMaterializer = _
+  private var remoteRefB: RemoteActorRef = _
+  private var resolvedRef: InternalActorRef = _
+  private var senderStringA: String = _
+  private var recipientStringB: String = _
+
+  @Setup
+  def setup(): Unit = {
+    val settings = ActorMaterializerSettings(system)
+    materializer = ActorMaterializer(settings)
+
+    val actorOnSystemA = system.actorOf(Props.empty, "a")
+    senderStringA = actorOnSystemA.path.toSerializationFormatWithAddress(uniqueLocalAddress.address)
+
+    val actorOnSystemB = systemB.actorOf(Props.empty, "b")
+    val addressB = systemB.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+    val rootB = RootActorPath(addressB)
+    remoteRefB =
+      Await.result(system.actorSelection(rootB / "user" / "b").resolveOne(5.seconds), 5.seconds)
+        .asInstanceOf[RemoteActorRef]
+    resolvedRef = actorOnSystemA.asInstanceOf[InternalActorRef]
+    recipientStringB = remoteRefB.path.toSerializationFormatWithAddress(addressB)
+
+    val envelope = new EnvelopeBuffer(envelopeTemplateBuffer)
+    headerIn.version = 1
+    headerIn.uid = 42
+    headerIn.senderActorRef = senderStringA
+    headerIn.recipientActorRef = recipientStringB
+    headerIn.serializer = "4"
+    headerIn.classManifest = ""
+    envelope.writeHeader(headerIn)
+    envelope.byteBuffer.put(payload)
+    envelope.byteBuffer.flip()
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+    Await.result(systemB.terminate(), 5.seconds)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def reference(): Unit = {
+    val latch = new CountDownLatch(1)
+    val N = 100000
+
+    Source.fromGraph(new BenchTestSourceSameElement(N, "elem"))
+      .runWith(new LatchSink(N, latch))(materializer)
+
+    latch.await(30, TimeUnit.SECONDS)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def encode(): Unit = {
+    val latch = new CountDownLatch(1)
+    val N = 100000
+
+    val encoder: Flow[Send, EnvelopeBuffer, NotUsed] =
+      Flow.fromGraph(new Encoder(uniqueLocalAddress, system, compression, envelopePool))
+
+    Source.fromGraph(new BenchTestSourceSameElement(N, "elem"))
+      .map(_ ⇒ Send(payload, None, remoteRefB, None))
+      .via(encoder)
+      .map(envelope => envelopePool.release(envelope))
+      .runWith(new LatchSink(N, latch))(materializer)
+
+    latch.await(30, TimeUnit.SECONDS)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def decode(): Unit = {
+    val latch = new CountDownLatch(1)
+    val N = 100000
+
+    val localRecipient = resolvedRef.path.toSerializationFormatWithAddress(uniqueLocalAddress.address)
+    val provider = RARP(system).provider
+    val resolveActorRefWithLocalAddress: String ⇒ InternalActorRef = {
+      recipient ⇒
+        // juggling with the refs, since we don't run the real thing
+        val resolved = provider.resolveActorRefWithLocalAddress(localRecipient, uniqueLocalAddress.address)
+        resolved
+    }
+
+    val decoder: Flow[EnvelopeBuffer, InboundEnvelope, NotUsed] =
+      Flow.fromGraph(new Decoder(uniqueLocalAddress, system.asInstanceOf[ExtendedActorSystem],
+        resolveActorRefWithLocalAddress, compression, envelopePool))
+
+    Source.fromGraph(new BenchTestSourceSameElement(N, "elem"))
+      .map { _ =>
+        val envelope = envelopePool.acquire()
+        envelopeTemplateBuffer.rewind()
+        envelope.byteBuffer.put(envelopeTemplateBuffer)
+        envelope.byteBuffer.flip()
+        envelope
+      }
+      .via(decoder)
+      .runWith(new LatchSink(N, latch))(materializer)
+
+    latch.await(30, TimeUnit.SECONDS)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def encode_decode(): Unit = {
+    val latch = new CountDownLatch(1)
+    val N = 100000
+
+    val encoder: Flow[Send, EnvelopeBuffer, NotUsed] =
+      Flow.fromGraph(new Encoder(uniqueLocalAddress, system, compression, envelopePool))
+
+    val localRecipient = resolvedRef.path.toSerializationFormatWithAddress(uniqueLocalAddress.address)
+    val provider = RARP(system).provider
+    val resolveActorRefWithLocalAddress: String ⇒ InternalActorRef = {
+      recipient ⇒
+        // juggling with the refs, since we don't run the real thing
+        val resolved = provider.resolveActorRefWithLocalAddress(localRecipient, uniqueLocalAddress.address)
+        resolved
+    }
+
+    val decoder: Flow[EnvelopeBuffer, InboundEnvelope, NotUsed] =
+      Flow.fromGraph(new Decoder(uniqueLocalAddress, system.asInstanceOf[ExtendedActorSystem],
+        resolveActorRefWithLocalAddress, compression, envelopePool))
+
+    Source.fromGraph(new BenchTestSourceSameElement(N, "elem"))
+      .map(_ ⇒ Send(payload, None, remoteRefB, None))
+      .via(encoder)
+      .via(decoder)
+      .runWith(new LatchSink(N, latch))(materializer)
+
+    latch.await(30, TimeUnit.SECONDS)
+  }
+
+}

--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/LatchSink.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/LatchSink.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.util.concurrent.CountDownLatch
+
+import akka.stream.Attributes
+import akka.stream.Inlet
+import akka.stream.SinkShape
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+
+class LatchSink(countDownAfter: Int, latch: CountDownLatch) extends GraphStage[SinkShape[Any]] {
+  val in: Inlet[Any] = Inlet("LatchSink")
+  override val shape: SinkShape[Any] = SinkShape(in)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler {
+
+      var n = 0
+
+      override def preStart(): Unit = pull(in)
+
+      override def onPush(): Unit = {
+        n += 1
+        if (n == countDownAfter)
+          latch.countDown()
+        grab(in)
+        pull(in)
+      }
+
+      setHandler(in, this)
+    }
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -150,7 +150,7 @@ private[akka] class Association(
 
   private def isLargeMessageDestination(recipient: ActorRef): Boolean = {
     recipient match {
-      case r: RemoteActorRef if r.cachedLargeMessageDestinationFlag ne null ⇒ r.cachedLargeMessageDestinationFlag == LargeDestination
+      case r: RemoteActorRef if r.cachedLargeMessageDestinationFlag ne null ⇒ r.cachedLargeMessageDestinationFlag eq LargeDestination
       case r: RemoteActorRef ⇒
         if (largeMessageDestinations.find(r.path.elements.iterator).data.isEmpty) {
           r.cachedLargeMessageDestinationFlag = RegularDestination


### PR DESCRIPTION
The encoder/decoder is our largest bottleneck right now and these tests will be useful when integrating the compression table and doing further optimizations in this area. Decode is around 1,200,000 msg/s.
- CodecBenchmark that tests encode, decode and combined
  encode + decode
- refactoring of codec stages to make it possible to
  run them without real ArteryTransport
- also fixed a bug in inbound stream for large messages,
  it was using wrong envelope pool

For reference, on my machine I have raw stream throughput of 21,000,000 elements/s with these test source/sink.

```
[info] Benchmark                      Mode  Cnt      Score     Error   Units
[info] CodecBenchmark.decode         thrpt   10   1197.490 ±  46.666  ops/ms
[info] CodecBenchmark.encode         thrpt   10   1668.532 ± 290.483  ops/ms
[info] CodecBenchmark.encode_decode  thrpt   10    857.031 ±  63.380  ops/ms
[info] CodecBenchmark.reference      thrpt   10  21005.895 ± 627.483  ops/ms
```
