### PR TITLE
Java HttpEntity should not care about the materialized type of its Source

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
@@ -66,25 +66,29 @@ public final class HttpEntities {
         return HttpEntity$.MODULE$.fromPath((akka.http.scaladsl.model.ContentType) contentType, file, chunkSize);
     }
 
-    public static HttpEntity.Default create(ContentType contentType, long contentLength, Source<ByteString, Object> data) {
-        return new akka.http.scaladsl.model.HttpEntity.Default((akka.http.scaladsl.model.ContentType) contentType, contentLength, data.asScala());
+    public static HttpEntity.Default create(ContentType contentType, long contentLength, Source<ByteString, ?> data) {
+        return new akka.http.scaladsl.model.HttpEntity.Default((akka.http.scaladsl.model.ContentType) contentType, contentLength, toScala(data));
     }
 
-    public static HttpEntity.Chunked create(ContentType contentType, Source<ByteString, Object> data) {
-        return akka.http.scaladsl.model.HttpEntity.Chunked$.MODULE$.fromData((akka.http.scaladsl.model.ContentType) contentType, data.asScala());
+    public static HttpEntity.Chunked create(ContentType contentType, Source<ByteString, ?> data) {
+        return akka.http.scaladsl.model.HttpEntity.Chunked$.MODULE$.fromData((akka.http.scaladsl.model.ContentType) contentType, toScala(data));
     }
 
-    public static HttpEntity.CloseDelimited createCloseDelimited(ContentType contentType, Source<ByteString, Object> data) {
-        return new akka.http.scaladsl.model.HttpEntity.CloseDelimited((akka.http.scaladsl.model.ContentType) contentType, data.asScala());
+    public static HttpEntity.CloseDelimited createCloseDelimited(ContentType contentType, Source<ByteString, ?> data) {
+        return new akka.http.scaladsl.model.HttpEntity.CloseDelimited((akka.http.scaladsl.model.ContentType) contentType, toScala(data));
     }
 
-    public static HttpEntity.IndefiniteLength createIndefiniteLength(ContentType contentType, Source<ByteString, Object> data) {
-        return new akka.http.scaladsl.model.HttpEntity.IndefiniteLength((akka.http.scaladsl.model.ContentType) contentType, data.asScala());
+    public static HttpEntity.IndefiniteLength createIndefiniteLength(ContentType contentType, Source<ByteString, ?> data) {
+        return new akka.http.scaladsl.model.HttpEntity.IndefiniteLength((akka.http.scaladsl.model.ContentType) contentType, toScala(data));
     }
 
-    public static HttpEntity.Chunked createChunked(ContentType contentType, Source<ByteString, Object> data) {
+    public static HttpEntity.Chunked createChunked(ContentType contentType, Source<ByteString, ?> data) {
         return akka.http.scaladsl.model.HttpEntity.Chunked$.MODULE$.fromData(
                 (akka.http.scaladsl.model.ContentType) contentType,
-                data.asScala());
+                toScala(data));
+    }
+    
+    private static akka.stream.scaladsl.Source<ByteString,Object> toScala(Source<ByteString, ?> javaSource) {
+        return (akka.stream.scaladsl.Source<ByteString,Object>)javaSource.asScala();
     }
 }

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
@@ -6,6 +6,8 @@ package akka.http.javadsl.model;
 
 import akka.http.javadsl.model.headers.*;
 import akka.japi.Pair;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
 
 public class JavaApiTestCases {
   /**
@@ -95,5 +97,10 @@ public class JavaApiTestCases {
     anything = (akka.http.javadsl.model.ContentType.WithFixedCharset) type;
 
     return anything;
+  }
+  
+  public static void HttpEntity_should_not_care_about_materialized_value_of_its_source() {
+      Source<ByteString, Integer> src = Source.single(ByteString.fromString("hello, world")).mapMaterializedValue(m -> 42);
+      HttpEntity entity = HttpEntities.create(ContentTypes.TEXT_PLAIN_UTF8, src); // this needs to accept Source<ByteString, ?>
   }
 }


### PR DESCRIPTION
At the moment, when having a `Source<ByteString,M>` that materializes into something else than plain `Object` (which is almost everything that akka itself returns), you can't directly create an `HttpEntity` of that in Java, without first doing a `.mapMaterializedValue(m -> null)`.

This PR adds type variance that should be completely safe, since `Source` is actually variant in `M` itself on the scala side.

The test I added shows what I mean.

@ktoso
