### PR TITLE
add serialization api based on ByteBuffer, #20324

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -5,7 +5,6 @@
 package akka.serialization
 
 import language.postfixOps
-
 import akka.testkit.{ AkkaSpec, EventFilter }
 import akka.actor._
 import akka.dispatch.sysmsg._
@@ -17,6 +16,8 @@ import scala.beans.BeanInfo
 import com.typesafe.config._
 import akka.pattern.ask
 import org.apache.commons.codec.binary.Hex.encodeHex
+import java.nio.ByteOrder
+import java.nio.ByteBuffer
 
 object SerializationTests {
 
@@ -247,7 +248,25 @@ class SerializeSpec extends AkkaSpec(SerializationTests.serializeConf) {
 
       intercept[IllegalArgumentException] {
         byteSerializer.toBinary("pigdog")
-      }.getMessage should ===("ByteArraySerializer only serializes byte arrays, not [pigdog]")
+      }.getMessage should ===(s"${classOf[ByteArraySerializer].getName} only serializes byte arrays, not [java.lang.String]")
+    }
+
+    "support ByteBuffer serialization for byte arrays" in {
+      val byteSerializer = ser.serializerFor(classOf[Array[Byte]]).asInstanceOf[ByteBufferSerializer]
+
+      val byteBuffer = ByteBuffer.allocate(128).order(ByteOrder.LITTLE_ENDIAN)
+      val str = "abcdef"
+      val payload = str.getBytes("UTF-8")
+      byteSerializer.toBinary(payload, byteBuffer)
+      byteBuffer.position() should ===(payload.length)
+      byteBuffer.flip()
+      val deserialized = byteSerializer.fromBinary(byteBuffer, "").asInstanceOf[Array[Byte]]
+      byteBuffer.remaining() should ===(0)
+      new String(deserialized, "UTF-8") should ===(str)
+
+      intercept[IllegalArgumentException] {
+        byteSerializer.toBinary("pigdog", byteBuffer)
+      }.getMessage should ===(s"${classOf[ByteArraySerializer].getName} only serializes byte arrays, not [java.lang.String]")
     }
   }
 }

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -598,7 +598,7 @@ akka {
     # Identifier values from 0 to 16 are reserved for Akka internal usage.
     serialization-identifiers {
       "akka.serialization.JavaSerializer" = 1
-      "akka.serialization.ByteArraySerializer" = 4  
+      "akka.serialization.ByteArraySerializer" = 4
     }
 
     # Configuration items which are used by the akka.actor.ActorDSL._ methods

--- a/akka-actor/src/main/scala/akka/serialization/Serializer.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serializer.scala
@@ -5,6 +5,7 @@ package akka.serialization
  */
 
 import java.io.{ ObjectOutputStream, ByteArrayOutputStream, ByteArrayInputStream }
+import java.nio.ByteBuffer
 import java.util.concurrent.Callable
 import akka.util.ClassLoaderObjectInputStream
 import akka.actor.ExtendedActorSystem
@@ -129,6 +130,56 @@ abstract class SerializerWithStringManifest extends Serializer {
     }
     fromBinary(bytes, manifestString)
   }
+
+}
+
+/**
+ * Serializer between an object and a `ByteBuffer` representing that object.
+ *
+ * Implementations should typically extend [[SerializerWithStringManifest]] and
+ * in addition to the `ByteBuffer` based `toBinary` and `fromBinary` methods also
+ * implement the array based `toBinary` and `fromBinary` methods. The array based
+ * methods will be used when `ByteBuffer` is not used, e.g. in Akka Persistence.
+ *
+ * Note that the array based methods can for example be implemented by delegation
+ * like this:
+ * {{{
+ *   // you need to know the maximum size in bytes of the serialized messages
+ *   val pool = new akka.io.DirectByteBufferPool(defaultBufferSize = 1024 * 1024, maxPoolEntries = 10)
+ *
+ *
+ *  // Implement this method for compatibility with `SerializerWithStringManifest`.
+ *  override def toBinary(o: AnyRef): Array[Byte] = {
+ *    val buf = pool.acquire()
+ *    try {
+ *      toBinary(o, buf)
+ *      buf.flip()
+ *      val bytes = Array.ofDim[Byte](buf.remaining)
+ *      buf.get(bytes)
+ *      bytes
+ *    } finally {
+ *      pool.release(buf)
+ *    }
+ *  }
+ *
+ *  // Implement this method for compatibility with `SerializerWithStringManifest`.
+ *  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef =
+ *    fromBinary(ByteBuffer.wrap(bytes), manifest)
+ *
+ * }}}
+ */
+trait ByteBufferSerializer {
+
+  /**
+   * Serializes the given object into the `ByteBuffer`.
+   */
+  def toBinary(o: AnyRef, buf: ByteBuffer): Unit
+
+  /**
+   * Produces an object from a `ByteBuffer`, with an optional type-hint;
+   * the class should be loaded using ActorSystem.dynamicAccess.
+   */
+  def fromBinary(buf: ByteBuffer, manifest: String): AnyRef
 
 }
 
@@ -260,7 +311,7 @@ class NullSerializer extends Serializer {
  * This is a special Serializer that Serializes and deserializes byte arrays only,
  * (just returns the byte array unchanged/uncopied)
  */
-class ByteArraySerializer(val system: ExtendedActorSystem) extends BaseSerializer {
+class ByteArraySerializer(val system: ExtendedActorSystem) extends BaseSerializer with ByteBufferSerializer {
 
   @deprecated("Use constructor with ExtendedActorSystem", "2.4")
   def this() = this(null)
@@ -274,7 +325,22 @@ class ByteArraySerializer(val system: ExtendedActorSystem) extends BaseSerialize
   def toBinary(o: AnyRef) = o match {
     case null           ⇒ null
     case o: Array[Byte] ⇒ o
-    case other          ⇒ throw new IllegalArgumentException("ByteArraySerializer only serializes byte arrays, not [" + other + "]")
+    case other ⇒ throw new IllegalArgumentException(
+      s"${getClass.getName} only serializes byte arrays, not [${other.getClass.getName}]")
   }
   def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = bytes
+
+  override def toBinary(o: AnyRef, buf: ByteBuffer): Unit =
+    o match {
+      case null               ⇒
+      case bytes: Array[Byte] ⇒ buf.put(bytes)
+      case other ⇒ throw new IllegalArgumentException(
+        s"${getClass.getName} only serializes byte arrays, not [${other.getClass.getName}]")
+    }
+
+  override def fromBinary(buf: ByteBuffer, manifest: String): AnyRef = {
+    val bytes = Array.ofDim[Byte](buf.remaining())
+    buf.get(bytes)
+    bytes
+  }
 }

--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
@@ -86,10 +86,10 @@ class CodecBenchmark {
     val envelope = new EnvelopeBuffer(envelopeTemplateBuffer)
     headerIn.version = 1
     headerIn.uid = 42
+    headerIn.serializer = 4
     headerIn.senderActorRef = senderStringA
     headerIn.recipientActorRef = recipientStringB
-    headerIn.serializer = "4"
-    headerIn.classManifest = ""
+    headerIn.manifest = ""
     envelope.writeHeader(headerIn)
     envelope.byteBuffer.put(payload)
     envelope.byteBuffer.flip()

--- a/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
@@ -52,8 +52,7 @@ private[akka] object MessageSerializer {
   def serializeForArtery(serialization: Serialization, message: AnyRef, headerBuilder: HeaderBuilder, envelope: EnvelopeBuffer): Unit = {
     val serializer = serialization.findSerializerFor(message)
 
-    // FIXME: This should be a FQCN instead
-    headerBuilder.serializer = serializer.identifier.toString
+    headerBuilder.serializer = serializer.identifier
 
     def manifest: String = serializer match {
       case ser: SerializerWithStringManifest ⇒ ser.manifest(message)
@@ -62,11 +61,11 @@ private[akka] object MessageSerializer {
 
     serializer match {
       case ser: ByteBufferSerializer ⇒
-        headerBuilder.classManifest = manifest
+        headerBuilder.manifest = manifest
         envelope.writeHeader(headerBuilder)
         ser.toBinary(message, envelope.byteBuffer)
       case _ ⇒
-        headerBuilder.classManifest = manifest
+        headerBuilder.manifest = manifest
         envelope.writeHeader(headerBuilder)
         envelope.byteBuffer.put(serializer.toBinary(message))
     }
@@ -76,7 +75,7 @@ private[akka] object MessageSerializer {
                            envelope: EnvelopeBuffer): AnyRef = {
     serialization.deserializeByteBuffer(
       envelope.byteBuffer,
-      Integer.parseInt(headerBuilder.serializer), // FIXME: Use FQCN
-      headerBuilder.classManifest)
+      headerBuilder.serializer,
+      headerBuilder.manifest)
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
@@ -72,7 +72,8 @@ private[akka] object MessageSerializer {
     }
   }
 
-  def deserializeForArtery(system: ExtendedActorSystem, serialization: Serialization, headerBuilder: HeaderBuilder, envelope: EnvelopeBuffer): AnyRef = {
+  def deserializeForArtery(system: ExtendedActorSystem, serialization: Serialization, headerBuilder: HeaderBuilder,
+                           envelope: EnvelopeBuffer): AnyRef = {
     serialization.deserializeByteBuffer(
       envelope.byteBuffer,
       Integer.parseInt(headerBuilder.serializer), // FIXME: Use FQCN

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -173,7 +173,7 @@ class Decoder(
         } catch {
           case NonFatal(e) ⇒
             log.warning("Failed to deserialize message with serializer id [{}] and manifest [{}]. {}",
-              headerBuilder.serializer, headerBuilder.classManifest, e.getMessage)
+              headerBuilder.serializer, headerBuilder.manifest, e.getMessage)
             pull(in)
         } finally {
           pool.release(envelope)

--- a/akka-remote/src/main/scala/akka/remote/artery/Compression.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Compression.scala
@@ -14,9 +14,6 @@ private[remote] class Compression(system: ActorSystem) extends LiteralCompressio
   override def compressActorRef(ref: String): Int = -1
   override def decompressActorRef(idx: Int): String = ???
 
-  override def compressSerializer(serializer: String): Int = -1
-  override def decompressSerializer(idx: Int): String = ???
-
   override def compressClassManifest(manifest: String): Int = -1
   override def decompressClassManifest(idx: Int): String = ???
 

--- a/akka-remote/src/test/scala/akka/remote/artery/SerializationErrorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SerializationErrorSpec.scala
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+import akka.actor.{ ActorIdentity, ActorSystem, ExtendedActorSystem, Identify, RootActorPath }
+import akka.testkit.{ AkkaSpec, ImplicitSender }
+import akka.testkit.TestActors
+import com.typesafe.config.ConfigFactory
+import akka.testkit.EventFilter
+
+object SerializationErrorSpec {
+
+  val config = ConfigFactory.parseString(s"""
+     akka {
+       actor.provider = "akka.remote.RemoteActorRefProvider"
+       remote.artery.enabled = on
+       remote.artery.hostname = localhost
+       remote.artery.port = 0
+       actor {
+         serialize-creators = false
+         serialize-messages = false
+       }
+     }
+  """)
+
+  object NotSerializableMsg
+
+}
+
+class SerializationErrorSpec extends AkkaSpec(SerializationErrorSpec.config) with ImplicitSender {
+  import SerializationErrorSpec._
+
+  val configB = ConfigFactory.parseString("""
+     akka.actor.serialization-identifiers {
+       # this will cause deserialization error
+       "akka.serialization.ByteArraySerializer" = -4
+     }
+     """).withFallback(system.settings.config)
+  val systemB = ActorSystem("systemB", configB)
+  systemB.actorOf(TestActors.echoActorProps, "echo")
+  val addressB = systemB.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+  val rootB = RootActorPath(addressB)
+
+  override def afterTermination(): Unit = shutdown(systemB)
+
+  "Serialization error" must {
+
+    "be logged when serialize fails" in {
+      val remoteRef = {
+        system.actorSelection(rootB / "user" / "echo") ! Identify(None)
+        expectMsgType[ActorIdentity].ref.get
+      }
+
+      remoteRef ! "ping"
+      expectMsg("ping")
+
+      EventFilter[java.io.NotSerializableException](start = "Failed to serialize message", occurrences = 1).intercept {
+        remoteRef ! NotSerializableMsg
+      }
+
+      remoteRef ! "ping2"
+      expectMsg("ping2")
+    }
+
+    "be logged when deserialize fails" in {
+      val remoteRef = {
+        system.actorSelection(rootB / "user" / "echo") ! Identify(None)
+        expectMsgType[ActorIdentity].ref.get
+      }
+
+      remoteRef ! "ping"
+      expectMsg("ping")
+
+      EventFilter.warning(
+        start = "Failed to deserialize message with serializer id [4]", occurrences = 1).intercept {
+          remoteRef ! "boom".getBytes("utf-8")
+        }(systemB)
+
+      remoteRef ! "ping2"
+      expectMsg("ping2")
+    }
+
+  }
+
+}


### PR DESCRIPTION
- new trait ByteBufferSerializer with fromBinary and toBinary
  methods that takes ByteBuffer, this can be mixed in to
  existing serializer without breaking compatibility
- implement the ByteBufferSerializer in the ByteArraySerializer
- minor adjustment of the class manifest cache
