### PR TITLE
Less confusing logging for dead letters without sender

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
@@ -134,7 +134,7 @@ abstract class MailboxSpec extends AkkaSpec with BeforeAndAfterAll with BeforeAn
     ensureInitialMailboxState(config, q)
 
     EventFilter.warning(
-      pattern = ".*received dead letter from Actor.*MailboxSpec/deadLetters.*",
+      pattern = "received dead letter without sender",
       occurrences = (enqueueN - dequeueN)) intercept {
 
       def createProducer(fromNum: Int, toNum: Int): Future[Vector[Envelope]] = spawn {

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -472,7 +472,9 @@ sealed trait AllDeadLetters {
 
 /**
  * When a message is sent to an Actor that is terminated before receiving the message, it will be sent as a DeadLetter
- * to the ActorSystem's EventStream
+ * to the ActorSystem's EventStream.
+ *
+ * When this message was sent without a sender [[ActorRef]], `sender` will be `system.deadLetters`.
  */
 @SerialVersionUID(1L)
 final case class DeadLetter(message: Any, sender: ActorRef, recipient: ActorRef) extends AllDeadLetters {

--- a/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
+++ b/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
@@ -28,10 +28,11 @@ class DeadLetterListener extends Actor {
   def receive = {
     case DeadLetter(message, snd, rcp) ⇒
       count += 1
+      val origin = if (snd eq context.system.deadLetters) "without sender" else s"from $snd"
       val done = maxCount != Int.MaxValue && count >= maxCount
       val doneMsg = if (done) ", no more dead letters will be logged" else ""
       eventStream.publish(Info(rcp.path.toString, rcp.getClass,
-        s"Message [${message.getClass.getName}] from $snd to $rcp was not delivered. [$count] dead letters encountered$doneMsg. " +
+        s"Message [${message.getClass.getName}] $origin to $rcp was not delivered. [$count] dead letters encountered$doneMsg. " +
           "This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' " +
           "and 'akka.log-dead-letters-during-shutdown'."))
       if (done) context.stop(self)


### PR DESCRIPTION
Of course it'd be much neater if `DeadLetter.sender` were an `Option` to begin
with, but we can't do that due to backwards compatibility.