### PR TITLE
=rem #22579 initialize SSLContext eagerly in SSLSettings

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
@@ -62,7 +62,7 @@ object Configuration {
       val fullConfig = config.withFallback(AkkaSpec.testConf).withFallback(ConfigFactory.load).getConfig("akka.remote.netty.ssl.security")
       val settings = new SSLSettings(fullConfig)
 
-      val rng = settings.createSecureRandom(NoMarkerLogging)
+      val rng = settings.createSecureRandom()
 
       rng.nextInt() // Has to work
       val sRng = settings.SSLRandomNumberGenerator


### PR DESCRIPTION
This will prevent that Akka remoting will stall for a long time in initialization
of Akka remoting which will prevent that other initialization like akka-cluster's
which depends on remoting will run into strange timeouts when SSL initialization
is slow (especially PRNG's which might block on slow `/dev/random`).