### PR TITLE
+doc,per #21689 document calling persist() in Future is unsafe

### DIFF
--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -326,6 +326,12 @@ In this case no stashing is happening, yet events are still persisted and callba
 While it is possible to nest mixed ``persist`` and ``persistAsync`` with keeping their respective semantics
 it is not a recommended practice, as it may lead to overly complex nesting.
 
+.. warning::
+  While it is possible to next ``persist`` calls within one another, 
+  it is *not* legal to nest ``persist`` calls in Futures! Doing so will break the 
+  guarantees that the persist methods aim to provide. Always call ``persist`` and ``persistAsync``
+  from within the Actor's receive block (or methods synchronously invoked from there).
+
 .. _failures-java:
 
 Failures

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -327,10 +327,11 @@ While it is possible to nest mixed ``persist`` and ``persistAsync`` with keeping
 it is not a recommended practice, as it may lead to overly complex nesting.
 
 .. warning::
-  While it is possible to next ``persist`` calls within one another, 
-  it is *not* legal to nest ``persist`` calls in Futures! Doing so will break the 
-  guarantees that the persist methods aim to provide. Always call ``persist`` and ``persistAsync``
-  from within the Actor's receive block (or methods synchronously invoked from there).
+  While it is possible to nest ``persist`` calls within one another, 
+  it is *not* legal call ``persist`` from any other Thread than the Actors message processing Thread.
+  For example, it is not legal to call ``persist`` from Futures! Doing so will break the guarantees 
+  that the persist methods aim to provide. Always call ``persist`` and ``persistAsync`` from within 
+  the Actor's receive block (or methods synchronously invoked from there).
 
 .. _failures-java:
 

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -313,10 +313,11 @@ While it is possible to nest mixed ``persist`` and ``persistAsync`` with keeping
 it is not a recommended practice, as it may lead to overly complex nesting.
 
 .. warning::
-  While it is possible to next ``persist`` calls within one another, 
-  it is *not* legal to nest ``persist`` calls in Futures! Doing so will break the 
-  guarantees that the persist methods aim to provide. Always call ``persist`` and ``persistAsync``
-  from within the Actor's receive block (or methods synchronously invoked from there).
+  While it is possible to nest ``persist`` calls within one another, 
+  it is *not* legal call ``persist`` from any other Thread than the Actors message processing Thread.
+  For example, it is not legal to call ``persist`` from Futures! Doing so will break the guarantees 
+  that the persist methods aim to provide. Always call ``persist`` and ``persistAsync`` from within 
+  the Actor's receive block (or methods synchronously invoked from there).
 
 .. _failures-scala:
 

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -312,6 +312,12 @@ In this case no stashing is happening, yet events are still persisted and callba
 While it is possible to nest mixed ``persist`` and ``persistAsync`` with keeping their respective semantics
 it is not a recommended practice, as it may lead to overly complex nesting.
 
+.. warning::
+  While it is possible to next ``persist`` calls within one another, 
+  it is *not* legal to nest ``persist`` calls in Futures! Doing so will break the 
+  guarantees that the persist methods aim to provide. Always call ``persist`` and ``persistAsync``
+  from within the Actor's receive block (or methods synchronously invoked from there).
+
 .. _failures-scala:
 
 Failures


### PR DESCRIPTION
Refs #21689 by adding more explicit docs about it.
