### PR TITLE
#22246 cluster-sharding PersistentShardCoordinator with remember-entities doesn't recover properly

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -782,12 +782,11 @@ class PersistentShardCoordinator(typeName: String, settings: ClusterShardingSett
 
     case SnapshotOffer(_, st: State) ⇒
       log.debug("receiveRecover SnapshotOffer {}", st)
+      state = st.withRememberEntities(settings.rememberEntities)
       //Old versions of the state object may not have unallocatedShard set,
       // thus it will be null.
-      if (st.unallocatedShards == null)
-        state = st.copy(unallocatedShards = Set.empty)
-      else
-        state = st
+      if (state.unallocatedShards == null)
+        state = state.copy(unallocatedShards = Set.empty)
 
     case RecoveryCompleted ⇒
       state = state.withRememberEntities(settings.rememberEntities)


### PR DESCRIPTION
Fixes #22246
when `State` is persisted (a snapshot is saved) `rememberEntities` value is not included, but when the snapshot is loaded `rememberEntities` is not set from settings, that makes messages replay end up with wrong state as some of the message are processed with `rememberEntities` taken into account.