### PR TITLE
Add apiURL setting

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -441,6 +441,8 @@ object AkkaBuild extends Build {
     licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     homepage := Some(url("http://akka.io/")),
 
+    apiURL := Some(url(s"http://doc.akka.io/api/akka/${version.value}")),
+
     initialCommands :=
       """|import language.postfixOps
          |import akka.actor._


### PR DESCRIPTION
to enable cross-linking scaladoc in projects depending on Akka.

We should merge this before releasing 2.4.12.
