### PR TITLE
make remote deployment work with Artery, #20715

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/AttemptSysMsgRedeliverySpec.scala
@@ -37,13 +37,12 @@ class AttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec(
 class AttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec(
   new AttemptSysMsgRedeliveryMultiJvmSpec(artery = false))
 
-// FIXME this test is failing for Artery, a DeathWatchNotification is not delivered as expected?
-//class ArteryAttemptSysMsgRedeliveryMultiJvmNode1 extends AttemptSysMsgRedeliverySpec(
-//  new AttemptSysMsgRedeliveryMultiJvmSpec(artery = true))
-//class ArteryAttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec(
-//  new AttemptSysMsgRedeliveryMultiJvmSpec(artery = true))
-//class ArteryAttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec(
-//  new AttemptSysMsgRedeliveryMultiJvmSpec(artery = true))
+class ArteryAttemptSysMsgRedeliveryMultiJvmNode1 extends AttemptSysMsgRedeliverySpec(
+  new AttemptSysMsgRedeliveryMultiJvmSpec(artery = true))
+class ArteryAttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec(
+  new AttemptSysMsgRedeliveryMultiJvmSpec(artery = true))
+class ArteryAttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec(
+  new AttemptSysMsgRedeliveryMultiJvmSpec(artery = true))
 
 object AttemptSysMsgRedeliverySpec {
   class Echo extends Actor {

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/RemoteRestartedQuarantinedSpec.scala
@@ -82,11 +82,6 @@ abstract class RemoteRestartedQuarantinedSpec
       runOn(first) {
         val secondAddress = node(second).address
 
-        // FIXME this should not be needed, see issue #20566
-        within(30.seconds) {
-          identifyWithUid(second, "subject", 1.seconds)
-        }
-
         val (uid, ref) = identifyWithUid(second, "subject", 5.seconds)
 
         enterBarrier("before-quarantined")

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -4,6 +4,7 @@
 
 package akka.remote
 
+import scala.concurrent.duration._
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import akka.actor.{ VirtualPathContainer, Deploy, Props, Nobody, InternalActorRef, ActorSystemImpl, ActorRef, ActorPathExtractor, ActorPath, Actor, AddressTerminated }
@@ -22,6 +23,7 @@ import akka.actor.EmptyLocalActorRef
 import akka.event.AddressTerminatedTopic
 import java.util.concurrent.ConcurrentHashMap
 import akka.dispatch.sysmsg.Unwatch
+import akka.NotUsed
 
 /**
  * INTERNAL API
@@ -57,6 +59,7 @@ private[akka] class RemoteSystemDaemon(
   AddressTerminatedTopic(system).subscribe(this)
 
   private val parent2children = new ConcurrentHashMap[ActorRef, Set[ActorRef]]
+  private val dedupDaemonMsgCreateMessages = new ConcurrentHashMap[String, NotUsed]
 
   @tailrec private def addChildParentNeedsWatch(parent: ActorRef, child: ActorRef): Boolean =
     parent2children.get(parent) match {
@@ -138,32 +141,41 @@ private[akka] class RemoteSystemDaemon(
     case message: DaemonMsg ⇒
       log.debug("Received command [{}] to RemoteSystemDaemon on [{}]", message, path.address)
       message match {
-        case DaemonMsgCreate(_, _, path, _) if untrustedMode ⇒ log.debug("does not accept deployments (untrusted) for [{}]", path)
+        case DaemonMsgCreate(_, _, path, _) if untrustedMode ⇒
+          log.debug("does not accept deployments (untrusted) for [{}]", path)
         case DaemonMsgCreate(props, deploy, path, supervisor) ⇒
-          path match {
-            case ActorPathExtractor(address, elems) if elems.nonEmpty && elems.head == "remote" ⇒
-              // TODO RK currently the extracted “address” is just ignored, is that okay?
-              // TODO RK canonicalize path so as not to duplicate it always #1446
-              val subpath = elems.drop(1)
-              val p = this.path / subpath
-              val childName = {
-                val s = subpath.mkString("/")
-                val i = s.indexOf('#')
-                if (i < 0) s
-                else s.substring(0, i)
-              }
-              val isTerminating = !terminating.whileOff {
-                val parent = supervisor.asInstanceOf[InternalActorRef]
-                val actor = system.provider.actorOf(system, props, parent,
-                  p, systemService = false, Some(deploy), lookupDeploy = true, async = false)
-                addChild(childName, actor)
-                actor.sendSystemMessage(Watch(actor, this))
-                actor.start()
-                if (addChildParentNeedsWatch(parent, actor)) parent.sendSystemMessage(Watch(parent, this))
-              }
-              if (isTerminating) log.error("Skipping [{}] to RemoteSystemDaemon on [{}] while terminating", message, p.address)
-            case _ ⇒
-              log.debug("remote path does not match path from message [{}]", message)
+          // Artery sends multiple DaemonMsgCreate over several streams to preserve ordering assumptions,
+          // DaemonMsgCreate for this unique path is already handled and therefore deduplicated
+          if (dedupDaemonMsgCreateMessages.putIfAbsent(path, NotUsed) == null) {
+            // we only need to keep the dedup info for a short period
+            // this is not a real actor, so no point in scheduling message
+            system.scheduler.scheduleOnce(5.seconds)(dedupDaemonMsgCreateMessages.remove(path))(system.dispatcher)
+
+            path match {
+              case ActorPathExtractor(address, elems) if elems.nonEmpty && elems.head == "remote" ⇒
+                // TODO RK currently the extracted “address” is just ignored, is that okay?
+                // TODO RK canonicalize path so as not to duplicate it always #1446
+                val subpath = elems.drop(1)
+                val p = this.path / subpath
+                val childName = {
+                  val s = subpath.mkString("/")
+                  val i = s.indexOf('#')
+                  if (i < 0) s
+                  else s.substring(0, i)
+                }
+                val isTerminating = !terminating.whileOff {
+                  val parent = supervisor.asInstanceOf[InternalActorRef]
+                  val actor = system.provider.actorOf(system, props, parent,
+                    p, systemService = false, Some(deploy), lookupDeploy = true, async = false)
+                  addChild(childName, actor)
+                  actor.sendSystemMessage(Watch(actor, this))
+                  actor.start()
+                  if (addChildParentNeedsWatch(parent, actor)) parent.sendSystemMessage(Watch(parent, this))
+                }
+                if (isTerminating) log.error("Skipping [{}] to RemoteSystemDaemon on [{}] while terminating", message, p.address)
+              case _ ⇒
+                log.debug("remote path does not match path from message [{}]", message)
+            }
           }
       }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
@@ -99,6 +99,9 @@ sealed trait HeaderBuilder {
   def setNoSender(): Unit
   def isNoSender: Boolean
 
+  def setNoRecipient(): Unit
+  def isNoRecipient: Boolean
+
   def recipientActorRef_=(ref: String): Unit
   def recipientActorRef: String
 
@@ -146,6 +149,14 @@ private[remote] final class HeaderBuilderImpl(val compressionTable: LiteralCompr
       _senderActorRef
     }
   }
+
+  def setNoRecipient(): Unit = {
+    _recipientActorRef = null
+    _recipientActorRefIdx = EnvelopeBuffer.DeadLettersCode
+  }
+
+  def isNoRecipient: Boolean =
+    (_recipientActorRef eq null) && _recipientActorRefIdx == EnvelopeBuffer.DeadLettersCode
 
   def recipientActorRef_=(ref: String): Unit = {
     _recipientActorRef = ref

--- a/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/InboundControlJunctionSpec.scala
@@ -39,7 +39,7 @@ class InboundControlJunctionSpec extends AkkaSpec with ImplicitSender {
     "be emitted via side channel" in {
       val observerProbe = TestProbe()
       val inboundContext = new TestInboundContext(localAddress = addressB)
-      val recipient = null.asInstanceOf[InternalActorRef] // not used
+      val recipient = OptionVal.None // not used
 
       val ((upstream, controlSubject), downstream) = TestSource.probe[AnyRef]
         .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, OptionVal.None, addressA.uid, OptionVal.None))

--- a/akka-remote/src/test/scala/akka/remote/artery/InboundHandshakeSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/InboundHandshakeSpec.scala
@@ -39,7 +39,7 @@ class InboundHandshakeSpec extends AkkaSpec with ImplicitSender {
   val addressB = UniqueAddress(Address("artery", "sysB", "hostB", 1002), 2)
 
   private def setupStream(inboundContext: InboundContext, timeout: FiniteDuration = 5.seconds): (TestPublisher.Probe[AnyRef], TestSubscriber.Probe[Any]) = {
-    val recipient = null.asInstanceOf[InternalActorRef] // not used
+    val recipient = OptionVal.None // not used
     TestSource.probe[AnyRef]
       .map(msg ⇒ InboundEnvelope(recipient, addressB.address, msg, OptionVal.None, addressA.uid,
         inboundContext.association(addressA.uid)))

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
@@ -59,8 +59,7 @@ class RemoteDeploymentSpec extends AkkaSpec("""
 
   "Remoting" must {
 
-    // FIXME this test is failing with Artery
-    "create and supervise children on remote node" ignore {
+    "create and supervise children on remote node" in {
       val senderProbe = TestProbe()(masterSystem)
       val r = masterSystem.actorOf(Props[Echo1], "blub")
       r.path.toString should ===(s"artery://${system.name}@localhost:${port}/remote/artery/${masterSystem.name}@localhost:${masterPort}/user/blub")

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
@@ -22,7 +22,6 @@ object RemoteRouterSpec {
 }
 
 class RemoteRouterSpec extends AkkaSpec("""
-    akka.loglevel=DEBUG
     akka.actor.provider = remote
     akka.remote.artery.enabled = on
     akka.remote.artery.hostname = localhost
@@ -99,8 +98,7 @@ class RemoteRouterSpec extends AkkaSpec("""
 
   "A Remote Router" must {
 
-    // FIXME this test is failing with Artery
-    "deploy its children on remote host driven by configuration" ignore {
+    "deploy its children on remote host driven by configuration" in {
       val probe = TestProbe()(masterSystem)
       val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps), "blub")
       val replies = collectRouteePaths(probe, router, 5)
@@ -112,8 +110,7 @@ class RemoteRouterSpec extends AkkaSpec("""
       masterSystem.stop(router)
     }
 
-    // FIXME this test is failing with Artery
-    "deploy its children on remote host driven by programatic definition" ignore {
+    "deploy its children on remote host driven by programatic definition" in {
       val probe = TestProbe()(masterSystem)
       val router = masterSystem.actorOf(new RemoteRouterConfig(
         RoundRobinPool(2),
@@ -126,8 +123,7 @@ class RemoteRouterSpec extends AkkaSpec("""
       masterSystem.stop(router)
     }
 
-    // FIXME this test is failing with Artery
-    "deploy dynamic resizable number of children on remote host driven by configuration" ignore {
+    "deploy dynamic resizable number of children on remote host driven by configuration" in {
       val probe = TestProbe()(masterSystem)
       val router = masterSystem.actorOf(FromConfig.props(echoActorProps), "elastic-blub")
       val replies = collectRouteePaths(probe, router, 5000)
@@ -152,8 +148,7 @@ class RemoteRouterSpec extends AkkaSpec("""
       masterSystem.stop(router)
     }
 
-    // FIXME this test is failing with Artery
-    "deploy remote routers based on explicit deployment" ignore {
+    "deploy remote routers based on explicit deployment" in {
       val probe = TestProbe()(masterSystem)
       val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps)
         .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"artery://${sysName}@localhost:${port}")))), "remote-blub2")
@@ -168,8 +163,7 @@ class RemoteRouterSpec extends AkkaSpec("""
       masterSystem.stop(router)
     }
 
-    // FIXME this test is failing with Artery
-    "let remote deployment be overridden by local configuration" ignore {
+    "let remote deployment be overridden by local configuration" in {
       val probe = TestProbe()(masterSystem)
       val router = masterSystem.actorOf(RoundRobinPool(2).props(echoActorProps)
         .withDeploy(Deploy(scope = RemoteScope(AddressFromURIString(s"artery://${sysName}@localhost:${port}")))), "local-blub")
@@ -214,8 +208,7 @@ class RemoteRouterSpec extends AkkaSpec("""
       masterSystem.stop(router)
     }
 
-    // FIXME this test is failing with Artery
-    "set supplied supervisorStrategy" ignore {
+    "set supplied supervisorStrategy" in {
       val probe = TestProbe()(masterSystem)
       val escalator = OneForOneStrategy() {
         case e ⇒ probe.ref ! e; SupervisorStrategy.Escalate

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -73,7 +73,7 @@ class SystemMessageDeliverySpec extends AkkaSpec(SystemMessageDeliverySpec.confi
   }
 
   private def inbound(inboundContext: InboundContext): Flow[Send, InboundEnvelope, NotUsed] = {
-    val recipient = null.asInstanceOf[InternalActorRef] // not used
+    val recipient = OptionVal.None // not used
     Flow[Send]
       .map {
         case Send(sysEnv: SystemMessageEnvelope, _, _, _) ⇒

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -85,7 +85,7 @@ private[akka] class TestOutboundContext(
 
   override def sendControl(message: ControlMessage) = {
     controlProbe.foreach(_ ! message)
-    controlSubject.sendControl(InboundEnvelope(null, remoteAddress, message, OptionVal.None, localAddress.uid,
+    controlSubject.sendControl(InboundEnvelope(OptionVal.None, remoteAddress, message, OptionVal.None, localAddress.uid,
       OptionVal.None))
   }
 


### PR DESCRIPTION
WARNING: Your quota of dislike for remote deployment might be exceed when reviewing this ;-)

There were two related problems with remote deployment when
using Artery.
- DaemonMsgCreate is not a SystemMessage, but must be sent over the control stream because
  remote deployment process depends on message ordering for DaemonMsgCreate and Watch messages. It must also be sent over the ordinary message stream so that it arrives (and creates the
  destination) before the first ordinary message arrives.
- The first point solves the creation of the remote deployed actor but it's not enough.
  Resolve of the recipient actor ref may still happen before the actor is created. This
  is solved by retrying the resolve for the first message of a remote deployed actor.
