### PR TITLE
akka http javadsl - add debugging directive test

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.directives;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.headers.Host;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.server.RequestContext;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import java.util.function.Function;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import akka.http.javadsl.model.Uri;
+import akka.http.javadsl.model.headers.Location;
+import akka.http.javadsl.server.directives.DebuggingDirectives;
+import akka.http.javadsl.server.directives.RouteDirectives;
+import akka.event.Logging;
+import akka.event.Logging.LogLevel;
+import akka.http.javadsl.server.directives.LogEntry;
+import java.util.List;
+import akka.http.scaladsl.server.Rejection;
+
+import static akka.event.Logging.InfoLevel;
+import java.util.stream.Collectors;
+import java.util.Optional;
+
+public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
+
+  @Test
+  public void testLogRequest() {
+    //#logRequest
+    // logs request with "get-user"
+    final Route routeBasicLogRequest = get(() -> 
+                            logRequest("get-user", ()-> 
+                                       complete("logged")));
+    
+    // logs request with "get-user" as Info
+    final Route routeBasicLogRequestAsInfo = get(() -> 
+                            logRequest("get-user", InfoLevel(), ()-> 
+                                       complete("logged")));
+
+    // logs just the request method at info level
+    Function<HttpRequest, LogEntry> requestMethodAsInfo = (request)->
+      LogEntry.create(request.method().toString(), InfoLevel());
+    final Route routeUsingFunction = get(() -> 
+                            logRequest(requestMethodAsInfo, ()-> 
+                                       complete("logged")));
+
+    // tests:
+    testRoute(routeBasicLogRequest).run(HttpRequest.GET("/")).assertEntity("logged");
+    //#logRequest
+  }
+
+  @Test
+  public void testLogRequestResult() {
+    //#logRequestResult
+    // using logRequestResult
+
+    // handle request to optionally generate a log entry
+    BiFunction<HttpRequest, HttpResponse, Optional<LogEntry>> requestMethodAsInfo = 
+      (request, response)->
+        (response.status().isSuccess())  ? 
+            Optional.of(
+              LogEntry
+                .create(request.method().toString() + ":" + response.status().intValue(), 
+                        InfoLevel())
+            )
+          : Optional.empty(); // not a successful response
+
+    // handle rejections to optionally generate a log entry
+    BiFunction<HttpRequest, List<Rejection>, Optional<LogEntry>> rejectionsAsInfo = 
+      (request, rejections)->
+        (!rejections.isEmpty())  ? 
+          Optional.of(
+            LogEntry.create(rejections
+                          .stream()
+                          .map(Rejection::toString)
+                          .collect(Collectors.joining(", ")), 
+                        InfoLevel())
+            )
+          : Optional.empty(); // no rejections
+
+    final Route route = get(() -> 
+                            logRequestResultOptional(
+                                             requestMethodAsInfo, 
+                                             rejectionsAsInfo,
+                                             ()-> complete("logged")));
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/")).assertEntity("logged");
+    //#logRequestResult
+  }
+
+  @Test
+  public void testLogResult() {
+    //#logResult
+    // logs result with "get-user"
+    final Route routeBasicLogResult = get(() -> 
+                            logResult("get-user", ()-> 
+                                       complete("logged")));
+
+    // logs result with "get-user" as Info
+    final Route routeBasicLogResultAsInfo = get(() -> 
+                            logResult("get-user", InfoLevel(), ()-> 
+                                       complete("logged")));
+
+    // logs the result and the rejections as LogEntry
+    Function<HttpResponse, LogEntry> showSuccessAsInfo = (response)->
+      LogEntry.create(String.format("Response code '%d'", response.status().intValue()), 
+                      InfoLevel());
+
+    Function<List<Rejection>, LogEntry> showRejectionAsInfo = (rejections)->
+      LogEntry.create(rejections
+                        .stream()
+                        .map(rejection->rejection.toString())
+                        .collect(Collectors.joining(", ")), 
+                      InfoLevel());
+
+    final Route routeUsingFunction = get(() -> 
+                            logResult(showSuccessAsInfo, 
+                                      showRejectionAsInfo, ()-> 
+                                       complete("logged")));
+    // tests:
+    testRoute(routeBasicLogResult).run(HttpRequest.GET("/")).assertEntity("logged");
+    //#logResult
+  }
+
+}

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
@@ -40,23 +40,22 @@ public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
     //#logRequest
     // logs request with "get-user"
     final Route routeBasicLogRequest = get(() -> 
-                            logRequest("get-user", ()-> 
-                                       complete("logged")));
+      logRequest("get-user", () -> complete("logged")));
     
     // logs request with "get-user" as Info
     final Route routeBasicLogRequestAsInfo = get(() -> 
-                            logRequest("get-user", InfoLevel(), ()-> 
-                                       complete("logged")));
+      logRequest("get-user", InfoLevel(), () -> complete("logged")));
 
     // logs just the request method at info level
-    Function<HttpRequest, LogEntry> requestMethodAsInfo = (request)->
+    Function<HttpRequest, LogEntry> requestMethodAsInfo = (request) -> 
       LogEntry.create(request.method().toString(), InfoLevel());
+
     final Route routeUsingFunction = get(() -> 
-                            logRequest(requestMethodAsInfo, ()-> 
-                                       complete("logged")));
+      logRequest(requestMethodAsInfo, () -> complete("logged")));
 
     // tests:
-    testRoute(routeBasicLogRequest).run(HttpRequest.GET("/")).assertEntity("logged");
+    testRoute(routeBasicLogRequest).run(HttpRequest.GET("/"))
+      .assertEntity("logged");
     //#logRequest
   }
 
@@ -67,33 +66,31 @@ public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
 
     // handle request to optionally generate a log entry
     BiFunction<HttpRequest, HttpResponse, Optional<LogEntry>> requestMethodAsInfo = 
-      (request, response)->
+      (request, response) ->
         (response.status().isSuccess())  ? 
             Optional.of(
-              LogEntry
-                .create(request.method().toString() + ":" + response.status().intValue(), 
-                        InfoLevel())
-            )
+              LogEntry.create(
+                request.method().toString() + ":" + response.status().intValue(), 
+                InfoLevel()))
           : Optional.empty(); // not a successful response
 
     // handle rejections to optionally generate a log entry
     BiFunction<HttpRequest, List<Rejection>, Optional<LogEntry>> rejectionsAsInfo = 
-      (request, rejections)->
+      (request, rejections) ->
         (!rejections.isEmpty())  ? 
           Optional.of(
-            LogEntry.create(rejections
-                          .stream()
-                          .map(Rejection::toString)
-                          .collect(Collectors.joining(", ")), 
-                        InfoLevel())
-            )
+            LogEntry.create(
+                rejections
+                .stream()
+                .map(Rejection::toString)
+                .collect(Collectors.joining(", ")), 
+              InfoLevel()))
           : Optional.empty(); // no rejections
 
-    final Route route = get(() -> 
-                            logRequestResultOptional(
-                                             requestMethodAsInfo, 
-                                             rejectionsAsInfo,
-                                             ()-> complete("logged")));
+    final Route route = get(() -> logRequestResultOptional(
+      requestMethodAsInfo, 
+      rejectionsAsInfo,
+      () -> complete("logged")));
     // tests:
     testRoute(route).run(HttpRequest.GET("/")).assertEntity("logged");
     //#logRequestResult
@@ -103,33 +100,31 @@ public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
   public void testLogResult() {
     //#logResult
     // logs result with "get-user"
-    final Route routeBasicLogResult = get(() -> 
-                            logResult("get-user", ()-> 
-                                       complete("logged")));
+    final Route routeBasicLogResult = get(() ->
+      logResult("get-user", () -> complete("logged")));
 
     // logs result with "get-user" as Info
-    final Route routeBasicLogResultAsInfo = get(() -> 
-                            logResult("get-user", InfoLevel(), ()-> 
-                                       complete("logged")));
+    final Route routeBasicLogResultAsInfo = get(() ->
+      logResult("get-user", InfoLevel(), () -> complete("logged")));
 
     // logs the result and the rejections as LogEntry
-    Function<HttpResponse, LogEntry> showSuccessAsInfo = (response)->
+    Function<HttpResponse, LogEntry> showSuccessAsInfo = (response) ->
       LogEntry.create(String.format("Response code '%d'", response.status().intValue()), 
-                      InfoLevel());
+        InfoLevel());
 
-    Function<List<Rejection>, LogEntry> showRejectionAsInfo = (rejections)->
-      LogEntry.create(rejections
-                        .stream()
-                        .map(rejection->rejection.toString())
-                        .collect(Collectors.joining(", ")), 
-                      InfoLevel());
+    Function<List<Rejection>, LogEntry> showRejectionAsInfo = (rejections) ->
+      LogEntry.create(
+        rejections
+        .stream()
+        .map(rejection->rejection.toString())
+        .collect(Collectors.joining(", ")), 
+      InfoLevel());
 
-    final Route routeUsingFunction = get(() -> 
-                            logResult(showSuccessAsInfo, 
-                                      showRejectionAsInfo, ()-> 
-                                       complete("logged")));
+    final Route routeUsingFunction = get(() ->
+      logResult(showSuccessAsInfo, showRejectionAsInfo, () -> complete("logged")));
     // tests:
-    testRoute(routeBasicLogResult).run(HttpRequest.GET("/")).assertEntity("logged");
+    testRoute(routeBasicLogResult).run(HttpRequest.GET("/"))
+      .assertEntity("logged");
     //#logResult
   }
 

--- a/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequest.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequest.rst
@@ -16,4 +16,4 @@ Use ``logResult`` for logging the response, or ``logRequestResult`` for logging 
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java#logRequest

--- a/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequestResult.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequestResult.rst
@@ -13,4 +13,4 @@ See :ref:`-logRequest-java-` for the general description how these directives wo
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java#logRequestResult

--- a/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logResult.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logResult.rst
@@ -13,4 +13,4 @@ Use ``logRequest`` for logging the request, or ``logRequestResult`` for logging 
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java#logResult


### PR DESCRIPTION
Adds a **debugging directive example** to the Java DSL, following the instructions given in [issue 20466](https://github.com/akka/akka/issues/20466)
