### PR TITLE
Add resolveOneCS to ActorSelection for Java CompletionStage 

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/ActorSelectionTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorSelectionTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.actor;
+
+import akka.testkit.AkkaJUnitActorSystemResource;
+import akka.testkit.AkkaSpec;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class ActorSelectionTest extends JUnitSuite {
+
+  @ClassRule
+  public static AkkaJUnitActorSystemResource actorSystemResource = new AkkaJUnitActorSystemResource("ActorSelectionTest",
+    AkkaSpec.testConf());
+
+  private final ActorSystem system = actorSystemResource.getSystem();
+
+  @Test
+  public void testResolveOneCS() throws Exception {
+    ActorRef actorRef = system.actorOf(Props.create(JavaAPITestActor.class), "ref1");
+    ActorSelection selection = system.actorSelection("user/ref1");
+    FiniteDuration timeout = new FiniteDuration(10, TimeUnit.MILLISECONDS);
+
+    CompletionStage<ActorRef> cs = selection.resolveOneCS(timeout);
+
+    ActorRef resolvedRef = cs.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    assertEquals(actorRef, resolvedRef);
+  }
+}

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -3,7 +3,8 @@
  */
 package akka.actor
 
-import language.implicitConversions
+import java.util.concurrent.CompletionStage
+
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -11,11 +12,14 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.Success
 import java.util.regex.Pattern
+
 import akka.pattern.ask
 import akka.routing.MurmurHash
 import akka.util.Helpers
 import akka.util.Timeout
 import akka.dispatch.ExecutionContexts
+
+import scala.compat.java8.FutureConverters
 
 /**
  * An ActorSelection is a logical view of a section of an ActorSystem's tree of Actors,
@@ -77,6 +81,19 @@ abstract class ActorSelection extends Serializable {
    * [[ActorRef]].
    */
   def resolveOne(timeout: FiniteDuration): Future[ActorRef] = resolveOne()(timeout)
+
+  /**
+   * Java API (8) for [[#resolveOne]]
+   *
+   * Resolve the [[ActorRef]] matching this selection.
+   * The result is returned as a CompletionStage that is completed with the [[ActorRef]]
+   * if such an actor exists. It is completed with failure [[ActorNotFound]] if
+   * no such actor exists or the identification didn't complete within the
+   * supplied `timeout`.
+   *
+   */
+  def resolveOneCS(timeout: FiniteDuration): CompletionStage[ActorRef] =
+    FutureConverters.toJava[ActorRef](resolveOne(timeout))
 
   override def toString: String = {
     val builder = new java.lang.StringBuilder()

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -83,7 +83,7 @@ abstract class ActorSelection extends Serializable {
   def resolveOne(timeout: FiniteDuration): Future[ActorRef] = resolveOne()(timeout)
 
   /**
-   * Java API (8) for [[#resolveOne]]
+   * Java API for [[#resolveOne]]
    *
    * Resolve the [[ActorRef]] matching this selection.
    * The result is returned as a CompletionStage that is completed with the [[ActorRef]]


### PR DESCRIPTION
Refs #21726

Does this look ok? I followed how [CircuitBreaker implemented callWithCircuitBreakerCS()](https://github.com/akka/akka/blob/4a7cd147313404eb8137e56163e54f06c23640d0/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala#L172L182).

JavaDoc looks like this.

![image](https://cloud.githubusercontent.com/assets/7414320/20064212/440a9a5a-a54d-11e6-9837-da998235eac6.png)
