### PR TITLE
Make 'watch' and 'unwatch' return void (#22664)

### DIFF
--- a/akka-typed/src/main/java/akka/typed/javadsl/ActorContext.java
+++ b/akka-typed/src/main/java/akka/typed/javadsl/ActorContext.java
@@ -104,13 +104,13 @@ public interface ActorContext<T> {
    * {@link akka.typed.ActorSystem} to which the referenced Actor belongs is declared as failed
    * (e.g. in reaction to being unreachable).
    */
-  public <U> ActorRef<U> watch(ActorRef<U> other);
+  public void watch(ActorRef<?> other);
 
   /**
    * Revoke the registration established by {@link #watch}. A {@link akka.typed.Terminated}
    * notification will not subsequently be received for the referenced Actor.
    */
-  public <U> ActorRef<U> unwatch(ActorRef<U> other);
+  public void unwatch(ActorRef<?> other);
 
   /**
    * Schedule the sending of a notification in case no other message is received

--- a/akka-typed/src/main/scala/akka/typed/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/ActorContext.scala
@@ -105,8 +105,8 @@ class StubbedActorContext[T](
       case Some(inbox) ⇒ inbox.ref == child
     }
   }
-  override def watch[U](other: ActorRef[U]): ActorRef[U] = other
-  override def unwatch[U](other: ActorRef[U]): ActorRef[U] = other
+  override def watch(other: ActorRef[_]): Unit = ()
+  override def unwatch(other: ActorRef[_]): Unit = ()
   override def setReceiveTimeout(d: FiniteDuration, msg: T): Unit = ()
   override def cancelReceiveTimeout(): Unit = ()
 

--- a/akka-typed/src/main/scala/akka/typed/Effects.scala
+++ b/akka-typed/src/main/scala/akka/typed/Effects.scala
@@ -77,11 +77,11 @@ class EffectfulActorContext[T](_name: String, _initialBehavior: Behavior[T], _ma
     effectQueue.offer(Stopped(child.path.name))
     super.stop(child)
   }
-  override def watch[U](other: ActorRef[U]): ActorRef[U] = {
+  override def watch(other: ActorRef[_]): Unit = {
     effectQueue.offer(Watched(other))
     super.watch(other)
   }
-  override def unwatch[U](other: ActorRef[U]): ActorRef[U] = {
+  override def unwatch(other: ActorRef[_]): Unit = {
     effectQueue.offer(Unwatched(other))
     super.unwatch(other)
   }

--- a/akka-typed/src/main/scala/akka/typed/ScalaDSL.scala
+++ b/akka-typed/src/main/scala/akka/typed/ScalaDSL.scala
@@ -166,7 +166,7 @@ object ScalaDSL {
       lazy val fallback: (MessageOrSignal[T]) ⇒ Behavior[T] = {
         case Sig(context, PreRestart) ⇒
           context.children foreach { child ⇒
-            context.unwatch[Nothing](child)
+            context.unwatch(child)
             context.stop(child)
           }
           behavior.applyOrElse(Sig(context, PostStop), fallback)

--- a/akka-typed/src/main/scala/akka/typed/adapter/ActorContextAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/adapter/ActorContextAdapter.scala
@@ -36,8 +36,8 @@ private[typed] class ActorContextAdapter[T](ctx: a.ActorContext) extends ActorCo
             false // none of our business
         }
     }
-  override def watch[U](other: ActorRef[U]) = { ctx.watch(toUntyped(other)); other }
-  override def unwatch[U](other: ActorRef[U]) = { ctx.unwatch(toUntyped(other)); other }
+  override def watch(other: ActorRef[_]) = ctx.watch(toUntyped(other))
+  override def unwatch(other: ActorRef[_]) = ctx.unwatch(toUntyped(other))
   var receiveTimeoutMsg: T = null.asInstanceOf[T]
   override def setReceiveTimeout(d: FiniteDuration, msg: T) = {
     receiveTimeoutMsg = msg

--- a/akka-typed/src/main/scala/akka/typed/internal/DeathWatch.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/DeathWatch.scala
@@ -44,7 +44,7 @@ private[typed] trait DeathWatch[T] {
   private var watching = Set.empty[ARImpl]
   private var watchedBy = Set.empty[ARImpl]
 
-  final def watch[U](_a: ActorRef[U]): ActorRef[U] = {
+  final def watch(_a: ActorRef[_]): Unit = {
     val a = _a.sorry
     if (a != self && !watching.contains(a)) {
       maintainAddressTerminatedSubscription(a) {
@@ -52,10 +52,9 @@ private[typed] trait DeathWatch[T] {
         watching += a
       }
     }
-    a
   }
 
-  final def unwatch[U](_a: ActorRef[U]): ActorRef[U] = {
+  final def unwatch(_a: ActorRef[_]): Unit = {
     val a = _a.sorry
     if (a != self && watching.contains(a)) {
       a.sendSystem(Unwatch(a, self))
@@ -63,7 +62,6 @@ private[typed] trait DeathWatch[T] {
         watching -= a
       }
     }
-    a
   }
 
   /**
@@ -137,7 +135,7 @@ private[typed] trait DeathWatch[T] {
         if (system.settings.untyped.DebugLifecycle) publish(Debug(self.path.toString, clazz(behavior), s"now watched by $watcher"))
       }
     } else if (!watcheeSelf && watcherSelf) {
-      watch[Nothing](watchee)
+      watch(watchee)
     } else {
       publish(Warning(self.path.toString, clazz(behavior), "BUG: illegal Watch(%s,%s) for %s".format(watchee, watcher, self)))
     }
@@ -153,7 +151,7 @@ private[typed] trait DeathWatch[T] {
         if (system.settings.untyped.DebugLifecycle) publish(Debug(self.path.toString, clazz(behavior), s"no longer watched by $watcher"))
       }
     } else if (!watcheeSelf && watcherSelf) {
-      unwatch[Nothing](watchee)
+      unwatch(watchee)
     } else {
       publish(Warning(self.path.toString, clazz(behavior), "BUG: illegal Unwatch(%s,%s) for %s".format(watchee, watcher, self)))
     }

--- a/akka-typed/src/main/scala/akka/typed/internal/EventStreamImpl.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/EventStreamImpl.scala
@@ -45,7 +45,7 @@ private[typed] class EventStreamImpl(private val debug: Boolean)(implicit privat
     Full[Command] {
       case Msg(ctx, Register(actor)) ⇒
         if (debug) publish(e.Logging.Debug(simpleName(getClass), getClass, s"watching $actor in order to unsubscribe from EventStream when it terminates"))
-        ctx.watch[Nothing](actor)
+        ctx.watch(actor)
         Same
 
       case Msg(ctx, UnregisterIfNoMoreSubscribedChannels(actor)) if hasSubscriptions(actor) ⇒ Same
@@ -53,7 +53,7 @@ private[typed] class EventStreamImpl(private val debug: Boolean)(implicit privat
 
       case Msg(ctx, UnregisterIfNoMoreSubscribedChannels(actor)) ⇒
         if (debug) publish(e.Logging.Debug(simpleName(getClass), getClass, s"unwatching $actor, since has no subscriptions"))
-        ctx.unwatch[Nothing](actor)
+        ctx.unwatch(actor)
         Same
 
       case Sig(ctx, Terminated(actor)) ⇒

--- a/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
+++ b/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
@@ -89,13 +89,13 @@ trait ActorContext[T] { this: akka.typed.javadsl.ActorContext[T] ⇒
    * [[ActorSystem]] to which the referenced Actor belongs is declared as
    * failed (e.g. in reaction to being unreachable).
    */
-  def watch[U](other: ActorRef[U]): ActorRef[U]
+  def watch(other: ActorRef[_]): Unit
 
   /**
    * Revoke the registration established by `watch`. A [[Terminated]]
    * notification will not subsequently be received for the referenced Actor.
    */
-  def unwatch[U](other: ActorRef[U]): ActorRef[U]
+  def unwatch(other: ActorRef[_]): Unit
 
   /**
    * Schedule the sending of a notification in case no other

--- a/akka-typed/src/test/scala/akka/typed/ActorContextSpec.scala
+++ b/akka-typed/src/test/scala/akka/typed/ActorContextSpec.scala
@@ -114,11 +114,11 @@ object ActorContextSpec {
           else replyTo ! NotKilled
           Actor.Same
         case Watch(ref, replyTo) ⇒
-          ctx.watch[Nothing](ref)
+          ctx.watch(ref)
           replyTo ! Watched
           Actor.Same
         case Unwatch(ref, replyTo) ⇒
-          ctx.unwatch[Nothing](ref)
+          ctx.unwatch(ref)
           replyTo ! Unwatched
           Actor.Same
         case GetInfo(replyTo) ⇒
@@ -200,11 +200,11 @@ object ActorContextSpec {
           else replyTo ! NotKilled
           Same
         case Watch(ref, replyTo) ⇒
-          ctx.watch[Nothing](ref)
+          ctx.watch(ref)
           replyTo ! Watched
           Same
         case Unwatch(ref, replyTo) ⇒
-          ctx.unwatch[Nothing](ref)
+          ctx.unwatch(ref)
           replyTo ! Unwatched
           Same
         case GetInfo(replyTo) ⇒

--- a/akka-typed/src/test/scala/akka/typed/internal/EventStreamSpec.scala
+++ b/akka-typed/src/test/scala/akka/typed/internal/EventStreamSpec.scala
@@ -22,7 +22,9 @@ object EventStreamSpec {
       ContextAware { ctx ⇒
         Total {
           case Logger.Initialize(es, replyTo) ⇒
-            replyTo ! ctx.watch(ctx.spawn(Static { (ev: LogEvent) ⇒ logged :+= ev }, "logger"))
+            val logger = ctx.spawn(Static { (ev: LogEvent) ⇒ logged :+= ev }, "logger")
+            ctx.watch(logger)
+            replyTo ! logger
             Empty
         }
       }


### PR DESCRIPTION
This indeed makes both the call sites and the implementations a little more
elegant. The only non-trivial change was in EventStreamSpec, which while a bit
more verbose, seems more readable like this, too.