### PR TITLE
Add a note about RecoveryCompleted for new actors

### DIFF
--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -195,6 +195,10 @@ and before any other received messages.
 
 .. includecode:: code/docs/persistence/PersistenceDocTest.java#recovery-completed
 
+The actor will always receive a :class:`RecoveryCompleted` message, even if there are no events
+in the journal and the snapshot store is empty, or if it's a new persistent actor with a previously
+unused ``persistenceId``.
+
 If there is a problem with recovering the state of the actor from the journal, ``onRecoveryFailure``
 is called (logging the error by default) and the actor will be stopped.
 

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -180,6 +180,10 @@ and before any other received messages.
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#recovery-completed
 
+The actor will always receive a :class:`RecoveryCompleted` message, even if there are no events
+in the journal and the snapshot store is empty, or if it's a new persistent actor with a previously
+unused ``persistenceId``.
+
 If there is a problem with recovering the state of the actor from the journal, ``onRecoveryFailure``
 is called (logging the error by default) and the actor will be stopped.
 


### PR DESCRIPTION
Since [I asked](https://gitter.im/akka/akka?at=581c842feed0c3125f36ae46) and got an answer:

Clarify behaviour of `RecoveryCompleted` when we are dealing with a new persistent actor or one that has not persisted any events or snapshots.