### PR TITLE
+str #20795 IOResult construction exposed, in bincompat way

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/IOResult.scala
+++ b/akka-stream/src/main/scala/akka/stream/IOResult.scala
@@ -44,9 +44,11 @@ final case class IOResult (count: Long, status: Try[Done]) {
 
 object IOResult {
 
+  /** JAVA API: Creates successful IOResult */
   def createSuccessful(count: Long): IOResult =
     new IOResult(count, Success(Done))
 
+  /** JAVA API: Creates failed IOResult, `count` should be the number of bytes (or other unit, please document in your APIs) processed before failing */
   def createFailed(count: Long, ex: Throwable): IOResult =
     new IOResult(count, Failure(ex))
 }

--- a/akka-stream/src/main/scala/akka/stream/IOResult.scala
+++ b/akka-stream/src/main/scala/akka/stream/IOResult.scala
@@ -3,7 +3,11 @@
  */
 package akka.stream
 
+import java.util.Objects
+
 import akka.Done
+
+import scala.runtime.AbstractFunction2
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -12,7 +16,11 @@ import scala.util.{ Failure, Success, Try }
  * @param count Numeric value depending on context, for example IO operations performed or bytes processed.
  * @param status Status of the result. Can be either [[akka.Done]] or an exception.
  */
-final case class IOResult private[stream] (count: Long, status: Try[Done]) {
+final case class IOResult private (count: Long, status: Try[Done])
+  extends Serializable with Product {
+
+  def withCount(value: Long): IOResult = copy(count = value)
+  def withStatus(value: Try[Done]): IOResult = copy(status = value)
 
   /**
    * Java API: Numeric value depending on context, for example IO operations performed or bytes processed.
@@ -33,4 +41,13 @@ final case class IOResult private[stream] (count: Long, status: Try[Done]) {
     case Success(_) ⇒ throw new UnsupportedOperationException("IO operation was successful.")
   }
 
+}
+
+object IOResult extends AbstractFunction2[Long, Try[Done], IOResult] {
+
+  def createSuccessful(count: Long): IOResult =
+    new IOResult(count, Success(Done))
+
+  def createFailed(count: Long, ex: Throwable): IOResult =
+    new IOResult(count, Failure(ex))
 }

--- a/akka-stream/src/main/scala/akka/stream/IOResult.scala
+++ b/akka-stream/src/main/scala/akka/stream/IOResult.scala
@@ -16,8 +16,7 @@ import scala.util.{ Failure, Success, Try }
  * @param count Numeric value depending on context, for example IO operations performed or bytes processed.
  * @param status Status of the result. Can be either [[akka.Done]] or an exception.
  */
-final case class IOResult private (count: Long, status: Try[Done])
-  extends Serializable with Product {
+final case class IOResult (count: Long, status: Try[Done]) {
 
   def withCount(value: Long): IOResult = copy(count = value)
   def withStatus(value: Try[Done]): IOResult = copy(status = value)
@@ -43,7 +42,7 @@ final case class IOResult private (count: Long, status: Try[Done])
 
 }
 
-object IOResult extends AbstractFunction2[Long, Try[Done], IOResult] {
+object IOResult {
 
   def createSuccessful(count: Long): IOResult =
     new IOResult(count, Success(Done))

--- a/akka-stream/src/main/scala/akka/stream/IOResult.scala
+++ b/akka-stream/src/main/scala/akka/stream/IOResult.scala
@@ -3,11 +3,7 @@
  */
 package akka.stream
 
-import java.util.Objects
-
 import akka.Done
-
-import scala.runtime.AbstractFunction2
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -16,7 +12,7 @@ import scala.util.{ Failure, Success, Try }
  * @param count Numeric value depending on context, for example IO operations performed or bytes processed.
  * @param status Status of the result. Can be either [[akka.Done]] or an exception.
  */
-final case class IOResult (count: Long, status: Try[Done]) {
+final case class IOResult(count: Long, status: Try[Done]) {
 
   def withCount(value: Long): IOResult = copy(count = value)
   def withStatus(value: Try[Done]): IOResult = copy(status = value)

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -998,6 +998,10 @@ object MiMa extends AutoPlugin {
 
         // #21330 takeWhile inclusive flag
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.takeWhile")
+      ),
+      "2.4.11" -> Seq(
+        // #20795  IOResult construction exposed
+        ProblemFilters.exclude[MissingTypesProblem]("akka.stream.IOResult$")
       )
     )
   }


### PR DESCRIPTION
`unapply` is missing.
Let me know if we'd like to include this change and then I add the unapply

Thanks https://github.com/ktoso/kaze-class 😉 
