### PR TITLE
=htp cache default RejectionHandler instance, it's safe to share

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -322,7 +322,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
         check { (a: ByteString) ⇒ a.asByteBuffers.foldLeft(ByteString.empty) { (bs, bb) ⇒ bs ++ ByteString(bb) } == a }
         check { (a: ByteString) ⇒ a.asByteBuffers.forall(_.isReadOnly) }
         check { (a: ByteString) ⇒
-          import scala.collection.JavaConverters.iterableAsScalaIterableConverter;
+          import scala.collection.JavaConverters.iterableAsScalaIterableConverter
           a.asByteBuffers.zip(a.getByteBuffers().asScala).forall(x ⇒ x._1 == x._2)
         }
       }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -122,9 +122,9 @@ object RejectionHandler {
   import Directives._
 
   /**
-   * Creates a new default [[RejectionHandler]] instance.
+   * Default [[RejectionHandler]] instance.
    */
-  def default =
+  final val default =
     newBuilder()
       .handleAll[SchemeRejection] { rejections ⇒
         val schemes = rejections.map(_.supported).mkString(", ")


### PR DESCRIPTION
I don't see a reason why we can't cache it, it's not supposed to side effect or do actor stuff anyway.

cc @2beaucoup @jrudolph 

Performance impacted positively a bit, but I'll stress benchmark it longer to have a number we can trust.

Being a bit lazy, pasting general outline:

![step-03_rejectionhandler_default_cached_-_google_docs](https://cloud.githubusercontent.com/assets/120979/16971193/f086070c-4e21-11e6-88b7-52de2ff8553d.png)
