### PR TITLE
asOutputStream did never complete on close and exposed a unsafe callback #20503, #21864

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
@@ -32,9 +32,6 @@ private[stream] object OutputStreamSourceStage {
   case object Ok extends DownstreamStatus
   case object Canceled extends DownstreamStatus
 
-  sealed trait StageWithCallback {
-    def wakeUp(msg: AdapterToStageMessage): Future[Unit]
-  }
 }
 
 final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration) extends GraphStageWithMaterializedValue[SourceShape[ByteString], OutputStream] {
@@ -52,7 +49,7 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
     val dataQueue = new LinkedBlockingQueue[ByteString](maxBuffer)
     val downstreamStatus = new AtomicReference[DownstreamStatus](Ok)
 
-    val logic = new GraphStageLogic(shape) with StageWithCallback {
+    val logic = new GraphStageLogic(shape) with CallbackWrapper[(AdapterToStageMessage, Promise[Unit])] {
       var flush: Option[Promise[Unit]] = None
       var close: Option[Promise[Unit]] = None
 
@@ -68,9 +65,9 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
       private val upstreamCallback: AsyncCallback[(AdapterToStageMessage, Promise[Unit])] =
         getAsyncCallback(onAsyncMessage)
 
-      override def wakeUp(msg: AdapterToStageMessage): Future[Unit] = {
+      def wakeUp(msg: AdapterToStageMessage): Future[Unit] = {
         val p = Promise[Unit]()
-        upstreamCallback.invoke((msg, p))
+        this.invoke((msg, p))
         p.future
       }
 
@@ -81,11 +78,7 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
             sendResponseIfNeed()
           case Close ⇒
             close = Some(event._2)
-            if (dataQueue.isEmpty) {
-              downstreamStatus.set(Canceled)
-              completeStage()
-              unblockUpstream()
-            } else sendResponseIfNeed()
+            sendResponseIfNeed()
         }
 
       private def unblockUpstream(): Boolean =
@@ -96,8 +89,10 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
             true
           case None ⇒ close match {
             case Some(p) ⇒
+              downstreamStatus.set(Canceled)
               p.complete(Success(()))
               close = None
+              completeStage()
               true
             case None ⇒ false
           }
@@ -115,6 +110,7 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
       override def preStart(): Unit = {
         dispatcher = ActorMaterializerHelper.downcast(materializer).system.dispatchers.lookup(dispatcherId)
         super.preStart()
+        initCallback(upstreamCallback.invoke)
       }
 
       setHandler(out, new OutHandler {
@@ -151,6 +147,7 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
         super.postStop()
       }
     }
+
     (logic, new OutputStreamAdapter(dataQueue, downstreamStatus, logic.wakeUp, writeTimeout))
   }
 }


### PR DESCRIPTION
StreamConverters.asOutputStream did never complete if the buffer size was greater than zero,
this lead to a bad state, where the close was unblocked, but the stage was never completed.
Also the OutputStream uses getAsyncCallback which had the problem that it always lead to races,
if flush or close was called to early.

Apparently the test takes 8 seconds to complete, however it was the only way to actually catch these issue's. Maybe somebody could guide me to a better idea.