### PR TITLE
Clustering documentation example link fix

### DIFF
--- a/akka-docs/rst/scala/cluster-singleton.rst
+++ b/akka-docs/rst/scala/cluster-singleton.rst
@@ -106,7 +106,7 @@ configured proxy.
 
 .. includecode:: ../../../akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerSpec.scala#create-singleton-proxy
 
-A more comprehensive sample is available in the tutorial named `Distributed workers with Akka and Scala! <https://github.com/typesafehub/activator-akka-distributed-workers-java>`_.
+A more comprehensive sample is available in the tutorial named `Distributed workers with Akka and Scala! <https://github.com/typesafehub/activator-akka-distributed-workers>`_.
 
 Dependencies
 ------------


### PR DESCRIPTION
I think that there is wrong link in cluster singleton part of Scala documentation.