### PR TITLE
Custom frame size computation support in Framing #22129

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
@@ -153,6 +153,16 @@ class FramingSpec extends StreamSpec {
     val fieldOffsets = List(0, 1, 2, 3, 15, 16, 31, 32, 44, 107)
 
     def encode(payload: ByteString, fieldOffset: Int, fieldLength: Int, byteOrder: ByteOrder): ByteString = {
+      encodeComplexFrame(payload, fieldOffset, fieldLength, byteOrder, ByteString(new Array[Byte](fieldOffset)), ByteString.empty)
+    }
+
+    def encodeComplexFrame(
+      payload:     ByteString,
+      fieldOffset: Int,
+      fieldLength: Int,
+      byteOrder:   ByteOrder,
+      offset:      ByteString,
+      tail:        ByteString): ByteString = {
       val header = {
         val h = (new ByteStringBuilder).putInt(payload.size)(byteOrder).result()
         byteOrder match {
@@ -160,8 +170,7 @@ class FramingSpec extends StreamSpec {
           case ByteOrder.BIG_ENDIAN    ⇒ h.drop(4 - fieldLength)
         }
       }
-
-      ByteString(new Array[Byte](fieldOffset)) ++ header ++ payload
+      offset ++ header ++ payload ++ tail
     }
 
     "work with various byte orders, frame lengths and offsets" taggedAs LongRunningTest in {
@@ -179,6 +188,41 @@ class FramingSpec extends StreamSpec {
         Source(encodedFrames)
           .via(rechunk)
           .via(Framing.lengthField(fieldLength, fieldOffset, Int.MaxValue, byteOrder))
+          .grouped(10000)
+          .runWith(Sink.head)
+          .futureValue(Timeout(5.seconds)) should ===(encodedFrames)
+      }
+
+    }
+
+    "work with various byte orders, frame lengths and offsets using computeFrameSize" taggedAs LongRunningTest in {
+      for {
+        byteOrder ← byteOrders
+        fieldOffset ← fieldOffsets
+        fieldLength ← fieldLengths
+      } {
+
+        def computeFrameSize(offset: Array[Byte], length: Int): Int = {
+          val sizeWithoutTail = offset.length + fieldLength + length
+          if (offset.length > 0) offset(0) + sizeWithoutTail else sizeWithoutTail
+        }
+
+        def offset(): Array[Byte] = {
+          val arr = new Array[Byte](fieldOffset)
+          if (arr.length > 0) arr(0) = Random.nextInt(128).toByte
+          arr
+        }
+
+        val encodedFrames = frameLengths.filter(_ < (1L << (fieldLength * 8))).map { length ⇒
+          val payload = referenceChunk.take(length)
+          val offsetBytes = offset()
+          val tailBytes = if (offsetBytes.length > 0) new Array[Byte](offsetBytes(0)) else Array.empty[Byte]
+          encodeComplexFrame(payload, fieldOffset, fieldLength, byteOrder, ByteString(offsetBytes), ByteString(tailBytes))
+        }
+
+        Source(encodedFrames)
+          .via(rechunk)
+          .via(Framing.lengthField(fieldLength, fieldOffset, Int.MaxValue, byteOrder, computeFrameSize))
           .grouped(10000)
           .runWith(Sink.head)
           .futureValue(Timeout(5.seconds)) should ===(encodedFrames)
@@ -282,6 +326,25 @@ class FramingSpec extends StreamSpec {
       val ex = res.failed.futureValue
       ex shouldBe a[FramingException]
       ex.getMessage should ===("Decoded frame header reported negative size -4")
+    }
+
+    "fail the stage on computeFrameSize values less than minimum chunk size" in {
+      implicit val bo = java.nio.ByteOrder.LITTLE_ENDIAN
+
+      def computeFrameSize(arr: Array[Byte], l: Int): Int = 3
+
+      // A 4-byte message containing only an Int specifying the length of the payload
+      val bs = ByteString.newBuilder.putInt(4).result()
+
+      val res =
+        Source
+          .single(bs)
+          .via(Flow[ByteString].via(Framing.lengthField(4, 0, 1000, bo, computeFrameSize)))
+          .runWith(Sink.seq)
+
+      val ex = res.failed.futureValue
+      ex shouldBe a[FramingException]
+      ex.getMessage should ===("Computed frame size 3 is less than minimum chunk size 4")
     }
 
     "let zero length field values pass through (#22367)" in {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
@@ -27,7 +27,7 @@ object Framing {
    * @param maximumFrameLength The maximum length of allowed frames while decoding. If the maximum length is
    *                           exceeded this Flow will fail the stream.
    */
-  def delimiter(delimiter: ByteString, maximumFrameLength: Integer): Flow[ByteString, ByteString, NotUsed] = {
+  def delimiter(delimiter: ByteString, maximumFrameLength: Int): Flow[ByteString, ByteString, NotUsed] = {
     scaladsl.Framing.delimiter(delimiter, maximumFrameLength).asJava
   }
 
@@ -46,7 +46,7 @@ object Framing {
    * @param maximumFrameLength The maximum length of allowed frames while decoding. If the maximum length is
    *                           exceeded this Flow will fail the stream.
    */
-  def delimiter(delimiter: ByteString, maximumFrameLength: Integer, allowTruncation: FramingTruncation): Flow[ByteString, ByteString, NotUsed] = {
+  def delimiter(delimiter: ByteString, maximumFrameLength: Int, allowTruncation: FramingTruncation): Flow[ByteString, ByteString, NotUsed] = {
     val truncationAllowed = allowTruncation == FramingTruncation.ALLOW
     scaladsl.Framing.delimiter(delimiter, maximumFrameLength, truncationAllowed).asJava
   }
@@ -67,9 +67,9 @@ object Framing {
    *                           the length of the size field)
    */
   def lengthField(
-    fieldLength:        Integer,
-    fieldOffset:        Integer,
-    maximumFrameLength: Integer): Flow[ByteString, ByteString, NotUsed] =
+    fieldLength:        Int,
+    fieldOffset:        Int,
+    maximumFrameLength: Int): Flow[ByteString, ByteString, NotUsed] =
     scaladsl.Framing.lengthField(fieldLength, fieldOffset, maximumFrameLength).asJava
 
   /**
@@ -87,9 +87,9 @@ object Framing {
    * @param byteOrder The ''ByteOrder'' to be used when decoding the field
    */
   def lengthField(
-    fieldLength:        Integer,
-    fieldOffset:        Integer,
-    maximumFrameLength: Integer,
+    fieldLength:        Int,
+    fieldOffset:        Int,
+    maximumFrameLength: Int,
     byteOrder:          ByteOrder): Flow[ByteString, ByteString, NotUsed] =
     scaladsl.Framing.lengthField(fieldLength, fieldOffset, maximumFrameLength, byteOrder).asJava
 
@@ -113,9 +113,9 @@ object Framing {
    *
    */
   def lengthField(
-    fieldLength:        Integer,
-    fieldOffset:        Integer,
-    maximumFrameLength: Integer,
+    fieldLength:        Int,
+    fieldOffset:        Int,
+    maximumFrameLength: Int,
     byteOrder:          ByteOrder,
     computeFrameSize:   akka.japi.function.Function2[Array[Byte], Integer, Integer]): Flow[ByteString, ByteString, NotUsed] =
     scaladsl.Framing.lengthField(
@@ -144,7 +144,7 @@ object Framing {
    *                             limit this BidiFlow will fail the stream. The header attached by this BidiFlow are not
    *                             included in this limit.
    */
-  def simpleFramingProtocol(maximumMessageLength: Integer): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
+  def simpleFramingProtocol(maximumMessageLength: Int): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
     scaladsl.Framing.simpleFramingProtocol(maximumMessageLength).asJava
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
@@ -27,7 +27,7 @@ object Framing {
    * @param maximumFrameLength The maximum length of allowed frames while decoding. If the maximum length is
    *                           exceeded this Flow will fail the stream.
    */
-  def delimiter(delimiter: ByteString, maximumFrameLength: Int): Flow[ByteString, ByteString, NotUsed] = {
+  def delimiter(delimiter: ByteString, maximumFrameLength: Integer): Flow[ByteString, ByteString, NotUsed] = {
     scaladsl.Framing.delimiter(delimiter, maximumFrameLength).asJava
   }
 
@@ -46,7 +46,7 @@ object Framing {
    * @param maximumFrameLength The maximum length of allowed frames while decoding. If the maximum length is
    *                           exceeded this Flow will fail the stream.
    */
-  def delimiter(delimiter: ByteString, maximumFrameLength: Int, allowTruncation: FramingTruncation): Flow[ByteString, ByteString, NotUsed] = {
+  def delimiter(delimiter: ByteString, maximumFrameLength: Integer, allowTruncation: FramingTruncation): Flow[ByteString, ByteString, NotUsed] = {
     val truncationAllowed = allowTruncation == FramingTruncation.ALLOW
     scaladsl.Framing.delimiter(delimiter, maximumFrameLength, truncationAllowed).asJava
   }
@@ -55,7 +55,7 @@ object Framing {
    * Creates a Flow that decodes an incoming stream of unstructured byte chunks into a stream of frames, assuming that
    * incoming frames have a field that encodes their length.
    *
-   * If the input stream finishes before the last frame has been fully decoded this Flow will fail the stream reporting
+   * If the input stream finishes before the last frame has been fully decoded, this Flow will fail the stream reporting
    * a truncated frame.
    *
    * The byte order used for when decoding the field defaults to little-endian.
@@ -67,16 +67,16 @@ object Framing {
    *                           the length of the size field)
    */
   def lengthField(
-    fieldLength:        Int,
-    fieldOffset:        Int,
-    maximumFrameLength: Int): Flow[ByteString, ByteString, NotUsed] =
+    fieldLength:        Integer,
+    fieldOffset:        Integer,
+    maximumFrameLength: Integer): Flow[ByteString, ByteString, NotUsed] =
     scaladsl.Framing.lengthField(fieldLength, fieldOffset, maximumFrameLength).asJava
 
   /**
    * Creates a Flow that decodes an incoming stream of unstructured byte chunks into a stream of frames, assuming that
    * incoming frames have a field that encodes their length.
    *
-   * If the input stream finishes before the last frame has been fully decoded this Flow will fail the stream reporting
+   * If the input stream finishes before the last frame has been fully decoded, this Flow will fail the stream reporting
    * a truncated frame.
    *
    * @param fieldLength The length of the "size" field in bytes
@@ -87,11 +87,44 @@ object Framing {
    * @param byteOrder The ''ByteOrder'' to be used when decoding the field
    */
   def lengthField(
-    fieldLength:        Int,
-    fieldOffset:        Int,
-    maximumFrameLength: Int,
+    fieldLength:        Integer,
+    fieldOffset:        Integer,
+    maximumFrameLength: Integer,
     byteOrder:          ByteOrder): Flow[ByteString, ByteString, NotUsed] =
     scaladsl.Framing.lengthField(fieldLength, fieldOffset, maximumFrameLength, byteOrder).asJava
+
+  /**
+   * Creates a Flow that decodes an incoming stream of unstructured byte chunks into a stream of frames, assuming that
+   * incoming frames have a field that encodes their length.
+   *
+   * If the input stream finishes before the last frame has been fully decoded, this Flow will fail the stream reporting
+   * a truncated frame.
+   *
+   * @param fieldLength The length of the "size" field in bytes
+   * @param fieldOffset The offset of the field from the beginning of the frame in bytes
+   * @param maximumFrameLength The maximum length of allowed frames while decoding. If the maximum length is exceeded
+   *                           this Flow will fail the stream. This length *includes* the header (i.e the offset and
+   *                           the length of the size field)
+   * @param byteOrder The ''ByteOrder'' to be used when decoding the field
+   * @param computeFrameSize This function can be supplied if frame size is varied or needs to be computed in a special fashion.
+   *                         For example, frame can have a shape like this: `[offset bytes][body size bytes][body bytes][footer bytes]`.
+   *                         Then computeFrameSize can be used to compute the frame size: `(offset bytes, computed size) => (actual frame size)`.
+   *                         ''Actual frame size'' must be equal or bigger than sum of `fieldOffset` and `fieldLength`, the stage fails otherwise.
+   *
+   */
+  def lengthField(
+    fieldLength:        Integer,
+    fieldOffset:        Integer,
+    maximumFrameLength: Integer,
+    byteOrder:          ByteOrder,
+    computeFrameSize:   akka.japi.function.Function2[Array[Byte], Integer, Integer]): Flow[ByteString, ByteString, NotUsed] =
+    scaladsl.Framing.lengthField(
+      fieldLength,
+      fieldOffset,
+      maximumFrameLength,
+      byteOrder,
+      (a: Array[Byte], s: Int) ⇒ computeFrameSize.apply(a, s)
+    ).asJava
 
   /**
    * Returns a BidiFlow that implements a simple framing protocol. This is a convenience wrapper over [[Framing#lengthField]]
@@ -111,7 +144,7 @@ object Framing {
    *                             limit this BidiFlow will fail the stream. The header attached by this BidiFlow are not
    *                             included in this limit.
    */
-  def simpleFramingProtocol(maximumMessageLength: Int): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
+  def simpleFramingProtocol(maximumMessageLength: Integer): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
     scaladsl.Framing.simpleFramingProtocol(maximumMessageLength).asJava
 
 }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1230,13 +1230,6 @@ object MiMa extends AutoPlugin {
         // #23023 added a new overload with implementation to trait, so old transport implementations compiled against
         // older versions will be missing the method. We accept that incompatibility for now.
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.transport.AssociationHandle.disassociate")
-      ),
-      "2.5.3" -> Seq(
-
-        // #22129 Framing, custom frame size
-        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.javadsl.Framing.lengthField"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.javadsl.Framing.delimiter"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.javadsl.Framing.simpleFramingProtocol")
       )
     )
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1230,6 +1230,13 @@ object MiMa extends AutoPlugin {
         // #23023 added a new overload with implementation to trait, so old transport implementations compiled against
         // older versions will be missing the method. We accept that incompatibility for now.
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.transport.AssociationHandle.disassociate")
+      ),
+      "2.5.3" -> Seq(
+
+        // #22129 Framing, custom frame size
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.javadsl.Framing.lengthField"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.javadsl.Framing.delimiter"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.javadsl.Framing.simpleFramingProtocol")
       )
     )
 


### PR DESCRIPTION
Framing did not supported custom frame size computation depending on header bytes.
For example different headers can assume static footers of different length that are not included in length field.
PR adds support for this scenario.

Refs #22129