### PR TITLE
(for validation) InputStream from StreamConverters.asInputStream respects read() contr…

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
@@ -217,6 +217,13 @@ class InputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
 
       inputStream.close()
     }
+
+    "read next byte as an int from InputStream" in assertAllStagesStopped {
+      val bytes = ByteString(0, 100, 200, 255)
+      val inputStream = Source.single(bytes).runWith(StreamConverters.asInputStream())
+      List.fill(5)(inputStream.read()) should ===(List(0, 100, 200, 255, -1))
+      inputStream.close()
+    }
   }
 
   "fail to materialize with zero sized input buffer" in {

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -117,7 +117,7 @@ private[akka] class InputStreamAdapter(
   @scala.throws(classOf[IOException])
   override def read(): Int = {
     val a = Array[Byte](1)
-    if (read(a, 0, 1) != -1) a(0)
+    if (read(a, 0, 1) != -1) a(0) & 0xff
     else -1
   }
 


### PR DESCRIPTION
Backport of https://github.com/akka/akka/pull/21954