### PR TITLE
remove unuse placeholder

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -609,7 +609,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
         publish(latestGossip)
       case Some(_) ⇒ // already down
       case None ⇒
-        logInfo("Ignoring down of unknown node [{}] as [{}]", address)
+        logInfo("Ignoring down of unknown node [{}]", address)
     }
 
   }


### PR DESCRIPTION
`2016-07-05 06:21:31,299,Cluster Node [akka.tcp://example@seed.example.local:2551] - Ignoring down of unknown node [akka.tcp://example@192.168.0.101:2551] as [{}]` 
remove miss pasted word `as [{}]`
