### PR TITLE
Handle IncompatibleClassChangeError by writing "fix your akka version"

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -654,11 +654,11 @@ private[akka] class ActorSystemImpl(
             if (cause.isInstanceOf[IncompatibleClassChangeError] && cause.getMessage.startsWith("akka"))
               System.err.println(
                 s"""Detected ${cause.getClass.getName} error, which MAY be caused by incompatible Akka versions on the classpath.
-                   |Please note that a given Akka version MUST be the same across all modules of Akka that you are using,
-                   |e.g. if you use akka-actor [${akka.Version.current} (resolved from current classpath)] all other core
-                   |Akka modules MUST be of the same version. External projects like Alpakka, Persistence plugins or Akka
-                   |HTTP etc. have their own version numbers - please make sure you're using a compatible set of libraries.
-                 """.stripMargin.replaceAll("\n", " "))
+                  | Please note that a given Akka version MUST be the same across all modules of Akka that you are using,
+                  | e.g. if you use akka-actor [${akka.Version.current} (resolved from current classpath)] all other core
+                  | Akka modules MUST be of the same version. External projects like Alpakka, Persistence plugins or Akka
+                  | HTTP etc. have their own version numbers - please make sure you're using a compatible set of libraries.
+                 """.stripMargin.replaceAll("[\r\n]", ""))
 
             if (settings.JvmExitOnFatalError) {
               try {

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -651,6 +651,15 @@ private[akka] class ActorSystemImpl(
         cause match {
           case NonFatal(_) | _: InterruptedException | _: NotImplementedError | _: ControlThrowable ⇒ log.error(cause, "Uncaught error from thread [{}]", thread.getName)
           case _ ⇒
+            if (cause.isInstanceOf[IncompatibleClassChangeError] && cause.getMessage.startsWith("akka"))
+              println(
+                s"""Detected ${cause.getClass.getName} error, which MAY be caused by incompatible Akka versions on the classpath.
+                   |Please note that a given Akka version MUST be the same across all modules of Akka that you are using,
+                   |e.g. if you use akka-actor [${akka.Version.current} (resolved from current classpath)] all other core
+                   |Akka modules MUST be of the same version. External projects like Alpakka, Persistence plugins or Akka
+                   |HTTP etc. have their own version numbers - please make sure you're using a compatible set of libraries.
+                 """.stripMargin.replaceAll("\n", " "))
+
             if (settings.JvmExitOnFatalError) {
               try {
                 markerLogging.error(LogMarker.Security, cause, "Uncaught error from thread [{}] shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled", thread.getName)

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -652,7 +652,7 @@ private[akka] class ActorSystemImpl(
           case NonFatal(_) | _: InterruptedException | _: NotImplementedError | _: ControlThrowable ⇒ log.error(cause, "Uncaught error from thread [{}]", thread.getName)
           case _ ⇒
             if (cause.isInstanceOf[IncompatibleClassChangeError] && cause.getMessage.startsWith("akka"))
-              println(
+              System.err.println(
                 s"""Detected ${cause.getClass.getName} error, which MAY be caused by incompatible Akka versions on the classpath.
                    |Please note that a given Akka version MUST be the same across all modules of Akka that you are using,
                    |e.g. if you use akka-actor [${akka.Version.current} (resolved from current classpath)] all other core


### PR DESCRIPTION
Refs #21891

Test with removed `ActorSystem.isTerminated` method

```scala
class MyActor extends Actor {
  def receive = {
    case _ => println(context.system.isTerminated)
  }
}
```
compiled: 2.4.17
tested: 2.5-SNAPSHOT 