### PR TITLE
Add docs sitemap generation #12760

### DIFF
--- a/akka-docs/_sphinx/exts/sitemap.py
+++ b/akka-docs/_sphinx/exts/sitemap.py
@@ -1,0 +1,36 @@
+from sets import Set
+import xml.etree.ElementTree as ET
+
+def add_html_link(app, pagename, templatename, context, doctree):
+    """As each page is built, collect page names for the sitemap"""
+    base_url = app.config['html_theme_options'].get('base_url', '')
+    if base_url:
+        app.sitemap_links.add(base_url + pagename + ".html")
+
+
+def create_sitemap(app, exception):
+    """Generates the sitemap.xml from the collected HTML page links"""
+    if (not app.config['html_theme_options'].get('base_url', '') or
+                exception is not None or
+            not app.sitemap_links):
+        return
+
+    filename = app.outdir + "/sitemap.xml"
+    print("Generating sitemap.xml in %s" % filename)
+
+    root = ET.Element("urlset")
+    root.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")
+
+    for link in app.sitemap_links:
+        url = ET.SubElement(root, "url")
+        ET.SubElement(url, "loc").text = link
+
+    ET.ElementTree(root).write(filename)
+
+
+def setup(app):
+    """Setup conntects events to the sitemap builder"""
+    app.require_sphinx('1.0')
+    app.connect('html-page-context', add_html_link)
+    app.connect('build-finished', create_sitemap)
+    app.sitemap_links = Set()

--- a/akka-docs/_sphinx/themes/akka/theme.conf
+++ b/akka-docs/_sphinx/themes/akka/theme.conf
@@ -4,3 +4,4 @@ stylesheet = style.css
 
 [options]
 full_logo         = false
+base_url  =

--- a/akka-docs/rst/conf.py
+++ b/akka-docs/rst/conf.py
@@ -8,7 +8,7 @@ import sys, os
 # -- General configuration -----------------------------------------------------
 
 sys.path.append(os.path.abspath('../_sphinx/exts'))
-extensions = ['sphinx.ext.todo', 'includecode', 'includecode2']
+extensions = ['sphinx.ext.todo', 'includecode', 'includecode2', 'sitemap']
 
 templates_path = ['_templates']
 source_suffix = '.rst'
@@ -29,8 +29,11 @@ show_authors = True
 
 html_theme = 'akka'
 html_theme_path = ['../_sphinx/themes']
-html_favicon = '../_sphinx/static/favicon.ico'
+html_theme_options = {
+    "base_url": "http://doc.akka.io/docs/akka/current/"
+}
 
+html_favicon = '../_sphinx/static/favicon.ico'
 html_title = 'Akka Documentation'
 html_logo = '../_sphinx/static/logo.png'
 #html_favicon = None


### PR DESCRIPTION
In order to help with issue #12760, this PR will generate a valid ```sitemap.xml``` file alongside the rest of the documentation (At the root level)

The base URL that will be used is: __http://doc.akka.io/docs/akka-http/current__ but I don't know if we should support versioning.

Here is an example of the generated file: https://gist.github.com/athieriot/612ea9705dd05f79f3947edf3c3b43c9

Note: Most of the code comes from the Guzzle project: https://github.com/guzzle/guzzle_sphinx_theme
Should I add something about licensing or copyright?