### PR TITLE
fix broken refs in docs for Cluster Usage (for validation)

### DIFF
--- a/akka-docs/rst/java/cluster-usage.rst
+++ b/akka-docs/rst/java/cluster-usage.rst
@@ -91,7 +91,7 @@ seed nodes in the existing cluster.
 
 If you don't configure seed nodes you need to join the cluster programmatically or manually.
 
-Manual joining can be performed by using ref:`cluster_jmx_java` or :ref:`cluster_command_line_java`.
+Manual joining can be performed by using :ref:`cluster_jmx_java` or :ref:`cluster_command_line_java`.
 Joining programmatically can be performed with ``Cluster.get(system).join``. Unsuccessful join attempts are
 automatically retried after the time period defined in configuration property ``retry-unsuccessful-join-after``.
 Retries can be disabled by setting the property to ``off``.

--- a/akka-docs/rst/scala/cluster-usage.rst
+++ b/akka-docs/rst/scala/cluster-usage.rst
@@ -85,7 +85,7 @@ seed nodes in the existing cluster.
 
 If you don't configure seed nodes you need to join the cluster programmatically or manually.
 
-Manual joining can be performed by using ref:`cluster_jmx_scala` or :ref:`cluster_command_line_scala`.
+Manual joining can be performed by using :ref:`cluster_jmx_scala` or :ref:`cluster_command_line_scala`.
 Joining programmatically can be performed with ``Cluster(system).join``. Unsuccessful join attempts are
 automatically retried after the time period defined in configuration property ``retry-unsuccessful-join-after``.
 Retries can be disabled by setting the property to ``off``.


### PR DESCRIPTION
(cherry picked from commit c67641b0ebcba824482783f1aaaeb9e0a9464791)