### PR TITLE
rewrite TestStage to use thread-safe shared state, #21431

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
@@ -366,17 +366,10 @@ abstract class SurviveNetworkInstabilitySpec
       }
 
       runOn(side2: _*) {
-        if (RARP(system).provider.remoteSettings.Artery.Enabled) {
-          // with artery the other side stays quarantined
-          val expected = (side2 map address).toSet
-          clusterView.members.map(_.address) should ===(expected)
-
-        } else {
-          // with the old remoting side2 comes back but stays unreachable
-          val expected = ((side2 ++ side1) map address).toSet
-          clusterView.members.map(_.address) should ===(expected)
-          assertUnreachable(side1: _*)
-        }
+        // side2 comes back but stays unreachable
+        val expected = ((side2 ++ side1) map address).toSet
+        clusterView.members.map(_.address) should ===(expected)
+        assertUnreachable(side1: _*)
       }
 
       enterBarrier("after-7")

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -623,10 +623,12 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
             }
 
           case Quarantined(from, to) if to == localAddress ⇒
+            // Don't quarantine the other system here, since that will result cluster member removal
+            // and can result in forming two separate clusters (cluster split).
+            // Instead, the downing strategy should act on ThisActorSystemQuarantinedEvent, e.g.
+            // use it as a STONITH signal.
             val lifecycleEvent = ThisActorSystemQuarantinedEvent(localAddress.address, from.address)
             publishLifecycleEvent(lifecycleEvent)
-            // quarantine the other system from here
-            association(from.address).quarantine(lifecycleEvent.toString, Some(from.uid))
 
           case _: ActorSystemTerminating ⇒
             inboundEnvelope.sender match {


### PR DESCRIPTION
- The previous approach was based on sending the
  test commands to the active stages themselves and let
  them keep track of the state.
- The problem with that is that Association/OutboundTestStage
  that is created afterwards will not have the right state.
  Similar problems can occur for restarts.
- Instead using thread-safe mutable state that is
  updated directly and used by all test stages.
