### PR TITLE
failed: BalancingSpec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
@@ -17,6 +17,9 @@ object BalancingSpec {
 
   class Worker(latch: TestLatch) extends Actor {
     lazy val id = counter.getAndIncrement()
+
+    override def preStart(): Unit = latch.countDown()
+
     def receive = {
       case msg: Int ⇒
         if (id != 1)
@@ -65,6 +68,10 @@ class BalancingSpec extends AkkaSpec(
   }
 
   def test(pool: ActorRef, latch: TestLatch): Unit = {
+    // wait until all routees have started
+    Await.ready(latch, remainingOrDefault)
+
+    latch.reset()
     val iterationCount = 100
 
     for (i ← 1 to iterationCount) {
@@ -77,7 +84,7 @@ class BalancingSpec extends AkkaSpec(
     // all replies from the unblocked worker so far
     replies1.toSet should be(Set(1))
 
-    latch.countDown()
+    latch.open()
     val replies2 = receiveN(poolSize - 1)
     // the remaining replies come from the blocked
     replies2.toSet should be((2 to poolSize).toSet)
@@ -88,21 +95,21 @@ class BalancingSpec extends AkkaSpec(
   "balancing pool" must {
 
     "deliver messages in a balancing fashion when defined programatically" in {
-      val latch = TestLatch(1)
+      val latch = TestLatch(poolSize)
       val pool = system.actorOf(BalancingPool(poolSize).props(routeeProps =
         Props(classOf[Worker], latch)), name = "balancingPool-1")
       test(pool, latch)
     }
 
     "deliver messages in a balancing fashion when defined in config" in {
-      val latch = TestLatch(1)
+      val latch = TestLatch(poolSize)
       val pool = system.actorOf(FromConfig().props(routeeProps =
         Props(classOf[Worker], latch)), name = "balancingPool-2")
       test(pool, latch)
     }
 
     "deliver messages in a balancing fashion when overridden in config" in {
-      val latch = TestLatch(1)
+      val latch = TestLatch(poolSize)
       val pool = system.actorOf(BalancingPool(1).props(routeeProps =
         Props(classOf[Worker], latch)), name = "balancingPool-3")
       test(pool, latch)


### PR DESCRIPTION
Refs #22040

One of the reason of this failure is some routees are not started in time. This failure can be simulated by putting this statement `if (id == 2) Thread.sleep(1000)` before [this line](https://github.com/akka/akka/blob/789626c0437d3a39636e0481d441ec6f0253c73f/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala#L20)

It is better to wait for routees until they have started.