### PR TITLE
Update package declaration to fit directory.

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/Unfold.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Unfold.scala
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
  */
-package akka.stream.scaladsl
+package akka.stream.impl
 
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.stage.{ OutHandler, GraphStageLogic, GraphStage }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1001,7 +1001,11 @@ object MiMa extends AutoPlugin {
       ),
       "2.4.11" -> Seq(
         // #20795  IOResult construction exposed
-        ProblemFilters.exclude[MissingTypesProblem]("akka.stream.IOResult$")
+        ProblemFilters.exclude[MissingTypesProblem]("akka.stream.IOResult$"),
+
+        // #21727 moved all of Unfold.scala in package akka.stream.impl
+        ProblemFilters.exclude[MissingClassProblem]("akka.stream.scaladsl.UnfoldAsync"),
+        ProblemFilters.exclude[MissingClassProblem]("akka.stream.scaladsl.Unfold")
       )
     )
   }


### PR DESCRIPTION
Package-directory correspondence seems to be followed in Akka. Misplaced
files may trip tools like Ensime or Eclipse, too.

Actually, I don't know which one is right, the package declaration or the folder. But I assume the package declaration should have the final word as it's part of the API.
