### PR TITLE
send terminationMessage to singleton when leaving last, #21592

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaveSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaveSpec.scala
@@ -143,7 +143,7 @@ class ClusterSingletonManagerLeaveSpec extends MultiNodeSpec(ClusterSingletonMan
       runOn(second, third) {
         val p = TestProbe()
         val firstAddress = node(first).address
-        p.within(10.seconds) {
+        p.within(15.seconds) {
           p.awaitAssert {
             echoProxy.tell("hello2", p.ref)
             p.expectMsgType[ActorRef](1.seconds).path.address should not be (firstAddress)
@@ -158,7 +158,7 @@ class ClusterSingletonManagerLeaveSpec extends MultiNodeSpec(ClusterSingletonMan
       }
 
       runOn(second) {
-        expectMsg(10.seconds, "stop")
+        expectMsg(15.seconds, "stop")
         expectMsg("postStop")
       }
       enterBarrier("second-stopped")

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaveSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaveSpec.scala
@@ -45,11 +45,17 @@ object ClusterSingletonManagerLeaveSpec extends MultiNodeConfig {
    * The singleton actor
    */
   class Echo(testActor: ActorRef) extends Actor {
+    override def preStart(): Unit = {
+      testActor ! "preStart"
+    }
     override def postStop(): Unit = {
-      testActor ! "stopped"
+      testActor ! "postStop"
     }
 
     def receive = {
+      case "stop" ⇒
+        testActor ! "stop"
+        context.stop(self)
       case _ ⇒
         sender() ! self
     }
@@ -78,7 +84,7 @@ class ClusterSingletonManagerLeaveSpec extends MultiNodeSpec(ClusterSingletonMan
     system.actorOf(
       ClusterSingletonManager.props(
         singletonProps = Props(classOf[Echo], testActor),
-        terminationMessage = PoisonPill,
+        terminationMessage = "stop",
         settings = ClusterSingletonManagerSettings(system)),
       name = "echo")
   }
@@ -97,12 +103,22 @@ class ClusterSingletonManagerLeaveSpec extends MultiNodeSpec(ClusterSingletonMan
       join(first, first)
 
       runOn(first) {
-        echoProxy ! "hello"
-        expectMsgType[ActorRef](5.seconds)
+        within(5.seconds) {
+          expectMsg("preStart")
+          echoProxy ! "hello"
+          expectMsgType[ActorRef]
+        }
       }
       enterBarrier("first-active")
 
       join(second, first)
+      runOn(first, second) {
+        within(10.seconds) {
+          awaitAssert(cluster.state.members.count(m ⇒ m.status == MemberStatus.Up) should be(2))
+        }
+      }
+      enterBarrier("second-up")
+
       join(third, first)
       within(10.seconds) {
         awaitAssert(cluster.state.members.count(m ⇒ m.status == MemberStatus.Up) should be(3))
@@ -114,9 +130,15 @@ class ClusterSingletonManagerLeaveSpec extends MultiNodeSpec(ClusterSingletonMan
       }
 
       runOn(first) {
-        expectMsg(10.seconds, "stopped")
+        expectMsg(10.seconds, "stop")
+        expectMsg("postStop")
       }
       enterBarrier("first-stopped")
+
+      runOn(second) {
+        expectMsg("preStart")
+      }
+      enterBarrier("second-started")
 
       runOn(second, third) {
         val p = TestProbe()
@@ -129,8 +151,33 @@ class ClusterSingletonManagerLeaveSpec extends MultiNodeSpec(ClusterSingletonMan
           }
         }
       }
+      enterBarrier("second-working")
 
-      enterBarrier("hand-over-done")
+      runOn(third) {
+        cluster.leave(node(second).address)
+      }
+
+      runOn(second) {
+        expectMsg(10.seconds, "stop")
+        expectMsg("postStop")
+      }
+      enterBarrier("second-stopped")
+
+      runOn(third) {
+        expectMsg("preStart")
+      }
+      enterBarrier("third-started")
+
+      runOn(third) {
+        cluster.leave(node(third).address)
+      }
+
+      runOn(third) {
+        expectMsg(5.seconds, "stop")
+        expectMsg("postStop")
+      }
+      enterBarrier("third-stopped")
+
     }
 
   }


### PR DESCRIPTION
- When leaving last node, i.e. no newOldestOption, the manager was
  just stopped. The change is to send the terminationMessage also
  in this case and wait until the singleton actor is terminated
  before stopping the manager.
- Also changed so that the singleton is stopped immediately when
  cluster has been terminated when last node is leaving, i.e.
  no newOldestOption. Previously it retried until maxTakeOverRetries
  before stopping.
- More comprehensive test of this scenario in ClusterSingletonManagerLeaveSpec
