### PR TITLE
Fix doubly namespaced setting

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -138,7 +138,7 @@ akka.cluster.sharding {
     # When using many entities with "remember entities" the Gossip message
     # can become to large if including to many in same message. Limit to
     # the same number as the number of ORSet per shard.
-    akka.cluster.sharding.distributed-data.max-delta-elements = 5
+    max-delta-elements = 5
     
   }
 


### PR DESCRIPTION
I don't know what this setting does and haven't seen any problems caused by this setting, but I'm almost certain that it's doubly namespaced and shouldn't be.