### PR TITLE
22295 Allow user define what is failure in terms on circuit breaker

### DIFF
--- a/akka-actor-tests/src/test/java/akka/pattern/CircuitBreakerTest.java
+++ b/akka-actor-tests/src/test/java/akka/pattern/CircuitBreakerTest.java
@@ -13,9 +13,11 @@ import scala.compat.java8.FutureConverters;
 import scala.concurrent.Await;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 
 import static org.junit.Assert.assertEquals;
 
@@ -39,4 +41,19 @@ public class CircuitBreakerTest extends JUnitSuite {
     assertEquals("hello", Await.result(FutureConverters.toScala(res), fiveSeconds));
   }
 
+  @Test
+  public void useCircuitBreakerWithCompletableFutureAndCustomDefineFailure() throws Exception {
+    final FiniteDuration fiveSeconds = FiniteDuration.create(5, TimeUnit.SECONDS);
+    final FiniteDuration fiveHundredMillis = FiniteDuration.create(500, TimeUnit.MILLISECONDS);
+    final CircuitBreaker breaker = new CircuitBreaker(system.dispatcher(), system.scheduler(), 1, fiveSeconds, fiveHundredMillis);
+
+    final BiFunction<Optional<String>, Optional<Throwable>, java.lang.Boolean> fn =
+            (result, err) -> (result.isPresent() && result.get().equals("hello"));
+
+    final CompletableFuture<String> f = new CompletableFuture<>();
+    f.complete("hello");
+    final CompletionStage<String> res = breaker.callWithCircuitBreakerCS(() -> f, fn);
+    assertEquals("hello", Await.result(FutureConverters.toScala(res), fiveSeconds));
+    assertEquals(1, breaker.currentFailureCount());
+  }
 }

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -178,9 +178,11 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       "even number is considered failure" in {
         val breaker = CircuitBreakerSpec.longCallTimeoutCb()
         breaker().currentFailureCount should ===(0)
-        breaker().withSyncCircuitBreaker(2, CircuitBreakerSpec.evenNumberIsFailure)
+        val result = breaker().withSyncCircuitBreaker(2, CircuitBreakerSpec.evenNumberIsFailure)
         checkLatch(breaker.openLatch)
+
         breaker().currentFailureCount should ===(1)
+        result should ===(2)
       }
     }
 
@@ -371,9 +373,10 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       "even number is considered failure" in {
         val breaker = CircuitBreakerSpec.longCallTimeoutCb()
         breaker().currentFailureCount should ===(0)
-        Await.result(breaker().withCircuitBreaker(Future(2), CircuitBreakerSpec.evenNumberIsFailure), awaitTimeout)
+        val result = Await.result(breaker().withCircuitBreaker(Future(2), CircuitBreakerSpec.evenNumberIsFailure), awaitTimeout)
         checkLatch(breaker.openLatch)
         breaker().currentFailureCount should ===(1)
+        result should ===(2)
       }
     }
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -5,13 +5,14 @@
 package akka.pattern
 
 import language.postfixOps
-
 import scala.concurrent.duration._
 import scala.concurrent.TimeoutException
 import akka.testkit._
 import org.scalatest.BeforeAndAfter
-import akka.actor.{ ActorSystem }
-import scala.concurrent.{ ExecutionContext, Future, Await }
+import akka.actor.ActorSystem
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.util.{ Try, Success, Failure }
 
 object CircuitBreakerSpec {
 
@@ -43,6 +44,11 @@ object CircuitBreakerSpec {
 
   def nonOneFactorCb()(implicit system: ActorSystem, ec: ExecutionContext): Breaker =
     new Breaker(new CircuitBreaker(system.scheduler, 1, 2000.millis.dilated, 1000.millis.dilated, 1.day.dilated, 5))
+
+  val evenNumberIsFailure: Try[Int] ⇒ Boolean = {
+    case Success(i) ⇒ i % 2 == 0
+    case _          ⇒ true
+  }
 }
 
 class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
@@ -103,6 +109,19 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       checkLatch(breaker.closedLatch)
     }
 
+    "pass through next call and close on exception" when {
+      "exception is defined as call succeeded" in {
+        val breaker = CircuitBreakerSpec.shortResetTimeoutCb()
+        intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
+        checkLatch(breaker.halfOpenLatch)
+
+        val allReturnIsSuccess: Try[String] ⇒ Boolean = _ ⇒ false
+
+        intercept[TestException] { breaker().withSyncCircuitBreaker(throwException, allReturnIsSuccess) }
+        checkLatch(breaker.closedLatch)
+      }
+    }
+
     "open on exception in call" in {
       val breaker = CircuitBreakerSpec.shortResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -110,6 +129,17 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       breaker.openLatch.reset
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.openLatch)
+    }
+
+    "open on even number" when {
+      "even number is defined as failure" in {
+        val breaker = CircuitBreakerSpec.shortResetTimeoutCb()
+        intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
+        checkLatch(breaker.halfOpenLatch)
+        breaker.openLatch.reset
+        breaker().withSyncCircuitBreaker(2, CircuitBreakerSpec.evenNumberIsFailure)
+        checkLatch(breaker.openLatch)
+      }
     }
 
     "open on calling fail method" in {
@@ -144,6 +174,16 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       breaker().currentFailureCount should ===(1)
     }
 
+    "increment failure count on even number" when {
+      "even number is considered failure" in {
+        val breaker = CircuitBreakerSpec.longCallTimeoutCb()
+        breaker().currentFailureCount should ===(0)
+        breaker().withSyncCircuitBreaker(2, CircuitBreakerSpec.evenNumberIsFailure)
+        checkLatch(breaker.openLatch)
+        breaker().currentFailureCount should ===(1)
+      }
+    }
+
     "increment failure count on fail method" in {
       val breaker = CircuitBreakerSpec.longCallTimeoutCb()
       breaker().currentFailureCount should ===(0)
@@ -162,6 +202,30 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       breaker().currentFailureCount should ===(1)
       breaker().withSyncCircuitBreaker(sayHi)
       breaker().currentFailureCount should ===(0)
+    }
+
+    "reset failure count after exception in call" when {
+      "exception is defined as Success" in {
+        val breaker = CircuitBreakerSpec.multiFailureCb()
+        breaker().currentFailureCount should ===(0)
+        intercept[TestException] {
+          val ct = Thread.currentThread() // Ensure that the thunk is executed in the tests thread
+          breaker().withSyncCircuitBreaker({ if (Thread.currentThread() eq ct) throwException else "fail" })
+        }
+        breaker().currentFailureCount should ===(1)
+
+        val harmlessException = new TestException
+        val harmlessExceptionAsSuccess: Try[String] ⇒ Boolean = {
+          case Success(_)  ⇒ false
+          case Failure(ex) ⇒ ex != harmlessException
+        }
+
+        intercept[TestException] {
+          breaker().withSyncCircuitBreaker(throw harmlessException, harmlessExceptionAsSuccess)
+        }
+
+        breaker().currentFailureCount should ===(0)
+      }
     }
 
     "reset failure count after success method" in {
@@ -248,6 +312,17 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       checkLatch(breaker.closedLatch)
     }
 
+    "pass through next call and close on exception" when {
+      "exception is defined as call succeeded" in {
+        val breaker = CircuitBreakerSpec.shortResetTimeoutCb()
+        breaker().withCircuitBreaker(Future(throwException))
+        checkLatch(breaker.halfOpenLatch)
+        val allReturnIsSuccess: Try[String] ⇒ Boolean = _ ⇒ false
+        Await.ready(breaker().withCircuitBreaker(Future(throwException), allReturnIsSuccess), awaitTimeout)
+        checkLatch(breaker.closedLatch)
+      }
+    }
+
     "re-open on exception in call" in {
       val breaker = CircuitBreakerSpec.shortResetTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
@@ -255,6 +330,17 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       breaker.openLatch.reset
       intercept[TestException] { Await.result(breaker().withCircuitBreaker(Future(throwException)), awaitTimeout) }
       checkLatch(breaker.openLatch)
+    }
+
+    "re-open on even number" when {
+      "even number is defined as failure" in {
+        val breaker = CircuitBreakerSpec.shortResetTimeoutCb()
+        intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
+        checkLatch(breaker.halfOpenLatch)
+        breaker.openLatch.reset
+        Await.result(breaker().withCircuitBreaker(Future(2), CircuitBreakerSpec.evenNumberIsFailure), awaitTimeout)
+        checkLatch(breaker.openLatch)
+      }
     }
 
     "re-open on async failure" in {
@@ -281,6 +367,16 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       breaker().currentFailureCount should ===(1)
     }
 
+    "increment failure count on even number" when {
+      "even number is considered failure" in {
+        val breaker = CircuitBreakerSpec.longCallTimeoutCb()
+        breaker().currentFailureCount should ===(0)
+        Await.result(breaker().withCircuitBreaker(Future(2), CircuitBreakerSpec.evenNumberIsFailure), awaitTimeout)
+        checkLatch(breaker.openLatch)
+        breaker().currentFailureCount should ===(1)
+      }
+    }
+
     "increment failure count on async failure" in {
       val breaker = CircuitBreakerSpec.longCallTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
@@ -295,6 +391,24 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
       awaitCond(breaker().currentFailureCount == 4, awaitTimeout)
       breaker().withCircuitBreaker(Future(sayHi))
       awaitCond(breaker().currentFailureCount == 0, awaitTimeout)
+    }
+
+    "reset failure count after exception in call" when {
+      "exception is defined as Success" in {
+        val breaker = CircuitBreakerSpec.multiFailureCb()
+        breaker().withCircuitBreaker(Future(sayHi))
+        for (n ← 1 to 4) breaker().withCircuitBreaker(Future(throwException))
+        awaitCond(breaker().currentFailureCount == 4, awaitTimeout)
+
+        val harmlessException = new TestException
+        val harmlessExceptionAsSuccess: Try[String] ⇒ Boolean = {
+          case Success(_)  ⇒ false
+          case Failure(ex) ⇒ ex != harmlessException
+        }
+
+        breaker().withCircuitBreaker(Future(throw harmlessException), harmlessExceptionAsSuccess)
+        awaitCond(breaker().currentFailureCount == 0, awaitTimeout)
+      }
     }
 
     "increment failure count on callTimeout" in {
@@ -314,5 +428,4 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter {
 
     }
   }
-
 }

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -58,12 +58,12 @@ object CircuitBreaker {
   def create(scheduler: Scheduler, maxFailures: Int, callTimeout: FiniteDuration, resetTimeout: FiniteDuration): CircuitBreaker =
     apply(scheduler, maxFailures, callTimeout, resetTimeout)
 
-  val exceptionAsFailure: Try[_] ⇒ Boolean = {
+  private val exceptionAsFailure: Try[_] ⇒ Boolean = {
     case _: Success[_] ⇒ false
     case _             ⇒ true
   }
 
-  def exceptionAsFailureJava[T]: BiFunction[Optional[T], Optional[Throwable], java.lang.Boolean] =
+  private def exceptionAsFailureJava[T]: BiFunction[Optional[T], Optional[Throwable], java.lang.Boolean] =
     new BiFunction[Optional[T], Optional[Throwable], java.lang.Boolean] {
       override def apply(t: Optional[T], err: Optional[Throwable]) = {
         if (err.isPresent)

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -101,8 +101,12 @@ object MiMa extends AutoPlugin {
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.DDataShardCoordinator.updatingStateTimeout"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.DDataShardCoordinator.waitingForStateTimeout"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.DDataShardCoordinator.this"),
-      
-      // #21423 Remove deprecated metrics
+
+      // #22295 Improve Circuit breaker
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.pattern.CircuitBreaker#State.callThrough"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.pattern.CircuitBreaker#State.invoke"),
+
+        // #21423 Remove deprecated metrics
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterReadView.clusterMetrics"),
       ProblemFilters.exclude[MissingClassProblem]("akka.cluster.InternalClusterAction$MetricsTick$"),
       ProblemFilters.exclude[MissingClassProblem]("akka.cluster.MetricsCollector"),


### PR DESCRIPTION
This PR is to address #22295 

I overloaded `withCircuitBreaker` and it's siblings with an additional argument which allow user to specify what result should increase failure count and what should not.

Default behaviour is not changed, thus should be backward compatible