### PR TITLE
be 2.13 friendly

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ConstantFun.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ConstantFun.scala
@@ -19,11 +19,13 @@ private[akka] object ConstantFun {
 
   def javaIdentityFunction[T]: JFun[T, T] = JavaIdentityFunction.asInstanceOf[JFun[T, T]]
 
-  def scalaIdentityFunction[T]: T ⇒ T = conforms
+  def scalaIdentityFunction[T]: T ⇒ T = conforms.asInstanceOf[Function[T, T]]
 
   def scalaAnyToNone[A, B]: A ⇒ Option[B] = none
   def scalaAnyTwoToNone[A, B, C]: (A, B) ⇒ Option[C] = two2none
   def javaAnyToNone[A, B]: A ⇒ Option[B] = none
+
+  val conforms = (a: Any) ⇒ a
 
   val zeroLong = (_: Any) ⇒ 0L
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1170,7 +1170,7 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[T](source: Graph[SourceShape[T], _]): SubFlow[In, Out @uncheckedVariance Pair T, Mat] =
+  def zip[T](source: Graph[SourceShape[T], _]): SubFlow[In, Out @uncheckedVariance Tuple2 T, Mat] =
     new SubFlow(delegate.zip(source))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1163,7 +1163,7 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[T](source: Graph[SourceShape[T], _]): SubSource[Out @uncheckedVariance Pair T, Mat] =
+  def zip[T](source: Graph[SourceShape[T], _]): SubSource[Out @uncheckedVariance Tuple2 T, Mat] =
     new SubSource(delegate.zip(source))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -694,7 +694,7 @@ object Zip {
  *
  * '''Cancels when''' downstream cancels
  */
-final class Zip[A, B] extends ZipWith2[A, B, (A, B)](Pair.apply) {
+final class Zip[A, B] extends ZipWith2[A, B, (A, B)](Tuple2.apply) {
   override def toString = "Zip"
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,13 +21,17 @@ object Dependencies {
     scalaVersion := System.getProperty("akka.build.scalaVersion", crossScalaVersions.value.head),
     scalaStmVersion := sys.props.get("akka.build.scalaStmVersion").getOrElse("0.8"),
     scalaCheckVersion := sys.props.get("akka.build.scalaCheckVersion").getOrElse(
-      if (scalaVersion.value.startsWith("2.12")) "1.13.4" // does not work for 2.11
-      else "1.13.2"
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 12 =>
+          "1.13.4" // does not work for 2.11
+        case _ =>
+          "1.13.2"
+      }
     ),
     scalaTestVersion := "3.0.0",
     java8CompatVersion := {
-      scalaVersion.value match {
-        case x if x.startsWith("2.12") => "0.8.0"
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 12 => "0.8.0"
         case _ => "0.7.0"
       }
     }


### PR DESCRIPTION
* treat 2.13 and 2.12 the same, for the time being, in scalaVersion
  handling in the build
* `Pair` is a deprecated type alias for `Tuple2` and was removed in 2.13
* temporary workaround (marked TODO) for removal of deprecated
  `conforms` from scala.Predef; Akka team to substitute a proper fix;
  details at https://github.com/akka/akka/issues/22451