### PR TITLE
+htp #21340 Add withMaterializer to Java DSL Unmarshaller

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MarshallerTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MarshallerTest.java
@@ -41,6 +41,8 @@ public class MarshallerTest extends JUnitRouteTest {
         }
       }, Marshaller.stringToEntity(), MediaTypes.TEXT_X_SPEECH);
 
+    // Test that oneOf compiles:
+    Marshaller<Integer, RequestEntity> dummy = Marshaller.oneOf(numberAsNameMarshaller, numberAsNameMarshaller);
 
     final Function<Integer, Route> nummerHandler = integer -> completeOK(integer, numberAsNameMarshaller);
 

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -17,6 +17,7 @@ import akka.util.ByteString
 
 import scala.concurrent.ExecutionContext
 import scala.annotation.unchecked.uncheckedVariance
+import scala.annotation.varargs;
 import scala.language.implicitConversions
 
 object Marshaller {
@@ -88,32 +89,8 @@ object Marshaller {
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    */
-  def oneOf[A, B](ms: Marshaller[A, B]*): Marshaller[A, B] = {
+  @SafeVarargs @varargs def oneOf[A, B](ms: Marshaller[A, B]*): Marshaller[A, B] = {
     fromScala(marshalling.Marshaller.oneOf[A, B](ms.map(_.asScala): _*))
-  }
-
-  /**
-   * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
-   * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
-   */
-  def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B]): Marshaller[A, B] = {
-    fromScala(marshalling.Marshaller.oneOf(m1.asScala, m2.asScala, m3.asScala))
-  }
-
-  /**
-   * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
-   * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
-   */
-  def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B], m4: Marshaller[A, B]): Marshaller[A, B] = {
-    fromScala(marshalling.Marshaller.oneOf(m1.asScala, m2.asScala, m3.asScala, m4.asScala))
-  }
-
-  /**
-   * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
-   * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
-   */
-  def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B], m4: Marshaller[A, B], m5: Marshaller[A, B]): Marshaller[A, B] = {
-    fromScala(marshalling.Marshaller.oneOf(m1.asScala, m2.asScala, m3.asScala, m4.asScala, m5.asScala))
   }
 
   /**


### PR DESCRIPTION
This gives access to the `Materializer` for custom unmarshallers, and creates a convenience `entityToSource()` unmarshaller.

Also repairs `Marshaller.oneOf` with 2 args, which Java wouldn't resolve properly.

Fixes https://github.com/akka/akka/issues/21340
