### PR TITLE
Remove scalatest from OSGi sample

### DIFF
--- a/akka-samples/akka-sample-osgi-dining-hakkers/assembly-dist/pom.xml
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/assembly-dist/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>features-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf.tooling.maven.version}</version>
                 <executions>
                     <execution>
                         <id>add-features-to-repo</id>
@@ -57,8 +57,8 @@
                         </goals>
                         <configuration>
                             <descriptors>
-                                <descriptor>mvn:org.apache.karaf.assemblies.features/standard/${karaf.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.karaf.assemblies.features/enterprise/${karaf.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.assemblies.features/standard/${karaf.tooling.maven.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.assemblies.features/enterprise/${karaf.tooling.maven.version}/xml/features</descriptor>
                                 <descriptor>mvn:com.typesafe.akka.akka-sample-osgi-dining-hakkers/akka-sample-osgi-dining-hakkers/${project.version}/xml/features</descriptor>
                             </descriptors>
                             <repository>target/generated-features-repo</repository>

--- a/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/pom.xml
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>akka-testkit_${scala.dep.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.dep.version}</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/HakkerStatusTest.scala
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/HakkerStatusTest.scala
@@ -5,13 +5,12 @@ import akka.sample.osgi.api._
 import akka.sample.osgi.test.TestOptions._
 import akka.testkit.TestProbe
 import javax.inject.Inject
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.{ Before, Test }
 import org.ops4j.pax.exam.junit.{ Configuration, JUnit4TestRunner }
 import org.ops4j.pax.exam.util.Filter
 import org.ops4j.pax.exam.{ Option => PaxOption }
-import org.scalatest.junit.{AssertionsForJUnit, JUnitSuite}
-import org.scalatest.Matchers
 import scala.concurrent.duration._
 import org.apache.karaf.tooling.exam.options.LogLevelOption
 
@@ -30,7 +29,7 @@ import org.apache.karaf.tooling.exam.options.LogLevelOption
  * TODO attempt to use the Akka test probe
  */
 @RunWith(classOf[JUnit4TestRunner])
-class HakkerStatusTest extends JUnitSuite with Matchers with AssertionsForJUnit {
+class HakkerStatusTest {
 
   @Inject @Filter(timeout = 30000)
   var actorSystem: ActorSystem = _
@@ -66,8 +65,8 @@ class HakkerStatusTest extends JUnitSuite with Matchers with AssertionsForJUnit 
       val Identification(fromHakker, busyWith) = testProbe.expectMsgType[Identification]
 
       println("---------------> %s is busy with %s.".format(fromHakker, busyWith))
-      fromHakker should be("TestHakker")
-      busyWith should not be (null)
+      assertEquals(fromHakker, "TestHakker")
+      assertNotNull(busyWith)
     }
 
   }
@@ -84,8 +83,8 @@ class HakkerStatusTest extends JUnitSuite with Matchers with AssertionsForJUnit 
         testProbe.within(1.second) {
           tracker.tell(GetEatingCount(name), testProbe.ref)
           val reply = testProbe.expectMsgType[EatingCount]
-          reply.hakkerName should be(name)
-          reply.count should be > (0)
+          assertEquals(reply.hakkerName, name)
+          assertTrue(reply.count > 0)
         }
       }
     }

--- a/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/TestOptions.scala
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/integration-test/src/test/scala/akka/sample/osgi/test/TestOptions.scala
@@ -26,7 +26,6 @@ object TestOptions {
   def testBundles(): PaxOption = {
     new DefaultCompositeOption(
       mavenBundle("com.typesafe.akka", "akka-testkit_%s".format(scalaDepVersion)).versionAsInProject,
-      mavenBundle("org.scalatest", "scalatest_%s".format(scalaDepVersion)).versionAsInProject,
       junitBundles)
   }
 

--- a/akka-samples/akka-sample-osgi-dining-hakkers/pom.xml
+++ b/akka-samples/akka-sample-osgi-dining-hakkers/pom.xml
@@ -10,8 +10,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <akka.version>2.4-SNAPSHOT</akka.version>
-        <karaf.version>2.3.1</karaf.version>
-        <karaf.tooling.exam.version>${karaf.version}</karaf.tooling.exam.version>
+        <!-- Support for eecap-1.8 (Java 8) is from 3.0.2 -->
+        <!-- https://github.com/apache/karaf/blob/karaf-3.0.2/assemblies/features/framework/src/main/filtered-resources/resources/etc/config.properties -->
+        <karaf.version>3.0.8</karaf.version>
+        <karaf.tooling.exam.version>2.3.12</karaf.tooling.exam.version>
+        <karaf.tooling.maven.version>2.4.4</karaf.tooling.maven.version>
         <netty.version>3.10.5.Final</netty.version>
         <osgi.version>4.3.1</osgi.version>
         <paxexam.version>2.6.0</paxexam.version>
@@ -19,7 +22,6 @@
         <protobuf.version>2.5.0</protobuf.version>
         <scala.version>2.11.7</scala.version>
         <scala.dep.version>2.11</scala.dep.version>
-        <scalatest.version>2.2.3</scalatest.version>
         <typesafe.config.version>1.3.0</typesafe.config.version>
         <leveldb.version>0.7</leveldb.version>
         <leveldbjni.version>1.8</leveldbjni.version>
@@ -144,12 +146,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest_${scala.dep.version}</artifactId>
-                <version>${scalatest.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.10</version>
@@ -183,6 +179,14 @@
         <repository>
             <id>oss-sonatype-releases</id>
             <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
+        <repository>
+            <id>springsource-releases</id>
+            <url>http://repository.springsource.com/maven/bundles/release</url>
+        </repository>
+        <repository>
+            <id>springsource-external</id>
+            <url>http://repository.springsource.com/maven/bundles/external</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Removes scalatest dependency from the dining hakkers sample, as scalatest does not support OSGi (https://github.com/scalatest/scalatest/issues/484).

Also updates to Karaf which supports Java 8.

This still does *not* make dining hakkers integration tests pass (`akka-sample-osgi-dining-hakkers-maven-test/test`) as now these tests stop with a `NullPointerException` which I had no time to investigate.

What this fixes is running the sample manually works as described in the sample [README.md](akka-samples/akka-sample-osgi-dining-hakkers/README.md). After starting karaf manually good old dining hakkers are dining again:
```
...
[INFO] [11/09/2016 13:37:41.778] [akka-osgi-sample-akka.actor.default-dispatcher-16] [akka.tcp://akka-osgi-sample@localhost:4242/user/table/Chopstick5] akka://akka-osgi-sample/user/table/Chopstick5 is taken by Actor[akka://akka-osgi-sample/user/$a#-1086748197]
[INFO] [11/09/2016 13:37:41.778] [akka-osgi-sample-akka.actor.default-dispatcher-18] [akka.tcp://akka-osgi-sample@localhost:4242/user/table/Chopstick1] akka://akka-osgi-sample/user/table/Chopstick1 is taken by Actor[akka://akka-osgi-sample/user/$a#-1086748197]
[INFO] [11/09/2016 13:37:41.778] [akka-osgi-sample-akka.actor.default-dispatcher-18] [akka.tcp://akka-osgi-sample@localhost:4242/user/$a] com.typesafe.akka.akka-sample-osgi-dining-hakkers.command:54 has picked up Chopstick5 and Chopstick1 and starts to eat
[INFO] [11/09/2016 13:37:46.798] [akka-osgi-sample-akka.actor.default-dispatcher-20] [akka.tcp://akka-osgi-sample@localhost:4242/user/$a] com.typesafe.akka.akka-sample-osgi-dining-hakkers.command:54 puts down his chopsticks and starts to think
[INFO] [11/09/2016 13:37:51.817] [akka-osgi-sample-akka.actor.default-dispatcher-16] [akka.tcp://akka-osgi-sample@localhost:4242/user/table/Chopstick5] akka://akka-osgi-sample/user/table/Chopstick5 is taken by Actor[akka://akka-osgi-sample/user/$a#-1086748197]
[INFO] [11/09/2016 13:37:51.817] [akka-osgi-sample-akka.actor.default-dispatcher-20] [akka.tcp://akka-osgi-sample@localhost:4242/user/table/Chopstick1] akka://akka-osgi-sample/user/table/Chopstick1 is taken by Actor[akka://akka-osgi-sample/user/$a#-1086748197]
[INFO] [11/09/2016 13:37:51.817] [akka-osgi-sample-akka.actor.default-dispatcher-16] [akka.tcp://akka-osgi-sample@localhost:4242/user/$a] com.typesafe.akka.akka-sample-osgi-dining-hakkers.command:54 has picked up Chopstick5 and Chopstick1 and starts to eat
...
```

I have tested this on Akka 2.4.10, because later versions depend on Aeron, which at the time was not OSGi compatible.

We can merge this as it is. It does not add the integration test back to the build, so it will not break the build.

