### PR TITLE
Fix typo in the spray migration guide

### DIFF
--- a/akka-docs/rst/scala/http/migration-from-spray.rst
+++ b/akka-docs/rst/scala/http/migration-from-spray.rst
@@ -90,7 +90,7 @@ Was::
 
 Replace with::
 
-    MediaType.applicationWithFixedCharset("application/vnd.acme+json", HttpCharsets.`UTF-8`)
+    MediaType.applicationWithFixedCharset("vnd.acme+json", HttpCharsets.`UTF-8`)
 
 Changes in Rejection Handling
 -----------------------------


### PR DESCRIPTION
First argument of `MediaType.applicationWithFixedCharset` is only the subType, not the full MediaType name.
