### PR TITLE
Add samples to run HTTP and HTTPS servers in the same app

### DIFF
--- a/akka-docs/rst/java/http/server-side-https-support.rst
+++ b/akka-docs/rst/java/http/server-side-https-support.rst
@@ -21,6 +21,8 @@ For detailed documentation for client-side HTTPS support refer to :ref:`clientSi
 
 .. _akka.http.javadsl.Http: https://github.com/akka/akka/blob/master/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
 
+.. _ssl-config-java:
+
 SSL-Config
 ----------
 
@@ -57,6 +59,8 @@ keystores using the JDK keytool utility can be found `here <https://docs.oracle.
 SSL-Config provides a more targeted guide on generating certificates, so we recommend you start with the guide
 titled `Generating X.509 Certificates <http://typesafehub.github.io/ssl-config/CertificateGeneration.html>`_.
 
+.. _using-https-java:
+
 Using HTTPS
 -----------
 
@@ -64,11 +68,34 @@ Once you have obtained the server certificate, using it is as simple as preparin
 and either setting it as the default one to be used by all servers started by the given ``Http`` extension
 or passing it in explicitly when binding the server.
 
-The below example shows how setting up HTTPS works when using the ``akka.http.javadsl.server.HttpApp`` convenience class:
+The below example shows how setting up HTTPS works when using the ``akka.http.javadsl.server.HttpApp`` convenience class.
+Firstly you will create and configure an instance of ``akka.http.javadsl.HttpsConnectionContext`` :
+
+.. includecode2:: ../../../../akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
+   :snippet: https-http-config
+
+Then pass it to ``akka.http.javadsl.Http`` class's ``setDefaultServerHttpContext`` method, like in the below ``main`` method.
 
 .. includecode2:: ../../../../akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
    :snippet: https-http-app
 
+Running both HTTP and HTTPS
+---------------------------
+If you want to run HTTP and HTTPS servers in a single application, you can call ``bind...`` methods twice,
+one for HTTPS, and the other for HTTP.
+
+When configuring HTTPS, you can do it up like explained in the above :ref:`using-https-java` section,
+
+.. includecode2:: ../../../../akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
+   :snippet: https-http-config
+
+or via :ref:`ssl-config-java` (not explained here though).
+
+Then, call ``bind...`` methods twice like below.
+The blow ``SimpleServerApp.useHttps(system)`` is calling the above defined HTTP ``public static HttpsConnectionContext useHttps(ActorSystem system)`` method.
+
+.. includecode2:: ../../../../akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerHttpHttpsApp.java
+   :snippet: both-https-and-http
 
 Further reading
 ---------------

--- a/akka-docs/rst/scala/code/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/akka-docs/rst/scala/code/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -54,10 +54,13 @@ abstract class HttpsServerExampleSpec extends WordSpec with Matchers
     val sslContext: SSLContext = SSLContext.getInstance("TLS")
     sslContext.init(keyManagerFactory.getKeyManagers, tmf.getTrustManagers, new SecureRandom)
     val https: HttpsConnectionContext = ConnectionContext.https(sslContext)
+    //#
 
-    // sets default context to HTTPS – all Http() bound servers for this ActorSystem will use HTTPS from now on
-    Http().setDefaultServerHttpContext(https)
-
+    //#both-https-and-http
+    // you can run both HTTP and HTTPS in the same application as follows:
+    val commonRoutes: Route = get { complete("Hello world!") }
+    Http().bindAndHandle(commonRoutes, "127.0.0.1", 443, connectionContext = https)
+    Http().bindAndHandle(commonRoutes, "127.0.0.1", 80)
     //#
 
     //#bind-low-level-context
@@ -67,6 +70,14 @@ abstract class HttpsServerExampleSpec extends WordSpec with Matchers
     val routes: Route = get { complete("Hello world!") }
     Http().bindAndHandle(routes, "127.0.0.1", 8080, connectionContext = https)
     //#
+
+    //#set-low-level-context-default
+    // sets default context to HTTPS – all Http() bound servers for this ActorSystem will use HTTPS from now on
+    Http().setDefaultServerHttpContext(https)
+    Http().bindAndHandle(routes, "127.0.0.1", 9090, connectionContext = https)
+    //#
+
+    system.terminate()
   }
 
 }

--- a/akka-docs/rst/scala/http/server-side-https-support.rst
+++ b/akka-docs/rst/scala/http/server-side-https-support.rst
@@ -21,6 +21,9 @@ For detailed documentation for client-side HTTPS support refer to :ref:`clientSi
 
 .. _akka.http.scaladsl.Http: https://github.com/akka/akka/blob/master/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
 
+
+.. _ssl-config-scala:
+
 SSL-Config
 ----------
 
@@ -57,6 +60,9 @@ keystores using the JDK keytool utility can be found `here <https://docs.oracle.
 SSL-Config provides a more targeted guide on generating certificates, so we recommend you start with the guide
 titled `Generating X.509 Certificates <http://typesafehub.github.io/ssl-config/CertificateGeneration.html>`_.
 
+
+.. _using-https-scala:
+
 Using HTTPS
 -----------
 
@@ -71,13 +77,33 @@ or passing it in explicitly when binding the server:
 .. includecode2:: ../code/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
    :snippet: low-level-default
 
+Once you configured the HTTPS context, you can set it as default:
+
+.. includecode2:: ../code/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+   :snippet: set-low-level-context-default
+
 It is also possible to pass in the context to specific ``bind...`` (or client) calls, like displayed below:
 
 .. includecode2:: ../code/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
    :snippet: bind-low-level-context
 
 
+Running both HTTP and HTTPS
+---------------------------
+If you want to run HTTP and HTTPS servers in a single application, you can call ``bind...`` methods twice,
+one for HTTPS, and the other for HTTP.
 
+When configuring HTTPS, you can do it up like explained in the above :ref:`using-https-scala` section,
+
+.. includecode2:: ../code/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+   :snippet: low-level-default
+
+or via :ref:`ssl-config-scala` (not explained here though).
+
+Then, call ``bind...`` methods twice like below. The passed ``https`` context is from the above code snippet.
+
+.. includecode2:: ../code/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+   :snippet: both-https-and-http
 
 Further reading
 ---------------

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
@@ -4,7 +4,6 @@
 
 package akka.http.javadsl.server.examples.simple;
 
-//#https-http-app
 
 import akka.NotUsed;
 import static akka.http.javadsl.server.PathMatchers.segment;
@@ -39,6 +38,8 @@ import static akka.http.javadsl.unmarshalling.Unmarshaller.entityToString;
 
 public class SimpleServerApp extends AllDirectives { // or import Directives.*
 
+
+  //#https-http-app
   public Route multiply(int x, int y) {
     int result = x * y;
     return complete(String.format("%d * %d = %d", x, y, result));
@@ -103,7 +104,10 @@ public class SimpleServerApp extends AllDirectives { // or import Directives.*
     final Http http = Http.get(system);
 
     boolean useHttps = false; // pick value from anywhere
-    useHttps(system, http, useHttps);
+    if ( useHttps ) {
+      HttpsConnectionContext https = useHttps(system);
+      http.setDefaultServerHttpContext(https);
+    }
 
     final SimpleServerApp app = new SimpleServerApp();
     final Flow<HttpRequest, HttpResponse, NotUsed> flow = app.createRoute().flow(system, materializer);
@@ -114,12 +118,12 @@ public class SimpleServerApp extends AllDirectives { // or import Directives.*
     System.in.read();
     system.terminate();
   }
+  //#
 
+  //#https-http-config
   // ** CONFIGURING ADDITIONAL SETTINGS ** //
 
-  public static void useHttps(ActorSystem system, Http http, boolean useHttps) {
-    if (useHttps) {
-
+  public static HttpsConnectionContext useHttps(ActorSystem system) {
       HttpsConnectionContext https = null;
       try {
         // initialise the keystore
@@ -150,9 +154,7 @@ public class SimpleServerApp extends AllDirectives { // or import Directives.*
         system.log().error("Exception while ", e);
       }
 
-      http.setDefaultServerHttpContext(https);
-    }
+      return https;
   }
-
+  //#
 }
-//#

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerHttpHttpsApp.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerHttpHttpsApp.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.javadsl.server.examples.simple;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.HttpsConnectionContext;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+
+import java.io.IOException;
+
+public class SimpleServerHttpHttpsApp extends AllDirectives { // or import Directives.*
+
+  public Route createRoute() {
+    return get( () -> complete("Hello World!") );
+  }
+
+  // ** STARTING THE SERVER ** //
+
+  public static void main(String[] args) throws IOException {
+    final ActorSystem system = ActorSystem.create("SimpleServerHttpHttpsApp");
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    final SimpleServerApp app = new SimpleServerApp();
+    final Flow<HttpRequest, HttpResponse, NotUsed> flow = app.createRoute().flow(system, materializer);
+
+    //#both-https-and-http
+    final Http http = Http.get(system);
+    //Run HTTP server firstly
+    http.bindAndHandle(flow, ConnectHttp.toHost("localhost", 80), materializer);
+
+    //get configured HTTPS context
+    HttpsConnectionContext https = SimpleServerApp.useHttps(system);
+
+    // sets default context to HTTPS – all Http() bound servers for this ActorSystem will use HTTPS from now on
+    http.setDefaultServerHttpContext(https);
+
+    //Then run HTTPS server
+    http.bindAndHandle(flow, ConnectHttp.toHost("localhost", 443), materializer);
+    //#
+
+    System.out.println("Type RETURN to exit");
+    System.in.read();
+    system.terminate();
+  }
+}


### PR DESCRIPTION
Fixes #18551 

The generated documentation looks like as in the screenshots, on the following pages:
- [Scala Server Side HTTPS Support](http://doc.akka.io/docs/akka/2.4/scala/http/server-side-https-support.html)
- [Java Server Side HTTPS Support](http://doc.akka.io/docs/akka/2.4/java/http/server-side-https-support.html)

![image](https://cloud.githubusercontent.com/assets/7414320/17276632/9350fd20-5769-11e6-9526-ed80611be11f.png)
