### PR TITLE
Adding ScalaDocs for FlowOps.async

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1825,6 +1825,14 @@ trait FlowOps[+Out, +Mat] {
 
   def named(name: String): Repr[Out]
 
+  /**
+   * Put an asynchronous boundary around this `Flow`.
+   * 
+   * If this is a `SubFlow` (created e.g. by `groupBy`), this creates an
+   * asynchronous boundary around each materialized sub-flow, not the
+   * super-flow. That way, the super-flow will communicate with sub-flows
+   * asynchronously.
+   */
   def async: Repr[Out]
 
   /** INTERNAL API */


### PR DESCRIPTION
With a dedicated section for the behavior when used on SubFlow

As discussed on gitter with @ktoso 
I was thinking about adding something to the docs, but in the end I suppose just having this specified in the scaladocs is more DRY ;)
