### PR TITLE
Serialization Docs: Better intro to custom serializer section

### DIFF
--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -95,14 +95,12 @@ For more information, have a look at the ``ScalaDoc`` for ``akka.serialization._
 Customization
 =============
 
-So, lets say that you want to create your own ``Serializer``,
-you saw the ``docs.serialization.MyOwnSerializer`` in the config example above?
+The first code snippet on this page contains a configuration file that references a custom serializer ``docs.serialization.MyOwnSerializer``. How would we go about creating such a custom serializer ?
 
 Creating new Serializers
 ------------------------
 
-First you need to create a class definition of your ``Serializer``,
-which is done by extending ``akka.serialization.JSerializer``, like this:
+A custom ``Serializer`` has to inherit from ``akka.serialization.JSerializer`` and can be defined like the following:
 
 .. includecode:: code/jdocs/serialization/SerializationDocTest.java
    :include: imports

--- a/akka-docs/rst/java/serialization.rst
+++ b/akka-docs/rst/java/serialization.rst
@@ -95,7 +95,7 @@ For more information, have a look at the ``ScalaDoc`` for ``akka.serialization._
 Customization
 =============
 
-The first code snippet on this page contains a configuration file that references a custom serializer ``docs.serialization.MyOwnSerializer``. How would we go about creating such a custom serializer ?
+The first code snippet on this page contains a configuration file that references a custom serializer ``docs.serialization.MyOwnSerializer``. How would we go about creating such a custom serializer?
 
 Creating new Serializers
 ------------------------

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -89,13 +89,12 @@ For more information, have a look at the ``ScalaDoc`` for ``akka.serialization._
 Customization
 =============
 
-So, lets say that you want to create your own ``Serializer``,
-you saw the ``docs.serialization.MyOwnSerializer`` in the config example above?
+The first code snippet on this page contains a configuration file that references a custom serializer ``docs.serialization.MyOwnSerializer``. How would we go about creating such a custom serializer ?
 
 Creating new Serializers
 ------------------------
 
-First you need to create a class definition of your ``Serializer`` like so:
+A custom ``Serializer`` has to inherit from ``akka.serialization.Serializer`` and can be defined like the following:
 
 .. includecode:: code/docs/serialization/SerializationDocSpec.scala
    :include: imports,my-own-serializer

--- a/akka-docs/rst/scala/serialization.rst
+++ b/akka-docs/rst/scala/serialization.rst
@@ -89,7 +89,7 @@ For more information, have a look at the ``ScalaDoc`` for ``akka.serialization._
 Customization
 =============
 
-The first code snippet on this page contains a configuration file that references a custom serializer ``docs.serialization.MyOwnSerializer``. How would we go about creating such a custom serializer ?
+The first code snippet on this page contains a configuration file that references a custom serializer ``docs.serialization.MyOwnSerializer``. How would we go about creating such a custom serializer?
 
 Creating new Serializers
 ------------------------


### PR DESCRIPTION
The intro sentence to the Custom Serializer section need a bit rephrasing. 

The original is "So, lets say that you want to create your own Serializer, you saw the docs.serialization.MyOwnSerializer in the config example above?" .... can we come up with a better intro paragraph here ? 