### PR TITLE
make restart materialization of outbound streams lazy, #21347

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
@@ -49,8 +49,9 @@ class HandshakeFailureSpec extends AkkaSpec(HandshakeFailureSpec.commonConfig) w
 
       within(10.seconds) {
         awaitAssert {
-          sel ! "hello2"
-          expectMsg(1.second, "hello2")
+          val probe = TestProbe()
+          sel.tell("hello2", probe.ref)
+          probe.expectMsg(1.second, "hello2")
         }
       }
 


### PR DESCRIPTION
- Materialize on first message instead, otherwise handshake attempts
  to non-existing nodes will continue forever
- also fix HandshakeFailureSpec
