### PR TITLE
Expose success and fail methods in CircuitBreaker #18347

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -167,6 +167,24 @@ class CircuitBreaker(scheduler: Scheduler, maxFailures: Int, callTimeout: Finite
   def callWithSyncCircuitBreaker[T](body: Callable[T]): T = withSyncCircuitBreaker(body.call)
 
   /**
+   * Mark a successful call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
+   * caller Actor. In such a case, it is convenient to mark a successful call instead of using Future
+   * via [[withCircuitBreaker]]
+   */
+  def succeed(): Unit = {
+    currentState.callSucceeds()
+  }
+
+  /**
+   * Mark a failed call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
+   * caller Actor. In such a case, it is convenient to mark a failed call instead of using Future
+   * via [[withCircuitBreaker]]
+   */
+  def fail(): Unit = {
+    currentState.callFails()
+  }
+
+  /**
    * Adds a callback to execute when circuit breaker opens
    *
    * The callback is run in the [[scala.concurrent.ExecutionContext]] supplied in the constructor.

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -185,6 +185,36 @@ class CircuitBreaker(scheduler: Scheduler, maxFailures: Int, callTimeout: Finite
   }
 
   /**
+   * Return true if the internal state is Closed. WARNING: It is a "power API" call which you should use with care.
+   * Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in withCircuitBreaker.
+   * So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+   * manage the state yourself.
+   */
+  def isClosed: Boolean = {
+    currentState == Closed
+  }
+
+  /**
+   * Return true if the internal state is Open. WARNING: It is a "power API" call which you should use with care.
+   * Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in withCircuitBreaker.
+   * So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+   * manage the state yourself.
+   */
+  def isOpen: Boolean = {
+    currentState == Open
+  }
+
+  /**
+   * Return true if the internal state is HalfOpen. WARNING: It is a "power API" call which you should use with care.
+   * Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in withCircuitBreaker.
+   * So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+   * manage the state yourself.
+   */
+  def isHalfOpen: Boolean = {
+    currentState == HalfOpen
+  }
+
+  /**
    * Adds a callback to execute when circuit breaker opens
    *
    * The callback is run in the [[scala.concurrent.ExecutionContext]] supplied in the constructor.
@@ -207,7 +237,6 @@ class CircuitBreaker(scheduler: Scheduler, maxFailures: Int, callTimeout: Finite
 
   /**
    * Adds a callback to execute when circuit breaker transitions to half-open
-   *
    * The callback is run in the [[scala.concurrent.ExecutionContext]] supplied in the constructor.
    *
    * @param callback Handler to be invoked on state change

--- a/akka-docs/rst/common/circuitbreaker.rst
+++ b/akka-docs/rst/common/circuitbreaker.rst
@@ -115,9 +115,14 @@ Tell Pattern
 
 The above ``Call Protection`` pattern works well when the return from a remote call is wrapped in a ``Future``.
 However, when a remote call sends back a message or timeout to the caller ``Actor``, the ``Call Protection`` pattern
-is awkward.
+is awkward. CircuitBreaker doesn't support it natively at the moment, so you need to use below low-level power-user APIs,
+``succeed``  and  ``fail`` methods, as well as ``isClose``, ``isOpen``, ``isHalfOpen``.
 
-CircuitBreaker doesn't support it natively at the moment, so you need to use below low-level power-user APIs.
+.. note::
+
+	The below examples doesn't make a remote call when the state is `HalfOpen`. Using the power-user APIs, it is
+	your responsibility to judge when to make remote calls in `HalfOpen`.
+
 
 ^^^^^^^
 Scala
@@ -134,14 +139,3 @@ Java
    :include: circuit-breaker-tell-pattern
 
 
----------------------------------------------------
-FAQ: Why not CircuitBreaker internal state exposed?
----------------------------------------------------
-
-There is a frequently asked question about how to get CircuitBreaker's internal state.
-
-We don't expose the state via CircuitBreaker's API intentionally. You are not supposed
-to implement logic to handle remote calls, based on whether CircuitBreaker's internal state
-is close, open or half-open. Instead, you should rely on CircuitBreaker to handle call
-failure, timeout accordingly, and detect CircuitBreakerOpenException when remote calls
-are not working.

--- a/akka-docs/rst/common/circuitbreaker.rst
+++ b/akka-docs/rst/common/circuitbreaker.rst
@@ -107,3 +107,39 @@ Java
 	will return a :class:`CircuitBreaker` where callbacks are executed in the caller's thread.
 	This can be useful if the asynchronous :class:`Future` behavior is unnecessary, for
 	example invoking a synchronous-only API.
+
+
+------------
+Tell Pattern
+------------
+
+The above ``Call Protection`` pattern works well when the return from a remote call is wrapped in a ``Future``.
+However, when a remote call sends back a message or timeout to the caller ``Actor``, the ``Call Protection`` pattern
+is awkward. In such a case, you can use ``succeed`` and ``fail`` methods on ``CircuitBreaker`` like below.
+
+^^^^^^^
+Scala
+^^^^^^^
+
+.. includecode:: code/docs/circuitbreaker/CircuitBreakerDocSpec.scala
+   :include: circuit-breaker-tell-pattern
+
+^^^^^^^
+Java
+^^^^^^^
+
+.. includecode:: code/docs/circuitbreaker/TellPatternJavaActor.java
+   :include: circuit-breaker-tell-pattern
+
+
+---------------------------------------------------
+FAQ: Why not CircuitBreaker internal state exposed?
+---------------------------------------------------
+
+There is a frequently asked question about how to get CircuitBreaker's internal state.
+
+We don't expose the state via CircuitBreaker's API intentionally. You are not supposed
+to implement logic to handle remote calls, based on whether CircuitBreaker's internal state
+is close, open or half-open. Instead, you should rely on CircuitBreaker to handle call
+failure, timeout accordingly, and detect CircuitBreakerOpenException when remote calls
+are not working.

--- a/akka-docs/rst/common/circuitbreaker.rst
+++ b/akka-docs/rst/common/circuitbreaker.rst
@@ -115,7 +115,9 @@ Tell Pattern
 
 The above ``Call Protection`` pattern works well when the return from a remote call is wrapped in a ``Future``.
 However, when a remote call sends back a message or timeout to the caller ``Actor``, the ``Call Protection`` pattern
-is awkward. In such a case, you can use ``succeed`` and ``fail`` methods on ``CircuitBreaker`` like below.
+is awkward.
+
+CircuitBreaker doesn't support it natively at the moment, so you need to use below low-level power-user APIs.
 
 ^^^^^^^
 Scala

--- a/akka-docs/rst/common/code/docs/circuitbreaker/TellPatternJavaActor.java
+++ b/akka-docs/rst/common/code/docs/circuitbreaker/TellPatternJavaActor.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package docs.circuitbreaker;
+
+import akka.actor.ReceiveTimeout;
+import akka.actor.UntypedActor;
+import akka.event.Logging;
+import akka.event.LoggingAdapter;
+import akka.pattern.CircuitBreaker;
+import scala.concurrent.duration.Duration;
+
+import static akka.dispatch.Futures.future;
+import static akka.pattern.Patterns.pipe;
+
+public class TellPatternJavaActor extends UntypedActor {
+
+  private final CircuitBreaker breaker;
+  private final LoggingAdapter log = Logging.getLogger(getContext().system(), this);
+
+  public TellPatternJavaActor() {
+    this.breaker = new CircuitBreaker(
+      getContext().dispatcher(), getContext().system().scheduler(),
+      5, Duration.create(10, "s"), Duration.create(1, "m"))
+      .onOpen(new Runnable() {
+        public void run() {
+          notifyMeOnOpen();
+        }
+      });
+  }
+
+  public void notifyMeOnOpen() {
+    log.warning("My CircuitBreaker is now open, and will not close for one minute");
+  }
+
+  public void handleExpected( String s ) { log.info(s); }
+
+  public void handleUnExpected( String s ) { log.warning(s); }
+
+  //#circuit-breaker-tell-pattern
+  class ExpectedRemoteResponse{
+    private final String _s;
+    public ExpectedRemoteResponse( String s ) {
+      _s = s;
+    }
+    String getMessage() { return _s; }
+  }
+
+  class UnExpectedRemoteResponse{
+    private final String _s;
+    public UnExpectedRemoteResponse( String s ) {
+      _s = s;
+    }
+    String getMessage() { return _s; }
+  }
+
+  @Override
+  public void onReceive(Object message) {
+    if ( message instanceof ExpectedRemoteResponse ) {
+      String m = ((ExpectedRemoteResponse) message).getMessage();
+      handleExpected(m);
+      breaker.succeed();
+    } else if ( message instanceof UnExpectedRemoteResponse ) {
+      String m = ((ExpectedRemoteResponse) message).getMessage();
+      handleUnExpected(m);
+      breaker.fail();
+    } else if ( message instanceof ReceiveTimeout ) {
+      breaker.fail();
+    }
+  }
+  //#
+
+}

--- a/akka-docs/rst/common/code/docs/circuitbreaker/TellPatternJavaActor.java
+++ b/akka-docs/rst/common/code/docs/circuitbreaker/TellPatternJavaActor.java
@@ -46,6 +46,6 @@ public class TellPatternJavaActor extends UntypedActor {
       breaker.fail();
     }
   }
-  //#
+  //#circuit-breaker-tell-pattern
 
 }


### PR DESCRIPTION
Fixes #18347 , but still work in progress.
#18347 asked for `succeed`, `fail`, and `state` methods, but `state` might not be good to add?

CircuitBreaker's [currentState](https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala#L110L111) is internal. I think outside callers of CircuitBreaker shouldn't know its state, but rely on CircuitBreaker to manage call failures, timeout, and throw CircuitBreakerOpenException when it's open. [(Akka Docs)](http://doc.akka.io/docs/akka/2.4/common/circuitbreaker.html) 

Same question in -> [Akka User List](https://groups.google.com/forum/#!searchin/akka-user/circuitbreaker%7Csort:relevance/akka-user/ViI5PrBOZn8/TJ9zGNSQUMwJ)

By the way, sorry I failed to understand this by @patriknw in #18347 ... fire-forget but get reply messages...?

> For fire-forget messaging it is more difficult. One way is to create a Promise corresponding to the Future of the withCircuitBreaker, that you keep around in the actor and when you get reply messages corresponding to the request you would complete the promise with success or failure.
