### PR TITLE
DO NOT MERGE; Wip on unexpected close / races in Pool handling

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
@@ -61,7 +61,7 @@ private object PoolConductor {
                     |             +----+----+
                     |                  | RawSlotEvent
                     | Request-         |
-                    | Context     +---------+
+                    | Context     +---------+ // TODO retry merge to be replaced with Retry stage
                     +-------------+  retry  |<-------- RawSlotEvent (from slotEventMerge)
                                   |  Split  |
                                   +---------+

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
@@ -72,7 +72,7 @@ private object PoolFlow {
     connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]],
     settings:       ConnectionPoolSettings, log: LoggingAdapter)(
     implicit
-    system: ActorSystem, fm: Materializer): Flow[RequestContext, ResponseContext, NotUsed] =
+    system: ActorSystem, mat: Materializer): Flow[RequestContext, ResponseContext, NotUsed] =
     Flow.fromGraph(GraphDSL.create[FlowShape[RequestContext, ResponseContext]]() { implicit b ⇒
       import settings._
       import GraphDSL.Implicits._
@@ -82,7 +82,7 @@ private object PoolFlow {
       )
 
       val slots = Vector
-        .tabulate(maxConnections)(PoolSlot(_, connectionFlow))
+        .tabulate(maxConnections)(PoolSlot(_, connectionFlow)(mat))
         .map(b.add)
 
       val responseMerge = b.add(Merge[ResponseContext](maxConnections))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
@@ -33,6 +33,7 @@ private[http] final class PoolGateway(gatewayRef: ActorRef, val hcps: HostConnec
    * @return the response
    */
   def apply(request: HttpRequest): Future[HttpResponse] = {
+    println(s"== apply(${request})")
     val responsePromise = Promise[HttpResponse]()
     gatewayRef ! SendRequest(this, request, responsePromise, fm)
     responsePromise.future
@@ -46,6 +47,7 @@ private[http] final class PoolGateway(gatewayRef: ActorRef, val hcps: HostConnec
    * @return the gateway itself
    */
   def startPool(): PoolGateway = {
+    println("== startPool()")
     gatewayRef ! StartPool(this, fm)
     this
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
@@ -5,12 +5,14 @@
 package akka.http.impl.engine.client
 
 import akka.actor._
+import akka.event.LoggingAdapter
 import akka.http.impl.engine.client.PoolConductor.{ ConnectEagerlyCommand, DispatchCommand, SlotCommand }
 import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
+import akka.stream.impl.{ ActorMaterializerImpl, ConstantFun }
 import akka.stream._
-import akka.stream.actor._
-import akka.stream.impl.{ ActorProcessor, ConstantFun, ExposedPublisher, SeqActorName, SubscribePending }
 import akka.stream.scaladsl._
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import akka.stream.{ Graph, Materializer }
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -36,240 +38,214 @@ private object PoolSlot {
     final case class ConnectedEagerly(slotIx: Int) extends SlotEvent
   }
 
-  private val slotProcessorActorName = SeqActorName("SlotProcessor")
-
   /*
     Stream Setup
     ============
 
-    Request-   +-----------+              +-------------+              +-------------+     +------------+
-    Context    | Slot-     |  List[       |   flatten   |  Processor-  |   doubler   |     | SlotEvent- |  Response-
-    +--------->| Processor +------------->| (MapConcat) +------------->| (MapConcat) +---->| Split      +------------->
-               |           |  Processor-  |             |  Out         |             |     |            |  Context
-               +-----------+  Out]        +-------------+              +-------------+     +-----+------+
-                                                                                                 | RawSlotEvent
-                                                                                                 | (to Conductor
-                                                                                                 |  via slotEventMerge)
-                                                                                                 v
+    Request-   +-----------+              +-------------+              +------------+
+    Context    | Slot-     |  List[       |   flatten   |  Processor-  | SlotEvent- |  Response-
+    +--------->| Processor +------------->| (MapConcat) +------------->| Split      +------------->
+               |           |  Processor-  |             |  Out         |            |  Context
+               +-----------+  Out]        +-------------+              +-----+------+
+                                                                             | RawSlotEvent
+                                                                             | (to Conductor
+                                                                             |  via slotEventMerge)
+                                                                             v
    */
-  def apply(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any])(implicit system: ActorSystem, fm: Materializer): Graph[FanOutShape2[SlotCommand, ResponseContext, RawSlotEvent], Any] =
+  def apply(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any])(implicit m: Materializer): Graph[FanOutShape2[SlotCommand, ResponseContext, RawSlotEvent], Any] =
     GraphDSL.create() { implicit b ⇒
       import GraphDSL.Implicits._
 
-      // TODO wouldn't be better to have them under a known parent? /user/SlotProcessor-0 seems weird
-      val name = slotProcessorActorName.next()
+      val log = ActorMaterializerHelper.downcast(m).logger
+      val slotProcessor: FlowShape[SlotCommand, ProcessorOut] = b.add(new SlotProcessor(slotIx, connectionFlow, log))
+      val partition = b.add(Partition[ProcessorOut](2, {
+        case ResponseDelivery(r) ⇒ 0
+        case r: RawSlotEvent     ⇒ 1
+      }))
+      slotProcessor.out ~> partition.in
 
-      val slotProcessor = b.add {
-        Flow.fromProcessor { () ⇒
-          val actor = system.actorOf(
-            Props(new SlotProcessor(slotIx, connectionFlow)).withDeploy(Deploy.local),
-            name)
-          ActorProcessor[SlotCommand, List[ProcessorOut]](actor)
-        }.mapConcat(ConstantFun.scalaIdentityFunction)
-      }
-      val split = b.add(Broadcast[ProcessorOut](2))
-
-      slotProcessor ~> split.in
-
-      new FanOutShape2(
-        slotProcessor.in,
-        split.out(0).collect { case ResponseDelivery(r) ⇒ r }.outlet,
-        split.out(1).collect { case r: RawSlotEvent ⇒ r }.outlet)
+      val deliveries = partition.out(0).map(_.asInstanceOf[ResponseDelivery].response)
+      val events = partition.out(1).map(_.asInstanceOf[RawSlotEvent])
+      new FanOutShape2[SlotCommand, ResponseContext, RawSlotEvent](slotProcessor.in, deliveries.outlet, events.outlet)
     }
-
-  import ActorPublisherMessage._
-  import ActorSubscriberMessage._
 
   /**
    * An actor managing a series of materializations of the given `connectionFlow`.
-   * To the outside it provides a stable flow stage, consuming `SlotCommand` instances on its
-   * input (ActorSubscriber) side and producing `List[ProcessorOut]` instances on its output
-   * (ActorPublisher) side.
+   *
+   * To the outside it provides a stable flow stage, consuming `SlotCommand` instances on its internal connection flows.
+   *
    * The given `connectionFlow` is materialized into a running flow whenever required.
    * Completion and errors from the connection are not surfaced to the outside (unless we are
    * shutting down completely).
    */
-  private class SlotProcessor(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any])(implicit fm: Materializer)
-    extends ActorSubscriber with ActorPublisher[List[ProcessorOut]] with ActorLogging {
-    var exposedPublisher: akka.stream.impl.ActorPublisher[Any] = _
-    var inflightRequests = immutable.Queue.empty[RequestContext]
+  private class SlotProcessor(slotIx: Int, connectionFlow: Flow[HttpRequest, HttpResponse, Any], log: LoggingAdapter)(implicit fm: Materializer)
+    extends GraphStage[FlowShape[SlotCommand, ProcessorOut]] {
 
-    val runnableGraph = Source.actorPublisher[HttpRequest](flowInportProps(self))
-      .via(connectionFlow)
-      .toMat(Sink.actorSubscriber[HttpResponse](flowOutportProps(self)))(Keep.both)
-      .named("SlotProcessorInternalConnectionFlow")
+    val in: Inlet[SlotCommand] = Inlet("SlotProcessor.in")
+    val out: Outlet[ProcessorOut] = Outlet("SlotProcessor.out")
 
-    override def requestStrategy = ZeroRequestStrategy
+    override def shape: FlowShape[SlotCommand, ProcessorOut] = new FlowShape(in, out)
 
-    /**
-     * How PoolProcessor changes its `receive`:
-     * waitingExposedPublisher -> waitingForSubscribePending -> unconnected ->
-     * waitingForDemandFromConnection OR waitingEagerlyConnected -> running
-     * Given slot can become get to 'running' state via 'waitingForDemandFromConnection' or 'waitingEagerlyConnected'.
-     * The difference between those two paths is that the first one is lazy - reacts to DispatchCommand and then uses
-     * inport and outport actors to obtain more items.
-     * Where the second one is eager - reacts to SlotShouldConnectCommand from PoolConductor, sends SlotEvent.ConnectedEagerly
-     * back to conductor and then waits for the first DispatchCommand
-     */
-    override def receive = waitingExposedPublisher
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) 
+      with InHandler with OutHandler { self ⇒
+      private final val inflightRequests = new java.util.ArrayDeque[RequestContext]()
 
-    def waitingExposedPublisher: Receive = {
-      case ExposedPublisher(publisher) ⇒
-        exposedPublisher = publisher
-        context.become(waitingForSubscribePending)
-      case other ⇒ throw new IllegalStateException(s"The first message must be `ExposedPublisher` but was [$other]")
-    }
+      private[this] var connectionFlowSource: SubSourceOutlet[HttpRequest] = _
+      private[this] var connectionFlowSink: SubSinkInlet[HttpResponse] = _
 
-    def waitingForSubscribePending: Receive = {
-      case SubscribePending ⇒
-        exposedPublisher.takePendingSubscribers() foreach (s ⇒ self ! ActorPublisher.Internal.Subscribe(s))
-        log.debug("become unconnected, from subscriber pending")
-        context.become(unconnected)
-    }
+      private[this] var firstRequest: RequestContext = _
 
-    val unconnected: Receive = {
-      case OnNext(DispatchCommand(rc: RequestContext)) ⇒
-        val (connInport, connOutport) = runnableGraph.run()
-        connOutport ! Request(totalDemand)
-        context.become(waitingForDemandFromConnection(connInport = connInport, connOutport = connOutport, rc))
+      // request first request/command
+      override def preStart(): Unit = pull(in)
 
-      case OnNext(ConnectEagerlyCommand) ⇒
-        val (in, out) = runnableGraph.run()
-        onNext(SlotEvent.ConnectedEagerly(slotIx) :: Nil)
-        out ! Request(totalDemand)
-        context.become(waitingEagerlyConnected(connInport = in, connOutport = out))
+      private lazy val connectionOutFlowHandler = new OutHandler {
+        // connectionFlowSource is ready for an element, we can send a HttpRequest to the subflow
+        override def onPull(): Unit = {
+          log.debug("BERN-{}: connectionFlow: onPull, first {} inflight {}", slotIx, firstRequest, inflightRequests)
+          // give the connectionFlow a HttpRequest
+          if (firstRequest ne null) {
+            inflightRequests.add(firstRequest)
+            connectionFlowSource.push(firstRequest.request)
 
-      case Request(_) ⇒ if (remainingRequested == 0) request(1) // ask for first request if necessary
+            firstRequest = null
+          } else if (isAvailable(in)) grab(in) match {
+            case DispatchCommand(rc) ⇒
+              inflightRequests.add(rc)
+              connectionFlowSource.push(rc.request)
+          }
+          if (!hasBeenPulled(in)) pull(in)
+        }
 
-      case OnComplete ⇒ onComplete()
-      case OnError(e) ⇒ onError(e)
-      case Cancel ⇒
-        cancel()
-        shutdown()
+        // connectionFlowSource has been closed (IgnoreTerminateOutput)
+        override def onDownstreamFinish(): Unit = {
+          log.debug("BERN-{}: onDownstreamFinish first {} inflight {}!!", slotIx, firstRequest, inflightRequests)
 
-      case c @ FromConnection(msg) ⇒ // ignore ...
-    }
+          connectionFlowSource.complete()
 
-    def waitingEagerlyConnected(connInport: ActorRef, connOutport: ActorRef): Receive = {
-      case FromConnection(Request(n)) ⇒
-        request(n)
+          if (firstRequest == null && inflightRequests.isEmpty) {
+            push(out, SlotEvent.Disconnected(slotIx, 0))
 
-      case OnNext(DispatchCommand(rc: RequestContext)) ⇒
-        inflightRequests = inflightRequests.enqueue(rc)
-        request(1)
-        connInport ! OnNext(rc.request)
-        context.become(running(connInport, connOutport))
-    }
+            connectionFlowSource.complete()
+            setHandler(in, self)
 
-    def waitingForDemandFromConnection(connInport: ActorRef, connOutport: ActorRef,
-                                       firstRequest: RequestContext): Receive = {
-      case ev @ (Request(_) | Cancel)     ⇒ connOutport ! ev
-      case ev @ (OnComplete | OnError(_)) ⇒ connInport ! ev
-      case OnNext(x)                      ⇒ throw new IllegalStateException("Unrequested RequestContext: " + x)
-
-      case FromConnection(Request(n)) ⇒
-        inflightRequests = inflightRequests.enqueue(firstRequest)
-        request(n - remainingRequested)
-        connInport ! OnNext(firstRequest.request)
-        context.become(running(connInport, connOutport))
-
-      case FromConnection(Cancel)     ⇒ if (!isActive) { cancel(); shutdown() } // else ignore and wait for accompanying OnComplete or OnError
-      case FromConnection(OnComplete) ⇒ handleDisconnect(sender(), None, Some(firstRequest))
-      case FromConnection(OnError(e)) ⇒ handleDisconnect(sender(), Some(e), Some(firstRequest))
-      case FromConnection(OnNext(x))  ⇒ throw new IllegalStateException("Unexpected HttpResponse: " + x)
-    }
-
-    def running(connInport: ActorRef, connOutport: ActorRef): Receive = {
-      case ev @ (Request(_) | Cancel)     ⇒ connOutport ! ev
-      case ev @ (OnComplete | OnError(_)) ⇒ connInport ! ev
-      case OnNext(DispatchCommand(rc: RequestContext)) ⇒
-        inflightRequests = inflightRequests.enqueue(rc)
-        connInport ! OnNext(rc.request)
-
-      case FromConnection(Request(n)) ⇒ request(n)
-      case FromConnection(Cancel)     ⇒ if (!isActive) { cancel(); shutdown() } // else ignore and wait for accompanying OnComplete or OnError
-
-      case FromConnection(OnNext(response: HttpResponse)) ⇒
-        val requestContext = inflightRequests.head
-        inflightRequests = inflightRequests.tail
-        val (entity, whenCompleted) = HttpEntity.captureTermination(response.entity)
-        val delivery = ResponseDelivery(ResponseContext(requestContext, Success(response withEntity entity)))
-        import fm.executionContext
-        val requestCompleted = SlotEvent.RequestCompletedFuture(whenCompleted.map(_ ⇒ SlotEvent.RequestCompleted(slotIx)))
-        onNext(delivery :: requestCompleted :: Nil)
-
-      case FromConnection(OnComplete) ⇒ handleDisconnect(sender(), None)
-      case FromConnection(OnError(e)) ⇒ handleDisconnect(sender(), Some(e))
-    }
-
-    def handleDisconnect(connInport: ActorRef, error: Option[Throwable], firstContext: Option[RequestContext] = None): Unit = {
-      log.debug("Slot {} disconnected after {}", slotIx, error getOrElse "regular connection close")
-
-      val results: List[ProcessorOut] = {
-        if (inflightRequests.isEmpty && firstContext.isDefined) {
-          (error match {
-            case Some(err) ⇒ ResponseDelivery(ResponseContext(firstContext.get, Failure(new UnexpectedDisconnectException("Unexpected (early) disconnect", err))))
-            case _         ⇒ ResponseDelivery(ResponseContext(firstContext.get, Failure(new UnexpectedDisconnectException("Unexpected (early) disconnect"))))
-          }) :: Nil
-        } else {
-          inflightRequests.map { rc ⇒
-            if (rc.retriesLeft == 0) {
-              val reason = error.fold[Throwable](new UnexpectedDisconnectException("Unexpected disconnect"))(ConstantFun.scalaIdentityFunction)
-              connInport ! ActorPublisherMessage.Cancel
-              ResponseDelivery(ResponseContext(rc, Failure(reason)))
-            } else SlotEvent.RetryRequest(rc.copy(retriesLeft = rc.retriesLeft - 1))
-          }(collection.breakOut)
+          }
         }
       }
-      inflightRequests = immutable.Queue.empty
-      onNext(SlotEvent.Disconnected(slotIx, results.size) :: results)
-      if (canceled) onComplete()
 
-      context.become(unconnected)
+      private lazy val connectionInFlowHandler = new InHandler {
+
+        // a new element is available on connectionFlowSink Inlet - that is a HttpResponse is being returned
+        override def onPush(): Unit = {
+          log.debug("BERN-{}: connectionFlow: onPush", slotIx)
+          // consume a HttpResponse from the connectonFlow
+
+          val response: HttpResponse = connectionFlowSink.grab()
+
+          log.debug("BERN-{}: connectionFlow: onPush {} {}", slotIx, response)
+          val requestContext = inflightRequests.pop()
+
+          val (entity, whenCompleted) = HttpEntity.captureTermination(response.entity)
+          val delivery = ResponseDelivery(ResponseContext(requestContext, Success(response withEntity entity)))
+          import fm.executionContext
+          val requestCompleted = SlotEvent.RequestCompletedFuture(whenCompleted.map(_ ⇒ SlotEvent.RequestCompleted(slotIx)))
+          emitMultiple(out, delivery :: requestCompleted :: Nil)
+
+          connectionFlowSink.pull()
+        }
+
+        // this would happen if we closed the source (so won't happen)
+        override def onUpstreamFinish(): Unit = ()
+
+        // a Failure[HttpResponse] is coming back instead
+        override def onUpstreamFailure(ex: Throwable): Unit = {
+          log.error(ex, "BERN-{}: onUpstreamFailure first {} inflight {}", slotIx, firstRequest, inflightRequests)
+          val results: List[ProcessorOut] =
+            if (firstRequest ne null) {
+              ResponseDelivery(ResponseContext(firstRequest, Failure(new UnexpectedDisconnectException("Unexpected (early) disconnect", ex)))) :: Nil
+            } else {
+              // TODO replace ad-hoc retries with Retry stage?
+              var rs: List[ProcessorOut] = Nil
+              val it = inflightRequests.descendingIterator()
+              while (it.hasNext) {
+                val rc = it.next()
+                val modified =
+                  if (rc.retriesLeft == 0) ResponseDelivery(ResponseContext(rc, Failure(ex)))
+                  else SlotEvent.RetryRequest(rc.copy(retriesLeft = rc.retriesLeft - 1))
+                rs = modified :: rs
+              }
+              rs
+            }
+          firstRequest = null
+          inflightRequests.clear()
+          emitMultiple(out, SlotEvent.Disconnected(slotIx, results.size) :: results)
+
+          connectionFlowSource.complete()
+          setHandler(in, self)
+        }
+      }
+
+      private lazy val connected = new InHandler {
+        override def onPush(): Unit = {
+          log.debug("BERN-{}: PoolSlot: onPush when connected", slotIx)
+          if (connectionFlowSource.isAvailable) {
+            grab(in) match {
+              case DispatchCommand(rc: RequestContext) ⇒
+                inflightRequests.add(rc)
+                connectionFlowSource.push(rc.request)
+              case x ⇒
+                log.error("invalid command {}", x)
+            }
+            pull(in)
+          } else if (!connectionFlowSink.hasBeenPulled) {
+            log.warning("connectionFlowSink.isAvailable = " + connectionFlowSink.isAvailable)
+            log.warning("connectionFlowSink.hasBeenPulled = " + connectionFlowSink.hasBeenPulled)
+            log.warning("connectionFlowSink.isClosed = " + connectionFlowSink.isClosed)
+            if (!connectionFlowSink.isClosed) connectionFlowSink.pull() // FIXME, weird?
+          }
+        }
+      }
+
+      // unconnected
+      override def onPush(): Unit = grab(in) match {
+        case ConnectEagerlyCommand ⇒
+          log.debug("BERN-{}: PoolSlot: onPush ConnectEagerlyCommand when unconnected", slotIx)
+          connectionFlowSource = new SubSourceOutlet[HttpRequest]("RequestSource")
+          connectionFlowSource.setHandler(connectionOutFlowHandler)
+
+          connectionFlowSink = new SubSinkInlet[HttpResponse]("ResponseSink")
+          connectionFlowSink.setHandler(connectionInFlowHandler)
+
+          setHandler(in, connected)
+
+          Source.fromGraph(connectionFlowSource.source).via(connectionFlow).runWith(Sink.fromGraph(connectionFlowSink.sink))(subFusingMaterializer)
+
+          connectionFlowSink.pull()
+
+        case DispatchCommand(rc: RequestContext) ⇒
+          log.debug("BERN-{}: PoolSlot: onPush({}) when unconnected", slotIx, rc)
+          connectionFlowSource = new SubSourceOutlet[HttpRequest]("RequestSource")
+          connectionFlowSource.setHandler(connectionOutFlowHandler)
+
+          connectionFlowSink = new SubSinkInlet[HttpResponse]("ResponseSink")
+          connectionFlowSink.setHandler(connectionInFlowHandler)
+
+          firstRequest = rc
+
+          setHandler(in, connected)
+
+          Source.fromGraph(connectionFlowSource.source).via(connectionFlow).runWith(Sink.fromGraph(connectionFlowSink.sink))(subFusingMaterializer)
+
+          connectionFlowSink.pull()
+      }
+
+      // OutHandler, downstream has requested an element
+      override def onPull(): Unit = {
+        log.debug("BERN-{}: PoolSlot: onPull", slotIx)
+      }
+
+      setHandlers(in, out, this)
     }
-
-    override def onComplete(): Unit = {
-      exposedPublisher.shutdown(None)
-      super.onComplete()
-      shutdown()
-    }
-
-    override def onError(cause: Throwable): Unit = {
-      exposedPublisher.shutdown(Some(cause))
-      super.onError(cause)
-      shutdown()
-    }
-
-    def shutdown(): Unit = context.stop(self)
   }
-
-  private case class FromConnection(ev: Any) extends NoSerializationVerificationNeeded
-
-  private class FlowInportActor(slotProcessor: ActorRef) extends ActorPublisher[HttpRequest] with ActorLogging {
-    def receive: Receive = {
-      case ev: Request            ⇒ slotProcessor ! FromConnection(ev)
-      case OnNext(r: HttpRequest) ⇒ onNext(r)
-      case OnComplete             ⇒ onCompleteThenStop()
-      case OnError(e)             ⇒ onErrorThenStop(e)
-      case Cancel ⇒
-        slotProcessor ! FromConnection(Cancel)
-        context.stop(self)
-    }
-  }
-  def flowInportProps(s: ActorRef) = Props(new FlowInportActor(s)).withDeploy(Deploy.local)
-
-  private class FlowOutportActor(slotProcessor: ActorRef) extends ActorSubscriber with ActorLogging {
-    def requestStrategy = ZeroRequestStrategy
-    def receive: Receive = {
-      case Request(n) ⇒ request(n)
-      case Cancel     ⇒ cancel()
-      case ev: OnNext ⇒ slotProcessor ! FromConnection(ev)
-      case ev @ (OnComplete | OnError(_)) ⇒
-        slotProcessor ! FromConnection(ev)
-        context.stop(self)
-    }
-  }
-  def flowOutportProps(s: ActorRef) = Props(new FlowOutportActor(s)).withDeploy(Deploy.local)
 
   final class UnexpectedDisconnectException(msg: String, cause: Throwable) extends RuntimeException(msg, cause) {
     def this(msg: String) = this(msg, null)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -624,6 +624,7 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
     fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] =
     clientFlow[T](hcps.setup.settings)(_ → gateway)
       .mapMaterializedValue(_ ⇒ HostConnectionPool(hcps)(gateway))
+      .named(s"gatewayClientFlow-${hcps.host}-${hcps.port}")
 
   private def clientFlow[T](settings: ConnectionPoolSettings)(f: HttpRequest ⇒ (HttpRequest, PoolGateway))(
     implicit


### PR DESCRIPTION
On top of #21316 
PR only for commenting or someone else having a look as well.

The branch includes additional tests, most specifically in `ConnectionPoolSpec` the `xoxo be able to handle 500 pipelined requests with connection termination` (run via `testOnly *ConnectionPoolSpec* -- -z xoxo`), which reproduces #19643
