### PR TITLE
Fail all stages on abrupt termination

### DIFF
--- a/akka-docs/rst/java/stream/stream-customize.rst
+++ b/akka-docs/rst/java/stream/stream-customize.rst
@@ -469,3 +469,15 @@ stage as state of an actor, and the callbacks as the ``receive`` block of the ac
    is unsafe to access the state of an actor from the outside. This means that Future callbacks should **not close over**
    internal state of custom stages because such access can be concurrent with the provided callbacks, leading to undefined
    behavior.
+
+
+Resources and the stage lifecycle
+=================================
+
+If a stage manages a resource with a lifecycle, for example objects that needs to be shutdown when it is not
+used anymore, returned to a pool etc. it is important to make sure this will happen in all circumstances when the stage
+shuts down.
+
+Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``InHandler``
+callbacks. The reason for this is that when the ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while
+a stream is still running this leads to an "abrupt termination" and none of the callbacks are invoked.

--- a/akka-docs/rst/java/stream/stream-customize.rst
+++ b/akka-docs/rst/java/stream/stream-customize.rst
@@ -479,5 +479,7 @@ used anymore, returned to a pool etc. it is important to make sure this will hap
 shuts down.
 
 Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``OutHandler``
-callbacks. The reason for this is that when the ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while
-a stream is still running this leads to an "abrupt termination" and none of the callbacks are invoked.
+callbacks. The reason for this is that when the stage itself completes or is failed there is no signal from the upstreams
+or the downstreams. Even for stages that does not complete or fail in this manner can have this happen when the
+``Materializer`` is shutdown or the ``ActorSystem`` is terminated while a stream is still running, what is called an
+"abrupt termination".

--- a/akka-docs/rst/java/stream/stream-customize.rst
+++ b/akka-docs/rst/java/stream/stream-customize.rst
@@ -474,12 +474,11 @@ stage as state of an actor, and the callbacks as the ``receive`` block of the ac
 Resources and the stage lifecycle
 =================================
 
-If a stage manages a resource with a lifecycle, for example objects that needs to be shutdown when it is not
-used anymore, returned to a pool etc. it is important to make sure this will happen in all circumstances when the stage
-shuts down.
+If a stage manages a resource with a lifecycle, for example objects that need to be shutdown when they are not
+used anymore it is important to make sure this will happen in all circumstances when the stage shuts down.
 
-Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``OutHandler``
+Cleaning up resources should be done in ``GraphStageLogic.postStop`` and not in the ``InHandler`` and ``OutHandler``
 callbacks. The reason for this is that when the stage itself completes or is failed there is no signal from the upstreams
-or the downstreams. Even for stages that does not complete or fail in this manner can have this happen when the
+or the downstreams. Even for stages that do not complete or fail in this manner, this can happen when the
 ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while a stream is still running, what is called an
 "abrupt termination".

--- a/akka-docs/rst/java/stream/stream-customize.rst
+++ b/akka-docs/rst/java/stream/stream-customize.rst
@@ -478,6 +478,6 @@ If a stage manages a resource with a lifecycle, for example objects that needs t
 used anymore, returned to a pool etc. it is important to make sure this will happen in all circumstances when the stage
 shuts down.
 
-Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``InHandler``
+Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``OutHandler``
 callbacks. The reason for this is that when the ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while
 a stream is still running this leads to an "abrupt termination" and none of the callbacks are invoked.

--- a/akka-docs/rst/scala/stream/stream-customize.rst
+++ b/akka-docs/rst/scala/stream/stream-customize.rst
@@ -488,8 +488,10 @@ used anymore, returned to a pool etc. it is important to make sure this will hap
 shuts down.
 
 Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``OutHandler``
-callbacks. The reason for this is that when the ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while
-a stream is still running this leads to an "abrupt termination" and none of the callbacks are invoked.
+callbacks. The reason for this is that when the stage itself completes or is failed there is no signal from the upstreams
+or the downstreams. Even for stages that does not complete or fail in this manner can have this happen when the
+``Materializer`` is shutdown or the ``ActorSystem`` is terminated while a stream is still running, what is called an
+"abrupt termination".
 
 Extending Flow Combinators with Custom Operators
 ================================================

--- a/akka-docs/rst/scala/stream/stream-customize.rst
+++ b/akka-docs/rst/scala/stream/stream-customize.rst
@@ -487,7 +487,7 @@ If a stage manages a resource with a lifecycle, for example objects that needs t
 used anymore, returned to a pool etc. it is important to make sure this will happen in all circumstances when the stage
 shuts down.
 
-Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``InHandler``
+Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``OutHandler``
 callbacks. The reason for this is that when the ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while
 a stream is still running this leads to an "abrupt termination" and none of the callbacks are invoked.
 

--- a/akka-docs/rst/scala/stream/stream-customize.rst
+++ b/akka-docs/rst/scala/stream/stream-customize.rst
@@ -480,6 +480,17 @@ stage as state of an actor, and the callbacks as the ``receive`` block of the ac
   internal state of custom stages because such access can be concurrent with the provided callbacks, leading to undefined
   behavior.
 
+Resources and the stage lifecycle
+=================================
+
+If a stage manages a resource with a lifecycle, for example objects that needs to be shutdown when it is not
+used anymore, returned to a pool etc. it is important to make sure this will happen in all circumstances when the stage
+shuts down.
+
+Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``InHandler``
+callbacks. The reason for this is that when the ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while
+a stream is still running this leads to an "abrupt termination" and none of the callbacks are invoked.
+
 Extending Flow Combinators with Custom Operators
 ================================================
 

--- a/akka-docs/rst/scala/stream/stream-customize.rst
+++ b/akka-docs/rst/scala/stream/stream-customize.rst
@@ -483,13 +483,12 @@ stage as state of an actor, and the callbacks as the ``receive`` block of the ac
 Resources and the stage lifecycle
 =================================
 
-If a stage manages a resource with a lifecycle, for example objects that needs to be shutdown when it is not
-used anymore, returned to a pool etc. it is important to make sure this will happen in all circumstances when the stage
-shuts down.
+If a stage manages a resource with a lifecycle, for example objects that need to be shutdown when they are not
+used anymore it is important to make sure this will happen in all circumstances when the stage shuts down.
 
-Cleaning up resources should be done in ``GraphStageLogic.postStop` and not in the ``InHandler`` and ``OutHandler``
+Cleaning up resources should be done in ``GraphStageLogic.postStop`` and not in the ``InHandler`` and ``OutHandler``
 callbacks. The reason for this is that when the stage itself completes or is failed there is no signal from the upstreams
-or the downstreams. Even for stages that does not complete or fail in this manner can have this happen when the
+or the downstreams. Even for stages that do not complete or fail in this manner, this can happen when the
 ``Materializer`` is shutdown or the ``ActorSystem`` is terminated while a stream is still running, what is called an
 "abrupt termination".
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -392,24 +392,10 @@ class ActorGraphInterpreterSpec extends StreamSpec {
       upstream.expectCancellation()
     }
 
-    "trigger postStop in all stages when abruptly terminated (and no upstream boundaries)" in assertAllStagesStopped {
+    "trigger postStop in all stages when abruptly terminated (and no upstream boundaries)" in {
       val mat = ActorMaterializer()
       val gotStop = TestLatch(1)
 
-      object PostStopSnitchSource extends GraphStage[SourceShape[String]] {
-        val out = Outlet[String]("out")
-        val shape = SourceShape.of(out)
-        def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) {
-          setHandler(out, new OutHandler {
-            def onPull(): Unit = {
-              push(out, "whatever")
-            }
-          })
-          override def postStop(): Unit = {
-
-          }
-        }
-      }
       object PostStopSnitchFlow extends SimpleLinearGraphStage[String] {
         override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
           setHandler(in, new InHandler {

--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
@@ -241,7 +241,7 @@ class InputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
       }
     }
 
-    "throw from inputstream read if terminated abruptly" in assertAllStagesStopped {
+    "throw from inputstream read if terminated abruptly" in {
       val mat = ActorMaterializer()
       val probe = TestPublisher.probe[ByteString]()
       val inputStream = Source.fromPublisher(probe).runWith(StreamConverters.asInputStream())(mat)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -3,30 +3,27 @@
  */
 package akka.stream.io
 
-import akka.{ Done, NotUsed }
-import akka.actor.{ ActorSystem, Address, Kill }
-import akka.io.Tcp._
-import akka.stream.scaladsl.Tcp.{ IncomingConnection, ServerBinding }
-import akka.stream.scaladsl.{ Flow, _ }
-import akka.stream.testkit.TestUtils.temporaryServerAddress
-
-import scala.util.control.NonFatal
-import akka.stream.testkit.Utils._
-import akka.stream.testkit._
-import akka.stream._
-import akka.util.{ ByteString, Helpers }
-
-import scala.collection.immutable
-import scala.concurrent.{ Await, Future, Promise }
-import scala.concurrent.duration._
 import java.net._
 import java.util.concurrent.atomic.AtomicInteger
 
+import akka.actor.{ ActorSystem, Kill }
+import akka.io.Tcp._
+import akka.stream._
+import akka.stream.scaladsl.Tcp.{ IncomingConnection, ServerBinding }
+import akka.stream.scaladsl.{ Flow, _ }
+import akka.stream.testkit.TestUtils.temporaryServerAddress
+import akka.stream.testkit.Utils._
+import akka.stream.testkit._
 import akka.testkit.{ EventFilter, TestKit, TestLatch, TestProbe }
+import akka.util.ByteString
+import akka.{ Done, NotUsed }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
-import scala.util.Try
+import scala.collection.immutable
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future, Promise }
+import scala.util.control.NonFatal
 
 class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.timeout = 2s") with TcpHelper {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOnCompleteSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOnCompleteSpec.scala
@@ -78,7 +78,7 @@ class FlowOnCompleteSpec extends StreamSpec with ScriptedTest {
       onCompleteProbe.expectMsg(Success(Done))
     }
 
-    "yield error on abrupt termination" in assertAllStagesStopped {
+    "yield error on abrupt termination" in {
       val mat = ActorMaterializer()
       val onCompleteProbe = TestProbe()
       val p = TestPublisher.manualProbe[Int]()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOnCompleteSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOnCompleteSpec.scala
@@ -78,6 +78,18 @@ class FlowOnCompleteSpec extends StreamSpec with ScriptedTest {
       onCompleteProbe.expectMsg(Success(Done))
     }
 
+    "yield error on abrupt termination" in assertAllStagesStopped {
+      val mat = ActorMaterializer()
+      val onCompleteProbe = TestProbe()
+      val p = TestPublisher.manualProbe[Int]()
+      Source.fromPublisher(p).to(Sink.onComplete[Int](onCompleteProbe.ref ! _)).run()(mat)
+      val proc = p.expectSubscription()
+      proc.expectRequest()
+      mat.shutdown()
+
+      onCompleteProbe.expectMsgType[Failure[_]]
+    }
+
   }
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
@@ -65,6 +65,15 @@ class FlowWatchTerminationSpec extends StreamSpec {
         .expectComplete()
     }
 
+    "fail future when stream abruptly terminated" in assertAllStagesStopped {
+      val mat = ActorMaterializer()
+
+      val (p, future) = TestSource.probe[Int].watchTermination()(Keep.both).to(Sink.ignore).run()(mat)
+      mat.shutdown()
+
+      future.failed.futureValue shouldBe an[AbruptTerminationException]
+    }
+
   }
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
@@ -65,7 +65,7 @@ class FlowWatchTerminationSpec extends StreamSpec {
         .expectComplete()
     }
 
-    "fail future when stream abruptly terminated" in assertAllStagesStopped {
+    "fail future when stream abruptly terminated" in {
       val mat = ActorMaterializer()
 
       val (p, future) = TestSource.probe[Int].watchTermination()(Keep.both).to(Sink.ignore).run()(mat)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HeadSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HeadSinkSpec.scala
@@ -80,7 +80,7 @@ class HeadSinkSpec extends StreamSpec with ScriptedTest {
       Await.result(Source.empty[Int].runWith(Sink.headOption), 1.second) should be(None)
     }
 
-    "fail on abrupt termination" in assertAllStagesStopped {
+    "fail on abrupt termination" in {
       val mat = ActorMaterializer()
       val source = TestPublisher.probe()
       val f = Source.fromPublisher(source)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HeadSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HeadSinkSpec.scala
@@ -6,9 +6,7 @@ package akka.stream.scaladsl
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
+import akka.stream.{ AbruptStageTerminationException, AbruptTerminationException, ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit._
 import akka.stream.testkit.Utils._
 
@@ -80,6 +78,18 @@ class HeadSinkSpec extends StreamSpec with ScriptedTest {
 
     "yield None for empty stream" in assertAllStagesStopped {
       Await.result(Source.empty[Int].runWith(Sink.headOption), 1.second) should be(None)
+    }
+
+    "fail on abrupt termination" in assertAllStagesStopped {
+      val mat = ActorMaterializer()
+      val source = TestPublisher.probe()
+      val f = Source.fromPublisher(source)
+        .runWith(Sink.headOption)(mat)
+      mat.shutdown()
+
+      // this one always fails with the AbruptTerminationException rather than the
+      // AbruptStageTerminationException for some reason
+      f.failed.futureValue shouldBe an[AbruptTerminationException]
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SeqSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SeqSinkSpec.scala
@@ -3,10 +3,11 @@
  */
 package akka.stream.scaladsl
 
-import akka.stream.testkit.StreamSpec
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.testkit.{ StreamSpec, TestPublisher }
+import akka.stream.{ AbruptTerminationException, ActorMaterializer, ActorMaterializerSettings }
+
 import scala.collection.immutable
-import scala.concurrent.{ Future, Await }
+import scala.concurrent.{ Await, Future }
 
 class SeqSinkSpec extends StreamSpec {
 
@@ -28,6 +29,15 @@ class SeqSinkSpec extends StreamSpec {
       val future: Future[immutable.Seq[Int]] = Source.fromIterator(() ⇒ input.iterator).runWith(Sink.seq)
       val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
       result should be(input)
+    }
+
+    "fail the future on abrupt termination" in {
+      val mat = ActorMaterializer()
+      val probe = TestPublisher.probe()
+      val future: Future[immutable.Seq[Int]] =
+        Source.fromPublisher(probe).runWith(Sink.seq)(mat)
+      mat.shutdown()
+      future.failed.futureValue shouldBe an[AbruptTerminationException]
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
@@ -15,6 +15,7 @@ import akka.stream.impl.{ PhasedFusingActorMaterializer, StreamSupervisor }
 import akka.stream.testkit.{ StreamSpec, TestSubscriber }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestLatch
 import akka.util.ByteString
 
 import scala.concurrent.{ Await, Future, Promise }
@@ -246,6 +247,25 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
       sub.request(61)
       c.expectNextN(60)
       c.expectError()
+    }
+
+    "close resource when stream is abruptly terminated" in assertAllStagesStopped {
+      val closeLatch = TestLatch(1)
+      val mat = ActorMaterializer()
+      val p = Source.unfoldResourceAsync[String, BufferedReader](
+        open,
+        read,
+        reader ⇒ Future.successful {
+          closeLatch.countDown()
+          Done
+        })
+        .runWith(Sink.asPublisher(false))(mat)
+      val c = TestSubscriber.manualProbe[String]()
+      p.subscribe(c)
+
+      mat.shutdown()
+
+      Await.ready(closeLatch, remainingOrDefault)
     }
   }
   override def afterTermination(): Unit = {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
@@ -249,7 +249,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
       c.expectError()
     }
 
-    "close resource when stream is abruptly terminated" in assertAllStagesStopped {
+    "close resource when stream is abruptly terminated" in {
       val closeLatch = TestLatch(1)
       val mat = ActorMaterializer()
       val p = Source.unfoldResourceAsync[String, BufferedReader](

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -17,6 +17,7 @@ import com.typesafe.config.Config
 import scala.concurrent.duration._
 import akka.japi.function
 import akka.stream.impl.fusing.GraphInterpreterShell
+import akka.stream.stage.GraphStageLogic
 
 import scala.util.control.NoStackTrace
 
@@ -220,6 +221,15 @@ class MaterializationException(msg: String, cause: Throwable = null) extends Run
  */
 final case class AbruptTerminationException(actor: ActorRef)
   extends RuntimeException(s"Processor actor [$actor] terminated abruptly") with NoStackTrace
+
+/**
+ * Signal that the stage was abruptly terminated, usually seen as a call to `postStop` of the `GraphStageLogic` without
+ * any of the handler callbacks seeing completion, cancellation or failure from up or downstream. This can happen when
+ * the actor running the graph is killed, which happens when the materializer or actor system is terminated.
+ */
+final class AbruptStageTerminationException(logic: GraphStageLogic)
+  extends RuntimeException(s"GraphStage [$logic] terminated abruptly, caused by for example materializer or actor system termination.")
+  with NoStackTrace
 
 object ActorMaterializerSettings {
 

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -224,7 +224,7 @@ final case class AbruptTerminationException(actor: ActorRef)
 
 /**
  * Signal that the stage was abruptly terminated, usually seen as a call to `postStop` of the `GraphStageLogic` without
- * any of the handler callbacks seeing completion, cancellation or failure from up or downstream. This can happen when
+ * any of the handler callbacks seeing completion or failure from upstream or cancellation from downstream. This can happen when
  * the actor running the graph is killed, which happens when the materializer or actor system is terminated.
  */
 final class AbruptStageTerminationException(logic: GraphStageLogic)

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -255,6 +255,12 @@ import akka.util.OptionVal
         failStage(ex)
       }
 
+      override def postStop(): Unit = {
+        if (!p.isCompleted) {
+          p.failure(new AbruptStageTerminationException(this))
+        }
+      }
+
       setHandler(in, this)
     }, p.future)
   }
@@ -295,6 +301,12 @@ import akka.util.OptionVal
       override def onUpstreamFailure(ex: Throwable): Unit = {
         p.tryFailure(ex)
         failStage(ex)
+      }
+
+      override def postStop(): Unit = {
+        if (!p.isCompleted) {
+          p.failure(new AbruptStageTerminationException(this))
+        }
       }
 
       setHandler(in, this)

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -256,9 +256,7 @@ import akka.util.OptionVal
       }
 
       override def postStop(): Unit = {
-        if (!p.isCompleted) {
-          p.failure(new AbruptStageTerminationException(this))
-        }
+        if (!p.isCompleted) p.failure(new AbruptStageTerminationException(this))
       }
 
       setHandler(in, this)
@@ -304,9 +302,7 @@ import akka.util.OptionVal
       }
 
       override def postStop(): Unit = {
-        if (!p.isCompleted) {
-          p.failure(new AbruptStageTerminationException(this))
-        }
+        if (!p.isCompleted) p.failure(new AbruptStageTerminationException(this))
       }
 
       setHandler(in, this)

--- a/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
@@ -263,9 +263,7 @@ import scala.util.control.NonFatal
       }
 
     override def postStop(): Unit = {
-      if (open) {
-        close(blockingStream)
-      }
+      if (open) close(blockingStream)
     }
 
   }
@@ -358,9 +356,7 @@ import scala.util.control.NonFatal
     private def closeStage(): Unit = closeAndThen(completeStage)
 
     override def postStop(): Unit = {
-      if (open) {
-        closeStage()
-      }
+      if (open) closeStage()
     }
 
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sources.scala
@@ -17,6 +17,7 @@ import akka.Done
 import java.util.concurrent.CompletionStage
 
 import akka.annotation.InternalApi
+import akka.util.OptionVal
 
 import scala.compat.java8.FutureConverters._
 import scala.util.Try
@@ -212,10 +213,14 @@ import scala.util.control.NonFatal
 
   def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with OutHandler {
     lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    var open = false
     var blockingStream: S = _
     setHandler(out, this)
 
-    override def preStart(): Unit = blockingStream = create()
+    override def preStart(): Unit = {
+      blockingStream = create()
+      open = true
+    }
 
     @tailrec
     final override def onPull(): Unit = {
@@ -245,15 +250,23 @@ import scala.util.control.NonFatal
     private def restartState(): Unit = {
       close(blockingStream)
       blockingStream = create()
+      open = true
     }
 
     private def closeStage(): Unit =
       try {
         close(blockingStream)
+        open = false
         completeStage()
       } catch {
         case NonFatal(ex) ⇒ failStage(ex)
       }
+
+    override def postStop(): Unit = {
+      if (open) {
+        close(blockingStream)
+      }
+    }
 
   }
   override def toString = "UnfoldResourceSource"
@@ -273,6 +286,7 @@ import scala.util.control.NonFatal
   def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with OutHandler {
     lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
     var resource = Promise[S]()
+    var open = false
     implicit val context = ExecutionContexts.sameThreadExecutionContext
 
     setHandler(out, this)
@@ -280,22 +294,21 @@ import scala.util.control.NonFatal
     override def preStart(): Unit = createStream(false)
 
     private def createStream(withPull: Boolean): Unit = {
-      val cb = getAsyncCallback[Try[S]] {
+      val createdCallback = getAsyncCallback[Try[S]] {
         case scala.util.Success(res) ⇒
+          open = true
           resource.success(res)
           if (withPull) onPull()
         case scala.util.Failure(t) ⇒ failStage(t)
       }
       try {
-        create().onComplete(cb.invoke)
+        create().onComplete(createdCallback.invoke)
       } catch {
         case NonFatal(ex) ⇒ failStage(ex)
       }
     }
 
-    private def onResourceReady(f: (S) ⇒ Unit): Unit = resource.future.foreach {
-      resource ⇒ f(resource)
-    }
+    private def onResourceReady(f: (S) ⇒ Unit): Unit = resource.future.foreach(f)
 
     val errorHandler: PartialFunction[Throwable, Unit] = {
       case NonFatal(ex) ⇒ decider(ex) match {
@@ -306,7 +319,8 @@ import scala.util.control.NonFatal
         case Supervision.Resume  ⇒ onPull()
       }
     }
-    val callback = getAsyncCallback[Try[Option[T]]] {
+
+    val readCallback = getAsyncCallback[Try[Option[T]]] {
       case scala.util.Success(data) ⇒ data match {
         case Some(d) ⇒ push(out, d)
         case None    ⇒ closeStage()
@@ -314,22 +328,26 @@ import scala.util.control.NonFatal
       case scala.util.Failure(t) ⇒ errorHandler(t)
     }.invoke _
 
-    final override def onPull(): Unit = onResourceReady {
-      case resource ⇒
-        try { readData(resource).onComplete(callback) } catch errorHandler
-    }
+    final override def onPull(): Unit =
+      onResourceReady { resource ⇒
+        try { readData(resource).onComplete(readCallback) } catch errorHandler
+      }
 
     override def onDownstreamFinish(): Unit = closeStage()
 
     private def closeAndThen(f: () ⇒ Unit): Unit = {
       setKeepGoing(true)
-      val cb = getAsyncCallback[Try[Done]] {
-        case scala.util.Success(_) ⇒ f()
-        case scala.util.Failure(t) ⇒ failStage(t)
+      val closedCallback = getAsyncCallback[Try[Done]] {
+        case scala.util.Success(_) ⇒
+          open = false
+          f()
+        case scala.util.Failure(t) ⇒
+          open = false
+          failStage(t)
       }
 
       onResourceReady(res ⇒
-        try { close(res).onComplete(cb.invoke) } catch {
+        try { close(res).onComplete(closedCallback.invoke) } catch {
           case NonFatal(ex) ⇒ failStage(ex)
         })
     }
@@ -337,7 +355,13 @@ import scala.util.control.NonFatal
       resource = Promise[S]()
       createStream(true)
     })
-    private def closeStage(): Unit = closeAndThen(completeStage _)
+    private def closeStage(): Unit = closeAndThen(completeStage)
+
+    override def postStop(): Unit = {
+      if (open) {
+        closeStage()
+      }
+    }
 
   }
   override def toString = "UnfoldResourceSourceAsync"

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -605,14 +605,6 @@ import scala.util.control.NonFatal
     // call has no effect and therefore does the right thing: nothing.
     try {
       inputs.foreach(_.onInternalError(reason))
-      // fail all sources
-      logics.foreach { logic ⇒
-        // source
-        if (logic.inCount == 0 && logic.outCount > 0) {
-          logic.failStage(reason)
-          interpreter.finalizeStage(logic)
-        }
-      }
       interpreter.execute(abortLimit)
       interpreter.finish()
     } catch {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -605,6 +605,14 @@ import scala.util.control.NonFatal
     // call has no effect and therefore does the right thing: nothing.
     try {
       inputs.foreach(_.onInternalError(reason))
+      // fail all sources
+      logics.foreach { logic ⇒
+        // source
+        if (logic.inCount == 0 && logic.outCount > 0) {
+          logic.failStage(reason)
+          interpreter.finalizeStage(logic)
+        }
+      }
       interpreter.execute(abortLimit)
       interpreter.finish()
     } catch {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -546,7 +546,7 @@ import scala.util.control.NonFatal
     if (enabled) shutdownCounter(logic.stageId) |= KeepGoingFlag
     else shutdownCounter(logic.stageId) &= KeepGoingMask
 
-  private def finalizeStage(logic: GraphStageLogic): Unit = {
+  private[stream] def finalizeStage(logic: GraphStageLogic): Unit = {
     try {
       logic.postStop()
       logic.afterPostStop()

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -139,9 +139,7 @@ import scala.concurrent.{ Future, Promise }
         }
 
         override def postStop(): Unit = {
-          if (!finishPromise.isCompleted) {
-            finishPromise.failure(new AbruptStageTerminationException(this))
-          }
+          if (!finishPromise.isCompleted) finishPromise.failure(new AbruptStageTerminationException(this))
         }
 
         setHandlers(in, out, this)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -138,6 +138,12 @@ import scala.concurrent.{ Future, Promise }
           completeStage()
         }
 
+        override def postStop(): Unit = {
+          if (!finishPromise.isCompleted) {
+            finishPromise.failure(new AbruptStageTerminationException(this))
+          }
+        }
+
         setHandlers(in, out, this)
       }, finishPromise.future)
     }
@@ -186,6 +192,13 @@ import scala.concurrent.{ Future, Promise }
         override def onDownstreamFinish(): Unit = {
           super.onDownstreamFinish()
           monitor.set(Finished)
+        }
+
+        override def postStop(): Unit = {
+          monitor.state match {
+            case Finished | _: Failed ⇒
+            case _                    ⇒ monitor.set(Failed(new AbruptStageTerminationException(this)))
+          }
         }
 
         setHandler(in, this)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -90,9 +90,7 @@ private[stream] object InputStreamSinkStage {
       }
 
       override def postStop(): Unit = {
-        if (!completionSignalled) {
-          dataQueue.add(Failed(new AbruptStageTerminationException(this)))
-        }
+        if (!completionSignalled) dataQueue.add(Failed(new AbruptStageTerminationException(this)))
       }
 
       setHandler(in, this)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -11,7 +11,7 @@ import akka.stream.Attributes.InputBuffer
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl.io.InputStreamSinkStage._
 import akka.stream.stage._
-import akka.stream.{ Attributes, Inlet, SinkShape }
+import akka.stream.{ AbruptStageTerminationException, Attributes, Inlet, SinkShape }
 import akka.util.ByteString
 
 import scala.annotation.tailrec
@@ -51,6 +51,8 @@ private[stream] object InputStreamSinkStage {
 
     val logic = new GraphStageLogic(shape) with StageWithCallback with InHandler {
 
+      var completionSignalled = false
+
       private val callback: AsyncCallback[AdapterToStageMessage] =
         getAsyncCallback {
           case ReadElementAcknowledgement ⇒ sendPullIfAllowed()
@@ -77,15 +79,24 @@ private[stream] object InputStreamSinkStage {
 
       override def onUpstreamFinish(): Unit = {
         dataQueue.add(Finished)
+        completionSignalled = true
         completeStage()
       }
 
       override def onUpstreamFailure(ex: Throwable): Unit = {
         dataQueue.add(Failed(ex))
+        completionSignalled = true
         failStage(ex)
       }
 
+      override def postStop(): Unit = {
+        if (!completionSignalled) {
+          dataQueue.add(Failed(new AbruptStageTerminationException(this)))
+        }
+      }
+
       setHandler(in, this)
+
     }
 
     (logic, new InputStreamAdapter(dataQueue, logic.wakeUp, readTimeout))

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -54,7 +54,7 @@ import scala.util.Try
 
       val connectionFlowsAwaitingInitialization = new AtomicLong()
       var listener: ActorRef = _
-      var unbindPromise = Promise[Unit]()
+      val unbindPromise = Promise[Unit]()
       var unbindStarted = false
 
       override def preStart(): Unit = {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -315,9 +315,7 @@ object Sink {
             }
 
             override def postStop(): Unit = {
-              if (!completionSignalled) {
-                callback(Failure(new AbruptStageTerminationException(this)))
-              }
+              if (!completionSignalled) callback(Failure(new AbruptStageTerminationException(this)))
             }
 
             setHandlers(in, out, this)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -296,21 +296,32 @@ object Sink {
         override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
           new GraphStageLogic(shape) with InHandler with OutHandler {
 
+            var completionSignalled = false
+
             override def onPush(): Unit = pull(in)
 
             override def onPull(): Unit = pull(in)
 
             override def onUpstreamFailure(cause: Throwable): Unit = {
               callback(Failure(cause))
+              completionSignalled = true
               failStage(cause)
             }
 
             override def onUpstreamFinish(): Unit = {
               callback(Success(Done))
+              completionSignalled = true
               completeStage()
             }
 
+            override def postStop(): Unit = {
+              if (!completionSignalled) {
+                callback(Failure(new AbruptStageTerminationException(this)))
+              }
+            }
+
             setHandlers(in, out, this)
+
           }
       }
     }

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -217,9 +217,13 @@ object GraphStageLogic {
  *  * The lifecycle hooks [[preStart()]] and [[postStop()]]
  *  * Methods for performing stream processing actions, like pulling or pushing elements
  *
- *  The stage logic is always once all its input and output ports have been closed, i.e. it is not possible to
- *  keep the stage alive for further processing once it does not have any open ports. This can be changed by
- *  overriding `keepGoingAfterAllPortsClosed` to return true.
+ * The stage logic is completed once all its input and output ports have been closed. This can be changed by
+ * setting `setKeepGoing` to true.
+ *
+ * The `postStop` lifecycle hook on the logic itself is called once all ports are closed. This is the only tear down
+ * callback that is guaranteed to happen, if the actor system or the materializer is terminated the handlers may never
+ * see any callbacks to `onUpstreamFailure`, `onUpstreamFinish` or `onDownstreamFinish`. Therefore stage resource
+ * cleanup should always be done in `postStop`.
  */
 abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: Int) {
   import GraphInterpreter._
@@ -538,7 +542,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
 
   /**
    * Automatically invokes [[cancel()]] or [[complete()]] on all the input or output ports that have been called,
-   * then stops the stage, then [[postStop()]] is called.
+   * then marks the stage as stopped.
    */
   final def completeStage(): Unit = {
     var i = 0
@@ -556,7 +560,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
 
   /**
    * Automatically invokes [[cancel()]] or [[fail()]] on all the input or output ports that have been called,
-   * then stops the stage, then [[postStop()]] is called.
+   * then marks the stage as stopped.
    */
   final def failStage(ex: Throwable): Unit = {
     var i = 0


### PR DESCRIPTION
Fixes #22652 in a general way, somewhat like how @avakhrenev proposed the fix. When the abrupt termination is triggered the source stages are failed and that failure is propagated through the graph.