### PR TITLE
#20623 Make sure external (mapped) resources are properly cleaned on shutdown

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
@@ -88,8 +88,9 @@ abstract class AeronStreamLatencySpec
 
   val pool = new EnvelopeBufferPool(1024 * 1024, 128)
 
+  val cncByteBuffer = IoUtil.mapExistingFile(new File(driver.aeronDirectoryName, CncFileDescriptor.CNC_FILE), "cnc");
   val stats =
-    new AeronStat(AeronStat.mapCounters(new File(driver.aeronDirectoryName, CncFileDescriptor.CNC_FILE)))
+    new AeronStat(AeronStat.mapCounters(cncByteBuffer))
 
   val aeron = {
     val ctx = new Aeron.Context
@@ -129,6 +130,7 @@ abstract class AeronStreamLatencySpec
     taskRunner.stop()
     aeron.close()
     driver.close()
+    IoUtil.unmap(cncByteBuffer)
     IoUtil.delete(new File(driver.aeronDirectoryName), true)
     runOn(first) {
       println(plots.plot50.csv(system.name + "50"))

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
@@ -86,8 +86,9 @@ abstract class AeronStreamMaxThroughputSpec
 
   val pool = new EnvelopeBufferPool(1024 * 1024, 128)
 
+  val cncByteBuffer = IoUtil.mapExistingFile(new File(driver.aeronDirectoryName, CncFileDescriptor.CNC_FILE), "cnc");
   val stats =
-    new AeronStat(AeronStat.mapCounters(new File(driver.aeronDirectoryName, CncFileDescriptor.CNC_FILE)))
+    new AeronStat(AeronStat.mapCounters(cncByteBuffer))
 
   val aeron = {
     val ctx = new Aeron.Context
@@ -129,6 +130,7 @@ abstract class AeronStreamMaxThroughputSpec
     taskRunner.stop()
     aeron.close()
     driver.close()
+    IoUtil.unmap(cncByteBuffer)
     IoUtil.delete(new File(driver.aeronDirectoryName), true)
     runOn(second) {
       println(plot.csv(system.name))

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -294,6 +294,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   private[this] val mediaDriver = new AtomicReference[Option[MediaDriver]](None)
   @volatile private[this] var aeron: Aeron = _
   @volatile private[this] var aeronErrorLogTask: Cancellable = _
+  @volatile private[this] var areonErrorLog: AeronErrorLog = _
 
   @volatile private[this] var inboundCompressions: Option[InboundCompressions] = None
 
@@ -541,12 +542,12 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
 
   // TODO Add FR Events
   private def startAeronErrorLog(): Unit = {
-    val errorLog = new AeronErrorLog(new File(aeronDir, CncFileDescriptor.CNC_FILE))
+    areonErrorLog = new AeronErrorLog(new File(aeronDir, CncFileDescriptor.CNC_FILE))
     val lastTimestamp = new AtomicLong(0L)
     import system.dispatcher
     aeronErrorLogTask = system.scheduler.schedule(3.seconds, 5.seconds) {
       if (!isShutdown) {
-        val newLastTimestamp = errorLog.logErrors(log, lastTimestamp.get)
+        val newLastTimestamp = areonErrorLog.logErrors(log, lastTimestamp.get)
         lastTimestamp.set(newLastTimestamp + 1)
       }
     }
@@ -757,6 +758,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
         topLevelFREvents.loFreq(Transport_AeronErrorLogTaskStopped, NoMetaData)
       }
       if (aeron != null) aeron.close()
+      if (areonErrorLog != null) areonErrorLog.close()
       if (mediaDriver.get.isDefined) {
         stopMediaDriver()
         topLevelFREvents.loFreq(Transport_MediaFileDeleted, NoMetaData)

--- a/akka-remote/src/test/java/akka/remote/artery/AeronStat.java
+++ b/akka-remote/src/test/java/akka/remote/artery/AeronStat.java
@@ -117,7 +117,22 @@ public class AeronStat
     {
       return mapCounters(CommonContext.newDefaultCncFile()); 
     }
-    
+
+    public static CountersReader mapCounters(final MappedByteBuffer cncByteBuffer)
+    {
+        final DirectBuffer cncMetaData = createMetaDataBuffer(cncByteBuffer);
+        final int cncVersion = cncMetaData.getInt(cncVersionOffset(0));
+
+        if (CncFileDescriptor.CNC_VERSION != cncVersion)
+        {
+            throw new IllegalStateException("CnC version not supported: file version=" + cncVersion);
+        }
+
+        return new CountersReader(
+          createCountersMetaDataBuffer(cncByteBuffer, cncMetaData),
+          createCountersValuesBuffer(cncByteBuffer, cncMetaData));
+    }
+
     public static CountersReader mapCounters(final File cncFile)
     {
         System.out.println("Command `n Control file " + cncFile);
@@ -132,8 +147,8 @@ public class AeronStat
         }
 
         return new CountersReader(
-            createCountersMetaDataBuffer(cncByteBuffer, cncMetaData),
-            createCountersValuesBuffer(cncByteBuffer, cncMetaData));
+          createCountersMetaDataBuffer(cncByteBuffer, cncMetaData),
+          createCountersValuesBuffer(cncByteBuffer, cncMetaData));
     }
 
     public static void main(final String[] args) throws Exception


### PR DESCRIPTION
Make sure mapped files are properly unmapped before attempting to delete them (due to Windows restrictions).

Fixes #20623 
