### PR TITLE
Remove unecessary implicit in test

### DIFF
--- a/akka-camel/src/test/scala/akka/camel/CamelExchangeAdapterTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/CamelExchangeAdapterTest.scala
@@ -4,108 +4,108 @@
 
 package akka.camel
 
-import language.implicitConversions
-
-import internal.CamelExchangeAdapter
+import akka.camel.TestSupport.SharedCamelSystem
+import akka.camel.internal.CamelExchangeAdapter
 import org.apache.camel.impl.DefaultExchange
-import org.apache.camel.{ Exchange, ExchangePattern }
-import akka.camel.TestSupport.{ SharedCamelSystem }
+import org.apache.camel.{Exchange, ExchangePattern}
 import org.scalatest.FunSuite
+
+import scala.language.implicitConversions
 
 class CamelExchangeAdapterTest extends FunSuite with SharedCamelSystem {
 
-  //TODO: Get rid of implicit.
-  // It is here, as was easier to add this implicit than to rewrite the whole test...
-  implicit def exchangeToAdapter(e: Exchange) = new CamelExchangeAdapter(e)
-
   test("mustSetInMessageFromRequestMessage") {
     val e1 = sampleInOnly
-    e1.setRequest(CamelMessage("x", Map.empty))
+    exchangeToAdapter(e1).setRequest(CamelMessage("x", Map.empty))
     assert(e1.getIn.getBody === "x")
     val e2 = sampleInOut
-    e2.setRequest(CamelMessage("y", Map.empty))
+    exchangeToAdapter(e2).setRequest(CamelMessage("y", Map.empty))
     assert(e2.getIn.getBody === "y")
   }
 
   test("mustSetOutMessageFromResponseMessage") {
     val e1 = sampleInOut
-    e1.setResponse(CamelMessage("y", Map.empty))
+    exchangeToAdapter(e1).setResponse(CamelMessage("y", Map.empty))
     assert(e1.getOut.getBody === "y")
   }
 
   test("mustSetInMessageFromResponseMessage") {
     val e1 = sampleInOnly
-    e1.setResponse(CamelMessage("x", Map.empty))
+    exchangeToAdapter(e1).setResponse(CamelMessage("x", Map.empty))
     assert(e1.getIn.getBody === "x")
   }
 
   test("mustSetExceptionFromFailureMessage") {
     val e1 = sampleInOnly
-    e1.setFailure(FailureResult(new Exception("test1")))
+    exchangeToAdapter(e1).setFailure(FailureResult(new Exception("test1")))
     assert(e1.getException.getMessage === "test1")
     val e2 = sampleInOut
-    e2.setFailure(FailureResult(new Exception("test2")))
+    exchangeToAdapter(e2).setFailure(FailureResult(new Exception("test2")))
     assert(e2.getException.getMessage === "test2")
   }
 
   test("mustCreateRequestMessageFromInMessage") {
-    val m = sampleInOnly.toRequestMessage
+    val m = exchangeToAdapter(sampleInOnly).toRequestMessage
     assert(m === CamelMessage("test-in", Map("key-in" → "val-in")))
   }
 
   test("mustCreateResponseMessageFromInMessage") {
-    val m = sampleInOnly.toResponseMessage
+    val m = exchangeToAdapter(sampleInOnly).toResponseMessage
     assert(m === CamelMessage("test-in", Map("key-in" → "val-in")))
   }
 
   test("mustCreateResponseMessageFromOutMessage") {
-    val m = sampleInOut.toResponseMessage
+    val m = exchangeToAdapter(sampleInOut).toResponseMessage
     assert(m === CamelMessage("test-out", Map("key-out" → "val-out")))
   }
 
   test("mustCreateFailureMessageFromExceptionAndInMessage") {
     val e1 = sampleInOnly
     e1.setException(new Exception("test1"))
-    assert(e1.toAkkaCamelException.getMessage === "test1")
-    assert(e1.toAkkaCamelException.headers("key-in") === "val-in")
-    assert(e1.toFailureMessage.cause.getMessage === "test1")
-    assert(e1.toFailureMessage.headers("key-in") === "val-in")
+    val a1 = exchangeToAdapter(e1)
+    assert(a1.toAkkaCamelException.getMessage === "test1")
+    assert(a1.toAkkaCamelException.headers("key-in") === "val-in")
+    assert(a1.toFailureMessage.cause.getMessage === "test1")
+    assert(a1.toFailureMessage.headers("key-in") === "val-in")
   }
 
   test("mustCreateFailureMessageFromExceptionAndOutMessage") {
     val e1 = sampleInOut
     e1.setException(new Exception("test2"))
-    assert(e1.toAkkaCamelException.getMessage === "test2")
-    assert(e1.toAkkaCamelException.headers("key-out") === "val-out")
-    assert(e1.toFailureMessage.cause.getMessage === "test2")
-    assert(e1.toFailureMessage.headers("key-out") === "val-out")
+    val a1 = exchangeToAdapter(e1)
+    assert(a1.toAkkaCamelException.getMessage === "test2")
+    assert(a1.toAkkaCamelException.headers("key-out") === "val-out")
+    assert(a1.toFailureMessage.cause.getMessage === "test2")
+    assert(a1.toFailureMessage.headers("key-out") === "val-out")
   }
 
   test("mustCreateRequestMessageFromInMessageWithAdditionalHeader") {
-    val m = sampleInOnly.toRequestMessage(Map("x" → "y"))
+    val m = exchangeToAdapter(sampleInOnly).toRequestMessage(Map("x" → "y"))
     assert(m === CamelMessage("test-in", Map("key-in" → "val-in", "x" → "y")))
   }
 
   test("mustCreateResponseMessageFromInMessageWithAdditionalHeader") {
-    val m = sampleInOnly.toResponseMessage(Map("x" → "y"))
+    val m = exchangeToAdapter(sampleInOnly).toResponseMessage(Map("x" → "y"))
     assert(m === CamelMessage("test-in", Map("key-in" → "val-in", "x" → "y")))
   }
 
   test("mustCreateResponseMessageFromOutMessageWithAdditionalHeader") {
-    val m = sampleInOut.toResponseMessage(Map("x" → "y"))
+    val m = exchangeToAdapter(sampleInOut).toResponseMessage(Map("x" → "y"))
     assert(m === CamelMessage("test-out", Map("key-out" → "val-out", "x" → "y")))
   }
 
   test("mustCreateFailureMessageFromExceptionAndInMessageWithAdditionalHeader") {
     val e1 = sampleInOnly
     e1.setException(new Exception("test1"))
-    assert(e1.toAkkaCamelException.getMessage === "test1")
-    val headers = e1.toAkkaCamelException(Map("x" → "y")).headers
+    val a1 = exchangeToAdapter(e1)
+    assert(a1.toAkkaCamelException.getMessage === "test1")
+    val headers = a1.toAkkaCamelException(Map("x" → "y")).headers
     assert(headers("key-in") === "val-in")
     assert(headers("x") === "y")
 
-    assert(e1.toFailureMessage.cause.getMessage === "test1")
-    val failureHeaders = e1.toFailureResult(Map("x" → "y")).headers
+    val a2 = exchangeToAdapter(e1)
+    assert(a2.toFailureMessage.cause.getMessage === "test1")
+    val failureHeaders = a2.toFailureResult(Map("x" → "y")).headers
     assert(failureHeaders("key-in") === "val-in")
     assert(failureHeaders("x") === "y")
 
@@ -114,12 +114,15 @@ class CamelExchangeAdapterTest extends FunSuite with SharedCamelSystem {
   test("mustCreateFailureMessageFromExceptionAndOutMessageWithAdditionalHeader") {
     val e1 = sampleInOut
     e1.setException(new Exception("test2"))
-    assert(e1.toAkkaCamelException.getMessage === "test2")
-    val headers = e1.toAkkaCamelException(Map("x" → "y")).headers
+    val a1 = exchangeToAdapter(e1)
+    assert(a1.toAkkaCamelException.getMessage === "test2")
+    val headers = a1.toAkkaCamelException(Map("x" → "y")).headers
     assert(headers("key-out") === "val-out")
     assert(headers("x") === "y")
-    assert(e1.toFailureMessage.cause.getMessage === "test2")
-    val failureHeaders = e1.toFailureResult(Map("x" → "y")).headers
+
+    val a2 = exchangeToAdapter(e1)
+    assert(a2.toFailureMessage.cause.getMessage === "test2")
+    val failureHeaders = a2.toFailureResult(Map("x" → "y")).headers
     assert(failureHeaders("key-out") === "val-out")
     assert(failureHeaders("x") === "y")
   }
@@ -136,4 +139,6 @@ class CamelExchangeAdapterTest extends FunSuite with SharedCamelSystem {
     exchange.setPattern(pattern)
     exchange
   }
-}
+
+  private def exchangeToAdapter(e: Exchange) = new CamelExchangeAdapter(e)
+} 


### PR DESCRIPTION
Looking at the various TODOs I found that one, asking to remove the need for implicit in the  ```CamelExchangeAdapterTest``` class.

As a user of Akka I wanted to do a little bit more and try to contribute back.
In order to familiarised myself with the code base I was searching for a small, self contained issue to tackle.

I know it's just a test class and far from critical but I thought it was a good first baby-step to start with.

I had be very happy to comply to any feedback

Thanks