### PR TITLE
eager initialization of CoordinatedShutdown, #22191

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -938,6 +938,9 @@ private[akka] class ActorSystemImpl(
       }
     }
 
+    // eager initialization of CoordinatedShutdown
+    CoordinatedShutdown(this)
+
     loadExtensions("akka.library-extensions", throwOnLoadFail = true)
     loadExtensions("akka.extensions", throwOnLoadFail = false)
   }

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -214,6 +214,7 @@ object MultiNodeSpec {
         loggers = ["akka.testkit.TestEventListener"]
         loglevel = "WARNING"
         stdout-loglevel = "WARNING"
+        coordinated-shutdown.run-by-jvm-shutdown-hook = off
         actor {
           default-dispatcher {
             executor = "fork-join-executor"

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -324,7 +324,6 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
    */
   private[this] val _inboundCompressions = {
     if (settings.Advanced.Compression.Enabled) {
-      println(s"settings.Advanced.Compression.Enabled = ${settings.Advanced.Compression.Enabled}")
       val eventSink = createFlightRecorderEventSink(synchr = false)
       new InboundCompressionsImpl(system, this, settings.Advanced.Compression, eventSink)
     } else NoInboundCompressions


### PR DESCRIPTION
* e.g. the jvm shutdown hook should be installed immediately
* noticed that it was initialized from artery shutdown
* run-by-jvm-shutdown-hook=off in multi-jvm tests

This also caused the shm files to not be deleted in some tests.