### PR TITLE
Wraps CombinedReadEventAdapter into NoopWriteEventAdapter (for validation)

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
@@ -92,7 +92,7 @@ private[akka] object EventAdapters {
     val bindings: immutable.Seq[ClassHandler] = {
       val bs = for ((k: FQN, as: BoundAdapters) ← adapterBindings)
         yield if (as.size == 1) (system.dynamicAccess.getClassFor[Any](k).get, handlers(as.head))
-      else (system.dynamicAccess.getClassFor[Any](k).get, CombinedReadEventAdapter(as.map(handlers)))
+      else (system.dynamicAccess.getClassFor[Any](k).get, NoopWriteEventAdapter(CombinedReadEventAdapter(as.map(handlers))))
 
       sort(bs)
     }


### PR DESCRIPTION
When multiple event-adapters are configured they are combined into a single instance of `CombinedReadEventAdapter`.

However `CombinedReadEventAdpater` is not just a `ReadEventAdapter` but a full `EventAdapter`
which throws an `IllegalStateException("CombinedReadEventAdapter must not be used when writing (creating manifests) events!")`
when its `toJournal` method is called.

The `CombinedReadEventAdapter` is not wrapped into `NoopWriteEventAdapter` (because it's not a `ReadEventAdapter`)
and therefore it doesn't avoid the `toJournal` calls.

This is especially problematic when multiple `ReadEventAdapter` are combined together as illustrated in the new testcase.

(cherry picked from commit 2aaee675a6e292d074f775f4f794695882340cd3)