### PR TITLE
increase timeout for fist message in RemoteSendConsistencySpec, #21529

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
@@ -54,7 +54,7 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config) extends AkkaSpe
 
       val remoteRef = {
         system.actorSelection(rootB / "user" / "echo") ! Identify(None)
-        expectMsgType[ActorIdentity].ref.get
+        expectMsgType[ActorIdentity](5.seconds).ref.get
       }
 
       remoteRef ! "ping"


### PR DESCRIPTION
Reproduced once rather immediately in a repeat job yesterday morning. Then I increased the timeout for the first message and then no more failures. Ran on repeat all day yesterday.
