### PR TITLE
CountMinSketch with murmur3 and other performance improvements

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/compress/CountMinSketchBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/compress/CountMinSketchBenchmark.scala
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery.compress
+
+import java.util.Random
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(2)
+class CountMinSketchBenchmark {
+
+  //  @Param(Array("4", "8", "12", "16"))
+  @Param(Array("16", "256", "4096", "65536"))
+  var w: Int = _
+  @Param(Array("16", "128", "1024"))
+  var d: Int = _
+
+  private val seed: Int = 20160726
+
+  val rand = new Random(seed)
+
+  val preallocateIds = Array.ofDim[Int](8192)
+  val preallocateValues = Array.ofDim[Long](8192)
+
+  var countMinSketch: CountMinSketch = _
+
+  @Setup
+  def init(): Unit = {
+    countMinSketch = new CountMinSketch(d, w, seed)
+    (0 to 8191).foreach { index =>
+      preallocateIds(index) = rand.nextInt()
+      preallocateValues(index) = Math.abs(rand.nextInt())
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(8192)
+  def updateRandomNumbers(blackhole: Blackhole): Unit = {
+    var i: Int = 0;
+    while (i < 8192) {
+      blackhole.consume(countMinSketch.addObjectAndEstimateCount(preallocateIds(i), preallocateValues(i)))
+      i += 1
+    }
+  }
+
+}

--- a/akka-remote/src/main/java/akka/remote/artery/compress/CountMinSketch.java
+++ b/akka-remote/src/main/java/akka/remote/artery/compress/CountMinSketch.java
@@ -6,35 +6,32 @@ package akka.remote.artery.compress;
 
 import akka.actor.ActorRef;
 
-import java.util.Random;
-
 /**
  * INTERNAL API: Count-Min Sketch datastructure.
- * 
+ *
  * Not thread-safe.
- * 
+ *
  * An Improved Data Stream Summary: The Count-Min Sketch and its Applications
  * https://web.archive.org/web/20060907232042/http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf
- * 
  * This implementation is mostly taken and adjusted from the Apache V2 licensed project `stream-lib`, located here:
  * https://github.com/clearspring/stream-lib/blob/master/src/main/java/com/clearspring/analytics/stream/frequency/CountMinSketch.java
  */
 public class CountMinSketch {
 
-  public static final long PRIME_MODULUS = (1L << 31) - 1;
-
   private int depth;
   private int width;
   private long[][] table;
-  private long[] hashA;
   private long size;
   private double eps;
   private double confidence;
 
   private int[] recyclableCMSHashBuckets;
-  
-  
+
+
   public CountMinSketch(int depth, int width, int seed) {
+    if((width & (width-1)) != 0){
+      throw new IllegalArgumentException("width must be a power of 2, was: " + width );
+    }
     this.depth = depth;
     this.width = width;
     this.eps = 2.0 / width;
@@ -43,46 +40,14 @@ public class CountMinSketch {
     initTablesWith(depth, width, seed);
   }
 
-  @SuppressWarnings("unused")
-  public CountMinSketch(double epsOfTotalCount, double confidence, int seed) {
-    // 2/w = eps ; w = 2/eps
-    // 1/2^depth <= 1-confidence ; depth >= -log2 (1-confidence)
-    this.eps = epsOfTotalCount;
-    this.confidence = confidence;
-    this.width = (int) Math.ceil(2 / epsOfTotalCount);
-    this.depth = (int) Math.ceil(-Math.log(1 - confidence) / Math.log(2));
-    recyclableCMSHashBuckets = preallocateHashBucketsArray(depth);
-    initTablesWith(depth, width, seed);
-  }
-
-  @SuppressWarnings("unused")
-  public CountMinSketch(int depth, int width, int size, long[] hashA, long[][] table) {
-    this.depth = depth;
-    this.width = width;
-    this.eps = 2.0 / width;
-    this.confidence = 1 - 1 / Math.pow(2, depth);
-    this.hashA = hashA;
-    this.table = table;
-    this.size = size;
-    recyclableCMSHashBuckets = preallocateHashBucketsArray(depth);
-  }
 
   private void initTablesWith(int depth, int width, int seed) {
     this.table = new long[depth][width];
-    this.hashA = new long[depth];
-    Random r = new Random(seed);
-    // We're using a linear hash functions
-    // of the form (a*x+b) mod p.
-    // a,b are chosen independently for each hash function.
-    // However we can set b = 0 as all it does is shift the results
-    // without compromising their uniformity or independence with
-    // the other hashes.
-    for (int i = 0; i < depth; ++i) {
-      hashA[i] = r.nextInt(Integer.MAX_VALUE);
-    }
   }
 
-  /** Referred to as {@code epsilon} in the whitepaper */
+  /**
+   * Referred to as {@code epsilon} in the whitepaper
+   */
   public double relativeError() {
     return eps;
   }
@@ -91,46 +56,6 @@ public class CountMinSketch {
     return confidence;
   }
 
-  private int hash(long item, int i) {
-    long hash = hashA[i] * item;
-    // A super fast way of computing x mod 2^p-1
-    // See http://www.cs.princeton.edu/courses/archive/fall09/cos521/Handouts/universalclasses.pdf
-    // page 149, right after Proposition 7.
-    hash += hash >> 32;
-    hash &= PRIME_MODULUS;
-    // Doing "%" after (int) conversion is ~2x faster than %'ing longs.
-    return ((int) hash) % width;
-  }
-
-  public void add(long item, long count) {
-    if (count < 0) {
-      // Actually for negative increments we'll need to use the median
-      // instead of minimum, and accuracy will suffer somewhat.
-      // Probably makes sense to add an "allow negative increments"
-      // parameter to constructor.
-      throw new IllegalArgumentException("Negative increments not implemented");
-    }
-    for (int i = 0; i < depth; ++i) {
-      table[i][hash(item, i)] += count;
-    }
-    size += count;
-  }
-
-  public void addObject(Object item, long count) {
-    if (count < 0) {
-      // Actually for negative increments we'll need to use the median
-      // instead of minimum, and accuracy will suffer somewhat.
-      // Probably makes sense to add an "allow negative increments"
-      // parameter to constructor.
-      throw new IllegalArgumentException("Negative increments not implemented");
-    }
-    MurmurHash.hashBuckets(item, recyclableCMSHashBuckets, width);
-    for (int i = 0; i < depth; ++i) {
-      table[i][recyclableCMSHashBuckets[i]] += count;
-    }
-    size += count;
-  }
-  
   /**
    * Similar to {@code add}, however we reuse the fact that the hask buckets have to be calculated for {@code add}
    * already, and a separate {@code estimateCount} operation would have to calculate them again, so we do it all in one go.
@@ -143,34 +68,31 @@ public class CountMinSketch {
       // parameter to constructor.
       throw new IllegalArgumentException("Negative increments not implemented");
     }
-    MurmurHash.hashBuckets(item, recyclableCMSHashBuckets, width);
+    Murmur3.hashBuckets(item, recyclableCMSHashBuckets, width);
     for (int i = 0; i < depth; ++i) {
       table[i][recyclableCMSHashBuckets[i]] += count;
     }
     size += count;
     return estimateCount(recyclableCMSHashBuckets);
   }
-  
+
   public long size() {
     return size;
-  }
-  
-  /**
-   * The estimate is correct within {@code 'epsilon' * (total item count)},
-   * with probability {@code confidence}.
-   */
-  public long estimateCount(long item) {
-    long res = Long.MAX_VALUE;
-    for (int i = 0; i < depth; ++i) {
-      res = Math.min(res, table[i][hash(item, i)]);
-    }
-    return res;
   }
 
   /**
    * The estimate is correct within {@code 'epsilon' * (total item count)},
    * with probability {@code confidence}.
-   * 
+   */
+  public long estimateCount(Object item) {
+    Murmur3.hashBuckets(item, recyclableCMSHashBuckets, width);
+    return estimateCount(recyclableCMSHashBuckets);
+  }
+
+  /**
+   * The estimate is correct within {@code 'epsilon' * (total item count)},
+   * with probability {@code confidence}.
+   *
    * @param buckets the "indexes" of buckets from which we want to calculate the count
    */
   private long estimateCount(int[] buckets) {
@@ -180,173 +102,142 @@ public class CountMinSketch {
     }
     return res;
   }
-  
+
+
   /**
-   * This is copied from https://github.com/addthis/stream-lib/blob/master/src/main/java/com/clearspring/analytics/hash/MurmurHash.java
-   * Which is Apache V2 licensed.
-   * <p></p>
-   * This is a very fast, non-cryptographic hash suitable for general hash-based
-   * lookup. See http://murmurhash.googlepages.com/ for more details.
-   * <p/>
-   * <p>
-   * The C version of MurmurHash 2.0 found at that site was ported to Java by
-   * Andrzej Bialecki (ab at getopt org).
-   * </p>
+   * Local implementation of murmur3 hash optimized to used in count min sketch
+   *
+   * Inspired by scala (scala.util.hashing.MurmurHash3) and C port of MurmurHash3
+   *
+   * scala.util.hashing => https://github.com/scala/scala/blob/2.12.x/src/library/scala/util/hashing/MurmurHash3.scala
+   * C port of MurmurHash3 => https://github.com/PeterScott/murmur3/blob/master/murmur3.c
    */
-  // TODO replace with Scala's Murmur3, it's much faster
-  private static class MurmurHash {
-  
+  private static class Murmur3 {
+
+    /**
+     * Force all bits of the hash to avalanche. Used for finalizing the hash.
+     */
+    private static int avalanche(int hash) {
+      int h = hash;
+
+      h ^= h >>> 16;
+      h *= 0x85ebca6b;
+      h ^= h >>> 13;
+      h *= 0xc2b2ae35;
+      h ^= h >>> 16;
+
+      return h;
+    }
+
+    private static int mixLast(int hash, int data) {
+      int k = data;
+
+      k *= 0xcc9e2d51; //c1
+      k = Integer.rotateLeft(k, 15);
+      k *= 0x1b873593; //c2
+
+      return hash ^ k;
+    }
+
+
+    private static int mix(int hash, int data) {
+      int h = mixLast(hash, data);
+      h = Integer.rotateLeft(h, 13);
+      return h * 5 + 0xe6546b64;
+    }
+
     public static int hash(Object o) {
       if (o == null) {
         return 0;
       }
       if (o instanceof ActorRef) { // TODO possibly scary optimisation
-        // ActorRef hashcode is the ActorPath#uid, which is a random number assigned at its creation, 
+        // ActorRef hashcode is the ActorPath#uid, which is a random number assigned at its creation,
         // thus no hashing happens here - the value is already cached.
         // TODO it should be thought over if this preciseness (just a random number, and not hashing) is good enough here?
+        // this is not cryptographic one, anything which is stable and random is good enough
         return o.hashCode();
       }
       if (o instanceof String) {
         return hash(((String) o).getBytes());
       }
       if (o instanceof Long) {
-        return hashLong((Long) o);
+        return hashLong((Long) o, 0);
       }
       if (o instanceof Integer) {
-        return hashLong((Integer) o);
+        return hashLong((Integer) o, 0);
       }
       if (o instanceof Double) {
-        return hashLong(Double.doubleToRawLongBits((Double) o));
+        return hashLong(Double.doubleToRawLongBits((Double) o), 0);
       }
       if (o instanceof Float) {
-        return hashLong(Float.floatToRawIntBits((Float) o));
+        return hashLong(Float.floatToRawIntBits((Float) o), 0);
       }
       if (o instanceof byte[]) {
-        return hash((byte[]) o);
+        return bytesHash((byte[]) o, 0);
       }
       return hash(o.toString());
     }
-  
-    public static int hash(byte[] data) {
-      return hash(data, data.length, -1);
+
+    static int hashLong(long value, int seed) {
+      int h = seed;
+      h = mix(h, (int) (value));
+      h = mixLast(h, (int) (value >>> 32));
+      return avalanche(h ^ 2);
     }
-  
-    public static int hash(byte[] data, int seed) {
-      return hash(data, data.length, seed);
-    }
-  
-    public static int hash(byte[] data, int length, int seed) {
-      int m = 0x5bd1e995;
-      int r = 24;
-  
-      int h = seed ^ length;
-  
-      int len_4 = length >> 2;
-  
-      for (int i = 0; i < len_4; i++) {
-        int i_4 = i << 2;
-        int k = data[i_4 + 3];
-        k = k << 8;
-        k = k | (data[i_4 + 2] & 0xff);
-        k = k << 8;
-        k = k | (data[i_4 + 1] & 0xff);
-        k = k << 8;
-        k = k | (data[i_4 + 0] & 0xff);
-        k *= m;
-        k ^= k >>> r;
-        k *= m;
-        h *= m;
-        h ^= k;
+
+    static int bytesHash(final byte[] data, int seed) {
+      int len = data.length;
+      int h = seed;
+
+      // Body
+      int i = 0;
+      while (len >= 4) {
+        int k = data[i] & 0xFF;
+        k |= (data[i + 1] & 0xFF) << 8;
+        k |= (data[i + 2] & 0xFF) << 16;
+        k |= (data[i + 3] & 0xFF) << 24;
+
+        h = mix(h, k);
+
+        i += 4;
+        len -= 4;
       }
-  
-      // avoid calculating modulo
-      int len_m = len_4 << 2;
-      int left = length - len_m;
-  
-      if (left != 0) {
-        if (left >= 3) {
-          h ^= (int) data[length - 3] << 16;
-        }
-        if (left >= 2) {
-          h ^= (int) data[length - 2] << 8;
-        }
-        if (left >= 1) {
-          h ^= (int) data[length - 1];
-        }
-  
-        h *= m;
+
+      // Tail
+      int k = 0;
+      if (len == 3) k ^= (data[i + 2] & 0xFF) << 16;
+      if (len >= 2) k ^= (data[i + 1] & 0xFF) << 8;
+      if (len >= 1) {
+        k ^= (data[i] & 0xFF);
+        h = mixLast(h, k);
       }
-  
-      h ^= h >>> 13;
-      h *= m;
-      h ^= h >>> 15;
-  
-      return h;
+
+      // Finalization
+      return avalanche(h ^ data.length);
     }
-  
-    public static int hashLong(long data) {
-      return hashLong(data, 0);
-    }
-    public static int hashLong(long data, int seed) {
-      int m = 0x5bd1e995;
-      int r = 24;
-  
-     int h = seed;
-      // int h = seed ^ length;
-  
-      int k = (int) data * m;
-      k ^= k >>> r;
-      h ^= k * m;
-  
-      k = (int) (data >> 32) * m;
-      k ^= k >>> r;
-      h *= m;
-      h ^= k * m;
-  
-      h ^= h >>> 13;
-      h *= m;
-      h ^= h >>> 15;
-  
-      return h;
-    }
-  
-    // Murmur is faster than an SHA-based approach and provides as-good collision
-    // resistance.  The combinatorial generation approach described in
-    // http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
-    // does prove to work in actual tests, and is obviously faster
-    // than performing further iterations of murmur.
-//    public static int[] hashBuckets(String key, int hashCount, int max) {
-//      byte[] b;
-//      try {
-//        b = key.getBytes("UTF-16");// TODO Use the Unsafe trick @patriknw used to access the backing array directly -- via Endre
-//      } catch (UnsupportedEncodingException e) {
-//        throw new RuntimeException(e);
-//      }
-//      return hashBuckets(b, hashCount, max);
-//    }
-    
-//    static int[] hashBuckets(byte[] b, int hashCount, int max) {
-//      // TODO we could reuse the arrays
-//      int[] result = preallocateHashBucketsArray(hashCount);
-//      int hash1 = hash(b, b.length, 0);
-//      int hash2 = hash(b, b.length, hash1);
-//      for (int i = 0; i < hashCount; i++) {
-//        result[i] = Math.abs((hash1 + i * hash2) % max);
-//      }
-//      return result;
-//    }
-    
-    /** Mutates passed in {@code hashBuckets} */
-    static void hashBuckets(Object item, int[] hashBuckets, int max) {
-      int hash1 = hash(item); // specialized hash for ActorRef and Strings
-      int hash2 = hashLong(hash1, hash1);
+
+    /**
+     * Hash item using pair independent hash functions.
+     *
+     * Implemetation based on "Less Hashing, Same Performance: Building a
+     * Better Bloom Filter" http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
+     * @param item what should be hashed
+     * @param hashBuckets where hashes should be placed
+     * @param limit value to shrink result
+     */
+    static void hashBuckets(Object item, final int[] hashBuckets, int limit) {
+      final int hash1 = hash(item); // specialized hash for ActorRef and Strings
+      final int hash2 = hashLong(hash1, hash1);
       final int depth = hashBuckets.length;
-      for (int i = 0; i < depth; i++) 
-        hashBuckets[i] = Math.abs((hash1 + i * hash2) % max);
+      final int mask = limit - 1;
+      for (int i = 0; i < depth; i++) {
+        hashBuckets[i] = Math.abs((hash1 + i * hash2) & mask); //shrink done by AND instead MOD. Assume limit is power of 2
+      }
     }
+
   }
 
-  public int[] preallocateHashBucketsArray(int depth) {
+  private int[] preallocateHashBucketsArray(int depth) {
     return new int[depth];
   }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
@@ -114,7 +114,7 @@ private[remote] abstract class InboundCompression[T >: Null](
   private[this] val state: AtomicReference[InboundCompression.State[T]] = new AtomicReference(InboundCompression.State.empty)
 
   // TODO calibrate properly (h/w have direct relation to preciseness and max capacity)
-  private[this] val cms = new CountMinSketch(100, 100, System.currentTimeMillis().toInt)
+  private[this] val cms = new CountMinSketch(16, 1024, System.currentTimeMillis().toInt)
 
   /* ==== COMPRESSION ==== */
 


### PR DESCRIPTION
Following comments in CountMinSketch implementation i made some experiments.
Firstly the mini benchmark for testing impact in performance of change in  CountMinSketch.
Original performance benchmark (all benchmarks are done on 5 warm-up and 10 test)

Murmur2 - original

```
Benchmark                                     (d)    (w)   Mode  Cnt        Score        Error  Units
CountMinSketchBenchmark.updateRandomNumbers    16     16  thrpt   10  5071847,700 ± 599776,070  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16    256  thrpt   10  5292403,206 ± 300999,643  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16   4096  thrpt   10  4195135,147 ± 426174,321  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16  65536  thrpt   10  3259349,593 ± 166442,545  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128     16  thrpt   10   551644,769 ±  64707,287  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128    256  thrpt   10   477573,163 ±  45206,820  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128   4096  thrpt   10   251547,277 ±  20476,403  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128  65536  thrpt   10   173895,758 ±  14594,083  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024     16  thrpt   10    70717,050 ±   7587,764  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024    256  thrpt   10    54422,812 ±   4433,996  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024   4096  thrpt   10    19657,091 ±    803,474  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024  65536  thrpt   10    10216,899 ±    503,151  ops/s
```

Performance strongly depends on depth (d) and weakly from width (w) of sketch.

Using Murmur3 (implementation heavy inspired by scala.util.hashing and C port of Murmur3):

```
Benchmark                                     (d)    (w)   Mode  Cnt        Score        Error  Units
CountMinSketchBenchmark.updateRandomNumbers    16     16  thrpt   10  5160677,096 ± 353406,242  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16    256  thrpt   10  5051564,204 ± 614775,651  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16   4096  thrpt   10  4077927,596 ± 471112,322  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16  65536  thrpt   10  2762806,964 ± 335388,203  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128     16  thrpt   10   549624,418 ±  24382,376  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128    256  thrpt   10   496671,622 ±  54879,408  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128   4096  thrpt   10   253235,271 ±  21384,410  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128  65536  thrpt   10   180593,317 ±   9189,173  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024     16  thrpt   10    67087,705 ±   7991,082  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024    256  thrpt   10    55819,859 ±   3689,422  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024   4096  thrpt   10    18955,689 ±    768,839  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024  65536  thrpt   10    10322,591 ±    505,292  ops/s
```

Impact in performance was on measurement error level :disappointed: 

Introduce assumption that width in sketch is power of 2 we can use bit AND instead of modulo.

```
Benchmark                                     (d)    (w)   Mode  Cnt        Score        Error  Units
CountMinSketchBenchmark.updateRandomNumbers    16     16  thrpt   10  7893372,127 ± 627471,690  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16    256  thrpt   10  7681907,710 ± 525085,574  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16   4096  thrpt   10  5617095,972 ± 441099,811  ops/s
CountMinSketchBenchmark.updateRandomNumbers    16  65536  thrpt   10  2677862,878 ± 212243,946  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128     16  thrpt   10  1188241,086 ±  39775,051  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128    256  thrpt   10   888476,539 ±  41251,477  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128   4096  thrpt   10   301300,667 ±  32820,088  ops/s
CountMinSketchBenchmark.updateRandomNumbers   128  65536  thrpt   10   191870,636 ±  18779,725  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024     16  thrpt   10   114457,446 ±   6086,099  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024    256  thrpt   10    73254,657 ±   9722,829  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024   4096  thrpt   10    21823,306 ±   1742,029  ops/s
CountMinSketchBenchmark.updateRandomNumbers  1024  65536  thrpt   10    11248,726 ±    531,326  ops/s
```

This give us significant improvement of performance. :smile: 

Last change around was changing default value for CMS in `InboundCompression`.
Default was d=100, w=100 i have adjust to d=16, w=1024. The way how akka use
count min sketch confidence (depends on d) on 0.9999847 level should be enough
This is probability with holds inequation:
`result < real + epslion * size (sum of all added count)`
Moreover w=1024 give us epsilon on level 0.0019 ( epsilon = 2 / w), which could be still not
sufficient in some scenarios (long table advertise period). 
