### PR TITLE
Update rel="canonical" to better reflect current locations

### DIFF
--- a/akka-docs/_sphinx/themes/akka/layout.html
+++ b/akka-docs/_sphinx/themes/akka/layout.html
@@ -26,7 +26,11 @@
 {% block extrahead %}
   {%- if include_analytics %}
     <!-- Hint to search engines that the "canonical" page is under "current", which will boost it appearing in search results -->
-    <link rel="canonical" href="http://akka.io/docs/akka/current/{{ pagename }}.html" />
+    {% if "scala/http" in pagename or "java/http" in pagename %}
+      <link rel="canonical" href="http://doc.akka.io/docs/akka-http/current/{{ pagename }}.html" />
+    {% else %}
+      <link rel="canonical" href="http://doc.akka.io/docs/akka/current/{{ pagename }}.html" />
+    {% endif %}
 
     <!--Google Analytics-->
     <script type="text/javascript">


### PR DESCRIPTION
This makes the rel="canonical" links in the documentation header no longer point to a destination with status code 404.  The 404 page would redirect to the new path, but I am not sure search engines would make the connection.
Significantly, this also communicates Akka HTTP documentation has moved to a different path hopefully helping users get to the appropriate source of documentation.


This would really have the most impact if backported and documentation for older versions of Akka where Akka HTTP is still in the main documentation (example: http://doc.akka.io/docs/akka/2.4.7/scala/http/) are rebuilt so that search engines could learn the new paths.  I tested this on top of 09a6d2ede12991c1fc97aa6f0b6fab7c4651289b which was the last commit before HTTP was split from the repository.