### PR TITLE
#18733 provide rejection reason when path matcher throws an exception

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.http.scaladsl.server.directives
 
-import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
 import org.scalatest.Inside
 
@@ -414,12 +414,14 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
       Get("/foo") ~> Route.seal(route) ~> check { status shouldEqual NotFound }
     }
     "be raised" in {
-      Get("/foo/1.0/test") ~> route ~> check { rejection shouldEqual PathMatcherExtractionFailedRejection }
+      Get("/foo/a.0") ~>
+        path("foo" / DoubleNumber) { i ⇒ complete(s"$i") } ~>
+        check { rejection shouldEqual PathMatcherExtractionFailedRejection }
     }
   }
 
-  import akka.http.scaladsl.model.headers.Location
   import akka.http.scaladsl.model.Uri
+  import akka.http.scaladsl.model.headers.Location
 
   private def checkRedirectTo(expectedUri: Uri) =
     check {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -4,9 +4,11 @@
 
 package akka.http.scaladsl.server.directives
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server._
 import org.scalatest.Inside
+
+import scala.util.Success
 
 class PathDirectivesSpec extends RoutingSpec with Inside {
   val echoUnmatchedPath = extractUnmatchedPath { echoComplete }
@@ -295,12 +297,12 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
       "support the map modifier in accept [/yes-no]" in test("List(yes, no)")
     }
     {
-      val test = testFor(path(Remaining.tflatMap { case Tuple1(s) ⇒ Some(s).filter("yes" ==).map(x ⇒ Tuple1(x)) }) { echoComplete })
+      val test = testFor(path(Remaining.tflatMap { case Tuple1(s) ⇒ Some(s).filter("yes" ==).map(x ⇒ Success(Tuple1(x))) }) { echoComplete })
       "support the hflatMap modifier in accept [/yes]" in test("yes")
       "support the hflatMap modifier in reject [/blub]" in test()
     }
     {
-      val test = testFor(path(Remaining.flatMap(s ⇒ Some(s).filter("yes" ==))) { echoComplete })
+      val test = testFor(path(Remaining.flatMap(s ⇒ Some(Success(s).filter("yes" ==)))) { echoComplete })
       "support the flatMap modifier in accept [/yes]" in test("yes")
       "support the flatMap modifier reject [/blub]" in test()
     }
@@ -389,6 +391,30 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
       Get("/foo/bar/") ~>
         redirectToNoTrailingSlashIfPresent(MovedPermanently) { completeOk } ~>
         check { status shouldEqual MovedPermanently }
+    }
+  }
+
+  "Path matcher extraction failed rejection" should {
+    val route =
+      pathPrefix("foo") {
+        path(IntNumber / "test") { i ⇒ complete(s"$i") } ~
+          path("bar") { complete("ok") }
+      }
+
+    "not be raised, when path is correct" in {
+      Get("/foo/1/test") ~> route ~> check { responseAs[String] shouldEqual "1" }
+    }
+    "not be raised, when next route matched" in {
+      Get("/foo/bar") ~> route ~> check { responseAs[String] shouldEqual "ok" }
+    }
+    "not be raised, when the part route not found" in {
+      Get("/foo/xy") ~> Route.seal(route) ~> check { status shouldEqual NotFound }
+    }
+    "not be raised, when the full route not found" in {
+      Get("/foo") ~> Route.seal(route) ~> check { status shouldEqual NotFound }
+    }
+    "be raised" in {
+      Get("/foo/1.0/test") ~> route ~> check { rejection shouldEqual PathMatcherExtractionFailedRejection }
     }
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
@@ -293,6 +293,11 @@ trait TransformationRejection extends Rejection {
   def getTransform: JFunction[JIterable[Rejection], JIterable[Rejection]]
 }
 
+trait PathMatcherExtractionFailedRejection extends Rejection
+object PathMatcherExtractionFailedRejection extends PathMatcherExtractionFailedRejection {
+  def get = scaladsl.server.PathMatcherExtractionFailedRejection
+}
+
 /**
  * A Throwable wrapping a Rejection.
  * Can be used for marshalling `Future[T]` or `Try[T]` instances, whose failure side is supposed to trigger a route

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.server
 
 import java.util.UUID
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 import scala.util.matching.Regex
 import scala.annotation.tailrec
 import akka.http.scaladsl.server.util.Tuple
@@ -93,13 +93,13 @@ abstract class PathMatcher[L](implicit val ev: Tuple[L]) extends (Path ⇒ PathM
                   case Matched(`remaining2`, _) ⇒ done1 // we made no progress, so "go back" to before the separator
                   case Matched(rest, result)    ⇒ Matched(rest, lift(extractions, result))
                   case Unmatched                ⇒ Unmatched
-                  case Unextracted              => Unextracted
+                  case Unextracted              ⇒ Unextracted
                 }
-                case Unmatched ⇒ done1
-                case Unextracted => done1
+                case Unmatched   ⇒ done1
+                case Unextracted ⇒ done1
               }
-            case Unmatched ⇒ done
-            case Unextracted => done
+            case Unmatched   ⇒ done
+            case Unextracted ⇒ done
           }
         } else done
       }
@@ -114,11 +114,11 @@ object PathMatcher extends ImplicitPathMatcherConstruction {
     def orElse[R >: L](other: ⇒ Matching[R]): Matching[R]
   }
   case class Matched[L: Tuple](pathRest: Path, extractions: L) extends Matching[L] {
-    def map[R: Tuple](f: L ⇒ R) =  Matched(pathRest, f(extractions))
+    def map[R: Tuple](f: L ⇒ R) = Matched(pathRest, f(extractions))
     def flatMap[R: Tuple](f: L ⇒ Option[Try[R]]) = f(extractions) match {
       case Some(Success(valuesR)) ⇒ Matched(pathRest, valuesR)
-      case Some(Failure(e)) ⇒ Unextracted
-      case None ⇒ Unmatched
+      case Some(Failure(e))       ⇒ Unextracted
+      case None                   ⇒ Unmatched
     }
     def andThen[R: Tuple](f: (Path, L) ⇒ Matching[R]) = f(pathRest, extractions)
     def orElse[R >: L](other: ⇒ Matching[R]) = this
@@ -131,10 +131,10 @@ object PathMatcher extends ImplicitPathMatcherConstruction {
     def orElse[R](other: ⇒ Matching[R]) = other
   }
   case object Unextracted extends Matching[Nothing] {
-    def map[R: Tuple](f: (Nothing) => R): Matching[R] = this
-    def flatMap[R: Tuple](f: (Nothing) => Option[Try[R]]): Matching[R] = this
-    def andThen[R: Tuple](f: (Path, Nothing) => Matching[R]): Matching[R] = this
-    def orElse[R](other: => Matching[R]): Matching[R] = other
+    def map[R: Tuple](f: (Nothing) ⇒ R): Matching[R] = this
+    def flatMap[R: Tuple](f: (Nothing) ⇒ Option[Try[R]]): Matching[R] = this
+    def andThen[R: Tuple](f: (Path, Nothing) ⇒ Matching[R]): Matching[R] = this
+    def orElse[R](other: ⇒ Matching[R]): Matching[R] = other
   }
 
   /**
@@ -474,7 +474,7 @@ trait PathMatchers {
       try Some(Success(java.lang.Double.parseDouble(string)))
       catch {
         case e: NumberFormatException ⇒ Some(Failure(e))
-        case _: Throwable => None
+        case _: Throwable             ⇒ None
       }
     }
 
@@ -488,7 +488,7 @@ trait PathMatchers {
       try Some(Success(UUID.fromString(string)))
       catch {
         case e: IllegalArgumentException ⇒ Some(Failure(e))
-        case _: Throwable => None
+        case _: Throwable                ⇒ None
       }
     }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -282,3 +282,6 @@ final case class CircuitBreakerOpenRejection(cause: CircuitBreakerOpenException)
  * (Custom marshallers can of course use it as well.)
  */
 final case class RejectionError(rejection: Rejection) extends RuntimeException
+
+case object PathMatcherExtractionFailedRejection
+  extends jserver.PathMatcherExtractionFailedRejection with Rejection

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -135,6 +135,10 @@ object RejectionHandler {
         complete((MethodNotAllowed, List(Allow(methods)), "HTTP method not allowed, supported methods: " + names.mkString(", ")))
       }
       .handle {
+        case PathMatcherExtractionFailedRejection ⇒
+          complete((NotFound, "The requested resource could not be found"))
+      }
+      .handle {
         case AuthorizationFailedRejection ⇒
           complete((Forbidden, "The supplied authentication is not authorized to access this resource"))
       }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -48,6 +48,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
     implicit val LIsTuple = pm.ev
     extract(ctx ⇒ pm(ctx.unmatchedPath)).flatMap {
       case Matched(rest, values) ⇒ tprovide(values) & mapRequestContext(_ withUnmatchedPath rest)
+      case Unextracted           ⇒ reject(PathMatcherExtractionFailedRejection)
       case Unmatched             ⇒ reject
     }
   }


### PR DESCRIPTION
Refers to #18733 

I've added a new rejection `PathMatcherExtractionFailedRejection`, which should be used when  the `PathMatcher` throws an exception. There is also a new `Matching` result - `Unextracted`. It means that there was some exception thrown. 
To make it possible to recognize this situation I've changed `Matching`'s `flatMap` signature in such way that it takes as parameter function which returns `Option[Try[R]]`. In this case `Try` means that there was parsing exception.
I've tried to change the `NumberMatcher` that it checks if whole segment was parsed and if not there should be `Unextracted` returned. But this have broken tests with `IntNumber.repeat(...)` because it assumes that parsing segment works on "prefix" style. It means that path is being parsed char by char and if it cannot parse some char then path matcher tries to match this char with separator.

Any suggestions if this is the way it should be solved? Some help would be highly appreciated. There is one test that fails, correct me if I'm wrong, but I think this is the case when this feature should be useful.  
