### PR TITLE
adjust time assertion in TestConductorSpec

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/testconductor/TestConductorSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/testconductor/TestConductorSpec.scala
@@ -75,7 +75,7 @@ class TestConductorSpec extends RemotingMultiNodeSpec(TestConductorMultiJvmSpec)
         for (i ← 0 to 9) echo ! i
       }
 
-      within(0.6 seconds, 2 seconds) {
+      within(0.5 seconds, 2 seconds) {
         expectMsg(500 millis, 0)
         receiveN(9) should ===(1 to 9)
       }


### PR DESCRIPTION
* assertion failed: block took 583.856 milliseconds, should at least have been 600 milliseconds


I have no clue of why this started failing now. I could repeat it locally.