### PR TITLE
Update Aeron to 1.1.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,8 +68,8 @@ object Dependencies {
     // For Java 8 Conversions
     val java8Compat = Def.setting {"org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value} // Scala License
     
-    val aeronDriver = "io.aeron"                      % "aeron-driver"                 % "1.0.5"       // ApacheV2
-    val aeronClient = "io.aeron"                      % "aeron-client"                 % "1.0.5"       // ApacheV2
+    val aeronDriver = "io.aeron"                      % "aeron-driver"                 % "1.1.0"       // ApacheV2
+    val aeronClient = "io.aeron"                      % "aeron-client"                 % "1.1.0"       // ApacheV2
 
     object Docs {
       val sprayJson   = "io.spray"                   %%  "spray-json"                  % "1.3.2"             % "test"


### PR DESCRIPTION
If we think we can bump such. I think we could since used internally mostly anyway hm.

https://github.com/real-logic/Aeron/releases/tag/1.1.0