### PR TITLE
Remove unnecesary s when printing unit times

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -504,7 +504,7 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
 
       case RecoveryTick(true) ⇒
         try onRecoveryFailure(
-          new RecoveryTimedOut(s"Recovery timed out, didn't get snapshot within $timeout s"),
+          new RecoveryTimedOut(s"Recovery timed out, didn't get snapshot within $timeout"),
           event = None)
         finally context.stop(self)
 
@@ -562,7 +562,7 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
         case RecoveryTick(false) if !eventSeenInInterval ⇒
           timeoutCancellable.cancel()
           try onRecoveryFailure(
-            new RecoveryTimedOut(s"Recovery timed out, didn't get event within $timeout s, highest sequence number seen $sequenceNr"),
+            new RecoveryTimedOut(s"Recovery timed out, didn't get event within $timeout, highest sequence number seen $sequenceNr"),
             event = None)
           finally context.stop(self)
         case RecoveryTick(false) ⇒


### PR DESCRIPTION
Here is the logic
https://github.com/scala/scala/blob/2.11.x/src/library/scala/concurrent/duration/Duration.scala#L601-L602
