### PR TITLE
adaptive sampling of hit counting

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
@@ -71,11 +71,8 @@ private[akka] object MessageSerializer {
     }
   }
 
-  def deserializeForArtery(system: ExtendedActorSystem, originUid: Long, serialization: Serialization, headerBuilder: HeaderBuilder,
-                           envelope: EnvelopeBuffer): AnyRef = {
-    serialization.deserializeByteBuffer(
-      envelope.byteBuffer,
-      headerBuilder.serializer,
-      headerBuilder.manifest(originUid)) // FIXME currently compression will not work for manifests
+  def deserializeForArtery(system: ExtendedActorSystem, originUid: Long, serialization: Serialization,
+                           serializer: Int, classManifest: String, envelope: EnvelopeBuffer): AnyRef = {
+    serialization.deserializeByteBuffer(envelope.byteBuffer, serializer, classManifest)
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
@@ -75,7 +75,7 @@ private[remote] object EnvelopeBuffer {
 private[remote] object HeaderBuilder {
 
   // We really only use the Header builder on one "side" or the other, thus in order to avoid having to split its impl
-  // we inject no-op compression's of the "other side".  
+  // we inject no-op compression's of the "other side".
 
   def in(compression: InboundCompressions): HeaderBuilder = new HeaderBuilderImpl(compression, NoOutboundCompressions)
   def out(compression: OutboundCompressions): HeaderBuilder = new HeaderBuilderImpl(NoInboundCompressions, compression)
@@ -193,7 +193,9 @@ private[remote] final class HeaderBuilderImpl(inboundCompression: InboundCompres
 
   def setRecipientActorRef(ref: ActorRef): Unit = {
     _recipientActorRefIdx = outboundCompression.compressActorRef(ref)
-    if (_recipientActorRefIdx == -1) _recipientActorRef = ref.path.toSerializationFormat
+    if (_recipientActorRefIdx == -1) {
+      _recipientActorRef = ref.path.toSerializationFormat
+    }
   }
   def recipientActorRef(originUid: Long): OptionVal[ActorRef] =
     if (_recipientActorRef eq null) inboundCompression.decompressActorRef(originUid, actorRefCompressionTableVersion, _recipientActorRefIdx)

--- a/akka-remote/src/main/scala/akka/remote/artery/NoLiteralCompression.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/NoLiteralCompression.scala
@@ -13,15 +13,17 @@ import akka.util.OptionVal
  * Literarily, no compression!
  */
 case object NoInboundCompressions extends InboundCompressions {
-  override def hitActorRef(originUid: Long, tableVersion: Int, remote: Address, ref: ActorRef): Unit = ()
+  override def hitActorRef(originUid: Long, tableVersion: Int, remote: Address, ref: ActorRef, n: Int): Unit = ()
   override def decompressActorRef(originUid: Long, tableVersion: Int, idx: Int): OptionVal[ActorRef] =
     if (idx == -1) throw new IllegalArgumentException("Attemted decompression of illegal compression id: -1")
     else OptionVal.None
+  override def confirmActorRefCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit = ()
 
-  override def hitClassManifest(originUid: Long, tableVersion: Int, remote: Address, manifest: String): Unit = ()
+  override def hitClassManifest(originUid: Long, tableVersion: Int, remote: Address, manifest: String, n: Int): Unit = ()
   override def decompressClassManifest(originUid: Long, tableVersion: Int, idx: Int): OptionVal[String] =
     if (idx == -1) throw new IllegalArgumentException("Attemted decompression of illegal compression id: -1")
     else OptionVal.None
+  override def confirmClassManifestCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit = ()
 }
 
 /**

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/AllCompressions.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/AllCompressions.scala
@@ -14,11 +14,13 @@ import akka.util.OptionVal
  * One per inbound message stream thus must demux by originUid to use the right tables.
  */
 private[remote] trait InboundCompressions {
-  def hitActorRef(originUid: Long, tableVersion: Int, remote: Address, ref: ActorRef): Unit
+  def hitActorRef(originUid: Long, tableVersion: Int, remote: Address, ref: ActorRef, n: Int): Unit
   def decompressActorRef(originUid: Long, tableVersion: Int, idx: Int): OptionVal[ActorRef]
+  def confirmActorRefCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit
 
-  def hitClassManifest(originUid: Long, tableVersion: Int, remote: Address, manifest: String): Unit
+  def hitClassManifest(originUid: Long, tableVersion: Int, remote: Address, manifest: String, n: Int): Unit
   def decompressClassManifest(originUid: Long, tableVersion: Int, idx: Int): OptionVal[String]
+  def confirmClassManifestCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit
 }
 /**
  * INTERNAL API

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionProtocol.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionProtocol.scala
@@ -9,7 +9,7 @@ import akka.actor.{ ActorRef, Address }
 import akka.remote.UniqueAddress
 import akka.remote.artery.ControlMessage
 
-// FIXME serialization 
+// FIXME serialization
 /** INTERNAL API */
 object CompressionProtocol {
 
@@ -25,9 +25,29 @@ object CompressionProtocol {
 
   /**
    * INTERNAL API
+   * Sent by the "sending" node after receiving [[ActorRefCompressionAdvertisement]]
+   * The advertisement is also confirmed by the first message using that table version,
+   * but we need separate ack in case the sender is not using any of the refs in the advertised
+   * table.
+   */
+  private[remote] final case class ActorRefCompressionAdvertisementAck(from: UniqueAddress, tableVersion: Int)
+    extends ControlMessage with CompressionMessage
+
+  /**
+   * INTERNAL API
    * Sent by the "receiving" node after allocating a compression id to a given class manifest
    */
   private[remote] final case class ClassManifestCompressionAdvertisement(from: UniqueAddress, table: CompressionTable[String])
+    extends ControlMessage with CompressionMessage
+
+  /**
+   * INTERNAL API
+   * Sent by the "sending" node after receiving [[ClassManifestCompressionAdvertisement]]
+   * The advertisement is also confirmed by the first message using that table version,
+   * but we need separate ack in case the sender is not using any of the refs in the advertised
+   * table.
+   */
+  private[remote] final case class ClassManifestCompressionAdvertisementAck(from: UniqueAddress, tableVersion: Int)
     extends ControlMessage with CompressionMessage
 
   /** INTERNAL API */
@@ -39,7 +59,10 @@ object CompressionProtocol {
     final case class HeavyHitterDetected(key: Any, id: Int, count: Long) extends Event
 
     /** INTERNAL API */
-    final case class ReceivedCompressionTable[T](from: UniqueAddress, table: CompressionTable[T]) extends Event
+    final case class ReceivedActorRefCompressionTable(from: UniqueAddress, table: CompressionTable[ActorRef]) extends Event
+
+    /** INTERNAL API */
+    final case class ReceivedClassManifestCompressionTable(from: UniqueAddress, table: CompressionTable[String]) extends Event
 
   }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/DecompressionTable.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/DecompressionTable.scala
@@ -25,8 +25,7 @@ private[remote] final case class DecompressionTable[T](version: Int, table: Arra
       s"(version: $version, " +
       (
         if (length == 0) "[empty]"
-        else s"table: [${table.zipWithIndex.map({ case (t, i) ⇒ s"$i -> $t" }).mkString(",")}"
-      ) + "])"
+        else s"table: [${table.zipWithIndex.map({ case (t, i) ⇒ s"$i -> $t" }).mkString(",")}") + "])"
 }
 
 /** INTERNAL API */

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/OutboundActorRefCompression.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/OutboundActorRefCompression.scala
@@ -61,7 +61,7 @@ private[remote] class OutboundCompressionTable[T](system: ActorSystem, remoteAdd
       else
         flipTable(activate) // retry
     else if (state.version == activate.version)
-      log.warning("Received duplicate compression table (version: {})! Ignoring it.", state.version)
+      log.debug("Received duplicate compression table (version: {})! Ignoring it.", state.version)
     else
       log.error("Received unexpected compression table with version nr [{}]! " +
         "Current version number is [{}].", activate.version, state.version)

--- a/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
@@ -34,14 +34,16 @@ class EnvelopeBufferSpec extends AkkaSpec {
     override def applyActorRefCompressionTable(table: CompressionTable[ActorRef]): Unit = ??? // dynamic allocating not needed in these tests
     override def actorRefCompressionTableVersion: Int = 0
     override def compressActorRef(ref: ActorRef): Int = refToIdx.getOrElse(ref, -1)
-    override def hitActorRef(originUid: Long, tableVersion: Int, remote: Address, ref: ActorRef): Unit = ()
+    override def hitActorRef(originUid: Long, tableVersion: Int, remote: Address, ref: ActorRef, n: Int): Unit = ()
     override def decompressActorRef(originUid: Long, tableVersion: Int, idx: Int): OptionVal[ActorRef] = OptionVal(idxToRef(idx))
+    override def confirmActorRefCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit = ()
 
     override def applyClassManifestCompressionTable(table: CompressionTable[String]): Unit = ??? // dynamic allocating not needed in these tests
     override def classManifestCompressionTableVersion: Int = 0
     override def compressClassManifest(manifest: String): Int = manifestToIdx.getOrElse(manifest, -1)
-    override def hitClassManifest(originUid: Long, tableVersion: Int, remote: Address, manifest: String): Unit = ()
+    override def hitClassManifest(originUid: Long, tableVersion: Int, remote: Address, manifest: String, n: Int): Unit = ()
     override def decompressClassManifest(originUid: Long, tableVersion: Int, idx: Int): OptionVal[String] = OptionVal(idxToManifest(idx))
+    override def confirmClassManifestCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit = ()
   }
 
   "EnvelopeBuffer" must {

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionIntegrationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionIntegrationSpec.scala
@@ -22,7 +22,7 @@ object CompressionIntegrationSpec {
   val commonConfig = ConfigFactory.parseString(s"""
      akka {
        loglevel = INFO
-        
+
        actor.provider = "akka.remote.RemoteActorRefProvider"
        remote.artery.enabled = on
        remote.artery.advanced {
@@ -32,7 +32,7 @@ object CompressionIntegrationSpec {
        remote.artery.hostname = localhost
        remote.artery.port = 0
        remote.handshake-timeout = 10s
-       
+
        remote.artery.advanced.compression {
          enabled = on
          actor-refs {
@@ -40,7 +40,7 @@ object CompressionIntegrationSpec {
            advertisement-interval = 3 seconds
          }
        }
-       
+
      }
   """)
 
@@ -75,7 +75,7 @@ class CompressionIntegrationSpec extends AkkaSpec(CompressionIntegrationSpec.com
       // cause testActor-1 to become a heavy hitter
       (1 to messagesToExchange).foreach { i ⇒ voidSel ! "hello" } // does not reply, but a hot receiver should be advertised
 
-      val a1 = aProbe.expectMsgType[Events.ReceivedCompressionTable[ActorRef]](10.seconds)
+      val a1 = aProbe.expectMsgType[Events.ReceivedActorRefCompressionTable](10.seconds)
       info("System [A] received: " + a1)
       assertCompression[ActorRef](a1.table, 0, _ should ===(system.deadLetters))
       assertCompression[ActorRef](a1.table, 1, _ should ===(testActor))

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionTestKit.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionTestKit.scala
@@ -5,7 +5,7 @@
 package akka.remote.artery.compress
 
 /* INTERNAL API */
-private[remote] trait CompressionTestKit {
+private[akka] trait CompressionTestKit {
   def assertCompression[T](table: CompressionTable[T], id: Int, assertion: T ⇒ Unit): Unit = {
     table.map.find(_._2 == id)
       .orElse { throw new AssertionError(s"No key was compressed to the id [$id]! Table was: $table") }
@@ -14,4 +14,4 @@ private[remote] trait CompressionTestKit {
 }
 
 /* INTERNAL API */
-private[remote] object CompressionTestKit extends CompressionTestKit
+private[akka] object CompressionTestKit extends CompressionTestKit

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
@@ -11,7 +11,7 @@ import akka.util.Timeout
 import akka.pattern.ask
 import akka.remote.RARP
 import akka.remote.artery.ArteryTransport
-import akka.remote.artery.compress.CompressionProtocol.Events.{ Event, ReceivedCompressionTable }
+import akka.remote.artery.compress.CompressionProtocol.Events.{ Event, ReceivedActorRefCompressionTable }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfter
 
@@ -82,7 +82,7 @@ class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDr
       waitForEcho(this, s"hello-$messagesToExchange")
       systemBTransport.triggerCompressionAdvertisements(actorRef = true, manifest = false)
 
-      val a0 = aProbe.expectMsgType[ReceivedCompressionTable[ActorRef]](10.seconds)
+      val a0 = aProbe.expectMsgType[ReceivedActorRefCompressionTable](10.seconds)
       info("System [A] received: " + a0)
       a0.table.map.keySet should contain(testActor)
 
@@ -91,7 +91,7 @@ class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDr
       waitForEcho(a1Probe, s"hello-$messagesToExchange")
       systemBTransport.triggerCompressionAdvertisements(actorRef = true, manifest = false)
 
-      val a1 = aProbe.expectMsgType[ReceivedCompressionTable[ActorRef]](10.seconds)
+      val a1 = aProbe.expectMsgType[ReceivedActorRefCompressionTable](10.seconds)
       info("System [A] received: " + a1)
       a1.table.map.keySet should contain(a1Probe.ref)
 
@@ -113,7 +113,7 @@ class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDr
       waitForEcho(this, s"hello-$messagesToExchange", max = 10.seconds)
       systemBTransport.triggerCompressionAdvertisements(actorRef = true, manifest = false)
 
-      val a2 = aNewProbe.expectMsgType[ReceivedCompressionTable[ActorRef]](10.seconds)
+      val a2 = aNewProbe.expectMsgType[ReceivedActorRefCompressionTable](10.seconds)
       info("System [A] received: " + a2)
       a2.table.map.keySet should contain(testActor)
 
@@ -122,7 +122,7 @@ class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDr
       waitForEcho(aNew2Probe, s"hello-$messagesToExchange")
       systemBTransport.triggerCompressionAdvertisements(actorRef = true, manifest = false)
 
-      val a3 = aNewProbe.expectMsgType[ReceivedCompressionTable[ActorRef]](10.seconds)
+      val a3 = aNewProbe.expectMsgType[ReceivedActorRefCompressionTable](10.seconds)
       info("Received second compression: " + a3)
       a3.table.map.keySet should contain(aNew2Probe.ref)
     }

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -82,7 +82,7 @@ object AkkaBuild extends Build {
     protobuf,
     remote,
     remoteTests,
-    samples,
+//    samples,
     slf4j,
     stream,
     streamTestkit,


### PR DESCRIPTION
- when rate exceeds 1000 msg/s adaptive sampling of the
  heavy hitters tracking is enabled by sampling every 256th message
- also fixed some bugs related to advertise in progress
