### PR TITLE
=htc #21281 render empty params double quoted in headers like `Authorization`

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -185,10 +185,10 @@ private[http] trait Rendering {
 
   /**
    * Renders the given string either directly (if it only contains token chars)
-   * or in double quotes (if it contains at least one non-token char).
+   * or in double quotes (if it is empty or contains at least one non-token char).
    */
   def ~~#(s: String): this.type =
-    if (CharacterClasses.tchar matchesAll s) this ~~ s else ~~#!(s)
+    if (s.nonEmpty && CharacterClasses.tchar.matchesAll(s)) this ~~ s else ~~#!(s)
 
   /**
    * Renders the given string in double quotes.

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -140,6 +140,8 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
           """Fancy yes="n:o",nonce=42""")
       """Authorization: Fancy yes=no,nonce="4\\2"""" =!=
         Authorization(GenericHttpCredentials("Fancy", Map("yes" → "no", "nonce" → """4\2""")))
+      """Authorization: Other yes=no,empty=""""" =!=
+        Authorization(GenericHttpCredentials("Other", Map("yes" → "no", "empty" → "")))
       "Authorization: Basic Qm9iOg==" =!=
         Authorization(BasicHttpCredentials("Bob", ""))
       """Authorization: Digest name=Bob""" =!=
@@ -182,6 +184,8 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       "Content-Disposition: form-data" =!= `Content-Disposition`(ContentDispositionTypes.`form-data`)
       "Content-Disposition: attachment; name=field1; filename=\"file/txt\"" =!=
         `Content-Disposition`(ContentDispositionTypes.attachment, Map("name" → "field1", "filename" → "file/txt"))
+      "Content-Disposition: attachment; name=field1; other=\"\"" =!=
+        `Content-Disposition`(ContentDispositionTypes.attachment, Map("name" → "field1", "other" → ""))
     }
 
     "Content-Encoding" in {

--- a/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
@@ -29,7 +29,7 @@ class RenderingSpec extends WordSpec with Matchers {
     }
 
     "correctly render escaped Strings" in {
-      (new StringRendering ~~# "").get shouldEqual ""
+      (new StringRendering ~~# "").get shouldEqual "\"\""
       (new StringRendering ~~# "hello").get shouldEqual "hello"
       (new StringRendering ~~# """hel"lo""").get shouldEqual """"hel\"lo""""
     }


### PR DESCRIPTION
Otherwise, empty params are rendered as "key=" which is usually invalid in places where `token | quoted-string` is expected (thanks @2beaucoup for looking that up in #21281):

https://tools.ietf.org/html/rfc7235#section-4.2:

```
Authorization = credentials
credentials   = auth-scheme [ 1*SP ( token68 / [ ( "," / auth-param )
    *( OWS "," [ OWS auth-param ] ) ] ) ]
auth-param    = token BWS "=" BWS ( token / quoted-string )
```

https://tools.ietf.org/html/rfc7230#section-3.2.6:

```
token         = 1*tchar
quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE
```
