### PR TITLE
=act change Unsubscribers visibility.

### DIFF
--- a/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * Watches all actors which subscribe on the given event stream, and unsubscribes them from it when they are Terminated.
  */
-private[akka] class ActorClassificationUnsubscriber(bus: ManagedActorClassification, debug: Boolean) extends Actor with Stash {
+protected[akka] class ActorClassificationUnsubscriber(bus: ManagedActorClassification, debug: Boolean) extends Actor with Stash {
 
   import ActorClassificationUnsubscriber._
 

--- a/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * subscribe calls * because of the need of linearizing the history message sequence and the possibility of sometimes
  * watching a few actors too much - we opt for the 2nd choice here.
  */
-private[akka] class EventStreamUnsubscriber(eventStream: EventStream, debug: Boolean = false) extends Actor {
+protected[akka] class EventStreamUnsubscriber(eventStream: EventStream, debug: Boolean = false) extends Actor {
 
   import EventStreamUnsubscriber._
 


### PR DESCRIPTION
In Scala.Js `private` and inner classes couldn't be exported so they are not reachable for a Dynamic instatiation.
