### PR TITLE
Misleading sentence deleted from doc

### DIFF
--- a/akka-docs/rst/java/io-udp.rst
+++ b/akka-docs/rst/java/io-udp.rst
@@ -86,8 +86,7 @@ the biggest difference is the absence of remote address information in
 UDP Multicast
 ------------------------------------------
 
-If you want to use UDP multicast you will need to use Java 7. Akka provides
-a way to control various options of ``DatagramChannel`` through the
+Akka provides a way to control various options of ``DatagramChannel`` through the
 ``akka.io.Inet.SocketOption`` interface. The example below shows
 how to setup a receiver of multicast messages using IPv6 protocol.
 

--- a/akka-docs/rst/scala/io-udp.rst
+++ b/akka-docs/rst/scala/io-udp.rst
@@ -86,8 +86,7 @@ the biggest difference is the absence of remote address information in
 UDP Multicast
 ------------------------------------------
 
-If you want to use UDP multicast you will need to use Java 7. Akka provides
-a way to control various options of ``DatagramChannel`` through the
+Akka provides a way to control various options of ``DatagramChannel`` through the
 ``akka.io.Inet.SocketOption`` interface. The example below shows
 how to setup a receiver of multicast messages using IPv6 protocol.
 


### PR DESCRIPTION
We don't 'need java7', we need 'at least java7' but we need java8 already from 2.3 so we will have at least java7 :D So that sentance is totally redundant and misleading...