### PR TITLE
include initialAttributes of GraphStage, #22463

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -13,7 +13,7 @@ import akka.stream._
 import akka.stream.impl.fusing.GraphInterpreterShell
 
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{Await, ExecutionContextExecutor}
+import scala.concurrent.{ Await, ExecutionContextExecutor }
 
 /**
  * ExtendedActorMaterializer used by subtypes which materializer using GraphInterpreterShell

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamLayout.scala
@@ -357,5 +357,5 @@ final case class ProcessorModule[In, Out, Mat](
   override def toString: String = f"ProcessorModule [${System.identityHashCode(this)}%08x]"
 
   override private[stream] def traversalBuilder =
-    LinearTraversalBuilder.fromModule(this).makeIsland(ProcessorModuleIslandTag)
+    LinearTraversalBuilder.fromModule(this, attributes).makeIsland(ProcessorModuleIslandTag)
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -36,7 +36,7 @@ final case class GraphStageModule[+S <: Shape @uncheckedVariance, +M](
     if (attributes ne this.attributes) new GraphStageModule(shape, attributes, stage)
     else this
 
-  override private[stream] def traversalBuilder = LinearTraversalBuilder.fromModule(this)
+  override private[stream] def traversalBuilder = LinearTraversalBuilder.fromModule(this, attributes)
 
   override def toString: String = f"GraphStage($stage) [${System.identityHashCode(this)}%08x]"
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
@@ -28,7 +28,7 @@ private[stream] final case class TlsModule(plainIn: Inlet[SslTlsOutbound], plain
 
   override def toString: String = f"TlsModule($closing) [${System.identityHashCode(this)}%08x]"
 
-  override private[stream] def traversalBuilder = TraversalBuilder.atomic(this).makeIsland(TlsModuleIslandTag)
+  override private[stream] def traversalBuilder = TraversalBuilder.atomic(this, attributes).makeIsland(TlsModuleIslandTag)
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -30,8 +30,7 @@ import scala.compat.java8.FutureConverters._
  */
 final class Source[+Out, +Mat](
   override val traversalBuilder: LinearTraversalBuilder,
-  override val shape:            SourceShape[Out]
-)
+  override val shape:            SourceShape[Out])
   extends FlowOpsMat[Out, Mat] with Graph[SourceShape[Out], Mat] {
 
   override type Repr[+O] = Source[O, Mat @uncheckedVariance]
@@ -53,8 +52,7 @@ final class Source[+Out, +Mat](
 
     new Source[T, Mat3](
       traversalBuilder.append(toAppend, flow.shape, combine),
-      SourceShape(flow.shape.out)
-    )
+      SourceShape(flow.shape.out))
   }
 
   /**
@@ -157,8 +155,7 @@ final class Source[+Out, +Mat](
    */
   override def async: Repr[Out] = new Source(
     traversalBuilder.makeIsland(GraphStageTag),
-    shape
-  )
+    shape)
 
   /**
    * Converts this Scala DSL element to it's Java DSL counterpart.

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -28,7 +28,10 @@ abstract class GraphStageWithMaterializedValue[+S <: Shape, +M] extends Graph[S,
 
   protected def initialAttributes: Attributes = Attributes.none
 
-  final override lazy val traversalBuilder: TraversalBuilder = TraversalBuilder.atomic(GraphStageModule(shape, initialAttributes, this))
+  final override lazy val traversalBuilder: TraversalBuilder = {
+    val attr = initialAttributes
+    TraversalBuilder.atomic(GraphStageModule(shape, attr, this), attr)
+  }
 
   final override def withAttributes(attr: Attributes): Graph[S, M] = new Graph[S, M] {
     override def shape = GraphStageWithMaterializedValue.this.shape


### PR DESCRIPTION
Review last commit only.
This should be rebased and merged after https://github.com/akka/akka/pull/22482

* these must also be included via setAttributes because
  because it will create island for async (dispatcher attribute)
* better actor name of GraphStageIsland, we need it in tests for
  lookup of the actor
* this unlocks OutputStreamSourceSpec and InputStreamSinkSpec

Refs #22463

