### PR TITLE
Fix #21760  - Close Tls connection if Inbound closed before receiving peer's close_notify (v.1)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -120,21 +120,41 @@ class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=o
     }
 
     trait CommunicationSetup extends Named {
+      val ignoresShutdown: Boolean = true
       def decorateFlow(leftClosing: TLSClosing, rightClosing: TLSClosing,
-                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any]): Flow[SslTlsOutbound, SslTlsInbound, NotUsed]
+                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any], ks: SharedKillSwitch): Flow[SslTlsOutbound, SslTlsInbound, NotUsed]
       def cleanup(): Unit = ()
     }
 
     object ClientInitiates extends CommunicationSetup {
       def decorateFlow(leftClosing: TLSClosing, rightClosing: TLSClosing,
-                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any]) =
+                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any], ks: SharedKillSwitch) =
         clientTls(leftClosing) atop serverTls(rightClosing).reversed join rhs
+    }
+
+    object ClientInitiatesServerTruncates extends CommunicationSetup {
+      override val ignoresShutdown = false
+      def decorateFlow(leftClosing: TLSClosing, rightClosing: TLSClosing,
+                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any], ks: SharedKillSwitch) = {
+        val terminator = BidiFlow.fromFlows(Flow[ByteString], ks.flow[ByteString])
+        clientTls(leftClosing) atop terminator atop serverTls(rightClosing).reversed join rhs
+      }
     }
 
     object ServerInitiates extends CommunicationSetup {
       def decorateFlow(leftClosing: TLSClosing, rightClosing: TLSClosing,
-                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any]) =
+                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any], ks: SharedKillSwitch) =
         serverTls(leftClosing) atop clientTls(rightClosing).reversed join rhs
+    }
+
+    object ServerInitiatesClientTruncates extends CommunicationSetup {
+      override val ignoresShutdown = false
+
+      def decorateFlow(leftClosing: TLSClosing, rightClosing: TLSClosing,
+                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any], ks: SharedKillSwitch) = {
+        val terminator = BidiFlow.fromFlows(Flow[ByteString], ks.flow[ByteString])
+        serverTls(leftClosing) atop terminator atop clientTls(rightClosing).reversed join rhs
+      }
     }
 
     def server(flow: Flow[ByteString, ByteString, Any]) = {
@@ -148,7 +168,7 @@ class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=o
     object ClientInitiatesViaTcp extends CommunicationSetup {
       var binding: Tcp.ServerBinding = null
       def decorateFlow(leftClosing: TLSClosing, rightClosing: TLSClosing,
-                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any]) = {
+                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any], ks: SharedKillSwitch) = {
         binding = server(serverTls(rightClosing).reversed join rhs)
         clientTls(leftClosing) join Tcp().outgoingConnection(binding.localAddress)
       }
@@ -158,7 +178,7 @@ class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=o
     object ServerInitiatesViaTcp extends CommunicationSetup {
       var binding: Tcp.ServerBinding = null
       def decorateFlow(leftClosing: TLSClosing, rightClosing: TLSClosing,
-                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any]) = {
+                       rhs: Flow[SslTlsInbound, SslTlsOutbound, Any], ks: SharedKillSwitch) = {
         binding = server(clientTls(rightClosing).reversed join rhs)
         serverTls(leftClosing) join Tcp().outgoingConnection(binding.localAddress)
       }
@@ -170,7 +190,10 @@ class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=o
         ClientInitiates,
         ServerInitiates,
         ClientInitiatesViaTcp,
-        ServerInitiatesViaTcp)
+        ServerInitiatesViaTcp,
+        ClientInitiatesServerTruncates,
+        ServerInitiatesClientTruncates
+      )
 
     trait PayloadScenario extends Named {
       def flow: Flow[SslTlsInbound, SslTlsOutbound, Any] =
@@ -348,9 +371,10 @@ class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=o
     } {
       s"work in mode ${commPattern.name} while sending ${scenario.name}" in assertAllStagesStopped {
         val onRHS = debug.via(scenario.flow)
+        val ks = KillSwitches.shared("ks")
         val f =
           Source(scenario.inputs)
-            .via(commPattern.decorateFlow(scenario.leftClosing, scenario.rightClosing, onRHS))
+            .via(commPattern.decorateFlow(scenario.leftClosing, scenario.rightClosing, onRHS, ks))
             .transform(() ⇒ new PushStage[SslTlsInbound, SslTlsInbound] {
               override def onPush(elem: SslTlsInbound, ctx: Context[SslTlsInbound]) =
                 ctx.push(elem)
@@ -364,7 +388,8 @@ class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=o
             .scan(ByteString.empty)(_ ++ _)
             .via(new Timeout(6.seconds))
             .dropWhile(_.size < scenario.output.size)
-            .runWith(Sink.head)
+            .map(bs ⇒ {  ks.shutdown(); bs })
+            .runWith(if (commPattern.ignoresShutdown) Sink.head else Sink.last)
 
         Await.result(f, 8.seconds).utf8String should be(scenario.output.utf8String)
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -292,6 +292,7 @@ class TLSActor(
       if (tracing) log.debug("closing inbound")
       try engine.closeInbound()
       catch { case ex: SSLException ⇒ outputBunch.enqueue(UserOut, SessionTruncated) }
+      lastHandshakeStatus = engine.getHandshakeStatus
       completeOrFlush()
       false
     } else if (inboundState != inboundHalfClosed && outputBunch.isCancelled(UserOut)) {
@@ -314,8 +315,8 @@ class TLSActor(
         case ex: SSLException ⇒
           if (tracing) log.debug(s"SSLException during doUnwrap: $ex")
           fail(ex, closeTransport = false)
-          engine.closeInbound()
-          completeOrFlush()
+          engine.closeInbound() // we don't need to add lastHandshakeStatus check here because
+          completeOrFlush()     // it doesn't make any sense to write anything to the network anymore
           false
       }
     } else true


### PR DESCRIPTION
Fixes #21760
Also fixes akka/akka-http#380 and probably akka/akka-http#87

This is a first variant of testing the fix (an alternative is #21786)
Initial discussion is in #21761

When application closes inboud using `engine.closeInbound` the engine can generate an alert message and put it into `writer.outboundList`. As a result the engine can have a new data packet in outbound and its `isOutboundDone` will be `false`. We have to ensure that it will be flushed to the network, that's why we have to update `lastHandshakeStatus` via the actual status of the engine. Otherwise the actor will transition to the `flushingOutbound` state but will never flush outbound, since `engineNeedsWrap` precondition will be `false`.

Generally speaking whenever we signal something to the SSLEngine, we should also read `getHandshakeStatus` afterwards to understand what we need to do next. This was done everywhere but for this `engine.closeInbound`.

