### PR TITLE
+doc add missing java documentation for scanAsync/foldAsync

### DIFF
--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -649,13 +649,13 @@ the second element is required from downstream.
 
 scanAsync
 ^^^^^^^^^
-Just like ``scan`` but receiving a function that results in a ``Future`` to the next value.
+Just like ``scan`` but receiving a function that results in a ``CompletionStage`` to the next value.
 
-**emits** when the ``Future`` resulting from the function scanning the element resolves to the next value
+**emits** when the ``CompletionStage`` resulting from the function scanning the element resolves to the next value
 
 **backpressures** when downstream backpressures
 
-**completes** when upstream completes and the last ``Future`` is resolved
+**completes** when upstream completes and the last ``CompletionStage`` is resolved
 
 fold
 ^^^^
@@ -670,13 +670,13 @@ complete the current value is emitted downstream.
 
 foldAsync
 ^^^^^^^^^
-Just like ``fold`` but receiving a function that results in a ``Future`` to the next value.
+Just like ``fold`` but receiving a function that results in a ``CompletionStage`` to the next value.
 
-**emits** when upstream completes and the last ``Future`` is resolved
+**emits** when upstream completes and the last ``CompletionStage`` is resolved
 
 **backpressures** when downstream backpressures
 
-**completes** when upstream completes and the last ``Future`` is resolved
+**completes** when upstream completes and the last ``CompletionStage`` is resolved
 
 reduce
 ^^^^^^

--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -647,6 +647,16 @@ the second element is required from downstream.
 
 **completes** when upstream completes
 
+scanAsync
+^^^^^^^^^
+Just like ``scan`` but receiving a function that results in a ``Future`` to the next value.
+
+**emits** when the ``Future`` resulting from the function scanning the element resolves to the next value
+
+**backpressures** when downstream backpressures
+
+**completes** when upstream completes and the last ``Future`` is resolved
+
 fold
 ^^^^
 Start with current value ``zero`` and then apply the current and next value to the given function, when upstream
@@ -657,6 +667,16 @@ complete the current value is emitted downstream.
 **backpressures** when downstream backpressures
 
 **completes** when upstream completes
+
+foldAsync
+^^^^^^^^^
+Just like ``fold`` but receiving a function that results in a ``Future`` to the next value.
+
+**emits** when upstream completes and the last ``Future`` is resolved
+
+**backpressures** when downstream backpressures
+
+**completes** when upstream completes and the last ``Future`` is resolved
 
 reduce
 ^^^^^^

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -637,7 +637,7 @@ the second element is required from downstream.
 **completes** when upstream completes
 
 scanAsync
-^^^^
+^^^^^^^^^
 Just like ``scan`` but receiving a function that results in a ``Future`` to the next value.
 
 **emits** when the ``Future`` resulting from the function scanning the element resolves to the next value
@@ -658,7 +658,7 @@ complete the current value is emitted downstream.
 **completes** when upstream completes
 
 foldAsync
-^^^^
+^^^^^^^^^
 Just like ``fold`` but receiving a function that results in a ``Future`` to the next value.
 
 **emits** when upstream completes and the last ``Future`` is resolved


### PR DESCRIPTION
=doc fix formatting in stages overview (scanAsync/foldAsync)
