### PR TITLE
#21725 cluster-sharding doesn't delete snapshots and messages

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -78,6 +78,13 @@ akka.cluster.sharding {
   # Only used when state-store-mode=persistence
   snapshot-after = 1000
 
+  # The shard deletes persistent events (messages and snapshots) after doing snapshot
+  # keeping this number of old persistent batches.
+  # Batch is of size `snapshot-after`.
+  # When set to 0 after snapshot is successfully done all messages with equal or lower sequence number will be deleted.
+  # Default value of 2 leaves last maximum 2*`snapshot-after` messages and 3 snapshots (2 old ones + fresh snapshot)
+  keep-nr-of-batches = 2
+
   # Setting for the default shard allocation strategy
   least-shard-allocation-strategy {
     # Threshold of how large the difference between most and least number of

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -37,6 +37,7 @@ object ClusterShardingSettings {
       entityRestartBackoff = config.getDuration("entity-restart-backoff", MILLISECONDS).millis,
       rebalanceInterval = config.getDuration("rebalance-interval", MILLISECONDS).millis,
       snapshotAfter = config.getInt("snapshot-after"),
+      keepNrOfBatches = config.getInt("keep-nr-of-batches"),
       leastShardAllocationRebalanceThreshold =
         config.getInt("least-shard-allocation-strategy.rebalance-threshold"),
       leastShardAllocationMaxSimultaneousRebalance =
@@ -87,6 +88,7 @@ object ClusterShardingSettings {
     val entityRestartBackoff:                               FiniteDuration,
     val rebalanceInterval:                                  FiniteDuration,
     val snapshotAfter:                                      Int,
+    val keepNrOfBatches:                                    Int,
     val leastShardAllocationRebalanceThreshold:             Int,
     val leastShardAllocationMaxSimultaneousRebalance:       Int,
     val waitingForStateTimeout:                             FiniteDuration,
@@ -98,6 +100,44 @@ object ClusterShardingSettings {
     require(
       entityRecoveryStrategy == "all" || entityRecoveryStrategy == "constant",
       s"Unknown 'entity-recovery-strategy' [$entityRecoveryStrategy], valid values are 'all' or 'constant'")
+
+    // included for binary compatibility
+    def this(
+      coordinatorFailureBackoff:                          FiniteDuration,
+      retryInterval:                                      FiniteDuration,
+      bufferSize:                                         Int,
+      handOffTimeout:                                     FiniteDuration,
+      shardStartTimeout:                                  FiniteDuration,
+      shardFailureBackoff:                                FiniteDuration,
+      entityRestartBackoff:                               FiniteDuration,
+      rebalanceInterval:                                  FiniteDuration,
+      snapshotAfter:                                      Int,
+      leastShardAllocationRebalanceThreshold:             Int,
+      leastShardAllocationMaxSimultaneousRebalance:       Int,
+      waitingForStateTimeout:                             FiniteDuration,
+      updatingStateTimeout:                               FiniteDuration,
+      entityRecoveryStrategy:                             String,
+      entityRecoveryConstantRateStrategyFrequency:        FiniteDuration,
+      entityRecoveryConstantRateStrategyNumberOfEntities: Int) = {
+      this(
+        coordinatorFailureBackoff,
+        retryInterval,
+        bufferSize,
+        handOffTimeout,
+        shardStartTimeout,
+        shardFailureBackoff,
+        entityRestartBackoff,
+        rebalanceInterval,
+        snapshotAfter,
+        2,
+        leastShardAllocationRebalanceThreshold,
+        leastShardAllocationMaxSimultaneousRebalance,
+        waitingForStateTimeout,
+        updatingStateTimeout,
+        entityRecoveryStrategy,
+        entityRecoveryConstantRateStrategyFrequency,
+        entityRecoveryConstantRateStrategyNumberOfEntities)
+    }
 
     // included for binary compatibility
     def this(

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -806,7 +806,19 @@ class PersistentShardCoordinator(typeName: String, settings: ClusterShardingSett
   def receiveSnapshotResult: Receive = {
     case SaveSnapshotSuccess(m) ⇒
       log.debug("Persistent snapshot saved successfully")
-      deleteMessages(m.sequenceNr)
+      /*
+       * delete old events but keep the latest around because
+       *
+       * it's not safe to delete all events immediate because snapshots are typically stored with a weaker consistency
+       * level which means that a replay might "see" the deleted events before it sees the stored snapshot,
+       * i.e. it will use an older snapshot and then not replay the full sequence of events
+       *
+       * for debugging if something goes wrong in production it's very useful to be able to inspect the events
+       */
+      val deleteToSequenceNr = m.sequenceNr - keepNrOfBatches * snapshotAfter
+      if (deleteToSequenceNr > 0) {
+        deleteMessages(deleteToSequenceNr)
+      }
 
     case SaveSnapshotFailure(_, reason) ⇒
       log.warning("Persistent snapshot failure: {}", reason.getMessage)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RemoveInternalClusterShardingDataSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RemoveInternalClusterShardingDataSpec.scala
@@ -39,6 +39,7 @@ object RemoveInternalClusterShardingDataSpec {
     akka.persistence.snapshot-store.local.dir = "target/snapshots-RemoveInternalClusterShardingDataSpec"
     akka.cluster.sharding.snapshot-after = 5
     akka.cluster.sharding.state-store-mode = persistence
+    |akka.cluster.sharding.keep-nr-of-batches = 0
     """
 
   val extractEntityId: ShardRegion.ExtractEntityId = {
@@ -97,11 +98,11 @@ class RemoveInternalClusterShardingDataSpec extends AkkaSpec(RemoveInternalClust
     "akka.persistence.journal.leveldb.dir",
     "akka.persistence.snapshot-store.local.dir").map(s ⇒ new File(system.settings.config.getString(s)))
 
-  override protected def atStartup() {
+  override protected def atStartup(): Unit = {
     storageLocations.foreach(dir ⇒ if (dir.exists) FileUtils.deleteDirectory(dir))
   }
 
-  override protected def afterTermination() {
+  override protected def afterTermination(): Unit = {
     storageLocations.foreach(dir ⇒ if (dir.exists) FileUtils.deleteDirectory(dir))
   }
 
@@ -122,8 +123,8 @@ class RemoveInternalClusterShardingDataSpec extends AkkaSpec(RemoveInternalClust
     "setup sharding" in {
       Cluster(system).join(Cluster(system).selfAddress)
       val settings = ClusterShardingSettings(system)
-      ClusterSharding(system).start("type1", Props[EchoActor], settings, extractEntityId, extractShardId)
-      ClusterSharding(system).start("type2", Props[EchoActor], settings, extractEntityId, extractShardId)
+      ClusterSharding(system).start("type1", Props[EchoActor](), settings, extractEntityId, extractShardId)
+      ClusterSharding(system).start("type2", Props[EchoActor](), settings, extractEntityId, extractShardId)
     }
 
     "work when no data" in within(10.seconds) {
@@ -132,7 +133,7 @@ class RemoveInternalClusterShardingDataSpec extends AkkaSpec(RemoveInternalClust
       val rm = system.actorOf(RemoveInternalClusterShardingData.RemoveOnePersistenceId.props(
         journalPluginId = "", persistenceId("type1"), testActor))
       watch(rm)
-      expectMsg(Result(Success(Removals(false, false))))
+      expectMsg(Result(Success(Removals(events = false, snapshots = false))))
       expectTerminated(rm)
     }
 
@@ -146,7 +147,7 @@ class RemoveInternalClusterShardingDataSpec extends AkkaSpec(RemoveInternalClust
       val rm = system.actorOf(RemoveInternalClusterShardingData.RemoveOnePersistenceId.props(
         journalPluginId = "", persistenceId("type1"), testActor))
       watch(rm)
-      expectMsg(Result(Success(Removals(true, false))))
+      expectMsg(Result(Success(Removals(events = true, snapshots = false))))
       expectTerminated(rm)
       hasSnapshots("type1") should ===(false)
       hasEvents("type1") should ===(false)
@@ -165,7 +166,7 @@ class RemoveInternalClusterShardingDataSpec extends AkkaSpec(RemoveInternalClust
       val rm = system.actorOf(RemoveInternalClusterShardingData.RemoveOnePersistenceId.props(
         journalPluginId = "", persistenceId("type2"), testActor))
       watch(rm)
-      expectMsg(Result(Success(Removals(true, true))))
+      expectMsg(Result(Success(Removals(events = true, snapshots = true))))
       expectTerminated(rm)
       hasSnapshots("type2") should ===(false)
       hasEvents("type2") should ===(false)
@@ -179,7 +180,7 @@ class RemoveInternalClusterShardingDataSpec extends AkkaSpec(RemoveInternalClust
       Cluster(system).join(Cluster(system).selfAddress)
       val settings = ClusterShardingSettings(system)
       typeNames.foreach { typeName ⇒
-        ClusterSharding(system).start(typeName, Props[EchoActor], settings, extractEntityId, extractShardId)
+        ClusterSharding(system).start(typeName, Props[EchoActor](), settings, extractEntityId, extractShardId)
       }
     }
 


### PR DESCRIPTION
Fixes #21725
Without deleting messages those pollute persistence with not needed anymore messages. Naive and bullet proof flow is snapshot -> delete messges -> delete snapshots.