### PR TITLE
Add a retry for a check for stopped actors

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
@@ -204,10 +204,7 @@ class ActorsLeakSpec extends AkkaSpec(ActorsLeakSpec.config) with ImplicitSender
 
       EventFilter[TimeoutException](occurrences = 1).intercept {}
 
-      val finalActors = targets.flatMap(collectLiveActors).toSet
-
-      assertResult(initialActors)(finalActors)
-
+      awaitAssert(assertResult(initialActors)(targets.flatMap(collectLiveActors).toSet), 5.seconds)
     }
 
   }


### PR DESCRIPTION
Fixes #21122

This should guard against the case when actors would be stopped just after the original check has been made.
