### PR TITLE
Test documenting LineNumber behaviour on Scala 2.11, 2.12, Java 8

### DIFF
--- a/akka-actor-tests/src/test/java/akka/util/LineNumberSpecCodeForJava.java
+++ b/akka-actor-tests/src/test/java/akka/util/LineNumberSpecCodeForJava.java
@@ -11,21 +11,20 @@ import java.io.Serializable;
 
 public class LineNumberSpecCodeForJava {
 
-	// @FunctionalInterface // will be uncommented as soon as '-source 1.8' is set
 	public static interface F extends Serializable {
 		public String doit(String arg);
 	}
 
-	// public F f1() { // FIXME These are commented out until the build is switched to Java 8
-	// return (s) -> s;
-	// }
+	public F f1() {
+		return (s) -> s;
+	}
 
-	// public F f2() {
-	// return (s) -> {
-	// System.out.println(s);
-	// return s;
-	// };
-	// }
+	public F f2() {
+		return (s) -> {
+			System.out.println(s);
+			return s;
+		};
+	}
 
 	public F f3() {
 		return new F() {

--- a/akka-actor-tests/src/test/java/akka/util/LineNumberSpecCodeForJava.java
+++ b/akka-actor-tests/src/test/java/akka/util/LineNumberSpecCodeForJava.java
@@ -11,29 +11,30 @@ import java.io.Serializable;
 
 public class LineNumberSpecCodeForJava {
 
-	public static interface F extends Serializable {
-		public String doit(String arg);
-	}
+  public static interface F extends Serializable {
+    public String doit(String arg);
+  }
 
-	public F f1() {
-		return (s) -> s;
-	}
+  public F f1() {
+    return (s) -> s;
+  }
 
-	public F f2() {
-		return (s) -> {
-			System.out.println(s);
-			return s;
-		};
-	}
+  public F f2() {
+    return (s) -> {
+      System.out.println(s);
+      return s;
+    };
+  }
 
-	public F f3() {
-		return new F() {
-			private static final long serialVersionUID = 1L;
-			@Override
-			public String doit(String arg) {
-				return arg;
-			}
-		};
-	}
-	
+  public F f3() {
+    return new F() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public String doit(String arg) {
+        return arg;
+      }
+    };
+  }
+
 }

--- a/akka-actor-tests/src/test/scala/akka/util/LineNumberSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/LineNumberSpec.scala
@@ -56,7 +56,7 @@ class LineNumberSpec extends AkkaSpec {
       }
 
       "work for anonymous classes" in {
-        LineNumbers(l.f3()) should ===(SourceFileLines("LineNumberSpecCodeForJava.java", 30, 34))
+        LineNumbers(l.f3()) should ===(SourceFileLines("LineNumberSpecCodeForJava.java", 30, 35))
       }
 
     }

--- a/akka-actor-tests/src/test/scala/akka/util/LineNumberSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/LineNumberSpec.scala
@@ -6,19 +6,34 @@ package akka.util
 import akka.testkit.AkkaSpec
 import LineNumbers._
 
+import scala.util.Properties
+
 class LineNumberSpec extends AkkaSpec {
+
+  private val isScala212 = Properties.versionNumberString.startsWith("2.12")
 
   "LineNumbers" when {
 
     "writing Scala" must {
       import LineNumberSpecCodeForScala._
 
-      "work for small functions" taggedAs IgnoreForScala212 in {
-        LineNumbers(oneline) should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 12, 12))
+      "work for small functions" in {
+        val result = LineNumbers(oneline)
+
+        if (isScala212)
+          // because how scala 2.12 does the same as Java Lambdas
+          result should ===(NoSourceInfo)
+        else
+          result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 12, 12))
       }
 
-      "work for larger functions" taggedAs IgnoreForScala212 in {
-        LineNumbers(twoline) should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 14, 16))
+      "work for larger functions" in {
+        val result = LineNumbers(twoline)
+        if (isScala212)
+          // because how scala 2.12 does the same as Java Lambdas
+          result should ===(NoSourceInfo)
+        else
+          result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 14, 16))
       }
 
       "work for partial functions" in {
@@ -30,17 +45,18 @@ class LineNumberSpec extends AkkaSpec {
     "writing Java" must {
       val l = new LineNumberSpecCodeForJava
 
-      // FIXME uncomment when compiling with '-source 1.8'
-      //      "work for small functions" in {
-      //        LineNumbers(l.f1()) should ===(SourceFileLines("LineNumberSpecCodeForJava.java", 20, 20))
-      //      }
+      "work for small functions" in {
+        // because how java Lambdas are implemented/designed
+        LineNumbers(l.f1()) should ===(NoSourceInfo)
+      }
 
-      //      "work for larger functions" in {
-      //        LineNumbers(l.f2()) should ===(SourceFileLines("LineNumberSpecCodeForJava.java", 25, 26))
-      //      }
+      "work for larger functions" in {
+        // because how java Lambdas are implemented/designed
+        LineNumbers(l.f2()) should ===(NoSourceInfo)
+      }
 
       "work for anonymous classes" in {
-        LineNumbers(l.f3()) should ===(SourceFileLines("LineNumberSpecCodeForJava.java", 31, 35))
+        LineNumbers(l.f3()) should ===(SourceFileLines("LineNumberSpecCodeForJava.java", 30, 34))
       }
 
     }


### PR DESCRIPTION
Refs #21773

Not much of an improvement, but as far as I understand the line number info is not there with 2.12/Java 8 lambdas because of how lambdas are done (`LambdaMetaFactory`). So this at least documents the behaviour rather than just disabling the tests.