### PR TITLE
Refactor SimpleDateFormat to the new DateTimeFormatter of JDK 8

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -3,6 +3,8 @@
  */
 package akka.event
 
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -12,13 +14,13 @@ import akka.dispatch.RequiresMessageQueue
 import akka.event.Logging._
 import akka.util.ReentrantGuard
 import akka.util.Helpers.toRootLowerCase
-import akka.{ AkkaException, ConfigurationException }
+import akka.{AkkaException, ConfigurationException}
 
 import scala.annotation.implicitNotFound
 import scala.collection.immutable
 import scala.concurrent.Await
 import scala.language.existentials
-import scala.util.control.{ NoStackTrace, NonFatal }
+import scala.util.control.{NoStackTrace, NonFatal}
 
 /**
  * This trait brings log level handling to the EventStream: it reads the log
@@ -861,14 +863,11 @@ object Logging {
    */
   class LoggerInitializationException(msg: String) extends AkkaException(msg)
 
+  private val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss.SSS")
+
   trait StdOutLogger {
 
     import StdOutLogger._
-    import java.text.SimpleDateFormat
-    import java.util.Date
-
-    private val date = new Date()
-    private val dateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss.SSS")
 
     // format: OFF
     // FIXME: remove those when we have the chance to break binary compatibility
@@ -879,10 +878,9 @@ object Logging {
     private val debugFormat             = DebugFormat
     // format: ON
 
-    def timestamp(event: LogEvent): String = synchronized {
-      date.setTime(event.timestamp)
-      dateFormat.format(date)
-    } // SDF isn't threadsafe
+    def timestamp(event: LogEvent): String = {
+      formatter.format(Instant.ofEpochMilli(event.timestamp))
+    }
 
     def print(event: Any): Unit = event match {
       case e: Error   ⇒ error(e)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/BenchmarkFileReporter.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/BenchmarkFileReporter.scala
@@ -5,8 +5,8 @@ package akka.remote.artery
 
 import java.io.File
 import java.nio.file.Files
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 
 import akka.actor.ActorSystem
 
@@ -27,6 +27,8 @@ object BenchmarkFileReporter {
     target
   }
 
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
+
   def apply(testName: String, system: ActorSystem): BenchmarkFileReporter =
     new BenchmarkFileReporter {
       val gitCommit = {
@@ -34,8 +36,7 @@ object BenchmarkFileReporter {
         Try("git describe".!!.trim).getOrElse("[unknown]")
       }
       val testResultFile: File = {
-        val format = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss")
-        val fileName = s"${format.format(new Date())}-Artery-$testName-$gitCommit-results.txt"
+        val fileName = s"${formatter.format(Instant.now())}-Artery-$testName-$gitCommit-results.txt"
         new File(targetDirectory, fileName)
       }
       val config = system.settings.config

--- a/project/TimeStampede.scala
+++ b/project/TimeStampede.scala
@@ -3,6 +3,9 @@
  */
 package akka
 
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
 import sbt._
 import sbt.Keys._
 
@@ -26,8 +29,9 @@ object TimeStampede extends AutoPlugin {
     else version
   }
 
+  val formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+
   def timestamp(time: Long): String = {
-    val format = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss")
-    format.format(new java.util.Date(time))
+    formatter.format(Instant.ofEpochMilli(time))
   }
 }


### PR DESCRIPTION
Refactor `SimpleDateFormat` to the new `DateTimeFormatter` of JDK 8 which is thread safe.