### PR TITLE
new send queue

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
@@ -113,7 +113,8 @@ class CodecBenchmark {
     Source.fromGraph(new BenchTestSourceSameElement(N, "elem"))
       .runWith(new LatchSink(N, latch))(materializer)
 
-    latch.await(30, TimeUnit.SECONDS)
+    if (!latch.await(30, TimeUnit.SECONDS))
+      throw new RuntimeException("Latch didn't complete in time")
   }
 
   @Benchmark
@@ -131,7 +132,8 @@ class CodecBenchmark {
       .map(envelope => envelopePool.release(envelope))
       .runWith(new LatchSink(N, latch))(materializer)
 
-    latch.await(30, TimeUnit.SECONDS)
+    if (!latch.await(30, TimeUnit.SECONDS))
+      throw new RuntimeException("Latch didn't complete in time")
   }
 
   @Benchmark
@@ -164,7 +166,8 @@ class CodecBenchmark {
       .via(decoder)
       .runWith(new LatchSink(N, latch))(materializer)
 
-    latch.await(30, TimeUnit.SECONDS)
+    if (!latch.await(30, TimeUnit.SECONDS))
+      throw new RuntimeException("Latch didn't complete in time")
   }
 
   @Benchmark
@@ -195,7 +198,8 @@ class CodecBenchmark {
       .via(decoder)
       .runWith(new LatchSink(N, latch))(materializer)
 
-    latch.await(30, TimeUnit.SECONDS)
+    if (!latch.await(30, TimeUnit.SECONDS))
+      throw new RuntimeException("Latch didn't complete in time")
   }
 
 }

--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/SendQueueBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/SendQueueBenchmark.scala
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.util.concurrent.TimeUnit
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl._
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+import scala.concurrent.Lock
+import scala.util.Success
+import akka.stream.impl.fusing.GraphStages
+import org.reactivestreams._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import akka.stream.ActorMaterializer
+import akka.stream.ActorMaterializerSettings
+import java.util.concurrent.Semaphore
+import akka.stream.OverflowStrategy
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.CountDownLatch
+import akka.stream.KillSwitches
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(2)
+@Warmup(iterations = 4)
+@Measurement(iterations = 10)
+class SendQueueBenchmark {
+
+  val config = ConfigFactory.parseString(
+    """
+    """)
+
+  implicit val system = ActorSystem("SendQueueBenchmark", config)
+
+  var materializer: ActorMaterializer = _
+
+  @Setup
+  def setup(): Unit = {
+    val settings = ActorMaterializerSettings(system)
+    materializer = ActorMaterializer(settings)
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def queue(): Unit = {
+    val latch = new CountDownLatch(1)
+    val barrier = new CyclicBarrier(2)
+    val N = 100000
+    val burstSize = 1000
+
+    val source = Source.queue[Int](1024, OverflowStrategy.dropBuffer)
+
+    val (queue, killSwitch) = source.viaMat(KillSwitches.single)(Keep.both)
+      .toMat(new BarrierSink(N, latch, burstSize, barrier))(Keep.left).run()(materializer)
+
+    var n = 1
+    while (n <= N) {
+      queue.offer(n)
+      if (n % burstSize == 0 && n < N) {
+        barrier.await()
+      }
+      n += 1
+    }
+
+    if (!latch.await(30, TimeUnit.SECONDS))
+      throw new RuntimeException("Latch didn't complete in time")
+    killSwitch.shutdown()
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def actorRef(): Unit = {
+    val latch = new CountDownLatch(1)
+    val barrier = new CyclicBarrier(2)
+    val N = 100000
+    val burstSize = 1000
+
+    val source = Source.actorRef(1024, OverflowStrategy.dropBuffer)
+
+    val (ref, killSwitch) = source.viaMat(KillSwitches.single)(Keep.both)
+      .toMat(new BarrierSink(N, latch, burstSize, barrier))(Keep.left).run()(materializer)
+
+    var n = 1
+    while (n <= N) {
+      ref ! n
+      if (n % burstSize == 0 && n < N) {
+        barrier.await()
+      }
+      n += 1
+    }
+
+    if (!latch.await(30, TimeUnit.SECONDS))
+      throw new RuntimeException("Latch didn't complete in time")
+    killSwitch.shutdown()
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def sendQueue(): Unit = {
+    val latch = new CountDownLatch(1)
+    val barrier = new CyclicBarrier(2)
+    val N = 100000
+    val burstSize = 1000
+
+    val queue = new ManyToOneConcurrentArrayQueue[Int](1024)
+    val source = Source.fromGraph(new SendQueue[Int])
+
+    val (sendQueue, killSwitch) = source.viaMat(KillSwitches.single)(Keep.both)
+      .toMat(new BarrierSink(N, latch, burstSize, barrier))(Keep.left).run()(materializer)
+    sendQueue.inject(queue)
+
+    var n = 1
+    while (n <= N) {
+      if (!sendQueue.offer(n))
+        println(s"offer failed $n") // should not happen
+      if (n % burstSize == 0 && n < N) {
+        barrier.await()
+      }
+      n += 1
+    }
+
+    if (!latch.await(30, TimeUnit.SECONDS))
+      throw new RuntimeException("Latch didn't complete in time")
+    killSwitch.shutdown()
+  }
+
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -464,7 +464,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
 
   // InboundContext
   override def sendControl(to: Address, message: ControlMessage) =
-    association(to).outboundControlIngress.sendControlMessage(message)
+    association(to).sendControl(message)
 
   override def send(message: Any, senderOption: Option[ActorRef], recipient: RemoteActorRef): Unit = {
     val cached = recipient.cachedAssociation

--- a/akka-remote/src/main/scala/akka/remote/artery/SendQueue.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SendQueue.scala
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.util.Queue
+import akka.stream.stage.GraphStage
+import akka.stream.stage.OutHandler
+import akka.stream.Attributes
+import akka.stream.Outlet
+import akka.stream.SourceShape
+import akka.stream.stage.GraphStageLogic
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue
+import akka.stream.stage.GraphStageWithMaterializedValue
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueueTail
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.tailrec
+import scala.concurrent.Promise
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
+
+/**
+ * INTERNAL API
+ */
+private[remote] object SendQueue {
+  trait ProducerApi[T] {
+    def offer(message: T): Boolean
+  }
+
+  trait QueueValue[T] extends ProducerApi[T] {
+    def inject(queue: Queue[T]): Unit
+  }
+
+  private trait WakeupSignal {
+    def wakeup(): Unit
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+private[remote] final class SendQueue[T] extends GraphStageWithMaterializedValue[SourceShape[T], SendQueue.QueueValue[T]] {
+  import SendQueue._
+
+  val out: Outlet[T] = Outlet("SendQueue.out")
+  override val shape: SourceShape[T] = SourceShape(out)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, QueueValue[T]) = {
+    @volatile var needWakeup = false
+    val queuePromise = Promise[Queue[T]]()
+
+    val logic = new GraphStageLogic(shape) with OutHandler with WakeupSignal {
+
+      // using a local field for the consumer side of queue to avoid volatile access
+      private var consumerQueue: Queue[T] = null
+
+      private val wakeupCallback = getAsyncCallback[Unit] { _ ⇒
+        if (isAvailable(out))
+          tryPush()
+      }
+
+      override def preStart(): Unit = {
+        implicit val ec = materializer.executionContext
+        queuePromise.future.onComplete(getAsyncCallback[Try[Queue[T]]] {
+          case Success(q) ⇒
+            consumerQueue = q
+            needWakeup = true
+            if (isAvailable(out))
+              tryPush()
+          case Failure(e) ⇒
+            failStage(e)
+        }.invoke)
+      }
+
+      override def onPull(): Unit = {
+        if (consumerQueue ne null)
+          tryPush()
+      }
+
+      @tailrec private def tryPush(firstAttempt: Boolean = true): Unit = {
+        consumerQueue.poll() match {
+          case null ⇒
+            needWakeup = true
+            // additional poll() to grab any elements that might missed the needWakeup
+            // and have been enqueued just after it
+            if (firstAttempt)
+              tryPush(firstAttempt = false)
+          case elem ⇒
+            needWakeup = false // there will be another onPull
+            push(out, elem)
+        }
+      }
+
+      // external call
+      override def wakeup(): Unit = {
+        wakeupCallback.invoke(())
+      }
+
+      override def postStop(): Unit = {
+        if (consumerQueue ne null)
+          consumerQueue.clear()
+        super.postStop()
+      }
+
+      setHandler(out, this)
+    }
+
+    val queueValue = new QueueValue[T] {
+      @volatile private var producerQueue: Queue[T] = null
+
+      override def inject(q: Queue[T]): Unit = {
+        producerQueue = q
+        queuePromise.success(q)
+      }
+
+      override def offer(message: T): Boolean = {
+        val q = producerQueue
+        if (q eq null) throw new IllegalStateException("offer not allowed before injecting the queue")
+        val result = q.offer(message)
+        if (result && needWakeup)
+          logic.wakeup()
+        result
+      }
+    }
+
+    (logic, queueValue)
+
+  }
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/SendQueueSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SendQueueSpec.scala
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.util.Queue
+
+import scala.concurrent.duration._
+
+import akka.actor.Actor
+import akka.actor.Props
+import akka.stream.ActorMaterializer
+import akka.stream.ActorMaterializerSettings
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue
+
+object SendQueueSpec {
+
+  case class ProduceToQueue(from: Int, until: Int, queue: Queue[Msg])
+  case class ProduceToQueueValue(from: Int, until: Int, queue: SendQueue.QueueValue[Msg])
+  case class Msg(fromProducer: String, value: Int)
+
+  def producerProps(producerId: String): Props =
+    Props(new Producer(producerId))
+
+  class Producer(producerId: String) extends Actor {
+    def receive = {
+      case ProduceToQueue(from, until, queue) ⇒
+        var i = from
+        while (i < until) {
+          if (!queue.offer(Msg(producerId, i)))
+            throw new IllegalStateException(s"offer failed from $producerId value $i")
+          i += 1
+        }
+      case ProduceToQueueValue(from, until, queue) ⇒
+        var i = from
+        while (i < until) {
+          if (!queue.offer(Msg(producerId, i)))
+            throw new IllegalStateException(s"offer failed from $producerId value $i")
+          i += 1
+        }
+    }
+
+  }
+}
+
+class SendQueueSpec extends AkkaSpec("akka.actor.serialize-messages = off") with ImplicitSender {
+  import SendQueueSpec._
+
+  val matSettings = ActorMaterializerSettings(system).withFuzzing(true)
+  implicit val mat = ActorMaterializer(matSettings)(system)
+
+  "SendQueue" must {
+
+    "deliver all messages" in {
+      val queue = new ManyToOneConcurrentArrayQueue[String](128)
+      val (sendQueue, downstream) = Source.fromGraph(new SendQueue[String])
+        .toMat(TestSink.probe)(Keep.both).run()
+
+      downstream.request(10)
+      sendQueue.inject(queue)
+      sendQueue.offer("a")
+      sendQueue.offer("b")
+      sendQueue.offer("c")
+      downstream.expectNext("a")
+      downstream.expectNext("b")
+      downstream.expectNext("c")
+      downstream.cancel()
+    }
+
+    "deliver messages enqueued before materialization" in {
+      val queue = new ManyToOneConcurrentArrayQueue[String](128)
+      queue.offer("a")
+      queue.offer("b")
+
+      val (sendQueue, downstream) = Source.fromGraph(new SendQueue[String])
+        .toMat(TestSink.probe)(Keep.both).run()
+
+      downstream.request(10)
+      downstream.expectNoMsg(200.millis)
+      sendQueue.inject(queue)
+      downstream.expectNext("a")
+      downstream.expectNext("b")
+
+      sendQueue.offer("c")
+      downstream.expectNext("c")
+      downstream.cancel()
+    }
+
+    "deliver bursts of messages" in {
+      // this test verifies that the wakeup signal is triggered correctly
+      val queue = new ManyToOneConcurrentArrayQueue[Int](128)
+      val burstSize = 100
+      val (sendQueue, downstream) = Source.fromGraph(new SendQueue[Int])
+        .grouped(burstSize)
+        .async
+        .toMat(TestSink.probe)(Keep.both).run()
+
+      downstream.request(10)
+      sendQueue.inject(queue)
+
+      for (round ← 1 to 100000) {
+        for (n ← 1 to burstSize) {
+          if (!sendQueue.offer(round * 1000 + n))
+            fail(s"offer failed at round $round message $n")
+        }
+        downstream.expectNext((1 to burstSize).map(_ + round * 1000).toList)
+        downstream.request(1)
+      }
+
+      downstream.cancel()
+    }
+
+    "support multiple producers" in {
+      val numberOfProducers = 5
+      val queue = new ManyToOneConcurrentArrayQueue[Msg](numberOfProducers * 512)
+      val producers = Vector.tabulate(numberOfProducers)(i ⇒ system.actorOf(producerProps(s"producer-$i")))
+
+      // send 100 per producer before materializing
+      producers.foreach(_ ! ProduceToQueue(0, 100, queue))
+
+      val (sendQueue, downstream) = Source.fromGraph(new SendQueue[Msg])
+        .toMat(TestSink.probe)(Keep.both).run()
+
+      sendQueue.inject(queue)
+      producers.foreach(_ ! ProduceToQueueValue(100, 200, sendQueue))
+
+      // send 100 more per producer
+      downstream.request(producers.size * 200)
+      val msgByProducer = downstream.expectNextN(producers.size * 200).groupBy(_.fromProducer)
+      (0 until producers.size).foreach { i ⇒
+        msgByProducer(s"producer-$i").map(_.value) should ===(0 until 200)
+      }
+
+      // send 500 per producer
+      downstream.request(producers.size * 1000) // more than enough
+      producers.foreach(_ ! ProduceToQueueValue(200, 700, sendQueue))
+      val msgByProducer2 = downstream.expectNextN(producers.size * 500).groupBy(_.fromProducer)
+      (0 until producers.size).foreach { i ⇒
+        msgByProducer2(s"producer-$i").map(_.value) should ===(200 until 700)
+      }
+
+      downstream.cancel()
+    }
+
+  }
+
+}


### PR DESCRIPTION
- new SendQueue Source based on agrona ManyToOneConcurrentArrayQueue
- JMH benchmark for Source.queue, Source.actorRef and the new SendQueue

```
[info] Benchmark                                                       Mode  Cnt     Score      Error   Units
[info] SendQueueBenchmark.actorRef                                    thrpt   20   851.698 ±  146.260  ops/ms
[info] SendQueueBenchmark.actorRef:·gc.alloc.rate                     thrpt   20   145.674 ±   25.134  MB/sec
[info] SendQueueBenchmark.queue                                       thrpt   20  1651.769 ±  309.520  ops/ms
[info] SendQueueBenchmark.queue:·gc.alloc.rate                        thrpt   20   278.663 ±   52.128  MB/sec
[info] SendQueueBenchmark.sendQueue                                   thrpt   20  4769.884 ± 1179.381  ops/ms
[info] SendQueueBenchmark.sendQueue:·gc.alloc.rate                    thrpt   20   144.605 ±   27.811  MB/sec
```
