### PR TITLE
fix ReverseArrowSpec, #22463

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ReverseArrowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ReverseArrowSpec.scala
@@ -161,7 +161,7 @@ class ReverseArrowSpec extends StreamSpec {
         val src = b.add(source)
         src ~> f
         sink2 <~ f
-        (the[IllegalArgumentException] thrownBy (s <~ f <~ src)).getMessage should include("already connected")
+        (the[UnsupportedOperationException] thrownBy (s <~ f <~ src)).getMessage should include("Cannot wire ports in a completed builder")
         ClosedShape
       }).run(), 1.second) should ===(Seq(1, 2, 3))
     }


### PR DESCRIPTION
`IllegalArgumentException` vs `UnsupportedOperationException` in ReverseArrowSpec

Is it better to change back to `IllegalArgumentException`?

Refs #22463