### PR TITLE
PersistentFSMBase - matchEvent API bug fix (for validation)

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
@@ -752,7 +752,7 @@ abstract class AbstractPersistentFSMBase[S, D, E] extends PersistentFSMBase[S, D
    * @return the builder with the case statement added
    */
   final def matchEvent[ET, DT <: D](eventType: Class[ET], dataType: Class[DT], predicate: TypedPredicate2[ET, DT], apply: Apply2[ET, DT, State]): FSMStateFunctionBuilder[S, D, E] =
-    new FSMStateFunctionBuilder[S, D, E]().event(eventType, dataType, apply)
+    new FSMStateFunctionBuilder[S, D, E]().event(eventType, dataType, predicate, apply)
 
   /**
    * Create an [[akka.japi.pf.FSMStateFunctionBuilder]] with the first case statement set.


### PR DESCRIPTION
Parameter "predicate" not being propagated to created builder.
(cherry picked from commit 80019db016588bae36bb1c2740109817010b6169)

Refs https://github.com/akka/akka/issues/22285