### PR TITLE
reduce allocations in ActorModelSpec, #22085

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -115,11 +115,16 @@ object ActorModelSpec {
     val stops = new AtomicLong(0)
 
     def getStats(actorRef: ActorRef) = {
-      val is = new InterceptorStats
-      stats.putIfAbsent(actorRef, is) match {
-        case null  ⇒ is
-        case other ⇒ other
+      stats.get(actorRef) match {
+        case null ⇒
+          val is = new InterceptorStats
+          stats.putIfAbsent(actorRef, is) match {
+            case null  ⇒ is
+            case other ⇒ other
+          }
+        case existing ⇒ existing
       }
+
     }
 
     protected[akka] abstract override def suspend(actor: ActorCell) {
@@ -414,7 +419,7 @@ abstract class ActorModelSpec(config: String) extends AkkaSpec(config) with Defa
         }
       }
       for (run ← 1 to 3) {
-        flood(50000)
+        flood(10000)
         assertDispatcher(dispatcher)(stops = run)
       }
     }


### PR DESCRIPTION
* this reduces the number of allocated AtomicLong instances when running
  BalancingDispatcherModelSpec from 4.2 million to 200 thousand.

Refs #22085