### PR TITLE
use exclusive fromSequenceNumber in eventsByTag, #22145

### DIFF
--- a/akka-docs/rst/java/code/docs/persistence/query/MyEventsByTagJavaPublisher.java
+++ b/akka-docs/rst/java/code/docs/persistence/query/MyEventsByTagJavaPublisher.java
@@ -84,7 +84,7 @@ class MyEventsByTagJavaPublisher extends AbstractActorPublisher<EventEnvelope> {
   private void query() {
     if (buf.isEmpty()) {
       final String query = "SELECT id, persistent_repr " +
-        "FROM journal WHERE tag = ? AND id >= ? " +
+        "FROM journal WHERE tag = ? AND id > ? " +
         "ORDER BY id LIMIT ?";
 
       try (PreparedStatement s = connection.prepareStatement(query)) {

--- a/akka-docs/rst/java/persistence-query-leveldb.rst
+++ b/akka-docs/rst/java/persistence-query-leveldb.rst
@@ -95,10 +95,14 @@ with the given ``tags``.
 
 .. includecode:: code/docs/persistence/query/LeveldbPersistenceQueryDocTest.java#tagger
 
-You can retrieve a subset of all events by specifying ``offset``, or use ``0L`` to retrieve all
-events with a given tag. The ``offset`` corresponds to an ordered sequence number for the specific tag.
-Note that the corresponding offset of each event is provided in the ``EventEnvelope``, which makes it possible
-to resume the stream at a later point from a given offset.
+You can use ``NoOffset`` to retrieve all events with a given tag or retrieve a subset of all
+events by specifying a ``Sequence`` ``offset``. The ``offset`` corresponds to an ordered sequence number for
+the specific tag. Note that the corresponding offset of each event is provided in the
+``EventEnvelope``, which makes it possible to resume the stream at a later point from a given offset.
+
+The ``offset`` is exclusive, i.e. the event with the exact same sequence number will not be included
+in the returned stream. This means that you can use the offset that is returned in ``EventEnvelope``
+as the ``offset`` parameter in a subsequent query.
 
 In addition to the ``offset`` the ``EventEnvelope`` also provides ``persistenceId`` and ``sequenceNr``
 for each event. The ``sequenceNr`` is the sequence number for the persistent actor with the

--- a/akka-docs/rst/scala/code/docs/persistence/query/MyEventsByTagPublisher.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/query/MyEventsByTagPublisher.scala
@@ -51,7 +51,7 @@ class MyEventsByTagPublisher(tag: String, offset: Long, refreshInterval: FiniteD
     private def statement() = connection.prepareStatement(
       """
         SELECT id, persistent_repr FROM journal
-        WHERE tag = ? AND id >= ?
+        WHERE tag = ? AND id > ?
         ORDER BY id LIMIT ?
       """)
 

--- a/akka-docs/rst/scala/persistence-query-leveldb.rst
+++ b/akka-docs/rst/scala/persistence-query-leveldb.rst
@@ -90,10 +90,14 @@ with the given ``tags``.
 
 .. includecode:: code/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala#tagger
 
-You can retrieve a subset of all events by specifying ``offset``, or use ``0L`` to retrieve all
-events with a given tag. The ``offset`` corresponds to an ordered sequence number for the specific tag.
-Note that the corresponding offset of each event is provided in the ``EventEnvelope``, which makes it possible
-to resume the stream at a later point from a given offset.
+You can use ``NoOffset`` to retrieve all events with a given tag or retrieve a subset of all
+events by specifying a ``Sequence`` ``offset``. The ``offset`` corresponds to an ordered sequence number for
+the specific tag. Note that the corresponding offset of each event is provided in the
+``EventEnvelope``, which makes it possible to resume the stream at a later point from a given offset.
+
+The ``offset`` is exclusive, i.e. the event with the exact same sequence number will not be included
+in the returned stream. This means that you can use the offset that is returned in ``EventEnvelope``
+as the ``offset`` parameter in a subsequent query.
 
 In addition to the ``offset`` the ``EventEnvelope`` also provides ``persistenceId`` and ``sequenceNr``
 for each event. The ``sequenceNr`` is the sequence number for the persistent actor with the

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/Offset.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/Offset.scala
@@ -17,10 +17,28 @@ object Offset {
 
 abstract class Offset
 
+/**
+ * Corresponds to an ordered sequence number for the events. Note that the corresponding
+ * offset of each event is provided in the [[akka.persistence.query.EventEnvelope]],
+ * which makes it possible to resume the stream at a later point from a given offset.
+ *
+ * The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+ * in the returned stream. This means that you can use the offset that is returned in `EventEnvelope`
+ * as the `offset` parameter in a subsequent query.
+ */
 final case class Sequence(value: Long) extends Offset with Ordered[Sequence] {
   override def compare(that: Sequence): Int = value.compare(that.value)
 }
 
+/**
+ * Corresponds to an ordered unique identifier of the events. Note that the corresponding
+ * offset of each event is provided in the [[akka.persistence.query.EventEnvelope]],
+ * which makes it possible to resume the stream at a later point from a given offset.
+ *
+ * The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+ * in the returned stream. This means that you can use the offset that is returned in `EventEnvelope`
+ * as the `offset` parameter in a subsequent query.
+ */
 final case class TimeBasedUUID(value: UUID) extends Offset with Ordered[TimeBasedUUID] {
   if (value == null || value.version != 1) {
     throw new IllegalArgumentException("UUID " + value + " is not a time-based UUID")
@@ -29,6 +47,9 @@ final case class TimeBasedUUID(value: UUID) extends Offset with Ordered[TimeBase
   override def compare(other: TimeBasedUUID): Int = value.compareTo(other.value)
 }
 
+/**
+ * Used when retrieving all events.
+ */
 final case object NoOffset extends Offset {
   /**
    * Java API:

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
@@ -116,6 +116,10 @@ class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.lev
    * `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
    * identifier for the event.
    *
+   * The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+   * in the returned stream. This means that you can use the offset that is returned in `EventEnvelope`
+   * as the `offset` parameter in a subsequent query.
+   *
    * The returned event stream is ordered by the offset (tag sequence number), which corresponds
    * to the same order as the write journal stored the events. The same stream elements (in same order)
    * are returned for multiple executions of the query. Deleted events are not deleted from the

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
@@ -100,6 +100,10 @@ private[persistence] object LeveldbJournal {
   final case class SubscribeTag(tag: String) extends SubscriptionCommand
   final case class TaggedEventAppended(tag: String) extends DeadLetterSuppression
 
+  /**
+   * `fromSequenceNr` is exclusive
+   * `toSequenceNr` is inclusive
+   */
   final case class ReplayTaggedMessages(fromSequenceNr: Long, toSequenceNr: Long, max: Long,
                                         tag: String, replyTo: ActorRef) extends SubscriptionCommand
   final case class ReplayedTaggedMessage(persistent: PersistentRepr, tag: String, offset: Long)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbRecovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbRecovery.scala
@@ -100,7 +100,8 @@ private[persistence] trait LeveldbRecovery extends AsyncRecovery { this: Leveldb
     }
 
     withIterator { iter ⇒
-      val startKey = Key(tagNid, if (fromSequenceNr < 1L) 1L else fromSequenceNr, 0)
+      // fromSequenceNr is exclusive, i.e. start with +1
+      val startKey = Key(tagNid, if (fromSequenceNr < 1L) 1L else fromSequenceNr + 1, 0)
       iter.seek(keyToBytes(startKey))
       go(iter, startKey, 0L, replayCallback)
     }

--- a/akka-persistence/src/test/scala/akka/persistence/SnapshotFailureRobustnessSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SnapshotFailureRobustnessSpec.scala
@@ -96,10 +96,10 @@ object SnapshotFailureRobustnessSpec {
 }
 
 class SnapshotFailureRobustnessSpec extends PersistenceSpec(PersistenceSpec.config("leveldb", "SnapshotFailureRobustnessSpec", serialization = "off", extraConfig = Some(
-  """
-  akka.persistence.snapshot-store.local.class = "akka.persistence.SnapshotFailureRobustnessSpec$FailingLocalSnapshotStore"
-  akka.persistence.snapshot-store.local-delete-fail = ${akka.persistence.snapshot-store.local}
-  akka.persistence.snapshot-store.local-delete-fail.class = "akka.persistence.SnapshotFailureRobustnessSpec$DeleteFailingLocalSnapshotStore"
+  s"""
+  akka.persistence.snapshot-store.local.class = "akka.persistence.SnapshotFailureRobustnessSpec$$FailingLocalSnapshotStore"
+  akka.persistence.snapshot-store.local-delete-fail = $${akka.persistence.snapshot-store.local}
+  akka.persistence.snapshot-store.local-delete-fail.class = "akka.persistence.SnapshotFailureRobustnessSpec$$DeleteFailingLocalSnapshotStore"
   """))) with ImplicitSender {
 
   import SnapshotFailureRobustnessSpec._

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -10,7 +10,7 @@ import akka.stream.impl.StreamLayout.Module
 import akka.stream.impl._
 import akka.stream.impl.fusing._
 import akka.stream.stage._
-import org.reactivestreams.{Processor, Publisher, Subscriber, Subscription}
+import org.reactivestreams.{ Processor, Publisher, Subscriber, Subscription }
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable


### PR DESCRIPTION
* The reason is to have a consistent approach for Sequence and
  TimeBasedUUID, which are both intended as unique event identifiers.
* This means that you can use the offset that is returned in `EventEnvelope`
  as the `offset` parameter in a subsequent query.