### PR TITLE
Add generic parameter to watch/unwatch

### DIFF
--- a/akka-typed-testkit/src/main/scala/akka/typed/testkit/Effects.scala
+++ b/akka-typed-testkit/src/main/scala/akka/typed/testkit/Effects.scala
@@ -82,11 +82,11 @@ class EffectfulActorContext[T](_name: String, _initialBehavior: Behavior[T], _ma
     effectQueue.offer(Stopped(child.path.name))
     super.stop(child)
   }
-  override def watch(other: ActorRef[_]): Unit = {
+  override def watch[U](other: ActorRef[U]): Unit = {
     effectQueue.offer(Watched(other))
     super.watch(other)
   }
-  override def unwatch(other: ActorRef[_]): Unit = {
+  override def unwatch[U](other: ActorRef[U]): Unit = {
     effectQueue.offer(Unwatched(other))
     super.unwatch(other)
   }

--- a/akka-typed-testkit/src/main/scala/akka/typed/testkit/StubbedActorContext.scala
+++ b/akka-typed-testkit/src/main/scala/akka/typed/testkit/StubbedActorContext.scala
@@ -53,8 +53,8 @@ class StubbedActorContext[T](
       case Some(inbox) ⇒ inbox.ref == child
     }
   }
-  override def watch(other: ActorRef[_]): Unit = ()
-  override def unwatch(other: ActorRef[_]): Unit = ()
+  override def watch[U](other: ActorRef[U]): Unit = ()
+  override def unwatch[U](other: ActorRef[U]): Unit = ()
   override def setReceiveTimeout(d: FiniteDuration, msg: T): Unit = ()
   override def cancelReceiveTimeout(): Unit = ()
 

--- a/akka-typed-tests/src/test/java/akka/typed/javadsl/MonitoringTest.java
+++ b/akka-typed-tests/src/test/java/akka/typed/javadsl/MonitoringTest.java
@@ -1,0 +1,67 @@
+package akka.typed.javadsl;
+
+import java.util.concurrent.CompletionStage;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import akka.Done;
+import org.scalatest.junit.JUnitSuite;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+import akka.util.Timeout;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import akka.typed.*;
+import static akka.typed.javadsl.Actor.*;
+import static akka.typed.javadsl.AskPattern.*;
+
+import akka.testkit.AkkaSpec;
+
+public class MonitoringTest extends JUnitSuite {
+
+    static final class RunTest<T> {
+        private final ActorRef<T> replyTo;
+        public RunTest(ActorRef<T> replyTo) {
+            this.replyTo = replyTo;
+        }
+    }
+    static final class Stop {}
+
+    // final FiniteDuration fiveSeconds = FiniteDuration.create(5, TimeUnit.SECONDS);
+    final Timeout timeout = new Timeout(Duration.create(5, TimeUnit.SECONDS));
+
+    final Behavior<Stop> exitingActor = stateful((ctx, msg) -> {
+        System.out.println("Stopping!");
+        return stopped();
+    });
+
+    private Behavior<RunTest<Done>> waitingForTermination(ActorRef<Done> replyWhenTerminated) {
+        return stateful(
+            (ctx, msg) -> unhandled(),
+            (ctx, sig) -> {
+                if (sig instanceof Terminated) {
+                    replyWhenTerminated.tell(Done.getInstance());
+                }
+                return same();
+            }
+        );
+    }
+
+
+    @Test
+    public void shouldWatchTerminatingActor() throws Exception {
+        Behavior<RunTest<Done>> root = stateful((ctx, msg) -> {
+            ActorRef<Stop> watched = ctx.spawn(exitingActor, "exitingActor");
+            ctx.watch(watched);
+            watched.tell(new Stop());
+            return waitingForTermination(msg.replyTo);
+        });
+        ActorSystem<RunTest<Done>> system = ActorSystem$.MODULE$.create("sysname", root, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+
+        // Not sure why this does not compile without an explicit cast?
+        // system.tell(new RunTest());
+        CompletionStage<Done> result = AskPattern.ask((ActorRef<RunTest<Done>>)system, (ActorRef<Done> ref) -> new RunTest<Done>(ref), timeout, system.scheduler());
+        result.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    }
+}

--- a/akka-typed/src/main/java/akka/typed/javadsl/ActorContext.java
+++ b/akka-typed/src/main/java/akka/typed/javadsl/ActorContext.java
@@ -104,13 +104,13 @@ public interface ActorContext<T> {
    * {@link akka.typed.ActorSystem} to which the referenced Actor belongs is declared as failed
    * (e.g. in reaction to being unreachable).
    */
-  public void watch(ActorRef<?> other);
+  public <U> void watch(ActorRef<U> other);
 
   /**
    * Revoke the registration established by {@link #watch}. A {@link akka.typed.Terminated}
    * notification will not subsequently be received for the referenced Actor.
    */
-  public void unwatch(ActorRef<?> other);
+  public <U> void unwatch(ActorRef<U> other);
 
   /**
    * Schedule the sending of a notification in case no other message is received

--- a/akka-typed/src/main/scala/akka/typed/ActorSystem.scala
+++ b/akka-typed/src/main/scala/akka/typed/ActorSystem.scala
@@ -170,6 +170,18 @@ object ActorSystem {
   }
 
   /**
+   * Java API
+   */
+  def create[T](name: String, guardianBehavior: Behavior[T],
+                guardianDeployment: java.util.Optional[DeploymentConfig],
+                config:             java.util.Optional[Config],
+                classLoader:        java.util.Optional[ClassLoader],
+                executionContext:   java.util.Optional[ExecutionContext]): ActorSystem[T] = {
+    import scala.compat.java8.OptionConverters._
+    apply(name, guardianBehavior, guardianDeployment.asScala.getOrElse(EmptyDeploymentConfig), config.asScala, classLoader.asScala, executionContext.asScala)
+  }
+
+  /**
    * Create an ActorSystem based on the untyped [[akka.actor.ActorSystem]]
    * which runs Akka Typed [[Behavior]] on an emulation layer. In this
    * system typed and untyped actors can coexist.

--- a/akka-typed/src/main/scala/akka/typed/internal/DeathWatch.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/DeathWatch.scala
@@ -44,7 +44,7 @@ private[typed] trait DeathWatch[T] {
   private var watching = Set.empty[ARImpl]
   private var watchedBy = Set.empty[ARImpl]
 
-  final def watch(_a: ActorRef[_]): Unit = {
+  final def watch[U](_a: ActorRef[U]): Unit = {
     val a = _a.sorry
     if (a != self && !watching.contains(a)) {
       maintainAddressTerminatedSubscription(a) {
@@ -54,7 +54,7 @@ private[typed] trait DeathWatch[T] {
     }
   }
 
-  final def unwatch(_a: ActorRef[_]): Unit = {
+  final def unwatch[U](_a: ActorRef[U]): Unit = {
     val a = _a.sorry
     if (a != self && watching.contains(a)) {
       a.sendSystem(Unwatch(a, self))

--- a/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorContextAdapter.scala
@@ -41,8 +41,8 @@ import akka.annotation.InternalApi
             false // none of our business
         }
     }
-  override def watch(other: ActorRef[_]) = { untyped.watch(toUntyped(other)) }
-  override def unwatch(other: ActorRef[_]) = { untyped.unwatch(toUntyped(other)) }
+  override def watch[U](other: ActorRef[U]) = { untyped.watch(toUntyped(other)) }
+  override def unwatch[U](other: ActorRef[U]) = { untyped.unwatch(toUntyped(other)) }
   var receiveTimeoutMsg: T = null.asInstanceOf[T]
   override def setReceiveTimeout(d: FiniteDuration, msg: T) = {
     receiveTimeoutMsg = msg

--- a/akka-typed/src/main/scala/akka/typed/javadsl/Ask.scala
+++ b/akka-typed/src/main/scala/akka/typed/javadsl/Ask.scala
@@ -1,0 +1,14 @@
+package akka.typed
+package javadsl
+
+import java.util.concurrent.CompletionStage
+import scala.compat.java8.FutureConverters
+import akka.util.Timeout
+import akka.actor.Scheduler
+import scaladsl.AskPattern._
+import akka.japi.function.Function
+
+object AskPattern {
+  def ask[T, U](actor: ActorRef[T], message: Function[ActorRef[U], T], timeout: Timeout, scheduler: Scheduler): CompletionStage[U] =
+    FutureConverters.toJava[U](actor.?(message.apply)(timeout, scheduler))
+}

--- a/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
+++ b/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
@@ -89,13 +89,13 @@ trait ActorContext[T] { this: akka.typed.javadsl.ActorContext[T] ⇒
    * [[ActorSystem]] to which the referenced Actor belongs is declared as
    * failed (e.g. in reaction to being unreachable).
    */
-  def watch(other: ActorRef[_]): Unit
+  def watch[U](other: ActorRef[U]): Unit
 
   /**
    * Revoke the registration established by `watch`. A [[Terminated]]
    * notification will not subsequently be received for the referenced Actor.
    */
-  def unwatch(other: ActorRef[_]): Unit
+  def unwatch[U](other: ActorRef[U]): Unit
 
   /**
    * Schedule the sending of a notification in case no other


### PR DESCRIPTION
@ktoso mentioned in https://github.com/akka/akka/pull/22683#discussion_r110620041
this makes the methods more usable in the Java API. It'd have been nice to
include some docs/tests for the Java API to demonstrate the effect, but I
wasn't sure how/where to fit those in.