### PR TITLE
20597 - Make BackoffSupervisor respect OneForOneStrategy's maxNumRetries property

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
@@ -187,7 +187,7 @@ class BackoffOnRestartSupervisorSpec extends AkkaSpec with ImplicitSender {
             probe.expectMsg(4 seconds, "STARTED")
           }
         }
-        // Superviser should've terminated.
+        // Supervisor should've terminated.
         probe.expectTerminated(supervisor)
       }
     }
@@ -196,7 +196,7 @@ class BackoffOnRestartSupervisorSpec extends AkkaSpec with ImplicitSender {
       val probe = TestProbe()
       // withinTimeRange indicates the time range in which maxNrOfRetries will cause the child to
       // stop. IE: If we restart more than maxNrOfRetries in a time range longer than withinTimeRange
-      // that is acceptible.
+      // that is acceptable.
       val options = Backoff.onFailure(TestActor.props(probe.ref), "someChildName", 300 millis, 10 seconds, 0.0)
         .withSupervisorStrategy(OneForOneStrategy(withinTimeRange = 1 seconds, maxNrOfRetries = 3) {
           case _: TestActor.StoppingException ⇒ SupervisorStrategy.Stop

--- a/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
@@ -175,7 +175,6 @@ class BackoffOnRestartSupervisorSpec extends AkkaSpec with ImplicitSender {
         probe.watch(supervisor)
         // Have the child throw an exception 5 times, which is more than the max restarts allowed.
         for (i ← 1 to 5) {
-          println(s"iteration $i")
           supervisor ! "THROW"
           if (i < 5) {
             // Since we should've died on this throw, don't expect to be started.

--- a/akka-actor/src/main/scala/akka/pattern/BackoffOnRestartSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffOnRestartSupervisor.scala
@@ -41,7 +41,7 @@ private class BackoffOnRestartSupervisor(
           val nextRestartCount = restartCount + 1
           if (strategy.maxNrOfRetries >= 0 && nextRestartCount > strategy.maxNrOfRetries) {
             // If we've exceeded the maximum # of retries allowed by the Strategy, die.
-            log.debug(s"Terminating on restart # $nextRestartCount which exceeds max allowed restarts (${strategy.maxNrOfRetries})")
+            log.debug(s"Terminating on restart #{} which exceeds max allowed restarts ({})", nextRestartCount, strategy.maxNrOfRetries)
             become(receive)
             stop(self)
           } else {

--- a/akka-actor/src/main/scala/akka/pattern/BackoffOnRestartSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffOnRestartSupervisor.scala
@@ -43,7 +43,7 @@ private class BackoffOnRestartSupervisor(
             // to ourselves every time that range elapses, to reset the restart counter. We hide it
             // behind this conditional to avoid queuing the message unnecessarily
             val finiteWithinTimeRange = strategy.withinTimeRange.asInstanceOf[FiniteDuration]
-            system.scheduler.schedule(finiteWithinTimeRange, finiteWithinTimeRange, self, ResetRestartCount(restartCount))
+            system.scheduler.scheduleOnce(finiteWithinTimeRange, self, ResetRestartCount(restartCount))
           }
           val childRef = sender()
           val nextRestartCount = restartCount + 1

--- a/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
@@ -231,15 +231,11 @@ private[akka] trait HandleBackoff { this: Actor ⇒
 
   var child: Option[ActorRef] = None
   var restartCount = 0
-  var lastResetTime = Deadline.now
 
   import BackoffSupervisor._
   import context.dispatcher
 
-  override def preStart(): Unit = {
-    lastResetTime = Deadline.now
-    startChild()
-  }
+  override def preStart(): Unit = startChild()
 
   def startChild(): Unit = {
     if (child.isEmpty) {
@@ -258,16 +254,13 @@ private[akka] trait HandleBackoff { this: Actor ⇒
 
     case Reset ⇒
       reset match {
-        case ManualReset ⇒
-          restartCount = 0
-          lastResetTime = Deadline.now
+        case ManualReset ⇒ restartCount = 0
         case msg         ⇒ unhandled(msg)
       }
 
     case ResetRestartCount(current) ⇒
       if (current == restartCount) {
         restartCount = 0
-        lastResetTime = Deadline.now
       }
 
     case GetRestartCount ⇒


### PR DESCRIPTION
Regards #20597 

I think I've managed to follow the contributing guidelines correctly. I had some issues running sbt (namely, it seems to like to blow the stack while running scalariform - win10,x64,latest scala/java) but I was able to run the test suite through IntelliJ at least.

Thanks for your reviews!
