### PR TITLE
parsable output to stderr for pipe command (e.g. jq)

### DIFF
--- a/akka-cluster/jmx-client/akka-cluster
+++ b/akka-cluster/jmx-client/akka-cluster
@@ -45,7 +45,7 @@ function ensureNodeIsRunningAndAvailable {
     fi
 }
 
-echo "This tool is deprecated use curl and https://github.com/akka/akka-cluster-management instead, since 2.5.0"
+echo "This tool is deprecated use curl and https://github.com/akka/akka-cluster-management instead, since 2.5.0" >&2
 
 # switch on command
 case "$1" in


### PR DESCRIPTION
before
```
$ akka-cluster localhost 2551 cluster-status | jq                     
parse error: Invalid numeric literal at line 1, column 5
```

after
```
$ akka-cluster localhost 2551 cluster-status | jq
This tool is deprecated use curl and https://github.com/akka/akka-cluster-management instead, since 2.5.0
{
  "self-address": ...snip...
```