### PR TITLE
Fix JSON formatting of the jmx-cluster/akka-cluster tool

### DIFF
--- a/akka-cluster/jmx-client/akka-cluster
+++ b/akka-cluster/jmx-client/akka-cluster
@@ -45,7 +45,7 @@ function ensureNodeIsRunningAndAvailable {
     fi
 }
 
-echo "This tool is deprecated use curl and https://github.com/akka/akka-cluster-management instead, since 2.5.0"
+echo "This jmx-client/akka-cluster tool is deprecated use curl and https://github.com/akka/akka-cluster-management instead, since 2.5.0." >&2
 
 # switch on command
 case "$1" in


### PR DESCRIPTION
Refs #21250 

As in akka-cluster/jmx-client/akka-cluster, the below deprecation message is in STDERR, so you will only pipe the JSON without the deprecation message.

```
This jmx-client/akka-cluster tool is deprecated use curl and https://github.com/akka/akka-cluster-management instead, since 2.5.0.
```

Output JSON looks like this (validated with http://jsonlint.com/):

```
{
  "members": [
    {
      "address": "akka.tcp://ClusterSystem@127.0.0.1:2551",
      "roles": [
        "aaaa",
        "bbbb",
        "ccccc"
      ],
      "status": "Up"
    },
    {
      "address": "akka.tcp://ClusterSystem@127.0.0.1:2552",
      "roles": [
        "aaaa",
        "bbbb",
        "ccccc"
      ],
      "status": "Up"
    },
    {
      "address": "akka.tcp://ClusterSystem@127.0.0.1:2553",
      "roles": [
        "aaaa",
        "bbbb",
        "ccccc"
      ],
      "status": "Up"
    },
    {
      "address": "akka.tcp://ClusterSystem@127.0.0.1:51881",
      "roles": [
        "aaaa",
        "bbbb",
        "ccccc"
      ],
      "status": "Up"
    }
  ],
  "self-address": "akka.tcp://ClusterSystem@127.0.0.1:2551",
  "unreachable": [
    {
      "node": "akka.tcp://ClusterSystem@127.0.0.1:2552",
      "observed-by": [
        "akka.tcp://ClusterSystem@127.0.0.1:2551",
        "akka.tcp://ClusterSystem@127.0.0.1:2553",
        "akka.tcp://ClusterSystem@127.0.0.1:51881"
      ]
    },
    {
      "node": "akka.tcp://ClusterSystem@127.0.0.1:2553",
      "observed-by": [
        "akka.tcp://ClusterSystem@127.0.0.1:2551",
        "akka.tcp://ClusterSystem@127.0.0.1:51881"
      ]
    }
  ]
}
```

When "roles" are empty:

```
    {
      "address": "akka.tcp://ClusterSystem@127.0.0.1:2551",
      "roles": [],
      "status": "Up"
    }
```

and when "unreachable" is empty:

```
  "self-address": "akka.tcp://ClusterSystem@127.0.0.1:2551",
  "unreachable": []

```