### PR TITLE
Add serialize-messages=off config

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
@@ -16,7 +16,10 @@ import scala.concurrent.duration._
 import scala.concurrent.Await
 import scala.util.control.NoStackTrace
 
-class FlowLogSpec extends StreamSpec("akka.loglevel = DEBUG") with ScriptedTest {
+class FlowLogSpec extends StreamSpec("""
+     akka.loglevel = DEBUG
+     akka.actor.serialize-messages = off
+     """) with ScriptedTest {
 
   implicit val mat: Materializer = ActorMaterializer()
 


### PR DESCRIPTION
The failure can be simulated by putting `Thread.sleep(1000)` before [this line](https://github.com/akka/akka/blob/91d6a3f125c48f12affc990d08e609d4ace91cd6/akka-actor/src/main/scala/akka/event/EventBus.scala#L166). 

When `logProbe` subscribes to eventStream, `Serialization.serializerFor` generates debug event `Using serializer[{}] for message [{}]` for `EventStreamUnsubscriber.Register` message. Then there is a race that `logProbe` can see `Using serializer...` event. I think that in this spec message serialization check is not required, so i disabled it.

Refs #22128