### PR TITLE
#21145 ShardRestart shouldn't go to userspace

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -258,7 +258,7 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
    * @param entityProps the `Props` of the entity actors that will be created by the `ShardRegion`
    * @param settings configuration settings, see [[ClusterShardingSettings]]
    * @param messageExtractor functions to extract the entity id, shard id, and the message to send to the
-   *   entity from the incoming message
+   *   entity from the incoming message, see [[ShardRegion.MessageExtractor]]
    * @param allocationStrategy possibility to use a custom shard allocation and
    *   rebalancing logic
    * @param handOffStopMessage the message that will be sent to entities when they are to be stopped

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -367,8 +367,8 @@ object ShardCoordinator {
     }
 
     def stoppingShard: Receive = {
-      case ShardStopped(shard) ⇒ done(ok = true)
-      case ReceiveTimeout      ⇒ done(ok = false)
+      case ShardStopped(`shard`) ⇒ done(ok = true)
+      case ReceiveTimeout        ⇒ done(ok = false)
     }
 
     def done(ok: Boolean): Unit = {


### PR DESCRIPTION
Fixes #21145
Due to order in pattern match `ShardRestart` message can be received in user-defined `messageExtractorId` (when set via providing `MessageExtractor` which is not returning null in case of unknown messages).
To avoid this it's sufficient to only change the order in the pattern match.
Also added note to documentation for using `MessageExtractor` to clarify that it should return null in case of unhandled message.

Additionally I've added minor fix for shadowing in pattern match in `RebalanceWorker` and minor cleanups in `ShardRegion`.
