### PR TITLE
#20887: Reduce GC pressure by compacting to reduce long lived garbage

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -193,7 +193,7 @@ object Framing {
         } else if (buffer.slice(possibleMatchPos, possibleMatchPos + separatorBytes.size) == separatorBytes) {
           // Found a match
           val parsedFrame = buffer.slice(0, possibleMatchPos).compact
-          buffer = buffer.drop(possibleMatchPos + separatorBytes.size)
+          buffer = buffer.drop(possibleMatchPos + separatorBytes.size).compact
           nextPossibleMatch = 0
           if (isClosed(in) && buffer.isEmpty) {
             push(out, parsedFrame)


### PR DESCRIPTION
Reduce potentially long lived garbage by compacting ByteStrings in DelimiterFraming and Rechunker
