### PR TITLE
Parse URIs with many query string segments

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -639,5 +639,14 @@ class UriSpec extends WordSpec with Matchers {
       val uri = Uri(s"http://foo.bar/$slashes")
       uri.toString // was reported to throw StackOverflowException in Spray's URI
     }
+
+    "survive parsing a URI with thousands of query string values" in {
+      val uriString = (1 to 2000).map("a=" + _).mkString("http://foo.bar/?", "&", "")
+      val uri = Uri(uriString)
+      val query = uri.query()
+      query.size shouldEqual 2000
+      query.head._2 shouldEqual "1"
+      query.last._2 shouldEqual "2000"
+    }
   }
 }


### PR DESCRIPTION
We are using akka-http to replace a legacy system that currently receives and processes some requests with on the order of 1000 query-string parameters. When we set `akka.http.parsing.max-uri-length` to an appropriate value, we get an `akka.parboiled2.ValueStackOverflowException` when the URI is being parsed. This is because the parser deliberately makes heavy use of the Parboiled parser’s value stack in order to efficiently construct the URI’s `Query` instance.

The proposed solution is to continue to use the existing efficient this stack-heavy approach as long as there is sufficient space on the value-stack, but to switch to a stack-friendly approach when necessary.

An alternative solution would have been to introduce a configuration variable named something like `akka.http.parsing.max-value-stack-depth`, which would be used similarly to `max-uri-length`, but this approach seems cleaner, given that URI length can already be used to avoid parsing overly complex URIs.
