### PR TITLE
Documentation note for large-message-frame-size

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -783,6 +783,8 @@ akka {
         buffer-pool-size = 128
 
         # Maximum serialized message size for the large messages, including header data.
+        # It is currently restricted to 1/8th the size of a term buffer what can be 
+        # configured by setting the 'aeron.term.buffer.length' system property.
         # See 'large-message-destinations'.
         maximum-large-frame-size = 2 MiB
 

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -783,7 +783,7 @@ akka {
         buffer-pool-size = 128
 
         # Maximum serialized message size for the large messages, including header data.
-        # It is currently restricted to 1/8th the size of a term buffer what can be 
+        # It is currently restricted to 1/8th the size of a term buffer that can be 
         # configured by setting the 'aeron.term.buffer.length' system property.
         # See 'large-message-destinations'.
         maximum-large-frame-size = 2 MiB


### PR DESCRIPTION
Added to docs that large-message-frame-size is restricted to 1/8th of aeron.term.buffer.length #22257.