### PR TITLE
reduce allocations with specialized ImmutableLongMap

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/FlightRecorderBench.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/FlightRecorderBench.scala
@@ -1,12 +1,14 @@
-package akka.artery
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
 
 import java.io.File
 import java.nio.channels.FileChannel
 import java.nio.file.StandardOpenOption
-import java.util.concurrent.{CountDownLatch, TimeUnit}
-
-import akka.remote.artery.FlightRecorder
-import org.openjdk.jmh.annotations.{OperationsPerInvocation, _}
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{ OperationsPerInvocation, _ }
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -18,12 +20,12 @@ class FlightRecorderBench {
 
   val Writes = 10000000
 
-  var file: File = _
-  var fileChannel: FileChannel = _
-  var recorder: FlightRecorder = _
+  private var file: File = _
+  private var fileChannel: FileChannel = _
+  private var recorder: FlightRecorder = _
 
   @Setup
-  def setup():Unit = {
+  def setup(): Unit = {
     file = File.createTempFile("akka-flightrecorder", "dat")
     file.deleteOnExit()
     fileChannel = FileChannel.open(file.toPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.READ)
@@ -31,7 +33,7 @@ class FlightRecorderBench {
   }
 
   @TearDown
-  def shutdown():Unit = {
+  def shutdown(): Unit = {
     fileChannel.force(false)
     recorder.close()
     fileChannel.close()

--- a/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
@@ -196,7 +196,7 @@ private[akka] class InboundHandshake(inboundContext: InboundContext, inControlSt
       }
 
       private def onMessage(env: InboundEnvelope): Unit = {
-        if (isKnownOrigin(env.originUid))
+        if (isKnownOrigin(env))
           push(out, env)
         else {
           // FIXME remove, only debug
@@ -215,10 +215,8 @@ private[akka] class InboundHandshake(inboundContext: InboundContext, inControlSt
         }
       }
 
-      private def isKnownOrigin(originUid: Long): Boolean = {
-        // FIXME these association lookups are probably too costly for each message, need local cache or something
-        inboundContext.association(originUid).isDefined
-      }
+      private def isKnownOrigin(env: InboundEnvelope): Boolean =
+        env.association.isDefined
 
       // OutHandler
       override def onPull(): Unit = pull(in)

--- a/akka-remote/src/main/scala/akka/remote/artery/ImmutableLongMap.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ImmutableLongMap.scala
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.annotation.tailrec
+import akka.util.OptionVal
+import scala.reflect.ClassTag
+import java.util.Arrays
+
+/**
+ * INTERNAL API
+ */
+private[akka] object ImmutableLongMap {
+  def empty[A >: Null](implicit t: ClassTag[A]): ImmutableLongMap[A] =
+    new ImmutableLongMap(Array.emptyLongArray, Array.empty)
+
+  private val MaxScanLength = 10
+}
+
+/**
+ * INTERNAL API
+ * Specialized Map for primitive `Long` keys to avoid allocations (boxing).
+ * Keys and values are backed by arrays and lookup is performed with binary
+ * search. It's intended for rather small (<1000) maps.
+ */
+private[akka] class ImmutableLongMap[A >: Null] private (keys: Array[Long], values: Array[A])(implicit t: ClassTag[A]) {
+  import ImmutableLongMap.MaxScanLength
+
+  val size: Int = keys.length
+
+  /**
+   * Worst case `O(log n)`, allocation free.
+   */
+  def get(key: Long): OptionVal[A] = {
+    val i = Arrays.binarySearch(keys, key)
+    if (i >= 0) OptionVal(values(i))
+    else OptionVal.None
+  }
+
+  /**
+   * Worst case `O(log n)`, allocation free.
+   */
+  def contains(key: Long): Boolean = {
+    Arrays.binarySearch(keys, key) >= 0
+  }
+
+  /**
+   * Worst case `O(log n)`, creates new `ImmutableLongMap`
+   * with copies of the internal arrays for the keys and
+   * values.
+   */
+  def updated(key: Long, value: A): ImmutableLongMap[A] = {
+    if (size == 0)
+      new ImmutableLongMap(Array(key), Array(value))
+    else {
+      val i = Arrays.binarySearch(keys, key)
+      if (i >= 0) {
+        // existing key, replace value
+        val newValues = Array.ofDim[A](values.length)
+        System.arraycopy(values, 0, newValues, 0, values.length)
+        newValues(i) = value
+        new ImmutableLongMap(keys, newValues)
+      } else {
+        // insert the entry at the right position, and keep the arrays sorted
+        val j = -(i + 1)
+        val newKeys = Array.ofDim[Long](size + 1)
+        System.arraycopy(keys, 0, newKeys, 0, j)
+        newKeys(j) = key
+        System.arraycopy(keys, j, newKeys, j + 1, keys.length - j)
+
+        val newValues = Array.ofDim[A](size + 1)
+        System.arraycopy(values, 0, newValues, 0, j)
+        newValues(j) = value
+        System.arraycopy(values, j, newValues, j + 1, values.length - j)
+
+        new ImmutableLongMap(newKeys, newValues)
+      }
+    }
+  }
+
+  /**
+   * All keys
+   */
+  def keysIterator: Iterator[Long] =
+    keys.iterator
+
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
@@ -28,7 +28,7 @@ private[akka] class InboundQuarantineCheck(inboundContext: InboundContext) exten
       // InHandler
       override def onPush(): Unit = {
         val env = grab(in)
-        inboundContext.association(env.originUid) match {
+        env.association match {
           case OptionVal.None ⇒
             // unknown, handshake not completed
             push(out, env)

--- a/akka-remote/src/main/scala/akka/remote/artery/TestStage.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/TestStage.scala
@@ -157,7 +157,7 @@ private[remote] class InboundTestStage(inboundContext: InboundContext)
       // InHandler
       override def onPush(): Unit = {
         val env = grab(in)
-        inboundContext.association(env.originUid) match {
+        env.association match {
           case OptionVal.None ⇒
             // unknown, handshake not completed
             push(out, env)

--- a/akka-remote/src/test/scala/akka/remote/artery/ImmutableLongMapSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/ImmutableLongMapSpec.scala
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+import akka.util.OptionVal
+
+class ImmutableLongMapSpec extends WordSpec with Matchers {
+
+  "ImmutableLongMap" must {
+
+    "have no entries when empty" in {
+      val empty = ImmutableLongMap.empty[String]
+      empty.size should be(0)
+      empty.keysIterator.toList should be(Nil)
+    }
+
+    "add and get entries" in {
+      val m1 = ImmutableLongMap.empty[String].updated(10L, "10")
+      m1.keysIterator.toList should be(List(10L))
+      m1.keysIterator.map(m1.get).toList should be(List(OptionVal("10")))
+
+      val m2 = m1.updated(20L, "20")
+      m2.keysIterator.toList should be(List(10L, 20L))
+      m2.keysIterator.map(m2.get).toList should be(List(OptionVal("10"), OptionVal("20")))
+
+      val m3 = m1.updated(5L, "5")
+      m3.keysIterator.toList should be(List(5L, 10L))
+      m3.keysIterator.map(m3.get).toList should be(List(OptionVal("5"), OptionVal("10")))
+
+      val m4 = m2.updated(5L, "5")
+      m4.keysIterator.toList should be(List(5L, 10L, 20L))
+      m4.keysIterator.map(m4.get).toList should be(List(OptionVal("5"), OptionVal("10"), OptionVal("20")))
+
+      val m5 = m4.updated(15L, "15")
+      m5.keysIterator.toList should be(List(5L, 10L, 15L, 20L))
+      m5.keysIterator.map(m5.get).toList should be(List(OptionVal("5"), OptionVal("10"), OptionVal("15"),
+        OptionVal("20")))
+    }
+
+    "replace entries" in {
+      val m1 = ImmutableLongMap.empty[String].updated(10L, "10a").updated(10, "10b")
+      m1.keysIterator.map(m1.get).toList should be(List(OptionVal("10b")))
+
+      val m2 = m1.updated(20L, "20a").updated(30L, "30a")
+        .updated(20L, "20b").updated(30L, "30b")
+      m2.keysIterator.map(m2.get).toList should be(List(OptionVal("10b"), OptionVal("20b"), OptionVal("30b")))
+    }
+
+    "get None when entry doesn't exist" in {
+      val m1 = ImmutableLongMap.empty[String].updated(10L, "10").updated(20L, "20").updated(30L, "30")
+      m1.get(5L) should be(OptionVal.None)
+      m1.get(15L) should be(OptionVal.None)
+      m1.get(25L) should be(OptionVal.None)
+      m1.get(35L) should be(OptionVal.None)
+    }
+
+    "contain keys" in {
+      val m1 = ImmutableLongMap.empty[String].updated(10L, "10").updated(20L, "20").updated(30L, "30")
+      m1.contains(10L) should be(true)
+      m1.contains(20L) should be(true)
+      m1.contains(30L) should be(true)
+      m1.contains(5L) should be(false)
+      m1.contains(25L) should be(false)
+    }
+
+  }
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/ImmutableLongMapSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/ImmutableLongMapSpec.scala
@@ -7,6 +7,7 @@ import scala.concurrent.duration._
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import akka.util.OptionVal
+import scala.util.Random
 
 class ImmutableLongMapSpec extends WordSpec with Matchers {
 
@@ -50,6 +51,52 @@ class ImmutableLongMapSpec extends WordSpec with Matchers {
       m2.keysIterator.map(m2.get).toList should be(List(OptionVal("10b"), OptionVal("20b"), OptionVal("30b")))
     }
 
+    "have toString" in {
+      ImmutableLongMap.empty[String].toString should be("ImmutableLongMap()")
+      ImmutableLongMap.empty[String].updated(10L, "a").toString should be("ImmutableLongMap(10 -> a)")
+      ImmutableLongMap.empty[String].updated(10L, "a").updated(20, "b").toString should be(
+        "ImmutableLongMap(10 -> a, 20 -> b)")
+    }
+
+    "have equals and hashCode" in {
+      ImmutableLongMap.empty[String].updated(10L, "10") should be(ImmutableLongMap.empty[String].updated(10L, "10"))
+      ImmutableLongMap.empty[String].updated(10L, "10").hashCode should be(
+        ImmutableLongMap.empty[String].updated(10L, "10").hashCode)
+
+      ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20").updated(30, "30") should be(
+        ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20").updated(30, "30"))
+      ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20").updated(30, "30").hashCode should be(
+        ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20").updated(30, "30").hashCode)
+
+      ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20") should not be (ImmutableLongMap.empty[String].updated(10L, "10"))
+
+      ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20").updated(30, "30") should not be (
+        ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20b").updated(30, "30"))
+
+      ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20").updated(30, "30") should not be (
+        ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20b").updated(31, "30"))
+
+      ImmutableLongMap.empty[String] should be(ImmutableLongMap.empty[String])
+      ImmutableLongMap.empty[String].hashCode should be(ImmutableLongMap.empty[String].hashCode)
+    }
+
+    "remove entries" in {
+      val m1 = ImmutableLongMap.empty[String].updated(10L, "10").updated(20, "20").updated(30, "30")
+
+      val m2 = m1.remove(10L)
+      m2.keysIterator.map(m2.get).toList should be(List(OptionVal("20"), OptionVal("30")))
+
+      val m3 = m1.remove(20L)
+      m3.keysIterator.map(m3.get).toList should be(List(OptionVal("10"), OptionVal("30")))
+
+      val m4 = m1.remove(30L)
+      m4.keysIterator.map(m4.get).toList should be(List(OptionVal("10"), OptionVal("20")))
+
+      m1.remove(5L) should be(m1)
+
+      m1.remove(10L).remove(20L).remove(30L) should be(ImmutableLongMap.empty)
+    }
+
     "get None when entry doesn't exist" in {
       val m1 = ImmutableLongMap.empty[String].updated(10L, "10").updated(20L, "20").updated(30L, "30")
       m1.get(5L) should be(OptionVal.None)
@@ -65,6 +112,36 @@ class ImmutableLongMapSpec extends WordSpec with Matchers {
       m1.contains(30L) should be(true)
       m1.contains(5L) should be(false)
       m1.contains(25L) should be(false)
+    }
+
+    "have correct behavior for random operations" in {
+      val seed = System.nanoTime()
+      val rnd = new Random(seed)
+
+      var longMap = ImmutableLongMap.empty[String]
+      var reference = Map.empty[Long, String]
+
+      def verify(): Unit = {
+        val m = longMap.keysIterator.map(key ⇒ key → longMap.get(key).get).toMap
+
+        m should be(reference)
+      }
+
+      (1 to 1000).foreach { i ⇒
+        withClue(s"seed=$seed, iteration=$i") {
+          val key = rnd.nextInt(100)
+          val value = String.valueOf(rnd.nextPrintableChar())
+          rnd.nextInt(3) match {
+            case 0 | 1 ⇒
+              longMap = longMap.updated(key, value)
+              reference = reference.updated(key, value)
+            case 2 ⇒
+              longMap = longMap.remove(key)
+              reference = reference - key
+          }
+          verify()
+        }
+      }
     }
 
   }

--- a/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
@@ -42,7 +42,7 @@ class InboundControlJunctionSpec extends AkkaSpec with ImplicitSender {
       val recipient = null.asInstanceOf[InternalActorRef] // not used
 
       val ((upstream, controlSubject), downstream) = TestSource.probe[AnyRef]
-        .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, OptionVal.None, addressA.uid))
+        .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, OptionVal.None, addressA.uid, OptionVal.None))
         .viaMat(new InboundControlJunction)(Keep.both)
         .map { case env: InboundEnvelope ⇒ env.message }
         .toMat(TestSink.probe[Any])(Keep.both)

--- a/akka-remote/src/test/scala/akka/remote/artery/InboundHandshakeSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/InboundHandshakeSpec.scala
@@ -41,7 +41,8 @@ class InboundHandshakeSpec extends AkkaSpec with ImplicitSender {
   private def setupStream(inboundContext: InboundContext, timeout: FiniteDuration = 5.seconds): (TestPublisher.Probe[AnyRef], TestSubscriber.Probe[Any]) = {
     val recipient = null.asInstanceOf[InternalActorRef] // not used
     TestSource.probe[AnyRef]
-      .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, OptionVal.None, addressA.uid))
+      .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, OptionVal.None, addressA.uid,
+        inboundContext.association(addressA.uid)))
       .via(new InboundHandshake(inboundContext, inControlStream = true))
       .map { case env: InboundEnvelope ⇒ env.message }
       .toMat(TestSink.probe[Any])(Keep.both)

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -76,7 +76,8 @@ class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.confi
     Flow[Send]
       .map {
         case Send(sysEnv: SystemMessageEnvelope, _, _, _) ⇒
-          InboundEnvelope(recipient, addressB.address, sysEnv, OptionVal.None, addressA.uid)
+          InboundEnvelope(recipient, addressB.address, sysEnv, OptionVal.None, addressA.uid,
+            inboundContext.association(addressA.uid))
       }
       .async
       .via(new SystemMessageAcker(inboundContext))

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -85,7 +85,8 @@ private[akka] class TestOutboundContext(
 
   override def sendControl(message: ControlMessage) = {
     controlProbe.foreach(_ ! message)
-    controlSubject.sendControl(InboundEnvelope(null, remoteAddress, message, OptionVal.None, localAddress.uid))
+    controlSubject.sendControl(InboundEnvelope(null, remoteAddress, message, OptionVal.None, localAddress.uid,
+      OptionVal.None))
   }
 
   // FIXME we should be able to Send without a recipient ActorRef


### PR DESCRIPTION
- backed by arrays, allocation free lookups with binary search
- use it for UID -> Association Map
- pass Association in InboundEnvelope to reduce to only
  one lookup per incoming message
- use ImmutableLongMap instead of the QuarantinedUIDSet
