### PR TITLE
Change Flow.apply to use parentheses

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -497,7 +497,7 @@ class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=o
     "pass through data" in {
       val f = Source(1 to 3)
         .map(b ⇒ SendBytes(ByteString(b.toByte)))
-        .via(TLSPlacebo() join Flow.apply)
+        .via(TLSPlacebo() join Flow())
         .grouped(10)
         .runWith(Sink.head)
       val result = Await.result(f, 3.seconds)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -283,13 +283,13 @@ object Flow {
   /**
    * Returns a `Flow` which outputs all its inputs.
    */
-  def apply[T]: Flow[T, T, NotUsed] = identity.asInstanceOf[Flow[T, T, NotUsed]]
+  def apply[T](): Flow[T, T, NotUsed] = identity.asInstanceOf[Flow[T, T, NotUsed]]
 
   /**
    * Creates a [Flow] which will use the given function to transform its inputs to outputs. It is equivalent
-   * to `Flow[T].map(f)`
+   * to `Flow[T]().map(f)`
    */
-  def fromFunction[A, B](f: A ⇒ B): Flow[A, B, NotUsed] = apply[A].map(f)
+  def fromFunction[A, B](f: A ⇒ B): Flow[A, B, NotUsed] = apply()[A].map(f)
 
   /**
    * A graph with the shape of a flow logically is a flow, this method makes


### PR DESCRIPTION
the `apply` method in the companion of `Flow` in `Flow.scala` does not have parentheses.

I think it is much nicer to use it with parentheses, compare for example:

`Flow.apply.map(...)` and `Flow().map(...)`.

I added the parens and adapted the `2` usages in the project.