### PR TITLE
handle longer network partitions, #21399

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamConcistencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamConcistencySpec.scala
@@ -82,7 +82,7 @@ abstract class AeronStreamConsistencySpec
   }
 
   val streamId = 1
-  val giveUpSendAfter = 30.seconds
+  val giveUpMessageAfter = 30.seconds
 
   override def afterAll(): Unit = {
     taskRunner.stop()
@@ -98,7 +98,7 @@ abstract class AeronStreamConsistencySpec
       runOn(second) {
         // just echo back
         Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink))
-          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpSendAfter, IgnoreEventSink))
+          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
       }
       enterBarrier("echo-started")
     }
@@ -139,7 +139,7 @@ abstract class AeronStreamConsistencySpec
             envelope
           }
             .throttle(1, 200.milliseconds, 1, ThrottleMode.Shaping)
-            .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpSendAfter, IgnoreEventSink))
+            .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
           started.expectMsg(Done)
         }
 
@@ -151,7 +151,7 @@ abstract class AeronStreamConsistencySpec
             envelope.byteBuffer.flip()
             envelope
           }
-          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpSendAfter, IgnoreEventSink))
+          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
 
         Await.ready(done, 20.seconds)
         killSwitch.shutdown()

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
@@ -115,7 +115,7 @@ abstract class AeronStreamLatencySpec
   }
 
   val streamId = 1
-  val giveUpSendAfter = 30.seconds
+  val giveUpMessageAfter = 30.seconds
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
   def reporter(name: String): TestRateReporter = {
@@ -245,7 +245,7 @@ abstract class AeronStreamLatencySpec
           envelope
         }
           .throttle(1, 200.milliseconds, 1, ThrottleMode.Shaping)
-          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpSendAfter, IgnoreEventSink))
+          .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
         started.expectMsg(Done)
       }
 
@@ -264,7 +264,7 @@ abstract class AeronStreamLatencySpec
 
         val queueValue = Source.fromGraph(new SendQueue[Unit])
           .via(sendFlow)
-          .to(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpSendAfter, IgnoreEventSink))
+          .to(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
           .run()
 
         val queue = new ManyToOneConcurrentArrayQueue[Unit](1024)
@@ -314,7 +314,7 @@ abstract class AeronStreamLatencySpec
       runOn(second) {
         // just echo back
         Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink))
-          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpSendAfter, IgnoreEventSink))
+          .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
       }
       enterBarrier("echo-started")
     }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
@@ -115,7 +115,7 @@ abstract class AeronStreamMaxThroughputSpec
   }
 
   val streamId = 1
-  val giveUpSendAfter = 30.seconds
+  val giveUpMessageAfter = 30.seconds
 
   lazy val reporterExecutor = Executors.newFixedThreadPool(1)
   def reporter(name: String): TestRateReporter = {
@@ -213,7 +213,7 @@ abstract class AeronStreamMaxThroughputSpec
           envelope.byteBuffer.flip()
           envelope
         }
-        .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpSendAfter, IgnoreEventSink))
+        .runWith(new AeronSink(channel(second), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
 
       printStats("sender")
       enterBarrier(testName + "-done")

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveNetworkPartitionSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveNetworkPartitionSpec.scala
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import scala.concurrent.duration._
+import akka.actor._
+import akka.actor.ActorIdentity
+import akka.actor.Identify
+import akka.remote.RARP
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.STMultiNodeSpec
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+import akka.remote.QuarantinedEvent
+
+object SurviveNetworkPartitionSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+
+  commonConfig(debugConfig(on = false).withFallback(
+    ConfigFactory.parseString("""
+      akka.loglevel = INFO
+      akka.remote.artery.enabled = on
+      akka.remote.artery.advanced.give-up-system-message-after = 4s
+      """)))
+
+  testTransport(on = true)
+}
+
+class SurviveNetworkPartitionSpecMultiJvmNode1 extends SurviveNetworkPartitionSpec
+class SurviveNetworkPartitionSpecMultiJvmNode2 extends SurviveNetworkPartitionSpec
+
+abstract class SurviveNetworkPartitionSpec
+  extends MultiNodeSpec(SurviveNetworkPartitionSpec)
+  with STMultiNodeSpec with ImplicitSender {
+
+  import SurviveNetworkPartitionSpec._
+
+  override def initialParticipants = roles.size
+
+  "Network partition" must {
+
+    "not quarantine system when it heals within 'give-up-system-message-after'" taggedAs LongRunningTest in {
+
+      runOn(second) {
+        system.actorOf(TestActors.echoActorProps, "echo1")
+      }
+      enterBarrier("echo-started")
+
+      runOn(first) {
+        system.actorSelection(node(second) / "user" / "echo1") ! Identify(None)
+        val ref = expectMsgType[ActorIdentity].ref.get
+        ref ! "ping1"
+        expectMsg("ping1")
+
+        // network partition
+        testConductor.blackhole(first, second, Direction.Both).await
+
+        // send system message during network partition
+        watch(ref)
+        // keep the network partition for a while, but shorter than give-up-system-message-after
+        expectNoMsg(RARP(system).provider.remoteSettings.Artery.Advanced.GiveUpSystemMessageAfter - 2.second)
+
+        // heal the network partition
+        testConductor.passThrough(first, second, Direction.Both).await
+
+        // not quarantined
+        ref ! "ping2"
+        expectMsg("ping2")
+
+        ref ! PoisonPill
+        expectTerminated(ref)
+      }
+
+      enterBarrier("done")
+    }
+
+    "quarantine system when it doesn't heal within 'give-up-system-message-after'" taggedAs LongRunningTest in {
+
+      runOn(second) {
+        system.actorOf(TestActors.echoActorProps, "echo2")
+      }
+      enterBarrier("echo-started")
+
+      runOn(first) {
+        val qProbe = TestProbe()
+        system.eventStream.subscribe(qProbe.ref, classOf[QuarantinedEvent])
+        system.actorSelection(node(second) / "user" / "echo2") ! Identify(None)
+        val ref = expectMsgType[ActorIdentity].ref.get
+        ref ! "ping1"
+        expectMsg("ping1")
+
+        // network partition
+        testConductor.blackhole(first, second, Direction.Both).await
+
+        // send system message during network partition
+        watch(ref)
+        // keep the network partition for a while, longer than give-up-system-message-after
+        expectNoMsg(RARP(system).provider.remoteSettings.Artery.Advanced.GiveUpSystemMessageAfter - 1.second)
+        qProbe.expectMsgType[QuarantinedEvent](5.seconds).address should ===(node(second).address)
+
+        expectTerminated(ref)
+      }
+
+      enterBarrier("done")
+    }
+
+  }
+}

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -209,7 +209,12 @@ akka {
         inject-handshake-interval = 1 second
 
         # messages that are not accepted by Aeron are dropped after retrying for this period
-        give-up-send-after = 60 seconds
+        give-up-message-after = 60 seconds
+        
+        # System messages that are not acknowledged after re-sending for this period are
+        # dropped and will trigger quarantine. The value should be longer than the length
+        # of a network partition that you need to survive.
+        give-up-system-message-after = 6 hours
 
         # during ActorSystem termination the remoting will wait this long for
         # an acknowledgment by the destination system that flushing of outstanding

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -71,8 +71,10 @@ private[akka] final class ArterySettings private (config: Config) {
       interval > Duration.Zero, "handshake-retry-interval must be more than zero")
     val InjectHandshakeInterval = config.getMillisDuration("inject-handshake-interval").requiring(interval ⇒
       interval > Duration.Zero, "inject-handshake-interval must be more than zero")
-    val GiveUpSendAfter = config.getMillisDuration("give-up-send-after").requiring(interval ⇒
-      interval > Duration.Zero, "give-up-send-after must be more than zero")
+    val GiveUpMessageAfter = config.getMillisDuration("give-up-message-after").requiring(interval ⇒
+      interval > Duration.Zero, "give-up-message-after must be more than zero")
+    val GiveUpSystemMessageAfter = config.getMillisDuration("give-up-system-message-after").requiring(interval ⇒
+      interval > Duration.Zero, "give-up-system-message-after must be more than zero")
     val ShutdownFlushTimeout = config.getMillisDuration("shutdown-flush-timeout").requiring(interval ⇒
       interval > Duration.Zero, "shutdown-flush-timeout must be more than zero")
     val InboundRestartTimeout = config.getMillisDuration("inbound-restart-timeout").requiring(interval ⇒

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -863,8 +863,11 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     aeronSink(outboundContext, ordinaryStreamId)
 
   private def aeronSink(outboundContext: OutboundContext, streamId: Int): Sink[EnvelopeBuffer, Future[Done]] = {
+    val giveUpAfter =
+      if (streamId == controlStreamId) settings.Advanced.GiveUpSystemMessageAfter
+      else settings.Advanced.GiveUpMessageAfter
     Sink.fromGraph(new AeronSink(outboundChannel(outboundContext.remoteAddress), streamId, aeron, taskRunner,
-      envelopeBufferPool, settings.Advanced.GiveUpSendAfter, createFlightRecorderEventSink()))
+      envelopeBufferPool, giveUpAfter, createFlightRecorderEventSink()))
   }
 
   def outboundLane(outboundContext: OutboundContext): Flow[OutboundEnvelope, EnvelopeBuffer, ChangeOutboundCompression] =

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -24,7 +24,7 @@ import akka.event.Logging
 import akka.remote._
 import akka.remote.DaemonMsgCreate
 import akka.remote.QuarantinedEvent
-import akka.remote.artery.AeronSink.GaveUpSendingException
+import akka.remote.artery.AeronSink.GaveUpMessageException
 import akka.remote.artery.Encoder.ChangeOutboundCompression
 import akka.remote.artery.Encoder.ChangeOutboundCompressionFailed
 import akka.remote.artery.InboundControlJunction.ControlMessageSubject
@@ -587,7 +587,7 @@ private[remote] class Association(
         // don't restart after shutdown, but log some details so we notice
         log.error(cause, s"{} to {} failed after shutdown. {}", streamName, remoteAddress, cause.getMessage)
       case _: AbruptTerminationException ⇒ // ActorSystem shutdown
-      case cause: GaveUpSendingException ⇒
+      case cause: GaveUpMessageException ⇒
         log.debug("{} to {} failed. Restarting it. {}", streamName, remoteAddress, cause.getMessage)
         // restart unconditionally, without counting restarts
         lazyRestart()

--- a/akka-remote/src/test/scala/akka/remote/artery/AeronSinkSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/AeronSinkSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 import akka.actor.ExtendedActorSystem
-import akka.remote.artery.AeronSink.GaveUpSendingException
+import akka.remote.artery.AeronSink.GaveUpMessageException
 import akka.stream.ActorMaterializer
 import akka.stream.ActorMaterializerSettings
 import akka.stream.scaladsl.Sink
@@ -75,7 +75,7 @@ class AeronSinkSpec extends AkkaSpec with ImplicitSender {
         .runWith(new AeronSink(channel, 1, aeron, taskRunner, pool, 500.millis, IgnoreEventSink))
 
       // without the give up timeout the stream would not complete/fail
-      intercept[GaveUpSendingException] {
+      intercept[GaveUpMessageException] {
         Await.result(done, 5.seconds)
       }
     }


### PR DESCRIPTION
Refs #21399

I think this is needed, and a good improvement, but we need to do manual testing with real network partitions before closing the ticket. Might need something more. I'll like to merge this first though, as a first step.
- system messages in flight should not trigger premature quarantine
  in case of longer network partitions, therefore we keep the control
  stream alive
- add give-up-system-message-after property that is used by both
  SystemMessageDelivery and AeronSink in the control stream
- also unwrap SystemMessageEnvelope in RemoteDeadLetterActorRef
- skip sending control messages after shutdown, can be triggered
  by scheduled compression advertisment
