### PR TITLE
-doc remove promise of macro based actorOf

### DIFF
--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -94,9 +94,7 @@ Dangerous Variants
 This method is not recommended to be used within another actor because it
 encourages to close over the enclosing scope, resulting in non-serializable
 :class:`Props` and possibly race conditions (breaking the actor encapsulation).
-We will provide a macro-based solution in a future release which allows similar
-syntax without the headaches, at which point this variant will be properly
-deprecated. On the other hand using this variant in a :class:`Props` factory in
+On the other hand using this variant in a :class:`Props` factory in
 the actor’s companion object as documented under “Recommended Practices” below
 is completely fine.
 


### PR DESCRIPTION
we're moving away from remote deployment in any case which was the
prime reason for the worry about serializable Props. The macro style
actually will be implemented in macWire it seems.