### PR TITLE
=htc #20570 handle regular remote conection closing

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
@@ -44,12 +44,12 @@ private object PoolConductor {
   /*
     Stream Setup
     ============
-                                                                                                  Request-
-    Request-   +-----------+     +-----------+    Switch-    +-------------+     +-----------+    Context
-    Context    |   retry   |     |   slot-   |    Command    |   doubler   |     |   route   +-------------->
-    +--------->|   Merge   +---->| Selector  +-------------->| (MapConcat) +---->|  (Flexi   +-------------->
-               |           |     |           |               |             |     |   Route)  +-------------->
-               +----+------+     +-----+-----+               +-------------+     +-----------+       to slots
+                                                                              Request-
+    Request-   +-----------+     +-----------+    Switch-    +-----------+    Context
+    Context    |   retry   |     |   slot-   |    Command    |   route   +-------------->
+    +--------->|   Merge   +---->| Selector  +-------------->|  (Flexi   +-------------->
+               |           |     |           |               |   Route)  +-------------->
+               +----+------+     +-----+-----+               +-----------+       to slots
                     ^                  ^
                     |                  | SlotEvent
                     |             +----+----+

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -60,8 +60,8 @@ class EntityDiscardingSpec extends AkkaSpec {
       val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
       val bound = Http().bindAndHandleSync(
         req ⇒
-        HttpResponse(entity = HttpEntity(
-          ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() ⇒ testData.iterator))),
+          HttpResponse(entity = HttpEntity(
+            ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() ⇒ testData.iterator))),
         host, port).futureValue
 
       try {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
@@ -4,13 +4,13 @@
 
 package akka.http.scaladsl.model
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import org.scalatest.{BeforeAndAfterAll, Inside, Matchers, WordSpec}
+import org.scalatest.{ BeforeAndAfterAll, Inside, Matchers, WordSpec }
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import headers._
@@ -43,7 +43,7 @@ class MultipartSpec extends WordSpec with Matchers with Inside with BeforeAndAft
       val result = streamed.toEntity(boundary = "boundary")
       result.contentType shouldBe MediaTypes.`multipart/mixed`.withBoundary("boundary").withCharset(HttpCharsets.`UTF-8`)
       val encoding = Await.result(result.dataBytes.runWith(Sink.seq), 1.second)
-      encoding .map(_.utf8String).mkString shouldBe "--boundary\r\nContent-Type: text/plain; charset=UTF-8\r\nETag: \"xzy\"\r\n\r\ndata\r\n--boundary--"
+      encoding.map(_.utf8String).mkString shouldBe "--boundary\r\nContent-Type: text/plain; charset=UTF-8\r\nETag: \"xzy\"\r\n\r\ndata\r\n--boundary--"
     }
   }
 

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -636,9 +636,9 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
         writeInProgress = false
         () // it will be stopped by the first WriteMessageFailure message
 
-      case _: RecoveryTick =>
-        // we may have one of these in the mailbox before the scheduled timeout
-        // is cancelled when recovery has completed, just consume it so the concrete actor never sees it
+      case _: RecoveryTick ⇒
+      // we may have one of these in the mailbox before the scheduled timeout
+      // is cancelled when recovery has completed, just consume it so the concrete actor never sees it
     }
 
     def onWriteMessageComplete(err: Boolean): Unit

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -888,6 +888,8 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.rendering.BodyPartRenderer.streamed")
       ),
       "2.4.8" -> Seq(
+        FilterAnyProblemStartingWith("akka.http.impl"),
+
         // #20717 example snippet for akka http java dsl: SecurityDirectives
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage#MessageTransformations.addCredentials"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.addCredentials")


### PR DESCRIPTION
This stops sending requests after `Connection: close` responses are received and instead stashes and retries them (without spending any of their retry budget).
Especially non-idempotent requests benefit from this as they will not be retried on connection failures which were triggered before this change.
