### PR TITLE
No default OSGi private package to avoid publish build warnings

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -19,6 +19,7 @@ object OSGi {
     // This will fail the build instead of accidentally removing classes from the resulting artifact.
     // Each package contained in a project MUST be known to be private or exported, if it's undecided we MUST resolve this
     OsgiKeys.failOnUndecidedPackage := true,
+    // By default an entry is generated from module group-id, but our modules do not adhere to such package naming
     OsgiKeys.privatePackage := Seq()
   )
 

--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -18,7 +18,8 @@ object OSGi {
     packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
     // This will fail the build instead of accidentally removing classes from the resulting artifact.
     // Each package contained in a project MUST be known to be private or exported, if it's undecided we MUST resolve this
-    OsgiKeys.failOnUndecidedPackage := true 
+    OsgiKeys.failOnUndecidedPackage := true,
+    OsgiKeys.privatePackage := Seq()
   )
 
   val actor = osgiSettings ++ Seq(


### PR DESCRIPTION
Refs #21899 

Disclaimer: I'm not very familiar with SBT and OSGi, so please let me know anything wrong here..

### what I found

The below warning:

```
[warn] bnd: Unused Private-Package instructions, no such package(s) on the class path: [com.typesafe.akka.distributed.data.experimental.*]
```

came from [bndtools/bnd -> Builder.java](https://github.com/bndtools/bnd/blob/1f3bafc331902bf16d47d083a36934b4960357b9/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java#L569L571), which was used in  [sbtOsgi plugin's SbtOsgi.scala](https://github.com/sbt/sbt-osgi/blob/16ad2f8910530d24977efb9dc6cee40cbe619ae7/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala#L75L82).

`SbtOsgi` sets the default private package as :

```
  def defaultOsgiSettings: Seq[Setting[_]] = {
       ...
      bundleSymbolicName <<= (organization, normalizedName)(Osgi.defaultBundleSymbolicName),
       ...
      privatePackage <<= bundleSymbolicName(name => List(name + ".*")),
         //this becomes like "com.typesafe.akka.distributed.data.experimental.*"
         //or "com.typesafe.akka.testkit.*", etc
```

which is used in [akka's OSGi.scala]() as the default value for `OsgiKeys.privatePackage`, since it was not overriden.

This resulted in the unused (default) private packages.