### PR TITLE
19174 unify naming scheme for persistence queries

### DIFF
--- a/akka-docs/rst/java/code/docs/persistence/PersistenceQueryDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/PersistenceQueryDocTest.java
@@ -104,7 +104,7 @@ public class PersistenceQueryDocTest {
   akka.persistence.query.javadsl.ReadJournal,
   akka.persistence.query.javadsl.EventsByTagQuery,
   akka.persistence.query.javadsl.EventsByPersistenceIdQuery,
-  akka.persistence.query.javadsl.AllPersistenceIdsQuery,
+  akka.persistence.query.javadsl.PersistenceIdsQuery,
   akka.persistence.query.javadsl.CurrentPersistenceIdsQuery {
     
     private final FiniteDuration refreshInterval;
@@ -130,7 +130,7 @@ public class PersistenceQueryDocTest {
     }
 
     @Override
-    public Source<String, NotUsed> allPersistenceIds() {
+    public Source<String, NotUsed> persistenceIds() {
       // implement in a similar way as eventsByTag
       throw new UnsupportedOperationException("Not implemented yet");
     }
@@ -159,7 +159,7 @@ public class PersistenceQueryDocTest {
   akka.persistence.query.scaladsl.ReadJournal,
   akka.persistence.query.scaladsl.EventsByTagQuery,
   akka.persistence.query.scaladsl.EventsByPersistenceIdQuery,
-  akka.persistence.query.scaladsl.AllPersistenceIdsQuery,
+  akka.persistence.query.scaladsl.PersistenceIdsQuery,
   akka.persistence.query.scaladsl.CurrentPersistenceIdsQuery {
     
     private final MyJavadslReadJournal javadslReadJournal;
@@ -182,8 +182,8 @@ public class PersistenceQueryDocTest {
     }
 
     @Override
-    public akka.stream.scaladsl.Source<String, NotUsed> allPersistenceIds() {
-      return javadslReadJournal.allPersistenceIds().asScala();
+    public akka.stream.scaladsl.Source<String, NotUsed> persistenceIds() {
+      return javadslReadJournal.persistenceIds().asScala();
     }
     
     @Override
@@ -221,14 +221,14 @@ public class PersistenceQueryDocTest {
     //#basic-usage
   }
 
-  void demonstrateAllPersistenceIdsLive() {
+  void demonstratePersistenceIdsLive() {
     final MyJavadslReadJournal readJournal =
         PersistenceQuery.get(system).getReadJournalFor(MyJavadslReadJournal.class,
             "akka.persistence.query.my-read-journal");
 
-    //#all-persistence-ids-live
-    readJournal.allPersistenceIds();
-    //#all-persistence-ids-live
+    //#persistence-ids-live
+    readJournal.persistenceIds();
+    //#persistence-ids-live
   }
 
   void demonstrateNoRefresh() {
@@ -238,9 +238,9 @@ public class PersistenceQueryDocTest {
         PersistenceQuery.get(system).getReadJournalFor(MyJavadslReadJournal.class,
             "akka.persistence.query.my-read-journal");
 
-    //#all-persistence-ids-snap
+    //#persistence-ids-snap
     readJournal.currentPersistenceIds();
-    //#all-persistence-ids-snap
+    //#persistence-ids-snap
   }
 
   void demonstrateRefresh() {

--- a/akka-docs/rst/java/code/docs/persistence/query/LeveldbPersistenceQueryDocTest.java
+++ b/akka-docs/rst/java/code/docs/persistence/query/LeveldbPersistenceQueryDocTest.java
@@ -42,14 +42,14 @@ public class LeveldbPersistenceQueryDocTest {
     //#EventsByPersistenceId
   }
   
-  public void demonstrateAllPersistenceIds() {
-    //#AllPersistenceIds
+  public void demonstratePersistenceIds() {
+    //#PersistenceIds
     LeveldbReadJournal queries =
         PersistenceQuery.get(system).getReadJournalFor(LeveldbReadJournal.class, 
             LeveldbReadJournal.Identifier());
     
-    Source<String, NotUsed> source = queries.allPersistenceIds();
-    //#AllPersistenceIds
+    Source<String, NotUsed> source = queries.persistenceIds();
+    //#PersistenceIds
   }
   
   public void demonstrateEventsByTag() {

--- a/akka-docs/rst/java/persistence-query-leveldb.rst
+++ b/akka-docs/rst/java/persistence-query-leveldb.rst
@@ -68,12 +68,12 @@ hint.
 The stream is completed with failure if there is a failure in executing the query in the
 backend journal.
 
-AllPersistenceIdsQuery and CurrentPersistenceIdsQuery 
+PersistenceIdsQuery and CurrentPersistenceIdsQuery 
 -----------------------------------------------------
 
-``allPersistenceIds`` is used for retrieving all ``persistenceIds`` of all persistent actors.
+``persistenceIds`` is used for retrieving all ``persistenceIds`` of all persistent actors.
 
-.. includecode:: code/docs/persistence/query/LeveldbPersistenceQueryDocTest.java#AllPersistenceIds
+.. includecode:: code/docs/persistence/query/LeveldbPersistenceQueryDocTest.java#PersistenceIds
 
 The returned event stream is unordered and you can expect different order for multiple
 executions of the query.

--- a/akka-docs/rst/java/persistence-query.rst
+++ b/akka-docs/rst/java/persistence-query.rst
@@ -75,18 +75,18 @@ significantly inefficient.
 
 The predefined queries are:
 
-AllPersistenceIdsQuery and CurrentPersistenceIdsQuery 
+PersistenceIdsQuery and CurrentPersistenceIdsQuery 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``allPersistenceIds`` which is designed to allow users to subscribe to a stream of all persistent ids in the system.
+``persistenceIds`` which is designed to allow users to subscribe to a stream of all persistent ids in the system.
 By default this stream should be assumed to be a "live" stream, which means that the journal should keep emitting new
 persistence ids as they come into the system:
 
-.. includecode:: code/docs/persistence/PersistenceQueryDocTest.java#all-persistence-ids-live
+.. includecode:: code/docs/persistence/PersistenceQueryDocTest.java#persistence-ids-live
 
 If your usage does not require a live stream, you can use the ``currentPersistenceIds`` query:
 
-.. includecode:: code/docs/persistence/PersistenceQueryDocTest.java#all-persistence-ids-snap
+.. includecode:: code/docs/persistence/PersistenceQueryDocTest.java#persistence-ids-snap
 
 EventsByPersistenceIdQuery and CurrentEventsByPersistenceIdQuery
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/akka-docs/rst/scala/code/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
@@ -64,14 +64,14 @@ class LeveldbPersistenceQueryDocSpec(config: String) extends AkkaSpec(config) {
       //#EventsByPersistenceId
     }
 
-    "demonstrate AllPersistenceIds" in {
-      //#AllPersistenceIds
+    "demonstrate PersistenceIds" in {
+      //#PersistenceIds
       implicit val mat = ActorMaterializer()(system)
       val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](
         LeveldbReadJournal.Identifier)
 
-      val src: Source[String, NotUsed] = queries.allPersistenceIds()
-      //#AllPersistenceIds
+      val src: Source[String, NotUsed] = queries.persistenceIds()
+      //#PersistenceIds
     }
 
     "demonstrate EventsByTag" in {

--- a/akka-docs/rst/scala/code/docs/persistence/query/PersistenceQueryDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/query/PersistenceQueryDocSpec.scala
@@ -47,7 +47,7 @@ object PersistenceQueryDocSpec {
     extends akka.persistence.query.scaladsl.ReadJournal
     with akka.persistence.query.scaladsl.EventsByTagQuery
     with akka.persistence.query.scaladsl.EventsByPersistenceIdQuery
-    with akka.persistence.query.scaladsl.AllPersistenceIdsQuery
+    with akka.persistence.query.scaladsl.PersistenceIdsQuery
     with akka.persistence.query.scaladsl.CurrentPersistenceIdsQuery {
 
     private val refreshInterval: FiniteDuration =
@@ -67,7 +67,7 @@ object PersistenceQueryDocSpec {
       ???
     }
 
-    override def allPersistenceIds(): Source[String, NotUsed] = {
+    override def persistenceIds(): Source[String, NotUsed] = {
       // implement in a similar way as eventsByTag
       ???
     }
@@ -92,7 +92,7 @@ object PersistenceQueryDocSpec {
     extends akka.persistence.query.javadsl.ReadJournal
     with akka.persistence.query.javadsl.EventsByTagQuery
     with akka.persistence.query.javadsl.EventsByPersistenceIdQuery
-    with akka.persistence.query.javadsl.AllPersistenceIdsQuery
+    with akka.persistence.query.javadsl.PersistenceIdsQuery
     with akka.persistence.query.javadsl.CurrentPersistenceIdsQuery {
 
     override def eventsByTag(
@@ -105,8 +105,8 @@ object PersistenceQueryDocSpec {
       scaladslReadJournal.eventsByPersistenceId(
         persistenceId, fromSequenceNr, toSequenceNr).asJava
 
-    override def allPersistenceIds(): javadsl.Source[String, NotUsed] =
-      scaladslReadJournal.allPersistenceIds().asJava
+    override def persistenceIds(): javadsl.Source[String, NotUsed] =
+      scaladslReadJournal.persistenceIds().asJava
 
     override def currentPersistenceIds(): javadsl.Source[String, NotUsed] =
       scaladslReadJournal.currentPersistenceIds().asJava
@@ -210,13 +210,13 @@ class PersistenceQueryDocSpec(s: String) extends AkkaSpec(s) {
     source.runForeach { event => println("Event: " + event) }
     //#basic-usage
 
-    //#all-persistence-ids-live
-    readJournal.allPersistenceIds()
-    //#all-persistence-ids-live
+    //#persistence-ids-live
+    readJournal.persistenceIds()
+    //#persistence-ids-live
 
-    //#all-persistence-ids-snap
+    //#persistence-ids-snap
     readJournal.currentPersistenceIds()
-    //#all-persistence-ids-snap
+    //#persistence-ids-snap
 
     //#events-by-tag
     // assuming journal is able to work with numeric offsets we can:

--- a/akka-docs/rst/scala/persistence-query-leveldb.rst
+++ b/akka-docs/rst/scala/persistence-query-leveldb.rst
@@ -63,12 +63,12 @@ hint.
 The stream is completed with failure if there is a failure in executing the query in the
 backend journal.
 
-AllPersistenceIdsQuery and CurrentPersistenceIdsQuery 
+PersistenceIdsQuery and CurrentPersistenceIdsQuery 
 -----------------------------------------------------
 
-``allPersistenceIds`` is used for retrieving all ``persistenceIds`` of all persistent actors.
+``persistenceIds`` is used for retrieving all ``persistenceIds`` of all persistent actors.
 
-.. includecode:: code/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala#AllPersistenceIds
+.. includecode:: code/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala#PersistenceIds
 
 The returned event stream is unordered and you can expect different order for multiple
 executions of the query.

--- a/akka-docs/rst/scala/persistence-query.rst
+++ b/akka-docs/rst/scala/persistence-query.rst
@@ -71,18 +71,18 @@ significantly inefficient.
 
 The predefined queries are:
 
-AllPersistenceIdsQuery and CurrentPersistenceIdsQuery 
+PersistenceIdsQuery and CurrentPersistenceIdsQuery 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``allPersistenceIds`` which is designed to allow users to subscribe to a stream of all persistent ids in the system.
+``persistenceIds`` which is designed to allow users to subscribe to a stream of all persistent ids in the system.
 By default this stream should be assumed to be a "live" stream, which means that the journal should keep emitting new
 persistence ids as they come into the system:
 
-.. includecode:: code/docs/persistence/query/PersistenceQueryDocSpec.scala#all-persistence-ids-live
+.. includecode:: code/docs/persistence/query/PersistenceQueryDocSpec.scala#persistence-ids-live
 
 If your usage does not require a live stream, you can use the ``currentPersistenceIds`` query:
 
-.. includecode:: code/docs/persistence/query/PersistenceQueryDocSpec.scala#all-persistence-ids-snap
+.. includecode:: code/docs/persistence/query/PersistenceQueryDocSpec.scala#persistence-ids-snap
 
 EventsByPersistenceIdQuery and CurrentEventsByPersistenceIdQuery
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentPersistenceIdsQuery.scala
@@ -12,7 +12,7 @@ import akka.stream.javadsl.Source
 trait CurrentPersistenceIdsQuery extends ReadJournal {
 
   /**
-   * Same type of query as [[AllPersistenceIdsQuery#allPersistenceIds]] but the stream
+   * Same type of query as [[PersistenceIdsQuery#persistenceIds]] but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    */

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/PersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/PersistenceIdsQuery.scala
@@ -9,7 +9,7 @@ import akka.stream.javadsl.Source
 /**
  * A plugin may optionally support this query by implementing this interface.
  */
-trait AllPersistenceIdsQuery extends ReadJournal {
+trait PersistenceIdsQuery extends ReadJournal {
 
   /**
    * Query all `PersistentActor` identifiers, i.e. as defined by the
@@ -20,6 +20,6 @@ trait AllPersistenceIdsQuery extends ReadJournal {
    * Corresponding query that is completed when it reaches the end of the currently
    * currently used `persistenceIds` is provided by [[CurrentPersistenceIdsQuery#currentPersistenceIds]].
    */
-  def allPersistenceIds(): Source[String, NotUsed]
+  def persistenceIds(): Source[String, NotUsed]
 
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/ReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/ReadJournal.scala
@@ -12,7 +12,7 @@ package akka.persistence.query.javadsl
  * The interface is very open so that different journals may implement specific queries.
  *
  * There are a few pre-defined queries that a query implementation may implement,
- * such as [[EventsByPersistenceIdQuery]], [[AllPersistenceIdsQuery]] and [[EventsByTagQuery]]
+ * such as [[EventsByPersistenceIdQuery]], [[PersistenceIdsQuery]] and [[EventsByTagQuery]]
  * Implementation of these queries are optional and query (journal) plugins may define
  * their own specialized queries by implementing other methods.
  *

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/PersistenceIdsPublisher.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/PersistenceIdsPublisher.scala
@@ -16,9 +16,9 @@ import akka.stream.actor.ActorPublisherMessage.Request
 /**
  * INTERNAL API
  */
-private[akka] object AllPersistenceIdsPublisher {
+private[akka] object PersistenceIdsPublisher {
   def props(liveQuery: Boolean, maxBufSize: Int, writeJournalPluginId: String): Props =
-    Props(new AllPersistenceIdsPublisher(liveQuery, maxBufSize, writeJournalPluginId))
+    Props(new PersistenceIdsPublisher(liveQuery, maxBufSize, writeJournalPluginId))
 
   private case object Continue
 }
@@ -26,7 +26,7 @@ private[akka] object AllPersistenceIdsPublisher {
 /**
  * INTERNAL API
  */
-private[akka] class AllPersistenceIdsPublisher(liveQuery: Boolean, maxBufSize: Int, writeJournalPluginId: String)
+private[akka] class PersistenceIdsPublisher(liveQuery: Boolean, maxBufSize: Int, writeJournalPluginId: String)
   extends ActorPublisher[String] with DeliveryBuffer[String] with ActorLogging {
 
   val journal: ActorRef = Persistence(context.system).journalFor(writeJournalPluginId)
@@ -35,14 +35,14 @@ private[akka] class AllPersistenceIdsPublisher(liveQuery: Boolean, maxBufSize: I
 
   def init: Receive = {
     case _: Request ⇒
-      journal ! LeveldbJournal.SubscribeAllPersistenceIds
+      journal ! LeveldbJournal.SubscribePersistenceIds
       context.become(active)
     case Cancel ⇒ context.stop(self)
   }
 
   def active: Receive = {
-    case LeveldbJournal.CurrentPersistenceIds(allPersistenceIds) ⇒
-      buf ++= allPersistenceIds
+    case LeveldbJournal.CurrentPersistenceIds(persistenceIds) ⇒
+      buf ++= persistenceIds
       deliverBuf()
       if (!liveQuery && buf.isEmpty)
         onCompleteThenStop()

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
@@ -27,7 +27,7 @@ import akka.stream.javadsl.Source
  */
 class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal)
   extends ReadJournal
-  with AllPersistenceIdsQuery
+  with PersistenceIdsQuery
   with CurrentPersistenceIdsQuery
   with EventsByPersistenceIdQuery
   with CurrentEventsByPersistenceIdQuery
@@ -35,7 +35,7 @@ class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.lev
   with CurrentEventsByTagQuery {
 
   /**
-   * `allPersistenceIds` is used for retrieving all `persistenceIds` of all
+   * `persistenceIds` is used for retrieving all `persistenceIds` of all
    * persistent actors.
    *
    * The returned event stream is unordered and you can expect different order for multiple
@@ -52,11 +52,11 @@ class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.lev
    * The stream is completed with failure if there is a failure in executing the query in the
    * backend journal.
    */
-  override def allPersistenceIds(): Source[String, NotUsed] =
-    scaladslReadJournal.allPersistenceIds().asJava
+  override def persistenceIds(): Source[String, NotUsed] =
+    scaladslReadJournal.persistenceIds().asJava
 
   /**
-   * Same type of query as [[#allPersistenceIds]] but the stream
+   * Same type of query as [[#persistenceIds]] but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    */

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentPersistenceIdsQuery.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.Source
 trait CurrentPersistenceIdsQuery extends ReadJournal {
 
   /**
-   * Same type of query as [[AllPersistenceIdsQuery#allPersistenceIds]] but the stream
+   * Same type of query as [[PersistenceIdsQuery#persistenceIds]] but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    */

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/PersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/PersistenceIdsQuery.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.Source
 /**
  * A plugin may optionally support this query by implementing this trait.
  */
-trait AllPersistenceIdsQuery extends ReadJournal {
+trait PersistenceIdsQuery extends ReadJournal {
 
   /**
    * Query all `PersistentActor` identifiers, i.e. as defined by the
@@ -20,6 +20,6 @@ trait AllPersistenceIdsQuery extends ReadJournal {
    * Corresponding query that is completed when it reaches the end of the currently
    * currently used `persistenceIds` is provided by [[CurrentPersistenceIdsQuery#currentPersistenceIds]].
    */
-  def allPersistenceIds(): Source[String, NotUsed]
+  def persistenceIds(): Source[String, NotUsed]
 
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/ReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/ReadJournal.scala
@@ -12,7 +12,7 @@ package akka.persistence.query.scaladsl
  * The interface is very open so that different journals may implement specific queries.
  *
  * There are a few pre-defined queries that a query implementation may implement,
- * such as [[EventsByPersistenceIdQuery]], [[AllPersistenceIdsQuery]] and [[EventsByTagQuery]]
+ * such as [[EventsByPersistenceIdQuery]], [[PersistenceIdsQuery]] and [[EventsByTagQuery]]
  * Implementation of these queries are optional and query (journal) plugins may define
  * their own specialized queries by implementing other methods.
  *

--- a/akka-persistence-query/src/test/java/akka/persistence/query/DummyJavaReadJournal.java
+++ b/akka-persistence-query/src/test/java/akka/persistence/query/DummyJavaReadJournal.java
@@ -7,7 +7,7 @@ package akka.persistence.query;
 import java.util.Iterator;
 
 import akka.NotUsed;
-import akka.persistence.query.javadsl.AllPersistenceIdsQuery;
+import akka.persistence.query.javadsl.PersistenceIdsQuery;
 import akka.persistence.query.javadsl.ReadJournal;
 import akka.stream.javadsl.Source;
 
@@ -15,12 +15,12 @@ import akka.stream.javadsl.Source;
  * Use for tests only!
  * Emits infinite stream of strings (representing queried for events).
  */
-public class DummyJavaReadJournal implements ReadJournal, AllPersistenceIdsQuery {
+public class DummyJavaReadJournal implements ReadJournal, PersistenceIdsQuery {
   public static final String Identifier = "akka.persistence.query.journal.dummy-java";
 
 
   @Override
-  public Source<String, NotUsed> allPersistenceIds() {
+  public Source<String, NotUsed> persistenceIds() {
     return Source.fromIterator(() -> new Iterator<String>() {
       private int i = 0;
       @Override public boolean hasNext() { return true; }

--- a/akka-persistence-query/src/test/java/akka/persistence/query/DummyJavaReadJournalForScala.java
+++ b/akka-persistence-query/src/test/java/akka/persistence/query/DummyJavaReadJournalForScala.java
@@ -11,7 +11,7 @@ import akka.NotUsed;
  * Emits infinite stream of strings (representing queried for events).
  */
 public class DummyJavaReadJournalForScala implements akka.persistence.query.scaladsl.ReadJournal,
-    akka.persistence.query.scaladsl.AllPersistenceIdsQuery {
+    akka.persistence.query.scaladsl.PersistenceIdsQuery {
 
   public static final String Identifier = DummyJavaReadJournal.Identifier;
 
@@ -22,8 +22,8 @@ public class DummyJavaReadJournalForScala implements akka.persistence.query.scal
   }
 
   @Override
-  public akka.stream.scaladsl.Source<String, NotUsed> allPersistenceIds() {
-    return readJournal.allPersistenceIds().asScala();
+  public akka.stream.scaladsl.Source<String, NotUsed> persistenceIds() {
+    return readJournal.persistenceIds().asScala();
   }
 
 }

--- a/akka-persistence-query/src/test/java/akka/persistence/query/PersistenceQueryTest.java
+++ b/akka-persistence-query/src/test/java/akka/persistence/query/PersistenceQueryTest.java
@@ -23,6 +23,6 @@ public class PersistenceQueryTest {
   public void shouldExposeJavaDSLFriendlyQueryJournal() throws Exception {
     final DummyJavaReadJournal readJournal = PersistenceQuery.get(system).getReadJournalFor(DummyJavaReadJournal.class,
         "noop-journal");
-    final akka.stream.javadsl.Source<String, NotUsed> ids = readJournal.allPersistenceIds();
+    final akka.stream.javadsl.Source<String, NotUsed> ids = readJournal.persistenceIds();
   }
 }

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/DummyReadJournal.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/DummyReadJournal.scala
@@ -12,8 +12,8 @@ import com.typesafe.config.{ Config, ConfigFactory }
  * Use for tests only!
  * Emits infinite stream of strings (representing queried for events).
  */
-class DummyReadJournal extends scaladsl.ReadJournal with scaladsl.AllPersistenceIdsQuery {
-  override def allPersistenceIds(): Source[String, NotUsed] =
+class DummyReadJournal extends scaladsl.ReadJournal with scaladsl.PersistenceIdsQuery {
+  override def persistenceIds(): Source[String, NotUsed] =
     Source.fromIterator(() ⇒ Iterator.from(0)).map(_.toString)
 }
 
@@ -21,9 +21,9 @@ object DummyReadJournal {
   final val Identifier = "akka.persistence.query.journal.dummy"
 }
 
-class DummyReadJournalForJava(readJournal: DummyReadJournal) extends javadsl.ReadJournal with javadsl.AllPersistenceIdsQuery {
-  override def allPersistenceIds(): akka.stream.javadsl.Source[String, NotUsed] =
-    readJournal.allPersistenceIds().asJava
+class DummyReadJournalForJava(readJournal: DummyReadJournal) extends javadsl.ReadJournal with javadsl.PersistenceIdsQuery {
+  override def persistenceIds(): akka.stream.javadsl.Source[String, NotUsed] =
+    readJournal.persistenceIds().asJava
 }
 
 object DummyReadJournalProvider {

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/PersistenceIdsSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/PersistenceIdsSpec.scala
@@ -7,32 +7,32 @@ import scala.concurrent.duration._
 
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
-import akka.persistence.query.scaladsl.AllPersistenceIdsQuery
+import akka.persistence.query.scaladsl.PersistenceIdsQuery
 import akka.stream.ActorMaterializer
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
 
-object AllPersistenceIdsSpec {
+object PersistenceIdsSpec {
   val config = """
     akka.loglevel = INFO
     akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
-    akka.persistence.journal.leveldb.dir = "target/journal-AllPersistenceIdsSpec"
+    akka.persistence.journal.leveldb.dir = "target/journal-PersistenceIdsSpec"
     akka.test.single-expect-default = 10s
     """
 }
 
-class AllPersistenceIdsSpec extends AkkaSpec(AllPersistenceIdsSpec.config)
+class PersistenceIdsSpec extends AkkaSpec(PersistenceIdsSpec.config)
   with Cleanup with ImplicitSender {
 
   implicit val mat = ActorMaterializer()(system)
 
   val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
 
-  "Leveldb query AllPersistenceIds" must {
+  "Leveldb query PersistenceIds" must {
 
-    "implement standard AllPersistenceIdsQuery" in {
-      queries.isInstanceOf[AllPersistenceIdsQuery] should ===(true)
+    "implement standard PersistenceIdsQuery" in {
+      queries.isInstanceOf[PersistenceIdsQuery] should ===(true)
     }
 
     "find existing persistenceIds" in {
@@ -57,7 +57,7 @@ class AllPersistenceIdsSpec extends AkkaSpec(AllPersistenceIdsSpec.config)
       system.actorOf(TestActor.props("d")) ! "d1"
       expectMsg("d1-done")
 
-      val src = queries.allPersistenceIds()
+      val src = queries.persistenceIds()
       val probe = src.runWith(TestSink.probe[String])
       probe.within(10.seconds) {
         probe.request(5)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbIdMapping.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbIdMapping.scala
@@ -40,7 +40,7 @@ private[persistence] trait LeveldbIdMapping extends Actor { this: LeveldbStore â
     !idMap.contains(id)
   }
 
-  def allPersistenceIds: Set[String] = idMapLock.synchronized {
+  def persistenceIds: Set[String] = idMapLock.synchronized {
     idMap.keySet
   }
 

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
@@ -48,8 +48,8 @@ private[persistence] class LeveldbJournal extends { val configPath = "akka.persi
     case SubscribePersistenceId(persistenceId: String) ⇒
       addPersistenceIdSubscriber(sender(), persistenceId)
       context.watch(sender())
-    case SubscribeAllPersistenceIds ⇒
-      addAllPersistenceIdsSubscriber(sender())
+    case SubscribePersistenceIds ⇒
+      addPersistenceIdsSubscriber(sender())
       context.watch(sender())
     case SubscribeTag(tag: String) ⇒
       addTagSubscriber(sender(), tag)
@@ -79,8 +79,8 @@ private[persistence] object LeveldbJournal {
    * subscriber followed by [[PersistenceIdAdded]] messages when new persistenceIds
    * are created.
    */
-  final case object SubscribeAllPersistenceIds extends SubscriptionCommand
-  final case class CurrentPersistenceIds(allPersistenceIds: Set[String]) extends DeadLetterSuppression
+  final case object SubscribePersistenceIds extends SubscriptionCommand
+  final case class CurrentPersistenceIds(persistenceIds: Set[String]) extends DeadLetterSuppression
   final case class PersistenceIdAdded(persistenceId: String) extends DeadLetterSuppression
 
   /**


### PR DESCRIPTION
#19174

Refactoring:
- Rename trait 'AllPersistenceIdsQuery' to 'PersistenceIdsQuery'
- Rename Method 'allPersistenceIds' to 'persistenceIds'

I'm not quiet sure if this PR is what is expected or whether it can be merged into master, since the refactoring breaks the akka persistence query api.
