### PR TITLE
configurable message serializer to use either manifest or serializerId

### DIFF
--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -22,6 +22,10 @@ akka.persistence {
         plugin = ""
         # List of journal plugins to start automatically. Use "" for the default journal plugin.
         auto-start-journals = []
+
+      message-serializer {
+        deserialize-using-manifest = false
+      }
     }
     snapshot-store {
         # Absolute path to the snapshot plugin configuration entry used by

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -636,9 +636,9 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
         writeInProgress = false
         () // it will be stopped by the first WriteMessageFailure message
 
-      case _: RecoveryTick =>
-        // we may have one of these in the mailbox before the scheduled timeout
-        // is cancelled when recovery has completed, just consume it so the concrete actor never sees it
+      case _: RecoveryTick ⇒
+      // we may have one of these in the mailbox before the scheduled timeout
+      // is cancelled when recovery has completed, just consume it so the concrete actor never sees it
     }
 
     def onWriteMessageComplete(err: Boolean): Unit

--- a/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
@@ -26,6 +26,7 @@ trait Message extends Serializable
  * Protobuf serializer for [[akka.persistence.PersistentRepr]], [[akka.persistence.AtLeastOnceDelivery]] and [[akka.persistence.fsm.PersistentFSM.StateChangeEvent]] messages.
  */
 class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer {
+
   import PersistentRepr.Undefined
 
   val AtomicWriteClass = classOf[AtomicWrite]
@@ -34,6 +35,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
   val AtLeastOnceDeliverySnapshotClass = classOf[AtLeastOnceDeliverySnapshot]
   val PersistentStateChangeEventClass = classOf[StateChangeEvent]
   val PersistentFSMSnapshotClass = classOf[PersistentFSMSnapshot[Any]]
+  val deserializeUsingManifest: Boolean = system.settings.config.getBoolean("akka.persistence.journal.message-serializer.deserialize-using-manifest")
 
   private lazy val serialization = SerializationExtension(system)
 
@@ -184,8 +186,10 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
 
     // serialize actor references with full address information (defaultAddress)
     transportInformation match {
-      case Some(ti) ⇒ Serialization.currentTransportInformation.withValue(ti) { payloadBuilder() }
-      case None     ⇒ payloadBuilder()
+      case Some(ti) ⇒ Serialization.currentTransportInformation.withValue(ti) {
+        payloadBuilder()
+      }
+      case None ⇒ payloadBuilder()
     }
   }
 
@@ -209,14 +213,21 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
     AtomicWrite(atomicWrite.getPayloadList.asScala.map(persistent)(collection.breakOut))
   }
 
-  private def payload(persistentPayload: mf.PersistentPayload): Any = {
+  protected def payload(persistentPayload: mf.PersistentPayload): Any = {
     val manifest = if (persistentPayload.hasPayloadManifest)
-      persistentPayload.getPayloadManifest.toStringUtf8 else ""
+      persistentPayload.getPayloadManifest.toStringUtf8
+    else ""
 
-    serialization.deserialize(
-      persistentPayload.getPayload.toByteArray,
-      persistentPayload.getSerializerId,
-      manifest).get
+    if (deserializeUsingManifest) {
+      serialization.deserialize(
+        persistentPayload.getPayload.toByteArray,
+        Class.forName(manifest)).get
+    } else {
+      serialization.deserialize(
+        persistentPayload.getPayload.toByteArray,
+        persistentPayload.getSerializerId,
+        manifest).get
+    }
   }
 
 }

--- a/akka-persistence/src/test/scala/akka/persistence/serialization/MessageSerializerTest.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/serialization/MessageSerializerTest.scala
@@ -1,0 +1,118 @@
+package akka.persistence.serialization
+
+import java.util.Base64
+
+import akka.actor.ActorSystem
+import akka.persistence.PersistentRepr
+import akka.serialization.{ Serialization, SerializationExtension, SerializerWithStringManifest }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FlatSpec, Matchers, TryValues }
+
+object MessageSerializerTest {
+  val useIdentifier = ConfigFactory.parseString(
+    """
+      | akka.actor {
+      |    serializers {
+      |        foo = "akka.persistence.serialization.FooSerializer"
+      |        bar = "akka.persistence.serialization.BarSerializer"
+      |    }
+      |
+      |    serialization-bindings {
+      |      "akka.persistence.serialization.Foo" = foo
+      |      "akka.persistence.serialization.Bar" = bar
+      |    }
+      |}
+      |akka.persistence.journal.message-serializer.deserialize-using-manifest = false
+    """.stripMargin
+  )
+
+  val useManifest = ConfigFactory.parseString(
+    """
+      | akka.actor {
+      |    serializers {
+      |        foo = "akka.persistence.serialization.FooSerializer"
+      |        bar = "akka.persistence.serialization.BarSerializer"
+      |    }
+      |
+      |    serialization-bindings {
+      |      "akka.persistence.serialization.Foo" = foo
+      |      "akka.persistence.serialization.Bar" = bar
+      |    }
+      |}
+      |akka.persistence.journal.message-serializer.deserialize-using-manifest = true
+    """.stripMargin
+  )
+
+  // contains id=20 and manifest Foo classname
+  val FooWithId20 =
+    "CjMIFBILZm9vLWluLXJlcHIaImFra2EucGVyc2lzdGVuY2Uuc2VyaWFsaXphdGlvbi5Gb28QARoiYWtrYS5wZXJzaXN0ZW5jZS5zZXJpYWxpemF0aW9uLkZvbw=="
+
+  // contains id=21 and manifest Foo classname
+  val FooWithId21 =
+    "CjMIFRILZm9vLWluLXJlcHIaImFra2EucGVyc2lzdGVuY2Uuc2VyaWFsaXphdGlvbi5Gb28QARoiYWtrYS5wZXJzaXN0ZW5jZS5zZXJpYWxpemF0aW9uLkZvbw=="
+
+  implicit class StringOps(that: String) {
+    def toByteArray: Array[Byte] = Base64.getDecoder.decode(that)
+  }
+}
+
+class MessageSerializerTest extends FlatSpec with Matchers with TryValues with ScalaFutures {
+
+  import MessageSerializerTest._
+
+  def withSerializer(config: Config)(test: Serialization ⇒ Unit): Unit = {
+    val system: ActorSystem = ActorSystem("test", config)
+    try test(SerializationExtension(system)) finally system.terminate().futureValue
+  }
+
+  "MessageSerializer configured to use serializer identifier to Foo" should "decode payload with serializerId=20" in withSerializer(MessageSerializerTest.useIdentifier) { serialization ⇒
+    val repr = serialization.deserialize(FooWithId20.toByteArray, classOf[PersistentRepr])
+    repr.success.value.payload shouldBe Foo("foo-in-repr")
+  }
+
+  it should "decode payload with serializerId=21 should not be Foo but a Bar" in withSerializer(MessageSerializerTest.useIdentifier) { serialization ⇒
+    val repr = serialization.deserialize(FooWithId21.toByteArray, classOf[PersistentRepr])
+    repr.success.value.payload should not be Foo("foo-in-repr")
+  }
+
+  "MessageSerializer configured to use manifest to Foo" should "decode payload using manifest" in withSerializer(MessageSerializerTest.useManifest) { serialization ⇒
+    val repr = serialization.deserialize(FooWithId20.toByteArray, classOf[PersistentRepr])
+    repr.success.value.payload shouldBe Foo("foo-in-repr")
+  }
+
+  it should "decode payload using manifest to Foo" in withSerializer(MessageSerializerTest.useManifest) { serialization ⇒
+    val repr = serialization.deserialize(FooWithId21.toByteArray, classOf[PersistentRepr])
+    repr.success.value.payload shouldBe Foo("foo-in-repr")
+  }
+}
+
+final case class Foo(str: String)
+
+final case class Bar(str: String)
+
+class FooSerializer extends SerializerWithStringManifest {
+  override def identifier: Int = 20
+
+  override def manifest(o: AnyRef): String = o.getClass.getName
+
+  override def toBinary(o: AnyRef): Array[Byte] = o match {
+    case Foo(str) ⇒ str.getBytes
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef =
+    Foo(new String(bytes))
+}
+
+class BarSerializer extends SerializerWithStringManifest {
+  override def identifier: Int = 21
+
+  override def manifest(o: AnyRef): String = o.getClass.getName
+
+  override def toBinary(o: AnyRef): Array[Byte] = o match {
+    case Bar(str) ⇒ str.getBytes
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef =
+    Bar(new String(bytes))
+}


### PR DESCRIPTION
The akka persistence MessageSerializer is hard-wired to use the serializerId that has been stored together with the message in the journal to deserialize the event. This can cause errors when for some reason the serializationId on a system has been changed. A more decoupled way would be to use the stored manifest to detect which serializer to use, as akka-serialization does when finding a serializer to use. This PR makes it possible to configure the strategy to use when resolving a serializer, either to use the stored serializerId or using the manifest. This is handy for situations when the serializerId is not stable. Akka shouldn't enforce a one-strategy fits all solution solutions can change depending on the context.
