### PR TITLE
=act implement ByteString#takeRight(...)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -351,6 +351,25 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteString1.fromString("0123456789").take(3).drop(1) should ===(ByteString("12"))
       ByteString1.fromString("0123456789").take(10).take(8).drop(3).take(5) should ===(ByteString("34567"))
     }
+    "takeRight" in {
+      ByteString1.empty.takeRight(-1) should ===(ByteString(""))
+      ByteString1.empty.takeRight(0) should ===(ByteString(""))
+      ByteString1.empty.takeRight(1) should ===(ByteString(""))
+      ByteString1.fromString("a").takeRight(-1) should ===(ByteString(""))
+      ByteString1.fromString("a").takeRight(0) should ===(ByteString(""))
+      ByteString1.fromString("a").takeRight(1) should ===(ByteString("a"))
+      ByteString1.fromString("a").takeRight(2) should ===(ByteString("a"))
+      ByteString1.fromString("abc").takeRight(-1) should ===(ByteString(""))
+      ByteString1.fromString("abc").takeRight(0) should ===(ByteString(""))
+      ByteString1.fromString("abc").takeRight(1) should ===(ByteString("c"))
+      ByteString1.fromString("abc").takeRight(2) should ===(ByteString("bc"))
+      ByteString1.fromString("abc").takeRight(3) should ===(ByteString("abc"))
+      ByteString1.fromString("abc").takeRight(4) should ===(ByteString("abc"))
+      ByteString1.fromString("0123456789").takeRight(5).take(5) should ===(ByteString("56789"))
+      ByteString1.fromString("0123456789").takeRight(5).take(4) should ===(ByteString("5678"))
+      ByteString1.fromString("0123456789").takeRight(5).drop(1) should ===(ByteString("6789"))
+      ByteString1.fromString("0123456789").takeRight(5).drop(4) should ===(ByteString("9"))
+    }
   }
   "ByteString1C" must {
     "drop" in {
@@ -393,6 +412,25 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteString1.fromString("abcdefg").drop(1).take(-2) should ===(ByteString(""))
       ByteString1.fromString("abcdefg").drop(2) should ===(ByteString("cdefg"))
       ByteString1.fromString("abcdefg").drop(2).take(1) should ===(ByteString("c"))
+    }
+    "takeRight" in {
+      ByteString1C.fromString("").takeRight(-1) should ===(ByteString(""))
+      ByteString1C.fromString("").takeRight(0) should ===(ByteString(""))
+      ByteString1C.fromString("").takeRight(1) should ===(ByteString(""))
+      ByteString1C.fromString("a").takeRight(-1) should ===(ByteString(""))
+      ByteString1C.fromString("a").takeRight(0) should ===(ByteString(""))
+      ByteString1C.fromString("a").takeRight(1) should ===(ByteString("a"))
+      ByteString1C.fromString("a").takeRight(2) should ===(ByteString("a"))
+      ByteString1C.fromString("abc").takeRight(-1) should ===(ByteString(""))
+      ByteString1C.fromString("abc").takeRight(0) should ===(ByteString(""))
+      ByteString1C.fromString("abc").takeRight(1) should ===(ByteString("c"))
+      ByteString1C.fromString("abc").takeRight(2) should ===(ByteString("bc"))
+      ByteString1C.fromString("abc").takeRight(3) should ===(ByteString("abc"))
+      ByteString1C.fromString("abc").takeRight(4) should ===(ByteString("abc"))
+      ByteString1C.fromString("0123456789").takeRight(5).take(5) should ===(ByteString("56789"))
+      ByteString1C.fromString("0123456789").takeRight(5).take(4) should ===(ByteString("5678"))
+      ByteString1C.fromString("0123456789").takeRight(5).drop(1) should ===(ByteString("6789"))
+      ByteString1C.fromString("0123456789").takeRight(5).drop(4) should ===(ByteString("9"))
     }
   }
   "ByteStrings" must {
@@ -535,6 +573,49 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).drop(2).take(1) should ===(ByteString("c"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).take(100) should ===(ByteString("abc"))
       ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("bc")).drop(1).take(100) should ===(ByteString("bc"))
+    }
+    "takeRight" in {
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).takeRight(Int.MinValue) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).takeRight(-1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).takeRight(0) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).takeRight(1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).takeRight(Int.MaxValue) should ===(ByteString(""))
+
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).takeRight(Int.MinValue) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).takeRight(-1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).takeRight(0) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).takeRight(1) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).takeRight(2) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString("")).takeRight(Int.MaxValue) should ===(ByteString("a"))
+
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).takeRight(Int.MinValue) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).takeRight(-1) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).takeRight(0) should ===(ByteString(""))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).takeRight(1) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).takeRight(2) should ===(ByteString("a"))
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a")).takeRight(Int.MaxValue) should ===(ByteString("a"))
+
+      val bss = ByteStrings(Vector(
+        ByteString1.fromString("a"),
+        ByteString1.fromString("bc"),
+        ByteString1.fromString("def")))
+
+      bss.takeRight(Int.MinValue) should ===(ByteString(""))
+      bss.takeRight(-1) should ===(ByteString(""))
+      bss.takeRight(0) should ===(ByteString(""))
+      bss.takeRight(1) should ===(ByteString("f"))
+      bss.takeRight(2) should ===(ByteString("ef"))
+      bss.takeRight(3) should ===(ByteString("def"))
+      bss.takeRight(4) should ===(ByteString("cdef"))
+      bss.takeRight(5) should ===(ByteString("bcdef"))
+      bss.takeRight(6) should ===(ByteString("abcdef"))
+      bss.takeRight(7) should ===(ByteString("abcdef"))
+      bss.takeRight(Int.MaxValue) should ===(ByteString("abcdef"))
+
+      ByteString("0123456789").takeRight(5).take(2) should ===(ByteString("56"))
+
+      ByteString("0123456789").takeRight(5).drop(3).take(1) should ===(ByteString("8"))
+      (ByteString1C.fromString("a") ++ ByteString1.fromString("bc")).takeRight(2) should ===(ByteString("bc"))
     }
     "indexOf" in {
       ByteString.empty.indexOf(5) should ===(-1)

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -542,26 +542,27 @@ object ByteString {
     }
 
     override def takeRight(n: Int): ByteString =
-      if (n <= 0) ByteString.empty
-      else if (n >= length) this
-      else takeRight0(n)
+      if (0 < n && n < length) takeRight0(n)
+      else if (n <= 0) ByteString.empty
+      else this
 
     private def takeRight0(n: Int): ByteString = {
       val byteStringsSize = bytestrings.size
-      @tailrec def findSplit(fullTakes: Int, remainingToTake: Int): (Int, Int) = {
+      @tailrec def takeRightWithFullTakesAndRemaining(fullTakes: Int, remainingToTake: Int): ByteString = {
         val bs = bytestrings(byteStringsSize - fullTakes - 1)
-        if (bs.length > remainingToTake) (fullTakes, remainingToTake)
-        else findSplit(fullTakes + 1, remainingToTake - bs.length)
+        if (bs.length > remainingToTake) {
+          if (fullTakes == 0)
+            bytestrings(byteStringsSize - 1).takeRight(n)
+          else if (remainingToTake == 0)
+            new ByteStrings(bytestrings.takeRight(fullTakes), n)
+          else
+            new ByteStrings(bytestrings(byteStringsSize - fullTakes - 1).takeRight1(remainingToTake) +: bytestrings.takeRight(fullTakes), n)
+        } else {
+          takeRightWithFullTakesAndRemaining(fullTakes + 1, remainingToTake - bs.length)
+        }
       }
 
-      val (fullTakes, remainingToTake) = findSplit(0, n)
-
-      if (fullTakes == 0)
-        bytestrings(byteStringsSize - 1).takeRight(n)
-      else if (remainingToTake == 0)
-        new ByteStrings(bytestrings.takeRight(fullTakes), n)
-      else
-        new ByteStrings(bytestrings(byteStringsSize - fullTakes - 1).takeRight1(remainingToTake) +: bytestrings.takeRight(fullTakes), n)
+      takeRightWithFullTakesAndRemaining(0, n)
     }
 
     override def dropRight(n: Int): ByteString =

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_takeRight_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_takeRight_Benchmark.scala
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2014-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import akka.util.ByteString.{ ByteString1, ByteStrings }
+import org.openjdk.jmh.annotations._
+
+import scala.util.Random
+
+@State(Scope.Benchmark)
+@Measurement(timeUnit = TimeUnit.MILLISECONDS)
+class ByteString_takeRight_Benchmark {
+
+  val str = List.fill[Byte](4)(0).mkString
+  val numVec = 1024
+  val bss = ByteStrings(Vector.fill(numVec)(ByteString1.fromString(str)))
+
+  val rand = new Random()
+  val len = str.size * numVec
+  val n_greater_or_eq_to_len = len + rand.nextInt(Int.MaxValue - len)
+  val n_neg = rand.nextInt(Int.MaxValue) * -1
+  val n_avg = len / 2
+  val n_best = 1
+  val n_worst = len - 1
+
+  /*
+   --------------------------------- BASELINE ----------------------------------------------------------------------
+   commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
+   [info] Benchmark                                                 Mode  Cnt          Score          Error  Units
+   [info] ByteString_takeRight_Benchmark.bss_avg                   thrpt   40     486281.351 ±    14023.517  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_best                  thrpt   40     242096.480 ±     7029.451  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40  918217840.623 ± 12576483.168  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_negative              thrpt   40  895754845.562 ± 18965575.377  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_worst                 thrpt   40   11491250.938 ±   187949.479  ops/s
+
+   --------------------------------- AFTER -------------------------------------------------------------------------
+
+   ------ TODAY –––––––
+   [info] Benchmark                                                 Mode  Cnt           Score          Error  Units
+   [info] ByteString_takeRight_Benchmark.bss_avg                   thrpt   40      477028.892 ±     8846.994  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_best                  thrpt   40   106455228.296 ±   940597.222  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40   878842311.758 ±  9382511.848  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_negative              thrpt   40  1151544955.244 ± 21398125.610  ops/s
+   [info] ByteString_takeRight_Benchmark.bss_worst                 thrpt   40      230406.055 ±     6075.782  ops/s
+
+   */
+
+  @Benchmark
+  def bss_negative(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.takeRight(n_neg)
+  }
+
+  @Benchmark
+  def bss_greater_or_eq_to_len(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.takeRight(n_greater_or_eq_to_len)
+  }
+
+  @Benchmark
+  def bss_avg(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.takeRight(n_avg)
+  }
+
+  @Benchmark
+  def bss_best(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.takeRight(n_best)
+  }
+
+  @Benchmark
+  def bss_worst(): Unit = {
+    @volatile var bs: ByteString = null
+    bs = bss.takeRight(n_worst)
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_takeRight_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_takeRight_Benchmark.scala
@@ -1,6 +1,7 @@
 /**
- * Copyright (C) 2014-2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.util
 
 import java.util.concurrent.TimeUnit

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_takeRight_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_takeRight_Benchmark.scala
@@ -49,32 +49,22 @@ class ByteString_takeRight_Benchmark {
    */
 
   @Benchmark
-  def bss_negative(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.takeRight(n_neg)
-  }
+  def bss_negative(): ByteString =
+    bss.takeRight(n_neg)
 
   @Benchmark
-  def bss_greater_or_eq_to_len(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.takeRight(n_greater_or_eq_to_len)
-  }
+  def bss_greater_or_eq_to_len(): ByteString =
+    bss.takeRight(n_greater_or_eq_to_len)
 
   @Benchmark
-  def bss_avg(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.takeRight(n_avg)
-  }
+  def bss_avg(): ByteString =
+    bss.takeRight(n_avg)
 
   @Benchmark
-  def bss_best(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.takeRight(n_best)
-  }
+  def bss_best(): ByteString =
+    bss.takeRight(n_best)
 
   @Benchmark
-  def bss_worst(): Unit = {
-    @volatile var bs: ByteString = null
-    bs = bss.takeRight(n_worst)
-  }
+  def bss_worst(): ByteString =
+    bss.takeRight(n_worst)
 }


### PR DESCRIPTION
Add implementation of takeRight(...).
### Benchmark

```
   --------------------------------- BASELINE ----------------------------------------------------------------------
   commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
   [info] Benchmark                                                 Mode  Cnt          Score          Error  Units
   [info] ByteString_takeRight_Benchmark.bss_avg                   thrpt   40     486281.351 ±    14023.517  ops/s
   [info] ByteString_takeRight_Benchmark.bss_best                  thrpt   40     242096.480 ±     7029.451  ops/s
   [info] ByteString_takeRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40  918217840.623 ± 12576483.168  ops/s
   [info] ByteString_takeRight_Benchmark.bss_negative              thrpt   40  895754845.562 ± 18965575.377  ops/s
   [info] ByteString_takeRight_Benchmark.bss_worst                 thrpt   40   11491250.938 ±   187949.479  ops/s

   --------------------------------- AFTER -------------------------------------------------------------------------

   ------ TODAY –––––––
   [info] Benchmark                                                 Mode  Cnt           Score          Error  Units
   [info] ByteString_takeRight_Benchmark.bss_avg                   thrpt   40      477028.892 ±     8846.994  ops/s
   [info] ByteString_takeRight_Benchmark.bss_best                  thrpt   40   106455228.296 ±   940597.222  ops/s
   [info] ByteString_takeRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40   878842311.758 ±  9382511.848  ops/s
   [info] ByteString_takeRight_Benchmark.bss_negative              thrpt   40  1151544955.244 ± 21398125.610  ops/s
   [info] ByteString_takeRight_Benchmark.bss_worst                 thrpt   40      230406.055 ±     6075.782  ops/s
```
