### PR TITLE
Docs: fix broken refs in docs for Cluster Usage

### DIFF
--- a/akka-docs/rst/java/cluster-usage.rst
+++ b/akka-docs/rst/java/cluster-usage.rst
@@ -125,7 +125,7 @@ seed nodes in the existing cluster.
 
 If you don't configure seed nodes you need to join the cluster programmatically or manually.
 
-Manual joining can be performed by using ref:`cluster_jmx_java` or :ref:`cluster_http_java`.
+Manual joining can be performed by using :ref:`cluster_jmx_java` or :ref:`cluster_http_java`.
 Joining programmatically can be performed with ``Cluster.get(system).join``. Unsuccessful join attempts are
 automatically retried after the time period defined in configuration property ``retry-unsuccessful-join-after``.
 Retries can be disabled by setting the property to ``off``.

--- a/akka-docs/rst/scala/cluster-usage.rst
+++ b/akka-docs/rst/scala/cluster-usage.rst
@@ -119,7 +119,7 @@ seed nodes in the existing cluster.
 
 If you don't configure seed nodes you need to join the cluster programmatically or manually.
 
-Manual joining can be performed by using ref:`cluster_jmx_scala` or :ref:`cluster_http_scala`.
+Manual joining can be performed by using :ref:`cluster_jmx_scala` or :ref:`cluster_http_scala`.
 Joining programmatically can be performed with ``Cluster(system).join``. Unsuccessful join attempts are
 automatically retried after the time period defined in configuration property ``retry-unsuccessful-join-after``.
 Retries can be disabled by setting the property to ``off``.


### PR DESCRIPTION
One of the refs is broken, you can see this at: [http://doc.akka.io/docs/akka/2.4/scala/cluster-usage.html](http://doc.akka.io/docs/akka/2.4/scala/cluster-usage.html) in the paragraph beginning with "Manual joining can be performed by using "...