### PR TITLE
fix problem with quick restart, #21512

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
@@ -35,7 +35,7 @@ object SharedMediaDriverSupport {
       val driverContext = new MediaDriver.Context
       driverContext.aeronDirectoryName(aeronDir)
       driverContext.clientLivenessTimeoutNs(arterySettings.Advanced.ClientLivenessTimeout.toNanos)
-      driverContext.imageLivenessTimeoutNs(arterySettings.Advanced.ImageLivenessTimeoutNs.toNanos)
+      driverContext.imageLivenessTimeoutNs(arterySettings.Advanced.ImageLivenessTimeout.toNanos)
       driverContext.driverTimeoutMs(arterySettings.Advanced.DriverTimeout.toMillis)
 
       val idleCpuLevel = arterySettings.Advanced.IdleCpuLevel

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -227,7 +227,8 @@ akka {
         system-message-resend-interval = 1 second
 
         # The timeout for outbound associations to perform the handshake.
-        handshake-timeout = 15 s
+        # This timeout must be greater than the 'image-liveness-timeout'.
+        handshake-timeout = 20 s
 
         # incomplete handshake attempt is retried with this interval
         handshake-retry-interval = 1 second
@@ -274,7 +275,8 @@ akka {
 
         # Timeout for each the INACTIVE and LINGER stages an aeron image
         # will be retained for when it is no longer referenced.
-        image-liveness-timeout = 20 seconds
+        # This timeout must be less than the 'handshake-timeout'.
+        image-liveness-timeout = 10 seconds
 
         # Timeout after which the aeron driver is considered dead
         # if it does not update its C'n'C timestamp.

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -103,8 +103,9 @@ private[akka] final class ArterySettings private (config: Config) {
       interval > Duration.Zero, "stop-quarantined-after-idle must be more than zero")
     val ClientLivenessTimeout = config.getMillisDuration("client-liveness-timeout").requiring(interval ⇒
       interval > Duration.Zero, "client-liveness-timeout must be more than zero")
-    val ImageLivenessTimeoutNs = config.getMillisDuration("image-liveness-timeout").requiring(interval ⇒
+    val ImageLivenessTimeout = config.getMillisDuration("image-liveness-timeout").requiring(interval ⇒
       interval > Duration.Zero, "image-liveness-timeout must be more than zero")
+    require(ImageLivenessTimeout < HandshakeTimeout, "image-liveness-timeout must be less than handshake-timeout")
     val DriverTimeout = config.getMillisDuration("driver-timeout").requiring(interval ⇒
       interval > Duration.Zero, "driver-timeout must be more than zero")
     val FlightRecorderEnabled: Boolean = getBoolean("flight-recorder.enabled")

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -443,7 +443,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
         driverContext.aeronDirectoryName(randomName)
       }
       driverContext.clientLivenessTimeoutNs(settings.Advanced.ClientLivenessTimeout.toNanos)
-      driverContext.imageLivenessTimeoutNs(settings.Advanced.ImageLivenessTimeoutNs.toNanos)
+      driverContext.imageLivenessTimeoutNs(settings.Advanced.ImageLivenessTimeout.toNanos)
       driverContext.driverTimeoutMs(settings.Advanced.DriverTimeout.toMillis)
 
       val idleCpuLevel = settings.Advanced.IdleCpuLevel

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeDenySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeDenySpec.scala
@@ -20,6 +20,7 @@ object HandshakeDenySpec {
        remote.artery.canonical.hostname = localhost
        remote.artery.canonical.port = 0
        remote.artery.advanced.handshake-timeout = 2s
+       remote.artery.advanced.image-liveness-timeout = 1.9s
      }
   """)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
@@ -24,6 +24,7 @@ object HandshakeFailureSpec {
        remote.artery.canonical.hostname = localhost
        remote.artery.canonical.port = 0
        remote.artery.advanced.handshake-timeout = 2s
+       remote.artery.advanced.image-liveness-timeout = 1.9s
      }
   """)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
@@ -23,6 +23,7 @@ object HandshakeRetrySpec {
        remote.artery.canonical.hostname = localhost
        remote.artery.canonical.port = 0
        remote.artery.advanced.handshake-timeout = 10s
+       remote.artery.advanced.image-liveness-timeout = 7s
      }
   """)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
@@ -24,6 +24,7 @@ object LateConnectSpec {
        remote.artery.canonical.hostname = localhost
        remote.artery.canonical.port = 0
        remote.artery.advanced.handshake-timeout = 3s
+       remote.artery.advanced.image-liveness-timeout = 2.9s
      }
   """)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
@@ -31,6 +31,7 @@ object HandshakeShouldDropCompressionTableSpec {
        remote.artery.canonical.hostname = localhost
        remote.artery.canonical.port = 0
        remote.artery.advanced.handshake-timeout = 10s
+       remote.artery.advanced.image-liveness-timeout = 7s
 
        remote.artery.advanced.compression {
          actor-refs {


### PR DESCRIPTION
- image-liveness-timeout must be less than the handshake-timeout,
  otherwise the publication for the handshake will give up too early
  when previous image is still considered alive
