### PR TITLE
Remove use of deprecated Scala features #22581

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
@@ -85,6 +85,12 @@ object DispatchersSpec {
       queue add handle
     }
   }
+
+  // Workaround to narrow the type of unapplySeq of Regex since the unapplySeq(Any) will be removed in Scala 2.13
+  case class R(s: String) {
+    private val r = s.r
+    def unapplySeq(arg: CharSequence) = r.unapplySeq(arg)
+  }
 }
 
 class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSender {
@@ -118,7 +124,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
 
   def assertMyDispatcherIsUsed(actor: ActorRef): Unit = {
     actor ! "what's the name?"
-    val Expected = "(DispatchersSpec-myapp.mydispatcher-[1-9][0-9]*)".r
+    val Expected = R("(DispatchersSpec-myapp.mydispatcher-[1-9][0-9]*)")
     expectMsgPF() {
       case Expected(x) ⇒
     }
@@ -172,7 +178,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
 
     "include system name and dispatcher id in thread names for thread-pool-executor" in {
       system.actorOf(Props[ThreadNameEcho].withDispatcher("myapp.thread-pool-dispatcher")) ! "what's the name?"
-      val Expected = "(DispatchersSpec-myapp.thread-pool-dispatcher-[1-9][0-9]*)".r
+      val Expected = R("(DispatchersSpec-myapp.thread-pool-dispatcher-[1-9][0-9]*)")
       expectMsgPF() {
         case Expected(x) ⇒
       }
@@ -180,7 +186,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
 
     "include system name and dispatcher id in thread names for default-dispatcher" in {
       system.actorOf(Props[ThreadNameEcho]) ! "what's the name?"
-      val Expected = "(DispatchersSpec-akka.actor.default-dispatcher-[1-9][0-9]*)".r
+      val Expected = R("(DispatchersSpec-akka.actor.default-dispatcher-[1-9][0-9]*)")
       expectMsgPF() {
         case Expected(x) ⇒
       }
@@ -188,7 +194,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
 
     "include system name and dispatcher id in thread names for pinned dispatcher" in {
       system.actorOf(Props[ThreadNameEcho].withDispatcher("myapp.my-pinned-dispatcher")) ! "what's the name?"
-      val Expected = "(DispatchersSpec-myapp.my-pinned-dispatcher-[1-9][0-9]*)".r
+      val Expected = R("(DispatchersSpec-myapp.my-pinned-dispatcher-[1-9][0-9]*)")
       expectMsgPF() {
         case Expected(x) ⇒
       }
@@ -196,7 +202,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
 
     "include system name and dispatcher id in thread names for balancing dispatcher" in {
       system.actorOf(Props[ThreadNameEcho].withDispatcher("myapp.balancing-dispatcher")) ! "what's the name?"
-      val Expected = "(DispatchersSpec-myapp.balancing-dispatcher-[1-9][0-9]*)".r
+      val Expected = R("(DispatchersSpec-myapp.balancing-dispatcher-[1-9][0-9]*)")
       expectMsgPF() {
         case Expected(x) ⇒
       }
@@ -216,7 +222,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
       pool ! Identify(None)
       val routee = expectMsgType[ActorIdentity].ref.get
       routee ! "what's the name?"
-      val Expected = """(DispatchersSpec-akka\.actor\.deployment\./pool1\.pool-dispatcher-[1-9][0-9]*)""".r
+      val Expected = R("""(DispatchersSpec-akka\.actor\.deployment\./pool1\.pool-dispatcher-[1-9][0-9]*)""")
       expectMsgPF() {
         case Expected(x) ⇒
       }
@@ -224,7 +230,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
 
     "use balancing-pool router with special routees mailbox of deployment config" in {
       system.actorOf(FromConfig.props(Props[ThreadNameEcho]), name = "balanced") ! "what's the name?"
-      val Expected = """(DispatchersSpec-BalancingPool-/balanced-[1-9][0-9]*)""".r
+      val Expected = R("""(DispatchersSpec-BalancingPool-/balanced-[1-9][0-9]*)""")
       expectMsgPF() {
         case Expected(x) ⇒
       }

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -12,7 +12,6 @@ import java.io._
 import scala.concurrent.Await
 import akka.util.Timeout
 import scala.concurrent.duration._
-import scala.beans.BeanInfo
 import com.typesafe.config._
 import akka.pattern.ask
 import org.apache.commons.codec.binary.Hex.encodeHex
@@ -44,9 +43,8 @@ object SerializationTests {
     }
   """
 
-  @BeanInfo
   final case class Address(no: String, street: String, city: String, zip: String) { def this() = this("", "", "", "") }
-  @BeanInfo
+
   final case class Person(name: String, age: Int, address: Address) { def this() = this("", 0, null) }
 
   final case class Record(id: Int, person: Person)

--- a/akka-actor/build.sbt
+++ b/akka-actor/build.sbt
@@ -5,5 +5,9 @@ Formatting.formatSettings
 OSGi.actor
 Dependencies.actor
 Version.versionSettings
+unmanagedSourceDirectories in Compile += {
+  val ver = scalaVersion.value.take(4)
+  (scalaSource in Compile).value.getParentFile / s"scala-$ver"
+}
 
 enablePlugins(spray.boilerplate.BoilerplatePlugin)

--- a/akka-actor/src/main/scala-2.11/akka/compat/Future.scala
+++ b/akka-actor/src/main/scala-2.11/akka/compat/Future.scala
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.compat
+
+import akka.annotation.InternalApi
+import scala.concurrent.{ ExecutionContext, Future ⇒ SFuture }
+
+/**
+ * INTERNAL API
+ *
+ * Compatibility wrapper for `scala.concurrent.Future` to be able to compile the same code
+ * against Scala 2.11, 2.12, 2.13
+ *
+ * Remove these classes as soon as support for Scala 2.11 is dropped!
+ */
+@InternalApi private[akka] object Future {
+  def fold[T, R](futures: TraversableOnce[SFuture[T]])(zero: R)(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.fold[T, R](futures)(zero)(op)(executor)
+
+  def reduce[T, R >: T](futures: TraversableOnce[SFuture[T]])(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.reduce[T, R](futures)(op)(executor)
+
+  def find[T](futures: TraversableOnce[SFuture[T]])(p: T ⇒ Boolean)(implicit executor: ExecutionContext): SFuture[Option[T]] =
+    SFuture.find[T](futures)(p)(executor)
+}

--- a/akka-actor/src/main/scala-2.12/akka/compat/Future.scala
+++ b/akka-actor/src/main/scala-2.12/akka/compat/Future.scala
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.compat
+
+import akka.annotation.InternalApi
+import scala.concurrent.{ ExecutionContext, Future ⇒ SFuture }
+import scala.collection.immutable
+
+/**
+ * INTERNAL API
+ *
+ * Compatibility wrapper for `scala.concurrent.Future` to be able to compile the same code
+ * against Scala 2.11, 2.12, 2.13
+ *
+ * Remove these classes as soon as support for Scala 2.11 is dropped!
+ */
+@InternalApi private[akka] object Future {
+  def fold[T, R](futures: TraversableOnce[SFuture[T]])(zero: R)(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.fold[T, R](futures)(zero)(op)(executor)
+
+  def fold[T, R](futures: immutable.Iterable[SFuture[T]])(zero: R)(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.foldLeft[T, R](futures)(zero)(op)(executor)
+
+  def reduce[T, R >: T](futures: TraversableOnce[SFuture[T]])(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.reduce[T, R](futures)(op)(executor)
+
+  def reduce[T, R >: T](futures: immutable.Iterable[SFuture[T]])(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.reduceLeft[T, R](futures)(op)(executor)
+
+  def find[T](futures: TraversableOnce[SFuture[T]])(p: T ⇒ Boolean)(implicit executor: ExecutionContext): SFuture[Option[T]] =
+    SFuture.find[T](futures)(p)(executor)
+
+  def find[T](futures: immutable.Iterable[SFuture[T]])(p: T ⇒ Boolean)(implicit executor: ExecutionContext): SFuture[Option[T]] =
+    SFuture.find[T](futures)(p)(executor)
+}
+

--- a/akka-actor/src/main/scala-2.13/akka/compat/Future.scala
+++ b/akka-actor/src/main/scala-2.13/akka/compat/Future.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.compat
+
+import akka.annotation.InternalApi
+import scala.concurrent.{ ExecutionContext, Future ⇒ SFuture }
+import scala.collection.immutable
+
+/**
+ * INTERNAL API
+ *
+ * Compatibility wrapper for `scala.concurrent.Future` to be able to compile the same code
+ * against Scala 2.11, 2.12, 2.13
+ *
+ * Remove these classes as soon as support for Scala 2.11 is dropped!
+ */
+@InternalApi private[akka] object Future {
+  def fold[T, R](futures: TraversableOnce[SFuture[T]])(zero: R)(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] = {
+    // This will have performance implications since the elements are copied to a Vector
+    SFuture.foldLeft[T, R](futures.to[immutable.Iterable])(zero)(op)(executor)
+  }
+
+  def fold[T, R](futures: immutable.Iterable[SFuture[T]])(zero: R)(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.foldLeft[T, R](futures)(zero)(op)(executor)
+
+  def reduce[T, R >: T](futures: TraversableOnce[SFuture[T]])(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] = {
+    // This will have performance implications since the elements are copied to a Vector
+    SFuture.reduceLeft[T, R](futures.to[immutable.Iterable])(op)(executor)
+  }
+
+  def reduce[T, R >: T](futures: immutable.Iterable[SFuture[T]])(op: (R, T) ⇒ R)(implicit executor: ExecutionContext): SFuture[R] =
+    SFuture.reduceLeft[T, R](futures)(op)(executor)
+
+  def find[T](futures: TraversableOnce[SFuture[T]])(p: T ⇒ Boolean)(implicit executor: ExecutionContext): SFuture[Option[T]] = {
+    // This will have performance implications since the elements are copied to a Vector
+    SFuture.find[T](futures.to[immutable.Iterable])(p)(executor)
+  }
+
+  def find[T](futures: immutable.Iterable[SFuture[T]])(p: T ⇒ Boolean)(implicit executor: ExecutionContext): SFuture[Option[T]] =
+    SFuture.find[T](futures)(p)(executor)
+}

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -13,6 +13,8 @@ import java.util.concurrent.{ Executor, ExecutorService, Callable }
 import scala.util.{ Try, Success, Failure }
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
+import scala.collection.immutable
+import akka.compat
 
 /**
  * ExecutionContexts is the Java API for ExecutionContexts
@@ -127,7 +129,7 @@ object Futures {
    */
   def find[T <: AnyRef](futures: JIterable[Future[T]], predicate: JFunc[T, java.lang.Boolean], executor: ExecutionContext): Future[JOption[T]] = {
     implicit val ec = executor
-    Future.find[T](futures.asScala)(predicate.apply(_))(executor) map JOption.fromScalaOption
+    compat.Future.find[T](futures.asScala)(predicate.apply(_))(executor) map JOption.fromScalaOption
   }
 
   /**
@@ -143,13 +145,13 @@ object Futures {
    * or the result of the fold.
    */
   def fold[T <: AnyRef, R <: AnyRef](zero: R, futures: JIterable[Future[T]], fun: akka.japi.Function2[R, T, R], executor: ExecutionContext): Future[R] =
-    Future.fold(futures.asScala)(zero)(fun.apply)(executor)
+    compat.Future.fold(futures.asScala)(zero)(fun.apply)(executor)
 
   /**
    * Reduces the results of the supplied futures and binary function.
    */
   def reduce[T <: AnyRef, R >: T](futures: JIterable[Future[T]], fun: akka.japi.Function2[R, T, R], executor: ExecutionContext): Future[R] =
-    Future.reduce[T, R](futures.asScala)(fun.apply)(executor)
+    compat.Future.reduce[T, R](futures.asScala)(fun.apply)(executor)
 
   /**
    * Simple version of [[#traverse]]. Transforms a JIterable[Future[A]] into a Future[JIterable[A]].

--- a/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
+++ b/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
@@ -15,7 +15,7 @@ class SimpleDnsCache extends Dns with PeriodicCacheCleanup {
 
   private val cache = new AtomicReference(new Cache(
     immutable.SortedSet()(ExpiryEntryOrdering),
-    immutable.Map(), clock))
+    immutable.Map(), clock _))
 
   private val nanoBase = System.nanoTime()
 

--- a/akka-bench-jmh/src/main/scala/akka/BenchRunner.scala
+++ b/akka-bench-jmh/src/main/scala/akka/BenchRunner.scala
@@ -6,7 +6,7 @@ import org.openjdk.jmh.runner.options.CommandLineOptions
 
 object BenchRunner {
   def main(args: Array[String]) = {
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
 
     val args2 = args.toList.flatMap {
       case "quick" => "-i 1 -wi 1 -f1 -t1".split(" ").toList
@@ -18,9 +18,9 @@ object BenchRunner {
     val opts = new CommandLineOptions(args2: _*)
     val results = new Runner(opts).run()
 
-    val report = results.map { result: RunResult ⇒
+    val report = results.asScala.map { result: RunResult ⇒
       val bench = result.getParams.getBenchmark
-      val params = result.getParams.getParamsKeys.map(key => s"$key=${result.getParams.getParam(key)}").mkString("_")
+      val params = result.getParams.getParamsKeys.asScala.map(key => s"$key=${result.getParams.getParam(key)}").mkString("_")
       val score = result.getAggregatedResult.getPrimaryResult.getScore.round
       val unit = result.getAggregatedResult.getPrimaryResult.getScoreUnit
       s"\t${bench}_${params}\t$score\t$unit"

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -10,7 +10,7 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl._
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
-import scala.concurrent.Lock
+import java.util.concurrent.Semaphore
 import scala.util.Success
 import akka.stream.impl.fusing.GraphStages
 import org.reactivestreams._
@@ -119,7 +119,7 @@ class FlowMapBenchmark {
   @Benchmark
   @OperationsPerInvocation(100000)
   def flow_map_100k_elements(): Unit = {
-    val lock = new Lock() // todo rethink what is the most lightweight way to await for a streams completion
+    val lock = new Semaphore(1) // todo rethink what is the most lightweight way to await for a streams completion
     lock.acquire()
 
     flow.runWith(Sink.onComplete(_ ⇒ lock.release()))(materializer)

--- a/akka-camel/src/main/scala/akka/camel/internal/CamelExchangeAdapter.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/CamelExchangeAdapter.scala
@@ -78,8 +78,8 @@ private[camel] class CamelExchangeAdapter(val exchange: Exchange) {
    *                in the exchange.
    */
   def toAkkaCamelException(headers: Map[String, Any]): AkkaCamelException = {
-    import scala.collection.JavaConversions._
-    new AkkaCamelException(exchange.getException, headers ++ response.getHeaders)
+    import scala.collection.JavaConverters._
+    new AkkaCamelException(exchange.getException, headers ++ response.getHeaders.asScala)
   }
 
   /**
@@ -94,8 +94,8 @@ private[camel] class CamelExchangeAdapter(val exchange: Exchange) {
    *                in the Camel message.
    */
   def toFailureResult(headers: Map[String, Any]): FailureResult = {
-    import scala.collection.JavaConversions._
-    FailureResult(exchange.getException, headers ++ response.getHeaders)
+    import scala.collection.JavaConverters._
+    FailureResult(exchange.getException, headers ++ response.getHeaders.asScala)
   }
 
   /**

--- a/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/ConcurrentActivationTest.scala
@@ -133,8 +133,8 @@ class Registrar(val start: Int, val number: Int, activationsPromise: Promise[Lis
       actorRefs.foreach { aref ⇒
         context.stop(aref)
         val result = camel.deactivationFutureFor(aref)
-        result.onFailure {
-          case e ⇒ log.error("deactivationFutureFor {} failed: {}", aref, e.getMessage)
+        result.failed.foreach {
+          e ⇒ log.error("deactivationFutureFor {} failed: {}", aref, e.getMessage)
         }
         deActivations += result
         if (deActivations.size == number * 2) {
@@ -147,8 +147,8 @@ class Registrar(val start: Int, val number: Int, activationsPromise: Promise[Lis
     val ref = context.actorOf(Props(actor), name)
     actorRefs = actorRefs + ref
     val result = camel.activationFutureFor(ref)
-    result.onFailure {
-      case e ⇒ log.error("activationFutureFor {} failed: {}", ref, e.getMessage)
+    result.failed.foreach {
+      e ⇒ log.error("activationFutureFor {} failed: {}", ref, e.getMessage)
     }
     activations += result
   }

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReceivePipeline.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReceivePipeline.scala
@@ -78,7 +78,7 @@ trait ReceivePipeline extends Actor {
     val zipped = pipeline.foldRight(innerReceiveHandler) { (outerInterceptor, innerHandler) ⇒
       outerInterceptor.andThen {
         case Inner(msg)                ⇒ innerHandler(msg)
-        case InnerAndAfter(msg, after) ⇒ try innerHandler(msg) finally after()
+        case InnerAndAfter(msg, after) ⇒ try innerHandler(msg) finally after(())
         case HandledCompletely         ⇒ Done
       }
     }

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -549,7 +549,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def ormapToProto(ormap: ORMap[_, _]): rd.ORMap = {
     val ormapBuilder = rd.ORMap.newBuilder()
-    val entries: jl.Iterable[rd.ORMap.Entry] = getEntries(ormap.values, rd.ORMap.Entry.newBuilder, otherMessageToProto)
+    val entries: jl.Iterable[rd.ORMap.Entry] = getEntries(ormap.values, rd.ORMap.Entry.newBuilder _, otherMessageToProto)
     ormapBuilder.setKeys(orsetToProto(ormap.keys)).addAllEntries(entries).build()
   }
 
@@ -731,7 +731,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def lwwmapToProto(lwwmap: LWWMap[_, _]): rd.LWWMap = {
     val lwwmapBuilder = rd.LWWMap.newBuilder()
-    val entries: jl.Iterable[rd.LWWMap.Entry] = getEntries(lwwmap.underlying.entries, rd.LWWMap.Entry.newBuilder, lwwRegisterToProto)
+    val entries: jl.Iterable[rd.LWWMap.Entry] = getEntries(lwwmap.underlying.entries, rd.LWWMap.Entry.newBuilder _, lwwRegisterToProto)
     lwwmapBuilder.setKeys(orsetToProto(lwwmap.underlying.keys)).addAllEntries(entries).build()
   }
 
@@ -747,7 +747,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def pncountermapToProto(pncountermap: PNCounterMap[_]): rd.PNCounterMap = {
     val pncountermapBuilder = rd.PNCounterMap.newBuilder()
-    val entries: jl.Iterable[rd.PNCounterMap.Entry] = getEntries(pncountermap.underlying.entries, rd.PNCounterMap.Entry.newBuilder, pncounterToProto)
+    val entries: jl.Iterable[rd.PNCounterMap.Entry] = getEntries(pncountermap.underlying.entries, rd.PNCounterMap.Entry.newBuilder _, pncounterToProto)
     pncountermapBuilder.setKeys(orsetToProto(pncountermap.underlying.keys)).addAllEntries(entries).build()
   }
 
@@ -763,7 +763,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
 
   def multimapToProto(multimap: ORMultiMap[_, _]): rd.ORMultiMap = {
     val ormultimapBuilder = rd.ORMultiMap.newBuilder()
-    val entries: jl.Iterable[rd.ORMultiMap.Entry] = getEntries(multimap.underlying.entries, rd.ORMultiMap.Entry.newBuilder, orsetToProto)
+    val entries: jl.Iterable[rd.ORMultiMap.Entry] = getEntries(multimap.underlying.entries, rd.ORMultiMap.Entry.newBuilder _, orsetToProto)
     ormultimapBuilder.setKeys(orsetToProto(multimap.underlying.keys)).addAllEntries(entries)
     if (multimap.withValueDeltas)
       ormultimapBuilder.setWithValueDeltas(true)

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -242,7 +242,7 @@ private[akka] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress)
 
           val cmdFuture = TestConductor().transport.managementCommand(SetThrottle(t.target, t.direction, mode))
 
-          cmdFuture onSuccess {
+          cmdFuture foreach {
             case true ⇒ self ! ToServer(Done)
             case _ ⇒ throw new RuntimeException("Throttle was requested from the TestConductor, but no transport " +
               "adapters available that support throttling. Specify `testTransport(on = true)` in your MultiNodeConfig")

--- a/akka-osgi/src/test/scala/akka/osgi/PojoSRTestSupport.scala
+++ b/akka-osgi/src/test/scala/akka/osgi/PojoSRTestSupport.scala
@@ -5,7 +5,7 @@ package akka.osgi
 
 import de.kalpatec.pojosr.framework.launch.{ BundleDescriptor, PojoServiceRegistryFactory, ClasspathScanner }
 
-import scala.collection.JavaConversions.seqAsJavaList
+import scala.collection.JavaConverters._
 import org.apache.commons.io.IOUtils.copy
 
 import org.osgi.framework._
@@ -40,7 +40,7 @@ trait PojoSRTestSupport extends Suite with BeforeAndAfterAll {
     System.setProperty("org.osgi.framework.storage", "target/akka-osgi/" + UUID.randomUUID().toString)
 
     val bundles = new ClasspathScanner().scanForBundles()
-    bundles.addAll(testBundles)
+    bundles.addAll(testBundles.asJava)
     config.put(PojoServiceRegistryFactory.BUNDLE_DESCRIPTORS, bundles)
 
     val oldErr = System.err

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -150,8 +150,8 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
             highSeqNr ⇒ RecoverySuccess(highSeqNr)
           }.recover {
             case e ⇒ ReplayMessagesFailure(e)
-          }.pipeTo(replyTo).onSuccess {
-            case _ ⇒ if (publish) context.system.eventStream.publish(r)
+          }.pipeTo(replyTo).foreach {
+            _ ⇒ if (publish) context.system.eventStream.publish(r)
           }
 
       case d @ DeleteMessagesTo(persistenceId, toSequenceNr, persistentActor) ⇒

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -761,9 +761,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
 
         // tear down the upstream hub part if downstream lane fails
         // lanes are not completed with success by themselves so we don't have to care about onSuccess
-        completed.onFailure {
-          case reason: Throwable ⇒ hubKillSwitch.abort(reason)
-        }
+        completed.failed.foreach { reason ⇒ hubKillSwitch.abort(reason) }
 
         (resourceLife, compressionAccess, completed)
       }
@@ -788,7 +786,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
 
   private def attachStreamRestart(streamName: String, streamCompleted: Future[Done], restart: () ⇒ Unit): Unit = {
     implicit val ec = materializer.executionContext
-    streamCompleted.onFailure {
+    streamCompleted.failed.foreach {
       case ShutdownSignal     ⇒ // shutdown as expected
       case _: AeronTerminated ⇒ // shutdown already in progress
       case cause if isShutdown ⇒

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -302,12 +302,12 @@ private[remote] object Decoder {
      * External call from ChangeInboundCompression materialized value
      */
     override def runNextActorRefAdvertisement(): Unit =
-      runNextActorRefAdvertisementCb.invoke()
+      runNextActorRefAdvertisementCb.invoke(())
     /**
      * External call from ChangeInboundCompression materialized value
      */
     override def runNextClassManifestAdvertisement(): Unit =
-      runNextClassManifestAdvertisementCb.invoke()
+      runNextClassManifestAdvertisementCb.invoke(())
   }
 
   private[remote] class AccessInboundCompressionFailed

--- a/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
@@ -81,11 +81,11 @@ private[remote] class FailureInjectorTransportAdapter(wrappedTransport: Transpor
     listenAddress:  Address,
     listenerFuture: Future[AssociationEventListener]): Future[AssociationEventListener] = {
     log.warning("FailureInjectorTransport is active on this system. Gremlins might munch your packets.")
-    listenerFuture.onSuccess {
+    listenerFuture.foreach {
       // Side effecting: As this class is not an actor, the only way to safely modify state is through volatile vars.
       // Listen is called only during the initialization of the stack, and upstreamListener is not read before this
       // finishes.
-      case listener: AssociationEventListener ⇒ upstreamListener = Some(listener)
+      listener ⇒ upstreamListener = Some(listener)
     }
     Future.successful(this)
   }
@@ -151,8 +151,8 @@ private[remote] final case class FailureInjectorHandle(
   @volatile private var upstreamListener: HandleEventListener = null
 
   override val readHandlerPromise: Promise[HandleEventListener] = Promise()
-  readHandlerPromise.future.onSuccess {
-    case listener: HandleEventListener ⇒
+  readHandlerPromise.future.foreach {
+    listener ⇒
       upstreamListener = listener
       wrappedHandle.readHandlerPromise.success(this)
   }

--- a/akka-remote/src/test/scala/akka/remote/RemoteInitErrorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteInitErrorSpec.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.concurrent.Eventually._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable.Set
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -38,7 +38,7 @@ class RemoteInitErrorSpec extends FlatSpec with Matchers {
 
   def currentThreadIds(): Set[Long] = {
     val threads = Thread.getAllStackTraces().keySet()
-    threads.collect({ case t: Thread if (!t.isDaemon()) ⇒ t.getId() })
+    threads.asScala.collect({ case t: Thread if (!t.isDaemon()) ⇒ t.getId() })
   }
 
   "Remoting" must "shut down properly on RemoteActorRefProvider initialization failure" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowForeachSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowForeachSpec.scala
@@ -18,8 +18,8 @@ class FlowForeachSpec extends StreamSpec {
   "A Foreach" must {
 
     "call the procedure for each element" in assertAllStagesStopped {
-      Source(1 to 3).runForeach(testActor ! _) onSuccess {
-        case _ ⇒ testActor ! "done"
+      Source(1 to 3).runForeach(testActor ! _) foreach {
+        _ ⇒ testActor ! "done"
       }
       expectMsg(1)
       expectMsg(2)
@@ -28,16 +28,16 @@ class FlowForeachSpec extends StreamSpec {
     }
 
     "complete the future for an empty stream" in assertAllStagesStopped {
-      Source.empty[String].runForeach(testActor ! _) onSuccess {
-        case _ ⇒ testActor ! "done"
+      Source.empty[String].runForeach(testActor ! _) foreach {
+        _ ⇒ testActor ! "done"
       }
       expectMsg("done")
     }
 
     "yield the first error" in assertAllStagesStopped {
       val p = TestPublisher.manualProbe[Int]()
-      Source.fromPublisher(p).runForeach(testActor ! _) onFailure {
-        case ex ⇒ testActor ! ex
+      Source.fromPublisher(p).runForeach(testActor ! _).failed foreach {
+        ex ⇒ testActor ! ex
       }
       val proc = p.expectSubscription()
       proc.expectRequest()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
@@ -109,7 +109,7 @@ class QueueSinkSpec extends StreamSpec {
       sub.sendComplete()
       Await.result(queue.pull(), noMsgTimeout) should be(None)
 
-      queue.pull().onFailure { case e ⇒ e.isInstanceOf[IllegalStateException] should ===(true) }
+      queue.pull().failed.foreach { e ⇒ e.isInstanceOf[IllegalStateException] should ===(true) }
     }
 
     "keep on sending even after the buffer has been full" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSourceSpec.scala
@@ -215,7 +215,7 @@ class QueueSourceSpec extends StreamSpec {
       sub.cancel()
       expectMsg(Done)
 
-      queue.offer(1).onFailure { case e ⇒ e.isInstanceOf[IllegalStateException] should ===(true) }
+      queue.offer(1).failed.foreach { e ⇒ e.isInstanceOf[IllegalStateException] should ===(true) }
     }
 
     "not share future across materializations" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -243,7 +243,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
     "fail if getting the supplier fails" in {
       def failedSupplier(): Supplier[Array[Int]] = throw TE("")
       val future = Source(1 to 100).runWith(StreamConverters.javaCollector(
-        () ⇒ new TestCollector(failedSupplier, accumulator, combiner, finisher)))
+        () ⇒ new TestCollector(failedSupplier _, accumulator _, combiner _, finisher _)))
       a[TE] shouldBe thrownBy {
         Await.result(future, 300.millis)
       }
@@ -254,7 +254,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
         override def get(): Array[Int] = throw TE("")
       }
       val future = Source(1 to 100).runWith(StreamConverters.javaCollector(
-        () ⇒ new TestCollector(failedSupplier, accumulator, combiner, finisher)))
+        () ⇒ new TestCollector(failedSupplier _, accumulator _, combiner _, finisher _)))
       a[TE] shouldBe thrownBy {
         Await.result(future, 300.millis)
       }
@@ -264,7 +264,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       def failedAccumulator(): BiConsumer[Array[Int], Int] = throw TE("")
 
       val future = Source(1 to 100).runWith(StreamConverters.javaCollector(
-        () ⇒ new TestCollector(supplier, failedAccumulator, combiner, finisher)))
+        () ⇒ new TestCollector(supplier _, failedAccumulator _, combiner _, finisher _)))
       a[TE] shouldBe thrownBy {
         Await.result(future, 300.millis)
       }
@@ -276,7 +276,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       }
 
       val future = Source(1 to 100).runWith(StreamConverters.javaCollector(
-        () ⇒ new TestCollector(supplier, failedAccumulator, combiner, finisher)))
+        () ⇒ new TestCollector(supplier _, failedAccumulator _, combiner _, finisher _)))
       a[TE] shouldBe thrownBy {
         Await.result(future, 300.millis)
       }
@@ -286,7 +286,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       def failedFinisher(): function.Function[Array[Int], Int] = throw TE("")
 
       val future = Source(1 to 100).runWith(StreamConverters.javaCollector(
-        () ⇒ new TestCollector(supplier, accumulator, combiner, failedFinisher)))
+        () ⇒ new TestCollector(supplier _, accumulator _, combiner _, failedFinisher _)))
       a[TE] shouldBe thrownBy {
         Await.result(future, 300.millis)
       }
@@ -297,7 +297,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
         override def apply(a: Array[Int]): Int = throw TE("")
       }
       val future = Source(1 to 100).runWith(StreamConverters.javaCollector(
-        () ⇒ new TestCollector(supplier, accumulator, combiner, failedFinisher)))
+        () ⇒ new TestCollector(supplier _, accumulator _, combiner _, failedFinisher _)))
       a[TE] shouldBe thrownBy {
         Await.result(future, 300.millis)
       }

--- a/akka-stream/src/main/scala/akka/stream/impl/CompletedPublishers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/CompletedPublishers.scala
@@ -79,8 +79,8 @@ import scala.concurrent.{ ExecutionContext, Promise }
     try {
       requireNonNullSubscriber(subscriber)
       tryOnSubscribe(subscriber, new MaybeSubscription(subscriber))
-      promise.future onFailure {
-        case error ⇒ tryOnError(subscriber, error)
+      promise.future.failed.foreach {
+        error ⇒ tryOnError(subscriber, error)
       }
     } catch {
       case sv: SpecViolation ⇒ ec.reportFailure(sv)

--- a/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
@@ -293,8 +293,8 @@ import scala.util.control.NonFatal
       }
     }
 
-    private def onResourceReady(f: (S) ⇒ Unit): Unit = resource.future.onSuccess {
-      case resource ⇒ f(resource)
+    private def onResourceReady(f: (S) ⇒ Unit): Unit = resource.future.foreach {
+      resource ⇒ f(resource)
     }
 
     val errorHandler: PartialFunction[Throwable, Unit] = {
@@ -337,7 +337,7 @@ import scala.util.control.NonFatal
       resource = Promise[S]()
       createStream(true)
     })
-    private def closeStage(): Unit = closeAndThen(completeStage)
+    private def closeStage(): Unit = closeAndThen(completeStage _)
 
   }
   override def toString = "UnfoldResourceSourceAsync"

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -23,7 +23,7 @@ import akka.stream.impl.PublisherSource
 import akka.stream.impl.CancellingSubscriber
 import akka.stream.impl.{ Buffer ⇒ BufferImpl }
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
  * INTERNAL API
@@ -245,13 +245,13 @@ import scala.collection.JavaConversions._
 
     private def tryCompleteAll(): Boolean =
       if (activeSubstreamsMap.isEmpty || (!hasNextElement && firstPushCounter == 0)) {
-        for (value ← activeSubstreamsMap.values()) value.complete()
+        for (value ← activeSubstreamsMap.values().asScala) value.complete()
         completeStage()
         true
       } else false
 
     private def fail(ex: Throwable): Unit = {
-      for (value ← activeSubstreamsMap.values()) value.fail(ex)
+      for (value ← activeSubstreamsMap.values().asScala) value.fail(ex)
       failStage(ex)
     }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -395,7 +395,7 @@ object Source {
     read:   function.Function[S, Optional[T]],
     close:  function.Procedure[S]): javadsl.Source[T, NotUsed] =
     new Source(scaladsl.Source.unfoldResource[T, S](
-      create.create,
+      create.create _,
       (s: S) ⇒ read.apply(s).asScala, close.apply))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
@@ -175,7 +175,7 @@ object StreamConverters {
    * and the rest of flow.
    */
   def fromJavaStream[O, S <: java.util.stream.BaseStream[O, S]](stream: function.Creator[java.util.stream.BaseStream[O, S]]): javadsl.Source[O, NotUsed] =
-    new Source(scaladsl.StreamConverters.fromJavaStream(stream.create))
+    new Source(scaladsl.StreamConverters.fromJavaStream(stream.create _))
 
   /**
    * Creates a sink which materializes into a ``CompletionStage`` which will be completed with a result of the Java 8 ``Collector``

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -736,7 +736,7 @@ object Zip {
  *
  * '''Cancels when''' downstream cancels
  */
-final class Zip[A, B] extends ZipWith2[A, B, (A, B)](Pair.apply) {
+final class Zip[A, B] extends ZipWith2[A, B, (A, B)](Tuple2.apply) {
   override def toString = "Zip"
 }
 

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -654,7 +654,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    * handler upon receiving the `onPush()` signal (before invoking the `andThen` function).
    */
   final protected def read[T](in: Inlet[T], andThen: Procedure[T], onClose: Effect): Unit = {
-    read(in)(andThen.apply, onClose.apply)
+    read(in)(andThen.apply, onClose.apply _)
   }
 
   /**

--- a/akka-typed/src/test/scala/akka/typed/AskSpec.scala
+++ b/akka-typed/src/test/scala/akka/typed/AskSpec.scala
@@ -37,7 +37,7 @@ class AskSpec extends TypedSpec with ScalaFutures {
         foo.replyTo ! "foo"
         Same
       case Stop(r) ⇒
-        r ! ()
+        r ! (())
         Stopped
     }
 


### PR DESCRIPTION
Most things are pretty straight forward. Only `Future` has some issues since things that are deprecated in 2.12 don't have the replacement methods available in 2.11, so I've added a compatibility helper that compiles differently on 2.11, 2.12 and 2.13.

Fixes #22581 