### PR TITLE
update to Aeron 1.2.4, and fix the SharedMediaDriverSupport, #22693

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val sslConfigVersion = "0.2.1"
   val slf4jVersion = "1.7.23"
   val scalaXmlVersion = "1.0.6"
-  val aeronVersion = "1.2.3"
+  val aeronVersion = "1.2.4"
 
   val Versions = Seq(
     crossScalaVersions := Seq("2.11.8", "2.12.1"),


### PR DESCRIPTION
* SharedMediaDriverSupport failed with NPE with Aeron 1.2.4, and
  concludeAeronDirectory solves that

Refs #22693

I would like to have this included in Akka 2.5.0, because Aeron changed cnc version in 1.2.4, and that is a compile time constant so it's not possible for users to just update the dependency.