### PR TITLE
Change signature of addJvmShutdownHook

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -377,14 +377,14 @@ final class CoordinatedShutdown private[akka] (
    * concurrently, but they are running before Akka internal shutdown
    * hooks, e.g. those shutting down Artery.
    */
-  @tailrec def addJvmShutdownHook(hook: () ⇒ Unit): Unit = {
+  @tailrec def addJvmShutdownHook[T](hook: ⇒ T): Unit = {
     if (!runStarted.get) {
       val currentLatch = _jvmHooksLatch.get
       val newLatch = new CountDownLatch(currentLatch.getCount.toInt + 1)
       if (_jvmHooksLatch.compareAndSet(currentLatch, newLatch)) {
         try Runtime.getRuntime.addShutdownHook(new Thread {
           override def run(): Unit = {
-            try hook() finally _jvmHooksLatch.get.countDown()
+            try hook finally _jvmHooksLatch.get.countDown()
           }
         }) catch {
           case e: IllegalStateException ⇒
@@ -404,6 +404,6 @@ final class CoordinatedShutdown private[akka] (
    * hooks, e.g. those shutting down Artery.
    */
   def addJvmShutdownHook(hook: Runnable): Unit =
-    addJvmShutdownHook(() ⇒ hook.run())
+    addJvmShutdownHook(hook.run())
 
 }

--- a/akka-docs/rst/scala/code/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/actor/ActorDocSpec.scala
@@ -646,7 +646,7 @@ class ActorDocSpec extends AkkaSpec("""
     //#coordinated-shutdown-addTask
 
     //#coordinated-shutdown-jvm-hook
-    CoordinatedShutdown(system).addJvmShutdownHook { () =>
+    CoordinatedShutdown(system).addJvmShutdownHook {
       println("custom JVM shutdown hook...")
     }
     //#coordinated-shutdown-jvm-hook


### PR DESCRIPTION
* because with Scala 2.12 it can't infer the right overload
* prefer the `() =>`, but here it's clear that it's a callback
* similar in ActorSystem.registerOnTermination