### PR TITLE
complete the Future[Done] in AeronSink in finally, #21538

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/AeronSink.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/AeronSink.scala
@@ -122,12 +122,15 @@ class AeronSink(
       }
 
       override def postStop(): Unit = {
-        taskRunner.command(Remove(addOfferTask.task))
-        flightRecorder.loFreq(AeronSink_TaskRunnerRemoved, channelMetadata)
-        pub.close()
-        flightRecorder.loFreq(AeronSink_PublicationClosed, channelMetadata)
-        completed.complete(completedValue)
-        flightRecorder.loFreq(AeronSink_Stopped, channelMetadata)
+        try {
+          taskRunner.command(Remove(addOfferTask.task))
+          flightRecorder.loFreq(AeronSink_TaskRunnerRemoved, channelMetadata)
+          pub.close()
+          flightRecorder.loFreq(AeronSink_PublicationClosed, channelMetadata)
+        } finally {
+          flightRecorder.loFreq(AeronSink_Stopped, channelMetadata)
+          completed.complete(completedValue)
+        }
       }
 
       // InHandler


### PR DESCRIPTION
- might not be possible to close the publication if the
  media driver has crashed
- important to always complete the future, otherwise the
  shutdown process will not complete
