### PR TITLE
Handle delta None correctly, #22655

### DIFF
--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
@@ -345,13 +345,15 @@ final class ORSet[A] private[akka] (
    * INTERNAL API
    */
   @InternalApi private[akka] def remove(node: UniqueAddress, element: A): ORSet[A] = {
-    val deltaDot = VersionVector(node, vvector.versionAt(node))
-    val rmOp = ORSet.RemoveDeltaOp(new ORSet(Map(element → deltaDot), vvector))
-    val newDelta = delta match {
-      case None    ⇒ rmOp
-      case Some(d) ⇒ d.merge(rmOp)
-    }
-    assignAncestor(copy(elementsMap = elementsMap - element, delta = Some(newDelta)))
+    // FIXME use full state for removals, until issue #22648 is fixed
+    //    val deltaDot = VersionVector(node, vvector.versionAt(node))
+    //    val rmOp = ORSet.RemoveDeltaOp(new ORSet(Map(element → deltaDot), vvector))
+    //    val newDelta = delta match {
+    //      case None    ⇒ rmOp
+    //      case Some(d) ⇒ d.merge(rmOp)
+    //    }
+    //    assignAncestor(copy(elementsMap = elementsMap - element, delta = Some(newDelta)))
+    assignAncestor(copy(elementsMap = elementsMap - element, delta = None))
   }
 
   /**

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounter.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounter.scala
@@ -97,19 +97,15 @@ final class PNCounter private[akka] (
       decrements = that.decrements.merge(this.decrements))
 
   override def delta: Option[PNCounter] = {
-    if (increments.delta.isEmpty && decrements.delta.isEmpty)
-      None
-    else {
-      val incrementsDelta = increments.delta match {
-        case Some(d) ⇒ d
-        case None    ⇒ GCounter.empty
-      }
-      val decrementsDelta = decrements.delta match {
-        case Some(d) ⇒ d
-        case None    ⇒ GCounter.empty
-      }
-      Some(new PNCounter(incrementsDelta, decrementsDelta))
+    val incrementsDelta = increments.delta match {
+      case Some(d) ⇒ d
+      case None    ⇒ GCounter.empty
     }
+    val decrementsDelta = decrements.delta match {
+      case Some(d) ⇒ d
+      case None    ⇒ GCounter.empty
+    }
+    Some(new PNCounter(incrementsDelta, decrementsDelta))
   }
 
   override def mergeDelta(thatDelta: PNCounter): PNCounter = merge(thatDelta)

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -123,29 +123,29 @@ object ReplicatorSettings {
  *        in the `Set`.
  */
 final class ReplicatorSettings(
-  val role:                           Option[String],
-  val gossipInterval:                 FiniteDuration,
-  val notifySubscribersInterval:      FiniteDuration,
-  val maxDeltaElements:               Int,
-  val dispatcher:                     String,
-  val pruningInterval:                FiniteDuration,
-  val maxPruningDissemination:        FiniteDuration,
-  val durableStoreProps:              Either[(String, Config), Props],
-  val durableKeys:                    Set[KeyId],
-  val pruningMarkerTimeToLive:        FiniteDuration,
+  val role: Option[String],
+  val gossipInterval: FiniteDuration,
+  val notifySubscribersInterval: FiniteDuration,
+  val maxDeltaElements: Int,
+  val dispatcher: String,
+  val pruningInterval: FiniteDuration,
+  val maxPruningDissemination: FiniteDuration,
+  val durableStoreProps: Either[(String, Config), Props],
+  val durableKeys: Set[KeyId],
+  val pruningMarkerTimeToLive: FiniteDuration,
   val durablePruningMarkerTimeToLive: FiniteDuration,
-  val deltaCrdtEnabled:               Boolean) {
+  val deltaCrdtEnabled: Boolean) {
 
   // For backwards compatibility
   def this(role: Option[String], gossipInterval: FiniteDuration, notifySubscribersInterval: FiniteDuration,
-           maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration) =
+    maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration) =
     this(role, gossipInterval, notifySubscribersInterval, maxDeltaElements, dispatcher, pruningInterval,
       maxPruningDissemination, Right(Props.empty), Set.empty, 6.hours, 10.days, true)
 
   // For backwards compatibility
   def this(role: Option[String], gossipInterval: FiniteDuration, notifySubscribersInterval: FiniteDuration,
-           maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration,
-           durableStoreProps: Either[(String, Config), Props], durableKeys: Set[String]) =
+    maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration,
+    durableStoreProps: Either[(String, Config), Props], durableKeys: Set[String]) =
     this(role, gossipInterval, notifySubscribersInterval, maxDeltaElements, dispatcher, pruningInterval,
       maxPruningDissemination, durableStoreProps, durableKeys, 6.hours, 10.days, true)
 
@@ -174,7 +174,7 @@ final class ReplicatorSettings(
     copy(pruningInterval = pruningInterval, maxPruningDissemination = maxPruningDissemination)
 
   def withPruningMarkerTimeToLive(
-    pruningMarkerTimeToLive:        FiniteDuration,
+    pruningMarkerTimeToLive: FiniteDuration,
     durablePruningMarkerTimeToLive: FiniteDuration): ReplicatorSettings =
     copy(
       pruningMarkerTimeToLive = pruningMarkerTimeToLive,
@@ -201,18 +201,18 @@ final class ReplicatorSettings(
     copy(deltaCrdtEnabled = deltaCrdtEnabled)
 
   private def copy(
-    role:                           Option[String]                  = role,
-    gossipInterval:                 FiniteDuration                  = gossipInterval,
-    notifySubscribersInterval:      FiniteDuration                  = notifySubscribersInterval,
-    maxDeltaElements:               Int                             = maxDeltaElements,
-    dispatcher:                     String                          = dispatcher,
-    pruningInterval:                FiniteDuration                  = pruningInterval,
-    maxPruningDissemination:        FiniteDuration                  = maxPruningDissemination,
-    durableStoreProps:              Either[(String, Config), Props] = durableStoreProps,
-    durableKeys:                    Set[KeyId]                      = durableKeys,
-    pruningMarkerTimeToLive:        FiniteDuration                  = pruningMarkerTimeToLive,
-    durablePruningMarkerTimeToLive: FiniteDuration                  = durablePruningMarkerTimeToLive,
-    deltaCrdtEnabled:               Boolean                         = deltaCrdtEnabled): ReplicatorSettings =
+    role: Option[String] = role,
+    gossipInterval: FiniteDuration = gossipInterval,
+    notifySubscribersInterval: FiniteDuration = notifySubscribersInterval,
+    maxDeltaElements: Int = maxDeltaElements,
+    dispatcher: String = dispatcher,
+    pruningInterval: FiniteDuration = pruningInterval,
+    maxPruningDissemination: FiniteDuration = maxPruningDissemination,
+    durableStoreProps: Either[(String, Config), Props] = durableStoreProps,
+    durableKeys: Set[KeyId] = durableKeys,
+    pruningMarkerTimeToLive: FiniteDuration = pruningMarkerTimeToLive,
+    durablePruningMarkerTimeToLive: FiniteDuration = durablePruningMarkerTimeToLive,
+    deltaCrdtEnabled: Boolean = deltaCrdtEnabled): ReplicatorSettings =
     new ReplicatorSettings(role, gossipInterval, notifySubscribersInterval, maxDeltaElements, dispatcher,
       pruningInterval, maxPruningDissemination, durableStoreProps, durableKeys,
       pruningMarkerTimeToLive, durablePruningMarkerTimeToLive, deltaCrdtEnabled)
@@ -436,7 +436,7 @@ object Replicator {
    * for example not access `sender()` reference of an enclosing actor.
    */
   final case class Update[A <: ReplicatedData](key: Key[A], writeConsistency: WriteConsistency,
-                                               request: Option[Any])(val modify: Option[A] ⇒ A)
+    request: Option[Any])(val modify: Option[A] ⇒ A)
     extends Command[A] with NoSerializationVerificationNeeded {
 
     /**
@@ -606,9 +606,9 @@ object Replicator {
      * The `DataEnvelope` wraps a data entry and carries state of the pruning process for the entry.
      */
     final case class DataEnvelope(
-      data:          ReplicatedData,
-      pruning:       Map[UniqueAddress, PruningState] = Map.empty,
-      deltaVersions: VersionVector                    = VersionVector.empty)
+      data: ReplicatedData,
+      pruning: Map[UniqueAddress, PruningState] = Map.empty,
+      deltaVersions: VersionVector = VersionVector.empty)
       extends ReplicatorMessage {
 
       import PruningState._
@@ -1227,7 +1227,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
   def isLocalSender(): Boolean = !replyTo.path.address.hasGlobalScope
 
   def receiveUpdate(key: KeyR, modify: Option[ReplicatedData] ⇒ ReplicatedData,
-                    writeConsistency: WriteConsistency, req: Option[Any]): Unit = {
+    writeConsistency: WriteConsistency, req: Option[Any]): Unit = {
     val localValue = getData(key.id)
 
     def deltaOrPlaceholder(d: DeltaReplicatedData): Option[ReplicatedDelta] = {
@@ -1542,7 +1542,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
         case NonFatal(e) ⇒
           // catching in case we need to support rolling upgrades that are
           // mixing nodes with incompatible delta-CRDT types
-          log.warning("Couldn't process DeltaPropagation from [] due to {}", fromNode, e)
+          log.warning("Couldn't process DeltaPropagation from [{}] due to {}", fromNode, e)
       }
     } else {
       // !deltaCrdtEnabled
@@ -1880,15 +1880,15 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  */
 @InternalApi private[akka] object WriteAggregator {
   def props(
-    key:         KeyR,
-    envelope:    Replicator.Internal.DataEnvelope,
-    delta:       Option[Replicator.Internal.Delta],
+    key: KeyR,
+    envelope: Replicator.Internal.DataEnvelope,
+    delta: Option[Replicator.Internal.Delta],
     consistency: Replicator.WriteConsistency,
-    req:         Option[Any],
-    nodes:       Set[Address],
+    req: Option[Any],
+    nodes: Set[Address],
     unreachable: Set[Address],
-    replyTo:     ActorRef,
-    durable:     Boolean): Props =
+    replyTo: ActorRef,
+    durable: Boolean): Props =
     Props(new WriteAggregator(key, envelope, delta, consistency, req, nodes, unreachable, replyTo, durable))
       .withDeploy(Deploy.local)
 }
@@ -1897,15 +1897,15 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  * INTERNAL API
  */
 @InternalApi private[akka] class WriteAggregator(
-  key:                      KeyR,
-  envelope:                 Replicator.Internal.DataEnvelope,
-  delta:                    Option[Replicator.Internal.Delta],
-  consistency:              Replicator.WriteConsistency,
-  req:                      Option[Any],
-  override val nodes:       Set[Address],
+  key: KeyR,
+  envelope: Replicator.Internal.DataEnvelope,
+  delta: Option[Replicator.Internal.Delta],
+  consistency: Replicator.WriteConsistency,
+  req: Option[Any],
+  override val nodes: Set[Address],
   override val unreachable: Set[Address],
-  replyTo:                  ActorRef,
-  durable:                  Boolean) extends ReadWriteAggregator {
+  replyTo: ActorRef,
+  durable: Boolean) extends ReadWriteAggregator {
 
   import Replicator._
   import Replicator.Internal._
@@ -2009,13 +2009,13 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  */
 @InternalApi private[akka] object ReadAggregator {
   def props(
-    key:         KeyR,
+    key: KeyR,
     consistency: Replicator.ReadConsistency,
-    req:         Option[Any],
-    nodes:       Set[Address],
+    req: Option[Any],
+    nodes: Set[Address],
     unreachable: Set[Address],
-    localValue:  Option[Replicator.Internal.DataEnvelope],
-    replyTo:     ActorRef): Props =
+    localValue: Option[Replicator.Internal.DataEnvelope],
+    replyTo: ActorRef): Props =
     Props(new ReadAggregator(key, consistency, req, nodes, unreachable, localValue, replyTo))
       .withDeploy(Deploy.local)
 
@@ -2025,13 +2025,13 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  * INTERNAL API
  */
 @InternalApi private[akka] class ReadAggregator(
-  key:                      KeyR,
-  consistency:              Replicator.ReadConsistency,
-  req:                      Option[Any],
-  override val nodes:       Set[Address],
+  key: KeyR,
+  consistency: Replicator.ReadConsistency,
+  req: Option[Any],
+  override val nodes: Set[Address],
   override val unreachable: Set[Address],
-  localValue:               Option[Replicator.Internal.DataEnvelope],
-  replyTo:                  ActorRef) extends ReadWriteAggregator {
+  localValue: Option[Replicator.Internal.DataEnvelope],
+  replyTo: ActorRef) extends ReadWriteAggregator {
 
   import Replicator._
   import Replicator.Internal._

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -123,29 +123,29 @@ object ReplicatorSettings {
  *        in the `Set`.
  */
 final class ReplicatorSettings(
-  val role: Option[String],
-  val gossipInterval: FiniteDuration,
-  val notifySubscribersInterval: FiniteDuration,
-  val maxDeltaElements: Int,
-  val dispatcher: String,
-  val pruningInterval: FiniteDuration,
-  val maxPruningDissemination: FiniteDuration,
-  val durableStoreProps: Either[(String, Config), Props],
-  val durableKeys: Set[KeyId],
-  val pruningMarkerTimeToLive: FiniteDuration,
+  val role:                           Option[String],
+  val gossipInterval:                 FiniteDuration,
+  val notifySubscribersInterval:      FiniteDuration,
+  val maxDeltaElements:               Int,
+  val dispatcher:                     String,
+  val pruningInterval:                FiniteDuration,
+  val maxPruningDissemination:        FiniteDuration,
+  val durableStoreProps:              Either[(String, Config), Props],
+  val durableKeys:                    Set[KeyId],
+  val pruningMarkerTimeToLive:        FiniteDuration,
   val durablePruningMarkerTimeToLive: FiniteDuration,
-  val deltaCrdtEnabled: Boolean) {
+  val deltaCrdtEnabled:               Boolean) {
 
   // For backwards compatibility
   def this(role: Option[String], gossipInterval: FiniteDuration, notifySubscribersInterval: FiniteDuration,
-    maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration) =
+           maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration) =
     this(role, gossipInterval, notifySubscribersInterval, maxDeltaElements, dispatcher, pruningInterval,
       maxPruningDissemination, Right(Props.empty), Set.empty, 6.hours, 10.days, true)
 
   // For backwards compatibility
   def this(role: Option[String], gossipInterval: FiniteDuration, notifySubscribersInterval: FiniteDuration,
-    maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration,
-    durableStoreProps: Either[(String, Config), Props], durableKeys: Set[String]) =
+           maxDeltaElements: Int, dispatcher: String, pruningInterval: FiniteDuration, maxPruningDissemination: FiniteDuration,
+           durableStoreProps: Either[(String, Config), Props], durableKeys: Set[String]) =
     this(role, gossipInterval, notifySubscribersInterval, maxDeltaElements, dispatcher, pruningInterval,
       maxPruningDissemination, durableStoreProps, durableKeys, 6.hours, 10.days, true)
 
@@ -174,7 +174,7 @@ final class ReplicatorSettings(
     copy(pruningInterval = pruningInterval, maxPruningDissemination = maxPruningDissemination)
 
   def withPruningMarkerTimeToLive(
-    pruningMarkerTimeToLive: FiniteDuration,
+    pruningMarkerTimeToLive:        FiniteDuration,
     durablePruningMarkerTimeToLive: FiniteDuration): ReplicatorSettings =
     copy(
       pruningMarkerTimeToLive = pruningMarkerTimeToLive,
@@ -201,18 +201,18 @@ final class ReplicatorSettings(
     copy(deltaCrdtEnabled = deltaCrdtEnabled)
 
   private def copy(
-    role: Option[String] = role,
-    gossipInterval: FiniteDuration = gossipInterval,
-    notifySubscribersInterval: FiniteDuration = notifySubscribersInterval,
-    maxDeltaElements: Int = maxDeltaElements,
-    dispatcher: String = dispatcher,
-    pruningInterval: FiniteDuration = pruningInterval,
-    maxPruningDissemination: FiniteDuration = maxPruningDissemination,
-    durableStoreProps: Either[(String, Config), Props] = durableStoreProps,
-    durableKeys: Set[KeyId] = durableKeys,
-    pruningMarkerTimeToLive: FiniteDuration = pruningMarkerTimeToLive,
-    durablePruningMarkerTimeToLive: FiniteDuration = durablePruningMarkerTimeToLive,
-    deltaCrdtEnabled: Boolean = deltaCrdtEnabled): ReplicatorSettings =
+    role:                           Option[String]                  = role,
+    gossipInterval:                 FiniteDuration                  = gossipInterval,
+    notifySubscribersInterval:      FiniteDuration                  = notifySubscribersInterval,
+    maxDeltaElements:               Int                             = maxDeltaElements,
+    dispatcher:                     String                          = dispatcher,
+    pruningInterval:                FiniteDuration                  = pruningInterval,
+    maxPruningDissemination:        FiniteDuration                  = maxPruningDissemination,
+    durableStoreProps:              Either[(String, Config), Props] = durableStoreProps,
+    durableKeys:                    Set[KeyId]                      = durableKeys,
+    pruningMarkerTimeToLive:        FiniteDuration                  = pruningMarkerTimeToLive,
+    durablePruningMarkerTimeToLive: FiniteDuration                  = durablePruningMarkerTimeToLive,
+    deltaCrdtEnabled:               Boolean                         = deltaCrdtEnabled): ReplicatorSettings =
     new ReplicatorSettings(role, gossipInterval, notifySubscribersInterval, maxDeltaElements, dispatcher,
       pruningInterval, maxPruningDissemination, durableStoreProps, durableKeys,
       pruningMarkerTimeToLive, durablePruningMarkerTimeToLive, deltaCrdtEnabled)
@@ -436,7 +436,7 @@ object Replicator {
    * for example not access `sender()` reference of an enclosing actor.
    */
   final case class Update[A <: ReplicatedData](key: Key[A], writeConsistency: WriteConsistency,
-    request: Option[Any])(val modify: Option[A] ⇒ A)
+                                               request: Option[Any])(val modify: Option[A] ⇒ A)
     extends Command[A] with NoSerializationVerificationNeeded {
 
     /**
@@ -606,9 +606,9 @@ object Replicator {
      * The `DataEnvelope` wraps a data entry and carries state of the pruning process for the entry.
      */
     final case class DataEnvelope(
-      data: ReplicatedData,
-      pruning: Map[UniqueAddress, PruningState] = Map.empty,
-      deltaVersions: VersionVector = VersionVector.empty)
+      data:          ReplicatedData,
+      pruning:       Map[UniqueAddress, PruningState] = Map.empty,
+      deltaVersions: VersionVector                    = VersionVector.empty)
       extends ReplicatorMessage {
 
       import PruningState._
@@ -1227,7 +1227,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
   def isLocalSender(): Boolean = !replyTo.path.address.hasGlobalScope
 
   def receiveUpdate(key: KeyR, modify: Option[ReplicatedData] ⇒ ReplicatedData,
-    writeConsistency: WriteConsistency, req: Option[Any]): Unit = {
+                    writeConsistency: WriteConsistency, req: Option[Any]): Unit = {
     val localValue = getData(key.id)
 
     def deltaOrPlaceholder(d: DeltaReplicatedData): Option[ReplicatedDelta] = {
@@ -1880,15 +1880,15 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  */
 @InternalApi private[akka] object WriteAggregator {
   def props(
-    key: KeyR,
-    envelope: Replicator.Internal.DataEnvelope,
-    delta: Option[Replicator.Internal.Delta],
+    key:         KeyR,
+    envelope:    Replicator.Internal.DataEnvelope,
+    delta:       Option[Replicator.Internal.Delta],
     consistency: Replicator.WriteConsistency,
-    req: Option[Any],
-    nodes: Set[Address],
+    req:         Option[Any],
+    nodes:       Set[Address],
     unreachable: Set[Address],
-    replyTo: ActorRef,
-    durable: Boolean): Props =
+    replyTo:     ActorRef,
+    durable:     Boolean): Props =
     Props(new WriteAggregator(key, envelope, delta, consistency, req, nodes, unreachable, replyTo, durable))
       .withDeploy(Deploy.local)
 }
@@ -1897,15 +1897,15 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  * INTERNAL API
  */
 @InternalApi private[akka] class WriteAggregator(
-  key: KeyR,
-  envelope: Replicator.Internal.DataEnvelope,
-  delta: Option[Replicator.Internal.Delta],
-  consistency: Replicator.WriteConsistency,
-  req: Option[Any],
-  override val nodes: Set[Address],
+  key:                      KeyR,
+  envelope:                 Replicator.Internal.DataEnvelope,
+  delta:                    Option[Replicator.Internal.Delta],
+  consistency:              Replicator.WriteConsistency,
+  req:                      Option[Any],
+  override val nodes:       Set[Address],
   override val unreachable: Set[Address],
-  replyTo: ActorRef,
-  durable: Boolean) extends ReadWriteAggregator {
+  replyTo:                  ActorRef,
+  durable:                  Boolean) extends ReadWriteAggregator {
 
   import Replicator._
   import Replicator.Internal._
@@ -2009,13 +2009,13 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  */
 @InternalApi private[akka] object ReadAggregator {
   def props(
-    key: KeyR,
+    key:         KeyR,
     consistency: Replicator.ReadConsistency,
-    req: Option[Any],
-    nodes: Set[Address],
+    req:         Option[Any],
+    nodes:       Set[Address],
     unreachable: Set[Address],
-    localValue: Option[Replicator.Internal.DataEnvelope],
-    replyTo: ActorRef): Props =
+    localValue:  Option[Replicator.Internal.DataEnvelope],
+    replyTo:     ActorRef): Props =
     Props(new ReadAggregator(key, consistency, req, nodes, unreachable, localValue, replyTo))
       .withDeploy(Deploy.local)
 
@@ -2025,13 +2025,13 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
  * INTERNAL API
  */
 @InternalApi private[akka] class ReadAggregator(
-  key: KeyR,
-  consistency: Replicator.ReadConsistency,
-  req: Option[Any],
-  override val nodes: Set[Address],
+  key:                      KeyR,
+  consistency:              Replicator.ReadConsistency,
+  req:                      Option[Any],
+  override val nodes:       Set[Address],
   override val unreachable: Set[Address],
-  localValue: Option[Replicator.Internal.DataEnvelope],
-  replyTo: ActorRef) extends ReadWriteAggregator {
+  localValue:               Option[Replicator.Internal.DataEnvelope],
+  replyTo:                  ActorRef) extends ReadWriteAggregator {
 
   import Replicator._
   import Replicator.Internal._

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -744,6 +744,27 @@ object Replicator {
 
     final case class Delta(dataEnvelope: DataEnvelope, fromSeqNr: Long, toSeqNr: Long)
     final case class DeltaPropagation(fromNode: UniqueAddress, reply: Boolean, deltas: Map[KeyId, Delta]) extends ReplicatorMessage
+    object DeltaPropagation {
+      /**
+       * When a DeltaReplicatedData returns `None` from `delta` it must still be
+       * treated as a delta that increase the version counter in `DeltaPropagationSelector`.
+       * Otherwise a later delta might be applied before the full state gossip is received
+       * and thereby violating `RequiresCausalDeliveryOfDeltas`.
+       *
+       * This is used as a placeholder for such `None` delta. It's filtered out
+       * in `createDeltaPropagation`, i.e. never sent to the other replicas.
+       */
+      val NoDeltaPlaceholder: ReplicatedDelta =
+        new DeltaReplicatedData with RequiresCausalDeliveryOfDeltas with ReplicatedDelta {
+          type T = ReplicatedData
+          type D = ReplicatedDelta
+          override def merge(other: ReplicatedData): ReplicatedData = this
+          override def mergeDelta(other: ReplicatedDelta): ReplicatedDelta = this
+          override def zero: DeltaReplicatedData = this
+          override def delta: Option[ReplicatedDelta] = None
+          override def resetDelta: ReplicatedData = this
+        }
+    }
     case object DeltaNack extends ReplicatorMessage with DeadLetterSuppression
 
   }
@@ -941,6 +962,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
 
   import Replicator._
   import Replicator.Internal._
+  import Replicator.Internal.DeltaPropagation.NoDeltaPlaceholder
   import PruningState._
   import settings._
 
@@ -991,11 +1013,12 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
     override def createDeltaPropagation(deltas: Map[KeyId, (ReplicatedData, Long, Long)]): DeltaPropagation = {
       // Important to include the pruning state in the deltas. For example if the delta is based
       // on an entry that has been pruned but that has not yet been performed on the target node.
-      DeltaPropagation(selfUniqueAddress, reply = false, deltas.map {
-        case (key, (d, fromSeqNr, toSeqNr)) ⇒ getData(key) match {
-          case Some(envelope) ⇒ key → Delta(envelope.copy(data = d), fromSeqNr, toSeqNr)
-          case None           ⇒ key → Delta(DataEnvelope(d), fromSeqNr, toSeqNr)
-        }
+      DeltaPropagation(selfUniqueAddress, reply = false, deltas.collect {
+        case (key, (d, fromSeqNr, toSeqNr)) if d != NoDeltaPlaceholder ⇒
+          getData(key) match {
+            case Some(envelope) ⇒ key → Delta(envelope.copy(data = d), fromSeqNr, toSeqNr)
+            case None           ⇒ key → Delta(DataEnvelope(d), fromSeqNr, toSeqNr)
+          }
       }(collection.breakOut))
     }
   }
@@ -1206,18 +1229,27 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
   def receiveUpdate(key: KeyR, modify: Option[ReplicatedData] ⇒ ReplicatedData,
                     writeConsistency: WriteConsistency, req: Option[Any]): Unit = {
     val localValue = getData(key.id)
+
+    def deltaOrPlaceholder(d: DeltaReplicatedData): Option[ReplicatedDelta] = {
+      d.delta match {
+        case s @ Some(_) ⇒ s
+        case None        ⇒ Some(NoDeltaPlaceholder)
+      }
+    }
+
     Try {
       localValue match {
         case Some(DataEnvelope(DeletedData, _, _)) ⇒ throw new DataDeleted(key, req)
         case Some(envelope @ DataEnvelope(existing, _, _)) ⇒
           modify(Some(existing)) match {
             case d: DeltaReplicatedData if deltaCrdtEnabled ⇒
-              (envelope.merge(d.resetDelta.asInstanceOf[existing.T]), d.delta)
+              (envelope.merge(d.resetDelta.asInstanceOf[existing.T]), deltaOrPlaceholder(d))
             case d ⇒
               (envelope.merge(d.asInstanceOf[existing.T]), None)
           }
         case None ⇒ modify(None) match {
-          case d: DeltaReplicatedData if deltaCrdtEnabled ⇒ (DataEnvelope(d.resetDelta), d.delta)
+          case d: DeltaReplicatedData if deltaCrdtEnabled ⇒
+            (DataEnvelope(d.resetDelta), deltaOrPlaceholder(d))
           case d ⇒ (DataEnvelope(d), None)
         }
       }
@@ -1244,6 +1276,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
             replyTo ! UpdateSuccess(key, req)
         } else {
           val (writeEnvelope, writeDelta) = delta match {
+            case Some(NoDeltaPlaceholder) ⇒ (newEnvelope, None)
             case Some(d: RequiresCausalDeliveryOfDeltas) ⇒
               val v = deltaPropagationSelector.currentVersion(key.id)
               (newEnvelope, Some(Delta(newEnvelope.copy(data = d), v, v)))
@@ -1458,7 +1491,8 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
     deltaPropagationSelector.collectPropagations().foreach {
       case (node, deltaPropagation) ⇒
         // TODO split it to several DeltaPropagation if too many entries
-        replica(node) ! deltaPropagation
+        if (deltaPropagation.deltas.nonEmpty)
+          replica(node) ! deltaPropagation
     }
 
     if (deltaPropagationSelector.propagationCount % deltaPropagationSelector.gossipIntervalDivisor == 0)

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
@@ -118,11 +118,12 @@ object ReplicatorDeltaSpec extends MultiNodeConfig {
         case 3 ⇒
           // ORSet
           val key = rndOrSetkey()
-          // only removals for KeyF on node first
-          if (key == KeyF && onNode == first && rnd.nextBoolean())
-            Remove(key, rndRemoveElement(), consistency())
-          else
-            Add(key, rndAddElement(), consistency())
+          // FIXME use full state for removals, until issue #22648 is fixed
+          //          // only removals for KeyF on node first
+          //          if (key == KeyF && onNode == first && rnd.nextBoolean())
+          //            Remove(key, rndRemoveElement(), consistency())
+          //          else
+          Add(key, rndAddElement(), consistency())
       }
     }.toVector
   }

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
@@ -29,6 +29,25 @@ object ReplicatorDeltaSpec extends MultiNodeConfig {
 
   testTransport(on = true)
 
+  case class Highest(n: Int, delta: Option[Highest] = None)
+    extends DeltaReplicatedData with RequiresCausalDeliveryOfDeltas with ReplicatedDelta {
+    type T = Highest
+    type D = Highest
+
+    override def merge(other: Highest): Highest =
+      if (n >= other.n) this else other
+
+    override def mergeDelta(other: Highest): Highest = merge(other)
+
+    override def zero: Highest = Highest(0)
+
+    override def resetDelta: Highest = Highest(n)
+
+    def incr(i: Int): Highest = Highest(n + i, Some(Highest(n + i)))
+
+    def incrNoDelta(i: Int): Highest = Highest(n + i, None)
+  }
+
   sealed trait Op
   final case class Delay(n: Int) extends Op
   final case class Incr(key: PNCounterKey, n: Int, consistency: WriteConsistency) extends Op
@@ -40,6 +59,7 @@ object ReplicatorDeltaSpec extends MultiNodeConfig {
   val writeTwo = WriteTo(2, timeout)
   val writeMajority = WriteMajority(timeout)
 
+  val KeyHigh = new Key[Highest]("High") {}
   val KeyA = PNCounterKey("A")
   val KeyB = PNCounterKey("B")
   val KeyC = PNCounterKey("C")
@@ -246,6 +266,81 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
       enterBarrier("write-3")
       fullStateReplicator.tell(Get(KeyD, ReadLocal), p.ref)
       p.expectMsgType[GetSuccess[ORSet[String]]].dataValue.elements should ===(Set("a", "A", "B", "C", "D"))
+
+      enterBarrierAfterTestStep()
+    }
+
+    "preserve causal consistency for None delta" in {
+      runOn(first) {
+        val p1 = TestProbe()
+        deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incr(1)), p1.ref)
+        p1.expectMsgType[UpdateSuccess[_]]
+      }
+      enterBarrier("write-1")
+
+      runOn(first) {
+        val p = TestProbe()
+        deltaReplicator.tell(Get(KeyHigh, ReadLocal), p.ref)
+        p.expectMsgType[GetSuccess[Highest]].dataValue.n should ===(1)
+      }
+      runOn(second, third, fourth) {
+        within(5.seconds) {
+          awaitAssert {
+            val p = TestProbe()
+            deltaReplicator.tell(Get(KeyHigh, ReadLocal), p.ref)
+            p.expectMsgType[GetSuccess[Highest]].dataValue.n should ===(1)
+          }
+        }
+      }
+      enterBarrier("read-1")
+
+      runOn(first) {
+        val p1 = TestProbe()
+        deltaReplicator.tell(Update(KeyHigh, Highest(0), writeAll)(_.incr(2)), p1.ref)
+        p1.expectMsgType[UpdateSuccess[_]]
+        deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incrNoDelta(5)), p1.ref)
+        deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incr(10)), p1.ref)
+        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[_]]
+      }
+      enterBarrier("write-2")
+
+      runOn(first) {
+        val p = TestProbe()
+        deltaReplicator.tell(Get(KeyHigh, ReadLocal), p.ref)
+        p.expectMsgType[GetSuccess[Highest]].dataValue.n should ===(18)
+      }
+      runOn(second, third, fourth) {
+        within(5.seconds) {
+          awaitAssert {
+            val p = TestProbe()
+            deltaReplicator.tell(Get(KeyHigh, ReadLocal), p.ref)
+            // the incrNoDelta(5) is not propagated as delta, and then incr(10) is also skipped
+            p.expectMsgType[GetSuccess[Highest]].dataValue.n should ===(3)
+          }
+        }
+      }
+      enterBarrier("read-2")
+
+      runOn(first) {
+        val p1 = TestProbe()
+        // WriteAll will send full state when delta can't be applied and thereby syncing the
+        // delta versions again. Same would happen via full state gossip.
+        // Thereafter delta can be propagated and applied again.
+        deltaReplicator.tell(Update(KeyHigh, Highest(0), writeAll)(_.incr(100)), p1.ref)
+        p1.expectMsgType[UpdateSuccess[_]]
+        deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incr(4)), p1.ref)
+        p1.expectMsgType[UpdateSuccess[_]]
+      }
+      enterBarrier("write-3")
+
+      within(5.seconds) {
+        awaitAssert {
+          val p = TestProbe()
+          deltaReplicator.tell(Get(KeyHigh, ReadLocal), p.ref)
+          p.expectMsgType[GetSuccess[Highest]].dataValue.n should ===(122)
+        }
+      }
 
       enterBarrierAfterTestStep()
     }

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorMapDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorMapDeltaSpec.scala
@@ -105,11 +105,12 @@ object ReplicatorMapDeltaSpec extends MultiNodeConfig {
         case 3 ⇒
           // ORSet
           val key = rndOrSetkey()
-          // only removals for KeyF on node first
-          if (key == KeyF && onNode == first && rnd.nextBoolean())
-            Remove(key, rndRemoveElement(), consistency())
-          else
-            Add(key, rndAddElement(), consistency())
+          // FIXME use full state for removals, until issue #22648 is fixed
+          //          // only removals for KeyF on node first
+          //          if (key == KeyF && onNode == first && rnd.nextBoolean())
+          //            Remove(key, rndRemoveElement(), consistency())
+          //          else
+          Add(key, rndAddElement(), consistency())
       }
     }.toVector
   }

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/LWWMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/LWWMapSpec.scala
@@ -60,6 +60,9 @@ class LWWMapSpec extends WordSpec with Matchers {
 
       val merged1 = m1 merge m2
 
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val m3 = merged1.resetDelta.remove(node1, "b")
       (merged1 mergeDelta m3.delta.get).entries should be(Map("a" → 1, "c" → 3))
 

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
@@ -55,6 +55,9 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "be able to remove entry using a delta" in {
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val m = ORMap().put(node1, "a", GSet() + "A").put(node1, "b", GSet() + "B")
       val addDelta = m.delta.get
 
@@ -325,6 +328,9 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 8" in {
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A")
         .put(node1, "b", GSet.empty + "B").put(node2, "b", GSet.empty + "B")
       val m2 = ORMap.empty.put(node2, "c", GSet.empty + "C")
@@ -348,6 +354,9 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 9" in {
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A")
         .put(node1, "b", GSet.empty + "B").put(node2, "b", GSet.empty + "B")
       val m2 = ORMap.empty.put(node2, "c", GSet.empty + "C")

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
@@ -78,6 +78,9 @@ class ORMultiMapSpec extends WordSpec with Matchers {
       val merged2 = m2 merge m1
       merged2.entries should be(expectedMerged)
 
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val merged3 = m1 mergeDelta m2.delta.get
       merged3.entries should be(expectedMerged)
 
@@ -114,6 +117,9 @@ class ORMultiMapSpec extends WordSpec with Matchers {
   }
 
   "not have usual anomalies for remove+addBinding scenario and delta-deltas" in {
+    // FIXME use full state for removals, until issue #22648 is fixed
+    pending
+
     val m1 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
     val m2 = ORMultiMap.emptyWithValueDeltas[String, String].put(node2, "c", Set("C"))
 
@@ -142,6 +148,9 @@ class ORMultiMapSpec extends WordSpec with Matchers {
   }
 
   "not have usual anomalies for remove+addBinding scenario and delta-deltas 2" in {
+    // FIXME use full state for removals, until issue #22648 is fixed
+    pending
+
     // the new delta-delta ORMultiMap is free from this anomaly
     val m1 = ORMultiMap.emptyWithValueDeltas[String, String].put(node1, "a", Set("A")).put(node1, "b", Set("B"))
     val m2 = ORMultiMap.emptyWithValueDeltas[String, String].put(node2, "c", Set("C"))

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
@@ -294,6 +294,9 @@ class ORSetSpec extends WordSpec with Matchers {
       s1.mergeDelta(d4) should ===(s3)
       s2.mergeDelta(d4) should ===(s3)
 
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val s5 = s3.resetDelta.remove(node1, "b")
       val d5 = s5.delta.get
       val d6 = (d4 merge d5).asInstanceOf[ORSet.DeltaGroup[String]]
@@ -312,6 +315,9 @@ class ORSetSpec extends WordSpec with Matchers {
     }
 
     "work for removals" in {
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val s1 = ORSet.empty[String]
       val s2 = s1.add(node1, "a").add(node1, "b").resetDelta
       val s3 = s2.remove(node1, "b")
@@ -357,6 +363,9 @@ class ORSetSpec extends WordSpec with Matchers {
     }
 
     "handle a mixed add/remove scenario" in {
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val s1 = ORSet.empty[String]
       val s2 = s1.resetDelta.remove(node1, "e")
       val s3 = s2.resetDelta.add(node1, "b")
@@ -376,6 +385,9 @@ class ORSetSpec extends WordSpec with Matchers {
     }
 
     "handle a mixed add/remove scenario 2" in {
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val s1 = ORSet.empty[String]
       val s2 = s1.resetDelta.add(node1, "a")
       val s3 = s2.resetDelta.add(node1, "b")
@@ -398,6 +410,9 @@ class ORSetSpec extends WordSpec with Matchers {
     }
 
     "handle a mixed add/remove scenario 3" in {
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val s1 = ORSet.empty[String]
       val s2 = s1.resetDelta.add(node1, "a")
       val s3 = s2.resetDelta.add(node1, "b")

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
@@ -56,6 +56,9 @@ class PNCounterMapSpec extends WordSpec with Matchers {
 
       val merged1 = m1 merge m2
 
+      // FIXME use full state for removals, until issue #22648 is fixed
+      pending
+
       val m3 = merged1.resetDelta.remove(node1, "b")
       (merged1 mergeDelta m3.delta.get).entries should be(Map("a" → 1, "c" → 7))
 

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
@@ -113,8 +113,9 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem(
 
     "serialize ORSet delta" in {
       checkSerialization(ORSet().add(address1, "a").delta.get)
-      checkSerialization(ORSet().add(address1, "a").resetDelta.remove(address2, "a").delta.get)
-      checkSerialization(ORSet().add(address1, "a").remove(address2, "a").delta.get)
+      // FIXME use full state for removals, until issue #22648 is fixed
+      //checkSerialization(ORSet().add(address1, "a").resetDelta.remove(address2, "a").delta.get)
+      //      checkSerialization(ORSet().add(address1, "a").remove(address2, "a").delta.get)
       checkSerialization(ORSet().add(address1, "a").resetDelta.clear(address2).delta.get)
       checkSerialization(ORSet().add(address1, "a").clear(address2).delta.get)
     }
@@ -196,8 +197,9 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem(
 
     "serialize ORMap delta" in {
       checkSerialization(ORMap().put(address1, "a", GSet() + "A").put(address2, "b", GSet() + "B").delta.get)
-      checkSerialization(ORMap().put(address1, "a", GSet() + "A").resetDelta.remove(address2, "a").delta.get)
-      checkSerialization(ORMap().put(address1, "a", GSet() + "A").remove(address2, "a").delta.get)
+      // FIXME use full state for removals, until issue #22648 is fixed
+      //      checkSerialization(ORMap().put(address1, "a", GSet() + "A").resetDelta.remove(address2, "a").delta.get)
+      //      checkSerialization(ORMap().put(address1, "a", GSet() + "A").remove(address2, "a").delta.get)
       checkSerialization(ORMap().put(address1, 1, GSet() + "A").delta.get)
       checkSerialization(ORMap().put(address1, 1L, GSet() + "A").delta.get)
       checkSerialization(ORMap.empty[String, ORSet[String]]
@@ -281,7 +283,8 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem(
       checkSerialization(ORMultiMap._emptyWithValueDeltas.addBinding(address1, 1, "A"))
       checkSerialization(ORMultiMap._emptyWithValueDeltas.addBinding(address1, 1L, "A"))
       checkSerialization(ORMultiMap._emptyWithValueDeltas.addBinding(address1, Flag(), "A"))
-      checkSerialization(ORMultiMap.emptyWithValueDeltas[String, String].addBinding(address1, "a", "A").remove(address1, "a").delta.get)
+      // FIXME use full state for removals, until issue #22648 is fixed
+      //      checkSerialization(ORMultiMap.emptyWithValueDeltas[String, String].addBinding(address1, "a", "A").remove(address1, "a").delta.get)
       checkSerialization(ORMultiMap.emptyWithValueDeltas[String, String]
         .addBinding(address1, "a", "A1")
         .put(address2, "b", Set("B1", "B2", "B3"))


### PR DESCRIPTION
When a DeltaReplicatedData returns None from delta it must still be
treated as a delta that increase the version counter in DeltaPropagationSelector.
Otherwise a later delta might be applied before the full state gossip is received
and thereby violating RequiresCausalDeliveryOfDeltas.

Refs #22655

This is not critical for the 2.5.0-RC2 release