### PR TITLE
OptionVals and no requires() in materializer

### DIFF
--- a/akka-actor/src/main/scala/akka/util/OptionVal.scala
+++ b/akka-actor/src/main/scala/akka/util/OptionVal.scala
@@ -50,6 +50,9 @@ private[akka] final class OptionVal[+A >: Null](val x: A) extends AnyVal {
   def getOrElse[B >: A](default: B): B =
     if (x == null) default else x
 
+  def contains[B >: A](it: B): Boolean =
+    x != null && x == it
+
   /**
    *  Returns the option's value if it is nonempty, or `null` if it is empty.
    */

--- a/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
@@ -5,6 +5,9 @@
 package akka.stream
 
 import java.util.concurrent.TimeUnit
+
+import akka.NotUsed
+import akka.stream.scaladsl.RunnableGraph
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
@@ -16,22 +19,18 @@ class GraphBuilderBenchmark {
   var complexity = 0
 
   @Benchmark
-  def flow_with_map(): Unit = {
+  def flow_with_map(): RunnableGraph[NotUsed] = 
     MaterializationBenchmark.flowWithMapBuilder(complexity)
-  }
 
   @Benchmark
-  def graph_with_junctions(): Unit = {
+  def graph_with_junctions(): RunnableGraph[NotUsed] =
     MaterializationBenchmark.graphWithJunctionsBuilder(complexity)
-  }
 
   @Benchmark
-  def graph_with_nested_imports(): Unit = {
+  def graph_with_nested_imports(): RunnableGraph[NotUsed] = 
     MaterializationBenchmark.graphWithNestedImportsBuilder(complexity)
-  }
 
   @Benchmark
-  def graph_with_imported_flow(): Unit = {
+  def graph_with_imported_flow(): RunnableGraph[NotUsed] =
     MaterializationBenchmark.graphWithImportedFlowBuilder(complexity)
-  }
 }

--- a/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/GraphBuilderBenchmark.scala
@@ -19,7 +19,7 @@ class GraphBuilderBenchmark {
   var complexity = 0
 
   @Benchmark
-  def flow_with_map(): RunnableGraph[NotUsed] = 
+  def flow_with_map(): RunnableGraph[NotUsed] =
     MaterializationBenchmark.flowWithMapBuilder(complexity)
 
   @Benchmark
@@ -27,7 +27,7 @@ class GraphBuilderBenchmark {
     MaterializationBenchmark.graphWithJunctionsBuilder(complexity)
 
   @Benchmark
-  def graph_with_nested_imports(): RunnableGraph[NotUsed] = 
+  def graph_with_nested_imports(): RunnableGraph[NotUsed] =
     MaterializationBenchmark.graphWithNestedImportsBuilder(complexity)
 
   @Benchmark

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -84,7 +84,7 @@ class MaterializationBenchmark {
   var graphWithNestedImports: RunnableGraph[NotUsed] = _
   var graphWithImportedFlow: RunnableGraph[NotUsed] = _
 
-  @Param(Array("1", "10"))
+  @Param(Array("1", "10", "100", "1000"))
   var complexity = 0
 
   @Setup

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -101,14 +101,14 @@ class MaterializationBenchmark {
   }
 
   @Benchmark
-  def flow_with_map(): Unit = flowWithMap.run()
+  def flow_with_map(): NotUsed = flowWithMap.run()
 
   @Benchmark
-  def graph_with_junctions(): Unit = graphWithJunctions.run()
+  def graph_with_junctions(): NotUsed = graphWithJunctions.run()
 
   @Benchmark
-  def graph_with_nested_imports(): Unit = graphWithNestedImports.run()
+  def graph_with_nested_imports(): NotUsed = graphWithNestedImports.run()
 
   @Benchmark
-  def graph_with_imported_flow(): Unit = graphWithImportedFlow.run()
+  def graph_with_imported_flow(): NotUsed = graphWithImportedFlow.run()
 }

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -84,7 +84,7 @@ class MaterializationBenchmark {
   var graphWithNestedImports: RunnableGraph[NotUsed] = _
   var graphWithImportedFlow: RunnableGraph[NotUsed] = _
 
-  @Param(Array("1", "10", "100", "1000"))
+  @Param(Array("1", "10"))
   var complexity = 0
 
   @Setup

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -228,7 +228,7 @@ private[akka] class Shard(
 
   def passivate(entity: ActorRef, stopMessage: Any): Unit = {
     idByRef.get(entity) match {
-      case Some(id) => if (!messageBuffers.contains(id)) {
+      case Some(id) ⇒ if (!messageBuffers.contains(id)) {
         log.debug("Passivating started on entity {}", id)
 
         passivating = passivating + entity
@@ -237,7 +237,7 @@ private[akka] class Shard(
       } else {
         log.debug("Passivation already in progress for {}. Not sending stopMessage back to entity.", entity)
       }
-      case None    => log.debug("Unknown entity {}. Not sending stopMessage back to entity.", entity)
+      case None ⇒ log.debug("Unknown entity {}. Not sending stopMessage back to entity.", entity)
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -11,6 +11,7 @@ import akka.event.LoggingAdapter
 import akka.pattern.ask
 import akka.stream._
 import akka.stream.impl.fusing.GraphInterpreterShell
+import akka.util.OptionVal
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ Await, ExecutionContextExecutor }
@@ -90,7 +91,7 @@ private[akka] class SubFusingActorMaterializerImpl(val delegate: ExtendedActorMa
 
   val subFusingPhase = new Phase[Any] {
     override def apply(settings: ActorMaterializerSettings, materializer: PhasedFusingActorMaterializer, islandName: String): PhaseIsland[Any] = {
-      new GraphStageIsland(settings, materializer, islandName, Some(registerShell)).asInstanceOf[PhaseIsland[Any]]
+      new GraphStageIsland(settings, materializer, islandName, OptionVal(registerShell)).asInstanceOf[PhaseIsland[Any]]
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -87,8 +87,6 @@ abstract class ExtendedActorMaterializer extends ActorMaterializer {
  * The default phases are left in-tact since we still respect `.async` and other tags that were marked within a sub-fused graph.
  */
 private[akka] class SubFusingActorMaterializerImpl(val delegate: ExtendedActorMaterializer, registerShell: GraphInterpreterShell ⇒ ActorRef) extends Materializer {
-  require(registerShell ne null, "When using SubFusing the subflowFuser MUST NOT be null.") // FIXME remove check?
-
   val subFusingPhase = new Phase[Any] {
     override def apply(settings: ActorMaterializerSettings, materializer: PhasedFusingActorMaterializer, islandName: String): PhaseIsland[Any] = {
       new GraphStageIsland(settings, materializer, islandName, OptionVal(registerShell)).asInstanceOf[PhaseIsland[Any]]

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -47,8 +47,9 @@ private[akka] class ActorProcessor[I, O](impl: ActorRef) extends ActorPublisher[
  * INTERNAL API
  */
 private[akka] abstract class BatchingInputBuffer(val size: Int, val pump: Pump) extends DefaultInputTransferStates {
-  require(size > 0, "buffer size cannot be zero")
-  require((size & (size - 1)) == 0, "buffer size must be a power of two")
+  if (size < 1) throw new IllegalArgumentException(s"buffer size MSUT be positive (was: $size")
+  if ((size & (size - 1)) != 0) throw new IllegalArgumentException("buffer size must be a power of two")
+
   // TODO: buffer and batch sizing heuristics
   private var upstream: Subscription = _
   private val inputBuffer = Array.ofDim[AnyRef](size)
@@ -114,7 +115,7 @@ private[akka] abstract class BatchingInputBuffer(val size: Int, val pump: Pump) 
   }
 
   protected def onSubscribe(subscription: Subscription): Unit = {
-    require(subscription != null)
+    ReactiveStreamsCompliance.requireNonNullSubscription(subscription)
     if (upstreamCompleted) subscription.cancel()
     else {
       upstream = subscription

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -47,8 +47,8 @@ private[akka] class ActorProcessor[I, O](impl: ActorRef) extends ActorPublisher[
  * INTERNAL API
  */
 private[akka] abstract class BatchingInputBuffer(val size: Int, val pump: Pump) extends DefaultInputTransferStates {
-  if (size < 1) throw new IllegalArgumentException(s"buffer size MSUT be positive (was: $size")
-  if ((size & (size - 1)) != 0) throw new IllegalArgumentException("buffer size must be a power of two")
+  if (size < 1) throw new IllegalArgumentException(s"buffer size must be positive (was: $size)")
+  if ((size & (size - 1)) != 0) throw new IllegalArgumentException(s"buffer size must be a power of two (was: $size)")
 
   // TODO: buffer and batch sizing heuristics
   private var upstream: Subscription = _

--- a/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
@@ -12,6 +12,7 @@ import org.reactivestreams._
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.Promise
 import akka.event.Logging
+import akka.util.OptionVal
 
 /**
  * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -37,6 +37,7 @@ import scala.compat.java8.OptionConverters._
 import java.util.Optional
 
 import akka.event.Logging
+import akka.util.OptionVal
 
 /**
  * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -480,8 +480,8 @@ object LinearTraversalBuilder {
    * than its generic counterpart. It can be freely mixed with the generic builder in both ways.
    */
   def fromModule(module: AtomicModule[Shape, Any], attributes: Attributes): LinearTraversalBuilder = {
-    require(module.shape.inlets.size <= 1, "Modules with more than one input port cannot be linear.")
-    require(module.shape.outlets.size <= 1, "Modules with more than one input port cannot be linear.")
+    if (module.shape.inlets.size > 1) throw new IllegalStateException("Modules with more than one input port cannot be linear.")
+    if (module.shape.outlets.size > 1) throw new IllegalStateException("Modules with more than one input port cannot be linear.")
     TraversalBuilder.initShape(module.shape)
 
     val inPortOpt = OptionVal(module.shape.inlets.headOption.orNull)
@@ -708,8 +708,8 @@ final case class LinearTraversalBuilder(
         traversalSoFar = toAppend.traversalSoFar.concat(LinearTraversalBuilder.addMatCompose(traversal, matCompose)))
     } else {
       if (outPort.isDefined) {
-        require(toAppend.inPort.isDefined, "Appended linear module must have an unwired input port " +
-          "because there is a dangling output.")
+        if (toAppend.inPort.isEmpty)
+          throw new IllegalArgumentException("Appended linear module must have an unwired input port because there is a dangling output.")
 
         /*
          * To understand how append work, first the general structure of the LinearTraversalBuilder must be

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -7,6 +7,8 @@ package akka.stream.impl
 import akka.stream._
 import akka.stream.impl.StreamLayout.AtomicModule
 import akka.stream.scaladsl.Keep
+import akka.util.OptionVal
+import scala.language.existentials
 
 /**
  * Graphs to be materialized are defined by their traversal. There is no explicit graph information tracked, instead
@@ -464,14 +466,14 @@ final case class AtomicTraversalBuilder(
 object LinearTraversalBuilder {
 
   // TODO: Remove
-  private val cachedEmptyLinear = LinearTraversalBuilder(None, None, 0, 0, PushNotUsed, None, Attributes.none)
+  private val cachedEmptyLinear = LinearTraversalBuilder(OptionVal.None, OptionVal.None, 0, 0, PushNotUsed, OptionVal.None, Attributes.none)
 
   private[this] final val wireBackward: Array[Int] = Array(-1)
   private[this] final val noWire: Array[Int] = Array()
 
   def empty(attributes: Attributes = Attributes.none): LinearTraversalBuilder =
     if (attributes eq Attributes.none) cachedEmptyLinear
-    else LinearTraversalBuilder(None, None, 0, 0, PushNotUsed, None, attributes, EmptyTraversal)
+    else LinearTraversalBuilder(OptionVal.None, OptionVal.None, 0, 0, PushNotUsed, OptionVal.None, attributes, EmptyTraversal)
 
   /**
    * Create a traversal builder specialized for linear graphs. This is designed to be much faster and lightweight
@@ -482,8 +484,8 @@ object LinearTraversalBuilder {
     require(module.shape.outlets.size <= 1, "Modules with more than one input port cannot be linear.")
     TraversalBuilder.initShape(module.shape)
 
-    val inPortOpt = module.shape.inlets.headOption
-    val outPortOpt = module.shape.outlets.headOption
+    val inPortOpt = OptionVal(module.shape.inlets.headOption.orNull)
+    val outPortOpt = OptionVal(module.shape.outlets.headOption.orNull)
 
     val wiring = if (outPortOpt.isDefined) wireBackward else noWire
 
@@ -493,7 +495,7 @@ object LinearTraversalBuilder {
       inOffset = 0,
       if (inPortOpt.isDefined) 1 else 0,
       traversalSoFar = MaterializeAtomic(module, wiring),
-      pendingBuilder = None,
+      pendingBuilder = OptionVal.None,
       attributes)
   }
 
@@ -523,12 +525,12 @@ object LinearTraversalBuilder {
         }
 
         LinearTraversalBuilder(
-          inPort = inOpt,
-          outPort = None,
+          inPort = OptionVal(inOpt.orNull),
+          outPort = OptionVal.None,
           inOffset = inOffs,
           inSlots = completed.inSlots,
           completed.traversal.concat(addMatCompose(PushNotUsed, combine)),
-          pendingBuilder = None,
+          pendingBuilder = OptionVal.None,
           Attributes.none)
 
       case composite ⇒
@@ -540,12 +542,12 @@ object LinearTraversalBuilder {
         }
 
         LinearTraversalBuilder(
-          inPort = inOpt,
-          outPort = Some(out),
+          inPort = OptionVal(inOpt.orNull),
+          outPort = OptionVal.Some(out),
           inOffset = inOffs,
           inSlots = composite.inSlots,
           addMatCompose(PushNotUsed, combine),
-          pendingBuilder = Some(composite),
+          pendingBuilder = OptionVal.Some(composite),
           Attributes.none,
           beforeBuilder = EmptyTraversal)
 
@@ -562,15 +564,15 @@ object LinearTraversalBuilder {
  * -1 relative offset to something else (see rewireLastOutTo).
  */
 final case class LinearTraversalBuilder(
-  inPort:               Option[InPort],
-  outPort:              Option[OutPort],
+  inPort:               OptionVal[InPort],
+  outPort:              OptionVal[OutPort],
   inOffset:             Int,
   override val inSlots: Int,
   traversalSoFar:       Traversal,
-  pendingBuilder:       Option[TraversalBuilder],
+  pendingBuilder:       OptionVal[TraversalBuilder],
   attributes:           Attributes,
-  beforeBuilder:        Traversal                = EmptyTraversal,
-  islandTag:            Option[IslandTag]        = None) extends TraversalBuilder {
+  beforeBuilder:        Traversal                   = EmptyTraversal,
+  islandTag:            OptionVal[IslandTag]        = OptionVal.None) extends TraversalBuilder {
 
   protected def isEmpty: Boolean = inSlots == 0 && outPort.isEmpty
 
@@ -583,7 +585,7 @@ final case class LinearTraversalBuilder(
    * This builder can always return a traversal.
    */
   override def traversal: Traversal = {
-    if (outPort.nonEmpty)
+    if (outPort.isDefined)
       throw new IllegalStateException("Traversal cannot be acquired until all output ports have been wired")
     applyIslandAndAttributes(traversalSoFar)
   }
@@ -598,8 +600,8 @@ final case class LinearTraversalBuilder(
 
   private def applyIslandAndAttributes(t: Traversal): Traversal = {
     val withIslandTag = islandTag match {
-      case None      ⇒ t
-      case Some(tag) ⇒ EnterIsland(tag).concat(t).concat(ExitIsland)
+      case OptionVal.None      ⇒ t
+      case OptionVal.Some(tag) ⇒ EnterIsland(tag).concat(t).concat(ExitIsland)
     }
 
     if (attributes eq Attributes.none) withIslandTag
@@ -625,19 +627,19 @@ final case class LinearTraversalBuilder(
   override def wire(out: OutPort, in: InPort): TraversalBuilder = {
     if (outPort.contains(out) && inPort.contains(in)) {
       pendingBuilder match {
-        case Some(composite) ⇒
+        case OptionVal.Some(composite) ⇒
           copy(
-            inPort = None,
-            outPort = None,
+            inPort = OptionVal.None,
+            outPort = OptionVal.None,
             traversalSoFar =
               applyIslandAndAttributes(
                 beforeBuilder.concat(
                   composite
                   .assign(out, inOffset - composite.offsetOfModule(out))
                   .traversal).concat(traversalSoFar)),
-            pendingBuilder = None, beforeBuilder = EmptyTraversal)
-        case None ⇒
-          copy(inPort = None, outPort = None, traversalSoFar = rewireLastOutTo(traversalSoFar, inOffset))
+            pendingBuilder = OptionVal.None, beforeBuilder = EmptyTraversal)
+        case OptionVal.None ⇒
+          copy(inPort = OptionVal.None, outPort = OptionVal.None, traversalSoFar = rewireLastOutTo(traversalSoFar, inOffset))
       }
     } else
       throw new IllegalArgumentException(s"The ports $in and $out cannot be accessed in this builder.")
@@ -646,8 +648,8 @@ final case class LinearTraversalBuilder(
   override def offsetOfModule(out: OutPort): Int = {
     if (outPort.contains(out)) {
       pendingBuilder match {
-        case Some(composite) ⇒ composite.offsetOfModule(out)
-        case None            ⇒ 0 // Output belongs to the last module, which will be materialized *first*
+        case OptionVal.Some(composite) ⇒ composite.offsetOfModule(out)
+        case OptionVal.None            ⇒ 0 // Output belongs to the last module, which will be materialized *first*
       }
     } else
       throw new IllegalArgumentException(s"Port $out cannot be accessed in this builder")
@@ -665,9 +667,9 @@ final case class LinearTraversalBuilder(
   override def assign(out: OutPort, relativeSlot: Int): TraversalBuilder = {
     if (outPort.contains(out)) {
       pendingBuilder match {
-        case Some(composite) ⇒
+        case OptionVal.Some(composite) ⇒
           copy(
-            outPort = None,
+            outPort = OptionVal.None,
             traversalSoFar =
               applyIslandAndAttributes(
                 beforeBuilder.concat(
@@ -675,10 +677,10 @@ final case class LinearTraversalBuilder(
                     .assign(out, relativeSlot)
                     .traversal
                     .concat(traversalSoFar))),
-            pendingBuilder = None,
+            pendingBuilder = OptionVal.None,
             beforeBuilder = EmptyTraversal)
-        case None ⇒
-          copy(outPort = None, traversalSoFar = rewireLastOutTo(traversalSoFar, relativeSlot))
+        case OptionVal.None ⇒
+          copy(outPort = OptionVal.None, traversalSoFar = rewireLastOutTo(traversalSoFar, relativeSlot))
       }
     } else
       throw new IllegalArgumentException(s"Port $out cannot be assigned in this builder")
@@ -705,7 +707,7 @@ final case class LinearTraversalBuilder(
       toAppend.copy(
         traversalSoFar = toAppend.traversalSoFar.concat(LinearTraversalBuilder.addMatCompose(traversal, matCompose)))
     } else {
-      if (outPort.nonEmpty) {
+      if (outPort.isDefined) {
         require(toAppend.inPort.isDefined, "Appended linear module must have an unwired input port " +
           "because there is a dangling output.")
 
@@ -749,7 +751,7 @@ final case class LinearTraversalBuilder(
          * different.
          */
         val assembledTraversalForThis = this.pendingBuilder match {
-          case None ⇒
+          case OptionVal.None ⇒
             /*
              * This is the case where we are a pure linear builder (all composites have been already completed),
              * which means that traversalSoFar contains everything already, except the final attributes and islands
@@ -788,7 +790,7 @@ final case class LinearTraversalBuilder(
               rewireLastOutTo(traversalSoFar, toAppend.inOffset - toAppend.inSlots)
             }
 
-          case Some(composite) ⇒
+          case OptionVal.Some(composite) ⇒
             /*
              * This is the case where our last module is a composite, and since it does not have its output port
              * wired yet, the traversal is split into the parts, traversalSoFar, pendingBuilder and beforeBuilder.
@@ -842,7 +844,7 @@ final case class LinearTraversalBuilder(
          * There are two variants, depending whether toAppend is purely linear or if it has a composite at the end.
          */
         toAppend.pendingBuilder match {
-          case None ⇒
+          case OptionVal.None ⇒
             /*
              * This is the simple case, when the other is purely linear. We just concatenate the traversals
              * and do some bookkeeping.
@@ -855,13 +857,13 @@ final case class LinearTraversalBuilder(
               inOffset = inOffset + toAppend.inSlots,
               // Build in reverse so it yields a more efficient layout for left-to-right building
               traversalSoFar = toAppend.applyIslandAndAttributes(toAppend.traversalSoFar).concat(finalTraversalForThis),
-              pendingBuilder = None,
+              pendingBuilder = OptionVal.None,
               attributes = Attributes.none, // attributes are none for the new enclosing builder
               beforeBuilder = EmptyTraversal, // no need for beforeBuilder as there are no composites
-              islandTag = None // islandTag is reset for the new enclosing builder
+              islandTag = OptionVal.None // islandTag is reset for the new enclosing builder
             )
 
-          case Some(composite) ⇒
+          case OptionVal.Some(composite) ⇒
             /*
              * In this case we need to assemble as much as we can, and create a new "sandwich" of
              *   beforeBuilder ~ pendingBuilder ~ traversalSoFar
@@ -875,9 +877,9 @@ final case class LinearTraversalBuilder(
 
             // First prepare island enter and exit if tags are present
             toAppend.islandTag match {
-              case None ⇒
+              case OptionVal.None ⇒
               // Nothing changes
-              case Some(tag) ⇒
+              case OptionVal.Some(tag) ⇒
                 // Enter the island just before the appended builder (keeping the toAppend.beforeBuilder steps)
                 newBeforeTraversal = EnterIsland(tag).concat(newBeforeTraversal)
                 // Exit the island just after the appended builder (they should not applied to _this_ builder)
@@ -908,7 +910,7 @@ final case class LinearTraversalBuilder(
               pendingBuilder = toAppend.pendingBuilder,
               attributes = Attributes.none, // attributes are none for the new enclosing builder
               beforeBuilder = newBeforeTraversal, // no need for beforeBuilder as there are no composites
-              islandTag = None // islandTag is reset for the new enclosing builder
+              islandTag = OptionVal.None // islandTag is reset for the new enclosing builder
             )
         }
       } else throw new Exception("should this happen?")
@@ -927,8 +929,8 @@ final case class LinearTraversalBuilder(
    */
   override def makeIsland(islandTag: IslandTag): LinearTraversalBuilder =
     this.islandTag match {
-      case Some(tag) ⇒ this // Wrapping with an island, then immediately re-wrapping makes the second island empty, so can be omitted
-      case None      ⇒ copy(islandTag = Some(islandTag))
+      case OptionVal.Some(tag) ⇒ this // Wrapping with an island, then immediately re-wrapping makes the second island empty, so can be omitted
+      case OptionVal.None      ⇒ copy(islandTag = OptionVal.Some(islandTag))
     }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -89,8 +89,8 @@ object ActorGraphInterpreter {
       override def logic: GraphStageLogic = BatchingActorInputBoundary.this
     }
 
-    require(size > 0, "buffer size cannot be zero")
-    require((size & (size - 1)) == 0, "buffer size must be a power of two")
+    if (size <= 0) throw new IllegalArgumentException("buffer size cannot be zero")
+    if ((size & (size - 1)) != 0) throw new IllegalArgumentException("buffer size must be a power of two")
 
     private var actor: ActorRef = ActorRef.noSender
     private var upstream: Subscription = _
@@ -136,7 +136,7 @@ object ActorGraphInterpreter {
 
     private def dequeue(): Any = {
       val elem = inputBuffer(nextInputElementCursor)
-      require(elem ne null, "Internal queue must never contain a null")
+      if (elem eq null) throw new IllegalArgumentException("Internal queue must never contain a null")
       inputBuffer(nextInputElementCursor) = null
 
       batchRemaining -= 1
@@ -196,7 +196,7 @@ object ActorGraphInterpreter {
       }
 
     def onSubscribe(subscription: Subscription): Unit = {
-      require(subscription != null, "Subscription cannot be null")
+      ReactiveStreamsCompliance.requireNonNullSubscription(subscription)
       if (upstreamCompleted) {
         tryCancel(subscription)
       } else if (downstreamCanceled) {

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TlsModule.scala
@@ -8,7 +8,7 @@ import akka.stream._
 import akka.stream.impl.StreamLayout.AtomicModule
 import akka.stream.TLSProtocol._
 import akka.stream.impl.{ TlsModuleIslandTag, TraversalBuilder }
-import akka.util.ByteString
+import akka.util.{ ByteString, OptionVal }
 
 import scala.util.Try
 

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -14,7 +14,7 @@ import akka.japi.function.{ Effect, Procedure }
 import akka.stream._
 import akka.stream.impl.StreamLayout.AtomicModule
 import akka.stream.impl.fusing.{ GraphInterpreter, GraphStageModule, SubSink, SubSource }
-import akka.stream.impl.{ ReactiveStreamsCompliance, TraversalBuilder }
+import akka.stream.impl.{ EmptyTraversal, LinearTraversalBuilder, ReactiveStreamsCompliance, TraversalBuilder }
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{ immutable, mutable }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -540,7 +540,11 @@ object MiMa extends AutoPlugin {
       ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.stage.GraphStageWithMaterializedValue.module"),
       ProblemFilters.exclude[MissingClassProblem]("akka.stream.scaladsl.ModuleExtractor"),
       ProblemFilters.exclude[MissingClassProblem]("akka.stream.scaladsl.ModuleExtractor$"),
-      ProblemFilters.excludePackage("akka.stream.impl")
+      ProblemFilters.excludePackage("akka.stream.impl"),
+      
+      // small changes in attributes 
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.testkit.StreamTestKit#ProbeSource.withAttributes"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.testkit.StreamTestKit#ProbeSink.withAttributes")
 
       // NOTE: filters that will be backported to 2.4 should go to the latest 2.4 version below
     )


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/22438
Resolves https://github.com/akka/akka/issues/22437

Measured just on my laptop to numbers are a bit nonsense, but here they are for reference.
Too much other stuff happening on my laptop to get a meaningful measurement here I think.

Before:

```
[info]
[info] Benchmark                               (complexity)   Mode  Cnt       Score       Error  Units
[info] MaterializationBenchmark.flow_with_map             1  thrpt   20  173573.332 ± 24454.250  ops/s
[info] MaterializationBenchmark.flow_with_map            10  thrpt   20   94503.123 ± 11538.851  ops/s
```

After: 

```
[info] Benchmark                               (complexity)   Mode  Cnt       Score       Error  Units
[info] MaterializationBenchmark.flow_with_map             1  thrpt   20  169334.168 ± 19569.725  ops/s
[info] MaterializationBenchmark.flow_with_map            10  thrpt   20   85744.876 ±  8376.737  ops/s
```