### PR TITLE
Testconductor allows more 10s of time to pass to give artery time to shutdown

### DIFF
--- a/akka-multi-node-testkit/src/main/resources/reference.conf
+++ b/akka-multi-node-testkit/src/main/resources/reference.conf
@@ -13,7 +13,7 @@ akka {
     barrier-timeout = 30s
     
     # Timeout for interrogation of TestConductor’s Controller actor
-    query-timeout = 5s
+    query-timeout = 10s
     
     # Threshold for packet size in time unit above which the failure injector will
     # split the packet and deliver in smaller portions; do not give value smaller


### PR DESCRIPTION
Refs #21500 

Deleting the Aeron file/directory is what took time.
