### PR TITLE
=str 20843 Scan.in cannot pull closed port

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanSpec.scala
@@ -64,5 +64,18 @@ class FlowScanSpec extends AkkaSpec {
       Source(List(1, 3, -1, 5, 7)).via(scan).runWith(TestSink.probe)
         .toStrict(1.second) should ===(Seq(0, 1, 4, 9, 16))
     }
+
+    "scan normally for empty source" in {
+      Source.empty[Int].scan(0) { case (a, b) ⇒ a + b }.runWith(TestSink.probe[Int])
+        .request(2)
+        .expectNext(0)
+        .expectComplete()
+    }
+    "fail after emitting first element when upsrteam failed" in {
+      Source.failed[Int](TE("")).scan(0) { case (a, b) ⇒ a + b }.runWith(TestSink.probe[Int])
+        .request(2)
+        .expectNext(0)
+        .expectError(TE(""))
+    }
   }
 }


### PR DESCRIPTION
fixed scan for cases when source is empty or failed before emitting something.
Ref #20843 
