### PR TITLE
deferAsync adds cases with persist, not only persistAsync

### DIFF
--- a/akka-docs/rst/java/code/jdocs/persistence/LambdaPersistenceDocTest.java
+++ b/akka-docs/rst/java/code/jdocs/persistence/LambdaPersistenceDocTest.java
@@ -422,6 +422,41 @@ public class LambdaPersistenceDocTest {
     }
   };
 
+  static Object o100 = new Object() {
+    //#defer-with-persist
+    class MyPersistentActor extends AbstractPersistentActor {
+
+      @Override public String persistenceId() {
+        return "my-stable-persistence-id";
+      }
+
+      private void handleCommand(String c) {
+        persist(String.format("evt-%s-1", c), e -> {
+          sender().tell(e, self());
+        });
+        persist(String.format("evt-%s-2", c), e -> {
+          sender().tell(e, self());
+        });
+
+        deferAsync(String.format("evt-%s-3", c), e -> {
+          sender().tell(e, self());
+        });
+      }
+
+      @Override public Receive createReceiveRecover() {
+        return receiveBuilder().
+                match(String.class, this::handleCommand).build();
+      }
+
+      @Override public Receive createReceive() {
+        return receiveBuilder().
+                match(String.class, this::handleCommand).build();
+      }
+    }
+    //#defer-with-persist
+
+  };
+
   static Object o11 = new Object() {
 
     class MyPersistentActor extends AbstractPersistentActor {

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -273,8 +273,8 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 Deferring actions until preceding persist handlers have executed
 ----------------------------------------------------------------
 
-Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
-''happens-after the previous ``persistAsync`` handlers have been invoked''. ``PersistentActor`` provides an utility method
+Sometimes when working with ``persistAsync`` or ``persist`` you may find that it would be nice to define some actions in terms of
+''happens-after the previous ``persistAsync``/``persist`` handlers have been invoked''. ``PersistentActor`` provides an utility method
 called ``deferAsync``, which works similarly to ``persistAsync`` yet does not persist the passed in event. It is recommended to
 use it for *read* operations, and actions which do not have corresponding events in your domain model.
 
@@ -287,6 +287,10 @@ Notice that the ``getSender()`` method is **safe** to call in the handler callba
 of the command for which this ``deferAsync`` handler was called.
 
 .. includecode:: code/jdocs/persistence/LambdaPersistenceDocTest.java#defer-caller
+
+You can also call ``deferAsync`` with ``persist``.
+
+.. includecode:: code/docs/persistence/LambdaPersistenceDocTest.java#defer-with-persist
 
 .. warning::
   The callback will not be invoked if the actor is restarted (or stopped) in between the call to

--- a/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/persistence/PersistenceDocSpec.scala
@@ -280,6 +280,28 @@ object PersistenceDocSpec {
     //#defer-caller
   }
 
+  object DeferWithPersist {
+    //#defer-with-persist
+    class MyPersistentActor extends PersistentActor {
+
+      override def persistenceId = "my-stable-persistence-id"
+
+      override def receiveRecover: Receive = {
+        case _ => // handle recovery here
+      }
+
+      override def receiveCommand: Receive = {
+        case c: String => {
+          sender() ! c
+          persist(s"evt-$c-1") { e => sender() ! e }
+          persist(s"evt-$c-2") { e => sender() ! e }
+          deferAsync(s"evt-$c-3") { e => sender() ! e }
+        }
+      }
+    }
+    //#defer-with-persist
+  }
+
   object NestedPersists {
 
     class MyPersistentActor extends PersistentActor {

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -273,8 +273,8 @@ The ordering between events is still guaranteed ("evt-b-1" will be sent after "e
 Deferring actions until preceding persist handlers have executed
 ----------------------------------------------------------------
 
-Sometimes when working with ``persistAsync`` you may find that it would be nice to define some actions in terms of
-''happens-after the previous ``persistAsync`` handlers have been invoked''. ``PersistentActor`` provides an utility method
+Sometimes when working with ``persistAsync`` or ``persist`` you may find that it would be nice to define some actions in terms of
+''happens-after the previous ``persistAsync``/``persist`` handlers have been invoked''. ``PersistentActor`` provides an utility method
 called ``deferAsync``, which works similarly to ``persistAsync`` yet does not persist the passed in event. It is recommended to
 use it for *read* operations, and actions which do not have corresponding events in your domain model.
 
@@ -289,6 +289,10 @@ of the command for which this ``deferAsync`` handler was called.
 The calling side will get the responses in this (guaranteed) order:
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#defer-caller
+
+You can also call ``deferAsync`` with ``persist``.
+
+.. includecode:: code/docs/persistence/PersistenceDocSpec.scala#defer-with-persist
 
 .. warning::
   The callback will not be invoked if the actor is restarted (or stopped) in between the call to

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -351,7 +351,7 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
    */
   @InternalApi
   final private[akka] def internalDeferAsync[A](event: A)(handler: A ⇒ Unit): Unit = {
-    if (recoveryRunning) throw new IllegalStateException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.")
+    if (recoveryRunning) throw new IllegalStateException("Cannot defer during replay. Events can be deferred when receiving RecoveryCompleted or later.")
     if (pendingInvocations.isEmpty) {
       handler(event)
     } else {

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
@@ -246,7 +246,7 @@ trait PersistentActor extends Eventsourced with PersistenceIdentity {
   /**
    * Defer the handler execution until all pending handlers have been executed.
    * Allows to define logic within the actor, which will respect the invocation-order-guarantee
-   * in respect to `persistAsync` calls. That is, if `persistAsync` was invoked before `deferAsync`,
+   * in respect to `persistAsync` or `persist` calls. That is, if `persistAsync` or `persist` was invoked before `deferAsync`,
    * the corresponding handlers will be invoked in the same order as they were registered in.
    *
    * This call will NOT result in `event` being persisted, use `persist` or `persistAsync` instead
@@ -360,7 +360,7 @@ abstract class UntypedPersistentActor extends UntypedActor with Eventsourced wit
   /**
    * Defer the handler execution until all pending handlers have been executed.
    * Allows to define logic within the actor, which will respect the invocation-order-guarantee
-   * in respect to `persistAsync` calls. That is, if `persistAsync` was invoked before defer,
+   * in respect to `persistAsync` or `persist` calls. That is, if `persistAsync` or `persist` was invoked before `deferAsync`,
    * the corresponding handlers will be invoked in the same order as they were registered in.
    *
    * This call will NOT result in `event` being persisted, please use `persist` or `persistAsync`,


### PR DESCRIPTION
Refs #20873 

As in the above referenced issue, I wanted to remove the test cases ([[1]](https://github.com/akka/akka/blob/5ee25d9d40b26a526cc78c0ad58f1258c8bc2da8/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala#L260#L264), [[2]](https://github.com/akka/akka/blob/5ee25d9d40b26a526cc78c0ad58f1258c8bc2da8/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala#L275#L286)) of the mixed use `persist`/`persistAsync`cases, but I did not. Please let me know if I can remove them, then I wil update the commit. 


#### DOC ([Scala](http://doc.akka.io/docs/akka/2.4.17/scala/persistence.html#Deferring_actions_until_preceding_persist_handlers_have_executed), [Java](http://doc.akka.io/docs/akka/2.4.17/java/persistence.html#Deferring_actions_until_preceding_persist_handlers_have_executed)) , BEFORE 

<img width="723" alt="2017-03-04 0 42 14" src="https://cloud.githubusercontent.com/assets/7414320/23557685/3268c614-0074-11e7-863c-9fae14086be6.png">

#### AFTER 

<img width="738" alt="2017-03-04 0 42 01" src="https://cloud.githubusercontent.com/assets/7414320/23557684/3264fa0c-0074-11e7-836e-f1e9b10e683e.png">

and I added a new code sample with `persist` following the `//order of received messages:` sample.

<img width="718" alt="2017-03-04 0 49 36" src="https://cloud.githubusercontent.com/assets/7414320/23557766/7f16b6b0-0074-11e7-93fd-a39b911ae6dd.png">
