### PR TITLE
Add GraphDSL validation, fix GraphDSLCompileSpec

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
@@ -214,22 +214,36 @@ class GraphDSLCompileSpec extends StreamSpec {
       }).run()
     }
 
-    "distinguish between input and output ports" in {
-      intercept[IllegalArgumentException] {
-        RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
-          val zip = b.add(Zip[Int, String]())
-          val unzip = b.add(Unzip[Int, String]())
-          val wrongOut = Sink.asPublisher[(Int, Int)](false)
-          val whatever = Sink.asPublisher[Any](false)
-          "Flow(List(1, 2, 3)) ~> zip.left ~> wrongOut" shouldNot compile
-          """Flow(List("a", "b", "c")) ~> zip.left""" shouldNot compile
-          """Flow(List("a", "b", "c")) ~> zip.out""" shouldNot compile
-          "zip.left ~> zip.right" shouldNot compile
-          "Flow(List(1, 2, 3)) ~> zip.left ~> wrongOut" shouldNot compile
-          """Flow(List(1 -> "a", 2 -> "b", 3 -> "c")) ~> unzip.in ~> whatever""" shouldNot compile
+    "throw an error if some ports are not connected" in {
+      intercept[IllegalStateException] {
+        GraphDSL.create() { implicit b ⇒
+          val s = b.add(Source.empty[Int])
+          val op = b.add(Flow[Int].map(_ + 1))
+          val sink = b.add(Sink.foreach[Int](println))
+
+          op ~> sink.in
+
           ClosedShape
-        })
-      }.getMessage should include("must correspond to")
+        }
+      }.getMessage should be("Illegal GraphDSL usage. " +
+        "Inlets [Map.in] were not returned in the resulting shape and not connected. " +
+        "Outlets [EmptySource.out] were not returned in the resulting shape and not connected.")
+    }
+
+    "throw an error if a connected port is returned in the shape" in {
+      intercept[IllegalStateException] {
+        GraphDSL.create() { implicit b ⇒
+          val s = b.add(Source.empty[Int])
+          val op = b.add(Flow[Int].map(_ + 1))
+          val sink = b.add(Sink.foreach[Int](println))
+
+          s ~> op ~> sink.in
+
+          op
+        }
+      }.getMessage should be("Illegal GraphDSL usage. " +
+        "Inlets [Map.in] were returned in the resulting shape but were already connected. " +
+        "Outlets [Map.out] were returned in the resulting shape but were already connected.")
     }
 
     "build with variance" in {

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -15,7 +15,7 @@ trait GraphApply {
     val builder = new GraphDSL.Builder
     val s = buildBlock(builder)
 
-    new GraphApply.GraphImpl(s, builder.traversalBuilder)
+    createGraph(s, builder)
   }
 
   /**
@@ -27,7 +27,7 @@ trait GraphApply {
     val s1 = builder.add(g1, Keep.right)
     val s = buildBlock(builder)(s1)
 
-    new GraphApply.GraphImpl(s, builder.traversalBuilder)
+    createGraph(s, builder)
   }
 
 
@@ -45,25 +45,11 @@ trait GraphApply {
     ]
     val s = buildBlock(builder)([#s1#])
 
-    new GraphApply.GraphImpl(s, builder.traversalBuilder)
+    createGraph(s, builder)
   }#
 
   ]
+
+  private def createGraph[S <: Shape, Mat](shape: S, graphBuilder: GraphDSL.Builder[Mat]): Graph[S, Mat] =
+    new GenericGraph(shape, graphBuilder.traversalBuilder)
 }
-
-/**
- * INTERNAL API
- */
-object GraphApply {
-  final class GraphImpl[S <: Shape, Mat](override val shape: S, override val traversalBuilder: TraversalBuilder)
-    extends Graph[S, Mat] {
-    
-    override def toString: String = s"Graph($shape)"
-
-    override def withAttributes(attr: Attributes): Graph[S, Mat] =
-      new GraphImpl(shape, traversalBuilder.setAttributes(attr))
-
-    override def named(name: String): Graph[S, Mat] = addAttributes(Attributes.name(name))
-  }
-}
-

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -51,5 +51,5 @@ trait GraphApply {
   ]
 
   private def createGraph[S <: Shape, Mat](shape: S, graphBuilder: GraphDSL.Builder[Mat]): Graph[S, Mat] =
-    new GenericGraph(shape, graphBuilder.traversalBuilder)
+    new GenericGraph(shape, graphBuilder.result(shape))
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -17,6 +17,37 @@ import scala.collection.immutable
 import scala.concurrent.Promise
 import scala.util.control.{ NoStackTrace, NonFatal }
 
+/**
+ * INTERNAL API
+ *
+ * The implementation of a graph with an arbitrary shape.
+ */
+private[stream] final class GenericGraph[S <: Shape, Mat](override val shape: S, override val traversalBuilder: TraversalBuilder)
+  extends Graph[S, Mat] { outer ⇒
+
+  override def toString: String = s"GenericGraph($shape)"
+
+  override def withAttributes(attr: Attributes): Graph[S, Mat] =
+    new GenericGraphWithChangedAttributes(shape, traversalBuilder, attr)
+}
+
+/**
+ * INTERNAL API
+ *
+ * The implementation of a graph with an arbitrary shape with changed attributes. Changing attributes again
+ * prevents building up a chain of changes.
+ */
+private[stream] final class GenericGraphWithChangedAttributes[S <: Shape, Mat](override val shape: S, originalTraversalBuilder: TraversalBuilder, newAttributes: Attributes)
+  extends Graph[S, Mat] { outer ⇒
+
+  private[stream] def traversalBuilder: TraversalBuilder = originalTraversalBuilder.setAttributes(newAttributes)
+
+  override def toString: String = s"GenericGraphWithChangedAttributes($shape)"
+
+  override def withAttributes(attr: Attributes): Graph[S, Mat] =
+    new GenericGraphWithChangedAttributes(shape, originalTraversalBuilder, attr)
+}
+
 object Merge {
   /**
    * Create a new `Merge` with the specified number of input ports.

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration.FiniteDuration
 import akka.stream.actor.ActorSubscriberMessage
+import akka.stream.scaladsl.{ GenericGraph, GenericGraphWithChangedAttributes }
 
 abstract class GraphStageWithMaterializedValue[+S <: Shape, +M] extends Graph[S, M] {
 
@@ -33,12 +34,8 @@ abstract class GraphStageWithMaterializedValue[+S <: Shape, +M] extends Graph[S,
     TraversalBuilder.atomic(GraphStageModule(shape, attr, this), attr)
   }
 
-  final override def withAttributes(attr: Attributes): Graph[S, M] = new Graph[S, M] {
-    override def shape = GraphStageWithMaterializedValue.this.shape
-    override def traversalBuilder = GraphStageWithMaterializedValue.this.traversalBuilder.setAttributes(attr)
-
-    override def withAttributes(attr: Attributes) = GraphStageWithMaterializedValue.this.withAttributes(attr)
-  }
+  final override def withAttributes(attr: Attributes): Graph[S, M] =
+    new GenericGraphWithChangedAttributes(shape, GraphStageWithMaterializedValue.this.traversalBuilder, attr)
 }
 
 /**


### PR DESCRIPTION
This will help users a lot debugging the graphs they are building.  On the other hand, it will also slow down graph building (which doesn't matter so much if graphs are reused).

I wonder if we can do better than collecting things in a `Set` (which we know was one of the slow things of the old stuff).

Refs #22463 