### PR TITLE
Documentation hint for large-message-destinations

### DIFF
--- a/akka-docs/rst/java/remoting-artery.rst
+++ b/akka-docs/rst/java/remoting-artery.rst
@@ -529,7 +529,7 @@ helpful to separate actors that have different QoS requirements: large messages 
 Akka remoting provides a dedicated channel for large messages if configured. Since actor message ordering must
 not be violated the channel is actually dedicated for *actors* instead of messages, to ensure all of the messages
 arrive in send order. It is possible to assign actors on given paths to use this dedicated channel by using
-path patterns::
+path patterns that have to be specified in the actor system's configuration on both the sending and the receiving side::
 
    akka.remote.artery.large-message-destinations = [
       "/user/largeMessageActor",

--- a/akka-docs/rst/scala/remoting-artery.rst
+++ b/akka-docs/rst/scala/remoting-artery.rst
@@ -529,7 +529,7 @@ helpful to separate actors that have different QoS requirements: large messages 
 Akka remoting provides a dedicated channel for large messages if configured. Since actor message ordering must
 not be violated the channel is actually dedicated for *actors* instead of messages, to ensure all of the messages
 arrive in send order. It is possible to assign actors on given paths to use this dedicated channel by using
-path patterns::
+path patterns that have to be specified in the actor system's configuration on both the sending and the receiving side::
 
    akka.remote.artery.large-message-destinations = [
       "/user/largeMessageActor",

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -744,6 +744,7 @@ akka {
       # "/user/supervisor/actor/*" will match any direct child to actor,
       # while "/supervisor/*/child" will match any grandchild to "supervisor" that
       # has the name "child"
+      # Entries have to be specified on both the sending and receiving side.
       # Messages sent to ActorSelections will not be passed through the large message
       # stream, to pass such messages through the large message stream the selections
       # but must be resolved to ActorRefs first.


### PR DESCRIPTION
Adding hint in remote-artery docs that large-message-destinations have to match on sending and receiving side. #22256