### PR TITLE
BACKPORT: =str fix typo in GraphStage port validations (for Validation)

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -455,7 +455,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
 
       // Detailed error information should not add overhead to the hot path
       ReactiveStreamsCompliance.requireNonNullElement(elem)
-      require(!isClosed(out), s"Cannot pull closed port ($out)")
+      require(!isClosed(out), s"Cannot push closed port ($out)")
       require(isAvailable(out), s"Cannot push port ($out) twice")
 
       // No error, just InClosed caused the actual pull to be ignored, but the status flag still needs to be flipped


### PR DESCRIPTION
Backport of https://github.com/akka/akka/issues/22061