### PR TITLE
abort streams on shutdown, #21388

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -537,6 +537,7 @@ private[remote] class Association(
     implicit val ec = materializer.executionContext
     updateStreamCompletion(streamName, streamCompleted.recover { case _ ⇒ Done })
     streamCompleted.onFailure {
+      case ArteryTransport.ShutdownSignal ⇒ // shutdown as expected
       case cause if transport.isShutdown ⇒
         // don't restart after shutdown, but log some details so we notice
         log.error(cause, s"{} to {} failed after shutdown. {}", streamName, remoteAddress, cause.getMessage)


### PR DESCRIPTION
- otherwise AeronSink will continue sending outstanding messages
  before completing
- this was noticed by RemoteDeathWatchSpec couldn't shutdown,
  since it was trying to send to unknown
