### PR TITLE
Race condition fix for Test{Sink/Source}Stage

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/TestGraphStage.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/TestGraphStage.scala
@@ -6,6 +6,9 @@ import akka.stream.stage.{ GraphStageWithMaterializedValue, InHandler, OutHandle
 import akka.stream._
 import akka.testkit.TestProbe
 
+/**
+ * Messages emitted after the corresponding `stageUnderTest` methods has been invoked.
+ */
 object GraphStageMessages {
   case object Push extends NoSerializationVerificationNeeded
   case object UpstreamFinish extends NoSerializationVerificationNeeded
@@ -45,8 +48,8 @@ private[testkit] class TestSinkStage[T, M](
     val inHandler = logic.handlers(in.id).asInstanceOf[InHandler]
     logic.handlers(in.id) = new InHandler {
       override def onPush(): Unit = {
-        probe.ref ! GraphStageMessages.Push
         inHandler.onPush()
+        probe.ref ! GraphStageMessages.Push
       }
       override def onUpstreamFinish(): Unit = {
         try {
@@ -98,8 +101,8 @@ private[testkit] class TestSourceStage[T, M](
     val outHandler = logic.handlers(out.id).asInstanceOf[OutHandler]
     logic.handlers(out.id) = new OutHandler {
       override def onPull(): Unit = {
-        probe.ref ! GraphStageMessages.Pull
         outHandler.onPull()
+        probe.ref ! GraphStageMessages.Pull
       }
       override def onDownstreamFinish(): Unit = {
         try {

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -485,7 +485,7 @@ object MiMa extends AutoPlugin {
         // #20553 Tree flattening should be separate from Fusing
         ProblemFilters.exclude[MissingClassProblem]("akka.stream.Fusing$StructuralInfo"),
         ProblemFilters.exclude[MissingClassProblem]("akka.stream.Fusing$StructuralInfo$")
-      ), 
+      ),
       "2.4.14" -> Seq(
         // #21423 removal of deprecated stages (in 2.5.x)
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.javadsl.Source.transform"),
@@ -532,11 +532,14 @@ object MiMa extends AutoPlugin {
 
         // # 21944
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ClusterEvent#ReachabilityEvent.member"),
-        
+
         // #21645 durable distributed data
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.WriteAggregator.props"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.WriteAggregator.this"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.ddata.Replicator.write")
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.ddata.Replicator.write"),
+
+        // #20737 aligned test sink and test source stage factory methods types
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.testkit.TestSinkStage.apply")
       )
     )
   }


### PR DESCRIPTION
Hopefully fixes #20737

Let's see what you think of this. 

My thinking: there was a race in the TestSinkStage/TestSourceStage where it would signal to the probe that it finished, canceled etc before it actually called the callback on the stage, so that should cause a race when used like in `OutputStreamSourceSpec` which does:

```
s.cancel()
sourceProbe.expectMsg(GraphStageMessages.DownstreamFinish)
the[Exception] thrownBy outputStream.write(bytesArray) shouldBe a[IOException]
```

We could get the `DownstreamFinish` before it actually had happened. I'm guessing that the reversed order is what we always want.