### PR TITLE
Make the akka-scala-nightly project work as expected

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -95,7 +95,7 @@ object AkkaBuild extends Build {
     base = file("akka-scala-nightly"),
     // remove dependencies that we have to build ourselves (Scala STM)
     // samples don't work with dbuild right now
-    aggregate = aggregatedProjects diff List(agent, docs, samples)
+    aggregate = aggregatedProjects diff List[ProjectReference](agent, docs, samples)
   ).disablePlugins(ValidatePullRequest, MimaPlugin)
 
   lazy val actor = Project(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,6 +29,7 @@ object Dependencies {
     java8CompatVersion := {
       scalaVersion.value match {
         case x if x.startsWith("2.12.0-RC1") => "0.8.0-RC7"
+        case x if x.startsWith("2.12.0") => "0.8.0-RC8"
         case _ => "0.7.0"
       }
     }


### PR DESCRIPTION
- Added new scala-java8-compat version for Scala 2.12.0-RC2+
- Fixed a `diff` between `ProjectRef` and `Project` that never matched
