### PR TITLE
=str 19921 Error in documentation: Graph_cycles

### DIFF
--- a/akka-docs/rst/java/stream/stream-graphs.rst
+++ b/akka-docs/rst/java/stream/stream-graphs.rst
@@ -235,7 +235,7 @@ Cycles in bounded stream topologies need special considerations to avoid potenti
 This section shows several examples of problems that can arise from the presence of feedback arcs in stream processing
 graphs.
 
-In examples below runnable graphs are created but do not run because each have some issue and will not complete normally.
+In the following examples runnable graphs are created but do not run because each have some issue and will deadlock after start.
 ``Source`` variable is not defined as the nature and number of element does not matter for described problems.
 
 The first example demonstrates a graph that contains a naive cycle.

--- a/akka-docs/rst/java/stream/stream-graphs.rst
+++ b/akka-docs/rst/java/stream/stream-graphs.rst
@@ -235,6 +235,9 @@ Cycles in bounded stream topologies need special considerations to avoid potenti
 This section shows several examples of problems that can arise from the presence of feedback arcs in stream processing
 graphs.
 
+In examples below runnable graphs are created but do not run because each have some issue and will not complete normally.
+``Source`` variable is not defined as the nature and number of element does not matter for described problems.
+
 The first example demonstrates a graph that contains a naive cycle.
 The graph takes elements from the source, prints them, then broadcasts those elements
 to a consumer (we just used ``Sink.ignore`` for now) and to a feedback arc that is merged back into the main

--- a/akka-docs/rst/scala/stream/stream-graphs.rst
+++ b/akka-docs/rst/scala/stream/stream-graphs.rst
@@ -292,7 +292,7 @@ Cycles in bounded stream topologies need special considerations to avoid potenti
 This section shows several examples of problems that can arise from the presence of feedback arcs in stream processing
 graphs.
 
-In examples below runnable graphs are created but do not run because each have some issue and will not complete normally.
+In the following examples runnable graphs are created but do not run because each have some issue and will deadlock after start.
 ``Source`` variable is not defined as the nature and number of element does not matter for described problems.
 
 The first example demonstrates a graph that contains a naïve cycle.

--- a/akka-docs/rst/scala/stream/stream-graphs.rst
+++ b/akka-docs/rst/scala/stream/stream-graphs.rst
@@ -292,6 +292,9 @@ Cycles in bounded stream topologies need special considerations to avoid potenti
 This section shows several examples of problems that can arise from the presence of feedback arcs in stream processing
 graphs.
 
+In examples below runnable graphs are created but do not run because each have some issue and will not complete normally.
+``Source`` variable is not defined as the nature and number of element does not matter for described problems.
+
 The first example demonstrates a graph that contains a naïve cycle.
 The graph takes elements from the source, prints them, then broadcasts those elements
 to a consumer (we just used ``Sink.ignore`` for now) and to a feedback arc that is merged back into the main stream via


### PR DESCRIPTION
added one paragraph to doc to clarify that examples are abstract and graphs actually do no run because of problems in each snippet.
Ref: 19921
