### PR TITLE
=act improve ByteString#dropRight(...)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -437,14 +437,20 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(4, 0) should ===(ByteString(""))
     }
     "dropRight" in {
+      ByteString.empty.dropRight(-1) should ===(ByteString(""))
+      ByteString.empty.dropRight(0) should ===(ByteString(""))
+      ByteString.empty.dropRight(1) should ===(ByteString(""))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(0) should ===(ByteString("a"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(-1) should ===(ByteString("a"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(Int.MinValue) should ===(ByteString("a"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(1) should ===(ByteString(""))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(Int.MaxValue) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(-1) should ===(ByteString("abc"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(0) should ===(ByteString("abc"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(1) should ===(ByteString("ab"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(2) should ===(ByteString("a"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(3) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(4) should ===(ByteString(""))
     }
     "take" in {
       ByteString.empty.take(-1) should ===(ByteString(""))

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -309,6 +309,23 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteString1.fromString("0123456789").drop(1).take(2) should ===(ByteString("12"))
       ByteString1.fromString("0123456789").drop(5).take(4).drop(1).take(2) should ===(ByteString("67"))
     }
+    "dropRight" in {
+      ByteString1.empty.dropRight(-1) should ===(ByteString(""))
+      ByteString1.empty.dropRight(0) should ===(ByteString(""))
+      ByteString1.empty.dropRight(1) should ===(ByteString(""))
+      ByteString1.fromString("a").dropRight(-1) should ===(ByteString("a"))
+      ByteString1.fromString("a").dropRight(0) should ===(ByteString("a"))
+      ByteString1.fromString("a").dropRight(1) should ===(ByteString(""))
+      ByteString1.fromString("a").dropRight(2) should ===(ByteString(""))
+      ByteString1.fromString("abc").dropRight(-1) should ===(ByteString("abc"))
+      ByteString1.fromString("abc").dropRight(0) should ===(ByteString("abc"))
+      ByteString1.fromString("abc").dropRight(1) should ===(ByteString("ab"))
+      ByteString1.fromString("abc").dropRight(2) should ===(ByteString("a"))
+      ByteString1.fromString("abc").dropRight(3) should ===(ByteString(""))
+      ByteString1.fromString("abc").dropRight(4) should ===(ByteString(""))
+      ByteString1.fromString("0123456789").dropRight(1).take(2) should ===(ByteString("01"))
+      ByteString1.fromString("0123456789").dropRight(5).take(4).drop(1).take(2) should ===(ByteString("12"))
+    }
     "take" in {
       ByteString1.empty.take(-1) should ===(ByteString(""))
       ByteString1.empty.take(0) should ===(ByteString(""))
@@ -340,6 +357,23 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteString1C.fromString("abc").drop(4) should ===(ByteString(""))
       ByteString1C.fromString("0123456789").drop(1).take(2) should ===(ByteString("12"))
       ByteString1C.fromString("0123456789").drop(5).take(4).drop(1).take(2) should ===(ByteString("67"))
+    }
+    "dropRight" in {
+      ByteString1C.fromString("").dropRight(-1) should ===(ByteString(""))
+      ByteString1C.fromString("").dropRight(0) should ===(ByteString(""))
+      ByteString1C.fromString("").dropRight(1) should ===(ByteString(""))
+      ByteString1C.fromString("a").dropRight(-1) should ===(ByteString("a"))
+      ByteString1C.fromString("a").dropRight(0) should ===(ByteString("a"))
+      ByteString1C.fromString("a").dropRight(1) should ===(ByteString(""))
+      ByteString1C.fromString("a").dropRight(2) should ===(ByteString(""))
+      ByteString1C.fromString("abc").dropRight(-1) should ===(ByteString("abc"))
+      ByteString1C.fromString("abc").dropRight(0) should ===(ByteString("abc"))
+      ByteString1C.fromString("abc").dropRight(1) should ===(ByteString("ab"))
+      ByteString1C.fromString("abc").dropRight(2) should ===(ByteString("a"))
+      ByteString1C.fromString("abc").dropRight(3) should ===(ByteString(""))
+      ByteString1C.fromString("abc").dropRight(4) should ===(ByteString(""))
+      ByteString1C.fromString("0123456789").dropRight(1).take(2) should ===(ByteString("01"))
+      ByteString1C.fromString("0123456789").dropRight(5).take(4).drop(1).take(2) should ===(ByteString("12"))
     }
     "take" in {
       ByteString1.fromString("abcdefg").drop(1).take(0) should ===(ByteString(""))
@@ -392,6 +426,48 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteString("0123456789").drop(5).drop(3).take(1) should ===(ByteString("8"))
       (ByteString1C.fromString("a") ++ ByteString1.fromString("bc")).drop(2) should ===(ByteString("c"))
     }
+    "dropRight" in {
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).dropRight(Int.MinValue) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).dropRight(-1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).dropRight(0) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).dropRight(1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).dropRight(Int.MaxValue) should ===(ByteString(""))
+
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(Int.MinValue) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(-1) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(0) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(2) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(Int.MaxValue) should ===(ByteString(""))
+
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).dropRight(Int.MinValue) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).dropRight(-1) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).dropRight(0) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).dropRight(1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).dropRight(2) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).dropRight(Int.MaxValue) should ===(ByteString(""))
+
+      val bss = ByteStrings(Vector(
+        ByteString1.fromString("a"),
+        ByteString1.fromString("bc"),
+        ByteString1.fromString("def")))
+
+      bss.dropRight(Int.MinValue) should ===(ByteString("abcdef"))
+      bss.dropRight(-1) should ===(ByteString("abcdef"))
+      bss.dropRight(0) should ===(ByteString("abcdef"))
+      bss.dropRight(1) should ===(ByteString("abcde"))
+      bss.dropRight(2) should ===(ByteString("abcd"))
+      bss.dropRight(3) should ===(ByteString("abc"))
+      bss.dropRight(4) should ===(ByteString("ab"))
+      bss.dropRight(5) should ===(ByteString("a"))
+      bss.dropRight(6) should ===(ByteString(""))
+      bss.dropRight(7) should ===(ByteString(""))
+      bss.dropRight(Int.MaxValue) should ===(ByteString(""))
+
+      ByteString("0123456789").dropRight(5).take(2) should ===(ByteString("01"))
+      ByteString("0123456789").dropRight(5).drop(3).take(1) should ===(ByteString("3"))
+      (ByteString1C.fromString("a") ++ ByteString1.fromString("bc")).dropRight(2) should ===(ByteString("a"))
+    }
     "slice" in {
       ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).slice(1, 1) should ===(ByteString(""))
       // We explicitly test all edge cases to always test them, refs bug #21237
@@ -435,22 +511,6 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
 
       // Get an empty if `from` is greater than `until`
       ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd")).slice(4, 0) should ===(ByteString(""))
-    }
-    "dropRight" in {
-      ByteString.empty.dropRight(-1) should ===(ByteString(""))
-      ByteString.empty.dropRight(0) should ===(ByteString(""))
-      ByteString.empty.dropRight(1) should ===(ByteString(""))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(0) should ===(ByteString("a"))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(-1) should ===(ByteString("a"))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(Int.MinValue) should ===(ByteString("a"))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(1) should ===(ByteString(""))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).dropRight(Int.MaxValue) should ===(ByteString(""))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(-1) should ===(ByteString("abc"))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(0) should ===(ByteString("abc"))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(1) should ===(ByteString("ab"))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(2) should ===(ByteString("a"))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(3) should ===(ByteString(""))
-      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).dropRight(4) should ===(ByteString(""))
     }
     "take" in {
       ByteString.empty.take(-1) should ===(ByteString(""))

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -492,20 +492,21 @@ object ByteString {
       else dropRight0(n)
 
     private def dropRight0(n: Int): ByteString = {
+      val byteStringsSize = bytestrings.length
       @tailrec def findSplit(fullDrops: Int, remainingToDrop: Int): (Int, Int) = {
-        val bs = bytestrings(fullDrops)
+        val bs = bytestrings(byteStringsSize - fullDrops - 1)
         if (bs.length > remainingToDrop) (fullDrops, remainingToDrop)
-        else findSplit(fullDrops - 1, remainingToDrop - bs.length)
+        else findSplit(fullDrops + 1, remainingToDrop - bs.length)
       }
 
-      val (fullDrops, remainingToDrop) = findSplit(bytestrings.length - 1, n)
+      val (fullDrops, remainingToDrop) = findSplit(0, n)
 
-      if (fullDrops == 0)
+      if (fullDrops == byteStringsSize - 1)
         bytestrings(0).dropRight(remainingToDrop)
       else if (remainingToDrop == 0)
-        new ByteStrings(bytestrings.take(fullDrops + 1), length - n)
+        new ByteStrings(bytestrings.dropRight(fullDrops), length - n)
       else
-        new ByteStrings(bytestrings.take(fullDrops) :+ bytestrings(fullDrops).dropRight1(remainingToDrop), length - n)
+        new ByteStrings(bytestrings.dropRight(fullDrops + 1) :+ bytestrings(byteStringsSize - fullDrops - 1).dropRight1(remainingToDrop), length - n)
     }
 
     override def slice(from: Int, until: Int): ByteString =

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -492,17 +492,20 @@ object ByteString {
       else dropRight0(n)
 
     private def dropRight0(n: Int): ByteString = {
-      @tailrec def go(last: Int, restToDropRight: Int): (Int, Int) = {
-        val bs = bytestrings(last)
-        if (bs.length > restToDropRight) (last, restToDropRight)
-        else go(last - 1, restToDropRight - bs.length)
+      @tailrec def findSplit(fullDrops: Int, remainingToDrop: Int): (Int, Int) = {
+        val bs = bytestrings(fullDrops)
+        if (bs.length > remainingToDrop) (fullDrops, remainingToDrop)
+        else findSplit(fullDrops - 1, remainingToDrop - bs.length)
       }
 
-      val (last, restToDropRight) = go(bytestrings.length - 1, n)
+      val (fullDrops, remainingToDrop) = findSplit(bytestrings.length - 1, n)
 
-      if (last == 0) bytestrings(0).dropRight(restToDropRight)
-      else if (restToDropRight == 0) new ByteStrings(bytestrings.take(last + 1), length - n)
-      else new ByteStrings(bytestrings.take(last) :+ bytestrings(last).dropRight1(restToDropRight), length - n)
+      if (fullDrops == 0)
+        bytestrings(0).dropRight(remainingToDrop)
+      else if (remainingToDrop == 0)
+        new ByteStrings(bytestrings.take(fullDrops + 1), length - n)
+      else
+        new ByteStrings(bytestrings.take(fullDrops) :+ bytestrings(fullDrops).dropRight1(remainingToDrop), length - n)
     }
 
     override def slice(from: Int, until: Int): ByteString =

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -491,7 +491,7 @@ object ByteString {
       else if (n >= length) ByteString.empty
       else dropRight0(n)
 
-    private[akka] def dropRight0(n: Int): ByteString = {
+    private def dropRight0(n: Int): ByteString = {
       @tailrec def go(last: Int, restToDropRight: Int): (Int, Int) = {
         val bs = bytestrings(last)
         if (bs.length > restToDropRight) (last, restToDropRight)

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -487,26 +487,27 @@ object ByteString {
     }
 
     override def dropRight(n: Int): ByteString =
-      if (n <= 0) this
+      if (0 < n && n < length) dropRight0(n)
       else if (n >= length) ByteString.empty
-      else dropRight0(n)
+      else this
 
     private def dropRight0(n: Int): ByteString = {
       val byteStringsSize = bytestrings.length
-      @tailrec def findSplit(fullDrops: Int, remainingToDrop: Int): (Int, Int) = {
+      @tailrec def dropRightWithFullDropsAndRemainig(fullDrops: Int, remainingToDrop: Int): ByteString = {
         val bs = bytestrings(byteStringsSize - fullDrops - 1)
-        if (bs.length > remainingToDrop) (fullDrops, remainingToDrop)
-        else findSplit(fullDrops + 1, remainingToDrop - bs.length)
+        if (bs.length > remainingToDrop) {
+          if (fullDrops == byteStringsSize - 1)
+            bytestrings(0).dropRight(remainingToDrop)
+          else if (remainingToDrop == 0)
+            new ByteStrings(bytestrings.dropRight(fullDrops), length - n)
+          else
+            new ByteStrings(bytestrings.dropRight(fullDrops + 1) :+ bytestrings(byteStringsSize - fullDrops - 1).dropRight1(remainingToDrop), length - n)
+        } else {
+          dropRightWithFullDropsAndRemainig(fullDrops + 1, remainingToDrop - bs.length)
+        }
       }
 
-      val (fullDrops, remainingToDrop) = findSplit(0, n)
-
-      if (fullDrops == byteStringsSize - 1)
-        bytestrings(0).dropRight(remainingToDrop)
-      else if (remainingToDrop == 0)
-        new ByteStrings(bytestrings.dropRight(fullDrops), length - n)
-      else
-        new ByteStrings(bytestrings.dropRight(fullDrops + 1) :+ bytestrings(byteStringsSize - fullDrops - 1).dropRight1(remainingToDrop), length - n)
+      dropRightWithFullDropsAndRemainig(0, n)
     }
 
     override def slice(from: Int, until: Int): ByteString =

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_dropRight_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_dropRight_Benchmark.scala
@@ -49,32 +49,22 @@ class ByteString_dropRight_Benchmark {
    */
 
   @Benchmark
-  def bss_negative(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.dropRight(n_neg)
-  }
+  def bss_negative(): ByteString =
+    bss.dropRight(n_neg)
 
   @Benchmark
-  def bss_greater_or_eq_to_len(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.dropRight(n_greater_or_eq_to_len)
-  }
+  def bss_greater_or_eq_to_len(): ByteString =
+    bss.dropRight(n_greater_or_eq_to_len)
 
   @Benchmark
-  def bss_avg(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.dropRight(n_avg)
-  }
+  def bss_avg(): ByteString =
+    bss.dropRight(n_avg)
 
   @Benchmark
-  def bss_best(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.dropRight(n_best)
-  }
+  def bss_best(): ByteString =
+    bss.dropRight(n_best)
 
   @Benchmark
-  def bss_worst(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.dropRight(n_worst)
-  }
+  def bss_worst(): ByteString =
+    bss.dropRight(n_worst)
 }

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_dropRight_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_dropRight_Benchmark.scala
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2014-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import akka.util.ByteString.{ ByteString1, ByteStrings }
+import org.openjdk.jmh.annotations._
+
+import scala.util.Random
+
+@State(Scope.Benchmark)
+@Measurement(timeUnit = TimeUnit.MILLISECONDS)
+class ByteString_dropRight_Benchmark {
+
+  val str = List.fill[Byte](4)(0).mkString
+  val numVec = 1024
+  val bss = ByteStrings(Vector.fill(numVec)(ByteString1.fromString(str)))
+
+  val rand = new Random()
+  val len = str.size * numVec
+  val n_greater_or_eq_to_len = len + rand.nextInt(Int.MaxValue - len)
+  val n_neg = rand.nextInt(Int.MaxValue) * -1
+  val n_avg = len / 2
+  val n_best = 1
+  val n_worst = len - 1
+
+  /*
+   --------------------------------- BASELINE -----------------------------------------------------------------------
+   commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
+   [info] Benchmark                                                 Mode  Cnt           Score          Error  Units
+   [info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40       25626.311 ±     1395.662  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40     8667558.031 ±   200233.008  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40       12658.684 ±      376.730  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  1214680926.895 ± 10661843.507  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40       13087.245 ±      246.911  ops/s
+
+   --------------------------------- AFTER --------------------------------------------------------------------------
+
+   ------ TODAY –––––––
+   [info] Benchmark                                                 Mode  Cnt           Score         Error  Units
+   [info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40      528969.025 ±    6039.001  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40     7925951.396 ±  249279.950  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40   893475724.604 ± 9836471.105  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  1182275022.613 ± 9710755.955  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40      244599.957 ±    3276.140  ops/s
+
+   */
+
+  @Benchmark
+  def bss_negative(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.dropRight(n_neg)
+  }
+
+  @Benchmark
+  def bss_greater_or_eq_to_len(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.dropRight(n_greater_or_eq_to_len)
+  }
+
+  @Benchmark
+  def bss_avg(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.dropRight(n_avg)
+  }
+
+  @Benchmark
+  def bss_best(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.dropRight(n_best)
+  }
+
+  @Benchmark
+  def bss_worst(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.dropRight(n_worst)
+  }
+}


### PR DESCRIPTION
Currently, we recursively call `dropRight(...)` and obtain the rest of `bytestrings` by calling `Vector#init`, which would not be quite efficient.

Instead of doing this, we can do as follows so that we can achieve better performance:
1. Seek the index of _last_ vector element we need to _dropRight_
2. Find the number of characters left to _dropRight_ from the _last_ ByteString1 element.
3. Create `ByteString` based on the information we obtained from 1 and 2

Then we just need to create a new `Vector[ByteString1]` at most twice, which should be better than the current implementation, i.e., create the rest `bytestrings` every time we check `bytestrings(Vector[ByteString1])` element, which ends up O(N) _init_ execution where _N_ is the length of `bytestrings`.
### Benchmark

I measured the performance using sbt-jmh with this [code](https://gist.github.com/monkey-mas/684ec6a5e2a0ce42f28417dcd53c9636).  Benchmark code was executed with some parameters such as `-t1 -f2 -wi 10 -i 20`.
#### Test environment

```
OS: Ubuntu 14.0.4 (Linux kernel version 3.13.0-95-generic)
CPU: Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz
VM version: JDK 1.8.0_77
```
#### Before

```
Benchmark                                  Mode  Cnt           Score         Error  Units
DropRight.dropRight_avg                   thrpt   40       26184.435 ±     403.058  ops/s
DropRight.dropRight_best                  thrpt   40     8707856.806 ±   50699.447  ops/s
DropRight.dropRight_greater_or_eq_to_len  thrpt   40       12289.742 ±     149.310  ops/s
DropRight.dropRight_negative              thrpt   40  1191630555.447 ± 5225134.083  ops/s
DropRight.dropRight_worst                 thrpt   40       12329.187 ±     283.525  ops/s
```
#### After

```
DropRight.dropRight_avg                   thrpt   40      630595.880 ±     3895.122  ops/s
DropRight.dropRight_best                  thrpt   40     7608841.379 ±   264211.274  ops/s
DropRight.dropRight_greater_or_eq_to_len  thrpt   40   877987542.956 ± 12697839.317  ops/s
DropRight.dropRight_negative              thrpt   40  1125036409.900 ± 17180858.452  ops/s
DropRight.dropRight_worst                 thrpt   40      224135.469 ±     4563.056  ops/s
```
