### PR TITLE
Better configurable timeouts for Akka-HTTP, #20798

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -53,8 +53,8 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
     if (dynRR.value ne null) dynRR.value
     else sys.error("This value is only available inside of a `check` construct!")
 
-  implicit def routeTestTimeout2Timeout(implicit timeout: RouteTestTimeout): Timeout =
-    Timeout(timeout.duration)
+  implicit def timeout2RouteTestTimeout(implicit timeout: Timeout): RouteTestTimeout =
+    RouteTestTimeout(timeout.duration)
 
   def check[T](body: ⇒ T): RouteTestResult ⇒ T = result ⇒ dynRR.withValue(result.awaitResult)(body)
 

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -4,11 +4,11 @@
 
 package akka.http.scaladsl.testkit
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import org.scalatest.FreeSpec
 import org.scalatest.Matchers
 import akka.testkit.TestProbe
-import akka.util.Timeout
 import akka.pattern.ask
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server._
@@ -48,6 +48,18 @@ class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteT
       }
     }
 
+    "long running routes" in {
+      implicit val timeout = RouteTestTimeout(2.seconds)
+      Post("/abc", "content") ~> complete {
+        Future {
+          Thread.sleep(1200)
+          "res"
+        }
+      } ~> check {
+        responseAs[String] shouldEqual "res"
+      }
+    }
+
     "separation of route execution from checking" in {
       val pinkHeader = RawHeader("Fancy", "pink")
 
@@ -55,7 +67,6 @@ class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteT
       val service = TestProbe()
       val handler = TestProbe()
       implicit def serviceRef = service.ref
-      implicit val askTimeout: Timeout = 1.second
 
       val result =
         Get() ~> pinkHeader ~> {

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -16,6 +16,7 @@ import akka.http.scaladsl.model._
 import StatusCodes._
 import HttpMethods._
 import Directives._
+import akka.util.Timeout
 
 class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteTest {
 
@@ -49,7 +50,7 @@ class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteT
     }
 
     "long running routes" in {
-      implicit val timeout = RouteTestTimeout(2.seconds)
+      implicit val timeout = Timeout(2.seconds)
       Post("/abc", "content") ~> complete {
         Future {
           Thread.sleep(1200)

--- a/akka-http/src/main/scala/akka/http/scaladsl/client/RequestBuilding.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/client/RequestBuilding.scala
@@ -18,29 +18,31 @@ import HttpMethods._
 trait RequestBuilding extends TransformerPipelineSupport {
   type RequestTransformer = HttpRequest ⇒ HttpRequest
 
+  implicit val timeout = Timeout(1.second)
+
   class RequestBuilder(val method: HttpMethod) {
     def apply(): HttpRequest =
       apply("/")
 
-    def apply(uri: String): HttpRequest =
+    def apply(uri: String)(implicit timeout: Timeout): HttpRequest =
       apply(uri, HttpEntity.Empty)
 
-    def apply[T](uri: String, content: T)(implicit m: ToEntityMarshaller[T], ec: ExecutionContext): HttpRequest =
+    def apply[T](uri: String, content: T)(implicit m: ToEntityMarshaller[T], ec: ExecutionContext, timeout: Timeout): HttpRequest =
       apply(uri, Some(content))
 
-    def apply[T](uri: String, content: Option[T])(implicit m: ToEntityMarshaller[T], ec: ExecutionContext): HttpRequest =
+    def apply[T](uri: String, content: Option[T])(implicit m: ToEntityMarshaller[T], ec: ExecutionContext, timeout: Timeout): HttpRequest =
       apply(Uri(uri), content)
 
-    def apply(uri: String, entity: RequestEntity): HttpRequest =
+    def apply(uri: String, entity: RequestEntity)(implicit timeout: Timeout): HttpRequest =
       apply(Uri(uri), entity)
 
-    def apply(uri: Uri): HttpRequest =
+    def apply(uri: Uri)(implicit timeout: Timeout): HttpRequest =
       apply(uri, HttpEntity.Empty)
 
-    def apply[T](uri: Uri, content: T)(implicit m: ToEntityMarshaller[T], ec: ExecutionContext): HttpRequest =
+    def apply[T](uri: Uri, content: T)(implicit m: ToEntityMarshaller[T], ec: ExecutionContext, timeout: Timeout): HttpRequest =
       apply(uri, Some(content))
 
-    def apply[T](uri: Uri, content: Option[T])(implicit m: ToEntityMarshaller[T], timeout: Timeout = Timeout(1.second), ec: ExecutionContext): HttpRequest =
+    def apply[T](uri: Uri, content: Option[T])(implicit m: ToEntityMarshaller[T], ec: ExecutionContext, timeout: Timeout): HttpRequest =
       content match {
         case None ⇒ apply(uri, HttpEntity.Empty)
         case Some(value) ⇒
@@ -48,7 +50,7 @@ trait RequestBuilding extends TransformerPipelineSupport {
           apply(uri, entity)
       }
 
-    def apply(uri: Uri, entity: RequestEntity): HttpRequest =
+    def apply(uri: Uri, entity: RequestEntity)(implicit timeout: Timeout): HttpRequest =
       HttpRequest(method, uri, Nil, entity)
   }
 


### PR DESCRIPTION
- Add implicit timeout to all `RequestBuilding` overloads
- Uniformize the usage of `RouteTestTimeout` 

Reference #20798.
