### PR TITLE
system messages to deadLetters

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -36,6 +36,7 @@ import akka.stream.scaladsl.Source
 import akka.util.{ Unsafe, WildcardTree }
 import org.agrona.concurrent.ManyToOneConcurrentArrayQueue
 import akka.util.OptionVal
+import akka.remote.QuarantinedEvent
 
 /**
  * INTERNAL API
@@ -223,6 +224,8 @@ private[remote] class Association(
                 log.warning(
                   "Association to [{}] with UID [{}] is irrecoverably failed. Quarantining address. {}",
                   remoteAddress, u, reason)
+                // FIXME when we complete the switch to Long UID we must use Long here also, issue #20644
+                transport.eventPublisher.notifyListeners(QuarantinedEvent(remoteAddress, u.toInt))
                 // end delivery of system messages to that incarnation after this point
                 send(ClearSystemMessageDelivery, OptionVal.None, dummyRecipient)
                 // try to tell the other system that we have quarantined it

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
@@ -72,8 +72,7 @@ class RemoteDeathWatchSpec extends AkkaSpec(RemoteDeathWatchSpec.config) with Im
     }
   }
 
-  // FIXME this is failing with Artery
-  "receive Terminated when watched node is unknown host" ignore {
+  "receive Terminated when watched node is unknown host" in {
     val path = RootActorPath(Address("artery", system.name, "unknownhost", 2552)) / "user" / "subject"
     system.actorOf(Props(new Actor {
       context.watch(context.actorFor(path))
@@ -85,8 +84,7 @@ class RemoteDeathWatchSpec extends AkkaSpec(RemoteDeathWatchSpec.config) with Im
     expectMsg(60.seconds, path)
   }
 
-  // FIXME this is failing with Artery
-  "receive ActorIdentity(None) when identified node is unknown host" ignore {
+  "receive ActorIdentity(None) when identified node is unknown host" in {
     val path = RootActorPath(Address("artery", system.name, "unknownhost2", 2552)) / "user" / "subject"
     system.actorSelection(path) ! Identify(path)
     expectMsg(60.seconds, ActorIdentity(path, None))

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -66,9 +66,10 @@ class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.confi
 
   private def send(sendCount: Int, resendInterval: FiniteDuration, outboundContext: OutboundContext): Source[Send, NotUsed] = {
     val remoteRef = null.asInstanceOf[RemoteActorRef] // not used
+    val deadLetters = TestProbe().ref
     Source(1 to sendCount)
       .map(n ⇒ Send("msg-" + n, OptionVal.None, remoteRef, None))
-      .via(new SystemMessageDelivery(outboundContext, resendInterval, maxBufferSize = 1000))
+      .via(new SystemMessageDelivery(outboundContext, deadLetters, resendInterval, maxBufferSize = 1000))
   }
 
   private def inbound(inboundContext: InboundContext): Flow[Send, InboundEnvelope, NotUsed] = {


### PR DESCRIPTION
I have reviewed old remoting and added a few things to Artery that I found useful. Well, the deadLetters for system messages are critical.
