### PR TITLE
Use delta in direct write also, #22188

### DIFF
--- a/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
+++ b/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
@@ -12721,6 +12721,24 @@ public final class ReplicatorMessages {
      */
     akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.EntryOrBuilder getEntriesOrBuilder(
         int index);
+
+    // optional bool reply = 3;
+    /**
+     * <code>optional bool reply = 3;</code>
+     *
+     * <pre>
+     * no reply if not set 
+     * </pre>
+     */
+    boolean hasReply();
+    /**
+     * <code>optional bool reply = 3;</code>
+     *
+     * <pre>
+     * no reply if not set 
+     * </pre>
+     */
+    boolean getReply();
   }
   /**
    * Protobuf type {@code akka.cluster.ddata.DeltaPropagation}
@@ -12792,6 +12810,11 @@ public final class ReplicatorMessages {
                 mutable_bitField0_ |= 0x00000002;
               }
               entries_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry.PARSER, extensionRegistry));
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000002;
+              reply_ = input.readBool();
               break;
             }
           }
@@ -13784,9 +13807,34 @@ public final class ReplicatorMessages {
       return entries_.get(index);
     }
 
+    // optional bool reply = 3;
+    public static final int REPLY_FIELD_NUMBER = 3;
+    private boolean reply_;
+    /**
+     * <code>optional bool reply = 3;</code>
+     *
+     * <pre>
+     * no reply if not set 
+     * </pre>
+     */
+    public boolean hasReply() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional bool reply = 3;</code>
+     *
+     * <pre>
+     * no reply if not set 
+     * </pre>
+     */
+    public boolean getReply() {
+      return reply_;
+    }
+
     private void initFields() {
       fromNode_ = akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress.getDefaultInstance();
       entries_ = java.util.Collections.emptyList();
+      reply_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -13820,6 +13868,9 @@ public final class ReplicatorMessages {
       for (int i = 0; i < entries_.size(); i++) {
         output.writeMessage(2, entries_.get(i));
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeBool(3, reply_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -13836,6 +13887,10 @@ public final class ReplicatorMessages {
       for (int i = 0; i < entries_.size(); i++) {
         size += akka.protobuf.CodedOutputStream
           .computeMessageSize(2, entries_.get(i));
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += akka.protobuf.CodedOutputStream
+          .computeBoolSize(3, reply_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -13967,6 +14022,8 @@ public final class ReplicatorMessages {
         } else {
           entriesBuilder_.clear();
         }
+        reply_ = false;
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -14012,6 +14069,10 @@ public final class ReplicatorMessages {
         } else {
           result.entries_ = entriesBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.reply_ = reply_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -14056,6 +14117,9 @@ public final class ReplicatorMessages {
               entriesBuilder_.addAllMessages(other.entries_);
             }
           }
+        }
+        if (other.hasReply()) {
+          setReply(other.getReply());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -14453,6 +14517,55 @@ public final class ReplicatorMessages {
           entries_ = null;
         }
         return entriesBuilder_;
+      }
+
+      // optional bool reply = 3;
+      private boolean reply_ ;
+      /**
+       * <code>optional bool reply = 3;</code>
+       *
+       * <pre>
+       * no reply if not set 
+       * </pre>
+       */
+      public boolean hasReply() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional bool reply = 3;</code>
+       *
+       * <pre>
+       * no reply if not set 
+       * </pre>
+       */
+      public boolean getReply() {
+        return reply_;
+      }
+      /**
+       * <code>optional bool reply = 3;</code>
+       *
+       * <pre>
+       * no reply if not set 
+       * </pre>
+       */
+      public Builder setReply(boolean value) {
+        bitField0_ |= 0x00000004;
+        reply_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool reply = 3;</code>
+       *
+       * <pre>
+       * no reply if not set 
+       * </pre>
+       */
+      public Builder clearReply() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        reply_ = false;
+        onChanged();
+        return this;
       }
 
       // @@protoc_insertion_point(builder_scope:akka.cluster.ddata.DeltaPropagation)
@@ -19212,27 +19325,28 @@ public final class ReplicatorMessages {
       " \002(\010\0221\n\007entries\030\002 \003(\0132 .akka.cluster.dda",
       "ta.Gossip.Entry\032H\n\005Entry\022\013\n\003key\030\001 \002(\t\0222\n" +
       "\010envelope\030\002 \002(\0132 .akka.cluster.ddata.Dat" +
-      "aEnvelope\"\362\001\n\020DeltaPropagation\0223\n\010fromNo" +
+      "aEnvelope\"\201\002\n\020DeltaPropagation\0223\n\010fromNo" +
       "de\030\001 \002(\0132!.akka.cluster.ddata.UniqueAddr" +
       "ess\022;\n\007entries\030\002 \003(\0132*.akka.cluster.ddat" +
-      "a.DeltaPropagation.Entry\032l\n\005Entry\022\013\n\003key" +
-      "\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132 .akka.cluster." +
-      "ddata.DataEnvelope\022\021\n\tfromSeqNr\030\003 \002(\003\022\017\n" +
-      "\007toSeqNr\030\004 \001(\003\"X\n\rUniqueAddress\022,\n\007addre" +
-      "ss\030\001 \002(\0132\033.akka.cluster.ddata.Address\022\013\n",
-      "\003uid\030\002 \002(\017\022\014\n\004uid2\030\003 \001(\017\")\n\007Address\022\020\n\010h" +
-      "ostname\030\001 \002(\t\022\014\n\004port\030\002 \002(\r\"\224\001\n\rVersionV" +
-      "ector\0228\n\007entries\030\001 \003(\0132\'.akka.cluster.dd" +
-      "ata.VersionVector.Entry\032I\n\005Entry\022/\n\004node" +
-      "\030\001 \002(\0132!.akka.cluster.ddata.UniqueAddres" +
-      "s\022\017\n\007version\030\002 \002(\003\"V\n\014OtherMessage\022\027\n\017en" +
-      "closedMessage\030\001 \002(\014\022\024\n\014serializerId\030\002 \002(" +
-      "\005\022\027\n\017messageManifest\030\004 \001(\014\"\036\n\nStringGSet" +
-      "\022\020\n\010elements\030\001 \003(\t\"\205\001\n\023DurableDataEnvelo" +
-      "pe\022.\n\004data\030\001 \002(\0132 .akka.cluster.ddata.Ot",
-      "herMessage\022>\n\007pruning\030\002 \003(\0132-.akka.clust" +
-      "er.ddata.DataEnvelope.PruningEntryB#\n\037ak" +
-      "ka.cluster.ddata.protobuf.msgH\001"
+      "a.DeltaPropagation.Entry\022\r\n\005reply\030\003 \001(\010\032" +
+      "l\n\005Entry\022\013\n\003key\030\001 \002(\t\0222\n\010envelope\030\002 \002(\0132" +
+      " .akka.cluster.ddata.DataEnvelope\022\021\n\tfro" +
+      "mSeqNr\030\003 \002(\003\022\017\n\007toSeqNr\030\004 \001(\003\"X\n\rUniqueA" +
+      "ddress\022,\n\007address\030\001 \002(\0132\033.akka.cluster.d",
+      "data.Address\022\013\n\003uid\030\002 \002(\017\022\014\n\004uid2\030\003 \001(\017\"" +
+      ")\n\007Address\022\020\n\010hostname\030\001 \002(\t\022\014\n\004port\030\002 \002" +
+      "(\r\"\224\001\n\rVersionVector\0228\n\007entries\030\001 \003(\0132\'." +
+      "akka.cluster.ddata.VersionVector.Entry\032I" +
+      "\n\005Entry\022/\n\004node\030\001 \002(\0132!.akka.cluster.dda" +
+      "ta.UniqueAddress\022\017\n\007version\030\002 \002(\003\"V\n\014Oth" +
+      "erMessage\022\027\n\017enclosedMessage\030\001 \002(\014\022\024\n\014se" +
+      "rializerId\030\002 \002(\005\022\027\n\017messageManifest\030\004 \001(" +
+      "\014\"\036\n\nStringGSet\022\020\n\010elements\030\001 \003(\t\"\205\001\n\023Du" +
+      "rableDataEnvelope\022.\n\004data\030\001 \002(\0132 .akka.c",
+      "luster.ddata.OtherMessage\022>\n\007pruning\030\002 \003" +
+      "(\0132-.akka.cluster.ddata.DataEnvelope.Pru" +
+      "ningEntryB#\n\037akka.cluster.ddata.protobuf" +
+      ".msgH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -19346,7 +19460,7 @@ public final class ReplicatorMessages {
           internal_static_akka_cluster_ddata_DeltaPropagation_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_cluster_ddata_DeltaPropagation_descriptor,
-              new java.lang.String[] { "FromNode", "Entries", });
+              new java.lang.String[] { "FromNode", "Entries", "Reply", });
           internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor =
             internal_static_akka_cluster_ddata_DeltaPropagation_descriptor.getNestedTypes().get(0);
           internal_static_akka_cluster_ddata_DeltaPropagation_Entry_fieldAccessorTable = new

--- a/akka-distributed-data/src/main/protobuf/ReplicatorMessages.proto
+++ b/akka-distributed-data/src/main/protobuf/ReplicatorMessages.proto
@@ -107,6 +107,7 @@ message DeltaPropagation {
   
   required UniqueAddress fromNode = 1;
   repeated Entry entries = 2;
+  optional bool reply = 3; // no reply if not set 
 }
 
 message UniqueAddress {

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorORSetDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorORSetDeltaSpec.scala
@@ -19,7 +19,7 @@ object ReplicatorORSetDeltaSpec extends MultiNodeConfig {
   val third = role("third")
 
   commonConfig(ConfigFactory.parseString("""
-    akka.loglevel = DEBUG
+    akka.loglevel = INFO
     akka.actor.provider = "cluster"
     akka.log-dead-letters-during-shutdown = off
     """))

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/DeltaPropagationSelectorSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/DeltaPropagationSelectorSpec.scala
@@ -19,7 +19,7 @@ object DeltaPropagationSelectorSpec {
     override val allNodes: Vector[Address]) extends DeltaPropagationSelector {
     override val gossipIntervalDivisor = 5
     override def createDeltaPropagation(deltas: Map[KeyId, (ReplicatedData, Long, Long)]): DeltaPropagation =
-      DeltaPropagation(selfUniqueAddress, deltas.mapValues {
+      DeltaPropagation(selfUniqueAddress, false, deltas.mapValues {
         case (d, fromSeqNr, toSeqNr) ⇒ Delta(DataEnvelope(d), fromSeqNr, toSeqNr)
       })
   }
@@ -50,7 +50,7 @@ class DeltaPropagationSelectorSpec extends WordSpec with Matchers with TypeCheck
       selector.cleanupDeltaEntries()
       selector.hasDeltaEntries("A") should ===(true)
       selector.hasDeltaEntries("B") should ===(true)
-      val expected = DeltaPropagation(selfUniqueAddress, Map(
+      val expected = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(deltaA), 1L, 1L),
         "B" → Delta(DataEnvelope(deltaB), 1L, 1L)))
       selector.collectPropagations() should ===(Map(nodes(0) → expected))
@@ -64,7 +64,7 @@ class DeltaPropagationSelectorSpec extends WordSpec with Matchers with TypeCheck
       val selector = new TestSelector(selfUniqueAddress, nodes.take(3))
       selector.update("A", deltaA)
       selector.update("B", deltaB)
-      val expected = DeltaPropagation(selfUniqueAddress, Map(
+      val expected = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(deltaA), 1L, 1L),
         "B" → Delta(DataEnvelope(deltaB), 1L, 1L)))
       selector.collectPropagations() should ===(Map(nodes(0) → expected, nodes(1) → expected))
@@ -82,17 +82,17 @@ class DeltaPropagationSelectorSpec extends WordSpec with Matchers with TypeCheck
       val selector = new TestSelector(selfUniqueAddress, nodes.take(3))
       selector.update("A", deltaA)
       selector.update("B", deltaB)
-      val expected1 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected1 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(deltaA), 1L, 1L),
         "B" → Delta(DataEnvelope(deltaB), 1L, 1L)))
       selector.collectPropagations() should ===(Map(nodes(0) → expected1, nodes(1) → expected1))
       // new update before previous was propagated to all nodes
       selector.update("C", deltaC)
-      val expected2 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected2 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(deltaA), 1L, 1L),
         "B" → Delta(DataEnvelope(deltaB), 1L, 1L),
         "C" → Delta(DataEnvelope(deltaC), 1L, 1L)))
-      val expected3 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected3 = DeltaPropagation(selfUniqueAddress, false, Map(
         "C" → Delta(DataEnvelope(deltaC), 1L, 1L)))
       selector.collectPropagations() should ===(Map(nodes(2) → expected2, nodes(0) → expected3))
       selector.cleanupDeltaEntries()
@@ -114,12 +114,12 @@ class DeltaPropagationSelectorSpec extends WordSpec with Matchers with TypeCheck
       selector.currentVersion("A") should ===(1L)
       selector.update("A", delta2)
       selector.currentVersion("A") should ===(2L)
-      val expected1 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected1 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(delta1.merge(delta2)), 1L, 2L)))
       selector.collectPropagations() should ===(Map(nodes(0) → expected1))
       selector.update("A", delta3)
       selector.currentVersion("A") should ===(3L)
-      val expected2 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected2 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(delta3), 3L, 3L)))
       selector.collectPropagations() should ===(Map(nodes(0) → expected2))
       selector.collectPropagations() should ===(Map.empty[Address, DeltaPropagation])
@@ -133,25 +133,25 @@ class DeltaPropagationSelectorSpec extends WordSpec with Matchers with TypeCheck
         override def nodesSliceSize(allNodesSize: Int): Int = 1
       }
       selector.update("A", delta1)
-      val expected1 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected1 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(delta1), 1L, 1L)))
       selector.collectPropagations() should ===(Map(nodes(0) → expected1))
 
       selector.update("A", delta2)
-      val expected2 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected2 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(delta1.merge(delta2)), 1L, 2L)))
       selector.collectPropagations() should ===(Map(nodes(1) → expected2))
 
       selector.update("A", delta3)
-      val expected3 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected3 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(delta1.merge(delta2).merge(delta3)), 1L, 3L)))
       selector.collectPropagations() should ===(Map(nodes(2) → expected3))
 
-      val expected4 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected4 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(delta2.merge(delta3)), 2L, 3L)))
       selector.collectPropagations() should ===(Map(nodes(0) → expected4))
 
-      val expected5 = DeltaPropagation(selfUniqueAddress, Map(
+      val expected5 = DeltaPropagation(selfUniqueAddress, false, Map(
         "A" → Delta(DataEnvelope(delta3), 3L, 3L)))
       selector.collectPropagations() should ===(Map(nodes(1) → expected5))
 

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializerSpec.scala
@@ -78,6 +78,7 @@ class ReplicatorMessageSerializerSpec extends TestKit(ActorSystem(
       checkSerialization(Write("A", DataEnvelope(data1)))
       checkSerialization(WriteAck)
       checkSerialization(WriteNack)
+      checkSerialization(DeltaNack)
       checkSerialization(Read("A"))
       checkSerialization(ReadResult(Some(DataEnvelope(data1))))
       checkSerialization(ReadResult(None))
@@ -87,7 +88,7 @@ class ReplicatorMessageSerializerSpec extends TestKit(ActorSystem(
       checkSerialization(Gossip(Map(
         "A" → DataEnvelope(data1),
         "B" → DataEnvelope(GSet() + "b" + "c")), sendBack = true))
-      checkSerialization(DeltaPropagation(address1, Map(
+      checkSerialization(DeltaPropagation(address1, reply = true, Map(
         "A" → Delta(DataEnvelope(delta1), 1L, 1L),
         "B" → Delta(DataEnvelope(delta2), 3L, 5L))))
       checkSerialization(new DurableDataEnvelope(data1))


### PR DESCRIPTION
* Follow up on the causal delivery of deltas. #22331
* The first implementation used full state for the direct
  Write messages, i.e. updates with WriteConsistency != LocalWrite
* This is an optimization so that delatas are tried first and if
  they can't be applied it falls back to full state.
* For simultanious updates the messages may be reordered because we
  create separate WriteAggregator actor and such, but normally they
  will be sent in order so the deltas will typically be received in
  order, otherwise we fall back to retrying with full state in the
  second round in the WriteAggregator.

Refs #22188