### PR TITLE
harden ClusterShardingSpec, #21718 and #21535

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
@@ -158,6 +158,7 @@ abstract class ClusterShardingSpecConfig(
         max-simultaneous-rebalance = 1
       }
     }
+    akka.testconductor.barrier-timeout = 70s
     """))
   nodeConfig(sixth) {
     ConfigFactory.parseString("""akka.cluster.roles = ["frontend"]""")


### PR DESCRIPTION
For #21718 we can see in the logs that the first node is removed
as expected and then come back in the membership, which is possible in
case of conflicting membership state merge. It is supposed to be
removed again by the auto-down. That doesn't happen within the barrier-timeout.