### PR TITLE
causal delivery of deltas and ORSet deltas, #22188

### DIFF
--- a/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
+++ b/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
@@ -8,6 +8,97 @@ public final class ReplicatedDataMessages {
   public static void registerAllExtensions(
       akka.protobuf.ExtensionRegistry registry) {
   }
+  /**
+   * Protobuf enum {@code akka.cluster.ddata.ORSetDeltaOp}
+   */
+  public enum ORSetDeltaOp
+      implements akka.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>Add = 0;</code>
+     */
+    Add(0, 0),
+    /**
+     * <code>Remove = 1;</code>
+     */
+    Remove(1, 1),
+    /**
+     * <code>Full = 2;</code>
+     */
+    Full(2, 2),
+    ;
+
+    /**
+     * <code>Add = 0;</code>
+     */
+    public static final int Add_VALUE = 0;
+    /**
+     * <code>Remove = 1;</code>
+     */
+    public static final int Remove_VALUE = 1;
+    /**
+     * <code>Full = 2;</code>
+     */
+    public static final int Full_VALUE = 2;
+
+
+    public final int getNumber() { return value; }
+
+    public static ORSetDeltaOp valueOf(int value) {
+      switch (value) {
+        case 0: return Add;
+        case 1: return Remove;
+        case 2: return Full;
+        default: return null;
+      }
+    }
+
+    public static akka.protobuf.Internal.EnumLiteMap<ORSetDeltaOp>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static akka.protobuf.Internal.EnumLiteMap<ORSetDeltaOp>
+        internalValueMap =
+          new akka.protobuf.Internal.EnumLiteMap<ORSetDeltaOp>() {
+            public ORSetDeltaOp findValueByNumber(int number) {
+              return ORSetDeltaOp.valueOf(number);
+            }
+          };
+
+    public final akka.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final akka.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final akka.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.getDescriptor().getEnumTypes().get(0);
+    }
+
+    private static final ORSetDeltaOp[] VALUES = values();
+
+    public static ORSetDeltaOp valueOf(
+        akka.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private ORSetDeltaOp(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:akka.cluster.ddata.ORSetDeltaOp)
+  }
+
   public interface GSetOrBuilder
       extends akka.protobuf.MessageOrBuilder {
 
@@ -1224,22 +1315,22 @@ public final class ReplicatedDataMessages {
     /**
      * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
      */
-    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector getVvector();
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getVvector();
     /**
      * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
      */
-    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder getVvectorOrBuilder();
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getVvectorOrBuilder();
 
     // repeated .akka.cluster.ddata.VersionVector dots = 2;
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector> 
+    java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector> 
         getDotsList();
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector getDots(int index);
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getDots(int index);
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
@@ -1247,12 +1338,12 @@ public final class ReplicatedDataMessages {
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder> 
+    java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> 
         getDotsOrBuilderList();
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder getDotsOrBuilder(
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getDotsOrBuilder(
         int index);
 
     // repeated string stringElements = 3;
@@ -1380,11 +1471,11 @@ public final class ReplicatedDataMessages {
               break;
             }
             case 10: {
-              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder subBuilder = null;
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = vvector_.toBuilder();
               }
-              vvector_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.PARSER, extensionRegistry);
+              vvector_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.PARSER, extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(vvector_);
                 vvector_ = subBuilder.buildPartial();
@@ -1394,10 +1485,10 @@ public final class ReplicatedDataMessages {
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                dots_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector>();
+                dots_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector>();
                 mutable_bitField0_ |= 0x00000002;
               }
-              dots_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.PARSER, extensionRegistry));
+              dots_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.PARSER, extensionRegistry));
               break;
             }
             case 26: {
@@ -1515,7 +1606,7 @@ public final class ReplicatedDataMessages {
     private int bitField0_;
     // required .akka.cluster.ddata.VersionVector vvector = 1;
     public static final int VVECTOR_FIELD_NUMBER = 1;
-    private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector vvector_;
+    private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector vvector_;
     /**
      * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
      */
@@ -1525,29 +1616,29 @@ public final class ReplicatedDataMessages {
     /**
      * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
      */
-    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector getVvector() {
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getVvector() {
       return vvector_;
     }
     /**
      * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
      */
-    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder getVvectorOrBuilder() {
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getVvectorOrBuilder() {
       return vvector_;
     }
 
     // repeated .akka.cluster.ddata.VersionVector dots = 2;
     public static final int DOTS_FIELD_NUMBER = 2;
-    private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector> dots_;
+    private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector> dots_;
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector> getDotsList() {
+    public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector> getDotsList() {
       return dots_;
     }
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder> 
+    public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> 
         getDotsOrBuilderList() {
       return dots_;
     }
@@ -1560,13 +1651,13 @@ public final class ReplicatedDataMessages {
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector getDots(int index) {
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getDots(int index) {
       return dots_.get(index);
     }
     /**
      * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
      */
-    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder getDotsOrBuilder(
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getDotsOrBuilder(
         int index) {
       return dots_.get(index);
     }
@@ -1686,7 +1777,7 @@ public final class ReplicatedDataMessages {
     }
 
     private void initFields() {
-      vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance();
+      vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
       dots_ = java.util.Collections.emptyList();
       stringElements_ = akka.protobuf.LazyStringArrayList.EMPTY;
       intElements_ = java.util.Collections.emptyList();
@@ -1929,7 +2020,7 @@ public final class ReplicatedDataMessages {
       public Builder clear() {
         super.clear();
         if (vvectorBuilder_ == null) {
-          vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance();
+          vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
         } else {
           vvectorBuilder_.clear();
         }
@@ -2171,9 +2262,9 @@ public final class ReplicatedDataMessages {
       private int bitField0_;
 
       // required .akka.cluster.ddata.VersionVector vvector = 1;
-      private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance();
+      private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
       private akka.protobuf.SingleFieldBuilder<
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder> vvectorBuilder_;
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> vvectorBuilder_;
       /**
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
@@ -2183,7 +2274,7 @@ public final class ReplicatedDataMessages {
       /**
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector getVvector() {
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getVvector() {
         if (vvectorBuilder_ == null) {
           return vvector_;
         } else {
@@ -2193,7 +2284,7 @@ public final class ReplicatedDataMessages {
       /**
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
-      public Builder setVvector(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector value) {
+      public Builder setVvector(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector value) {
         if (vvectorBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2210,7 +2301,7 @@ public final class ReplicatedDataMessages {
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
       public Builder setVvector(
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder builderForValue) {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder builderForValue) {
         if (vvectorBuilder_ == null) {
           vvector_ = builderForValue.build();
           onChanged();
@@ -2223,12 +2314,12 @@ public final class ReplicatedDataMessages {
       /**
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
-      public Builder mergeVvector(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector value) {
+      public Builder mergeVvector(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector value) {
         if (vvectorBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001) &&
-              vvector_ != akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance()) {
+              vvector_ != akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance()) {
             vvector_ =
-              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.newBuilder(vvector_).mergeFrom(value).buildPartial();
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.newBuilder(vvector_).mergeFrom(value).buildPartial();
           } else {
             vvector_ = value;
           }
@@ -2244,7 +2335,7 @@ public final class ReplicatedDataMessages {
        */
       public Builder clearVvector() {
         if (vvectorBuilder_ == null) {
-          vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance();
+          vvector_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
           onChanged();
         } else {
           vvectorBuilder_.clear();
@@ -2255,7 +2346,7 @@ public final class ReplicatedDataMessages {
       /**
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder getVvectorBuilder() {
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder getVvectorBuilder() {
         bitField0_ |= 0x00000001;
         onChanged();
         return getVvectorFieldBuilder().getBuilder();
@@ -2263,7 +2354,7 @@ public final class ReplicatedDataMessages {
       /**
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder getVvectorOrBuilder() {
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getVvectorOrBuilder() {
         if (vvectorBuilder_ != null) {
           return vvectorBuilder_.getMessageOrBuilder();
         } else {
@@ -2274,11 +2365,11 @@ public final class ReplicatedDataMessages {
        * <code>required .akka.cluster.ddata.VersionVector vvector = 1;</code>
        */
       private akka.protobuf.SingleFieldBuilder<
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder> 
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> 
           getVvectorFieldBuilder() {
         if (vvectorBuilder_ == null) {
           vvectorBuilder_ = new akka.protobuf.SingleFieldBuilder<
-              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder>(
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder>(
                   vvector_,
                   getParentForChildren(),
                   isClean());
@@ -2288,22 +2379,22 @@ public final class ReplicatedDataMessages {
       }
 
       // repeated .akka.cluster.ddata.VersionVector dots = 2;
-      private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector> dots_ =
+      private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector> dots_ =
         java.util.Collections.emptyList();
       private void ensureDotsIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-          dots_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector>(dots_);
+          dots_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector>(dots_);
           bitField0_ |= 0x00000002;
          }
       }
 
       private akka.protobuf.RepeatedFieldBuilder<
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder> dotsBuilder_;
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> dotsBuilder_;
 
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector> getDotsList() {
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector> getDotsList() {
         if (dotsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(dots_);
         } else {
@@ -2323,7 +2414,7 @@ public final class ReplicatedDataMessages {
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector getDots(int index) {
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getDots(int index) {
         if (dotsBuilder_ == null) {
           return dots_.get(index);
         } else {
@@ -2334,7 +2425,7 @@ public final class ReplicatedDataMessages {
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
       public Builder setDots(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector value) {
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector value) {
         if (dotsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2351,7 +2442,7 @@ public final class ReplicatedDataMessages {
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
       public Builder setDots(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder builderForValue) {
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder builderForValue) {
         if (dotsBuilder_ == null) {
           ensureDotsIsMutable();
           dots_.set(index, builderForValue.build());
@@ -2364,7 +2455,7 @@ public final class ReplicatedDataMessages {
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public Builder addDots(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector value) {
+      public Builder addDots(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector value) {
         if (dotsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2381,7 +2472,7 @@ public final class ReplicatedDataMessages {
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
       public Builder addDots(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector value) {
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector value) {
         if (dotsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2398,7 +2489,7 @@ public final class ReplicatedDataMessages {
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
       public Builder addDots(
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder builderForValue) {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder builderForValue) {
         if (dotsBuilder_ == null) {
           ensureDotsIsMutable();
           dots_.add(builderForValue.build());
@@ -2412,7 +2503,7 @@ public final class ReplicatedDataMessages {
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
       public Builder addDots(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder builderForValue) {
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder builderForValue) {
         if (dotsBuilder_ == null) {
           ensureDotsIsMutable();
           dots_.add(index, builderForValue.build());
@@ -2426,7 +2517,7 @@ public final class ReplicatedDataMessages {
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
       public Builder addAllDots(
-          java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector> values) {
+          java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector> values) {
         if (dotsBuilder_ == null) {
           ensureDotsIsMutable();
           super.addAll(values, dots_);
@@ -2465,14 +2556,14 @@ public final class ReplicatedDataMessages {
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder getDotsBuilder(
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder getDotsBuilder(
           int index) {
         return getDotsFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder getDotsOrBuilder(
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getDotsOrBuilder(
           int index) {
         if (dotsBuilder_ == null) {
           return dots_.get(index);  } else {
@@ -2482,7 +2573,7 @@ public final class ReplicatedDataMessages {
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder> 
+      public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> 
            getDotsOrBuilderList() {
         if (dotsBuilder_ != null) {
           return dotsBuilder_.getMessageOrBuilderList();
@@ -2493,31 +2584,31 @@ public final class ReplicatedDataMessages {
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder addDotsBuilder() {
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder addDotsBuilder() {
         return getDotsFieldBuilder().addBuilder(
-            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance());
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance());
       }
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder addDotsBuilder(
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder addDotsBuilder(
           int index) {
         return getDotsFieldBuilder().addBuilder(
-            index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance());
+            index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance());
       }
       /**
        * <code>repeated .akka.cluster.ddata.VersionVector dots = 2;</code>
        */
-      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder> 
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder> 
            getDotsBuilderList() {
         return getDotsFieldBuilder().getBuilderList();
       }
       private akka.protobuf.RepeatedFieldBuilder<
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder> 
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> 
           getDotsFieldBuilder() {
         if (dotsBuilder_ == null) {
           dotsBuilder_ = new akka.protobuf.RepeatedFieldBuilder<
-              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder>(
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder>(
                   dots_,
                   ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
@@ -3001,6 +3092,1313 @@ public final class ReplicatedDataMessages {
     }
 
     // @@protoc_insertion_point(class_scope:akka.cluster.ddata.ORSet)
+  }
+
+  public interface ORSetDeltaGroupOrBuilder
+      extends akka.protobuf.MessageOrBuilder {
+
+    // repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry> 
+        getEntriesList();
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry getEntries(int index);
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    int getEntriesCount();
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder> 
+        getEntriesOrBuilderList();
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder getEntriesOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code akka.cluster.ddata.ORSetDeltaGroup}
+   */
+  public static final class ORSetDeltaGroup extends
+      akka.protobuf.GeneratedMessage
+      implements ORSetDeltaGroupOrBuilder {
+    // Use ORSetDeltaGroup.newBuilder() to construct.
+    private ORSetDeltaGroup(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private ORSetDeltaGroup(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final ORSetDeltaGroup defaultInstance;
+    public static ORSetDeltaGroup getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public ORSetDeltaGroup getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final akka.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final akka.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ORSetDeltaGroup(
+        akka.protobuf.CodedInputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      akka.protobuf.UnknownFieldSet.Builder unknownFields =
+          akka.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              entries_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new akka.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          entries_ = java.util.Collections.unmodifiableList(entries_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final akka.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+    }
+
+    protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Builder.class);
+    }
+
+    public static akka.protobuf.Parser<ORSetDeltaGroup> PARSER =
+        new akka.protobuf.AbstractParser<ORSetDeltaGroup>() {
+      public ORSetDeltaGroup parsePartialFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return new ORSetDeltaGroup(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public akka.protobuf.Parser<ORSetDeltaGroup> getParserForType() {
+      return PARSER;
+    }
+
+    public interface EntryOrBuilder
+        extends akka.protobuf.MessageOrBuilder {
+
+      // required .akka.cluster.ddata.ORSetDeltaOp operation = 1;
+      /**
+       * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+       */
+      boolean hasOperation();
+      /**
+       * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp getOperation();
+
+      // required .akka.cluster.ddata.ORSet underlying = 2;
+      /**
+       * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+       */
+      boolean hasUnderlying();
+      /**
+       * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet getUnderlying();
+      /**
+       * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetOrBuilder getUnderlyingOrBuilder();
+    }
+    /**
+     * Protobuf type {@code akka.cluster.ddata.ORSetDeltaGroup.Entry}
+     */
+    public static final class Entry extends
+        akka.protobuf.GeneratedMessage
+        implements EntryOrBuilder {
+      // Use Entry.newBuilder() to construct.
+      private Entry(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+        super(builder);
+        this.unknownFields = builder.getUnknownFields();
+      }
+      private Entry(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+      private static final Entry defaultInstance;
+      public static Entry getDefaultInstance() {
+        return defaultInstance;
+      }
+
+      public Entry getDefaultInstanceForType() {
+        return defaultInstance;
+      }
+
+      private final akka.protobuf.UnknownFieldSet unknownFields;
+      @java.lang.Override
+      public final akka.protobuf.UnknownFieldSet
+          getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Entry(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        initFields();
+        int mutable_bitField0_ = 0;
+        akka.protobuf.UnknownFieldSet.Builder unknownFields =
+            akka.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 8: {
+                int rawValue = input.readEnum();
+                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp value = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp.valueOf(rawValue);
+                if (value == null) {
+                  unknownFields.mergeVarintField(1, rawValue);
+                } else {
+                  bitField0_ |= 0x00000001;
+                  operation_ = value;
+                }
+                break;
+              }
+              case 18: {
+                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                  subBuilder = underlying_.toBuilder();
+                }
+                underlying_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(underlying_);
+                  underlying_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000002;
+                break;
+              }
+            }
+          }
+        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new akka.protobuf.InvalidProtocolBufferException(
+              e.getMessage()).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final akka.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+      }
+
+      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder.class);
+      }
+
+      public static akka.protobuf.Parser<Entry> PARSER =
+          new akka.protobuf.AbstractParser<Entry>() {
+        public Entry parsePartialFrom(
+            akka.protobuf.CodedInputStream input,
+            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobuf.InvalidProtocolBufferException {
+          return new Entry(input, extensionRegistry);
+        }
+      };
+
+      @java.lang.Override
+      public akka.protobuf.Parser<Entry> getParserForType() {
+        return PARSER;
+      }
+
+      private int bitField0_;
+      // required .akka.cluster.ddata.ORSetDeltaOp operation = 1;
+      public static final int OPERATION_FIELD_NUMBER = 1;
+      private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp operation_;
+      /**
+       * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+       */
+      public boolean hasOperation() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp getOperation() {
+        return operation_;
+      }
+
+      // required .akka.cluster.ddata.ORSet underlying = 2;
+      public static final int UNDERLYING_FIELD_NUMBER = 2;
+      private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet underlying_;
+      /**
+       * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+       */
+      public boolean hasUnderlying() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet getUnderlying() {
+        return underlying_;
+      }
+      /**
+       * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetOrBuilder getUnderlyingOrBuilder() {
+        return underlying_;
+      }
+
+      private void initFields() {
+        operation_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp.Add;
+        underlying_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.getDefaultInstance();
+      }
+      private byte memoizedIsInitialized = -1;
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized != -1) return isInitialized == 1;
+
+        if (!hasOperation()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!hasUnderlying()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!getUnderlying().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      public void writeTo(akka.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        getSerializedSize();
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeEnum(1, operation_.getNumber());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          output.writeMessage(2, underlying_);
+        }
+        getUnknownFields().writeTo(output);
+      }
+
+      private int memoizedSerializedSize = -1;
+      public int getSerializedSize() {
+        int size = memoizedSerializedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeEnumSize(1, operation_.getNumber());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeMessageSize(2, underlying_);
+        }
+        size += getUnknownFields().getSerializedSize();
+        memoizedSerializedSize = size;
+        return size;
+      }
+
+      private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      protected java.lang.Object writeReplace()
+          throws java.io.ObjectStreamException {
+        return super.writeReplace();
+      }
+
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(
+          akka.protobuf.ByteString data)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(
+          akka.protobuf.ByteString data,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(byte[] data)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(
+          byte[] data,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(
+          java.io.InputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseDelimitedFrom(
+          java.io.InputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(
+          akka.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+
+      public static Builder newBuilder() { return Builder.create(); }
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry prototype) {
+        return newBuilder().mergeFrom(prototype);
+      }
+      public Builder toBuilder() { return newBuilder(this); }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          akka.protobuf.GeneratedMessage.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code akka.cluster.ddata.ORSetDeltaGroup.Entry}
+       */
+      public static final class Builder extends
+          akka.protobuf.GeneratedMessage.Builder<Builder>
+         implements akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder {
+        public static final akka.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+        }
+
+        protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder.class);
+        }
+
+        // Construct using akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            akka.protobuf.GeneratedMessage.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            getUnderlyingFieldBuilder();
+          }
+        }
+        private static Builder create() {
+          return new Builder();
+        }
+
+        public Builder clear() {
+          super.clear();
+          operation_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp.Add;
+          bitField0_ = (bitField0_ & ~0x00000001);
+          if (underlyingBuilder_ == null) {
+            underlying_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.getDefaultInstance();
+          } else {
+            underlyingBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+
+        public Builder clone() {
+          return create().mergeFrom(buildPartial());
+        }
+
+        public akka.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry getDefaultInstanceForType() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.getDefaultInstance();
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry build() {
+          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry buildPartial() {
+          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry result = new akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.operation_ = operation_;
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000002;
+          }
+          if (underlyingBuilder_ == null) {
+            result.underlying_ = underlying_;
+          } else {
+            result.underlying_ = underlyingBuilder_.build();
+          }
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        public Builder mergeFrom(akka.protobuf.Message other) {
+          if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry) {
+            return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry other) {
+          if (other == akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.getDefaultInstance()) return this;
+          if (other.hasOperation()) {
+            setOperation(other.getOperation());
+          }
+          if (other.hasUnderlying()) {
+            mergeUnderlying(other.getUnderlying());
+          }
+          this.mergeUnknownFields(other.getUnknownFields());
+          return this;
+        }
+
+        public final boolean isInitialized() {
+          if (!hasOperation()) {
+            
+            return false;
+          }
+          if (!hasUnderlying()) {
+            
+            return false;
+          }
+          if (!getUnderlying().isInitialized()) {
+            
+            return false;
+          }
+          return true;
+        }
+
+        public Builder mergeFrom(
+            akka.protobuf.CodedInputStream input,
+            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (akka.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry) e.getUnfinishedMessage();
+            throw e;
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        // required .akka.cluster.ddata.ORSetDeltaOp operation = 1;
+        private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp operation_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp.Add;
+        /**
+         * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+         */
+        public boolean hasOperation() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp getOperation() {
+          return operation_;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+         */
+        public Builder setOperation(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          bitField0_ |= 0x00000001;
+          operation_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSetDeltaOp operation = 1;</code>
+         */
+        public Builder clearOperation() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          operation_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaOp.Add;
+          onChanged();
+          return this;
+        }
+
+        // required .akka.cluster.ddata.ORSet underlying = 2;
+        private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet underlying_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.getDefaultInstance();
+        private akka.protobuf.SingleFieldBuilder<
+            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetOrBuilder> underlyingBuilder_;
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public boolean hasUnderlying() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet getUnderlying() {
+          if (underlyingBuilder_ == null) {
+            return underlying_;
+          } else {
+            return underlyingBuilder_.getMessage();
+          }
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public Builder setUnderlying(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet value) {
+          if (underlyingBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            underlying_ = value;
+            onChanged();
+          } else {
+            underlyingBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public Builder setUnderlying(
+            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder builderForValue) {
+          if (underlyingBuilder_ == null) {
+            underlying_ = builderForValue.build();
+            onChanged();
+          } else {
+            underlyingBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public Builder mergeUnderlying(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet value) {
+          if (underlyingBuilder_ == null) {
+            if (((bitField0_ & 0x00000002) == 0x00000002) &&
+                underlying_ != akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.getDefaultInstance()) {
+              underlying_ =
+                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.newBuilder(underlying_).mergeFrom(value).buildPartial();
+            } else {
+              underlying_ = value;
+            }
+            onChanged();
+          } else {
+            underlyingBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public Builder clearUnderlying() {
+          if (underlyingBuilder_ == null) {
+            underlying_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.getDefaultInstance();
+            onChanged();
+          } else {
+            underlyingBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder getUnderlyingBuilder() {
+          bitField0_ |= 0x00000002;
+          onChanged();
+          return getUnderlyingFieldBuilder().getBuilder();
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetOrBuilder getUnderlyingOrBuilder() {
+          if (underlyingBuilder_ != null) {
+            return underlyingBuilder_.getMessageOrBuilder();
+          } else {
+            return underlying_;
+          }
+        }
+        /**
+         * <code>required .akka.cluster.ddata.ORSet underlying = 2;</code>
+         */
+        private akka.protobuf.SingleFieldBuilder<
+            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetOrBuilder> 
+            getUnderlyingFieldBuilder() {
+          if (underlyingBuilder_ == null) {
+            underlyingBuilder_ = new akka.protobuf.SingleFieldBuilder<
+                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetOrBuilder>(
+                    underlying_,
+                    getParentForChildren(),
+                    isClean());
+            underlying_ = null;
+          }
+          return underlyingBuilder_;
+        }
+
+        // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.ORSetDeltaGroup.Entry)
+      }
+
+      static {
+        defaultInstance = new Entry(true);
+        defaultInstance.initFields();
+      }
+
+      // @@protoc_insertion_point(class_scope:akka.cluster.ddata.ORSetDeltaGroup.Entry)
+    }
+
+    // repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;
+    public static final int ENTRIES_FIELD_NUMBER = 1;
+    private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry> entries_;
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry> getEntriesList() {
+      return entries_;
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder> 
+        getEntriesOrBuilderList() {
+      return entries_;
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    public int getEntriesCount() {
+      return entries_.size();
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry getEntries(int index) {
+      return entries_.get(index);
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder getEntriesOrBuilder(
+        int index) {
+      return entries_.get(index);
+    }
+
+    private void initFields() {
+      entries_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      for (int i = 0; i < getEntriesCount(); i++) {
+        if (!getEntries(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(akka.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < entries_.size(); i++) {
+        output.writeMessage(1, entries_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < entries_.size(); i++) {
+        size += akka.protobuf.CodedOutputStream
+          .computeMessageSize(1, entries_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(
+        akka.protobuf.ByteString data)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(
+        akka.protobuf.ByteString data,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(byte[] data)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(
+        byte[] data,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(
+        java.io.InputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseDelimitedFrom(
+        java.io.InputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(
+        akka.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseFrom(
+        akka.protobuf.CodedInputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code akka.cluster.ddata.ORSetDeltaGroup}
+     */
+    public static final class Builder extends
+        akka.protobuf.GeneratedMessage.Builder<Builder>
+       implements akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroupOrBuilder {
+      public static final akka.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+      }
+
+      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Builder.class);
+      }
+
+      // Construct using akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          akka.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getEntriesFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          entriesBuilder_.clear();
+        }
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public akka.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup getDefaultInstanceForType() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.getDefaultInstance();
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup build() {
+        akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup buildPartial() {
+        akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup result = new akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup(this);
+        int from_bitField0_ = bitField0_;
+        if (entriesBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            entries_ = java.util.Collections.unmodifiableList(entries_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.entries_ = entries_;
+        } else {
+          result.entries_ = entriesBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(akka.protobuf.Message other) {
+        if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup) {
+          return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup other) {
+        if (other == akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.getDefaultInstance()) return this;
+        if (entriesBuilder_ == null) {
+          if (!other.entries_.isEmpty()) {
+            if (entries_.isEmpty()) {
+              entries_ = other.entries_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureEntriesIsMutable();
+              entries_.addAll(other.entries_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.entries_.isEmpty()) {
+            if (entriesBuilder_.isEmpty()) {
+              entriesBuilder_.dispose();
+              entriesBuilder_ = null;
+              entries_ = other.entries_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              entriesBuilder_ = 
+                akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getEntriesFieldBuilder() : null;
+            } else {
+              entriesBuilder_.addAllMessages(other.entries_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        for (int i = 0; i < getEntriesCount(); i++) {
+          if (!getEntries(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;
+      private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry> entries_ =
+        java.util.Collections.emptyList();
+      private void ensureEntriesIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry>(entries_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private akka.protobuf.RepeatedFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder> entriesBuilder_;
+
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry> getEntriesList() {
+        if (entriesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(entries_);
+        } else {
+          return entriesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public int getEntriesCount() {
+        if (entriesBuilder_ == null) {
+          return entries_.size();
+        } else {
+          return entriesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry getEntries(int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);
+        } else {
+          return entriesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder setEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.set(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder setEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder addEntries(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder addAllEntries(
+          java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry> values) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          super.addAll(values, entries_);
+          onChanged();
+        } else {
+          entriesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder clearEntries() {
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          entriesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public Builder removeEntries(int index) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.remove(index);
+          onChanged();
+        } else {
+          entriesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder getEntriesBuilder(
+          int index) {
+        return getEntriesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder getEntriesOrBuilder(
+          int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);  } else {
+          return entriesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder> 
+           getEntriesOrBuilderList() {
+        if (entriesBuilder_ != null) {
+          return entriesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(entries_);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder addEntriesBuilder() {
+        return getEntriesFieldBuilder().addBuilder(
+            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder addEntriesBuilder(
+          int index) {
+        return getEntriesFieldBuilder().addBuilder(
+            index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORSetDeltaGroup.Entry entries = 1;</code>
+       */
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder> 
+           getEntriesBuilderList() {
+        return getEntriesFieldBuilder().getBuilderList();
+      }
+      private akka.protobuf.RepeatedFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder> 
+          getEntriesFieldBuilder() {
+        if (entriesBuilder_ == null) {
+          entriesBuilder_ = new akka.protobuf.RepeatedFieldBuilder<
+              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.EntryOrBuilder>(
+                  entries_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          entries_ = null;
+        }
+        return entriesBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.ORSetDeltaGroup)
+    }
+
+    static {
+      defaultInstance = new ORSetDeltaGroup(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:akka.cluster.ddata.ORSetDeltaGroup)
   }
 
   public interface FlagOrBuilder
@@ -6257,1304 +7655,6 @@ public final class ReplicatedDataMessages {
     }
 
     // @@protoc_insertion_point(class_scope:akka.cluster.ddata.PNCounter)
-  }
-
-  public interface VersionVectorOrBuilder
-      extends akka.protobuf.MessageOrBuilder {
-
-    // repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry> 
-        getEntriesList();
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry getEntries(int index);
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    int getEntriesCount();
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder> 
-        getEntriesOrBuilderList();
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder getEntriesOrBuilder(
-        int index);
-  }
-  /**
-   * Protobuf type {@code akka.cluster.ddata.VersionVector}
-   */
-  public static final class VersionVector extends
-      akka.protobuf.GeneratedMessage
-      implements VersionVectorOrBuilder {
-    // Use VersionVector.newBuilder() to construct.
-    private VersionVector(akka.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
-    }
-    private VersionVector(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final VersionVector defaultInstance;
-    public static VersionVector getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public VersionVector getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private VersionVector(
-        akka.protobuf.CodedInputStream input,
-        akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              entries_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.PARSER, extensionRegistry));
-              break;
-            }
-          }
-        }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          entries_ = java.util.Collections.unmodifiableList(entries_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final akka.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
-    }
-
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder.class);
-    }
-
-    public static akka.protobuf.Parser<VersionVector> PARSER =
-        new akka.protobuf.AbstractParser<VersionVector>() {
-      public VersionVector parsePartialFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws akka.protobuf.InvalidProtocolBufferException {
-        return new VersionVector(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<VersionVector> getParserForType() {
-      return PARSER;
-    }
-
-    public interface EntryOrBuilder
-        extends akka.protobuf.MessageOrBuilder {
-
-      // required .akka.cluster.ddata.UniqueAddress node = 1;
-      /**
-       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-       */
-      boolean hasNode();
-      /**
-       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-       */
-      akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getNode();
-      /**
-       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-       */
-      akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getNodeOrBuilder();
-
-      // required int64 version = 2;
-      /**
-       * <code>required int64 version = 2;</code>
-       */
-      boolean hasVersion();
-      /**
-       * <code>required int64 version = 2;</code>
-       */
-      long getVersion();
-    }
-    /**
-     * Protobuf type {@code akka.cluster.ddata.VersionVector.Entry}
-     */
-    public static final class Entry extends
-        akka.protobuf.GeneratedMessage
-        implements EntryOrBuilder {
-      // Use Entry.newBuilder() to construct.
-      private Entry(akka.protobuf.GeneratedMessage.Builder<?> builder) {
-        super(builder);
-        this.unknownFields = builder.getUnknownFields();
-      }
-      private Entry(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-      private static final Entry defaultInstance;
-      public static Entry getDefaultInstance() {
-        return defaultInstance;
-      }
-
-      public Entry getDefaultInstanceForType() {
-        return defaultInstance;
-      }
-
-      private final akka.protobuf.UnknownFieldSet unknownFields;
-      @java.lang.Override
-      public final akka.protobuf.UnknownFieldSet
-          getUnknownFields() {
-        return this.unknownFields;
-      }
-      private Entry(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws akka.protobuf.InvalidProtocolBufferException {
-        initFields();
-        int mutable_bitField0_ = 0;
-        akka.protobuf.UnknownFieldSet.Builder unknownFields =
-            akka.protobuf.UnknownFieldSet.newBuilder();
-        try {
-          boolean done = false;
-          while (!done) {
-            int tag = input.readTag();
-            switch (tag) {
-              case 0:
-                done = true;
-                break;
-              default: {
-                if (!parseUnknownField(input, unknownFields,
-                                       extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
-              case 10: {
-                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder subBuilder = null;
-                if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                  subBuilder = node_.toBuilder();
-                }
-                node_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.PARSER, extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(node_);
-                  node_ = subBuilder.buildPartial();
-                }
-                bitField0_ |= 0x00000001;
-                break;
-              }
-              case 16: {
-                bitField0_ |= 0x00000002;
-                version_ = input.readInt64();
-                break;
-              }
-            }
-          }
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(this);
-        } catch (java.io.IOException e) {
-          throw new akka.protobuf.InvalidProtocolBufferException(
-              e.getMessage()).setUnfinishedMessage(this);
-        } finally {
-          this.unknownFields = unknownFields.build();
-          makeExtensionsImmutable();
-        }
-      }
-      public static final akka.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
-      }
-
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder.class);
-      }
-
-      public static akka.protobuf.Parser<Entry> PARSER =
-          new akka.protobuf.AbstractParser<Entry>() {
-        public Entry parsePartialFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
-          return new Entry(input, extensionRegistry);
-        }
-      };
-
-      @java.lang.Override
-      public akka.protobuf.Parser<Entry> getParserForType() {
-        return PARSER;
-      }
-
-      private int bitField0_;
-      // required .akka.cluster.ddata.UniqueAddress node = 1;
-      public static final int NODE_FIELD_NUMBER = 1;
-      private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress node_;
-      /**
-       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-       */
-      public boolean hasNode() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      /**
-       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getNode() {
-        return node_;
-      }
-      /**
-       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getNodeOrBuilder() {
-        return node_;
-      }
-
-      // required int64 version = 2;
-      public static final int VERSION_FIELD_NUMBER = 2;
-      private long version_;
-      /**
-       * <code>required int64 version = 2;</code>
-       */
-      public boolean hasVersion() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
-      }
-      /**
-       * <code>required int64 version = 2;</code>
-       */
-      public long getVersion() {
-        return version_;
-      }
-
-      private void initFields() {
-        node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
-        version_ = 0L;
-      }
-      private byte memoizedIsInitialized = -1;
-      public final boolean isInitialized() {
-        byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
-
-        if (!hasNode()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-        if (!hasVersion()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-        if (!getNode().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-        memoizedIsInitialized = 1;
-        return true;
-      }
-
-      public void writeTo(akka.protobuf.CodedOutputStream output)
-                          throws java.io.IOException {
-        getSerializedSize();
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          output.writeMessage(1, node_);
-        }
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          output.writeInt64(2, version_);
-        }
-        getUnknownFields().writeTo(output);
-      }
-
-      private int memoizedSerializedSize = -1;
-      public int getSerializedSize() {
-        int size = memoizedSerializedSize;
-        if (size != -1) return size;
-
-        size = 0;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          size += akka.protobuf.CodedOutputStream
-            .computeMessageSize(1, node_);
-        }
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          size += akka.protobuf.CodedOutputStream
-            .computeInt64Size(2, version_);
-        }
-        size += getUnknownFields().getSerializedSize();
-        memoizedSerializedSize = size;
-        return size;
-      }
-
-      private static final long serialVersionUID = 0L;
-      @java.lang.Override
-      protected java.lang.Object writeReplace()
-          throws java.io.ObjectStreamException {
-        return super.writeReplace();
-      }
-
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(
-          akka.protobuf.ByteString data)
-          throws akka.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(
-          akka.protobuf.ByteString data,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws akka.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data, extensionRegistry);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(byte[] data)
-          throws akka.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(
-          byte[] data,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws akka.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data, extensionRegistry);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(java.io.InputStream input)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(
-          java.io.InputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseDelimitedFrom(java.io.InputStream input)
-          throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseDelimitedFrom(
-          java.io.InputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input, extensionRegistry);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(
-          akka.protobuf.CodedInputStream input)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input);
-      }
-      public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parseFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
-      }
-
-      public static Builder newBuilder() { return Builder.create(); }
-      public Builder newBuilderForType() { return newBuilder(); }
-      public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry prototype) {
-        return newBuilder().mergeFrom(prototype);
-      }
-      public Builder toBuilder() { return newBuilder(this); }
-
-      @java.lang.Override
-      protected Builder newBuilderForType(
-          akka.protobuf.GeneratedMessage.BuilderParent parent) {
-        Builder builder = new Builder(parent);
-        return builder;
-      }
-      /**
-       * Protobuf type {@code akka.cluster.ddata.VersionVector.Entry}
-       */
-      public static final class Builder extends
-          akka.protobuf.GeneratedMessage.Builder<Builder>
-         implements akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder {
-        public static final akka.protobuf.Descriptors.Descriptor
-            getDescriptor() {
-          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
-        }
-
-        protected akka.protobuf.GeneratedMessage.FieldAccessorTable
-            internalGetFieldAccessorTable() {
-          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                  akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder.class);
-        }
-
-        // Construct using akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.newBuilder()
-        private Builder() {
-          maybeForceBuilderInitialization();
-        }
-
-        private Builder(
-            akka.protobuf.GeneratedMessage.BuilderParent parent) {
-          super(parent);
-          maybeForceBuilderInitialization();
-        }
-        private void maybeForceBuilderInitialization() {
-          if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-            getNodeFieldBuilder();
-          }
-        }
-        private static Builder create() {
-          return new Builder();
-        }
-
-        public Builder clear() {
-          super.clear();
-          if (nodeBuilder_ == null) {
-            node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
-          } else {
-            nodeBuilder_.clear();
-          }
-          bitField0_ = (bitField0_ & ~0x00000001);
-          version_ = 0L;
-          bitField0_ = (bitField0_ & ~0x00000002);
-          return this;
-        }
-
-        public Builder clone() {
-          return create().mergeFrom(buildPartial());
-        }
-
-        public akka.protobuf.Descriptors.Descriptor
-            getDescriptorForType() {
-          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
-        }
-
-        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry getDefaultInstanceForType() {
-          return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.getDefaultInstance();
-        }
-
-        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry build() {
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry result = buildPartial();
-          if (!result.isInitialized()) {
-            throw newUninitializedMessageException(result);
-          }
-          return result;
-        }
-
-        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry buildPartial() {
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry result = new akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry(this);
-          int from_bitField0_ = bitField0_;
-          int to_bitField0_ = 0;
-          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-            to_bitField0_ |= 0x00000001;
-          }
-          if (nodeBuilder_ == null) {
-            result.node_ = node_;
-          } else {
-            result.node_ = nodeBuilder_.build();
-          }
-          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-            to_bitField0_ |= 0x00000002;
-          }
-          result.version_ = version_;
-          result.bitField0_ = to_bitField0_;
-          onBuilt();
-          return result;
-        }
-
-        public Builder mergeFrom(akka.protobuf.Message other) {
-          if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry) {
-            return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry)other);
-          } else {
-            super.mergeFrom(other);
-            return this;
-          }
-        }
-
-        public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry other) {
-          if (other == akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.getDefaultInstance()) return this;
-          if (other.hasNode()) {
-            mergeNode(other.getNode());
-          }
-          if (other.hasVersion()) {
-            setVersion(other.getVersion());
-          }
-          this.mergeUnknownFields(other.getUnknownFields());
-          return this;
-        }
-
-        public final boolean isInitialized() {
-          if (!hasNode()) {
-            
-            return false;
-          }
-          if (!hasVersion()) {
-            
-            return false;
-          }
-          if (!getNode().isInitialized()) {
-            
-            return false;
-          }
-          return true;
-        }
-
-        public Builder mergeFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry parsedMessage = null;
-          try {
-            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-          } catch (akka.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry) e.getUnfinishedMessage();
-            throw e;
-          } finally {
-            if (parsedMessage != null) {
-              mergeFrom(parsedMessage);
-            }
-          }
-          return this;
-        }
-        private int bitField0_;
-
-        // required .akka.cluster.ddata.UniqueAddress node = 1;
-        private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
-        private akka.protobuf.SingleFieldBuilder<
-            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder> nodeBuilder_;
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public boolean hasNode() {
-          return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getNode() {
-          if (nodeBuilder_ == null) {
-            return node_;
-          } else {
-            return nodeBuilder_.getMessage();
-          }
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public Builder setNode(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress value) {
-          if (nodeBuilder_ == null) {
-            if (value == null) {
-              throw new NullPointerException();
-            }
-            node_ = value;
-            onChanged();
-          } else {
-            nodeBuilder_.setMessage(value);
-          }
-          bitField0_ |= 0x00000001;
-          return this;
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public Builder setNode(
-            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder builderForValue) {
-          if (nodeBuilder_ == null) {
-            node_ = builderForValue.build();
-            onChanged();
-          } else {
-            nodeBuilder_.setMessage(builderForValue.build());
-          }
-          bitField0_ |= 0x00000001;
-          return this;
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public Builder mergeNode(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress value) {
-          if (nodeBuilder_ == null) {
-            if (((bitField0_ & 0x00000001) == 0x00000001) &&
-                node_ != akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance()) {
-              node_ =
-                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.newBuilder(node_).mergeFrom(value).buildPartial();
-            } else {
-              node_ = value;
-            }
-            onChanged();
-          } else {
-            nodeBuilder_.mergeFrom(value);
-          }
-          bitField0_ |= 0x00000001;
-          return this;
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public Builder clearNode() {
-          if (nodeBuilder_ == null) {
-            node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
-            onChanged();
-          } else {
-            nodeBuilder_.clear();
-          }
-          bitField0_ = (bitField0_ & ~0x00000001);
-          return this;
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder getNodeBuilder() {
-          bitField0_ |= 0x00000001;
-          onChanged();
-          return getNodeFieldBuilder().getBuilder();
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getNodeOrBuilder() {
-          if (nodeBuilder_ != null) {
-            return nodeBuilder_.getMessageOrBuilder();
-          } else {
-            return node_;
-          }
-        }
-        /**
-         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
-         */
-        private akka.protobuf.SingleFieldBuilder<
-            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder> 
-            getNodeFieldBuilder() {
-          if (nodeBuilder_ == null) {
-            nodeBuilder_ = new akka.protobuf.SingleFieldBuilder<
-                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder>(
-                    node_,
-                    getParentForChildren(),
-                    isClean());
-            node_ = null;
-          }
-          return nodeBuilder_;
-        }
-
-        // required int64 version = 2;
-        private long version_ ;
-        /**
-         * <code>required int64 version = 2;</code>
-         */
-        public boolean hasVersion() {
-          return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-        /**
-         * <code>required int64 version = 2;</code>
-         */
-        public long getVersion() {
-          return version_;
-        }
-        /**
-         * <code>required int64 version = 2;</code>
-         */
-        public Builder setVersion(long value) {
-          bitField0_ |= 0x00000002;
-          version_ = value;
-          onChanged();
-          return this;
-        }
-        /**
-         * <code>required int64 version = 2;</code>
-         */
-        public Builder clearVersion() {
-          bitField0_ = (bitField0_ & ~0x00000002);
-          version_ = 0L;
-          onChanged();
-          return this;
-        }
-
-        // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.VersionVector.Entry)
-      }
-
-      static {
-        defaultInstance = new Entry(true);
-        defaultInstance.initFields();
-      }
-
-      // @@protoc_insertion_point(class_scope:akka.cluster.ddata.VersionVector.Entry)
-    }
-
-    // repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;
-    public static final int ENTRIES_FIELD_NUMBER = 1;
-    private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry> entries_;
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry> getEntriesList() {
-      return entries_;
-    }
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder> 
-        getEntriesOrBuilderList() {
-      return entries_;
-    }
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    public int getEntriesCount() {
-      return entries_.size();
-    }
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry getEntries(int index) {
-      return entries_.get(index);
-    }
-    /**
-     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-     */
-    public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder getEntriesOrBuilder(
-        int index) {
-      return entries_.get(index);
-    }
-
-    private void initFields() {
-      entries_ = java.util.Collections.emptyList();
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-
-      for (int i = 0; i < getEntriesCount(); i++) {
-        if (!getEntries(i).isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    public void writeTo(akka.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      for (int i = 0; i < entries_.size(); i++) {
-        output.writeMessage(1, entries_.get(i));
-      }
-      getUnknownFields().writeTo(output);
-    }
-
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      for (int i = 0; i < entries_.size(); i++) {
-        size += akka.protobuf.CodedOutputStream
-          .computeMessageSize(1, entries_.get(i));
-      }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
-    }
-
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(
-        akka.protobuf.ByteString data)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(
-        akka.protobuf.ByteString data,
-        akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(byte[] data)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(
-        byte[] data,
-        akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(
-        java.io.InputStream input,
-        akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseDelimitedFrom(
-        java.io.InputStream input,
-        akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(
-        akka.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parseFrom(
-        akka.protobuf.CodedInputStream input,
-        akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        akka.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * Protobuf type {@code akka.cluster.ddata.VersionVector}
-     */
-    public static final class Builder extends
-        akka.protobuf.GeneratedMessage.Builder<Builder>
-       implements akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVectorOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
-      }
-
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.class, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Builder.class);
-      }
-
-      // Construct using akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          akka.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getEntriesFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-
-      public Builder clear() {
-        super.clear();
-        if (entriesBuilder_ == null) {
-          entries_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          entriesBuilder_.clear();
-        }
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
-      }
-
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector getDefaultInstanceForType() {
-        return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance();
-      }
-
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector build() {
-        akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector buildPartial() {
-        akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector result = new akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector(this);
-        int from_bitField0_ = bitField0_;
-        if (entriesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            entries_ = java.util.Collections.unmodifiableList(entries_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.entries_ = entries_;
-        } else {
-          result.entries_ = entriesBuilder_.build();
-        }
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(akka.protobuf.Message other) {
-        if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector) {
-          return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector other) {
-        if (other == akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.getDefaultInstance()) return this;
-        if (entriesBuilder_ == null) {
-          if (!other.entries_.isEmpty()) {
-            if (entries_.isEmpty()) {
-              entries_ = other.entries_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureEntriesIsMutable();
-              entries_.addAll(other.entries_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.entries_.isEmpty()) {
-            if (entriesBuilder_.isEmpty()) {
-              entriesBuilder_.dispose();
-              entriesBuilder_ = null;
-              entries_ = other.entries_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-              entriesBuilder_ = 
-                akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getEntriesFieldBuilder() : null;
-            } else {
-              entriesBuilder_.addAllMessages(other.entries_);
-            }
-          }
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        for (int i = 0; i < getEntriesCount(); i++) {
-          if (!getEntries(i).isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      // repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;
-      private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry> entries_ =
-        java.util.Collections.emptyList();
-      private void ensureEntriesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry>(entries_);
-          bitField0_ |= 0x00000001;
-         }
-      }
-
-      private akka.protobuf.RepeatedFieldBuilder<
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder> entriesBuilder_;
-
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry> getEntriesList() {
-        if (entriesBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(entries_);
-        } else {
-          return entriesBuilder_.getMessageList();
-        }
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public int getEntriesCount() {
-        if (entriesBuilder_ == null) {
-          return entries_.size();
-        } else {
-          return entriesBuilder_.getCount();
-        }
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry getEntries(int index) {
-        if (entriesBuilder_ == null) {
-          return entries_.get(index);
-        } else {
-          return entriesBuilder_.getMessage(index);
-        }
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder setEntries(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry value) {
-        if (entriesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureEntriesIsMutable();
-          entries_.set(index, value);
-          onChanged();
-        } else {
-          entriesBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder setEntries(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder builderForValue) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          entriesBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder addEntries(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry value) {
-        if (entriesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureEntriesIsMutable();
-          entries_.add(value);
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder addEntries(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry value) {
-        if (entriesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureEntriesIsMutable();
-          entries_.add(index, value);
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder addEntries(
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder builderForValue) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.add(builderForValue.build());
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder addEntries(
-          int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder builderForValue) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder addAllEntries(
-          java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry> values) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          super.addAll(values, entries_);
-          onChanged();
-        } else {
-          entriesBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder clearEntries() {
-        if (entriesBuilder_ == null) {
-          entries_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          entriesBuilder_.clear();
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public Builder removeEntries(int index) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.remove(index);
-          onChanged();
-        } else {
-          entriesBuilder_.remove(index);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder getEntriesBuilder(
-          int index) {
-        return getEntriesFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder getEntriesOrBuilder(
-          int index) {
-        if (entriesBuilder_ == null) {
-          return entries_.get(index);  } else {
-          return entriesBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder> 
-           getEntriesOrBuilderList() {
-        if (entriesBuilder_ != null) {
-          return entriesBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(entries_);
-        }
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder addEntriesBuilder() {
-        return getEntriesFieldBuilder().addBuilder(
-            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder addEntriesBuilder(
-          int index) {
-        return getEntriesFieldBuilder().addBuilder(
-            index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
-       */
-      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder> 
-           getEntriesBuilderList() {
-        return getEntriesFieldBuilder().getBuilderList();
-      }
-      private akka.protobuf.RepeatedFieldBuilder<
-          akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder> 
-          getEntriesFieldBuilder() {
-        if (entriesBuilder_ == null) {
-          entriesBuilder_ = new akka.protobuf.RepeatedFieldBuilder<
-              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.VersionVector.EntryOrBuilder>(
-                  entries_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
-                  getParentForChildren(),
-                  isClean());
-          entries_ = null;
-        }
-        return entriesBuilder_;
-      }
-
-      // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.VersionVector)
-    }
-
-    static {
-      defaultInstance = new VersionVector(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:akka.cluster.ddata.VersionVector)
   }
 
   public interface ORMapOrBuilder
@@ -15336,6 +15436,16 @@ public final class ReplicatedDataMessages {
     akka.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_akka_cluster_ddata_ORSet_fieldAccessorTable;
   private static akka.protobuf.Descriptors.Descriptor
+    internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
+  private static
+    akka.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable;
+  private static akka.protobuf.Descriptors.Descriptor
+    internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
+  private static
+    akka.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable;
+  private static akka.protobuf.Descriptors.Descriptor
     internal_static_akka_cluster_ddata_Flag_descriptor;
   private static
     akka.protobuf.GeneratedMessage.FieldAccessorTable
@@ -15360,16 +15470,6 @@ public final class ReplicatedDataMessages {
   private static
     akka.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_akka_cluster_ddata_PNCounter_fieldAccessorTable;
-  private static akka.protobuf.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_VersionVector_descriptor;
-  private static
-    akka.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable;
-  private static akka.protobuf.Descriptors.Descriptor
-    internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
-  private static
-    akka.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable;
   private static akka.protobuf.Descriptors.Descriptor
     internal_static_akka_cluster_ddata_ORMap_descriptor;
   private static
@@ -15430,49 +15530,51 @@ public final class ReplicatedDataMessages {
       "onVector\022\026\n\016stringElements\030\003 \003(\t\022\027\n\013intE" +
       "lements\030\004 \003(\021B\002\020\001\022\030\n\014longElements\030\005 \003(\022B",
       "\002\020\001\0227\n\rotherElements\030\006 \003(\0132 .akka.cluste" +
-      "r.ddata.OtherMessage\"\027\n\004Flag\022\017\n\007enabled\030" +
-      "\001 \002(\010\"\202\001\n\013LWWRegister\022\021\n\ttimestamp\030\001 \002(\022" +
-      "\022/\n\004node\030\002 \002(\0132!.akka.cluster.ddata.Uniq" +
-      "ueAddress\022/\n\005state\030\003 \002(\0132 .akka.cluster." +
-      "ddata.OtherMessage\"\210\001\n\010GCounter\0223\n\007entri" +
-      "es\030\001 \003(\0132\".akka.cluster.ddata.GCounter.E" +
-      "ntry\032G\n\005Entry\022/\n\004node\030\001 \002(\0132!.akka.clust" +
-      "er.ddata.UniqueAddress\022\r\n\005value\030\002 \002(\014\"o\n" +
-      "\tPNCounter\0220\n\nincrements\030\001 \002(\0132\034.akka.cl",
-      "uster.ddata.GCounter\0220\n\ndecrements\030\002 \002(\013" +
-      "2\034.akka.cluster.ddata.GCounter\"\224\001\n\rVersi" +
-      "onVector\0228\n\007entries\030\001 \003(\0132\'.akka.cluster" +
-      ".ddata.VersionVector.Entry\032I\n\005Entry\022/\n\004n" +
-      "ode\030\001 \002(\0132!.akka.cluster.ddata.UniqueAdd" +
-      "ress\022\017\n\007version\030\002 \002(\003\"\205\002\n\005ORMap\022\'\n\004keys\030" +
-      "\001 \002(\0132\031.akka.cluster.ddata.ORSet\0220\n\007entr" +
-      "ies\030\002 \003(\0132\037.akka.cluster.ddata.ORMap.Ent" +
-      "ry\032\240\001\n\005Entry\022\021\n\tstringKey\030\001 \001(\t\022/\n\005value" +
-      "\030\002 \002(\0132 .akka.cluster.ddata.OtherMessage",
-      "\022\016\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022\0222\n\010oth" +
-      "erKey\030\005 \001(\0132 .akka.cluster.ddata.OtherMe" +
-      "ssage\"\206\002\n\006LWWMap\022\'\n\004keys\030\001 \002(\0132\031.akka.cl" +
-      "uster.ddata.ORSet\0221\n\007entries\030\002 \003(\0132 .akk" +
-      "a.cluster.ddata.LWWMap.Entry\032\237\001\n\005Entry\022\021" +
-      "\n\tstringKey\030\001 \001(\t\022.\n\005value\030\002 \002(\0132\037.akka." +
-      "cluster.ddata.LWWRegister\022\016\n\006intKey\030\003 \001(" +
-      "\021\022\017\n\007longKey\030\004 \001(\022\0222\n\010otherKey\030\005 \001(\0132 .a" +
-      "kka.cluster.ddata.OtherMessage\"\220\002\n\014PNCou" +
-      "nterMap\022\'\n\004keys\030\001 \002(\0132\031.akka.cluster.dda",
-      "ta.ORSet\0227\n\007entries\030\002 \003(\0132&.akka.cluster" +
-      ".ddata.PNCounterMap.Entry\032\235\001\n\005Entry\022\021\n\ts" +
-      "tringKey\030\001 \001(\t\022,\n\005value\030\002 \002(\0132\035.akka.clu" +
-      "ster.ddata.PNCounter\022\016\n\006intKey\030\003 \001(\021\022\017\n\007" +
-      "longKey\030\004 \001(\022\0222\n\010otherKey\030\005 \001(\0132 .akka.c" +
-      "luster.ddata.OtherMessage\"\210\002\n\nORMultiMap" +
-      "\022\'\n\004keys\030\001 \002(\0132\031.akka.cluster.ddata.ORSe" +
-      "t\0225\n\007entries\030\002 \003(\0132$.akka.cluster.ddata." +
-      "ORMultiMap.Entry\032\231\001\n\005Entry\022\021\n\tstringKey\030" +
-      "\001 \001(\t\022(\n\005value\030\002 \002(\0132\031.akka.cluster.ddat",
-      "a.ORSet\022\016\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022" +
-      "\0222\n\010otherKey\030\005 \001(\0132 .akka.cluster.ddata." +
-      "OtherMessageB#\n\037akka.cluster.ddata.proto" +
-      "buf.msgH\001"
+      "r.ddata.OtherMessage\"\272\001\n\017ORSetDeltaGroup" +
+      "\022:\n\007entries\030\001 \003(\0132).akka.cluster.ddata.O" +
+      "RSetDeltaGroup.Entry\032k\n\005Entry\0223\n\toperati" +
+      "on\030\001 \002(\0162 .akka.cluster.ddata.ORSetDelta" +
+      "Op\022-\n\nunderlying\030\002 \002(\0132\031.akka.cluster.dd" +
+      "ata.ORSet\"\027\n\004Flag\022\017\n\007enabled\030\001 \002(\010\"\202\001\n\013L" +
+      "WWRegister\022\021\n\ttimestamp\030\001 \002(\022\022/\n\004node\030\002 " +
+      "\002(\0132!.akka.cluster.ddata.UniqueAddress\022/" +
+      "\n\005state\030\003 \002(\0132 .akka.cluster.ddata.Other",
+      "Message\"\210\001\n\010GCounter\0223\n\007entries\030\001 \003(\0132\"." +
+      "akka.cluster.ddata.GCounter.Entry\032G\n\005Ent" +
+      "ry\022/\n\004node\030\001 \002(\0132!.akka.cluster.ddata.Un" +
+      "iqueAddress\022\r\n\005value\030\002 \002(\014\"o\n\tPNCounter\022" +
+      "0\n\nincrements\030\001 \002(\0132\034.akka.cluster.ddata" +
+      ".GCounter\0220\n\ndecrements\030\002 \002(\0132\034.akka.clu" +
+      "ster.ddata.GCounter\"\205\002\n\005ORMap\022\'\n\004keys\030\001 " +
+      "\002(\0132\031.akka.cluster.ddata.ORSet\0220\n\007entrie" +
+      "s\030\002 \003(\0132\037.akka.cluster.ddata.ORMap.Entry" +
+      "\032\240\001\n\005Entry\022\021\n\tstringKey\030\001 \001(\t\022/\n\005value\030\002",
+      " \002(\0132 .akka.cluster.ddata.OtherMessage\022\016" +
+      "\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022\0222\n\010other" +
+      "Key\030\005 \001(\0132 .akka.cluster.ddata.OtherMess" +
+      "age\"\206\002\n\006LWWMap\022\'\n\004keys\030\001 \002(\0132\031.akka.clus" +
+      "ter.ddata.ORSet\0221\n\007entries\030\002 \003(\0132 .akka." +
+      "cluster.ddata.LWWMap.Entry\032\237\001\n\005Entry\022\021\n\t" +
+      "stringKey\030\001 \001(\t\022.\n\005value\030\002 \002(\0132\037.akka.cl" +
+      "uster.ddata.LWWRegister\022\016\n\006intKey\030\003 \001(\021\022" +
+      "\017\n\007longKey\030\004 \001(\022\0222\n\010otherKey\030\005 \001(\0132 .akk" +
+      "a.cluster.ddata.OtherMessage\"\220\002\n\014PNCount",
+      "erMap\022\'\n\004keys\030\001 \002(\0132\031.akka.cluster.ddata" +
+      ".ORSet\0227\n\007entries\030\002 \003(\0132&.akka.cluster.d" +
+      "data.PNCounterMap.Entry\032\235\001\n\005Entry\022\021\n\tstr" +
+      "ingKey\030\001 \001(\t\022,\n\005value\030\002 \002(\0132\035.akka.clust" +
+      "er.ddata.PNCounter\022\016\n\006intKey\030\003 \001(\021\022\017\n\007lo" +
+      "ngKey\030\004 \001(\022\0222\n\010otherKey\030\005 \001(\0132 .akka.clu" +
+      "ster.ddata.OtherMessage\"\210\002\n\nORMultiMap\022\'" +
+      "\n\004keys\030\001 \002(\0132\031.akka.cluster.ddata.ORSet\022" +
+      "5\n\007entries\030\002 \003(\0132$.akka.cluster.ddata.OR" +
+      "MultiMap.Entry\032\231\001\n\005Entry\022\021\n\tstringKey\030\001 ",
+      "\001(\t\022(\n\005value\030\002 \002(\0132\031.akka.cluster.ddata." +
+      "ORSet\022\016\n\006intKey\030\003 \001(\021\022\017\n\007longKey\030\004 \001(\022\0222" +
+      "\n\010otherKey\030\005 \001(\0132 .akka.cluster.ddata.Ot" +
+      "herMessage*-\n\014ORSetDeltaOp\022\007\n\003Add\020\000\022\n\n\006R" +
+      "emove\020\001\022\010\n\004Full\020\002B#\n\037akka.cluster.ddata." +
+      "protobuf.msgH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -15491,20 +15593,32 @@ public final class ReplicatedDataMessages {
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_ORSet_descriptor,
               new java.lang.String[] { "Vvector", "Dots", "StringElements", "IntElements", "LongElements", "OtherElements", });
-          internal_static_akka_cluster_ddata_Flag_descriptor =
+          internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor =
             getDescriptor().getMessageTypes().get(2);
+          internal_static_akka_cluster_ddata_ORSetDeltaGroup_fieldAccessorTable = new
+            akka.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor,
+              new java.lang.String[] { "Entries", });
+          internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor =
+            internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor.getNestedTypes().get(0);
+          internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_fieldAccessorTable = new
+            akka.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor,
+              new java.lang.String[] { "Operation", "Underlying", });
+          internal_static_akka_cluster_ddata_Flag_descriptor =
+            getDescriptor().getMessageTypes().get(3);
           internal_static_akka_cluster_ddata_Flag_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_Flag_descriptor,
               new java.lang.String[] { "Enabled", });
           internal_static_akka_cluster_ddata_LWWRegister_descriptor =
-            getDescriptor().getMessageTypes().get(3);
+            getDescriptor().getMessageTypes().get(4);
           internal_static_akka_cluster_ddata_LWWRegister_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_LWWRegister_descriptor,
               new java.lang.String[] { "Timestamp", "Node", "State", });
           internal_static_akka_cluster_ddata_GCounter_descriptor =
-            getDescriptor().getMessageTypes().get(4);
+            getDescriptor().getMessageTypes().get(5);
           internal_static_akka_cluster_ddata_GCounter_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_GCounter_descriptor,
@@ -15516,23 +15630,11 @@ public final class ReplicatedDataMessages {
               internal_static_akka_cluster_ddata_GCounter_Entry_descriptor,
               new java.lang.String[] { "Node", "Value", });
           internal_static_akka_cluster_ddata_PNCounter_descriptor =
-            getDescriptor().getMessageTypes().get(5);
+            getDescriptor().getMessageTypes().get(6);
           internal_static_akka_cluster_ddata_PNCounter_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_PNCounter_descriptor,
               new java.lang.String[] { "Increments", "Decrements", });
-          internal_static_akka_cluster_ddata_VersionVector_descriptor =
-            getDescriptor().getMessageTypes().get(6);
-          internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable = new
-            akka.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_akka_cluster_ddata_VersionVector_descriptor,
-              new java.lang.String[] { "Entries", });
-          internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor =
-            internal_static_akka_cluster_ddata_VersionVector_descriptor.getNestedTypes().get(0);
-          internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable = new
-            akka.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor,
-              new java.lang.String[] { "Node", "Version", });
           internal_static_akka_cluster_ddata_ORMap_descriptor =
             getDescriptor().getMessageTypes().get(7);
           internal_static_akka_cluster_ddata_ORMap_fieldAccessorTable = new

--- a/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
+++ b/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
@@ -7442,6 +7442,20 @@ public final class ReplicatorMessages {
      */
     akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntryOrBuilder getPruningOrBuilder(
         int index);
+
+    // optional .akka.cluster.ddata.VersionVector deltaVersions = 3;
+    /**
+     * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+     */
+    boolean hasDeltaVersions();
+    /**
+     * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getDeltaVersions();
+    /**
+     * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getDeltaVersionsOrBuilder();
   }
   /**
    * Protobuf type {@code akka.cluster.ddata.DataEnvelope}
@@ -7513,6 +7527,19 @@ public final class ReplicatorMessages {
                 mutable_bitField0_ |= 0x00000002;
               }
               pruning_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntry.PARSER, extensionRegistry));
+              break;
+            }
+            case 26: {
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                subBuilder = deltaVersions_.toBuilder();
+              }
+              deltaVersions_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(deltaVersions_);
+                deltaVersions_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
               break;
             }
           }
@@ -8891,9 +8918,32 @@ public final class ReplicatorMessages {
       return pruning_.get(index);
     }
 
+    // optional .akka.cluster.ddata.VersionVector deltaVersions = 3;
+    public static final int DELTAVERSIONS_FIELD_NUMBER = 3;
+    private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector deltaVersions_;
+    /**
+     * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+     */
+    public boolean hasDeltaVersions() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getDeltaVersions() {
+      return deltaVersions_;
+    }
+    /**
+     * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getDeltaVersionsOrBuilder() {
+      return deltaVersions_;
+    }
+
     private void initFields() {
       data_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessage.getDefaultInstance();
       pruning_ = java.util.Collections.emptyList();
+      deltaVersions_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -8914,6 +8964,12 @@ public final class ReplicatorMessages {
           return false;
         }
       }
+      if (hasDeltaVersions()) {
+        if (!getDeltaVersions().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -8926,6 +8982,9 @@ public final class ReplicatorMessages {
       }
       for (int i = 0; i < pruning_.size(); i++) {
         output.writeMessage(2, pruning_.get(i));
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeMessage(3, deltaVersions_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -8943,6 +9002,10 @@ public final class ReplicatorMessages {
       for (int i = 0; i < pruning_.size(); i++) {
         size += akka.protobuf.CodedOutputStream
           .computeMessageSize(2, pruning_.get(i));
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += akka.protobuf.CodedOutputStream
+          .computeMessageSize(3, deltaVersions_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -9054,6 +9117,7 @@ public final class ReplicatorMessages {
         if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getDataFieldBuilder();
           getPruningFieldBuilder();
+          getDeltaVersionsFieldBuilder();
         }
       }
       private static Builder create() {
@@ -9074,6 +9138,12 @@ public final class ReplicatorMessages {
         } else {
           pruningBuilder_.clear();
         }
+        if (deltaVersionsBuilder_ == null) {
+          deltaVersions_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
+        } else {
+          deltaVersionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -9118,6 +9188,14 @@ public final class ReplicatorMessages {
           result.pruning_ = pruning_;
         } else {
           result.pruning_ = pruningBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        if (deltaVersionsBuilder_ == null) {
+          result.deltaVersions_ = deltaVersions_;
+        } else {
+          result.deltaVersions_ = deltaVersionsBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -9164,6 +9242,9 @@ public final class ReplicatorMessages {
             }
           }
         }
+        if (other.hasDeltaVersions()) {
+          mergeDeltaVersions(other.getDeltaVersions());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -9179,6 +9260,12 @@ public final class ReplicatorMessages {
         }
         for (int i = 0; i < getPruningCount(); i++) {
           if (!getPruning(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasDeltaVersions()) {
+          if (!getDeltaVersions().isInitialized()) {
             
             return false;
           }
@@ -9560,6 +9647,123 @@ public final class ReplicatorMessages {
           pruning_ = null;
         }
         return pruningBuilder_;
+      }
+
+      // optional .akka.cluster.ddata.VersionVector deltaVersions = 3;
+      private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector deltaVersions_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
+      private akka.protobuf.SingleFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> deltaVersionsBuilder_;
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public boolean hasDeltaVersions() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getDeltaVersions() {
+        if (deltaVersionsBuilder_ == null) {
+          return deltaVersions_;
+        } else {
+          return deltaVersionsBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public Builder setDeltaVersions(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector value) {
+        if (deltaVersionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          deltaVersions_ = value;
+          onChanged();
+        } else {
+          deltaVersionsBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public Builder setDeltaVersions(
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder builderForValue) {
+        if (deltaVersionsBuilder_ == null) {
+          deltaVersions_ = builderForValue.build();
+          onChanged();
+        } else {
+          deltaVersionsBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public Builder mergeDeltaVersions(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector value) {
+        if (deltaVersionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+              deltaVersions_ != akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance()) {
+            deltaVersions_ =
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.newBuilder(deltaVersions_).mergeFrom(value).buildPartial();
+          } else {
+            deltaVersions_ = value;
+          }
+          onChanged();
+        } else {
+          deltaVersionsBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public Builder clearDeltaVersions() {
+        if (deltaVersionsBuilder_ == null) {
+          deltaVersions_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
+          onChanged();
+        } else {
+          deltaVersionsBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder getDeltaVersionsBuilder() {
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return getDeltaVersionsFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder getDeltaVersionsOrBuilder() {
+        if (deltaVersionsBuilder_ != null) {
+          return deltaVersionsBuilder_.getMessageOrBuilder();
+        } else {
+          return deltaVersions_;
+        }
+      }
+      /**
+       * <code>optional .akka.cluster.ddata.VersionVector deltaVersions = 3;</code>
+       */
+      private akka.protobuf.SingleFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder> 
+          getDeltaVersionsFieldBuilder() {
+        if (deltaVersionsBuilder_ == null) {
+          deltaVersionsBuilder_ = new akka.protobuf.SingleFieldBuilder<
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder>(
+                  deltaVersions_,
+                  getParentForChildren(),
+                  isClean());
+          deltaVersions_ = null;
+        }
+        return deltaVersionsBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.DataEnvelope)
@@ -12479,27 +12683,41 @@ public final class ReplicatorMessages {
   public interface DeltaPropagationOrBuilder
       extends akka.protobuf.MessageOrBuilder {
 
-    // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;
+    // required .akka.cluster.ddata.UniqueAddress fromNode = 1;
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+     */
+    boolean hasFromNode();
+    /**
+     * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getFromNode();
+    /**
+     * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getFromNodeOrBuilder();
+
+    // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;
+    /**
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> 
         getEntriesList();
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry getEntries(int index);
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     int getEntriesCount();
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> 
         getEntriesOrBuilderList();
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder getEntriesOrBuilder(
         int index);
@@ -12556,9 +12774,22 @@ public final class ReplicatorMessages {
               break;
             }
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                subBuilder = fromNode_.toBuilder();
+              }
+              fromNode_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(fromNode_);
+                fromNode_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
                 entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry>();
-                mutable_bitField0_ |= 0x00000001;
+                mutable_bitField0_ |= 0x00000002;
               }
               entries_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.PARSER, extensionRegistry));
               break;
@@ -12571,7 +12802,7 @@ public final class ReplicatorMessages {
         throw new akka.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
           entries_ = java.util.Collections.unmodifiableList(entries_);
         }
         this.unknownFields = unknownFields.build();
@@ -12636,6 +12867,34 @@ public final class ReplicatorMessages {
        * <code>required .akka.cluster.ddata.DataEnvelope envelope = 2;</code>
        */
       akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelopeOrBuilder getEnvelopeOrBuilder();
+
+      // required int64 fromSeqNr = 3;
+      /**
+       * <code>required int64 fromSeqNr = 3;</code>
+       */
+      boolean hasFromSeqNr();
+      /**
+       * <code>required int64 fromSeqNr = 3;</code>
+       */
+      long getFromSeqNr();
+
+      // optional int64 toSeqNr = 4;
+      /**
+       * <code>optional int64 toSeqNr = 4;</code>
+       *
+       * <pre>
+       * if not set then same as fromSequenceNr
+       * </pre>
+       */
+      boolean hasToSeqNr();
+      /**
+       * <code>optional int64 toSeqNr = 4;</code>
+       *
+       * <pre>
+       * if not set then same as fromSequenceNr
+       * </pre>
+       */
+      long getToSeqNr();
     }
     /**
      * Protobuf type {@code akka.cluster.ddata.DeltaPropagation.Entry}
@@ -12704,6 +12963,16 @@ public final class ReplicatorMessages {
                   envelope_ = subBuilder.buildPartial();
                 }
                 bitField0_ |= 0x00000002;
+                break;
+              }
+              case 24: {
+                bitField0_ |= 0x00000004;
+                fromSeqNr_ = input.readInt64();
+                break;
+              }
+              case 32: {
+                bitField0_ |= 0x00000008;
+                toSeqNr_ = input.readInt64();
                 break;
               }
             }
@@ -12811,9 +13080,51 @@ public final class ReplicatorMessages {
         return envelope_;
       }
 
+      // required int64 fromSeqNr = 3;
+      public static final int FROMSEQNR_FIELD_NUMBER = 3;
+      private long fromSeqNr_;
+      /**
+       * <code>required int64 fromSeqNr = 3;</code>
+       */
+      public boolean hasFromSeqNr() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>required int64 fromSeqNr = 3;</code>
+       */
+      public long getFromSeqNr() {
+        return fromSeqNr_;
+      }
+
+      // optional int64 toSeqNr = 4;
+      public static final int TOSEQNR_FIELD_NUMBER = 4;
+      private long toSeqNr_;
+      /**
+       * <code>optional int64 toSeqNr = 4;</code>
+       *
+       * <pre>
+       * if not set then same as fromSequenceNr
+       * </pre>
+       */
+      public boolean hasToSeqNr() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional int64 toSeqNr = 4;</code>
+       *
+       * <pre>
+       * if not set then same as fromSequenceNr
+       * </pre>
+       */
+      public long getToSeqNr() {
+        return toSeqNr_;
+      }
+
       private void initFields() {
         key_ = "";
         envelope_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.getDefaultInstance();
+        fromSeqNr_ = 0L;
+        toSeqNr_ = 0L;
       }
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
@@ -12825,6 +13136,10 @@ public final class ReplicatorMessages {
           return false;
         }
         if (!hasEnvelope()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!hasFromSeqNr()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -12845,6 +13160,12 @@ public final class ReplicatorMessages {
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
           output.writeMessage(2, envelope_);
         }
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          output.writeInt64(3, fromSeqNr_);
+        }
+        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          output.writeInt64(4, toSeqNr_);
+        }
         getUnknownFields().writeTo(output);
       }
 
@@ -12861,6 +13182,14 @@ public final class ReplicatorMessages {
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
           size += akka.protobuf.CodedOutputStream
             .computeMessageSize(2, envelope_);
+        }
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeInt64Size(3, fromSeqNr_);
+        }
+        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeInt64Size(4, toSeqNr_);
         }
         size += getUnknownFields().getSerializedSize();
         memoizedSerializedSize = size;
@@ -12987,6 +13316,10 @@ public final class ReplicatorMessages {
             envelopeBuilder_.clear();
           }
           bitField0_ = (bitField0_ & ~0x00000002);
+          fromSeqNr_ = 0L;
+          bitField0_ = (bitField0_ & ~0x00000004);
+          toSeqNr_ = 0L;
+          bitField0_ = (bitField0_ & ~0x00000008);
           return this;
         }
 
@@ -13027,6 +13360,14 @@ public final class ReplicatorMessages {
           } else {
             result.envelope_ = envelopeBuilder_.build();
           }
+          if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+            to_bitField0_ |= 0x00000004;
+          }
+          result.fromSeqNr_ = fromSeqNr_;
+          if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+            to_bitField0_ |= 0x00000008;
+          }
+          result.toSeqNr_ = toSeqNr_;
           result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
@@ -13051,6 +13392,12 @@ public final class ReplicatorMessages {
           if (other.hasEnvelope()) {
             mergeEnvelope(other.getEnvelope());
           }
+          if (other.hasFromSeqNr()) {
+            setFromSeqNr(other.getFromSeqNr());
+          }
+          if (other.hasToSeqNr()) {
+            setToSeqNr(other.getToSeqNr());
+          }
           this.mergeUnknownFields(other.getUnknownFields());
           return this;
         }
@@ -13061,6 +13408,10 @@ public final class ReplicatorMessages {
             return false;
           }
           if (!hasEnvelope()) {
+            
+            return false;
+          }
+          if (!hasFromSeqNr()) {
             
             return false;
           }
@@ -13281,6 +13632,88 @@ public final class ReplicatorMessages {
           return envelopeBuilder_;
         }
 
+        // required int64 fromSeqNr = 3;
+        private long fromSeqNr_ ;
+        /**
+         * <code>required int64 fromSeqNr = 3;</code>
+         */
+        public boolean hasFromSeqNr() {
+          return ((bitField0_ & 0x00000004) == 0x00000004);
+        }
+        /**
+         * <code>required int64 fromSeqNr = 3;</code>
+         */
+        public long getFromSeqNr() {
+          return fromSeqNr_;
+        }
+        /**
+         * <code>required int64 fromSeqNr = 3;</code>
+         */
+        public Builder setFromSeqNr(long value) {
+          bitField0_ |= 0x00000004;
+          fromSeqNr_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required int64 fromSeqNr = 3;</code>
+         */
+        public Builder clearFromSeqNr() {
+          bitField0_ = (bitField0_ & ~0x00000004);
+          fromSeqNr_ = 0L;
+          onChanged();
+          return this;
+        }
+
+        // optional int64 toSeqNr = 4;
+        private long toSeqNr_ ;
+        /**
+         * <code>optional int64 toSeqNr = 4;</code>
+         *
+         * <pre>
+         * if not set then same as fromSequenceNr
+         * </pre>
+         */
+        public boolean hasToSeqNr() {
+          return ((bitField0_ & 0x00000008) == 0x00000008);
+        }
+        /**
+         * <code>optional int64 toSeqNr = 4;</code>
+         *
+         * <pre>
+         * if not set then same as fromSequenceNr
+         * </pre>
+         */
+        public long getToSeqNr() {
+          return toSeqNr_;
+        }
+        /**
+         * <code>optional int64 toSeqNr = 4;</code>
+         *
+         * <pre>
+         * if not set then same as fromSequenceNr
+         * </pre>
+         */
+        public Builder setToSeqNr(long value) {
+          bitField0_ |= 0x00000008;
+          toSeqNr_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>optional int64 toSeqNr = 4;</code>
+         *
+         * <pre>
+         * if not set then same as fromSequenceNr
+         * </pre>
+         */
+        public Builder clearToSeqNr() {
+          bitField0_ = (bitField0_ & ~0x00000008);
+          toSeqNr_ = 0L;
+          onChanged();
+          return this;
+        }
+
         // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.DeltaPropagation.Entry)
       }
 
@@ -13292,36 +13725,59 @@ public final class ReplicatorMessages {
       // @@protoc_insertion_point(class_scope:akka.cluster.ddata.DeltaPropagation.Entry)
     }
 
-    // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;
-    public static final int ENTRIES_FIELD_NUMBER = 1;
+    private int bitField0_;
+    // required .akka.cluster.ddata.UniqueAddress fromNode = 1;
+    public static final int FROMNODE_FIELD_NUMBER = 1;
+    private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress fromNode_;
+    /**
+     * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+     */
+    public boolean hasFromNode() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getFromNode() {
+      return fromNode_;
+    }
+    /**
+     * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getFromNodeOrBuilder() {
+      return fromNode_;
+    }
+
+    // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;
+    public static final int ENTRIES_FIELD_NUMBER = 2;
     private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> entries_;
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> getEntriesList() {
       return entries_;
     }
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> 
         getEntriesOrBuilderList() {
       return entries_;
     }
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     public int getEntriesCount() {
       return entries_.size();
     }
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry getEntries(int index) {
       return entries_.get(index);
     }
     /**
-     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+     * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
      */
     public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder getEntriesOrBuilder(
         int index) {
@@ -13329,6 +13785,7 @@ public final class ReplicatorMessages {
     }
 
     private void initFields() {
+      fromNode_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
       entries_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
@@ -13336,6 +13793,14 @@ public final class ReplicatorMessages {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized != -1) return isInitialized == 1;
 
+      if (!hasFromNode()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getFromNode().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
       for (int i = 0; i < getEntriesCount(); i++) {
         if (!getEntries(i).isInitialized()) {
           memoizedIsInitialized = 0;
@@ -13349,8 +13814,11 @@ public final class ReplicatorMessages {
     public void writeTo(akka.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeMessage(1, fromNode_);
+      }
       for (int i = 0; i < entries_.size(); i++) {
-        output.writeMessage(1, entries_.get(i));
+        output.writeMessage(2, entries_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -13361,9 +13829,13 @@ public final class ReplicatorMessages {
       if (size != -1) return size;
 
       size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += akka.protobuf.CodedOutputStream
+          .computeMessageSize(1, fromNode_);
+      }
       for (int i = 0; i < entries_.size(); i++) {
         size += akka.protobuf.CodedOutputStream
-          .computeMessageSize(1, entries_.get(i));
+          .computeMessageSize(2, entries_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -13473,6 +13945,7 @@ public final class ReplicatorMessages {
       }
       private void maybeForceBuilderInitialization() {
         if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getFromNodeFieldBuilder();
           getEntriesFieldBuilder();
         }
       }
@@ -13482,9 +13955,15 @@ public final class ReplicatorMessages {
 
       public Builder clear() {
         super.clear();
+        if (fromNodeBuilder_ == null) {
+          fromNode_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
+        } else {
+          fromNodeBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
         if (entriesBuilder_ == null) {
           entries_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ = (bitField0_ & ~0x00000002);
         } else {
           entriesBuilder_.clear();
         }
@@ -13515,15 +13994,25 @@ public final class ReplicatorMessages {
       public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation buildPartial() {
         akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation result = new akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation(this);
         int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        if (fromNodeBuilder_ == null) {
+          result.fromNode_ = fromNode_;
+        } else {
+          result.fromNode_ = fromNodeBuilder_.build();
+        }
         if (entriesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
             entries_ = java.util.Collections.unmodifiableList(entries_);
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ = (bitField0_ & ~0x00000002);
           }
           result.entries_ = entries_;
         } else {
           result.entries_ = entriesBuilder_.build();
         }
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -13539,11 +14028,14 @@ public final class ReplicatorMessages {
 
       public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation other) {
         if (other == akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.getDefaultInstance()) return this;
+        if (other.hasFromNode()) {
+          mergeFromNode(other.getFromNode());
+        }
         if (entriesBuilder_ == null) {
           if (!other.entries_.isEmpty()) {
             if (entries_.isEmpty()) {
               entries_ = other.entries_;
-              bitField0_ = (bitField0_ & ~0x00000001);
+              bitField0_ = (bitField0_ & ~0x00000002);
             } else {
               ensureEntriesIsMutable();
               entries_.addAll(other.entries_);
@@ -13556,7 +14048,7 @@ public final class ReplicatorMessages {
               entriesBuilder_.dispose();
               entriesBuilder_ = null;
               entries_ = other.entries_;
-              bitField0_ = (bitField0_ & ~0x00000001);
+              bitField0_ = (bitField0_ & ~0x00000002);
               entriesBuilder_ = 
                 akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getEntriesFieldBuilder() : null;
@@ -13570,6 +14062,14 @@ public final class ReplicatorMessages {
       }
 
       public final boolean isInitialized() {
+        if (!hasFromNode()) {
+          
+          return false;
+        }
+        if (!getFromNode().isInitialized()) {
+          
+          return false;
+        }
         for (int i = 0; i < getEntriesCount(); i++) {
           if (!getEntries(i).isInitialized()) {
             
@@ -13598,13 +14098,130 @@ public final class ReplicatorMessages {
       }
       private int bitField0_;
 
-      // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;
+      // required .akka.cluster.ddata.UniqueAddress fromNode = 1;
+      private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress fromNode_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
+      private akka.protobuf.SingleFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder> fromNodeBuilder_;
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public boolean hasFromNode() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getFromNode() {
+        if (fromNodeBuilder_ == null) {
+          return fromNode_;
+        } else {
+          return fromNodeBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public Builder setFromNode(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress value) {
+        if (fromNodeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          fromNode_ = value;
+          onChanged();
+        } else {
+          fromNodeBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public Builder setFromNode(
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder builderForValue) {
+        if (fromNodeBuilder_ == null) {
+          fromNode_ = builderForValue.build();
+          onChanged();
+        } else {
+          fromNodeBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public Builder mergeFromNode(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress value) {
+        if (fromNodeBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+              fromNode_ != akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance()) {
+            fromNode_ =
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.newBuilder(fromNode_).mergeFrom(value).buildPartial();
+          } else {
+            fromNode_ = value;
+          }
+          onChanged();
+        } else {
+          fromNodeBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public Builder clearFromNode() {
+        if (fromNodeBuilder_ == null) {
+          fromNode_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
+          onChanged();
+        } else {
+          fromNodeBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder getFromNodeBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getFromNodeFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getFromNodeOrBuilder() {
+        if (fromNodeBuilder_ != null) {
+          return fromNodeBuilder_.getMessageOrBuilder();
+        } else {
+          return fromNode_;
+        }
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress fromNode = 1;</code>
+       */
+      private akka.protobuf.SingleFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder> 
+          getFromNodeFieldBuilder() {
+        if (fromNodeBuilder_ == null) {
+          fromNodeBuilder_ = new akka.protobuf.SingleFieldBuilder<
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder>(
+                  fromNode_,
+                  getParentForChildren(),
+                  isClean());
+          fromNode_ = null;
+        }
+        return fromNodeBuilder_;
+      }
+
+      // repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;
       private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> entries_ =
         java.util.Collections.emptyList();
       private void ensureEntriesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
           entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry>(entries_);
-          bitField0_ |= 0x00000001;
+          bitField0_ |= 0x00000002;
          }
       }
 
@@ -13612,7 +14229,7 @@ public final class ReplicatorMessages {
           akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> entriesBuilder_;
 
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> getEntriesList() {
         if (entriesBuilder_ == null) {
@@ -13622,7 +14239,7 @@ public final class ReplicatorMessages {
         }
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public int getEntriesCount() {
         if (entriesBuilder_ == null) {
@@ -13632,7 +14249,7 @@ public final class ReplicatorMessages {
         }
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry getEntries(int index) {
         if (entriesBuilder_ == null) {
@@ -13642,7 +14259,7 @@ public final class ReplicatorMessages {
         }
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder setEntries(
           int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry value) {
@@ -13659,7 +14276,7 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder setEntries(
           int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder builderForValue) {
@@ -13673,7 +14290,7 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder addEntries(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry value) {
         if (entriesBuilder_ == null) {
@@ -13689,7 +14306,7 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder addEntries(
           int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry value) {
@@ -13706,7 +14323,7 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder addEntries(
           akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder builderForValue) {
@@ -13720,7 +14337,7 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder addEntries(
           int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder builderForValue) {
@@ -13734,7 +14351,7 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder addAllEntries(
           java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry> values) {
@@ -13748,12 +14365,12 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder clearEntries() {
         if (entriesBuilder_ == null) {
           entries_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ = (bitField0_ & ~0x00000002);
           onChanged();
         } else {
           entriesBuilder_.clear();
@@ -13761,7 +14378,7 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public Builder removeEntries(int index) {
         if (entriesBuilder_ == null) {
@@ -13774,14 +14391,14 @@ public final class ReplicatorMessages {
         return this;
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder getEntriesBuilder(
           int index) {
         return getEntriesFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder getEntriesOrBuilder(
           int index) {
@@ -13791,7 +14408,7 @@ public final class ReplicatorMessages {
         }
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder> 
            getEntriesOrBuilderList() {
@@ -13802,14 +14419,14 @@ public final class ReplicatorMessages {
         }
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder addEntriesBuilder() {
         return getEntriesFieldBuilder().addBuilder(
             akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.getDefaultInstance());
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder addEntriesBuilder(
           int index) {
@@ -13817,7 +14434,7 @@ public final class ReplicatorMessages {
             index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.getDefaultInstance());
       }
       /**
-       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 1;</code>
+       * <code>repeated .akka.cluster.ddata.DeltaPropagation.Entry entries = 2;</code>
        */
       public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder> 
            getEntriesBuilderList() {
@@ -13830,7 +14447,7 @@ public final class ReplicatorMessages {
           entriesBuilder_ = new akka.protobuf.RepeatedFieldBuilder<
               akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder>(
                   entries_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000002) == 0x00000002),
                   getParentForChildren(),
                   isClean());
           entries_ = null;
@@ -15140,6 +15757,1304 @@ public final class ReplicatorMessages {
     }
 
     // @@protoc_insertion_point(class_scope:akka.cluster.ddata.Address)
+  }
+
+  public interface VersionVectorOrBuilder
+      extends akka.protobuf.MessageOrBuilder {
+
+    // repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry> 
+        getEntriesList();
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry getEntries(int index);
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    int getEntriesCount();
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder> 
+        getEntriesOrBuilderList();
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder getEntriesOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code akka.cluster.ddata.VersionVector}
+   */
+  public static final class VersionVector extends
+      akka.protobuf.GeneratedMessage
+      implements VersionVectorOrBuilder {
+    // Use VersionVector.newBuilder() to construct.
+    private VersionVector(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private VersionVector(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final VersionVector defaultInstance;
+    public static VersionVector getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public VersionVector getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final akka.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final akka.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private VersionVector(
+        akka.protobuf.CodedInputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      akka.protobuf.UnknownFieldSet.Builder unknownFields =
+          akka.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              entries_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new akka.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          entries_ = java.util.Collections.unmodifiableList(entries_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final akka.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
+    }
+
+    protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder.class);
+    }
+
+    public static akka.protobuf.Parser<VersionVector> PARSER =
+        new akka.protobuf.AbstractParser<VersionVector>() {
+      public VersionVector parsePartialFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return new VersionVector(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public akka.protobuf.Parser<VersionVector> getParserForType() {
+      return PARSER;
+    }
+
+    public interface EntryOrBuilder
+        extends akka.protobuf.MessageOrBuilder {
+
+      // required .akka.cluster.ddata.UniqueAddress node = 1;
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+       */
+      boolean hasNode();
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getNode();
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getNodeOrBuilder();
+
+      // required int64 version = 2;
+      /**
+       * <code>required int64 version = 2;</code>
+       */
+      boolean hasVersion();
+      /**
+       * <code>required int64 version = 2;</code>
+       */
+      long getVersion();
+    }
+    /**
+     * Protobuf type {@code akka.cluster.ddata.VersionVector.Entry}
+     */
+    public static final class Entry extends
+        akka.protobuf.GeneratedMessage
+        implements EntryOrBuilder {
+      // Use Entry.newBuilder() to construct.
+      private Entry(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+        super(builder);
+        this.unknownFields = builder.getUnknownFields();
+      }
+      private Entry(boolean noInit) { this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+      private static final Entry defaultInstance;
+      public static Entry getDefaultInstance() {
+        return defaultInstance;
+      }
+
+      public Entry getDefaultInstanceForType() {
+        return defaultInstance;
+      }
+
+      private final akka.protobuf.UnknownFieldSet unknownFields;
+      @java.lang.Override
+      public final akka.protobuf.UnknownFieldSet
+          getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Entry(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        initFields();
+        int mutable_bitField0_ = 0;
+        akka.protobuf.UnknownFieldSet.Builder unknownFields =
+            akka.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 10: {
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                  subBuilder = node_.toBuilder();
+                }
+                node_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(node_);
+                  node_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000001;
+                break;
+              }
+              case 16: {
+                bitField0_ |= 0x00000002;
+                version_ = input.readInt64();
+                break;
+              }
+            }
+          }
+        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new akka.protobuf.InvalidProtocolBufferException(
+              e.getMessage()).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final akka.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+      }
+
+      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder.class);
+      }
+
+      public static akka.protobuf.Parser<Entry> PARSER =
+          new akka.protobuf.AbstractParser<Entry>() {
+        public Entry parsePartialFrom(
+            akka.protobuf.CodedInputStream input,
+            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobuf.InvalidProtocolBufferException {
+          return new Entry(input, extensionRegistry);
+        }
+      };
+
+      @java.lang.Override
+      public akka.protobuf.Parser<Entry> getParserForType() {
+        return PARSER;
+      }
+
+      private int bitField0_;
+      // required .akka.cluster.ddata.UniqueAddress node = 1;
+      public static final int NODE_FIELD_NUMBER = 1;
+      private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress node_;
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+       */
+      public boolean hasNode() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getNode() {
+        return node_;
+      }
+      /**
+       * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getNodeOrBuilder() {
+        return node_;
+      }
+
+      // required int64 version = 2;
+      public static final int VERSION_FIELD_NUMBER = 2;
+      private long version_;
+      /**
+       * <code>required int64 version = 2;</code>
+       */
+      public boolean hasVersion() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required int64 version = 2;</code>
+       */
+      public long getVersion() {
+        return version_;
+      }
+
+      private void initFields() {
+        node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
+        version_ = 0L;
+      }
+      private byte memoizedIsInitialized = -1;
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized != -1) return isInitialized == 1;
+
+        if (!hasNode()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!hasVersion()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!getNode().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      public void writeTo(akka.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        getSerializedSize();
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeMessage(1, node_);
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          output.writeInt64(2, version_);
+        }
+        getUnknownFields().writeTo(output);
+      }
+
+      private int memoizedSerializedSize = -1;
+      public int getSerializedSize() {
+        int size = memoizedSerializedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeMessageSize(1, node_);
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          size += akka.protobuf.CodedOutputStream
+            .computeInt64Size(2, version_);
+        }
+        size += getUnknownFields().getSerializedSize();
+        memoizedSerializedSize = size;
+        return size;
+      }
+
+      private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      protected java.lang.Object writeReplace()
+          throws java.io.ObjectStreamException {
+        return super.writeReplace();
+      }
+
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(
+          akka.protobuf.ByteString data)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(
+          akka.protobuf.ByteString data,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(byte[] data)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(
+          byte[] data,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(
+          java.io.InputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseDelimitedFrom(
+          java.io.InputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(
+          akka.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+
+      public static Builder newBuilder() { return Builder.create(); }
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry prototype) {
+        return newBuilder().mergeFrom(prototype);
+      }
+      public Builder toBuilder() { return newBuilder(this); }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          akka.protobuf.GeneratedMessage.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code akka.cluster.ddata.VersionVector.Entry}
+       */
+      public static final class Builder extends
+          akka.protobuf.GeneratedMessage.Builder<Builder>
+         implements akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder {
+        public static final akka.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+        }
+
+        protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder.class);
+        }
+
+        // Construct using akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            akka.protobuf.GeneratedMessage.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            getNodeFieldBuilder();
+          }
+        }
+        private static Builder create() {
+          return new Builder();
+        }
+
+        public Builder clear() {
+          super.clear();
+          if (nodeBuilder_ == null) {
+            node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
+          } else {
+            nodeBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          version_ = 0L;
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+
+        public Builder clone() {
+          return create().mergeFrom(buildPartial());
+        }
+
+        public akka.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry getDefaultInstanceForType() {
+          return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.getDefaultInstance();
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry build() {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry buildPartial() {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry result = new akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          if (nodeBuilder_ == null) {
+            result.node_ = node_;
+          } else {
+            result.node_ = nodeBuilder_.build();
+          }
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000002;
+          }
+          result.version_ = version_;
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        public Builder mergeFrom(akka.protobuf.Message other) {
+          if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry) {
+            return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry other) {
+          if (other == akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.getDefaultInstance()) return this;
+          if (other.hasNode()) {
+            mergeNode(other.getNode());
+          }
+          if (other.hasVersion()) {
+            setVersion(other.getVersion());
+          }
+          this.mergeUnknownFields(other.getUnknownFields());
+          return this;
+        }
+
+        public final boolean isInitialized() {
+          if (!hasNode()) {
+            
+            return false;
+          }
+          if (!hasVersion()) {
+            
+            return false;
+          }
+          if (!getNode().isInitialized()) {
+            
+            return false;
+          }
+          return true;
+        }
+
+        public Builder mergeFrom(
+            akka.protobuf.CodedInputStream input,
+            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (akka.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry) e.getUnfinishedMessage();
+            throw e;
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        // required .akka.cluster.ddata.UniqueAddress node = 1;
+        private akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
+        private akka.protobuf.SingleFieldBuilder<
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder> nodeBuilder_;
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public boolean hasNode() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress getNode() {
+          if (nodeBuilder_ == null) {
+            return node_;
+          } else {
+            return nodeBuilder_.getMessage();
+          }
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public Builder setNode(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress value) {
+          if (nodeBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            node_ = value;
+            onChanged();
+          } else {
+            nodeBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public Builder setNode(
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder builderForValue) {
+          if (nodeBuilder_ == null) {
+            node_ = builderForValue.build();
+            onChanged();
+          } else {
+            nodeBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public Builder mergeNode(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress value) {
+          if (nodeBuilder_ == null) {
+            if (((bitField0_ & 0x00000001) == 0x00000001) &&
+                node_ != akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance()) {
+              node_ =
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.newBuilder(node_).mergeFrom(value).buildPartial();
+            } else {
+              node_ = value;
+            }
+            onChanged();
+          } else {
+            nodeBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public Builder clearNode() {
+          if (nodeBuilder_ == null) {
+            node_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
+            onChanged();
+          } else {
+            nodeBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder getNodeBuilder() {
+          bitField0_ |= 0x00000001;
+          onChanged();
+          return getNodeFieldBuilder().getBuilder();
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder getNodeOrBuilder() {
+          if (nodeBuilder_ != null) {
+            return nodeBuilder_.getMessageOrBuilder();
+          } else {
+            return node_;
+          }
+        }
+        /**
+         * <code>required .akka.cluster.ddata.UniqueAddress node = 1;</code>
+         */
+        private akka.protobuf.SingleFieldBuilder<
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder> 
+            getNodeFieldBuilder() {
+          if (nodeBuilder_ == null) {
+            nodeBuilder_ = new akka.protobuf.SingleFieldBuilder<
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddressOrBuilder>(
+                    node_,
+                    getParentForChildren(),
+                    isClean());
+            node_ = null;
+          }
+          return nodeBuilder_;
+        }
+
+        // required int64 version = 2;
+        private long version_ ;
+        /**
+         * <code>required int64 version = 2;</code>
+         */
+        public boolean hasVersion() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>required int64 version = 2;</code>
+         */
+        public long getVersion() {
+          return version_;
+        }
+        /**
+         * <code>required int64 version = 2;</code>
+         */
+        public Builder setVersion(long value) {
+          bitField0_ |= 0x00000002;
+          version_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required int64 version = 2;</code>
+         */
+        public Builder clearVersion() {
+          bitField0_ = (bitField0_ & ~0x00000002);
+          version_ = 0L;
+          onChanged();
+          return this;
+        }
+
+        // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.VersionVector.Entry)
+      }
+
+      static {
+        defaultInstance = new Entry(true);
+        defaultInstance.initFields();
+      }
+
+      // @@protoc_insertion_point(class_scope:akka.cluster.ddata.VersionVector.Entry)
+    }
+
+    // repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;
+    public static final int ENTRIES_FIELD_NUMBER = 1;
+    private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry> entries_;
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry> getEntriesList() {
+      return entries_;
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder> 
+        getEntriesOrBuilderList() {
+      return entries_;
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    public int getEntriesCount() {
+      return entries_.size();
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry getEntries(int index) {
+      return entries_.get(index);
+    }
+    /**
+     * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+     */
+    public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder getEntriesOrBuilder(
+        int index) {
+      return entries_.get(index);
+    }
+
+    private void initFields() {
+      entries_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      for (int i = 0; i < getEntriesCount(); i++) {
+        if (!getEntries(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(akka.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < entries_.size(); i++) {
+        output.writeMessage(1, entries_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < entries_.size(); i++) {
+        size += akka.protobuf.CodedOutputStream
+          .computeMessageSize(1, entries_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(
+        akka.protobuf.ByteString data)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(
+        akka.protobuf.ByteString data,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(byte[] data)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(
+        byte[] data,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(
+        java.io.InputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseDelimitedFrom(
+        java.io.InputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(
+        akka.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseFrom(
+        akka.protobuf.CodedInputStream input,
+        akka.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code akka.cluster.ddata.VersionVector}
+     */
+    public static final class Builder extends
+        akka.protobuf.GeneratedMessage.Builder<Builder>
+       implements akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVectorOrBuilder {
+      public static final akka.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
+      }
+
+      protected akka.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.class, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Builder.class);
+      }
+
+      // Construct using akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          akka.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getEntriesFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          entriesBuilder_.clear();
+        }
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public akka.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector getDefaultInstanceForType() {
+        return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance();
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector build() {
+        akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector buildPartial() {
+        akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector result = new akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector(this);
+        int from_bitField0_ = bitField0_;
+        if (entriesBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            entries_ = java.util.Collections.unmodifiableList(entries_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.entries_ = entries_;
+        } else {
+          result.entries_ = entriesBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(akka.protobuf.Message other) {
+        if (other instanceof akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector) {
+          return mergeFrom((akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector other) {
+        if (other == akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.getDefaultInstance()) return this;
+        if (entriesBuilder_ == null) {
+          if (!other.entries_.isEmpty()) {
+            if (entries_.isEmpty()) {
+              entries_ = other.entries_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureEntriesIsMutable();
+              entries_.addAll(other.entries_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.entries_.isEmpty()) {
+            if (entriesBuilder_.isEmpty()) {
+              entriesBuilder_.dispose();
+              entriesBuilder_ = null;
+              entries_ = other.entries_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              entriesBuilder_ = 
+                akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getEntriesFieldBuilder() : null;
+            } else {
+              entriesBuilder_.addAllMessages(other.entries_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        for (int i = 0; i < getEntriesCount(); i++) {
+          if (!getEntries(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          akka.protobuf.CodedInputStream input,
+          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;
+      private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry> entries_ =
+        java.util.Collections.emptyList();
+      private void ensureEntriesIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          entries_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry>(entries_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private akka.protobuf.RepeatedFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder> entriesBuilder_;
+
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry> getEntriesList() {
+        if (entriesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(entries_);
+        } else {
+          return entriesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public int getEntriesCount() {
+        if (entriesBuilder_ == null) {
+          return entries_.size();
+        } else {
+          return entriesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry getEntries(int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);
+        } else {
+          return entriesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder setEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.set(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder setEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder addEntries(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder addEntries(
+          int index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder addAllEntries(
+          java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry> values) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          super.addAll(values, entries_);
+          onChanged();
+        } else {
+          entriesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder clearEntries() {
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          entriesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public Builder removeEntries(int index) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.remove(index);
+          onChanged();
+        } else {
+          entriesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder getEntriesBuilder(
+          int index) {
+        return getEntriesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder getEntriesOrBuilder(
+          int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);  } else {
+          return entriesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder> 
+           getEntriesOrBuilderList() {
+        if (entriesBuilder_ != null) {
+          return entriesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(entries_);
+        }
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder addEntriesBuilder() {
+        return getEntriesFieldBuilder().addBuilder(
+            akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder addEntriesBuilder(
+          int index) {
+        return getEntriesFieldBuilder().addBuilder(
+            index, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.VersionVector.Entry entries = 1;</code>
+       */
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder> 
+           getEntriesBuilderList() {
+        return getEntriesFieldBuilder().getBuilderList();
+      }
+      private akka.protobuf.RepeatedFieldBuilder<
+          akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder> 
+          getEntriesFieldBuilder() {
+        if (entriesBuilder_ == null) {
+          entriesBuilder_ = new akka.protobuf.RepeatedFieldBuilder<
+              akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.EntryOrBuilder>(
+                  entries_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          entries_ = null;
+        }
+        return entriesBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.VersionVector)
+    }
+
+    static {
+      defaultInstance = new VersionVector(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:akka.cluster.ddata.VersionVector)
   }
 
   public interface OtherMessageOrBuilder
@@ -17222,6 +19137,16 @@ public final class ReplicatorMessages {
     akka.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_akka_cluster_ddata_Address_fieldAccessorTable;
   private static akka.protobuf.Descriptors.Descriptor
+    internal_static_akka_cluster_ddata_VersionVector_descriptor;
+  private static
+    akka.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable;
+  private static akka.protobuf.Descriptors.Descriptor
+    internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
+  private static
+    akka.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable;
+  private static akka.protobuf.Descriptors.Descriptor
     internal_static_akka_cluster_ddata_OtherMessage_descriptor;
   private static
     akka.protobuf.GeneratedMessage.FieldAccessorTable
@@ -17269,38 +19194,45 @@ public final class ReplicatorMessages {
       "key\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .akka.clust" +
       "er.ddata.DataEnvelope\"\007\n\005Empty\"\023\n\004Read\022\013" +
       "\n\003key\030\001 \002(\t\"@\n\nReadResult\0222\n\010envelope\030\001 " +
-      "\001(\0132 .akka.cluster.ddata.DataEnvelope\"\327\002" +
+      "\001(\0132 .akka.cluster.ddata.DataEnvelope\"\221\003" +
       "\n\014DataEnvelope\022.\n\004data\030\001 \002(\0132 .akka.clus" +
       "ter.ddata.OtherMessage\022>\n\007pruning\030\002 \003(\0132" +
       "-.akka.cluster.ddata.DataEnvelope.Prunin" +
-      "gEntry\032\326\001\n\014PruningEntry\0229\n\016removedAddres" +
-      "s\030\001 \002(\0132!.akka.cluster.ddata.UniqueAddre",
-      "ss\0227\n\014ownerAddress\030\002 \002(\0132!.akka.cluster." +
-      "ddata.UniqueAddress\022\021\n\tperformed\030\003 \002(\010\022)" +
-      "\n\004seen\030\004 \003(\0132\033.akka.cluster.ddata.Addres" +
-      "s\022\024\n\014obsoleteTime\030\005 \001(\022\"\203\001\n\006Status\022\r\n\005ch" +
-      "unk\030\001 \002(\r\022\021\n\ttotChunks\030\002 \002(\r\0221\n\007entries\030" +
-      "\003 \003(\0132 .akka.cluster.ddata.Status.Entry\032" +
-      "$\n\005Entry\022\013\n\003key\030\001 \002(\t\022\016\n\006digest\030\002 \002(\014\"\227\001" +
-      "\n\006Gossip\022\020\n\010sendBack\030\001 \002(\010\0221\n\007entries\030\002 " +
-      "\003(\0132 .akka.cluster.ddata.Gossip.Entry\032H\n" +
-      "\005Entry\022\013\n\003key\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .",
-      "akka.cluster.ddata.DataEnvelope\"\231\001\n\020Delt" +
-      "aPropagation\022;\n\007entries\030\001 \003(\0132*.akka.clu" +
-      "ster.ddata.DeltaPropagation.Entry\032H\n\005Ent" +
-      "ry\022\013\n\003key\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .akka" +
-      ".cluster.ddata.DataEnvelope\"X\n\rUniqueAdd" +
-      "ress\022,\n\007address\030\001 \002(\0132\033.akka.cluster.dda" +
-      "ta.Address\022\013\n\003uid\030\002 \002(\017\022\014\n\004uid2\030\003 \001(\017\")\n" +
-      "\007Address\022\020\n\010hostname\030\001 \002(\t\022\014\n\004port\030\002 \002(\r" +
-      "\"V\n\014OtherMessage\022\027\n\017enclosedMessage\030\001 \002(" +
-      "\014\022\024\n\014serializerId\030\002 \002(\005\022\027\n\017messageManife",
-      "st\030\004 \001(\014\"\036\n\nStringGSet\022\020\n\010elements\030\001 \003(\t" +
-      "\"\205\001\n\023DurableDataEnvelope\022.\n\004data\030\001 \002(\0132 " +
-      ".akka.cluster.ddata.OtherMessage\022>\n\007prun" +
-      "ing\030\002 \003(\0132-.akka.cluster.ddata.DataEnvel" +
-      "ope.PruningEntryB#\n\037akka.cluster.ddata.p" +
-      "rotobuf.msgH\001"
+      "gEntry\0228\n\rdeltaVersions\030\003 \001(\0132!.akka.clu" +
+      "ster.ddata.VersionVector\032\326\001\n\014PruningEntr",
+      "y\0229\n\016removedAddress\030\001 \002(\0132!.akka.cluster" +
+      ".ddata.UniqueAddress\0227\n\014ownerAddress\030\002 \002" +
+      "(\0132!.akka.cluster.ddata.UniqueAddress\022\021\n" +
+      "\tperformed\030\003 \002(\010\022)\n\004seen\030\004 \003(\0132\033.akka.cl" +
+      "uster.ddata.Address\022\024\n\014obsoleteTime\030\005 \001(" +
+      "\022\"\203\001\n\006Status\022\r\n\005chunk\030\001 \002(\r\022\021\n\ttotChunks" +
+      "\030\002 \002(\r\0221\n\007entries\030\003 \003(\0132 .akka.cluster.d" +
+      "data.Status.Entry\032$\n\005Entry\022\013\n\003key\030\001 \002(\t\022" +
+      "\016\n\006digest\030\002 \002(\014\"\227\001\n\006Gossip\022\020\n\010sendBack\030\001" +
+      " \002(\010\0221\n\007entries\030\002 \003(\0132 .akka.cluster.dda",
+      "ta.Gossip.Entry\032H\n\005Entry\022\013\n\003key\030\001 \002(\t\0222\n" +
+      "\010envelope\030\002 \002(\0132 .akka.cluster.ddata.Dat" +
+      "aEnvelope\"\362\001\n\020DeltaPropagation\0223\n\010fromNo" +
+      "de\030\001 \002(\0132!.akka.cluster.ddata.UniqueAddr" +
+      "ess\022;\n\007entries\030\002 \003(\0132*.akka.cluster.ddat" +
+      "a.DeltaPropagation.Entry\032l\n\005Entry\022\013\n\003key" +
+      "\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .akka.cluster." +
+      "ddata.DataEnvelope\022\021\n\tfromSeqNr\030\003 \002(\003\022\017\n" +
+      "\007toSeqNr\030\004 \001(\003\"X\n\rUniqueAddress\022,\n\007addre" +
+      "ss\030\001 \002(\0132\033.akka.cluster.ddata.Address\022\013\n",
+      "\003uid\030\002 \002(\017\022\014\n\004uid2\030\003 \001(\017\")\n\007Address\022\020\n\010h" +
+      "ostname\030\001 \002(\t\022\014\n\004port\030\002 \002(\r\"\224\001\n\rVersionV" +
+      "ector\0228\n\007entries\030\001 \003(\0132\'.akka.cluster.dd" +
+      "ata.VersionVector.Entry\032I\n\005Entry\022/\n\004node" +
+      "\030\001 \002(\0132!.akka.cluster.ddata.UniqueAddres" +
+      "s\022\017\n\007version\030\002 \002(\003\"V\n\014OtherMessage\022\027\n\017en" +
+      "closedMessage\030\001 \002(\014\022\024\n\014serializerId\030\002 \002(" +
+      "\005\022\027\n\017messageManifest\030\004 \001(\014\"\036\n\nStringGSet" +
+      "\022\020\n\010elements\030\001 \003(\t\"\205\001\n\023DurableDataEnvelo" +
+      "pe\022.\n\004data\030\001 \002(\0132 .akka.cluster.ddata.Ot",
+      "herMessage\022>\n\007pruning\030\002 \003(\0132-.akka.clust" +
+      "er.ddata.DataEnvelope.PruningEntryB#\n\037ak" +
+      "ka.cluster.ddata.protobuf.msgH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -17378,7 +19310,7 @@ public final class ReplicatorMessages {
           internal_static_akka_cluster_ddata_DataEnvelope_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_DataEnvelope_descriptor,
-              new java.lang.String[] { "Data", "Pruning", });
+              new java.lang.String[] { "Data", "Pruning", "DeltaVersions", });
           internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor =
             internal_static_akka_cluster_ddata_DataEnvelope_descriptor.getNestedTypes().get(0);
           internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_fieldAccessorTable = new
@@ -17414,13 +19346,13 @@ public final class ReplicatorMessages {
           internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_DeltaPropagation_descriptor,
-              new java.lang.String[] { "Entries", });
+              new java.lang.String[] { "FromNode", "Entries", });
           internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor =
             internal_static_akka_cluster_ddata_DeltaPropagation_descriptor.getNestedTypes().get(0);
           internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor,
-              new java.lang.String[] { "Key", "Envelope", });
+              new java.lang.String[] { "Key", "Envelope", "FromSeqNr", "ToSeqNr", });
           internal_static_akka_cluster_ddata_UniqueAddress_descriptor =
             getDescriptor().getMessageTypes().get(15);
           internal_static_akka_cluster_ddata_UniqueAddress_fieldAccessorTable = new
@@ -17433,20 +19365,32 @@ public final class ReplicatorMessages {
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_Address_descriptor,
               new java.lang.String[] { "Hostname", "Port", });
-          internal_static_akka_cluster_ddata_OtherMessage_descriptor =
+          internal_static_akka_cluster_ddata_VersionVector_descriptor =
             getDescriptor().getMessageTypes().get(17);
+          internal_static_akka_cluster_ddata_VersionVector_fieldAccessorTable = new
+            akka.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_akka_cluster_ddata_VersionVector_descriptor,
+              new java.lang.String[] { "Entries", });
+          internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor =
+            internal_static_akka_cluster_ddata_VersionVector_descriptor.getNestedTypes().get(0);
+          internal_static_akka_cluster_ddata_VersionVector_Entry_fieldAccessorTable = new
+            akka.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor,
+              new java.lang.String[] { "Node", "Version", });
+          internal_static_akka_cluster_ddata_OtherMessage_descriptor =
+            getDescriptor().getMessageTypes().get(18);
           internal_static_akka_cluster_ddata_OtherMessage_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_OtherMessage_descriptor,
               new java.lang.String[] { "EnclosedMessage", "SerializerId", "MessageManifest", });
           internal_static_akka_cluster_ddata_StringGSet_descriptor =
-            getDescriptor().getMessageTypes().get(18);
+            getDescriptor().getMessageTypes().get(19);
           internal_static_akka_cluster_ddata_StringGSet_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_StringGSet_descriptor,
               new java.lang.String[] { "Elements", });
           internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor =
-            getDescriptor().getMessageTypes().get(19);
+            getDescriptor().getMessageTypes().get(20);
           internal_static_akka_cluster_ddata_DurableDataEnvelope_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor,

--- a/akka-distributed-data/src/main/protobuf/ReplicatedDataMessages.proto
+++ b/akka-distributed-data/src/main/protobuf/ReplicatedDataMessages.proto
@@ -21,7 +21,21 @@ message ORSet {
   repeated sint32 intElements = 4 [packed=true];
   repeated sint64 longElements = 5 [packed=true];
   repeated OtherMessage otherElements = 6;
+}
+
+message ORSetDeltaGroup {
+  message Entry {
+    required ORSetDeltaOp operation = 1;
+    required ORSet underlying = 2;
+  }
   
+  repeated Entry entries = 1;
+}
+
+enum ORSetDeltaOp {
+  Add = 0;
+  Remove = 1;
+  Full = 2;
 }
 
 message Flag {
@@ -46,14 +60,6 @@ message GCounter {
 message PNCounter {
   required GCounter increments = 1;
   required GCounter decrements = 2;
-}
-
-message VersionVector {
-  message Entry {
-    required UniqueAddress node = 1;
-    required int64 version = 2;
-  }
-  repeated Entry entries = 1;
 }
 
 message ORMap {

--- a/akka-distributed-data/src/main/protobuf/ReplicatorMessages.proto
+++ b/akka-distributed-data/src/main/protobuf/ReplicatorMessages.proto
@@ -73,6 +73,7 @@ message DataEnvelope {
   
   required OtherMessage data = 1;
   repeated PruningEntry pruning = 2;
+  optional VersionVector deltaVersions = 3;
 }
 
 message Status {
@@ -100,9 +101,12 @@ message DeltaPropagation {
   message Entry {
     required string key = 1;
     required DataEnvelope envelope = 2;
+    required int64 fromSeqNr = 3;
+    optional int64 toSeqNr = 4; // if not set then same as fromSequenceNr
   }
   
-  repeated Entry entries = 1;
+  required UniqueAddress fromNode = 1;
+  repeated Entry entries = 2;
 }
 
 message UniqueAddress {
@@ -115,6 +119,14 @@ message UniqueAddress {
 message Address {
   required string hostname = 1;
   required uint32 port = 2;
+}
+
+message VersionVector {
+  message Entry {
+    required UniqueAddress node = 1;
+    required int64 version = 2;
+  }
+  repeated Entry entries = 1;
 }
 
 message OtherMessage {

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/DeltaPropagationSelector.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/DeltaPropagationSelector.scala
@@ -4,48 +4,53 @@
 package akka.cluster.ddata
 
 import scala.collection.immutable.TreeMap
-import akka.cluster.ddata.Replicator.Internal.DeltaPropagation
+
 import akka.actor.Address
-import akka.cluster.ddata.Replicator.Internal.DataEnvelope
+import akka.annotation.InternalApi
+import akka.cluster.ddata.Key.KeyId
+import akka.cluster.ddata.Replicator.Internal.DeltaPropagation
 
 /**
  * INTERNAL API: Used by the Replicator actor.
  * Extracted to separate trait to make it easy to test.
  */
-private[akka] trait DeltaPropagationSelector {
+@InternalApi private[akka] trait DeltaPropagationSelector {
 
   private var _propagationCount = 0L
   def propagationCount: Long = _propagationCount
-  private var deltaCounter = Map.empty[String, Long]
-  private var deltaEntries = Map.empty[String, TreeMap[Long, ReplicatedData]]
-  private var deltaSentToNode = Map.empty[String, Map[Address, Long]]
+  private var deltaCounter = Map.empty[KeyId, Long]
+  private var deltaEntries = Map.empty[KeyId, TreeMap[Long, ReplicatedData]]
+  private var deltaSentToNode = Map.empty[KeyId, Map[Address, Long]]
   private var deltaNodeRoundRobinCounter = 0L
 
-  def divisor: Int
+  def gossipIntervalDivisor: Int
 
   def allNodes: Vector[Address]
 
-  def createDeltaPropagation(deltas: Map[String, ReplicatedData]): DeltaPropagation
+  def createDeltaPropagation(deltas: Map[KeyId, (ReplicatedData, Long, Long)]): DeltaPropagation
 
-  def update(key: String, delta: ReplicatedData): Unit = {
-    val c = deltaCounter.get(key) match {
-      case Some(c) ⇒ c
-      case None ⇒
-        deltaCounter = deltaCounter.updated(key, 1L)
-        1L
-    }
-    val deltaEntriesForKey = deltaEntries.getOrElse(key, TreeMap.empty[Long, ReplicatedData])
-    val updatedEntriesForKey =
-      deltaEntriesForKey.get(c) match {
-        case Some(existingDelta) ⇒
-          deltaEntriesForKey.updated(c, existingDelta.merge(delta.asInstanceOf[existingDelta.T]))
-        case None ⇒
-          deltaEntriesForKey.updated(c, delta)
-      }
-    deltaEntries = deltaEntries.updated(key, updatedEntriesForKey)
+  def currentVersion(key: KeyId): Long = deltaCounter.get(key) match {
+    case Some(v) ⇒ v
+    case None    ⇒ 0L
   }
 
-  def delete(key: String): Unit = {
+  def update(key: KeyId, delta: ReplicatedData): Unit = {
+    // bump the counter for each update
+    val version = deltaCounter.get(key) match {
+      case Some(c) ⇒ c + 1
+      case None    ⇒ 1L
+    }
+    deltaCounter = deltaCounter.updated(key, version)
+
+    val deltaEntriesForKey = deltaEntries.get(key) match {
+      case Some(m) ⇒ m
+      case None    ⇒ TreeMap.empty[Long, ReplicatedData]
+    }
+
+    deltaEntries = deltaEntries.updated(key, deltaEntriesForKey.updated(version, delta))
+  }
+
+  def delete(key: KeyId): Unit = {
     deltaEntries -= key
     deltaCounter -= key
     deltaSentToNode -= key
@@ -53,7 +58,7 @@ private[akka] trait DeltaPropagationSelector {
 
   def nodesSliceSize(allNodesSize: Int): Int = {
     // 2 - 10 nodes
-    math.min(math.max((allNodesSize / divisor) + 1, 2), math.min(allNodesSize, 10))
+    math.min(math.max((allNodesSize / gossipIntervalDivisor) + 1, 2), math.min(allNodesSize, 10))
   }
 
   def collectPropagations(): Map[Address, DeltaPropagation] = {
@@ -80,20 +85,32 @@ private[akka] trait DeltaPropagationSelector {
 
       var result = Map.empty[Address, DeltaPropagation]
 
+      var cache = Map.empty[(KeyId, Long, Long), ReplicatedData]
       slice.foreach { node ⇒
         // collect the deltas that have not already been sent to the node and merge
         // them into a delta group
-        var deltas = Map.empty[String, ReplicatedData]
+        var deltas = Map.empty[KeyId, (ReplicatedData, Long, Long)]
         deltaEntries.foreach {
           case (key, entries) ⇒
             val deltaSentToNodeForKey = deltaSentToNode.getOrElse(key, TreeMap.empty[Address, Long])
             val j = deltaSentToNodeForKey.getOrElse(node, 0L)
             val deltaEntriesAfterJ = deltaEntriesAfter(entries, j)
             if (deltaEntriesAfterJ.nonEmpty) {
-              val deltaGroup = deltaEntriesAfterJ.valuesIterator.reduceLeft {
-                (d1, d2) ⇒ d1.merge(d2.asInstanceOf[d1.T])
+              val fromSeqNr = deltaEntriesAfterJ.head._1
+              val toSeqNr = deltaEntriesAfterJ.last._1
+              // in most cases the delta group merging will be the same for each node,
+              // so we cache the merged results
+              val cacheKey = (key, fromSeqNr, toSeqNr)
+              val deltaGroup = cache.get(cacheKey) match {
+                case None ⇒
+                  val group = deltaEntriesAfterJ.valuesIterator.reduceLeft {
+                    (d1, d2) ⇒ d1.merge(d2.asInstanceOf[d1.T])
+                  }
+                  cache = cache.updated(cacheKey, group)
+                  group
+                case Some(group) ⇒ group
               }
-              deltas = deltas.updated(key, deltaGroup)
+              deltas = deltas.updated(key, (deltaGroup, fromSeqNr, toSeqNr))
               deltaSentToNode = deltaSentToNode.updated(key, deltaSentToNodeForKey.updated(node, deltaEntriesAfterJ.lastKey))
             }
         }
@@ -104,15 +121,6 @@ private[akka] trait DeltaPropagationSelector {
           val deltaPropagation = createDeltaPropagation(deltas)
           result = result.updated(node, deltaPropagation)
         }
-      }
-
-      // increase the counter
-      deltaCounter = deltaCounter.map {
-        case (key, value) ⇒
-          if (deltaEntries.contains(key))
-            key → (value + 1)
-          else
-            key → value
       }
 
       result
@@ -126,14 +134,14 @@ private[akka] trait DeltaPropagationSelector {
       case ntrs                             ⇒ ntrs
     }
 
-  def hasDeltaEntries(key: String): Boolean = {
+  def hasDeltaEntries(key: KeyId): Boolean = {
     deltaEntries.get(key) match {
       case Some(m) ⇒ m.nonEmpty
       case None    ⇒ false
     }
   }
 
-  private def findSmallestVersionPropagatedToAllNodes(key: String, all: Vector[Address]): Long = {
+  private def findSmallestVersionPropagatedToAllNodes(key: KeyId, all: Vector[Address]): Long = {
     deltaSentToNode.get(key) match {
       case None ⇒ 0L
       case Some(deltaSentToNodeForKey) ⇒
@@ -154,7 +162,7 @@ private[akka] trait DeltaPropagationSelector {
 
           val deltaEntriesAfterMin = deltaEntriesAfter(entries, minVersion)
 
-          // TODO perhaps also remove oldest when deltaCounter are too far ahead (e.g. 10 cylces)
+          // TODO perhaps also remove oldest when deltaCounter is too far ahead (e.g. 10 cycles)
 
           key → deltaEntriesAfterMin
       }

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/FastMerge.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/FastMerge.scala
@@ -3,6 +3,8 @@
  */
 package akka.cluster.ddata
 
+import akka.annotation.InternalApi
+
 /**
  * INTERNAL API
  *
@@ -19,11 +21,11 @@ package akka.cluster.ddata
  * i.e. if used outside the Replicator infrastructure, but the worst thing that can happen is that
  * a full merge is performed instead of the fast forward merge.
  */
-private[akka] trait FastMerge { self: ReplicatedData ⇒
+@InternalApi private[akka] trait FastMerge { self: ReplicatedData ⇒
 
   private var ancestor: FastMerge = null
 
-  /** INTERNAL API: should be called from "updating" methods */
+  /** INTERNAL API: should be called from "updating" methods, and `resetDelta` */
   private[akka] def assignAncestor(newData: T with FastMerge): T = {
     newData.ancestor = if (this.ancestor eq null) this else this.ancestor
     this.ancestor = null // only one level, for GC

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Key.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Key.scala
@@ -11,6 +11,8 @@ object Key {
 
   private[akka]type KeyR = Key[ReplicatedData]
 
+  type KeyId = String
+
 }
 
 /**
@@ -21,7 +23,7 @@ object Key {
  * Specific classes are provided for the built in data types, e.g. [[ORSetKey]],
  * and you can create your own keys.
  */
-abstract class Key[+T <: ReplicatedData](val id: String) extends Serializable {
+abstract class Key[+T <: ReplicatedData](val id: Key.KeyId) extends Serializable {
 
   override final def equals(o: Any): Boolean = o match {
     case k: Key[_] ⇒ id == k.id

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
@@ -5,6 +5,7 @@ package akka.cluster.ddata
 
 import akka.cluster.Cluster
 import akka.cluster.UniqueAddress
+import akka.annotation.InternalApi
 
 object LWWMap {
   private val _empty: LWWMap[Any, Any] = new LWWMap(ORMap.empty)
@@ -111,7 +112,7 @@ final class LWWMap[A, B] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def put(node: UniqueAddress, key: A, value: B, clock: Clock[B]): LWWMap[A, B] = {
+  @InternalApi private[akka] def put(node: UniqueAddress, key: A, value: B, clock: Clock[B]): LWWMap[A, B] = {
     val newRegister = underlying.get(key) match {
       case Some(r) ⇒ r.withValue(node, value, clock)
       case None    ⇒ LWWRegister(node, value, clock)
@@ -137,7 +138,7 @@ final class LWWMap[A, B] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def remove(node: UniqueAddress, key: A): LWWMap[A, B] =
+  @InternalApi private[akka] def remove(node: UniqueAddress, key: A): LWWMap[A, B] =
     new LWWMap(underlying.remove(node, key))
 
   override def merge(that: LWWMap[A, B]): LWWMap[A, B] =

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
@@ -6,6 +6,7 @@ package akka.cluster.ddata
 import akka.cluster.Cluster
 import akka.cluster.UniqueAddress
 import akka.util.HashCode
+import akka.annotation.InternalApi
 
 object LWWRegister {
 
@@ -43,7 +44,7 @@ object LWWRegister {
   /**
    * INTERNAL API
    */
-  private[akka] def apply[A](node: UniqueAddress, initialValue: A, clock: Clock[A]): LWWRegister[A] =
+  @InternalApi private[akka] def apply[A](node: UniqueAddress, initialValue: A, clock: Clock[A]): LWWRegister[A] =
     new LWWRegister(node, initialValue, clock(0L, initialValue))
 
   def apply[A](initialValue: A)(implicit node: Cluster, clock: Clock[A] = defaultClock[A]): LWWRegister[A] =
@@ -148,7 +149,7 @@ final class LWWRegister[A] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def withValue(node: UniqueAddress, value: A, clock: Clock[A]): LWWRegister[A] =
+  @InternalApi private[akka] def withValue(node: UniqueAddress, value: A, clock: Clock[A]): LWWRegister[A] =
     new LWWRegister(node, value, clock(timestamp, value))
 
   override def merge(that: LWWRegister[A]): LWWRegister[A] =

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
@@ -6,6 +6,7 @@ package akka.cluster.ddata
 import akka.cluster.Cluster
 import akka.cluster.UniqueAddress
 import akka.util.HashCode
+import akka.annotation.InternalApi
 
 object ORMap {
   private val _empty: ORMap[Any, ReplicatedData] = new ORMap(ORSet.empty, Map.empty)
@@ -93,7 +94,7 @@ final class ORMap[A, B <: ReplicatedData] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def put(node: UniqueAddress, key: A, value: B): ORMap[A, B] =
+  @InternalApi private[akka] def put(node: UniqueAddress, key: A, value: B): ORMap[A, B] =
     if (value.isInstanceOf[ORSet[_]] && values.contains(key))
       throw new IllegalArgumentException(
         "`ORMap.put` must not be used to replace an existing `ORSet` " +
@@ -123,7 +124,7 @@ final class ORMap[A, B <: ReplicatedData] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def updated(node: UniqueAddress, key: A, initial: B)(modify: B ⇒ B): ORMap[A, B] = {
+  @InternalApi private[akka] def updated(node: UniqueAddress, key: A, initial: B)(modify: B ⇒ B): ORMap[A, B] = {
     val newValue = values.get(key) match {
       case Some(old) ⇒ modify(old)
       case _         ⇒ modify(initial)
@@ -148,7 +149,7 @@ final class ORMap[A, B <: ReplicatedData] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def remove(node: UniqueAddress, key: A): ORMap[A, B] = {
+  @InternalApi private[akka] def remove(node: UniqueAddress, key: A): ORMap[A, B] = {
     new ORMap(keys.remove(node, key), values - key)
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
@@ -4,6 +4,7 @@
 package akka.cluster.ddata
 
 import akka.cluster.{ UniqueAddress, Cluster }
+import akka.annotation.InternalApi
 
 object ORMultiMap {
 
@@ -113,7 +114,7 @@ final class ORMultiMap[A, B] private[akka] (private[akka] val underlying: ORMap[
   /**
    * INTERNAL API
    */
-  private[akka] def put(node: UniqueAddress, key: A, value: Set[B]): ORMultiMap[A, B] = {
+  @InternalApi private[akka] def put(node: UniqueAddress, key: A, value: Set[B]): ORMultiMap[A, B] = {
     val newUnderlying = underlying.updated(node, key, ORSet.empty[B]) { existing ⇒
       value.foldLeft(existing.clear(node)) { (s, element) ⇒ s.add(node, element) }
     }
@@ -136,7 +137,7 @@ final class ORMultiMap[A, B] private[akka] (private[akka] val underlying: ORMap[
   /**
    * INTERNAL API
    */
-  private[akka] def remove(node: UniqueAddress, key: A): ORMultiMap[A, B] =
+  @InternalApi private[akka] def remove(node: UniqueAddress, key: A): ORMultiMap[A, B] =
     new ORMultiMap(underlying.remove(node, key))
 
   /**
@@ -154,7 +155,7 @@ final class ORMultiMap[A, B] private[akka] (private[akka] val underlying: ORMap[
   /**
    * INTERNAL API
    */
-  private[akka] def addBinding(node: UniqueAddress, key: A, element: B): ORMultiMap[A, B] = {
+  @InternalApi private[akka] def addBinding(node: UniqueAddress, key: A, element: B): ORMultiMap[A, B] = {
     val newUnderlying = underlying.updated(node, key, ORSet.empty[B])(_.add(node, element))
     new ORMultiMap(newUnderlying)
   }
@@ -176,7 +177,7 @@ final class ORMultiMap[A, B] private[akka] (private[akka] val underlying: ORMap[
   /**
    * INTERNAL API
    */
-  private[akka] def removeBinding(node: UniqueAddress, key: A, element: B): ORMultiMap[A, B] = {
+  @InternalApi private[akka] def removeBinding(node: UniqueAddress, key: A, element: B): ORMultiMap[A, B] = {
     val newUnderlying = {
       val u = underlying.updated(node, key, ORSet.empty[B])(_.remove(node, element))
       u.get(key) match {
@@ -198,7 +199,7 @@ final class ORMultiMap[A, B] private[akka] (private[akka] val underlying: ORMap[
   /**
    * INTERNAL API
    */
-  private[akka] def replaceBinding(node: UniqueAddress, key: A, oldElement: B, newElement: B): ORMultiMap[A, B] =
+  @InternalApi private[akka] def replaceBinding(node: UniqueAddress, key: A, oldElement: B, newElement: B): ORMultiMap[A, B] =
     if (newElement != oldElement)
       addBinding(node, key, newElement).removeBinding(node, key, oldElement)
     else

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
@@ -6,6 +6,7 @@ package akka.cluster.ddata
 import akka.cluster.Cluster
 import akka.cluster.UniqueAddress
 import java.math.BigInteger
+import akka.annotation.InternalApi
 
 object PNCounterMap {
   def empty[A]: PNCounterMap[A] = new PNCounterMap(ORMap.empty)
@@ -75,7 +76,7 @@ final class PNCounterMap[A] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def increment(node: UniqueAddress, key: A, delta: Long): PNCounterMap[A] =
+  @InternalApi private[akka] def increment(node: UniqueAddress, key: A, delta: Long): PNCounterMap[A] =
     new PNCounterMap(underlying.updated(node, key, PNCounter())(_.increment(node, delta)))
 
   /**
@@ -95,7 +96,7 @@ final class PNCounterMap[A] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def decrement(node: UniqueAddress, key: A, delta: Long): PNCounterMap[A] = {
+  @InternalApi private[akka] def decrement(node: UniqueAddress, key: A, delta: Long): PNCounterMap[A] = {
     new PNCounterMap(underlying.updated(node, key, PNCounter())(_.decrement(node, delta)))
   }
 
@@ -117,7 +118,7 @@ final class PNCounterMap[A] private[akka] (
   /**
    * INTERNAL API
    */
-  private[akka] def remove(node: UniqueAddress, key: A): PNCounterMap[A] =
+  @InternalApi private[akka] def remove(node: UniqueAddress, key: A): PNCounterMap[A] =
     new PNCounterMap(underlying.remove(node, key))
 
   override def merge(that: PNCounterMap[A]): PNCounterMap[A] =

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PruningState.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PruningState.scala
@@ -6,11 +6,12 @@ package akka.cluster.ddata
 import akka.actor.Address
 import akka.cluster.Member
 import akka.cluster.UniqueAddress
+import akka.annotation.InternalApi
 
 /**
  * INTERNAL API
  */
-private[akka] object PruningState {
+@InternalApi private[akka] object PruningState {
   final case class PruningInitialized(owner: UniqueAddress, seen: Set[Address]) extends PruningState {
     override def addSeen(node: Address): PruningState = {
       if (seen(node) || owner.address == node) this
@@ -25,7 +26,7 @@ private[akka] object PruningState {
 /**
  * INTERNAL API
  */
-private[akka] sealed trait PruningState {
+@InternalApi private[akka] sealed trait PruningState {
   import PruningState._
 
   def merge(that: PruningState): PruningState =

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/PerformanceSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/PerformanceSpec.scala
@@ -38,6 +38,8 @@ object PerformanceSpec extends MultiNodeConfig {
     #akka.cluster.distributed-data.durable.keys = ["*"]
     #akka.cluster.distributed-data.durable.lmdb.dir = target/PerformanceSpec-${System.currentTimeMillis}-ddata
     #akka.cluster.distributed-data.durable.lmdb.write-behind-interval = 200ms
+
+    #akka.cluster.distributed-data.delta-crdt.enabled = off
     """))
 
   def countDownProps(latch: TestLatch): Props = Props(new CountDown(latch)).withDeploy(Deploy.local)

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorORSetDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorORSetDeltaSpec.scala
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.ddata
+
+import scala.concurrent.duration._
+
+import akka.cluster.Cluster
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+
+object ReplicatorORSetDeltaSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(ConfigFactory.parseString("""
+    akka.loglevel = DEBUG
+    akka.actor.provider = "cluster"
+    akka.log-dead-letters-during-shutdown = off
+    """))
+
+  testTransport(on = true)
+}
+
+class ReplicatorORSetDeltaSpecMultiJvmNode1 extends ReplicatorORSetDeltaSpec
+class ReplicatorORSetDeltaSpecMultiJvmNode2 extends ReplicatorORSetDeltaSpec
+class ReplicatorORSetDeltaSpecMultiJvmNode3 extends ReplicatorORSetDeltaSpec
+
+class ReplicatorORSetDeltaSpec extends MultiNodeSpec(ReplicatorORSetDeltaSpec) with STMultiNodeSpec with ImplicitSender {
+  import Replicator._
+  import ReplicatorORSetDeltaSpec._
+
+  override def initialParticipants = roles.size
+
+  implicit val cluster = Cluster(system)
+  val replicator = system.actorOf(Replicator.props(
+    ReplicatorSettings(system).withGossipInterval(1.second)), "replicator")
+  val timeout = 3.seconds.dilated
+
+  val KeyA = ORSetKey[String]("A")
+  val KeyB = ORSetKey[String]("B")
+  val KeyC = ORSetKey[String]("C")
+
+  def join(from: RoleName, to: RoleName): Unit = {
+    runOn(from) {
+      cluster join node(to).address
+    }
+    enterBarrier(from.name + "-joined")
+  }
+
+  def assertValue(key: Key[ReplicatedData], expected: Any): Unit =
+    within(10.seconds) {
+      awaitAssert {
+        replicator ! Get(key, ReadLocal)
+        val value = expectMsgPF() {
+          case g @ GetSuccess(`key`, _) ⇒ g.dataValue match {
+            case c: ORSet[_] ⇒ c.elements
+          }
+        }
+        value should be(expected)
+      }
+    }
+
+  "ORSet delta" must {
+
+    "replicate data in initial phase" in {
+      join(first, first)
+      join(second, first)
+      join(third, first)
+
+      replicator ! Replicator.Internal.TestFullStateGossip(enabled = false)
+
+      within(10.seconds) {
+        awaitAssert {
+          replicator ! GetReplicaCount
+          expectMsg(ReplicaCount(3))
+        }
+      }
+
+      runOn(first) {
+        replicator ! Update(KeyA, ORSet.empty[String], WriteLocal)(_ + "a")
+        expectMsg(UpdateSuccess(KeyA, None))
+      }
+
+      enterBarrier("initial-updates-done")
+
+      assertValue(KeyA, Set("a"))
+
+      enterBarrier("after-1")
+    }
+
+    "be propagated with causal consistency during network split" in {
+      runOn(first) {
+        // third is isolated
+        testConductor.blackhole(first, third, Direction.Both).await
+        testConductor.blackhole(second, third, Direction.Both).await
+      }
+      enterBarrier("split")
+
+      runOn(first) {
+        replicator ! Update(KeyA, ORSet.empty[String], WriteLocal)(_ + "b")
+        expectMsg(UpdateSuccess(KeyA, None))
+      }
+      runOn(second) {
+        replicator ! Update(KeyA, ORSet.empty[String], WriteLocal)(_ + "d")
+        expectMsg(UpdateSuccess(KeyA, None))
+      }
+      runOn(first, second) {
+        assertValue(KeyA, Set("a", "b", "d"))
+        Thread.sleep(2000) // all deltas sent
+      }
+      enterBarrier("added-b-and-d")
+
+      runOn(first) {
+        testConductor.passThrough(first, third, Direction.Both).await
+        testConductor.passThrough(second, third, Direction.Both).await
+      }
+      enterBarrier("healed")
+
+      runOn(first) {
+        // delta for "c" will be sent to third, but it has not received the previous delta for "b"
+        replicator ! Update(KeyA, ORSet.empty[String], WriteLocal)(_ + "c")
+        expectMsg(UpdateSuccess(KeyA, None))
+        // let the delta be propagated (will not fail if it takes longer)
+        Thread.sleep(1000)
+      }
+      enterBarrier("added-c")
+
+      runOn(first, second) {
+        assertValue(KeyA, Set("a", "b", "c", "d"))
+      }
+      runOn(third) {
+        // the delta for "c" should not be applied because it has not received previous delta for "b"
+        // and full gossip is turned off so far
+        assertValue(KeyA, Set("a"))
+      }
+      enterBarrier("verified-before-full-gossip")
+
+      replicator ! Replicator.Internal.TestFullStateGossip(enabled = true)
+      assertValue(KeyA, Set("a", "b", "c", "d"))
+      enterBarrier("verified-after-full-gossip")
+
+      replicator ! Replicator.Internal.TestFullStateGossip(enabled = false)
+
+      // and now the delta seqNr should be in sync again
+      runOn(first) {
+        replicator ! Update(KeyA, ORSet.empty[String], WriteLocal)(_ + "e")
+        expectMsg(UpdateSuccess(KeyA, None))
+      }
+      assertValue(KeyA, Set("a", "b", "c", "d", "e"))
+
+      enterBarrier("after-2")
+    }
+
+  }
+
+}
+

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
@@ -22,6 +22,7 @@ object ReplicatorSpec extends MultiNodeConfig {
     akka.loglevel = INFO
     akka.actor.provider = "cluster"
     akka.log-dead-letters-during-shutdown = off
+    #akka.cluster.distributed-data.delta-crdt.enabled = off
     """))
 
   testTransport(on = true)

--- a/akka-distributed-data/src/test/java/akka/cluster/ddata/JavaImplOfDeltaReplicatedData.java
+++ b/akka-distributed-data/src/test/java/akka/cluster/ddata/JavaImplOfDeltaReplicatedData.java
@@ -3,10 +3,12 @@
  */
 package akka.cluster.ddata;
 
-import akka.cluster.UniqueAddress;
 
-public class JavaImplOfDeltaReplicatedData extends AbstractDeltaReplicatedData<JavaImplOfDeltaReplicatedData> implements
-    RemovedNodePruning {
+import java.util.Optional;
+
+// same delta type
+public class JavaImplOfDeltaReplicatedData extends AbstractDeltaReplicatedData<JavaImplOfDeltaReplicatedData, JavaImplOfDeltaReplicatedData>
+  implements ReplicatedDelta {
 
   @Override
   public JavaImplOfDeltaReplicatedData mergeData(JavaImplOfDeltaReplicatedData other) {
@@ -14,8 +16,13 @@ public class JavaImplOfDeltaReplicatedData extends AbstractDeltaReplicatedData<J
   }
 
   @Override
-  public JavaImplOfDeltaReplicatedData delta() {
+  public JavaImplOfDeltaReplicatedData mergeDeltaData(JavaImplOfDeltaReplicatedData other) {
     return this;
+  }
+
+  @Override
+  public Optional<JavaImplOfDeltaReplicatedData> deltaData() {
+    return Optional.empty();
   }
 
   @Override
@@ -24,22 +31,8 @@ public class JavaImplOfDeltaReplicatedData extends AbstractDeltaReplicatedData<J
   }
 
   @Override
-  public scala.collection.immutable.Set<UniqueAddress> modifiedByNodes() {
-    return akka.japi.Util.immutableSeq(new java.util.ArrayList<UniqueAddress>()).toSet();
+  public JavaImplOfDeltaReplicatedData zero() {
+    return new JavaImplOfDeltaReplicatedData();
   }
 
-  @Override
-  public boolean needPruningFrom(UniqueAddress removedNode) {
-    return false;
-  }
-
-  @Override
-  public JavaImplOfDeltaReplicatedData prune(UniqueAddress removedNode, UniqueAddress collapseInto) {
-    return this;
-  }
-
-  @Override
-  public JavaImplOfDeltaReplicatedData pruningCleanup(UniqueAddress removedNode) {
-    return this;
-  }
 }

--- a/akka-distributed-data/src/test/java/akka/cluster/ddata/JavaImplOfDeltaReplicatedData2.java
+++ b/akka-distributed-data/src/test/java/akka/cluster/ddata/JavaImplOfDeltaReplicatedData2.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.ddata;
+
+
+import java.util.Optional;
+
+import akka.cluster.UniqueAddress;
+
+// different delta type
+public class JavaImplOfDeltaReplicatedData2
+  extends AbstractDeltaReplicatedData<JavaImplOfDeltaReplicatedData2, JavaImplOfDeltaReplicatedData2.Delta> {
+
+  public static class Delta extends AbstractReplicatedData<Delta> implements ReplicatedDelta, RequiresCausalDeliveryOfDeltas {
+    @Override
+    public Delta mergeData(Delta other) {
+      return this;
+    }
+
+    @Override
+    public JavaImplOfDeltaReplicatedData2 zero() {
+      return new JavaImplOfDeltaReplicatedData2();
+    }
+  }
+
+  @Override
+  public JavaImplOfDeltaReplicatedData2 mergeData(JavaImplOfDeltaReplicatedData2 other) {
+    return this;
+  }
+
+  @Override
+  public JavaImplOfDeltaReplicatedData2 mergeDeltaData(Delta other) {
+    return this;
+  }
+
+  @Override
+  public Optional<Delta> deltaData() {
+    return Optional.empty();
+  }
+
+  @Override
+  public JavaImplOfDeltaReplicatedData2 resetDelta() {
+    return this;
+  }
+
+
+
+}

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/GCounterSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/GCounterSpec.scala
@@ -30,9 +30,12 @@ class GCounterSpec extends WordSpec with Matchers {
       c6.state(node1) should be(2)
       c6.state(node2) should be(3)
 
-      c2.delta.state(node1) should be(1)
-      c3.delta.state(node1) should be(2)
-      c6.delta.state(node2) should be(3)
+      c2.delta.get.state(node1) should be(1)
+      c1.mergeDelta(c2.delta.get) should be(c2)
+      c3.delta.get.state(node1) should be(2)
+      c2.mergeDelta(c3.delta.get) should be(c3)
+      c6.delta.get.state(node2) should be(3)
+      c5.mergeDelta(c6.delta.get) should be(c6)
     }
 
     "be able to increment each node's record by arbitrary delta" in {
@@ -95,13 +98,13 @@ class GCounterSpec extends WordSpec with Matchers {
       merged1.state(node1) should be(7)
       merged1.state(node2) should be(10)
       merged1.value should be(17)
-      merged1.delta should be(GCounter.empty)
+      merged1.delta should ===(None)
 
       val merged2 = c26 merge c16
       merged2.state(node1) should be(7)
       merged2.state(node2) should be(10)
       merged2.value should be(17)
-      merged2.delta should be(GCounter.empty)
+      merged2.delta should ===(None)
     }
 
     "be able to have its history correctly merged with another GCounter 2" in {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/GSetSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/GSetSpec.scala
@@ -64,14 +64,14 @@ class GSetSpec extends WordSpec with Matchers {
       val c12 = c11 + user1
       val c13 = c12 + user2
 
-      c12.delta.elements should ===(Set(user1))
-      c13.delta.elements should ===(Set(user1, user2))
+      c12.delta.get.elements should ===(Set(user1))
+      c13.delta.get.elements should ===(Set(user1, user2))
 
       // deltas build state
-      (c12 merge c13.delta) should ===(c13)
+      (c12 mergeDelta c13.delta.get) should ===(c13)
 
       // own deltas are idempotent
-      (c13 merge c13.delta) should ===(c13)
+      (c13 mergeDelta c13.delta.get) should ===(c13)
 
       // set 2
       val c21 = GSet.empty[String]
@@ -79,18 +79,18 @@ class GSetSpec extends WordSpec with Matchers {
       val c22 = c21 + user3
       val c23 = c22.resetDelta + user4
 
-      c22.delta.elements should ===(Set(user3))
-      c23.delta.elements should ===(Set(user4))
+      c22.delta.get.elements should ===(Set(user3))
+      c23.delta.get.elements should ===(Set(user4))
 
       c23.elements should ===(Set(user3, user4))
 
       val c33 = c13 merge c23
 
       // merge both ways
-      val merged1 = GSet.empty[String] merge c12.delta merge c13.delta merge c22.delta merge c23.delta
+      val merged1 = GSet.empty[String] mergeDelta c12.delta.get mergeDelta c13.delta.get mergeDelta c22.delta.get mergeDelta c23.delta.get
       merged1.elements should ===(Set(user1, user2, user3, user4))
 
-      val merged2 = GSet.empty[String] merge c23.delta merge c13.delta merge c22.delta
+      val merged2 = GSet.empty[String] mergeDelta c23.delta.get mergeDelta c13.delta.get mergeDelta c22.delta.get
       merged2.elements should ===(Set(user1, user2, user3, user4))
 
       merged1 should ===(c33)

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterSpec.scala
@@ -29,13 +29,13 @@ class PNCounterSpec extends WordSpec with Matchers {
       c6.increments.state(node1) should be(2)
       c6.increments.state(node2) should be(3)
 
-      c2.delta.value.toLong should be(1)
-      c2.delta.increments.state(node1) should be(1)
-      c3.delta.value should be(2)
-      c3.delta.increments.state(node1) should be(2)
+      c2.delta.get.value.toLong should be(1)
+      c2.delta.get.increments.state(node1) should be(1)
+      c3.delta.get.value should be(2)
+      c3.delta.get.increments.state(node1) should be(2)
 
-      c6.delta.value should be(3)
-      c6.delta.increments.state(node2) should be(3)
+      c6.delta.get.value should be(3)
+      c6.delta.get.increments.state(node2) should be(3)
     }
 
     "be able to decrement each node's record by one" in {
@@ -51,11 +51,11 @@ class PNCounterSpec extends WordSpec with Matchers {
       c6.decrements.state(node1) should be(2)
       c6.decrements.state(node2) should be(3)
 
-      c3.delta.value should be(-2)
-      c3.delta.decrements.state(node1) should be(2)
+      c3.delta.get.value should be(-2)
+      c3.delta.get.decrements.state(node1) should be(2)
 
-      c6.delta.value should be(-3)
-      c6.delta.decrements.state(node2) should be(3)
+      c6.delta.get.value should be(-3)
+      c6.delta.get.decrements.state(node2) should be(3)
     }
 
     "be able to increment each node's record by arbitrary delta" in {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
@@ -101,9 +101,17 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem(
       checkSameContent(s3.merge(s4), s4.merge(s3))
     }
 
+    "serialize ORSet delta" in {
+      checkSerialization(ORSet().add(address1, "a").delta.get)
+      checkSerialization(ORSet().add(address1, "a").resetDelta.remove(address2, "a").delta.get)
+      checkSerialization(ORSet().add(address1, "a").remove(address2, "a").delta.get)
+      checkSerialization(ORSet().add(address1, "a").resetDelta.clear(address2).delta.get)
+      checkSerialization(ORSet().add(address1, "a").clear(address2).delta.get)
+    }
+
     "serialize large GSet" in {
       val largeSet = (10000 until 20000).foldLeft(GSet.empty[String]) {
-        case (acc, n) ⇒ acc.add(n.toString)
+        case (acc, n) ⇒ acc.resetDelta.add(n.toString)
       }
       val numberOfBytes = checkSerialization(largeSet)
       info(s"size of GSet with ${largeSet.size} elements: $numberOfBytes bytes")
@@ -118,7 +126,7 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem(
             case 1 ⇒ address2
             case 2 ⇒ address3
           }
-          acc.add(address, n.toString)
+          acc.resetDelta.add(address, n.toString)
       }
       val numberOfBytes = checkSerialization(largeSet)
       // note that ORSet is compressed, and therefore smaller than GSet

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializerSpec.scala
@@ -87,9 +87,9 @@ class ReplicatorMessageSerializerSpec extends TestKit(ActorSystem(
       checkSerialization(Gossip(Map(
         "A" → DataEnvelope(data1),
         "B" → DataEnvelope(GSet() + "b" + "c")), sendBack = true))
-      checkSerialization(DeltaPropagation(Map(
-        "A" → DataEnvelope(delta1),
-        "B" → DataEnvelope(delta2))))
+      checkSerialization(DeltaPropagation(address1, Map(
+        "A" → Delta(DataEnvelope(delta1), 1L, 1L),
+        "B" → Delta(DataEnvelope(delta2), 3L, 5L))))
       checkSerialization(new DurableDataEnvelope(data1))
       checkSerialization(new DurableDataEnvelope(DataEnvelope(data1, pruning = Map(
         address1 → PruningPerformed(System.currentTimeMillis()),

--- a/akka-docs/rst/java/distributed-data.rst
+++ b/akka-docs/rst/java/distributed-data.rst
@@ -272,18 +272,21 @@ for updates. For example adding element ``'c'`` and ``'d'`` to set ``{'a', 'b'}`
 result in sending the delta ``{'c', 'd'}`` and merge that with the state on the
 receiving side, resulting in set ``{'a', 'b', 'c', 'd'}``.
 
-Current protocol for replicating the deltas does not support causal consistency.
-It is only eventually consistent. This means that if elements ``'c'`` and ``'d'`` are
+The protocol for replicating the deltas supports causal consistency if the data type
+is marked with ``RequiresCausalDeliveryOfDeltas``. Otherwise it is only eventually
+consistent. Without causal consistency it means that if elements ``'c'`` and ``'d'`` are
 added in two separate `Update` operations these deltas may occasionally be propagated
 to nodes in different order than the causal order of the updates. For this example it
 can result in that set ``{'a', 'b', 'd'}`` can be seen before element 'c' is seen. Eventually
-it will be ``{'a', 'b', 'c', 'd'}``. If causal consistency is needed the delta propagation
-should be disabled with configuration property
-``akka.cluster.distributed-data.delta-crdt.enabled=off``.
+it will be ``{'a', 'b', 'c', 'd'}``.
 
 Note that the full state is occasionally also replicated for delta-CRDTs, for example when 
 new nodes are added to the cluster or when deltas could not be propagated because
 of network partitions or similar problems.
+
+The the delta propagation can be disabled with configuration property::
+
+  akka.cluster.distributed-data.delta-crdt.enabled=off
 
 Data Types
 ==========
@@ -316,7 +319,8 @@ The value of the counter is the value of the P counter minus the value of the N 
 
 .. includecode:: code/docs/ddata/DistributedDataDocTest.java#pncounter
 
-``GCounter`` and ``PNCounter`` have support for :ref:`delta_crdt_java`.
+``GCounter`` and ``PNCounter`` have support for :ref:`delta_crdt_java` and don't need causal
+delivery of deltas.
 
 Several related counters can be managed in a map with the ``PNCounterMap`` data type.
 When the counters are placed in a ``PNCounterMap`` as opposed to placing them as separate top level
@@ -334,6 +338,8 @@ Merge is simply the union of the two sets.
 
 .. includecode:: code/docs/ddata/DistributedDataDocTest.java#gset
 
+``GSet`` has support for :ref:`delta_crdt_java` and it doesn't require causal delivery of deltas.
+
 If you need add and remove operations you should use the ``ORSet`` (observed-remove set).
 Elements can be added and removed any number of times. If an element is concurrently added and
 removed, the add will win. You cannot remove an element that you have not seen.
@@ -344,6 +350,8 @@ called "birth dot". The version vector and the dots are used by the ``merge`` fu
 track causality of the operations and resolve concurrent updates.
 
 .. includecode:: code/docs/ddata/DistributedDataDocTest.java#orset
+
+``ORSet`` has support for :ref:`delta_crdt_java` and it requires causal delivery of deltas.
 
 Maps
 ----

--- a/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
@@ -4,7 +4,7 @@
 
 package docs.serialization {
 
-  import akka.actor.{ExtensionId, ExtensionIdProvider}
+  import akka.actor.{ ExtensionId, ExtensionIdProvider }
   import akka.testkit._
   //#imports
   import akka.actor.{ ActorRef, ActorSystem }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -101,7 +101,15 @@ object MiMa extends AutoPlugin {
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.GSet.this"), // constructor supplied by companion object
 
       // #21875 delta-CRDT
-      ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.GCounter.this"), 
+      ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.GCounter.this"),
+      
+      // #22188 ORSet delta-CRDT
+      ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.ORSet.this"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.protobuf.SerializationSupport.versionVectorToProto"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.protobuf.SerializationSupport.versionVectorFromProto"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.protobuf.SerializationSupport.versionVectorFromBinary"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.ddata.protobuf.ReplicatedDataSerializer.versionVectorToProto"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.ddata.protobuf.ReplicatedDataSerializer.versionVectorFromProto"),
       
       // #22141 sharding minCap
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.DDataShardCoordinator.updatingStateTimeout"),


### PR DESCRIPTION
* keep track of delta interval versions and skip deltas
  that are not consequtive, i.e. when some delta message was lost
* send the delta versions in the full state gossip to sync up the
  expected versions after dropped deltas
* incomplete sketch of ORSet delta