### PR TITLE
Add expectNext(d: FiniteDuration) and requestNext(d: FiniteDuration)

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -605,6 +605,9 @@ object TestSubscriber {
       this
     }
 
+    /**
+      * Request and expect a stream element.
+      */
     def requestNext(element: T): Self = {
       subscription.request(1)
       expectNext(element)
@@ -616,11 +619,17 @@ object TestSubscriber {
       this
     }
 
+    /**
+      * Request and expect a stream element.
+      */
     def requestNext(): T = {
       subscription.request(1)
       expectNext()
     }
 
+    /**
+      * Request and expect a stream element during the specified time or timeout.
+      */
     def requestNext(d: FiniteDuration): T = {
       subscription.request(1)
       expectNext(d)

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -252,7 +252,14 @@ object TestSubscriber {
      * Expect and return a stream element.
      */
     def expectNext(): I = {
-      val t = probe.remainingOr(probe.testKitSettings.SingleExpectDefaultTimeout.dilated)
+      expectNext(probe.testKitSettings.SingleExpectDefaultTimeout.dilated)
+    }
+
+    /**
+     * Expect and return a stream element during specified time or timeout.
+     */
+    def expectNext(d: FiniteDuration): I = {
+      val t = probe.remainingOr(d)
       probe.receiveOne(t) match {
         case null         ⇒ throw new AssertionError(s"Expected OnNext(_), yet no element signaled during $t")
         case OnNext(elem) ⇒ elem.asInstanceOf[I]
@@ -612,6 +619,11 @@ object TestSubscriber {
     def requestNext(): T = {
       subscription.request(1)
       expectNext()
+    }
+
+    def requestNext(d: FiniteDuration): T = {
+      subscription.request(1)
+      expectNext(d)
     }
   }
 }


### PR DESCRIPTION
For issue #20815, ran validatePullRequest and all tests passed.
