### PR TITLE
Backport: Fail fast + docs around mixing major Scala versions serializing 

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -72,6 +72,11 @@ final case class Identify(messageId: Any) extends AutoReceivedMessage with NotIn
  */
 @SerialVersionUID(1L)
 final case class ActorIdentity(correlationId: Any, ref: Option[ActorRef]) {
+  if (ref.isDefined && ref.get == null) {
+    throw new IllegalArgumentException("ActorIdentity created with ref = Some(null) is not allowed, " +
+      "this could happen when serializing with Scala 2.12 and deserializing with Scala 2.11 which is not supported.")
+  }
+
   /**
    * Java API: `ActorRef` of the actor replying to the request or
    * null if no actor matched the request.

--- a/akka-docs/rst/common/binary-compatibility-rules.rst
+++ b/akka-docs/rst/common/binary-compatibility-rules.rst
@@ -151,3 +151,13 @@ called ``MiMa`` for short, for enforcing binary compatibility is kept where it w
 
 All Pull Requests must pass MiMa validation (which happens automatically), and if failures are detected,
 manual exception overrides may be put in place if the change happened to be in an Internal API for example.
+
+Serialization compatibility across Scala versions
+=================================================
+
+Scala does not maintain serialization compatibility across major versions. This means that if Java serialization is used
+there is no guarantee objects can be cleanly deserialized if serialized with a different version of Scala.
+
+The internal Akka Protobuf serializers that can be enabled explicitly with ``enable-additional-serialization-bindings``
+or implicitly with ``akka.actor.allow-java-serialization = off`` (which is preferable from a security standpoint)
+does not suffer from this problem.

--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -228,6 +228,17 @@ representation into a real reference. :class:`DynamicVariable` is a
 thread-local variable, so be sure to have it set while deserializing anything
 which might contain actor references.
 
+Serialization compatibility
+===========================
+
+It is not safe to mix major Scala versions when using the Java serialization as Scala does not guarantee compatibility
+and this could lead to very surprising errors.
+
+If using the Akka Protobuf serializers (implicitly with ``akka.actor.allow-java-serialization = off`` or explicitly with
+``enable-additional-serialization-bindings = true``) for the internal Akka messages those will not require the same major
+Scala version however you must also ensure the serializers used for your own types does not introduce the same
+incompatibility as Java serialization does.
+
 External Akka Serializers
 =========================
 

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -215,6 +215,18 @@ thread-local variable, so be sure to have it set while deserializing anything
 which might contain actor references.
 
 
+Serialization compatibility
+===========================
+
+It is not safe to mix major Scala versions when using the Java serialization as Scala does not guarantee compatibility
+and this could lead to very surprising errors.
+
+If using the Akka Protobuf serializers (implicitly with ``akka.actor.allow-java-serialization = off`` or explicitly with
+``enable-additional-serialization-bindings = true``) for the internal Akka messages those will not require the same major
+Scala version however you must also ensure the serializers used for your own types does not introduce the same
+incompatibility as Java serialization does.
+
+
 External Akka Serializers
 =========================
 


### PR DESCRIPTION
Backport of #22004 to 2.4