### PR TITLE
=str #22584 make subfusing work if diff materialize() is called

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -36,6 +36,7 @@ abstract class Materializer {
    * stream. The result can be highly implementation specific, ranging from
    * local actor chains to remote-deployed processing networks.
    */
+  // TODO can we deprecate this overload?
   def materialize[Mat](runnable: Graph[ClosedShape, Mat]): Mat
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -95,8 +95,15 @@ private[akka] class SubFusingActorMaterializerImpl(val delegate: ExtendedActorMa
 
   override def executionContext: ExecutionContextExecutor = delegate.executionContext
 
-  override def materialize[Mat](runnable: Graph[ClosedShape, Mat]): Mat =
-    delegate.materialize(runnable)
+  override def materialize[Mat](runnable: Graph[ClosedShape, Mat]): Mat = 
+    delegate match {
+      case am: PhasedFusingActorMaterializer => 
+        materialize(runnable, am.defaultInitialAttributes)
+        
+      case other => 
+        throw new IllegalStateException(s"SubFusing only supported by [PhasedFusingActorMaterializer], " +
+          s"yet was used with [${other.getClass.getName}]!")
+    }
 
   override def materialize[Mat](runnable: Graph[ClosedShape, Mat], initialAttributes: Attributes): Mat = {
     if (PhasedFusingActorMaterializer.Debug) println(s"Using [${getClass.getSimpleName}] to materialize [${runnable}]")

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -365,7 +365,8 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
 
   private[this] def createFlowName(): String = flowNames.next()
 
-  private val defaultInitialAttributes = {
+  /** INTERNAL API */
+  private[akka] val defaultInitialAttributes = {
     val a = Attributes(
       Attributes.InputBuffer(settings.initialInputBufferSize, settings.maxInputBufferSize) ::
         ActorAttributes.SupervisionStrategy(settings.supervisionDecider) ::


### PR DESCRIPTION
A pretty simple fix to https://github.com/akka/akka/issues/22584
Should we deprecate the overload without the params right away btw? Having two is a bit confusing, as witnessed here - in my benchmarking I used the other one it seems, yet in real world the one now fixed was used.