### PR TITLE
doc akka http java dsl example snippets timeout directives (#20466)

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
@@ -22,6 +22,7 @@ import akka.testkit.TestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import scala.Tuple2;
 import scala.Tuple3;
@@ -151,6 +152,8 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
         //#
     }
 
+    // make it compile only to avoid flaking in slow builds
+    @Ignore("Compile only test")
     @Test
     public void testRequestTimeoutCustomResponseCanBeAddedSeparately() {
         //#withRequestTimeoutResponse

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2016-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.directives;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCode;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.http.scaladsl.TestUtils;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+import akka.testkit.TestKit;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.After;
+import org.junit.Test;
+import scala.Tuple2;
+import scala.Tuple3;
+import scala.concurrent.duration.Duration;
+import scala.runtime.BoxedUnit;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.concurrent.*;
+
+public class TimeoutDirectivesExamplesTest extends AllDirectives {
+    //#testSetup
+    private final Config testConf = ConfigFactory.parseString("akka.loggers = [\"akka.testkit.TestEventListener\"]\n"
+            + "akka.loglevel = ERROR\n"
+            + "akka.stdout-loglevel = ERROR\n"
+            + "windows-connection-abort-workaround-enabled = auto\n"
+            + "akka.log-dead-letters = OFF\n"
+            + "akka.http.server.request-timeout = 1000s");
+
+    private final ActorSystem system = ActorSystem.create("TimeoutDirectivesExamplesTest", testConf);
+
+    private final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    private final Http http = Http.get(system);
+
+    private CompletionStage<Void> shutdown(CompletionStage<ServerBinding> binding) {
+        return binding.thenAccept(b -> {
+            System.out.println(String.format("Unbinding from %s", b.localAddress()));
+
+            final CompletionStage<BoxedUnit> unbound = b.unbind();
+            try {
+                unbound.toCompletableFuture().get(3, TimeUnit.SECONDS); // block...
+            } catch (TimeoutException | InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private Optional<HttpResponse> runRoute(ActorSystem system, ActorMaterializer materializer, Route route, String routePath) {
+        final Tuple3<InetSocketAddress, String, Object> inetaddrHostAndPort = TestUtils.temporaryServerHostnameAndPort("127.0.0.1");
+        Tuple2<String, Integer> hostAndPort = new Tuple2<>(
+                inetaddrHostAndPort._2(),
+                (Integer) inetaddrHostAndPort._3()
+        );
+
+        final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = route.flow(system, materializer);
+        final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost(hostAndPort._1(), hostAndPort._2()), materializer);
+
+        final CompletionStage<HttpResponse> responseCompletionStage = http.singleRequest(HttpRequest.create("http://" + hostAndPort._1() + ":" + hostAndPort._2() + "/" + routePath), materializer);
+
+        CompletableFuture<HttpResponse> responseFuture = responseCompletionStage.toCompletableFuture();
+
+        Optional<HttpResponse> responseOptional;
+        try {
+            responseOptional = Optional.of(responseFuture.get(3, TimeUnit.SECONDS)); // patienceConfig
+        } catch (Exception e) {
+            responseOptional = Optional.empty();
+        }
+
+        shutdown(binding);
+
+        return responseOptional;
+    }
+    //#
+
+    @After
+    public void shutDown() {
+        TestKit.shutdownActorSystem(system, Duration.create(1, TimeUnit.SECONDS), false);
+    }
+
+    @Test
+    public void testRequestTimeoutIsConfigurable() {
+        //#withRequestTimeout-plain
+        final Duration timeout = Duration.create(1, TimeUnit.SECONDS);
+        CompletionStage<String> slowFuture = new CompletableFuture<>();
+
+        final Route route = path("timeout", () ->
+                withRequestTimeout(timeout, () -> {
+                    return completeOKWithFutureString(slowFuture); // very slow
+                })
+        );
+
+        // test:
+        StatusCode statusCode = runRoute(system, materializer, route, "timeout").get().status();
+        assert (StatusCodes.SERVICE_UNAVAILABLE.equals(statusCode));
+        //#
+    }
+
+    @Test
+    public void testRequestWithoutTimeoutCancelsTimeout() {
+        //#withoutRequestTimeout-1
+        final Duration timeout = Duration.create(1, TimeUnit.SECONDS);
+        CompletionStage<String> slowFuture = new CompletableFuture<>();
+
+        final Route route = path("timeout", () ->
+                withoutRequestTimeout(() -> {
+                    return completeOKWithFutureString(slowFuture); // very slow
+                })
+        );
+
+        // test:
+        Boolean receivedReply = runRoute(system, materializer, route, "timeout").isPresent();
+        assert (!receivedReply); // timed-out
+        //#
+    }
+
+    @Test
+    public void testRequestTimeoutAllowsCustomResponse() {
+        //#withRequestTimeout-with-handler
+        final Duration timeout = Duration.create(1, TimeUnit.MILLISECONDS);
+        CompletionStage<String> slowFuture = new CompletableFuture<>();
+
+        HttpResponse enhanceYourCalmResponse = HttpResponse.create()
+                .withStatus(StatusCodes.ENHANCE_YOUR_CALM)
+                .withEntity("Unable to serve response within time limit, please enchance your calm.");
+
+        final Route route = path("timeout", () ->
+                withRequestTimeout(timeout, (request) -> enhanceYourCalmResponse, () -> {
+                    return completeOKWithFutureString(slowFuture); // very slow
+                })
+        );
+
+        // test:
+        StatusCode statusCode = runRoute(system, materializer, route, "timeout").get().status();
+        assert (StatusCodes.ENHANCE_YOUR_CALM.equals(statusCode));
+        //#
+    }
+
+    @Test
+    public void testRequestTimeoutCustomResponseCanBeAddedSeparately() {
+        //#withRequestTimeoutResponse
+        final Duration timeout = Duration.create(100, TimeUnit.MILLISECONDS);
+        CompletionStage<String> slowFuture = new CompletableFuture<>();
+
+        HttpResponse enhanceYourCalmResponse = HttpResponse.create()
+                .withStatus(StatusCodes.ENHANCE_YOUR_CALM)
+                .withEntity("Unable to serve response within time limit, please enchance your calm.");
+
+        final Route route = path("timeout", () ->
+                withRequestTimeout(timeout, () ->
+                        // racy! for a very short timeout like 1.milli you can still get 503
+                        withRequestTimeoutResponse((request) -> enhanceYourCalmResponse, () -> {
+                            return completeOKWithFutureString(slowFuture); // very slow
+                        }))
+        );
+
+        // test:
+        StatusCode statusCode = runRoute(system, materializer, route, "timeout").get().status();
+        assert (StatusCodes.ENHANCE_YOUR_CALM.equals(statusCode));
+        //#
+    }
+}

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
@@ -40,6 +40,7 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
             + "windows-connection-abort-workaround-enabled = auto\n"
             + "akka.log-dead-letters = OFF\n"
             + "akka.http.server.request-timeout = 1000s");
+    // large timeout - 1000s (please note - setting to infinite will disable withRequestTimeout at the moment)
 
     private final ActorSystem system = ActorSystem.create("TimeoutDirectivesExamplesTest", testConf);
 
@@ -113,7 +114,6 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
     @Test
     public void testRequestWithoutTimeoutCancelsTimeout() {
         //#withoutRequestTimeout-1
-        final Duration timeout = Duration.create(1, TimeUnit.SECONDS);
         CompletionStage<String> slowFuture = new CompletableFuture<>();
 
         final Route route = path("timeout", () ->
@@ -136,7 +136,7 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
 
         HttpResponse enhanceYourCalmResponse = HttpResponse.create()
                 .withStatus(StatusCodes.ENHANCE_YOUR_CALM)
-                .withEntity("Unable to serve response within time limit, please enchance your calm.");
+                .withEntity("Unable to serve response within time limit, please enhance your calm.");
 
         final Route route = path("timeout", () ->
                 withRequestTimeout(timeout, (request) -> enhanceYourCalmResponse, () -> {
@@ -158,7 +158,7 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
 
         HttpResponse enhanceYourCalmResponse = HttpResponse.create()
                 .withStatus(StatusCodes.ENHANCE_YOUR_CALM)
-                .withEntity("Unable to serve response within time limit, please enchance your calm.");
+                .withEntity("Unable to serve response within time limit, please enhance your calm.");
 
         final Route route = path("timeout", () ->
                 withRequestTimeout(timeout, () ->

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
@@ -40,8 +40,9 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
             + "windows-connection-abort-workaround-enabled = auto\n"
             + "akka.log-dead-letters = OFF\n"
             + "akka.http.server.request-timeout = 1000s");
-    // large timeout - 1000s (please note - setting to infinite will disable withRequestTimeout at the moment)
-
+    // large timeout - 1000s (please note - setting to infinite will disable Timeout-Access header
+    // and withRequestTimeout will not work)
+    
     private final ActorSystem system = ActorSystem.create("TimeoutDirectivesExamplesTest", testConf);
 
     private final ActorMaterializer materializer = ActorMaterializer.create(system);

--- a/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withRequestTimeout.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withRequestTimeout.rst
@@ -33,8 +33,10 @@ For more information about various timeouts in Akka HTTP see :ref:`http-timeouts
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode2:: ../../../../code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+   :snippet: withRequestTimeout-plain
 
 With setting the handler at the same time:
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode2:: ../../../../code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+   :snippet: withRequestTimeout-with-handler

--- a/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withRequestTimeoutResponse.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withRequestTimeoutResponse.rst
@@ -23,4 +23,5 @@ To learn more about various timeouts in Akka HTTP and how to configure them see 
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode2:: ../../../../code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+   :snippet: withRequestTimeoutResponse

--- a/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withoutRequestTimeout.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withoutRequestTimeout.rst
@@ -20,4 +20,5 @@ For more information about various timeouts in Akka HTTP see :ref:`http-timeouts
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode2:: ../../../../code/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+   :snippet: withoutRequestTimeout

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -4,20 +4,20 @@
 
 package docs.http.scaladsl.server.directives
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Route
 import docs.CompileOnlySpec
 import akka.actor.ActorSystem
-import akka.http.scaladsl.{Http, TestUtils}
+import akka.http.scaladsl.{ Http, TestUtils }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model._
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
 import scala.concurrent.duration._
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import akka.testkit.TestKit
 
 class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with CompileOnlySpec {
@@ -60,12 +60,13 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
       //#withRequestTimeout-plain
       val route =
         path("timeout") {
-          withRequestTimeout(1.seconds) { // less than akka.http.server.request-timeout value of 1000s
+          withRequestTimeout(1.seconds) { // modifies the global akka.http.server.request-timeout for this request
             val response: Future[String] = slowFuture() // very slow
             complete(response)
           }
         }
 
+      // check
       runRoute(route, "timeout").status should ===(StatusCodes.ServiceUnavailable) // the timeout response
       //#
     }
@@ -79,7 +80,7 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
           }
         }
 
-      // no check as there is no time-out, the future will time out failing the test
+      // no check as there is no time-out, the future would time out failing the test
       //#
     }
 
@@ -98,6 +99,7 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
           }
         }
 
+      // check
       runRoute(route, "timeout").status should ===(StatusCodes.EnhanceYourCalm) // the timeout response
       //#
     }
@@ -118,6 +120,7 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
           }
         }
 
+      // check
       runRoute(route, "timeout").status should ===(StatusCodes.EnhanceYourCalm) // the timeout response
       //#
     }

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -29,7 +29,8 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
     windows-connection-abort-workaround-enabled = auto
     akka.log-dead-letters = OFF
     akka.http.server.request-timeout = 1000s""")
-  // large timeout - 1000s (please note - setting to infinite will disable withRequestTimeout at the moment)
+  // large timeout - 1000s (please note - setting to infinite will disable Timeout-Access header
+  // and withRequestTimeout will not work)
 
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -29,7 +29,7 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
     windows-connection-abort-workaround-enabled = auto
     akka.log-dead-letters = OFF
     akka.http.server.request-timeout = 1000s""")
-  // large timeout - 1000s
+  // large timeout - 1000s (please note - setting to infinite will disable withRequestTimeout at the moment)
 
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
@@ -88,7 +88,7 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
       //#withRequestTimeout-with-handler
       val timeoutResponse = HttpResponse(
         StatusCodes.EnhanceYourCalm,
-        entity = "Unable to serve response within time limit, please enchance your calm.")
+        entity = "Unable to serve response within time limit, please enhance your calm.")
 
       val route =
         path("timeout") {
@@ -108,7 +108,7 @@ class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAn
       //#withRequestTimeoutResponse
       val timeoutResponse = HttpResponse(
         StatusCodes.EnhanceYourCalm,
-        entity = "Unable to serve response within time limit, please enchance your calm.")
+        entity = "Unable to serve response within time limit, please enhance your calm.")
 
       val route =
         path("timeout") {

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -4,25 +4,69 @@
 
 package docs.http.scaladsl.server.directives
 
-import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
-import akka.http.scaladsl.server.RoutingSpec
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Route
 import docs.CompileOnlySpec
-
+import akka.actor.ActorSystem
+import akka.http.scaladsl.{Http, TestUtils}
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+import akka.http.scaladsl.model.HttpEntity._
+import akka.http.scaladsl.model._
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
+import akka.testkit.TestKit
 
-class TimeoutDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
+class TimeoutDirectivesExamplesSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with CompileOnlySpec {
+  //#testSetup
+  val testConf: Config = ConfigFactory.parseString("""
+    akka.loggers = ["akka.testkit.TestEventListener"]
+    akka.loglevel = ERROR
+    akka.stdout-loglevel = ERROR
+    windows-connection-abort-workaround-enabled = auto
+    akka.log-dead-letters = OFF
+    akka.http.server.request-timeout = 1000s""")
+  // large timeout - 1000s
+
+  implicit val system = ActorSystem(getClass.getSimpleName, testConf)
+  import system.dispatcher
+  implicit val materializer = ActorMaterializer()
+  implicit val patience = PatienceConfig(3.seconds)
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  def slowFuture(): Future[String] = Promise[String].future
+
+  def runRoute(route: Route, routePath: String): HttpResponse = {
+    val (_, hostname, port) = TestUtils.temporaryServerHostnameAndPort()
+    val binding = Http().bindAndHandle(route, hostname, port)
+
+    val response = Http().singleRequest(HttpRequest(uri = s"http://$hostname:$port/$routePath")).futureValue
+
+    binding.flatMap(_.unbind()).futureValue
+
+    response
+  }
+
+  //#
 
   "Request Timeout" should {
-    "be configurable in routing layer" in compileOnlySpec {
+    "be configurable in routing layer" in {
       //#withRequestTimeout-plain
       val route =
         path("timeout") {
-          withRequestTimeout(3.seconds) {
+          withRequestTimeout(1.seconds) { // less than akka.http.server.request-timeout value of 1000s
             val response: Future[String] = slowFuture() // very slow
             complete(response)
           }
         }
+
+      runRoute(route, "timeout").status should ===(StatusCodes.ServiceUnavailable) // the timeout response
       //#
     }
     "without timeout" in compileOnlySpec {
@@ -34,10 +78,12 @@ class TimeoutDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
             complete(response)
           }
         }
+
+      // no check as there is no time-out, the future will time out failing the test
       //#
     }
 
-    "allow mapping the response while setting the timeout" in compileOnlySpec {
+    "allow mapping the response while setting the timeout" in {
       //#withRequestTimeout-with-handler
       val timeoutResponse = HttpResponse(
         StatusCodes.EnhanceYourCalm,
@@ -51,10 +97,12 @@ class TimeoutDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
             complete(response)
           }
         }
+
+      runRoute(route, "timeout").status should ===(StatusCodes.EnhanceYourCalm) // the timeout response
       //#
     }
 
-    "allow mapping the response" in compileOnlySpec {
+    "allow mapping the response" in {
       //#withRequestTimeoutResponse
       val timeoutResponse = HttpResponse(
         StatusCodes.EnhanceYourCalm,
@@ -62,17 +110,17 @@ class TimeoutDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
       val route =
         path("timeout") {
-          withRequestTimeout(1.milli) {
+          withRequestTimeout(100.milli) { // racy! for a very short timeout like 1.milli you can still get 503
             withRequestTimeoutResponse(request => timeoutResponse) {
               val response: Future[String] = slowFuture() // very slow
               complete(response)
             }
           }
         }
+
+      runRoute(route, "timeout").status should ===(StatusCodes.EnhanceYourCalm) // the timeout response
       //#
     }
   }
-
-  def slowFuture(): Future[String] = Promise[String].future
 
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/TimeoutDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/TimeoutDirectives.scala
@@ -43,4 +43,15 @@ abstract class TimeoutDirectives extends WebSocketDirectives {
     D.withoutRequestTimeout { inner.get.delegate }
   }
 
+  /**
+   * Tries to set a new request timeout handler, which produces the timeout response for a
+   * given request. Note that the handler must produce the response synchronously and shouldn't block!
+   *
+   * Due to the inherent raciness it is not guaranteed that the update will be applied before
+   * the previously set timeout has expired!
+   */
+  def withRequestTimeoutResponse(timeoutHandler: JFunction[HttpRequest, HttpResponse], inner: Supplier[Route]): RouteAdapter = RouteAdapter {
+    D.withRequestTimeoutResponse(in ⇒ timeoutHandler(in.asJava).asScala) { inner.get.delegate }
+  }
+
 }


### PR DESCRIPTION
- added checks to TimeoutDirectivesExampleSpec
- added TimeoutDirectivesExamplesTest
- modified comments in Java Timeout Directives docs to include snippets
- added missing Java directive wrapper
- added working Timeout example in JavaTestServer
