### PR TITLE
Suppress Java Serializer warnings when extending NoSerializationVerificationNeeded

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/serialization/NoVerification.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/NoVerification.scala
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package test.akka.serialization
+
+import akka.actor.NoSerializationVerificationNeeded
+
+/**
+ *  This is currently used in NoSerializationVerificationNeeded test cases in SerializeSpec,
+ *  as they needed a serializable class whose top package is not akka.
+ */
+class NoVerification extends NoSerializationVerificationNeeded with java.io.Serializable {
+}

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -17,6 +17,8 @@ import scala.beans.BeanInfo
 import com.typesafe.config._
 import akka.pattern.ask
 import org.apache.commons.codec.binary.Hex.encodeHex
+import akka.actor.NoSerializationVerificationNeeded
+import test.akka.serialization.NoVerification
 
 object SerializationTests {
 
@@ -424,24 +426,72 @@ class DefaultSerializationWarningSpec extends AkkaSpec(
   ConfigFactory.parseString("akka.actor.warn-about-java-serializer-usage = on")) {
 
   val ser = SerializationExtension(system)
-  val messagePrefix = "Using the default Java serializer for class.*"
+  val messagePrefix = "Using the default Java serializer for class"
 
   "Using the default Java serializer" must {
 
     "log a warning when serializing classes outside of java.lang package" in {
-      EventFilter.warning(message = messagePrefix) intercept {
+      EventFilter.warning(start = messagePrefix, occurrences = 1) intercept {
         ser.serializerFor(classOf[java.math.BigDecimal])
       }
     }
 
     "not log warning when serializing classes from java.lang package" in {
-      EventFilter.warning(message = messagePrefix, occurrences = 0) intercept {
+      EventFilter.warning(start = messagePrefix, occurrences = 0) intercept {
         ser.serializerFor(classOf[java.lang.String])
       }
     }
 
   }
 
+}
+
+class NoVerificationWarningSpec extends AkkaSpec(
+  ConfigFactory.parseString(
+    "akka.actor.warn-about-java-serializer-usage = on\n" +
+      "akka.actor.warn-on-no-serialization-verification = on")) {
+
+  val ser = SerializationExtension(system)
+  val messagePrefix = "Using the default Java serializer for class"
+
+  "When warn-on-no-serialization-verification = on, using the default Java serializer" must {
+
+    "log a warning on classes without extending NoSerializationVerificationNeeded" in {
+      EventFilter.warning(start = messagePrefix, occurrences = 1) intercept {
+        ser.serializerFor(classOf[java.math.BigDecimal])
+      }
+    }
+
+    "still log warning on classes extending NoSerializationVerificationNeeded" in {
+      EventFilter.warning(start = messagePrefix, occurrences = 1) intercept {
+        ser.serializerFor(classOf[NoVerification])
+      }
+    }
+  }
+}
+
+class NoVerificationWarningOffSpec extends AkkaSpec(
+  ConfigFactory.parseString(
+    "akka.actor.warn-about-java-serializer-usage = on\n" +
+      "akka.actor.warn-on-no-serialization-verification = off")) {
+
+  val ser = SerializationExtension(system)
+  val messagePrefix = "Using the default Java serializer for class"
+
+  "When warn-on-no-serialization-verification = off, using the default Java serializer" must {
+
+    "log a warning on classes without extending NoSerializationVerificationNeeded" in {
+      EventFilter.warning(start = messagePrefix, occurrences = 1) intercept {
+        ser.serializerFor(classOf[java.math.BigDecimal])
+      }
+    }
+
+    "not log warning on classes extending NoSerializationVerificationNeeded" in {
+      EventFilter.warning(start = messagePrefix, occurrences = 0) intercept {
+        ser.serializerFor(classOf[NoVerification])
+      }
+    }
+  }
 }
 
 protected[akka] trait TestSerializable

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -590,6 +590,12 @@ akka {
     # you can turn this off.
     warn-about-java-serializer-usage = on
 
+    # To be used with the above warn-about-java-serializer-usage
+    # When warn-about-java-serializer-usage = on, and this warn-on-no-serialization-verification = off,
+    # warnings are suppressed for classes extending NoSerializationVerificationNeeded
+    # to reduce noize.
+    warn-on-no-serialization-verification = on
+
     # Configuration namespace of serialization identifiers.
     # Each serializer implementation must have an entry in the following format:
     # `akka.actor.serialization-identifiers."FQCN" = ID`


### PR DESCRIPTION
Refs #19963 This is work-in-progress (tests **WILL** fail), but wanted reviewers advice on this.

I'm having difficulty adding test cases...

Because of this line:
`!serializedClass.getName.startsWith("akka.") &&`
 in Serialization.scala -> [shouldWarnAboutJavaSerializer](https://github.com/akka/akka/blob/65a9e0a0f9372d2e2ecb945c8a9dae129a438f77/akka-actor/src/main/scala/akka/serialization/Serialization.scala#L254), 

any class created in the Akka repository (i.e. under akka. package) disables Java serialization warnings, **regardless of** NoSerializationVerificationNeeded.

So the new flag suppress-warning-on-no-verification doesn't do anything for classes created in Akka.
