### PR TITLE
ignore PubSub Status message from unknown node, #20846

### DIFF
--- a/akka-cluster-tools/src/main/java/akka/cluster/pubsub/protobuf/msg/DistributedPubSubMessages.java
+++ b/akka-cluster-tools/src/main/java/akka/cluster/pubsub/protobuf/msg/DistributedPubSubMessages.java
@@ -35,6 +35,16 @@ public final class DistributedPubSubMessages {
      */
     akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status.VersionOrBuilder getVersionsOrBuilder(
         int index);
+
+    // optional bool reply = 2;
+    /**
+     * <code>optional bool reply = 2;</code>
+     */
+    boolean hasReply();
+    /**
+     * <code>optional bool reply = 2;</code>
+     */
+    boolean getReply();
   }
   /**
    * Protobuf type {@code Status}
@@ -93,6 +103,11 @@ public final class DistributedPubSubMessages {
                 mutable_bitField0_ |= 0x00000001;
               }
               versions_.add(input.readMessage(akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status.Version.PARSER, extensionRegistry));
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000001;
+              reply_ = input.readBool();
               break;
             }
           }
@@ -749,6 +764,7 @@ public final class DistributedPubSubMessages {
       // @@protoc_insertion_point(class_scope:Status.Version)
     }
 
+    private int bitField0_;
     // repeated .Status.Version versions = 1;
     public static final int VERSIONS_FIELD_NUMBER = 1;
     private java.util.List<akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status.Version> versions_;
@@ -785,8 +801,25 @@ public final class DistributedPubSubMessages {
       return versions_.get(index);
     }
 
+    // optional bool reply = 2;
+    public static final int REPLY_FIELD_NUMBER = 2;
+    private boolean reply_;
+    /**
+     * <code>optional bool reply = 2;</code>
+     */
+    public boolean hasReply() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional bool reply = 2;</code>
+     */
+    public boolean getReply() {
+      return reply_;
+    }
+
     private void initFields() {
       versions_ = java.util.Collections.emptyList();
+      reply_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -809,6 +842,9 @@ public final class DistributedPubSubMessages {
       for (int i = 0; i < versions_.size(); i++) {
         output.writeMessage(1, versions_.get(i));
       }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBool(2, reply_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -821,6 +857,10 @@ public final class DistributedPubSubMessages {
       for (int i = 0; i < versions_.size(); i++) {
         size += akka.protobuf.CodedOutputStream
           .computeMessageSize(1, versions_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += akka.protobuf.CodedOutputStream
+          .computeBoolSize(2, reply_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -945,6 +985,8 @@ public final class DistributedPubSubMessages {
         } else {
           versionsBuilder_.clear();
         }
+        reply_ = false;
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -972,6 +1014,7 @@ public final class DistributedPubSubMessages {
       public akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status buildPartial() {
         akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status result = new akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status(this);
         int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
         if (versionsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
             versions_ = java.util.Collections.unmodifiableList(versions_);
@@ -981,6 +1024,11 @@ public final class DistributedPubSubMessages {
         } else {
           result.versions_ = versionsBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.reply_ = reply_;
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -1021,6 +1069,9 @@ public final class DistributedPubSubMessages {
               versionsBuilder_.addAllMessages(other.versions_);
             }
           }
+        }
+        if (other.hasReply()) {
+          setReply(other.getReply());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1293,6 +1344,39 @@ public final class DistributedPubSubMessages {
           versions_ = null;
         }
         return versionsBuilder_;
+      }
+
+      // optional bool reply = 2;
+      private boolean reply_ ;
+      /**
+       * <code>optional bool reply = 2;</code>
+       */
+      public boolean hasReply() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional bool reply = 2;</code>
+       */
+      public boolean getReply() {
+        return reply_;
+      }
+      /**
+       * <code>optional bool reply = 2;</code>
+       */
+      public Builder setReply(boolean value) {
+        bitField0_ |= 0x00000002;
+        reply_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool reply = 2;</code>
+       */
+      public Builder clearReply() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        reply_ = false;
+        onChanged();
+        return this;
       }
 
       // @@protoc_insertion_point(builder_scope:Status)
@@ -7508,24 +7592,25 @@ public final class DistributedPubSubMessages {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\037DistributedPubSubMessages.proto\"d\n\006Sta" +
-      "tus\022!\n\010versions\030\001 \003(\0132\017.Status.Version\0327" +
-      "\n\007Version\022\031\n\007address\030\001 \002(\0132\010.Address\022\021\n\t" +
-      "timestamp\030\002 \002(\003\"\256\001\n\005Delta\022\036\n\007buckets\030\001 \003" +
-      "(\0132\r.Delta.Bucket\0322\n\005Entry\022\013\n\003key\030\001 \002(\t\022" +
-      "\017\n\007version\030\002 \002(\003\022\013\n\003ref\030\003 \001(\t\032Q\n\006Bucket\022" +
-      "\027\n\005owner\030\001 \002(\0132\010.Address\022\017\n\007version\030\002 \002(" +
-      "\003\022\035\n\007content\030\003 \003(\0132\014.Delta.Entry\"K\n\007Addr" +
-      "ess\022\016\n\006system\030\001 \002(\t\022\020\n\010hostname\030\002 \002(\t\022\014\n" +
-      "\004port\030\003 \002(\r\022\020\n\010protocol\030\004 \001(\t\"F\n\004Send\022\014\n",
-      "\004path\030\001 \002(\t\022\025\n\rlocalAffinity\030\002 \002(\010\022\031\n\007pa" +
-      "yload\030\003 \002(\0132\010.Payload\"H\n\tSendToAll\022\014\n\004pa" +
-      "th\030\001 \002(\t\022\022\n\nallButSelf\030\002 \002(\010\022\031\n\007payload\030" +
-      "\003 \002(\0132\010.Payload\"3\n\007Publish\022\r\n\005topic\030\001 \002(" +
-      "\t\022\031\n\007payload\030\003 \002(\0132\010.Payload\"Q\n\007Payload\022" +
-      "\027\n\017enclosedMessage\030\001 \002(\014\022\024\n\014serializerId" +
-      "\030\002 \002(\005\022\027\n\017messageManifest\030\004 \001(\014B$\n akka." +
-      "cluster.pubsub.protobuf.msgH\001"
+      "\n\037DistributedPubSubMessages.proto\"s\n\006Sta" +
+      "tus\022!\n\010versions\030\001 \003(\0132\017.Status.Version\022\r" +
+      "\n\005reply\030\002 \001(\010\0327\n\007Version\022\031\n\007address\030\001 \002(" +
+      "\0132\010.Address\022\021\n\ttimestamp\030\002 \002(\003\"\256\001\n\005Delta" +
+      "\022\036\n\007buckets\030\001 \003(\0132\r.Delta.Bucket\0322\n\005Entr" +
+      "y\022\013\n\003key\030\001 \002(\t\022\017\n\007version\030\002 \002(\003\022\013\n\003ref\030\003" +
+      " \001(\t\032Q\n\006Bucket\022\027\n\005owner\030\001 \002(\0132\010.Address\022" +
+      "\017\n\007version\030\002 \002(\003\022\035\n\007content\030\003 \003(\0132\014.Delt" +
+      "a.Entry\"K\n\007Address\022\016\n\006system\030\001 \002(\t\022\020\n\010ho" +
+      "stname\030\002 \002(\t\022\014\n\004port\030\003 \002(\r\022\020\n\010protocol\030\004",
+      " \001(\t\"F\n\004Send\022\014\n\004path\030\001 \002(\t\022\025\n\rlocalAffin" +
+      "ity\030\002 \002(\010\022\031\n\007payload\030\003 \002(\0132\010.Payload\"H\n\t" +
+      "SendToAll\022\014\n\004path\030\001 \002(\t\022\022\n\nallButSelf\030\002 " +
+      "\002(\010\022\031\n\007payload\030\003 \002(\0132\010.Payload\"3\n\007Publis" +
+      "h\022\r\n\005topic\030\001 \002(\t\022\031\n\007payload\030\003 \002(\0132\010.Payl" +
+      "oad\"Q\n\007Payload\022\027\n\017enclosedMessage\030\001 \002(\014\022" +
+      "\024\n\014serializerId\030\002 \002(\005\022\027\n\017messageManifest" +
+      "\030\004 \001(\014B$\n akka.cluster.pubsub.protobuf.m" +
+      "sgH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -7537,7 +7622,7 @@ public final class DistributedPubSubMessages {
           internal_static_Status_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_Status_descriptor,
-              new java.lang.String[] { "Versions", });
+              new java.lang.String[] { "Versions", "Reply", });
           internal_static_Status_Version_descriptor =
             internal_static_Status_descriptor.getNestedTypes().get(0);
           internal_static_Status_Version_fieldAccessorTable = new

--- a/akka-cluster-tools/src/main/java/akka/cluster/pubsub/protobuf/msg/DistributedPubSubMessages.java
+++ b/akka-cluster-tools/src/main/java/akka/cluster/pubsub/protobuf/msg/DistributedPubSubMessages.java
@@ -36,15 +36,15 @@ public final class DistributedPubSubMessages {
     akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status.VersionOrBuilder getVersionsOrBuilder(
         int index);
 
-    // optional bool reply = 2;
+    // optional bool replyToStatus = 2;
     /**
-     * <code>optional bool reply = 2;</code>
+     * <code>optional bool replyToStatus = 2;</code>
      */
-    boolean hasReply();
+    boolean hasReplyToStatus();
     /**
-     * <code>optional bool reply = 2;</code>
+     * <code>optional bool replyToStatus = 2;</code>
      */
-    boolean getReply();
+    boolean getReplyToStatus();
   }
   /**
    * Protobuf type {@code Status}
@@ -107,7 +107,7 @@ public final class DistributedPubSubMessages {
             }
             case 16: {
               bitField0_ |= 0x00000001;
-              reply_ = input.readBool();
+              replyToStatus_ = input.readBool();
               break;
             }
           }
@@ -801,25 +801,25 @@ public final class DistributedPubSubMessages {
       return versions_.get(index);
     }
 
-    // optional bool reply = 2;
-    public static final int REPLY_FIELD_NUMBER = 2;
-    private boolean reply_;
+    // optional bool replyToStatus = 2;
+    public static final int REPLYTOSTATUS_FIELD_NUMBER = 2;
+    private boolean replyToStatus_;
     /**
-     * <code>optional bool reply = 2;</code>
+     * <code>optional bool replyToStatus = 2;</code>
      */
-    public boolean hasReply() {
+    public boolean hasReplyToStatus() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional bool reply = 2;</code>
+     * <code>optional bool replyToStatus = 2;</code>
      */
-    public boolean getReply() {
-      return reply_;
+    public boolean getReplyToStatus() {
+      return replyToStatus_;
     }
 
     private void initFields() {
       versions_ = java.util.Collections.emptyList();
-      reply_ = false;
+      replyToStatus_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -843,7 +843,7 @@ public final class DistributedPubSubMessages {
         output.writeMessage(1, versions_.get(i));
       }
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBool(2, reply_);
+        output.writeBool(2, replyToStatus_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -860,7 +860,7 @@ public final class DistributedPubSubMessages {
       }
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += akka.protobuf.CodedOutputStream
-          .computeBoolSize(2, reply_);
+          .computeBoolSize(2, replyToStatus_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -985,7 +985,7 @@ public final class DistributedPubSubMessages {
         } else {
           versionsBuilder_.clear();
         }
-        reply_ = false;
+        replyToStatus_ = false;
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
@@ -1027,7 +1027,7 @@ public final class DistributedPubSubMessages {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000001;
         }
-        result.reply_ = reply_;
+        result.replyToStatus_ = replyToStatus_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1070,8 +1070,8 @@ public final class DistributedPubSubMessages {
             }
           }
         }
-        if (other.hasReply()) {
-          setReply(other.getReply());
+        if (other.hasReplyToStatus()) {
+          setReplyToStatus(other.getReplyToStatus());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1346,35 +1346,35 @@ public final class DistributedPubSubMessages {
         return versionsBuilder_;
       }
 
-      // optional bool reply = 2;
-      private boolean reply_ ;
+      // optional bool replyToStatus = 2;
+      private boolean replyToStatus_ ;
       /**
-       * <code>optional bool reply = 2;</code>
+       * <code>optional bool replyToStatus = 2;</code>
        */
-      public boolean hasReply() {
+      public boolean hasReplyToStatus() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional bool reply = 2;</code>
+       * <code>optional bool replyToStatus = 2;</code>
        */
-      public boolean getReply() {
-        return reply_;
+      public boolean getReplyToStatus() {
+        return replyToStatus_;
       }
       /**
-       * <code>optional bool reply = 2;</code>
+       * <code>optional bool replyToStatus = 2;</code>
        */
-      public Builder setReply(boolean value) {
+      public Builder setReplyToStatus(boolean value) {
         bitField0_ |= 0x00000002;
-        reply_ = value;
+        replyToStatus_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional bool reply = 2;</code>
+       * <code>optional bool replyToStatus = 2;</code>
        */
-      public Builder clearReply() {
+      public Builder clearReplyToStatus() {
         bitField0_ = (bitField0_ & ~0x00000002);
-        reply_ = false;
+        replyToStatus_ = false;
         onChanged();
         return this;
       }
@@ -7592,25 +7592,25 @@ public final class DistributedPubSubMessages {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\037DistributedPubSubMessages.proto\"s\n\006Sta" +
-      "tus\022!\n\010versions\030\001 \003(\0132\017.Status.Version\022\r" +
-      "\n\005reply\030\002 \001(\010\0327\n\007Version\022\031\n\007address\030\001 \002(" +
-      "\0132\010.Address\022\021\n\ttimestamp\030\002 \002(\003\"\256\001\n\005Delta" +
-      "\022\036\n\007buckets\030\001 \003(\0132\r.Delta.Bucket\0322\n\005Entr" +
-      "y\022\013\n\003key\030\001 \002(\t\022\017\n\007version\030\002 \002(\003\022\013\n\003ref\030\003" +
-      " \001(\t\032Q\n\006Bucket\022\027\n\005owner\030\001 \002(\0132\010.Address\022" +
-      "\017\n\007version\030\002 \002(\003\022\035\n\007content\030\003 \003(\0132\014.Delt" +
-      "a.Entry\"K\n\007Address\022\016\n\006system\030\001 \002(\t\022\020\n\010ho" +
-      "stname\030\002 \002(\t\022\014\n\004port\030\003 \002(\r\022\020\n\010protocol\030\004",
-      " \001(\t\"F\n\004Send\022\014\n\004path\030\001 \002(\t\022\025\n\rlocalAffin" +
-      "ity\030\002 \002(\010\022\031\n\007payload\030\003 \002(\0132\010.Payload\"H\n\t" +
-      "SendToAll\022\014\n\004path\030\001 \002(\t\022\022\n\nallButSelf\030\002 " +
-      "\002(\010\022\031\n\007payload\030\003 \002(\0132\010.Payload\"3\n\007Publis" +
-      "h\022\r\n\005topic\030\001 \002(\t\022\031\n\007payload\030\003 \002(\0132\010.Payl" +
-      "oad\"Q\n\007Payload\022\027\n\017enclosedMessage\030\001 \002(\014\022" +
-      "\024\n\014serializerId\030\002 \002(\005\022\027\n\017messageManifest" +
-      "\030\004 \001(\014B$\n akka.cluster.pubsub.protobuf.m" +
-      "sgH\001"
+      "\n\037DistributedPubSubMessages.proto\"{\n\006Sta" +
+      "tus\022!\n\010versions\030\001 \003(\0132\017.Status.Version\022\025" +
+      "\n\rreplyToStatus\030\002 \001(\010\0327\n\007Version\022\031\n\007addr" +
+      "ess\030\001 \002(\0132\010.Address\022\021\n\ttimestamp\030\002 \002(\003\"\256" +
+      "\001\n\005Delta\022\036\n\007buckets\030\001 \003(\0132\r.Delta.Bucket" +
+      "\0322\n\005Entry\022\013\n\003key\030\001 \002(\t\022\017\n\007version\030\002 \002(\003\022" +
+      "\013\n\003ref\030\003 \001(\t\032Q\n\006Bucket\022\027\n\005owner\030\001 \002(\0132\010." +
+      "Address\022\017\n\007version\030\002 \002(\003\022\035\n\007content\030\003 \003(" +
+      "\0132\014.Delta.Entry\"K\n\007Address\022\016\n\006system\030\001 \002" +
+      "(\t\022\020\n\010hostname\030\002 \002(\t\022\014\n\004port\030\003 \002(\r\022\020\n\010pr",
+      "otocol\030\004 \001(\t\"F\n\004Send\022\014\n\004path\030\001 \002(\t\022\025\n\rlo" +
+      "calAffinity\030\002 \002(\010\022\031\n\007payload\030\003 \002(\0132\010.Pay" +
+      "load\"H\n\tSendToAll\022\014\n\004path\030\001 \002(\t\022\022\n\nallBu" +
+      "tSelf\030\002 \002(\010\022\031\n\007payload\030\003 \002(\0132\010.Payload\"3" +
+      "\n\007Publish\022\r\n\005topic\030\001 \002(\t\022\031\n\007payload\030\003 \002(" +
+      "\0132\010.Payload\"Q\n\007Payload\022\027\n\017enclosedMessag" +
+      "e\030\001 \002(\014\022\024\n\014serializerId\030\002 \002(\005\022\027\n\017message" +
+      "Manifest\030\004 \001(\014B$\n akka.cluster.pubsub.pr" +
+      "otobuf.msgH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -7622,7 +7622,7 @@ public final class DistributedPubSubMessages {
           internal_static_Status_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_Status_descriptor,
-              new java.lang.String[] { "Versions", "Reply", });
+              new java.lang.String[] { "Versions", "ReplyToStatus", });
           internal_static_Status_Version_descriptor =
             internal_static_Status_descriptor.getNestedTypes().get(0);
           internal_static_Status_Version_fieldAccessorTable = new

--- a/akka-cluster-tools/src/main/protobuf/DistributedPubSubMessages.proto
+++ b/akka-cluster-tools/src/main/protobuf/DistributedPubSubMessages.proto
@@ -11,7 +11,7 @@ message Status {
     required int64 timestamp = 2;
   }
   repeated Version versions = 1;
-  optional bool reply = 2;
+  optional bool replyToStatus = 2;
 }
 
 message Delta {

--- a/akka-cluster-tools/src/main/protobuf/DistributedPubSubMessages.proto
+++ b/akka-cluster-tools/src/main/protobuf/DistributedPubSubMessages.proto
@@ -11,6 +11,7 @@ message Status {
     required int64 timestamp = 2;
   }
   repeated Version versions = 1;
+  optional bool reply = 2;
 }
 
 message Delta {

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -221,11 +221,14 @@ object DistributedPubSubMediator {
     }
 
     @SerialVersionUID(1L)
-    final case class Status(versions: Map[Address, Long]) extends DistributedPubSubMessage
+    final case class Status(versions: Map[Address, Long], reply: Boolean) extends DistributedPubSubMessage
       with DeadLetterSuppression
     @SerialVersionUID(1L)
     final case class Delta(buckets: immutable.Iterable[Bucket]) extends DistributedPubSubMessage
       with DeadLetterSuppression
+
+    // Only for testing purposes, to verify replication
+    case object DeltaCount
 
     case object GossipTick
 
@@ -500,6 +503,7 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
 
   var registry: Map[Address, Bucket] = Map.empty.withDefault(a ⇒ Bucket(a, 0L, TreeMap.empty))
   var nodes: Set[Address] = Set.empty
+  var deltaCount = 0L
 
   // the version is a timestamp because it is also used when pruning removed entries
   val nextVersion = {
@@ -615,15 +619,21 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
     case msg @ Unsubscribed(ack, ref) ⇒
       ref ! ack
 
-    case Status(otherVersions) ⇒
-      // gossip chat starts with a Status message, containing the bucket versions of the other node
-      val delta = collectDelta(otherVersions)
-      if (delta.nonEmpty)
-        sender() ! Delta(delta)
-      if (otherHasNewerVersions(otherVersions))
-        sender() ! Status(versions = myVersions) // it will reply with Delta
+    case Status(otherVersions, reply) ⇒
+      // only accept status from known nodes, otherwise old cluster with same address may interact
+      // also accept from local for testing purposes
+      if (nodes(sender().path.address) || sender().path.address.hasLocalScope) {
+        // gossip chat starts with a Status message, containing the bucket versions of the other node
+        val delta = collectDelta(otherVersions)
+        if (delta.nonEmpty)
+          sender() ! Delta(delta)
+        if (!reply && otherHasNewerVersions(otherVersions))
+          sender() ! Status(versions = myVersions, reply = true) // it will reply with Delta
+      }
 
     case Delta(buckets) ⇒
+      deltaCount += 1
+
       // reply from Status message in the gossip chat
       // the Delta contains potential updates (newer versions) from the other node
       // only accept deltas/buckets from known nodes, otherwise there is a risk of
@@ -683,6 +693,9 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
         }
       }.sum
       sender() ! count
+
+    case DeltaCount ⇒
+      sender() ! deltaCount
   }
 
   private def sendToDeadLetters(msg: Any) = context.system.deadLetters ! DeadLetter(msg, sender(), context.self)
@@ -783,7 +796,7 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
   def gossip(): Unit = selectRandomNode((nodes - selfAddress).toVector) foreach gossipTo
 
   def gossipTo(address: Address): Unit = {
-    context.actorSelection(self.path.toStringWithAddress(address)) ! Status(versions = myVersions)
+    context.actorSelection(self.path.toStringWithAddress(address)) ! Status(versions = myVersions, reply = false)
   }
 
   def selectRandomNode(addresses: immutable.IndexedSeq[Address]): Option[Address] =

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
@@ -116,7 +116,7 @@ private[akka] class DistributedPubSubMessageSerializer(val system: ExtendedActor
     }.toVector.asJava
     dm.Status.newBuilder()
       .addAllVersions(versions)
-      .setReply(status.reply)
+      .setReplyToStatus(status.isReplyToStatus)
       .build()
   }
 
@@ -124,9 +124,9 @@ private[akka] class DistributedPubSubMessageSerializer(val system: ExtendedActor
     statusFromProto(dm.Status.parseFrom(decompress(bytes)))
 
   private def statusFromProto(status: dm.Status): Status = {
-    val reply = if (status.hasReply) status.getReply else false
+    val isReplyToStatus = if (status.hasReplyToStatus) status.getReplyToStatus else false
     Status(status.getVersionsList.asScala.map(v ⇒
-      addressFromProto(v.getAddress) → v.getTimestamp)(breakOut), reply)
+      addressFromProto(v.getAddress) → v.getTimestamp)(breakOut), isReplyToStatus)
   }
 
   private def deltaToProto(delta: Delta): dm.Delta = {

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
@@ -114,15 +114,20 @@ private[akka] class DistributedPubSubMessageSerializer(val system: ExtendedActor
           setTimestamp(v).
           build()
     }.toVector.asJava
-    dm.Status.newBuilder().addAllVersions(versions).build()
+    dm.Status.newBuilder()
+      .addAllVersions(versions)
+      .setReply(status.reply)
+      .build()
   }
 
   private def statusFromBinary(bytes: Array[Byte]): Status =
     statusFromProto(dm.Status.parseFrom(decompress(bytes)))
 
-  private def statusFromProto(status: dm.Status): Status =
+  private def statusFromProto(status: dm.Status): Status = {
+    val reply = if (status.hasReply) status.getReply else false
     Status(status.getVersionsList.asScala.map(v ⇒
-      addressFromProto(v.getAddress) → v.getTimestamp)(breakOut))
+      addressFromProto(v.getAddress) → v.getTimestamp)(breakOut), reply)
+  }
 
   private def deltaToProto(delta: Delta): dm.Delta = {
     val buckets = delta.buckets.map { b ⇒

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
@@ -454,7 +454,7 @@ class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMedia
       val thirdAddress = node(third).address
 
       runOn(first) {
-        mediator ! Status(versions = Map.empty)
+        mediator ! Status(versions = Map.empty, reply = false)
         val deltaBuckets = expectMsgType[Delta].buckets
         deltaBuckets.size should ===(3)
         deltaBuckets.find(_.owner == firstAddress).get.content.size should ===(10)
@@ -469,15 +469,15 @@ class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMedia
         for (i ← 0 until many)
           mediator ! Put(createChatUser("u" + (1000 + i)))
 
-        mediator ! Status(versions = Map.empty)
+        mediator ! Status(versions = Map.empty, reply = false)
         val deltaBuckets1 = expectMsgType[Delta].buckets
         deltaBuckets1.map(_.content.size).sum should ===(500)
 
-        mediator ! Status(versions = deltaBuckets1.map(b ⇒ b.owner → b.version).toMap)
+        mediator ! Status(versions = deltaBuckets1.map(b ⇒ b.owner → b.version).toMap, reply = false)
         val deltaBuckets2 = expectMsgType[Delta].buckets
         deltaBuckets1.map(_.content.size).sum should ===(500)
 
-        mediator ! Status(versions = deltaBuckets2.map(b ⇒ b.owner → b.version).toMap)
+        mediator ! Status(versions = deltaBuckets2.map(b ⇒ b.owner → b.version).toMap, reply = false)
         val deltaBuckets3 = expectMsgType[Delta].buckets
 
         deltaBuckets3.map(_.content.size).sum should ===(10 + 9 + 2 + many - 500 - 500)

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
@@ -454,7 +454,7 @@ class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMedia
       val thirdAddress = node(third).address
 
       runOn(first) {
-        mediator ! Status(versions = Map.empty, reply = false)
+        mediator ! Status(versions = Map.empty, isReplyToStatus = false)
         val deltaBuckets = expectMsgType[Delta].buckets
         deltaBuckets.size should ===(3)
         deltaBuckets.find(_.owner == firstAddress).get.content.size should ===(10)
@@ -469,15 +469,15 @@ class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMedia
         for (i ← 0 until many)
           mediator ! Put(createChatUser("u" + (1000 + i)))
 
-        mediator ! Status(versions = Map.empty, reply = false)
+        mediator ! Status(versions = Map.empty, isReplyToStatus = false)
         val deltaBuckets1 = expectMsgType[Delta].buckets
         deltaBuckets1.map(_.content.size).sum should ===(500)
 
-        mediator ! Status(versions = deltaBuckets1.map(b ⇒ b.owner → b.version).toMap, reply = false)
+        mediator ! Status(versions = deltaBuckets1.map(b ⇒ b.owner → b.version).toMap, isReplyToStatus = false)
         val deltaBuckets2 = expectMsgType[Delta].buckets
         deltaBuckets1.map(_.content.size).sum should ===(500)
 
-        mediator ! Status(versions = deltaBuckets2.map(b ⇒ b.owner → b.version).toMap, reply = false)
+        mediator ! Status(versions = deltaBuckets2.map(b ⇒ b.owner → b.version).toMap, isReplyToStatus = false)
         val deltaBuckets3 = expectMsgType[Delta].buckets
 
         deltaBuckets3.map(_.content.size).sum should ===(10 + 9 + 2 + many - 500 - 500)

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubRestartSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubRestartSpec.scala
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.pubsub
+
+import language.postfixOps
+import scala.concurrent.duration._
+import com.typesafe.config.ConfigFactory
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent._
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.STMultiNodeSpec
+import akka.testkit._
+import akka.actor.ActorLogging
+import akka.cluster.pubsub.DistributedPubSubMediator.Internal.Status
+import akka.cluster.pubsub.DistributedPubSubMediator.Internal.Delta
+import akka.actor.ActorSystem
+import scala.concurrent.Await
+import akka.actor.Identify
+import akka.actor.RootActorPath
+import akka.actor.ActorIdentity
+
+object DistributedPubSubRestartSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(ConfigFactory.parseString("""
+    akka.loglevel = INFO
+    akka.cluster.pub-sub.gossip-interval = 500ms
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.remote.log-remote-lifecycle-events = off
+    akka.cluster.auto-down-unreachable-after = off
+    """))
+
+  testTransport(on = true)
+
+  class Shutdown extends Actor {
+    def receive = {
+      case "shutdown" ⇒ context.system.terminate()
+    }
+  }
+
+}
+
+class DistributedPubSubRestartMultiJvmNode1 extends DistributedPubSubRestartSpec
+class DistributedPubSubRestartMultiJvmNode2 extends DistributedPubSubRestartSpec
+class DistributedPubSubRestartMultiJvmNode3 extends DistributedPubSubRestartSpec
+
+class DistributedPubSubRestartSpec extends MultiNodeSpec(DistributedPubSubRestartSpec) with STMultiNodeSpec with ImplicitSender {
+  import DistributedPubSubRestartSpec._
+  import DistributedPubSubMediator._
+
+  override def initialParticipants = roles.size
+
+  def join(from: RoleName, to: RoleName): Unit = {
+    runOn(from) {
+      Cluster(system) join node(to).address
+      createMediator()
+    }
+    enterBarrier(from.name + "-joined")
+  }
+
+  def createMediator(): ActorRef = DistributedPubSub(system).mediator
+  def mediator: ActorRef = DistributedPubSub(system).mediator
+
+  def awaitCount(expected: Int): Unit = {
+    val probe = TestProbe()
+    awaitAssert {
+      mediator.tell(Count, probe.ref)
+      probe.expectMsgType[Int] should ===(expected)
+    }
+  }
+
+  "A Cluster with DistributedPubSub" must {
+
+    "startup 3 node cluster" in within(15 seconds) {
+      join(first, first)
+      join(second, first)
+      join(third, first)
+      enterBarrier("after-1")
+    }
+
+    "handle restart of nodes with same address" in within(30 seconds) {
+      mediator ! Subscribe("topic1", testActor)
+      expectMsgType[SubscribeAck]
+      awaitCount(3)
+
+      runOn(first) {
+        mediator ! Publish("topic1", "msg1")
+      }
+      enterBarrier("pub-msg1")
+
+      expectMsg("msg1")
+      enterBarrier("got-msg1")
+
+      runOn(second) {
+        mediator ! Internal.DeltaCount
+        val oldDeltaCount = expectMsgType[Long]
+
+        enterBarrier("end")
+
+        mediator ! Internal.DeltaCount
+        val deltaCount = expectMsgType[Long]
+        deltaCount should ===(oldDeltaCount)
+      }
+
+      runOn(first) {
+        mediator ! Internal.DeltaCount
+        val oldDeltaCount = expectMsgType[Long]
+
+        val thirdAddress = node(third).address
+        testConductor.shutdown(third).await
+
+        within(20.seconds) {
+          awaitAssert {
+            system.actorSelection(RootActorPath(thirdAddress) / "user" / "shutdown") ! Identify(None)
+            expectMsgType[ActorIdentity](1.second).ref.get
+          }
+        }
+
+        system.actorSelection(RootActorPath(thirdAddress) / "user" / "shutdown") ! "shutdown"
+
+        enterBarrier("end")
+
+        mediator ! Internal.DeltaCount
+        val deltaCount = expectMsgType[Long]
+        deltaCount should ===(oldDeltaCount)
+      }
+
+      runOn(third) {
+        Await.result(system.whenTerminated, 10.seconds)
+        val newSystem = ActorSystem(
+          system.name,
+          ConfigFactory.parseString(s"akka.remote.netty.tcp.port=${Cluster(system).selfAddress.port.get}").withFallback(
+            system.settings.config))
+        // don't join the old cluster
+        Cluster(newSystem).join(Cluster(newSystem).selfAddress)
+        val newMediator = DistributedPubSub(newSystem).mediator
+        val probe = TestProbe()(newSystem)
+        newMediator.tell(Subscribe("topic2", probe.ref), probe.ref)
+        probe.expectMsgType[SubscribeAck]
+
+        // let them gossip, but Delta should not be exchanged
+        probe.expectNoMsg(5.seconds)
+        newMediator.tell(Internal.DeltaCount, probe.ref)
+        probe.expectMsg(0L)
+
+        newSystem.actorOf(Props[Shutdown], "shutdown")
+        Await.ready(newSystem.whenTerminated, 10.seconds)
+      }
+
+    }
+  }
+
+}

--- a/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
@@ -30,7 +30,7 @@ class DistributedPubSubMessageSerializerSpec extends AkkaSpec {
       val u2 = system.actorOf(Props.empty, "u2")
       val u3 = system.actorOf(Props.empty, "u3")
       val u4 = system.actorOf(Props.empty, "u4")
-      checkSerialization(Status(Map(address1 → 3, address2 → 17, address3 → 5)))
+      checkSerialization(Status(Map(address1 → 3, address2 → 17, address3 → 5), reply = true))
       checkSerialization(Delta(List(
         Bucket(address1, 3, TreeMap("/user/u1" → ValueHolder(2, Some(u1)), "/user/u2" → ValueHolder(3, Some(u2)))),
         Bucket(address2, 17, TreeMap("/user/u3" → ValueHolder(17, Some(u3)))),

--- a/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
@@ -30,7 +30,7 @@ class DistributedPubSubMessageSerializerSpec extends AkkaSpec {
       val u2 = system.actorOf(Props.empty, "u2")
       val u3 = system.actorOf(Props.empty, "u3")
       val u4 = system.actorOf(Props.empty, "u4")
-      checkSerialization(Status(Map(address1 → 3, address2 → 17, address3 → 5), reply = true))
+      checkSerialization(Status(Map(address1 → 3, address2 → 17, address3 → 5), isReplyToStatus = true))
       checkSerialization(Delta(List(
         Bucket(address1, 3, TreeMap("/user/u1" → ValueHolder(2, Some(u1)), "/user/u2" → ValueHolder(3, Some(u2)))),
         Bucket(address2, 17, TreeMap("/user/u3" → ValueHolder(17, Some(u3)))),

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -896,7 +896,11 @@ object MiMa extends AutoPlugin {
         // #20456 adding hot connection pool option
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.getMinConnections"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.minConnections"),
-        FilterAnyProblemStartingWith("akka.http.impl")
+        FilterAnyProblemStartingWith("akka.http.impl"),
+        
+        // #20846 change of internal Status message
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages#StatusOrBuilder.getReplyToStatus"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages#StatusOrBuilder.hasReplyToStatus")
       )
     )
   }


### PR DESCRIPTION
Reproducer:
1. old cluster of node1, node2 and node3
2. shutdown node3 and start it again with same host:port, let it
   join itself and not the old cluster
3. node1 and node2 will continue to gossip to the node3 address and
   Status message is accepted and replied to (Delta is ignored from
   unknown node)

Solution:
- ignore status message from unknown node
- also added a reply flag in the Status message to break the
  back-and-forth replies in case the deltas are not accepted,
  this is not needed for fixing this bug, but it adds an extra
  level of safety
