### PR TITLE
#22424: Use InputBuffer attribute for asynchronous inputs

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -219,6 +219,11 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   /**
    * INTERNAL API
    */
+  private[stream] var attributes: Attributes = Attributes.none
+
+  /**
+   * INTERNAL API
+   */
   // Using common array to reduce overhead for small port counts
   private[stream] val handlers = Array.ofDim[Any](inCount + outCount)
 


### PR DESCRIPTION
A little bit hacky solution, because it inflates the GraphStageLogic with an extra pointer. Unfortunately there is no real nicer way to propagate the Attributes of the relevant input port to the `takePublisher` call. At the point where that callback is called it is not known which stage is the corresponding input, nor what its attributes where (there is a reason why `takePublisher` is the only callback that does not present the `logic` field). Tracking these would add both memory and computational overhead. If someone has a better solution don't hesitate to share.