### PR TITLE
Provide how to build docs on Linux in docs #22455

### DIFF
--- a/akka-docs/rst/dev/documentation.rst
+++ b/akka-docs/rst/dev/documentation.rst
@@ -144,3 +144,72 @@ If you get the error "unknown locale: UTF-8" when generating the documentation t
   export LANG=en_US.UTF-8
   export LC_ALL=en_US.UTF-8
 
+Installing Sphinx on Linux
+--------------------------
+Install Python with your package manager:
+
+::
+
+  apt-get install python # for Debian based systems
+  yum install python     # for CentOS/RHEL systems
+
+This will automatically add Python executable to your $PATH and pip is a part of the default Python installation. Remember you need `sudo` rights to run this command.
+
+More information in case of trouble:
+https://packaging.python.org/install_requirements_linux/ 
+
+Install Sphinx:
+
+::
+
+  apt-get install python-sphinx # for Debian based systems
+  #alternatively
+  pip install sphinx
+
+For other Linux systems please check Sphinx website:
+http://www.sphinx-doc.org/en/stable/install.html#other-linux-distributions
+
+Install TextLive:
+
+::
+
+  apt-get install texlive-latex-base texlive-latex-extra texlive-latex-recommended
+  # additionally you may need xzdec
+  apt-get install xzdec
+  
+In case you get the following error:
+
+
+
+ Unknown directive ...containerchecksum c59200574a316416a23695c258edf3a32531fbda43ccdc09360ee105c3f07f9fb77df17c4ba4c2ea4f3a5ea6667e064b51e3d8c2fe6c984ba3e71b4e32716955... , please fix it! at /usr/share/texlive/tlpkg/TeXLive/TLPOBJ.pm line 210, <$retfh> line 5579.
+
+you need to specify you want to continue using the 2015 version:
+
+::
+
+  tlmgr option repository ftp://tug.org/historic/systems/texlive/2015/tlnet-final 
+
+Add missing tex packages:
+
+::
+
+  sudo tlmgr update --self
+  sudo tlmgr install titlesec
+  sudo tlmgr install framed
+  sudo tlmgr install threeparttable
+  sudo tlmgr install wrapfig
+  sudo tlmgr install helvetic
+  sudo tlmgr install courier
+  sudo tlmgr install multirow
+  sudo tlmgr install capt-of
+  sudo tlmgr install needspace
+  sudo tlmgr install eqparbox
+  sudo tlmgr install environ
+  sudo tlmgr install trimspaces
+
+If you get the error "unknown locale: UTF-8" when generating the documentation the solution is to define the following environment variables:
+
+::
+
+  export LANG=en_US.UTF-8
+  export LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Issue: #22455
Provide information on how to build the docs on a Linux system.
Contains step-by-step guide and common troubleshooting.