### PR TITLE
+str implement "bind completions" flow

### DIFF
--- a/akka-docs/rst/java/stream/stream-composition.rst
+++ b/akka-docs/rst/java/stream/stream-composition.rst
@@ -51,6 +51,13 @@ One interesting example above is a :class:`Flow` which is composed of a disconne
 This can be achieved by using the ``fromSinkAndSource()`` constructor method on :class:`Flow` which takes the two parts as
 parameters.
 
+Please note that when combining a :class:`Flow` using that method, the termination signals are not carried 
+"through" as the :class:`Sink` and :class:`Source` are assumed to be fully independent. If however you want to construct
+a :class:`Flow` like this but need the termination events to trigger "the other side" of the composite flow, you can use
+``CoupledTerminationFlow.fromSinkAndSource`` which does just that. For example the cancelation of the composite flows 
+source-side will then lead to completion of its sink-side. Read :class:`CoupledTerminationFlow`'s scaladoc for a 
+detailed explanation how this works.
+
 The example :class:`BidiFlow` demonstrates that internally a module can be of arbitrary complexity, and the exposed
 ports can be wired in flexible ways. The only constraint is that all the ports of enclosed modules must be either
 connected to each other, or exposed as interface ports, and the number of such ports needs to match the requirement

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -859,6 +859,47 @@ number of times. Each time a failure is fed into the partial function and a new 
 
 **completes** when upstream completes or upstream failed with exception provided partial function can handle
 
+Flow stages composed of Sinks and Sources
+-----------------------------------------
+
+Flow.fromSinkAndSource
+^^^^^^^^^^^^^^^^^^^^^^
+
+Creates a ``Flow`` from a ``Sink`` and a ``Source`` where the Flow's input will be sent to the ``Sink`` 
+and the ``Flow`` 's output will come from the Source.
+
+Note that termination events, like completion and cancelation is not automatically propagated through to the "other-side"
+of the such-composed Flow. Use ``CoupledTerminationFlow`` if you want to couple termination of both of the ends,
+for example most useful in handling websocket connections.
+
+CoupledTerminationFlow.fromSinkAndSource
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Allows coupling termination (cancellation, completion, erroring) of Sinks and Sources while creating a Flow them them.
+Similar to ``Flow.fromSinkAndSource`` however that API does not connect the completion signals of the wrapped stages.
+
+Similar to ``Flow.fromSinkAndSource`` however couples the termination of these two stages.
+
+E.g. if the emitted ``Flow`` gets a cancellation, the ``Source`` of course is cancelled,
+however the Sink will also be completed. The table below illustrates the effects in detail:
+
++-------------------------------------------------+-----------------------------+---------------------------------+
+| Returned Flow                                   | Sink (in)                   | Source (out)                    |
++=================================================+=============================+=================================+
+| cause: upstream (sink-side) receives completion | effect: receives completion | effect: receives cancel         | 
++-------------------------------------------------+-----------------------------+---------------------------------+
+| cause: upstream (sink-side) receives error      | effect: receives error      | effect: receives cancel         |
++-------------------------------------------------+-----------------------------+---------------------------------+
+| cause: downstream (source-side) receives cancel | effect: completes           | effect: receives cancel         |
++-------------------------------------------------+-----------------------------+---------------------------------+
+| effect: cancels upstream, completes downstream  | effect: completes           | cause: signals complete         |
++-------------------------------------------------+-----------------------------+---------------------------------+
+| effect: cancels upstream, errors downstream     | effect: receives error      | cause: signals error or throws  |
++-------------------------------------------------+-----------------------------+---------------------------------+
+| effect: cancels upstream, completes downstream  | cause: cancels              | effect: receives cancel         |
++=================================================+=============================+=================================+
+
+The order in which the `in` and `out` sides receive their respective completion signals is not defined, do not rely on its ordering.
 
 Asynchronous processing stages
 ------------------------------

--- a/akka-docs/rst/scala/stream/stream-composition.rst
+++ b/akka-docs/rst/scala/stream/stream-composition.rst
@@ -49,7 +49,14 @@ hiding them behind a *shape* that looks like a :class:`Source`, :class:`Flow`, e
 
 One interesting example above is a :class:`Flow` which is composed of a disconnected :class:`Sink` and :class:`Source`.
 This can be achieved by using the ``fromSinkAndSource()`` constructor method on :class:`Flow` which takes the two parts as
-parameters.
+parameters. 
+
+Please note that when combining a :class:`Flow` using that method, the termination signals are not carried 
+"through" as the :class:`Sink` and :class:`Source` are assumed to be fully independent. If however you want to construct
+a :class:`Flow` like this but need the termination events to trigger "the other side" of the composite flow, you can use
+``CoupledTerminationFlow.fromSinkAndSource`` which does just that. For example the cancelation of the composite flows 
+source-side will then lead to completion of its sink-side. Read :class:`CoupledTerminationFlow`'s scaladoc for a 
+detailed explanation how this works.
 
 The example :class:`BidiFlow` demonstrates that internally a module can be of arbitrary complexity, and the exposed
 ports can be wired in flexible ways. The only constraint is that all the ports of enclosed modules must be either

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CoupledTerminationFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CoupledTerminationFlowSpec.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import akka.{ Done, NotUsed }
+import akka.stream._
+import akka.stream.testkit._
+import akka.testkit.TestProbe
+import org.reactivestreams.{ Publisher, Subscriber, Subscription }
+import org.scalatest.Assertion
+
+import scala.util.{ Failure, Success, Try }
+import scala.xml.Node
+
+class CoupledTerminationFlowSpec extends StreamSpec with ScriptedTest {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val materializer = ActorMaterializer(settings)
+  import system.dispatcher
+
+  /**
+   * The table of effects is exactly the same one as in the scaladoc of the class,
+   * so we're able to directly copy that table to check we wrote correct docs.
+   */
+  val effectsTable =
+    <table>
+      <tr>
+        <td>flow <i>cause:</i> upstream (sink-side) receives completion</td>
+        <td>sink <i>effect:</i> receives completion</td>
+        <td>source <i>effect:</i> receives cancel</td>
+      </tr>
+      <tr>
+        <td>flow <i>cause:</i> upstream (sink-side) receives error</td>
+        <td>sink <i>effect:</i> receives error</td>
+        <td>source <i>effect:</i> receives cancel</td>
+      </tr>
+      <tr>
+        <td>flow <i>cause:</i> downstream (source-side) receives cancel</td>
+        <td>sink <i>effect:</i> completes</td>
+        <td>source <i>effect:</i> receives cancel</td>
+      </tr>
+      <tr>
+        <td>flow <i>effect:</i> cancels upstream, completes downstream</td>
+        <td>sink <i>effect:</i> completes</td>
+        <td>source <i>cause:</i> signals complete</td>
+      </tr>
+      <tr>
+        <td>flow <i>effect:</i> cancels upstream, errors downstream</td>
+        <td>sink <i>effect:</i> receives error</td>
+        <td>source <i>cause:</i> signals error or throws</td>
+      </tr>
+      <tr>
+        <td>flow <i>effect:</i> cancels upstream, completes downstream</td>
+        <td>sink <i>cause:</i> cancels</td>
+        <td>source <i>effect:</i> receives cancel</td>
+      </tr>
+    </table>
+
+  "Completion" must {
+    (effectsTable \ "tr").foreach { testCase ⇒
+      val rules = testCase \\ "td"
+      val outerRule = rules.head.toString()
+      val innerSinkRule = rules.drop(1).head.toString()
+      val innerSourceRule = rules.drop(2).head.toString()
+
+      s"test interpreter: ${testName(testCase)}" in {
+
+        val (outerSource, outerSink, outerAssertions) = interpretOuter(outerRule)
+        val (innerSink, innerSinkAssertion) = interpretInnerSink(innerSinkRule)
+        val (innerSource, innerSourceAssertion) = interpretInnerSource(innerSourceRule)
+
+        val flow = CoupledTerminationFlow.fromSinkAndSource(innerSink, innerSource)
+        outerSource.via(flow).to(outerSink).run()
+
+        outerAssertions()
+        innerSinkAssertion()
+        innerSourceAssertion()
+      }
+    }
+
+    "completed out:Source => complete in:Sink" in {
+      val probe = TestProbe()
+      val f = CoupledTerminationFlow.fromSinkAndSource(
+        Sink.onComplete(d ⇒ probe.ref ! "done"),
+        Source.empty) // completes right away, should complete the sink as well
+
+      f.runWith(Source.maybe, Sink.ignore) // these do nothing.
+
+      probe.expectMsg("done")
+    }
+
+    "cancel in:Sink => cancel out:Source" in {
+      val probe = TestProbe()
+      val f = CoupledTerminationFlow.fromSinkAndSource(
+        Sink.cancelled,
+        Source.fromPublisher(new Publisher[String] {
+          override def subscribe(subscriber: Subscriber[_ >: String]): Unit = {
+            subscriber.onSubscribe(new Subscription {
+              override def cancel(): Unit = probe.ref ! "cancelled"
+
+              override def request(l: Long): Unit = () // do nothing
+            })
+          }
+        })) // completes right away, should complete the sink as well
+
+      f.runWith(Source.maybe, Sink.ignore) // these do nothing.
+
+      probe.expectMsg("cancelled")
+    }
+
+    "error wrapped Sink when wrapped Source errors " in {
+      val probe = TestProbe()
+      val f = CoupledTerminationFlow.fromSinkAndSource(
+        Sink.onComplete(e ⇒ probe.ref ! e.failed.get.getMessage),
+        Source.failed(new Exception("BOOM!"))) // completes right away, should complete the sink as well
+
+      f.runWith(Source.maybe, Sink.ignore) // these do nothing.
+
+      probe.expectMsg("BOOM!")
+    }
+
+  }
+
+  def interpretOuter(rule: String): (Source[String, NotUsed], Sink[String, NotUsed], () ⇒ Any) = {
+    val probe = TestProbe()
+    val causeUpstreamCompletes = Source.empty[String]
+    val causeUpstreamErrors = Source.failed(new Exception("Boom"))
+    val causeDownstreamCancels = Sink.cancelled[String]
+
+    val downstreamEffect = Sink.onComplete(s ⇒ probe.ref ! s)
+    val upstreamEffect = Source.fromPublisher(new Publisher[String] {
+      override def subscribe(s: Subscriber[_ >: String]): Unit = s.onSubscribe(new Subscription {
+        override def cancel(): Unit = probe.ref ! "cancel-received"
+
+        override def request(n: Long): Unit = ()
+      })
+    })
+    val assertCancel = () ⇒ {
+      val m = probe.expectMsgType[String]
+      m should ===("cancel-received")
+    }
+    val assertComplete = () ⇒ {
+      val m = probe.expectMsgType[Try[Done]]
+      m.isFailure should ===(false)
+    }
+    val assertCompleteAndCancel = () ⇒ {
+      probe.expectMsgPF() {
+        case Success(v)        ⇒ // good 
+        case "cancel-received" ⇒ // good 
+      }
+      probe.expectMsgPF() {
+        case Success(v)        ⇒ // good 
+        case "cancel-received" ⇒ // good 
+      }
+    }
+    val assertError = () ⇒ {
+      val m = probe.expectMsgType[Try[Done]]
+      m.isFailure should ===(true)
+      m.failed.get.getMessage should include("Boom")
+    }
+    val assertErrorAndCancel = () ⇒ {
+      probe.expectMsgPF() {
+        case Failure(ex)       ⇒ // good 
+        case "cancel-received" ⇒ // good 
+      }
+      probe.expectMsgPF() {
+        case Failure(ex)       ⇒ // good 
+        case "cancel-received" ⇒ // good 
+      }
+    }
+
+    if (rule contains "cause") {
+      if (rule.contains("upstream") && (rule.contains("completion") || rule.contains("complete")))
+        (causeUpstreamCompletes, downstreamEffect, assertComplete)
+      else if (rule.contains("upstream") && rule.contains("error"))
+        (causeUpstreamErrors, downstreamEffect, assertError)
+      else if (rule.contains("downstream") && rule.contains("cancel"))
+        (upstreamEffect, causeDownstreamCancels, assertCancel)
+      else
+        throw UnableToInterpretRule(rule)
+    } else if (rule contains "effect") {
+      if (rule.contains("cancel") && rule.contains("complete"))
+        (upstreamEffect, downstreamEffect, assertCompleteAndCancel)
+      else if (rule.contains("cancel") && rule.contains("error"))
+        (upstreamEffect, downstreamEffect, assertErrorAndCancel)
+      else throw UnableToInterpretRule(rule)
+    } else throw UnableToInterpretRule(rule)
+  }
+
+  def interpretInnerSink(rule: String): (Sink[String, NotUsed], () ⇒ Assertion) = {
+    val probe = TestProbe()
+    val causeCancel = Sink.cancelled[String]
+
+    val catchEffect = Sink.onComplete(s ⇒ probe.ref ! s)
+    val assertComplete = () ⇒ {
+      val m = probe.expectMsgType[Try[Done]]
+      m.isFailure should ===(false)
+    }
+    val assertError = () ⇒ {
+      val m = probe.expectMsgType[Try[Done]]
+      m.isFailure should ===(true)
+      m.failed.get.getMessage should include("Boom")
+    }
+    val assertionOK = () ⇒ 1 should ===(1)
+
+    if (rule contains "cause") {
+      if (rule.contains("cancels")) (causeCancel, assertionOK)
+      else throw UnableToInterpretRule(rule)
+    } else if (rule contains "effect") {
+      if (rule.contains("complete") || rule.contains("completion")) (catchEffect, assertComplete)
+      else if (rule.contains("error")) (catchEffect, assertError)
+      else throw UnableToInterpretRule(rule)
+    } else throw UnableToInterpretRule(rule)
+  }
+
+  def interpretInnerSource(rule: String): (Source[String, NotUsed], () ⇒ Assertion) = {
+    val probe = TestProbe()
+    val causeComplete = Source.empty[String]
+    val causeError = Source.failed(new Exception("Boom"))
+
+    val catchEffect = Source.maybe[String].mapMaterializedValue(p ⇒ {
+      p.future.onComplete(t ⇒ probe.ref ! t)
+      NotUsed
+    })
+    val assertCancel = () ⇒ {
+      val m = probe.expectMsgType[Try[Option[String]]]
+      m.isFailure should ===(false)
+      m.get should ===(None) // downstream cancelled
+    }
+    val assertionOK = () ⇒ 1 should ===(1)
+
+    if (rule contains "cause") {
+      if (rule.contains("complete")) (causeComplete, assertionOK)
+      else if (rule.contains("error")) (causeError, assertionOK)
+      else ???
+    } else if (rule contains "effect") {
+      (catchEffect, assertCancel)
+    } else ???
+  }
+
+  def testName(n: Node): String =
+    n.text.split("\n").drop(1).map(_.trim).filterNot(_.isEmpty).mkString(", ")
+
+  case class UnableToInterpretRule(msg: String) extends AssertionError("Unable to interpret rule: " + msg)
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
@@ -7,7 +7,7 @@ import akka.NotUsed
 import akka.stream._
 import akka.stream.testkit._
 
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 
 class GraphMatValueSpec extends StreamSpec {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/CoupledTerminationFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/CoupledTerminationFlow.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.javadsl
+
+/**
+ * Allows coupling termination (cancellation, completion, erroring) of Sinks and Sources while creating a Flow them them.
+ * Similar to `Flow.fromSinkAndSource` however that API does not connect the completion signals of the wrapped stages.
+ */
+object CoupledTerminationFlow {
+
+  /**
+   * Similar to [[Flow.fromSinkAndSource]] however couples the termination of these two stages.
+   *
+   * E.g. if the emitted [[Flow]] gets a cancellation, the [[Source]] of course is cancelled,
+   * however the Sink will also be completed. The table below illustrates the effects in detail:
+   *
+   * <table>
+   *   <tr>
+   *     <th>Returned Flow</th>
+   *     <th>Sink (<code>in</code>)</th>
+   *     <th>Source (<code>out</code>)</th>
+   *   </tr>
+   *   <tr>
+   *     <td><i>cause:</i> upstream (sink-side) receives completion</td>
+   *     <td><i>effect:</i> receives completion</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>cause:</i> upstream (sink-side) receives error</td>
+   *     <td><i>effect:</i> receives error</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>cause:</i> downstream (source-side) receives cancel</td>
+   *     <td><i>effect:</i> completes</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>effect:</i> cancels upstream, completes downstream</td>
+   *     <td><i>effect:</i> completes</td>
+   *     <td><i>cause:</i> signals complete</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>effect:</i> cancels upstream, errors downstream</td>
+   *     <td><i>effect:</i> receives error</td>
+   *     <td><i>cause:</i> signals error or throws</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>effect:</i> cancels upstream, completes downstream</td>
+   *     <td><i>cause:</i> cancels</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   * </table>
+   *
+   * The order in which the `in` and `out` sides receive their respective completion signals is not defined, do not rely on its ordering.
+   */
+  def fromSinkAndSource[I, O, M1, M2](in: Sink[I, M1], out: Source[O, M2]): Flow[I, O, (M1, M2)] =
+    akka.stream.scaladsl.CoupledTerminationFlow.fromSinkAndSource(in.asScala, out.asScala).asJava
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/CoupledTerminationFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/CoupledTerminationFlow.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream._
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+
+/**
+ * Allows coupling termination (cancellation, completion, erroring) of Sinks and Sources while creating a Flow them them.
+ * Similar to `Flow.fromSinkAndSource` however that API does not connect the completion signals of the wrapped stages.
+ */
+object CoupledTerminationFlow {
+
+  /**
+   * Similar to [[Flow.fromSinkAndSource]] however couples the termination of these two stages.
+   *
+   * E.g. if the emitted [[Flow]] gets a cancellation, the [[Source]] of course is cancelled,
+   * however the Sink will also be completed. The table below illustrates the effects in detail:
+   *
+   * <table>
+   *   <tr>
+   *     <th>Returned Flow</th>
+   *     <th>Sink (<code>in</code>)</th>
+   *     <th>Source (<code>out</code>)</th>
+   *   </tr>
+   *   <tr>
+   *     <td><i>cause:</i> upstream (sink-side) receives completion</td>
+   *     <td><i>effect:</i> receives completion</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>cause:</i> upstream (sink-side) receives error</td>
+   *     <td><i>effect:</i> receives error</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>cause:</i> downstream (source-side) receives cancel</td>
+   *     <td><i>effect:</i> completes</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>effect:</i> cancels upstream, completes downstream</td>
+   *     <td><i>effect:</i> completes</td>
+   *     <td><i>cause:</i> signals complete</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>effect:</i> cancels upstream, errors downstream</td>
+   *     <td><i>effect:</i> receives error</td>
+   *     <td><i>cause:</i> signals error or throws</td>
+   *   </tr>
+   *   <tr>
+   *     <td><i>effect:</i> cancels upstream, completes downstream</td>
+   *     <td><i>cause:</i> cancels</td>
+   *     <td><i>effect:</i> receives cancel</td>
+   *   </tr>
+   * </table>
+   *
+   * The order in which the `in` and `out` sides receive their respective completion signals is not defined, do not rely on its ordering.
+   */
+  def fromSinkAndSource[I, O, M1, M2](in: Sink[I, M1], out: Source[O, M2]): Flow[I, O, (M1, M2)] =
+      // format: OFF
+      Flow.fromGraph(GraphDSL.create(in, out)(Keep.both) { implicit b => (i, o) =>
+        import GraphDSL.Implicits._
+        val bidi = b.add(new CoupledTerminationBidi[I, O])
+        /* bidi.in1 ~> */ bidi.out1 ~> i; o ~> bidi.in2 /* ~> bidi.out2 */
+        FlowShape(bidi.in1, bidi.out2)
+      })
+  // format: ON
+
+}
+
+/** INTERNAL API */
+private[stream] class CoupledTerminationBidi[I, O] extends GraphStage[BidiShape[I, I, O, O]] {
+  val in1: Inlet[I] = Inlet("CoupledCompletion.in1")
+  val out1: Outlet[I] = Outlet("CoupledCompletion.out1")
+  val in2: Inlet[O] = Inlet("CoupledCompletion.in2")
+  val out2: Outlet[O] = Outlet("CoupledCompletion.out2")
+  override val shape: BidiShape[I, I, O, O] = BidiShape(in1, out1, in2, out2)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    val handler1 = new InHandler with OutHandler {
+      override def onPush(): Unit = push(out1, grab(in1))
+      override def onPull(): Unit = pull(in1)
+
+      override def onDownstreamFinish(): Unit = completeStage()
+      override def onUpstreamFinish(): Unit = completeStage()
+      override def onUpstreamFailure(ex: Throwable): Unit = failStage(ex)
+    }
+
+    val handler2 = new InHandler with OutHandler {
+      override def onPush(): Unit = push(out2, grab(in2))
+      override def onPull(): Unit = pull(in2)
+
+      override def onDownstreamFinish(): Unit = completeStage()
+      override def onUpstreamFinish(): Unit = completeStage()
+      override def onUpstreamFailure(ex: Throwable): Unit = failStage(ex)
+    }
+
+    setHandlers(in1, out1, handler1)
+    setHandlers(in2, out2, handler2)
+  }
+}


### PR DESCRIPTION
Implements basic version of #21549.

Pending:
- decide where to put it. I like the naming of BindCompletion.inSomeDescriptiveWay
- adding docs

Implements just the basic one that forwards errors/completion/cancellation "all the way",
should already be useful for users who implement websockets using `Flow.fromSinkAndSource`
