### PR TITLE
fix eventbus doc-code

### DIFF
--- a/akka-docs/rst/scala/code/docs/event/LoggingDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/event/LoggingDocSpec.scala
@@ -152,12 +152,13 @@ class LoggingDocSpec extends AkkaSpec {
 
   "demonstrate superclass subscriptions on eventStream" in {
     def println(s: String) = ()
-    //#superclass-subscription-eventstream
-    abstract class AllKindsOfMusic { def artist: String }
-    case class Jazz(artist: String) extends AllKindsOfMusic
-    case class Electronic(artist: String) extends AllKindsOfMusic
 
     new AnyRef {
+      //#superclass-subscription-eventstream
+      abstract class AllKindsOfMusic { def artist: String }
+      case class Jazz(artist: String) extends AllKindsOfMusic
+      case class Electronic(artist: String) extends AllKindsOfMusic
+
       class Listener extends Actor {
         def receive = {
           case m: Jazz       => println(s"${self.path.name} is listening to: ${m.artist}")


### PR DESCRIPTION
remove `new AnyRef {`

before: http://doc.akka.io/docs/akka/2.4/scala/event-bus.html

![image](https://cloud.githubusercontent.com/assets/1635885/17648049/7bcb6278-6243-11e6-9229-a6994756c5c7.png)

after:

![image](https://cloud.githubusercontent.com/assets/1635885/17648051/877b09d4-6243-11e6-89b2-bb242bb8438e.png)
