### PR TITLE
Backport: Reset `pendingSend` on address resolution failure

### DIFF
--- a/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
+++ b/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
@@ -59,6 +59,13 @@ private[io] trait WithUdpSend {
                 pendingCommander = null
             }
           case None ⇒
+            sender() ! CommandFailed(send)
+            log.debug(
+              "Name resolution failed for remote address [{}]",
+              send.target)
+            retriedSend = false
+            pendingSend = null
+            pendingCommander = null
         }
       } else {
         doSend(registration)


### PR DESCRIPTION
Refs #22076