### PR TITLE
fix byte order issue in DaemonMsgCreateSerializer, #22366

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
@@ -110,10 +110,10 @@ private[akka] final class DaemonMsgCreateSerializer(val system: ExtendedActorSys
             val manifest =
               if (protoProps.getHasManifest(idx)) protoProps.getManifests(idx)
               else ""
-            serialization.deserializeByteBuffer(
-              protoProps.getArgs(idx).asReadOnlyByteBuffer(),
+            serialization.deserialize(
+              protoProps.getArgs(idx).toByteArray(),
               protoProps.getSerializerIds(idx),
-              manifest)
+              manifest).get
           }
         } else {
           // message from an older node, which only provides data and class name


### PR DESCRIPTION
* We used the Array based toBinary but the ByteBuffer based fromBinary.
  and IntSerializer is only using the same format for those when the byte order
  is  LITTLE_ENDIAN, which we didn't get from protbuf's asReadOnlyByteBuffer
* We can use the Array based methods in DaemonMsgCreateSerializer,
  performance is not important here
* Added some more testing in PrimitivesSerializationSpec

Refs  #22366