### PR TITLE
Clean up HttpEntity.toString

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -369,6 +369,10 @@ object HttpEntity {
 
     override def productPrefix = "HttpEntity.Default"
 
+    override def toString: String = {
+      s"$productPrefix($contentType,$contentLength bytes total)"
+    }
+
     /** Java API */
     override def getContentLength = contentLength
   }
@@ -414,6 +418,10 @@ object HttpEntity {
     override def withData(data: Source[ByteString, Any]): HttpEntity.CloseDelimited = copy(data = data)
 
     override def productPrefix = "HttpEntity.CloseDelimited"
+
+    override def toString: String = {
+      s"$productPrefix($contentType)"
+    }
   }
 
   /**
@@ -431,6 +439,10 @@ object HttpEntity {
     override def withData(data: Source[ByteString, Any]): HttpEntity.IndefiniteLength = copy(data = data)
 
     override def productPrefix = "HttpEntity.IndefiniteLength"
+
+    override def toString: String = {
+      s"$productPrefix($contentType)"
+    }
   }
 
   /**
@@ -468,6 +480,10 @@ object HttpEntity {
       if (contentType == this.contentType) this else copy(contentType = contentType)
 
     override def productPrefix = "HttpEntity.Chunked"
+
+    override def toString: String = {
+      s"$productPrefix($contentType)"
+    }
 
     /** Java API */
     def getChunks: stream.javadsl.Source[jm.HttpEntity.ChunkStreamPart, AnyRef] =

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -141,14 +141,23 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
       "Default" in {
         val entity = Default(tpe, 11, source(abc, de, fgh, ijk))
         entity.toString must include(entity.productPrefix)
+        entity.toString must include("11")
+        entity.toString mustNot include("Source")
       }
       "CloseDelimited" in {
         val entity = CloseDelimited(tpe, source(abc, de, fgh, ijk))
         entity.toString must include(entity.productPrefix)
+        entity.toString mustNot include("Source")
       }
       "Chunked" in {
         val entity = Chunked(tpe, source(Chunk(abc)))
         entity.toString must include(entity.productPrefix)
+        entity.toString mustNot include("Source")
+      }
+      "IndefiniteLength" in {
+        val entity = IndefiniteLength(tpe, source(abc, de, fgh, ijk))
+        entity.toString must include(entity.productPrefix)
+        entity.toString mustNot include("Source")
       }
     }
     "support withoutSizeLimit" - {


### PR DESCRIPTION
#20739

As per mentioned ticket, `HttpEntity.toString` output is usually too verbose. This commit overrides `toString` for all `HttpEntity` implementations (except `HttpEntity.Strict` which already has it overridden) excluding `source.toString` from output.
