### PR TITLE
Fix typo in migration guide

### DIFF
--- a/akka-docs/rst/project/migration-guide-2.4.x-2.5.x.rst
+++ b/akka-docs/rst/project/migration-guide-2.4.x-2.5.x.rst
@@ -229,7 +229,7 @@ Old::
 
 New::
 
-  object MyExtension extends extends ExtensionId[MyExtension] with ExtensionIdProvider {
+  object MyExtension extends ExtensionId[MyExtension] with ExtensionIdProvider {
 
     override def lookup = MyExtension
 


### PR DESCRIPTION
- Remove duplication of keyword 'extends' in code snippet of Akka 2.4 -> 2.5 migration guide in 2.5-RC2

Fixes issue #22676 