### PR TITLE
Fix #21791 by adding a version override for scala.util.parser

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -110,7 +110,8 @@ object OSGi {
     OsgiKeys.importPackage := imports ++ scalaVersion(defaultImports).value,
     OsgiKeys.exportPackage := packages
   )
-  def defaultImports(scalaVersion: String) = Seq("!sun.misc", akkaImport(), configImport(), scalaImport(scalaVersion), "*")
+  def defaultImports(scalaVersion: String) = Seq("!sun.misc", akkaImport(), configImport(), "!scala.compat.java8.*",
+    "!scala.util.parsing.*", scalaImport(scalaVersion), "*")
   def akkaImport(packageName: String = "akka.*") = versionedImport(packageName, "2.4", "2.5")
   def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.3.0", "1.4.0")
   def scalaImport(version: String) = {


### PR DESCRIPTION
This patch fixes akka-stream's OSGi manifest so it references
valid version of scala.util.parser.combinators, 1.0.4, instead
of the scala version we build for.

Signed-off-by: Robert Varga <nite@hq.sk>