### PR TITLE
Serialization Docs: remove link from Serialization page

### DIFF
--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -242,9 +242,6 @@ incompatibility as Java serialization does.
 External Akka Serializers
 =========================
 
-`Akka-protostuff by Roman Levenstein <https://github.com/romix/akka-protostuff-serialization>`_
-
-
 `Akka-quickser by Roman Levenstein <https://github.com/romix/akka-quickser-serialization>`_
 
 

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -230,9 +230,6 @@ incompatibility as Java serialization does.
 External Akka Serializers
 =========================
 
-`Akka-protostuff by Roman Levenstein <https://github.com/romix/akka-protostuff-serialization>`_
-
-
 `Akka-quickser by Roman Levenstein <https://github.com/romix/akka-quickser-serialization>`_
 
 


### PR DESCRIPTION
The akka-protostuff project on github seems pretty much dead and not working (not even building ..) so we should remove it from the list of external akka serializers.

P.S. The other projects (e.g. akka-quickser) may also be dead - going to investigate ...