### PR TITLE
improve performance of literal encoding

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/LiteralEncodingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/LiteralEncodingBenchmark.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(2)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+class LiteralEncodingBenchmark {
+
+  private val UsAscii = Charset.forName("US-ASCII")
+  private val str = "artery://SomeSystem@host12:1234/user/foo"
+  private val buffer = ByteBuffer.allocate(128).order(ByteOrder.LITTLE_ENDIAN)
+  private val literalChars = Array.ofDim[Char](64)
+  private val literalBytes = Array.ofDim[Byte](64)
+  private val unsafe = akka.util.Unsafe.instance
+  private val stringValueFieldOffset = unsafe.objectFieldOffset(classOf[String].getDeclaredField("value"))
+
+  @Benchmark
+  def getBytesNewArray(): String = {
+    val length = str.length()
+    // write
+    buffer.clear()
+    val bytes = str.getBytes(UsAscii)
+    buffer.put(bytes)
+    buffer.flip()
+
+    // read
+    val bytes2 = Array.ofDim[Byte](length)
+    buffer.get(bytes2)
+    new String(bytes2, UsAscii)
+  }
+
+  @Benchmark
+  def getBytesReuseArray(): String = {
+    val length = str.length()
+    // write
+    buffer.clear()
+    val bytes = str.getBytes(UsAscii)
+    buffer.put(bytes)
+    buffer.flip()
+
+    // read
+    buffer.get(literalBytes, 0, length)
+    new String(literalBytes, UsAscii)
+  }
+
+  @Benchmark
+  def getChars(): String = {
+    val length = str.length()
+    // write
+    buffer.clear()
+    str.getChars(0, length, literalChars, 0)
+    var i = 0
+    while (i < length) {
+      literalBytes(i) = literalChars(i).asInstanceOf[Byte]
+      i += 1
+    }
+    buffer.put(literalBytes, 0, length)
+    buffer.flip()
+
+    // read
+    buffer.get(literalBytes, 0, length)
+    i = 0
+    while (i < length) {
+      // UsAscii
+      literalChars(i) = literalBytes(i).asInstanceOf[Char]
+      i += 1
+    }
+    String.valueOf(literalChars, 0, length)
+  }
+
+  @Benchmark
+  def getCharsUnsafe(): String = {
+    val length = str.length()
+    // write
+    buffer.clear()
+    val chars = unsafe.getObject(str, stringValueFieldOffset).asInstanceOf[Array[Char]]
+    var i = 0
+    while (i < length) {
+      literalBytes(i) = chars(i).asInstanceOf[Byte]
+      i += 1
+    }
+    buffer.put(literalBytes, 0, length)
+    buffer.flip()
+
+    // read
+    buffer.get(literalBytes, 0, length)
+    i = 0
+    while (i < length) {
+      // UsAscii
+      literalChars(i) = literalBytes(i).asInstanceOf[Char]
+      i += 1
+    }
+    String.valueOf(literalChars, 0, length)
+  }
+
+}


### PR DESCRIPTION
- use char array instead of getBytes
- JMH benchmark

```
[info] Benchmark                                                                      Mode  Cnt      Score      Error   Units
[info] LiteralEncodingBenchmark.getBytesNewArray                                     thrpt   20   7044.384 ±  331.657  ops/ms
[info] LiteralEncodingBenchmark.getBytesNewArray:·gc.alloc.rate                      thrpt   20   2364.296 ±  111.321  MB/sec
[info] LiteralEncodingBenchmark.getBytesReuseArray                                   thrpt   20   7071.578 ±  660.010  ops/ms
[info] LiteralEncodingBenchmark.getBytesReuseArray:·gc.alloc.rate                    thrpt   20   2319.501 ±  216.485  MB/sec
[info] LiteralEncodingBenchmark.getChars                                             thrpt   20  14829.715 ±  141.039  ops/ms
[info] LiteralEncodingBenchmark.getChars:·gc.alloc.rate                              thrpt   20   1696.782 ±   16.116  MB/sec
[info] LiteralEncodingBenchmark.getCharsUnsafe                                       thrpt   20  16064.698 ± 1158.760  ops/ms
[info] LiteralEncodingBenchmark.getCharsUnsafe:·gc.alloc.rate                        thrpt   20   1837.963 ±  132.556  MB/sec
```
