### PR TITLE
temorary disable additional-serializers for ReliableProxySpec, #22224

### DIFF
--- a/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
+++ b/akka-contrib/src/multi-jvm/scala/akka/contrib/pattern/ReliableProxySpec.scala
@@ -18,10 +18,16 @@ import akka.actor.ActorRef
 import akka.testkit.TestKitExtension
 import akka.actor.ActorIdentity
 import akka.actor.Identify
+import com.typesafe.config.ConfigFactory
 
 object ReliableProxySpec extends MultiNodeConfig {
   val local = role("local")
   val remote = role("remote")
+
+  commonConfig(ConfigFactory.parseString("""
+    # Remove this when issue #22224 has been fixed
+    akka.actor.enable-additional-serialization-bindings = off
+    """))
 
   testTransport(on = true)
 }


### PR DESCRIPTION
We have to find a proper solution later, but right now I just want all tests to pass.