### PR TITLE
Remove distributed pubsub nodes on leave

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -666,6 +666,12 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
       if (matchingRole(m))
         nodes += m.address
 
+    case MemberLeft(m) ⇒
+      if (matchingRole(m)) {
+        nodes -= m.address
+        registry -= m.address
+      }
+
     case MemberRemoved(m, _) ⇒
       if (m.address == selfAddress)
         context stop self


### PR DESCRIPTION
This ensures that gracefully leaving nodes (which would terminate after
their own removed event) are already unregistered on all other pubsub
nodes, before termination.

See #20826 
