### PR TITLE
fixed corruption of ordering in MergePreferred caused by using emit (for validation)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -149,7 +149,14 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit {
 
       Source.empty.via(g).runWith(TestSink.probe)
         .request(9)
-        .expectNextN(1 to 8)
+        .expectNext(1)
+        //emitting with callback gives nondeterminism whether 2 or 3 will be pushed first
+        .expectNextUnordered(2, 3)
+        .expectNext(4)
+        .expectNext(5)
+        //emitting with callback gives nondeterminism whether 6 or 7 will be pushed first
+        .expectNextUnordered(6, 7)
+        .expectNext(8)
         .expectComplete()
     }
 
@@ -158,7 +165,14 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit {
 
       Source.empty.via(g).runWith(TestSink.probe)
         .request(9)
-        .expectNextN(1 to 8)
+        .expectNext(1)
+        //emitting with callback gives nondeterminism whether 2 or 3 will be pushed first
+        .expectNextUnordered(2, 3)
+        .expectNext(4)
+        .expectNext(5)
+        //emitting with callback gives nondeterminism whether 6 or 7 will be pushed first
+        .expectNextUnordered(6, 7)
+        .expectNext(8)
         .expectComplete()
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -136,7 +136,10 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit {
 
       Source.empty.via(emit1234.named("testStage")).runWith(TestSink.probe)
         .request(5)
-        .expectNext(1, 2, 3, 4)
+        .expectNext(1)
+        //emitting with callback gives nondeterminism whether 2 or 3 will be pushed first
+        .expectNextUnordered(2, 3)
+        .expectNext(4)
         .expectComplete()
 
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSpec.scala
@@ -49,13 +49,16 @@ class GraphMergeSpec extends TwoStreamsSetup {
 
       val subscription = probe.expectSubscription()
 
-      var collected = Set.empty[Int]
+      var collected = Seq.empty[Int]
       for (_ ← 1 to 10) {
         subscription.request(1)
-        collected += probe.expectNext()
+        collected :+= probe.expectNext()
       }
+      //test ordering of elements coming from each of nonempty flows
+      collected.filter(_ <= 4) should ===(1 to 4)
+      collected.filter(_ >= 5) should ===(5 to 10)
 
-      collected should be(Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+      collected.toSet should be(Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
       probe.expectComplete()
     }
 

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -777,12 +777,27 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
       setHandler(out, previous)
       andThen()
       if (followUps != null) {
-        getHandler(out) match {
-          case e: Emitting[_] ⇒ e.as[T].addFollowUps(this)
-          case _ ⇒
-            val next = dequeue()
-            if (next.isInstanceOf[EmittingCompletion[_]]) complete(out)
-            else setHandler(out, next)
+        /**
+         * If (while executing andThen() callback) handler was changed to new emitting,
+         * we should add it to the end of emission queue
+         */
+        val currentHandler = getHandler(out)
+        if (currentHandler.isInstanceOf[Emitting[_]])
+          addFollowUp(currentHandler.asInstanceOf[Emitting[T]])
+
+        val next = dequeue()
+        if (next.isInstanceOf[EmittingCompletion[_]]) {
+          /**
+           * If next element is emitting completion and there are some elements after it,
+           * we to need pass them before completion
+           */
+          if (next.followUps != null) {
+            setHandler(out, dequeueHeadAndAddToTail(next))
+          } else {
+            complete(out)
+          }
+        } else {
+          setHandler(out, next)
         }
       }
     }
@@ -795,6 +810,14 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
         followUpsTail.followUps = e
         followUpsTail = e
       }
+
+    private def dequeueHeadAndAddToTail(head: Emitting[T]): Emitting[T] = {
+      val next = head.dequeue()
+      next.addFollowUp(head)
+      head.followUps = null
+      head.followUpsTail = null
+      next
+    }
 
     private def addFollowUps(e: Emitting[T]): Unit =
       if (followUps == null) {


### PR DESCRIPTION
… with emit in andThen() callback #22446

(cherry picked from commit 5704c72ece3fefe22fd6ec1020e0171946ba2ef5)

Refs #22446