### PR TITLE
properly shutdown ArteryTransport using CoordinatedShutdown, #22671

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -299,7 +299,10 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
   val selfExiting = Promise[Done]()
   val coordShutdown = CoordinatedShutdown(context.system)
   coordShutdown.addTask(CoordinatedShutdown.PhaseClusterExiting, "wait-exiting") { () ⇒
-    selfExiting.future
+    if (latestGossip.members.isEmpty)
+      Future.successful(Done) // not joined yet
+    else
+      selfExiting.future
   }
   coordShutdown.addTask(CoordinatedShutdown.PhaseClusterExitingDone, "exiting-completed") {
     val sys = context.system

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -49,7 +49,7 @@ object ClusterEvent {
   /**
    * Marker interface for cluster domain events.
    */
-  sealed trait ClusterDomainEvent
+  sealed trait ClusterDomainEvent extends DeadLetterSuppression
 
   /**
    * Current snapshot state of the cluster. Sent to new subscriber.
@@ -198,7 +198,7 @@ object ClusterEvent {
    * This event is published when the cluster node is shutting down,
    * before the final [[MemberRemoved]] events are published.
    */
-  final case object ClusterShuttingDown extends ClusterDomainEvent with DeadLetterSuppression
+  final case object ClusterShuttingDown extends ClusterDomainEvent
 
   /**
    * Java API: get the singleton instance of `ClusterShuttingDown` event

--- a/akka-cluster/src/main/scala/akka/cluster/CoordinatedShutdownLeave.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/CoordinatedShutdownLeave.scala
@@ -41,16 +41,21 @@ private[akka] class CoordinatedShutdownLeave extends Actor {
 
   def waitingLeaveCompleted(replyTo: ActorRef): Receive = {
     case s: CurrentClusterState ⇒
-      if (s.members.exists(m ⇒ m.uniqueAddress == cluster.selfUniqueAddress &&
+      if (s.members.isEmpty) {
+        // not joined yet
+        done(replyTo)
+      } else if (s.members.exists(m ⇒ m.uniqueAddress == cluster.selfUniqueAddress &&
         (m.status == Leaving || m.status == Exiting || m.status == Down))) {
-        replyTo ! Done
-        context.stop(self)
+        done(replyTo)
       }
     case evt: MemberEvent ⇒
-      if (evt.member.uniqueAddress == cluster.selfUniqueAddress) {
-        replyTo ! Done
-        context.stop(self)
-      }
+      if (evt.member.uniqueAddress == cluster.selfUniqueAddress)
+        done(replyTo)
+  }
+
+  private def done(replyTo: ActorRef): Unit = {
+    replyTo ! Done
+    context.stop(self)
   }
 
 }

--- a/akka-cluster/src/main/scala/akka/cluster/CoordinatedShutdownLeave.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/CoordinatedShutdownLeave.scala
@@ -48,8 +48,12 @@ private[akka] class CoordinatedShutdownLeave extends Actor {
         (m.status == Leaving || m.status == Exiting || m.status == Down))) {
         done(replyTo)
       }
-    case evt: MemberEvent ⇒
-      if (evt.member.uniqueAddress == cluster.selfUniqueAddress)
+    case MemberLeft(m) ⇒
+      if (m.uniqueAddress == cluster.selfUniqueAddress)
+        done(replyTo)
+    case MemberRemoved(m, _) ⇒
+      // in case it was downed instead
+      if (m.uniqueAddress == cluster.selfUniqueAddress)
         done(replyTo)
   }
 


### PR DESCRIPTION
* The shutdownHook changed hasBeenShutdown flag to true, and then when
  the transport.shutdown was invoked the shutdown sequence was ignored
  until it was too late, ActorSystem already terminated.
* Also improved the cluster shutdown tasks when the cluster node had not
  joined

Refs #22671