### PR TITLE
make cluster.StressSpec pass with Artery, #21458

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -83,12 +83,14 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
 
   private val cachedAddresses = new ConcurrentHashMap[RoleName, Address]
 
-  override def atStartup(): Unit = {
+  override protected def atStartup(): Unit = {
     startCoroner()
     muteLog()
+    self.atStartup()
   }
 
-  override def afterTermination(): Unit = {
+  override protected def afterTermination(): Unit = {
+    self.afterTermination()
     stopCoroner()
   }
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster
+
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.Consumer
+
+import scala.annotation.tailrec
+import scala.util.control.NonFatal
+
+import akka.remote.RemoteSettings
+import akka.remote.artery.ArterySettings
+import akka.remote.artery.TaskRunner
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import com.typesafe.config.ConfigFactory
+import io.aeron.driver.MediaDriver
+import io.aeron.driver.ThreadingMode
+import org.agrona.IoUtil
+
+object SharedMediaDriverSupport {
+
+  private val mediaDriver = new AtomicReference[Option[MediaDriver]](None)
+
+  def loadArterySettings(config: MultiNodeConfig): ArterySettings =
+    (new RemoteSettings(ConfigFactory.load(config.config))).Artery
+
+  def startMediaDriver(config: MultiNodeConfig): Unit = {
+    val arterySettings = loadArterySettings(config)
+    if (arterySettings.Enabled) {
+      val aeronDir = arterySettings.Advanced.AeronDirectoryName
+      require(aeronDir.nonEmpty, "aeron-dir must be defined")
+      val driverContext = new MediaDriver.Context
+      driverContext.aeronDirectoryName(aeronDir)
+      driverContext.clientLivenessTimeoutNs(arterySettings.Advanced.ClientLivenessTimeout.toNanos)
+      driverContext.imageLivenessTimeoutNs(arterySettings.Advanced.ImageLivenessTimeoutNs.toNanos)
+      driverContext.driverTimeoutMs(arterySettings.Advanced.DriverTimeout.toMillis)
+
+      val idleCpuLevel = arterySettings.Advanced.IdleCpuLevel
+      driverContext
+        .threadingMode(ThreadingMode.SHARED)
+        .sharedIdleStrategy(TaskRunner.createIdleStrategy(idleCpuLevel))
+
+      // Check if the media driver is already started by another multi-node jvm.
+      // It checks more than one time with a sleep inbetween. The number of checks
+      // depends on the multi-node index (i).
+      @tailrec def isDriverInactive(i: Int): Boolean = {
+        if (i < 0) true
+        else {
+          val active = driverContext.isDriverActive(5000, new Consumer[String] {
+            override def accept(msg: String): Unit = {
+              println(msg)
+            }
+          })
+          if (active) false
+          else {
+            Thread.sleep(500)
+            isDriverInactive(i - 1)
+          }
+        }
+      }
+
+      try {
+        if (isDriverInactive(MultiNodeSpec.selfIndex)) {
+          val driver = MediaDriver.launchEmbedded(driverContext)
+          println(s"Started media driver in directory [${driver.aeronDirectoryName}]")
+          if (!mediaDriver.compareAndSet(None, Some(driver))) {
+            throw new IllegalStateException("media driver started more than once")
+          }
+        }
+      } catch {
+        case NonFatal(e) ⇒
+          println(s"Failed to start media driver in [${aeronDir}]: ${e.getMessage}")
+      }
+    }
+  }
+
+  def isMediaDriverRunningByThisNode: Boolean = mediaDriver.get.isDefined
+
+  def stopMediaDriver(config: MultiNodeConfig): Unit = {
+    val maybeDriver = mediaDriver.getAndSet(None)
+    maybeDriver.foreach { driver ⇒
+      val arterySettings = loadArterySettings(config)
+
+      // let other nodes shutdown first
+      Thread.sleep(5000)
+
+      driver.close()
+
+      try {
+        if (arterySettings.Advanced.DeleteAeronDirectory) {
+          IoUtil.delete(new File(driver.aeronDirectoryName), false)
+        }
+      } catch {
+        case NonFatal(e) ⇒
+          println(
+            s"Couldn't delete Aeron embedded media driver files in [${driver.aeronDirectoryName}] " +
+              s"due to [${e.getMessage}]")
+      }
+    }
+  }
+
+}

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -97,7 +97,7 @@ abstract class MultiNodeConfig {
     _roles(MultiNodeSpec.selfIndex)
   }
 
-  private[testkit] def config: Config = {
+  private[akka] def config: Config = {
     val transportConfig =
       if (_testTransport) ConfigFactory.parseString(
         """

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -462,7 +462,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       }
 
       val driver = MediaDriver.launchEmbedded(driverContext)
-      log.debug("Started embedded media driver in directory [{}]", driver.aeronDirectoryName)
+      log.info("Started embedded media driver in directory [{}]", driver.aeronDirectoryName)
       topLevelFREvents.loFreq(Transport_MediaDriverStarted, driver.aeronDirectoryName().getBytes("US-ASCII"))
       Runtime.getRuntime.addShutdownHook(stopMediaDriverShutdownHook)
       if (!mediaDriver.compareAndSet(None, Some(driver))) {


### PR DESCRIPTION
- need to use a shared media driver to get the cpu usage
  at a reasonable level
- also changed to SleepingIdleStrategy(1 ms) when cpu-level=1
  not needed for the test to pass, but can be good to make level 1
  more extreme

This is how it looks on my local now when running the StressSpec:
![screen shot 2016-09-14 at 09 48 31](https://cloud.githubusercontent.com/assets/336161/18504347/257bc228-7a62-11e6-8aa6-177941ea012f.png)
