### PR TITLE
Make viaMat on identity Flow preserve upstreams/downstreams #22585

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -50,7 +50,7 @@ final class Flow[-In, +Out, +Mat](override val module: Module)
         if (combine == Keep.left) {
           if (IgnorableMatValComp(m)) Ignore else Transform(_ ⇒ NotUsed, Atomic(m))
         } else Combine(combine.asInstanceOf[(Any, Any) ⇒ Any], Ignore, Atomic(m))
-      new Flow(CompositeModule(Set(m), m.shape, empty, empty, mat, Attributes.none))
+      new Flow(CompositeModule(Set(m), m.shape, m.downstreams, m.upstreams, mat, m.attributes))
     } else {
       val flowCopy = flow.module.carbonCopy
       new Flow(


### PR DESCRIPTION
Fixes #22585

Passes all `akka-stream-tests`, `akka-stream-test-tck` and also `akka-http` tests.
