### PR TITLE
WIP separate prio artery channel

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -458,9 +458,10 @@ private[akka] trait RemoteRef extends ActorRefScope {
 /**
  * INTERNAL API
  */
-private[remote] sealed abstract class LargeMessageDestinationFlag
-private[remote] case object RegularDestination extends LargeMessageDestinationFlag
-private[remote] case object LargeDestination extends LargeMessageDestinationFlag
+private[remote] sealed abstract class MessageDestinationFlag
+private[remote] case object RegularDestination extends MessageDestinationFlag
+private[remote] case object LargeDestination extends MessageDestinationFlag
+private[remote] case object PriorityDestination extends MessageDestinationFlag
 
 /**
  * INTERNAL API
@@ -486,8 +487,8 @@ private[akka] class RemoteActorRef private[akka] (
   }
   @volatile private[remote] var cachedAssociation: artery.Association = null
 
-  // used by artery to direct messages to a separate stream for large messages
-  @volatile private[remote] var cachedLargeMessageDestinationFlag: LargeMessageDestinationFlag = null
+  // used by artery to direct messages to separate specialized streams
+  @volatile private[remote] var cachedMessageDestinationFlag: MessageDestinationFlag = null
 
   def getChild(name: Iterator[String]): InternalActorRef = {
     val s = name.toStream

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -54,6 +54,8 @@ private[remote] object RARP extends ExtensionId[RARP] with ExtensionIdProvider {
  * Messages marked with this trait will be sent before other messages when buffering is active.
  * This means that these messages don't obey normal message ordering.
  * It is used for failure detector heartbeat messages.
+ *
+ * In Artery this is not used, and instead a preconfigured set of destinations select the priority lane.
  */
 private[akka] trait PriorityMessage
 

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -328,11 +328,22 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   val largeMessageChannelEnabled =
     !largeMessageDestinations.wildcardTree.isEmpty || !largeMessageDestinations.doubleWildcardTree.isEmpty
 
+  private val priorityMessageDestinations =
+    WildcardIndex[NotUsed]()
+      // this comes from remoting so is semi-ok to be hardcoded here
+      .insert(Array("system", "remote-watcher"), NotUsed)
+      // these belongs to cluster and should come from there
+      .insert(Array("system", "cluster", "core", "daemon", "heartbeatSender"), NotUsed)
+      .insert(Array("system", "cluster", "heartbeatReceiver"), NotUsed)
+
   private def inboundChannel = s"aeron:udp?endpoint=${localAddress.address.host.get}:${localAddress.address.port.get}"
   private def outboundChannel(a: Address) = s"aeron:udp?endpoint=${a.host.get}:${a.port.get}"
+
   private val controlStreamId = 1
+  private val priorityStreamId = 2
   private val ordinaryStreamId = 3
   private val largeStreamId = 4
+
   private val taskRunner = new TaskRunner(system, remoteSettings.IdleCpuLevel)
 
   private val restartTimeout: FiniteDuration = 5.seconds // FIXME config
@@ -367,7 +378,13 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     createFlightRecorderEventSink(synchr = true)
 
   private val associationRegistry = new AssociationRegistry(
-    remoteAddress ⇒ new Association(this, materializer, remoteAddress, controlSubject, largeMessageDestinations,
+    remoteAddress ⇒ new Association(
+      this,
+      materializer,
+      remoteAddress,
+      controlSubject,
+      largeMessageDestinations,
+      priorityMessageDestinations,
       outboundEnvelopePool))
 
   def remoteSettings: RemoteSettings = provider.remoteSettings
@@ -528,6 +545,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
 
     runInboundControlStream(noCompressions) // TODO should understand compressions too
     runInboundOrdinaryMessagesStream(compressions)
+    runInboundPriorityMessagesStream(compressions)
     if (largeMessageChannelEnabled) {
       runInboundLargeMessagesStream()
     }
@@ -616,6 +634,26 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       }
 
     attachStreamRestart("Inbound message stream", completed, () ⇒ runInboundOrdinaryMessagesStream(compression))
+  }
+
+  private def runInboundPriorityMessagesStream(compression: InboundCompressions): Unit = {
+    val completed =
+      if (remoteSettings.TestMode) {
+        val (mgmt, c) = aeronSource(priorityStreamId, envelopePool)
+          .via(inboundPriorityFlow(compression))
+          .viaMat(inboundTestFlow)(Keep.right)
+          .toMat(inboundSink)(Keep.both)
+          .run()(materializer)
+        testStages.add(mgmt)
+        c
+      } else {
+        aeronSource(priorityStreamId, envelopePool)
+          .via(inboundPriorityFlow(compression))
+          .toMat(inboundSink)(Keep.right)
+          .run()(materializer)
+      }
+
+    attachStreamRestart("Inbound priority message stream", completed, () ⇒ runInboundPriorityMessagesStream(compression))
   }
 
   private def runInboundLargeMessagesStream(): Unit = {
@@ -749,21 +787,21 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     association(remoteAddress).quarantine(reason = "", uid.map(_.toLong))
   }
 
-  def outbound(outboundContext: OutboundContext, compression: OutboundCompressions): Sink[OutboundEnvelope, Future[Done]] = {
-    Flow.fromGraph(killSwitch.flow[OutboundEnvelope])
-      .via(new OutboundHandshake(system, outboundContext, outboundEnvelopePool, handshakeTimeout,
-        handshakeRetryInterval, injectHandshakeInterval))
-      .via(encoder(compression))
-      .toMat(new AeronSink(outboundChannel(outboundContext.remoteAddress), ordinaryStreamId, aeron, taskRunner,
-        envelopePool, giveUpSendAfter, createFlightRecorderEventSink()))(Keep.right)
-  }
+  def outbound(outboundContext: OutboundContext, compression: OutboundCompressions): Sink[OutboundEnvelope, Future[Done]] =
+    createOutboundSink(ordinaryStreamId, outboundContext, compression, envelopePool)
 
-  def outboundLarge(outboundContext: OutboundContext, compression: OutboundCompressions): Sink[OutboundEnvelope, Future[Done]] = {
+  def outboundPriority(outboundContext: OutboundContext, compression: OutboundCompressions): Sink[OutboundEnvelope, Future[Done]] =
+    createOutboundSink(priorityStreamId, outboundContext, compression, envelopePool)
+
+  def outboundLarge(outboundContext: OutboundContext, compression: OutboundCompressions): Sink[OutboundEnvelope, Future[Done]] =
+    createOutboundSink(largeStreamId, outboundContext, compression, largeEnvelopePool)
+
+  private def createOutboundSink(streamId: Int, outboundContext: OutboundContext, compression: OutboundCompressions, bufferPool: EnvelopeBufferPool): Sink[OutboundEnvelope, Future[Done]] = {
     Flow.fromGraph(killSwitch.flow[OutboundEnvelope])
       .via(new OutboundHandshake(system, outboundContext, outboundEnvelopePool, handshakeTimeout,
         handshakeRetryInterval, injectHandshakeInterval))
-      .via(createEncoder(largeEnvelopePool, compression))
-      .toMat(new AeronSink(outboundChannel(outboundContext.remoteAddress), largeStreamId, aeron, taskRunner,
+      .via(createEncoder(bufferPool, compression))
+      .toMat(new AeronSink(outboundChannel(outboundContext.remoteAddress), streamId, aeron, taskRunner,
         envelopePool, giveUpSendAfter, createFlightRecorderEventSink()))(Keep.right)
   }
 
@@ -831,6 +869,12 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       .toMat(messageDispatcherSink)(Keep.right)
 
   def inboundFlow(compression: InboundCompressions): Flow[EnvelopeBuffer, InboundEnvelope, NotUsed] = {
+    Flow[EnvelopeBuffer]
+      .via(killSwitch.flow)
+      .via(decoder(compression))
+  }
+
+  def inboundPriorityFlow(compression: InboundCompressions): Flow[EnvelopeBuffer, InboundEnvelope, NotUsed] = {
     Flow[EnvelopeBuffer]
       .via(killSwitch.flow)
       .via(decoder(compression))

--- a/akka-remote/src/test/scala/akka/remote/artery/LargeMessagesStreamSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LargeMessagesStreamSpec.scala
@@ -51,7 +51,7 @@ class LargeMessagesStreamSpec extends ArteryMultiNodeSpec(
       senderProbeA.expectMsg(Pong(0))
 
       // flag should be cached now
-      regularRemote.asInstanceOf[RemoteActorRef].cachedLargeMessageDestinationFlag should ===(RegularDestination)
+      regularRemote.asInstanceOf[RemoteActorRef].cachedMessageDestinationFlag should ===(RegularDestination)
 
     }
 
@@ -75,7 +75,7 @@ class LargeMessagesStreamSpec extends ArteryMultiNodeSpec(
       senderProbeA.expectMsg(Pong(0))
 
       // flag should be cached now
-      largeRemote.asInstanceOf[RemoteActorRef].cachedLargeMessageDestinationFlag should ===(LargeDestination)
+      largeRemote.asInstanceOf[RemoteActorRef].cachedMessageDestinationFlag should ===(LargeDestination)
 
     }
 
@@ -112,8 +112,8 @@ class LargeMessagesStreamSpec extends ArteryMultiNodeSpec(
       remoteProbe.expectMsg(10.seconds, Pong(largeBytes))
 
       // cached flags should be set now
-      largeRemote.asInstanceOf[RemoteActorRef].cachedLargeMessageDestinationFlag should ===(LargeDestination)
-      regularRemote.asInstanceOf[RemoteActorRef].cachedLargeMessageDestinationFlag should ===(RegularDestination)
+      largeRemote.asInstanceOf[RemoteActorRef].cachedMessageDestinationFlag should ===(LargeDestination)
+      regularRemote.asInstanceOf[RemoteActorRef].cachedMessageDestinationFlag should ===(RegularDestination)
     }
   }
 


### PR DESCRIPTION
Refs #20577

First commit is incorrect in that it uses an entirely separate stream, instead of routing the prioritized messages over control as the ticket says.
