### PR TITLE
customise test for race between GetState and persistAsync handler

### DIFF
--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
@@ -1154,9 +1154,7 @@ abstract class PersistentActorSpec(config: Config) extends PersistenceSpec(confi
     "be able to persist events that happen during recovery" in {
       val persistentActor = namedPersistentActor[PersistInRecovery]
       persistentActor ! GetState
-      expectMsg(List("a-1", "a-2", "rc-1", "rc-2"))
-      persistentActor ! GetState
-      expectMsg(List("a-1", "a-2", "rc-1", "rc-2", "rc-3"))
+      expectMsgAnyOf(List("a-1", "a-2", "rc-1", "rc-2"), List("a-1", "a-2", "rc-1", "rc-2", "rc-3"))
       persistentActor ! Cmd("invalid")
       persistentActor ! GetState
       expectMsg(List("a-1", "a-2", "rc-1", "rc-2", "rc-3", "invalid"))


### PR DESCRIPTION
In this failure, updateState handler in persistAsync(Evt("rc-3"))(updateState) processed before GetState message. And there is also chance GetState message handler may execute before this handler. So the result message may contain "rc-3" or not.

Refs #22052