### PR TITLE
Correct typo in "Backpressure aware stages" section

### DIFF
--- a/akka-docs/rst/java/stream/stages-overview.rst
+++ b/akka-docs/rst/java/stream/stages-overview.rst
@@ -1033,7 +1033,7 @@ aggregated to the batched value.
 expand
 ^^^^^^
 Allow for a faster downstream by expanding the last incoming element to an ``Iterator``. For example
-``Iterator.continually(element)`` to keep repating the last incoming element.
+``Iterator.continually(element)`` to keep repeating the last incoming element.
 
 **emits** when downstream stops backpressuring
 

--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -1025,7 +1025,7 @@ aggregated to the batched value.
 expand
 ^^^^^^
 Allow for a faster downstream by expanding the last incoming element to an ``Iterator``. For example
-``Iterator.continually(element)`` to keep repating the last incoming element.
+``Iterator.continually(element)`` to keep repeating the last incoming element.
 
 **emits** when downstream stops backpressuring
 


### PR DESCRIPTION
Correct the `expand` stage description (`s/repating/repeating`).