### PR TITLE
+htp,spray allow Marshal(T).to[ByteString] given JSON marshallers

### DIFF
--- a/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
@@ -47,6 +47,10 @@ trait SprayJsonSupport {
     sprayJsValueMarshaller compose writer.write
   implicit def sprayJsValueMarshaller(implicit printer: JsonPrinter = CompactPrinter): ToEntityMarshaller[JsValue] =
     Marshaller.StringMarshaller.wrap(MediaTypes.`application/json`)(printer)
+  implicit def sprayJsValueByteStringMarshaller(implicit printer: JsonPrinter = CompactPrinter): ToByteStringMarshaller[JsValue] =
+    Marshaller.strict(js => Marshalling.WithFixedContentType(ContentTypes.`application/json`, () => ByteString(printer(js))))
+  implicit def sprayJsonByteStringMarshaller[T](implicit writer: RootJsonWriter[T], printer: JsonPrinter = CompactPrinter): ToByteStringMarshaller[T] =
+    sprayJsValueByteStringMarshaller compose writer.write
 
   // support for as[Source[T, NotUsed]]
   implicit def sprayJsonSourceReader[T](implicit rootJsonReader: RootJsonReader[T], support: EntityStreamingSupport): FromRequestUnmarshaller[Source[T, NotUsed]] =

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
@@ -28,6 +28,9 @@ trait Unmarshaller[-A, B] extends akka.http.javadsl.unmarshalling.Unmarshaller[A
   def flatMap[C](f: ExecutionContext ⇒ Materializer ⇒ B ⇒ Future[C]): Unmarshaller[A, C] =
     transform(implicit ec ⇒ mat ⇒ _.fast flatMap f(ec)(mat))
 
+  def flatMap[C](u: Unmarshaller[_ >: B, C]): Unmarshaller[A, C] =
+    flatMap { ctx ⇒ mat ⇒ b ⇒ u.apply(b)(ctx, mat) }
+
   def recover[C >: B](pf: ExecutionContext ⇒ Materializer ⇒ PartialFunction[Throwable, C]): Unmarshaller[A, C] =
     transform(implicit ec ⇒ mat ⇒ _.fast recover pf(ec)(mat))
 


### PR DESCRIPTION
Added missing marshalling side, unmarshalling was part of JSON Streaming PR
