### PR TITLE
don't use Down member as leader, #21906 (for validation)

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Gossip.scala
@@ -189,8 +189,9 @@ private[cluster] final case class Gossip(
 
   private def leaderOf(mbrs: immutable.SortedSet[Member], selfUniqueAddress: UniqueAddress): Option[UniqueAddress] = {
     val reachableMembers =
-      if (overview.reachability.isAllReachable) mbrs
-      else mbrs.filter(m ⇒ overview.reachability.isReachable(m.uniqueAddress) || m.uniqueAddress == selfUniqueAddress)
+      if (overview.reachability.isAllReachable) mbrs.filterNot(_.status == Down)
+      else mbrs.filter(m ⇒ m.status != Down &&
+        (overview.reachability.isReachable(m.uniqueAddress) || m.uniqueAddress == selfUniqueAddress))
     if (reachableMembers.isEmpty) None
     else reachableMembers.find(m ⇒ Gossip.leaderMemberStatus(m.status)).
       orElse(Some(reachableMembers.min(Member.leaderStatusOrdering))).map(_.uniqueAddress)

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -132,6 +132,10 @@ class GossipSpec extends WordSpec with Matchers {
       g1.leader(c2.uniqueAddress) should ===(Some(c2.uniqueAddress))
     }
 
+    "not have Down member as leader" in {
+      Gossip(members = SortedSet(e3)).leader(e3.uniqueAddress) should ===(None)
+    }
+
     "merge seen table correctly" in {
       val vclockNode = VectorClock.Node("something")
       val g1 = (Gossip(members = SortedSet(a1, b1, c1, d1)) :+ vclockNode).seen(a1.uniqueAddress).seen(b1.uniqueAddress)


### PR DESCRIPTION
* in the failed test it was noticed that a Down member removed
  itself in leaderActionsOnConvergence which resulted in
  later "Failed to serialize Gossip, Unknown address"
* never use member with status Down as leader
* a node will anyway shutdown itself when it's Down,
  but leader actions could happen before that

(cherry picked from commit 3de306557873f311fc683e99ed4146d5444a3e49)

Refs #21906