### PR TITLE
Remove the outdated doc of PersistentView

### DIFF
--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -42,10 +42,6 @@ Architecture
   When a persistent actor is started or restarted, journaled messages are replayed to that actor so that it can
   recover internal state from these messages.
 
-* *PersistentView*: A view is a persistent, stateful actor that receives journaled messages that have been written by another
-  persistent actor. A view itself does not journal new messages, instead, it updates internal state only from a persistent actor's
-  replicated message stream.
-
 * *AtLeastOnceDelivery*: To send messages with at-least-once delivery semantics to destinations, also in
   case of sender and receiver JVM crashes.
 


### PR DESCRIPTION
Since `PersistentView` have been removed(#21423), I think this paragraph can be removed too.