### PR TITLE
Enable flight recorder in more artery tests

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/ArteryMultiNodeSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/ArteryMultiNodeSpec.scala
@@ -12,33 +12,12 @@ import akka.testkit.AkkaSpec
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.Outcome
 
-object ArteryMultiNodeSpec {
-
-  def defaultConfig =
-    ConfigFactory.parseString(s"""
-      akka {
-        actor.provider = remote
-        actor.warn-about-java-serializer-usage = off
-        remote.artery {
-          enabled = on
-          canonical {
-            hostname = localhost
-            port = 0
-          }
-          advanced.flight-recorder {
-            enabled=on
-            destination=target/flight-recorder-${UUID.randomUUID().toString}.afr
-          }
-        }
-      }
-    """)
-}
-
 /**
  * Base class for remoting tests what needs to test interaction between a "local" actor system
  * which is always created (the usual AkkaSpec system), and multiple additional actor systems over artery
  */
-abstract class ArteryMultiNodeSpec(config: Config) extends AkkaSpec(config.withFallback(ArteryMultiNodeSpec.defaultConfig)) {
+abstract class ArteryMultiNodeSpec(config: Config) extends AkkaSpec(config.withFallback(ArterySpecSupport.defaultConfig))
+  with FlightRecorderSpecIntegration {
 
   def this() = this(ConfigFactory.empty())
   def this(extraConfig: String) = this(ConfigFactory.parseString(extraConfig))
@@ -50,8 +29,6 @@ abstract class ArteryMultiNodeSpec(config: Config) extends AkkaSpec(config.withF
   def address(sys: ActorSystem) = RARP(sys).provider.getDefaultAddress
   def rootActorPath(sys: ActorSystem) = RootActorPath(address(sys))
   def nextGeneratedSystemName = s"${localSystem.name}-remote-${remoteSystems.size}"
-  private val flightRecorderFile: Path =
-    FileSystems.getDefault.getPath(RARP(system).provider.remoteSettings.Artery.Advanced.FlightRecorderDestination)
 
   private var remoteSystems: Vector[ActorSystem] = Vector.empty
 
@@ -73,29 +50,10 @@ abstract class ArteryMultiNodeSpec(config: Config) extends AkkaSpec(config.withF
     remoteSystem
   }
 
-  // keep track of failure so that we can print flight recorder output on failures
-  private var failed = false
-  override protected def withFixture(test: NoArgTest): Outcome = {
-    val out = super.withFixture(test)
-    if (!out.isSucceeded) failed = true
-    out
-  }
-
   override def afterTermination(): Unit = {
     remoteSystems.foreach(sys ⇒ shutdown(sys))
     remoteSystems = Vector.empty
-    handleFlightRecorderFile()
-  }
-
-  private def handleFlightRecorderFile(): Unit = {
-    if (Files.exists(flightRecorderFile)) {
-      if (failed) {
-        // logger may not be alive anymore so we have to use stdout here
-        println("Flight recorder dump:")
-        FlightRecorderReader.dumpToStdout(flightRecorderFile)
-      }
-      Files.delete(flightRecorderFile)
-    }
+    super.afterTermination()
   }
 
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/ArterySpecSupport.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/ArterySpecSupport.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.nio.file.{ FileSystems, Files, Path }
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.remote.RARP
+import akka.testkit.AkkaSpec
+import com.typesafe.config.ConfigFactory
+import org.scalatest.Outcome
+
+object ArterySpecSupport {
+  // same for all artery enabled remoting tests
+  private val staticArteryRemotingConfig = ConfigFactory.parseString(s"""
+    akka {
+      actor {
+        provider = remote
+        warn-about-java-serializer-usage = off
+        serialize-creators = off
+      }
+      remote.artery {
+        enabled = on
+        canonical {
+          hostname = localhost
+          port = 0
+        }
+      }
+    }""")
+
+  /** artery enabled, flight recorder enabled, dynamic selection of port on localhost */
+  def defaultConfig =
+    ConfigFactory.parseString(s"""
+      akka {
+        remote.artery {
+          advanced.flight-recorder {
+            enabled=on
+            destination=target/flight-recorder-${UUID.randomUUID().toString}.afr
+          }
+        }
+      }
+    """).withFallback(staticArteryRemotingConfig)
+
+}
+
+/**
+ * Dumps flight recorder data on test failure if artery flight recorder is enabled
+ */
+trait FlightRecorderSpecIntegration { self: AkkaSpec ⇒
+
+  def system: ActorSystem
+
+  private val flightRecorderFile: Path =
+    FileSystems.getDefault.getPath(RARP(system).provider.remoteSettings.Artery.Advanced.FlightRecorderDestination)
+
+  // keep track of failure so that we can print flight recorder output on failures
+  private var failed = false
+  override protected def withFixture(test: NoArgTest): Outcome = {
+    val out = test()
+    if (!out.isSucceeded) failed = true
+    out
+  }
+
+  override def afterTermination(): Unit = {
+    self.afterTermination()
+    handleFlightRecorderFile()
+  }
+
+  protected def handleFlightRecorderFile(): Unit = {
+    if (Files.exists(flightRecorderFile)) {
+      if (failed) {
+        // logger may not be alive anymore so we have to use stdout here
+        println("Flight recorder dump:")
+        FlightRecorderReader.dumpToStdout(flightRecorderFile)
+      }
+      Files.delete(flightRecorderFile)
+    }
+  }
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/FlushOnShutdownSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/FlushOnShutdownSpec.scala
@@ -11,21 +11,7 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-object FlushOnShutdownSpec {
-
-  val config = ConfigFactory.parseString(s"""
-     akka {
-       actor.provider = remote
-       actor.serialize-creators = off
-       remote.artery.enabled = on
-       remote.artery.canonical.hostname = localhost
-       remote.artery.canonical.port = 0
-     }
-  """)
-
-}
-
-class FlushOnShutdownSpec extends ArteryMultiNodeSpec(FlushOnShutdownSpec.config) {
+class FlushOnShutdownSpec extends ArteryMultiNodeSpec(ArterySpecSupport.defaultConfig) {
 
   val remoteSystem = newRemoteSystem()
 

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeDenySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeDenySpec.scala
@@ -14,15 +14,9 @@ object HandshakeDenySpec {
 
   val commonConfig = ConfigFactory.parseString(s"""
      akka.loglevel = WARNING
-     akka {
-       actor.provider = remote
-       remote.artery.enabled = on
-       remote.artery.canonical.hostname = localhost
-       remote.artery.canonical.port = 0
-       remote.artery.advanced.handshake-timeout = 2s
-       remote.artery.advanced.image-liveness-timeout = 1.9s
-     }
-  """)
+     akka.remote.artery.advanced.handshake-timeout = 2s
+     akka.remote.artery.advanced.image-liveness-timeout = 1.9s
+  """).withFallback(ArterySpecSupport.defaultConfig)
 
 }
 

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
@@ -18,22 +18,16 @@ object HandshakeFailureSpec {
   val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
 
   val commonConfig = ConfigFactory.parseString(s"""
-     akka {
-       actor.provider = remote
-       remote.artery.enabled = on
-       remote.artery.canonical.hostname = localhost
-       remote.artery.canonical.port = 0
-       remote.artery.advanced.handshake-timeout = 2s
-       remote.artery.advanced.image-liveness-timeout = 1.9s
-     }
-  """)
+     akka.remote.artery.advanced.handshake-timeout = 2s
+     akka.remote.artery.advanced.image-liveness-timeout = 1.9s
+  """).withFallback(ArterySpecSupport.defaultConfig)
 
   val configB = ConfigFactory.parseString(s"akka.remote.artery.canonical.port = $portB")
     .withFallback(commonConfig)
 
 }
 
-class HandshakeFailureSpec extends AkkaSpec(HandshakeFailureSpec.commonConfig) with ImplicitSender {
+class HandshakeFailureSpec extends AkkaSpec(HandshakeFailureSpec.commonConfig) with ImplicitSender with FlightRecorderSpecIntegration {
   import HandshakeFailureSpec._
 
   var systemB: ActorSystem = null

--- a/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
@@ -24,12 +24,12 @@ object LateConnectSpec {
 
 }
 
-class LateConnectSpec extends AkkaSpec(LateConnectSpec.config) with ImplicitSender {
+class LateConnectSpec extends ArteryMultiNodeSpec(LateConnectSpec.config) with ImplicitSender {
 
   val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
-  val configB = ConfigFactory.parseString(s"akka.remote.artery.canonical.port = $portB")
-    .withFallback(system.settings.config)
-  lazy val systemB = ActorSystem("systemB", configB)
+  lazy val systemB = newRemoteSystem(
+    name = Some("systemB"),
+    extraConfig = Some(s"akka.remote.artery.canonical.port = $portB"))
 
   "Connection" must {
 
@@ -54,10 +54,4 @@ class LateConnectSpec extends AkkaSpec(LateConnectSpec.config) with ImplicitSend
       expectMsg("ping3")
     }
   }
-
-  override def afterTermination(): Unit = {
-    shutdown(systemB)
-    super.afterTermination()
-  }
-
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
@@ -18,15 +18,9 @@ import com.typesafe.config.ConfigFactory
 object LateConnectSpec {
 
   val config = ConfigFactory.parseString(s"""
-     akka {
-       actor.provider = remote
-       remote.artery.enabled = on
-       remote.artery.canonical.hostname = localhost
-       remote.artery.canonical.port = 0
-       remote.artery.advanced.handshake-timeout = 3s
-       remote.artery.advanced.image-liveness-timeout = 2.9s
-     }
-  """)
+     akka.remote.artery.advanced.handshake-timeout = 3s
+     akka.remote.artery.advanced.image-liveness-timeout = 2.9s
+  """).withFallback(ArterySpecSupport.defaultConfig)
 
 }
 
@@ -61,6 +55,9 @@ class LateConnectSpec extends AkkaSpec(LateConnectSpec.config) with ImplicitSend
     }
   }
 
-  override def afterTermination(): Unit = shutdown(systemB)
+  override def afterTermination(): Unit = {
+    shutdown(systemB)
+    super.afterTermination()
+  }
 
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundControlJunctionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundControlJunctionSpec.scala
@@ -3,19 +3,12 @@
  */
 package akka.remote.artery
 
-import scala.concurrent.duration._
 import akka.actor.Address
-import akka.remote.EndpointManager.Send
-import akka.remote.RemoteActorRef
 import akka.remote.UniqueAddress
-import akka.remote.artery.SystemMessageDelivery._
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.scaladsl.Keep
-import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.testkit.scaladsl.TestSource
-import akka.testkit.AkkaSpec
-import akka.testkit.ImplicitSender
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.testkit.{ AkkaSpec, ImplicitSender }
 import akka.util.OptionVal
 
 object OutboundControlJunctionSpec {

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
@@ -26,14 +26,11 @@ object RemoteDeathWatchSpec {
             }
         }
         remote.watch-failure-detector.acceptable-heartbeat-pause = 3s
-        remote.artery.enabled = on
-        remote.artery.canonical.hostname = localhost
-        remote.artery.canonical.port = 0
     }
-    """)
+    """).withFallback(ArterySpecSupport.defaultConfig)
 }
 
-class RemoteDeathWatchSpec extends AkkaSpec(RemoteDeathWatchSpec.config) with ImplicitSender with DefaultTimeout with DeathWatchSpec {
+class RemoteDeathWatchSpec extends AkkaSpec(RemoteDeathWatchSpec.config) with ImplicitSender with DefaultTimeout with DeathWatchSpec with FlightRecorderSpecIntegration {
   import RemoteDeathWatchSpec._
 
   system.eventStream.publish(TestEvent.Mute(
@@ -44,6 +41,7 @@ class RemoteDeathWatchSpec extends AkkaSpec(RemoteDeathWatchSpec.config) with Im
 
   override def afterTermination() {
     shutdown(other)
+    super.afterTermination()
   }
 
   override def expectedTestDuration: FiniteDuration = 120.seconds

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
@@ -30,19 +30,13 @@ object RemoteDeathWatchSpec {
     """).withFallback(ArterySpecSupport.defaultConfig)
 }
 
-class RemoteDeathWatchSpec extends AkkaSpec(RemoteDeathWatchSpec.config) with ImplicitSender with DefaultTimeout with DeathWatchSpec with FlightRecorderSpecIntegration {
+class RemoteDeathWatchSpec extends ArteryMultiNodeSpec(RemoteDeathWatchSpec.config) with ImplicitSender with DefaultTimeout with DeathWatchSpec {
   import RemoteDeathWatchSpec._
 
   system.eventStream.publish(TestEvent.Mute(
     EventFilter[io.aeron.exceptions.RegistrationException]()))
 
-  val other = ActorSystem("other", ConfigFactory.parseString(s"akka.remote.artery.canonical.port=$otherPort")
-    .withFallback(system.settings.config))
-
-  override def afterTermination() {
-    shutdown(other)
-    super.afterTermination()
-  }
+  val other = newRemoteSystem(name = Some("other"), extraConfig = Some(s"akka.remote.artery.canonical.port=$otherPort"))
 
   override def expectedTestDuration: FiniteDuration = 120.seconds
 

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeployerSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeployerSpec.scala
@@ -12,7 +12,6 @@ import akka.remote.RemoteScope
 
 object RemoteDeployerSpec {
   val deployerConf = ConfigFactory.parseString("""
-      akka.actor.provider = remote
       akka.actor.deployment {
         /service2 {
           router = round-robin-pool
@@ -21,10 +20,7 @@ object RemoteDeployerSpec {
           dispatcher = mydispatcher
         }
       }
-      akka.remote.artery.enabled = on
-      akka.remote.artery.canonical.hostname = localhost
-      akka.remote.artery.canonical.port = 0
-      """, ConfigParseOptions.defaults)
+      """).withFallback(ArterySpecSupport.defaultConfig)
 
   class RecipeActor extends Actor {
     def receive = { case _ ⇒ }
@@ -32,7 +28,7 @@ object RemoteDeployerSpec {
 
 }
 
-class RemoteDeployerSpec extends AkkaSpec(RemoteDeployerSpec.deployerConf) {
+class RemoteDeployerSpec extends AkkaSpec(RemoteDeployerSpec.deployerConf) with FlightRecorderSpecIntegration {
 
   "A RemoteDeployer" must {
 

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
@@ -32,13 +32,7 @@ object RemoteDeploymentSpec {
   }
 }
 
-class RemoteDeploymentSpec extends AkkaSpec("""
-    #akka.loglevel=DEBUG
-    akka.actor.provider = remote
-    akka.remote.artery.enabled = on
-    akka.remote.artery.canonical.hostname = localhost
-    akka.remote.artery.canonical.port = 0
-    """) {
+class RemoteDeploymentSpec extends AkkaSpec(ArterySpecSupport.defaultConfig) {
 
   import RemoteDeploymentSpec._
 

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
@@ -32,24 +32,20 @@ object RemoteDeploymentSpec {
   }
 }
 
-class RemoteDeploymentSpec extends AkkaSpec(ArterySpecSupport.defaultConfig) {
+class RemoteDeploymentSpec extends ArteryMultiNodeSpec(ArterySpecSupport.defaultConfig) {
 
   import RemoteDeploymentSpec._
 
   val port = RARP(system).provider.getDefaultAddress.port.get
-  val conf = ConfigFactory.parseString(
+  val conf =
     s"""
     akka.actor.deployment {
       /blub.remote = "akka://${system.name}@localhost:$port"
     }
-    """).withFallback(system.settings.config)
+    """
 
-  val masterSystem = ActorSystem("Master" + system.name, conf)
-  val masterPort = RARP(masterSystem).provider.getDefaultAddress.port.get
-
-  override def afterTermination(): Unit = {
-    shutdown(masterSystem)
-  }
+  val masterSystem = newRemoteSystem(name = Some("Master" + system.name), extraConfig = Some(conf))
+  val masterPort = address(masterSystem).port.get
 
   "Remoting" must {
 

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
@@ -21,11 +21,7 @@ object RemoteRouterSpec {
   }
 }
 
-class RemoteRouterSpec extends AkkaSpec("""
-    akka.actor.provider = remote
-    akka.remote.artery.enabled = on
-    akka.remote.artery.canonical.hostname = localhost
-    akka.remote.artery.canonical.port = 0
+class RemoteRouterSpec extends AkkaSpec(ConfigFactory.parseString("""
     akka.actor.deployment {
       /remote-override {
         router = round-robin-pool
@@ -39,7 +35,7 @@ class RemoteRouterSpec extends AkkaSpec("""
         router = round-robin-pool
         nr-of-instances = 6
       }
-    }""") {
+    }""").withFallback(ArterySpecSupport.defaultConfig)) with FlightRecorderSpecIntegration {
 
   import RemoteRouterSpec._
 
@@ -85,6 +81,7 @@ class RemoteRouterSpec extends AkkaSpec("""
 
   override def afterTermination(): Unit = {
     shutdown(masterSystem)
+    super.afterTermination()
   }
 
   def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): immutable.Seq[ActorPath] = {

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
@@ -81,7 +81,8 @@ class RemoteRouterSpec extends AkkaSpec(ConfigFactory.parseString("""
 
   override def afterTermination(): Unit = {
     shutdown(masterSystem)
-    super.afterTermination()
+    handleFlightRecorderFile(system)
+    handleFlightRecorderFile(masterSystem)
   }
 
   def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): immutable.Seq[ActorPath] = {

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteRouterSpec.scala
@@ -75,7 +75,9 @@ class RemoteRouterSpec extends AkkaSpec(ConfigFactory.parseString("""
           target.nodes = ["akka://${sysName}@localhost:${port}"]
         }
       }
-    }""").withFallback(system.settings.config)
+    }"""
+  ).withFallback(ArterySpecSupport.newFlightRecorderConfig)
+    .withFallback(system.settings.config)
 
   val masterSystem = ActorSystem("Master" + sysName, conf)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
@@ -16,13 +16,12 @@ class RemoteSendConsistencyWithThreeLanesSpec extends AbstractRemoteSendConsiste
   ConfigFactory.parseString("""
       akka.remote.artery.advanced.outbound-lanes = 3
       akka.remote.artery.advanced.inbound-lanes = 3
-    """).withFallback(ArterySpecSupport.defaultConfig)) with FlightRecorderSpecIntegration
+    """).withFallback(ArterySpecSupport.defaultConfig))
 
-abstract class AbstractRemoteSendConsistencySpec(config: Config) extends AkkaSpec(config) with ImplicitSender {
+abstract class AbstractRemoteSendConsistencySpec(config: Config) extends ArteryMultiNodeSpec(config) with ImplicitSender {
 
-  val systemB = ActorSystem("systemB", system.settings.config)
-  val addressB = RARP(systemB).provider.getDefaultAddress
-  println(addressB)
+  val systemB = newRemoteSystem(name = Some("systemB"))
+  val addressB = address(systemB)
   val rootB = RootActorPath(addressB)
 
   "Artery" must {
@@ -117,11 +116,6 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config) extends AkkaSpe
       }
     }
 
-  }
-
-  override def afterTermination(): Unit = {
-    shutdown(systemB)
-    super.shutdown(systemB)
   }
 
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
@@ -63,15 +63,15 @@ object RemoteWatcherSpec {
 
 }
 
-class RemoteWatcherSpec extends AkkaSpec(ArterySpecSupport.defaultConfig) with ImplicitSender with FlightRecorderSpecIntegration {
+class RemoteWatcherSpec extends ArteryMultiNodeSpec(ArterySpecSupport.defaultConfig) with ImplicitSender {
 
   import RemoteWatcherSpec._
   import RemoteWatcher._
 
   override def expectedTestDuration = 2.minutes
 
-  val remoteSystem = ActorSystem("RemoteSystem", system.settings.config)
-  val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
+  val remoteSystem = newRemoteSystem(name = Some("RemoteSystem"))
+  val remoteAddress = address(remoteSystem)
   def remoteAddressUid = AddressUidExtension(remoteSystem).longAddressUid
 
   Seq(system, remoteSystem).foreach(muteDeadLetters(

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
@@ -63,15 +63,7 @@ object RemoteWatcherSpec {
 
 }
 
-class RemoteWatcherSpec extends AkkaSpec(
-  """akka {
-       loglevel = INFO
-       log-dead-letters-during-shutdown = false
-       actor.provider = remote
-       remote.artery.enabled = on
-       remote.artery.canonical.hostname = localhost
-       remote.artery.canonical.port = 0
-     }""") with ImplicitSender {
+class RemoteWatcherSpec extends AkkaSpec(ArterySpecSupport.defaultConfig) with ImplicitSender with FlightRecorderSpecIntegration {
 
   import RemoteWatcherSpec._
   import RemoteWatcher._
@@ -88,6 +80,7 @@ class RemoteWatcherSpec extends AkkaSpec(
 
   override def afterTermination() {
     shutdown(remoteSystem)
+    super.afterTermination()
   }
 
   val heartbeatRspB = ArteryHeartbeatRsp(remoteAddressUid)

--- a/akka-remote/src/test/scala/akka/remote/artery/SerializationErrorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SerializationErrorSpec.scala
@@ -13,24 +13,11 @@ import akka.testkit.EventFilter
 
 object SerializationErrorSpec {
 
-  val config = ConfigFactory.parseString(s"""
-     akka {
-       actor.provider = remote
-       remote.artery.enabled = on
-       remote.artery.canonical.hostname = localhost
-       remote.artery.canonical.port = 0
-       actor {
-         serialize-creators = false
-         serialize-messages = false
-       }
-     }
-  """)
-
   object NotSerializableMsg
 
 }
 
-class SerializationErrorSpec extends AkkaSpec(SerializationErrorSpec.config) with ImplicitSender {
+class SerializationErrorSpec extends AkkaSpec(ArterySpecSupport.defaultConfig) with ImplicitSender {
   import SerializationErrorSpec._
 
   val configB = ConfigFactory.parseString("""

--- a/akka-remote/src/test/scala/akka/remote/artery/UntrustedSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/UntrustedSpec.scala
@@ -69,11 +69,11 @@ object UntrustedSpec {
 
 }
 
-class UntrustedSpec extends AkkaSpec(UntrustedSpec.config) with ImplicitSender with FlightRecorderSpecIntegration {
+class UntrustedSpec extends ArteryMultiNodeSpec(UntrustedSpec.config) with ImplicitSender {
 
   import UntrustedSpec._
 
-  val client = ActorSystem("UntrustedSpec-client", ArterySpecSupport.defaultConfig)
+  val client = newRemoteSystem(name = Some("UntrustedSpec-client"))
   val addr = RARP(system).provider.getDefaultAddress
 
   val receptionist = system.actorOf(Props(classOf[Receptionist], testActor), "receptionist")
@@ -91,11 +91,6 @@ class UntrustedSpec extends AkkaSpec(UntrustedSpec.config) with ImplicitSender w
     client.actorSelection(RootActorPath(addr) / receptionist.path.elements).tell(
       IdentifyReq("child2"), p.ref)
     p.expectMsgType[ActorIdentity].ref.get
-  }
-
-  override def afterTermination() {
-    shutdown(client)
-    super.afterTermination()
   }
 
   // need to enable debug log-level without actually printing those messages

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
@@ -4,14 +4,13 @@
 
 package akka.remote.artery.compress
 
-import akka.actor.{ ActorIdentity, ActorRef, ActorSystem, Identify }
-import akka.remote.artery.compress.CompressionProtocol.Events
-import akka.testkit._
-import akka.util.Timeout
+import akka.actor.{ ActorIdentity, ActorSystem, Identify }
 import akka.pattern.ask
 import akka.remote.RARP
-import akka.remote.artery.ArteryTransport
 import akka.remote.artery.compress.CompressionProtocol.Events.{ Event, ReceivedActorRefCompressionTable }
+import akka.remote.artery.{ ArteryMultiNodeSpec, ArterySpecSupport, ArteryTransport }
+import akka.testkit._
+import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfter
 
@@ -24,12 +23,6 @@ object HandshakeShouldDropCompressionTableSpec {
 
   val commonConfig = ConfigFactory.parseString(s"""
      akka {
-       loglevel = INFO
-
-       actor.provider = remote
-       remote.artery.enabled = on
-       remote.artery.canonical.hostname = localhost
-       remote.artery.canonical.port = 0
        remote.artery.advanced.handshake-timeout = 10s
        remote.artery.advanced.image-liveness-timeout = 7s
 
@@ -40,14 +33,11 @@ object HandshakeShouldDropCompressionTableSpec {
          }
        }
      }
-  """)
-
-  val configB = ConfigFactory.parseString(s"akka.remote.artery.canonical.port = $portB")
-    .withFallback(commonConfig)
+  """).withFallback(ArterySpecSupport.defaultConfig)
 
 }
 
-class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDropCompressionTableSpec.commonConfig)
+class HandshakeShouldDropCompressionTableSpec extends ArteryMultiNodeSpec(HandshakeShouldDropCompressionTableSpec.commonConfig)
   with ImplicitSender with BeforeAndAfter {
   import HandshakeShouldDropCompressionTableSpec._
 
@@ -55,7 +45,9 @@ class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDr
   var systemB: ActorSystem = null
 
   before {
-    systemB = ActorSystem("systemB", configB)
+    systemB = newRemoteSystem(
+      name = Some("systemB"),
+      extraConfig = Some(s"akka.remote.artery.canonical.port = $portB"))
   }
 
   "Outgoing compression table" must {
@@ -92,11 +84,13 @@ class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDr
       info("System [A] received: " + a1)
       a1.table.dictionary.keySet should contain(a1Probe.ref)
 
-      log.warning("SHUTTING DOWN system {}...", systemB)
+      log.info("SHUTTING DOWN system {}...", systemB)
       shutdown(systemB)
-      systemB = ActorSystem("systemB", configB)
+      systemB = newRemoteSystem(
+        name = Some("systemB"),
+        extraConfig = Some(s"akka.remote.artery.canonical.port = $portB"))
       Thread.sleep(1000)
-      log.warning("SYSTEM READY {}...", systemB)
+      log.info("SYSTEM READY {}...", systemB)
 
       val aNewProbe = TestProbe()
       system.eventStream.subscribe(aNewProbe.ref, classOf[Event])
@@ -138,14 +132,4 @@ class HandshakeShouldDropCompressionTableSpec extends AkkaSpec(HandshakeShouldDr
     ref.get
   }
 
-  after {
-    shutdownAllActorSystems()
-  }
-
-  override def afterTermination(): Unit =
-    shutdownAllActorSystems()
-
-  private def shutdownAllActorSystems(): Unit = {
-    if (systemB != null) shutdown(systemB)
-  }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -227,7 +227,7 @@ object Source {
    * `create` factory is never called and the materialized `CompletionStage` is failed.
    */
   def lazily[T, M](create: function.Creator[Source[T, M]]): Source[T, CompletionStage[M]] =
-    scaladsl.Source.lazily[T, M](() => create.create().asScala).mapMaterializedValue(_.toJava).asJava
+    scaladsl.Source.lazily[T, M](() ⇒ create.create().asScala).mapMaterializedValue(_.toJava).asJava
 
   /**
    * Creates a `Source` that is materialized as a [[org.reactivestreams.Subscriber]]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -360,7 +360,7 @@ object Source {
    * the materialized future is completed with its value, if downstream cancels or fails without any demand the
    * create factory is never called and the materialized `Future` is failed.
    */
-  def lazily[T, M](create: () => Source[T, M]): Source[T, Future[M]] =
+  def lazily[T, M](create: () ⇒ Source[T, M]): Source[T, Future[M]] =
     Source.fromGraph(new LazySource[T, M](create))
 
   /**


### PR DESCRIPTION
While looking at some fails I noticed for many artery tests in akka-remote we actually do not record an afr file and no dump on fail. This adds flight recorder to as many of those as possible.