### PR TITLE
Scalacheck min max range could become max min and fail the test.

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSlidingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSlidingSpec.scala
@@ -31,7 +31,7 @@ class FlowSlidingSpec extends StreamSpec with GeneratorDrivenPropertyChecks {
       check(for {
         len ← Gen.choose(0, 31)
         win ← Gen.choose(1, 61)
-        step ← Gen.choose(1, win - 1)
+        step ← Gen.choose(1, (win - 1) max 1)
       } yield (len, win, step))
     }
 


### PR DESCRIPTION
Fails 2.12 build