### PR TITLE
fix compilation error in multi-jvm tests

### DIFF
--- a/akka-docs-new/build.sbt
+++ b/akka-docs-new/build.sbt
@@ -7,7 +7,7 @@ AkkaBuild.dontPublishSettings
 Formatting.docFormatSettings
 Dependencies.docs
 
-unmanagedSourceDirectories in ScalariformKeys.format in Test <<= unmanagedSourceDirectories in Test
+unmanagedSourceDirectories in ScalariformKeys.format in Test := (unmanagedSourceDirectories in Test).value
 //TODO: additionalTasks in ValidatePR += paradox in Paradox
 
 enablePlugins(ScaladocNoVerificationOfDiagrams)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/BenchmarkFileReporter.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/BenchmarkFileReporter.scala
@@ -4,7 +4,7 @@
 package akka.remote.artery
 
 import java.io.File
-import java.nio.Files
+import java.nio.file.Files
 import java.text.SimpleDateFormat
 import java.util.Date
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
* it was not detected by PR validation because of bug
  in sbt 0.13.13, <<= operator with triggeredBy
* updated to sbt 0.13.15

This was not working with sbt 0.13.13:
```
compile in MultiJvm := ((compile in MultiJvm) triggeredBy (compile in Test)).value
```