### PR TITLE
val minParkNanos is declared but not used.

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/TaskRunner.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/TaskRunner.scala
@@ -102,7 +102,7 @@ private[akka] object TaskRunner {
       val minParkNanos = 1
       // park between 250 and 10 micros depending on idleCpuLevel
       val maxParkNanos = MICROSECONDS.toNanos(280 - 30 * idleCpuLevel)
-      new BackoffIdleStrategy(spinning, yielding, 1, maxParkNanos)
+      new BackoffIdleStrategy(spinning, yielding, minParkNanos, maxParkNanos)
     }
   }
 }


### PR DESCRIPTION
`val minParkNanos = 1` is declared but not used, instead the constant `1` was used.
