### PR TITLE
Fix #21791 by adding exclusions scala packages in external moduls (for validation)

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -110,7 +110,8 @@ object OSGi {
     OsgiKeys.importPackage := imports ++ scalaVersion(defaultImports).value,
     OsgiKeys.exportPackage := packages
   )
-  def defaultImports(scalaVersion: String) = Seq("!sun.misc", akkaImport(), configImport(), scalaImport(scalaVersion), "*")
+  def defaultImports(scalaVersion: String) = Seq("!sun.misc", akkaImport(), configImport(), "!scala.compat.java8.*",
+    "!scala.util.parsing.*", scalaImport(scalaVersion), "*")
   def akkaImport(packageName: String = "akka.*") = versionedImport(packageName, "2.4", "2.5")
   def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.3.0", "1.4.0")
   def scalaImport(version: String) = {


### PR DESCRIPTION
Backport to 2.4

This patch fixes akka-stream's OSGi manifest by adding
an explicit exclusion for scala.* packages known to have
different versions, so they do not get expanded by scalaImport()
and subsequent "*".

Signed-off-by: Robert Varga <nite@hq.sk>
(cherry picked from commit e465f07d944164a252636d1beae812e9e9ac23e2)