### PR TITLE
#21743: FlattenMerge should propagate outer attributes

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
@@ -4,8 +4,10 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
-import akka.stream.{ ActorMaterializerSettings, ActorMaterializer }
+import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
+import akka.stream._
 import akka.stream.testkit.Utils.assertAllStagesStopped
+
 import scala.concurrent._
 import scala.concurrent.duration._
 import akka.stream.testkit.{ StreamSpec, TestPublisher }
@@ -163,6 +165,32 @@ class FlowFlattenMergeSpec extends StreamSpec {
       val elems = p.within(1.second)((1 to 1000).map(i ⇒ p.requestNext()).toSet)
       p.expectComplete()
       elems should ===((0 until 1000).toSet)
+    }
+
+    val attributesSource = Source.fromGraph(
+      new GraphStage[SourceShape[Attributes]] {
+        val out = Outlet[Attributes]("AttributesSource.out")
+        override val shape: SourceShape[Attributes] = SourceShape(out)
+        override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with OutHandler {
+          override def onPull(): Unit = {
+            push(out, inheritedAttributes)
+            completeStage()
+          }
+          setHandler(out, this)
+        }
+      }
+    )
+
+    "propagate attributes to inner streams" in assertAllStagesStopped {
+      val f = Source.single(attributesSource.addAttributes(Attributes.name("inner")))
+        .flatMapMerge(1, identity)
+        .addAttributes(Attributes.name("outer"))
+        .runWith(Sink.head)
+
+      val attributes = Await.result(f, 3.seconds).attributeList
+      attributes should contain(Attributes.Name("inner"))
+      attributes should contain(Attributes.Name("outer"))
+      attributes.indexOf(Attributes.Name("outer")) < attributes.indexOf(Attributes.Name("inner")) should be(true)
     }
 
   }

--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -27,6 +27,13 @@ abstract class Materializer {
   def materialize[Mat](runnable: Graph[ClosedShape, Mat]): Mat
 
   /**
+   * This method interprets the given Flow description and creates the running
+   * stream using an explicitly provided [[Attributes]] as top level attributes. The result can be highly
+   * implementation specific, ranging from local actor chains to remote-deployed processing networks.
+   */
+  def materialize[Mat](runnable: Graph[ClosedShape, Mat], initialAttributes: Attributes): Mat
+
+  /**
    * Running a flow graph will require execution resources, as will computations
    * within Sources, Sinks, etc. This [[scala.concurrent.ExecutionContextExecutor]]
    * can be used by parts of the flow to submit processing jobs for execution,
@@ -62,6 +69,9 @@ private[akka] object NoMaterializer extends Materializer {
     throw new UnsupportedOperationException("NoMaterializer cannot be named")
   override def materialize[Mat](runnable: Graph[ClosedShape, Mat]): Mat =
     throw new UnsupportedOperationException("NoMaterializer cannot materialize")
+  override def materialize[Mat](runnable: Graph[ClosedShape, Mat], initialAttributes: Attributes): Mat =
+    throw new UnsupportedOperationException("NoMaterializer cannot materialize")
+
   override def executionContext: ExecutionContextExecutor =
     throw new UnsupportedOperationException("NoMaterializer does not provide an ExecutionContext")
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1016,6 +1016,9 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.actor.VirtualPathContainer.this"),
         ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.RemoteSystemDaemon.this")
 
+      ),
+      "2.4.12" -> Seq(
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.Materializer.materialize")
       )
     )
   }


### PR DESCRIPTION
 - Added Materializer.materialize() version that takes explicit initial attributes