### PR TITLE
=act #21774 fix ByteString.toString to use fixed stringPrefix for all subclasses

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -600,6 +600,12 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
           a.asByteBuffers.zip(a.getByteBuffers().asScala).forall(x ⇒ x._1 == x._2)
         }
       }
+
+      "toString should start with ByteString(" in {
+        check { (bs: ByteString) ⇒
+          bs.toString.startsWith("ByteString(")
+        }
+      }
     }
     "behave like a Vector" when {
       "concatenating" in { check { (a: ByteString, b: ByteString) ⇒ likeVectors(a, b) { _ ++ _ } } }

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -605,6 +605,9 @@ object ByteString {
 sealed abstract class ByteString extends IndexedSeq[Byte] with IndexedSeqOptimized[Byte, ByteString] {
   def apply(idx: Int): Byte
   private[akka] def byteStringCompanion: ByteString.Companion
+  // override so that toString will also be `ByteString(...)` for the concrete subclasses
+  // of ByteString which changed for Scala 2.12, see https://github.com/akka/akka/issues/21774
+  override final def stringPrefix: String = "ByteString"
 
   override protected[this] def newBuilder: ByteStringBuilder = ByteString.newBuilder
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1018,7 +1018,10 @@ object MiMa extends AutoPlugin {
 
       ),
       "2.4.12" -> Seq(
-        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.Materializer.materialize")
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.Materializer.materialize"),
+        
+        // #21775 - overrode ByteString.stringPrefix and made it final
+        ProblemFilters.exclude[FinalMethodProblem]("akka.util.ByteString.stringPrefix")
       )
     )
   }


### PR DESCRIPTION
Otherwise, with 2.12,

ByteString().toString == "ByteString.ByteString1C()"

which would expose implementation details in the string representation.
This can lead to failing tests due to test expecting a particular string
representation of a ByteString which might be bad practice, yes, but is also
convenient.

The change is due to a fix in Scala for SI-9019 for which the string representation
of TraversableLike was changed which ByteString inherits.
See https://github.com/scala/scala/pull/5258/files