### PR TITLE
Fix CircuitBreaker Open state's remainingTimeout() method (#20029)

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -464,7 +464,8 @@ class CircuitBreaker(scheduler: Scheduler, maxFailures: Int, callTimeout: Finite
      * @return duration to when the breaker will attempt a reset by transitioning to half-open
      */
     private def remainingDuration(): FiniteDuration = {
-      val diff = System.nanoTime() - get
+      val fromOpened = System.nanoTime() - get
+      val diff = resetTimeout.toNanos - fromOpened
       if (diff <= 0L) Duration.Zero
       else diff.nanos
     }


### PR DESCRIPTION
Instead of:
- Current Time - Start Time (bug)

It should return
- Reset Timeout - Time Lapse from Start = Remaining Duration

I think [the test case in CircuitBreakerSpec](https://github.com/akka/akka/blob/78b88c419d26caf62e4a91bc1d4f2837a12c543a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala#L67L68) doesn't need to be changed. 
As the return value of remainingDuration is non-deterministic, it is hard to differentiate the return values before/after this code change.

```
(e.remainingDuration > Duration.Zero) should ===(true)
(e.remainingDuration <= CircuitBreakerSpec.longResetTimeout) should ===(true)
```
