### PR TITLE
Use InetSocketAddress.getHostString in favour of getHostName

### DIFF
--- a/akka-docs/rst/java/code/jdocs/stream/io/StreamTcpDocTest.java
+++ b/akka-docs/rst/java/code/jdocs/stream/io/StreamTcpDocTest.java
@@ -71,7 +71,7 @@ public class StreamTcpDocTest extends AbstractJavaTest {
 
       final InetSocketAddress localhost = SocketUtil.temporaryServerAddress("127.0.0.1", false);
       final Source<IncomingConnection, CompletionStage<ServerBinding>> connections =
-        Tcp.get(system).bind(localhost.getHostName(), localhost.getPort()); // TODO getHostString in Java7
+        Tcp.get(system).bind(localhost.getHostString(), localhost.getPort());
 
       //#echo-server-simple-handle
       connections.runForeach(connection -> {

--- a/akka-docs/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/stream/io/StreamTcpDocSpec.scala
@@ -63,7 +63,7 @@ class StreamTcpDocSpec extends AkkaSpec {
 
   "initial server banner echo server" in {
     val localhost = SocketUtil.temporaryServerAddress()
-    val connections = Tcp().bind(localhost.getHostName, localhost.getPort) // TODO getHostString in Java7
+    val connections = Tcp().bind(localhost.getHostString, localhost.getPort)
     val serverProbe = TestProbe()
 
     import akka.stream.scaladsl.Framing

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
@@ -59,7 +59,7 @@ public class TcpTest extends StreamTest {
   public void mustWorkInHappyCase() throws Exception {
     final InetSocketAddress serverAddress = TestUtils.temporaryServerAddress("127.0.0.1", false);
     final Source<IncomingConnection, CompletionStage<ServerBinding>> binding = Tcp.get(system)
-        .bind(serverAddress.getHostName(), serverAddress.getPort()); // TODO getHostString in Java7
+        .bind(serverAddress.getHostString(), serverAddress.getPort());
 
     final CompletionStage<ServerBinding> future = binding.to(echoHandler).run(materializer);
     final ServerBinding b = future.toCompletableFuture().get(5, TimeUnit.SECONDS);
@@ -85,7 +85,7 @@ public class TcpTest extends StreamTest {
   public void mustReportServerBindFailure() throws Exception {
     final InetSocketAddress serverAddress = TestUtils.temporaryServerAddress("127.0.0.1", false);
     final Source<IncomingConnection, CompletionStage<ServerBinding>> binding = Tcp.get(system)
-        .bind(serverAddress.getHostName(), serverAddress.getPort()); // TODO getHostString in Java7
+        .bind(serverAddress.getHostString(), serverAddress.getPort());
 
     final CompletionStage<ServerBinding> future = binding.to(echoHandler).run(materializer);
     final ServerBinding b = future.toCompletableFuture().get(5, TimeUnit.SECONDS);

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -366,14 +366,14 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
         Flow.fromSinkAndSourceMat(Sink.ignore, Source.single(ByteString("Early response")))(Keep.right)
 
       val binding =
-        Tcp().bind(serverAddress.getHostName, serverAddress.getPort, halfClose = false).toMat(Sink.foreach { conn ⇒
+        Tcp().bind(serverAddress.getHostString, serverAddress.getPort, halfClose = false).toMat(Sink.foreach { conn ⇒
           conn.flow.join(writeButIgnoreRead).run()
         })(Keep.left)
           .run()
           .futureValue
 
       val (promise, result) = Source.maybe[ByteString]
-        .via(Tcp().outgoingConnection(serverAddress.getHostName, serverAddress.getPort))
+        .via(Tcp().outgoingConnection(serverAddress.getHostString, serverAddress.getPort))
         .toMat(Sink.fold(ByteString.empty)(_ ++ _))(Keep.both)
         .run()
 
@@ -387,7 +387,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       val serverAddress = temporaryServerAddress()
 
       val binding =
-        Tcp().bind(serverAddress.getHostName, serverAddress.getPort, halfClose = false).toMat(Sink.foreach { conn ⇒
+        Tcp().bind(serverAddress.getHostString, serverAddress.getPort, halfClose = false).toMat(Sink.foreach { conn ⇒
           conn.flow.join(Flow[ByteString]).run()
         })(Keep.left)
           .run()
@@ -408,7 +408,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       val mat2 = ActorMaterializer.create(system2)
 
       val serverAddress = temporaryServerAddress()
-      val binding = Tcp(system2).bindAndHandle(Flow[ByteString], serverAddress.getHostName, serverAddress.getPort)(mat2)
+      val binding = Tcp(system2).bindAndHandle(Flow[ByteString], serverAddress.getHostString, serverAddress.getPort)(mat2)
 
       val probe = TestProbe()
       val testMsg = ByteString(0)
@@ -442,7 +442,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       val serverAddress = temporaryServerAddress()
       val (bindingFuture, echoServerFinish) =
         Tcp()
-          .bind(serverAddress.getHostName, serverAddress.getPort) // TODO getHostString in Java7
+          .bind(serverAddress.getHostString, serverAddress.getPort)
           .toMat(echoHandler)(Keep.both)
           .run()
 
@@ -557,7 +557,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
 
         import serverSystem.dispatcher
         val futureBinding: Future[ServerBinding] =
-          Tcp(serverSystem).bind(address.getHostName, address.getPort)
+          Tcp(serverSystem).bind(address.getHostString, address.getPort)
             // accept one connection, then cancel
             .take(1)
             // keep the accepted request hanging
@@ -619,7 +619,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
             }
           }.to(Sink.ignore)
 
-      val serverBound = Tcp().bind(address.getHostName, address.getPort)
+      val serverBound = Tcp().bind(address.getHostString, address.getPort)
         .toMat(accept2ConnectionSink)(Keep.left)
         .run()
 
@@ -655,7 +655,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       try {
         val address = temporaryServerAddress()
 
-        val bindingFuture = Tcp().bindAndHandle(Flow[ByteString], address.getHostName, address.getPort)(mat2)
+        val bindingFuture = Tcp().bindAndHandle(Flow[ByteString], address.getHostString, address.getPort)(mat2)
 
         // Ensure server is running
         bindingFuture.futureValue


### PR DESCRIPTION
Saves a reverse lookup when the address was initialized as an address.