### PR TITLE
support for Delta-CRDT, #21875

### DIFF
--- a/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
+++ b/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
@@ -12476,6 +12476,1379 @@ public final class ReplicatorMessages {
     // @@protoc_insertion_point(class_scope:akka.cluster.ddata.Gossip)
   }
 
+  public interface DeltaPropagationOrBuilder
+      extends akka.protobuf.MessageOrBuilder {
+
+    // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> 
+        getEntriesList();
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry getEntries(int index);
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    int getEntriesCount();
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> 
+        getEntriesOrBuilderList();
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder getEntriesOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code akka.cluster.ddata.DeltaPropagation}
+   */
+  public static final class DeltaPropagation extends
+      akka.protobuf.GeneratedMessage
+      implements DeltaPropagationOrBuilder {
+    // Use DeltaPropagation.newBuilder() to construct.
+    private DeltaPropagation(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private DeltaPropagation(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final DeltaPropagation defaultInstance;
+    public static DeltaPropagation getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public DeltaPropagation getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final akka.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final akka.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private DeltaPropagation(
+        akka.protobuf.CodedInputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      akka.protobuf.UnknownFieldSet.Builder unknownFields =
+          akka.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              entries_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new akka.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          entries_ = java.util.Collections.unmodifiableList(entries_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final akka.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+    }
+
+    protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Builder.class);
+    }
+
+    public static akka.protobuf.Parser<DeltaPropagation> PARSER =
+        new akka.protobuf.AbstractParser<DeltaPropagation>() {
+      public DeltaPropagation parsePartialFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return new DeltaPropagation(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public akka.protobuf.Parser<DeltaPropagation> getParserForType() {
+      return PARSER;
+    }
+
+    public interface EntryOrBuilder
+        extends akka.protobuf.MessageOrBuilder {
+
+      // required string key = 1;
+      /**
+       * <code>required string key = 1;</code>
+       */
+      boolean hasKey();
+      /**
+       * <code>required string key = 1;</code>
+       */
+      java.lang.String getKey();
+      /**
+       * <code>required string key = 1;</code>
+       */
+      akka.protobuf.ByteString
+          getKeyBytes();
+
+      // required .akka.cluster.ddata.DataEnvelope envelope = 2;
+      /**
+       * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+       */
+      boolean hasEnvelope();
+      /**
+       * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope getEnvelope();
+      /**
+       * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder getEnvelopeOrBuilder();
+    }
+    /**
+     * Protobuf type {@code akka.cluster.ddata.DeltaPropagation.Entry}
+     */
+    public static final class Entry extends
+        akka.protobuf.GeneratedMessage
+        implements EntryOrBuilder {
+      // Use Entry.newBuilder() to construct.
+      private Entry(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+        super(builder);
+        this.unknownFields = builder.getUnknownFields();
+      }
+      private Entry(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+      private static final Entry defaultInstance;
+      public static Entry getDefaultInstance() {
+        return defaultInstance;
+      }
+
+      public Entry getDefaultInstanceForType() {
+        return defaultInstance;
+      }
+
+      private final akka.protobuf.UnknownFieldSet unknownFields;
+      @java.lang.Override
+      public final akka.protobuf.UnknownFieldSet
+          getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Entry(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        initFields();
+        int mutable_bitField0_ = 0;
+        akka.protobuf.UnknownFieldSet.Builder unknownFields =
+            akka.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 10: {
+                bitField0_ |= 0x00000001;
+                key_ = input.readBytes();
+                break;
+              }
+              case 18: {
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                  subBuilder = envelope_.toBuilder();
+                }
+                envelope_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(envelope_);
+                  envelope_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000002;
+                break;
+              }
+            }
+          }
+        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new akka.protobuf.InvalidProtocolBufferException(
+              e.getMessage()).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final akka.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+      }
+
+      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder.class);
+      }
+
+      public static akka.protobuf.Parser<Entry> PARSER =
+          new akka.protobuf.AbstractParser<Entry>() {
+        public Entry parsePartialFrom(
+            akka.protobuf.CodedInputStream input,
+            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobuf.InvalidProtocolBufferException {
+          return new Entry(input, extensionRegistry);
+        }
+      };
+
+      @java.lang.Override
+      public akka.protobuf.Parser<Entry> getParserForType() {
+        return PARSER;
+      }
+
+      private int bitField0_;
+      // required string key = 1;
+      public static final int KEY_FIELD_NUMBER = 1;
+      private java.lang.Object key_;
+      /**
+       * <code>required string key = 1;</code>
+       */
+      public boolean hasKey() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required string key = 1;</code>
+       */
+      public java.lang.String getKey() {
+        java.lang.Object ref = key_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          akka.protobuf.ByteString bs = 
+              (akka.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            key_ = s;
+          }
+          return s;
+        }
+      }
+      /**
+       * <code>required string key = 1;</code>
+       */
+      public akka.protobuf.ByteString
+          getKeyBytes() {
+        java.lang.Object ref = key_;
+        if (ref instanceof java.lang.String) {
+          akka.protobuf.ByteString b = 
+              akka.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          key_ = b;
+          return b;
+        } else {
+          return (akka.protobuf.ByteString) ref;
+        }
+      }
+
+      // required .akka.cluster.ddata.DataEnvelope envelope = 2;
+      public static final int ENVELOPE_FIELD_NUMBER = 2;
+      private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope envelope_;
+      /**
+       * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+       */
+      public boolean hasEnvelope() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope getEnvelope() {
+        return envelope_;
+      }
+      /**
+       * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder getEnvelopeOrBuilder() {
+        return envelope_;
+      }
+
+      private void initFields() {
+        key_ = "";
+        envelope_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.getDefaultInstance();
+      }
+      private byte memoizedIsInitialized = -1;
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized != -1) return isInitialized == 1;
+
+        if (!hasKey()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!hasEnvelope()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!getEnvelope().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      public void writeTo(akka.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        getSerializedSize();
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeBytes(1, getKeyBytes());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          output.writeMessage(2, envelope_);
+        }
+        getUnknownFields().writeTo(output);
+      }
+
+      private int memoizedSerializedSize = -1;
+      public int getSerializedSize() {
+        int size = memoizedSerializedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeBytesSize(1, getKeyBytes());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeMessageSize(2, envelope_);
+        }
+        size += getUnknownFields().getSerializedSize();
+        memoizedSerializedSize = size;
+        return size;
+      }
+
+      private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      protected java.lang.Object writeReplace()
+          throws java.io.ObjectStreamException {
+        return super.writeReplace();
+      }
+
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(
+          akka.protobuf.ByteString data)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(
+          akka.protobuf.ByteString data,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(byte[] data)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(
+          byte[] data,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(
+          java.io.InputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseDelimitedFrom(
+          java.io.InputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(
+          akka.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+
+      public static Builder newBuilder() { return Builder.create(); }
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry prototype) {
+        return newBuilder().mergeFrom(prototype);
+      }
+      public Builder toBuilder() { return newBuilder(this); }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          akka.protobuf.GeneratedMessage.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code akka.cluster.ddata.DeltaPropagation.Entry}
+       */
+      public static final class Builder extends
+          akka.protobuf.GeneratedMessage.Builder<Builder>
+         implements akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder {
+        public static final akka.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+        }
+
+        protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder.class);
+        }
+
+        // Construct using akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            akka.protobuf.GeneratedMessage.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            getEnvelopeFieldBuilder();
+          }
+        }
+        private static Builder create() {
+          return new Builder();
+        }
+
+        public Builder clear() {
+          super.clear();
+          key_ = "";
+          bitField0_ = (bitField0_ & ~0x00000001);
+          if (envelopeBuilder_ == null) {
+            envelope_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.getDefaultInstance();
+          } else {
+            envelopeBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+
+        public Builder clone() {
+          return create().mergeFrom(buildPartial());
+        }
+
+        public akka.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry getDefaultInstanceForType() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.getDefaultInstance();
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry build() {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry buildPartial() {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry result = new akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.key_ = key_;
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000002;
+          }
+          if (envelopeBuilder_ == null) {
+            result.envelope_ = envelope_;
+          } else {
+            result.envelope_ = envelopeBuilder_.build();
+          }
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        public Builder mergeFrom(akka.protobuf.Message other) {
+          if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry) {
+            return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry other) {
+          if (other == akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.getDefaultInstance()) return this;
+          if (other.hasKey()) {
+            bitField0_ |= 0x00000001;
+            key_ = other.key_;
+            onChanged();
+          }
+          if (other.hasEnvelope()) {
+            mergeEnvelope(other.getEnvelope());
+          }
+          this.mergeUnknownFields(other.getUnknownFields());
+          return this;
+        }
+
+        public final boolean isInitialized() {
+          if (!hasKey()) {
+            
+            return false;
+          }
+          if (!hasEnvelope()) {
+            
+            return false;
+          }
+          if (!getEnvelope().isInitialized()) {
+            
+            return false;
+          }
+          return true;
+        }
+
+        public Builder mergeFrom(
+            akka.protobuf.CodedInputStream input,
+            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (akka.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry) e.getUnfinishedMessage();
+            throw e;
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        // required string key = 1;
+        private java.lang.Object key_ = "";
+        /**
+         * <code>required string key = 1;</code>
+         */
+        public boolean hasKey() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <code>required string key = 1;</code>
+         */
+        public java.lang.String getKey() {
+          java.lang.Object ref = key_;
+          if (!(ref instanceof java.lang.String)) {
+            java.lang.String s = ((akka.protobuf.ByteString) ref)
+                .toStringUtf8();
+            key_ = s;
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <code>required string key = 1;</code>
+         */
+        public akka.protobuf.ByteString
+            getKeyBytes() {
+          java.lang.Object ref = key_;
+          if (ref instanceof String) {
+            akka.protobuf.ByteString b = 
+                akka.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            key_ = b;
+            return b;
+          } else {
+            return (akka.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <code>required string key = 1;</code>
+         */
+        public Builder setKey(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+          key_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required string key = 1;</code>
+         */
+        public Builder clearKey() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          key_ = getDefaultInstance().getKey();
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required string key = 1;</code>
+         */
+        public Builder setKeyBytes(
+            akka.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+          key_ = value;
+          onChanged();
+          return this;
+        }
+
+        // required .akka.cluster.ddata.DataEnvelope envelope = 2;
+        private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope envelope_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.getDefaultInstance();
+        private akka.protobuf.SingleFieldBuilder<
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder> envelopeBuilder_;
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public boolean hasEnvelope() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope getEnvelope() {
+          if (envelopeBuilder_ == null) {
+            return envelope_;
+          } else {
+            return envelopeBuilder_.getMessage();
+          }
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public Builder setEnvelope(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope value) {
+          if (envelopeBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            envelope_ = value;
+            onChanged();
+          } else {
+            envelopeBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public Builder setEnvelope(
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder builderForValue) {
+          if (envelopeBuilder_ == null) {
+            envelope_ = builderForValue.build();
+            onChanged();
+          } else {
+            envelopeBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public Builder mergeEnvelope(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope value) {
+          if (envelopeBuilder_ == null) {
+            if (((bitField0_ & 0x00000002) == 0x00000002) &&
+                envelope_ != akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.getDefaultInstance()) {
+              envelope_ =
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.newBuilder(envelope_).mergeFrom(value).buildPartial();
+            } else {
+              envelope_ = value;
+            }
+            onChanged();
+          } else {
+            envelopeBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public Builder clearEnvelope() {
+          if (envelopeBuilder_ == null) {
+            envelope_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.getDefaultInstance();
+            onChanged();
+          } else {
+            envelopeBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder getEnvelopeBuilder() {
+          bitField0_ |= 0x00000002;
+          onChanged();
+          return getEnvelopeFieldBuilder().getBuilder();
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder getEnvelopeOrBuilder() {
+          if (envelopeBuilder_ != null) {
+            return envelopeBuilder_.getMessageOrBuilder();
+          } else {
+            return envelope_;
+          }
+        }
+        /**
+         * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
+         */
+        private akka.protobuf.SingleFieldBuilder<
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder> 
+            getEnvelopeFieldBuilder() {
+          if (envelopeBuilder_ == null) {
+            envelopeBuilder_ = new akka.protobuf.SingleFieldBuilder<
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder>(
+                    envelope_,
+                    getParentForChildren(),
+                    isClean());
+            envelope_ = null;
+          }
+          return envelopeBuilder_;
+        }
+
+        // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.DeltaPropagation.Entry)
+      }
+
+      static {
+        defaultInstance = new Entry(true);
+        defaultInstance.initFields();
+      }
+
+      // @@protoc_insertion_point(class_scope:akka.cluster.ddata.DeltaPropagation.Entry)
+    }
+
+    // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;
+    public static final int ENTRIES_FIELD_NUMBER = 1;
+    private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> entries_;
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> getEntriesList() {
+      return entries_;
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> 
+        getEntriesOrBuilderList() {
+      return entries_;
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    public int getEntriesCount() {
+      return entries_.size();
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry getEntries(int index) {
+      return entries_.get(index);
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder getEntriesOrBuilder(
+        int index) {
+      return entries_.get(index);
+    }
+
+    private void initFields() {
+      entries_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      for (int i = 0; i < getEntriesCount(); i++) {
+        if (!getEntries(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(akka.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < entries_.size(); i++) {
+        output.writeMessage(1, entries_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < entries_.size(); i++) {
+        size += akka.protobuf.CodedOutputStream
+          .computeMessageSize(1, entries_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(
+        akka.protobuf.ByteString data)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(
+        akka.protobuf.ByteString data,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(byte[] data)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(
+        byte[] data,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(
+        java.io.InputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseDelimitedFrom(
+        java.io.InputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(
+        akka.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseFrom(
+        akka.protobuf.CodedInputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code akka.cluster.ddata.DeltaPropagation}
+     */
+    public static final class Builder extends
+        akka.protobuf.GeneratedMessage.Builder<Builder>
+       implements akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagationOrBuilder {
+      public static final akka.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+      }
+
+      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Builder.class);
+      }
+
+      // Construct using akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          akka.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getEntriesFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          entriesBuilder_.clear();
+        }
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public akka.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation getDefaultInstanceForType() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.getDefaultInstance();
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation build() {
+        akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation buildPartial() {
+        akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation result = new akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation(this);
+        int from_bitField0_ = bitField0_;
+        if (entriesBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            entries_ = java.util.Collections.unmodifiableList(entries_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.entries_ = entries_;
+        } else {
+          result.entries_ = entriesBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(akka.protobuf.Message other) {
+        if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation) {
+          return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation other) {
+        if (other == akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.getDefaultInstance()) return this;
+        if (entriesBuilder_ == null) {
+          if (!other.entries_.isEmpty()) {
+            if (entries_.isEmpty()) {
+              entries_ = other.entries_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureEntriesIsMutable();
+              entries_.addAll(other.entries_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.entries_.isEmpty()) {
+            if (entriesBuilder_.isEmpty()) {
+              entriesBuilder_.dispose();
+              entriesBuilder_ = null;
+              entries_ = other.entries_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              entriesBuilder_ = 
+                akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getEntriesFieldBuilder() : null;
+            } else {
+              entriesBuilder_.addAllMessages(other.entries_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        for (int i = 0; i < getEntriesCount(); i++) {
+          if (!getEntries(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;
+      private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> entries_ =
+        java.util.Collections.emptyList();
+      private void ensureEntriesIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry>(entries_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private akka.protobuf.RepeatedFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> entriesBuilder_;
+
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> getEntriesList() {
+        if (entriesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(entries_);
+        } else {
+          return entriesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public int getEntriesCount() {
+        if (entriesBuilder_ == null) {
+          return entries_.size();
+        } else {
+          return entriesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry getEntries(int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);
+        } else {
+          return entriesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder setEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.set(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder setEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder addEntries(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder addAllEntries(
+          java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> values) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          super.addAll(values, entries_);
+          onChanged();
+        } else {
+          entriesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder clearEntries() {
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          entriesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public Builder removeEntries(int index) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.remove(index);
+          onChanged();
+        } else {
+          entriesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder getEntriesBuilder(
+          int index) {
+        return getEntriesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder getEntriesOrBuilder(
+          int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);  } else {
+          return entriesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> 
+           getEntriesOrBuilderList() {
+        if (entriesBuilder_ != null) {
+          return entriesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(entries_);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder addEntriesBuilder() {
+        return getEntriesFieldBuilder().addBuilder(
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder addEntriesBuilder(
+          int index) {
+        return getEntriesFieldBuilder().addBuilder(
+            index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       */
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder> 
+           getEntriesBuilderList() {
+        return getEntriesFieldBuilder().getBuilderList();
+      }
+      private akka.protobuf.RepeatedFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> 
+          getEntriesFieldBuilder() {
+        if (entriesBuilder_ == null) {
+          entriesBuilder_ = new akka.protobuf.RepeatedFieldBuilder<
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder>(
+                  entries_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          entries_ = null;
+        }
+        return entriesBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.DeltaPropagation)
+    }
+
+    static {
+      defaultInstance = new DeltaPropagation(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:akka.cluster.ddata.DeltaPropagation)
+  }
+
   public interface UniqueAddressOrBuilder
       extends akka.protobuf.MessageOrBuilder {
 
@@ -15829,6 +17202,16 @@ public final class ReplicatorMessages {
     akka.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_akka_cluster_ddata_Gossip_Entry_fieldAccessorTable;
   private static akka.protobuf.Descriptors.Descriptor
+    internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
+  private static
+    akka.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable;
+  private static akka.protobuf.Descriptors.Descriptor
+    internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
+  private static
+    akka.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable;
+  private static akka.protobuf.Descriptors.Descriptor
     internal_static_akka_cluster_ddata_UniqueAddress_descriptor;
   private static
     akka.protobuf.GeneratedMessage.FieldAccessorTable
@@ -15902,18 +17285,22 @@ public final class ReplicatorMessages {
       "\n\006Gossip\022\020\n\010sendBack\030\001 \002(\010\0221\n\007entries\030\002 " +
       "\003(\0132 .akka.cluster.ddata.Gossip.Entry\032H\n" +
       "\005Entry\022\013\n\003key\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .",
-      "akka.cluster.ddata.DataEnvelope\"X\n\rUniqu" +
-      "eAddress\022,\n\007address\030\001 \002(\0132\033.akka.cluster" +
-      ".ddata.Address\022\013\n\003uid\030\002 \002(\017\022\014\n\004uid2\030\003 \001(" +
-      "\017\")\n\007Address\022\020\n\010hostname\030\001 \002(\t\022\014\n\004port\030\002" +
-      " \002(\r\"V\n\014OtherMessage\022\027\n\017enclosedMessage\030" +
-      "\001 \002(\014\022\024\n\014serializerId\030\002 \002(\005\022\027\n\017messageMa" +
-      "nifest\030\004 \001(\014\"\036\n\nStringGSet\022\020\n\010elements\030\001" +
-      " \003(\t\"\205\001\n\023DurableDataEnvelope\022.\n\004data\030\001 \002" +
-      "(\0132 .akka.cluster.ddata.OtherMessage\022>\n\007" +
-      "pruning\030\002 \003(\0132-.akka.cluster.ddata.DataE",
-      "nvelope.PruningEntryB#\n\037akka.cluster.dda" +
-      "ta.protobuf.msgH\001"
+      "akka.cluster.ddata.DataEnvelope\"\231\001\n\020Delt" +
+      "aPropagation\022;\n\007entries\030\001 \003(\0132*.akka.clu" +
+      "ster.ddata.DeltaPropagation.Entry\032H\n\005Ent" +
+      "ry\022\013\n\003key\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .akka" +
+      ".cluster.ddata.DataEnvelope\"X\n\rUniqueAdd" +
+      "ress\022,\n\007address\030\001 \002(\0132\033.akka.cluster.dda" +
+      "ta.Address\022\013\n\003uid\030\002 \002(\017\022\014\n\004uid2\030\003 \001(\017\")\n" +
+      "\007Address\022\020\n\010hostname\030\001 \002(\t\022\014\n\004port\030\002 \002(\r" +
+      "\"V\n\014OtherMessage\022\027\n\017enclosedMessage\030\001 \002(" +
+      "\014\022\024\n\014serializerId\030\002 \002(\005\022\027\n\017messageManife",
+      "st\030\004 \001(\014\"\036\n\nStringGSet\022\020\n\010elements\030\001 \003(\t" +
+      "\"\205\001\n\023DurableDataEnvelope\022.\n\004data\030\001 \002(\0132 " +
+      ".akka.cluster.ddata.OtherMessage\022>\n\007prun" +
+      "ing\030\002 \003(\0132-.akka.cluster.ddata.DataEnvel" +
+      "ope.PruningEntryB#\n\037akka.cluster.ddata.p" +
+      "rotobuf.msgH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -16022,32 +17409,44 @@ public final class ReplicatorMessages {
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_Gossip_Entry_descriptor,
               new java.lang.String[] { "Key", "Envelope", });
-          internal_static_akka_cluster_ddata_UniqueAddress_descriptor =
+          internal_static_akka_cluster_ddata_DeltaPropagation_descriptor =
             getDescriptor().getMessageTypes().get(14);
+          internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable = new
+            akka.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_akka_cluster_ddata_DeltaPropagation_descriptor,
+              new java.lang.String[] { "Entries", });
+          internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor =
+            internal_static_akka_cluster_ddata_DeltaPropagation_descriptor.getNestedTypes().get(0);
+          internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable = new
+            akka.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor,
+              new java.lang.String[] { "Key", "Envelope", });
+          internal_static_akka_cluster_ddata_UniqueAddress_descriptor =
+            getDescriptor().getMessageTypes().get(15);
           internal_static_akka_cluster_ddata_UniqueAddress_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_UniqueAddress_descriptor,
               new java.lang.String[] { "Address", "Uid", "Uid2", });
           internal_static_akka_cluster_ddata_Address_descriptor =
-            getDescriptor().getMessageTypes().get(15);
+            getDescriptor().getMessageTypes().get(16);
           internal_static_akka_cluster_ddata_Address_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_Address_descriptor,
               new java.lang.String[] { "Hostname", "Port", });
           internal_static_akka_cluster_ddata_OtherMessage_descriptor =
-            getDescriptor().getMessageTypes().get(16);
+            getDescriptor().getMessageTypes().get(17);
           internal_static_akka_cluster_ddata_OtherMessage_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_OtherMessage_descriptor,
               new java.lang.String[] { "EnclosedMessage", "SerializerId", "MessageManifest", });
           internal_static_akka_cluster_ddata_StringGSet_descriptor =
-            getDescriptor().getMessageTypes().get(17);
+            getDescriptor().getMessageTypes().get(18);
           internal_static_akka_cluster_ddata_StringGSet_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_StringGSet_descriptor,
               new java.lang.String[] { "Elements", });
           internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor =
-            getDescriptor().getMessageTypes().get(18);
+            getDescriptor().getMessageTypes().get(19);
           internal_static_akka_cluster_ddata_DurableDataEnvelope_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor,

--- a/akka-distributed-data/src/main/protobuf/ReplicatorMessages.proto
+++ b/akka-distributed-data/src/main/protobuf/ReplicatorMessages.proto
@@ -96,6 +96,15 @@ message Gossip {
   repeated Entry entries = 2;
 }
 
+message DeltaPropagation {
+  message Entry {
+    required string key = 1;
+    required DataEnvelope envelope = 2;
+  }
+  
+  repeated Entry entries = 1;
+}
+
 message UniqueAddress {
   required Address address = 1;
   required sfixed32 uid = 2;

--- a/akka-distributed-data/src/main/resources/reference.conf
+++ b/akka-distributed-data/src/main/resources/reference.conf
@@ -18,7 +18,7 @@ akka.cluster.distributed-data {
 
   # How often the Replicator should send out gossip information
   gossip-interval = 2 s
-
+  
   # How often the subscribers will be notified of changes, if any
   notify-subscribers-interval = 500 ms
 
@@ -57,6 +57,12 @@ akka.cluster.distributed-data {
   # several nodes. If no further activity they are removed from the cache
   # after this duration.
   serializer-cache-time-to-live = 10s
+  
+  # Settings for delta-CRDT
+  delta-crdt {
+    # enable or disable delta-CRDT replication
+    enabled = on
+  }
   
   durable {
     # List of keys that are durable. Prefix matching is supported by using * at the

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/DeltaPropagationSelector.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/DeltaPropagationSelector.scala
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.ddata
+
+import scala.collection.immutable.TreeMap
+import akka.cluster.ddata.Replicator.Internal.DeltaPropagation
+import akka.actor.Address
+import akka.cluster.ddata.Replicator.Internal.DataEnvelope
+
+/**
+ * INTERNAL API: Used by the Replicator actor.
+ * Extracted to separate trait to make it easy to test.
+ */
+private[akka] trait DeltaPropagationSelector {
+
+  private var _propagationCount = 0L
+  def propagationCount: Long = _propagationCount
+  private var deltaCounter = Map.empty[String, Long]
+  private var deltaEntries = Map.empty[String, TreeMap[Long, ReplicatedData]]
+  private var deltaSentToNode = Map.empty[String, Map[Address, Long]]
+  private var deltaNodeRoundRobinCounter = 0L
+
+  def divisor: Int
+
+  def allNodes: Vector[Address]
+
+  def createDeltaPropagation(deltas: Map[String, ReplicatedData]): DeltaPropagation
+
+  def update(key: String, delta: ReplicatedData): Unit = {
+    val c = deltaCounter.get(key) match {
+      case Some(c) ⇒ c
+      case None ⇒
+        deltaCounter = deltaCounter.updated(key, 1L)
+        1L
+    }
+    val deltaEntriesForKey = deltaEntries.getOrElse(key, TreeMap.empty[Long, ReplicatedData])
+    val updatedEntriesForKey =
+      deltaEntriesForKey.get(c) match {
+        case Some(existingDelta) ⇒
+          deltaEntriesForKey.updated(c, existingDelta.merge(delta.asInstanceOf[existingDelta.T]))
+        case None ⇒
+          deltaEntriesForKey.updated(c, delta)
+      }
+    deltaEntries = deltaEntries.updated(key, updatedEntriesForKey)
+  }
+
+  def delete(key: String): Unit = {
+    deltaEntries -= key
+    deltaCounter -= key
+    deltaSentToNode -= key
+  }
+
+  def nodesSliceSize(allNodesSize: Int): Int = {
+    // 2 - 10 nodes
+    math.min(math.max((allNodesSize / divisor) + 1, 2), math.min(allNodesSize, 10))
+  }
+
+  def collectPropagations(): Map[Address, DeltaPropagation] = {
+    _propagationCount += 1
+    val all = allNodes
+    if (all.isEmpty)
+      Map.empty
+    else {
+      // For each tick we pick a few nodes in round-robin fashion, 2 - 10 nodes for each tick.
+      // Normally the delta is propagated to all nodes within the gossip tick, so that
+      // full state gossip is not needed.
+      val sliceSize = nodesSliceSize(all.size)
+      val slice = {
+        if (all.size <= sliceSize)
+          all
+        else {
+          val i = (deltaNodeRoundRobinCounter % all.size).toInt
+          val first = all.slice(i, i + sliceSize)
+          if (first.size == sliceSize) first
+          else first ++ all.take(sliceSize - first.size)
+        }
+      }
+      deltaNodeRoundRobinCounter += sliceSize
+
+      var result = Map.empty[Address, DeltaPropagation]
+
+      slice.foreach { node ⇒
+        // collect the deltas that have not already been sent to the node and merge
+        // them into a delta group
+        var deltas = Map.empty[String, ReplicatedData]
+        deltaEntries.foreach {
+          case (key, entries) ⇒
+            val deltaSentToNodeForKey = deltaSentToNode.getOrElse(key, TreeMap.empty[Address, Long])
+            val j = deltaSentToNodeForKey.getOrElse(node, 0L)
+            val deltaEntriesAfterJ = deltaEntriesAfter(entries, j)
+            if (deltaEntriesAfterJ.nonEmpty) {
+              val deltaGroup = deltaEntriesAfterJ.valuesIterator.reduceLeft {
+                (d1, d2) ⇒ d1.merge(d2.asInstanceOf[d1.T])
+              }
+              deltas = deltas.updated(key, deltaGroup)
+              deltaSentToNode = deltaSentToNode.updated(key, deltaSentToNodeForKey.updated(node, deltaEntriesAfterJ.lastKey))
+            }
+        }
+
+        if (deltas.nonEmpty) {
+          // Important to include the pruning state in the deltas. For example if the delta is based
+          // on an entry that has been pruned but that has not yet been performed on the target node.
+          val deltaPropagation = createDeltaPropagation(deltas)
+          result = result.updated(node, deltaPropagation)
+        }
+      }
+
+      // increase the counter
+      deltaCounter = deltaCounter.map {
+        case (key, value) ⇒
+          if (deltaEntries.contains(key))
+            key → (value + 1)
+          else
+            key → value
+      }
+
+      result
+    }
+  }
+
+  private def deltaEntriesAfter(entries: TreeMap[Long, ReplicatedData], version: Long): TreeMap[Long, ReplicatedData] =
+    entries.from(version) match {
+      case ntrs if ntrs.isEmpty             ⇒ ntrs
+      case ntrs if ntrs.firstKey == version ⇒ ntrs.tail // exclude first, i.e. version j that was already sent
+      case ntrs                             ⇒ ntrs
+    }
+
+  def hasDeltaEntries(key: String): Boolean = {
+    deltaEntries.get(key) match {
+      case Some(m) ⇒ m.nonEmpty
+      case None    ⇒ false
+    }
+  }
+
+  private def findSmallestVersionPropagatedToAllNodes(key: String, all: Vector[Address]): Long = {
+    deltaSentToNode.get(key) match {
+      case None ⇒ 0L
+      case Some(deltaSentToNodeForKey) ⇒
+        if (deltaSentToNodeForKey.isEmpty) 0L
+        else if (all.exists(node ⇒ !deltaSentToNodeForKey.contains(node))) 0L
+        else deltaSentToNodeForKey.valuesIterator.min
+    }
+  }
+
+  def cleanupDeltaEntries(): Unit = {
+    val all = allNodes
+    if (all.isEmpty)
+      deltaEntries = Map.empty
+    else {
+      deltaEntries = deltaEntries.map {
+        case (key, entries) ⇒
+          val minVersion = findSmallestVersionPropagatedToAllNodes(key, all)
+
+          val deltaEntriesAfterMin = deltaEntriesAfter(entries, minVersion)
+
+          // TODO perhaps also remove oldest when deltaCounter are too far ahead (e.g. 10 cylces)
+
+          key → deltaEntriesAfterMin
+      }
+    }
+  }
+
+  def cleanupRemovedNode(address: Address): Unit = {
+    deltaSentToNode = deltaSentToNode.map {
+      case (key, deltaSentToNodeForKey) ⇒
+        key → (deltaSentToNodeForKey - address)
+    }
+  }
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
@@ -39,8 +39,9 @@ object GCounter {
  */
 @SerialVersionUID(1L)
 final class GCounter private[akka] (
-  private[akka] val state: Map[UniqueAddress, BigInt] = Map.empty)
-  extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning with FastMerge {
+  private[akka] val state:  Map[UniqueAddress, BigInt] = Map.empty,
+  private[akka] val _delta: Option[GCounter]           = None)
+  extends DeltaReplicatedData with ReplicatedDataSerialization with RemovedNodePruning with FastMerge {
 
   import GCounter.Zero
 
@@ -57,17 +58,17 @@ final class GCounter private[akka] (
   def getValue: BigInteger = value.bigInteger
 
   /**
-   * Increment the counter with the delta specified.
+   * Increment the counter with the delta `n` specified.
    * The delta must be zero or positive.
    */
-  def +(delta: Long)(implicit node: Cluster): GCounter = increment(node, delta)
+  def +(n: Long)(implicit node: Cluster): GCounter = increment(node, n)
 
   /**
-   * Increment the counter with the delta specified.
-   * The delta must be zero or positive.
+   * Increment the counter with the delta `n` specified.
+   * The delta `n` must be zero or positive.
    */
-  def increment(node: Cluster, delta: Long = 1): GCounter =
-    increment(node.selfUniqueAddress, delta)
+  def increment(node: Cluster, n: Long = 1): GCounter =
+    increment(node.selfUniqueAddress, n)
 
   /**
    * INTERNAL API
@@ -77,14 +78,19 @@ final class GCounter private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def increment(key: UniqueAddress, delta: BigInt): GCounter = {
-    require(delta >= 0, "Can't decrement a GCounter")
-    if (delta == 0) this
-    else state.get(key) match {
-      case Some(v) ⇒
-        val tot = v + delta
-        assignAncestor(new GCounter(state + (key → tot)))
-      case None ⇒ assignAncestor(new GCounter(state + (key → delta)))
+  private[akka] def increment(key: UniqueAddress, n: BigInt): GCounter = {
+    require(n >= 0, "Can't decrement a GCounter")
+    if (n == 0) this
+    else {
+      val nextValue = state.get(key) match {
+        case Some(v) ⇒ v + n
+        case None    ⇒ n
+      }
+      val newDelta = _delta match {
+        case Some(d) ⇒ Some(new GCounter(d.state + (key → nextValue)))
+        case None    ⇒ Some(new GCounter(Map(key → nextValue)))
+      }
+      assignAncestor(new GCounter(state + (key → nextValue), newDelta))
     }
   }
 
@@ -101,6 +107,13 @@ final class GCounter private[akka] (
       clearAncestor()
       new GCounter(merged)
     }
+
+  override def delta: GCounter = _delta match {
+    case Some(d) ⇒ d
+    case None    ⇒ GCounter.empty
+  }
+
+  override def resetDelta: GCounter = new GCounter(state)
 
   override def modifiedByNodes: Set[UniqueAddress] = state.keySet
 

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
@@ -1,0 +1,205 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.ddata
+
+import java.util.concurrent.ThreadLocalRandom
+
+import scala.concurrent.duration._
+
+import akka.cluster.Cluster
+import akka.cluster.ddata.Replicator._
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+
+object ReplicatorDeltaSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+  val fourth = role("fourth")
+
+  commonConfig(ConfigFactory.parseString("""
+    akka.actor.provider = "cluster"
+    akka.log-dead-letters-during-shutdown = off
+    """))
+
+  testTransport(on = true)
+
+  sealed trait Op
+  final case class Delay(n: Int) extends Op
+  final case class Incr(key: PNCounterKey, n: Int, consistency: WriteConsistency) extends Op
+  final case class Decr(key: PNCounterKey, n: Int, consistency: WriteConsistency) extends Op
+
+  val timeout = 5.seconds
+  val writeTwo = WriteTo(2, timeout)
+  val writeMajority = WriteMajority(timeout)
+
+  val KeyA = PNCounterKey("A")
+  val KeyB = PNCounterKey("B")
+  val KeyC = PNCounterKey("C")
+
+  def generateOperations(): Vector[Op] = {
+    val rnd = ThreadLocalRandom.current()
+
+    def consistency(): WriteConsistency = {
+      rnd.nextInt(100) match {
+        case n if n < 90  ⇒ WriteLocal
+        case n if n < 95  ⇒ writeTwo
+        case n if n < 100 ⇒ writeMajority
+      }
+    }
+
+    def key(): PNCounterKey = {
+      rnd.nextInt(3) match {
+        case 0 ⇒ KeyA
+        case 1 ⇒ KeyB
+        case 2 ⇒ KeyC
+      }
+    }
+
+    (0 to (20 + rnd.nextInt(10))).map { _ ⇒
+      rnd.nextInt(3) match {
+        case 0 ⇒ Delay(rnd.nextInt(500))
+        case 1 ⇒ Incr(key(), rnd.nextInt(100), consistency())
+        case 2 ⇒ Decr(key(), rnd.nextInt(10), consistency())
+      }
+    }.toVector
+  }
+
+}
+
+class ReplicatorDeltaSpecMultiJvmNode1 extends ReplicatorDeltaSpec
+class ReplicatorDeltaSpecMultiJvmNode2 extends ReplicatorDeltaSpec
+class ReplicatorDeltaSpecMultiJvmNode3 extends ReplicatorDeltaSpec
+class ReplicatorDeltaSpecMultiJvmNode4 extends ReplicatorDeltaSpec
+
+class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMultiNodeSpec with ImplicitSender {
+  import Replicator._
+  import ReplicatorDeltaSpec._
+
+  override def initialParticipants = roles.size
+
+  implicit val cluster = Cluster(system)
+  val fullStateReplicator = system.actorOf(Replicator.props(
+    ReplicatorSettings(system).withGossipInterval(1.second).withDeltaCrdtEnabled(false)), "fullStateReplicator")
+  val deltaReplicator = {
+    val r = system.actorOf(Replicator.props(ReplicatorSettings(system)), "deltaReplicator")
+    r ! Replicator.Internal.TestFullStateGossip(enabled = false)
+    r
+  }
+
+  var afterCounter = 0
+  def enterBarrierAfterTestStep(): Unit = {
+    afterCounter += 1
+    enterBarrier("after-" + afterCounter)
+  }
+
+  def join(from: RoleName, to: RoleName): Unit = {
+    runOn(from) {
+      cluster join node(to).address
+    }
+    enterBarrier(from.name + "-joined")
+  }
+
+  "delta-CRDT" must {
+    "join cluster" in {
+      join(first, first)
+      join(second, first)
+      join(third, first)
+      join(fourth, first)
+
+      within(15.seconds) {
+        awaitAssert {
+          fullStateReplicator ! GetReplicaCount
+          expectMsg(ReplicaCount(4))
+        }
+      }
+
+      enterBarrierAfterTestStep()
+    }
+
+    "propagate delta" in {
+      join(first, first)
+      join(second, first)
+      join(third, first)
+      join(fourth, first)
+
+      within(15.seconds) {
+        awaitAssert {
+          fullStateReplicator ! GetReplicaCount
+          expectMsg(ReplicaCount(4))
+        }
+      }
+      enterBarrier("ready")
+
+      runOn(first) {
+        fullStateReplicator ! Update(KeyA, PNCounter.empty, WriteLocal)(_ + 1)
+        deltaReplicator ! Update(KeyA, PNCounter.empty, WriteLocal)(_ + 1)
+      }
+      enterBarrier("updated-1")
+
+      within(5.seconds) {
+        awaitAssert {
+          val p = TestProbe()
+          deltaReplicator.tell(Get(KeyA, ReadLocal), p.ref)
+          p.expectMsgType[GetSuccess[PNCounter]].dataValue.getValue.intValue should be(1)
+        }
+        awaitAssert {
+          val p = TestProbe()
+          deltaReplicator.tell(Get(KeyA, ReadLocal), p.ref)
+          p.expectMsgType[GetSuccess[PNCounter]].dataValue.getValue.intValue should be(1)
+        }
+      }
+
+      enterBarrierAfterTestStep()
+    }
+
+    "be eventually consistent" in {
+      val operations = generateOperations()
+      log.debug(s"random operations on [${myself.name}]: ${operations.mkString(", ")}")
+      try {
+        // perform random operations with both delta and full-state replicators
+        // and compare that the end result is the same
+
+        for (op ← operations) {
+          log.debug("operation: {}", op)
+          op match {
+            case Delay(d) ⇒ Thread.sleep(d)
+            case Incr(key, n, consistency) ⇒
+              fullStateReplicator ! Update(key, PNCounter.empty, consistency)(_ + n)
+              deltaReplicator ! Update(key, PNCounter.empty, WriteLocal)(_ + n)
+            case Decr(key, n, consistency) ⇒
+              fullStateReplicator ! Update(key, PNCounter.empty, consistency)(_ - n)
+              deltaReplicator ! Update(key, PNCounter.empty, WriteLocal)(_ - n)
+          }
+        }
+
+        enterBarrier("updated-2")
+
+        List(KeyA, KeyB, KeyC).foreach { key ⇒
+          within(5.seconds) {
+            awaitAssert {
+              val p = TestProbe()
+              fullStateReplicator.tell(Get(key, ReadLocal), p.ref)
+              val fullStateValue = p.expectMsgType[GetSuccess[PNCounter]].dataValue
+              deltaReplicator.tell(Get(key, ReadLocal), p.ref)
+              val deltaValue = p.expectMsgType[GetSuccess[PNCounter]].dataValue
+              deltaValue should ===(fullStateValue)
+            }
+          }
+        }
+
+        enterBarrierAfterTestStep()
+      } catch {
+        case e: Throwable ⇒
+          info(s"random operations on [${myself.name}]: ${operations.mkString(", ")}")
+          throw e
+      }
+    }
+  }
+
+}
+

--- a/akka-distributed-data/src/test/java/akka/cluster/ddata/JavaImplOfDeltaReplicatedData.java
+++ b/akka-distributed-data/src/test/java/akka/cluster/ddata/JavaImplOfDeltaReplicatedData.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.ddata;
+
+import akka.cluster.UniqueAddress;
+
+public class JavaImplOfDeltaReplicatedData extends AbstractDeltaReplicatedData<JavaImplOfDeltaReplicatedData> implements
+    RemovedNodePruning {
+
+  @Override
+  public JavaImplOfDeltaReplicatedData mergeData(JavaImplOfDeltaReplicatedData other) {
+    return this;
+  }
+
+  @Override
+  public JavaImplOfDeltaReplicatedData delta() {
+    return this;
+  }
+
+  @Override
+  public JavaImplOfDeltaReplicatedData resetDelta() {
+    return this;
+  }
+
+  @Override
+  public scala.collection.immutable.Set<UniqueAddress> modifiedByNodes() {
+    return akka.japi.Util.immutableSeq(new java.util.ArrayList<UniqueAddress>()).toSet();
+  }
+
+  @Override
+  public boolean needPruningFrom(UniqueAddress removedNode) {
+    return false;
+  }
+
+  @Override
+  public JavaImplOfDeltaReplicatedData prune(UniqueAddress removedNode, UniqueAddress collapseInto) {
+    return this;
+  }
+
+  @Override
+  public JavaImplOfDeltaReplicatedData pruningCleanup(UniqueAddress removedNode) {
+    return this;
+  }
+}

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/DeltaPropagationSelectorSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/DeltaPropagationSelectorSpec.scala
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.ddata
+
+import akka.actor.Address
+import akka.cluster.ddata.Replicator.Internal.DataEnvelope
+import akka.cluster.ddata.Replicator.Internal.DeltaPropagation
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+object DeltaPropagationSelectorSpec {
+  class TestSelector(override val allNodes: Vector[Address]) extends DeltaPropagationSelector {
+    override val divisor = 5
+    override def createDeltaPropagation(deltas: Map[String, ReplicatedData]): DeltaPropagation =
+      DeltaPropagation(deltas.mapValues(d ⇒ DataEnvelope(d)))
+  }
+
+  val deltaA = GSet.empty[String] + "a"
+  val deltaB = GSet.empty[String] + "b"
+  val deltaC = GSet.empty[String] + "c"
+}
+
+class DeltaPropagationSelectorSpec extends WordSpec with Matchers with TypeCheckedTripleEquals {
+  import DeltaPropagationSelectorSpec._
+  val nodes = (2500 until 2600).map(n ⇒ Address("akka", "Sys", "localhost", n)).toVector
+
+  "DeltaPropagationSelector" must {
+    "collect none when no nodes" in {
+      val selector = new TestSelector(Vector.empty)
+      selector.update("A", deltaA)
+      selector.collectPropagations() should ===(Map.empty[Address, DeltaPropagation])
+      selector.cleanupDeltaEntries()
+      selector.hasDeltaEntries("A") should ===(false)
+    }
+
+    "collect 1 when one node" in {
+      val selector = new TestSelector(nodes.take(1))
+      selector.update("A", deltaA)
+      selector.update("B", deltaB)
+      selector.cleanupDeltaEntries()
+      selector.hasDeltaEntries("A") should ===(true)
+      selector.hasDeltaEntries("B") should ===(true)
+      val expected = DeltaPropagation(Map("A" → DataEnvelope(deltaA), "B" → DataEnvelope(deltaB)))
+      selector.collectPropagations() should ===(Map(nodes(0) → expected))
+      selector.collectPropagations() should ===(Map.empty[Address, DeltaPropagation])
+      selector.cleanupDeltaEntries()
+      selector.hasDeltaEntries("A") should ===(false)
+      selector.hasDeltaEntries("B") should ===(false)
+    }
+
+    "collect 2+1 when three nodes" in {
+      val selector = new TestSelector(nodes.take(3))
+      selector.update("A", deltaA)
+      selector.update("B", deltaB)
+      val expected = DeltaPropagation(Map("A" → DataEnvelope(deltaA), "B" → DataEnvelope(deltaB)))
+      selector.collectPropagations() should ===(Map(nodes(0) → expected, nodes(1) → expected))
+      selector.cleanupDeltaEntries()
+      selector.hasDeltaEntries("A") should ===(true)
+      selector.hasDeltaEntries("B") should ===(true)
+      selector.collectPropagations() should ===(Map(nodes(2) → expected))
+      selector.collectPropagations() should ===(Map.empty[Address, DeltaPropagation])
+      selector.cleanupDeltaEntries()
+      selector.hasDeltaEntries("A") should ===(false)
+      selector.hasDeltaEntries("B") should ===(false)
+    }
+
+    "keep track of deltas per node" in {
+      val selector = new TestSelector(nodes.take(3))
+      selector.update("A", deltaA)
+      selector.update("B", deltaB)
+      val expected1 = DeltaPropagation(Map("A" → DataEnvelope(deltaA), "B" → DataEnvelope(deltaB)))
+      selector.collectPropagations() should ===(Map(nodes(0) → expected1, nodes(1) → expected1))
+      // new update before previous was propagated to all nodes
+      selector.update("C", deltaC)
+      val expected2 = DeltaPropagation(Map("A" → DataEnvelope(deltaA), "B" → DataEnvelope(deltaB),
+        "C" → DataEnvelope(deltaC)))
+      val expected3 = DeltaPropagation(Map("C" → DataEnvelope(deltaC)))
+      selector.collectPropagations() should ===(Map(nodes(2) → expected2, nodes(0) → expected3))
+      selector.cleanupDeltaEntries()
+      selector.hasDeltaEntries("A") should ===(false)
+      selector.hasDeltaEntries("B") should ===(false)
+      selector.hasDeltaEntries("C") should ===(true)
+      selector.collectPropagations() should ===(Map(nodes(1) → expected3))
+      selector.collectPropagations() should ===(Map.empty[Address, DeltaPropagation])
+      selector.cleanupDeltaEntries()
+      selector.hasDeltaEntries("C") should ===(false)
+    }
+
+    "merge updates that occur within same tick" in {
+      val delta1 = GSet.empty[String] + "a1"
+      val delta2 = GSet.empty[String] + "a2"
+      val delta3 = GSet.empty[String] + "a3"
+      val selector = new TestSelector(nodes.take(1))
+      selector.update("A", delta1)
+      selector.update("A", delta2)
+      val expected1 = DeltaPropagation(Map("A" → DataEnvelope(delta1.merge(delta2))))
+      selector.collectPropagations() should ===(Map(nodes(0) → expected1))
+      selector.update("A", delta3)
+      val expected2 = DeltaPropagation(Map("A" → DataEnvelope(delta3)))
+      selector.collectPropagations() should ===(Map(nodes(0) → expected2))
+      selector.collectPropagations() should ===(Map.empty[Address, DeltaPropagation])
+    }
+
+    "merge deltas" in {
+      val delta1 = GSet.empty[String] + "a1"
+      val delta2 = GSet.empty[String] + "a2"
+      val delta3 = GSet.empty[String] + "a3"
+      val selector = new TestSelector(nodes.take(3)) {
+        override def nodesSliceSize(allNodesSize: Int): Int = 1
+      }
+      selector.update("A", delta1)
+      val expected1 = DeltaPropagation(Map("A" → DataEnvelope(delta1)))
+      selector.collectPropagations() should ===(Map(nodes(0) → expected1))
+
+      selector.update("A", delta2)
+      val expected2 = DeltaPropagation(Map("A" → DataEnvelope(delta1.merge(delta2))))
+      selector.collectPropagations() should ===(Map(nodes(1) → expected2))
+
+      selector.update("A", delta3)
+      val expected3 = DeltaPropagation(Map("A" → DataEnvelope(delta1.merge(delta2).merge(delta3))))
+      selector.collectPropagations() should ===(Map(nodes(2) → expected3))
+
+      val expected4 = DeltaPropagation(Map("A" → DataEnvelope(delta2.merge(delta3))))
+      selector.collectPropagations() should ===(Map(nodes(0) → expected4))
+
+      val expected5 = DeltaPropagation(Map("A" → DataEnvelope(delta3)))
+      selector.collectPropagations() should ===(Map(nodes(1) → expected5))
+
+      selector.collectPropagations() should ===(Map.empty[Address, DeltaPropagation])
+    }
+
+    "calcualte right slice size" in {
+      val selector = new TestSelector(nodes)
+      selector.nodesSliceSize(0) should ===(0)
+      selector.nodesSliceSize(1) should ===(1)
+      (2 to 9).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(2)
+        }
+      }
+      (10 to 14).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(3)
+        }
+      }
+      (15 to 19).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(4)
+        }
+      }
+      (20 to 24).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(5)
+        }
+      }
+      (25 to 29).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(6)
+        }
+      }
+      (30 to 34).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(7)
+        }
+      }
+      (35 to 39).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(8)
+        }
+      }
+      (40 to 44).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(9)
+        }
+      }
+      (45 to 200).foreach { n ⇒
+        withClue(s"n=$n") {
+          selector.nodesSliceSize(n) should ===(10)
+        }
+      }
+    }
+  }
+}

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/GCounterSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/GCounterSpec.scala
@@ -11,9 +11,9 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
 class GCounterSpec extends WordSpec with Matchers {
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2)
-  val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3)
+  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
+  val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
 
   "A GCounter" must {
 
@@ -25,10 +25,14 @@ class GCounterSpec extends WordSpec with Matchers {
 
       val c4 = c3 increment node2
       val c5 = c4 increment node2
-      val c6 = c5 increment node2
+      val c6 = c5.resetDelta increment node2
 
       c6.state(node1) should be(2)
       c6.state(node2) should be(3)
+
+      c2.delta.state(node1) should be(1)
+      c3.delta.state(node1) should be(2)
+      c6.delta.state(node2) should be(3)
     }
 
     "be able to increment each node's record by arbitrary delta" in {
@@ -74,7 +78,7 @@ class GCounterSpec extends WordSpec with Matchers {
       c16.state(node2) should be(10)
       c16.value should be(17)
 
-      // counter 1
+      // counter 2
       val c21 = GCounter()
       val c22 = c21 increment (node1, 2)
       val c23 = c22 increment (node1, 2)
@@ -91,11 +95,13 @@ class GCounterSpec extends WordSpec with Matchers {
       merged1.state(node1) should be(7)
       merged1.state(node2) should be(10)
       merged1.value should be(17)
+      merged1.delta should be(GCounter.empty)
 
       val merged2 = c26 merge c16
       merged2.state(node1) should be(7)
       merged2.state(node2) should be(10)
       merged2.value should be(17)
+      merged2.delta should be(GCounter.empty)
     }
 
     "be able to have its history correctly merged with another GCounter 2" in {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterSpec.scala
@@ -11,8 +11,8 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
 class PNCounterSpec extends WordSpec with Matchers {
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1)
-  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2)
+  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
 
   "A PNCounter" must {
 
@@ -24,10 +24,18 @@ class PNCounterSpec extends WordSpec with Matchers {
 
       val c4 = c3 increment node2
       val c5 = c4 increment node2
-      val c6 = c5 increment node2
+      val c6 = c5.resetDelta increment node2
 
       c6.increments.state(node1) should be(2)
       c6.increments.state(node2) should be(3)
+
+      c2.delta.value.toLong should be(1)
+      c2.delta.increments.state(node1) should be(1)
+      c3.delta.value should be(2)
+      c3.delta.increments.state(node1) should be(2)
+
+      c6.delta.value should be(3)
+      c6.delta.increments.state(node2) should be(3)
     }
 
     "be able to decrement each node's record by one" in {
@@ -38,10 +46,16 @@ class PNCounterSpec extends WordSpec with Matchers {
 
       val c4 = c3 decrement node2
       val c5 = c4 decrement node2
-      val c6 = c5 decrement node2
+      val c6 = c5.resetDelta decrement node2
 
       c6.decrements.state(node1) should be(2)
       c6.decrements.state(node2) should be(3)
+
+      c3.delta.value should be(-2)
+      c3.delta.decrements.state(node1) should be(2)
+
+      c6.delta.value should be(-3)
+      c6.delta.decrements.state(node2) should be(3)
     }
 
     "be able to increment each node's record by arbitrary delta" in {

--- a/akka-docs/rst/java/distributed-data.rst
+++ b/akka-docs/rst/java/distributed-data.rst
@@ -38,7 +38,9 @@ The ``akka.cluster.ddata.Replicator`` actor provides the API for interacting wit
 The ``Replicator`` actor must be started on each node in the cluster, or group of nodes tagged 
 with a specific role. It communicates with other ``Replicator`` instances with the same path 
 (without address) that are running on other nodes . For convenience it can be used with the
-``akka.cluster.ddata.DistributedData`` extension.
+``akka.cluster.ddata.DistributedData`` extension but it can also be started as an ordinary
+actor using the ``Replicator.props``. If it is started as an ordinary actor it is important
+that it is given the same name, started on same path, on all nodes.
 
 Cluster members with status :ref:`WeaklyUp <weakly_up_java>`, if that feature is enabled,
 will participate in Distributed Data. This means that the data will be replicated to the
@@ -256,14 +258,38 @@ Subscribers will receive ``Replicator.DataDeleted``.
   where frequent adds and removes are required, you should use a fixed number of top-level data 
   types that support both updates and removals, for example ``ORMap`` or ``ORSet``.
 
+.. _delta_crdt_java:
+
+delta-CRDT
+----------
+
+`Delta State Replicated Data Types <http://arxiv.org/abs/1603.01529>`_
+are supported. delta-CRDT is a way to reduce the need for sending the full state
+for updates. For example adding element ``'c'`` and ``'d'`` to set ``{'a', 'b'}`` would
+result in sending the delta ``{'c', 'd'}`` and merge that with the state on the
+receiving side, resulting in set ``{'a', 'b', 'c', 'd'}``.
+
+Current protocol for replicating the deltas does not support causal consistency.
+It is only eventually consistent. This means that if elements ``'c'`` and ``'d'`` are
+added in two separate `Update` operations these deltas may occasionally be propagated
+to nodes in different order than the causal order of the updates. For this example it
+can result in that set ``{'a', 'b', 'd'}`` can be seen before element 'c' is seen. Eventually
+it will be ``{'a', 'b', 'c', 'd'}``. If causal consistency is needed the delta propagation
+should be disabled with configuration property
+``akka.cluster.distributed-data.delta-crdt.enabled=off``.
+
+Note that the full state is occasionally also replicated for delta-CRDTs, for example when 
+new nodes are added to the cluster or when deltas could not be propagated because
+of network partitions or similar problems.
+
 Data Types
 ==========
 
 The data types must be convergent (stateful) CRDTs and implement the ``ReplicatedData`` trait,
 i.e. they provide a monotonic merge function and the state changes always converge.
 
-You can use your own custom ``ReplicatedData`` types, and several types are provided
-by this package, such as:
+You can use your own custom ``AbstractReplicatedData`` or ``AbstractDeltaReplicatedData`` types, 
+and several types are provided by this package, such as:
 
 * Counters: ``GCounter``, ``PNCounter``
 * Sets: ``GSet``, ``ORSet``
@@ -286,6 +312,8 @@ as two internal ``GCounter``. Merge is handled by merging the internal P and N c
 The value of the counter is the value of the P counter minus the value of the N counter.
 
 .. includecode:: code/docs/ddata/DistributedDataDocTest.java#pncounter
+
+``GCounter`` and ``PNCounter`` have support for :ref:`delta_crdt_java`.
 
 Several related counters can be managed in a map with the ``PNCounterMap`` data type.
 When the counters are placed in a ``PNCounterMap`` as opposed to placing them as separate top level
@@ -405,6 +433,8 @@ removed, but never added again thereafter.
 .. includecode:: code/docs/ddata/japi/TwoPhaseSet.java#twophaseset
 
 Data types should be immutable, i.e. "modifying" methods should return a new instance.
+
+Implement the additional methods of ``AbstractDeltaReplicatedData`` if it has support for delta-CRDT replication.
 
 Serialization
 ^^^^^^^^^^^^^
@@ -563,11 +593,11 @@ be able to improve this if needed, but the design is still not intended for bill
 
 All data is held in memory, which is another reason why it is not intended for *Big Data*.
 
-When a data entry is changed the full state of that entry is replicated to other nodes. For example,
-if you add one element to a Set with 100 existing elements, all 101 elements are transferred to
-other nodes. This means that you cannot have too large data entries, because then the remote message
-size will be too large. We might be able to make this more efficient by implementing
-`Efficient State-based CRDTs by Delta-Mutation <http://gsd.di.uminho.pt/members/cbm/ps/delta-crdt-draft16may2014.pdf>`_.
+When a data entry is changed the full state of that entry may be replicated to other nodes
+if it doesn't support :ref:`delta_crdt_java`. The full state is also replicated for delta-CRDTs,
+for example when new nodes are added to the cluster or when deltas could not be propagated because
+of network partitions or similar problems. This means that you cannot have too large 
+data entries, because then the remote message size will be too large.
 
 Learn More about CRDTs
 ======================

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -82,6 +82,9 @@ object MiMa extends AutoPlugin {
     import com.typesafe.tools.mima.core._
 
     val bcIssuesBetween24and25 = Seq(
+
+      // #21875 delta-CRDT
+      ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.GCounter.this"),  
       // #21423 Remove deprecated metrics
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterReadView.clusterMetrics"),
       ProblemFilters.exclude[MissingClassProblem]("akka.cluster.InternalClusterAction$MetricsTick$"),
@@ -165,6 +168,12 @@ object MiMa extends AutoPlugin {
       // #21647 pruning
       FilterAnyProblemStartingWith("akka.cluster.ddata.PruningState"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.RemovedNodePruning.modifiedByNodes"),
+      FilterAnyProblemStartingWith("akka.cluster.ddata.Replicator"),
+      FilterAnyProblemStartingWith("akka.cluster.ddata.protobuf.msg"),
+
+      // #21647 pruning
+      FilterAnyProblemStartingWith("akka.cluster.ddata.PruningState"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.RemovedNodePruning.usingNodes"),
       FilterAnyProblemStartingWith("akka.cluster.ddata.Replicator"),
       FilterAnyProblemStartingWith("akka.cluster.ddata.protobuf.msg"),
 


### PR DESCRIPTION
I have started prototyping what we need to do be able to support delta-CRDTs.

Here is a first sketch of adding a `DeltaReplicatedData` trait that can be implemented by the data types that support deltas. Quick implementation of GCounter. I don't think that part will be difficult.

More challenging will be to implement the protocol for dissemination of the deltas, especially if we need causal consistency as described in section "Anti-Entropy Algorithm for Causal Consistency" of the [paper](http://arxiv.org/abs/1603.01529).

Refs https://github.com/akka/akka/issues/21875