### PR TITLE
Revert "update to Aeron 1.2.4", #22705

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
@@ -43,24 +43,17 @@ object SharedMediaDriverSupport {
         .threadingMode(ThreadingMode.SHARED)
         .sharedIdleStrategy(TaskRunner.createIdleStrategy(idleCpuLevel))
 
-      // concludeAeronDirectory needed for Aeron 1.2.4, otherwise NPE from isDriverActive
-      driverContext.concludeAeronDirectory()
-
       // Check if the media driver is already started by another multi-node jvm.
       // It checks more than one time with a sleep inbetween. The number of checks
       // depends on the multi-node index (i).
       @tailrec def isDriverInactive(i: Int): Boolean = {
         if (i < 0) true
         else {
-          val active = try driverContext.isDriverActive(5000, new Consumer[String] {
+          val active = driverContext.isDriverActive(5000, new Consumer[String] {
             override def accept(msg: String): Unit = {
               println(msg)
             }
-          }) catch {
-            case NonFatal(e) ⇒
-              println(e.getMessage)
-              false
-          }
+          })
           if (active) false
           else {
             Thread.sleep(500)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val sslConfigVersion = "0.2.1"
   val slf4jVersion = "1.7.23"
   val scalaXmlVersion = "1.0.6"
-  val aeronVersion = "1.2.4"
+  val aeronVersion = "1.2.3"
 
   val Versions = Seq(
     crossScalaVersions := Seq("2.11.8", "2.12.1"),


### PR DESCRIPTION
Seems like we can't use Aeron 1.2.4 in 2.5.0.
After updating to Aeron 1.2.4 AeronStreamConsistencySpec fails when shutting down with never ending:
```
[JVM-2] timeout await for agent: driver-conductor. Retrying...
[JVM-2] timeout await for agent: driver-conductor. Retrying...
[JVM-2] timeout await for agent: driver-conductor. Retrying...
[JVM-2] timeout await for agent: driver-conductor. Retrying...
[JVM-2] timeout await for agent: driver-conductor. Retrying...
```

It's unfortunate that we can't use 1.2.4 because Aeron changed cnc version in 1.2.4, and that is a compile time constant so it's not possible for users to just update the dependency.

We'll update in Akka 2.5.1.

This reverts commit 3d0d50e98bb6751fad26eeae2f31da2907bbaa9a.