### PR TITLE
Handle early termination of system when starting logger, #21674

### DIFF
--- a/akka-typed/src/main/scala/akka/typed/internal/EventStreamImpl.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/EventStreamImpl.scala
@@ -190,9 +190,11 @@ private[typed] class EventStreamImpl(private val debug: Boolean)(implicit privat
       }
     } catch {
       case e: Exception ⇒
-        System.err.println("error while starting up loggers")
-        e.printStackTrace()
-        throw new akka.ConfigurationException("Could not start logger due to [" + e.toString + "]")
+        if (!system.whenTerminated.isCompleted) {
+          System.err.println("error while starting up loggers")
+          e.printStackTrace()
+          throw new akka.ConfigurationException("Could not start logger due to [" + e.toString + "]")
+        }
     }
   }
 


### PR DESCRIPTION
* The IntroSpec terminates the system immediately via the root actor
  and when that happens before the logger is started the ask
  can't be scheduled.