### PR TITLE
akka-http: HttpMessageParser swallows IllegalHeaderException #20272

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -84,6 +84,8 @@ private[http] abstract class HttpMessageParser[Output >: MessageOutput <: Parser
         case NotEnoughDataException ⇒
           // we are missing a try/catch{continue} wrapper somewhere
           throw new IllegalStateException("unexpected NotEnoughDataException", NotEnoughDataException)
+        case IllegalHeaderException(error) ⇒
+          failMessageStart(StatusCodes.BadRequest, error)
       }) match {
         case Trampoline(x) ⇒ run(x)
         case x             ⇒ x

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -68,6 +68,12 @@ class HeaderSpec extends FreeSpec with Matchers {
         headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains") shouldEqual Right(headers.`Strict-Transport-Security`(30, true))
         headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; preload") shouldEqual Right(headers.`Strict-Transport-Security`(30, true))
       }
+      "successful parse run with additional values" in {
+        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; preload; dummy") shouldEqual
+          Right(headers.`Strict-Transport-Security`(30, true))
+        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; dummy; preload") shouldEqual
+          Right(headers.`Strict-Transport-Security`(30, true))
+      }
       "failing parse run" in {
         val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; preload;")
         summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': Invalid input 'EOI', expected OWS or token0 (line 1, column 40)"


### PR DESCRIPTION
Catch clause in HttpMessageParser.parseBytes will intercept IllegalHeaderException being thrown and translate them into proper errors.
Refs https://github.com/akka/akka/issues/20272
