### PR TITLE
Select right IP address based on Java preferences.

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/DnsSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/DnsSpec.scala
@@ -1,0 +1,38 @@
+package akka.io
+
+import java.net.{ Inet4Address, Inet6Address, InetAddress }
+
+import scala.collection.immutable.Seq
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+
+class DnsSpec extends WordSpec with BeforeAndAfterAll with Matchers {
+
+  val ip4Address = InetAddress.getByAddress("localhost", Array[Byte](127, 0, 0, 1)) match {
+    case address: Inet4Address ⇒ address
+  }
+  val ipv6Address = InetAddress.getByAddress("localhost", Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)) match {
+    case address: Inet6Address ⇒ address
+  }
+
+  var temporaryValue: Option[String] = None
+
+  override def beforeAll() = {
+    temporaryValue = sys.props.get("java.net.preferIPv6Addresses")
+  }
+
+  override def afterAll() = temporaryValue match {
+    case Some(value) ⇒ sys.props.put("java.net.preferIPv6Addresses", value)
+    case _           ⇒ sys.props.remove("java.net.preferIPv6Addresses")
+  }
+
+  "Dns" should {
+    "resolve to a IPv6 address if it is the preferred network stack" in {
+      sys.props.put("java.net.preferIPv6Addresses", true.toString)
+      Dns.Resolved("test", Seq(ip4Address), Seq(ipv6Address)).addr should ===(ipv6Address)
+    }
+    "resolve to a IPv4 address if IPv6 is not the preferred network stack" in {
+      sys.props.remove("java.net.preferIPv6Addresses")
+      Dns.Resolved("test", Seq(ip4Address), Seq(ipv6Address)).addr should ===(ip4Address)
+    }
+  }
+}

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -92,8 +92,8 @@ class DnsExt(system: ExtendedActorSystem) extends IO.Extension {
 
 object IpVersionSelector {
   def getInetAddress(ipv4: Option[Inet4Address], ipv6: Option[Inet6Address]): Option[InetAddress] =
-    sys.props.get("java.net.preferIPv6Addresses") match {
-      case Some(value: String) if ("true".equals(value)) ⇒ ipv6 orElse ipv4
-      case _ ⇒ ipv4 orElse ipv6
+    System.getProperty("java.net.preferIPv6Addresses") match {
+      case "true" ⇒ ipv6 orElse ipv4
+      case _      ⇒ ipv4 orElse ipv6
     }
 }


### PR DESCRIPTION
As described in the issue #22330 the Java property that determines the preference of the IP version is being ignored producing errors for hosts running under IPv6 only. Akka should not ignore this value and react accordingly by changing the priorities between selecting IPv4 or IPv6.