### PR TITLE
#22246 cluster-sharding PersistentShardCoordinator with remember-entities doesn't recover properly (for validation)

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -780,12 +780,11 @@ class PersistentShardCoordinator(typeName: String, settings: ClusterShardingSett
 
     case SnapshotOffer(_, st: State) ⇒
       log.debug("receiveRecover SnapshotOffer {}", st)
+      state = st.withRememberEntities(settings.rememberEntities)
       //Old versions of the state object may not have unallocatedShard set,
       // thus it will be null.
-      if (st.unallocatedShards == null)
-        state = st.copy(unallocatedShards = Set.empty)
-      else
-        state = st
+      if (state.unallocatedShards == null)
+        state = state.copy(unallocatedShards = Set.empty)
 
     case RecoveryCompleted ⇒
       state = state.withRememberEntities(settings.rememberEntities)


### PR DESCRIPTION
when `State` is persisted (a snapshot is saved) `rememberEntities` value is not included, but when the snapshot is loaded `rememberEntities` is not set from settings, that makes messages replay end up with wrong state as some of the message are processed with `rememberEntities` taken into account.

(cherry picked from commit 87687c18dfb1e3b6d07c30f3a0d06e8fb1a5a027)