### PR TITLE
Make flowspec great again drewhk

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -107,7 +107,7 @@ private[akka] final class FanoutPublisherSink[In](
     val actorMaterializer = ActorMaterializerHelper.downcast(context.materializer)
     val impl = actorMaterializer.actorOf(
       context,
-      FanoutProcessorImpl.props(actorMaterializer.effectiveSettings(attributes)))
+      FanoutProcessorImpl.props(actorMaterializer.effectiveSettings(context.effectiveAttributes)))
     val fanoutProcessor = new ActorProcessor[In, In](impl)
     impl ! ExposedPublisher(fanoutProcessor.asInstanceOf[ActorPublisher[Any]])
     // Resolve cyclic dependency with actor. This MUST be the first message no matter what.

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -356,5 +356,6 @@ final case class ProcessorModule[In, Out, Mat](
   override def withAttributes(attributes: Attributes) = copy(attributes = attributes)
   override def toString: String = f"ProcessorModule [${System.identityHashCode(this)}%08x]"
 
-  override private[stream] def traversalBuilder = LinearTraversalBuilder.fromModule(this)
+  override private[stream] def traversalBuilder =
+    LinearTraversalBuilder.fromModule(this).makeIsland(ProcessorModuleIslandTag)
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -612,7 +612,7 @@ final class GraphInterpreterShell(
 /**
  * INTERNAL API
  */
-class ActorGraphInterpreter(_initial: GraphInterpreterShell) extends Actor with ActorLogging {
+final class ActorGraphInterpreter(_initial: GraphInterpreterShell) extends Actor with ActorLogging {
   import ActorGraphInterpreter._
 
   var activeInterpreters = Set.empty[GraphInterpreterShell]


### PR DESCRIPTION
Fixes #22435 

Unfortunately getting the "faulty-flow" case working is really really hacky (it was already very hacky before). This test tries to inject an internal failure into the interpreter and check if it is correctly handles, but I am not sure how we can do this in a maintainable way. It is possible to create a new phase just for this purpose (which I tried) but then one needs to build a traversal manually, a phase manually and all these end up in a big mess. Unless someone wants this test badly, I propose to delete it.