### PR TITLE
fork stream TCK tests

### DIFF
--- a/akka-stream-tests-tck/build.sbt
+++ b/akka-stream-tests-tck/build.sbt
@@ -6,3 +6,9 @@ Formatting.formatSettings
 Dependencies.streamTestsTck
 
 disablePlugins(MimaPlugin)
+
+// These TCK tests are using System.gc(), which
+// is causing long GC pauses when running with G1 on
+// the CI build servers. Therefore we fork these tests
+// to run with small heap without G1. 
+fork in Test := true


### PR DESCRIPTION
The TCK tests are using System.gc(), which
is causing long GC pauses when running with G1 on
the CI build servers. Therefore we fork these tests
to run with small heap without G1.

Example of such pauses:
```
2280.296: [Full GC (System.gc())  2401M->2141M(3072M), 12.8830666 secs]
   [Eden: 66.0M(394.0M)->0.0B(595.0M) Survivors: 32.0M->0.0B Heap: 2401.3M(3072.0M)->2141.4M(3072.0M)], [Metaspace: 338153K->338063K(1337344K)]
 [Times: user=25.04 sys=0.35, real=12.88 secs] 

2326.808: [Full GC (System.gc())  2189M->2137M(3072M), 12.1603666 secs]
   [Eden: 38.0M(578.0M)->0.0B(593.0M) Survivors: 10.0M->0.0B Heap: 2189.3M(3072.0M)->2137.7M(3072.0M)], [Metaspace: 338622K->338622K(1337344K)]
 [Times: user=24.81 sys=0.21, real=12.16 secs]

2364.979: [Full GC (System.gc())  2192M->2134M(3072M), 12.1999061 secs]
   [Eden: 55.0M(593.0M)->0.0B(596.0M) Survivors: 0.0B->0.0B Heap: 2192.6M(3072.0M)->2134.8M(3072.0M)], [Metaspace: 338908K->338908K(1337344K)]
 [Times: user=24.70 sys=0.35, real=12.20 secs] 
```

and there are ~20 more