### PR TITLE
Faster ByteString with Extended Binary Indexed Tree

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -10,14 +10,16 @@ import java.lang.Float.floatToRawIntBits
 import java.nio.{ ByteBuffer, ByteOrder }
 import java.nio.ByteOrder.{ BIG_ENDIAN, LITTLE_ENDIAN }
 
-import akka.util.ByteString.{ ByteString1, ByteString1C, ByteStrings }
+import akka.util.ByteString.{ ByteString1, ByteString1C, ByteStrings, BinaryIndexedTree }
 import org.apache.commons.codec.binary.Hex.encodeHex
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{ Arbitrary, Gen }
+import org.scalactic._
 import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.prop.Checkers
 
 import scala.collection.mutable.Builder
+import scala.util.Random
 
 class ByteStringSpec extends WordSpec with Matchers with Checkers {
 
@@ -291,6 +293,644 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
     reference.toSeq == builder.result
   }
 
+  "BinaryIndexedTree" must {
+    implicit val BinaryIndexedTreeEquality = new Equality[BinaryIndexedTree] {
+      override def areEqual(a: BinaryIndexedTree, b: Any) = b match {
+        case it: BinaryIndexedTree ⇒
+          a.fullDrops == it.fullDrops &&
+            a.fullTakes == it.fullTakes &&
+            a.restToDrop == it.restToDrop &&
+            a.restToTake == it.restToTake &&
+            a.sumTable.deep == it.sumTable.deep &&
+            a.elemTable.deep == it.elemTable.deep
+        case _ ⇒ false
+      }
+    }
+
+    "BinaryIndexedTree#createSumTable" in {
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3)) should ===(Array(1, 3, 3))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4)) should ===(Array(1, 3, 3, 10))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5)) should ===(Array(1, 3, 3, 10, 5))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6)) should ===(Array(1, 3, 3, 10, 5, 11))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7)) should ===(Array(1, 3, 3, 10, 5, 11, 7))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8)) should ===(Array(1, 3, 3, 10, 5, 11, 7, 36))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9)) should ===(Array(1, 3, 3, 10, 5, 11, 7, 36, 9))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0)) should ===(Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 9))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1)) should ===(
+        Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 9, 1))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2)) should ===(
+        Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 9, 1, 12))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3)) should ===(
+        Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 9, 1, 12, 3))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4)) should ===(
+        Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 9, 1, 12, 3, 7))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5)) should ===(
+        Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 9, 1, 12, 3, 7, 5))
+      BinaryIndexedTree.createSumTable(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6)) should ===(
+        Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 9, 1, 12, 3, 7, 5, 66))
+    }
+
+    "init from Vector[ByteString1]" in {
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))) should ===(
+        BinaryIndexedTree(0, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"), ByteString1.fromString("ghij"))) should ===(
+        BinaryIndexedTree(0, 0, 4, 0, Array(1, 3, 3, 10), Array(1, 2, 3, 4)))
+
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString(""),
+        ByteString1.fromString("def"), ByteString1.fromString("ghij"))) should ===(
+        BinaryIndexedTree(0, 0, 5, 0, Array(1, 3, 0, 6, 4), Array(1, 2, 0, 3, 4)))
+    }
+    "bound" in {
+      val empty = BinaryIndexedTree.empty
+      val bit = BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a")))
+      val bit2 = BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc")))
+      val bit3 = BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def")))
+
+      empty.findLowerBoundIndexByNumberOfElements(0) should ===(0)
+      empty.findLowerBoundIndexByNumberOfElements(1) should ===(0)
+
+      bit.findLowerBoundIndexByNumberOfElements(0) should ===(0)
+      bit.findLowerBoundIndexByNumberOfElements(1) should ===(0)
+
+      bit2.findLowerBoundIndexByNumberOfElements(0) should ===(0)
+      bit2.findLowerBoundIndexByNumberOfElements(1) should ===(0)
+      bit2.findLowerBoundIndexByNumberOfElements(2) should ===(0)
+      bit2.findLowerBoundIndexByNumberOfElements(3) should ===(0)
+
+      bit3.findLowerBoundIndexByNumberOfElements(0) should ===(0)
+      bit3.findLowerBoundIndexByNumberOfElements(1) should ===(0)
+      bit3.findLowerBoundIndexByNumberOfElements(2) should ===(1)
+      bit3.findLowerBoundIndexByNumberOfElements(3) should ===(1)
+      bit3.findLowerBoundIndexByNumberOfElements(4) should ===(2)
+      bit3.findLowerBoundIndexByNumberOfElements(5) should ===(2)
+      bit3.findLowerBoundIndexByNumberOfElements(6) should ===(2)
+    }
+    "take" in {
+      BinaryIndexedTree.empty.take(-1) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.take(0) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.take(1) should ===(BinaryIndexedTree.empty)
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).take(-1) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).take(0) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).take(1) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).take(2) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).take(-1) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).take(0) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).take(1) should ===(
+        BinaryIndexedTree(0, 0, 0, 1, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).take(2) should ===(
+        BinaryIndexedTree(0, 0, 0, 2, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).take(3) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).take(4) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(-1) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(0) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(1) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(2) should ===(
+        BinaryIndexedTree(0, 0, 1, 1, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(3) should ===(
+        BinaryIndexedTree(0, 0, 2, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(4) should ===(
+        BinaryIndexedTree(0, 0, 2, 1, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(5) should ===(
+        BinaryIndexedTree(0, 0, 2, 2, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(6) should ===(
+        BinaryIndexedTree(0, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).take(7) should ===(
+        BinaryIndexedTree(0, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+
+      val sumTable = Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 19, 1, 22, 3, 7, 5, 76)
+      val elemTable = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6)
+      val it16 = BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable)
+
+      it16.take(60).take(50).take(40) should ===(BinaryIndexedTree(0, 0, 8, 4, sumTable, elemTable))
+      it16.take(40).take(50).take(60) should ===(BinaryIndexedTree(0, 0, 8, 4, sumTable, elemTable))
+      it16.take(0).take(60).take(50).take(40) should ===(BinaryIndexedTree.empty)
+      it16.take(60).take(50).take(40).take(0) should ===(BinaryIndexedTree.empty)
+
+      it16.take(0) should ===(BinaryIndexedTree.empty)
+      it16.take(1) should ===(BinaryIndexedTree(0, 0, 1, 0, sumTable, elemTable))
+      it16.take(2) should ===(BinaryIndexedTree(0, 0, 1, 1, sumTable, elemTable))
+      it16.take(3) should ===(BinaryIndexedTree(0, 0, 2, 0, sumTable, elemTable))
+      it16.take(4) should ===(BinaryIndexedTree(0, 0, 2, 1, sumTable, elemTable))
+      it16.take(5) should ===(BinaryIndexedTree(0, 0, 2, 2, sumTable, elemTable))
+      it16.take(6) should ===(BinaryIndexedTree(0, 0, 3, 0, sumTable, elemTable))
+      it16.take(7) should ===(BinaryIndexedTree(0, 0, 3, 1, sumTable, elemTable))
+      it16.take(9) should ===(BinaryIndexedTree(0, 0, 3, 3, sumTable, elemTable))
+      it16.take(10) should ===(BinaryIndexedTree(0, 0, 4, 0, sumTable, elemTable))
+      it16.take(11) should ===(BinaryIndexedTree(0, 0, 4, 1, sumTable, elemTable))
+      it16.take(14) should ===(BinaryIndexedTree(0, 0, 4, 4, sumTable, elemTable))
+      it16.take(15) should ===(BinaryIndexedTree(0, 0, 5, 0, sumTable, elemTable))
+      it16.take(16) should ===(BinaryIndexedTree(0, 0, 5, 1, sumTable, elemTable))
+      it16.take(20) should ===(BinaryIndexedTree(0, 0, 5, 5, sumTable, elemTable))
+      it16.take(21) should ===(BinaryIndexedTree(0, 0, 6, 0, sumTable, elemTable))
+      it16.take(22) should ===(BinaryIndexedTree(0, 0, 6, 1, sumTable, elemTable))
+      it16.take(27) should ===(BinaryIndexedTree(0, 0, 6, 6, sumTable, elemTable))
+      it16.take(28) should ===(BinaryIndexedTree(0, 0, 7, 0, sumTable, elemTable))
+      it16.take(29) should ===(BinaryIndexedTree(0, 0, 7, 1, sumTable, elemTable))
+      it16.take(35) should ===(BinaryIndexedTree(0, 0, 7, 7, sumTable, elemTable))
+      it16.take(36) should ===(BinaryIndexedTree(0, 0, 8, 0, sumTable, elemTable))
+      it16.take(37) should ===(BinaryIndexedTree(0, 0, 8, 1, sumTable, elemTable))
+      it16.take(44) should ===(BinaryIndexedTree(0, 0, 8, 8, sumTable, elemTable))
+      it16.take(45) should ===(BinaryIndexedTree(0, 0, 9, 0, sumTable, elemTable))
+      it16.take(46) should ===(BinaryIndexedTree(0, 0, 9, 1, sumTable, elemTable))
+      it16.take(54) should ===(BinaryIndexedTree(0, 0, 9, 9, sumTable, elemTable))
+      it16.take(55) should ===(BinaryIndexedTree(0, 0, 10, 0, sumTable, elemTable))
+      it16.take(56) should ===(BinaryIndexedTree(0, 0, 11, 0, sumTable, elemTable))
+      it16.take(57) should ===(BinaryIndexedTree(0, 0, 11, 1, sumTable, elemTable))
+      it16.take(58) should ===(BinaryIndexedTree(0, 0, 12, 0, sumTable, elemTable))
+      it16.take(59) should ===(BinaryIndexedTree(0, 0, 12, 1, sumTable, elemTable))
+      it16.take(60) should ===(BinaryIndexedTree(0, 0, 12, 2, sumTable, elemTable))
+      it16.take(61) should ===(BinaryIndexedTree(0, 0, 13, 0, sumTable, elemTable))
+      it16.take(62) should ===(BinaryIndexedTree(0, 0, 13, 1, sumTable, elemTable))
+      it16.take(64) should ===(BinaryIndexedTree(0, 0, 13, 3, sumTable, elemTable))
+      it16.take(65) should ===(BinaryIndexedTree(0, 0, 14, 0, sumTable, elemTable))
+      it16.take(66) should ===(BinaryIndexedTree(0, 0, 14, 1, sumTable, elemTable))
+      it16.take(69) should ===(BinaryIndexedTree(0, 0, 14, 4, sumTable, elemTable))
+      it16.take(70) should ===(BinaryIndexedTree(0, 0, 15, 0, sumTable, elemTable))
+      it16.take(71) should ===(BinaryIndexedTree(0, 0, 15, 1, sumTable, elemTable))
+      it16.take(75) should ===(BinaryIndexedTree(0, 0, 15, 5, sumTable, elemTable))
+      it16.take(76) should ===(BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable))
+
+      it16.drop(0).take(1) should ===(BinaryIndexedTree(0, 0, 1, 0, sumTable, elemTable))
+      it16.drop(1).take(1) should ===(BinaryIndexedTree(1, 0, 1, 1, sumTable, elemTable))
+      it16.drop(2).take(1) should ===(BinaryIndexedTree(1, 1, 2, 0, sumTable, elemTable))
+      it16.drop(3).take(1) should ===(BinaryIndexedTree(2, 0, 2, 1, sumTable, elemTable))
+      it16.drop(4).take(1) should ===(BinaryIndexedTree(2, 1, 2, 2, sumTable, elemTable))
+      it16.drop(5).take(1) should ===(BinaryIndexedTree(2, 2, 3, 0, sumTable, elemTable))
+      it16.drop(6).take(1) should ===(BinaryIndexedTree(3, 0, 3, 1, sumTable, elemTable))
+      it16.drop(7).take(1) should ===(BinaryIndexedTree(3, 1, 3, 2, sumTable, elemTable))
+      it16.drop(9).take(1) should ===(BinaryIndexedTree(3, 3, 4, 0, sumTable, elemTable))
+      it16.drop(10).take(1) should ===(BinaryIndexedTree(4, 0, 4, 1, sumTable, elemTable))
+      it16.drop(11).take(1) should ===(BinaryIndexedTree(4, 1, 4, 2, sumTable, elemTable))
+      it16.drop(14).take(1) should ===(BinaryIndexedTree(4, 4, 5, 0, sumTable, elemTable))
+      it16.drop(15).take(1) should ===(BinaryIndexedTree(5, 0, 5, 1, sumTable, elemTable))
+      it16.drop(16).take(1) should ===(BinaryIndexedTree(5, 1, 5, 2, sumTable, elemTable))
+      it16.drop(20).take(1) should ===(BinaryIndexedTree(5, 5, 6, 0, sumTable, elemTable))
+      it16.drop(21).take(1) should ===(BinaryIndexedTree(6, 0, 6, 1, sumTable, elemTable))
+      it16.drop(22).take(1) should ===(BinaryIndexedTree(6, 1, 6, 2, sumTable, elemTable))
+      it16.drop(27).take(1) should ===(BinaryIndexedTree(6, 6, 7, 0, sumTable, elemTable))
+      it16.drop(28).take(1) should ===(BinaryIndexedTree(7, 0, 7, 1, sumTable, elemTable))
+      it16.drop(29).take(1) should ===(BinaryIndexedTree(7, 1, 7, 2, sumTable, elemTable))
+      it16.drop(35).take(1) should ===(BinaryIndexedTree(7, 7, 8, 0, sumTable, elemTable))
+      it16.drop(36).take(1) should ===(BinaryIndexedTree(8, 0, 8, 1, sumTable, elemTable))
+      it16.drop(37).take(1) should ===(BinaryIndexedTree(8, 1, 8, 2, sumTable, elemTable))
+      it16.drop(44).take(1) should ===(BinaryIndexedTree(8, 8, 9, 0, sumTable, elemTable))
+      it16.drop(45).take(1) should ===(BinaryIndexedTree(9, 0, 9, 1, sumTable, elemTable))
+      it16.drop(46).take(1) should ===(BinaryIndexedTree(9, 1, 9, 2, sumTable, elemTable))
+      it16.drop(54).take(1) should ===(BinaryIndexedTree(9, 9, 10, 0, sumTable, elemTable))
+      it16.drop(55).take(1) should ===(BinaryIndexedTree(10, 0, 11, 0, sumTable, elemTable))
+      it16.drop(56).take(1) should ===(BinaryIndexedTree(11, 0, 11, 1, sumTable, elemTable))
+      it16.drop(57).take(1) should ===(BinaryIndexedTree(11, 1, 12, 0, sumTable, elemTable))
+      it16.drop(58).take(1) should ===(BinaryIndexedTree(12, 0, 12, 1, sumTable, elemTable))
+      it16.drop(59).take(1) should ===(BinaryIndexedTree(12, 1, 12, 2, sumTable, elemTable))
+      it16.drop(60).take(1) should ===(BinaryIndexedTree(12, 2, 13, 0, sumTable, elemTable))
+      it16.drop(61).take(1) should ===(BinaryIndexedTree(13, 0, 13, 1, sumTable, elemTable))
+      it16.drop(62).take(1) should ===(BinaryIndexedTree(13, 1, 13, 2, sumTable, elemTable))
+      it16.drop(64).take(1) should ===(BinaryIndexedTree(13, 3, 14, 0, sumTable, elemTable))
+      it16.drop(65).take(1) should ===(BinaryIndexedTree(14, 0, 14, 1, sumTable, elemTable))
+      it16.drop(66).take(1) should ===(BinaryIndexedTree(14, 1, 14, 2, sumTable, elemTable))
+      it16.drop(69).take(1) should ===(BinaryIndexedTree(14, 4, 15, 0, sumTable, elemTable))
+      it16.drop(70).take(1) should ===(BinaryIndexedTree(15, 0, 15, 1, sumTable, elemTable))
+      it16.drop(71).take(1) should ===(BinaryIndexedTree(15, 1, 15, 2, sumTable, elemTable))
+      it16.drop(75).take(1) should ===(BinaryIndexedTree(15, 5, 16, 0, sumTable, elemTable))
+      it16.drop(76).take(1) should ===(BinaryIndexedTree.empty)
+    }
+    "drop" in {
+      BinaryIndexedTree.empty.drop(-1) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.drop(0) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.drop(1) should ===(BinaryIndexedTree.empty)
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).drop(-1) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).drop(0) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).drop(1) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))).drop(2) should ===(
+        BinaryIndexedTree.empty)
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).drop(-1) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).drop(0) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).drop(1) should ===(
+        BinaryIndexedTree(0, 1, 1, 0, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).drop(2) should ===(
+        BinaryIndexedTree(0, 2, 1, 0, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).drop(3) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))).drop(4) should ===(
+        BinaryIndexedTree.empty)
+
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(-1) should ===(
+        BinaryIndexedTree(0, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(0) should ===(
+        BinaryIndexedTree(0, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(1) should ===(
+        BinaryIndexedTree(1, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(2) should ===(
+        BinaryIndexedTree(1, 1, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(3) should ===(
+        BinaryIndexedTree(2, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(4) should ===(
+        BinaryIndexedTree(2, 1, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(5) should ===(
+        BinaryIndexedTree(2, 2, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(6) should ===(
+        BinaryIndexedTree.empty)
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))).drop(7) should ===(
+        BinaryIndexedTree.empty)
+
+      val sumTable = Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 19, 1, 22, 3, 7, 5, 76)
+      val elemTable = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6)
+      val bit16 = BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable)
+
+      bit16.drop(10).drop(20).drop(30) should ===(BinaryIndexedTree(12, 2, 16, 0, sumTable, elemTable))
+      bit16.drop(30).drop(20).drop(10) should ===(BinaryIndexedTree(12, 2, 16, 0, sumTable, elemTable))
+      bit16.drop(0).drop(60).drop(50).drop(40) should ===(BinaryIndexedTree.empty)
+      bit16.drop(60).drop(50).drop(40).drop(0) should ===(BinaryIndexedTree.empty)
+
+      bit16.drop(0) should ===(BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(1) should ===(BinaryIndexedTree(1, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(2) should ===(BinaryIndexedTree(1, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(3) should ===(BinaryIndexedTree(2, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(4) should ===(BinaryIndexedTree(2, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(5) should ===(BinaryIndexedTree(2, 2, 16, 0, sumTable, elemTable))
+      bit16.drop(6) should ===(BinaryIndexedTree(3, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(7) should ===(BinaryIndexedTree(3, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(9) should ===(BinaryIndexedTree(3, 3, 16, 0, sumTable, elemTable))
+      bit16.drop(10) should ===(BinaryIndexedTree(4, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(11) should ===(BinaryIndexedTree(4, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(14) should ===(BinaryIndexedTree(4, 4, 16, 0, sumTable, elemTable))
+      bit16.drop(15) should ===(BinaryIndexedTree(5, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(16) should ===(BinaryIndexedTree(5, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(20) should ===(BinaryIndexedTree(5, 5, 16, 0, sumTable, elemTable))
+      bit16.drop(21) should ===(BinaryIndexedTree(6, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(22) should ===(BinaryIndexedTree(6, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(27) should ===(BinaryIndexedTree(6, 6, 16, 0, sumTable, elemTable))
+      bit16.drop(28) should ===(BinaryIndexedTree(7, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(29) should ===(BinaryIndexedTree(7, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(35) should ===(BinaryIndexedTree(7, 7, 16, 0, sumTable, elemTable))
+      bit16.drop(36) should ===(BinaryIndexedTree(8, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(37) should ===(BinaryIndexedTree(8, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(44) should ===(BinaryIndexedTree(8, 8, 16, 0, sumTable, elemTable))
+      bit16.drop(45) should ===(BinaryIndexedTree(9, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(46) should ===(BinaryIndexedTree(9, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(54) should ===(BinaryIndexedTree(9, 9, 16, 0, sumTable, elemTable))
+      bit16.drop(55) should ===(BinaryIndexedTree(10, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(56) should ===(BinaryIndexedTree(11, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(57) should ===(BinaryIndexedTree(11, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(58) should ===(BinaryIndexedTree(12, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(59) should ===(BinaryIndexedTree(12, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(60) should ===(BinaryIndexedTree(12, 2, 16, 0, sumTable, elemTable))
+      bit16.drop(61) should ===(BinaryIndexedTree(13, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(62) should ===(BinaryIndexedTree(13, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(64) should ===(BinaryIndexedTree(13, 3, 16, 0, sumTable, elemTable))
+      bit16.drop(65) should ===(BinaryIndexedTree(14, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(66) should ===(BinaryIndexedTree(14, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(69) should ===(BinaryIndexedTree(14, 4, 16, 0, sumTable, elemTable))
+      bit16.drop(70) should ===(BinaryIndexedTree(15, 0, 16, 0, sumTable, elemTable))
+      bit16.drop(71) should ===(BinaryIndexedTree(15, 1, 16, 0, sumTable, elemTable))
+      bit16.drop(75) should ===(BinaryIndexedTree(15, 5, 16, 0, sumTable, elemTable))
+      bit16.drop(76) should ===(BinaryIndexedTree.empty)
+
+      bit16.take(0).drop(1) should ===(BinaryIndexedTree.empty)
+      bit16.take(1).drop(0) should ===(BinaryIndexedTree(0, 0, 1, 0, sumTable, elemTable))
+      bit16.take(2).drop(1) should ===(BinaryIndexedTree(1, 0, 1, 1, sumTable, elemTable))
+      bit16.take(3).drop(2) should ===(BinaryIndexedTree(1, 1, 2, 0, sumTable, elemTable))
+      bit16.take(4).drop(3) should ===(BinaryIndexedTree(2, 0, 2, 1, sumTable, elemTable))
+      bit16.take(5).drop(4) should ===(BinaryIndexedTree(2, 1, 2, 2, sumTable, elemTable))
+      bit16.take(6).drop(5) should ===(BinaryIndexedTree(2, 2, 3, 0, sumTable, elemTable))
+      bit16.take(7).drop(6) should ===(BinaryIndexedTree(3, 0, 3, 1, sumTable, elemTable))
+      bit16.take(9).drop(8) should ===(BinaryIndexedTree(3, 2, 3, 3, sumTable, elemTable))
+      bit16.take(10).drop(9) should ===(BinaryIndexedTree(3, 3, 4, 0, sumTable, elemTable))
+      bit16.take(11).drop(10) should ===(BinaryIndexedTree(4, 0, 4, 1, sumTable, elemTable))
+      bit16.take(14).drop(13) should ===(BinaryIndexedTree(4, 3, 4, 4, sumTable, elemTable))
+      bit16.take(15).drop(14) should ===(BinaryIndexedTree(4, 4, 5, 0, sumTable, elemTable))
+      bit16.take(16).drop(15) should ===(BinaryIndexedTree(5, 0, 5, 1, sumTable, elemTable))
+      bit16.take(20).drop(19) should ===(BinaryIndexedTree(5, 4, 5, 5, sumTable, elemTable))
+      bit16.take(21).drop(20) should ===(BinaryIndexedTree(5, 5, 6, 0, sumTable, elemTable))
+      bit16.take(22).drop(21) should ===(BinaryIndexedTree(6, 0, 6, 1, sumTable, elemTable))
+      bit16.take(27).drop(26) should ===(BinaryIndexedTree(6, 5, 6, 6, sumTable, elemTable))
+      bit16.take(28).drop(27) should ===(BinaryIndexedTree(6, 6, 7, 0, sumTable, elemTable))
+      bit16.take(29).drop(28) should ===(BinaryIndexedTree(7, 0, 7, 1, sumTable, elemTable))
+      bit16.take(35).drop(34) should ===(BinaryIndexedTree(7, 6, 7, 7, sumTable, elemTable))
+      bit16.take(36).drop(35) should ===(BinaryIndexedTree(7, 7, 8, 0, sumTable, elemTable))
+      bit16.take(37).drop(36) should ===(BinaryIndexedTree(8, 0, 8, 1, sumTable, elemTable))
+      bit16.take(44).drop(43) should ===(BinaryIndexedTree(8, 7, 8, 8, sumTable, elemTable))
+      bit16.take(45).drop(44) should ===(BinaryIndexedTree(8, 8, 9, 0, sumTable, elemTable))
+      bit16.take(46).drop(45) should ===(BinaryIndexedTree(9, 0, 9, 1, sumTable, elemTable))
+      bit16.take(54).drop(53) should ===(BinaryIndexedTree(9, 8, 9, 9, sumTable, elemTable))
+      bit16.take(55).drop(54) should ===(BinaryIndexedTree(9, 9, 10, 0, sumTable, elemTable))
+      bit16.take(56).drop(55) should ===(BinaryIndexedTree(10, 0, 11, 0, sumTable, elemTable))
+      bit16.take(57).drop(56) should ===(BinaryIndexedTree(11, 0, 11, 1, sumTable, elemTable))
+      bit16.take(58).drop(57) should ===(BinaryIndexedTree(11, 1, 12, 0, sumTable, elemTable))
+      bit16.take(59).drop(58) should ===(BinaryIndexedTree(12, 0, 12, 1, sumTable, elemTable))
+      bit16.take(60).drop(59) should ===(BinaryIndexedTree(12, 1, 12, 2, sumTable, elemTable))
+      bit16.take(61).drop(60) should ===(BinaryIndexedTree(12, 2, 13, 0, sumTable, elemTable))
+      bit16.take(62).drop(61) should ===(BinaryIndexedTree(13, 0, 13, 1, sumTable, elemTable))
+      bit16.take(64).drop(63) should ===(BinaryIndexedTree(13, 2, 13, 3, sumTable, elemTable))
+      bit16.take(65).drop(64) should ===(BinaryIndexedTree(13, 3, 14, 0, sumTable, elemTable))
+      bit16.take(66).drop(65) should ===(BinaryIndexedTree(14, 0, 14, 1, sumTable, elemTable))
+      bit16.take(69).drop(68) should ===(BinaryIndexedTree(14, 3, 14, 4, sumTable, elemTable))
+      bit16.take(70).drop(69) should ===(BinaryIndexedTree(14, 4, 15, 0, sumTable, elemTable))
+      bit16.take(71).drop(70) should ===(BinaryIndexedTree(15, 0, 15, 1, sumTable, elemTable))
+      bit16.take(75).drop(74) should ===(BinaryIndexedTree(15, 4, 15, 5, sumTable, elemTable))
+      bit16.take(76).drop(75) should ===(BinaryIndexedTree(15, 5, 16, 0, sumTable, elemTable))
+      bit16.take(77).drop(76) should ===(BinaryIndexedTree.empty)
+    }
+    "slice" in {
+      BinaryIndexedTree.empty.slice(-2, -1) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(-1, 0) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(-1, 1) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(0, -1) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(0, 0) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(0, 1) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(1, -1) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(1, 0) should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty.slice(1, 1) should ===(BinaryIndexedTree.empty)
+
+      val bit = BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a")))
+      bit.slice(-1, 0) should ===(BinaryIndexedTree.empty)
+      bit.slice(-1, 1) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      bit.slice(-1, 2) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      bit.slice(0, 0) should ===(BinaryIndexedTree.empty)
+      bit.slice(0, 1) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      bit.slice(0, 2) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      bit.slice(1, 0) should ===(BinaryIndexedTree.empty)
+      bit.slice(1, 1) should ===(BinaryIndexedTree.empty)
+      bit.slice(1, 2) should ===(BinaryIndexedTree.empty)
+      bit.slice(2, 0) should ===(BinaryIndexedTree.empty)
+      bit.slice(2, 1) should ===(BinaryIndexedTree.empty)
+      bit.slice(2, 2) should ===(BinaryIndexedTree.empty)
+
+      val bit2 = BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc")))
+      bit2.slice(-1, 0) should ===(BinaryIndexedTree.empty)
+      bit2.slice(-1, 1) should ===(BinaryIndexedTree(0, 0, 0, 1, Array(3), Array(3)))
+      bit2.slice(-1, 2) should ===(BinaryIndexedTree(0, 0, 0, 2, Array(3), Array(3)))
+      bit2.slice(-1, 3) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      bit2.slice(-1, 4) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      bit2.slice(0, 0) should ===(BinaryIndexedTree.empty)
+      bit2.slice(0, 1) should ===(BinaryIndexedTree(0, 0, 0, 1, Array(3), Array(3)))
+      bit2.slice(0, 2) should ===(BinaryIndexedTree(0, 0, 0, 2, Array(3), Array(3)))
+      bit2.slice(0, 3) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      bit2.slice(0, 4) should ===(BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      bit2.slice(1, -1) should ===(BinaryIndexedTree.empty)
+      bit2.slice(1, 0) should ===(BinaryIndexedTree.empty)
+      bit2.slice(1, 1) should ===(BinaryIndexedTree.empty)
+      bit2.slice(1, 2) should ===(BinaryIndexedTree(0, 1, 0, 2, Array(3), Array(3)))
+      bit2.slice(1, 3) should ===(BinaryIndexedTree(0, 1, 1, 0, Array(3), Array(3)))
+      bit2.slice(1, 4) should ===(BinaryIndexedTree(0, 1, 1, 0, Array(3), Array(3)))
+      bit2.slice(2, -1) should ===(BinaryIndexedTree.empty)
+      bit2.slice(2, 0) should ===(BinaryIndexedTree.empty)
+      bit2.slice(2, 1) should ===(BinaryIndexedTree.empty)
+      bit2.slice(2, 2) should ===(BinaryIndexedTree.empty)
+      bit2.slice(2, 3) should ===(BinaryIndexedTree(0, 2, 1, 0, Array(3), Array(3)))
+      bit2.slice(2, 4) should ===(BinaryIndexedTree(0, 2, 1, 0, Array(3), Array(3)))
+      bit2.slice(3, -1) should ===(BinaryIndexedTree.empty)
+      bit2.slice(3, 0) should ===(BinaryIndexedTree.empty)
+      bit2.slice(3, 1) should ===(BinaryIndexedTree.empty)
+      bit2.slice(3, 2) should ===(BinaryIndexedTree.empty)
+      bit2.slice(3, 3) should ===(BinaryIndexedTree.empty)
+      bit2.slice(3, 4) should ===(BinaryIndexedTree.empty)
+
+      val sumTable = Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 19, 1, 22, 3, 7, 5, 76)
+      val elemTable = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6)
+      val bit16 = BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable)
+
+      bit16.slice(0, 76) should ===(BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable))
+      bit16.slice(0, 1) should ===(BinaryIndexedTree(0, 0, 1, 0, sumTable, elemTable))
+      bit16.slice(1, 2) should ===(BinaryIndexedTree(1, 0, 1, 1, sumTable, elemTable))
+      bit16.slice(2, 3) should ===(BinaryIndexedTree(1, 1, 2, 0, sumTable, elemTable))
+      bit16.slice(3, 4) should ===(BinaryIndexedTree(2, 0, 2, 1, sumTable, elemTable))
+      bit16.slice(4, 5) should ===(BinaryIndexedTree(2, 1, 2, 2, sumTable, elemTable))
+      bit16.slice(5, 6) should ===(BinaryIndexedTree(2, 2, 3, 0, sumTable, elemTable))
+      bit16.slice(6, 7) should ===(BinaryIndexedTree(3, 0, 3, 1, sumTable, elemTable))
+      bit16.slice(7, 9) should ===(BinaryIndexedTree(3, 1, 3, 3, sumTable, elemTable))
+      bit16.slice(9, 10) should ===(BinaryIndexedTree(3, 3, 4, 0, sumTable, elemTable))
+      bit16.slice(10, 11) should ===(BinaryIndexedTree(4, 0, 4, 1, sumTable, elemTable))
+      bit16.slice(11, 14) should ===(BinaryIndexedTree(4, 1, 4, 4, sumTable, elemTable))
+      bit16.slice(14, 15) should ===(BinaryIndexedTree(4, 4, 5, 0, sumTable, elemTable))
+      bit16.slice(15, 16) should ===(BinaryIndexedTree(5, 0, 5, 1, sumTable, elemTable))
+      bit16.slice(16, 20) should ===(BinaryIndexedTree(5, 1, 5, 5, sumTable, elemTable))
+      bit16.slice(20, 21) should ===(BinaryIndexedTree(5, 5, 6, 0, sumTable, elemTable))
+      bit16.slice(21, 22) should ===(BinaryIndexedTree(6, 0, 6, 1, sumTable, elemTable))
+      bit16.slice(22, 27) should ===(BinaryIndexedTree(6, 1, 6, 6, sumTable, elemTable))
+      bit16.slice(27, 28) should ===(BinaryIndexedTree(6, 6, 7, 0, sumTable, elemTable))
+      bit16.slice(28, 29) should ===(BinaryIndexedTree(7, 0, 7, 1, sumTable, elemTable))
+      bit16.slice(29, 35) should ===(BinaryIndexedTree(7, 1, 7, 7, sumTable, elemTable))
+      bit16.slice(35, 36) should ===(BinaryIndexedTree(7, 7, 8, 0, sumTable, elemTable))
+      bit16.slice(36, 37) should ===(BinaryIndexedTree(8, 0, 8, 1, sumTable, elemTable))
+      bit16.slice(37, 44) should ===(BinaryIndexedTree(8, 1, 8, 8, sumTable, elemTable))
+      bit16.slice(44, 45) should ===(BinaryIndexedTree(8, 8, 9, 0, sumTable, elemTable))
+      bit16.slice(45, 46) should ===(BinaryIndexedTree(9, 0, 9, 1, sumTable, elemTable))
+      bit16.slice(46, 54) should ===(BinaryIndexedTree(9, 1, 9, 9, sumTable, elemTable))
+      bit16.slice(54, 55) should ===(BinaryIndexedTree(9, 9, 10, 0, sumTable, elemTable))
+      bit16.slice(55, 56) should ===(BinaryIndexedTree(10, 0, 11, 0, sumTable, elemTable))
+      bit16.slice(56, 57) should ===(BinaryIndexedTree(11, 0, 11, 1, sumTable, elemTable))
+      bit16.slice(57, 58) should ===(BinaryIndexedTree(11, 1, 12, 0, sumTable, elemTable))
+      bit16.slice(58, 59) should ===(BinaryIndexedTree(12, 0, 12, 1, sumTable, elemTable))
+      bit16.slice(59, 60) should ===(BinaryIndexedTree(12, 1, 12, 2, sumTable, elemTable))
+      bit16.slice(60, 61) should ===(BinaryIndexedTree(12, 2, 13, 0, sumTable, elemTable))
+      bit16.slice(61, 62) should ===(BinaryIndexedTree(13, 0, 13, 1, sumTable, elemTable))
+      bit16.slice(62, 64) should ===(BinaryIndexedTree(13, 1, 13, 3, sumTable, elemTable))
+      bit16.slice(64, 65) should ===(BinaryIndexedTree(13, 3, 14, 0, sumTable, elemTable))
+      bit16.slice(65, 66) should ===(BinaryIndexedTree(14, 0, 14, 1, sumTable, elemTable))
+      bit16.slice(66, 69) should ===(BinaryIndexedTree(14, 1, 14, 4, sumTable, elemTable))
+      bit16.slice(69, 70) should ===(BinaryIndexedTree(14, 4, 15, 0, sumTable, elemTable))
+      bit16.slice(70, 71) should ===(BinaryIndexedTree(15, 0, 15, 1, sumTable, elemTable))
+      bit16.slice(71, 75) should ===(BinaryIndexedTree(15, 1, 15, 5, sumTable, elemTable))
+      bit16.slice(75, 76) should ===(BinaryIndexedTree(15, 5, 16, 0, sumTable, elemTable))
+      bit16.slice(76, 75) should ===(BinaryIndexedTree.empty)
+      bit16.slice(76, 77) should ===(BinaryIndexedTree.empty)
+
+      bit16.slice(1, 75).slice(0, 1) should ===(BinaryIndexedTree(1, 0, 1, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(1, 2) should ===(BinaryIndexedTree(1, 1, 2, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(2, 3) should ===(BinaryIndexedTree(2, 0, 2, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(3, 4) should ===(BinaryIndexedTree(2, 1, 2, 2, sumTable, elemTable))
+      bit16.slice(1, 75).slice(4, 5) should ===(BinaryIndexedTree(2, 2, 3, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(5, 6) should ===(BinaryIndexedTree(3, 0, 3, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(6, 8) should ===(BinaryIndexedTree(3, 1, 3, 3, sumTable, elemTable))
+      bit16.slice(1, 75).slice(8, 9) should ===(BinaryIndexedTree(3, 3, 4, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(9, 10) should ===(BinaryIndexedTree(4, 0, 4, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(10, 13) should ===(BinaryIndexedTree(4, 1, 4, 4, sumTable, elemTable))
+      bit16.slice(1, 75).slice(13, 14) should ===(BinaryIndexedTree(4, 4, 5, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(14, 15) should ===(BinaryIndexedTree(5, 0, 5, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(15, 19) should ===(BinaryIndexedTree(5, 1, 5, 5, sumTable, elemTable))
+      bit16.slice(1, 75).slice(19, 20) should ===(BinaryIndexedTree(5, 5, 6, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(20, 21) should ===(BinaryIndexedTree(6, 0, 6, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(21, 26) should ===(BinaryIndexedTree(6, 1, 6, 6, sumTable, elemTable))
+      bit16.slice(1, 75).slice(26, 27) should ===(BinaryIndexedTree(6, 6, 7, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(27, 28) should ===(BinaryIndexedTree(7, 0, 7, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(28, 34) should ===(BinaryIndexedTree(7, 1, 7, 7, sumTable, elemTable))
+      bit16.slice(1, 75).slice(34, 35) should ===(BinaryIndexedTree(7, 7, 8, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(35, 36) should ===(BinaryIndexedTree(8, 0, 8, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(36, 43) should ===(BinaryIndexedTree(8, 1, 8, 8, sumTable, elemTable))
+      bit16.slice(1, 75).slice(43, 44) should ===(BinaryIndexedTree(8, 8, 9, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(44, 45) should ===(BinaryIndexedTree(9, 0, 9, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(45, 53) should ===(BinaryIndexedTree(9, 1, 9, 9, sumTable, elemTable))
+      bit16.slice(1, 75).slice(53, 54) should ===(BinaryIndexedTree(9, 9, 10, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(54, 55) should ===(BinaryIndexedTree(10, 0, 11, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(55, 56) should ===(BinaryIndexedTree(11, 0, 11, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(56, 57) should ===(BinaryIndexedTree(11, 1, 12, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(57, 58) should ===(BinaryIndexedTree(12, 0, 12, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(58, 59) should ===(BinaryIndexedTree(12, 1, 12, 2, sumTable, elemTable))
+      bit16.slice(1, 75).slice(59, 60) should ===(BinaryIndexedTree(12, 2, 13, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(60, 61) should ===(BinaryIndexedTree(13, 0, 13, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(61, 63) should ===(BinaryIndexedTree(13, 1, 13, 3, sumTable, elemTable))
+      bit16.slice(1, 75).slice(63, 64) should ===(BinaryIndexedTree(13, 3, 14, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(64, 65) should ===(BinaryIndexedTree(14, 0, 14, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(65, 68) should ===(BinaryIndexedTree(14, 1, 14, 4, sumTable, elemTable))
+      bit16.slice(1, 75).slice(68, 69) should ===(BinaryIndexedTree(14, 4, 15, 0, sumTable, elemTable))
+      bit16.slice(1, 75).slice(69, 70) should ===(BinaryIndexedTree(15, 0, 15, 1, sumTable, elemTable))
+      bit16.slice(1, 75).slice(70, 75) should ===(BinaryIndexedTree(15, 1, 15, 5, sumTable, elemTable))
+      bit16.slice(1, 75).slice(70, 76) should ===(BinaryIndexedTree(15, 1, 15, 5, sumTable, elemTable))
+      bit16.slice(1, 75).slice(75, 76) should ===(BinaryIndexedTree.empty)
+    }
+    "append" in {
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))) ++ BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))) should ===(
+        BinaryIndexedTree(0, 0, 2, 0, Array(1, 2), Array(1, 1)))
+
+      val take9drop1: BinaryIndexedTree = BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"), ByteString1.fromString("ghij"))).take(9).drop(1)
+      val take8drop2 = BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"), ByteString1.fromString("ghij"))).take(8).drop(2)
+      val take7drop3 = BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"), ByteString1.fromString("ghij"))).take(7).drop(3)
+
+      take9drop1 ++ take9drop1 should ===(BinaryIndexedTree(0, 0, 6, 0, Array(2, 5, 3, 10, 3, 6), Array(2, 3, 3, 2, 3, 3)))
+      take9drop1 ++ take8drop2 should ===(BinaryIndexedTree(0, 0, 6, 0, Array(2, 5, 3, 9, 3, 5), Array(2, 3, 3, 1, 3, 2)))
+      take9drop1 ++ take7drop3 should ===(BinaryIndexedTree(0, 0, 5, 0, Array(2, 5, 3, 11, 1), Array(2, 3, 3, 3, 1)))
+      take8drop2 ++ take9drop1 should ===(BinaryIndexedTree(0, 0, 6, 0, Array(1, 4, 2, 8, 3, 6), Array(1, 3, 2, 2, 3, 3)))
+      take8drop2 ++ take8drop2 should ===(BinaryIndexedTree(0, 0, 6, 0, Array(1, 4, 2, 7, 3, 5), Array(1, 3, 2, 1, 3, 2)))
+      take8drop2 ++ take7drop3 should ===(BinaryIndexedTree(0, 0, 5, 0, Array(1, 4, 2, 9, 1), Array(1, 3, 2, 3, 1)))
+      take7drop3 ++ take9drop1 should ===(BinaryIndexedTree(0, 0, 5, 0, Array(3, 4, 2, 9, 3), Array(3, 1, 2, 3, 3)))
+      take7drop3 ++ take8drop2 should ===(BinaryIndexedTree(0, 0, 5, 0, Array(3, 4, 1, 8, 2), Array(3, 1, 1, 3, 2)))
+      take7drop3 ++ take7drop3 should ===(BinaryIndexedTree(0, 0, 4, 0, Array(3, 4, 3, 8), Array(3, 1, 3, 1)))
+
+      val bit = BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"),
+        ByteString1.fromString("bc"),
+        ByteString1.fromString("def"),
+        ByteString1.fromString("ghij"),
+        ByteString1.fromString("1"),
+        ByteString1.fromString("23"),
+        ByteString1.fromString("456"),
+        ByteString1.fromString("7890")
+      ))
+      bit ++ bit should ===(
+        BinaryIndexedTree(0, 0, 16, 0,
+          Array(1, 3, 3, 10, 1, 3, 3, 20, 1, 3, 3, 10, 1, 3, 3, 40),
+          Array(1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4)))
+    }
+    "append an element" in {
+      BinaryIndexedTree.empty :+ 0 should ===(BinaryIndexedTree.empty)
+      BinaryIndexedTree.empty :+ 1 should ===(BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))) :+ 0 should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))) :+ 1 should ===(
+        BinaryIndexedTree(0, 0, 2, 0, Array(1, 2), Array(1, 1)))
+
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))) :+ 0 should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))) :+ 1 should ===(
+        BinaryIndexedTree(0, 0, 2, 0, Array(3, 4), Array(3, 1)))
+
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))) :+ 0 should ===(
+        BinaryIndexedTree(0, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))) :+ 1 should ===(
+        BinaryIndexedTree(0, 0, 4, 0, Array(1, 3, 3, 7), Array(1, 2, 3, 1)))
+
+      val sumTable = Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 19, 1, 22, 3, 7, 5, 76)
+      val elemTable = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6)
+      val it16 = BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable)
+
+      it16 :+ 0 should ===(BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable))
+      it16 :+ 1 should ===(BinaryIndexedTree(0, 0, 17, 0, sumTable :+ 1, elemTable :+ 1))
+
+      it16.slice(9, 69) :+ 0 should ===(BinaryIndexedTree(3, 3, 14, 4, sumTable, elemTable))
+      it16.slice(9, 69) :+ 1 should ===(BinaryIndexedTree(0, 0, 13, 0,
+        Array(1, 6, 6, 19, 8, 17, 10, 47, 2, 5, 4, 13, 1),
+        Array(1, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 4, 1)))
+    }
+    "prepend an element" in {
+      0 +: BinaryIndexedTree.empty should ===(BinaryIndexedTree.empty)
+      1 +: BinaryIndexedTree.empty should ===(BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+
+      0 +: BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(1), Array(1)))
+      1 +: BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("a"))) should ===(
+        BinaryIndexedTree(0, 0, 2, 0, Array(1, 2), Array(1, 1)))
+
+      0 +: BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))) should ===(
+        BinaryIndexedTree(0, 0, 1, 0, Array(3), Array(3)))
+      1 +: BinaryIndexedTree(Vector[ByteString1](ByteString1.fromString("abc"))) should ===(
+        BinaryIndexedTree(0, 0, 2, 0, Array(1, 4), Array(1, 3)))
+
+      0 +: BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))) should ===(
+        BinaryIndexedTree(0, 0, 3, 0, Array(1, 3, 3), Array(1, 2, 3)))
+      1 +: BinaryIndexedTree(Vector[ByteString1](
+        ByteString1.fromString("a"), ByteString1.fromString("bc"), ByteString1.fromString("def"))) should ===(
+        BinaryIndexedTree(0, 0, 4, 0, Array(1, 2, 2, 7), Array(1, 1, 2, 3)))
+
+      val sumTable = Array(1, 3, 3, 10, 5, 11, 7, 36, 9, 19, 1, 22, 3, 7, 5, 76)
+      val elemTable = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6)
+      val it16 = BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable)
+
+      0 +: it16 should ===(BinaryIndexedTree(0, 0, 16, 0, sumTable, elemTable))
+      1 +: it16 should ===(BinaryIndexedTree(0, 0, 17, 0,
+        Array(1, 2, 2, 7, 4, 9, 6, 29, 8, 17, 10, 28, 2, 5, 4, 71, 6),
+        Array(1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6)))
+      0 +: it16.slice(9, 69) should ===(BinaryIndexedTree(3, 3, 14, 4, sumTable, elemTable))
+      1 +: it16.slice(9, 69) should ===(BinaryIndexedTree(0, 0, 13, 0,
+        Array(1, 2, 5, 13, 7, 15, 9, 47, 1, 3, 3, 10, 4),
+        Array(1, 1, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 4)))
+    }
+  }
   "ByteString1" must {
     "drop" in {
       ByteString1.empty.drop(-1) should ===(ByteString(""))
@@ -384,6 +1024,41 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
     }
   }
   "ByteStrings" must {
+    "i-th elem" in {
+      ByteStrings(ByteString1.fromString("a"), ByteString1.fromString(""))(0) should ===(97)
+      ByteStrings(ByteString1.fromString(""), ByteString1.fromString("a"))(0) should ===(97)
+
+      val bss = ByteStrings(Vector(
+        ByteString1.fromString("a"),
+        ByteString1.fromString("bc"),
+        ByteString1.fromString("def"),
+        ByteString1.fromString("ghij")))
+      bss(0) should ===(97)
+      bss(1) should ===(98)
+      bss(2) should ===(99)
+      bss(3) should ===(100)
+      bss(4) should ===(101)
+      bss(5) should ===(102)
+      bss(6) should ===(103)
+      bss(7) should ===(104)
+      bss(8) should ===(105)
+      bss(9) should ===(106)
+
+      val bss2 = bss.slice(2, 9)
+      bss2(0) should ===(99)
+      bss2(1) should ===(100)
+      bss2(2) should ===(101)
+      bss2(3) should ===(102)
+      bss2(4) should ===(103)
+      bss2(5) should ===(104)
+      bss2(6) should ===(105)
+
+      val str = List[Byte](0, 1, 2, 3).mkString
+      val numVec = 1024
+      val largeBss = ByteStrings(Vector.fill(numVec)(ByteString1.fromString(str)))
+      for (i ← 0 until numVec * str.size)
+        largeBss(i) should ===(str(i % 4).toByte)
+    }
     "drop" in {
       ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).drop(Int.MinValue) should ===(ByteString(""))
       ByteStrings(ByteString1.fromString(""), ByteString1.fromString("")).drop(-1) should ===(ByteString(""))
@@ -600,6 +1275,70 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       compact.indexOf('g', 5) should ===(5)
       compact.indexOf('g', 6) should ===(-1)
     }
+    "++" in {
+      ByteString.empty ++ ByteString.empty should ===(ByteString(""))
+      ByteString.empty ++ ByteString("a") should ===(ByteString("a"))
+      ByteString("a") ++ ByteString.empty should ===(ByteString("a"))
+      ByteString("a") ++ ByteString("b") should ===(ByteString("ab"))
+
+      ByteString.empty ++ ByteString.empty === (ByteString(""))
+      ByteString("a") ++ ByteString.empty should ===(ByteString("a"))
+      ByteString.empty ++ ByteString("a") ++ ByteString.empty should ===(ByteString("a"))
+      ByteString("a") ++ ByteString("b") should ===(ByteString("ab"))
+
+      val bss = ByteStrings(Vector(
+        ByteString1.fromString("a"),
+        ByteString1.fromString("bc"),
+        ByteString1.fromString("def"),
+        ByteString1.fromString("ghij"),
+        ByteString1.fromString("klmno"),
+        ByteString1.fromString("pqrstu"),
+        ByteString1.fromString("vwxyzAB"),
+        ByteString1.fromString("CDEFGHIJ"),
+        ByteString1.fromString("KLMNOPQRS"),
+        ByteString1.fromString("1234567890"),
+        ByteString1.fromString("a"),
+        ByteString1.fromString("bc"),
+        ByteString1.fromString("def"),
+        ByteString1.fromString("ghij"),
+        ByteString1.fromString("klmno"),
+        ByteString1.fromString("pqrstu")))
+      val str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS1234567890abcdefghijklmnopqrstu"
+
+      val slice1_76 = bss.slice(1, 76)
+      val strSlice1_76 = str.slice(1, 76)
+      val slice2_71 = bss.slice(2, 71)
+      val strSlice2_71 = str.slice(2, 71)
+      val slice3_70 = bss.slice(3, 70)
+      val strSlice3_70 = str.slice(3, 70)
+      slice1_76 ++ ByteString.empty === (ByteString(strSlice1_76))
+      slice1_76 ++ slice1_76 should ===(ByteString(strSlice1_76 + strSlice1_76))
+      slice1_76 ++ slice2_71 should ===(ByteString(strSlice1_76 + strSlice2_71))
+      slice1_76 ++ slice3_70 should ===(ByteString(strSlice1_76 + strSlice3_70))
+      slice2_71 ++ slice1_76 should ===(ByteString(strSlice2_71 + strSlice1_76))
+      slice2_71 ++ slice2_71 should ===(ByteString(strSlice2_71 + strSlice2_71))
+      slice2_71 ++ slice3_70 should ===(ByteString(strSlice2_71 + strSlice3_70))
+      slice3_70 ++ slice1_76 should ===(ByteString(strSlice3_70 + strSlice1_76))
+      slice3_70 ++ slice2_71 should ===(ByteString(strSlice3_70 + strSlice2_71))
+      slice3_70 ++ slice3_70 should ===(ByteString(strSlice3_70 + strSlice3_70))
+
+      val numTrial = 100
+      val minIdx = 0
+      val maxIdx = str.size - 1
+      for (_ ← 0 until numTrial) {
+        def range(): (Int, Int) = {
+          val start = Random.nextInt(maxIdx)
+          val last = Random.nextInt(maxIdx - start) + start
+          (start, last)
+        }
+        val first = range()
+        val second = range()
+        val last = range()
+        bss.slice(first._1, first._2 + 1) ++ bss.slice(second._1, second._2 + 1) ++ bss.slice(last._1, last._2 + 1) should ===(
+          ByteString(str.slice(first._1, first._2 + 1) ++ str.slice(second._1, second._2 + 1) ++ str.slice(last._1, last._2 + 1))
+        )
+      }
+    }
   }
 
   "A ByteString" must {
@@ -720,9 +1459,43 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       "calling take and drop" in {
         check { slice: ByteStringSlice ⇒
           slice match {
-            case (xs, from, until) ⇒ likeVector(xs)({
-              _.drop(from).take(until - from)
-            })
+            case (xs, from, until) ⇒
+              likeVector(xs)({
+                _.take(math.max(0, from) + math.abs(until)).drop(from)
+              })
+          }
+        }
+      }
+
+      "calling drop and take" in {
+        check { slice: ByteStringSlice ⇒
+          slice match {
+            case (xs, from, until) ⇒
+              likeVector(xs)({
+                _.drop(from).take(until - from)
+              })
+          }
+        }
+      }
+
+      "calling dropRight and drop" in {
+        check { slice: ByteStringSlice ⇒
+          slice match {
+            case (xs, from, until) ⇒
+              likeVector(xs)({
+                _.dropRight(math.min(xs.length, xs.length - from) + math.abs(until)).drop(from)
+              })
+          }
+        }
+      }
+
+      "calling takeRight and take" in {
+        check { slice: ByteStringSlice ⇒
+          slice match {
+            case (xs, from, until) ⇒
+              likeVector(xs)({
+                _.takeRight(xs.length - from).take(until - from)
+              })
           }
         }
       }

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_append_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_append_Benchmark.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2014-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import akka.util.ByteString.{ ByteString1, ByteStrings }
+import org.openjdk.jmh.annotations.{ Benchmark, Measurement, Scope, State }
+
+import scala.util.Random
+
+@State(Scope.Benchmark)
+@Measurement(timeUnit = TimeUnit.MILLISECONDS)
+class ByteString_append_Benchmark {
+
+  val str = List.fill[Byte](4)(0).mkString
+  val numVec = 1024
+  val bss_small = ByteStrings(Vector.fill(numVec / 32)(ByteString1.fromString(str)))
+  val bss_middle = ByteStrings(Vector.fill(numVec / 2)(ByteString1.fromString(str)))
+  val bss = ByteStrings(Vector.fill(numVec)(ByteString1.fromString(str)))
+
+  /*
+   --------------------------------- BASELINE -------------------------------------------------------------------
+   commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
+   [info] Benchmark                                             Mode  Cnt           Score          Error  Units
+   [info] ByteString_take_Benchmark.bss_avg                   thrpt   40       28710.870 ±      437.608  ops/s
+   [info] ByteString_take_Benchmark.bss_best                  thrpt   40    20987018.075 ±   443608.693  ops/s
+   [info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40   894573619.213 ±  4360367.026  ops/s
+   [info] ByteString_take_Benchmark.bss_negative              thrpt   40  1164398934.041 ± 15083443.165  ops/s
+   [info] ByteString_take_Benchmark.bss_worst                 thrpt   40       11936.857 ±      373.828  ops/s
+
+   --------------------------------- AFTER ----------------------------------------------------------------------
+
+   ------ TODAY –––––––
+   [info] Benchmark                                             Mode  Cnt           Score          Error  Units
+   [info] ByteString_take_Benchmark.bss_avg                   thrpt   40      539211.297 ±     9073.181  ops/s
+   [info] ByteString_take_Benchmark.bss_best                  thrpt   40   197237882.251 ±  2714956.732  ops/s
+   [info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40   866558812.838 ± 15343155.818  ops/s
+   [info] ByteString_take_Benchmark.bss_negative              thrpt   40  1114723770.487 ± 30945339.512  ops/s
+   [info] ByteString_take_Benchmark.bss_worst                 thrpt   40      233870.585 ±     7326.227  ops/s
+
+   */
+
+  @Benchmark
+  def bss_append_small(): ByteString =
+    bss_small ++ bss_small
+
+  @Benchmark
+  def bss_append_middle(): ByteString =
+    bss_middle ++ bss_middle
+
+  @Benchmark
+  def bss_append_large(): ByteString =
+    bss ++ bss
+}

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_dropRight_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_dropRight_Benchmark.scala
@@ -29,23 +29,24 @@ class ByteString_dropRight_Benchmark {
   /*
    --------------------------------- BASELINE -----------------------------------------------------------------------
    commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
-   [info] Benchmark                                                 Mode  Cnt           Score          Error  Units
-   [info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40       25626.311 ±     1395.662  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40     8667558.031 ±   200233.008  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40       12658.684 ±      376.730  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  1214680926.895 ± 10661843.507  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40       13087.245 ±      246.911  ops/s
+   [info] Benchmark                                                 Mode  Cnt          Score         Error  Units
+   [info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40      27775.584 ±     153.671  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40    8896435.523 ±   39693.086  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40      13166.278 ±     149.709  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_iteration             thrpt   40          6.361 ±       0.030  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  348765581.301 ± 5981494.625  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40      13364.024 ±      69.827  ops/s
 
    --------------------------------- AFTER --------------------------------------------------------------------------
 
    ------ TODAY –––––––
-   [info] Benchmark                                                 Mode  Cnt           Score         Error  Units
-   [info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40      528969.025 ±    6039.001  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40     7925951.396 ±  249279.950  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40   893475724.604 ± 9836471.105  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  1182275022.613 ± 9710755.955  ops/s
-   [info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40      244599.957 ±    3276.140  ops/s
-
+   [info] Benchmark                                                 Mode  Cnt          Score         Error  Units
+   [info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40    5546191.528 ±  129660.665  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40    3781902.387 ±   71481.259  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40  254119811.602 ± 3464120.268  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_iteratio              thrpt   40        975.490 ±      21.433  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  275402741.230 ± 8882548.856  ops/s
+   [info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40   16023701.310 ±  159979.511  ops/s
    */
 
   @Benchmark
@@ -67,4 +68,13 @@ class ByteString_dropRight_Benchmark {
   @Benchmark
   def bss_worst(): ByteString =
     bss.dropRight(n_worst)
+
+  @Benchmark
+  def bss_iteration(): Unit = {
+    var i = 0
+    while (i < len) {
+      bss.dropRight(i)
+      i += 1
+    }
+  }
 }

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_drop_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_drop_Benchmark.scala
@@ -28,42 +28,53 @@ class ByteString_drop_Benchmark {
 
   /*
    --------------------------------- BASELINE ------------------------------------------------------------------
-   [info] Benchmark                                             Mode  Cnt           Score          Error  Units
-   [info] ByteString_drop_Benchmark.bss_avg                   thrpt   40      544841.222 ±    12917.565  ops/s
-   [info] ByteString_drop_Benchmark.bss_best                  thrpt   40    10141204.609 ±   415441.925  ops/s
-   [info] ByteString_drop_Benchmark.bss_greater_or_eq_to_len  thrpt   40   902173327.723 ±  9921650.983  ops/s
-   [info] ByteString_drop_Benchmark.bss_negative              thrpt   40  1179430602.793 ± 12193702.247  ops/s
-   [info] ByteString_drop_Benchmark.bss_worst                 thrpt   40      297489.038 ±     5534.801  ops/s
+   commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
+   [info] Benchmark                                            Mode  Cnt          Score         Error  Units
+   [info] ByteString_drop_Benchmark.bss_avg                   thrpt   40     560979.826 ±    3124.876  ops/s
+   [info] ByteString_drop_Benchmark.bss_best                  thrpt   40   11367339.399 ±   98228.290  ops/s
+   [info] ByteString_drop_Benchmark.bss_greater_or_eq_to_len  thrpt   40  301077170.894 ± 6879088.905  ops/s
+   [info] ByteString_drop_Benchmark.bss_iteration             thrpt   40        106.565 ±       0.572  ops/s
+   [info] ByteString_drop_Benchmark.bss_negative              thrpt   40  353064310.406 ± 4106542.258  ops/s
+   [info] ByteString_drop_Benchmark.bss_worst                 thrpt   40     253302.470 ±    2162.730  ops/s
 
+   --------------------------------- AFTER ----------------------------------------------------------------------
+
+   ------ TODAY –––––––
+   [info] Benchmark                                            Mode  Cnt          Score         Error  Units
+   [info] ByteString_drop_Benchmark.bss_avg                   thrpt   40    5665514.987 ±  129576.190  ops/s
+   [info] ByteString_drop_Benchmark.bss_best                  thrpt   40    5903613.985 ±   81600.595  ops/s
+   [info] ByteString_drop_Benchmark.bss_greater_or_eq_to_len  thrpt   40  267368817.381 ± 2870511.427  ops/s
+   [info] ByteString_drop_Benchmark.bss_iteration             thrpt   40       1113.068 ±      12.832  ops/s
+   [info] ByteString_drop_Benchmark.bss_negative              thrpt   40  290322333.659 ± 5514237.109  ops/s
+   [info] ByteString_drop_Benchmark.bss_worst                 thrpt   40    7605597.466 ±   98944.995  ops/s
    */
 
   @Benchmark
-  def bss_negative(): Unit = {
-    @volatile var m: ByteString = null
-    m = bss.drop(n_neg)
-  }
+  def bss_negative(): ByteString =
+    bss.drop(n_neg)
 
   @Benchmark
-  def bss_greater_or_eq_to_len(): Unit = {
-    @volatile var m: ByteString = null
-    m = bss.drop(n_greater_or_eq_to_len)
-  }
+  def bss_greater_or_eq_to_len(): ByteString =
+    bss.drop(n_greater_or_eq_to_len)
 
   @Benchmark
-  def bss_avg(): Unit = {
-    @volatile var m: ByteString = null
-    m = bss.drop(n_avg)
-  }
+  def bss_avg(): ByteString =
+    bss.drop(n_avg)
 
   @Benchmark
-  def bss_best(): Unit = {
-    @volatile var m: ByteString = null
-    m = bss.drop(n_best)
-  }
+  def bss_best(): ByteString =
+    bss.drop(n_best)
 
   @Benchmark
-  def bss_worst(): Unit = {
-    @volatile var m: ByteString = null
-    m = bss.drop(n_worst)
+  def bss_worst(): ByteString =
+    bss.drop(n_worst)
+
+  @Benchmark
+  def bss_iteration(): Unit = {
+    var i = 0
+    while (i < len) {
+      bss.drop(i)
+      i += 1
+    }
   }
 }

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_get_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_get_Benchmark.scala
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2014-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import akka.util.ByteString.{ ByteString1, ByteStrings }
+import org.openjdk.jmh.annotations.{ Benchmark, Measurement, Scope, State }
+
+@State(Scope.Benchmark)
+@Measurement(timeUnit = TimeUnit.MILLISECONDS)
+class ByteString_get_Benchmark {
+  val numStr = 4
+  val numVec = 1024
+  val size = numStr * numVec
+  val str = List.fill[Byte](numStr)(0).mkString
+  val bss = ByteStrings(Vector.fill(numVec)(ByteString1.fromString(str)))
+
+  val n_best = 0
+  val n_worst = size - 1
+  val n_avg = size / 2 - 1
+
+  /*
+   --------------------------------- BASELINE -------------------------------------------------------------------
+   commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
+   [info] Benchmark                                Mode  Cnt          Score         Error  Units
+   [info] ByteString_get_Benchmark.bss_avg        thrpt   40     298246.372 ±    8249.457  ops/s
+   [info] ByteString_get_Benchmark.bss_best       thrpt   40  127761495.109 ± 1791133.787  ops/s
+   [info] ByteString_get_Benchmark.bss_iteration  thrpt   40         65.658 ±       1.106  ops/s
+   [info] ByteString_get_Benchmark.bss_worst      thrpt   40     157434.473 ±    2688.289  ops/s
+
+   --------------------------------- AFTER ----------------------------------------------------------------------
+
+   ------ TODAY –––––––
+   [info] Benchmark                                Mode  Cnt          Score        Error  Units
+   [info] ByteString_get_Benchmark.bss_avg        thrpt   40    9752370.455 ±  14669.714  ops/s
+   [info] ByteString_get_Benchmark.bss_best       thrpt   40  116327363.416 ± 213188.562  ops/s
+   [info] ByteString_get_Benchmark.bss_iteration  thrpt   40       2539.810 ±     10.192  ops/s
+   [info] ByteString_get_Benchmark.bss_worst      thrpt   40    8625257.769 ±  13954.126  ops/s
+   */
+
+  @Benchmark
+  def bss_iteration(): Unit = {
+    var i = 0
+    while (i < size) {
+      bss(i)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def bss_best: Byte = bss(n_best)
+
+  @Benchmark
+  def bss_worst: Byte = bss(n_worst)
+
+  @Benchmark
+  def bss_avg: Byte = bss(n_avg)
+}

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_slice_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_slice_Benchmark.scala
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2014-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import akka.util.ByteString.{ ByteString1, ByteStrings }
+import org.openjdk.jmh.annotations.{ Benchmark, Measurement, Scope, State }
+
+import scala.util.Random
+
+@State(Scope.Benchmark)
+@Measurement(timeUnit = TimeUnit.MILLISECONDS)
+class ByteString_slice_Benchmark {
+  val numVec = 1024
+  val str = List.fill[Byte](4)(0).mkString
+  val bss = ByteStrings(Vector.fill(numVec)(ByteString1.fromString(str)))
+
+  val rand = new Random()
+  val len = str.size * numVec
+  val n_greater_or_eq_to_len = len + rand.nextInt(Int.MaxValue - len)
+  val n_neg = rand.nextInt(Int.MaxValue) * -1
+
+  val from_half = 1
+  val until_half = len / 2
+  val from_half2 = len / 2 - 1
+  val until_half2 = len - 1
+  val from_half3 = len / 4
+  val until_half3 = len * 3 / 4 - 1
+
+  // take(1)
+  val from_take1 = 0
+  val until_take1 = 1
+  // dropRight(1)
+  val from_dropRight1 = 0
+  val until_dropRight1 = len - 1
+  // takeRight(1)
+  val from_takeRight1 = len - 1
+  val until_takeRight1 = len
+  // drop(1)
+  val from_drop1 = 1
+  val until_drop1 = len
+
+  // slice(n, n+1)
+  val from_case = len / 2 - 1
+  val until_case = len / 2
+  val from_case2 = len / 2
+  val until_case2 = len / 2 + 1
+  val from_case3 = 1
+  val until_case3 = 2
+  val from_case4 = len - 2
+  val until_case4 = len - 1
+
+  /*
+   --------------------------------- BASELINE -----------------------------------------------
+   commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
+   [info] Benchmark                                             Mode  Cnt          Score         Error  Units
+   [info] ByteString_slice_Benchmark.bss_case                  thrpt   40      25843.383 ±     666.859  ops/s
+   [info] ByteString_slice_Benchmark.bss_case2                 thrpt   40      25119.135 ±     452.224  ops/s
+   [info] ByteString_slice_Benchmark.bss_case3                 thrpt   40      13026.250 ±     125.890  ops/s
+   [info] ByteString_slice_Benchmark.bss_case4                 thrpt   40     270410.755 ±    1818.892  ops/s
+   [info] ByteString_slice_Benchmark.bss_drop1                 thrpt   40   10810904.114 ±  298279.889  ops/s
+   [info] ByteString_slice_Benchmark.bss_dropRight1            thrpt   40    8685247.609 ±  255687.700  ops/s
+   [info] ByteString_slice_Benchmark.bss_greater_or_eq_to_len  thrpt   40  273521343.650 ± 5460020.934  ops/s
+   [info] ByteString_slice_Benchmark.bss_iteration             thrpt   40         80.636 ±       1.081  ops/s
+   [info] ByteString_slice_Benchmark.bss_iteration2            thrpt   40          6.621 ±       0.034  ops/s
+   [info] ByteString_slice_Benchmark.bss_negative              thrpt   40      13245.372 ±      80.026  ops/s
+   [info] ByteString_slice_Benchmark.bss_slice_half            thrpt   40      25113.310 ±    1077.999  ops/s
+   [info] ByteString_slice_Benchmark.bss_slice_half2           thrpt   40     386212.913 ±   10184.987  ops/s
+   [info] ByteString_slice_Benchmark.bss_slice_half3           thrpt   40      47378.585 ±    1710.489  ops/s
+   [info] ByteString_slice_Benchmark.bss_take1                 thrpt   40      11416.887 ±     363.871  ops/s
+   [info] ByteString_slice_Benchmark.bss_takeRight1            thrpt   40     226438.341 ±    5231.196  ops/s
+
+   --------------------------------- AFTER --------------------------------------------------
+
+   ------ TODAY –––––––
+   [info] Benchmark                                             Mode  Cnt          Score         Error  Units
+   [info] ByteString_slice_Benchmark.bss_case                  thrpt   40    4966263.298 ±  139761.338  ops/s
+   [info] ByteString_slice_Benchmark.bss_case2                 thrpt   40    8678927.639 ±  159740.837  ops/s
+   [info] ByteString_slice_Benchmark.bss_case3                 thrpt   40    8960375.387 ±   96679.521  ops/s
+   [info] ByteString_slice_Benchmark.bss_case4                 thrpt   40    4443335.581 ±   43210.672  ops/s
+   [info] ByteString_slice_Benchmark.bss_drop1                 thrpt   40    3958787.348 ±   67623.829  ops/s
+   [info] ByteString_slice_Benchmark.bss_dropRight1            thrpt   40    3204187.452 ±   44179.937  ops/s
+   [info] ByteString_slice_Benchmark.bss_greater_or_eq_to_len  thrpt   40  203088545.418 ± 2338789.417  ops/s
+   [info] ByteString_slice_Benchmark.bss_iteration             thrpt   40        733.698 ±      10.027  ops/s
+   [info] ByteString_slice_Benchmark.bss_iteration2            thrpt   40        843.650 ±      17.940  ops/s
+   [info] ByteString_slice_Benchmark.bss_negative              thrpt   40  205334645.483 ± 1314458.684  ops/s
+   [info] ByteString_slice_Benchmark.bss_slice_half            thrpt   40    2977058.352 ±   48202.926  ops/s
+   [info] ByteString_slice_Benchmark.bss_slice_half2           thrpt   40    1691869.441 ±   26159.817  ops/s
+   [info] ByteString_slice_Benchmark.bss_slice_half3           thrpt   40    2295009.457 ±   29994.882  ops/s
+   [info] ByteString_slice_Benchmark.bss_take1                 thrpt   40    9017465.502 ±  129463.925  ops/s
+   [info] ByteString_slice_Benchmark.bss_takeRight1            thrpt   40    4758854.310 ±  158576.757  ops/s
+   */
+
+  @Benchmark
+  def bss_negative(): ByteString =
+    bss.slice(n_neg - 1, n_neg)
+
+  @Benchmark
+  def bss_greater_or_eq_to_len(): ByteString =
+    bss.slice(n_greater_or_eq_to_len, n_greater_or_eq_to_len + 1)
+
+  @Benchmark
+  def bss_slice_half(): ByteString =
+    bss.slice(from_half, until_half)
+
+  @Benchmark
+  def bss_slice_half2(): ByteString =
+    bss.slice(from_half2, until_half2)
+
+  @Benchmark
+  def bss_slice_half3(): ByteString =
+    bss.slice(from_half3, until_half3)
+
+  @Benchmark
+  def bss_take1(): ByteString =
+    bss.slice(from_take1, until_take1)
+
+  @Benchmark
+  def bss_dropRight1(): ByteString =
+    bss.slice(from_dropRight1, until_dropRight1)
+
+  @Benchmark
+  def bss_takeRight1(): ByteString =
+    bss.slice(from_takeRight1, until_takeRight1)
+
+  @Benchmark
+  def bss_drop1(): ByteString =
+    bss.slice(from_drop1, until_drop1)
+
+  @Benchmark
+  def bss_case(): ByteString =
+    bss.slice(from_case, until_case)
+
+  @Benchmark
+  def bss_case2(): ByteString =
+    bss.slice(from_case2, until_case2)
+
+  @Benchmark
+  def bss_case3(): ByteString =
+    bss.slice(from_case3, until_case3)
+
+  @Benchmark
+  def bss_case4(): ByteString =
+    bss.slice(from_case4, until_case4)
+
+  @Benchmark
+  def bss_iteration(): Unit = {
+    var i = 0
+    while (i < len) {
+      bss.slice(i, len)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def bss_iteration2(): Unit = {
+    var i = 0
+    while (i <= len) {
+      bss.slice(0, i)
+      i += 1
+    }
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_take_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_take_Benchmark.scala
@@ -29,47 +29,52 @@ class ByteString_take_Benchmark {
   /*
    --------------------------------- BASELINE -------------------------------------------------------------------
    commit 0f2da7b26b5c4af35be87d2bd4a1a2392365df15
-   [info] Benchmark                                             Mode  Cnt           Score          Error  Units
-   [info] ByteString_take_Benchmark.bss_avg                   thrpt   40       28710.870 ±      437.608  ops/s
-   [info] ByteString_take_Benchmark.bss_best                  thrpt   40    20987018.075 ±   443608.693  ops/s
-   [info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40   894573619.213 ±  4360367.026  ops/s
-   [info] ByteString_take_Benchmark.bss_negative              thrpt   40  1164398934.041 ± 15083443.165  ops/s
-   [info] ByteString_take_Benchmark.bss_worst                 thrpt   40       11936.857 ±      373.828  ops/s
+   [info] Benchmark                                            Mode  Cnt          Score          Error  Units
+   [info] ByteString_take_Benchmark.bss_avg                   thrpt   40      28019.740 ±     1175.456  ops/s
+   [info] ByteString_take_Benchmark.bss_best                  thrpt   40   20326905.468 ±   889508.335  ops/s
+   [info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40  324506235.049 ± 12040396.971  ops/s
+   [info] ByteString_take_Benchmark.bss_iteration             thrpt   40          6.890 ±        0.140  ops/s
+   [info] ByteString_take_Benchmark.bss_negative              thrpt   40  295420920.031 ±  4201642.454  ops/s
+   [info] ByteString_take_Benchmark.bss_worst                 thrpt   40      13378.362 ±      450.396  ops/s
 
    --------------------------------- AFTER ----------------------------------------------------------------------
 
    ------ TODAY –––––––
-   [info] Benchmark                                             Mode  Cnt           Score          Error  Units
-   [info] ByteString_take_Benchmark.bss_avg                   thrpt   40      539211.297 ±     9073.181  ops/s
-   [info] ByteString_take_Benchmark.bss_best                  thrpt   40   197237882.251 ±  2714956.732  ops/s
-   [info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40   866558812.838 ± 15343155.818  ops/s
-   [info] ByteString_take_Benchmark.bss_negative              thrpt   40  1114723770.487 ± 30945339.512  ops/s
-   [info] ByteString_take_Benchmark.bss_worst                 thrpt   40      233870.585 ±     7326.227  ops/s
-
+   [info] Benchmark                                            Mode  Cnt          Score          Error  Units
+   [info] ByteString_take_Benchmark.bss_avg                   thrpt   40    6658796.409 ±   147086.276  ops/s
+   [info] ByteString_take_Benchmark.bss_best                  thrpt   40   17825424.621 ±   213434.831  ops/s
+   [info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40  325472727.077 ± 10478779.758  ops/s
+   [info] ByteString_take_Benchmark.bss_iteration             thrpt   40       1162.864 ±       28.621  ops/s
+   [info] ByteString_take_Benchmark.bss_negative              thrpt   40  297056629.331 ±  4105606.094  ops/s
+   [info] ByteString_take_Benchmark.bss_worst                 thrpt   40    4357243.962 ±   133106.265  ops/s
    */
 
   @Benchmark
-  def bss_negative(): ByteString = {
+  def bss_negative(): ByteString =
     bss.take(n_neg)
-  }
 
   @Benchmark
-  def bss_greater_or_eq_to_len(): ByteString = {
+  def bss_greater_or_eq_to_len(): ByteString =
     bss.take(n_greater_or_eq_to_len)
-  }
 
   @Benchmark
-  def bss_avg(): ByteString = {
+  def bss_avg(): ByteString =
     bss.take(n_avg)
-  }
 
   @Benchmark
-  def bss_best(): ByteString = {
+  def bss_best(): ByteString =
     bss.take(n_best)
-  }
 
   @Benchmark
-  def bss_worst(): ByteString = {
+  def bss_worst(): ByteString =
     bss.take(n_worst)
+
+  @Benchmark
+  def bss_iteration(): Unit = {
+    var i = 0
+    while (i < len) {
+      bss.take(i)
+      i += 1
+    }
   }
 }


### PR DESCRIPTION
# Summary
By introducing additional data structure into [ByteStrings](https://github.com/akka/akka/blob/v2.4.16/akka-actor/src/main/scala/akka/util/ByteString.scala#L401), we can boost the performance of ByteString operations, such as `take(n)`, `takeRight(n)`, `drop(n)`, `dropRight(n)`, `apply(idx)` and `slice(start, until)`. As you can find from the benchmark result, it's 10x to 50x faster than before (in the end some operations are 100x to 300x faster than that of baseline!).
One cons is we have some speed down of `++(append)` operation due to the introduction of additional data(about 5 to 10% slowdown).

# Problem
As our ByteStrings contains multiple `ByteString1` as `Vector[ByteString1]`, iteration of ByteString(vector) is not fast. As a result, some operation, such as `take(N)` and `drop(N)`, is slow especially when the input size `N` is big. The bigger the `N`, the more time it takes to finish the operation because we need to keep searching for elements of the vector to find the right place of `take` or `drop` for example.

# Solution
I was wondering if we knew the right place to `take` or `drop`. If we knew the information, then there should be speed up of these operations.

The information we need is simply a nice _index_ table representing each length of a vector(internal strings of ByteString).
What we want are:
1. fast searching for index of `take`, `drop` and so on.
2. minimum time consumption when appending `ByteStrings`, which we can't avoid as we introduce a new data structure (whose cost must be greater than 0).

To satisfy these conditions, I chose [Binary Indexed Tree](https://www.topcoder.com/community/data-science/data-science-tutorials/binary-indexed-trees/)(BIT) with some extension.
The basic characteristics of BIT are:
1. easy to find sum between 1 to i-th elements, which is necessary to find
   index efficiently for our `take` operation for example.
2. easy to create the data structure using `Array[Int]` so we can expect a good performance. Actually, as the benchmark shows, `append` operation is not very _cheap_ so we need to discuss the best way to handle this issue.

More detailed explanation of our BIT is given in the source code.

# Benchmark
### take
```
PR
[info] Benchmark                                            Mode  Cnt          Score          Error  Units
[info] ByteString_take_Benchmark.bss_avg                   thrpt   40    6658796.409 ±   147086.276  ops/s
[info] ByteString_take_Benchmark.bss_best                  thrpt   40   17825424.621 ±   213434.831  ops/s
[info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40  325472727.077 ± 10478779.758  ops/s
[info] ByteString_take_Benchmark.bss_iteration             thrpt   40       1162.864 ±       28.621  ops/s
[info] ByteString_take_Benchmark.bss_negative              thrpt   40  297056629.331 ±  4105606.094  ops/s
[info] ByteString_take_Benchmark.bss_worst                 thrpt   40    4357243.962 ±   133106.265  ops/s

master
[info] Benchmark                                            Mode  Cnt          Score         Error  Units
[info] ByteString_take_Benchmark.bss_avg                   thrpt   40     550433.345 ±   11140.133  ops/s
[info] ByteString_take_Benchmark.bss_best                  thrpt   40   78981591.780 ± 1855206.075  ops/s
[info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40  335521917.824 ± 7621982.218  ops/s
[info] ByteString_take_Benchmark.bss_iteration             thrpt   40        115.829 ±       0.849  ops/s
[info] ByteString_take_Benchmark.bss_negative              thrpt   40  292741916.206 ± 4249335.897  ops/s
[info] ByteString_take_Benchmark.bss_worst                 thrpt   40     253931.502 ±    3403.806  ops/s

baseline (0f2da7b26b5c4af35be87d2bd4a1a2392365df15)
[info] Benchmark                                            Mode  Cnt          Score          Error  Units
[info] ByteString_take_Benchmark.bss_avg                   thrpt   40      28019.740 ±     1175.456  ops/s
[info] ByteString_take_Benchmark.bss_best                  thrpt   40   20326905.468 ±   889508.335  ops/s
[info] ByteString_take_Benchmark.bss_greater_or_eq_to_len  thrpt   40  324506235.049 ± 12040396.971  ops/s
[info] ByteString_take_Benchmark.bss_iteration             thrpt   40          6.890 ±        0.140  ops/s
[info] ByteString_take_Benchmark.bss_negative              thrpt   40  295420920.031 ±  4201642.454  ops/s
[info] ByteString_take_Benchmark.bss_worst                 thrpt   40      13378.362 ±      450.396  ops/s
```

### drop
```
PR
[info] Benchmark                                            Mode  Cnt          Score         Error  Units
[info] ByteString_drop_Benchmark.bss_avg                   thrpt   40    5665514.987 ±  129576.190  ops/s
[info] ByteString_drop_Benchmark.bss_best                  thrpt   40    5903613.985 ±   81600.595  ops/s
[info] ByteString_drop_Benchmark.bss_greater_or_eq_to_len  thrpt   40  267368817.381 ± 2870511.427  ops/s
[info] ByteString_drop_Benchmark.bss_iteration             thrpt   40       1113.068 ±      12.832  ops/s
[info] ByteString_drop_Benchmark.bss_negative              thrpt   40  290322333.659 ± 5514237.109  ops/s
[info] ByteString_drop_Benchmark.bss_worst                 thrpt   40    7605597.466 ±   98944.995  ops/s

master
[info] Benchmark                                            Mode  Cnt          Score         Error  Units
[info] ByteString_drop_Benchmark.bss_avg                   thrpt   40     565156.959 ±    2413.034  ops/s
[info] ByteString_drop_Benchmark.bss_best                  thrpt   40   11249226.167 ±   51661.484  ops/s
[info] ByteString_drop_Benchmark.bss_greater_or_eq_to_len  thrpt   40  301455048.816 ± 5303857.962  ops/s
[info] ByteString_drop_Benchmark.bss_iteration             thrpt   40        127.059 ±       0.666  ops/s
[info] ByteString_drop_Benchmark.bss_negative              thrpt   40  345910897.342 ± 8922811.503  ops/s
[info] ByteString_drop_Benchmark.bss_worst                 thrpt   40     318725.441 ±    2403.632  ops/s

baseline (0f2da7b26b5c4af35be87d2bd4a1a2392365df15)
[info] Benchmark                                            Mode  Cnt          Score         Error  Units
[info] ByteString_drop_Benchmark.bss_avg                   thrpt   40     560979.826 ±    3124.876  ops/s
[info] ByteString_drop_Benchmark.bss_best                  thrpt   40   11367339.399 ±   98228.290  ops/s
[info] ByteString_drop_Benchmark.bss_greater_or_eq_to_len  thrpt   40  301077170.894 ± 6879088.905  ops/s
[info] ByteString_drop_Benchmark.bss_iteration             thrpt   40        106.565 ±       0.572  ops/s
[info] ByteString_drop_Benchmark.bss_negative              thrpt   40  353064310.406 ± 4106542.258  ops/s
[info] ByteString_drop_Benchmark.bss_worst                 thrpt   40     253302.470 ±    2162.730  ops/s
```

### dropRight
```
PR
[info] Benchmark                                                 Mode  Cnt          Score         Error  Units
[info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40    5546191.528 ±  129660.665  ops/s
[info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40    3781902.387 ±   71481.259  ops/s
[info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40  254119811.602 ± 3464120.268  ops/s
[info] ByteString_dropRight_Benchmark.bss_iteratio              thrpt   40        975.490 ±      21.433  ops/s
[info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  275402741.230 ± 8882548.856  ops/s
[info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40   16023701.310 ±  159979.511  ops/s

master
[info] Benchmark                                                 Mode  Cnt          Score         Error  Units
[info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40     555219.367 ±    7298.578  ops/s
[info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40    8320591.466 ±   71728.196  ops/s
[info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40  299242841.693 ± 4649857.402  ops/s
[info] ByteString_dropRight_Benchmark.bss_iteration             thrpt   40        111.227 ±       1.242  ops/s
[info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  339347045.278 ± 5934805.704  ops/s
[info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40     275236.119 ±    1414.146  ops/s

baseline(0f2da7b26b5c4af35be87d2bd4a1a2392365df15)
[info] Benchmark                                                 Mode  Cnt          Score         Error  Units
[info] ByteString_dropRight_Benchmark.bss_avg                   thrpt   40      27775.584 ±     153.671  ops/s
[info] ByteString_dropRight_Benchmark.bss_best                  thrpt   40    8896435.523 ±   39693.086  ops/s
[info] ByteString_dropRight_Benchmark.bss_greater_or_eq_to_len  thrpt   40      13166.278 ±     149.709  ops/s
[info] ByteString_dropRight_Benchmark.bss_iteration             thrpt   40          6.361 ±       0.030  ops/s
[info] ByteString_dropRight_Benchmark.bss_negative              thrpt   40  348765581.301 ± 5981494.625  ops/s
[info] ByteString_dropRight_Benchmark.bss_worst                 thrpt   40      13364.024 ±      69.827  ops/s
```

### slice
```
PR
[info] Benchmark                                             Mode  Cnt          Score         Error  Units
[info] ByteString_slice_Benchmark.bss_case                  thrpt   40    4966263.298 ±  139761.338  ops/s
[info] ByteString_slice_Benchmark.bss_case2                 thrpt   40    8678927.639 ±  159740.837  ops/s
[info] ByteString_slice_Benchmark.bss_case3                 thrpt   40    8960375.387 ±   96679.521  ops/s
[info] ByteString_slice_Benchmark.bss_case4                 thrpt   40    4443335.581 ±   43210.672  ops/s
[info] ByteString_slice_Benchmark.bss_drop1                 thrpt   40    3958787.348 ±   67623.829  ops/s
[info] ByteString_slice_Benchmark.bss_dropRight1            thrpt   40    3204187.452 ±   44179.937  ops/s
[info] ByteString_slice_Benchmark.bss_greater_or_eq_to_len  thrpt   40  203088545.418 ± 2338789.417  ops/s
[info] ByteString_slice_Benchmark.bss_iteration             thrpt   40        733.698 ±      10.027  ops/s
[info] ByteString_slice_Benchmark.bss_iteration2            thrpt   40        843.650 ±      17.940  ops/s
[info] ByteString_slice_Benchmark.bss_negative              thrpt   40  205334645.483 ± 1314458.684  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half            thrpt   40    2977058.352 ±   48202.926  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half2           thrpt   40    1691869.441 ±   26159.817  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half3           thrpt   40    2295009.457 ±   29994.882  ops/s
[info] ByteString_slice_Benchmark.bss_take1                 thrpt   40    9017465.502 ±  129463.925  ops/s
[info] ByteString_slice_Benchmark.bss_takeRight1            thrpt   40    4758854.310 ±  158576.757  ops/s

master
[info] Benchmark                                             Mode  Cnt          Score         Error  Units
[info] ByteString_slice_Benchmark.bss_case                  thrpt   40     258012.601 ±    1349.323  ops/s
[info] ByteString_slice_Benchmark.bss_case2                 thrpt   40     255960.274 ±    1642.319  ops/s
[info] ByteString_slice_Benchmark.bss_case3                 thrpt   40     265296.726 ±    1438.386  ops/s
[info] ByteString_slice_Benchmark.bss_case4                 thrpt   40     293938.035 ±    1969.510  ops/s
[info] ByteString_slice_Benchmark.bss_drop1                 thrpt   40   10904437.010 ±  255556.034  ops/s
[info] ByteString_slice_Benchmark.bss_dropRight1            thrpt   40    8274232.023 ±   59598.419  ops/s
[info] ByteString_slice_Benchmark.bss_greater_or_eq_to_len  thrpt   40  278889716.136 ± 4253538.338  ops/s
[info] ByteString_slice_Benchmark.bss_iteration             thrpt   40        135.376 ±       1.258  ops/s
[info] ByteString_slice_Benchmark.bss_iteration2            thrpt   40        125.718 ±       0.643  ops/s
[info] ByteString_slice_Benchmark.bss_negative              thrpt   40  206380877.077 ± 7065266.102  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half            thrpt   40     394177.946 ±   11475.334  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half2           thrpt   40     400633.511 ±   14360.496  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half3           thrpt   40     400487.530 ±   11388.185  ops/s
[info] ByteString_slice_Benchmark.bss_take1                 thrpt   40     236971.246 ±    3017.895  ops/s
[info] ByteString_slice_Benchmark.bss_takeRight1            thrpt   40     232504.663 ±    3147.300  ops/s

baseline(0f2da7b26b5c4af35be87d2bd4a1a2392365df15)
[info] Benchmark                                             Mode  Cnt          Score         Error  Units
[info] ByteString_slice_Benchmark.bss_case                  thrpt   40      25843.383 ±     666.859  ops/s
[info] ByteString_slice_Benchmark.bss_case2                 thrpt   40      25119.135 ±     452.224  ops/s
[info] ByteString_slice_Benchmark.bss_case3                 thrpt   40      13026.250 ±     125.890  ops/s
[info] ByteString_slice_Benchmark.bss_case4                 thrpt   40     270410.755 ±    1818.892  ops/s
[info] ByteString_slice_Benchmark.bss_drop1                 thrpt   40   10810904.114 ±  298279.889  ops/s
[info] ByteString_slice_Benchmark.bss_dropRight1            thrpt   40    8685247.609 ±  255687.700  ops/s
[info] ByteString_slice_Benchmark.bss_greater_or_eq_to_len  thrpt   40  273521343.650 ± 5460020.934  ops/s
[info] ByteString_slice_Benchmark.bss_iteration             thrpt   40         80.636 ±       1.081  ops/s
[info] ByteString_slice_Benchmark.bss_iteration2            thrpt   40          6.621 ±       0.034  ops/s
[info] ByteString_slice_Benchmark.bss_negative              thrpt   40      13245.372 ±      80.026  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half            thrpt   40      25113.310 ±    1077.999  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half2           thrpt   40     386212.913 ±   10184.987  ops/s
[info] ByteString_slice_Benchmark.bss_slice_half3           thrpt   40      47378.585 ±    1710.489  ops/s
[info] ByteString_slice_Benchmark.bss_take1                 thrpt   40      11416.887 ±     363.871  ops/s
[info] ByteString_slice_Benchmark.bss_takeRight1            thrpt   40     226438.341 ±    5231.196  ops/s
```

### append
```
PR
[info] Benchmark                                       Mode  Cnt        Score      Error  Units
[info] ByteString_append_Benchmark.bss_append_large   thrpt   40    36102.591 ±  665.880  ops/s
[info] ByteString_append_Benchmark.bss_append_middle  thrpt   40    88761.412 ± 6325.612  ops/s
[info] ByteString_append_Benchmark.bss_append_small   thrpt   40  1082691.287 ± 5915.681  ops/s

master
[info] Benchmark                                       Mode  Cnt        Score       Error  Units
[info] ByteString_append_Benchmark.bss_append_large   thrpt   40    38055.113 ±   665.688  ops/s
[info] ByteString_append_Benchmark.bss_append_middle  thrpt   40    86436.829 ±  2109.875  ops/s
[info] ByteString_append_Benchmark.bss_append_small   thrpt   40  1181868.293 ± 26859.782  ops/s

baseline(0f2da7b26b5c4af35be87d2bd4a1a2392365df15)
[info] Benchmark                                       Mode  Cnt        Score       Error  Units
[info] ByteString_append_Benchmark.bss_append_large   thrpt   40    41476.060 ±  1434.070  ops/s
[info] ByteString_append_Benchmark.bss_append_middle  thrpt   40    89104.792 ±  1783.272  ops/s
[info] ByteString_append_Benchmark.bss_append_small   thrpt   40  1238889.193 ± 42408.936  ops/s
```

### get
```
PR
[info] Benchmark                                Mode  Cnt          Score        Error  Units
[info] ByteString_get_Benchmark.bss_avg        thrpt   40    9752370.455 ±  14669.714  ops/s
[info] ByteString_get_Benchmark.bss_best       thrpt   40  116327363.416 ± 213188.562  ops/s
[info] ByteString_get_Benchmark.bss_iteration  thrpt   40       2539.810 ±     10.192  ops/s
[info] ByteString_get_Benchmark.bss_worst      thrpt   40    8625257.769 ±  13954.126  ops/s

master
[info] Benchmark                                Mode  Cnt          Score         Error  Units
[info] ByteString_get_Benchmark.bss_avg        thrpt   40     295812.163 ±    4291.012  ops/s
[info] ByteString_get_Benchmark.bss_best       thrpt   40  121710366.422 ± 3029259.546  ops/s
[info] ByteString_get_Benchmark.bss_iteration  thrpt   40         64.131 ±       1.037  ops/s
[info] ByteString_get_Benchmark.bss_worst      thrpt   40     150304.249 ±    2688.072  ops/s

baseline(0f2da7b26b5c4af35be87d2bd4a1a2392365df15)
[info] Benchmark                                Mode  Cnt          Score         Error  Units
[info] ByteString_get_Benchmark.bss_avg        thrpt   40     298246.372 ±    8249.457  ops/s
[info] ByteString_get_Benchmark.bss_best       thrpt   40  127761495.109 ± 1791133.787  ops/s
[info] ByteString_get_Benchmark.bss_iteration  thrpt   40         65.658 ±       1.106  ops/s
[info] ByteString_get_Benchmark.bss_worst      thrpt   40     157434.473 ±    2688.289  ops/s
```