### PR TITLE
=rem #22277 log remoting connection errors (2.4 backport of #22278) 

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -351,7 +351,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
       val pipeline = newPipeline
       if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(isClient = false))
       val handler = if (isDatagram) new UdpServerHandler(NettyTransport.this, associationListenerPromise.future)
-      else new TcpServerHandler(NettyTransport.this, associationListenerPromise.future)
+      else new TcpServerHandler(NettyTransport.this, associationListenerPromise.future, log)
       pipeline.addLast("ServerHandler", handler)
       pipeline
     }
@@ -363,7 +363,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
         val pipeline = newPipeline
         if (EnableSsl) pipeline.addFirst("SslHandler", sslHandler(isClient = true))
         val handler = if (isDatagram) new UdpClientHandler(NettyTransport.this, remoteAddress)
-        else new TcpClientHandler(NettyTransport.this, remoteAddress)
+        else new TcpClientHandler(NettyTransport.this, remoteAddress, log)
         pipeline.addLast("clienthandler", handler)
         pipeline
       }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1165,7 +1165,12 @@ object MiMa extends AutoPlugin {
         // internal classes
         FilterAnyProblemStartingWith("akka.remote.artery")
       ),
-      "2.4.17" -> Seq()
+      "2.4.17" -> Seq(
+        // #22277 changes to internal classes
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.transport.netty.TcpServerHandler.this"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.transport.netty.TcpClientHandler.this"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.transport.netty.TcpHandlers.log")
+      )
       // make sure that
       //  * this list ends with the latest released version number
       //  * is kept in sync with the master branch


### PR DESCRIPTION
An alternative way of reporting might be to make the error part of the
DisassociationInfo. This would require changing or adding another subclass
which is a non-compatible change. Could still be worthwhile to do to prevent
double logging.

(cherry picked from commit 1b3d2acbcc5b2895fe79e8477fe815c711f94948)

Conflicts:
	project/MiMa.scala