### PR TITLE
Missing functionality akka-fsm (during onTransition): nextStateName

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
@@ -333,6 +333,13 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
   private[akka] final def stateNames: Iterable[S] = stateFunctions.keys
 
   /**
+   * Return next state name (i.e. object of type S) (available in onTransition handlers) 
+   */
+  final def nextStateName: S = 
+    if (nextState != null) nextState.stateName
+    else throw new IllegalStateException("nextStateName is only available during onTransition")
+  
+  /**
    * Return next state data (available in onTransition handlers)
    */
   final def nextStateData = nextState match {


### PR DESCRIPTION
To be used during onTransition similar to nextStateData.

