### PR TITLE
Update api mappings plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "0.2.2")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.0.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.17")
 


### PR DESCRIPTION
Was getting errors like:

```
[error] (akka-cluster/*:apiMappings) scala.MatchError: scala-xml_2.11-1.0.6.pom (of class java.lang.String)
[error] (akka-stream-testkit/*:apiMappings) scala.MatchError: scala-reflect-2.11.8.pom (of class java.lang.String)
[error] (akka-slf4j/*:apiMappings) scala.MatchError: scala-reflect-2.11.8.pom (of class java.lang.String)
```

during the release.