### PR TITLE
akka http javadsl - add path directive tests

### DIFF
--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.directives;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.headers.Host;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.server.RequestContext;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import java.util.function.Function;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import akka.http.javadsl.model.Uri;
+import akka.http.javadsl.model.headers.Location;
+import akka.http.javadsl.server.directives.DebuggingDirectives;
+import akka.http.javadsl.server.directives.RouteDirectives;
+import akka.event.Logging;
+import akka.event.Logging.LogLevel;
+import akka.http.javadsl.server.directives.LogEntry;
+import java.util.List;
+import akka.http.scaladsl.server.Rejection;
+
+import static akka.event.Logging.InfoLevel;
+import java.util.stream.Collectors;
+import java.util.Optional;
+
+public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
+
+  @Test
+  public void testLogRequest() {
+    //#logRequest
+    // logs request with "get-user"
+    final Route routeBasicLogRequest = get(() -> 
+                            logRequest("get-user", ()-> 
+                                       complete("logged")));
+    
+    // logs request with "get-user" as Info
+    final Route routeBasicLogRequestAsInfo = get(() -> 
+                            logRequest("get-user", InfoLevel(), ()-> 
+                                       complete("logged")));
+
+    // logs just the request method at info level
+    Function<HttpRequest, LogEntry> requestMethodAsInfo = (request)->
+      LogEntry.create(request.method().toString(), InfoLevel());
+    final Route routeUsingFunction = get(() -> 
+                            logRequest(requestMethodAsInfo, ()-> 
+                                       complete("logged")));
+
+    // tests:
+    testRoute(routeBasicLogRequest).run(HttpRequest.GET("/")).assertEntity("logged");
+    //#logRequest
+  }
+
+  @Test
+  public void testLogRequestResult() {
+    //#logRequestResult
+    // using logRequestResult
+
+    // handle request to optionally generate a log entry
+    BiFunction<HttpRequest, HttpResponse, Optional<LogEntry>> requestMethodAsInfo = 
+      (request, response)->
+        (response.status().isSuccess())  ? 
+            Optional.of(
+              LogEntry
+                .create(request.method().toString() + ":" + response.status().intValue(), 
+                        InfoLevel())
+            )
+          : Optional.empty(); // not a successful response
+
+    // handle rejections to optionally generate a log entry
+    BiFunction<HttpRequest, List<Rejection>, Optional<LogEntry>> rejectionsAsInfo = 
+      (request, rejections)->
+        (!rejections.isEmpty())  ? 
+          Optional.of(
+            LogEntry.create(rejections
+                          .stream()
+                          .map(Rejection::toString)
+                          .collect(Collectors.joining(", ")), 
+                        InfoLevel())
+            )
+          : Optional.empty(); // no rejections
+
+    final Route route = get(() -> 
+                            logRequestResultOptional(
+                                             requestMethodAsInfo, 
+                                             rejectionsAsInfo,
+                                             ()-> complete("logged")));
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/")).assertEntity("logged");
+    //#logRequestResult
+  }
+
+  @Test
+  public void testLogResult() {
+    //#logResult
+    // logs result with "get-user"
+    final Route routeBasicLogResult = get(() -> 
+                            logResult("get-user", ()-> 
+                                       complete("logged")));
+
+    // logs result with "get-user" as Info
+    final Route routeBasicLogResultAsInfo = get(() -> 
+                            logResult("get-user", InfoLevel(), ()-> 
+                                       complete("logged")));
+
+    // logs the result and the rejections as LogEntry
+    Function<HttpResponse, LogEntry> showSuccessAsInfo = (response)->
+      LogEntry.create(String.format("Response code '%d'", response.status().intValue()), 
+                      InfoLevel());
+
+    Function<List<Rejection>, LogEntry> showRejectionAsInfo = (rejections)->
+      LogEntry.create(rejections
+                        .stream()
+                        .map(rejection->rejection.toString())
+                        .collect(Collectors.joining(", ")), 
+                      InfoLevel());
+
+    final Route routeUsingFunction = get(() -> 
+                            logResult(showSuccessAsInfo, 
+                                      showRejectionAsInfo, ()-> 
+                                       complete("logged")));
+    // tests:
+    testRoute(routeBasicLogResult).run(HttpRequest.GET("/")).assertEntity("logged");
+    //#logResult
+  }
+
+}

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
@@ -40,23 +40,22 @@ public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
     //#logRequest
     // logs request with "get-user"
     final Route routeBasicLogRequest = get(() -> 
-                            logRequest("get-user", ()-> 
-                                       complete("logged")));
+      logRequest("get-user", () -> complete("logged")));
     
     // logs request with "get-user" as Info
     final Route routeBasicLogRequestAsInfo = get(() -> 
-                            logRequest("get-user", InfoLevel(), ()-> 
-                                       complete("logged")));
+      logRequest("get-user", InfoLevel(), () -> complete("logged")));
 
     // logs just the request method at info level
-    Function<HttpRequest, LogEntry> requestMethodAsInfo = (request)->
+    Function<HttpRequest, LogEntry> requestMethodAsInfo = (request) -> 
       LogEntry.create(request.method().toString(), InfoLevel());
+
     final Route routeUsingFunction = get(() -> 
-                            logRequest(requestMethodAsInfo, ()-> 
-                                       complete("logged")));
+      logRequest(requestMethodAsInfo, () -> complete("logged")));
 
     // tests:
-    testRoute(routeBasicLogRequest).run(HttpRequest.GET("/")).assertEntity("logged");
+    testRoute(routeBasicLogRequest).run(HttpRequest.GET("/"))
+      .assertEntity("logged");
     //#logRequest
   }
 
@@ -67,33 +66,31 @@ public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
 
     // handle request to optionally generate a log entry
     BiFunction<HttpRequest, HttpResponse, Optional<LogEntry>> requestMethodAsInfo = 
-      (request, response)->
+      (request, response) ->
         (response.status().isSuccess())  ? 
             Optional.of(
-              LogEntry
-                .create(request.method().toString() + ":" + response.status().intValue(), 
-                        InfoLevel())
-            )
+              LogEntry.create(
+                request.method().toString() + ":" + response.status().intValue(), 
+                InfoLevel()))
           : Optional.empty(); // not a successful response
 
     // handle rejections to optionally generate a log entry
     BiFunction<HttpRequest, List<Rejection>, Optional<LogEntry>> rejectionsAsInfo = 
-      (request, rejections)->
+      (request, rejections) ->
         (!rejections.isEmpty())  ? 
           Optional.of(
-            LogEntry.create(rejections
-                          .stream()
-                          .map(Rejection::toString)
-                          .collect(Collectors.joining(", ")), 
-                        InfoLevel())
-            )
+            LogEntry.create(
+                rejections
+                .stream()
+                .map(Rejection::toString)
+                .collect(Collectors.joining(", ")), 
+              InfoLevel()))
           : Optional.empty(); // no rejections
 
-    final Route route = get(() -> 
-                            logRequestResultOptional(
-                                             requestMethodAsInfo, 
-                                             rejectionsAsInfo,
-                                             ()-> complete("logged")));
+    final Route route = get(() -> logRequestResultOptional(
+      requestMethodAsInfo, 
+      rejectionsAsInfo,
+      () -> complete("logged")));
     // tests:
     testRoute(route).run(HttpRequest.GET("/")).assertEntity("logged");
     //#logRequestResult
@@ -103,33 +100,31 @@ public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
   public void testLogResult() {
     //#logResult
     // logs result with "get-user"
-    final Route routeBasicLogResult = get(() -> 
-                            logResult("get-user", ()-> 
-                                       complete("logged")));
+    final Route routeBasicLogResult = get(() ->
+      logResult("get-user", () -> complete("logged")));
 
     // logs result with "get-user" as Info
-    final Route routeBasicLogResultAsInfo = get(() -> 
-                            logResult("get-user", InfoLevel(), ()-> 
-                                       complete("logged")));
+    final Route routeBasicLogResultAsInfo = get(() ->
+      logResult("get-user", InfoLevel(), () -> complete("logged")));
 
     // logs the result and the rejections as LogEntry
-    Function<HttpResponse, LogEntry> showSuccessAsInfo = (response)->
+    Function<HttpResponse, LogEntry> showSuccessAsInfo = (response) ->
       LogEntry.create(String.format("Response code '%d'", response.status().intValue()), 
-                      InfoLevel());
+        InfoLevel());
 
-    Function<List<Rejection>, LogEntry> showRejectionAsInfo = (rejections)->
-      LogEntry.create(rejections
-                        .stream()
-                        .map(rejection->rejection.toString())
-                        .collect(Collectors.joining(", ")), 
-                      InfoLevel());
+    Function<List<Rejection>, LogEntry> showRejectionAsInfo = (rejections) ->
+      LogEntry.create(
+        rejections
+        .stream()
+        .map(rejection->rejection.toString())
+        .collect(Collectors.joining(", ")), 
+      InfoLevel());
 
-    final Route routeUsingFunction = get(() -> 
-                            logResult(showSuccessAsInfo, 
-                                      showRejectionAsInfo, ()-> 
-                                       complete("logged")));
+    final Route routeUsingFunction = get(() ->
+      logResult(showSuccessAsInfo, showRejectionAsInfo, () -> complete("logged")));
     // tests:
-    testRoute(routeBasicLogResult).run(HttpRequest.GET("/")).assertEntity("logged");
+    testRoute(routeBasicLogResult).run(HttpRequest.GET("/"))
+      .assertEntity("logged");
     //#logResult
   }
 

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
@@ -16,18 +16,40 @@ import akka.http.javadsl.testkit.JUnitRouteTest;
 import static akka.http.javadsl.server.PathMatchers.segment;
 import static akka.http.javadsl.server.PathMatchers.segments;
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
+import static akka.http.javadsl.server.PathMatchers.neutral;
+import static akka.http.javadsl.server.PathMatchers.slash;
 import java.util.function.Supplier;
 import akka.http.javadsl.server.directives.RouteAdapter;
+import static java.util.regex.Pattern.compile;
 
 public class PathDirectivesExamplesTest extends JUnitRouteTest {
 
-    //http://doc.akka.io/docs/akka/2.4.5/java/http/server-side-https-support.html
-    //http://doc.akka.io/docs/akka/2.4.6/java/http/routing-dsl/directives/path-directives.html#path-directives-java
-    //https://github.com/akka/akka/blob/acb71ac4e53d536fcba0ffe0fb0a48c09a63b108/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
-
-  //# pathPrefixTest-, rawPathPrefix-, rawPathPrefixTest-, pathSuffix-, pathSuffixTest-
+  //# path-prefix-test, path-suffix, raw-path-prefix, raw-path-prefix-test
   Supplier<RouteAdapter> completeWithUnmatchedPath = ()->
     extractUnmatchedPath((path) -> complete(path.toString()));
+  //#
+
+  @Test
+  public void testPathExamples() {
+    //# path-dsl
+    // matches /foo/
+    path(segment("foo").slash(), () -> complete(StatusCodes.OK));
+
+    // matches e.g. /foo/123 and extracts "123" as a String
+    path(segment("foo").slash(segment(compile("\\d+"))), (value) -> 
+        complete(StatusCodes.OK));
+
+    // matches e.g. /foo/bar123 and extracts "123" as a String
+    path(segment("foo").slash(segment(compile("bar(\\d+)"))), (value) -> 
+        complete(StatusCodes.OK));
+    
+    // similar to `path(Segments)`
+    path(neutral().repeat(0, 10), () -> complete(StatusCodes.OK));
+
+    // identical to path("foo" ~ (PathEnd | Slash))
+    path(segment("foo").orElse(slash()), () -> complete(StatusCodes.OK));
+    //# path-dsl
+  }
 
   @Test
   public void testBasicExamples() {
@@ -40,14 +62,16 @@ public class PathDirectivesExamplesTest extends JUnitRouteTest {
 
   @Test
   public void testPathExample() {
+    //# pathPrefix
     final Route route = 
         route(
             path("foo", () -> complete("/foo")),
             path(segment("foo").slash("bar"), () -> complete("/foo/bar")),
-            pathPrefix("ball", ()-> 
+            pathPrefix("ball", () -> 
                 route(
-                    pathEnd(()-> complete("/ball")),
-                    path(integerSegment(), (i)-> complete((i % 2 == 0) ? "even ball" : "odd ball"))
+                    pathEnd(() -> complete("/ball")),
+                    path(integerSegment(), (i) -> 
+                        complete((i % 2 == 0) ? "even ball" : "odd ball"))
                 )
             )
         );
@@ -57,15 +81,17 @@ public class PathDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("/foo");
     testRoute(route).run(HttpRequest.GET("/foo/bar")).assertEntity("/foo/bar");
     testRoute(route).run(HttpRequest.GET("/ball/1337")).assertEntity("odd ball");
+    //# pathPrefix
   }
 
   @Test
   public void testPathEnd() {
+    //# path-end
     final Route route = 
         route(
-            pathPrefix("foo", ()-> 
+            pathPrefix("foo", () -> 
                 route(
-                    pathEnd(()-> complete("/foo")),
+                    pathEnd(() -> complete("/foo")),
                     path("bar", () -> complete("/foo/bar"))
                 )
             )
@@ -75,15 +101,17 @@ public class PathDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("/foo");
     testRoute(route).run(HttpRequest.GET("/foo/")).assertStatusCode(StatusCodes.NOT_FOUND);
     testRoute(route).run(HttpRequest.GET("/foo/bar")).assertEntity("/foo/bar");
+    //# path-end
   }
 
   @Test
   public void testPathEndOrSingleSlash() {
+    //# path-end-or-single-slash
     final Route route = 
         route(
-            pathPrefix("foo", ()-> 
+            pathPrefix("foo", () -> 
                 route(
-                    pathEndOrSingleSlash(()-> complete("/foo")),
+                    pathEndOrSingleSlash(() -> complete("/foo")),
                     path("bar", () -> complete("/foo/bar"))
                 )
             )
@@ -92,16 +120,19 @@ public class PathDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("/foo");
     testRoute(route).run(HttpRequest.GET("/foo/")).assertEntity("/foo");
     testRoute(route).run(HttpRequest.GET("/foo/bar")).assertEntity("/foo/bar");
+    //# path-end-or-single-slash
   }
 
   @Test
   public void testPathPrefix() {
+    //# path-prefix
     final Route route = 
         route(
-            pathPrefix("ball", ()-> 
+            pathPrefix("ball", () -> 
                 route(
-                    pathEnd(()-> complete("/ball")),
-                    path(integerSegment(), (i)-> complete((i % 2 == 0) ? "even ball" : "odd ball"))
+                    pathEnd(() -> complete("/ball")),
+                    path(integerSegment(), (i) -> 
+                        complete((i % 2 == 0) ? "even ball" : "odd ball"))
                 )
             )
         );
@@ -109,30 +140,37 @@ public class PathDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(HttpRequest.GET("/")).assertStatusCode(StatusCodes.NOT_FOUND);
     testRoute(route).run(HttpRequest.GET("/ball")).assertEntity("/ball");
     testRoute(route).run(HttpRequest.GET("/ball/1337")).assertEntity("odd ball");
+    //# path-prefix
   }
 
   @Test
   public void testPathPrefixTest() {
-    // TODO: confirm this implementation with the akka guys!
+    //# path-prefix-test
     final Route route = 
         route(
-            pathPrefixTest("foo", ()-> pathPrefix("foo", ()-> completeWithUnmatchedPath.get())),
-            pathPrefixTest("bar", ()-> pathPrefix("bar", ()-> completeWithUnmatchedPath.get()))
+            pathPrefixTest(segment("foo").orElse("bar"), () ->
+                route(
+                      pathPrefix("foo", () -> completeWithUnmatchedPath.get()),
+                      pathPrefix("bar", () -> completeWithUnmatchedPath.get())
+                )
+            )
         );
     // tests:
     testRoute(route).run(HttpRequest.GET("/foo/doo")).assertEntity("/doo");
     testRoute(route).run(HttpRequest.GET("/bar/yes")).assertEntity("/yes");
+    //# path-prefix-test
   }
 
   @Test
   public void testPathSingleSlash() {
+    //# path-single-slash
     final Route route = 
         route(
-            pathSingleSlash(()-> complete("root")),
-            pathPrefix("ball", ()-> 
+            pathSingleSlash(() -> complete("root")),
+            pathPrefix("ball", () -> 
                 route(
-                    pathSingleSlash(()-> complete("/ball/")),
-                    path(integerSegment(), (i)-> complete((i % 2 == 0) ? "even ball" : "odd ball"))
+                    pathSingleSlash(() -> complete("/ball/")),
+                    path(integerSegment(), (i) -> complete((i % 2 == 0) ? "even ball" : "odd ball"))
                 )
             )
         );
@@ -141,22 +179,144 @@ public class PathDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(HttpRequest.GET("/ball")).assertStatusCode(StatusCodes.NOT_FOUND);
     testRoute(route).run(HttpRequest.GET("/ball/")).assertEntity("/ball/");
     testRoute(route).run(HttpRequest.GET("/ball/1337")).assertEntity("odd ball");
+    //# path-single-slash
   }
 
   @Test
   public void testPathSuffix() {
+    //# path-suffix
     final Route route = 
         route(
-            pathPrefix("start", ()-> 
+            pathPrefix("start", () -> 
                 route(
-                    pathSuffix("end", ()-> completeWithUnmatchedPath.get()),
-                    pathSuffix(segment("foo").slash("bar"), ()-> completeWithUnmatchedPath.get()),
-                    pathSuffix(segment("foo").slash("baz"), ()-> completeWithUnmatchedPath.get())
+                    pathSuffix("end", () -> completeWithUnmatchedPath.get()),
+                    pathSuffix(segment("foo").slash("bar").concat("baz"), () -> 
+                        completeWithUnmatchedPath.get())
                 )
             )
         );
     // tests:
-    
+    testRoute(route).run(HttpRequest.GET("/start/middle/end")).assertEntity("/middle/");
+    testRoute(route).run(HttpRequest.GET("/start/something/barbaz/foo")).assertEntity("/something/");
+    //# path-suffix
+  }
+
+  @Test
+  public void testPathSuffixTest() {
+    //# path-suffix-test
+    final Route route = 
+        route(
+            pathSuffixTest(slash(), () -> complete("slashed")),
+            complete("unslashed")
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foo/")).assertEntity("slashed");
+    testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("unslashed");
+    //# path-suffix-test
+  }
+
+  @Test
+  public void testRawPathPrefix() {
+    //# raw-path-prefix
+    final Route route = 
+        route(
+            pathPrefix("foo", () ->
+                route(
+                      rawPathPrefix("bar", () -> completeWithUnmatchedPath.get()),
+                      rawPathPrefix("doo", () -> completeWithUnmatchedPath.get())
+                )
+            )
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foobar/baz")).assertEntity("/baz");
+    testRoute(route).run(HttpRequest.GET("/foodoo/baz")).assertEntity("/baz");
+    //# raw-path-prefix
+  }
+
+  @Test
+  public void testRawPathPrefixTest() {
+    //# raw-path-prefix-test
+    final Route route = 
+        route(
+            pathPrefix("foo", () ->
+                rawPathPrefixTest("bar", () -> completeWithUnmatchedPath.get())
+            )
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foobar")).assertEntity("bar");
+    testRoute(route).run(HttpRequest.GET("/foobaz")).assertStatusCode(StatusCodes.NOT_FOUND);
+    //# raw-path-prefix-test
+  }
+
+  @Test
+  public void testRedirectToNoTrailingSlashIfMissing() {
+    //# redirect-notrailing-slash-missing
+    final Route route = 
+        redirectToTrailingSlashIfMissing(
+            StatusCodes.MOVED_PERMANENTLY, () ->
+            route(
+                path(segment("foo").slash(), () -> complete("OK")),
+                path(segment("bad-1"), () -> 
+                    // MISTAKE!
+                    // Missing `/` in path, causes this path to never match,
+                    // because it is inside a `redirectToTrailingSlashIfMissing`
+                    complete(StatusCodes.NOT_IMPLEMENTED)
+                ),
+                path(segment("bad-2").slash(), () -> 
+                    // MISTAKE!
+                    // / should be explicit as path element separator and not *in* the path element
+                    // So it should be: "bad-1" /
+                    complete(StatusCodes.NOT_IMPLEMENTED)
+                )
+            )
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foo"))
+        .assertStatusCode(StatusCodes.MOVED_PERMANENTLY)
+        .assertEntity("This and all future requests should be directed to " +
+          "<a href=\"http://example.com/foo/\">this URI</a>.");
+
+    testRoute(route).run(HttpRequest.GET("/foo/"))
+        .assertStatusCode(StatusCodes.OK)
+        .assertEntity("OK");
+
+    testRoute(route).run(HttpRequest.GET("/bad-1/"))
+        .assertStatusCode(StatusCodes.NOT_FOUND);
+    //# redirect-notrailing-slash-missing
+  }
+
+  @Test
+  public void testRedirectToNoTrailingSlashIfPresent() {
+    //# redirect-notrailing-slash-present
+    final Route route = 
+        redirectToNoTrailingSlashIfPresent(
+            StatusCodes.MOVED_PERMANENTLY, () ->
+            route(
+                path("foo", () -> complete("OK")),
+                path(segment("bad").slash(), () -> 
+                    // MISTAKE!
+                    // Since inside a `redirectToNoTrailingSlashIfPresent` directive
+                    // the matched path here will never contain a trailing slash,
+                    // thus this path will never match.
+                    //
+                    // It should be `path("bad")` instead.
+                     complete(StatusCodes.NOT_IMPLEMENTED)
+                )
+            )
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foo/"))
+        .assertStatusCode(StatusCodes.MOVED_PERMANENTLY)
+        .assertEntity("This and all future requests should be directed to " +
+          "<a href=\"http://example.com/foo\">this URI</a>.");
+
+    testRoute(route).run(HttpRequest.GET("/foo"))
+        .assertStatusCode(StatusCodes.OK)
+        .assertEntity("OK");
+
+    testRoute(route).run(HttpRequest.GET("/bad"))
+        .assertStatusCode(StatusCodes.NOT_FOUND);
+    //# redirect-notrailing-slash-present
   }
 
 }

--- a/akka-docs/rst/java/code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
+++ b/akka-docs/rst/java/code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.directives;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import static akka.http.javadsl.server.PathMatchers.segment;
+import static akka.http.javadsl.server.PathMatchers.segments;
+import static akka.http.javadsl.server.PathMatchers.integerSegment;
+import java.util.function.Supplier;
+import akka.http.javadsl.server.directives.RouteAdapter;
+
+public class PathDirectivesExamplesTest extends JUnitRouteTest {
+
+    //http://doc.akka.io/docs/akka/2.4.5/java/http/server-side-https-support.html
+    //http://doc.akka.io/docs/akka/2.4.6/java/http/routing-dsl/directives/path-directives.html#path-directives-java
+    //https://github.com/akka/akka/blob/acb71ac4e53d536fcba0ffe0fb0a48c09a63b108/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
+
+  //# pathPrefixTest-, rawPathPrefix-, rawPathPrefixTest-, pathSuffix-, pathSuffixTest-
+  Supplier<RouteAdapter> completeWithUnmatchedPath = ()->
+    extractUnmatchedPath((path) -> complete(path.toString()));
+
+  @Test
+  public void testBasicExamples() {
+    path("test", () -> complete(StatusCodes.OK));
+     
+    // matches "/test", as well
+    path(segment("test"), () -> complete(StatusCodes.OK));
+
+  }
+
+  @Test
+  public void testPathExample() {
+    final Route route = 
+        route(
+            path("foo", () -> complete("/foo")),
+            path(segment("foo").slash("bar"), () -> complete("/foo/bar")),
+            pathPrefix("ball", ()-> 
+                route(
+                    pathEnd(()-> complete("/ball")),
+                    path(integerSegment(), (i)-> complete((i % 2 == 0) ? "even ball" : "odd ball"))
+                )
+            )
+        );
+
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/")).assertStatusCode(StatusCodes.NOT_FOUND);
+    testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("/foo");
+    testRoute(route).run(HttpRequest.GET("/foo/bar")).assertEntity("/foo/bar");
+    testRoute(route).run(HttpRequest.GET("/ball/1337")).assertEntity("odd ball");
+  }
+
+  @Test
+  public void testPathEnd() {
+    final Route route = 
+        route(
+            pathPrefix("foo", ()-> 
+                route(
+                    pathEnd(()-> complete("/foo")),
+                    path("bar", () -> complete("/foo/bar"))
+                )
+            )
+        );
+
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("/foo");
+    testRoute(route).run(HttpRequest.GET("/foo/")).assertStatusCode(StatusCodes.NOT_FOUND);
+    testRoute(route).run(HttpRequest.GET("/foo/bar")).assertEntity("/foo/bar");
+  }
+
+  @Test
+  public void testPathEndOrSingleSlash() {
+    final Route route = 
+        route(
+            pathPrefix("foo", ()-> 
+                route(
+                    pathEndOrSingleSlash(()-> complete("/foo")),
+                    path("bar", () -> complete("/foo/bar"))
+                )
+            )
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("/foo");
+    testRoute(route).run(HttpRequest.GET("/foo/")).assertEntity("/foo");
+    testRoute(route).run(HttpRequest.GET("/foo/bar")).assertEntity("/foo/bar");
+  }
+
+  @Test
+  public void testPathPrefix() {
+    final Route route = 
+        route(
+            pathPrefix("ball", ()-> 
+                route(
+                    pathEnd(()-> complete("/ball")),
+                    path(integerSegment(), (i)-> complete((i % 2 == 0) ? "even ball" : "odd ball"))
+                )
+            )
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/")).assertStatusCode(StatusCodes.NOT_FOUND);
+    testRoute(route).run(HttpRequest.GET("/ball")).assertEntity("/ball");
+    testRoute(route).run(HttpRequest.GET("/ball/1337")).assertEntity("odd ball");
+  }
+
+  @Test
+  public void testPathPrefixTest() {
+    // TODO: confirm this implementation with the akka guys!
+    final Route route = 
+        route(
+            pathPrefixTest("foo", ()-> pathPrefix("foo", ()-> completeWithUnmatchedPath.get())),
+            pathPrefixTest("bar", ()-> pathPrefix("bar", ()-> completeWithUnmatchedPath.get()))
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/foo/doo")).assertEntity("/doo");
+    testRoute(route).run(HttpRequest.GET("/bar/yes")).assertEntity("/yes");
+  }
+
+  @Test
+  public void testPathSingleSlash() {
+    final Route route = 
+        route(
+            pathSingleSlash(()-> complete("root")),
+            pathPrefix("ball", ()-> 
+                route(
+                    pathSingleSlash(()-> complete("/ball/")),
+                    path(integerSegment(), (i)-> complete((i % 2 == 0) ? "even ball" : "odd ball"))
+                )
+            )
+        );
+    // tests:
+    testRoute(route).run(HttpRequest.GET("/")).assertEntity("root");
+    testRoute(route).run(HttpRequest.GET("/ball")).assertStatusCode(StatusCodes.NOT_FOUND);
+    testRoute(route).run(HttpRequest.GET("/ball/")).assertEntity("/ball/");
+    testRoute(route).run(HttpRequest.GET("/ball/1337")).assertEntity("odd ball");
+  }
+
+  @Test
+  public void testPathSuffix() {
+    final Route route = 
+        route(
+            pathPrefix("start", ()-> 
+                route(
+                    pathSuffix("end", ()-> completeWithUnmatchedPath.get()),
+                    pathSuffix(segment("foo").slash("bar"), ()-> completeWithUnmatchedPath.get()),
+                    pathSuffix(segment("foo").slash("baz"), ()-> completeWithUnmatchedPath.get())
+                )
+            )
+        );
+    // tests:
+    
+  }
+
+}

--- a/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequest.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequest.rst
@@ -16,4 +16,4 @@ Use ``logResult`` for logging the response, or ``logRequestResult`` for logging 
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java#logRequest

--- a/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequestResult.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logRequestResult.rst
@@ -13,4 +13,4 @@ See :ref:`-logRequest-java-` for the general description how these directives wo
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java#logRequestResult

--- a/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logResult.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/debugging-directives/logResult.rst
@@ -13,4 +13,4 @@ Use ``logRequest`` for logging the request, or ``logRequestResult`` for logging 
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java#logResult

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/path.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/path.rst
@@ -27,4 +27,4 @@ If the match fails the request is rejected with an :ref:`empty rejection set <em
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-dsl

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathEnd.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathEnd.rst
@@ -15,4 +15,4 @@ inner-level to discriminate "path already fully matched" from other alternatives
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-end

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathEndOrSingleSlash.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathEndOrSingleSlash.rst
@@ -16,4 +16,4 @@ It is equivalent to ``pathEnd | pathSingleSlash`` but slightly more efficient.
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-end-or-single-slash

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathPrefix.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathPrefix.rst
@@ -21,4 +21,4 @@ the URI. If the match fails the request is rejected with an :ref:`empty rejectio
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-prefix

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathPrefixTest.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathPrefixTest.rst
@@ -24,4 +24,4 @@ the URI. If the match fails the request is rejected with an :ref:`empty rejectio
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-prefix-test

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathSingleSlash.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathSingleSlash.rst
@@ -14,4 +14,4 @@ This directive is a simple alias for ``pathPrefix(PathEnd)`` and is mostly used 
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-single-slash

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathSuffix.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathSuffix.rst
@@ -24,4 +24,4 @@ the URI. If the match fails the request is rejected with an :ref:`empty rejectio
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-suffix

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathSuffixTest.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/pathSuffixTest.rst
@@ -25,4 +25,4 @@ the URI. If the match fails the request is rejected with an :ref:`empty rejectio
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#path-suffix-test

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/rawPathPrefix.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/rawPathPrefix.rst
@@ -21,4 +21,4 @@ the URI. If the match fails the request is rejected with an :ref:`empty rejectio
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#raw-path-prefix-test

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/rawPathPrefixTest.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/rawPathPrefixTest.rst
@@ -24,4 +24,4 @@ from the URI. If the match fails the request is rejected with an :ref:`empty rej
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#raw-path-prefix-test

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/redirectToNoTrailingSlashIfPresent.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/redirectToNoTrailingSlashIfPresent.rst
@@ -6,7 +6,7 @@ redirectToNoTrailingSlashIfPresent
 Description
 -----------
 If the requested path does end with a trailing ``/`` character,
-redirects to the same path without that trailing slash.. 
+redirects to the same path without that trailing slash..
 
 Redirects the HTTP Client to the same resource yet without the trailing ``/``, in case the request contained it.
 When redirecting an HttpResponse with the given redirect response code (i.e. ``MovedPermanently`` or ``TemporaryRedirect``
@@ -24,6 +24,6 @@ See also :ref:`-redirectToTrailingSlashIfMissing-java-` for the opposite behavio
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#redirect-notrailing-slash-present
 
 See also :ref:`-redirectToTrailingSlashIfMissing-java-` which achieves the opposite - redirecting paths in case they do *not* have a trailing slash.

--- a/akka-docs/rst/java/http/routing-dsl/directives/path-directives/redirectToTrailingSlashIfMissing.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/path-directives/redirectToTrailingSlashIfMissing.rst
@@ -20,6 +20,6 @@ See also :ref:`-redirectToNoTrailingSlashIfPresent-java-` for the opposite behav
 
 Example
 -------
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: `write example snippets for Akka HTTP Java DSL #20466 <https://github.com/akka/akka/issues/20466>`_.
+.. includecode:: ../../../../code/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java#redirect-notrailing-slash-missing
 
 See also :ref:`-redirectToNoTrailingSlashIfPresent-java-` which achieves the opposite - redirecting paths in case they do have a trailing slash.


### PR DESCRIPTION
Adds several **path directive examples** to the Java DSL, following the instructions given in [issue 20466](https://github.com/akka/akka/issues/20466)

It covers:
- path-directives/path.rst
- path-directives/pathEnd.rst
- path-directives/pathEndOrSingleSlash.rst
- path-directives/pathPrefix.rst
- path-directives/pathPrefixTest.rst
- path-directives/pathSingleSlash.rst
- path-directives/pathSuffix.rst
- path-directives/pathSuffixTest.rst
- path-directives/rawPathPrefix.rst
- path-directives/rawPathPrefixTest.rst
- path-directives/redirectToNoTrailingSlashIfPresent.rst
- path-directives/redirectToTrailingSlashIfMissing.rst
