### PR TITLE
#22446 fixed corruption of ordering in MergePreferred

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -140,7 +140,10 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit {
 
       Source.empty.via(emit1234.named("testStage")).runWith(TestSink.probe)
         .request(5)
-        .expectNext(1, 2, 3, 4)
+        .expectNext(1)
+        //emitting with callback gives nondeterminism whether 2 or 3 will be pushed first
+        .expectNextUnordered(2, 3)
+        .expectNext(4)
         .expectComplete()
 
     }
@@ -236,4 +239,3 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit {
   }
 
 }
-

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
@@ -49,13 +49,16 @@ class GraphMergeSpec extends TwoStreamsSetup {
 
       val subscription = probe.expectSubscription()
 
-      var collected = Set.empty[Int]
+      var collected = Seq.empty[Int]
       for (_ ← 1 to 10) {
         subscription.request(1)
-        collected += probe.expectNext()
+        collected :+= probe.expectNext()
       }
+      //test ordering of elements coming from each of nonempty flows
+      collected.filter(_ <= 4) should ===(1 to 4)
+      collected.filter(_ >= 5) should ===(5 to 10)
 
-      collected should be(Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+      collected.toSet should be(Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
       probe.expectComplete()
     }
 

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -825,12 +825,27 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
       setHandler(out, previous)
       andThen()
       if (followUps != null) {
-        getHandler(out) match {
-          case e: Emitting[_] ⇒ e.as[T].addFollowUps(this)
-          case _ ⇒
-            val next = dequeue()
-            if (next.isInstanceOf[EmittingCompletion[_]]) complete(out)
-            else setHandler(out, next)
+        /**
+         * If (while executing andThen() callback) handler was changed to new emitting,
+         * we should add it to the end of emission queue
+         */
+        val currentHandler = getHandler(out)
+        if (currentHandler.isInstanceOf[Emitting[_]])
+          addFollowUp(currentHandler.asInstanceOf[Emitting[T]])
+
+        val next = dequeue()
+        if (next.isInstanceOf[EmittingCompletion[_]]) {
+          /**
+           * If next element is emitting completion and there are some elements after it,
+           * we to need pass them before completion
+           */
+          if (next.followUps != null) {
+            setHandler(out, dequeueHeadAndAddToTail(next))
+          } else {
+            complete(out)
+          }
+        } else {
+          setHandler(out, next)
         }
       }
     }
@@ -843,6 +858,14 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
         followUpsTail.followUps = e
         followUpsTail = e
       }
+
+    private def dequeueHeadAndAddToTail(head: Emitting[T]): Emitting[T] = {
+      val next = head.dequeue()
+      next.addFollowUp(head)
+      head.followUps = null
+      head.followUpsTail = null
+      next
+    }
 
     private def addFollowUps(e: Emitting[T]): Unit =
       if (followUps == null) {


### PR DESCRIPTION
Using def emit[T](out: Outlet[T], elem: T, andThen: Effect) with emit in andThen() callback could corrupt ordering if consumer was slow.
For example:
```scala
emit(out, 1, () ⇒ emit(out, 3))
emit(out, 2, () ⇒ emit(out, 4))
```
would push first 1, then 2 or 3, then 4 depending on whether in port was pulled or not, because callback (`() ⇒ emit(out, x)`) is called on onPull event and not immediately after emit method execution. This caused wrong ordering of elements to be emitted if onPull was called after two or more emits with callback as in example above.

the sequence of actions was:
- after `emit(out, 1, () ⇒ emit(out, 3))` OuputHandler was set to `new EmittingSingle(out, 1, getNonEmittingHandler(out)`
- then `emit(out, 2, () ⇒ emit(out, 4))` was called and `new EmittingSingle(out, 2, getNonEmittingHandler(out)` was added to previous Emitting to the tail
- then `() ⇒ emit(out, 3)` was invoked and `new EmittingSingle(out, 3, getNonEmittingHandler(out), andThen)` prepended the resulting Emitting[] handler by the followUp call, causing 3 to be pushed before 2

Refs #22446 
