### PR TITLE
change checkSameOrigin to show allowed origins

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/HeaderDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/HeaderDirectivesExamplesTest.java
@@ -14,6 +14,7 @@ import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.model.headers.Host;
 import akka.http.javadsl.model.headers.HttpOrigin;
 import akka.http.javadsl.model.headers.HttpOriginRange;
+import akka.http.javadsl.model.headers.HttpOriginRangeDefault;
 import akka.http.javadsl.model.headers.Origin;
 import akka.http.javadsl.model.headers.RawHeader;
 import akka.http.javadsl.server.Route;
@@ -235,7 +236,7 @@ public class HeaderDirectivesExamplesTest extends JUnitRouteTest {
     final HttpOrigin validOriginHeader =
             HttpOrigin.create("http://localhost", Host.create("8080"));
 
-    final HttpOriginRange validOriginRange = HttpOriginRange.create(validOriginHeader);
+    final HttpOriginRangeDefault validOriginRange = HttpOriginRangeDefault.create(validOriginHeader);
 
     final TestRoute route = testRoute(
             checkSameOrigin(validOriginRange,

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/HeaderDirectivesExamplesSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/HeaderDirectivesExamplesSpec.scala
@@ -209,13 +209,13 @@ class HeaderDirectivesExamplesSpec extends RoutingSpec with Inside {
     val invalidOriginHeader = Origin(invalidHttpOrigin)
     Get("abc") ~> invalidOriginHeader ~> route ~> check {
       inside(rejection) {
-        case InvalidOriginRejection(invalidOrigins) ⇒
-          invalidOrigins shouldEqual Seq(invalidHttpOrigin)
+        case InvalidOriginRejection(allowedOrigins) ⇒
+          allowedOrigins shouldEqual Seq(correctOrigin)
       }
     }
     Get("abc") ~> invalidOriginHeader ~> Route.seal(route) ~> check {
       status shouldEqual StatusCodes.Forbidden
-      responseAs[String] should include(s"${invalidHttpOrigin.value}")
+      responseAs[String] should include(s"${correctOrigin.value}")
     }
   }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
@@ -10,10 +10,10 @@ import akka.http.impl.util.Util;
 /**
  * @see HttpOriginRanges for convenience access to often used values.
  */
-public abstract class HttpOriginRange {
-    public abstract boolean matches(HttpOrigin origin);
+public interface HttpOriginRange {
+    boolean matches(HttpOrigin origin);
 
-    public static HttpOriginRange create(HttpOrigin... origins) {
+    static HttpOriginRange create(HttpOrigin... origins) {
         return HttpOriginRange$.MODULE$.apply(Util.<HttpOrigin, akka.http.scaladsl.model.headers.HttpOrigin>convertArray(origins));
     }
 
@@ -24,5 +24,5 @@ public abstract class HttpOriginRange {
      */
     @Deprecated
     // FIXME: Remove in Akka 3.0
-    public static final HttpOriginRange ALL = HttpOriginRanges.ALL;
+    HttpOriginRange ALL = HttpOriginRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
@@ -24,5 +24,5 @@ public interface HttpOriginRange {
      */
     @Deprecated
     // FIXME: Remove in Akka 3.0
-    HttpOriginRange ALL = HttpOriginRanges.ALL;
+    public static final HttpOriginRange ALL = HttpOriginRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRangeDefault.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRangeDefault.java
@@ -1,11 +1,15 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.http.javadsl.model.headers;
 
 import akka.http.impl.util.Util;
 import akka.http.scaladsl.model.headers.HttpOriginRange$;
 
 
-public abstract class HttpOriginRangeDefault extends HttpOriginRange {
-    public static akka.http.scaladsl.model.headers.HttpOriginRange.Default create(HttpOrigin... origins) {
+public interface HttpOriginRangeDefault extends HttpOriginRange {
+    static akka.http.scaladsl.model.headers.HttpOriginRange.Default create(HttpOrigin... origins) {
         return HttpOriginRange$.MODULE$.apply(Util.convertArray(origins));
     }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRangeDefault.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRangeDefault.java
@@ -1,0 +1,11 @@
+package akka.http.javadsl.model.headers;
+
+import akka.http.impl.util.Util;
+import akka.http.scaladsl.model.headers.HttpOriginRange$;
+
+
+public abstract class HttpOriginRangeDefault extends HttpOriginRange {
+    public static akka.http.scaladsl.model.headers.HttpOriginRange.Default create(HttpOrigin... origins) {
+        return HttpOriginRange$.MODULE$.apply(Util.convertArray(origins));
+    }
+}

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -20,6 +20,7 @@ import akka.http.scaladsl.{ model ⇒ sm }
 import akka.http.javadsl.{ settings ⇒ js }
 
 import akka.http.impl.util.JavaMapping.Implicits._
+import akka.http.javadsl.model.headers.HttpOriginRangeDefault
 
 import scala.util.Try
 
@@ -225,6 +226,7 @@ private[http] object JavaMapping {
   implicit object HttpEncodingRange extends Inherited[jm.headers.HttpEncodingRange, sm.headers.HttpEncodingRange]
   implicit object HttpOrigin extends Inherited[jm.headers.HttpOrigin, sm.headers.HttpOrigin]
   implicit object HttpOriginRange extends Inherited[jm.headers.HttpOriginRange, sm.headers.HttpOriginRange]
+  implicit object HttpOriginRangeDefault extends Inherited[HttpOriginRangeDefault, sm.headers.HttpOriginRange.Default]
   implicit object Language extends Inherited[jm.headers.Language, sm.headers.Language]
   implicit object LanguageRange extends Inherited[jm.headers.LanguageRange, sm.headers.LanguageRange]
   implicit object LinkParam extends Inherited[jm.headers.LinkParam, sm.headers.LinkParam]

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.model.headers
 
 import akka.http.impl.model.JavaInitialization
-import akka.util.Unsafe
 
 import language.implicitConversions
 import scala.collection.immutable
@@ -16,12 +15,13 @@ import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.model.Uri
 import akka.http.impl.util.JavaMapping.Implicits._
 
-abstract class HttpOriginRange extends jm.headers.HttpOriginRange with ValueRenderable {
+trait HttpOriginRange extends jm.headers.HttpOriginRange with ValueRenderable {
   def matches(origin: HttpOrigin): Boolean
 
   /** Java API */
   def matches(origin: jm.headers.HttpOrigin): Boolean = matches(origin.asScala)
 }
+
 object HttpOriginRange {
   case object `*` extends HttpOriginRange {
     def matches(origin: HttpOrigin) = true
@@ -30,7 +30,7 @@ object HttpOriginRange {
 
   def apply(origins: HttpOrigin*): Default = Default(immutable.Seq(origins: _*))
 
-  final case class Default(origins: immutable.Seq[HttpOrigin]) extends HttpOriginRange {
+  final case class Default(origins: immutable.Seq[HttpOrigin]) extends jm.headers.HttpOriginRangeDefault with HttpOriginRange {
     def matches(origin: HttpOrigin): Boolean = origins contains origin
     def render[R <: Rendering](r: R): r.type = r ~~ origins
   }
@@ -43,6 +43,7 @@ object HttpOriginRange {
 final case class HttpOrigin(scheme: String, host: Host) extends jm.headers.HttpOrigin with ValueRenderable {
   def render[R <: Rendering](r: R): r.type = host.renderValue(r ~~ scheme ~~ "://")
 }
+
 object HttpOrigin {
   implicit val originsRenderer: Renderer[immutable.Seq[HttpOrigin]] = Renderer.seqRenderer(" ", "null")
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
@@ -15,7 +15,7 @@ import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.model.Uri
 import akka.http.impl.util.JavaMapping.Implicits._
 
-trait HttpOriginRange extends jm.headers.HttpOriginRange with ValueRenderable {
+abstract class HttpOriginRange extends jm.headers.HttpOriginRange with ValueRenderable {
   def matches(origin: HttpOrigin): Boolean
 
   /** Java API */
@@ -30,7 +30,7 @@ object HttpOriginRange {
 
   def apply(origins: HttpOrigin*): Default = Default(immutable.Seq(origins: _*))
 
-  final case class Default(origins: immutable.Seq[HttpOrigin]) extends jm.headers.HttpOriginRangeDefault with HttpOriginRange {
+  final case class Default(origins: immutable.Seq[HttpOrigin]) extends HttpOriginRange with jm.headers.HttpOriginRangeDefault {
     def matches(origin: HttpOrigin): Boolean = origins contains origin
     def render[R <: Rendering](r: R): r.type = r ~~ origins
   }

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/HeaderDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/HeaderDirectivesTest.java
@@ -186,7 +186,7 @@ public class HeaderDirectivesTest extends JUnitRouteTest {
   public void testCheckSameOrigin() {
     final HttpOrigin validOriginHeader = HttpOrigin.create("http://localhost", Host.create("8080"));
 
-    final HttpOriginRange validOriginRange = HttpOriginRange.create(validOriginHeader);
+    final HttpOriginRangeDefault validOriginRange = HttpOriginRangeDefault.create(validOriginHeader);
 
     TestRoute route = testRoute(checkSameOrigin(validOriginRange, () -> complete("Result")));
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -183,12 +183,12 @@ class HeaderDirectivesSpec extends RoutingSpec with Inside {
       val invalidOriginHeader = Origin(invalidHttpOrigin)
       Get("abc") ~> invalidOriginHeader ~> route ~> check {
         inside(rejection) {
-          case InvalidOriginRejection(invalidOrigins) ⇒ invalidOrigins shouldEqual Seq(invalidHttpOrigin)
+          case InvalidOriginRejection(allowedOrigins) ⇒ allowedOrigins shouldEqual Seq(correctOrigin)
         }
       }
       Get("abc") ~> invalidOriginHeader ~> Route.seal(route) ~> check {
         status shouldEqual StatusCodes.Forbidden
-        responseAs[String] should include(s"${invalidHttpOrigin.value}")
+        responseAs[String] should include(s"${correctOrigin.value}")
       }
     }
   }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
@@ -110,7 +110,7 @@ trait MalformedHeaderRejection extends Rejection {
  * Signals that the request was rejected because `Origin` header value is invalid.
  */
 trait InvalidOriginRejection extends Rejection {
-  def getInvalidOrigins: java.util.List[akka.http.javadsl.model.headers.HttpOrigin]
+  def getAllowedOrigins: java.util.List[akka.http.javadsl.model.headers.HttpOrigin]
 }
 
 /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
@@ -14,6 +14,7 @@ import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.javadsl.model.{ HttpHeader, StatusCodes }
 import akka.http.javadsl.model.headers.HttpOriginRange
 import akka.http.javadsl.server.{ InvalidOriginRejection, MissingHeaderRejection, Route }
+import akka.http.scaladsl.model.headers.HttpOriginRange.{ Default, `*` }
 import akka.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion, Origin }
 import akka.http.scaladsl.server.directives.{ HeaderMagnet, BasicDirectives ⇒ B, HeaderDirectives ⇒ D }
 import akka.stream.ActorMaterializer
@@ -34,7 +35,11 @@ abstract class HeaderDirectives extends FutureDirectives {
    * @group header
    */
   def checkSameOrigin(allowed: HttpOriginRange, inner: jf.Supplier[Route]): Route = RouteAdapter {
-    D.checkSameOrigin(allowed.asScala) { inner.get().delegate }
+    val a = allowed.asScala match {
+      case x: `*`.type ⇒ ???
+      case x: Default  ⇒ x
+    }
+    D.checkSameOrigin(a) { inner.get().delegate }
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
@@ -11,13 +11,11 @@ import akka.actor.ReflectiveDynamicAccess
 import scala.compat.java8.OptionConverters
 import scala.compat.java8.OptionConverters._
 import akka.http.impl.util.JavaMapping.Implicits._
+import akka.http.javadsl.model.headers.HttpOriginRangeDefault
 import akka.http.javadsl.model.{ HttpHeader, StatusCodes }
-import akka.http.javadsl.model.headers.HttpOriginRange
 import akka.http.javadsl.server.{ InvalidOriginRejection, MissingHeaderRejection, Route }
-import akka.http.scaladsl.model.headers.HttpOriginRange.{ Default, `*` }
 import akka.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion, Origin }
-import akka.http.scaladsl.server.directives.{ HeaderMagnet, BasicDirectives ⇒ B, HeaderDirectives ⇒ D }
-import akka.stream.ActorMaterializer
+import akka.http.scaladsl.server.directives.{ HeaderMagnet, HeaderDirectives ⇒ D }
 
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
@@ -34,12 +32,8 @@ abstract class HeaderDirectives extends FutureDirectives {
    *
    * @group header
    */
-  def checkSameOrigin(allowed: HttpOriginRange, inner: jf.Supplier[Route]): Route = RouteAdapter {
-    val a = allowed.asScala match {
-      case x: `*`.type ⇒ ???
-      case x: Default  ⇒ x
-    }
-    D.checkSameOrigin(a) { inner.get().delegate }
+  def checkSameOrigin(allowed: HttpOriginRangeDefault, inner: jf.Supplier[Route]): Route = RouteAdapter {
+    D.checkSameOrigin(allowed.asScala) { inner.get().delegate }
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -98,9 +98,9 @@ final case class MalformedHeaderRejection(headerName: String, errorMsg: String, 
  * Rejection created by [[akka.http.scaladsl.server.directives.HeaderDirectives.checkSameOrigin]].
  * Signals that the request was rejected because `Origin` header value is invalid.
  */
-final case class InvalidOriginRejection(invalidOrigins: immutable.Seq[SHttpOrigin])
+final case class InvalidOriginRejection(allowedOrigins: immutable.Seq[SHttpOrigin])
   extends jserver.InvalidOriginRejection with Rejection {
-  override def getInvalidOrigins: java.util.List[JHttpOrigin] = invalidOrigins.map(_.asJava).asJava
+  override def getAllowedOrigins: java.util.List[JHttpOrigin] = allowedOrigins.map(_.asJava).asJava
 }
 
 /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -167,8 +167,8 @@ object RejectionHandler {
           complete((BadRequest, "Request is missing required HTTP header '" + headerName + '\''))
       }
       .handle {
-        case InvalidOriginRejection(invalidOrigin) ⇒
-          complete((Forbidden, s"Invalid `Origin` header values: ${invalidOrigin.mkString(", ")}"))
+        case InvalidOriginRejection(allowedOrigins) ⇒
+          complete((Forbidden, s"Allowed `Origin` header values: ${allowedOrigins.mkString(", ")}"))
       }
       .handle {
         case MissingQueryParamRejection(paramName) ⇒

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -28,10 +28,10 @@ trait HeaderDirectives {
    *
    * @group header
    */
-  def checkSameOrigin(allowed: HttpOriginRange): Directive0 = {
+  def checkSameOrigin(allowed: HttpOriginRange.Default): Directive0 = {
     headerValueByType[Origin]().flatMap { origin ⇒
       if (origin.origins.exists(allowed.matches)) pass
-      else reject(InvalidOriginRejection(origin.origins))
+      else reject(InvalidOriginRejection(allowed.origins))
     }
   }
 


### PR DESCRIPTION
As mentioned in PR #20560 by @2beaucoup and @ktoso it could be helpful to see allowed origins if request rejected. This PR allows this for `checkSameOrigin`.

However, in the `akka.http.javadsl.server.directives.HeaderDirectives.scala` I didn't find any better way to extract type info than the following:

``` scala
  def checkSameOrigin(allowed: HttpOriginRange, inner: jf.Supplier[Route]): Route = RouteAdapter {
    val a = allowed.asScala match {
      case x: `*`.type ⇒ ???
      case x: Default ⇒ x
    }
    D.checkSameOrigin(a) { inner.get().delegate }
  }
```

So any hints are welcome
