### PR TITLE
fix shutdown race in sendControl, #21514

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -59,6 +59,10 @@ abstract class MultiNodeConfig {
           log-received-messages = on
           log-sent-messages = on
         }
+        akka.remote.artery {
+          log-received-messages = on
+          log-sent-messages = on
+        }
         akka.actor.debug {
           receive = on
           fsm = on

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -426,6 +426,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   private lazy val shutdownHook = new Thread {
     override def run(): Unit = {
       if (hasBeenShutdown.compareAndSet(false, true)) {
+        log.debug("Shutting down [{}] via shutdownHook", localAddress)
         Await.result(internalShutdown(), 20.seconds)
       }
     }


### PR DESCRIPTION
- the stack trace showed IllegalStateException: outboundControlIngress not initialized yet
  via the call to sendControl
- that could happen if there is a shutdown at the same time, which is exactly what the test does
- it was actually caused by a merge mistake, but now it got even better
