### PR TITLE
=htc #20789 fix double push of requestPrepOut in HTTP blueprint

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -368,7 +368,6 @@ private[http] object HttpServerBluePrint {
     val shape = new BidiShape(requestParsingIn, requestPrepOut, httpResponseIn, responseCtxOut)
 
     def createLogic(effectiveAttributes: Attributes) = new GraphStageLogic(shape) {
-      val pullHttpResponseIn = () ⇒ pull(httpResponseIn)
       var openRequests = immutable.Queue[RequestStart]()
       var oneHundredContinueResponsePending = false
       var pullSuppressed = false
@@ -392,7 +391,8 @@ private[http] object HttpServerBluePrint {
             case x: EntityStreamError if messageEndPending && openRequests.isEmpty ⇒
               // client terminated the connection after receiving an early response to 100-continue
               completeStage()
-            case x ⇒ push(requestPrepOut, x)
+            case x ⇒
+              push(requestPrepOut, x)
           }
         override def onUpstreamFinish() =
           if (openRequests.isEmpty) completeStage()
@@ -416,17 +416,22 @@ private[http] object HttpServerBluePrint {
             log.warning(
               """Sending 2xx response before end of request was received...
                 |Note that the connection will be closed after this response. Also, many clients will not read early responses!
-                |Consider waiting for the request end before dispatching this response!""".stripMargin)
+                |Consider only issuing this response after the request data has been completely read!""".stripMargin)
           val close = requestStart.closeRequested ||
-            requestStart.expect100Continue && oneHundredContinueResponsePending ||
-            isClosed(requestParsingIn) && openRequests.isEmpty ||
+            (requestStart.expect100Continue && oneHundredContinueResponsePending) ||
+            (isClosed(requestParsingIn) && openRequests.isEmpty) ||
             isEarlyResponse
+
           emit(responseCtxOut, ResponseRenderingContext(response, requestStart.method, requestStart.protocol, close),
-            pullHttpResponseIn)
-          if (close) complete(responseCtxOut)
-          // when the client closes the connection, we need to pull onc more time to get the
-          // request parser to complete
-          if (close && isEarlyResponse) pull(requestParsingIn)
+            () ⇒ {
+              if (close) {
+                complete(responseCtxOut)
+                // when the client closes the connection, we need to pull onc more time to get the
+                // request parser to complete (it will cause an incoming EntityStreamError)
+                if (requestStart.expect100Continue) pull(requestParsingIn)
+              } else pull(httpResponseIn)
+            }
+          )
         }
         override def onUpstreamFinish() =
           if (openRequests.isEmpty && isClosed(requestParsingIn)) completeStage()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -415,9 +415,9 @@ private[http] object HttpServerBluePrint {
           val isEarlyResponse = messageEndPending && openRequests.isEmpty
           if (isEarlyResponse && response.status.isSuccess)
             log.warning(
-              """Sending 2xx response before end of request was received...
-                |Note that the connection will be closed after this response. Also, many clients will not read early responses!
-                |Consider only issuing this response after the request data has been completely read!""".stripMargin)
+              "Sending an 2xx 'early' response before end of request was received... " + 
+              "Note that the connection will be closed after this response. Also, many clients will not read early responses! " +
+              "Consider only issuing this response after the request data has been completely read!")
           val close = requestStart.closeRequested ||
             (requestStart.expect100Continue && oneHundredContinueResponsePending) ||
             (isClosed(requestParsingIn) && openRequests.isEmpty) ||

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -684,7 +684,7 @@ class HttpServerSpec extends AkkaSpec(
 
       // client then closes the connection
       netIn.sendComplete()
-      requests.expectComplete() // this should happen, but never does
+      requests.expectComplete()
       netOut.expectComplete()
     })
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -60,8 +60,8 @@ class EntityDiscardingSpec extends AkkaSpec {
       val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
       val bound = Http().bindAndHandleSync(
         req ⇒
-        HttpResponse(entity = HttpEntity(
-          ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() ⇒ testData.iterator))),
+          HttpResponse(entity = HttpEntity(
+            ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() ⇒ testData.iterator))),
         host, port).futureValue
 
       try {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
@@ -4,13 +4,13 @@
 
 package akka.http.scaladsl.model
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import org.scalatest.{BeforeAndAfterAll, Inside, Matchers, WordSpec}
+import org.scalatest.{ BeforeAndAfterAll, Inside, Matchers, WordSpec }
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import headers._
@@ -43,7 +43,7 @@ class MultipartSpec extends WordSpec with Matchers with Inside with BeforeAndAft
       val result = streamed.toEntity(boundary = "boundary")
       result.contentType shouldBe MediaTypes.`multipart/mixed`.withBoundary("boundary").withCharset(HttpCharsets.`UTF-8`)
       val encoding = Await.result(result.dataBytes.runWith(Sink.seq), 1.second)
-      encoding .map(_.utf8String).mkString shouldBe "--boundary\r\nContent-Type: text/plain; charset=UTF-8\r\nETag: \"xzy\"\r\n\r\ndata\r\n--boundary--"
+      encoding.map(_.utf8String).mkString shouldBe "--boundary\r\nContent-Type: text/plain; charset=UTF-8\r\nETag: \"xzy\"\r\n\r\ndata\r\n--boundary--"
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/20789
Special situations, demand special handling.

Sadly I was unable to provide a reproducer of the Play behaviour as isolated Akka test :-(
I was testing with the actual Play project with SNAPSHOT built Akka

Reproducer is: https://github.com/wsargent/reproduce-akka-20642
