### PR TITLE
fix compilation warnings in akka-stream

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -739,7 +739,7 @@ private[stream] final class VirtualProcessor[T] extends AtomicReference[AnyRef] 
   object WrappedSubscription {
     sealed trait SubscriptionState { def demand: Long }
     case object PassThrough extends SubscriptionState { override def demand: Long = 0 }
-    final case class Buffering(demand: Long) extends SubscriptionState
+    case class Buffering(demand: Long) extends SubscriptionState
 
     val NoBufferedDemand = Buffering(0)
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
@@ -49,7 +49,9 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
     val dataQueue = new LinkedBlockingQueue[ByteString](maxBuffer)
     val downstreamStatus = new AtomicReference[DownstreamStatus](Ok)
 
-    val logic = new GraphStageLogic(shape) with CallbackWrapper[(AdapterToStageMessage, Promise[Unit])] {
+    final class OutputStreamSourceLogic extends GraphStageLogic(shape)
+      with CallbackWrapper[(AdapterToStageMessage, Promise[Unit])] {
+
       var flush: Option[Promise[Unit]] = None
       var close: Option[Promise[Unit]] = None
 
@@ -148,6 +150,7 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
       }
     }
 
+    val logic = new OutputStreamSourceLogic
     (logic, new OutputStreamAdapter(dataQueue, downstreamStatus, logic.wakeUp, writeTimeout))
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -146,6 +146,9 @@ private[stream] class TLSActor(
   private val transportInChoppingBlock = new ChoppingBlock(TransportIn, "TransportIn")
   transportInChoppingBlock.prepare(transportInBuffer)
 
+  var lastHandshakeStatus: HandshakeStatus = null
+  var corkUser = true
+
   // The engine could also be instantiated in ActorMaterializerImpl but if creation fails
   // during materialization it would be worse than failing later on.
   val engine =
@@ -188,9 +191,6 @@ private[stream] class TLSActor(
    * These conditions lead to the introduction of a synthetic TransferState
    * representing the Engine.
    */
-
-  var lastHandshakeStatus: HandshakeStatus = _
-  var corkUser = true
 
   val engineNeedsWrap = new TransferState {
     def isReady = lastHandshakeStatus == NEED_WRAP


### PR DESCRIPTION
* fix compilation warning in StreamLayout

StreamLayout.scala:742: The outer reference in this type test cannot be checked at run time.
[warn]     final case class Buffering(demand: Long) extends SubscriptionState

* fix compilation warning in OutputStreamSourceStage

logic.wakeUp
"method invocation uses reflection"

* fix compilation warning in TLSActor

TLSActor.scala:155: Reference to uninitialized variable lastHandshakeStatus
[warn]   lastHandshakeStatus = engine.getHandshakeStatus