### PR TITLE
Update the maximum serializer identifier reserved for Akka

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -652,7 +652,7 @@ akka {
     # `akka.actor.serialization-identifiers."FQCN" = ID`
     # where `FQCN` is fully qualified class name of the serializer implementation
     # and `ID` is globally unique serializer identifier number.
-    # Identifier values from 0 to 16 are reserved for Akka internal usage.
+    # Identifier values from 0 to 40 are reserved for Akka internal usage.
     serialization-identifiers {
       "akka.serialization.JavaSerializer" = 1
       "akka.serialization.ByteArraySerializer" = 4

--- a/akka-actor/src/main/scala/akka/serialization/Serializer.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serializer.scala
@@ -39,7 +39,7 @@ trait Serializer {
 
   /**
    * Completely unique value to identify this implementation of Serializer, used to optimize network traffic.
-   * Values from 0 to 16 are reserved for Akka internal usage.
+   * Values from 0 to 40 are reserved for Akka internal usage.
    */
   def identifier: Int
 
@@ -105,7 +105,7 @@ abstract class SerializerWithStringManifest extends Serializer {
 
   /**
    * Completely unique value to identify this implementation of Serializer, used to optimize network traffic.
-   * Values from 0 to 16 are reserved for Akka internal usage.
+   * Values from 0 to 40 are reserved for Akka internal usage.
    */
   def identifier: Int
 

--- a/akka-docs/rst/java/code/docs/serialization/SerializationDocTest.java
+++ b/akka-docs/rst/java/code/docs/serialization/SerializationDocTest.java
@@ -29,7 +29,7 @@ public class SerializationDocTest {
 
     // Pick a unique identifier for your Serializer,
     // you've got a couple of billions to choose from,
-    // 0 - 16 is reserved by Akka itself
+    // 0 - 40 is reserved by Akka itself
     @Override public int identifier() {
       return 1234567;
     }
@@ -80,7 +80,7 @@ public class SerializationDocTest {
     
     // Pick a unique identifier for your Serializer,
     // you've got a couple of billions to choose from,
-    // 0 - 16 is reserved by Akka itself
+    // 0 - 40 is reserved by Akka itself
     @Override public int identifier() {
       return 1234567;
     }

--- a/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
@@ -25,7 +25,7 @@ package docs.serialization {
 
     // Pick a unique identifier for your Serializer,
     // you've got a couple of billions to choose from,
-    // 0 - 16 is reserved by Akka itself
+    // 0 - 40 is reserved by Akka itself
     def identifier = 1234567
 
     // "toBinary" serializes the given object to an Array of Bytes
@@ -58,7 +58,7 @@ package docs.serialization {
 
     // Pick a unique identifier for your Serializer,
     // you've got a couple of billions to choose from,
-    // 0 - 16 is reserved by Akka itself
+    // 0 - 40 is reserved by Akka itself
     def identifier = 1234567
 
     // The manifest (type hint) that will be provided in the fromBinary method


### PR DESCRIPTION
The value 16 is no longer the highest serialization identifier reserved for Akka
