### PR TITLE
Implement watchWith to customize the termination msg (#18778)

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -153,6 +153,14 @@ trait ActorContext extends ActorRefFactory {
   def watch(subject: ActorRef): ActorRef
 
   /**
+   * Registers this actor as a Monitor for the provided ActorRef.
+   * This actor will receive the specified message when watched
+   * actor is terminated.
+   * @return the provided ActorRef
+   */
+  def watchWith(subject: ActorRef, msg: Any): ActorRef
+
+  /**
    * Unregisters this actor as Monitor for the provided ActorRef.
    * @return the provided ActorRef
    */

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -139,7 +139,7 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
       maintainAddressTerminatedSubscription() {
         try {
           watching foreach { // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-            case watchee: InternalActorRef ⇒ watchee.sendSystemMessage(Unwatch(watchee, self))
+            case (watchee: InternalActorRef, _) ⇒ watchee.sendSystemMessage(Unwatch(watchee, self))
           }
         } finally {
           watching = Map.empty

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -12,9 +12,9 @@ import akka.event.AddressTerminatedTopic
 private[akka] trait DeathWatch { this: ActorCell ⇒
 
   /**
-    * This map holds a [[None]] for actors for which we send a [[Terminated]] notification on termination,
-    * ``Some(message)`` for actors for which we send a custom termination message.
-    */
+   * This map holds a [[None]] for actors for which we send a [[Terminated]] notification on termination,
+   * ``Some(message)`` for actors for which we send a custom termination message.
+   */
   private var watching: Map[ActorRef, Option[Any]] = Map.empty
   private var watchedBy: Set[ActorRef] = ActorCell.emptyActorRefSet
   private var terminatedQueued: Set[ActorRef] = ActorCell.emptyActorRefSet

--- a/akka-typed-testkit/src/main/scala/akka/typed/testkit/StubbedActorContext.scala
+++ b/akka-typed-testkit/src/main/scala/akka/typed/testkit/StubbedActorContext.scala
@@ -56,6 +56,7 @@ class StubbedActorContext[T](
     }
   }
   override def watch[U](other: ActorRef[U]): Unit = ()
+  override def watchWith[U](other: ActorRef[U], msg: T): Unit = ()
   override def unwatch[U](other: ActorRef[U]): Unit = ()
   override def setReceiveTimeout(d: FiniteDuration, msg: T): Unit = ()
   override def cancelReceiveTimeout(): Unit = ()

--- a/akka-typed-tests/src/test/java/akka/typed/javadsl/MonitoringTest.java
+++ b/akka-typed-tests/src/test/java/akka/typed/javadsl/MonitoringTest.java
@@ -16,13 +16,15 @@ import static akka.typed.javadsl.AskPattern.*;
 
 public class MonitoringTest extends JUnitSuite {
 
-    static final class RunTest<T> {
+    static interface Message {}
+    static final class RunTest<T> implements Message {
         private final ActorRef<T> replyTo;
         public RunTest(ActorRef<T> replyTo) {
             this.replyTo = replyTo;
         }
     }
     static final class Stop {}
+    static final class CustomTerminationMessage implements Message {}
 
     // final FiniteDuration fiveSeconds = FiniteDuration.create(5, TimeUnit.SECONDS);
     final Timeout timeout = new Timeout(Duration.create(5, TimeUnit.SECONDS));
@@ -44,6 +46,18 @@ public class MonitoringTest extends JUnitSuite {
         );
     }
 
+    private Behavior<Message> waitingForMessage(ActorRef<Done> replyWhenReceived) {
+        return immutable(
+            (ctx, msg) -> {
+                if (msg instanceof CustomTerminationMessage) {
+                    replyWhenReceived.tell(Done.getInstance());
+                    return same();
+                } else {
+                    return unhandled();
+                }
+            }
+        );
+    }
 
     @Test
     public void shouldWatchTerminatingActor() throws Exception {
@@ -58,6 +72,26 @@ public class MonitoringTest extends JUnitSuite {
         // Not sure why this does not compile without an explicit cast?
         // system.tell(new RunTest());
         CompletionStage<Done> result = AskPattern.ask((ActorRef<RunTest<Done>>)system, (ActorRef<Done> ref) -> new RunTest<Done>(ref), timeout, system.scheduler());
+        result.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldWatchWithCustomMessage() throws Exception {
+        Behavior<Message> root = immutable((ctx, msg) -> {
+            if (msg instanceof RunTest) {
+                ActorRef<Stop> watched = ctx.spawn(exitingActor, "exitingActor");
+                ctx.watchWith(watched, new CustomTerminationMessage());
+                watched.tell(new Stop());
+                return waitingForMessage(((RunTest) msg).replyTo);
+            } else {
+                return unhandled();
+            }
+        });
+        ActorSystem<Message> system = ActorSystem$.MODULE$.create("sysname", root, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+
+        // Not sure why this does not compile without an explicit cast?
+        // system.tell(new RunTest());
+        CompletionStage<Done> result = AskPattern.ask((ActorRef<Message>)system, (ActorRef<Done> ref) -> new RunTest<Done>(ref), timeout, system.scheduler());
         result.toCompletableFuture().get(3, TimeUnit.SECONDS);
     }
 }

--- a/akka-typed-tests/src/test/scala/akka/typed/MonitoringSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/MonitoringSpec.scala
@@ -53,7 +53,8 @@ class MonitoringSpec extends TypedSpec {
       val watcher = Await.result(system ? TypedSpec.Create(Immutable[Message] {
         case (ctx, StartWatchingWith(watchee, msg)) ⇒
           ctx.watchWith(watchee, msg); Same
-        case (ctx, `CustomTerminationMessage`) ⇒ receivedTerminationSignal.success(()); Stopped
+        case (ctx, `CustomTerminationMessage`) ⇒
+          receivedTerminationSignal.success(()); Stopped
       }, "w"), 3.seconds /*.dilated*/ )
 
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)

--- a/akka-typed-tests/src/test/scala/akka/typed/MonitoringSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/MonitoringSpec.scala
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.typed
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import akka.typed.scaladsl.Actor._
+import akka.typed.scaladsl.AskPattern._
+import akka.testkit._
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class MonitoringSpec extends TypedSpec {
+
+  trait Tests {
+    implicit def system: ActorSystem[TypedSpec.Command]
+
+    def `get notified of actor termination`(): Unit = {
+      case object Stop
+      case class StartWatching(watchee: ActorRef[_])
+
+      val terminator = Await.result(system ? TypedSpec.Create(Immutable[Stop.type] {
+        case (ctx, `Stop`) ⇒ Stopped
+      }, "t"), 3.seconds /*.dilated*/ )
+
+      val receivedTerminationSignal: Promise[Unit] = Promise()
+
+      val watcher = Await.result(system ? TypedSpec.Create(Immutable[StartWatching] {
+        case (ctx, StartWatching(watchee)) ⇒ ctx.watch(watchee); Same
+      }.onSignal {
+        case (ctx, Terminated(_)) ⇒ receivedTerminationSignal.success(()); Stopped
+      }, "w"), 3.seconds /*.dilated*/ )
+
+      watcher ! StartWatching(terminator)
+      terminator ! Stop
+
+      Await.result(receivedTerminationSignal.future, 3.seconds /*.dilated*/ )
+    }
+
+    def `get notified of actor termination with a custom message`(): Unit = {
+      case object Stop
+
+      sealed trait Message
+      case object CustomTerminationMessage extends Message
+      case class StartWatchingWith(watchee: ActorRef[_], msg: CustomTerminationMessage.type) extends Message
+
+      val terminator = Await.result(system ? TypedSpec.Create(Immutable[Stop.type] {
+        case (ctx, `Stop`) ⇒ Stopped
+      }, "t"), 3.seconds /*.dilated*/ )
+
+      val receivedTerminationSignal: Promise[Unit] = Promise()
+
+      val watcher = Await.result(system ? TypedSpec.Create(Immutable[Message] {
+        case (ctx, StartWatchingWith(watchee, msg)) ⇒
+          ctx.watchWith(watchee, msg); Same
+        case (ctx, `CustomTerminationMessage`) ⇒ receivedTerminationSignal.success(()); Stopped
+      }, "w"), 3.seconds /*.dilated*/ )
+
+      watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
+      terminator ! Stop
+
+      Await.result(receivedTerminationSignal.future, 3.seconds /*.dilated*/ )
+    }
+  }
+
+  object `Actor monitoring (native)` extends Tests with NativeSystem
+  object `Actor monitoring (adapted)` extends Tests with AdaptedSystem
+}

--- a/akka-typed-tests/src/test/scala/akka/typed/MonitoringSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/MonitoringSpec.scala
@@ -19,16 +19,16 @@ class MonitoringSpec extends TypedSpec {
       case object Stop
       case class StartWatching(watchee: ActorRef[_])
 
-      val terminator = Await.result(system ? TypedSpec.Create(Immutable[Stop.type] {
-        case (ctx, `Stop`) ⇒ Stopped
+      val terminator = Await.result(system ? TypedSpec.Create(immutable[Stop.type] {
+        case (ctx, `Stop`) ⇒ stopped
       }, "t"), 3.seconds /*.dilated*/ )
 
       val receivedTerminationSignal: Promise[Unit] = Promise()
 
-      val watcher = Await.result(system ? TypedSpec.Create(Immutable[StartWatching] {
-        case (ctx, StartWatching(watchee)) ⇒ ctx.watch(watchee); Same
+      val watcher = Await.result(system ? TypedSpec.Create(immutable[StartWatching] {
+        case (ctx, StartWatching(watchee)) ⇒ ctx.watch(watchee); same
       }.onSignal {
-        case (ctx, Terminated(_)) ⇒ receivedTerminationSignal.success(()); Stopped
+        case (ctx, Terminated(_)) ⇒ receivedTerminationSignal.success(()); stopped
       }, "w"), 3.seconds /*.dilated*/ )
 
       watcher ! StartWatching(terminator)
@@ -44,17 +44,19 @@ class MonitoringSpec extends TypedSpec {
       case object CustomTerminationMessage extends Message
       case class StartWatchingWith(watchee: ActorRef[_], msg: CustomTerminationMessage.type) extends Message
 
-      val terminator = Await.result(system ? TypedSpec.Create(Immutable[Stop.type] {
-        case (ctx, `Stop`) ⇒ Stopped
+      val terminator = Await.result(system ? TypedSpec.Create(immutable[Stop.type] {
+        case (ctx, `Stop`) ⇒ stopped
       }, "t"), 3.seconds /*.dilated*/ )
 
       val receivedTerminationSignal: Promise[Unit] = Promise()
 
-      val watcher = Await.result(system ? TypedSpec.Create(Immutable[Message] {
+      val watcher = Await.result(system ? TypedSpec.Create(immutable[Message] {
         case (ctx, StartWatchingWith(watchee, msg)) ⇒
-          ctx.watchWith(watchee, msg); Same
+          ctx.watchWith(watchee, msg)
+          same
         case (ctx, `CustomTerminationMessage`) ⇒
-          receivedTerminationSignal.success(()); Stopped
+          receivedTerminationSignal.success(())
+          stopped
       }, "w"), 3.seconds /*.dilated*/ )
 
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)

--- a/akka-typed/src/main/scala/akka/typed/MessageAndSignals.scala
+++ b/akka-typed/src/main/scala/akka/typed/MessageAndSignals.scala
@@ -59,8 +59,9 @@ final case object PostStop extends PostStop {
  * idempotent, meaning that registering twice has the same effect as registering
  * once. Registration does not need to happen before the Actor terminates, a
  * notification is guaranteed to arrive after both registration and termination
- * have occurred. Termination of a remote Actor can also be effected by declaring
- * the Actor’s home system as failed (e.g. as a result of being unreachable).
+ * have occurred. Termination of a remote Actor can also be effected when
+ * the Actor’s home system is removed from the cluster (e.g. as a result of being
+ * unreachable).
  */
 final case class Terminated(ref: ActorRef[Nothing])(failed: Throwable) extends Signal {
   def wasFailed: Boolean = failed ne null

--- a/akka-typed/src/main/scala/akka/typed/MessageAndSignals.scala
+++ b/akka-typed/src/main/scala/akka/typed/MessageAndSignals.scala
@@ -59,9 +59,9 @@ final case object PostStop extends PostStop {
  * idempotent, meaning that registering twice has the same effect as registering
  * once. Registration does not need to happen before the Actor terminates, a
  * notification is guaranteed to arrive after both registration and termination
- * have occurred. Termination of a remote Actor can also be effected when
- * the Actor’s home system is removed from the cluster (e.g. as a result of being
- * unreachable).
+ * have occurred. This message is also sent when the watched actor is on a node
+ * that has been removed from the cluster when using akka-cluster or has been
+ * marked unreachable when using akka-remote directly.
  */
 final case class Terminated(ref: ActorRef[Nothing])(failed: Throwable) extends Signal {
   def wasFailed: Boolean = failed ne null

--- a/akka-typed/src/main/scala/akka/typed/internal/DeathWatch.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/DeathWatch.scala
@@ -42,9 +42,9 @@ private[typed] trait DeathWatch[T] {
   type ARImpl = ActorRefImpl[Nothing]
 
   /**
-    * This map holds a [[None]] for actors for which we send a [[Terminated]] notification on termination,
-    * ``Some(message)`` for actors for which we send a custom termination message.
-    */
+   * This map holds a [[None]] for actors for which we send a [[Terminated]] notification on termination,
+   * ``Some(message)`` for actors for which we send a custom termination message.
+   */
   private var watching = Map.empty[ARImpl, Option[T]]
   private var watchedBy = Set.empty[ARImpl]
 

--- a/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorContextAdapter.scala
@@ -41,6 +41,7 @@ import akka.annotation.InternalApi
         }
     }
   override def watch[U](other: ActorRef[U]) = { untyped.watch(toUntyped(other)) }
+  override def watchWith[U](other: ActorRef[U], msg: T) = { untyped.watchWith(toUntyped(other), msg) }
   override def unwatch[U](other: ActorRef[U]) = { untyped.unwatch(toUntyped(other)) }
   var receiveTimeoutMsg: T = null.asInstanceOf[T]
   override def setReceiveTimeout(d: FiniteDuration, msg: T) = {

--- a/akka-typed/src/main/scala/akka/typed/javadsl/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/javadsl/ActorContext.scala
@@ -103,17 +103,17 @@ trait ActorContext[T] {
 
   /**
    * Register for [[Terminated]] notification once the Actor identified by the
-   * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs has been removed
-   * from the cluster.
+   * given [[ActorRef]] terminates. This message is also sent when the watched actor
+   * is on a node that has been removed from the cluster when using akka-cluster
+   * or has been marked unreachable when using akka-remote directly.
    */
   def watch[U](other: ActorRef[U]): Unit
 
   /**
    * Register for termination notification with a custom message once the Actor identified by the
-   * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs has been removed
-   * from the cluster
+   * given [[ActorRef]] terminates. This message is also sent when the watched actor
+   * is on a node that has been removed from the cluster when using akka-cluster
+   * or has been marked unreachable when using akka-remote directly.
    */
   def watchWith[U](other: ActorRef[U], msg: T): Unit
 

--- a/akka-typed/src/main/scala/akka/typed/javadsl/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/javadsl/ActorContext.scala
@@ -110,6 +110,14 @@ trait ActorContext[T] {
   def watch[U](other: ActorRef[U]): Unit
 
   /**
+   * Register for termination notification with a custom message once the Actor identified by the
+   * given [[ActorRef]] terminates. This notification is also generated when the
+   * [[ActorSystem]] to which the referenced Actor belongs is declared as
+   * failed (e.g. in reaction to being unreachable).
+   */
+  def watchWith[U](other: ActorRef[U], msg: T): Unit
+
+  /**
    * Revoke the registration established by `watch`. A [[Terminated]]
    * notification will not subsequently be received for the referenced Actor.
    */

--- a/akka-typed/src/main/scala/akka/typed/javadsl/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/javadsl/ActorContext.scala
@@ -104,16 +104,16 @@ trait ActorContext[T] {
   /**
    * Register for [[Terminated]] notification once the Actor identified by the
    * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs is declared as
-   * failed (e.g. in reaction to being unreachable).
+   * [[ActorSystem]] to which the referenced Actor belongs has been removed
+   * from the cluster.
    */
   def watch[U](other: ActorRef[U]): Unit
 
   /**
    * Register for termination notification with a custom message once the Actor identified by the
    * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs is declared as
-   * failed (e.g. in reaction to being unreachable).
+   * [[ActorSystem]] to which the referenced Actor belongs has been removed
+   * from the cluster
    */
   def watchWith[U](other: ActorRef[U], msg: T): Unit
 

--- a/akka-typed/src/main/scala/akka/typed/scaladsl/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/scaladsl/ActorContext.scala
@@ -98,6 +98,14 @@ trait ActorContext[T] { this: akka.typed.javadsl.ActorContext[T] ⇒
   def watch[U](other: ActorRef[U]): Unit
 
   /**
+   * Register for termination notification with a custom message once the Actor identified by the
+   * given [[ActorRef]] terminates. This notification is also generated when the
+   * [[ActorSystem]] to which the referenced Actor belongs is declared as
+   * failed (e.g. in reaction to being unreachable).
+   */
+  def watchWith[U](other: ActorRef[U], msg: T): Unit
+
+  /**
    * Revoke the registration established by `watch`. A [[Terminated]]
    * notification will not subsequently be received for the referenced Actor.
    */

--- a/akka-typed/src/main/scala/akka/typed/scaladsl/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/scaladsl/ActorContext.scala
@@ -91,17 +91,17 @@ trait ActorContext[T] { this: akka.typed.javadsl.ActorContext[T] ⇒
 
   /**
    * Register for [[Terminated]] notification once the Actor identified by the
-   * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs has been removed
-   * from the cluster.
+   * given [[ActorRef]] terminates. This message is also sent when the watched actor
+   * is on a node that has been removed from the cluster when using akka-cluster
+   * or has been marked unreachable when using akka-remote directly
    */
   def watch[U](other: ActorRef[U]): Unit
 
   /**
    * Register for termination notification with a custom message once the Actor identified by the
-   * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs has been removed
-   * from the cluster.sbt
+   * given [[ActorRef]] terminates. This message is also sent when the watched actor
+   * is on a node that has been removed from the cluster when using akka-cluster
+   * or has been marked unreachable when using akka-remote directly.
    */
   def watchWith[U](other: ActorRef[U], msg: T): Unit
 

--- a/akka-typed/src/main/scala/akka/typed/scaladsl/ActorContext.scala
+++ b/akka-typed/src/main/scala/akka/typed/scaladsl/ActorContext.scala
@@ -92,16 +92,16 @@ trait ActorContext[T] { this: akka.typed.javadsl.ActorContext[T] ⇒
   /**
    * Register for [[Terminated]] notification once the Actor identified by the
    * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs is declared as
-   * failed (e.g. in reaction to being unreachable).
+   * [[ActorSystem]] to which the referenced Actor belongs has been removed
+   * from the cluster.
    */
   def watch[U](other: ActorRef[U]): Unit
 
   /**
    * Register for termination notification with a custom message once the Actor identified by the
    * given [[ActorRef]] terminates. This notification is also generated when the
-   * [[ActorSystem]] to which the referenced Actor belongs is declared as
-   * failed (e.g. in reaction to being unreachable).
+   * [[ActorSystem]] to which the referenced Actor belongs has been removed
+   * from the cluster.sbt
    */
   def watchWith[U](other: ActorRef[U], msg: T): Unit
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1147,6 +1147,13 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.WireFormats#DeployDataOrBuilder.hasConfigSerializerId"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.WireFormats#DeployDataOrBuilder.getScopeSerializerId"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.WireFormats#DeployDataOrBuilder.getScopeManifest")
+      ),
+      "2.5.1" -> Seq(
+        // #22794 watchWith
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.ActorContext.watchWith"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.dungeon.DeathWatch.watchWith"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.dungeon.DeathWatch.akka$actor$dungeon$DeathWatch$$watching"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.dungeon.DeathWatch.akka$actor$dungeon$DeathWatch$$watching_=")
       )
       // make sure that
       //  * this list ends with the latest released version number


### PR DESCRIPTION
For review: I implemented this in DeathWatch, alternatively we could spawn an
intermediate actor and use the regular DeathWatch `watch` there. Which
should we prefer?