### PR TITLE
Fix the RoundRobinLogic select function when Long is overflow.

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -27,7 +27,7 @@ final class RoundRobinRoutingLogic extends RoutingLogic {
     if (routees.nonEmpty) {
       val size = routees.size
       val index = (next.getAndIncrement % size).asInstanceOf[Int]
-      routees(if (index < 0) size + index - 1 else index)
+      routees(if (index < 0) size + index else index)
     } else NoRoutee
 
 }


### PR DESCRIPTION
The current RoundRobin select function which I provided some time ago has a small bug, it would never reach the max index of a collection of routees once the long counter is overflow and is in the neg values, such case is unlikely to happen but at the moment it is theoretically wrong.

Test code:
```
public class TestRoundRobinSelect {

  // Current Akka function.
  public static int selectCurrent(long counter, int size) {
    final int index = (int) (counter % size);
    return index < 0 ? index + size - 1 : index;
  }

  // The intended current function fixed:
  // Notice the condition is meant for the counter and not the calculated index.
  public static int selectFixed(long counter, int size) {
    final int index = (int) (counter % size);
    return counter < 0 ? index + size - 1 : index;
  }

  // A better version that in case of overflow will do less computations or none for divisible counters,
  // mathematically proven to be also correct, can elaborate here if needed.
  public static int selectBetter(long counter, int size) {
    final int index = (int) (counter % size);
    return index < 0 ? index + size : index;
  }

  public static void main(String[] args) {
    // When you try with different sizes it will show/prove that
    // the current function will never reach the max index once the Long counter is overflow.
    final int size = 5;
    long counter = Long.MAX_VALUE - size;
    for (int i = 0; i < size * 2; i++) {
      System.out.println("Result for counter = " + counter + " and size = " + size + ":");
      System.out.println("Current select index = " + selectCurrent(counter, size));
      System.out.println("Fixed select index = " + selectFixed(counter, size));
      System.out.println("Better select index = " + selectBetter(counter, size));
      counter++;
    }
  }
}
```