### PR TITLE
avoid thunk allocation in aroundReceive, #20748

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -643,6 +643,7 @@ private[akka] class ActorCell(
     setActorFields(actorInstance, context = null, self = if (recreate) self else system.deadLetters)
     currentMessage = null
     behaviorStack = emptyBehaviorStack
+    unhandledFun = null
   }
 
   final protected def setActorFields(actorInstance: Actor, context: ActorContext, self: ActorRef): Unit =

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -412,6 +412,13 @@ private[akka] class ActorCell(
     unstashed
   }
 
+  /**
+   * INTERNAL API
+   * Cached function to unhandled to avoid allocations in aroundReceive,
+   * can't use a val in Actor due to binary compatibility restriction
+   */
+  private[akka] var unhandledFun: Any ⇒ Unit = null
+
   /*
    * MESSAGE PROCESSING
    */


### PR DESCRIPTION
- had to cache the function in ActorCell due to binary compatibility
  limitation
