### PR TITLE
fix glitch in lazy restart, #21347

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+
+import akka.actor.ActorSystem
+import akka.actor.RootActorPath
+import akka.remote.RARP
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.testkit.SocketUtil
+import akka.testkit.TestActors
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+
+object LateConnectSpec {
+
+  val config = ConfigFactory.parseString(s"""
+     akka {
+       actor.provider = remote
+       remote.artery.enabled = on
+       remote.artery.hostname = localhost
+       remote.artery.port = 0
+       remote.artery.advanced.handshake-timeout = 3s
+     }
+  """)
+
+}
+
+class LateConnectSpec extends AkkaSpec(LateConnectSpec.config) with ImplicitSender {
+
+  val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
+  val configB = ConfigFactory.parseString(s"akka.remote.artery.port = $portB")
+    .withFallback(system.settings.config)
+  lazy val systemB = ActorSystem("systemB", configB)
+
+  "Connection" must {
+
+    "be established after initial lazy restart" in {
+      system.actorOf(TestActors.echoActorProps, "echoA")
+
+      val echoB = system.actorSelection(s"artery://systemB@localhost:$portB/user/echoB")
+      echoB ! "ping1"
+
+      // let the outbound streams be restarted (lazy), systemB is not started yet
+      Thread.sleep((RARP(system).provider.remoteSettings.Artery.Advanced.HandshakeTimeout + 1.second).toMillis)
+
+      // start systemB
+      systemB.actorOf(TestActors.echoActorProps, "echoB")
+
+      val probeB = TestProbe()(systemB)
+      val echoA = systemB.actorSelection(RootActorPath(RARP(system).provider.getDefaultAddress) / "user" / "echoA")
+      echoA.tell("ping2", probeB.ref)
+      probeB.expectMsg(10.seconds, "ping2")
+
+      echoB ! "ping3"
+      expectMsg("ping3")
+    }
+  }
+
+  override def afterTermination(): Unit = shutdown(systemB)
+
+}


### PR DESCRIPTION
This is a follow up on https://github.com/akka/akka/pull/21356
It was using old materialized values before the restart was triggered by the first message. Especially `clearCompression` stalled, because the future was never completed since the old stage was dead.
