### PR TITLE
#22429 Resize connections array when needed

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/EmptySourceBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/EmptySourceBenchmark.scala
@@ -22,18 +22,16 @@ class EmptySourceBenchmark {
   val materializerSettings = ActorMaterializerSettings(system).withDispatcher("akka.test.stream-dispatcher")
   implicit val materializer = ActorMaterializer(materializerSettings)
 
-
   @TearDown
   def shutdown(): Unit = {
     Await.result(system.terminate(), 5.seconds)
   }
 
   val setup = Source.empty[String].toMat(Sink.ignore)(Keep.right)
-  
-  @Benchmark def empty(): Unit = 
+
+  @Benchmark def empty(): Unit =
     Await.result(setup.run(), Duration.Inf)
 
-  
   /*
     (not serious benchmark, just sanity check: run on macbook 15, late 2013)
   

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -84,7 +84,7 @@ class MaterializationBenchmark {
   var graphWithNestedImports: RunnableGraph[NotUsed] = _
   var graphWithImportedFlow: RunnableGraph[NotUsed] = _
 
-  @Param(Array("1", "10"))
+  @Param(Array("1", "10", "100", "1000"))
   var complexity = 0
 
   @Setup

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -581,7 +581,7 @@ final class GraphStageIsland(
   private val logicArrayType = Array.empty[GraphStageLogic]
   private[this] val logics = new ArrayList[GraphStageLogic](64)
   // TODO: Resize
-  private val connections = new Array[Connection](64)
+  private var connections = new Array[Connection](16)
   private var maxConnections = 0
   private var outConnections: List[Connection] = Nil
   private var fullIslandName: OptionVal[String] = OptionVal.None
@@ -613,6 +613,9 @@ final class GraphStageIsland(
 
   def conn(slot: Int): Connection = {
     maxConnections = math.max(slot, maxConnections)
+    if (maxConnections >= connections.length) {
+      connections = connections.padTo(connections.length * 2, null)
+    }
     val c = connections(slot)
     if (c ne null) c
     else {

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -579,8 +579,8 @@ final class GraphStageIsland(
   subflowFuser:      OptionVal[GraphInterpreterShell ⇒ ActorRef]) extends PhaseIsland[GraphStageLogic] {
   // TODO: remove these
   private val logicArrayType = Array.empty[GraphStageLogic]
-  private[this] val logics = new ArrayList[GraphStageLogic](64)
-  // TODO: Resize
+  private[this] val logics = new ArrayList[GraphStageLogic](16)
+
   private var connections = new Array[Connection](16)
   private var maxConnections = 0
   private var outConnections: List[Connection] = Nil
@@ -614,7 +614,7 @@ final class GraphStageIsland(
   def conn(slot: Int): Connection = {
     maxConnections = math.max(slot, maxConnections)
     if (maxConnections >= connections.length) {
-      connections = connections.padTo(connections.length * 2, null)
+      connections = java.util.Arrays.copyOf(connections, connections.length * 2)
     }
     val c = connections(slot)
     if (c ne null) c


### PR DESCRIPTION
With the `connections` beeing of size 8 and without the resize 96/1638 stream tests failed. WIth the size of 16 - only 9. Therefore I left 16 as the initial size.

Fixes #22429