### PR TITLE
use index access instad of iterator in Broadcast, #22113

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -416,15 +416,13 @@ final class Broadcast[T](val outputPorts: Int, val eagerCancel: Boolean) extends
       pendingCount = downstreamsRunning
       val elem = grab(in)
 
+      val size = out.size
       var idx = 0
-      val itr = out.iterator
-
-      while (itr.hasNext) {
-        val o = itr.next()
-        val i = idx
+      while (idx < size) {
+        val o = out(idx)
         if (!isClosed(o)) {
           push(o, elem)
-          pending(i) = true
+          pending(idx) = true
         }
         idx += 1
       }
@@ -436,12 +434,12 @@ final class Broadcast[T](val outputPorts: Int, val eagerCancel: Boolean) extends
       if (pendingCount == 0 && !hasBeenPulled(in)) pull(in)
 
     {
+      val size = out.size
       var idx = 0
-      val itr = out.iterator
-      while (itr.hasNext) {
-        val out = itr.next()
-        val i = idx
-        setHandler(out, new OutHandler {
+      while (idx < size) {
+        val o = out(idx)
+        val i = idx // close over val
+        setHandler(o, new OutHandler {
           override def onPull(): Unit = {
             pending(i) = false
             pendingCount -= 1
@@ -881,10 +879,10 @@ final class Concat[T](val inputPorts: Int) extends GraphStage[UniformFanInShape[
 
     {
       var idxx = 0
-      val itr = in.iterator
-      while (itr.hasNext) {
-        val i = itr.next()
-        val idx = idxx
+      val size = in.size
+      while (idxx < size) {
+        val i = in(idxx)
+        val idx = idxx // close over val
         setHandler(i, new InHandler {
           override def onPush() = {
             push(out, grab(i))


### PR DESCRIPTION
* and a few more places
* to avoid object allocation

Refs #22113

For the record, I tested with a trival jmh bench:
```
[info] Benchmark                                             (count)   Mode  Cnt          Score         Error   Units
[info] VectorIter.index                                            2  thrpt   15  119216425.508 ± 8191087.562   ops/s
[info] VectorIter.index:·gc.alloc.rate                             2  thrpt   15          0.001 ±       0.001  MB/sec
[info] VectorIter.index:·gc.alloc.rate.norm                        2  thrpt   15         ≈ 10⁻⁵                  B/op
[info] VectorIter.index:·gc.count                                  2  thrpt   15            ≈ 0                counts
[info] VectorIter.index                                           10  thrpt   15   56119784.571 ± 3282112.863   ops/s
[info] VectorIter.index:·gc.alloc.rate                            10  thrpt   15          0.001 ±       0.001  MB/sec
[info] VectorIter.index:·gc.alloc.rate.norm                       10  thrpt   15         ≈ 10⁻⁵                  B/op
[info] VectorIter.index:·gc.count                                 10  thrpt   15            ≈ 0                counts
[info] VectorIter.index                                          100  thrpt   15    4348996.056 ±  113935.410   ops/s
[info] VectorIter.index:·gc.alloc.rate                           100  thrpt   15          0.001 ±       0.001  MB/sec
[info] VectorIter.index:·gc.alloc.rate.norm                      100  thrpt   15         ≈ 10⁻⁴                  B/op
[info] VectorIter.index:·gc.count                                100  thrpt   15            ≈ 0                counts
[info] VectorIter.iterator                                         2  thrpt   15   51892185.767 ± 3632533.208   ops/s
[info] VectorIter.iterator:·gc.alloc.rate                          2  thrpt   15       3166.433 ±     221.658  MB/sec
[info] VectorIter.iterator:·gc.alloc.rate.norm                     2  thrpt   15         64.000 ±       0.001    B/op
[info] VectorIter.iterator:·gc.churn.PS_Eden_Space                 2  thrpt   15       3158.592 ±     231.154  MB/sec
[info] VectorIter.iterator:·gc.churn.PS_Eden_Space.norm            2  thrpt   15         63.838 ±       1.280    B/op
[info] VectorIter.iterator:·gc.churn.PS_Survivor_Space             2  thrpt   15          0.154 ±       0.086  MB/sec
[info] VectorIter.iterator:·gc.churn.PS_Survivor_Space.norm        2  thrpt   15          0.003 ±       0.002    B/op
[info] VectorIter.iterator:·gc.count                               2  thrpt   15        303.000                counts
[info] VectorIter.iterator:·gc.time                                2  thrpt   15        139.000                    ms
[info] VectorIter.iterator                                        10  thrpt   15   29389105.774 ± 1714084.942   ops/s
[info] VectorIter.iterator:·gc.alloc.rate                         10  thrpt   15       1793.306 ±     104.570  MB/sec
[info] VectorIter.iterator:·gc.alloc.rate.norm                    10  thrpt   15         64.000 ±       0.001    B/op
[info] VectorIter.iterator:·gc.churn.PS_Eden_Space                10  thrpt   15       1796.790 ±     106.770  MB/sec
[info] VectorIter.iterator:·gc.churn.PS_Eden_Space.norm           10  thrpt   15         64.133 ±       1.432    B/op
[info] VectorIter.iterator:·gc.churn.PS_Survivor_Space            10  thrpt   15          0.145 ±       0.053  MB/sec
[info] VectorIter.iterator:·gc.churn.PS_Survivor_Space.norm       10  thrpt   15          0.005 ±       0.002    B/op
[info] VectorIter.iterator:·gc.count                              10  thrpt   15        308.000                counts
[info] VectorIter.iterator:·gc.time                               10  thrpt   15        136.000                    ms
[info] VectorIter.iterator                                       100  thrpt   15    4231925.619 ±  166432.196   ops/s
[info] VectorIter.iterator:·gc.alloc.rate                        100  thrpt   15        258.225 ±      10.155  MB/sec
[info] VectorIter.iterator:·gc.alloc.rate.norm                   100  thrpt   15         64.000 ±       0.001    B/op
[info] VectorIter.iterator:·gc.churn.PS_Eden_Space               100  thrpt   15        260.187 ±      21.668  MB/sec
[info] VectorIter.iterator:·gc.churn.PS_Eden_Space.norm          100  thrpt   15         64.471 ±       4.428    B/op
[info] VectorIter.iterator:·gc.churn.PS_Survivor_Space           100  thrpt   15          0.148 ±       0.062  MB/sec
[info] VectorIter.iterator:·gc.churn.PS_Survivor_Space.norm      100  thrpt   15          0.037 ±       0.016    B/op
[info] VectorIter.iterator:·gc.count                             100  thrpt   15        109.000                counts
[info] VectorIter.iterator:·gc.time                              100  thrpt   15         49.000                    ms
```