### PR TITLE
change router type in cluster.StressSpec

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -157,7 +157,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
         }
       }
       /master-node-3/workers = {
-        router = adaptive-pool
+        router = round-robin-pool
         cluster {
           enabled = on
           max-nr-of-instances-per-node = 1


### PR DESCRIPTION
* it was an oversight when old cluster metrics was removed

https://jenkins.akka.io:8498/job/akka-multi-node/1915/consoleText

```
[JVM-1]   java.lang.IllegalArgumentException: Cannot instantiate router [adaptive-pool], defined in [/master-node-3/workers], make sure it extends [interface akka.routing.RouterConfig] and has constructor with [com.typesafe.config.Config] and optional [akka.actor.DynamicAccess] parameter
[JVM-1]   at akka.actor.Deployer.akka$actor$Deployer$$throwCannotInstantiateRouter$1(Deployer.scala:193)
```

