### PR TITLE
+stk expose `within` for both TestSubscriber and TestPublisher

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -126,6 +126,29 @@ object TestPublisher {
       probe.expectMsgPF[T]()(f.asInstanceOf[PartialFunction[Any, T]])
 
     def getPublisher: Publisher[I] = this
+
+    /**
+     * Execute code block while bounding its execution time between `min` and
+     * `max`. `within` blocks may be nested. All methods in this trait which
+     * take maximum wait times are available in a version which implicitly uses
+     * the remaining time governed by the innermost enclosing `within` block.
+     *
+     * Note that the timeout is scaled using Duration.dilated, which uses the
+     * configuration entry "akka.test.timefactor", while the min Duration is not.
+     *
+     * {{{
+     * val ret = within(50 millis) {
+     *   test ! "ping"
+     *   expectMsgClass(classOf[String])
+     * }
+     * }}}
+     */
+    def within[T](min: FiniteDuration, max: FiniteDuration)(f: ⇒ T): T = probe.within(min, max)(f)
+
+    /**
+     * Same as calling `within(0 seconds, max)(f)`.
+     */
+    def within[T](max: FiniteDuration)(f: ⇒ T): T = probe.within(max)(f)
   }
 
   /**
@@ -588,7 +611,28 @@ object TestSubscriber {
       drain()
     }
 
-    def within[T](max: FiniteDuration)(f: ⇒ T): T = probe.within(0.seconds, max)(f)
+    /**
+     * Execute code block while bounding its execution time between `min` and
+     * `max`. `within` blocks may be nested. All methods in this trait which
+     * take maximum wait times are available in a version which implicitly uses
+     * the remaining time governed by the innermost enclosing `within` block.
+     *
+     * Note that the timeout is scaled using Duration.dilated, which uses the
+     * configuration entry "akka.test.timefactor", while the min Duration is not.
+     *
+     * {{{
+     * val ret = within(50 millis) {
+     *   test ! "ping"
+     *   expectMsgClass(classOf[String])
+     * }
+     * }}}
+     */
+    def within[T](min: FiniteDuration, max: FiniteDuration)(f: ⇒ T): T = probe.within(min, max)(f)
+
+    /**
+     * Same as calling `within(0 seconds, max)(f)`.
+     */
+    def within[T](max: FiniteDuration)(f: ⇒ T): T = probe.within(max)(f)
 
     def onSubscribe(subscription: Subscription): Unit = probe.ref ! OnSubscribe(subscription)
     def onNext(element: I): Unit = probe.ref ! OnNext(element)


### PR DESCRIPTION
This will allow us place limits on methods like `expectRequest` without
introducing other overloads.