### PR TITLE
flush messages on shutdown, #20811

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/routing/RemoteRandomSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/routing/RemoteRandomSpec.scala
@@ -99,9 +99,6 @@ class RemoteRandomSpec(multiNodeConfig: RemoteRandomConfig) extends MultiNodeSpe
         // "Terminate" to a shut down node
         system.stop(actor)
         enterBarrier("done")
-
-        // FIXME this test has problems shutting down actor system when running with Artery
-        // [akka.actor.ActorSystemImpl(RemoteRandomSpec)] Failed to stop [RemoteRandomSpec] within [5 seconds]
       }
     }
   }

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -134,6 +134,11 @@ akka {
         # Level 1 strongly prefer low CPU consumption over low latency.
         # Level 10 strongly prefer low latency over low CPU consumption. 
         idle-cpu-level = 5
+        
+        flight-recorder {
+          // FIXME it should be enabled by default, but there is some concurrency issue that crashes the JVM
+          enabled = off
+        }
 
         # compression of common strings in remoting messages, like actor destinations, serializers etc
         compression {

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -34,6 +34,8 @@ final class RemoteSettings(val config: Config) {
   val IdleCpuLevel: Int = getInt("akka.remote.artery.advanced.idle-cpu-level").requiring(level ⇒
     1 <= level && level <= 10, "idle-cpu-level must be between 1 and 10")
 
+  val FlightRecorderEnabled: Boolean = getBoolean("akka.remote.artery.advanced.flight-recorder.enabled")
+
   val ArteryCompressionSettings = CompressionSettings(getConfig("akka.remote.artery.advanced.compression"))
 
   val LogReceive: Boolean = getBoolean("akka.remote.log-received-messages")

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -171,7 +171,7 @@ private[remote] class Association(
     if (message.isInstanceOf[ActorSelectionMessage] || !associationState.isQuarantined() || message == ClearSystemMessageDelivery) {
       // FIXME: Use a different envelope than the old Send, but make sure the new is handled by deadLetters properly
       message match {
-        case _: SystemMessage | ClearSystemMessageDelivery ⇒
+        case _: SystemMessage | ClearSystemMessageDelivery | _: ControlMessage ⇒
           val send = Send(message, sender, recipient, None)
           if (!controlQueue.offer(send)) {
             quarantine(reason = s"Due to overflow of control queue, size [$controlQueueSize]")

--- a/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
@@ -205,7 +205,7 @@ private[remote] final class HeaderBuilderImpl(inboundCompression: InboundCompres
   override def isNoSender: Boolean =
     (_senderActorRef eq null) && _senderActorRefIdx == EnvelopeBuffer.DeadLettersCode
   override def senderActorRef(originUid: Long): OptionVal[ActorRef] =
-    if (_senderActorRef eq null) inboundCompression.decompressActorRef(originUid, actorRefCompressionTableVersion, _senderActorRefIdx) 
+    if (_senderActorRef eq null) inboundCompression.decompressActorRef(originUid, actorRefCompressionTableVersion, _senderActorRefIdx)
     else OptionVal.None
   def senderActorRefPath: OptionVal[String] =
     OptionVal(_senderActorRef)

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -76,7 +76,7 @@ private[remote] class Encoder(
                 throw e
               case _ if e.isInstanceOf[java.nio.BufferOverflowException] ⇒
                 val reason = new OversizedPayloadException(s"Discarding oversized payload sent to ${send.recipient}: max allowed size ${envelope.byteBuffer.limit()} bytes. Message type [${send.message.getClass.getName}].")
-                log.error(reason, "Transient association error (association remains live)")
+                log.error(reason, "Failed to serialize oversized message [{}].", send.message.getClass.getName)
                 pull(in)
               case _ ⇒
                 log.error(e, "Failed to serialize message [{}].", send.message.getClass.getName)

--- a/akka-remote/src/main/scala/akka/remote/artery/Control.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Control.scala
@@ -40,6 +40,16 @@ private[akka] final case class Quarantined(from: UniqueAddress, to: UniqueAddres
 /**
  * INTERNAL API
  */
+private[akka] case class ActorSystemTerminating(from: UniqueAddress) extends ControlMessage // FIXME serialization
+
+/**
+ * INTERNAL API
+ */
+private[akka] case class ActorSystemTerminatingAck(from: UniqueAddress) // FIXME serialization
+
+/**
+ * INTERNAL API
+ */
 private[akka] object InboundControlJunction {
 
   /**

--- a/akka-remote/src/main/scala/akka/remote/artery/FlightRecorder.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/FlightRecorder.scala
@@ -38,6 +38,27 @@ private[remote] object IgnoreEventSink extends EventSink {
 
 /**
  * INTERNAL API
+ */
+private[remote] class SynchronizedEventSink(delegate: EventSink) extends EventSink {
+  override def alert(code: Int, metadata: Array[Byte]): Unit = synchronized {
+    delegate.alert(code, metadata)
+  }
+
+  override def loFreq(code: Int, metadata: Array[Byte]): Unit = synchronized {
+    delegate.loFreq(code, metadata)
+  }
+
+  override def flushHiFreqBatch(): Unit = synchronized {
+    delegate.flushHiFreqBatch()
+  }
+
+  override def hiFreq(code: Long, param: Long): Unit = synchronized {
+    delegate.hiFreq(code, param)
+  }
+}
+
+/**
+ * INTERNAL API
  *
  * Update clock at various resolutions and aquire the resulting timestamp.
  */

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteActorForSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteActorForSpec.scala
@@ -51,36 +51,6 @@ class RemoteActorForSpec extends ArteryMultiNodeSpec("akka.loglevel=INFO") with 
       }(remoteSystem)
     }
 
-    // FIXME can't communicate with new ref looked up after starting a new instance (!?!)
-    "not send to remote re-created actor with same name" ignore {
-
-      def lookItUp() = localSystem.actorFor(s"artery://${remoteSystem.name}@localhost:$remotePort/user/re-created")
-
-      val echo1 = remoteSystem.actorOf(TestActors.echoActorProps, "re-created")
-      val remoteRef1 = lookItUp()
-      remoteRef1 ! 2
-      expectMsg(2)
-
-      // now stop and start a new actor with the same name
-      watch(echo1)
-      remoteSystem.stop(echo1)
-      expectTerminated(echo1)
-
-      val echo2 = remoteSystem.actorOf(TestActors.echoActorProps, "re-created")
-      val remoteRef2 = lookItUp()
-      remoteRef2 ! 2
-      expectMsg(2)
-
-      // the old ref should not interact with the
-      // new actor instance at the same path
-      remoteRef1 ! 3
-      expectNoMsg(1.second)
-
-      // and additionally, but it would have failed already
-      // if this wasn't true
-      remoteRef1.path.uid should !==(remoteRef2.path.uid)
-    }
-
     // FIXME needs remote deployment section
     "look-up actors across node boundaries" ignore {
       val l = localSystem.actorOf(Props(new Actor {

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
@@ -55,7 +55,7 @@ class RemoteMessageSerializationSpec extends ArteryMultiNodeSpec("""
 
     "drop sent messages over payload size" in {
       val oversized = byteStringOfSize(maxPayloadBytes + 1)
-      EventFilter[OversizedPayloadException](pattern = ".*Discarding oversized payload sent.*", occurrences = 1).intercept {
+      EventFilter[OversizedPayloadException](start = "Failed to serialize oversized message", occurrences = 1).intercept {
         verifySend(oversized) {
           expectNoMsg(1.second) // No AssocitionErrorEvent should be published
         }

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -80,6 +80,22 @@ object ActorMaterializer {
     apply(Some(materializerSettings), None)
 
   /**
+   * INTERNAL API: Creates the `StreamSupervisor` as a system actor.
+   */
+  private[akka] def systemMaterializer(materializerSettings: ActorMaterializerSettings, namePrefix: String,
+                                       system: ExtendedActorSystem): ActorMaterializer = {
+    val haveShutDown = new AtomicBoolean(false)
+    new ActorMaterializerImpl(
+      system,
+      materializerSettings,
+      system.dispatchers,
+      system.systemActorOf(StreamSupervisor.props(materializerSettings, haveShutDown)
+        .withDispatcher(materializerSettings.dispatcher), StreamSupervisor.nextName()),
+      haveShutDown,
+      FlowNames(system).name.copy(namePrefix))
+  }
+
+  /**
    * Java API: Creates a ActorMaterializer which will execute every step of a transformation
    * pipeline within its own [[akka.actor.Actor]]. The required [[akka.actor.ActorRefFactory]]
    * (which can be either an [[akka.actor.ActorSystem]] or an [[akka.actor.ActorContext]])


### PR DESCRIPTION
- StreamSupervisor as system actor so that it is
  stopped after ordinary actors
- when transport is shutdown send flush message to all
  outbound associations (over control stream) and wait for ack
  or timeout
