### PR TITLE
Log a warning if an entity ID extractor is not defined for a message

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -443,6 +443,7 @@ private[akka] class ShardRegion(
     case query: ShardRegionQuery                 ⇒ receiveQuery(query)
     case msg: RestartShard                       ⇒ deliverMessage(msg, sender())
     case msg if extractEntityId.isDefinedAt(msg) ⇒ deliverMessage(msg, sender())
+    case unknownMsg                              ⇒ log.warning(s"Message does not have an extractor defined so it was ignored: $unknownMsg")
   }
 
   def receiveClusterState(state: CurrentClusterState): Unit = {

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -443,7 +443,7 @@ private[akka] class ShardRegion(
     case query: ShardRegionQuery                 ⇒ receiveQuery(query)
     case msg: RestartShard                       ⇒ deliverMessage(msg, sender())
     case msg if extractEntityId.isDefinedAt(msg) ⇒ deliverMessage(msg, sender())
-    case unknownMsg                              ⇒ log.warning(s"Message does not have an extractor defined so it was ignored: $unknownMsg")
+    case unknownMsg                              ⇒ log.warning("Message does not have an extractor defined in shard [{}] so it was ignored: {}", typeName, unknownMsg)
   }
 
   def receiveClusterState(state: CurrentClusterState): Unit = {


### PR DESCRIPTION
This PR makes a change for the Shard Region so that it will log a warning if an entity ID extractor is not defined for a message sent to a cluster region (GH issue #22395). Without this warning there was no indication that a message was dropped if you sent a new message type to a shard region actor ref and forgot to add an extractor for it.