### PR TITLE
port some remote tests to Artery

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeployerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeployerSpec.scala
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import akka.testkit._
+import akka.actor._
+import akka.routing._
+import com.typesafe.config._
+import akka.ConfigurationException
+import akka.remote.RemoteScope
+
+object RemoteDeployerSpec {
+  val deployerConf = ConfigFactory.parseString("""
+      akka.actor.provider = "akka.remote.RemoteActorRefProvider"
+      akka.actor.deployment {
+        /service2 {
+          router = round-robin-pool
+          nr-of-instances = 3
+          remote = "akka://sys@wallace:2552"
+          dispatcher = mydispatcher
+        }
+      }
+      akka.remote.artery.enabled = on
+      akka.remote.artery.hostname = localhost
+      akka.remote.artery.port = 0
+      """, ConfigParseOptions.defaults)
+
+  class RecipeActor extends Actor {
+    def receive = { case _ ⇒ }
+  }
+
+}
+
+class RemoteDeployerSpec extends AkkaSpec(RemoteDeployerSpec.deployerConf) {
+
+  "A RemoteDeployer" must {
+
+    "be able to parse 'akka.actor.deployment._' with specified remote nodes" in {
+      val service = "/service2"
+      val deployment = system.asInstanceOf[ActorSystemImpl].provider.deployer.lookup(service.split("/").drop(1))
+
+      deployment should ===(Some(
+        Deploy(
+          service,
+          deployment.get.config,
+          RoundRobinPool(3),
+          RemoteScope(Address("akka", "sys", "wallace", 2552)),
+          "mydispatcher")))
+    }
+
+    "reject remote deployment when the source requires LocalScope" in {
+      intercept[ConfigurationException] {
+        system.actorOf(Props.empty.withDeploy(Deploy.local), "service2")
+      }.getMessage should ===("configuration requested remote deployment for local-only Props at [akka://RemoteDeployerSpec/user/service2]")
+    }
+
+  }
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.collection.immutable
+import akka.testkit._
+import akka.routing._
+import akka.actor._
+import akka.remote.routing._
+import com.typesafe.config._
+import akka.testkit.TestActors.echoActorProps
+import akka.remote.RemoteScope
+
+object RemoteDeploymentSpec {
+  class Echo1 extends Actor {
+    var target: ActorRef = context.system.deadLetters
+
+    def receive = {
+      case ex: Exception ⇒ throw ex
+      case x             ⇒ target = sender(); sender() ! x
+    }
+
+    override def preStart() {}
+    override def preRestart(cause: Throwable, msg: Option[Any]) {
+      target ! "preRestart"
+    }
+    override def postRestart(cause: Throwable) {}
+    override def postStop() {
+      target ! "postStop"
+    }
+  }
+}
+
+class RemoteDeploymentSpec extends AkkaSpec("""
+    #akka.loglevel=DEBUG
+    akka.actor.provider = "akka.remote.RemoteActorRefProvider"
+    akka.remote.artery.enabled = on
+    akka.remote.artery.hostname = localhost
+    akka.remote.artery.port = 0
+    """) {
+
+  import RemoteDeploymentSpec._
+
+  val port = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.port.get
+  val conf = ConfigFactory.parseString(
+    s"""
+    akka.actor.deployment {
+      /blub.remote = "artery://${system.name}@localhost:$port"
+    }
+    """).withFallback(system.settings.config)
+
+  val masterSystem = ActorSystem("Master" + system.name, conf)
+  val masterPort = masterSystem.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.port.get
+
+  override def afterTermination(): Unit = {
+    shutdown(masterSystem)
+  }
+
+  "Remoting" must {
+
+    // FIXME this test is failing with Artery
+    "create and supervise children on remote node" ignore {
+      val senderProbe = TestProbe()(masterSystem)
+      val r = masterSystem.actorOf(Props[Echo1], "blub")
+      r.path.toString should ===(s"artery://${system.name}@localhost:${port}/remote/artery/${masterSystem.name}@localhost:${masterPort}/user/blub")
+
+      r.tell(42, senderProbe.ref)
+      senderProbe.expectMsg(42)
+      EventFilter[Exception]("crash", occurrences = 1).intercept {
+        r ! new Exception("crash")
+      }(masterSystem)
+      senderProbe.expectMsg("preRestart")
+      r.tell(43, senderProbe.ref)
+      senderProbe.expectMsg(43)
+      system.stop(r)
+      senderProbe.expectMsg("postStop")
+    }
+
+  }
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
@@ -1,0 +1,258 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.collection.immutable
+import akka.testkit._
+import akka.routing._
+import akka.actor._
+import akka.remote.routing._
+import com.typesafe.config._
+import akka.testkit.TestActors.echoActorProps
+import akka.remote.RemoteScope
+
+object RemoteRouterSpec {
+  class Parent extends Actor {
+    def receive = {
+      case (p: Props, name: String) ⇒
+        sender() ! context.actorOf(p, name)
+    }
+  }
+}
+
+class RemoteRouterSpec extends AkkaSpec("""
+    akka.loglevel=DEBUG
+    akka.actor.provider = "akka.remote.RemoteActorRefProvider"
+    akka.remote.artery.enabled = on
+    akka.remote.artery.hostname = localhost
+    akka.remote.artery.port = 0
+    akka.actor.deployment {
+      /remote-override {
+        router = round-robin-pool
+        nr-of-instances = 4
+      }
+      /round {
+        router = round-robin-pool
+        nr-of-instances = 5
+      }
+      /sys-parent/round {
+        router = round-robin-pool
+        nr-of-instances = 6
+      }
+    }""") {
+
+  import RemoteRouterSpec._
+
+  val port = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.port.get
+  val sysName = system.name
+  val conf = ConfigFactory.parseString(
+    s"""
+    akka {
+      actor.deployment {
+        /blub {
+          router = round-robin-pool
+          nr-of-instances = 2
+          target.nodes = ["artery://${sysName}@localhost:${port}"]
+        }
+        /elastic-blub {
+          router = round-robin-pool
+          resizer {
+            lower-bound = 2
+            upper-bound = 3
+          }
+          target.nodes = ["artery://${sysName}@localhost:${port}"]
+        }
+        /remote-blub {
+          remote = "artery://${sysName}@localhost:${port}"
+          router = round-robin-pool
+          nr-of-instances = 2
+        }
+        /local-blub {
+          remote = "akka://MasterRemoteRouterSpec"
+          router = round-robin-pool
+          nr-of-instances = 2
+          target.nodes = ["artery://${sysName}@localhost:${port}"]
+        }
+        /local-blub2 {
+          router = round-robin-pool
+          nr-of-instances = 4
+          target.nodes = ["artery://${sysName}@localhost:${port}"]
+        }
+      }
+    }""").withFallback(system.settings.config)
+
+  val masterSystem = ActorSystem("Master" + sysName, conf)
+
+  override def afterTermination(): Unit = {
+    shutdown(masterSystem)
+  }
+
+  def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): immutable.Seq[ActorPath] = {
+    for (i ← 1 to n) yield {
+      val msg = i.toString
+      router.tell(msg, probe.ref)
+      probe.expectMsg(msg)
+      probe.lastSender.path
+    }
+  }
+
+  "A Remote Router" must {
+
+    // FIXME this test is failing with Artery
+    "deploy its children on remote host driven by configuration" ignore {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps), "blub")
+      val replies = collectRouteePaths(probe, router, 5)
+      println(s"# replies $replies") // FIXME
+      val children = replies.toSet
+      children should have size 2
+      children.map(_.parent) should have size 1
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    // FIXME this test is failing with Artery
+    "deploy its children on remote host driven by programatic definition" ignore {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(new RemoteRouterConfig(
+        RoundRobinPool(2),
+        Seq(Address("artery", sysName, "localhost", port))).props(echoActorProps), "blub2")
+      val replies = collectRouteePaths(probe, router, 5)
+      val children = replies.toSet
+      children should have size 2
+      children.map(_.parent) should have size 1
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    // FIXME this test is failing with Artery
+    "deploy dynamic resizable number of children on remote host driven by configuration" ignore {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(FromConfig.props(echoActorProps), "elastic-blub")
+      val replies = collectRouteePaths(probe, router, 5000)
+      val children = replies.toSet
+      children.size should be >= 2
+      children.map(_.parent) should have size 1
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    "deploy remote routers based on configuration" in {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(FromConfig.props(echoActorProps), "remote-blub")
+      router.path.address.toString should ===(s"artery://${sysName}@localhost:${port}")
+      val replies = collectRouteePaths(probe, router, 5)
+      val children = replies.toSet
+      children should have size 2
+      val parents = children.map(_.parent)
+      parents should have size 1
+      parents.head should ===(router.path)
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    // FIXME this test is failing with Artery
+    "deploy remote routers based on explicit deployment" ignore {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps)
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"artery://${sysName}@localhost:${port}")))), "remote-blub2")
+      router.path.address.toString should ===(s"artery://${sysName}@localhost:${port}")
+      val replies = collectRouteePaths(probe, router, 5)
+      val children = replies.toSet
+      children should have size 2
+      val parents = children.map(_.parent)
+      parents should have size 1
+      parents.head should ===(router.path)
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    // FIXME this test is failing with Artery
+    "let remote deployment be overridden by local configuration" ignore {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps)
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"artery://${sysName}@localhost:${port}")))), "local-blub")
+      router.path.address.toString should ===("akka://MasterRemoteRouterSpec")
+      val replies = collectRouteePaths(probe, router, 5)
+      val children = replies.toSet
+      children should have size 2
+      val parents = children.map(_.parent)
+      parents should have size 1
+      parents.head.address should ===(Address("artery", sysName, "localhost", port))
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    "let remote deployment router be overridden by local configuration" in {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps)
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"artery://${sysName}@localhost:${port}")))), "local-blub2")
+      router.path.address.toString should ===(s"artery://${sysName}@localhost:${port}")
+      val replies = collectRouteePaths(probe, router, 5)
+      val children = replies.toSet
+      children should have size 4
+      val parents = children.map(_.parent)
+      parents should have size 1
+      parents.head should ===(router.path)
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    "let remote deployment be overridden by remote configuration" in {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps)
+        .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"artery://${sysName}@localhost:${port}")))), "remote-override")
+      router.path.address.toString should ===(s"artery://${sysName}@localhost:${port}")
+      val replies = collectRouteePaths(probe, router, 5)
+      val children = replies.toSet
+      children should have size 4
+      val parents = children.map(_.parent)
+      parents should have size 1
+      parents.head should ===(router.path)
+      children foreach (_.address.toString should ===(s"artery://${sysName}@localhost:${port}"))
+      masterSystem.stop(router)
+    }
+
+    // FIXME this test is failing with Artery
+    "set supplied supervisorStrategy" ignore {
+      val probe = TestProbe()(masterSystem)
+      val escalator = OneForOneStrategy() {
+        case e ⇒ probe.ref ! e; SupervisorStrategy.Escalate
+      }
+      val router = masterSystem.actorOf(new RemoteRouterConfig(
+        RoundRobinPool(1, supervisorStrategy = escalator),
+        Seq(Address("artery", sysName, "localhost", port))).props(Props.empty), "blub3")
+
+      router.tell(GetRoutees, probe.ref)
+      EventFilter[ActorKilledException](occurrences = 1).intercept {
+        probe.expectMsgType[Routees].routees.head.send(Kill, testActor)
+      }(masterSystem)
+      probe.expectMsgType[ActorKilledException]
+    }
+
+    "load settings from config for local router" in {
+      val probe = TestProbe()(masterSystem)
+      val router = masterSystem.actorOf(FromConfig.props(echoActorProps), "round")
+      val replies = collectRouteePaths(probe, router, 10)
+      val children = replies.toSet
+      children should have size 5
+      masterSystem.stop(router)
+    }
+
+    "load settings from config for local child router of system actor" in {
+      // we don't really support deployment configuration of system actors, but
+      // it's used for the pool of the SimpleDnsManager "/IO-DNS/inet-address"
+      val probe = TestProbe()(masterSystem)
+      val parent = masterSystem.asInstanceOf[ExtendedActorSystem].systemActorOf(Props[Parent], "sys-parent")
+      parent.tell((FromConfig.props(echoActorProps), "round"), probe.ref)
+      val router = probe.expectMsgType[ActorRef]
+      val replies = collectRouteePaths(probe, router, 10)
+      val children = replies.toSet
+      children should have size 6
+      masterSystem.stop(router)
+    }
+
+  }
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
@@ -67,7 +67,7 @@ class RemoteSendConsistencySpec extends AkkaSpec(RemoteSendConsistencySpec.confi
       }
 
       val senderProps = Props(new Actor {
-        var counter = 100 // FIXME try this test with 1000, why does it take so long?
+        var counter = 1000
         remoteRef ! counter
 
         override def receive: Receive = {

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
@@ -1,0 +1,321 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import language.postfixOps
+import scala.concurrent.duration._
+import akka.testkit._
+import akka.actor._
+import akka.remote._
+
+object RemoteWatcherSpec {
+
+  class TestActorProxy(testActor: ActorRef) extends Actor {
+    def receive = {
+      case msg ⇒ testActor forward msg
+    }
+  }
+
+  class MyActor extends Actor {
+    def receive = Actor.emptyBehavior
+  }
+
+  // turn off all periodic activity
+  val TurnOff = 5.minutes
+
+  def createFailureDetector(): FailureDetectorRegistry[Address] = {
+    def createFailureDetector(): FailureDetector =
+      new PhiAccrualFailureDetector(
+        threshold = 8.0,
+        maxSampleSize = 200,
+        minStdDeviation = 100.millis,
+        acceptableHeartbeatPause = 3.seconds,
+        firstHeartbeatEstimate = 1.second)
+
+    new DefaultFailureDetectorRegistry(() ⇒ createFailureDetector())
+  }
+
+  object TestRemoteWatcher {
+    final case class AddressTerm(address: Address)
+    final case class Quarantined(address: Address, uid: Option[Int])
+  }
+
+  class TestRemoteWatcher(heartbeatExpectedResponseAfter: FiniteDuration) extends RemoteWatcher(
+    createFailureDetector,
+    heartbeatInterval = TurnOff,
+    unreachableReaperInterval = TurnOff,
+    heartbeatExpectedResponseAfter = heartbeatExpectedResponseAfter) {
+
+    def this() = this(heartbeatExpectedResponseAfter = TurnOff)
+
+    override def publishAddressTerminated(address: Address): Unit =
+      // don't publish the real AddressTerminated, but a testable message,
+      // that doesn't interfere with the real watch that is going on in the background
+      context.system.eventStream.publish(TestRemoteWatcher.AddressTerm(address))
+
+    override def quarantine(address: Address, uid: Option[Int]): Unit = {
+      // don't quarantine in remoting, but publish a testable message
+      context.system.eventStream.publish(TestRemoteWatcher.Quarantined(address, uid))
+    }
+
+  }
+
+}
+
+class RemoteWatcherSpec extends AkkaSpec(
+  """akka {
+       loglevel = INFO
+       log-dead-letters-during-shutdown = false
+       actor.provider = "akka.remote.RemoteActorRefProvider"
+       remote.artery.enabled = on
+       remote.artery.hostname = localhost
+       remote.artery.port = 0
+     }""") with ImplicitSender {
+
+  import RemoteWatcherSpec._
+  import RemoteWatcher._
+
+  override def expectedTestDuration = 2.minutes
+
+  val remoteSystem = ActorSystem("RemoteSystem", system.settings.config)
+  val remoteAddress = remoteSystem.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+  def remoteAddressUid = AddressUidExtension(remoteSystem).addressUid
+
+  Seq(system, remoteSystem).foreach(muteDeadLetters(
+    akka.remote.transport.AssociationHandle.Disassociated.getClass,
+    akka.remote.transport.ActorTransportAdapter.DisassociateUnderlying.getClass)(_))
+
+  override def afterTermination() {
+    shutdown(remoteSystem)
+  }
+
+  val heartbeatRspB = HeartbeatRsp(remoteAddressUid)
+
+  def createRemoteActor(props: Props, name: String): InternalActorRef = {
+    remoteSystem.actorOf(props, name)
+    system.actorSelection(RootActorPath(remoteAddress) / "user" / name) ! Identify(name)
+    expectMsgType[ActorIdentity].ref.get.asInstanceOf[InternalActorRef]
+  }
+
+  "A RemoteWatcher" must {
+
+    "have correct interaction when watching" in {
+
+      val fd = createFailureDetector()
+      val monitorA = system.actorOf(Props[TestRemoteWatcher], "monitor1")
+      val monitorB = createRemoteActor(Props(classOf[TestActorProxy], testActor), "monitor1")
+
+      val a1 = system.actorOf(Props[MyActor], "a1").asInstanceOf[InternalActorRef]
+      val a2 = system.actorOf(Props[MyActor], "a2").asInstanceOf[InternalActorRef]
+      val b1 = createRemoteActor(Props[MyActor], "b1")
+      val b2 = createRemoteActor(Props[MyActor], "b2")
+
+      monitorA ! WatchRemote(b1, a1)
+      monitorA ! WatchRemote(b2, a1)
+      monitorA ! WatchRemote(b2, a2)
+      monitorA ! Stats
+      // (a1->b1), (a1->b2), (a2->b2)
+      expectMsg(Stats.counts(watching = 3, watchingNodes = 1))
+      expectNoMsg(100 millis)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      expectNoMsg(100 millis)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      expectNoMsg(100 millis)
+      monitorA.tell(heartbeatRspB, monitorB)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      expectNoMsg(100 millis)
+
+      monitorA ! UnwatchRemote(b1, a1)
+      // still (a1->b2) and (a2->b2) left
+      monitorA ! Stats
+      expectMsg(Stats.counts(watching = 2, watchingNodes = 1))
+      expectNoMsg(100 millis)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      expectNoMsg(100 millis)
+
+      monitorA ! UnwatchRemote(b2, a2)
+      // still (a1->b2) left
+      monitorA ! Stats
+      expectMsg(Stats.counts(watching = 1, watchingNodes = 1))
+      expectNoMsg(100 millis)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      expectNoMsg(100 millis)
+
+      monitorA ! UnwatchRemote(b2, a1)
+      // all unwatched
+      monitorA ! Stats
+      expectMsg(Stats.empty)
+      expectNoMsg(100 millis)
+      monitorA ! HeartbeatTick
+      expectNoMsg(100 millis)
+      monitorA ! HeartbeatTick
+      expectNoMsg(100 millis)
+
+      // make sure nothing floods over to next test
+      expectNoMsg(2 seconds)
+    }
+
+    "generate AddressTerminated when missing heartbeats" in {
+      val p = TestProbe()
+      val q = TestProbe()
+      system.eventStream.subscribe(p.ref, classOf[TestRemoteWatcher.AddressTerm])
+      system.eventStream.subscribe(q.ref, classOf[TestRemoteWatcher.Quarantined])
+
+      val monitorA = system.actorOf(Props[TestRemoteWatcher], "monitor4")
+      val monitorB = createRemoteActor(Props(classOf[TestActorProxy], testActor), "monitor4")
+
+      val a = system.actorOf(Props[MyActor], "a4").asInstanceOf[InternalActorRef]
+      val b = createRemoteActor(Props[MyActor], "b4")
+
+      monitorA ! WatchRemote(b, a)
+
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA.tell(heartbeatRspB, monitorB)
+      expectNoMsg(1 second)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA.tell(heartbeatRspB, monitorB)
+
+      within(10 seconds) {
+        awaitAssert {
+          monitorA ! HeartbeatTick
+          expectMsg(Heartbeat)
+          // but no HeartbeatRsp
+          monitorA ! ReapUnreachableTick
+          p.expectMsg(1 second, TestRemoteWatcher.AddressTerm(b.path.address))
+          q.expectMsg(1 second, TestRemoteWatcher.Quarantined(b.path.address, Some(remoteAddressUid)))
+        }
+      }
+
+      // make sure nothing floods over to next test
+      expectNoMsg(2 seconds)
+    }
+
+    "generate AddressTerminated when missing first heartbeat" in {
+      val p = TestProbe()
+      val q = TestProbe()
+      system.eventStream.subscribe(p.ref, classOf[TestRemoteWatcher.AddressTerm])
+      system.eventStream.subscribe(q.ref, classOf[TestRemoteWatcher.Quarantined])
+
+      val fd = createFailureDetector()
+      val heartbeatExpectedResponseAfter = 2.seconds
+      val monitorA = system.actorOf(Props(classOf[TestRemoteWatcher], heartbeatExpectedResponseAfter), "monitor5")
+      val monitorB = createRemoteActor(Props(classOf[TestActorProxy], testActor), "monitor5")
+
+      val a = system.actorOf(Props[MyActor], "a5").asInstanceOf[InternalActorRef]
+      val b = createRemoteActor(Props[MyActor], "b5")
+
+      monitorA ! WatchRemote(b, a)
+
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      // no HeartbeatRsp sent
+
+      within(20 seconds) {
+        awaitAssert {
+          monitorA ! HeartbeatTick
+          expectMsg(Heartbeat)
+          // but no HeartbeatRsp
+          monitorA ! ReapUnreachableTick
+          p.expectMsg(1 second, TestRemoteWatcher.AddressTerm(b.path.address))
+          // no real quarantine when missing first heartbeat, uid unknown
+          q.expectMsg(1 second, TestRemoteWatcher.Quarantined(b.path.address, None))
+        }
+      }
+
+      // make sure nothing floods over to next test
+      expectNoMsg(2 seconds)
+    }
+
+    "generate AddressTerminated for new watch after broken connection that was re-established and broken again" in {
+      val p = TestProbe()
+      val q = TestProbe()
+      system.eventStream.subscribe(p.ref, classOf[TestRemoteWatcher.AddressTerm])
+      system.eventStream.subscribe(q.ref, classOf[TestRemoteWatcher.Quarantined])
+
+      val monitorA = system.actorOf(Props[TestRemoteWatcher], "monitor6")
+      val monitorB = createRemoteActor(Props(classOf[TestActorProxy], testActor), "monitor6")
+
+      val a = system.actorOf(Props[MyActor], "a6").asInstanceOf[InternalActorRef]
+      val b = createRemoteActor(Props[MyActor], "b6")
+
+      monitorA ! WatchRemote(b, a)
+
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA.tell(heartbeatRspB, monitorB)
+      expectNoMsg(1 second)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA.tell(heartbeatRspB, monitorB)
+
+      within(10 seconds) {
+        awaitAssert {
+          monitorA ! HeartbeatTick
+          expectMsg(Heartbeat)
+          // but no HeartbeatRsp
+          monitorA ! ReapUnreachableTick
+          p.expectMsg(1 second, TestRemoteWatcher.AddressTerm(b.path.address))
+          q.expectMsg(1 second, TestRemoteWatcher.Quarantined(b.path.address, Some(remoteAddressUid)))
+        }
+      }
+
+      // real AddressTerminated would trigger Terminated for b6, simulate that here
+      remoteSystem.stop(b)
+      awaitAssert {
+        monitorA ! Stats
+        expectMsg(Stats.empty)
+      }
+      expectNoMsg(2 seconds)
+
+      // assume that connection comes up again, or remote system is restarted
+      val c = createRemoteActor(Props[MyActor], "c6")
+
+      monitorA ! WatchRemote(c, a)
+
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA.tell(heartbeatRspB, monitorB)
+      expectNoMsg(1 second)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA.tell(heartbeatRspB, monitorB)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA ! ReapUnreachableTick
+      p.expectNoMsg(1 second)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA.tell(heartbeatRspB, monitorB)
+      monitorA ! HeartbeatTick
+      expectMsg(Heartbeat)
+      monitorA ! ReapUnreachableTick
+      p.expectNoMsg(1 second)
+      q.expectNoMsg(1 second)
+
+      // then stop heartbeating again, should generate new AddressTerminated
+      within(10 seconds) {
+        awaitAssert {
+          monitorA ! HeartbeatTick
+          expectMsg(Heartbeat)
+          // but no HeartbeatRsp
+          monitorA ! ReapUnreachableTick
+          p.expectMsg(1 second, TestRemoteWatcher.AddressTerm(c.path.address))
+          q.expectMsg(1 second, TestRemoteWatcher.Quarantined(c.path.address, Some(remoteAddressUid)))
+        }
+      }
+
+      // make sure nothing floods over to next test
+      expectNoMsg(2 seconds)
+    }
+
+  }
+
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/UntrustedSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/UntrustedSpec.scala
@@ -1,0 +1,187 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.remote.artery
+
+import scala.concurrent.duration._
+import com.typesafe.config.ConfigFactory
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Deploy
+import akka.actor.ExtendedActorSystem
+import akka.actor.Identify
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.actor.RootActorPath
+import akka.actor.Terminated
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.testkit.TestProbe
+import akka.actor.ActorSelection
+import akka.testkit.TestEvent
+import akka.event.Logging
+import akka.testkit.EventFilter
+
+object UntrustedSpec {
+  final case class IdentifyReq(path: String)
+  final case class StopChild(name: String)
+
+  class Receptionist(testActor: ActorRef) extends Actor {
+    context.actorOf(Props(classOf[Child], testActor), "child1")
+    context.actorOf(Props(classOf[Child], testActor), "child2")
+    context.actorOf(Props(classOf[FakeUser], testActor), "user")
+
+    def receive = {
+      case IdentifyReq(path) ⇒ context.actorSelection(path).tell(Identify(None), sender())
+      case StopChild(name)   ⇒ context.child(name) foreach context.stop
+      case msg               ⇒ testActor forward msg
+    }
+  }
+
+  class Child(testActor: ActorRef) extends Actor {
+    override def postStop(): Unit = {
+      testActor ! s"${self.path.name} stopped"
+    }
+    def receive = {
+      case msg ⇒ testActor forward msg
+    }
+  }
+
+  class FakeUser(testActor: ActorRef) extends Actor {
+    context.actorOf(Props(classOf[Child], testActor), "receptionist")
+    def receive = {
+      case msg ⇒ testActor forward msg
+    }
+  }
+
+}
+
+class UntrustedSpec extends AkkaSpec("""
+  akka.actor.provider = akka.remote.RemoteActorRefProvider
+  akka.remote.untrusted-mode = on
+  akka.remote.trusted-selection-paths = ["/user/receptionist", ]
+  akka.remote.artery.enabled = on
+  akka.remote.artery.hostname = localhost
+  akka.remote.artery.port = 0
+  akka.loglevel = DEBUG # the test is verifying some Debug logging
+  """) with ImplicitSender {
+
+  import UntrustedSpec._
+
+  val client = ActorSystem("UntrustedSpec-client", ConfigFactory.parseString("""
+      akka.actor.provider = akka.remote.RemoteActorRefProvider
+      akka.remote.artery.enabled = on
+      akka.remote.artery.hostname = localhost
+      akka.remote.artery.port = 0
+      """))
+  val addr = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+
+  val receptionist = system.actorOf(Props(classOf[Receptionist], testActor), "receptionist")
+
+  lazy val remoteDaemon = {
+    {
+      val p = TestProbe()(client)
+      client.actorSelection(RootActorPath(addr) / receptionist.path.elements).tell(IdentifyReq("/remote"), p.ref)
+      p.expectMsgType[ActorIdentity].ref.get
+    }
+  }
+
+  lazy val target2 = {
+    val p = TestProbe()(client)
+    client.actorSelection(RootActorPath(addr) / receptionist.path.elements).tell(
+      IdentifyReq("child2"), p.ref)
+    p.expectMsgType[ActorIdentity].ref.get
+  }
+
+  override def afterTermination() {
+    shutdown(client)
+  }
+
+  // need to enable debug log-level without actually printing those messages
+  system.eventStream.publish(TestEvent.Mute(EventFilter.debug()))
+
+  "UntrustedMode" must {
+
+    "allow actor selection to configured white list" in {
+      val sel = client.actorSelection(RootActorPath(addr) / receptionist.path.elements)
+      sel ! "hello"
+      expectMsg("hello")
+    }
+
+    "discard harmful messages to /remote" in {
+      val logProbe = TestProbe()
+      // but instead install our own listener
+      system.eventStream.subscribe(system.actorOf(Props(new Actor {
+        import Logging._
+        def receive = {
+          case d @ Debug(_, _, msg: String) if msg contains "dropping" ⇒ logProbe.ref ! d
+          case _ ⇒
+        }
+      }).withDeploy(Deploy.local), "debugSniffer"), classOf[Logging.Debug])
+
+      remoteDaemon ! "hello"
+      logProbe.expectMsgType[Logging.Debug]
+    }
+
+    "discard harmful messages to testActor" in {
+      target2 ! Terminated(remoteDaemon)(existenceConfirmed = true, addressTerminated = false)
+      target2 ! PoisonPill
+      client.stop(target2)
+      target2 ! "blech"
+      expectMsg("blech")
+    }
+
+    "discard watch messages" in {
+      client.actorOf(Props(new Actor {
+        context.watch(target2)
+        def receive = {
+          case x ⇒ testActor forward x
+        }
+      }).withDeploy(Deploy.local))
+      receptionist ! StopChild("child2")
+      expectMsg("child2 stopped")
+      // no Terminated msg, since watch was discarded
+      expectNoMsg(1.second)
+    }
+
+    "discard actor selection" in {
+      val sel = client.actorSelection(RootActorPath(addr) / testActor.path.elements)
+      sel ! "hello"
+      expectNoMsg(1.second)
+    }
+
+    "discard actor selection with non root anchor" in {
+      val p = TestProbe()(client)
+      client.actorSelection(RootActorPath(addr) / receptionist.path.elements).tell(
+        Identify(None), p.ref)
+      val clientReceptionistRef = p.expectMsgType[ActorIdentity].ref.get
+
+      val sel = ActorSelection(clientReceptionistRef, receptionist.path.toStringWithoutAddress)
+      sel ! "hello"
+      expectNoMsg(1.second)
+    }
+
+    "discard actor selection to child of matching white list" in {
+      val sel = client.actorSelection(RootActorPath(addr) / receptionist.path.elements / "child1")
+      sel ! "hello"
+      expectNoMsg(1.second)
+    }
+
+    "discard actor selection with wildcard" in {
+      val sel = client.actorSelection(RootActorPath(addr) / receptionist.path.elements / "*")
+      sel ! "hello"
+      expectNoMsg(1.second)
+    }
+
+    "discard actor selection containing harmful message" in {
+      val sel = client.actorSelection(RootActorPath(addr) / receptionist.path.elements)
+      sel ! PoisonPill
+      expectNoMsg(1.second)
+    }
+
+  }
+
+}


### PR DESCRIPTION
- Some are failing and are marked as ignored, will open
  separate issues for those.
- All interesting tests apart from the big RemotingSpec.scala are
  ported. Relevant parts of it should be ported but into smaller
  more focused tests.
