### PR TITLE
Flatten a `Future[Graph[SourceShape[T], M]]` as `Source[T, Future[M]]`

### DIFF
--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -76,7 +76,6 @@ If the ``CompletionStage`` fails the stream is failed with that exception.
 
 **completes** after the ``CompletionStage`` has completed or when it fails
 
-
 fromFuture
 ^^^^^^^^^^
 Send the single value of the Scala ``Future`` when it completes and there is demand.
@@ -85,6 +84,24 @@ If the future fails the stream is failed with that exception.
 **emits** the future completes
 
 **completes** after the future has completed
+
+fromFutureSource
+^^^^^^^^^^^^^^^^
+Streams the elements of the given future source once it successfully completes. 
+If the future fails the stream is failed.
+
+**emits** the next value from the `future` source, once it has completed
+
+**completes** after the `future` source completes
+
+fromSourceCompletionStage
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Streams the elements of an asynchronous source once its given `completion` stage completes.
+If the `completion` fails the stream is failed with that exception.
+
+**emits** the next value from the asynchronous source, once its `completion stage` has completed
+
+**completes** after the asynchronous source completes
 
 unfold
 ^^^^^^

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -86,8 +86,8 @@ If the future fails the stream is failed with that exception.
 
 fromFutureSource
 ^^^^^^^^^^^^^^^^
-Starts a new `Source` from another `future` source.
-The stream will consist of the elements of the given source, once it successfully completes.
+Streams the elements of the given future source once it successfully completes. 
+If the future fails the stream is failed.
 
 **emits** the next value from the `future` source, once it has completed
 
@@ -95,8 +95,8 @@ The stream will consist of the elements of the given source, once it successfull
 
 fromSourceCompletionStage
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Starts a new `Source` from a `completion` stage of an asynchronous source.
-The stream will consist of the elements of the given source, once it successfully completes.
+Streams the elements of an asynchronous source once its given `completion` stage completes.
+If the `completion` fails the stream is failed with that exception.
 
 **emits** the next value from the asynchronous source, once its `completion stage` has completed
 

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -84,6 +84,23 @@ If the future fails the stream is failed with that exception.
 
 **completes** after the future has completed
 
+fromFutureSource
+^^^^^^^^^^^^^^^^
+Starts a new `Source` from another `future` source.
+The stream will consist of the elements of the given source, once it successfully completes.
+
+**emits** the next value from the `future` source, once it has completed
+
+**completes** after the `future` source completes
+
+fromSourceCompletionStage
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Starts a new `Source` from a `completion` stage of an asynchronous source.
+The stream will consist of the elements of the given source, once it successfully completes.
+
+**emits** the next value from the asynchronous source, once its `completion stage` has completed
+
+**completes** after the asynchronous source completes
 
 unfold
 ^^^^^^

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -383,7 +383,7 @@ public class FlowTest extends StreamTest {
   }
 
   @Test
-  public void mustBeAbleToUseAsyncMerge() throws Exception {
+  public void mustBeAbleToUsefromSourceCompletionStage() throws Exception {
     final Flow<String, String, NotUsed> f1 =
         Flow.of(String.class).via(FlowTest.this.<String> op()).named("f1");
 

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -29,6 +29,7 @@ import scala.concurrent.duration.FiniteDuration;
 import akka.testkit.AkkaJUnitActorSystemResource;
 
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -372,6 +373,53 @@ public class FlowTest extends StreamTest {
                 return new SourceShape<String>(merge.out());
               }
             }));
+
+    // collecting
+    final Publisher<String> pub = source.runWith(publisher, materializer);
+    final CompletionStage<List<String>> all = Source.fromPublisher(pub).limit(100).runWith(Sink.<String>seq(), materializer);
+
+    final List<String> result = all.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    assertEquals(new HashSet<Object>(Arrays.asList("a", "b", "c", "d", "e", "f")), new HashSet<String>(result));
+  }
+
+  @Test
+  public void mustBeAbleToUseAsyncMerge() throws Exception {
+    final Flow<String, String, NotUsed> f1 =
+        Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f1");
+    final Flow<String, String, NotUsed> f2 =
+        Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f2");
+    @SuppressWarnings("unused")
+    final Flow<String, String, NotUsed> f3 =
+        Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f3");
+
+    final Source<String, NotUsed> in1 = Source.from(Arrays.asList("a", "b", "c"));
+    final Source<String, NotUsed> in2 = Source.from(Arrays.asList("d", "e", "f"));
+
+    final Sink<String, Publisher<String>> publisher = Sink.asPublisher(AsPublisher.WITHOUT_FANOUT);
+
+    final Graph<SourceShape<String>, NotUsed> graph = Source.fromGraph(
+            GraphDSL.create(new Function<GraphDSL.Builder<NotUsed>, SourceShape<String>>() {
+              @Override
+              public SourceShape<String> apply(Builder<NotUsed> b)
+                  throws Exception {
+                  final UniformFanInShape<String, String> merge =
+                  b.add(Merge.<String>create(2));
+                  b.from(b.add(in1)).via(b.add(f1)).toInlet(merge.in(0));
+                  b.from(b.add(in2)).via(b.add(f2)).toInlet(merge.in(1));
+                  return new SourceShape<String>(merge.out());
+              }
+                }));
+
+    final Supplier<Graph<SourceShape<String>, NotUsed>> fn =
+        new Supplier<Graph<SourceShape<String>, NotUsed>>() {
+            public Graph<SourceShape<String>, NotUsed> get() { return graph; }
+        };
+
+    final CompletionStage<Graph<SourceShape<String>, NotUsed>> stage =
+        CompletableFuture.supplyAsync(fn);
+
+    final Source<String, CompletionStage<NotUsed>> source =
+        Source.fromGraphCompletionStage(stage);
 
     // collecting
     final Publisher<String> pub = source.runWith(publisher, materializer);

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -421,7 +421,7 @@ public class FlowTest extends StreamTest {
         CompletableFuture.supplyAsync(fn);
 
     final Source<String, CompletionStage<NotUsed>> source =
-        Source.fromGraphCompletionStage(stage);
+        Source.fromSourceCompletionStage(stage);
 
     // collecting
     final Publisher<String> pub = source.runWith(publisher, materializer);

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -385,12 +385,14 @@ public class FlowTest extends StreamTest {
   @Test
   public void mustBeAbleToUseAsyncMerge() throws Exception {
     final Flow<String, String, NotUsed> f1 =
-        Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f1");
+        Flow.of(String.class).via(FlowTest.this.<String> op()).named("f1");
+
     final Flow<String, String, NotUsed> f2 =
-        Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f2");
+        Flow.of(String.class).via(FlowTest.this.<String> op()).named("f2");
+
     @SuppressWarnings("unused")
     final Flow<String, String, NotUsed> f3 =
-        Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f3");
+        Flow.of(String.class).via(FlowTest.this.<String> op()).named("f3");
 
     final Source<String, NotUsed> in1 = Source.from(Arrays.asList("a", "b", "c"));
     final Source<String, NotUsed> in2 = Source.from(Arrays.asList("d", "e", "f"));

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/StreamLayoutSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/StreamLayoutSpec.scala
@@ -174,33 +174,6 @@ class StreamLayoutSpec extends StreamSpec {
         fut.futureValue(veryPatient) should ===(List(42))
       }
 
-      "starting from a future Source" in {
-        val g = Source.fromFutureGraph(Future {
-          Thread.sleep(2000)
-          Fusing.aggressive((1 to tooDeepForStack).
-            foldLeft(Source.single(42).mapMaterializedValue(_ ⇒ 1))(
-              (f, i) ⇒ f.map(identity)))
-        })
-
-        val (mat, fut) = g.toMat(Sink.seq)(Keep.both).run()
-        mat.futureValue(veryPatient) should ===(1)
-        fut.futureValue(veryPatient) should ===(List(42))
-      }
-
-      "starting from a completion stage of Source" in {
-        val future: Future[Graph[SourceShape[Int], Int]] = Future {
-          Fusing.aggressive((1 to tooDeepForStack).
-            foldLeft(Source.single(43).mapMaterializedValue(_ ⇒ 1))(
-              (f, i) ⇒ f.map(identity)))
-        }
-        val stage: CompletionStage[Graph[SourceShape[Int], Int]] = future.toJava
-        val g = Source.fromGraphCompletionStage(stage)
-
-        val (mat, fut) = g.toMat(Sink.seq)(Keep.both).run()
-        mat.toScala.futureValue(veryPatient) should ===(1)
-        fut.futureValue(veryPatient) should ===(List(43))
-      }
-
       "starting from a Flow" in {
         val g = Flow fromGraph Fusing.aggressive((1 to tooDeepForStack).foldLeft(Flow[Int])((f, i) ⇒ f.map(identity)))
         val (mat, fut) = g.runWith(Source.single(42).mapMaterializedValue(_ ⇒ 1), Sink.seq)

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -13,12 +13,13 @@ import akka.stream.testkit.Utils._
 import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
 import akka.testkit.EventFilter
 
-import scala.concurrent.Await
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 
 class ActorGraphInterpreterSpec extends StreamSpec {
   implicit val materializer = ActorMaterializer()
+  implicit def ec: ExecutionContext = materializer.executionContext
 
   "ActorGraphInterpreter" must {
 
@@ -253,10 +254,17 @@ class ActorGraphInterpreterSpec extends StreamSpec {
         }
       }
 
-      EventFilter[IllegalArgumentException](pattern = "Error in stage.*", occurrences = 1).intercept {
-        Await.result(Source.fromGraph(failyStage).runWith(Sink.ignore), 3.seconds)
+      EventFilter[IllegalArgumentException](
+        pattern = "Error in stage.*", occurrences = 1).intercept {
+        Await.result(Source.fromGraph(failyStage).
+          runWith(Sink.ignore), 3.seconds)
       }
 
+      EventFilter[IllegalArgumentException](
+        pattern = "Error in stage.*", occurrences = 1).intercept {
+        Await.result(Source.fromFutureGraph(Future(failyStage)).
+          runWith(Sink.ignore), 3.seconds)
+      }
     }
 
     "be able to properly handle case where a stage fails before subscription happens" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -13,13 +13,12 @@ import akka.stream.testkit.Utils._
 import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
 import akka.testkit.EventFilter
 
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 
 class ActorGraphInterpreterSpec extends StreamSpec {
   implicit val materializer = ActorMaterializer()
-  implicit def ec: ExecutionContext = materializer.executionContext
 
   "ActorGraphInterpreter" must {
 
@@ -254,16 +253,8 @@ class ActorGraphInterpreterSpec extends StreamSpec {
         }
       }
 
-      EventFilter[IllegalArgumentException](
-        pattern = "Error in stage.*", occurrences = 1).intercept {
-        Await.result(Source.fromGraph(failyStage).
-          runWith(Sink.ignore), 3.seconds)
-      }
-
-      EventFilter[IllegalArgumentException](
-        pattern = "Error in stage.*", occurrences = 1).intercept {
-        Await.result(Source.fromFutureGraph(Future(failyStage)).
-          runWith(Sink.ignore), 3.seconds)
+      EventFilter[IllegalArgumentException](pattern = "Error in stage.*", occurrences = 1).intercept {
+        Await.result(Source.fromGraph(failyStage).runWith(Sink.ignore), 3.seconds)
       }
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
+import scala.concurrent.duration._
+
+import java.util.concurrent.CompletionStage
+import scala.compat.java8.FutureConverters._
+
+import akka.NotUsed
+import akka.stream._
+import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
+import akka.stream.scaladsl._
+import akka.stream.impl.fusing.GraphStages.FutureFlattenSource
+
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+
+import akka.testkit.EventFilter
+import akka.stream.testkit.{ StreamSpec, TestSubscriber }
+import akka.stream.testkit.Utils.assertAllStagesStopped
+
+class FutureFlattenSpec extends StreamSpec {
+  val materializer = ActorMaterializer()
+  //implicit def ec: ExecutionContext = materializer.executionContext
+
+  "Future source" must {
+    "use default materializer" when {
+      implicit def m = materializer
+      implicit def ec = materializer.executionContext
+
+      "flattening elements" in assertAllStagesStopped {
+        val subSource: Source[Int, String] =
+          Source(List(1, 2, 3)).mapMaterializedValue(_ ⇒ "foo")
+
+        val futureSource = new FutureFlattenSource(Future(subSource))
+        val source: Source[Int, Future[String]] = Source.fromGraph(futureSource)
+
+        val materialized = Promise[String]()
+        val watched: Source[Int, NotUsed] = source.watchTermination() { (m, d) ⇒
+          materialized.completeWith(d.flatMap(_ ⇒ m))
+          NotUsed
+        }
+
+        val p = watched.runWith(Sink.asPublisher(false))
+        val c = TestSubscriber.manualProbe[Int]()
+        p.subscribe(c)
+
+        val sub = c.expectSubscription()
+        sub.request(5)
+
+        c.expectNext(1)
+        c.expectNext(2)
+        c.expectNext(3)
+
+        c.expectComplete()
+
+        Await.result(materialized.future, 3.seconds) should ===("foo")
+      }
+    }
+
+    "use a materializer without auto-fusing" when {
+      implicit val noFusing = ActorMaterializer(
+        ActorMaterializerSettings(system).withAutoFusing(false))
+      implicit def ec = noFusing.executionContext
+
+      val tooDeepForStack = 50000
+
+      // Seen tests run in 9-10 seconds, these test cases are heavy on the GC
+      val veryPatient = Timeout(20.seconds)
+
+      "flattening from a future graph" in assertAllStagesStopped {
+        val g = Source.fromFutureGraph(Future {
+          Thread.sleep(2000)
+          Fusing.aggressive((1 to tooDeepForStack).
+            foldLeft(Source.single(42).mapMaterializedValue(_ ⇒ 1))(
+              (f, i) ⇒ f.map(identity)))
+        })
+
+        val (mat, fut) = g.toMat(Sink.seq)(Keep.both).run()
+        mat.futureValue(veryPatient) should ===(1)
+        fut.futureValue(veryPatient) should ===(List(42))
+      }
+
+      "flattening from a completion stage" in assertAllStagesStopped {
+        val future: Future[Graph[SourceShape[Int], Int]] = Future {
+          Fusing.aggressive((1 to tooDeepForStack).
+            foldLeft(Source.single(43).mapMaterializedValue(_ ⇒ 1))(
+              (f, i) ⇒ f.map(identity)))
+        }
+        val stage: CompletionStage[Graph[SourceShape[Int], Int]] = future.toJava
+        val g = Source.fromGraphCompletionStage(stage)
+
+        val (mat, fut) = g.toMat(Sink.seq)(Keep.both).run()
+        mat.toScala.futureValue(veryPatient) should ===(1)
+        fut.futureValue(veryPatient) should ===(List(43))
+      }
+    }
+
+    // TODO: downstream cancels before the future is completed
+    // TODO: the future is completed with a failure
+    // TODO: downstream is applying backpressure when the future completes
+    // TODO: the future is completed with a graph that fails to materialize (throws exception)
+  }
+
+  "ActorGraphInterpreter" must {
+    implicit def m = materializer
+    implicit def ec = materializer.executionContext
+
+    "be able to properly report errors if an error happens for an already completed stage" in {
+
+      val failyStage = new GraphStage[SourceShape[Int]] {
+        override val shape: SourceShape[Int] =
+          new SourceShape(Outlet[Int]("test.out"))
+
+        override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+          setHandler(shape.out, new OutHandler {
+            override def onPull(): Unit = {
+              completeStage()
+              // This cannot be propagated now since the stage is already closed
+              push(shape.out, -1)
+            }
+          })
+
+        }
+      }
+
+      EventFilter[IllegalArgumentException](
+        pattern = "Error in stage.*", occurrences = 1).intercept {
+        Await.result(Source.fromFutureGraph(Future(failyStage)).
+          runWith(Sink.ignore), 3.seconds)
+      }
+    }
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
@@ -25,11 +25,11 @@ class FutureFlattenSpec extends StreamSpec {
   val materializer = ActorMaterializer()
 
   "Future source" must {
-    "use default materializer" when {
+    {
       implicit def m = materializer
       implicit def ec = materializer.executionContext
 
-      "flattening elements" in assertAllStagesStopped {
+      "flatten elements" in assertAllStagesStopped {
         val subSource: Source[Int, String] =
           Source(List(1, 2, 3)).mapMaterializedValue(_ ⇒ "foo")
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
@@ -137,15 +137,15 @@ class FutureFlattenSpec extends StreamSpec {
       implicit def m = materializer
 
       assertAllStagesStopped {
-        val probe = TestSubscriber.probe[Float]()
-        val underlying = Iterator.iterate(0.1F)(_ + 0.1F).take(3)
-        val promise = Promise[Source[Float, NotUsed]]()
+        val probe = TestSubscriber.probe[Int]()
+        val underlying = Iterator.iterate(1)(_ + 1).take(3)
+        val promise = Promise[Source[Int, NotUsed]]()
         val first = Promise[Unit]()
         lazy val futureSource =
           Source.fromFutureSource(promise.future).map {
-            case 0.1F ⇒
-              first.success({}); 1.1F
-            case f ⇒ (f * 10F) + 0.1F
+            case 1 ⇒
+              first.success({}); 11
+            case f ⇒ (f * 10) + 1
           }
 
         futureSource.runWith(Sink asPublisher true).subscribe(probe)
@@ -157,9 +157,9 @@ class FutureFlattenSpec extends StreamSpec {
         first.isCompleted should ===(false)
 
         sub.request(5)
-        probe.expectNext(1.1F)
-        probe.expectNext(2.1F)
-        probe.expectNext(3.1F)
+        probe.expectNext(11)
+        probe.expectNext(21)
+        probe.expectNext(31)
         probe.expectComplete()
 
         first.isCompleted should ===(true)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
@@ -151,10 +151,13 @@ class FutureFlattenSpec extends StreamSpec {
         val sub = probe.expectSubscription()
 
         promise.success(Source.fromIterator(() ⇒ underlying))
-        first.future.futureValue should ===({})
 
         sub.request(5)
+
+        // First value
         probe.expectNext(11)
+        first.future.futureValue should ===({})
+
         probe.expectNext(21)
         probe.expectNext(31)
         probe.expectComplete()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSpec.scala
@@ -71,7 +71,7 @@ class FutureFlattenSpec extends StreamSpec {
       val veryPatient = Timeout(20.seconds)
 
       "flattening from a future graph" in assertAllStagesStopped {
-        val g = Source.fromFutureGraph(Future {
+        val g = Source.fromFutureSource(Future {
           Thread.sleep(2000)
           Fusing.aggressive((1 to tooDeepForStack).
             foldLeft(Source.single(42).mapMaterializedValue(_ ⇒ 1))(
@@ -90,7 +90,7 @@ class FutureFlattenSpec extends StreamSpec {
               (f, i) ⇒ f.map(identity)))
         }
         val stage: CompletionStage[Graph[SourceShape[Int], Int]] = future.toJava
-        val g = Source.fromGraphCompletionStage(stage)
+        val g = Source.fromSourceCompletionStage(stage)
 
         val (mat, fut) = g.toMat(Sink.seq)(Keep.both).run()
         mat.toScala.futureValue(veryPatient) should ===(1)
@@ -129,7 +129,7 @@ class FutureFlattenSpec extends StreamSpec {
 
       EventFilter[IllegalArgumentException](
         pattern = "Error in stage.*", occurrences = 1).intercept {
-        Await.result(Source.fromFutureGraph(Future(failyStage)).
+        Await.result(Source.fromFutureSource(Future(failyStage)).
           runWith(Sink.ignore), 3.seconds)
       }
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -331,15 +331,13 @@ object GraphStages {
             val runnable = src.to(sinkIn.sink)
 
             try {
-              val matVal = interpreter.subFusingMaterializer.materialize(
-                runnable,
-                initialAttributes = attr)
+              def materialize = interpreter.subFusingMaterializer.
+                materialize(runnable, initialAttributes = attr)
 
-              materialized.success(matVal)
+              materialized.success(materialize)
             } catch {
               case cause: Throwable ⇒
                 materialized.failure(cause)
-                failStage(cause)
             }
           }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -363,7 +363,7 @@ object GraphStages {
       (logic, materialized.future)
     }
 
-    override def toString: String = "FutureSource"
+    override def toString: String = "FutureFlattenSource"
   }
 
   final class FutureSource[T](val future: Future[T]) extends GraphStage[SourceShape[T]] {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -331,10 +331,8 @@ object GraphStages {
             val runnable = src.to(sinkIn.sink)
 
             try {
-              def materialize = interpreter.subFusingMaterializer.
-                materialize(runnable, initialAttributes = attr)
-
-              materialized.success(materialize)
+              materialized.success(interpreter.subFusingMaterializer.
+                materialize(runnable, initialAttributes = attr))
             } catch {
               case cause: Throwable ⇒
                 materialized.failure(cause)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -312,7 +312,7 @@ object GraphStages {
     val out = Outlet[T]("futureFlatten.out")
     val shape = SourceShape(out)
 
-    override def initialAttributes = DefaultAttributes.futureSource // TODO
+    override def initialAttributes = DefaultAttributes.futureSource
 
     def createLogicAndMaterializedValue(attr: Attributes): (GraphStageLogic, Future[M]) = {
       val materialized = Promise[M]()
@@ -332,7 +332,9 @@ object GraphStages {
                 done.map(_ ⇒ m)(ExecutionContexts.sameThreadExecutionContext))
             }
 
-            src.runWith(sinkIn.sink)(interpreter.subFusingMaterializer)
+            interpreter.subFusingMaterializer.materialize(
+              src.to(sinkIn.sink),
+              initialAttributes = attr)
           }
 
           case scala.util.Failure(t) ⇒ failStage(t)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -353,9 +353,7 @@ object GraphStages {
         def onPull(): Unit = {}
 
         override def onUpstreamFinish(): Unit =
-          if (!sinkIn.isAvailable /* && isClosed(in) */ ) {
-            completeStage()
-          }
+          if (!sinkIn.isAvailable) completeStage()
 
         override def postStop(): Unit = sinkIn.cancel()
       }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -303,6 +303,69 @@ object GraphStages {
     override def toString: String = s"SingleSource($elem)"
   }
 
+  final class FutureFlattenSource[T, M](
+    val future: Future[Graph[SourceShape[T], M]])
+    extends GraphStageWithMaterializedValue[SourceShape[T], Future[M]] {
+
+    ReactiveStreamsCompliance.requireNonNullElement(future)
+
+    val out = Outlet[T]("futureFlatten.out")
+    val shape = SourceShape(out)
+
+    override def initialAttributes = DefaultAttributes.futureSource // TODO
+
+    def createLogicAndMaterializedValue(attr: Attributes): (GraphStageLogic, Future[M]) = {
+      val materialized = Promise[M]()
+
+      val logic = new GraphStageLogic(shape) with InHandler with OutHandler {
+        private val sinkIn = new SubSinkInlet[T]("FlattenMergeSink")
+
+        private val cb = getAsyncCallback[Try[Graph[SourceShape[T], M]]] {
+          case scala.util.Success(graph) ⇒ {
+            setHandler(out, this)
+            sinkIn.setHandler(this)
+
+            sinkIn.pull()
+
+            val src = Source.fromGraph(graph).watchTermination() { (m, done) ⇒
+              materialized.completeWith(
+                done.map(_ ⇒ m)(ExecutionContexts.sameThreadExecutionContext))
+            }
+
+            src.runWith(sinkIn.sink)(interpreter.subFusingMaterializer)
+          }
+
+          case scala.util.Failure(t) ⇒ failStage(t)
+        }.invoke _
+
+        setHandler(out, new OutHandler {
+          def onPull(): Unit =
+            future.onComplete(cb)(ExecutionContexts.sameThreadExecutionContext)
+        })
+
+        def onPush(): Unit = {
+          if (isAvailable(out)) {
+            push(out, sinkIn.grab())
+            sinkIn.pull()
+          }
+        }
+
+        def onPull(): Unit = {}
+
+        override def onUpstreamFinish(): Unit =
+          if (!sinkIn.isAvailable /* && isClosed(in) */ ) {
+            completeStage()
+          }
+
+        override def postStop(): Unit = sinkIn.cancel()
+      }
+
+      (logic, materialized.future)
+    }
+
+    override def toString: String = "FutureSource"
+  }
+
   final class FutureSource[T](val future: Future[T]) extends GraphStage[SourceShape[T]] {
     ReactiveStreamsCompliance.requireNonNullElement(future)
     val shape = SourceShape(Outlet[T]("future.out"))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -168,7 +168,7 @@ object Source {
     new Source(scaladsl.Source.fromFuture(future))
 
   /**
-   * Start a new `Source` from the given `CompletionStage`. The stream will consist of
+   * Starts a new `Source` from the given `CompletionStage`. The stream will consist of
    * one element when the `CompletionStage` is completed with a successful value, which
    * may happen before or after materializing the `Flow`.
    * The stream terminates with a failure if the `CompletionStage` is completed with a failure.
@@ -177,18 +177,18 @@ object Source {
     new Source(scaladsl.Source.fromCompletionStage(future))
 
   /**
-   * A graph with the shape of a source logically is a source.
-   * This method makes an asynchronous graph of such shape in type with
-   * an asynchronous materialized value.
+   * Starts a new `Source` from another `future` source.
+   * The stream will consist of the elements of the given source,
+   * once it successfully completes.
    */
-  def fromFutureGraph[T, M](future: Future[Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] = new Source(scaladsl.Source.fromFutureGraph(future))
+  def fromFutureSource[T, M](future: Future[Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] = new Source(scaladsl.Source.fromFutureSource(future))
 
   /**
-   * A graph with the shape of a source logically is a source.
-   * This method makes an asynchronous graph of such shape in type with
-   * an asynchronous materialized value.
+   * Starts a new `Source` from a `completion` stage of an asynchronous source.
+   * The stream will consist of the elements of the given source,
+   * once it successfully completes.
    */
-  def fromGraphCompletionStage[T, M](future: CompletionStage[Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] = new Source(scaladsl.Source.fromGraphCompletionStage(future))
+  def fromSourceCompletionStage[T, M](completion: CompletionStage[Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] = new Source(scaladsl.Source.fromSourceCompletionStage(completion))
 
   /**
    * Elements are emitted periodically with the specified interval.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -177,6 +177,20 @@ object Source {
     new Source(scaladsl.Source.fromCompletionStage(future))
 
   /**
+   * A graph with the shape of a source logically is a source.
+   * This method makes an asynchronous graph of such shape in type with
+   * an asynchronous materialized value.
+   */
+  def fromFutureGraph[T, M](future: Future[Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] = new Source(scaladsl.Source.fromFutureGraph(future))
+
+  /**
+   * A graph with the shape of a source logically is a source.
+   * This method makes an asynchronous graph of such shape in type with
+   * an asynchronous materialized value.
+   */
+  def fromGraphCompletionStage[T, M](future: CompletionStage[Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] = new Source(scaladsl.Source.fromGraphCompletionStage(future))
+
+  /**
    * Elements are emitted periodically with the specified interval.
    * The tick element will be delivered to downstream consumers that has requested any elements.
    * If a consumer has not requested any elements at the point in time when the tick

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -177,16 +177,14 @@ object Source {
     new Source(scaladsl.Source.fromCompletionStage(future))
 
   /**
-   * Starts a new `Source` from another `future` source.
-   * The stream will consist of the elements of the given source,
-   * once it successfully completes.
+   * Streams the elements of the given future source once it successfully completes.
+   * If the future fails the stream is failed.
    */
   def fromFutureSource[T, M](future: Future[Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] = new Source(scaladsl.Source.fromFutureSource(future))
 
   /**
-   * Starts a new `Source` from a `completion` stage of an asynchronous source.
-   * The stream will consist of the elements of the given source,
-   * once it successfully completes.
+   * Streams the elements of an asynchronous source once its given `completion` stage completes.
+   * If the `completion` fails the stream is failed with that exception.
    */
   def fromSourceCompletionStage[T, M](completion: CompletionStage[Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] = new Source(scaladsl.Source.fromSourceCompletionStage(completion))
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -268,12 +268,6 @@ object Source {
     fromGraph(new FutureSource(future.toScala))
 
   /**
-   * Starts a new `Source` from a `future` source.
-   * The stream will consist of the elements of the given source,
-   * once it successfully completes.
-   */
-
-  /**
    * Starts a new `Source` from another `future` source.
    * The stream will consist of the elements of the given source,
    * once it successfully completes.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -268,16 +268,14 @@ object Source {
     fromGraph(new FutureSource(future.toScala))
 
   /**
-   * Starts a new `Source` from another `future` source.
-   * The stream will consist of the elements of the given source,
-   * once it successfully completes.
+   * Streams the elements of the given future source once it successfully completes. 
+   * If the future fails the stream is failed.
    */
   def fromFutureSource[T, M](future: Future[Graph[SourceShape[T], M]]): Source[T, Future[M]] = fromGraph(new FutureFlattenSource(future))
 
   /**
-   * Starts a new `Source` from a `completion` stage of an asynchronous source.
-   * The stream will consist of the elements of the given source,
-   * once it successfully completes.
+   * Streams the elements of an asynchronous source once its given `completion` stage completes.
+   * If the `completion` fails the stream is failed with that exception.
    */
   def fromSourceCompletionStage[T, M](completion: CompletionStage[Graph[SourceShape[T], M]]): Source[T, CompletionStage[M]] = fromFutureSource(completion.toScala).mapMaterializedValue(_.toJava)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -217,9 +217,9 @@ object Source {
     })
 
   /**
-   * Create [[Source]] that will continually produce given elements in specified order.
+   * Creates [[Source]] that will continually produce given elements in specified order.
    *
-   * Start a new 'cycled' `Source` from the given elements. The producer stream of elements
+   * Starts a new 'cycled' `Source` from the given elements. The producer stream of elements
    * will continue infinitely by repeating the sequence of elements provided by function parameter.
    */
   def cycle[T](f: () ⇒ Iterator[T]): Source[T, NotUsed] = {
@@ -250,7 +250,7 @@ object Source {
     single(iterable).mapConcat(ConstantFun.scalaIdentityFunction).withAttributes(DefaultAttributes.iterableSource)
 
   /**
-   * Start a new `Source` from the given `Future`. The stream will consist of
+   * Starts a new `Source` from the given `Future`. The stream will consist of
    * one element when the `Future` is completed with a successful value, which
    * may happen before or after materializing the `Flow`.
    * The stream terminates with a failure if the `Future` is completed with a failure.
@@ -259,13 +259,27 @@ object Source {
     fromGraph(new FutureSource(future))
 
   /**
-   * Start a new `Source` from the given `Future`. The stream will consist of
+   * Starts a new `Source` from the given `Future`. The stream will consist of
    * one element when the `Future` is completed with a successful value, which
    * may happen before or after materializing the `Flow`.
    * The stream terminates with a failure if the `Future` is completed with a failure.
    */
   def fromCompletionStage[T](future: CompletionStage[T]): Source[T, NotUsed] =
     fromGraph(new FutureSource(future.toScala))
+
+  /**
+   * A graph with the shape of a source logically is a source.
+   * This method makes an asynchronous graph of such shape in type with
+   * an asynchronous materialized value.
+   */
+  def fromFutureGraph[T, M](future: Future[Graph[SourceShape[T], M]]): Source[T, Future[M]] = fromGraph(new FutureFlattenSource(future))
+
+  /**
+   * A graph with the shape of a source logically is a source.
+   * This method makes an asynchronous graph of such shape in type with
+   * an asynchronous materialized value.
+   */
+  def fromGraphCompletionStage[T, M](future: CompletionStage[Graph[SourceShape[T], M]]): Source[T, CompletionStage[M]] = fromFutureGraph(future.toScala).mapMaterializedValue(_.toJava)
 
   /**
    * Elements are emitted periodically with the specified interval.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -268,7 +268,7 @@ object Source {
     fromGraph(new FutureSource(future.toScala))
 
   /**
-   * Streams the elements of the given future source once it successfully completes. 
+   * Streams the elements of the given future source once it successfully completes.
    * If the future fails the stream is failed.
    */
   def fromFutureSource[T, M](future: Future[Graph[SourceShape[T], M]]): Source[T, Future[M]] = fromGraph(new FutureFlattenSource(future))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -268,18 +268,24 @@ object Source {
     fromGraph(new FutureSource(future.toScala))
 
   /**
-   * A graph with the shape of a source logically is a source.
-   * This method makes an asynchronous graph of such shape in type with
-   * an asynchronous materialized value.
+   * Starts a new `Source` from a `future` source.
+   * The stream will consist of the elements of the given source,
+   * once it successfully completes.
    */
-  def fromFutureGraph[T, M](future: Future[Graph[SourceShape[T], M]]): Source[T, Future[M]] = fromGraph(new FutureFlattenSource(future))
 
   /**
-   * A graph with the shape of a source logically is a source.
-   * This method makes an asynchronous graph of such shape in type with
-   * an asynchronous materialized value.
+   * Starts a new `Source` from another `future` source.
+   * The stream will consist of the elements of the given source,
+   * once it successfully completes.
    */
-  def fromGraphCompletionStage[T, M](future: CompletionStage[Graph[SourceShape[T], M]]): Source[T, CompletionStage[M]] = fromFutureGraph(future.toScala).mapMaterializedValue(_.toJava)
+  def fromFutureSource[T, M](future: Future[Graph[SourceShape[T], M]]): Source[T, Future[M]] = fromGraph(new FutureFlattenSource(future))
+
+  /**
+   * Starts a new `Source` from a `completion` stage of an asynchronous source.
+   * The stream will consist of the elements of the given source,
+   * once it successfully completes.
+   */
+  def fromSourceCompletionStage[T, M](completion: CompletionStage[Graph[SourceShape[T], M]]): Source[T, CompletionStage[M]] = fromFutureSource(completion.toScala).mapMaterializedValue(_.toJava)
 
   /**
    * Elements are emitted periodically with the specified interval.


### PR DESCRIPTION
Having a `Future[Source[T, M]]`, with `M` not being `akka.NotUsed`, I'm trying to get a `Source[T, M]`.

Using [`Source.fromFuture`](http://doc.akka.io/api/akka/2.4.9/index.html#akka.stream.scaladsl.Source$@fromFuture[T]%28future:scala.concurrent.Future[T]%29:akka.stream.scaladsl.Source[T,akka.NotUsed]) from there lead to a `Source[Source[T, M], NotUsed]`.

I may have missed something on how to perform such "async flatten" on sources, in which case this PR can just be ignored.
