### PR TITLE
Explicitly handle SpecViolation exceptions in GraphStage callbacks in boundaries

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -364,7 +364,6 @@ class ActorGraphInterpreterSpec extends StreamSpec {
       ise.getCause.getCause should (have message ("violating your spec"))
     }
 
-    /* TODO this one does not work
     "be able to handle Subscriber spec violations without leaking" in assertAllStagesStopped {
       val filthySubscriber = new Subscriber[Int] {
         override def onSubscribe(s: Subscription): Unit = s.request(1)
@@ -391,7 +390,6 @@ class ActorGraphInterpreterSpec extends StreamSpec {
 
       upstream.expectCancellation()
     }
-    */
 
   }
 }


### PR DESCRIPTION
... otherwise they end up being handled by the interpreter, but no onError is signalled to downstream subscribers.