### PR TITLE
Java API for ActorSystem.create, #22847

### DIFF
--- a/akka-typed-tests/src/test/java/akka/typed/javadsl/ActorCompile.java
+++ b/akka-typed-tests/src/test/java/akka/typed/javadsl/ActorCompile.java
@@ -43,6 +43,8 @@ public class ActorCompile {
   });
   Behavior<MyMsg> actor9 = widened(actor7, pf -> pf.match(MyMsgA.class, x -> x));
 
+  ActorSystem<MyMsg> system = ActorSystem.create("Sys", actor1);
+
   {
     Actor.<MyMsg>immutable((ctx, msg) -> {
       if (msg instanceof MyMsgA) {

--- a/akka-typed-tests/src/test/scala/akka/typed/internal/ActorSystemStub.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/internal/ActorSystemStub.scala
@@ -11,8 +11,9 @@ import java.util.concurrent.ThreadFactory
 import akka.util.Timeout
 
 private[typed] class ActorSystemStub(val name: String)
-  extends ActorRef[Nothing](a.RootActorPath(a.Address("akka", name)) / "user")
-  with ActorSystem[Nothing] with ActorRefImpl[Nothing] {
+  extends ActorSystem[Nothing] with ActorRef[Nothing] with ActorRefImpl[Nothing] {
+
+  override val path: a.ActorPath = a.RootActorPath(a.Address("akka", name)) / "user"
 
   override val settings: Settings = new Settings(getClass.getClassLoader, ConfigFactory.empty, name)
 

--- a/akka-typed-tests/src/test/scala/akka/typed/internal/DebugRef.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/internal/DebugRef.scala
@@ -8,8 +8,8 @@ import akka.{ actor ⇒ a }
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec
 
-private[typed] class DebugRef[T](_path: a.ActorPath, override val isLocal: Boolean)
-  extends ActorRef[T](_path) with ActorRefImpl[T] {
+private[typed] class DebugRef[T](override val path: a.ActorPath, override val isLocal: Boolean)
+  extends ActorRef[T] with ActorRefImpl[T] {
 
   private val q = new ConcurrentLinkedQueue[Either[SystemMessage, T]]
 

--- a/akka-typed/build.sbt
+++ b/akka-typed/build.sbt
@@ -8,7 +8,7 @@ disablePlugins(MimaPlugin)
 
 initialCommands := """
   import akka.typed._
-  import ScalaDSL._
+  import import akka.typed.scaladsl.Actor
   import scala.concurrent._
   import duration._
   import akka.util.Timeout

--- a/akka-typed/src/main/scala/akka/typed/ActorRef.scala
+++ b/akka-typed/src/main/scala/akka/typed/ActorRef.scala
@@ -17,7 +17,8 @@ import scala.concurrent.Future
  * [[EventStream]] on a best effort basis
  * (i.e. this delivery is not reliable).
  */
-abstract class ActorRef[-T](_path: a.ActorPath) extends java.lang.Comparable[ActorRef[_]] { this: internal.ActorRefImpl[T] ⇒
+trait ActorRef[-T] extends java.lang.Comparable[ActorRef[_]] {
+  this: internal.ActorRefImpl[T] ⇒
 
   /**
    * Send a message to the Actor referenced by this ActorRef using *at-most-once*
@@ -28,14 +29,14 @@ abstract class ActorRef[-T](_path: a.ActorPath) extends java.lang.Comparable[Act
   /**
    * Narrow the type of this `ActorRef, which is always a safe operation.
    */
-  final def narrow[U <: T]: ActorRef[U] = this.asInstanceOf[ActorRef[U]]
+  def narrow[U <: T]: ActorRef[U]
 
   /**
    * Unsafe utility method for widening the type accepted by this ActorRef;
    * provided to avoid having to use `asInstanceOf` on the full reference type,
    * which would unfortunately also work on non-ActorRefs.
    */
-  def upcast[U >: T @uncheckedVariance]: ActorRef[U] = this.asInstanceOf[ActorRef[U]]
+  def upcast[U >: T @uncheckedVariance]: ActorRef[U]
 
   /**
    * The hierarchical path name of the referenced Actor. The lifecycle of the
@@ -43,28 +44,8 @@ abstract class ActorRef[-T](_path: a.ActorPath) extends java.lang.Comparable[Act
    * and more than one Actor instance can exist with the same path at different
    * points in time, but not concurrently.
    */
-  final val path: a.ActorPath = _path
+  def path: a.ActorPath
 
-  /**
-   * Comparison takes path and the unique id of the actor cell into account.
-   */
-  final override def compareTo(other: ActorRef[_]) = {
-    val x = this.path compareTo other.path
-    if (x == 0) if (this.path.uid < other.path.uid) -1 else if (this.path.uid == other.path.uid) 0 else 1
-    else x
-  }
-
-  final override def hashCode: Int = path.uid
-
-  /**
-   * Equals takes path and the unique id of the actor cell into account.
-   */
-  final override def equals(that: Any): Boolean = that match {
-    case other: ActorRef[_] ⇒ path.uid == other.path.uid && path == other.path
-    case _                  ⇒ false
-  }
-
-  final override def toString: String = s"Actor[${path}#${path.uid}]"
 }
 
 object ActorRef {
@@ -76,6 +57,8 @@ object ActorRef {
      */
     def !(msg: T): Unit = ref.tell(msg)
   }
+
+  // FIXME factory methods for below for Java (trait + object)
 
   /**
    * Create an ActorRef from a Future, buffering up to the given number of

--- a/akka-typed/src/main/scala/akka/typed/internal/ActorSystemImpl.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/ActorSystemImpl.scala
@@ -76,7 +76,7 @@ private[typed] class ActorSystemImpl[-T](
   _ec:                   Option[ExecutionContext],
   _userGuardianBehavior: Behavior[T],
   _userGuardianProps:    Props)
-  extends ActorRef[T](a.RootActorPath(a.Address("akka", name)) / "user") with ActorSystem[T] with ActorRefImpl[T] {
+  extends ActorSystem[T] with ActorRef[T] with ActorRefImpl[T] {
 
   import ActorSystemImpl._
 
@@ -84,6 +84,8 @@ private[typed] class ActorSystemImpl[-T](
     throw new IllegalArgumentException(
       "invalid ActorSystem name [" + name +
         "], must contain only word characters (i.e. [a-zA-Z0-9] plus non-leading '-' or '_')")
+
+  final override val path: a.ActorPath = a.RootActorPath(a.Address("akka", name)) / "user"
 
   override val settings: Settings = new Settings(_cl, _config, name)
 
@@ -189,7 +191,8 @@ private[typed] class ActorSystemImpl[-T](
   private val topLevelActors = new ConcurrentSkipListSet[ActorRefImpl[Nothing]]
   private val terminateTriggered = new AtomicBoolean
   private val theOneWhoWalksTheBubblesOfSpaceTime: ActorRefImpl[Nothing] =
-    new ActorRef[Nothing](rootPath) with ActorRefImpl[Nothing] {
+    new ActorRef[Nothing] with ActorRefImpl[Nothing] {
+      override def path: a.ActorPath = rootPath
       override def tell(msg: Nothing): Unit =
         throw new UnsupportedOperationException("Cannot send to theOneWhoWalksTheBubblesOfSpaceTime")
       override def sendSystem(signal: SystemMessage): Unit = signal match {
@@ -240,7 +243,8 @@ private[typed] class ActorSystemImpl[-T](
   override def whenTerminated: Future[Terminated] = terminationPromise.future
 
   override def deadLetters[U]: ActorRefImpl[U] =
-    new ActorRef[U](rootPath) with ActorRefImpl[U] {
+    new ActorRef[U] with ActorRefImpl[U] {
+      override def path: a.ActorPath = rootPath
       override def tell(msg: U): Unit = eventStream.publish(DeadLetter(msg))
       override def sendSystem(signal: SystemMessage): Unit = {
         signal match {

--- a/akka-typed/src/main/scala/akka/typed/internal/EventStreamImpl.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/EventStreamImpl.scala
@@ -124,7 +124,10 @@ private[typed] class EventStreamImpl(private val debug: Boolean)(implicit privat
    * started. Its log level can be defined by configuration setting
    * <code>akka.stdout-loglevel</code>.
    */
-  private[typed] class StandardOutLogger extends ActorRef[LogEvent](StandardOutLoggerPath) with ActorRefImpl[LogEvent] with StdOutLogger {
+  private[typed] class StandardOutLogger extends ActorRef[LogEvent] with ActorRefImpl[LogEvent] with StdOutLogger {
+
+    override def path: a.ActorPath = StandardOutLoggerPath
+
     override def tell(message: LogEvent): Unit =
       if (message == null) throw a.InvalidMessageException("Message must not be null")
       else print(message)

--- a/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorRefAdapter.scala
@@ -13,8 +13,9 @@ import akka.dispatch.sysmsg
  * INTERNAL API
  */
 @InternalApi private[typed] class ActorRefAdapter[-T](val untyped: a.InternalActorRef)
-  extends ActorRef[T](untyped.path) with internal.ActorRefImpl[T] {
+  extends ActorRef[T] with internal.ActorRefImpl[T] {
 
+  override def path: a.ActorPath = untyped.path
   override def tell(msg: T): Unit = untyped ! msg
   override def isLocal: Boolean = untyped.isLocal
   override def sendSystem(signal: internal.SystemMessage): Unit =

--- a/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorSystemAdapter.scala
@@ -11,6 +11,7 @@ import scala.concurrent.ExecutionContextExecutor
 import akka.util.Timeout
 import scala.concurrent.Future
 import akka.annotation.InternalApi
+import scala.annotation.unchecked.uncheckedVariance
 
 /**
  * INTERNAL API. Lightweight wrapper for presenting an untyped ActorSystem to a Behavior (via the context).
@@ -20,8 +21,7 @@ import akka.annotation.InternalApi
  * most circumstances.
  */
 @InternalApi private[typed] class ActorSystemAdapter[-T](val untyped: a.ActorSystemImpl)
-  extends ActorRef[T](a.RootActorPath(a.Address("akka", untyped.name)) / "user")
-  with ActorSystem[T] with internal.ActorRefImpl[T] {
+  extends ActorSystem[T] with ActorRef[T] with internal.ActorRefImpl[T] {
 
   import ActorSystemAdapter._
   import ActorRefAdapter.sendSystemMessage
@@ -30,6 +30,9 @@ import akka.annotation.InternalApi
   override def tell(msg: T): Unit = untyped.guardian ! msg
   override def isLocal: Boolean = true
   override def sendSystem(signal: internal.SystemMessage): Unit = sendSystemMessage(untyped.guardian, signal)
+  final override val path: a.ActorPath = a.RootActorPath(a.Address("akka", untyped.name)) / "user"
+
+  override def toString: String = untyped.toString
 
   // Members declared in akka.typed.ActorSystem
   override def deadLetters[U]: ActorRef[U] = ActorRefAdapter(untyped.deadLetters)

--- a/akka-typed/src/main/scala/akka/typed/javadsl/Actor.scala
+++ b/akka-typed/src/main/scala/akka/typed/javadsl/Actor.scala
@@ -29,8 +29,15 @@ object Actor {
   private def unitFunction[T] = _unitFunction.asInstanceOf[((SAC[T], Signal) ⇒ Unit)]
 
   /**
-   * Wrap a behavior factory so that it runs upon PreStart, i.e. behavior creation
-   * is deferred to the child actor instead of running within the parent.
+   * `deferred` is a factory for a behavior. Creation of the behavior instance is deferred until
+   * the actor is started, as opposed to `Actor.immutable` that creates the behavior instance
+   * immediately before the actor is running. The `factory` function pass the `ActorContext`
+   * as parameter and that can for example be used for spawning child actors.
+   *
+   * `deferred` is typically used as the outer most behavior when spawning an actor, but it
+   * can also be returned as the next behavior when processing a message or signal. In that
+   * case it will be "undeferred" immediately after it is returned, i.e. next message will be
+   * processed by the undeferred behavior.
    */
   def deferred[T](factory: akka.japi.function.Function[ActorContext[T], Behavior[T]]): Behavior[T] =
     Behavior.DeferredBehavior(ctx ⇒ factory.apply(ctx.asJava))

--- a/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
+++ b/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
@@ -39,8 +39,15 @@ object Actor {
   }
 
   /**
-   * Wrap a behavior factory so that it runs upon PreStart, i.e. behavior creation
-   * is deferred to the child actor instead of running within the parent.
+   * `deferred` is a factory for a behavior. Creation of the behavior instance is deferred until
+   * the actor is started, as opposed to `Actor.immutable` that creates the behavior instance
+   * immediately before the actor is running. The `factory` function pass the `ActorContext`
+   * as parameter and that can for example be used for spawning child actors.
+   *
+   * `deferred` is typically used as the outer most behavior when spawning an actor, but it
+   * can also be returned as the next behavior when processing a message or signal. In that
+   * case it will be "undeferred" immediately after it is returned, i.e. next message will be
+   * processed by the undeferred behavior.
    */
   def deferred[T](factory: ActorContext[T] ⇒ Behavior[T]): Behavior[T] =
     Behavior.DeferredBehavior(factory)


### PR DESCRIPTION
* because it's a trait the static forwardarders are missing when compiled with Scala 2.11
* changed ActorRef to a pure interface (trait) instead of abstract class and then ActorSystem
  can be an abstract class instead

Refs #22847