### PR TITLE
[WIP] Remove deprecated scala.concurrent.forkjoin references #18262

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -16,7 +16,6 @@ import com.typesafe.config.Config
 import scala.annotation.tailrec
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.concurrent.forkjoin.{ ForkJoinPool, ForkJoinTask }
 import scala.util.control.NonFatal
 
 final case class Envelope private (val message: Any, val sender: ActorRef)

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -17,7 +17,6 @@ import com.typesafe.config.Config
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.concurrent.forkjoin.ForkJoinTask
 import scala.util.control.NonFatal
 
 /**

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -7,12 +7,13 @@ package akka.dispatch
 import java.util.Collection
 import scala.concurrent.{ BlockContext, CanAwait }
 import scala.concurrent.duration.Duration
-import scala.concurrent.forkjoin._
 import java.util.concurrent.{
   ArrayBlockingQueue,
   BlockingQueue,
   Callable,
   ExecutorService,
+  ForkJoinPool,
+  ForkJoinWorkerThread,
   LinkedBlockingQueue,
   RejectedExecutionHandler,
   RejectedExecutionException,

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
@@ -10,7 +10,6 @@ import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import scala.concurrent.duration._
 import akka.testkit._
 import akka.testkit.TestEvent._
-import java.util.concurrent.ThreadLocalRandom
 import akka.remote.testconductor.RoleName
 import akka.actor.Props
 import akka.actor.Actor

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -948,6 +948,19 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.singleton.ClusterSingletonManager.selfAddressOption")
       ),
       "2.4.9" -> Seq(
+      ),
+      "2.5.0" -> Seq(
+        // #21101
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.MonitorableThreadFactory#AkkaForkJoinWorkerThread.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.MonitorableThreadFactory.newThread"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory.threadFactory"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator.validate"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.BalancingDispatcher$SharingMailbox"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinPool"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask"),
+        ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.MonitorableThreadFactory$AkkaForkJoinWorkerThread")
       )
     )
   }


### PR DESCRIPTION
- Replaced all instances of scala.concurrent.forkjoin.\* with their corresponding classes in java.util.concurrent
- Removed one unused import of ThreadLocalRandom

This work fixed #18262.

Binary compatibility warnings will need to be addressed, copy from the discussion on #18262:

The following methods and type hierarchies are affected

``` scala
akka.dispatch.BalancingDispatcher$SharingMailbox
akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool.this
akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory.this
akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory.threadFactory
akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinPool
akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask
akka.dispatch.ForkJoinExecutorConfigurator.validate
akka.dispatch.MonitorableThreadFactory#AkkaForkJoinWorkerThread.this
akka.dispatch.MonitorableThreadFactory$AkkaForkJoinWorkerThread
akka.dispatch.MonitorableThreadFactory.newThread
```

Raw log:

``` sbt
[info] akka-actor: found 13 potential binary incompatibilities while checking against com.typesafe.akka:akka-actor_2.11:2.3.15  (filtered 215)
[error]  * method threadFactory()scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory in class akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory has a different result type in current version, where it is java.util.concurrent.ForkJoinPool#ForkJoinWorkerThreadFactory rather than scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory
[error]    filter with: ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory.threadFactory")
[error]  * method this(akka.dispatch.ForkJoinExecutorConfigurator,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,Int)Unit in class akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory's type is different in current version, where it is (akka.dispatch.ForkJoinExecutorConfigurator,java.util.concurrent.ForkJoinPool#ForkJoinWorkerThreadFactory,Int)Unit instead of (akka.dispatch.ForkJoinExecutorConfigurator,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,Int)Unit
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory.this")
[error]  * method this(akka.dispatch.ForkJoinExecutorConfigurator,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,Int,Boolean)Unit in class akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory's type is different in current version, where it is (akka.dispatch.ForkJoinExecutorConfigurator,java.util.concurrent.ForkJoinPool#ForkJoinWorkerThreadFactory,Int,Boolean)Unit instead of (akka.dispatch.ForkJoinExecutorConfigurator,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,Int,Boolean)Unit
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#ForkJoinExecutorServiceFactory.this")
[error]  * method validate(java.util.concurrent.ThreadFactory)scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory in class akka.dispatch.ForkJoinExecutorConfigurator has a different result type in current version, where it is java.util.concurrent.ForkJoinPool#ForkJoinWorkerThreadFactory rather than scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory
[error]    filter with: ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator.validate")
[error]  * the type hierarchy of class akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinTask is different in current version. Missing types {java.lang.Object,scala.concurrent.forkjoin.ForkJoinTask}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask")
[error]  * method newThread(scala.concurrent.forkjoin.ForkJoinPool)scala.concurrent.forkjoin.ForkJoinWorkerThread in class akka.dispatch.MonitorableThreadFactory in current version does not have a correspondent with same parameter signature among (java.util.concurrent.ForkJoinPool)java.util.concurrent.ForkJoinWorkerThread, (java.lang.Runnable)java.lang.Thread
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.MonitorableThreadFactory.newThread")
[error]  * the type hierarchy of class akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool is different in current version. Missing types {java.util.concurrent.AbstractExecutorService,scala.concurrent.forkjoin.ForkJoinPool}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinPool")
[error]  * method this(Int,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,java.lang.Thread#UncaughtExceptionHandler)Unit in class akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool's type is different in current version, where it is (Int,java.util.concurrent.ForkJoinPool#ForkJoinWorkerThreadFactory,java.lang.Thread#UncaughtExceptionHandler)Unit instead of (Int,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,java.lang.Thread#UncaughtExceptionHandler)Unit
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool.this")
[error]  * method this(Int,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,java.lang.Thread#UncaughtExceptionHandler,Boolean)Unit in class akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool's type is different in current version, where it is (Int,java.util.concurrent.ForkJoinPool#ForkJoinWorkerThreadFactory,java.lang.Thread#UncaughtExceptionHandler,Boolean)Unit instead of (Int,scala.concurrent.forkjoin.ForkJoinPool#ForkJoinWorkerThreadFactory,java.lang.Thread#UncaughtExceptionHandler,Boolean)Unit
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool.this")
[error]  * the type hierarchy of class akka.dispatch.Mailbox is different in current version. Missing types {java.lang.Object}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.BalancingDispatcher$SharingMailbox")
[error]  * the type hierarchy of class akka.dispatch.MonitorableThreadFactory#AkkaForkJoinWorkerThread is different in current version. Missing types {java.lang.Thread,scala.concurrent.forkjoin.ForkJoinWorkerThread}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("akka.dispatch.MonitorableThreadFactory$AkkaForkJoinWorkerThread")
[error]  * method this(scala.concurrent.forkjoin.ForkJoinPool)Unit in class akka.dispatch.MonitorableThreadFactory#AkkaForkJoinWorkerThread's type is different in current version, where it is (java.util.concurrent.ForkJoinPool)Unit instead of (scala.concurrent.forkjoin.ForkJoinPool)Unit
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.dispatch.MonitorableThreadFactory#AkkaForkJoinWorkerThread.this")
```
