### PR TITLE
Fix snippet example in stream-rate doc

### DIFF
--- a/akka-docs/rst/java/code/docs/stream/StreamBuffersRateDocTest.java
+++ b/akka-docs/rst/java/code/docs/stream/StreamBuffersRateDocTest.java
@@ -65,7 +65,7 @@ public class StreamBuffersRateDocTest extends AbstractJavaTest {
     final Flow<Integer, Integer, NotUsed> flow1 =
       Flow.of(Integer.class)
       .map(elem -> elem * 2).async()
-      .withAttributes(Attributes.inputBuffer(1, 1)); // the buffer size of this map is 1
+      .addAttributes(Attributes.inputBuffer(1, 1)); // the buffer size of this map is 1
     final Flow<Integer, Integer, NotUsed> flow2 =
       flow1.via(
         Flow.of(Integer.class)

--- a/akka-docs/rst/scala/code/docs/stream/StreamBuffersRateSpec.scala
+++ b/akka-docs/rst/scala/code/docs/stream/StreamBuffersRateSpec.scala
@@ -30,7 +30,7 @@ class StreamBuffersRateSpec extends AkkaSpec {
 
     //#section-buffer
     val section = Flow[Int].map(_ * 2).async
-      .withAttributes(Attributes.inputBuffer(initial = 1, max = 1)) // the buffer size of this map is 1
+      .addAttributes(Attributes.inputBuffer(initial = 1, max = 1)) // the buffer size of this map is 1
     val flow = section.via(Flow[Int].map(_ / 2)).async // the buffer size of this map is the default
     //#section-buffer
   }


### PR DESCRIPTION
Fix #section-buffer by replacing .withAttributes by .addAttributes to avoid overwriting the .async option.
