### PR TITLE
Document ActorSystem termination

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -507,6 +507,7 @@ abstract class ActorSystem extends ActorRefFactory {
    * Multiple code blocks may be registered by calling this method multiple times.
    * The callbacks will be run sequentially in reverse order of registration, i.e.
    * last registration is run first.
+   * Note that ActorSystem will not terminate until all the registered callbacks are finished.
    *
    * Throws a RejectedExecutionException if the System has already shut down or if shutdown has been initiated.
    *
@@ -520,6 +521,7 @@ abstract class ActorSystem extends ActorRefFactory {
    * Multiple code blocks may be registered by calling this method multiple times.
    * The callbacks will be run sequentially in reverse order of registration, i.e.
    * last registration is run first.
+   * Note that ActorSystem will not terminate until all the registered callbacks are finished.
    *
    * Throws a RejectedExecutionException if the System has already shut down or if shutdown has been initiated.
    */
@@ -527,8 +529,8 @@ abstract class ActorSystem extends ActorRefFactory {
 
   /**
    * Terminates this actor system. This will stop the guardian actor, which in turn
-   * will recursively stop all its child actors, then the system guardian
-   * (below which the logging actors reside) and the execute all registered
+   * will recursively stop all its child actors, the system guardian
+   * (below which the logging actors reside) and then execute all registered
    * termination handlers (see [[ActorSystem#registerOnTermination]]).
    * Be careful to not schedule any operations on completion of the returned future
    * using the `dispatcher` of this actor system as it will have been shut down before the
@@ -538,7 +540,9 @@ abstract class ActorSystem extends ActorRefFactory {
 
   /**
    * Returns a Future which will be completed after the ActorSystem has been terminated
-   * and termination hooks have been executed. Be careful to not schedule any operations
+   * and termination hooks have been executed. If you registered any callback with
+   * [[ActorSystem#registerOnTermination]], the returned Future from this method will not complete
+   * until all the registered callbacks are finished. Be careful to not schedule any operations
    * on the `dispatcher` of this actor system as it will have been shut down before this
    * future completes.
    */

--- a/akka-docs/rst/general/actor-systems.rst
+++ b/akka-docs/rst/general/actor-systems.rst
@@ -169,3 +169,19 @@ in which messages are processed in large systems is not controllable by the
 application author, but this is also not intended. Take a step back and relax
 while Akka does the heavy lifting under the hood.
 
+Terminating ActorSystem
+-----------------------
+
+When you know everything is done for your application, you can call the
+``terminate`` method of ``ActorSystem``. That will stop the guardian
+actor, which in turn will recursively stop all its child actors, the system
+guardian.
+
+If you want to execute some operations when terminating ``ActorSystem``,
+you can register callback with the ``registerOnTermination`` method.
+You can call it multiple times to register multiple callbacks.
+
+There is also a ``whenTerminated`` method which returns ``Future``
+that completes when ``ActorSystem`` is fully terminated.
+Note that ``whenTerminated`` will not complete until all registered
+callbacks with ``registerOnTermination`` are finished.

--- a/akka-docs/rst/general/actor-systems.rst
+++ b/akka-docs/rst/general/actor-systems.rst
@@ -177,11 +177,5 @@ When you know everything is done for your application, you can call the
 actor, which in turn will recursively stop all its child actors, the system
 guardian.
 
-If you want to execute some operations when terminating ``ActorSystem``,
-you can register callback with the ``registerOnTermination`` method.
-You can call it multiple times to register multiple callbacks.
-
-There is also a ``whenTerminated`` method which returns ``Future``
-that completes when ``ActorSystem`` is fully terminated.
-Note that ``whenTerminated`` will not complete until all registered
-callbacks with ``registerOnTermination`` are finished.
+If you want to execute some operations while terminating ``ActorSystem``,
+look at ``CoordinatedShutdown`` [:ref:`Java <coordinated-shutdown-java>`, :ref:`Scala <routing-scala>`]

--- a/akka-docs/rst/general/actor-systems.rst
+++ b/akka-docs/rst/general/actor-systems.rst
@@ -178,4 +178,4 @@ actor, which in turn will recursively stop all its child actors, the system
 guardian.
 
 If you want to execute some operations while terminating ``ActorSystem``,
-look at ``CoordinatedShutdown`` [:ref:`Java <coordinated-shutdown-java>`, :ref:`Scala <routing-scala>`]
+look at ``CoordinatedShutdown`` [:ref:`Java <coordinated-shutdown-java>`, :ref:`Scala <coordinated-shutdown-scala>`]


### PR DESCRIPTION
Fixes #21840

Do these comments in the issue

> I could have sworn `onTermination` was deprecated along with the `awaitTermination` methods.

> Yeah, was thinking my surprise about it not being deprecated out loud there. :)

mean that 

- passing callbacks to `onComplete` or `onSuccess` of the `Future` from `whenTerminated` 

is preferred over 

- `registerOnTermination` ?