### PR TITLE
Better recovery timeout for persistent actors #20738

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -635,6 +635,10 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
       case WriteMessagesFailed(_) ⇒
         writeInProgress = false
         () // it will be stopped by the first WriteMessageFailure message
+
+      case _: RecoveryTick =>
+        // we may have one of these scheduled before the scheduled timeout
+        // is cancelled, just consume it so the concrete actor never sees it
     }
 
     def onWriteMessageComplete(err: Boolean): Unit

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -33,7 +33,7 @@ private[persistence] object Eventsourced {
   private final case class AsyncHandlerInvocation(evt: Any, handler: Any ⇒ Unit) extends PendingHandlerInvocation
 
   /** message used to detect that recovery timed out */
-  private case class RecoveryTick(snapshot: Boolean)
+  private final case class RecoveryTick(snapshot: Boolean)
 }
 
 /**

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -637,8 +637,8 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
         () // it will be stopped by the first WriteMessageFailure message
 
       case _: RecoveryTick =>
-        // we may have one of these scheduled before the scheduled timeout
-        // is cancelled, just consume it so the concrete actor never sees it
+        // we may have one of these in the mailbox before the scheduled timeout
+        // is cancelled when recovery has completed, just consume it so the concrete actor never sees it
     }
 
     def onWriteMessageComplete(err: Boolean): Unit

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorRecoveryTimeoutSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorRecoveryTimeoutSpec.scala
@@ -32,6 +32,28 @@ object PersistentActorRecoveryTimeoutSpec {
     }
   }
 
+  class TestReceiveTimeoutActor(receiveTimeout: FiniteDuration, probe: ActorRef) extends NamedPersistentActor("recovery-timeout-actor-2") {
+
+    override def preStart(): Unit = {
+      context.setReceiveTimeout(receiveTimeout)
+    }
+
+    override def receiveRecover: Receive = {
+      case RecoveryCompleted ⇒ probe ! context.receiveTimeout
+      case _                 ⇒ // we don't care
+    }
+
+    override def receiveCommand: Receive = {
+      case x ⇒ persist(x) { _ ⇒
+        sender() ! x
+      }
+    }
+
+    override protected def onRecoveryFailure(cause: Throwable, event: Option[Any]): Unit = {
+      probe ! Failure(cause)
+    }
+  }
+
 }
 
 class PersistentActorRecoveryTimeoutSpec extends AkkaSpec(PersistentActorRecoveryTimeoutSpec.config) with ImplicitSender {
@@ -68,6 +90,44 @@ class PersistentActorRecoveryTimeoutSpec extends AkkaSpec(PersistentActorRecover
 
       probe.expectMsgType[Failure].cause shouldBe a[RecoveryTimedOut]
       expectTerminated(replaying)
+
+      // avoid having it stuck in the next test from the
+      // last read request above
+      SteppingInmemJournal.step(journal)
+    }
+
+    "should not interfere with receive timeouts" in {
+      val timeout = 42.days
+
+      val probe = TestProbe()
+      val persisting = system.actorOf(Props(classOf[PersistentActorRecoveryTimeoutSpec.TestReceiveTimeoutActor], timeout, probe.ref))
+
+      awaitAssert(SteppingInmemJournal.getRef(journalId), 3.seconds)
+      val journal = SteppingInmemJournal.getRef(journalId)
+
+      // initial read highest
+      SteppingInmemJournal.step(journal)
+
+      persisting ! "A"
+      SteppingInmemJournal.step(journal)
+      expectMsg("A")
+
+      watch(persisting)
+      system.stop(persisting)
+      expectTerminated(persisting)
+
+      // now replay, but don't give the journal any tokens to replay events
+      // so that we cause the timeout to trigger
+      val replaying = system.actorOf(Props(classOf[PersistentActorRecoveryTimeoutSpec.TestReceiveTimeoutActor], timeout, probe.ref))
+
+      // initial read highest
+      SteppingInmemJournal.step(journal)
+
+      // read journal
+      SteppingInmemJournal.step(journal)
+
+      // we should get initial receive timeout back from actor when replay completes
+      probe.expectMsg(timeout)
 
     }
 


### PR DESCRIPTION
Fixes #20738 by using the scheduler instead of `receiveTimeout` additionally it will therefore not be affected by non-recovery messages passing by into the stash of the persistent actor.
