### PR TITLE
Serialization Docs: add info about adding a logger

### DIFF
--- a/akka-docs/rst/java/code/jdocs/serialization/SerializationDocTest.java
+++ b/akka-docs/rst/java/code/jdocs/serialization/SerializationDocTest.java
@@ -21,6 +21,11 @@ public class SerializationDocTest {
   //#my-own-serializer
   public class MyOwnSerializer extends JSerializer {
 
+    // If you need logging here, introduce a constructor that takes an ExtendedActorSystem.
+    // public MyOwnSerializer(ExtendedActorSystem actorSystem) 
+    // Get a logger using:
+    // private final LoggingAdapter logger = Logging.getLogger(actorSystem, this); 
+
     // This is whether "fromBinary" requires a "clazz" or not
     @Override public boolean includeManifest() {
       return false;

--- a/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
@@ -19,6 +19,11 @@ package docs.serialization {
 
   //#my-own-serializer
   class MyOwnSerializer extends Serializer {
+    
+    // If you need logging here, introduce a constructor that takes an ExtendedActorSystem.
+    // class MyOwnSerializer(actorSystem: ExtendedActorSystem) extends Serializer
+    // Get a logger using:
+    // private val logger = Logging.getLogger(actorSystem, this)
 
     // This is whether "fromBinary" requires a "clazz" or not
     def includeManifest: Boolean = true

--- a/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
@@ -19,7 +19,7 @@ package docs.serialization {
 
   //#my-own-serializer
   class MyOwnSerializer extends Serializer {
-    
+
     // If you need logging here, introduce a constructor that takes an ExtendedActorSystem.
     // class MyOwnSerializer(actorSystem: ExtendedActorSystem) extends Serializer
     // Get a logger using:

--- a/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/serialization/SerializationDocSpec.scala
@@ -23,7 +23,7 @@ package docs.serialization {
     // If you need logging here, introduce a constructor that takes an ExtendedActorSystem.
     // class MyOwnSerializer(actorSystem: ExtendedActorSystem) extends Serializer
     // Get a logger using:
-    // private val logger = Logging.getLogger(actorSystem, this)
+    // private val logger = Logging(actorSystem, this)
 
     // This is whether "fromBinary" requires a "clazz" or not
     def includeManifest: Boolean = true


### PR DESCRIPTION
When writing a serializer, people want to add some debug log statements to check that their serializer is working :-) So, we need to explain how to get a logger from the ActorSystem.

IMO the best way to do this is in a comment in the code for MyOwnSerializer but wondering if there's any other opinions on this. 