### PR TITLE
Fix #21760 - Close Tls connection if Inbound closed before receiving peer's close_notify

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -292,6 +292,7 @@ class TLSActor(
       if (tracing) log.debug("closing inbound")
       try engine.closeInbound()
       catch { case ex: SSLException ⇒ outputBunch.enqueue(UserOut, SessionTruncated) }
+      lastHandshakeStatus = engine.getHandshakeStatus
       completeOrFlush()
       false
     } else if (inboundState != inboundHalfClosed && outputBunch.isCancelled(UserOut)) {


### PR DESCRIPTION
also fixing akka/akka-http#380 and probably akka/akka-http#87
