### PR TITLE
Fix incorrect materialized types = Unit in stream documentation

### DIFF
--- a/akka-docs/rst/java/code/docs/stream/CompositionDocTest.java
+++ b/akka-docs/rst/java/code/docs/stream/CompositionDocTest.java
@@ -243,19 +243,19 @@ public class CompositionDocTest extends AbstractJavaTest {
   @Test
   public void materializedValues() throws Exception {
     //#mat-combine-1
-    // Materializes to Promise<BoxedUnit>                                     (red)
+    // Materializes to CompletableFuture<Optional<Integer>>                   (red)
     final Source<Integer, CompletableFuture<Optional<Integer>>> source = Source.<Integer>maybe();
 
-    // Materializes to BoxedUnit                                              (black)
+    // Materializes to NotUsed                                                (black)
     final Flow<Integer, Integer, NotUsed> flow1 = Flow.of(Integer.class).take(100);
 
-    // Materializes to Promise<Option<>>                                     (red)
+    // Materializes to CompletableFuture<Optional<Integer>>                  (red)
     final Source<Integer, CompletableFuture<Optional<Integer>>> nestedSource =
       source.viaMat(flow1, Keep.left()).named("nestedSource");
       //#mat-combine-1
 
     //#mat-combine-2
-    // Materializes to BoxedUnit                                              (orange)
+    // Materializes to NotUsed                                                (orange)
     final Flow<Integer, ByteString, NotUsed> flow2 = Flow.of(Integer.class)
       .map(i -> ByteString.fromString(i.toString()));
 

--- a/akka-docs/rst/java/stream/stream-composition.rst
+++ b/akka-docs/rst/java/stream/stream-composition.rst
@@ -247,7 +247,7 @@ The propagation of the individual materialized values from the enclosed modules 
 |
 
 To implement the above, first, we create a composite :class:`Source`, where the enclosed :class:`Source` have a
-materialized type of :class:`Promise<BoxedUnit>`. By using the combiner function ``Keep.left()``, the resulting materialized
+materialized type of :class:`CompletableFuture<Optional<Integer>>>`. By using the combiner function ``Keep.left()``, the resulting materialized
 type is of the nested module (indicated by the color *red* on the diagram):
 
 .. includecode:: ../code/docs/stream/CompositionDocTest.java#mat-combine-1

--- a/akka-docs/rst/java/stream/stream-customize.rst
+++ b/akka-docs/rst/java/stream/stream-customize.rst
@@ -50,7 +50,7 @@ override ``onPull()`` which indicates that we are free to emit a single element.
 ``onDownstreamFinish()`` which is called if the downstream cancelled. Since the default behavior of that callback is
 to stop the stage, we don't need to override it. In the ``onPull`` callback we simply emit the next number.
 
-Instances of the above :class:`GraphStage` are subclasses of ``Graph<SourceShape<Int>,Unit>`` which means
+Instances of the above :class:`GraphStage` are subclasses of ``Graph<SourceShape<Int>,NotUsed>`` which means
 that they are already usable in many situations, but do not provide the DSL methods we usually have for other
 :class:`Source` s. In order to convert this :class:`Graph` to a proper :class:`Source` we need to wrap it using
 ``Source.fromGraph`` (see :ref:`composition-java` for more details about graphs and DSLs). Now we can use the
@@ -379,7 +379,7 @@ or ``unwatch(ref)`` methods. The reference can be also watched by external actor
 Custom materialized values
 --------------------------
 
-Custom stages can return materialized values instead of ``Unit`` by inheriting from :class:`GraphStageWithMaterializedValue`
+Custom stages can return materialized values instead of ``NotUsed`` by inheriting from :class:`GraphStageWithMaterializedValue`
 instead of the simpler :class:`GraphStage`. The difference is that in this case the method
 ``createLogicAndMaterializedValue(inheritedAttributes)`` needs to be overridden, and in addition to the
 stage logic the materialized value must be provided

--- a/akka-docs/rst/java/stream/stream-customize.rst
+++ b/akka-docs/rst/java/stream/stream-customize.rst
@@ -50,7 +50,7 @@ override ``onPull()`` which indicates that we are free to emit a single element.
 ``onDownstreamFinish()`` which is called if the downstream cancelled. Since the default behavior of that callback is
 to stop the stage, we don't need to override it. In the ``onPull`` callback we simply emit the next number.
 
-Instances of the above :class:`GraphStage` are subclasses of ``Graph<SourceShape<Int>,NotUsed>`` which means
+Instances of the above :class:`GraphStage` are subclasses of ``Graph<SourceShape<Integer>,NotUsed>`` which means
 that they are already usable in many situations, but do not provide the DSL methods we usually have for other
 :class:`Source` s. In order to convert this :class:`Graph` to a proper :class:`Source` we need to wrap it using
 ``Source.fromGraph`` (see :ref:`composition-java` for more details about graphs and DSLs). Now we can use the

--- a/akka-docs/rst/java/stream/stream-quickstart.rst
+++ b/akka-docs/rst/java/stream/stream-quickstart.rst
@@ -184,7 +184,7 @@ more advanced graph elements to finally be consumed by a ``Sink<In,M3>``.
 
 The first type parameter—:class:`Tweet` in this case—designates the kind of elements produced
 by the source while the ``M`` type parameters describe the object that is created during
-materialization (:ref:`see below <materialized-values-quick-java>`)—:class:`BoxedUnit` (from the ``scala.runtime``
+materialization (:ref:`see below <materialized-values-quick-java>`)—:class:`NotUsed` (from the ``scala.runtime``
 package) means that no value is produced, it is the generic equivalent of ``void``.
 
 The operations should look familiar to anyone who has used the Scala Collections library,

--- a/akka-docs/rst/java/stream/stream-quickstart.rst
+++ b/akka-docs/rst/java/stream/stream-quickstart.rst
@@ -251,7 +251,7 @@ Graphs are constructed using :class:`GraphDSL` like this:
 
 As you can see, we use graph builder ``b`` to construct the graph using ``UniformFanOutShape`` and ``Flow`` s.
 
-``GraphDSL.create`` returns a :class:`Graph`, in this example a ``Graph<ClosedShape,Unit>`` where
+``GraphDSL.create`` returns a :class:`Graph`, in this example a ``Graph<ClosedShape,NotUsed>`` where
 :class:`ClosedShape` means that it is *a fully connected graph* or "closed" - there are no unconnected inputs or outputs.
 Since it is closed it is possible to transform the graph into a :class:`RunnableGraph` using ``RunnableGraph.fromGraph``.
 The runnable graph can then be ``run()`` to materialize a stream out of it.

--- a/akka-docs/rst/scala/code/docs/stream/CompositionDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/stream/CompositionDocSpec.scala
@@ -181,7 +181,7 @@ class CompositionDocSpec extends AkkaSpec {
     // Materializes to Promise[Option[Int]]                                   (red)
     val source: Source[Int, Promise[Option[Int]]] = Source.maybe[Int]
 
-    // Materializes to Unit                                                   (black)
+    // Materializes to NotUsed                                               (black)
     val flow1: Flow[Int, Int, NotUsed] = Flow[Int].take(100)
 
     // Materializes to Promise[Int]                                          (red)
@@ -190,7 +190,7 @@ class CompositionDocSpec extends AkkaSpec {
     //#mat-combine-1
 
     //#mat-combine-2
-    // Materializes to Unit                                                   (orange)
+    // Materializes to NotUsed                                                (orange)
     val flow2: Flow[Int, ByteString, NotUsed] = Flow[Int].map { i => ByteString(i.toString) }
 
     // Materializes to Future[OutgoingConnection]                             (yellow)

--- a/akka-docs/rst/scala/stream/stream-composition.rst
+++ b/akka-docs/rst/scala/stream/stream-composition.rst
@@ -248,7 +248,7 @@ The propagation of the individual materialized values from the enclosed modules 
 |
 
 To implement the above, first, we create a composite :class:`Source`, where the enclosed :class:`Source` have a
-materialized type of :class:`Promise[Unit]`. By using the combiner function ``Keep.left``, the resulting materialized
+materialized type of :class:`Promise[[Option[Int]]`. By using the combiner function ``Keep.left``, the resulting materialized
 type is of the nested module (indicated by the color *red* on the diagram):
 
 .. includecode:: ../code/docs/stream/CompositionDocSpec.scala#mat-combine-1

--- a/akka-docs/rst/scala/stream/stream-customize.rst
+++ b/akka-docs/rst/scala/stream/stream-customize.rst
@@ -53,7 +53,7 @@ is how it looks like in the end:
 
 .. includecode:: ../code/docs/stream/GraphStageDocSpec.scala#custom-source-example
 
-Instances of the above :class:`GraphStage` are subclasses of ``Graph[SourceShape[Int],Unit]`` which means
+Instances of the above :class:`GraphStage` are subclasses of ``Graph[SourceShape[Int],NotUsed]`` which means
 that they are already usable in many situations, but do not provide the DSL methods we usually have for other
 :class:`Source` s. In order to convert this :class:`Graph` to a proper :class:`Source` we need to wrap it using
 ``Source.fromGraph`` (see :ref:`composition-scala` for more details about graphs and DSLs). Now we can use the
@@ -385,7 +385,7 @@ or ``unwatch(ref)`` methods. The reference can be also watched by external actor
 Custom materialized values
 --------------------------
 
-Custom stages can return materialized values instead of ``Unit`` by inheriting from :class:`GraphStageWithMaterializedValue`
+Custom stages can return materialized values instead of ``NotUsed`` by inheriting from :class:`GraphStageWithMaterializedValue`
 instead of the simpler :class:`GraphStage`. The difference is that in this case the method
 ``createLogicAndMaterializedValue(inheritedAttributes)`` needs to be overridden, and in addition to the
 stage logic the materialized value must be provided

--- a/akka-docs/rst/scala/stream/stream-quickstart.rst
+++ b/akka-docs/rst/scala/stream/stream-quickstart.rst
@@ -248,7 +248,7 @@ As you can see, inside the :class:`GraphDSL` we use an implicit graph builder ``
 using the ``~>`` "edge operator" (also read as "connect" or "via" or "to"). The operator is provided implicitly
 by importing ``GraphDSL.Implicits._``.
 
-``GraphDSL.create`` returns a :class:`Graph`, in this example a :class:`Graph[ClosedShape, Unit]` where
+``GraphDSL.create`` returns a :class:`Graph`, in this example a :class:`Graph[ClosedShape, NotUsed]` where
 :class:`ClosedShape` means that it is *a fully connected graph* or "closed" - there are no unconnected inputs or outputs.
 Since it is closed it is possible to transform the graph into a :class:`RunnableGraph` using ``RunnableGraph.fromGraph``.
 The runnable graph can then be ``run()`` to materialize a stream out of it.


### PR DESCRIPTION
Refs #21937 

I did text search in akka-docs/rst/(java|scala)/stream directories, and fixed all I found.
Cross checked materialization types against class definitions.