### PR TITLE
=act #22568 mark ResumeReading with DeadLetterSuppression

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -393,8 +393,12 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
   /**
    * This command needs to be sent to the connection actor after a `SuspendReading`
    * command in order to resume reading from the socket.
+   *
+   * (This message is marked with DeadLetterSuppression as it is prone to end up in
+   *  DeadLetters when the connection is torn down at the same time as the user wants
+   *  to resume reading on that connection.)
    */
-  case object ResumeReading extends Command
+  case object ResumeReading extends Command with DeadLetterSuppression
 
   /**
    * This message enables the accepting of the next connection if read throttling is enabled

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -102,6 +102,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   def peerSentEOF(info: ConnectionInfo): Receive =
     handleWriteMessages(info) orElse {
       case cmd: CloseCommand ⇒ handleClose(info, Some(sender()), cmd.event)
+      case ResumeReading     ⇒ // ignore, no more data to read
     }
 
   /** connection is closing but a write has to be finished first */

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -84,7 +84,7 @@ object TlsSpec {
 
 }
 
-class TlsSpec extends StreamSpec("akka.loglevel=INFO\nakka.actor.debug.receive=off") {
+class TlsSpec extends StreamSpec("akka.loglevel=DEBUG\nakka.actor.debug.receive=off") {
   import TlsSpec._
 
   import system.dispatcher


### PR DESCRIPTION
ResumeReading will likely end up in DeadLetters when the connection is
torn down at the same time as the user tries to read more data from the
connection.

This will remove the spurious warnings in this case.