### PR TITLE
Don't leak sub flows when mat fails

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -532,7 +532,14 @@ final private[stream] class LazySink[T, M](sinkFactory: T ⇒ Future[Sink[T, M]]
         }
 
         switchToFirstElementHandlers()
-        promise.trySuccess(Source.fromGraph(sourceOut.source).runWith(sink)(interpreter.subFusingMaterializer))
+        try {
+          val matVal = Source.fromGraph(sourceOut.source).runWith(sink)(interpreter.subFusingMaterializer)
+          promise.trySuccess(matVal)
+        } catch {
+          case NonFatal(ex) ⇒
+            promise.tryFailure(ex)
+            failStage(ex)
+        }
       }
 
     }


### PR DESCRIPTION
Some I fixed, some I just added test coverage for, but were already behaving.

Refs #22646