### PR TITLE
+str #22425 re-implement sub-fusing with new materializer

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
@@ -25,7 +25,6 @@ import org.scalactic.ConversionCheckedTripleEquals
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import akka.stream.testkit.scaladsl.TestSource
 import akka.stream.testkit.scaladsl.TestSink
-
 import java.util.concurrent.ThreadLocalRandom
 
 object FlowGroupBySpec {

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2015-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.stream.impl
 
 import java.util
@@ -27,16 +30,15 @@ object PhasedFusingActorMaterializer {
   val Debug = false
 
   val DefaultPhase: Phase[Any] = new Phase[Any] {
-    override def apply(settings: ActorMaterializerSettings, materializer: PhasedFusingActorMaterializer,
-                       islandName: String): PhaseIsland[Any] =
-      new GraphStageIsland(settings, materializer, islandName).asInstanceOf[PhaseIsland[Any]]
+    override def apply(settings: ActorMaterializerSettings, materializer: PhasedFusingActorMaterializer, islandName: String): PhaseIsland[Any] =
+      new GraphStageIsland(settings, materializer, islandName, subflowFuser = None).asInstanceOf[PhaseIsland[Any]]
   }
 
   val DefaultPhases: Map[IslandTag, Phase[Any]] = Map[IslandTag, Phase[Any]](
     SinkModuleIslandTag → new Phase[Any] {
       override def apply(settings: ActorMaterializerSettings, materializer: PhasedFusingActorMaterializer,
                          islandName: String): PhaseIsland[Any] =
-        (new SinkModulePhase(materializer, islandName)).asInstanceOf[PhaseIsland[Any]]
+        new SinkModulePhase(materializer, islandName).asInstanceOf[PhaseIsland[Any]]
     },
     SourceModuleIslandTag → new Phase[Any] {
       override def apply(settings: ActorMaterializerSettings, materializer: PhasedFusingActorMaterializer,
@@ -371,6 +373,11 @@ case class PhasedFusingActorMaterializer(
     }
   }
 
+  override lazy val executionContext: ExecutionContextExecutor = dispatchers.lookup(settings.dispatcher match {
+    case Deploy.NoDispatcherGiven ⇒ Dispatchers.DefaultDispatcherId
+    case other                    ⇒ other
+  })
+
   override def schedulePeriodically(initialDelay: FiniteDuration, interval: FiniteDuration, task: Runnable): Cancellable =
     system.scheduler.schedule(initialDelay, interval, task)(executionContext)
 
@@ -378,37 +385,19 @@ case class PhasedFusingActorMaterializer(
     system.scheduler.scheduleOnce(delay, task)(executionContext)
 
   override def materialize[Mat](_runnableGraph: Graph[ClosedShape, Mat]): Mat =
-    materialize(_runnableGraph, null, defaultInitialAttributes)
-
-  override def materialize[Mat](_runnableGraph: Graph[ClosedShape, Mat], initialAttributes: Attributes): Mat =
-    materialize(_runnableGraph, null, initialAttributes)
-
-  override def materialize[Mat](_runnableGraph: Graph[ClosedShape, Mat], subflowFuser: (GraphInterpreterShell) ⇒ ActorRef): Mat =
-    materialize(_runnableGraph, subflowFuser, defaultInitialAttributes)
-
-  override def makeLogger(logSource: Class[_]): LoggingAdapter =
-    Logging(system, logSource)
-
-  override lazy val executionContext: ExecutionContextExecutor = dispatchers.lookup(settings.dispatcher match {
-    case Deploy.NoDispatcherGiven ⇒ Dispatchers.DefaultDispatcherId
-    case other                    ⇒ other
-  })
+    materialize(_runnableGraph, defaultInitialAttributes)
 
   override def materialize[Mat](
     _runnableGraph:    Graph[ClosedShape, Mat],
-    subflowFuser:      (GraphInterpreterShell) ⇒ ActorRef,
-    initialAttributes: Attributes): Mat = {
+    initialAttributes: Attributes): Mat =
     materialize(
       _runnableGraph,
-      subflowFuser,
       initialAttributes,
       PhasedFusingActorMaterializer.DefaultPhase,
       PhasedFusingActorMaterializer.DefaultPhases)
-  }
 
-  def materialize[Mat](
+  override def materialize[Mat](
     graph:             Graph[ClosedShape, Mat],
-    subflowFuser:      GraphInterpreterShell ⇒ ActorRef,
     initialAttributes: Attributes,
     defaultPhase:      Phase[Any],
     phases:            Map[IslandTag, Phase[Any]]): Mat = {
@@ -507,6 +496,9 @@ case class PhasedFusingActorMaterializer(
     matValueStack.peekLast().asInstanceOf[Mat]
   }
 
+  override def makeLogger(logSource: Class[_]): LoggingAdapter =
+    Logging(system, logSource)
+
 }
 
 trait IslandTag
@@ -541,7 +533,8 @@ object GraphStageTag extends IslandTag
 final class GraphStageIsland(
   effectiveSettings: ActorMaterializerSettings,
   materializer:      PhasedFusingActorMaterializer,
-  islandName:        String) extends PhaseIsland[GraphStageLogic] {
+  islandName:        String,
+  subflowFuser:      Option[GraphInterpreterShell ⇒ ActorRef]) extends PhaseIsland[GraphStageLogic] {
   // TODO: remove these
   private val logicArrayType = Array.empty[GraphStageLogic]
   private[this] val logics = new ArrayList[GraphStageLogic](64)
@@ -657,15 +650,17 @@ final class GraphStageIsland(
     shell.connections = finalConnections
     shell.logics = logics.toArray(logicArrayType)
 
-    // TODO: Subfusing
-    //    if (subflowFuser != null) {
-    //      subflowFuser(shell)
-    //    } else {
-    val props = ActorGraphInterpreter.props(shell)
-      .withDispatcher(effectiveSettings.dispatcher)
-    materializer.actorOf(props, islandName)
-    //    }
+    // TODO make OptionVal
+    subflowFuser match {
+      case Some(fuseIntoExistingInterperter) ⇒
+        fuseIntoExistingInterperter(shell)
 
+      case _ ⇒
+        val props = ActorGraphInterpreter.props(shell)
+          .withDispatcher(effectiveSettings.dispatcher)
+
+        materializer.actorOf(props, islandName)
+    }
   }
 
   override def toString: String = "GraphStagePhase"


### PR DESCRIPTION
Re-enable sub-fusing in the new materializer.
One of the tests in GroupBySpec SOMETIMES fails still, I'm investigating it still.

Simplified the Resume to only be a simple object, we did not use the more complex one nor the slit into ResumeActor.

Resolves https://github.com/akka/akka/issues/22425