### PR TITLE
Add bind-hostname tip

### DIFF
--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -600,7 +600,7 @@ special configuration that sets both the logical and the bind pairs for remoting
    }
   }
 
-Keep in mind that local.address must be in one of private network ranges: 
+Keep in mind that local.address will almost always be in one of private network ranges:
 
 * *10.0.0.0 - 10.255.255.255* (network class A)
 * *172.16.0.0 - 172.31.255.255* (network class B)

--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -600,7 +600,7 @@ special configuration that sets both the logical and the bind pairs for remoting
    }
   }
 
-Keep in mind that local.address will almost always be in one of private network ranges:
+Keep in mind that local.address will most likely be in one of private network ranges:
 
 * *10.0.0.0 - 10.255.255.255* (network class A)
 * *172.16.0.0 - 172.31.255.255* (network class B)

--- a/akka-docs/rst/java/remoting.rst
+++ b/akka-docs/rst/java/remoting.rst
@@ -599,3 +599,11 @@ special configuration that sets both the logical and the bind pairs for remoting
       }
    }
   }
+
+Keep in mind that local.address must be in one of private network ranges: 
+
+* *10.0.0.0 - 10.255.255.255* (network class A)
+* *172.16.0.0 - 172.31.255.255* (network class B)
+* *192.168.0.0 - 192.168.255.255* (network class C)
+
+For further details see [RFC 1597](https://tools.ietf.org/html/rfc1597) and [RFC 1918](https://tools.ietf.org/html/rfc1918).

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -628,7 +628,7 @@ special configuration that sets both the logical and the bind pairs for remoting
    }
   }
 
-Keep in mind that local.address will almost always be in one of private network ranges:
+Keep in mind that local.address will most likely be in one of private network ranges:
 
 * *10.0.0.0 - 10.255.255.255* (network class A)
 * *172.16.0.0 - 172.31.255.255* (network class B)

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -627,3 +627,11 @@ special configuration that sets both the logical and the bind pairs for remoting
       }
    }
   }
+
+Keep in mind that local.address must be in one of private network ranges: 
+
+* *10.0.0.0 - 10.255.255.255* (network class A)
+* *172.16.0.0 - 172.31.255.255* (network class B)
+* *192.168.0.0 - 192.168.255.255* (network class C)
+
+For further details see [RFC 1597](https://tools.ietf.org/html/rfc1597) and [RFC 1918](https://tools.ietf.org/html/rfc1918).

--- a/akka-docs/rst/scala/remoting.rst
+++ b/akka-docs/rst/scala/remoting.rst
@@ -628,7 +628,7 @@ special configuration that sets both the logical and the bind pairs for remoting
    }
   }
 
-Keep in mind that local.address must be in one of private network ranges: 
+Keep in mind that local.address will almost always be in one of private network ranges:
 
 * *10.0.0.0 - 10.255.255.255* (network class A)
 * *172.16.0.0 - 172.31.255.255* (network class B)


### PR DESCRIPTION
The bind-hostname requires the internal (local) IP, however not all IP's are considered "local".