### PR TITLE
=str less noisy logging of idle-timeout (for akka-http specifically)

### DIFF
--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -743,6 +743,8 @@ recover
 ^^^^^^^
 Allow sending of one last element downstream when a failure has happened upstream.
 
+Throwing an exception inside ``recover`` _will_ be logged on ERROR level automatically.
+
 **emits** when the element is available from the upstream or upstream is failed and pf returns an element
 
 **backpressures** when downstream backpressures, not when failure happened
@@ -753,11 +755,44 @@ recoverWith
 ^^^^^^^^^^^
 Allow switching to alternative Source when a failure has happened upstream.
 
+Throwing an exception inside ``recoverWith`` _will_ be logged on ERROR level automatically.
+
 **emits** the element is available from the upstream or upstream is failed and pf returns alternative Source
 
 **backpressures** downstream backpressures, after failure happened it backprssures to alternative Source
 
 **completes** upstream completes or upstream failed with exception pf can handle
+
+recoverWithRetries
+^^^^^^^^^^^^^^^^^^
+RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after
+a failure has been recovered up to `attempts` number of times so that each time there is a failure
+it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+attempt to recover at all. Passing -1 will behave exactly the same as  `recoverWith`.
+
+Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+
+**emits** when element is available from the upstream or upstream is failed and element is available from alternative Source
+
+**backpressures** when downstream backpressures
+
+**completes** when upstream completes or upstream failed with exception pf can handle
+
+mapError
+^^^^^^^^
+While similar to ``recover`` this stage can be used to transform an error signal to a different one *without* logging
+it as an error in the process. So in that sense it is NOT exactly equivalent to ``recover(t -> throw t2)`` since recover
+would log the ``t2`` error.
+
+Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+
+Similarily to ``recover`` throwing an exception inside ``mapError`` _will_ be logged on ERROR level automatically.
+
+**emits** when element is available from the upstream or upstream is failed and pf returns an element
+**backpressures** when downstream backpressures
+**completes** when upstream completes or upstream failed with exception pf can handle
 
 detach
 ^^^^^^

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -732,6 +732,8 @@ recover
 ^^^^^^^
 Allow sending of one last element downstream when a failure has happened upstream.
 
+Throwing an exception inside ``recover`` _will_ be logged on ERROR level automatically.
+
 **emits** when the element is available from the upstream or upstream is failed and pf returns an element
 
 **backpressures** when downstream backpressures, not when failure happened
@@ -742,11 +744,44 @@ recoverWith
 ^^^^^^^^^^^
 Allow switching to alternative Source when a failure has happened upstream.
 
+Throwing an exception inside ``recoverWith`` _will_ be logged on ERROR level automatically.
+
 **emits** the element is available from the upstream or upstream is failed and pf returns alternative Source
 
 **backpressures** downstream backpressures, after failure happened it backprssures to alternative Source
 
 **completes** upstream completes or upstream failed with exception pf can handle
+
+recoverWithRetries
+^^^^^^^^^^^^^^^^^^
+RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after
+a failure has been recovered up to `attempts` number of times so that each time there is a failure
+it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+attempt to recover at all. Passing -1 will behave exactly the same as  `recoverWith`.
+
+Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+
+**emits** when element is available from the upstream or upstream is failed and element is available from alternative Source
+
+**backpressures** when downstream backpressures
+
+**completes** when upstream completes or upstream failed with exception pf can handle
+
+mapError
+^^^^^^^^
+While similar to ``recover`` this stage can be used to transform an error signal to a different one *without* logging
+it as an error in the process. So in that sense it is NOT exactly equivalent to ``recover(t => throw t2)`` since recover
+would log the ``t2`` error.
+
+Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+
+Similarily to ``recover`` throwing an exception inside ``mapError`` _will_ be logged on ERROR level automatically.
+
+**emits** when element is available from the upstream or upstream is failed and pf returns an element
+**backpressures** when downstream backpressures
+**completes** when upstream completes or upstream failed with exception pf can handle
 
 detach
 ^^^^^^

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapErrorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapErrorSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.Utils._
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+
+import scala.util.control.NoStackTrace
+
+class FlowMapErrorSpec extends StreamSpec {
+
+  val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 1, maxSize = 1)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  val ex = new RuntimeException("ex") with NoStackTrace
+  val boom = new Exception("BOOM!") with NoStackTrace
+
+  "A MapError" must {
+    "mapError when there is a handler" in assertAllStagesStopped {
+      Source(1 to 4).map { a ⇒ if (a == 3) throw ex else a }
+        .mapError { case t: Throwable ⇒ boom }
+        .runWith(TestSink.probe[Int])
+        .request(3)
+        .expectNext(1)
+        .expectNext(2)
+        .expectError(boom)
+    }
+
+    "fail the stream with exception thrown in handler (and log it)" in assertAllStagesStopped {
+      Source(1 to 3).map { a ⇒ if (a == 2) throw ex else a }
+        .mapError { case t: Exception ⇒ throw boom }
+        .runWith(TestSink.probe[Int])
+        .requestNext(1)
+        .request(1)
+        .expectError(boom)
+    }
+
+    "pass through the original exception if partial function does not handle it" in assertAllStagesStopped {
+      Source(1 to 3).map { a ⇒ if (a == 2) throw ex else a }
+        .mapError { case t: IndexOutOfBoundsException ⇒ boom }
+        .runWith(TestSink.probe[Int])
+        .requestNext(1)
+        .request(1)
+        .expectError(ex)
+    }
+
+    "not influence stream when there is no exceptions" in assertAllStagesStopped {
+      Source(1 to 3).map(identity)
+        .mapError { case t: Throwable ⇒ boom }
+        .runWith(TestSink.probe[Int])
+        .request(3)
+        .expectNextN(1 to 3)
+        .expectComplete()
+    }
+
+    "finish stream if it's empty" in assertAllStagesStopped {
+      Source.empty.map(identity)
+        .mapError { case t: Throwable ⇒ boom }
+        .runWith(TestSink.probe[Int])
+        .request(1)
+        .expectComplete()
+    }
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -176,7 +176,7 @@ private[stream] object TcpConnectionStage {
    * to attach an extra, fused buffer to the end of this flow. Keeping this stage non-detached makes it much simpler and
    * easier to maintain and understand.
    */
-  class TcpStreamLogic(val shape: FlowShape[ByteString, ByteString], val role: TcpRole) extends GraphStageLogic(shape) {
+  class TcpStreamLogic(val shape: FlowShape[ByteString, ByteString], val role: TcpRole, remoteAddress: InetSocketAddress) extends GraphStageLogic(shape) {
     implicit def self: ActorRef = stageActor.ref
 
     private def bytesIn = shape.in
@@ -276,10 +276,10 @@ private[stream] object TcpConnectionStage {
       override def onUpstreamFailure(ex: Throwable): Unit = {
         if (connection != null) {
           if (interpreter.log.isDebugEnabled) {
-            interpreter.log.debug(
-              "Aborting tcp connection because of upstream failure: {}\n{}",
-              ex.getMessage,
-              ex.getStackTrace.mkString("\n"))
+            val msg = "Aborting tcp connection to {} because of upstream failure: {}"
+
+            if (ex.getStackTrace.isEmpty) interpreter.log.debug(msg, remoteAddress, ex.getMessage)
+            else interpreter.log.debug(msg + "\n{}", remoteAddress, ex.getMessage, ex.getStackTrace.mkString("\n"))
           }
           connection ! Abort
         } else failStage(ex)
@@ -313,7 +313,7 @@ class IncomingConnectionStage(connection: ActorRef, remoteAddress: InetSocketAdd
     if (hasBeenCreated.get) throw new IllegalStateException("Cannot materialize an incoming connection Flow twice.")
     hasBeenCreated.set(true)
 
-    new TcpStreamLogic(shape, Inbound(connection, halfClose))
+    new TcpStreamLogic(shape, Inbound(connection, halfClose), remoteAddress)
   }
 
   override def toString = s"TCP-from($remoteAddress)"
@@ -350,7 +350,8 @@ private[stream] class OutgoingConnectionStage(
       manager,
       Connect(remoteAddress, localAddress, options, connTimeout, pullMode = true),
       localAddressPromise,
-      halfClose))
+      halfClose),
+      remoteAddress)
 
     (logic, localAddressPromise.future.map(OutgoingConnection(remoteAddress, _))(ExecutionContexts.sameThreadExecutionContext))
   }
@@ -362,20 +363,20 @@ private[stream] class OutgoingConnectionStage(
 private[akka] object TcpIdleTimeout {
   def apply(idleTimeout: FiniteDuration, remoteAddress: Option[InetSocketAddress]): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
     val connectionToString = remoteAddress match {
-      case Some(addr) ⇒ s"on connection to [$addr]"
+      case Some(addr) ⇒ s" on connection to [$addr]"
       case _          ⇒ ""
     }
 
     val toNetTimeout: BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
       BidiFlow.fromFlows(
-        Flow[ByteString].mapError { case t: TimeoutException ⇒ new TcpIdleTimeoutException(s"TCP idle-timeout encountered $connectionToString, no bytes passed in the last $idleTimeout", idleTimeout) },
+        Flow[ByteString].mapError {
+          case t: TimeoutException ⇒
+            new TcpIdleTimeoutException(s"TCP idle-timeout encountered$connectionToString, no bytes passed in the last $idleTimeout", idleTimeout)
+        },
         Flow[ByteString]
       )
     val fromNetTimeout: BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
-      BidiFlow.fromFlows(
-        Flow[ByteString],
-        Flow[ByteString].mapError { case t: TimeoutException ⇒ new TcpIdleTimeoutException(s"TCP idle-timeout encountered $connectionToString, no bytes passed in the last $idleTimeout", idleTimeout) }
-      )
+      fromNetTimeout.reversed // now the bottom flow transforms the exception, the top one doesn't (since that one is "fromNet") 
 
     fromNetTimeout atop BidiFlow.bidirectionalIdleTimeout[ByteString, ByteString](idleTimeout) atop toNetTimeout
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -835,6 +835,8 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
    *
+   * Throwing an exception inside `recover` _will_ be logged on ERROR level automatically.
+   *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *
    * '''Backpressures when''' downstream backpressures
@@ -847,12 +849,36 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
     new Flow(delegate.recover(pf))
 
   /**
+   * While similar to [[recover]] this stage can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError(pf: PartialFunction[Throwable, Throwable]): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.mapError(pf))
+
+  /**
    * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
    * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
    * Source may be materialized.
    *
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWith` _will_ be logged on ERROR level automatically.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source
@@ -876,6 +902,8 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -929,6 +929,8 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
    *
+   * Throwing an exception inside `recover` _will_ be logged on ERROR level automatically.
+   *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *
    * '''Backpressures when''' downstream backpressures
@@ -942,12 +944,36 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
     new Source(delegate.recover(pf))
 
   /**
+   * While similar to [[recover]] this stage can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError(pf: PartialFunction[Throwable, Throwable]): javadsl.Source[Out, Mat] =
+    new Source(delegate.mapError(pf))
+
+  /**
    * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
    * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
    * Source may be materialized.
    *
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWith` _will_ be logged on ERROR level automatically.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source
@@ -970,6 +996,8 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
    *
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -8,13 +8,17 @@ import akka.event.LoggingAdapter
 import akka.japi.function
 import akka.stream._
 import akka.stream.impl.ConstantFun
+
 import scala.collection.JavaConverters._
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration.FiniteDuration
 import akka.japi.Util
 import java.util.Comparator
+
 import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
+
+import akka.stream.impl.fusing.MapError
 
 /**
  * A “stream of streams” sub-flow of data elements, e.g. produced by `groupBy`.
@@ -664,6 +668,8 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
    *
+   * Throwing an exception inside `recover` _will_ be logged on ERROR level automatically.
+   *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *
    * '''Backpressures when''' downstream backpressures
@@ -683,6 +689,8 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    *
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside ``recoverWith`` _will_ be logged on ERROR level automatically.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source
@@ -707,6 +715,8 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
    *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+   *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source
    *
@@ -719,6 +729,28 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    */
   def recoverWithRetries[T >: Out](attempts: Int, pf: PartialFunction[Throwable, _ <: Graph[SourceShape[T], NotUsed]]): SubFlow[In, T, Mat @uncheckedVariance] =
     new SubFlow(delegate.recoverWithRetries(attempts, pf))
+
+  /**
+   * While similar to [[recover]] this stage can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError(pf: PartialFunction[Throwable, Throwable]): SubFlow[In, Out, Mat @uncheckedVariance] =
+    new SubFlow(delegate.mapError(pf))
 
   /**
    * Terminate processing (and cancel the upstream publisher) after the given

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -8,12 +8,16 @@ import akka.event.LoggingAdapter
 import akka.japi.function
 import akka.stream._
 import akka.stream.impl.ConstantFun
+
 import scala.collection.JavaConverters._
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration.FiniteDuration
 import akka.japi.Util
 import java.util.Comparator
 import java.util.concurrent.CompletionStage
+
+import akka.stream.impl.fusing.MapError
+
 import scala.compat.java8.FutureConverters._
 
 /**
@@ -717,6 +721,28 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    */
   def recoverWithRetries[T >: Out](attempts: Int, pf: PartialFunction[Throwable, _ <: Graph[SourceShape[T], NotUsed]]): SubSource[T, Mat @uncheckedVariance] =
     new SubSource(delegate.recoverWithRetries(attempts, pf))
+
+  /**
+   * While similar to [[recover]] this stage can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError(pf: PartialFunction[Throwable, Throwable]): SubSource[Out, Mat] =
+    new SubSource(delegate.mapError(pf))
 
   /**
    * Terminate processing (and cancel the upstream publisher) after the given

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -238,4 +238,5 @@ object BidiFlow {
    */
   def bidirectionalIdleTimeout[I, O](timeout: FiniteDuration): BidiFlow[I, I, O, O, NotUsed] =
     fromGraph(new Timers.IdleTimeoutBidi(timeout))
+
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -405,6 +405,8 @@ trait FlowOps[+Out, +Mat] {
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
    *
+   * Throwing an exception inside `recover` _will_ be logged on ERROR level automatically.
+   *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *
    * '''Backpressures when''' downstream backpressures
@@ -423,6 +425,8 @@ trait FlowOps[+Out, +Mat] {
    *
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWith` _will_ be logged on ERROR level automatically.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source
@@ -447,6 +451,8 @@ trait FlowOps[+Out, +Mat] {
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
    *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+   *
    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
    * from alternative Source
    *
@@ -463,6 +469,27 @@ trait FlowOps[+Out, +Mat] {
    */
   def recoverWithRetries[T >: Out](attempts: Int, pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =
     via(new RecoverWith(attempts, pf))
+
+  /**
+   * While similar to [[recover]] this stage can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError(pf: PartialFunction[Throwable, Throwable]): Repr[Out] = via(MapError(pf))
 
   /**
    * Transform this stream by applying the given function to each of the elements

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -4,6 +4,7 @@
 package akka.stream.scaladsl
 
 import java.net.InetSocketAddress
+import java.util.concurrent.TimeoutException
 
 import akka.NotUsed
 import akka.actor._
@@ -11,7 +12,7 @@ import akka.io.Inet.SocketOption
 import akka.io.{ IO, Tcp ⇒ IoTcp }
 import akka.stream._
 import akka.stream.impl.fusing.GraphStages.detacher
-import akka.stream.impl.io.{ ConnectionSourceStage, OutgoingConnectionStage }
+import akka.stream.impl.io.{ ConnectionSourceStage, OutgoingConnectionStage, TcpIdleTimeout }
 import akka.util.ByteString
 
 import scala.collection.immutable
@@ -172,7 +173,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       connectTimeout)).via(detacher[ByteString]) // must read ahead for proper completions
 
     idleTimeout match {
-      case d: FiniteDuration ⇒ tcpFlow.join(BidiFlow.bidirectionalIdleTimeout[ByteString, ByteString](d))
+      case d: FiniteDuration ⇒ tcpFlow.join(TcpIdleTimeout(d, Some(remoteAddress)))
       case _                 ⇒ tcpFlow
     }
 
@@ -185,3 +186,5 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   def outgoingConnection(host: String, port: Int): Flow[ByteString, ByteString, Future[OutgoingConnection]] =
     outgoingConnection(InetSocketAddress.createUnresolved(host, port))
 }
+
+final class TcpIdleTimeoutException(msg: String, timeout: Duration) extends TimeoutException(msg: String)

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -646,7 +646,10 @@ object MiMa extends AutoPlugin {
 
         // https://github.com/akka/akka/pull/21688
         ProblemFilters.exclude[MissingClassProblem]("akka.stream.Fusing$StructuralInfo$"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.stream.Fusing$StructuralInfo")
+        ProblemFilters.exclude[MissingClassProblem]("akka.stream.Fusing$StructuralInfo"),
+        
+        // https://github.com/akka/akka/pull/21989 - add more information in tcp connection shutdown logs (add mapError)
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.mapError")
       ) ++ bcIssuesBetween24and25)
     )
   }


### PR DESCRIPTION
This noisy logging is not needed, and adding the stacktrace made people often think it's a real problem. Instead we log it where we want, e.g. in akka-http this special error type would be handled specifically.