### PR TITLE
Make it possible to use both Camel 2.13.4 and 2.17.1 #19615

### DIFF
--- a/akka-camel/src/test/scala/akka/camel/ConsumerIntegrationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConsumerIntegrationTest.scala
@@ -123,13 +123,13 @@ class ConsumerIntegrationTest extends WordSpec with Matchers with NonSharedCamel
     }
 
     "Error passing consumer supports redelivery through route modification" in {
-      val ref = start(new FailingOnceConsumer("direct:failing-once-concumer") {
+      val ref = start(new FailingOnceConsumer("direct:failing-once-consumer") {
         override def onRouteDefinition = (rd: RouteDefinition) ⇒ {
-          rd.onException(classOf[TestException]).maximumRedeliveries(1).end
+          rd.onException(classOf[TestException]).redeliveryDelay(0L).maximumRedeliveries(1).end
         }
       }, name = "direct-failing-once-consumer")
       filterEvents(EventFilter[TestException](occurrences = 1)) {
-        camel.sendTo("direct:failing-once-concumer", msg = "hello") should ===("accepted: hello")
+        camel.sendTo("direct:failing-once-consumer", msg = "hello") should ===("accepted: hello")
       }
       stop(ref)
     }


### PR DESCRIPTION
A small and humble contribution - addresses [issue 19615](https://github.com/akka/akka/issues/19615). It would be nice to schedule this into a release so we can start using the new camel component goodness.
