### PR TITLE
WIP - #20744 - Cluster Sharding with remember-entity enabled fails to recover after restart.

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -98,6 +98,23 @@ akka.cluster.sharding {
   # Zero to disable feature.
   entity-recovery-rate-interval = 0 s
 
+  # The shard uses this strategy to determines how to recover the underlying entity actors. The strategy is only used
+  # by the persistent shard when rebalancing or restarting. The value is fully qualified class name. It needs to be a
+  # subclass of akka.sharding.EntityRecoveryConfigurator The default strategy starts all the entity actors at once.
+  # Is also possible to use akka.cluster.sharding.ConstantRateEntityRecoveryConfigurator to have a set rate of recovery.
+  entity-recovery-strategy = "akka.cluster.sharding.AllAtOnceEntityRecoveryConfigurator"
+
+  # The path to the configuration of the entity recovery strategy.
+  entity-recovery-strategy-config-path = ""
+
+  # Default settings for the constant rate entity recovery strategy
+  entity-recovery-constant-rate-strategy {
+    # Sets the frequency at which a batch of entity actors is started.
+    frequency = 1 s
+    # Sets the number of entity actor to be restart at a particular interval
+    number-of-entities = 1
+  }
+
   # Settings for the coordinator singleton. Same layout as akka.cluster.singleton.
   # The "role" of the singleton configuration is not used. The singleton role will
   # be the same as "akka.cluster.sharding.role".

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -94,10 +94,6 @@ akka.cluster.sharding {
   # works only for state-store-mode = "ddata"
   updating-state-timeout = 5 s
 
-  # The interval beteween which remembered entities are restarted when initialing the shard
-  # Zero to disable feature.
-  entity-recovery-rate-interval = 0 s
-
   # The shard uses this strategy to determines how to recover the underlying entity actors. The strategy is only used
   # by the persistent shard when rebalancing or restarting. The value can either be "all" or "constant". The "all"
   # strategy start all the underlying entity actors at the same time. The constant strategy will start the underlying

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -99,20 +99,17 @@ akka.cluster.sharding {
   entity-recovery-rate-interval = 0 s
 
   # The shard uses this strategy to determines how to recover the underlying entity actors. The strategy is only used
-  # by the persistent shard when rebalancing or restarting. The value is fully qualified class name. It needs to be a
-  # subclass of akka.sharding.EntityRecoveryConfigurator The default strategy starts all the entity actors at once.
-  # Is also possible to use akka.cluster.sharding.ConstantRateEntityRecoveryConfigurator to have a set rate of recovery.
-  entity-recovery-strategy = "akka.cluster.sharding.AllAtOnceEntityRecoveryConfigurator"
-
-  # The path to the configuration of the entity recovery strategy.
-  entity-recovery-strategy-config-path = ""
+  # by the persistent shard when rebalancing or restarting. The value can either be "all" or "constant". The "all"
+  # strategy start all the underlying entity actors at the same time. The constant strategy will start the underlying
+  # entity actors at a fix rate. The default strategy "all".
+  entity-recovery-strategy = "all"
 
   # Default settings for the constant rate entity recovery strategy
   entity-recovery-constant-rate-strategy {
     # Sets the frequency at which a batch of entity actors is started.
-    frequency = 1 s
-    # Sets the number of entity actor to be restart at a particular interval
-    number-of-entities = 1
+    frequency = 100 ms
+    # Sets the number of entity actors to be restart at a particular interval
+    number-of-entities = 5
   }
 
   # Settings for the coordinator singleton. Same layout as akka.cluster.singleton.

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -94,6 +94,10 @@ akka.cluster.sharding {
   # works only for state-store-mode = "ddata"
   updating-state-timeout = 5 s
 
+  # The interval beteween which remembered entities are restarted when initialing the shard
+  # Zero to disable feature.
+  entity-recovery-rate-interval = 0 s
+
   # Settings for the coordinator singleton. Same layout as akka.cluster.singleton.
   # The "role" of the singleton configuration is not used. The singleton role will
   # be the same as "akka.cluster.sharding.role".

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -86,9 +86,42 @@ object ClusterShardingSettings {
     val leastShardAllocationMaxSimultaneousRebalance: Int,
     val waitingForStateTimeout:                       FiniteDuration,
     val updatingStateTimeout:                         FiniteDuration,
-    val entityRecoveryStrategy:                       String         = "akka.cluster.sharding.AllAtOnceEntityRecoveryConfigurator",
-    val entityRecoveryStrategyConfigPath:             String         = "")
+    val entityRecoveryStrategy:                       String,
+    val entityRecoveryStrategyConfigPath:             String) {
 
+    def this(
+      coordinatorFailureBackoff:                    FiniteDuration,
+      retryInterval:                                FiniteDuration,
+      bufferSize:                                   Int,
+      handOffTimeout:                               FiniteDuration,
+      shardStartTimeout:                            FiniteDuration,
+      shardFailureBackoff:                          FiniteDuration,
+      entityRestartBackoff:                         FiniteDuration,
+      rebalanceInterval:                            FiniteDuration,
+      snapshotAfter:                                Int,
+      leastShardAllocationRebalanceThreshold:       Int,
+      leastShardAllocationMaxSimultaneousRebalance: Int,
+      waitingForStateTimeout:                       FiniteDuration,
+      updatingStateTimeout:                         FiniteDuration) = {
+      this(
+        coordinatorFailureBackoff,
+        retryInterval,
+        bufferSize,
+        handOffTimeout,
+        shardStartTimeout,
+        shardFailureBackoff,
+        entityRestartBackoff,
+        rebalanceInterval,
+        snapshotAfter,
+        leastShardAllocationRebalanceThreshold,
+        leastShardAllocationMaxSimultaneousRebalance,
+        waitingForStateTimeout,
+        updatingStateTimeout,
+        "akka.cluster.sharding.AllAtOnceEntityRecoveryConfigurator",
+        ""
+      )
+    }
+  }
 }
 
 /**

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -95,6 +95,7 @@ object ClusterShardingSettings {
       entityRecoveryStrategy == "all" || entityRecoveryStrategy == "constant",
       s"Unknown 'entity-recovery-strategy' [$entityRecoveryStrategy], valid values are 'all' or 'constant'")
 
+    // included for binary compatibility
     def this(
       coordinatorFailureBackoff:                    FiniteDuration,
       retryInterval:                                FiniteDuration,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -38,7 +38,8 @@ object ClusterShardingSettings {
       leastShardAllocationMaxSimultaneousRebalance =
         config.getInt("least-shard-allocation-strategy.max-simultaneous-rebalance"),
       waitingForStateTimeout = config.getDuration("waiting-for-state-timeout", MILLISECONDS).millis,
-      updatingStateTimeout = config.getDuration("updating-state-timeout", MILLISECONDS).millis)
+      updatingStateTimeout = config.getDuration("updating-state-timeout", MILLISECONDS).millis,
+      entityRecoveryRateInterval = config.getDuration("entity-recovery-rate-interval", MILLISECONDS).millis)
 
     val coordinatorSingletonSettings = ClusterSingletonManagerSettings(config.getConfig("coordinator-singleton"))
 
@@ -83,7 +84,9 @@ object ClusterShardingSettings {
     val leastShardAllocationRebalanceThreshold:       Int,
     val leastShardAllocationMaxSimultaneousRebalance: Int,
     val waitingForStateTimeout:                       FiniteDuration,
-    val updatingStateTimeout:                         FiniteDuration)
+    val updatingStateTimeout:                         FiniteDuration,
+    val entityRecoveryRateInterval:                   FiniteDuration)
+
 }
 
 /**

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -39,7 +39,8 @@ object ClusterShardingSettings {
         config.getInt("least-shard-allocation-strategy.max-simultaneous-rebalance"),
       waitingForStateTimeout = config.getDuration("waiting-for-state-timeout", MILLISECONDS).millis,
       updatingStateTimeout = config.getDuration("updating-state-timeout", MILLISECONDS).millis,
-      entityRecoveryRateInterval = config.getDuration("entity-recovery-rate-interval", MILLISECONDS).millis)
+      entityRecoveryStrategy = config.getString("entity-recovery-strategy"),
+      entityRecoveryStrategyConfigPath = config.getString("entity-recovery-strategy-config-path"))
 
     val coordinatorSingletonSettings = ClusterSingletonManagerSettings(config.getConfig("coordinator-singleton"))
 
@@ -85,7 +86,8 @@ object ClusterShardingSettings {
     val leastShardAllocationMaxSimultaneousRebalance: Int,
     val waitingForStateTimeout:                       FiniteDuration,
     val updatingStateTimeout:                         FiniteDuration,
-    val entityRecoveryRateInterval:                   FiniteDuration)
+    val entityRecoveryStrategy:                       String         = "akka.cluster.sharding.AllAtOnceEntityRecoveryConfigurator",
+    val entityRecoveryStrategyConfigPath:             String         = "")
 
 }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -425,7 +425,8 @@ final class AllAtOnceEntityRecoveryStrategy extends EntityRecoveryStrategy {
   import akka.actor.ActorContext
   import Shard.RestartEntities
   override def recoverEntities(context: ActorContext, entities: Set[EntityId]): Unit =
-    context.self ! RestartEntities(entities)
+    if (entities.nonEmpty)
+      context.self ! RestartEntities(entities)
 }
 
 final class ConstantRateEntityRecoveryStrategy(val frequency: FiniteDuration, val numberOfEntities: Int) extends EntityRecoveryStrategy {

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
@@ -115,9 +115,8 @@ object ClusterShardingSpec {
 }
 
 abstract class ClusterShardingSpecConfig(
-  val mode:                     String,
-  val entityRecoveryStrategy:   String = "akka.cluster.sharding.AllAtOnceEntityRecoveryConfigurator",
-  val entityRecoveryConfigPath: String = "")
+  val mode:                   String,
+  val entityRecoveryStrategy: String = "all")
   extends MultiNodeConfig {
 
   val controller = role("controller")
@@ -150,7 +149,6 @@ abstract class ClusterShardingSpecConfig(
       rebalance-interval = 2 s
       state-store-mode = "$mode"
       entity-recovery-strategy = "$entityRecoveryStrategy"
-      entity-recovery-strategy-config-path = "$entityRecoveryConfigPath"
       entity-recovery-constant-rate-strategy {
         frequency = 1 ms
         number-of-entities = 1
@@ -190,13 +188,11 @@ object PersistentClusterShardingSpecConfig extends ClusterShardingSpecConfig("pe
 object DDataClusterShardingSpecConfig extends ClusterShardingSpecConfig("ddata")
 object PersistentClusterShardingWithEntityRecoverySpecConfig extends ClusterShardingSpecConfig(
   "persistence",
-  "akka.cluster.sharding.ConstantRateEntityRecoveryConfigurator",
-  "akka.cluster.sharding.entity-recovery-constant-rate-strategy"
+  "all"
 )
 object DDataClusterShardingWithEntityRecoverySpecConfig extends ClusterShardingSpecConfig(
   "ddata",
-  "akka.cluster.sharding.ConstantRateEntityRecoveryConfigurator",
-  "akka.cluster.sharding.entity-recovery-constant-rate-strategy"
+  "constant"
 )
 
 class PersistentClusterShardingSpec extends ClusterShardingSpec(PersistentClusterShardingSpecConfig)

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
@@ -114,7 +114,7 @@ object ClusterShardingSpec {
 
 }
 
-abstract class ClusterShardingSpecConfig(val mode: String) extends MultiNodeConfig {
+abstract class ClusterShardingSpecConfig(val mode: String, val entityRecoveryRateInterval: FiniteDuration = Duration.Zero) extends MultiNodeConfig {
   val controller = role("controller")
   val first = role("first")
   val second = role("second")
@@ -144,6 +144,7 @@ abstract class ClusterShardingSpecConfig(val mode: String) extends MultiNodeConf
       entity-restart-backoff = 1s
       rebalance-interval = 2 s
       state-store-mode = "$mode"
+      entity-recovery-rate-interval = "${entityRecoveryRateInterval.toMillis}ms"
       least-shard-allocation-strategy {
         rebalance-threshold = 2
         max-simultaneous-rebalance = 1
@@ -177,9 +178,13 @@ object ClusterShardingDocCode {
 
 object PersistentClusterShardingSpecConfig extends ClusterShardingSpecConfig("persistence")
 object DDataClusterShardingSpecConfig extends ClusterShardingSpecConfig("ddata")
+object PersistentClusterShardingWithEntityRecoverySpecConfig extends ClusterShardingSpecConfig("persistence", 1.millis)
+object DDataClusterShardingWithEntityRecoverySpecConfig extends ClusterShardingSpecConfig("ddata", 1.millis)
 
 class PersistentClusterShardingSpec extends ClusterShardingSpec(PersistentClusterShardingSpecConfig)
 class DDataClusterShardingSpec extends ClusterShardingSpec(DDataClusterShardingSpecConfig)
+class PersistentClusterShardingWithEntityRecoverySpec extends ClusterShardingSpec(PersistentClusterShardingWithEntityRecoverySpecConfig)
+class DDataClusterShardingWithEntityRecoverySpec extends ClusterShardingSpec(DDataClusterShardingWithEntityRecoverySpecConfig)
 
 class PersistentClusterShardingMultiJvmNode1 extends PersistentClusterShardingSpec
 class PersistentClusterShardingMultiJvmNode2 extends PersistentClusterShardingSpec
@@ -196,6 +201,22 @@ class DDataClusterShardingMultiJvmNode4 extends DDataClusterShardingSpec
 class DDataClusterShardingMultiJvmNode5 extends DDataClusterShardingSpec
 class DDataClusterShardingMultiJvmNode6 extends DDataClusterShardingSpec
 class DDataClusterShardingMultiJvmNode7 extends DDataClusterShardingSpec
+
+class PersistentClusterShardingWithEntityRecoveryMultiJvmNode1 extends PersistentClusterShardingSpec
+class PersistentClusterShardingWithEntityRecoveryMultiJvmNode2 extends PersistentClusterShardingSpec
+class PersistentClusterShardingWithEntityRecoveryMultiJvmNode3 extends PersistentClusterShardingSpec
+class PersistentClusterShardingWithEntityRecoveryMultiJvmNode4 extends PersistentClusterShardingSpec
+class PersistentClusterShardingWithEntityRecoveryMultiJvmNode5 extends PersistentClusterShardingSpec
+class PersistentClusterShardingWithEntityRecoveryMultiJvmNode6 extends PersistentClusterShardingSpec
+class PersistentClusterShardingWithEntityRecoveryMultiJvmNode7 extends PersistentClusterShardingSpec
+
+class DDataClusterShardingWithEntityRecoveryMultiJvmNode1 extends DDataClusterShardingSpec
+class DDataClusterShardingWithEntityRecoveryMultiJvmNode2 extends DDataClusterShardingSpec
+class DDataClusterShardingWithEntityRecoveryMultiJvmNode3 extends DDataClusterShardingSpec
+class DDataClusterShardingWithEntityRecoveryMultiJvmNode4 extends DDataClusterShardingSpec
+class DDataClusterShardingWithEntityRecoveryMultiJvmNode5 extends DDataClusterShardingSpec
+class DDataClusterShardingWithEntityRecoveryMultiJvmNode6 extends DDataClusterShardingSpec
+class DDataClusterShardingWithEntityRecoveryMultiJvmNode7 extends DDataClusterShardingSpec
 
 abstract class ClusterShardingSpec(config: ClusterShardingSpecConfig) extends MultiNodeSpec(config) with STMultiNodeSpec with ImplicitSender {
   import ClusterShardingSpec._

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/AllAtOnceEntityRecoveryStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/AllAtOnceEntityRecoveryStrategySpec.scala
@@ -1,0 +1,43 @@
+package akka.cluster.sharding
+
+import akka.actor.{ Actor, Deploy, Props }
+import akka.cluster.sharding.Shard.RestartEntities
+import akka.cluster.sharding.ShardRegion.EntityId
+import akka.testkit.{ AkkaSpec, TestProbe }
+import com.typesafe.config.ConfigFactory
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class AllAtOnceEntityRecoveryStrategySpec extends AkkaSpec {
+  val strategy = new AllAtOnceEntityRecoveryConfigurator().create(ConfigFactory.empty())
+
+  "AllAtOnceEntityRecoveryStrategy" must {
+    "recover entities" in {
+      val probe = TestProbe()
+      val probeRef = probe.ref
+      val shard = system.actorOf(Props(new Actor {
+        def receive = {
+          case "recover"          ⇒ strategy.recoverEntities(context, Set[EntityId]("1", "2", "3"))
+          case RestartEntities(e) ⇒ probeRef ! e
+        }
+      }).withDeploy(Deploy.local))
+
+      shard ! "recover"
+      probe.expectMsg(Set[EntityId]("1", "2", "3"))
+    }
+
+    "not recover when no entities to recover" in {
+      val probe = TestProbe()
+      val probeRef = probe.ref
+      val shard = system.actorOf(Props(new Actor {
+        def receive = {
+          case "recover"          ⇒ strategy.recoverEntities(context, Set[EntityId]())
+          case RestartEntities(e) ⇒ probeRef ! e
+        }
+      }).withDeploy(Deploy.local))
+
+      shard ! "recover"
+      probe.expectNoMsg(1 second)
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConstantRateEntityRecoveryStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConstantRateEntityRecoveryStrategySpec.scala
@@ -1,55 +1,45 @@
 package akka.cluster.sharding
 
-import akka.actor.{ Actor, Deploy, Props }
-import akka.cluster.sharding.Shard.RestartEntities
 import akka.cluster.sharding.ShardRegion.EntityId
-import akka.testkit.{ AkkaSpec, TestProbe }
-import com.typesafe.config.ConfigFactory
+import akka.testkit.AkkaSpec
+
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class ConstantRateEntityRecoveryStrategySpec extends AkkaSpec {
-  val config = ConfigFactory.parseString(
-    """
-      |frequency = 500ms
-      |number-of-entities = 2
-    """.stripMargin)
 
-  val strategy = new ConstantRateEntityRecoveryConfigurator().create(config)
+  import system.dispatcher
+
+  val strategy = EntityRecoveryStrategy.constantStrategy(system, 500 millis, 2)
 
   "ConstantRateEntityRecoveryStrategy" must {
     "recover entities" in {
-      val probe = TestProbe()
-      val probeRef = probe.ref
-      val shard = system.actorOf(Props(new Actor {
-        val entities = Set[EntityId]("1", "2", "3", "4", "5")
-        def receive = {
-          case "recover"          ⇒ strategy.recoverEntities(context, entities)
-          case RestartEntities(e) ⇒ probeRef ! e
-        }
-      }).withDeploy(Deploy.local))
+      val entities = Set[EntityId]("1", "2", "3", "4", "5")
+      val startTime = System.currentTimeMillis()
+      val resultWithTimes = strategy.recoverEntities(entities).map(
+        _.map(entityIds ⇒ (entityIds, System.currentTimeMillis() - startTime))
+      )
 
-      shard ! "recover"
-      probe.expectNoMsg(450 millis)
-      probe.expectMsg(Set[EntityId]("4", "5"))
-      probe.expectNoMsg(450 millis)
-      probe.expectMsg(Set[EntityId]("1", "2"))
-      probe.expectNoMsg(450 millis)
-      probe.expectMsg(Set[EntityId]("3"))
+      val result = Await.result(Future.sequence(resultWithTimes), 4 seconds).toList.sortWith(_._2 < _._2)
+      result.size should ===(3)
+
+      val scheduledEntities = result.map(_._1)
+      scheduledEntities.head.size should ===(2)
+      scheduledEntities(1).size should ===(2)
+      scheduledEntities(2).size should ===(1)
+      scheduledEntities.foldLeft(Set[EntityId]())(_ ++ _) should ===(entities)
+
+      val times = result.map(_._2)
+
+      times.head should ===(500L +- 30L)
+      times(1) should ===(1000L +- 30L)
+      times(2) should ===(1500L +- 30L)
     }
 
     "not recover when no entities to recover" in {
-      val probe = TestProbe()
-      val probeRef = probe.ref
-      val shard = system.actorOf(Props(new Actor {
-        def receive = {
-          case "recover"          ⇒ strategy.recoverEntities(context, Set[EntityId]())
-          case RestartEntities(e) ⇒ probeRef ! e
-        }
-      }).withDeploy(Deploy.local))
-
-      shard ! "recover"
-      probe.expectNoMsg(1 second)
+      val result = strategy.recoverEntities(Set[EntityId]())
+      result.size should ===(0)
     }
   }
 }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConstantRateEntityRecoveryStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConstantRateEntityRecoveryStrategySpec.scala
@@ -1,0 +1,55 @@
+package akka.cluster.sharding
+
+import akka.actor.{ Actor, Deploy, Props }
+import akka.cluster.sharding.Shard.RestartEntities
+import akka.cluster.sharding.ShardRegion.EntityId
+import akka.testkit.{ AkkaSpec, TestProbe }
+import com.typesafe.config.ConfigFactory
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class ConstantRateEntityRecoveryStrategySpec extends AkkaSpec {
+  val config = ConfigFactory.parseString(
+    """
+      |frequency = 500ms
+      |number-of-entities = 2
+    """.stripMargin)
+
+  val strategy = new ConstantRateEntityRecoveryConfigurator().create(config)
+
+  "ConstantRateEntityRecoveryStrategy" must {
+    "recover entities" in {
+      val probe = TestProbe()
+      val probeRef = probe.ref
+      val shard = system.actorOf(Props(new Actor {
+        val entities = Set[EntityId]("1", "2", "3", "4", "5")
+        def receive = {
+          case "recover"          ⇒ strategy.recoverEntities(context, entities)
+          case RestartEntities(e) ⇒ probeRef ! e
+        }
+      }).withDeploy(Deploy.local))
+
+      shard ! "recover"
+      probe.expectNoMsg(450 millis)
+      probe.expectMsg(Set[EntityId]("4", "5"))
+      probe.expectNoMsg(450 millis)
+      probe.expectMsg(Set[EntityId]("1", "2"))
+      probe.expectNoMsg(450 millis)
+      probe.expectMsg(Set[EntityId]("3"))
+    }
+
+    "not recover when no entities to recover" in {
+      val probe = TestProbe()
+      val probeRef = probe.ref
+      val shard = system.actorOf(Props(new Actor {
+        def receive = {
+          case "recover"          ⇒ strategy.recoverEntities(context, Set[EntityId]())
+          case RestartEntities(e) ⇒ probeRef ! e
+        }
+      }).withDeploy(Deploy.local))
+
+      shard ! "recover"
+      probe.expectNoMsg(1 second)
+    }
+  }
+}


### PR DESCRIPTION
Initial approach for solving the herd effect when restarting or rebalance a cluster when remember-entity is enabled. The approach recovers the underlying actors at a certain defined rate rather than all a once. We've tested the approach and it considerably reduces the latency on the underlying storage medium (cassandra in this case). 
