### PR TITLE
Add RecordIO framing flow (#21050)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RecordIOFramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RecordIOFramingSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Framing.FramingException
+import akka.testkit.AkkaSpec
+import akka.util.ByteString
+
+import scala.collection.immutable.Seq
+
+class RecordIOFramingSpec extends AkkaSpec {
+
+  implicit val mat = ActorMaterializer()
+
+  val FirstRecordData = """{"type": "SUBSCRIBED","subscribed": {"framework_id": {"value":"12220-3440-12532-2345"},"heartbeat_interval_seconds":15.0}"""
+  val SecondRecordData = """{"type":"HEARTBEAT"}"""
+
+  val FirstRecordWithPrefix = s"121\n$FirstRecordData"
+  val SecondRecordWithPrefix = s"20\n$SecondRecordData"
+
+  val stringSeqSink = (Flow[ByteString] map (_.utf8String) toMat Sink.seq)(Keep.right)
+
+  "RecordIO framing" should {
+    "parse a series of records" in {
+      // Given
+      val recordIOInput = FirstRecordWithPrefix + SecondRecordWithPrefix
+
+      // When
+      val result = Source.single(ByteString(recordIOInput)) via
+        RecordIOFraming.scanner() runWith
+        stringSeqSink
+
+      // Then
+      result.futureValue shouldBe Seq(FirstRecordData, SecondRecordData)
+    }
+
+    "parse input with additional whitespace" in {
+      // Given
+      val recordIOInput = s"\t\n $FirstRecordWithPrefix \r\n $SecondRecordWithPrefix \t"
+
+      // When
+      val result = Source.single(ByteString(recordIOInput)) via
+        RecordIOFraming.scanner() runWith
+        stringSeqSink
+
+      // Then
+      result.futureValue shouldBe Seq(FirstRecordData, SecondRecordData)
+    }
+
+    "parse a chunked stream" in {
+      // Given
+      val whitespaceChunk = "\n\n"
+      val (secondChunk, thirdChunk) = s"\n\n$FirstRecordWithPrefix\n\n".splitAt(50)
+      val (fifthChunk, sixthChunk) = s"\n\n$SecondRecordWithPrefix\n\n".splitAt(10)
+
+      val chunkedInput = Seq(
+        whitespaceChunk, secondChunk, thirdChunk, whitespaceChunk, fifthChunk, sixthChunk, whitespaceChunk)
+        .map(ByteString(_))
+
+      // When
+      val result = Source(chunkedInput) via
+        RecordIOFraming.scanner() runWith
+        stringSeqSink
+
+      // Then
+      result.futureValue shouldBe Seq(FirstRecordData, SecondRecordData)
+    }
+
+    "handle an empty stream" in {
+      // When
+      val result =
+        Source.empty via
+          RecordIOFraming.scanner() runWith
+          stringSeqSink
+
+      // Then
+      result.futureValue shouldBe Seq.empty
+    }
+
+    "handle a stream containing only whitespace" in {
+      // Given
+      val input = Seq("\n\n", "  ", "\t\t").map(ByteString(_))
+
+      // When
+      val result = Source(input) via
+        RecordIOFraming.scanner() runWith
+        stringSeqSink
+
+      // Then
+      result.futureValue shouldBe Seq.empty
+    }
+
+    "reject an unparseable record size prefix" in {
+      // Given
+      val recordIOInput = s"NAN\n$FirstRecordData"
+
+      // When
+      val result = Source.single(ByteString(recordIOInput)) via
+        RecordIOFraming.scanner(1024) runWith
+        stringSeqSink
+
+      // Then
+      result.failed.futureValue shouldBe a[NumberFormatException]
+    }
+
+    "reject an overly long record size prefix" in {
+      // Given
+      val infinitePrefixSource = Source.repeat(ByteString("1"))
+
+      // When
+      val result = infinitePrefixSource via
+        RecordIOFraming.scanner(1024) runWith
+        stringSeqSink
+
+      // Then
+      result.failed.futureValue shouldBe a[FramingException]
+    }
+
+    "reject an overly long record" in {
+      // Given
+      val recordIOInput = FirstRecordWithPrefix
+
+      // When
+      val result = Source.single(ByteString(recordIOInput)) via
+        RecordIOFraming.scanner(FirstRecordData.length - 1) runWith
+        stringSeqSink
+
+      // Then
+      result.failed.futureValue shouldBe a[FramingException]
+    }
+
+    "reject a truncated record" in {
+      // Given
+      val recordIOInput = FirstRecordWithPrefix.dropRight(1)
+
+      // When
+      val result = Source.single(ByteString(recordIOInput)) via
+        RecordIOFraming.scanner() runWith
+        stringSeqSink
+
+      // Then
+      result.failed.futureValue shouldBe a[FramingException]
+    }
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RecordIOFraming.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RecordIOFraming.scala
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import akka.NotUsed
+import akka.stream.Attributes.name
+import akka.stream.scaladsl.Framing.FramingException
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.util.ByteString
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
+object RecordIOFraming {
+
+  def scanner(maxRecordLength: Int = Int.MaxValue): Flow[ByteString, ByteString, NotUsed] =
+    Flow[ByteString].via(new RecordIOFramingStage(maxRecordLength))
+      .named("recordIOFraming")
+
+  final val LineFeed = '\n'.toByte
+  final val CarriageReturn = '\r'.toByte
+  final val Tab = '\t'.toByte
+  final val Space = ' '.toByte
+
+  final val Whitespace = Set(LineFeed, CarriageReturn, Tab, Space)
+
+  def isWhitespace(input: Byte): Boolean =
+    Whitespace.contains(input)
+
+  private class RecordIOFramingStage(maxRecordLength: Int)
+    extends GraphStage[FlowShape[ByteString, ByteString]] {
+
+    val in = Inlet[ByteString]("RecordIOFramingStage.in")
+    val out = Outlet[ByteString]("RecordIOFramingStage.out")
+    override val shape: FlowShape[ByteString, ByteString] = FlowShape(in, out)
+
+    override def initialAttributes: Attributes = name("recordIOFraming")
+    override def toString: String = "RecordIOFraming"
+
+    // The maximum length of the record prefix indicating its size.
+    private val maxRecordPrefixLength = maxRecordLength.toString.length
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with InHandler with OutHandler {
+      private var buffer = ByteString.empty
+
+      private def trimWhitespace(): Unit = while (buffer.nonEmpty && isWhitespace(buffer.head)) buffer = buffer.drop(1)
+
+      private var currentRecordLength: Option[Int] = None // the byte length of the next record, if known
+
+      override def onPush(): Unit = {
+        buffer ++= grab(in)
+        doParse()
+      }
+
+      override def onPull(): Unit = doParse()
+
+      override def onUpstreamFinish(): Unit = {
+        if (buffer.isEmpty) {
+          completeStage()
+        } else if (isAvailable(out)) {
+          doParse()
+        } // else swallow the termination and wait for pull
+      }
+
+      private def tryPull(): Unit = {
+        if (isClosed(in)) {
+          failStage(new FramingException(
+            "Stream finished but there was a truncated final record in the buffer."))
+        } else pull(in)
+      }
+
+      @tailrec
+      private def doParse(): Unit = {
+        currentRecordLength match {
+          case Some(length) if buffer.size >= length =>
+            val (record, buf) = buffer.splitAt(length)
+            buffer = buf.compact
+            trimWhitespace()
+
+            currentRecordLength = None
+
+            push(out, record.compact)
+          case Some(_) =>
+            tryPull()
+          case None =>
+            trimWhitespace()
+            buffer.indexOf(LineFeed) match {
+              case -1 if buffer.size > maxRecordPrefixLength =>
+                failStage(new FramingException(
+                  s"Invalid record size prefix; expected a number up to $maxRecordLength."))
+              case -1 if isClosed(in) && buffer.isEmpty =>
+                completeStage()
+              case -1 =>
+                tryPull()
+              case lfPos =>
+                val (recordSizePrefix, buf) = buffer.splitAt(lfPos)
+                buffer = buf.drop(1).compact
+
+                Try(recordSizePrefix.utf8String.toInt) match {
+                  case Success(length) if length > maxRecordLength =>
+                    failStage(new FramingException(
+                      s"Record of size $length bytes exceeds maximum of $maxRecordLength bytes."))
+                  case Success(length) =>
+                    currentRecordLength = Some(length)
+                    doParse()
+                  case Failure(ex) =>
+                    failStage(ex)
+                }
+            }
+        }
+      }
+
+      setHandlers(in, out, this)
+    }
+  }
+}


### PR DESCRIPTION
Implemented a RecordIO parsing flow. (Issue #21050)

Note that the spec gives the supported content types as application/x-protobuf and application/json; this implementation, however, parses records of arbitrary content (the only condition being that the records be delimited by valid record size prefixes).