### PR TITLE
BACKPORT: use log level when draining LoggerMailbox, #21895

### DIFF
--- a/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
+++ b/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
@@ -10,6 +10,8 @@ import com.typesafe.config.Config
 import akka.actor.ActorSystem
 import akka.actor.ActorRef
 import akka.dispatch.ProducesMessageQueue
+import akka.event.Logging.Debug
+import akka.event.Logging.LogEvent
 
 trait LoggerMessageQueueSemantics
 
@@ -33,13 +35,22 @@ private[akka] class LoggerMailbox(owner: ActorRef, system: ActorSystem)
 
   override def cleanUp(owner: ActorRef, deadLetters: MessageQueue): Unit = {
     if (hasMessages) {
+      val logLevel = system.eventStream.logLevel
       var envelope = dequeue
       // Drain all remaining messages to the StandardOutLogger.
       // cleanUp is called after switching out the mailbox, which is why
       // this kind of look works without a limit.
+      val loggingEnabled = Logging.AllLogLevels.contains(logLevel)
       while (envelope ne null) {
-        // Logging.StandardOutLogger is a MinimalActorRef, i.e. not a "real" actor
-        Logging.StandardOutLogger.tell(envelope.message, envelope.sender)
+        // skip logging if level is OFF
+        if (loggingEnabled)
+          envelope.message match {
+            case e: LogEvent if e.level <= logLevel ⇒
+              // Logging.StandardOutLogger is a MinimalActorRef, i.e. not a "real" actor
+              Logging.StandardOutLogger.tell(envelope.message, envelope.sender)
+            case _ ⇒ // skip
+          }
+
         envelope = dequeue
       }
     }


### PR DESCRIPTION
* use log level when draining LoggerMailbox, #21895
* Apply review comment

Backport of #21949