### PR TITLE
AbstractPersistentFSM should have getContext, getSelf, getSender

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
@@ -642,6 +642,32 @@ abstract class AbstractPersistentFSMBase[S, D, E] extends PersistentFSMBase[S, D
   import PersistentFSM._
 
   /**
+    * Returns this AbstractActor's ActorContext
+    * The ActorContext is not thread safe so do not expose it outside of the
+    * AbstractActor.
+    */
+  def getContext(): AbstractActor.ActorContext = context.asInstanceOf[AbstractActor.ActorContext]
+
+  /**
+    * Returns the ActorRef for this actor.
+    *
+    * Same as `self()`.
+    */
+  def getSelf(): ActorRef = self
+
+  /**
+    * The reference sender Actor of the currently processed message. This is
+    * always a legal destination to send to, even if there is no logical recipient
+    * for the reply, in which case it will be sent to the dead letter mailbox.
+    *
+    * Same as `sender()`.
+    *
+    * WARNING: Only valid within the Actor itself, so do not close over it and
+    * publish it to other threads!
+    */
+  def getSender(): ActorRef = sender()
+
+  /**
    * Insert a new StateFunction at the end of the processing chain for the
    * given state.
    *

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
  *     startWith(One, Data(42))
  *     when(One) {
  *         case Event(SomeMsg, Data(x)) => ...
- *         case Ev(SomeMsg) => ... // convenience when data not needed
+ *         case Event(SomeOtherMsg, _) => ... // convenience when data not needed
  *     }
  *     when(Two, stateTimeout = 5 seconds) { ... }
  *     initialize()
@@ -642,29 +642,29 @@ abstract class AbstractPersistentFSMBase[S, D, E] extends PersistentFSMBase[S, D
   import PersistentFSM._
 
   /**
-    * Returns this AbstractActor's ActorContext
-    * The ActorContext is not thread safe so do not expose it outside of the
-    * AbstractActor.
-    */
+   * Returns this AbstractActor's ActorContext
+   * The ActorContext is not thread safe so do not expose it outside of the
+   * AbstractActor.
+   */
   def getContext(): AbstractActor.ActorContext = context.asInstanceOf[AbstractActor.ActorContext]
 
   /**
-    * Returns the ActorRef for this actor.
-    *
-    * Same as `self()`.
-    */
+   * Returns the ActorRef for this actor.
+   *
+   * Same as `self()`.
+   */
   def getSelf(): ActorRef = self
 
   /**
-    * The reference sender Actor of the currently processed message. This is
-    * always a legal destination to send to, even if there is no logical recipient
-    * for the reply, in which case it will be sent to the dead letter mailbox.
-    *
-    * Same as `sender()`.
-    *
-    * WARNING: Only valid within the Actor itself, so do not close over it and
-    * publish it to other threads!
-    */
+   * The reference sender Actor of the currently processed message. This is
+   * always a legal destination to send to, even if there is no logical recipient
+   * for the reply, in which case it will be sent to the dead letter mailbox.
+   *
+   * Same as `sender()`.
+   *
+   * WARNING: Only valid within the Actor itself, so do not close over it and
+   * publish it to other threads!
+   */
   def getSender(): ActorRef = sender()
 
   /**


### PR DESCRIPTION
Refs #22541

There is required to create at least two intermediate trait in order to make AbstractPersistentFSM extend AbstractActor or AbstractPersistentActor.  Because AbstractPersistentFSMBase is class and it could not mix with AbstractActor or AbstractPersistentActor. 
So I just copied required methods for java api into AbstractPersistentFSMBase.
Or should I create intermediate traits to make AbstractPersistentFSM extend AbstractPersistentActor?