### PR TITLE
New authors-script for releasing

### DIFF
--- a/scripts/authors.scala
+++ b/scripts/authors.scala
@@ -1,0 +1,69 @@
+#!/bin/sh
+exec scala "$0" "$@"
+!#
+
+/*
+ * Usage:
+ *    authors.scala tag1 tag2
+ *
+ * or if on non unixy os:
+ *    scala authors.scala tag1 tag2
+ *
+ * requires scala 2.11.x+ and command line git on path
+ */
+
+import scala.sys.process._
+
+require(args.length == 2, "usage: authors prevTag currTag")
+
+val gitCmd = "git log --no-merges --shortstat -z --minimal -w -C " + args(0) + ".." + args(1)
+
+case class Stats(name: String, email: String, commits: Int = 0, inserts: Int = 0, deletes: Int = 0, filesChanged: Int = 0)
+
+val AuthorExp = """Author: (.*) <([^>]+)>""".r
+val FilesExp = """(\d+)\sfile[s]? changed""".r
+val InsertionsExp = """(\d+)\sinsertion[s]?\(\+\)""".r
+val DeletionsExp = """(\d+)\sdeletion[s]?\(-\)""".r
+
+val entries = gitCmd.lines_!.foldLeft("")(_ + "\n" + _).split('\0')
+
+val map = entries.foldLeft(Map.empty[String, Stats]) { (map, entry) =>
+  val lines = entry.trim.split('\n')
+  val authorLine = lines(1)
+  val summary = lines.last
+
+  val statsEntry = authorLine match {
+    case AuthorExp(name, email) =>
+      map.get(name.toLowerCase).orElse {
+        // look for same email, but different name
+        map.values.find(_.email.equalsIgnoreCase(email)).orElse {
+          Some(Stats(name, email))
+        }
+      }
+    case _ =>
+      println(s"Unparseable author line: \n$authorLine\n in entry $entry")
+      None
+  }
+
+  val updatedEntry =
+    statsEntry.map(entry => summary.trim.split(',').map(_.trim).foldLeft(entry.copy(commits = entry.commits + 1)) {
+      case (entry, FilesExp(f)) => entry.copy(filesChanged = entry.filesChanged + f.toInt)
+      case (entry, InsertionsExp(a)) => entry.copy(inserts = entry.inserts + a.toInt)
+      case (entry, DeletionsExp(d)) => entry.copy(deletes = entry.deletes + d.toInt)
+      case (entry, uff) =>
+        println(s"Couldn't parse summary section for $entry '$uff'")
+        entry
+    })
+
+  updatedEntry.fold(
+    map
+  )(entry => map + (entry.name.toLowerCase -> entry))
+}
+
+val sorted = map.values.toSeq.sortBy(s => (s.commits, s.inserts + s.deletes)).reverse
+
+println("commits  added  removed")
+sorted.foreach { entry =>
+  println("%7d%7d%9d %s".format(entry.commits, entry.inserts, entry.deletes, entry.name))
+}
+


### PR DESCRIPTION
Look ma - no perl!

Additionally: deals with people who check in with different email addresses correctly (tries to match on both name and email) and formats the output just like we want it for the releases.

Sample output (run with `authors.scala v2.4.11 v2.4.12`):
```
commits  added  removed
     14   2325   103740 Konrad Malawski
     10    864      300 Patrik Nordwall
      4    429      191 Johannes Rudolph
      4    305      117 Johan Andrén
      4     69        7 Martynas Mickevičius
      3    223       68 monkey-mas
      3    160       74 Richard Imaoka
      3    101       42 Ortigali
      2    461        5 Mateus Dubiela Oliveira
      1    579        6 Niko Will
      1    115       25 Falmarri
      1    107       27 Vsevolod Belousov
      1     81        5 Spencer Judge
      1     67        0 Wojciech Grajewski
      1     34       30 Stefano Bonetti
      1     56        4 Kirill Yankov
      1      5       13 olbpetersson
      1      8        8 Boris Korogvich
      1     13        0 Sergey Kisel
      1      9        1 Roland Kuhn
      1      6        2 Iulian Dragos
      1      2        2 Nafer Sanabria
      1      2        1 Björn Antonsson
      1      1        1 matsu-chara
      1      1        1 Guido Medina
```

Didn't quite dare to delete the perl script though