### PR TITLE
Fix typo in source-streaming-support #21103

### DIFF
--- a/akka-docs/rst/scala/http/routing-dsl/source-streaming-support.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/source-streaming-support.rst
@@ -26,7 +26,7 @@ In the below examples, we'll be refering to the ``Tweet`` and ``Measurement`` ca
 .. includecode2:: ../../code/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
    :snippet: models
 
-And as always with spray-json, we provide our (Un)Marshaller instances as implicit values uding the ``jsonFormat##``
+And as always with spray-json, we provide our (Un)Marshaller instances as implicit values using the ``jsonFormat##``
 method to generate them statically:
 
 .. includecode2:: ../../code/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala


### PR DESCRIPTION
The word "uding" should be "using". Sorry for such a small PR, I just noticed the typo while reading today.
