### PR TITLE
Improve performance of inbound lanes by making spinning loops in AeronSource configurable

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamConcistencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamConcistencySpec.scala
@@ -97,7 +97,7 @@ abstract class AeronStreamConsistencySpec
     "start echo" in {
       runOn(second) {
         // just echo back
-        Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink))
+        Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink, 0))
           .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
       }
       enterBarrier("echo-started")
@@ -111,7 +111,7 @@ abstract class AeronStreamConsistencySpec
         val killSwitch = KillSwitches.shared("test")
         val started = TestProbe()
         val startMsg = "0".getBytes("utf-8")
-        Source.fromGraph(new AeronSource(channel(first), streamId, aeron, taskRunner, pool, IgnoreEventSink))
+        Source.fromGraph(new AeronSource(channel(first), streamId, aeron, taskRunner, pool, IgnoreEventSink, 0))
           .via(killSwitch.flow)
           .runForeach { envelope ⇒
             val bytes = ByteString.fromByteBuffer(envelope.byteBuffer)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
@@ -218,7 +218,7 @@ abstract class AeronStreamLatencySpec
       val killSwitch = KillSwitches.shared(testName)
       val started = TestProbe()
       val startMsg = "0".getBytes("utf-8")
-      Source.fromGraph(new AeronSource(channel(first), streamId, aeron, taskRunner, pool, IgnoreEventSink))
+      Source.fromGraph(new AeronSource(channel(first), streamId, aeron, taskRunner, pool, IgnoreEventSink, 0))
         .via(killSwitch.flow)
         .runForeach { envelope ⇒
           val bytes = ByteString.fromByteBuffer(envelope.byteBuffer)
@@ -315,7 +315,7 @@ abstract class AeronStreamLatencySpec
     "start echo" in {
       runOn(second) {
         // just echo back
-        Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink))
+        Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink, 0))
           .runWith(new AeronSink(channel(first), streamId, aeron, taskRunner, pool, giveUpMessageAfter, IgnoreEventSink))
       }
       enterBarrier("echo-started")

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
@@ -177,7 +177,7 @@ abstract class AeronStreamMaxThroughputSpec
       var count = 0L
       val done = TestLatch(1)
       val killSwitch = KillSwitches.shared(testName)
-      Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink))
+      Source.fromGraph(new AeronSource(channel(second), streamId, aeron, taskRunner, pool, IgnoreEventSink, 0))
         .via(killSwitch.flow)
         .runForeach { envelope ⇒
           val bytes = ByteString.fromByteBuffer(envelope.byteBuffer)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/BenchmarkFileReporter.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/BenchmarkFileReporter.scala
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.io.File
+import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+
+import akka.actor.ActorSystem
+
+import scala.util.Try
+
+/**
+ * Simple to file logger for benchmark results. Will log relevant settings first to make sure
+ * results can be understood later.
+ */
+trait BenchmarkFileReporter {
+  def reportResults(result: String): Unit
+  def close(): Unit
+}
+object BenchmarkFileReporter {
+  val targetDirectory = {
+    val target = new File("akka-stream-tests/target/benchmark-results")
+    target.mkdirs()
+    target
+  }
+
+  def apply(testName: String, system: ActorSystem): BenchmarkFileReporter =
+    new BenchmarkFileReporter {
+      val gitCommit = {
+        import sys.process._
+        Try("git describe".!!.trim).getOrElse("[unknown]")
+      }
+      val testResultFile: File = {
+        val format = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss")
+        val fileName = s"${format.format(new Date())}-Artery-$testName-$gitCommit-results.txt"
+        new File(targetDirectory, fileName)
+      }
+      val config = system.settings.config
+
+      val fos = new FileOutputStream(testResultFile)
+      reportResults(s"Git commit: $gitCommit")
+
+      val settingsToReport =
+        Seq(
+          "akka.test.MaxThroughputSpec.totalMessagesFactor",
+          "akka.test.MaxThroughputSpec.real-message",
+          "akka.test.LatencySpec.totalMessagesFactor",
+          "akka.test.LatencySpec.repeatCount",
+          "akka.test.LatencySpec.real-message",
+          "akka.remote.artery.enabled",
+          "akka.remote.artery.advanced.inbound-lanes",
+          "akka.remote.artery.advanced.idle-cpu-level",
+          "akka.remote.artery.advanced.buffer-pool-size",
+          "akka.remote.artery.advanced.embedded-media-driver",
+          "akka.remote.default-remote-dispatcher.throughput",
+          "akka.remote.default-remote-dispatcher.fork-join-executor.parallelism-factor",
+          "akka.remote.default-remote-dispatcher.fork-join-executor.parallelism-min",
+          "akka.remote.default-remote-dispatcher.fork-join-executor.parallelism-max"
+        )
+      settingsToReport.foreach(reportSetting)
+
+      def reportResults(result: String): Unit = synchronized {
+        println(result)
+        fos.write(result.getBytes("utf8"))
+        fos.write('\n')
+        fos.flush()
+      }
+
+      def reportSetting(name: String): Unit = {
+        val value = if (config.hasPath(name)) config.getString(name) else "[unset]"
+        reportResults(s"$name: $value")
+      }
+
+      def close(): Unit = fos.close()
+    }
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
@@ -45,7 +45,15 @@ object LatencySpec extends MultiNodeConfig {
          }
          remote.artery {
            enabled = on
-           advanced.idle-cpu-level=7
+           advanced.idle-cpu-level = 7
+
+           # for serious measurements when running this test on only one machine
+           # it is recommended to use external media driver
+           # See akka-remote/src/test/resources/aeron.properties
+           # advanced.embedded-media-driver = off
+           # advanced.aeron-dir = "target/aeron"
+           # on linux, use directory on ram disk, instead
+           # advanced.aeron-dir = "/dev/shm/aeron"
 
            advanced.compression {
              actor-refs.advertisement-interval = 2 second

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
@@ -70,52 +70,80 @@ object MaxThroughputSpec extends MultiNodeConfig {
              actor-refs.advertisement-interval = 2 second
              manifests.advertisement-interval = 2 second
            }
+
+           advanced {
+             inbound-lanes = 2
+             # buffer-pool-size = 512
+           }
          }
+       }
+       akka.remote.default-remote-dispatcher {
+         fork-join-executor {
+           # parallelism-factor = 0.5
+           parallelism-min = 2
+           parallelism-max = 2
+         }
+         # Set to 10 by default. Might be worthwhile to experiment with.
+         # throughput = 100
        }
        """)).withFallback(RemotingMultiNodeSpec.commonConfig))
 
   case object Run
   sealed trait Echo extends DeadLetterSuppression with JavaSerializable
-  final case object Start extends Echo
+  final case class Start(correspondingReceiver: ActorRef) extends Echo
   final case object End extends Echo
+  final case class Warmup(msg: AnyRef)
   final case class EndResult(totalReceived: Long) extends JavaSerializable
   final case class FlowControl(burstStartTime: Long) extends Echo
 
-  def receiverProps(reporter: RateReporter, payloadSize: Int, printTaskRunnerMetrics: Boolean): Props =
-    Props(new Receiver(reporter, payloadSize, printTaskRunnerMetrics)).withDispatcher("akka.remote.default-remote-dispatcher")
+  def receiverProps(reporter: RateReporter, payloadSize: Int, printTaskRunnerMetrics: Boolean, numSenders: Int): Props =
+    Props(new Receiver(reporter, payloadSize, printTaskRunnerMetrics, numSenders)).withDispatcher("akka.remote.default-remote-dispatcher")
 
-  class Receiver(reporter: RateReporter, payloadSize: Int, printTaskRunnerMetrics: Boolean) extends Actor {
+  class Receiver(reporter: RateReporter, payloadSize: Int, printTaskRunnerMetrics: Boolean, numSenders: Int) extends Actor {
     private var c = 0L
     private val taskRunnerMetrics = new TaskRunnerMetrics(context.system)
+    private var endMessagesMissing = numSenders
+    private var correspondingSender: ActorRef = null // the Actor which send the Start message will also receive the report
 
     def receive = {
       case msg: Array[Byte] ⇒
         if (msg.length != payloadSize) throw new IllegalArgumentException("Invalid message")
-        reporter.onMessage(1, payloadSize)
-        c += 1
+
+        report()
       case msg: TestMessage ⇒
-        reporter.onMessage(1, payloadSize)
-        c += 1
-      case Start ⇒
-        c = 0
+        report()
+
+      case Start(corresponding) ⇒
+        if (corresponding == self) correspondingSender = sender()
         sender() ! Start
+
+      case End if endMessagesMissing > 1 ⇒
+        endMessagesMissing -= 1 // wait for End message from all senders
+
       case End ⇒
         if (printTaskRunnerMetrics)
           taskRunnerMetrics.printHistograms()
-        sender() ! EndResult(c)
+        correspondingSender ! EndResult(c)
         context.stop(self)
+
       case m: Echo ⇒
         sender() ! m
+    }
 
+    def report(): Unit = {
+      reporter.onMessage(1, payloadSize)
+      c += 1
     }
   }
 
-  def senderProps(target: ActorRef, testSettings: TestSettings, plotRef: ActorRef,
+  def senderProps(mainTarget: ActorRef, targets: Array[ActorRef], testSettings: TestSettings, plotRef: ActorRef,
                   printTaskRunnerMetrics: Boolean, reporter: BenchmarkFileReporter): Props =
-    Props(new Sender(target, testSettings, plotRef, printTaskRunnerMetrics, reporter))
+    Props(new Sender(mainTarget, targets, testSettings, plotRef, printTaskRunnerMetrics, reporter))
 
-  class Sender(target: ActorRef, testSettings: TestSettings, plotRef: ActorRef, printTaskRunnerMetrics: Boolean, reporter: BenchmarkFileReporter)
+  class Sender(target: ActorRef, targets: Array[ActorRef], testSettings: TestSettings, plotRef: ActorRef, printTaskRunnerMetrics: Boolean, reporter: BenchmarkFileReporter)
     extends Actor {
+    val numTargets = targets.size
+
     import testSettings._
     val payload = ("0" * testSettings.payloadSize).getBytes("utf-8")
     var startTime = 0L
@@ -132,50 +160,59 @@ object MaxThroughputSpec extends MultiNodeConfig {
     def receive = {
       case Run ⇒
         if (compressionEnabled) {
-          target ! payload
+          target ! Warmup(payload)
           context.setReceiveTimeout(1.second)
           context.become(waitingForCompression)
-        } else {
-          sendBatch() // first some warmup
-          target ! Start // then Start, which will echo back here
-          context.become(active)
-        }
+        } else runWarmup()
     }
 
     def waitingForCompression: Receive = {
       case ReceivedActorRefCompressionTable(_, table) ⇒
         if (table.dictionary.contains(target)) {
-          sendBatch() // first some warmup
-          target ! Start // then Start, which will echo back here
           context.setReceiveTimeout(Duration.Undefined)
-          context.become(active)
+          runWarmup()
         } else
-          target ! payload
+          target ! Warmup(payload)
       case ReceiveTimeout ⇒
-        target ! payload
+        target ! Warmup(payload)
     }
 
-    def active: Receive = {
+    def runWarmup(): Unit = {
+      sendBatch(warmup = true) // first some warmup
+      targets.foreach(_ ! Start(target)) // then Start, which will echo back here
+      context.become(warmup)
+    }
+
+    def warmup: Receive = {
       case Start ⇒
         println(s"${self.path.name}: Starting benchmark of $totalMessages messages with burst size " +
           s"$burstSize and payload size $payloadSize")
         startTime = System.nanoTime
         remaining = totalMessages
+        (0 until sent.size).foreach(i ⇒ sent(i) = 0)
         // have a few batches in flight to make sure there are always messages to send
         (1 to 3).foreach { _ ⇒
           val t0 = System.nanoTime()
-          sendBatch()
+          sendBatch(warmup = false)
           sendFlowControl(t0)
         }
 
+        context.become(active)
+
+      case _: Warmup ⇒
+    }
+
+    def active: Receive = {
       case c @ FlowControl(t0) ⇒
         val now = System.nanoTime()
         val duration = NANOSECONDS.toMillis(now - t0)
         maxRoundTripMillis = math.max(maxRoundTripMillis, duration)
 
-        sendBatch()
+        sendBatch(warmup = false)
         sendFlowControl(now)
+    }
 
+    val waitingForEndResult: Receive = {
       case EndResult(totalReceived) ⇒
         val took = NANOSECONDS.toMillis(System.nanoTime - startTime)
         val throughput = (totalReceived * 1000.0 / took)
@@ -191,7 +228,7 @@ object MaxThroughputSpec extends MultiNodeConfig {
             s"burst size $burstSize, " +
             s"payload size $payloadSize, " +
             s"total size ${totalSize(context.system)}, " +
-            s"$took ms to deliver $totalReceived messages")
+            s"$took ms to deliver $totalReceived messages.")
 
         if (printTaskRunnerMetrics)
           taskRunnerMetrics.printHistograms()
@@ -202,11 +239,12 @@ object MaxThroughputSpec extends MultiNodeConfig {
       case c: ReceivedActorRefCompressionTable ⇒
     }
 
-    def sendBatch(): Unit = {
+    val sent = new Array[Long](targets.size)
+    def sendBatch(warmup: Boolean): Unit = {
       val batchSize = math.min(remaining, burstSize)
       var i = 0
       while (i < batchSize) {
-        val msg =
+        val msg0 =
           if (realMessage)
             TestMessage(
               id = totalMessages - remaining + i,
@@ -217,17 +255,20 @@ object MaxThroughputSpec extends MultiNodeConfig {
               items = Vector(TestMessage.Item(1, "A"), TestMessage.Item(2, "B")))
           else payload
 
-        //        target ! msg
-        target.tell(msg, ActorRef.noSender)
+        val msg1 = if (warmup) Warmup(msg0) else msg0
+
+        targets(i % numTargets).tell(msg1, ActorRef.noSender)
+        sent(i % numTargets) += 1
         i += 1
       }
       remaining -= batchSize
     }
 
     def sendFlowControl(t0: Long): Unit = {
-      if (remaining <= 0)
-        target ! End
-      else
+      if (remaining <= 0) {
+        context.become(waitingForEndResult)
+        targets.foreach(_ ! End)
+      } else
         target ! FlowControl(t0)
     }
   }
@@ -315,7 +356,7 @@ abstract class MaxThroughputSpec extends RemotingMultiNodeSpec(MaxThroughputSpec
 
   def identifyReceiver(name: String, r: RoleName = second): ActorRef = {
     system.actorSelection(node(r) / "user" / name) ! Identify(None)
-    expectMsgType[ActorIdentity].ref.get
+    expectMsgType[ActorIdentity](10.seconds).ref.get
   }
 
   val scenarios = List(
@@ -365,7 +406,7 @@ abstract class MaxThroughputSpec extends RemotingMultiNodeSpec(MaxThroughputSpec
       val rep = reporter(testName)
       for (n ← 1 to senderReceiverPairs) {
         val receiver = system.actorOf(
-          receiverProps(rep, payloadSize, printTaskRunnerMetrics = n == 1),
+          receiverProps(rep, payloadSize, printTaskRunnerMetrics = n == 1, senderReceiverPairs),
           receiverName + n)
       }
       enterBarrier(receiverName + "-started")
@@ -376,11 +417,12 @@ abstract class MaxThroughputSpec extends RemotingMultiNodeSpec(MaxThroughputSpec
     runOn(first) {
       enterBarrier(receiverName + "-started")
       val ignore = TestProbe()
+      val receivers = (for (n ← 1 to senderReceiverPairs) yield identifyReceiver(receiverName + n)).toArray
       val senders = for (n ← 1 to senderReceiverPairs) yield {
-        val receiver = identifyReceiver(receiverName + n)
+        val receiver = receivers(n - 1)
         val plotProbe = TestProbe()
         val snd = system.actorOf(
-          senderProps(receiver, testSettings, plotProbe.ref, printTaskRunnerMetrics = n == 1, resultReporter),
+          senderProps(receiver, receivers, testSettings, plotProbe.ref, printTaskRunnerMetrics = n == 1, resultReporter),
           testName + "-snd" + n)
         val terminationProbe = TestProbe()
         terminationProbe.watch(snd)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
@@ -57,9 +57,11 @@ object MaxThroughputSpec extends MultiNodeConfig {
 
            # for serious measurements when running this test on only one machine
            # it is recommended to use external media driver
-           # See akka-remote-tests/src/test/resources/aeron.properties
-           #advanced.embedded-media-driver = off
-           #advanced.aeron-dir = "target/aeron"
+           # See akka-remote/src/test/resources/aeron.properties
+           # advanced.embedded-media-driver = off
+           # advanced.aeron-dir = "target/aeron"
+           # on linux, use directory on ram disk, instead
+           # advanced.aeron-dir = "/dev/shm/aeron"
 
            advanced.compression {
              actor-refs.advertisement-interval = 2 second

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -693,35 +693,31 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
 
       } else {
         val hubKillSwitch = KillSwitches.shared("hubKillSwitch")
-        val source = aeronSource(ordinaryStreamId, envelopeBufferPool)
-          .via(hubKillSwitch.flow)
-          .via(inboundFlow(compression))
-          .map(env ⇒ (env.recipient, env))
-
         val (resourceLife, broadcastHub) =
-          source
+          aeronSource(ordinaryStreamId, envelopeBufferPool)
+            .via(hubKillSwitch.flow)
+            .via(inboundFlow(compression))
+            .map(env ⇒ (env.recipient, env))
             .toMat(BroadcastHub.sink(bufferSize = settings.Advanced.InboundBroadcastHubBufferSize))(Keep.both)
             .run()(materializer)
 
-        val lane = inboundSink(envelopeBufferPool)
-
         // select lane based on destination, to preserve message order
-        val partitionFun: OptionVal[ActorRef] ⇒ Int = {
-          _ match {
-            case OptionVal.Some(r) ⇒ math.abs(r.path.uid) % inboundLanes
-            case OptionVal.None    ⇒ 0
+        def shouldUseLane(recipient: OptionVal[ActorRef], targetLane: Int): Boolean =
+          recipient match {
+            case OptionVal.Some(r) ⇒ math.abs(r.path.uid) % inboundLanes == targetLane
+            case OptionVal.None    ⇒ 0 == targetLane
           }
-        }
 
+        val lane = inboundSink(envelopeBufferPool)
         val completedValues: Vector[Future[Done]] =
-          (0 until inboundLanes).map { i ⇒
-            broadcastHub.runWith(
+          (0 until inboundLanes).map { laneId ⇒
+            broadcastHub
               // TODO replace filter with "PartitionHub" when that is implemented
-              // must use a tuple here because envelope is pooled and must only be touched in the selected lane
-              Flow[(OptionVal[ActorRef], InboundEnvelope)].collect {
-                case (recipient, env) if partitionFun(recipient) == i ⇒ env
-              }
-                .toMat(lane)(Keep.right))(materializer)
+              // must use a tuple here because envelope is pooled and must only be read in the selected lane
+              // otherwise, the lane that actually processes it might have already released it.
+              .collect { case (recipient, env) if shouldUseLane(recipient, laneId) ⇒ env }
+              .toMat(lane)(Keep.right)
+              .run()(materializer)
           }(collection.breakOut)
 
         import system.dispatcher

--- a/akka-remote/src/test/resources/aeron.properties
+++ b/akka-remote/src/test/resources/aeron.properties
@@ -16,6 +16,8 @@ aeron.threading.mode=SHARED_NETWORK
 #aeron.sender.idle.strategy=org.agrona.concurrent.BusySpinIdleStrategy
 #aeron.receiver.idle.strategy=org.agrona.concurrent.BusySpinIdleStrategy
 
-# use same director in akka.remote.artery.advanced.aeron-dir config 
-# of the Akka application 
+# use same directory in akka.remote.artery.advanced.aeron-dir config
+# of the Akka application
 aeron.dir=target/aeron
+# on linux, use directory on ram disk, instead
+# aeron.dir=/dev/shm/aeron

--- a/akka-remote/src/test/scala/akka/remote/artery/AeronSinkSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/AeronSinkSpec.scala
@@ -58,7 +58,7 @@ class AeronSinkSpec extends AkkaSpec with ImplicitSender {
       val port = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
       val channel = s"aeron:udp?endpoint=localhost:$port"
 
-      Source.fromGraph(new AeronSource(channel, 1, aeron, taskRunner, pool, IgnoreEventSink))
+      Source.fromGraph(new AeronSource(channel, 1, aeron, taskRunner, pool, IgnoreEventSink, 0))
         // fail receiver stream on first message
         .map(_ ⇒ throw new RuntimeException("stop") with NoStackTrace)
         .runWith(Sink.ignore)

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -174,7 +174,7 @@ object ValidatePullRequest extends AutoPlugin {
             .map(_.takeWhile(_ != '/'))
             .filter(dir => dir.startsWith("akka-") || dir == "project")
             .toSet
-          log.info("Detected uncomitted changes in directories (including in dependency analysis): " + dirtyDirectories.mkString("[", ",", "]"))
+          log.info("Detected uncommitted changes in directories (including in dependency analysis): " + dirtyDirectories.mkString("[", ",", "]"))
           dirtyDirectories
         }
 


### PR DESCRIPTION
This adds a new setting `advanced.inbound-source-spinning` which can be used to configure the number of spin loops in AeronSource. Using that setting (and slightly improved benchmarking infrastructure), I ran a set of benchmarks with the results attached.

The gist of it is that removing the spinning completely has mostly positive results with only a few small disadvantages. 

The biggest benefit of disabling spinning is that with `inbound-lanes > 1` latency is now only slightly worse than with 1 lane (66µs with 1 lane vs 76µs with 2 lanes in the 20000k case) and throughput improves by 25% (236k msgs/s with 1 lane vs. 300k msgs/s with 2 lanes) in the 5-to-5 case.

The biggest adverse effect I found was that when `inbound-lanes = 1` (no async boundary), latency in the 20000k/s case (which is the one with the overall best latency) takes a 25% hit from 55µs to 65µs when spinning is disabled (at the same time throughput is better). This might seem much relatively but in absolute numbers it is negligible imo because latency usually is more in the ranges of 100-200µs. 

[benchmark-results.zip](https://github.com/akka/akka/files/664265/benchmark-results.zip)

I added the extra setting mostly for allowing the benchmarks. I'd prefer to remove it in the end. We could also keep it for a while if third-parties would be interested in running their own tests.