### PR TITLE
delta-aggregation in the ORMap deltas (#22633)

### DIFF
--- a/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
+++ b/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
@@ -10906,19 +10906,30 @@ public final class ReplicatedDataMessages {
        */
       int getZeroTag();
 
-      // optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;
+      // repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;
       /**
-       * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
        */
-      boolean hasEntryData();
+      java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry> 
+          getEntryDataList();
       /**
-       * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
        */
-      akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry getEntryData();
+      akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry getEntryData(int index);
       /**
-       * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
        */
-      akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder getEntryDataOrBuilder();
+      int getEntryDataCount();
+      /**
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       */
+      java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder> 
+          getEntryDataOrBuilderList();
+      /**
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       */
+      akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder getEntryDataOrBuilder(
+          int index);
     }
     /**
      * Protobuf type {@code akka.cluster.ddata.ORMapDeltaGroup.Entry}
@@ -11001,16 +11012,11 @@ public final class ReplicatedDataMessages {
                 break;
               }
               case 34: {
-                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder subBuilder = null;
-                if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                  subBuilder = entryData_.toBuilder();
+                if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                  entryData_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry>();
+                  mutable_bitField0_ |= 0x00000008;
                 }
-                entryData_ = input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.PARSER, extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(entryData_);
-                  entryData_ = subBuilder.buildPartial();
-                }
-                bitField0_ |= 0x00000008;
+                entryData_.add(input.readMessage(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.PARSER, extensionRegistry));
                 break;
               }
             }
@@ -11021,6 +11027,9 @@ public final class ReplicatedDataMessages {
           throw new akka.protobuf.InvalidProtocolBufferException(
               e.getMessage()).setUnfinishedMessage(this);
         } finally {
+          if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+            entryData_ = java.util.Collections.unmodifiableList(entryData_);
+          }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
         }
@@ -11107,33 +11116,47 @@ public final class ReplicatedDataMessages {
         return zeroTag_;
       }
 
-      // optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;
+      // repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;
       public static final int ENTRYDATA_FIELD_NUMBER = 4;
-      private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry entryData_;
+      private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry> entryData_;
       /**
-       * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
        */
-      public boolean hasEntryData() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
-      }
-      /**
-       * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
-       */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry getEntryData() {
+      public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry> getEntryDataList() {
         return entryData_;
       }
       /**
-       * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
        */
-      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder getEntryDataOrBuilder() {
+      public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder> 
+          getEntryDataOrBuilderList() {
         return entryData_;
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       */
+      public int getEntryDataCount() {
+        return entryData_.size();
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry getEntryData(int index) {
+        return entryData_.get(index);
+      }
+      /**
+       * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+       */
+      public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder getEntryDataOrBuilder(
+          int index) {
+        return entryData_.get(index);
       }
 
       private void initFields() {
         operation_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaOp.ORMapPut;
         underlying_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet.getDefaultInstance();
         zeroTag_ = 0;
-        entryData_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.getDefaultInstance();
+        entryData_ = java.util.Collections.emptyList();
       }
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
@@ -11156,8 +11179,8 @@ public final class ReplicatedDataMessages {
           memoizedIsInitialized = 0;
           return false;
         }
-        if (hasEntryData()) {
-          if (!getEntryData().isInitialized()) {
+        for (int i = 0; i < getEntryDataCount(); i++) {
+          if (!getEntryData(i).isInitialized()) {
             memoizedIsInitialized = 0;
             return false;
           }
@@ -11178,8 +11201,8 @@ public final class ReplicatedDataMessages {
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
           output.writeSInt32(3, zeroTag_);
         }
-        if (((bitField0_ & 0x00000008) == 0x00000008)) {
-          output.writeMessage(4, entryData_);
+        for (int i = 0; i < entryData_.size(); i++) {
+          output.writeMessage(4, entryData_.get(i));
         }
         getUnknownFields().writeTo(output);
       }
@@ -11202,9 +11225,9 @@ public final class ReplicatedDataMessages {
           size += akka.protobuf.CodedOutputStream
             .computeSInt32Size(3, zeroTag_);
         }
-        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        for (int i = 0; i < entryData_.size(); i++) {
           size += akka.protobuf.CodedOutputStream
-            .computeMessageSize(4, entryData_);
+            .computeMessageSize(4, entryData_.get(i));
         }
         size += getUnknownFields().getSerializedSize();
         memoizedSerializedSize = size;
@@ -11335,11 +11358,11 @@ public final class ReplicatedDataMessages {
           zeroTag_ = 0;
           bitField0_ = (bitField0_ & ~0x00000004);
           if (entryDataBuilder_ == null) {
-            entryData_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.getDefaultInstance();
+            entryData_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000008);
           } else {
             entryDataBuilder_.clear();
           }
-          bitField0_ = (bitField0_ & ~0x00000008);
           return this;
         }
 
@@ -11384,10 +11407,11 @@ public final class ReplicatedDataMessages {
             to_bitField0_ |= 0x00000004;
           }
           result.zeroTag_ = zeroTag_;
-          if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-            to_bitField0_ |= 0x00000008;
-          }
           if (entryDataBuilder_ == null) {
+            if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              entryData_ = java.util.Collections.unmodifiableList(entryData_);
+              bitField0_ = (bitField0_ & ~0x00000008);
+            }
             result.entryData_ = entryData_;
           } else {
             result.entryData_ = entryDataBuilder_.build();
@@ -11417,8 +11441,31 @@ public final class ReplicatedDataMessages {
           if (other.hasZeroTag()) {
             setZeroTag(other.getZeroTag());
           }
-          if (other.hasEntryData()) {
-            mergeEntryData(other.getEntryData());
+          if (entryDataBuilder_ == null) {
+            if (!other.entryData_.isEmpty()) {
+              if (entryData_.isEmpty()) {
+                entryData_ = other.entryData_;
+                bitField0_ = (bitField0_ & ~0x00000008);
+              } else {
+                ensureEntryDataIsMutable();
+                entryData_.addAll(other.entryData_);
+              }
+              onChanged();
+            }
+          } else {
+            if (!other.entryData_.isEmpty()) {
+              if (entryDataBuilder_.isEmpty()) {
+                entryDataBuilder_.dispose();
+                entryDataBuilder_ = null;
+                entryData_ = other.entryData_;
+                bitField0_ = (bitField0_ & ~0x00000008);
+                entryDataBuilder_ = 
+                  akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                     getEntryDataFieldBuilder() : null;
+              } else {
+                entryDataBuilder_.addAllMessages(other.entryData_);
+              }
+            }
           }
           this.mergeUnknownFields(other.getUnknownFields());
           return this;
@@ -11441,8 +11488,8 @@ public final class ReplicatedDataMessages {
             
             return false;
           }
-          if (hasEntryData()) {
-            if (!getEntryData().isInitialized()) {
+          for (int i = 0; i < getEntryDataCount(); i++) {
+            if (!getEntryData(i).isInitialized()) {
               
               return false;
             }
@@ -11655,116 +11702,239 @@ public final class ReplicatedDataMessages {
           return this;
         }
 
-        // optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;
-        private akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry entryData_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.getDefaultInstance();
-        private akka.protobuf.SingleFieldBuilder<
-            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder> entryDataBuilder_;
-        /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
-         */
-        public boolean hasEntryData() {
-          return ((bitField0_ & 0x00000008) == 0x00000008);
+        // repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;
+        private java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry> entryData_ =
+          java.util.Collections.emptyList();
+        private void ensureEntryDataIsMutable() {
+          if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+            entryData_ = new java.util.ArrayList<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry>(entryData_);
+            bitField0_ |= 0x00000008;
+           }
         }
+
+        private akka.protobuf.RepeatedFieldBuilder<
+            akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder> entryDataBuilder_;
+
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
-        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry getEntryData() {
+        public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry> getEntryDataList() {
           if (entryDataBuilder_ == null) {
-            return entryData_;
+            return java.util.Collections.unmodifiableList(entryData_);
           } else {
-            return entryDataBuilder_.getMessage();
+            return entryDataBuilder_.getMessageList();
           }
         }
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
-        public Builder setEntryData(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry value) {
+        public int getEntryDataCount() {
+          if (entryDataBuilder_ == null) {
+            return entryData_.size();
+          } else {
+            return entryDataBuilder_.getCount();
+          }
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry getEntryData(int index) {
+          if (entryDataBuilder_ == null) {
+            return entryData_.get(index);
+          } else {
+            return entryDataBuilder_.getMessage(index);
+          }
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public Builder setEntryData(
+            int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry value) {
           if (entryDataBuilder_ == null) {
             if (value == null) {
               throw new NullPointerException();
             }
-            entryData_ = value;
+            ensureEntryDataIsMutable();
+            entryData_.set(index, value);
             onChanged();
           } else {
-            entryDataBuilder_.setMessage(value);
+            entryDataBuilder_.setMessage(index, value);
           }
-          bitField0_ |= 0x00000008;
           return this;
         }
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
         public Builder setEntryData(
+            int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder builderForValue) {
+          if (entryDataBuilder_ == null) {
+            ensureEntryDataIsMutable();
+            entryData_.set(index, builderForValue.build());
+            onChanged();
+          } else {
+            entryDataBuilder_.setMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public Builder addEntryData(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry value) {
+          if (entryDataBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureEntryDataIsMutable();
+            entryData_.add(value);
+            onChanged();
+          } else {
+            entryDataBuilder_.addMessage(value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public Builder addEntryData(
+            int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry value) {
+          if (entryDataBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureEntryDataIsMutable();
+            entryData_.add(index, value);
+            onChanged();
+          } else {
+            entryDataBuilder_.addMessage(index, value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public Builder addEntryData(
             akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder builderForValue) {
           if (entryDataBuilder_ == null) {
-            entryData_ = builderForValue.build();
+            ensureEntryDataIsMutable();
+            entryData_.add(builderForValue.build());
             onChanged();
           } else {
-            entryDataBuilder_.setMessage(builderForValue.build());
+            entryDataBuilder_.addMessage(builderForValue.build());
           }
-          bitField0_ |= 0x00000008;
           return this;
         }
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
-        public Builder mergeEntryData(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry value) {
+        public Builder addEntryData(
+            int index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder builderForValue) {
           if (entryDataBuilder_ == null) {
-            if (((bitField0_ & 0x00000008) == 0x00000008) &&
-                entryData_ != akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.getDefaultInstance()) {
-              entryData_ =
-                akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.newBuilder(entryData_).mergeFrom(value).buildPartial();
-            } else {
-              entryData_ = value;
-            }
+            ensureEntryDataIsMutable();
+            entryData_.add(index, builderForValue.build());
             onChanged();
           } else {
-            entryDataBuilder_.mergeFrom(value);
+            entryDataBuilder_.addMessage(index, builderForValue.build());
           }
-          bitField0_ |= 0x00000008;
           return this;
         }
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public Builder addAllEntryData(
+            java.lang.Iterable<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry> values) {
+          if (entryDataBuilder_ == null) {
+            ensureEntryDataIsMutable();
+            super.addAll(values, entryData_);
+            onChanged();
+          } else {
+            entryDataBuilder_.addAllMessages(values);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
         public Builder clearEntryData() {
           if (entryDataBuilder_ == null) {
-            entryData_ = akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.getDefaultInstance();
+            entryData_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000008);
             onChanged();
           } else {
             entryDataBuilder_.clear();
           }
-          bitField0_ = (bitField0_ & ~0x00000008);
           return this;
         }
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
-        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder getEntryDataBuilder() {
-          bitField0_ |= 0x00000008;
-          onChanged();
-          return getEntryDataFieldBuilder().getBuilder();
+        public Builder removeEntryData(int index) {
+          if (entryDataBuilder_ == null) {
+            ensureEntryDataIsMutable();
+            entryData_.remove(index);
+            onChanged();
+          } else {
+            entryDataBuilder_.remove(index);
+          }
+          return this;
         }
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
-        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder getEntryDataOrBuilder() {
-          if (entryDataBuilder_ != null) {
-            return entryDataBuilder_.getMessageOrBuilder();
-          } else {
-            return entryData_;
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder getEntryDataBuilder(
+            int index) {
+          return getEntryDataFieldBuilder().getBuilder(index);
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder getEntryDataOrBuilder(
+            int index) {
+          if (entryDataBuilder_ == null) {
+            return entryData_.get(index);  } else {
+            return entryDataBuilder_.getMessageOrBuilder(index);
           }
         }
         /**
-         * <code>optional .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
          */
-        private akka.protobuf.SingleFieldBuilder<
+        public java.util.List<? extends akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder> 
+             getEntryDataOrBuilderList() {
+          if (entryDataBuilder_ != null) {
+            return entryDataBuilder_.getMessageOrBuilderList();
+          } else {
+            return java.util.Collections.unmodifiableList(entryData_);
+          }
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder addEntryDataBuilder() {
+          return getEntryDataFieldBuilder().addBuilder(
+              akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.getDefaultInstance());
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder addEntryDataBuilder(
+            int index) {
+          return getEntryDataFieldBuilder().addBuilder(
+              index, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.getDefaultInstance());
+        }
+        /**
+         * <code>repeated .akka.cluster.ddata.ORMapDeltaGroup.MapEntry entryData = 4;</code>
+         */
+        public java.util.List<akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder> 
+             getEntryDataBuilderList() {
+          return getEntryDataFieldBuilder().getBuilderList();
+        }
+        private akka.protobuf.RepeatedFieldBuilder<
             akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder> 
             getEntryDataFieldBuilder() {
           if (entryDataBuilder_ == null) {
-            entryDataBuilder_ = new akka.protobuf.SingleFieldBuilder<
+            entryDataBuilder_ = new akka.protobuf.RepeatedFieldBuilder<
                 akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry.Builder, akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntryOrBuilder>(
                     entryData_,
+                    ((bitField0_ & 0x00000008) == 0x00000008),
                     getParentForChildren(),
                     isClean());
             entryData_ = null;
@@ -18398,7 +18568,7 @@ public final class ReplicatedDataMessages {
       "erMessage\032\275\001\n\005Entry\0223\n\toperation\030\001 \002(\0162 ",
       ".akka.cluster.ddata.ORMapDeltaOp\022-\n\nunde" +
       "rlying\030\002 \002(\0132\031.akka.cluster.ddata.ORSet\022" +
-      "\017\n\007zeroTag\030\003 \002(\021\022?\n\tentryData\030\004 \001(\0132,.ak" +
+      "\017\n\007zeroTag\030\003 \002(\021\022?\n\tentryData\030\004 \003(\0132,.ak" +
       "ka.cluster.ddata.ORMapDeltaGroup.MapEntr" +
       "y\"\206\002\n\006LWWMap\022\'\n\004keys\030\001 \002(\0132\031.akka.cluste" +
       "r.ddata.ORSet\0221\n\007entries\030\002 \003(\0132 .akka.cl" +

--- a/akka-distributed-data/src/main/protobuf/ReplicatedDataMessages.proto
+++ b/akka-distributed-data/src/main/protobuf/ReplicatedDataMessages.proto
@@ -87,7 +87,7 @@ message ORMapDeltaGroup {
     required ORMapDeltaOp operation = 1;
     required ORSet underlying = 2;
     required sint32 zeroTag = 3;
-    optional MapEntry entryData = 4;
+    repeated MapEntry entryData = 4;
   }
 
   repeated Entry entries = 1;

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
@@ -6,10 +6,18 @@ package akka.cluster.ddata
 import akka.cluster.Cluster
 import akka.cluster.UniqueAddress
 import akka.annotation.InternalApi
-import akka.cluster.ddata.ORMap.LWWMapTag
+import akka.cluster.ddata.ORMap.ZeroTag
 
 object LWWMap {
-  private val _empty: LWWMap[Any, Any] = new LWWMap(ORMap.emptyWithLWWMapTag)
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] case object LWWMapTag extends ZeroTag {
+    override def zero: DeltaReplicatedData = LWWMap.empty
+    override final val value: Int = 4
+  }
+
+  private val _empty: LWWMap[Any, Any] = new LWWMap(new ORMap(ORSet.empty, Map.empty, zeroTag = LWWMapTag))
   def empty[A, B]: LWWMap[A, B] = _empty.asInstanceOf[LWWMap[A, B]]
   def apply(): LWWMap[Any, Any] = _empty
   /**

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
@@ -8,9 +8,24 @@ import akka.annotation.InternalApi
 import akka.cluster.ddata.ORMap._
 
 object ORMultiMap {
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] case object ORMultiMapTag extends ZeroTag {
+    override def zero: DeltaReplicatedData = ORMultiMap.empty
+    override final val value: Int = 2
+  }
 
-  val _empty: ORMultiMap[Any, Any] = new ORMultiMap(ORMap.emptyWithORMultiMapTag, false)
-  val _emptyWithValueDeltas: ORMultiMap[Any, Any] = new ORMultiMap(ORMap.emptyWithORMultiMapTag, true)
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] case object ORMultiMapWithValueDeltasTag extends ZeroTag {
+    override def zero: DeltaReplicatedData = ORMultiMap.emptyWithValueDeltas
+    override final val value: Int = 3
+  }
+
+  val _empty: ORMultiMap[Any, Any] = new ORMultiMap(new ORMap(ORSet.empty, Map.empty, zeroTag = ORMultiMapTag), false)
+  val _emptyWithValueDeltas: ORMultiMap[Any, Any] = new ORMultiMap(new ORMap(ORSet.empty, Map.empty, zeroTag = ORMultiMapWithValueDeltasTag), true)
   /**
    * Provides an empty multimap.
    */

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
@@ -11,7 +11,15 @@ import akka.annotation.InternalApi
 import akka.cluster.ddata.ORMap._
 
 object PNCounterMap {
-  def empty[A]: PNCounterMap[A] = new PNCounterMap(ORMap.emptyWithPNCounterMapTag)
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] case object PNCounterMapTag extends ZeroTag {
+    override def zero: DeltaReplicatedData = PNCounterMap.empty
+    override final val value: Int = 1
+  }
+
+  def empty[A]: PNCounterMap[A] = new PNCounterMap(new ORMap(ORSet.empty, Map.empty, zeroTag = PNCounterMapTag))
   def apply[A](): PNCounterMap[A] = empty
   /**
    * Java API

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
@@ -439,6 +439,77 @@ class ORMapSpec extends WordSpec with Matchers {
       merged6.entries("c").elements should be(Set("C"))
     }
 
+    "work with delta-coalescing scenario 1" in {
+      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m2 = m1.resetDelta.put(node2, "b", GSet.empty + "B2").updated(node2, "b", GSet.empty[String])(_.add("B3"))
+
+      val merged1 = m1 merge m2
+
+      merged1.entries("a").elements should be(Set("A"))
+      merged1.entries("b").elements should be(Set("B", "B2", "B3"))
+
+      val merged2 = m1 mergeDelta m2.delta.get
+
+      merged2.entries("a").elements should be(Set("A"))
+      merged2.entries("b").elements should be(Set("B", "B2", "B3"))
+
+      val m3 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m4 = m3.resetDelta.put(node2, "b", GSet.empty + "B2").put(node2, "b", GSet.empty + "B3")
+
+      val merged3 = m3 merge m4
+
+      merged3.entries("a").elements should be(Set("A"))
+      merged3.entries("b").elements should be(Set("B", "B3"))
+
+      val merged4 = m3 mergeDelta m4.delta.get
+
+      merged4.entries("a").elements should be(Set("A"))
+      merged4.entries("b").elements should be(Set("B", "B3"))
+
+      val m5 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m6 = m5.resetDelta.put(node2, "b", GSet.empty + "B2").updated(node2, "b", GSet.empty[String])(_.add("B3"))
+        .updated(node2, "b", GSet.empty[String])(_.add("B4"))
+
+      val merged5 = m5 merge m6
+
+      merged5.entries("a").elements should be(Set("A"))
+      merged5.entries("b").elements should be(Set("B", "B2", "B3", "B4"))
+
+      val merged6 = m5 mergeDelta m6.delta.get
+
+      merged6.entries("a").elements should be(Set("A"))
+      merged6.entries("b").elements should be(Set("B", "B2", "B3", "B4"))
+
+      val m7 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m8 = m7.resetDelta.put(node2, "b", GSet.empty + "B2").put(node2, "d", GSet.empty + "D").put(node2, "b", GSet.empty + "B3")
+
+      val merged7 = m7 merge m8
+
+      merged7.entries("a").elements should be(Set("A"))
+      merged7.entries("b").elements should be(Set("B", "B3"))
+      merged7.entries("d").elements should be(Set("D"))
+
+      val merged8 = m7 mergeDelta m8.delta.get
+
+      merged8.entries("a").elements should be(Set("A"))
+      merged8.entries("b").elements should be(Set("B", "B3"))
+      merged8.entries("d").elements should be(Set("D"))
+
+      val m9 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m10 = m9.resetDelta.put(node2, "b", GSet.empty + "B2").put(node2, "d", GSet.empty + "D")
+        .remove(node2, "d").put(node2, "b", GSet.empty + "B3")
+
+      val merged9 = m9 merge m10
+
+      merged9.entries("a").elements should be(Set("A"))
+      merged9.entries("b").elements should be(Set("B", "B3"))
+
+      val merged10 = m9 mergeDelta m10.delta.get
+
+      merged10.entries("a").elements should be(Set("A"))
+      merged10.entries("b").elements should be(Set("B", "B3"))
+    }
+
     "work with deltas and updated for GSet elements type" in {
       val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A")
       val m2 = m1.resetDelta.updated(node1, "a", GSet.empty[String])(_.add("B"))

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
@@ -133,6 +133,12 @@ class ORMultiMapSpec extends WordSpec with Matchers {
     merged3.entries("a") should be(Set("A"))
     merged3.entries("b") should be(Set("B2"))
     merged3.entries("c") should be(Set("C"))
+
+    val merged4 = merged1 mergeDelta m3.delta.get.merge(m4.delta.get)
+
+    merged4.entries("a") should be(Set("A"))
+    merged4.entries("b") should be(Set("B2"))
+    merged4.entries("c") should be(Set("C"))
   }
 
   "not have usual anomalies for remove+addBinding scenario and delta-deltas 2" in {
@@ -179,6 +185,217 @@ class ORMultiMapSpec extends WordSpec with Matchers {
     merged6.entries("a") should be(Set("A"))
     merged6.entries("b") should be(Set("B2"))
     merged6.entries("c") should be(Set("C"))
+  }
+
+  "work with delta-coalescing scenario 1" in {
+    val m1 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m2 = m1.resetDelta.put(node2, "b", Set("B2")).addBinding(node2, "b", "B3")
+
+    val merged1 = m1 merge m2
+
+    merged1.entries("a") should be(Set("A"))
+    merged1.entries("b") should be(Set("B2", "B3"))
+
+    val merged2 = m1 mergeDelta m2.delta.get
+
+    merged2.entries("a") should be(Set("A"))
+    merged2.entries("b") should be(Set("B2", "B3"))
+
+    val m3 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m4 = m3.resetDelta.put(node2, "b", Set("B2")).put(node2, "b", Set("B3"))
+
+    val merged3 = m3 merge m4
+
+    merged3.entries("a") should be(Set("A"))
+    merged3.entries("b") should be(Set("B3"))
+
+    val merged4 = m3 mergeDelta m4.delta.get
+
+    merged4.entries("a") should be(Set("A"))
+    merged4.entries("b") should be(Set("B3"))
+
+    val m5 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m6 = m5.resetDelta.put(node2, "b", Set("B2")).addBinding(node2, "b", "B3").addBinding(node2, "b", "B4")
+
+    val merged5 = m5 merge m6
+
+    merged5.entries("a") should be(Set("A"))
+    merged5.entries("b") should be(Set("B2", "B3", "B4"))
+
+    val merged6 = m5 mergeDelta m6.delta.get
+
+    merged6.entries("a") should be(Set("A"))
+    merged6.entries("b") should be(Set("B2", "B3", "B4"))
+
+    val m7 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m8 = m7.resetDelta.put(node2, "d", Set("D")).addBinding(node2, "b", "B3").put(node2, "b", Set("B4"))
+
+    val merged7 = m7 merge m8
+
+    merged7.entries("a") should be(Set("A"))
+    merged7.entries("b") should be(Set("B4"))
+    merged7.entries("d") should be(Set("D"))
+
+    val merged8 = m7 mergeDelta m8.delta.get
+
+    merged8.entries("a") should be(Set("A"))
+    merged8.entries("b") should be(Set("B4"))
+    merged8.entries("d") should be(Set("D"))
+
+    val m9 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m10 = m9.resetDelta.addBinding(node2, "b", "B3").addBinding(node2, "b", "B4")
+
+    val merged9 = m9 merge m10
+
+    merged9.entries("a") should be(Set("A"))
+    merged9.entries("b") should be(Set("B", "B3", "B4"))
+
+    val merged10 = m9 mergeDelta m10.delta.get
+
+    merged10.entries("a") should be(Set("A"))
+    merged10.entries("b") should be(Set("B", "B3", "B4"))
+
+    val m11 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B", "B1"))
+      .remove(node1, "b")
+    val m12 = m11.resetDelta.addBinding(node2, "b", "B2").addBinding(node2, "b", "B3")
+
+    val merged11 = m11 merge m12
+
+    merged11.entries("a") should be(Set("A"))
+    merged11.entries("b") should be(Set("B2", "B3"))
+
+    val merged12 = m11 mergeDelta m12.delta.get
+
+    merged12.entries("a") should be(Set("A"))
+    merged12.entries("b") should be(Set("B2", "B3"))
+
+    val m13 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B", "B1"))
+      .remove(node1, "b")
+    val m14 = m13.resetDelta.addBinding(node2, "b", "B2").put(node2, "b", Set("B3"))
+
+    val merged13 = m13 merge m14
+
+    merged13.entries("a") should be(Set("A"))
+    merged13.entries("b") should be(Set("B3"))
+
+    val merged14 = m13 mergeDelta m14.delta.get
+
+    merged14.entries("a") should be(Set("A"))
+    merged14.entries("b") should be(Set("B3"))
+
+    val m15 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B", "B1"))
+      .put(node1, "c", Set("C"))
+    val m16 = m15.resetDelta.addBinding(node2, "b", "B2").addBinding(node2, "c", "C1")
+
+    val merged15 = m15 merge m16
+
+    merged15.entries("a") should be(Set("A"))
+    merged15.entries("b") should be(Set("B", "B1", "B2"))
+    merged15.entries("c") should be(Set("C", "C1"))
+
+    val merged16 = m15 mergeDelta m16.delta.get
+
+    merged16.entries("a") should be(Set("A"))
+    merged16.entries("b") should be(Set("B", "B1", "B2"))
+    merged16.entries("c") should be(Set("C", "C1"))
+
+    // somewhat artificial setup
+    val m17 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B", "B1"))
+    val m18 = m17.resetDelta.addBinding(node2, "b", "B2")
+    val m19 = ORMultiMap.emptyWithValueDeltas[String, String].resetDelta.put(node2, "b", Set("B3"))
+
+    val merged17 = m17 merge m18 merge m19
+
+    merged17.entries("a") should be(Set("A"))
+    merged17.entries("b") should be(Set("B", "B1", "B3"))
+
+    val merged18 = m17 mergeDelta m18.delta.get.merge(m19.delta.get)
+
+    merged18.entries("a") should be(Set("A"))
+    merged18.entries("b") should be(Set("B", "B1", "B3"))
+  }
+
+  "work with delta-coalescing scenario 2" in {
+    val m1 = ORMultiMap.empty[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m2 = m1.resetDelta.put(node2, "b", Set("B2")).addBinding(node2, "b", "B3")
+
+    val merged1 = m1 merge m2
+
+    merged1.entries("a") should be(Set("A"))
+    merged1.entries("b") should be(Set("B2", "B3"))
+
+    val merged2 = m1 mergeDelta m2.delta.get
+
+    merged2.entries("a") should be(Set("A"))
+    merged2.entries("b") should be(Set("B2", "B3"))
+
+    val m3 = ORMultiMap.empty[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m4 = m3.resetDelta.put(node2, "b", Set("B2")).put(node2, "b", Set("B3"))
+
+    val merged3 = m3 merge m4
+
+    merged3.entries("a") should be(Set("A"))
+    merged3.entries("b") should be(Set("B3"))
+
+    val merged4 = m3 mergeDelta m4.delta.get
+
+    merged4.entries("a") should be(Set("A"))
+    merged4.entries("b") should be(Set("B3"))
+
+    val m5 = ORMultiMap.empty[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m6 = m5.resetDelta.put(node2, "b", Set("B2")).addBinding(node2, "b", "B3").addBinding(node2, "b", "B4")
+
+    val merged5 = m5 merge m6
+
+    merged5.entries("a") should be(Set("A"))
+    merged5.entries("b") should be(Set("B2", "B3", "B4"))
+
+    val merged6 = m5 mergeDelta m6.delta.get
+
+    merged6.entries("a") should be(Set("A"))
+    merged6.entries("b") should be(Set("B2", "B3", "B4"))
+
+    val m7 = ORMultiMap.empty[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m8 = m7.resetDelta.put(node2, "d", Set("D")).addBinding(node2, "b", "B3").put(node2, "b", Set("B4"))
+
+    val merged7 = m7 merge m8
+
+    merged7.entries("a") should be(Set("A"))
+    merged7.entries("b") should be(Set("B4"))
+    merged7.entries("d") should be(Set("D"))
+
+    val merged8 = m7 mergeDelta m8.delta.get
+
+    merged8.entries("a") should be(Set("A"))
+    merged8.entries("b") should be(Set("B4"))
+    merged8.entries("d") should be(Set("D"))
+
+    val m9 = ORMultiMap.empty[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
+    val m10 = m9.resetDelta.addBinding(node2, "b", "B3").addBinding(node2, "b", "B4")
+
+    val merged9 = m9 merge m10
+
+    merged9.entries("a") should be(Set("A"))
+    merged9.entries("b") should be(Set("B", "B3", "B4"))
+
+    val merged10 = m9 mergeDelta m10.delta.get
+
+    merged10.entries("a") should be(Set("A"))
+    merged10.entries("b") should be(Set("B", "B3", "B4"))
+
+    val m11 = ORMultiMap.empty[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B", "B1"))
+      .remove(node1, "b")
+    val m12 = ORMultiMap.empty[String, String].addBinding(node2, "b", "B2").addBinding(node2, "b", "B3")
+
+    val merged11 = m11 merge m12
+
+    merged11.entries("a") should be(Set("A"))
+    merged11.entries("b") should be(Set("B2", "B3"))
+
+    val merged12 = m11 mergeDelta m12.delta.get
+
+    merged12.entries("a") should be(Set("A"))
+    merged12.entries("b") should be(Set("B2", "B3"))
   }
 
   "have unapply extractor" in {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
@@ -263,6 +263,10 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem(
       val m1 = ORMultiMap.empty[String, String].addBinding(address1, "a", "A1").addBinding(address2, "a", "A2")
       val m2 = ORMultiMap.empty[String, String].put(address2, "b", Set("B1", "B2", "B3"))
       checkSameContent(m1.merge(m2), m2.merge(m1))
+      checkSerialization(ORMultiMap.empty[String, String].addBinding(address1, "a", "A1").addBinding(address1, "a", "A2").delta.get)
+      val m3 = ORMultiMap.empty[String, String].addBinding(address1, "a", "A1")
+      val d3 = m3.resetDelta.addBinding(address1, "a", "A2").addBinding(address1, "a", "A3").delta.get
+      checkSerialization(d3)
     }
 
     "be compatible with old ORMultiMap serialization" in {


### PR DESCRIPTION
* Deltas for ORMap are now aggregated - two consecutive Puts for the same key and two consecutive Updates are now being coalesced together
* Tag types are moved to relevant map types
* Minor issue with wrong type of tag of ORMultiMap.withValueDeltas is fixed