### PR TITLE
Update Aeron to 1.1.0, backport of #22189

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,8 +70,8 @@ object Dependencies {
     // For Java 8 Conversions
     val java8Compat = Def.setting {"org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value} // Scala License
     
-    val aeronDriver = "io.aeron"                      % "aeron-driver"                 % "1.0.4"       // ApacheV2
-    val aeronClient = "io.aeron"                      % "aeron-client"                 % "1.0.4"       // ApacheV2
+    val aeronDriver = "io.aeron"                      % "aeron-driver"                 % "1.1.0"       // ApacheV2
+    val aeronClient = "io.aeron"                      % "aeron-client"                 % "1.1.0"       // ApacheV2
 
     object Docs {
       val sprayJson   = "io.spray"                   %%  "spray-json"                  % "1.3.2"             % "test"


### PR DESCRIPTION
If we think we can bump such. I think we could since used internally mostly anyway hm.

https://github.com/real-logic/Aeron/releases/tag/1.1.0

(cherry picked from commit bca071fa81f68004d47ff7c002b742f0b70d079e)