### PR TITLE
Exponential interval redelivery

### DIFF
--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -55,6 +55,11 @@ akka.persistence {
     at-least-once-delivery {
         # Interval between re-delivery attempts.
         redeliver-interval = 5s
+        # factor for expotential redelivery
+        redeliver-factor = 1 # for backward compatibility
+        # how big should be random part of interval should be positive
+        redeliver-random-part = 0 # for backword compatibility
+
         # Maximum number of unconfirmed messages that will be sent in one 
         # re-delivery burst.
         redelivery-burst-limit = 10000

--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -44,6 +44,15 @@ final class PersistenceSettings(config: Config) {
     val redeliverInterval: FiniteDuration =
       config.getMillisDuration("at-least-once-delivery.redeliver-interval")
 
+    val redeliverFactor: Int =
+      config.getInt("at-least-once-delivery.redeliver-factor")
+
+    val redeliverRandomPart: Double = {
+      val value = config.getDouble("at-least-once-delivery.redeliver-random-part")
+      require(value > 0, "akka.persistence.at-least-once-delivery.redeliver-random-part should be grater then 0. was = " + value)
+      value
+    }
+
     val redeliveryBurstLimit: Int =
       config.getInt("at-least-once-delivery.redelivery-burst-limit")
 

--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -49,7 +49,7 @@ final class PersistenceSettings(config: Config) {
 
     val redeliverRandomPart: Double = {
       val value = config.getDouble("at-least-once-delivery.redeliver-random-part")
-      require(value > 0, "akka.persistence.at-least-once-delivery.redeliver-random-part should be grater then 0. was = " + value)
+      require(value >= 0, "akka.persistence.at-least-once-delivery.redeliver-random-part should be greater or equal 0. was = " + value)
       value
     }
 


### PR DESCRIPTION
Will fix #19562. At least concept for solution. 

I think timestamp in `Delivery` should inform from which point of time we should attempt to redelivery.
Now it's point when last delivery was happen and it's make checks for redelivery harder.

Implementation of random:
`delay = basicInterval * (1 + random * part)`
where `random` is in `(0,1)`
`part` - setting how strong randomenss should affect interval
`basicInterval` - interval without any randomized part

@patriknw 
Is  random part is what did you mean in original issue? 
