### PR TITLE
Do not interpret DeferredBehaviors on termination

### DIFF
--- a/akka-typed-testkit/src/main/scala/akka/typed/testkit/Effects.scala
+++ b/akka-typed-testkit/src/main/scala/akka/typed/testkit/Effects.scala
@@ -51,7 +51,7 @@ class EffectfulActorContext[T](_name: String, _initialBehavior: Behavior[T], _ma
   }
   def hasEffects: Boolean = effectQueue.peek() != null
 
-  private var current = Behavior.preStart(_initialBehavior, this)
+  private var current = Behavior.validateAsInitial(Behavior.undefer(_initialBehavior, this))
 
   def currentBehavior: Behavior[T] = current
   def isAlive: Boolean = Behavior.isAlive(current)

--- a/akka-typed/src/main/scala/akka/typed/Behavior.scala
+++ b/akka-typed/src/main/scala/akka/typed/Behavior.scala
@@ -165,18 +165,12 @@ object Behavior {
    * notably the behavior can neither be `Same` nor `Unhandled`. Starting
    * out with a `Stopped` behavior is allowed, though.
    */
-  def validateAsInitial[T](behavior: BehaSo I get updates every day or so. Bleeding edge, but also works whenever I need it, which is quite rare as well. vior[T]): Behavior[T] =
+  def validateAsInitial[T](behavior: Behavior[T]): Behavior[T] =
     behavior match {
       case SameBehavior | UnhandledBehavior ⇒
         throw new IllegalArgumentException(s"cannot use $behavior as initial behavior")
       case x ⇒ x
     }
-
-  /**
-   * Validate the given behavior as initial, initialize it if it is deferred.
-   */
-  def preStart[T](behavior: Behavior[T], ctx: ActorContext[T]): Behavior[T] =
-    validateAsInitial(undefer(behavior, ctx))
 
   /**
    * Returns true if the given behavior is not stopped.

--- a/akka-typed/src/main/scala/akka/typed/internal/SupervisionMechanics.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/SupervisionMechanics.scala
@@ -6,7 +6,7 @@ package internal
 
 import scala.util.control.NonFatal
 import akka.event.Logging
-import akka.typed.Behavior.DeferredBehavior
+import akka.typed.Behavior.{ DeferredBehavior, undefer, validateAsInitial }
 
 /**
  * INTERNAL API
@@ -68,7 +68,7 @@ private[typed] trait SupervisionMechanics[T] {
     behavior = initialBehavior
     if (system.settings.untyped.DebugLifecycle)
       publish(Logging.Debug(self.path.toString, clazz(behavior), "started"))
-    behavior = Behavior.preStart(behavior, ctx)
+    behavior = validateAsInitial(undefer(behavior, ctx))
     if (!Behavior.isAlive(behavior)) self.sendSystem(Terminate())
     true
   }

--- a/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorAdapter.scala
@@ -58,11 +58,11 @@ import akka.annotation.InternalApi
   }
 
   override def preStart(): Unit =
-    behavior = Behavior.preStart(behavior, ctx)
+    behavior = validateAsInitial(undefer(behavior, ctx))
   override def preRestart(reason: Throwable, message: Option[Any]): Unit =
     next(Behavior.interpretSignal(behavior, ctx, PreRestart), PreRestart)
   override def postRestart(reason: Throwable): Unit =
-    behavior = Behavior.preStart(behavior, ctx)
+    behavior = validateAsInitial(undefer(behavior, ctx))
   override def postStop(): Unit = {
     next(Behavior.interpretSignal(behavior, ctx, PostStop), PostStop)
   }

--- a/akka-typed/src/main/scala/akka/typed/patterns/Restarter.scala
+++ b/akka-typed/src/main/scala/akka/typed/patterns/Restarter.scala
@@ -7,7 +7,7 @@ package patterns
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 import akka.event.Logging
-import akka.typed.Behavior.{ DeferredBehavior, SameBehavior, StoppedBehavior, UnhandledBehavior }
+import akka.typed.Behavior._
 import akka.typed.scaladsl.Actor._
 
 /**
@@ -22,7 +22,7 @@ final case class Restarter[T, Thr <: Throwable: ClassTag](initialBehavior: Behav
   private def restart(ctx: ActorContext[T], startedBehavior: Behavior[T]): Behavior[T] = {
     try Behavior.interpretSignal(startedBehavior, ctx, PreRestart) catch { case NonFatal(_) ⇒ }
     // no need to canonicalize, it's done in the calling methods
-    Behavior.preStart(initialBehavior, ctx)
+    validateAsInitial(undefer(initialBehavior, ctx))
   }
 
   private def canonical(b: Behavior[T], ctx: ActorContext[T]): Behavior[T] =
@@ -78,13 +78,13 @@ final case class MutableRestarter[T, Thr <: Throwable: ClassTag](initialBehavior
 
   private[this] var current: Behavior[T] = _
   private def startCurrent(ctx: ActorContext[T]) = {
-    // we need to pre-start it the first time we have access to a context
-    if (current eq null) current = Behavior.preStart(initialBehavior, ctx)
+    // we need to undefer it if needed the first time we have access to a context
+    if (current eq null) current = validateAsInitial(undefer(initialBehavior, ctx))
   }
 
   private def restart(ctx: ActorContext[T]): Behavior[T] = {
     try Behavior.interpretSignal(current, ctx, PreRestart) catch { case NonFatal(_) ⇒ }
-    Behavior.preStart(initialBehavior, ctx)
+    validateAsInitial(undefer(initialBehavior, ctx))
   }
 
   override def management(ctx: ActorContext[T], signal: Signal): Behavior[T] = {

--- a/akka-typed/src/main/scala/akka/typed/patterns/Restarter.scala
+++ b/akka-typed/src/main/scala/akka/typed/patterns/Restarter.scala
@@ -32,15 +32,13 @@ final case class Restarter[T, Thr <: Throwable: ClassTag](initialBehavior: Behav
     else if (b eq behavior) Same
     else {
       b match {
-        case d: DeferredBehavior[_] ⇒ canonical(Behavior.undefer(d.asInstanceOf[DeferredBehavior[T]], ctx), ctx)
+        case d: DeferredBehavior[_] ⇒ canonical(Behavior.undefer(d, ctx), ctx)
         case b                      ⇒ Restarter[T, Thr](initialBehavior, resume)(b)
       }
     }
 
-  private def preStart(b: Behavior[T], ctx: ActorContext[T]): Behavior[T] = b match {
-    case d: DeferredBehavior[_] ⇒ Behavior.undefer(d.asInstanceOf[DeferredBehavior[T]], ctx)
-    case b                      ⇒ b
-  }
+  private def preStart(b: Behavior[T], ctx: ActorContext[T]): Behavior[T] =
+    Behavior.undefer(b, ctx)
 
   override def management(ctx: ActorContext[T], signal: Signal): Behavior[T] = {
     val startedBehavior = preStart(behavior, ctx)


### PR DESCRIPTION
The actual fix is in `SupervisionMechanics.scala`. Other changes are to unify undefer usage across various code places.

Fixes #22687