### PR TITLE
Fix #21760 - Close Tls connection if Inbound closed before receiving peer's close_notify (v.2)

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -292,6 +292,7 @@ class TLSActor(
       if (tracing) log.debug("closing inbound")
       try engine.closeInbound()
       catch { case ex: SSLException ⇒ outputBunch.enqueue(UserOut, SessionTruncated) }
+      lastHandshakeStatus = engine.getHandshakeStatus
       completeOrFlush()
       false
     } else if (inboundState != inboundHalfClosed && outputBunch.isCancelled(UserOut)) {
@@ -314,8 +315,8 @@ class TLSActor(
         case ex: SSLException ⇒
           if (tracing) log.debug(s"SSLException during doUnwrap: $ex")
           fail(ex, closeTransport = false)
-          engine.closeInbound()
-          completeOrFlush()
+          engine.closeInbound() // we don't need to add lastHandshakeStatus check here because
+          completeOrFlush()     // it doesn't make any sense to write anything to the network anymore
           false
       }
     } else true


### PR DESCRIPTION
Fixes #21760
Also fixes akka/akka-http#380 and probably akka/akka-http#87

This is a second variant of testing the fix (an alternative is #21785)
Initial discussion is in #21761

When application closes inboud using engine.closeInbound the engine can generate an alert message and put it into writer.outboundList. As a result the engine can have a new data packet in outbound and its isOutboundDone will be false. We have to ensure that it will be flushed to the network, that's why we have to update lastHandshakeStatus via the actual status of the engine. Otherwise the actor will transition to the flushingOutbound state but will never flush outbound, since engineNeedsWrap precondition will be false.

Generally speaking whenever we signal something to the SSLEngine, weshould also read getHandshakeStatus afterwards to understand what we need to do next. This was done everywhere but for this engine.closeInbound.