### PR TITLE
#20872 Change tableVersion to Byte

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -13,11 +13,10 @@ import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.annotation.tailrec
-import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
+import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
-import scala.util.Try
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 import akka.Done
@@ -32,7 +31,6 @@ import akka.remote.AddressUidExtension
 import akka.remote.RemoteActorRef
 import akka.remote.RemoteActorRefProvider
 import akka.remote.RemoteTransport
-import akka.remote.RemotingLifecycleEvent
 import akka.remote.ThisActorSystemQuarantinedEvent
 import akka.remote.UniqueAddress
 import akka.remote.artery.ArteryTransport.ShuttingDown
@@ -48,7 +46,6 @@ import akka.remote.transport.ThrottlerTransportAdapter.Blackhole
 import akka.remote.transport.ThrottlerTransportAdapter.SetThrottle
 import akka.remote.transport.ThrottlerTransportAdapter.Unthrottled
 import akka.stream.AbruptTerminationException
-import akka.stream.ActorAttributes.Dispatcher
 import akka.stream.ActorMaterializer
 import akka.stream.KillSwitches
 import akka.stream.Materializer

--- a/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/BufferPool.scala
@@ -120,8 +120,8 @@ private[remote] sealed trait HeaderBuilder {
   def flag(byteFlag: ByteFlag): Boolean
   def setFlag(byteFlag: ByteFlag, value: Boolean): Unit
 
-  def inboundActorRefCompressionTableVersion: Int
-  def inboundClassManifestCompressionTableVersion: Int
+  def inboundActorRefCompressionTableVersion: Byte
+  def inboundClassManifestCompressionTableVersion: Byte
 
   def useOutboundCompression(on: Boolean): Unit
 
@@ -214,8 +214,8 @@ private[remote] final class HeaderBuilderImpl(
   var _version: Byte = 0
   var _flags: Byte = 0
   var _uid: Long = 0
-  var _inboundActorRefCompressionTableVersion: Int = 0
-  var _inboundClassManifestCompressionTableVersion: Int = 0
+  var _inboundActorRefCompressionTableVersion: Byte = 0
+  var _inboundClassManifestCompressionTableVersion: Byte = 0
   var _useOutboundCompression: Boolean = true
 
   var _senderActorRef: String = null
@@ -254,8 +254,8 @@ private[remote] final class HeaderBuilderImpl(
   override def setUid(uid: Long) = _uid = uid
   override def uid: Long = _uid
 
-  override def inboundActorRefCompressionTableVersion: Int = _inboundActorRefCompressionTableVersion
-  override def inboundClassManifestCompressionTableVersion: Int = _inboundClassManifestCompressionTableVersion
+  override def inboundActorRefCompressionTableVersion: Byte = _inboundActorRefCompressionTableVersion
+  override def inboundClassManifestCompressionTableVersion: Byte = _inboundClassManifestCompressionTableVersion
 
   def useOutboundCompression(on: Boolean): Unit =
     _useOutboundCompression = on
@@ -442,11 +442,11 @@ private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
     // compression table versions (stored in the Tag)
     val refCompressionVersionTag = byteBuffer.getInt(ActorRefCompressionTableVersionTagOffset)
     if ((refCompressionVersionTag & TagTypeMask) != 0) {
-      header._inboundActorRefCompressionTableVersion = refCompressionVersionTag & TagValueMask
+      header._inboundActorRefCompressionTableVersion = (refCompressionVersionTag & TagValueMask).byteValue
     }
     val manifestCompressionVersionTag = byteBuffer.getInt(ClassManifestCompressionTableVersionTagOffset)
     if ((manifestCompressionVersionTag & TagTypeMask) != 0) {
-      header._inboundClassManifestCompressionTableVersion = manifestCompressionVersionTag & TagValueMask
+      header._inboundClassManifestCompressionTableVersion = (manifestCompressionVersionTag & TagValueMask).byteValue
     }
 
     if (header.flag(MetadataPresentFlag)) {

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionProtocol.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionProtocol.scala
@@ -4,7 +4,6 @@
 
 package akka.remote.artery.compress
 
-import scala.language.existentials
 import akka.actor.ActorRef
 import akka.remote.UniqueAddress
 import akka.remote.artery.ControlMessage
@@ -36,7 +35,7 @@ object CompressionProtocol {
    * but we need separate ack in case the sender is not using any of the refs in the advertised
    * table.
    */
-  private[remote] final case class ActorRefCompressionAdvertisementAck(from: UniqueAddress, tableVersion: Int)
+  private[remote] final case class ActorRefCompressionAdvertisementAck(from: UniqueAddress, tableVersion: Byte)
     extends ControlMessage with CompressionMessage
 
   /**
@@ -53,7 +52,7 @@ object CompressionProtocol {
    * but we need separate ack in case the sender is not using any of the refs in the advertised
    * table.
    */
-  private[remote] final case class ClassManifestCompressionAdvertisementAck(from: UniqueAddress, tableVersion: Int)
+  private[remote] final case class ClassManifestCompressionAdvertisementAck(from: UniqueAddress, tableVersion: Byte)
     extends ControlMessage with CompressionMessage
 
   /** INTERNAL API */

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionTable.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionTable.scala
@@ -8,7 +8,7 @@ import java.util
 import java.util.Comparator
 
 /** INTERNAL API: Versioned compression table to be advertised between systems */
-private[remote] final case class CompressionTable[T](originUid: Long, version: Int, dictionary: Map[T, Int]) {
+private[remote] final case class CompressionTable[T](originUid: Long, version: Byte, dictionary: Map[T, Int]) {
   import CompressionTable.NotCompressedId
 
   def compress(value: T): Int =

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/DecompressionTable.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/DecompressionTable.scala
@@ -5,8 +5,8 @@
 package akka.remote.artery.compress
 
 /** INTERNAL API */
-private[artery] final case class DecompressionTable[T](originUid: Long, version: Int, table: Array[T]) {
-  // TODO version maybe better as Long? // OR implement roll-over
+private[artery] final case class DecompressionTable[T](originUid: Long, version: Byte, table: Array[T]) {
+
   private[this] val length = table.length
 
   def get(idx: Int): T = {

--- a/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
@@ -143,7 +143,7 @@ private[akka] final class ArteryMessageSerializer(val system: ExtendedActorSyste
       protoAdv.getKeysList.asScala.map(keyDeserializer).zip(
         protoAdv.getValuesList.asScala.asInstanceOf[Iterable[Int]] /* to avoid having to call toInt explicitly */ )
 
-    val table = CompressionTable(protoAdv.getOriginUid, protoAdv.getTableVersion, kvs.toMap)
+    val table = CompressionTable(protoAdv.getOriginUid, protoAdv.getTableVersion.byteValue, kvs.toMap)
     create(deserializeUniqueAddress(protoAdv.getFrom), table)
   }
 
@@ -153,9 +153,9 @@ private[akka] final class ArteryMessageSerializer(val system: ExtendedActorSyste
       .setVersion(version)
       .build()
 
-  def deserializeCompressionTableAdvertisementAck(bytes: Array[Byte], create: (UniqueAddress, Int) ⇒ AnyRef): AnyRef = {
+  def deserializeCompressionTableAdvertisementAck(bytes: Array[Byte], create: (UniqueAddress, Byte) ⇒ AnyRef): AnyRef = {
     val msg = ArteryControlFormats.CompressionTableAdvertisementAck.parseFrom(bytes)
-    create(deserializeUniqueAddress(msg.getFrom), msg.getVersion)
+    create(deserializeUniqueAddress(msg.getFrom), msg.getVersion.toByte)
   }
 
   def serializeSystemMessageEnvelope(env: SystemMessageDelivery.SystemMessageEnvelope): ArteryControlFormats.SystemMessageEnvelope = {

--- a/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
@@ -33,19 +33,18 @@ class EnvelopeBufferSpec extends AkkaSpec {
     val idxToManifest = manifestToIdx.map(_.swap)
 
     val outboundActorRefTable: CompressionTable[ActorRef] =
-      CompressionTable(17L, version = 0xCAFE, refToIdx)
+      CompressionTable(17L, version = 0xCA.byteValue, refToIdx)
 
     val outboundClassManifestTable: CompressionTable[String] =
-      CompressionTable(17L, version = 0xBABE, manifestToIdx)
+      CompressionTable(17L, version = 0xBA.byteValue, manifestToIdx)
 
     override def hitActorRef(originUid: Long, remote: Address, ref: ActorRef, n: Int): Unit = ()
-    override def decompressActorRef(originUid: Long, tableVersion: Int, idx: Int): OptionVal[ActorRef] = OptionVal(idxToRef(idx))
-    override def confirmActorRefCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit = ()
+    override def decompressActorRef(originUid: Long, tableVersion: Byte, idx: Int): OptionVal[ActorRef] = OptionVal(idxToRef(idx))
+    override def confirmActorRefCompressionAdvertisement(originUid: Long, tableVersion: Byte): Unit = ()
 
     override def hitClassManifest(originUid: Long, remote: Address, manifest: String, n: Int): Unit = ()
-    override def decompressClassManifest(originUid: Long, tableVersion: Int, idx: Int): OptionVal[String] = OptionVal(idxToManifest(idx))
-    override def confirmClassManifestCompressionAdvertisement(originUid: Long, tableVersion: Int): Unit = ()
-
+    override def decompressClassManifest(originUid: Long, tableVersion: Byte, idx: Int): OptionVal[String] = OptionVal(idxToManifest(idx))
+    override def confirmClassManifestCompressionAdvertisement(originUid: Long, tableVersion: Byte): Unit = ()
     override def close(): Unit = ()
     override def close(originUid: Long): Unit = ()
   }
@@ -79,8 +78,8 @@ class EnvelopeBufferSpec extends AkkaSpec {
 
       headerOut.version should ===(1)
       headerOut.uid should ===(42)
-      headerOut.inboundActorRefCompressionTableVersion should ===(0xCAFE)
-      headerOut.inboundClassManifestCompressionTableVersion should ===(0xBABE)
+      headerOut.inboundActorRefCompressionTableVersion should ===(0xCA.byteValue)
+      headerOut.inboundClassManifestCompressionTableVersion should ===(0xBA.byteValue)
       headerOut.serializer should ===(4)
       headerOut.senderActorRef(originUid).get.path.toSerializationFormat should ===("akka://EnvelopeBufferSpec/compressable0")
       headerOut.senderActorRefPath should ===(OptionVal.None)


### PR DESCRIPTION
Fixes #20872

Wraparounds table version to 1 after 127 to keep value 0 only for the initial table.
