### PR TITLE
Shouldn't Delay stage be dynamic and function of the element itself?

### DIFF
--- a/akka-docs/rst/scala/stream/stages-overview.rst
+++ b/akka-docs/rst/scala/stream/stages-overview.rst
@@ -1019,7 +1019,7 @@ Delay the initial element by a user specified duration from stream materializati
 
 delay
 ^^^^^
-Delay every element passed through with a specific duration.
+Delay every element passed through with a specific duration or a duration which is a function of the element.
 
 **emits** there is a pending element in the buffer and configured time for this element elapsed
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -763,7 +763,7 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
   def delay(of: FiniteDuration, strategy: DelayOverflowStrategy): Flow[In, Out, Mat] =
-    new Flow(delegate.delay(of, strategy))
+    new Flow(delegate.delay(_ ⇒ of, strategy))
 
   /**
    * Discard the given number of elements at the beginning of the stream.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -11,13 +11,12 @@ import akka.actor.{ ActorRef, Cancellable, Props }
 import akka.event.LoggingAdapter
 import akka.japi.{ Pair, Util, function }
 import akka.stream._
-import akka.stream.impl.{ ConstantFun, LinearTraversalBuilder, SourceQueueAdapter, StreamLayout }
+import akka.stream.impl.{ ConstantFun, LinearTraversalBuilder, SourceQueueAdapter }
 import org.reactivestreams.{ Publisher, Subscriber }
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.collection.immutable.Range.Inclusive
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ Future, Promise }
 import scala.compat.java8.OptionConverters._

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1188,7 +1188,12 @@ object MiMa extends AutoPlugin {
           ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.stream.Graph.addAttributes"),
           ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.stream.Graph.async")
       ),
-      "2.5.1" -> Seq()
+      "2.5.1" -> Seq(
+          // #22846 Adding dynamic delay in stream
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.delay"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.Delay.d"),
+          ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.impl.fusing.Delay.this")
+      )
     )
 
     val Latest24Filters = Release24Filters.last


### PR DESCRIPTION
While using the delay stage I found a use-case where delay for each element passing throw should be dynamic and a function of the element itself, i.e. ***ƒ(element)*** .

I have created a pull request modifying Delay class and adding a test case for the same.

Though it is not clear to me whether I should modify existing ***scaladsl*** and ***javadsl*** or add an independent stages like `dynamicDelay(f: T ⇒ FiniteDuration, strategy: DelayOverflowStrategy)`

I request you to go through my changes and validate the use-case. I am open to incorporation your valuable suggestions.