### PR TITLE
+act #22109 add documentation annotations in akka.annotation

### DIFF
--- a/akka-actor/src/main/java/akka/annotation/ApiMayChange.java
+++ b/akka-actor/src/main/java/akka/annotation/ApiMayChange.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks APIs that are meant to evolve towards becoming stable APIs, but are not stable APIs yet.
+ * 
+ * Evolving interfaces MAY change from one patch release to another (i.e. 2.4.10 to 2.4.11) without up-front notice.
+ * A best-effort approach is taken to not cause more breakage than really neccessary, and usual deprecation techniques 
+ * are utilised while evolving these APIs, however there is NO strong guarantee regarding the source or binary 
+ * compatibility of APIs marked using this annotation. 
+ * 
+ * It MAY also change when promoting the API to stable, for example such changes may include removal of deprecated 
+ * methods that were introduced during the evolution and final refactoring that were deferred because they would 
+ * have introduced to much breaking changes during the evolution phase. 
+ * 
+ * Promoting the API to stable MAY happen in a patch release.
+ * 
+ * It is encouraged to document in ScalaDoc how exactly this API is expected to evolve.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS) // to be accessible by MiMa
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.TYPE, ElementType.PACKAGE})
+public @interface ApiMayChange {
+}

--- a/akka-actor/src/main/java/akka/annotation/DoNotInherit.java
+++ b/akka-actor/src/main/java/akka/annotation/DoNotInherit.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks APIs that are designed under an closed-world assumption for and are NOT meant to be extended by user-code.
+ * It is fine to extend these classes within Akka itself however.
+ * <p/>
+ * This is most useful for binary compatibility purposes when a set of classes and interfaces assume a "closed world" 
+ * between them, and gain the ability to add methods to the interfaces without breaking binary compatibility for 
+ * users of this code. Specifically this assumption may be understood intuitively: as all classes that implement this 
+ * interface are in this compilation unit / artifact, it is impossible to obtain a "old" class with a "new" interface,
+ * as they are part of the same dependency.
+ * <p/>
+ * Notable examples of such API include the FlowOps trait in Akka Streams or Akka HTTP model interfaces,
+ * which extensively uses inheritance internally, but are not meant for extension by user code.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS) // to be accessible by MiMa
+@Target({ElementType.TYPE})
+public @interface DoNotInherit {
+  String description();
+}

--- a/akka-actor/src/main/java/akka/annotation/InternalApi.java
+++ b/akka-actor/src/main/java/akka/annotation/InternalApi.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks APIs that are considered internal to Akka and may change at any point in time without any warning.
+ * <p/>
+ * For example, this annotation should be used when the Scala {@code private[akka]} access restriction is used,
+ * as Java has no way of representing this package restricted access and such methods and classes are represented
+ * as {@code public} in byte-code.
+ * <p/>
+ * If a method/class annotated with this method has a javadoc/scaladoc comment, the first line MUST include 
+ * {@code INTERNAL API} in order to be easily identifiable from generated documentation. Additional information
+ * may be put on the same line as the INTERNAL API comment in order to clarify further.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS) // to be accessible by MiMa
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.TYPE, ElementType.PACKAGE})
+public @interface InternalApi {
+}


### PR DESCRIPTION
Please read through as we should get the naming and wording right here.
This was initially discussed on gitter.

Resolves #22109