### PR TITLE
=Fix regression of akka.util.ByteString#slice(...)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -365,13 +365,30 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteStrings(ByteString1.fromString(""), ByteString1.fromString("ab")).dropRight(Int.MinValue) should ===(ByteString("ab"))
     }
     "slice" in {
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(0, 1) should ===(ByteString("a"))
       ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).slice(1, 1) should ===(ByteString(""))
+      // Can obtain expected results from 6 basic patterns
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(-10, 10) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(-10, 0) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(-10, 1) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(0, 1) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(0, 10) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(1, 10) should ===(ByteString(""))
+      // Get an empty if `from` is greater then `until`
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).slice(1, 0) should ===(ByteString(""))
+
       ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(2, 2) should ===(ByteString(""))
       ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(2, 3) should ===(ByteString("c"))
       ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(2, 4) should ===(ByteString("cd"))
       ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(3, 4) should ===(ByteString("d"))
-      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(10, 100) should ===(ByteString(""))
+      // Can obtain expected results from 6 basic patterns
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(-10, 10) should ===(ByteString("abcd"))
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(-10, 0) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(-10, 4) should ===(ByteString("abcd"))
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(0, 4) should ===(ByteString("abcd"))
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(0, 10) should ===(ByteString("abcd"))
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(4, 10) should ===(ByteString(""))
+      // Get an empty if `from` is greater than `until`
+      ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(4, 0) should ===(ByteString(""))
     }
     "dropRight" in {
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(0) should ===(ByteString("a"))

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -163,8 +163,8 @@ object ByteString {
       else toByteString1.drop(n)
 
     override def slice(from: Int, until: Int): ByteString =
-      if ((from == 0) && (until == length)) this
-      else if (from > length) ByteString.empty
+      if (from >= length) ByteString.empty
+      else if (until <= 0) ByteString.empty
       else toByteString1.slice(from, until)
 
     private[akka] override def writeToOutputStream(os: ObjectOutputStream): Unit =
@@ -253,9 +253,11 @@ object ByteString {
       else ByteString1(bytes, startIndex, Math.min(n, length))
 
     override def slice(from: Int, until: Int): ByteString = {
-      if (from <= 0 && until >= length) this // we can do < / > since we're Compact
+      if (from <= 0 && length <= until) this // we can do < / > since we're Compact
       else if (until <= from) ByteString1.empty
-      else ByteString1(bytes, startIndex + from, until - from)
+      else if (0 <= from && until <= bytes.length) ByteString1(bytes, startIndex + from, until - from)
+      else if (from < 0) ByteString1(bytes, startIndex, until)
+      else /*(until > bytes.length)*/ ByteString1(bytes, startIndex + from, bytes.length - from)
     }
 
     override def copyToBuffer(buffer: ByteBuffer): Int =


### PR DESCRIPTION
Fixes #21237

Currently slice(...) method unexpectedly throws an error for some arguments. The issue comes from a corner-case of string _slice_ and we can fix this by correctly handling 6 basic patterns(scenarios) described as follows:

Suppose the two input arguments are;
1) from, until <= 0
We check if `until <= 0` is met and return `ByteString.empty` if this is the case.

2) length <= from, until
We check if `length <= from` is met and return `ByteString.empty` if this is the case.

3) from <= 0 && length <= until
We return the byte string itself as we can _compact_ it.

4) 0 <= from <= until <= length
We _slice_ the byte string starting from `from` with the length of `until - from`

5) from < 0
Based on the condition 1, 2, 3 and 4, we know that there're two cases left, i.e., either `from` or `until` is out of the _valid_ range, as we've checked a) both of them are in the valid range in 4 and b) neither of them is in the valid range (or we don't have to actually slice it where `from == 0` and `until == length`) in 3. If `from` is the one that is out of the valid range then `0 <= until <= length` is satisfied, which means we can return _slice_ from `0` to `until`.

6) length < until
Vice versa, if `until` is the one out of the valid range then `0 <= from <= length` is true, which indicates we can return _slice_ from `from` to `length` with the length of `length - from`.

To satisfy the condition 4, 5 and 6, we need to check if `from <= until` is met. To do this, ByteString1#slice(...) has the corresponding logic.

P.S.
I might misunderstand how the slice methods in `ByteString` and `ByteString1` should work, also this change might deteriorate the performance optimization of `slice`. If this is the case, please let me know. I'll do my best to fix my changes again :)
