### PR TITLE
Reachability.remove didn't always remove all, #22012

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
@@ -178,11 +178,8 @@ private[cluster] class Reachability private (
   def remove(nodes: Iterable[UniqueAddress]): Reachability = {
     val nodesSet = nodes.to[immutable.HashSet]
     val newRecords = records.filterNot(r ⇒ nodesSet(r.observer) || nodesSet(r.subject))
-    if (newRecords.size == records.size) this
-    else {
-      val newVersions = versions -- nodes
-      Reachability(newRecords, newVersions)
-    }
+    val newVersions = versions -- nodes
+    Reachability(newRecords, newVersions)
   }
 
   def removeObservers(nodes: Set[UniqueAddress]): Reachability =
@@ -190,11 +187,8 @@ private[cluster] class Reachability private (
       this
     else {
       val newRecords = records.filterNot(r ⇒ nodes(r.observer))
-      if (newRecords.size == records.size) this
-      else {
-        val newVersions = versions -- nodes
-        Reachability(newRecords, newVersions)
-      }
+      val newVersions = versions -- nodes
+      Reachability(newRecords, newVersions)
     }
 
   def status(observer: UniqueAddress, subject: UniqueAddress): ReachabilityStatus =

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
@@ -224,5 +224,16 @@ class ReachabilitySpec extends WordSpec with Matchers {
       r.status(nodeB, nodeE) should ===(Reachable)
     }
 
+    "remove correctly after pruning" in {
+      val r = Reachability.empty.
+        unreachable(nodeB, nodeA).unreachable(nodeB, nodeC).
+        unreachable(nodeD, nodeC).
+        reachable(nodeB, nodeA).reachable(nodeB, nodeC)
+      r.records should ===(Vector(Record(nodeD, nodeC, Unreachable, 1L)))
+      val r2 = r.remove(List(nodeB))
+      r2.allObservers should ===(Set(nodeD))
+      r2.versions.keySet should ===(Set(nodeD))
+    }
+
   }
 }


### PR DESCRIPTION
* the versions table in Reachability was not cleared
  if the records for removed node had been pruned, i.e.
  all reachable again