### PR TITLE
=act #22568 reduce spurious ResumeReading log messages

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -393,8 +393,12 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
   /**
    * This command needs to be sent to the connection actor after a `SuspendReading`
    * command in order to resume reading from the socket.
+   *
+   * (This message is marked with DeadLetterSuppression as it is prone to end up in
+   *  DeadLetters when the connection is torn down at the same time as the user wants
+   *  to resume reading on that connection.)
    */
-  case object ResumeReading extends Command
+  case object ResumeReading extends Command with DeadLetterSuppression
 
   /**
    * This message enables the accepting of the next connection if read throttling is enabled

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -102,6 +102,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   def peerSentEOF(info: ConnectionInfo): Receive =
     handleWriteMessages(info) orElse {
       case cmd: CloseCommand ⇒ handleClose(info, Some(sender()), cmd.event)
+      case ResumeReading     ⇒ // ignore, no more data to read
     }
 
   /** connection is closing but a write has to be finished first */


### PR DESCRIPTION
ResumeReading will likely end up in DeadLetters when the connection is
torn down at the same time as the user tries to read more data from the
connection.

For the same reason ResumeReading may arrive in peerSentEOF state. We
ignore it here to get rid of "unhandled message from Actor ... : ResumeReading"
warnings.

This will remove the spurious warnings in these cases.

(cherry picked from commit e915a16dbc8ffb39a311cea659e95f465113815c)

Refs #22568