### PR TITLE
Adding debug message when passivate method cannot identify entity

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -227,7 +227,7 @@ private[akka] class Shard(
         messageBuffers = messageBuffers.updated(id, Vector.empty)
         entity ! stopMessage
 
-      case _ ⇒ //ignored
+      case _ ⇒ log.debug("Unknown entity. Not sending stopMessage back to entity.")
     }
   }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -220,14 +220,16 @@ private[akka] class Shard(
 
   def passivate(entity: ActorRef, stopMessage: Any): Unit = {
     idByRef.get(entity) match {
-      case Some(id) if !messageBuffers.contains(id) ⇒
+      case Some(id) => if (!messageBuffers.contains(id)) {
         log.debug("Passivating started on entity {}", id)
 
         passivating = passivating + entity
         messageBuffers = messageBuffers.updated(id, Vector.empty)
         entity ! stopMessage
-
-      case None => log.debug("Unknown entity {}. Not sending stopMessage back to entity.", entity)
+      } else {
+        log.debug("Passivation already in progress for {}. Not sending stopMessage back to entity.", entity)
+      }
+      case None    => log.debug("Unknown entity {}. Not sending stopMessage back to entity.", entity)
     }
   }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -227,7 +227,7 @@ private[akka] class Shard(
         messageBuffers = messageBuffers.updated(id, Vector.empty)
         entity ! stopMessage
 
-      case _ ⇒ log.debug("Unknown entity. Not sending stopMessage back to entity.")
+      case None => log.debug("Unknown entity {}. Not sending stopMessage back to entity.", entity)
     }
   }
 


### PR DESCRIPTION
Hopefully this will help others to see an unmatched entity when expecting the stopMessage to be sent back to the entity. 