### PR TITLE
FAILED ActorSelectionSpec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
@@ -119,6 +119,11 @@ class ActorSelectionSpec extends AkkaSpec with DefaultTimeout {
       // not equal because it's terminated
       identify(a1.path) should ===(None)
 
+      // wait till path is freed
+      awaitCond {
+        system.asInstanceOf[ExtendedActorSystem].provider.resolveActorRef(a1.path) != a1
+      }
+
       val a2 = system.actorOf(p, name)
       a2.path should ===(a1.path)
       a2.path.toString should ===(a1.path.toString)


### PR DESCRIPTION
This failure can be simulated putting statement `if (self.path.name == "user" && actor.path.name == "abcdefg") Thread.sleep(1000)`  before [this line](https://github.com/akka/akka/blob/23ca48bdcca096170db3c396b762ff8dd3a91737/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala#L63)

Actually, actor was terminated but it's path was not freed in time

Refs  #22460

