### PR TITLE
=doc fix getStageActor docs typo (remove "not")

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -909,7 +909,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    * The messages are looped through the [[getAsyncCallback]] mechanism of [[GraphStage]] so they are safe to modify
    * internal state of this stage.
    *
-   * This method must not (the earliest) be called after the [[GraphStageLogic]] constructor has finished running,
+   * This method must (the earliest) be called after the [[GraphStageLogic]] constructor has finished running,
    * for example from the [[preStart]] callback the graph stage logic provides.
    *
    * Created [[StageActorRef]] to get messages and watch other actors in synchronous way.


### PR DESCRIPTION
As follow up to https://github.com/akka/akka/pull/21323
due to CLA not signed, and released into public domain.
