### PR TITLE
Move compression tests over from akka-http + fix for ByteStringParser

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/ByteStringParserSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/ByteStringParserSpec.scala
@@ -5,6 +5,8 @@ package akka.stream.io
 
 import akka.stream.{ ActorMaterializer, Attributes, ThrottleMode }
 import akka.stream.impl.io.ByteStringParser
+import akka.stream.impl.io.ByteStringParser.{ ByteReader, ParseResult, ParseStep }
+import akka.stream.io.compression.LogByteStringTools
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.stage.GraphStageLogic
 import akka.stream.testkit.StreamSpec
@@ -16,27 +18,27 @@ import scala.concurrent.duration._
 class ByteStringParserSpec extends StreamSpec() {
   implicit val materializer = ActorMaterializer()
 
-  class Chunker extends ByteStringParser[ByteString] {
-    import ByteStringParser._
-
-    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new ParsingLogic {
-
-      lazy val step: ParseStep[ByteString] = new ParseStep[ByteString] {
-        override def parse(reader: ByteReader): ParseResult[ByteString] = {
-          val bytes = reader.take(2)
-          ParseResult(Some(bytes), step)
-        }
-      }
-
-      startWith(step)
-
-    }
-
-  }
-
   "ByteStringParser" must {
 
     "respect backpressure" in {
+      class Chunker extends ByteStringParser[ByteString] {
+        import ByteStringParser._
+
+        override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new ParsingLogic {
+
+          lazy val step: ParseStep[ByteString] = new ParseStep[ByteString] {
+            override def parse(reader: ByteReader): ParseResult[ByteString] = {
+              val bytes = reader.take(2)
+              ParseResult(Some(bytes), step)
+            }
+          }
+
+          startWith(step)
+
+        }
+
+      }
+
       // The Chunker produces two frames for one incoming 4 byte chunk. Hence, the rate in the incoming
       // side of the Chunker should only be half than on its outgoing side.
 
@@ -51,6 +53,36 @@ class ByteStringParserSpec extends StreamSpec() {
 
     }
 
+    "continue parsing with multistep parsing logic if step doesn't produce element" in {
+      object MultistepParsing extends ByteStringParser[ByteString] {
+        def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new ParsingLogic {
+          object ReadHeader extends ParseStep[ByteString] {
+            def parse(reader: ByteReader): ParseResult[ByteString] = {
+              require(reader.readShortBE() == 0xcafe, "Magic header bytes not found")
+              ParseResult(None, ReadData)
+            }
+          }
+          object ReadData extends ParseStep[ByteString] {
+            def parse(reader: ByteReader): ParseResult[ByteString] =
+              ParseResult(Some(reader.takeAll()), ReadData)
+          }
+
+          startWith(ReadHeader)
+        }
+      }
+
+      def run(data: ByteString*): ByteString =
+        Await.result(
+          Source[ByteString](data.toVector)
+            .via(MultistepParsing)
+            .fold(ByteString.empty)(_ ++ _)
+            .runWith(Sink.head), 5.seconds)
+
+      run(ByteString(0xca), ByteString(0xfe), ByteString(0xef, 0x12)) shouldEqual ByteString(0xef, 0x12)
+      run(ByteString(0xca), ByteString(0xfe, 0xef, 0x12)) shouldEqual ByteString(0xef, 0x12)
+      run(ByteString(0xca, 0xfe), ByteString(0xef, 0x12)) shouldEqual ByteString(0xef, 0x12)
+      run(ByteString(0xca, 0xfe, 0xef, 0x12)) shouldEqual ByteString(0xef, 0x12)
+    }
   }
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.io.compression
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import akka.util.ByteString
+import org.scalatest.{ BeforeAndAfterAll, Matchers, Suite }
+
+trait CodecSpecSupport extends Matchers with BeforeAndAfterAll { self: Suite ⇒
+
+  def readAs(string: String, charset: String = "UTF8") = equal(string).matcher[String] compose { (_: ByteString).decodeString(charset) }
+  def hexDump(bytes: ByteString) = bytes.map("%02x".format(_)).mkString
+  def fromHexDump(dump: String) = dump.grouped(2).toArray.map(chars ⇒ Integer.parseInt(new String(chars), 16).toByte)
+
+  def printBytes(i: Int, id: String) = {
+    def byte(i: Int) = (i & 0xFF).toHexString
+    println(id + ": " + byte(i) + ":" + byte(i >> 8) + ":" + byte(i >> 16) + ":" + byte(i >> 24))
+    i
+  }
+
+  lazy val emptyTextBytes = ByteString(emptyText, "UTF8")
+  lazy val smallTextBytes = ByteString(smallText, "UTF8")
+  lazy val largeTextBytes = ByteString(largeText, "UTF8")
+
+  val emptyText = ""
+  val smallText = "Yeah!"
+  val largeText =
+    """Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
+elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
+et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor
+sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat
+nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis
+dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh
+euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
+
+Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo
+consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu
+feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit
+augue duis dolore te feugait nulla facilisi.
+
+Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim
+assum. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet
+dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit
+lobortis nisl ut aliquip ex ea commodo consequat.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat
+nulla facilisis.
+
+At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
+ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
+ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+consetetur sadipscing elitr, At accusam aliquyam diam diam dolore dolores duo eirmod eos erat, et nonumy sed tempor et
+et invidunt justo labore Stet clita ea et gubergren, kasd magna no rebum. sanctus sea sed takimata ut vero voluptua.
+est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat.
+
+Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy e""".replace("\r\n", "\n")
+
+  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+
+  override def afterAll() = TestKit.shutdownActorSystem(system)
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.io.compression
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream }
+import java.util
+import java.util.concurrent.ThreadLocalRandom
+import java.util.zip.DataFormatException
+
+import akka.NotUsed
+import akka.stream.impl.io.compression.Compressor
+import akka.stream.scaladsl.{ Compression, Flow, Sink, Source }
+import akka.util.ByteString
+import org.scalatest.{ Inspectors, WordSpec }
+
+import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+
+abstract class CoderSpec(codecName: String) extends WordSpec with CodecSpecSupport with Inspectors {
+  import CompressionTestingTools._
+
+  protected def newCompressor(): Compressor
+  protected def encoderFlow: Flow[ByteString, ByteString, Any]
+  protected def decoderFlow(maxBytesPerChunk: Int = Compression.MaxBytesPerChunkDefault): Flow[ByteString, ByteString, Any]
+
+  protected def newDecodedInputStream(underlying: InputStream): InputStream
+  protected def newEncodedOutputStream(underlying: OutputStream): OutputStream
+
+  case object AllDataAllowed extends Exception with NoStackTrace
+  protected def corruptInputCheck: Boolean = true
+
+  def extraTests(): Unit = {}
+
+  s"The $codecName codec" should {
+    "produce valid data on immediate finish" in {
+      streamDecode(newCompressor().finish()) should readAs(emptyText)
+    }
+    "properly encode an empty string" in {
+      streamDecode(ourEncode(emptyTextBytes)) should readAs(emptyText)
+    }
+    "properly decode an empty string" in {
+      ourDecode(streamEncode(emptyTextBytes)) should readAs(emptyText)
+    }
+    "properly round-trip encode/decode an empty string" in {
+      ourDecode(ourEncode(emptyTextBytes)) should readAs(emptyText)
+    }
+    "properly encode a small string" in {
+      streamDecode(ourEncode(smallTextBytes)) should readAs(smallText)
+    }
+    "properly decode a small string" in {
+      ourDecode(streamEncode(smallTextBytes)) should readAs(smallText)
+    }
+    "properly round-trip encode/decode a small string" in {
+      ourDecode(ourEncode(smallTextBytes)) should readAs(smallText)
+    }
+    "properly encode a large string" in {
+      streamDecode(ourEncode(largeTextBytes)) should readAs(largeText)
+    }
+    "properly decode a large string" in {
+      ourDecode(streamEncode(largeTextBytes)) should readAs(largeText)
+    }
+    "properly round-trip encode/decode a large string" in {
+      ourDecode(ourEncode(largeTextBytes)) should readAs(largeText)
+    }
+
+    if (corruptInputCheck) {
+      "throw an error on corrupt input" in {
+        (the[RuntimeException] thrownBy {
+          ourDecode(corruptContent)
+        }).getCause should be(a[DataFormatException])
+      }
+    }
+
+    "not throw an error if a subsequent block is corrupt" in {
+      pending // FIXME: should we read as long as possible and only then report an error, that seems somewhat arbitrary
+      ourDecode(Seq(encode("Hello,"), encode(" dear "), corruptContent).join) should readAs("Hello, dear ")
+    }
+    "decompress in very small chunks" in {
+      val compressed = encode("Hello")
+
+      decodeChunks(Source(Vector(compressed.take(10), compressed.drop(10)))) should readAs("Hello")
+    }
+    "support chunked round-trip encoding/decoding" in {
+      val chunks = largeTextBytes.grouped(512).toVector
+      val comp = newCompressor()
+      val compressedChunks = chunks.map { chunk ⇒ comp.compressAndFlush(chunk) } :+ comp.finish()
+      val uncompressed = decodeFromIterator(() ⇒ compressedChunks.iterator)
+
+      uncompressed should readAs(largeText)
+    }
+    "works for any split in prefix + suffix" in {
+      val compressed = streamEncode(smallTextBytes)
+      def tryWithPrefixOfSize(prefixSize: Int): Unit = {
+        val prefix = compressed.take(prefixSize)
+        val suffix = compressed.drop(prefixSize)
+
+        decodeChunks(Source(prefix :: suffix :: Nil)) should readAs(smallText)
+      }
+      (0 to compressed.size).foreach(tryWithPrefixOfSize)
+    }
+    "works for chunked compressed data of sizes just above 1024" in {
+      val comp = newCompressor()
+      val inputBytes = ByteString("""{"baseServiceURL":"http://www.acme.com","endpoints":{"assetSearchURL":"/search","showsURL":"/shows","mediaContainerDetailURL":"/container","featuredTapeURL":"/tape","assetDetailURL":"/asset","moviesURL":"/movies","recentlyAddedURL":"/recent","topicsURL":"/topics","scheduleURL":"/schedule"},"urls":{"aboutAweURL":"www.foobar.com"},"channelName":"Cool Stuff","networkId":"netId","slotProfile":"slot_1","brag":{"launchesUntilPrompt":10,"daysUntilPrompt":5,"launchesUntilReminder":5,"daysUntilReminder":2},"feedbackEmailAddress":"feedback@acme.com","feedbackEmailSubject":"Commends from User","splashSponsor":[],"adProvider":{"adProviderProfile":"","adProviderProfileAndroid":"","adProviderNetworkID":0,"adProviderSiteSectionNetworkID":0,"adProviderVideoAssetNetworkID":0,"adProviderSiteSectionCustomID":{},"adProviderServerURL":"","adProviderLiveVideoAssetID":""},"update":[{"forPlatform":"ios","store":{"iTunes":"www.something.com"},"minVer":"1.2.3","notificationVer":"1.2.5"},{"forPlatform":"android","store":{"amazon":"www.something.com","play":"www.something.com"},"minVer":"1.2.3","notificationVer":"1.2.5"}],"tvRatingPolicies":[{"type":"sometype","imageKey":"tv_rating_small","durationMS":15000,"precedence":1},{"type":"someothertype","imageKey":"tv_rating_big","durationMS":15000,"precedence":2}],"exts":{"adConfig":{"globals":{"#{adNetworkID}":"2620","#{ssid}":"usa_tveapp"},"iPad":{"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_ipad/shows","adSize":[{"#{height}":90,"#{width}":728}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_ipad&sz=1x1&t=&c=#{doubleclickrandom}"},"watchwithshowtile":{"adMobAdUnitID":"/2620/usa_tveapp_ipad/watchwithshowtile","adSize":[{"#{height}":120,"#{width}":240}]},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_ipad/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}},"iPadRetina":{"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_ipad/shows","adSize":[{"#{height}":90,"#{width}":728}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_ipad&sz=1x1&t=&c=#{doubleclickrandom}"},"watchwithshowtile":{"adMobAdUnitID":"/2620/usa_tveapp_ipad/watchwithshowtile","adSize":[{"#{height}":120,"#{width}":240}]},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_ipad/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}},"iPhone":{"home":{"adMobAdUnitID":"/2620/usa_tveapp_iphone/home","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_iphone/shows","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"episodepage":{"adMobAdUnitID":"/2620/usa_tveapp_iphone/shows/#{SHOW_NAME}","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_iphone&sz=1x1&t=&c=#{doubleclickrandom}"},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_iphone/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}},"iPhoneRetina":{"home":{"adMobAdUnitID":"/2620/usa_tveapp_iphone/home","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_iphone/shows","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"episodepage":{"adMobAdUnitID":"/2620/usa_tveapp_iphone/shows/#{SHOW_NAME}","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_iphone&sz=1x1&t=&c=#{doubleclickrandom}"},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_iphone/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}},"Tablet":{"home":{"adMobAdUnitID":"/2620/usa_tveapp_androidtab/home","adSize":[{"#{height}":90,"#{width}":728},{"#{height}":50,"#{width}":320},{"#{height}":50,"#{width}":300}]},"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_androidtab/shows","adSize":[{"#{height}":90,"#{width}":728},{"#{height}":50,"#{width}":320},{"#{height}":50,"#{width}":300}]},"episodepage":{"adMobAdUnitID":"/2620/usa_tveapp_androidtab/shows/#{SHOW_NAME}","adSize":[{"#{height}":90,"#{width}":728},{"#{height}":50,"#{width}":320},{"#{height}":50,"#{width}":300}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_androidtab&sz=1x1&t=&c=#{doubleclickrandom}"},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_androidtab/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}},"TabletHD":{"home":{"adMobAdUnitID":"/2620/usa_tveapp_androidtab/home","adSize":[{"#{height}":90,"#{width}":728},{"#{height}":50,"#{width}":320},{"#{height}":50,"#{width}":300}]},"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_androidtab/shows","adSize":[{"#{height}":90,"#{width}":728},{"#{height}":50,"#{width}":320},{"#{height}":50,"#{width}":300}]},"episodepage":{"adMobAdUnitID":"/2620/usa_tveapp_androidtab/shows/#{SHOW_NAME}","adSize":[{"#{height}":90,"#{width}":728},{"#{height}":50,"#{width}":320},{"#{height}":50,"#{width}":300}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_androidtab&sz=1x1&t=&c=#{doubleclickrandom}"},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_androidtab/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}},"Phone":{"home":{"adMobAdUnitID":"/2620/usa_tveapp_android/home","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_android/shows","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"episodepage":{"adMobAdUnitID":"/2620/usa_tveapp_android/shows/#{SHOW_NAME}","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_android&sz=1x1&t=&c=#{doubleclickrandom}"},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_android/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}},"PhoneHD":{"home":{"adMobAdUnitID":"/2620/usa_tveapp_android/home","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"showlist":{"adMobAdUnitID":"/2620/usa_tveapp_android/shows","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"episodepage":{"adMobAdUnitID":"/2620/usa_tveapp_android/shows/#{SHOW_NAME}","adSize":[{"#{height}":50,"#{width}":300},{"#{height}":50,"#{width}":320}]},"launch":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_android&sz=1x1&t=&c=#{doubleclickrandom}"},"showpage":{"doubleClickCallbackURL":"http://pubads.g.doubleclick.net/gampad/ad?iu=/2620/usa_tveapp_android/shows/#{SHOW_NAME}&sz=1x1&t=&c=#{doubleclickrandom}"}}}}}""", "utf8")
+      val compressed = comp.compressAndFinish(inputBytes)
+
+      ourDecode(compressed) should equal(inputBytes)
+    }
+
+    "shouldn't produce huge ByteStrings for some input" in {
+      val array = new Array[Byte](10) // FIXME
+      util.Arrays.fill(array, 1.toByte)
+      val compressed = streamEncode(ByteString(array))
+      val limit = 10000
+      val resultBs =
+        Source.single(compressed)
+          .via(decoderFlow(maxBytesPerChunk = limit))
+          .limit(4200).runWith(Sink.seq)
+          .awaitResult(3.seconds)
+
+      forAll(resultBs) { bs ⇒
+        bs.length should be < limit
+        bs.forall(_ == 1) should equal(true)
+      }
+    }
+
+    "be able to decode chunk-by-chunk (depending on input chunks)" in {
+      val minLength = 100
+      val maxLength = 1000
+      val numElements = 1000
+
+      val random = ThreadLocalRandom.current()
+      val sizes = Seq.fill(numElements)(random.nextInt(minLength, maxLength))
+      def createByteString(size: Int): ByteString =
+        ByteString(Array.fill(size)(1.toByte))
+
+      val sizesAfterRoundtrip =
+        Source.fromIterator(() ⇒ sizes.toIterator.map(createByteString))
+          .via(encoderFlow)
+          .via(decoderFlow())
+          .runFold(Seq.empty[Int])(_ :+ _.size)
+
+      sizesAfterRoundtrip.awaitResult(3.seconds) shouldEqual sizes
+    }
+
+    extraTests()
+  }
+
+  def encode(s: String) = ourEncode(ByteString(s, "UTF8"))
+  def ourEncode(bytes: ByteString): ByteString = newCompressor().compressAndFinish(bytes)
+  def ourDecode(bytes: ByteString): ByteString =
+    Source.single(bytes)
+      .via(decoderFlow())
+      .join
+      .awaitResult(3.seconds)
+
+  lazy val corruptContent = {
+    val content = encode(largeText).toArray
+    content(14) = 26.toByte
+    ByteString(content)
+  }
+
+  def streamEncode(bytes: ByteString): ByteString = {
+    val output = new ByteArrayOutputStream()
+    val gos = newEncodedOutputStream(output); gos.write(bytes.toArray); gos.close()
+    ByteString(output.toByteArray)
+  }
+
+  def streamDecode(bytes: ByteString): ByteString = {
+    val output = new ByteArrayOutputStream()
+    val input = newDecodedInputStream(new ByteArrayInputStream(bytes.toArray))
+
+    val buffer = new Array[Byte](500)
+    @tailrec def copy(from: InputStream, to: OutputStream): Unit = {
+      val read = from.read(buffer)
+      if (read >= 0) {
+        to.write(buffer, 0, read)
+        copy(from, to)
+      }
+    }
+
+    copy(input, output)
+    ByteString(output.toByteArray)
+  }
+
+  def decodeChunks(input: Source[ByteString, NotUsed]): ByteString =
+    input.via(decoderFlow()).join.awaitResult(3.seconds)
+
+  def decodeFromIterator(iterator: () ⇒ Iterator[ByteString]): ByteString =
+    Await.result(Source.fromIterator(iterator).via(decoderFlow()).join, 3.seconds)
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
@@ -71,7 +71,7 @@ abstract class CoderSpec(codecName: String) extends WordSpec with CodecSpecSuppo
       "throw an error on corrupt input" in {
         (the[RuntimeException] thrownBy {
           ourDecode(corruptContent)
-        }).getCause should be(a[DataFormatException])
+        }).ultimateCause should be(a[DataFormatException])
       }
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CompressionTestingTools.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CompressionTestingTools.scala
@@ -1,0 +1,32 @@
+package akka.stream.io.compression
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration.Duration
+import scala.util.{ Failure, Success }
+
+// a few useful helpers copied over from akka-http
+object CompressionTestingTools {
+  implicit class AddFutureAwaitResult[T](val future: Future[T]) extends AnyVal {
+    /** "Safe" Await.result that doesn't throw away half of the stacktrace */
+    def awaitResult(atMost: Duration): T = {
+      Await.ready(future, atMost)
+      future.value.get match {
+        case Success(t)  ⇒ t
+        case Failure(ex) ⇒ throw new RuntimeException("Trying to await result of failed Future, see the cause for the original problem.", ex)
+      }
+    }
+  }
+  implicit class EnhancedByteStringTraversableOnce(val byteStrings: TraversableOnce[ByteString]) extends AnyVal {
+    def join: ByteString = byteStrings.foldLeft(ByteString.empty)(_ ++ _)
+  }
+  implicit class EnhancedByteStringSource[Mat](val byteStringStream: Source[ByteString, Mat]) extends AnyVal {
+    def join(implicit materializer: Materializer): Future[ByteString] =
+      byteStringStream.runFold(ByteString.empty)(_ ++ _)
+    def utf8String(implicit materializer: Materializer, ec: ExecutionContext): Future[String] =
+      join.map(_.utf8String)
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CompressionTestingTools.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CompressionTestingTools.scala
@@ -4,6 +4,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
+import scala.annotation.tailrec
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success }
@@ -28,5 +29,15 @@ object CompressionTestingTools {
       byteStringStream.runFold(ByteString.empty)(_ ++ _)
     def utf8String(implicit materializer: Materializer, ec: ExecutionContext): Future[String] =
       join.map(_.utf8String)
+  }
+
+  implicit class EnhancedThrowable(val throwable: Throwable) extends AnyVal {
+    def ultimateCause: Throwable = {
+      @tailrec def rec(ex: Throwable): Throwable =
+        if (ex.getCause == null) ex
+        else rec(ex.getCause)
+
+      rec(throwable)
+    }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/DeflateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/DeflateSpec.scala
@@ -12,6 +12,8 @@ import akka.stream.scaladsl.{ Compression, Flow }
 import akka.util.ByteString
 
 class DeflateSpec extends CoderSpec("deflate") {
+  import CompressionTestingTools._
+
   protected def newCompressor(): Compressor = new DeflateCompressor
   protected val encoderFlow: Flow[ByteString, ByteString, Any] = Compression.deflate
   protected def decoderFlow(maxBytesPerChunk: Int): Flow[ByteString, ByteString, Any] =
@@ -27,7 +29,7 @@ class DeflateSpec extends CoderSpec("deflate") {
     "throw early if header is corrupt" in {
       (the[RuntimeException] thrownBy {
         ourDecode(ByteString(0, 1, 2, 3, 4))
-      }).getCause should be(a[DataFormatException])
+      }).ultimateCause should be(a[DataFormatException])
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/DeflateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/DeflateSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.io.compression
+
+import java.io.{ InputStream, OutputStream }
+import java.util.zip._
+
+import akka.stream.impl.io.compression.{ Compressor, DeflateCompressor }
+import akka.stream.scaladsl.{ Compression, Flow }
+import akka.util.ByteString
+
+class DeflateSpec extends CoderSpec("deflate") {
+  protected def newCompressor(): Compressor = new DeflateCompressor
+  protected val encoderFlow: Flow[ByteString, ByteString, Any] = Compression.deflate
+  protected def decoderFlow(maxBytesPerChunk: Int): Flow[ByteString, ByteString, Any] =
+    Compression.inflate(maxBytesPerChunk)
+
+  protected def newDecodedInputStream(underlying: InputStream): InputStream =
+    new InflaterInputStream(underlying)
+
+  protected def newEncodedOutputStream(underlying: OutputStream): OutputStream =
+    new DeflaterOutputStream(underlying)
+
+  override def extraTests(): Unit = {
+    "throw early if header is corrupt" in {
+      (the[RuntimeException] thrownBy {
+        ourDecode(ByteString(0, 1, 2, 3, 4))
+      }).getCause should be(a[DataFormatException])
+    }
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/GzipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/GzipSpec.scala
@@ -34,15 +34,15 @@ class GzipSpec extends CoderSpec("gzip") {
     }
     "throw an error on truncated input" in {
       val ex = the[RuntimeException] thrownBy ourDecode(streamEncode(smallTextBytes).dropRight(5))
-      ex.getCause.getMessage should equal("Truncated GZIP stream")
+      ex.ultimateCause.getMessage should equal("Truncated GZIP stream")
     }
     "throw an error if compressed data is just missing the trailer at the end" in {
       def brokenCompress(payload: String) = newCompressor().compress(ByteString(payload, "UTF-8"))
       val ex = the[RuntimeException] thrownBy ourDecode(brokenCompress("abcdefghijkl"))
-      ex.getCause.getMessage should equal("Truncated GZIP stream")
+      ex.ultimateCause.getMessage should equal("Truncated GZIP stream")
     }
     "throw early if header is corrupt" in {
-      val cause = (the[RuntimeException] thrownBy ourDecode(ByteString(0, 1, 2, 3, 4))).getCause
+      val cause = (the[RuntimeException] thrownBy ourDecode(ByteString(0, 1, 2, 3, 4))).ultimateCause
       cause should (be(a[ZipException]) and have message "Not in GZIP format")
     }
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/GzipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/GzipSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.io.compression
+
+import java.io.{ InputStream, OutputStream }
+import java.util.zip.{ GZIPInputStream, GZIPOutputStream, ZipException }
+
+import akka.stream.impl.io.compression.{ Compressor, GzipCompressor }
+import akka.stream.scaladsl.{ Compression, Flow }
+import akka.util.ByteString
+
+class GzipSpec extends CoderSpec("gzip") {
+  import CompressionTestingTools._
+
+  protected def newCompressor(): Compressor = new GzipCompressor
+  protected val encoderFlow: Flow[ByteString, ByteString, Any] = Compression.gzip
+  protected def decoderFlow(maxBytesPerChunk: Int): Flow[ByteString, ByteString, Any] =
+    Compression.gunzip(maxBytesPerChunk)
+
+  protected def newDecodedInputStream(underlying: InputStream): InputStream =
+    new GZIPInputStream(underlying)
+
+  protected def newEncodedOutputStream(underlying: OutputStream): OutputStream =
+    new GZIPOutputStream(underlying)
+
+  override def extraTests(): Unit = {
+    "decode concatenated compressions" in {
+      ourDecode(Seq(encode("Hello, "), encode("dear "), encode("User!")).join) should readAs("Hello, dear User!")
+    }
+    "provide a better compression ratio than the standard Gzip/Gunzip streams" in {
+      ourEncode(largeTextBytes).length should be < streamEncode(largeTextBytes).length
+    }
+    "throw an error on truncated input" in {
+      val ex = the[RuntimeException] thrownBy ourDecode(streamEncode(smallTextBytes).dropRight(5))
+      ex.getCause.getMessage should equal("Truncated GZIP stream")
+    }
+    "throw an error if compressed data is just missing the trailer at the end" in {
+      def brokenCompress(payload: String) = newCompressor().compress(ByteString(payload, "UTF-8"))
+      val ex = the[RuntimeException] thrownBy ourDecode(brokenCompress("abcdefghijkl"))
+      ex.getCause.getMessage should equal("Truncated GZIP stream")
+    }
+    "throw early if header is corrupt" in {
+      val cause = (the[RuntimeException] thrownBy ourDecode(ByteString(0, 1, 2, 3, 4))).getCause
+      cause should (be(a[ZipException]) and have message "Not in GZIP format")
+    }
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/io/ByteStringParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/ByteStringParser.scala
@@ -7,6 +7,7 @@ import akka.stream._
 import akka.stream.stage._
 import akka.util.ByteString
 
+import scala.annotation.tailrec
 import scala.util.control.{ NoStackTrace, NonFatal }
 
 /**
@@ -29,6 +30,8 @@ private[akka] abstract class ByteStringParser[T] extends GraphStage[FlowShape[By
 
     final protected def startWith(step: ParseStep[T]): Unit = current = step
 
+    protected def recursionLimit: Int = 1000
+
     /**
      * doParse() is the main driver for the parser. It can be called from onPush, onPull and onUpstreamFinish.
      * The general logic is that invocation of this method either results in an emitted parsed element, or an indication
@@ -40,8 +43,10 @@ private[akka] abstract class ByteStringParser[T] extends GraphStage[FlowShape[By
      *    buffer. This can lead to two conditions:
      *     - drained, empty buffer. This is either accepted completion (acceptUpstreamFinish) or a truncation.
      *     - parser demands more data than in buffer. This is always a truncation.
+     *
+     * If the return value is true the method must be called another time to continue processing.
      */
-    private def doParse(): Unit = {
+    private def doParseInner(): Boolean =
       if (buffer.nonEmpty) {
         val reader = new ByteReader(buffer)
         try {
@@ -51,13 +56,16 @@ private[akka] abstract class ByteStringParser[T] extends GraphStage[FlowShape[By
 
           if (parseResult.nextStep == FinishedParser) {
             completeStage()
+            DontRecurse
           } else {
             buffer = reader.remainingData
             current = parseResult.nextStep
 
             // If this step didn't produce a result, continue parsing.
             if (parseResult.result.isEmpty)
-              doParse()
+              Recurse
+            else
+              DontRecurse
           }
         } catch {
           case NeedMoreData ⇒
@@ -67,8 +75,12 @@ private[akka] abstract class ByteStringParser[T] extends GraphStage[FlowShape[By
             // Not enough data in buffer and upstream is closed
             if (isClosed(bytesIn)) current.onTruncation()
             else pull(bytesIn)
+
+            DontRecurse
           case NonFatal(ex) ⇒
             failStage(new ParsingException(s"Parsing failed in step $current", ex))
+
+            DontRecurse
         }
       } else {
         if (isClosed(bytesIn)) {
@@ -77,8 +89,21 @@ private[akka] abstract class ByteStringParser[T] extends GraphStage[FlowShape[By
           if (acceptUpstreamFinish) completeStage()
           else current.onTruncation()
         } else pull(bytesIn)
+
+        DontRecurse
       }
-    }
+
+    @tailrec private def doParse(remainingRecursions: Int = recursionLimit): Unit =
+      if (remainingRecursions == 0)
+        failStage(
+          new IllegalStateException(s"Parsing logic didn't produce result after $recursionLimit steps. " +
+            "Aborting processing to avoid infinite cycles. In the unlikely case that the parsing logic " +
+            "needs more recursion, override ParsingLogic.recursionLimit.")
+        )
+      else {
+        val recurse = doParseInner()
+        if (recurse) doParse(remainingRecursions - 1)
+      }
 
     // Completion is handled by doParse as the buffer either gets empty after this call, or the parser requests
     // data that we can no longer provide (truncation).
@@ -117,6 +142,9 @@ private[akka] abstract class ByteStringParser[T] extends GraphStage[FlowShape[By
 private[akka] object ByteStringParser {
 
   val CompactionThreshold = 16
+
+  private final val Recurse = true
+  private final val DontRecurse = false
 
   /**
    * @param result - parser can return some element for downstream or return None if no element was generated in this step

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/CompressionUtils.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/CompressionUtils.scala
@@ -22,7 +22,7 @@ private[stream] object CompressionUtils {
           val compressor = newCompressor()
 
           override def onPush(): Unit = {
-            val data = compressor.compress(grab(in))
+            val data = compressor.compressAndFlush(grab(in))
             if (data.nonEmpty) push(out, data)
             else pull(in)
           }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressor.scala
@@ -6,12 +6,9 @@ package akka.stream.impl.io.compression
 import java.util.zip.Inflater
 
 import akka.stream.Attributes
-import akka.stream.impl.io.ByteStringParser
-import akka.stream.impl.io.ByteStringParser.{ ParseResult, ParseStep }
-import akka.util.ByteString
 
 /** INTERNAL API */
-private[akka] class DeflateDecompressor(maxBytesPerChunk: Int = DeflateDecompressorBase.MaxBytesPerChunkDefault)
+private[akka] class DeflateDecompressor(maxBytesPerChunk: Int)
   extends DeflateDecompressorBase(maxBytesPerChunk) {
 
   override def createLogic(attr: Attributes) = new DecompressorParsingLogic {

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressor.scala
@@ -14,7 +14,7 @@ private[akka] class DeflateDecompressor(maxBytesPerChunk: Int)
   override def createLogic(attr: Attributes) = new DecompressorParsingLogic {
     override val inflater: Inflater = new Inflater()
 
-    override case object Inflating extends Inflate(true) {
+    override case object Inflating extends Inflate(noPostProcessing = true) {
       override def onTruncation(): Unit = completeStage()
     }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressor.scala
@@ -14,14 +14,14 @@ private[akka] class DeflateDecompressor(maxBytesPerChunk: Int)
   override def createLogic(attr: Attributes) = new DecompressorParsingLogic {
     override val inflater: Inflater = new Inflater()
 
-    override val inflateState = new Inflate(true) {
+    override case object Inflating extends Inflate(true) {
       override def onTruncation(): Unit = completeStage()
     }
 
-    override def afterInflate = inflateState
+    override def afterInflate = Inflating
     override def afterBytesRead(buffer: Array[Byte], offset: Int, length: Int): Unit = {}
 
-    startWith(inflateState)
+    startWith(Inflating)
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressorBase.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressorBase.scala
@@ -17,7 +17,7 @@ private[akka] abstract class DeflateDecompressorBase(maxBytesPerChunk: Int)
     val inflater: Inflater
     def afterInflate: ParseStep[ByteString]
     def afterBytesRead(buffer: Array[Byte], offset: Int, length: Int): Unit
-    val inflateState: Inflate
+    val Inflating: Inflate
 
     abstract class Inflate(noPostProcessing: Boolean) extends ParseStep[ByteString] {
       override def canWorkWithPartialData = true

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressorBase.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/DeflateDecompressorBase.scala
@@ -10,7 +10,7 @@ import akka.stream.impl.io.ByteStringParser.{ ParseResult, ParseStep }
 import akka.util.ByteString
 
 /** INTERNAL API */
-private[akka] abstract class DeflateDecompressorBase(maxBytesPerChunk: Int = DeflateDecompressorBase.MaxBytesPerChunkDefault)
+private[akka] abstract class DeflateDecompressorBase(maxBytesPerChunk: Int)
   extends ByteStringParser[ByteString] {
 
   abstract class DecompressorParsingLogic extends ParsingLogic {
@@ -45,6 +45,4 @@ private[akka] abstract class DeflateDecompressorBase(maxBytesPerChunk: Int = Def
 }
 
 /** INTERNAL API */
-private[akka] object DeflateDecompressorBase {
-  final val MaxBytesPerChunkDefault = 64 * 1024
-}
+private[akka] object DeflateDecompressorBase

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/GzipDecompressor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/GzipDecompressor.scala
@@ -11,7 +11,7 @@ import akka.stream.impl.io.ByteStringParser.{ ParseResult, ParseStep }
 import akka.util.ByteString
 
 /** INTERNAL API */
-private[akka] class GzipDecompressor(maxBytesPerChunk: Int = DeflateDecompressorBase.MaxBytesPerChunkDefault)
+private[akka] class GzipDecompressor(maxBytesPerChunk: Int)
   extends DeflateDecompressorBase(maxBytesPerChunk) {
 
   override def createLogic(attr: Attributes) = new DecompressorParsingLogic {

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/GzipDecompressor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/GzipDecompressor.scala
@@ -41,7 +41,7 @@ private[akka] class GzipDecompressor(maxBytesPerChunk: Int)
 
         inflater.reset()
         crc32.reset()
-        ParseResult(None, Inflating, false)
+        ParseResult(None, Inflating, acceptUpstreamFinish = false)
       }
     }
     var crc32: CRC32 = new CRC32
@@ -54,7 +54,7 @@ private[akka] class GzipDecompressor(maxBytesPerChunk: Int)
         if (readIntLE() != crc32.getValue.toInt) fail("Corrupt data (CRC32 checksum error)")
         if (readIntLE() != inflater.getBytesWritten.toInt /* truncated to 32bit */ )
           fail("Corrupt GZIP trailer ISIZE")
-        ParseResult(None, ReadHeaders, true)
+        ParseResult(None, ReadHeaders, acceptUpstreamFinish = true)
       }
     }
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/compression/GzipDecompressor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/compression/GzipDecompressor.scala
@@ -23,7 +23,7 @@ private[akka] class GzipDecompressor(maxBytesPerChunk: Int)
     trait Step extends ParseStep[ByteString] {
       override def onTruncation(): Unit = failStage(new ZipException("Truncated GZIP stream"))
     }
-    override val inflateState = new Inflate(false) with Step
+    override case object Inflating extends Inflate(false) with Step
     startWith(ReadHeaders)
 
     /** Reading the header bytes */
@@ -41,7 +41,7 @@ private[akka] class GzipDecompressor(maxBytesPerChunk: Int)
 
         inflater.reset()
         crc32.reset()
-        ParseResult(None, inflateState, false)
+        ParseResult(None, Inflating, false)
       }
     }
     var crc32: CRC32 = new CRC32

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Compression.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Compression.scala
@@ -8,6 +8,8 @@ import akka.stream.impl.io.compression._
 import akka.util.ByteString
 
 object Compression {
+  final val MaxBytesPerChunkDefault = 64 * 1024
+
   /**
    * Creates a flow that gzip-compresses a stream of ByteStrings. Note that the compressor
    * will SYNC_FLUSH after every [[ByteString]] so that it is guaranteed that every [[ByteString]]
@@ -24,7 +26,7 @@ object Compression {
    *
    * @param maxBytesPerChunk Maximum length of an output [[ByteString]] chunk.
    */
-  def gunzip(maxBytesPerChunk: Int = DeflateDecompressorBase.MaxBytesPerChunkDefault): Flow[ByteString, ByteString, NotUsed] =
+  def gunzip(maxBytesPerChunk: Int = MaxBytesPerChunkDefault): Flow[ByteString, ByteString, NotUsed] =
     Flow[ByteString].via(new GzipDecompressor(maxBytesPerChunk))
       .named("gunzip")
 
@@ -44,7 +46,7 @@ object Compression {
    *
    * @param maxBytesPerChunk Maximum length of an output [[ByteString]] chunk.
    */
-  def inflate(maxBytesPerChunk: Int = DeflateDecompressorBase.MaxBytesPerChunkDefault): Flow[ByteString, ByteString, NotUsed] =
+  def inflate(maxBytesPerChunk: Int = MaxBytesPerChunkDefault): Flow[ByteString, ByteString, NotUsed] =
     Flow[ByteString].via(new DeflateDecompressor(maxBytesPerChunk))
       .named("inflate")
 }


### PR DESCRIPTION
Also includes a fix for a bug I introduced during the move.

In this state, they will pass if run with the old version of the `ByteStringParser`. They will fail on current master. I'll try to find the problem next.

Refs #21395. Fixes #21850.