### PR TITLE
stop outbound streams when quarantined, #21407

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -397,6 +397,17 @@ object Logging {
   }
 
   /**
+   * Class name representation of a message.
+   * `ActorSelectionMessage` representation includes class name of
+   * wrapped message.
+   */
+  def messageClassName(message: Any): String = message match {
+    case null                           ⇒ "null"
+    case ActorSelectionMessage(m, _, _) ⇒ s"ActorSelectionMessage(${m.getClass.getName})"
+    case m                              ⇒ m.getClass.getName
+  }
+
+  /**
    * INTERNAL API
    */
   private[akka] object Extension extends ExtensionKey[LogExt]

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 import akka.actor.{ ActorLogging, ActorSelection, Address, Actor, RootActorPath }
 import akka.cluster.ClusterEvent._
 import akka.remote.FailureDetectorRegistry
-import akka.remote.PriorityMessage
+import akka.remote.HeartbeatMessage
 import akka.actor.DeadLetterSuppression
 
 /**
@@ -36,12 +36,12 @@ private[cluster] object ClusterHeartbeatSender {
   /**
    * Sent at regular intervals for failure detection.
    */
-  final case class Heartbeat(from: Address) extends ClusterMessage with PriorityMessage with DeadLetterSuppression
+  final case class Heartbeat(from: Address) extends ClusterMessage with HeartbeatMessage with DeadLetterSuppression
 
   /**
    * Sent as reply to [[Heartbeat]] messages.
    */
-  final case class HeartbeatRsp(from: UniqueAddress) extends ClusterMessage with PriorityMessage with DeadLetterSuppression
+  final case class HeartbeatRsp(from: UniqueAddress) extends ClusterMessage with HeartbeatMessage with DeadLetterSuppression
 
   // sent to self only
   case object HeartbeatTick

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -147,14 +147,6 @@ akka {
       # but must be resolved to ActorRefs first.
       large-message-destinations = []
 
-      # Sets the log granularity level at which Akka logs artery events. This setting
-      # can take the values OFF, ERROR, WARNING, INFO or DEBUG. Please note that the effective
-      # logging level is still determined by the global logging level of the actor system:
-      # for example debug level artery events will be only logged if the system
-      # is running with debug level logging.
-      # Failures to deserialize received messages also fall under this flag.
-      log-lifecycle-events = DEBUG
-
       # If set to a nonempty string artery will use the given dispatcher for
       # its internal actors otherwise the default dispatcher is used.
       use-dispatcher = "akka.remote.default-remote-dispatcher"
@@ -252,23 +244,29 @@ akka {
         # dropped and will trigger quarantine. The value should be longer than the length
         # of a network partition that you need to survive.
         give-up-system-message-after = 6 hours
-
+        
         # during ActorSystem termination the remoting will wait this long for
         # an acknowledgment by the destination system that flushing of outstanding
         # remote messages has been completed
         shutdown-flush-timeout = 1 second
 
-        # Timeout after which the inbound stream is going to be restarted.
+        # See 'inbound-max-restarts'
         inbound-restart-timeout = 5 seconds
 
-        # Max number of restarts for the inbound stream.
+        # Max number of restarts within 'inbound-restart-timeout' for the inbound streams.
+        # If more restarts occurs the ActorSystem will be terminated.
         inbound-max-restarts = 5
 
-        # Timeout after which outbout stream is going to be restarted for every association.
+        # See 'outbound-max-restarts'
         outbound-restart-timeout = 5 seconds
 
-        # Max number of restars of the outbound stream for every association.
+        # Max number of restarts within 'outbound-restart-timeout' for the outbound streams.
+        # If more restarts occurs the ActorSystem will be terminated.
         outbound-max-restarts = 5
+        
+        # Stop outbound stream of a quarantined association after this idle timeout, i.e.
+        # when not used any more.
+        stop-quarantined-after-idle = 3 seconds
 
         # Timeout after which aeron driver has not had keepalive messages
         # from a client before it considers the client dead.

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -31,8 +31,8 @@ private[akka] object RemoteWatcher {
   final case class WatchRemote(watchee: InternalActorRef, watcher: InternalActorRef)
   final case class UnwatchRemote(watchee: InternalActorRef, watcher: InternalActorRef)
 
-  @SerialVersionUID(1L) case object Heartbeat extends PriorityMessage
-  @SerialVersionUID(1L) final case class HeartbeatRsp(addressUid: Int) extends PriorityMessage
+  @SerialVersionUID(1L) case object Heartbeat extends HeartbeatMessage
+  @SerialVersionUID(1L) final case class HeartbeatRsp(addressUid: Int) extends HeartbeatMessage
 
   // sent to self only
   case object HeartbeatTick

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -60,6 +60,11 @@ private[akka] object RARP extends ExtensionId[RARP] with ExtensionIdProvider {
 private[akka] trait PriorityMessage
 
 /**
+ * Failure detector heartbeat messages are marked with this trait.
+ */
+private[akka] trait HeartbeatMessage extends PriorityMessage
+
+/**
  * INTERNAL API
  */
 private[remote] object Remoting {

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -53,10 +53,6 @@ private[akka] final class ArterySettings private (config: Config) {
       val segments = entry.split('/').tail
       tree.insert(segments, NotUsed)
     }
-  val LifecycleEventsLogLevel: LogLevel = Logging.levelFor(toRootLowerCase(getString("log-lifecycle-events"))) match {
-    case Some(level) ⇒ level
-    case None        ⇒ throw new ConfigurationException("Logging level must be one of (off, debug, info, warning, error)")
-  }
   val Dispatcher = getString("use-dispatcher")
 
   object Advanced {
@@ -103,6 +99,8 @@ private[akka] final class ArterySettings private (config: Config) {
     val OutboundRestartTimeout = config.getMillisDuration("outbound-restart-timeout").requiring(interval ⇒
       interval > Duration.Zero, "outbound-restart-timeout must be more than zero")
     val OutboundMaxRestarts = getInt("outbound-max-restarts")
+    val StopQuarantinedAfterIdle = config.getMillisDuration("stop-quarantined-after-idle").requiring(interval ⇒
+      interval > Duration.Zero, "stop-quarantined-after-idle must be more than zero")
     val ClientLivenessTimeout = config.getMillisDuration("client-liveness-timeout").requiring(interval ⇒
       interval > Duration.Zero, "client-liveness-timeout must be more than zero")
     val ImageLivenessTimeoutNs = config.getMillisDuration("image-liveness-timeout").requiring(interval ⇒

--- a/akka-remote/src/main/scala/akka/remote/artery/Control.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Control.scala
@@ -18,6 +18,7 @@ import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
 import akka.remote.UniqueAddress
 import akka.util.OptionVal
+import akka.event.Logging
 
 /** INTERNAL API: marker trait for protobuf-serializable artery messages */
 private[akka] trait ArteryMessage extends Serializable
@@ -206,7 +207,7 @@ private[akka] class OutboundControlJunction(
           buffer.offer(wrap(message))
         else {
           // it's alright to drop control messages
-          log.debug("Dropping control message [{}] due to full buffer.", message.getClass.getName)
+          log.debug("Dropping control message [{}] due to full buffer.", Logging.messageClassName(message))
         }
       }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
@@ -13,6 +13,9 @@ import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
 import akka.remote.UniqueAddress
 import akka.util.OptionVal
+import akka.event.Logging
+import akka.remote.HeartbeatMessage
+import akka.actor.ActorSelectionMessage
 
 /**
  * INTERNAL API
@@ -23,7 +26,9 @@ private[akka] class InboundQuarantineCheck(inboundContext: InboundContext) exten
   override val shape: FlowShape[InboundEnvelope, InboundEnvelope] = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with InHandler with OutHandler {
+    new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
+
+      override protected def logSource = classOf[InboundQuarantineCheck]
 
       // InHandler
       override def onPush(): Unit = {
@@ -34,13 +39,25 @@ private[akka] class InboundQuarantineCheck(inboundContext: InboundContext) exten
             push(out, env)
           case OptionVal.Some(association) ⇒
             if (association.associationState.isQuarantined(env.originUid)) {
-              inboundContext.sendControl(
-                association.remoteAddress,
-                Quarantined(inboundContext.localAddress, UniqueAddress(association.remoteAddress, env.originUid)))
+              if (log.isDebugEnabled)
+                log.debug(
+                  "Dropping message [{}] from [{}#{}] because the system is quarantined",
+                  Logging.messageClassName(env.message), association.remoteAddress, env.originUid)
+              // avoid starting outbound stream for heartbeats
+              if (!env.message.isInstanceOf[Quarantined] && !isHeartbeat(env.message))
+                inboundContext.sendControl(
+                  association.remoteAddress,
+                  Quarantined(inboundContext.localAddress, UniqueAddress(association.remoteAddress, env.originUid)))
               pull(in)
             } else
               push(out, env)
         }
+      }
+
+      private def isHeartbeat(msg: Any): Boolean = msg match {
+        case _: HeartbeatMessage ⇒ true
+        case ActorSelectionMessage(_: HeartbeatMessage, _, _) ⇒ true
+        case _ ⇒ false
       }
 
       // OutHandler

--- a/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
@@ -64,7 +64,9 @@ private[akka] class MessageDispatcher(
               // run the receive logic for ActorSelectionMessage here to make sure it is not stuck on busy user actor
               ActorSelection.deliverSelection(l, sender, sel)
           case msg: PossiblyHarmful if UntrustedMode ⇒
-            log.debug("operating in UntrustedMode, dropping inbound PossiblyHarmful message of type [{}]", msg.getClass.getName)
+            log.debug(
+              "operating in UntrustedMode, dropping inbound PossiblyHarmful message of type [{}]",
+              Logging.messageClassName(msg))
           case msg: SystemMessage ⇒ l.sendSystemMessage(msg)
           case msg                ⇒ l.!(msg)(sender)
         }
@@ -76,7 +78,7 @@ private[akka] class MessageDispatcher(
 
       case r ⇒ log.error(
         "dropping message [{}] for unknown recipient [{}] arriving at [{}] inbound addresses are [{}]",
-        message.getClass, r, recipientAddress, provider.transport.addresses.mkString(", "))
+        Logging.messageClassName(message), r, recipientAddress, provider.transport.addresses.mkString(", "))
 
     }
   }

--- a/akka-remote/src/main/scala/akka/remote/artery/TestStage.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/TestStage.scala
@@ -20,6 +20,7 @@ import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
 import akka.stream.stage.TimerGraphStageLogic
 import akka.util.OptionVal
+import akka.event.Logging
 
 /**
  * INTERNAL API: Thread safe mutable state that is shared among
@@ -98,7 +99,7 @@ private[remote] class OutboundTestStage(outboundContext: OutboundContext, state:
           if (state.isBlackhole(outboundContext.localAddress.address, outboundContext.remoteAddress)) {
             log.debug(
               "dropping outbound message [{}] to [{}] because of blackhole",
-              env.message.getClass.getName, outboundContext.remoteAddress)
+              Logging.messageClassName(env.message), outboundContext.remoteAddress)
             pull(in) // drop message
           } else
             push(out, env)
@@ -144,7 +145,7 @@ private[remote] class InboundTestStage(inboundContext: InboundContext, state: Sh
               if (state.isBlackhole(inboundContext.localAddress.address, association.remoteAddress)) {
                 log.debug(
                   "dropping inbound message [{}] from [{}] with UID [{}] because of blackhole",
-                  env.message.getClass.getName, association.remoteAddress, env.originUid)
+                  Logging.messageClassName(env.message), association.remoteAddress, env.originUid)
                 pull(in) // drop message
               } else
                 push(out, env)


### PR DESCRIPTION
- they can't be stopped immediately because we want to send
  some final message and we reply to inbound messages with `Quarantined`
- and improve logging
