### PR TITLE
[not for merge] printf-style debugging for #19611

### DIFF
--- a/akka-actor-tests/src/test/java/akka/MinimalTest.java
+++ b/akka-actor-tests/src/test/java/akka/MinimalTest.java
@@ -1,0 +1,111 @@
+package akka;
+
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
+import java.io.IOException;
+import java.net.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+
+public class MinimalTest extends JUnitSuite {
+  @Test
+  public void testResetConnection() throws IOException, InterruptedException {
+    Selector selector = SelectorProvider.provider().openSelector();
+
+    ServerSocketChannel serverSocketChannel = openServerSocket(selector);
+    ServerSocket serverSocket = serverSocketChannel.socket();
+
+
+    System.out.println("Bound to " + serverSocket.getLocalSocketAddress());
+    SocketChannel client = openClientSocket(serverSocket.getLocalSocketAddress());
+    SelectionKey clientKey = client.register(selector, 0);
+    clientKey.interestOps(SelectionKey.OP_READ);
+
+    System.out.println("Starting selector thread");
+    monitorSelector(selector);
+    System.out.println("Started selector thread");
+
+    SocketChannel socketChannel = serverSocketChannel.accept();
+    assertNotNull(socketChannel);
+    socketChannel.configureBlocking(false);
+    System.out.println("Accepted");
+
+
+    System.out.println("Registered");
+    //writeData(serverSocketChannel);
+    abort(socketChannel);
+	System.out.println("Closed");
+    Thread.sleep(100);
+  }
+
+  private void writeData(SocketChannel channel) throws IOException, InterruptedException {
+    ByteBuffer buffer = ByteBuffer.allocate( 1024 );
+
+    for (int i=0; i<5; ++i) {
+      buffer.put((byte) 0x42);
+    }
+    buffer.flip();
+    channel.write(buffer);
+    Thread.sleep(100);
+  }
+
+  private void abort(SocketChannel client) throws IOException {
+    client.socket().setSoLinger(true, 0);
+    client.close();
+  }
+
+  private void monitorSelector(Selector selector) {
+    new Thread(() -> {
+      try {
+        while (true) {
+          //System.out.println("Selecting...");
+          if (selector.select() > 0) {
+            Set selectedKeys = selector.selectedKeys();
+            Iterator it = selectedKeys.iterator();
+
+            while (it.hasNext()) {
+              SelectionKey key = (SelectionKey)it.next();
+              System.out.println("Selected " + key.readyOps());
+              if ((key.readyOps() & SelectionKey.OP_ACCEPT) == SelectionKey.OP_ACCEPT) {
+              }
+            }
+          }
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }).start();
+  }
+
+  private SocketChannel openClientSocket(SocketAddress serverAddress) throws IOException {
+    SocketChannel socketChannel = SocketChannel.open();
+    socketChannel.configureBlocking(false);
+
+    socketChannel.connect(serverAddress);
+    while (!socketChannel.finishConnect()) {
+      // Busy wait
+      System.out.println("Connecting");
+    }
+    return socketChannel;
+  }
+
+  private ServerSocketChannel openServerSocket(Selector selector) throws IOException {
+    ServerSocketChannel channel = ServerSocketChannel.open();
+    channel.configureBlocking(false);
+
+//    channel.register(selector, 0);
+    ServerSocket socket = channel.socket();
+    socket.bind(new InetSocketAddress("127.0.0.1", 0), 100);
+    System.out.println(socket.getLocalSocketAddress());
+    return channel;
+  }
+}

--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -37,6 +37,9 @@ object TcpConnectionSpec {
 class TcpConnectionSpec extends AkkaSpec("""
     akka.io.tcp.register-timeout = 500ms
     akka.actor.serialize-creators = on
+	akka.io.tcp.trace-logging = on
+	akka.loglevel = "DEBUG"
+	akka.io.tcp.direct-buffer-size = 512 KiB
     """) { thisSpecs ⇒
   import TcpConnectionSpec._
 

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -222,7 +222,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
     info.registration.enableInterest(OP_READ)
   }
 
-  def doRead(info: ConnectionInfo, closeCommander: Option[ActorRef]): Unit =
+  def doRead(info: ConnectionInfo, closeCommander: Option[ActorRef]): Unit = {
+    log.warning("doRead " + readingSuspended)
     if (!readingSuspended) {
       @tailrec def innerRead(buffer: ByteBuffer, remainingLimit: Int): ReadResult =
         if (remainingLimit > 0) {
@@ -261,6 +262,9 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         case e: IOException ⇒ handleError(info.handler, e)
       } finally bufferPool.release(buffer)
     }
+    log.warning("readingSuspended now " + readingSuspended)
+
+  }
 
   def doWrite(info: ConnectionInfo): Unit = pendingWrite = pendingWrite.doWrite(info)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpHelper.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpHelper.scala
@@ -34,7 +34,7 @@ object TcpHelper {
   def testServerProps(address: InetSocketAddress, probe: ActorRef): Props =
     Props(new TestServer(address, probe)).withDispatcher("akka.test.stream-dispatcher")
 
-  class TestClient(connection: ActorRef) extends Actor {
+  class TestClient(connection: ActorRef) extends Actor with ActorLogging {
     connection ! Tcp.Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
 
     var queuedWrites = Queue.empty[ByteString]
@@ -82,6 +82,7 @@ object TcpHelper {
         readTo ! c
         if (!c.isPeerClosed) context.stop(self)
       case ClientClose(cmd) ⇒
+        log.warning("Write pending: " + writePending)
         if (!writePending) connection ! cmd
         else closeAfterWrite = Some(cmd)
     }


### PR DESCRIPTION
on windows the test "shut down both streams when connection is aborted remotely" now logs:

```
[WARN] [05/09/2017 01:33:41.635] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 16, 1)
[WARN] [05/09/2017 01:33:41.807] [ScalaTest-run-running-TcpSpec] [TcpSpec(akka://TcpSpec)] Expecting
[WARN] [05/09/2017 01:33:41.854] [TcpSpec-akka.test.stream-dispatcher-6] [akka://TcpSpec/user/$a/$a] Write pending: false
[DEBUG] [05/09/2017 01:33:41.885] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a/2] Got Abort command. RESETing connection.
```
It seems the `selector` is selecting and has registered interest in `1` (`OP_READ`), but when the server resets the connection it does not return (like it does on Linux).

MinimalTest is an attempt to recreate the situation in a 'minimal' way, but there the `select` does in fact return when the connection is closed, also on Windows.

Full logs:
<details>
<pre>
"C:\Program Files\Java\jdk1.8.0_131\bin\java" "-javaagent:C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2017.1.2\lib\idea_rt.jar=53327:C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2017.1.2\bin" -Dfile.encoding=UTF-8 -classpath "C:\Users\raboof\.IdeaIC2017.1\config\plugins\Scala\lib\scala-plugin-runners.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\charsets.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\deploy.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\access-bridge-64.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\cldrdata.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\dnsns.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\jaccess.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\jfxrt.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\localedata.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\nashorn.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\sunec.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\sunjce_provider.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\sunmscapi.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\sunpkcs11.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\ext\zipfs.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\javaws.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\jce.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\jfr.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\jfxswt.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\jsse.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\management-agent.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\plugin.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\resources.jar;C:\Program Files\Java\jdk1.8.0_131\jre\lib\rt.jar;C:\Users\raboof\akka\akka-stream-tests\target\test-classes;C:\Users\raboof\akka\akka-stream\target\classes;C:\Users\raboof\akka\akka-actor\target\classes;C:\Users\raboof\.ivy2\cache\org.slf4j\slf4j-api\jars\slf4j-api-1.7.5.jar;C:\Users\raboof\.ivy2\cache\org.scalatest\scalatest_2.11\bundles\scalatest_2.11-3.0.0.jar;C:\Users\raboof\.ivy2\cache\org.scalactic\scalactic_2.11\bundles\scalactic_2.11-3.0.0.jar;C:\Users\raboof\.ivy2\cache\org.scalacheck\scalacheck_2.11\jars\scalacheck_2.11-1.13.2.jar;C:\Users\raboof\.ivy2\cache\org.scala-sbt\test-interface\jars\test-interface-1.0.jar;C:\Users\raboof\.ivy2\cache\org.scala-lang.modules\scala-xml_2.11\bundles\scala-xml_2.11-1.0.5.jar;C:\Users\raboof\.ivy2\cache\org.scala-lang.modules\scala-parser-combinators_2.11\bundles\scala-parser-combinators_2.11-1.0.4.jar;C:\Users\raboof\.ivy2\cache\org.scala-lang.modules\scala-java8-compat_2.11\bundles\scala-java8-compat_2.11-0.7.0.jar;C:\Users\raboof\.ivy2\cache\org.scala-lang\scala-reflect\jars\scala-reflect-2.11.8.jar;C:\Users\raboof\.ivy2\cache\org.scala-lang\scala-library\jars\scala-library-2.11.8.jar;C:\Users\raboof\.ivy2\cache\org.reactivestreams\reactive-streams\jars\reactive-streams-1.0.0.jar;C:\Users\raboof\.ivy2\cache\org.latencyutils\LatencyUtils\jars\LatencyUtils-1.0.3.jar;C:\Users\raboof\.ivy2\cache\org.hdrhistogram\HdrHistogram\bundles\HdrHistogram-2.1.9.jar;C:\Users\raboof\.ivy2\cache\org.hamcrest\hamcrest-core\jars\hamcrest-core-1.3.jar;C:\Users\raboof\.ivy2\cache\junit\junit\jars\junit-4.12.jar;C:\Users\raboof\.ivy2\cache\commons-io\commons-io\jars\commons-io-2.5.jar;C:\Users\raboof\.ivy2\cache\com.typesafe\ssl-config-core_2.11\bundles\ssl-config-core_2.11-0.2.1.jar;C:\Users\raboof\.ivy2\cache\com.typesafe\config\bundles\config-1.3.1.jar;C:\Users\raboof\.ivy2\cache\com.google.jimfs\jimfs\bundles\jimfs-1.1.jar;C:\Users\raboof\.ivy2\cache\com.google.guava\guava\bundles\guava-18.0.jar;C:\Users\raboof\.ivy2\cache\com.codahale.metrics\metrics-jvm\bundles\metrics-jvm-3.0.2.jar;C:\Users\raboof\.ivy2\cache\com.codahale.metrics\metrics-core\bundles\metrics-core-3.0.2.jar;C:\Users\raboof\akka\akka-stream-testkit\target\test-classes;C:\Users\raboof\akka\akka-stream-testkit\target\classes;C:\Users\raboof\akka\akka-testkit\target\test-classes;C:\Users\raboof\akka\akka-testkit\target\classes" org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner -s akka.stream.io.TcpSpec -testName "Outgoing TCP stream must shut down both streams when connection is aborted remotely" -C org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestReporter -showProgressMessages true
Testing started at 1:33 AM ...
[DEBUG] [05/09/2017 01:33:35.390] [ScalaTest-run] [EventStream(akka://TcpSpec)] logger log1-TestEventListener started
[DEBUG] [05/09/2017 01:33:35.390] [ScalaTest-run] [EventStream(akka://TcpSpec)] Default Loggers started
Coroner Thread Count starts at 13 in akka.stream.io.TcpSpec
[DEBUG] [05/09/2017 01:33:40.027] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a] Executing [WorkerForCommand(Bind(Actor[akka://TcpSpec/user/$a#1585306026],/127.0.0.1:4343,100,List(),true),Actor[akka://TcpSpec/user/$a#1585306026],<function1>)]
[WARN] [05/09/2017 01:33:40.027] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set()
[DEBUG] [05/09/2017 01:33:40.043] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a/0] Successfully bound to /127.0.0.1:4343
[WARN] [05/09/2017 01:33:40.043] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:40.043] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] registering
[WARN] [05/09/2017 01:33:40.074] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0)
[WARN] [05/09/2017 01:33:40.106] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:40.106] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Registering interest in 16
[WARN] [05/09/2017 01:33:40.106] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(16)
[WARN] [05/09/2017 01:33:40.106] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:40.106] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(16)
[DEBUG] [05/09/2017 01:33:41.135] [TcpSpec-akka.actor.default-dispatcher-4] [akka://TcpSpec/system/IO-TCP/selectors/$a] Executing [WorkerForCommand(Connect(/127.0.0.1:4343,None,List(),None,true),Actor[akka://TcpSpec/user/StreamSupervisor-0/$$a#-1008215396],<function1>)]
[WARN] [05/09/2017 01:33:41.322] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.322] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] registering
[WARN] [05/09/2017 01:33:41.322] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 16)
[DEBUG] [05/09/2017 01:33:41.354] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a/1] Attempting connection to [/127.0.0.1:4343]
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] select() > 0
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0)
[DEBUG] [05/09/2017 01:33:41.354] [TcpSpec-akka.actor.default-dispatcher-3] [akka://TcpSpec/system/IO-TCP/selectors/$a/0] New connection accepted
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Registering interest in 8
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 8)
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 8)
[WARN] [05/09/2017 01:33:41.354] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] select() > 0
[WARN] [05/09/2017 01:33:41.385] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0)
[DEBUG] [05/09/2017 01:33:41.385] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a] Executing [WorkerForCommand(RegisterIncoming(java.nio.channels.SocketChannel[connected local=/127.0.0.1:4343 remote=/127.0.0.1:53334]),Actor[akka://TcpSpec/system/IO-TCP/selectors/$a/0#1066649896],<function1>)]
[WARN] [05/09/2017 01:33:41.401] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.401] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] registering
[WARN] [05/09/2017 01:33:41.401] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0)
[DEBUG] [05/09/2017 01:33:41.401] [TcpSpec-akka.actor.default-dispatcher-9] [akka://TcpSpec/system/IO-TCP/selectors/$a/1] Connection established to [/127.0.0.1:4343]
[WARN] [05/09/2017 01:33:41.463] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.463] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Registering interest in 16
[WARN] [05/09/2017 01:33:41.463] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 16)
[WARN] [05/09/2017 01:33:41.463] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.463] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 16)
[DEBUG] [05/09/2017 01:33:41.541] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a/2] [Actor[akka://TcpSpec/user/$a/$a#-1203174657]] registered as connection handler
[DEBUG] [05/09/2017 01:33:41.573] [TcpSpec-akka.actor.default-dispatcher-9] [akka://TcpSpec/system/IO-TCP/selectors/$a/1] [Actor[akka://TcpSpec/user/StreamSupervisor-0/$$a#-1008215396]] registered as connection handler
[WARN] [05/09/2017 01:33:41.573] [TcpSpec-akka.actor.default-dispatcher-9] [akka://TcpSpec/system/IO-TCP/selectors/$a/1] doRead true
[WARN] [05/09/2017 01:33:41.573] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a/2] doRead true
[WARN] [05/09/2017 01:33:41.573] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a/2] readingSuspended now true
[WARN] [05/09/2017 01:33:41.573] [TcpSpec-akka.actor.default-dispatcher-9] [akka://TcpSpec/system/IO-TCP/selectors/$a/1] readingSuspended now true
[WARN] [05/09/2017 01:33:41.635] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.635] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Registering interest in 1
[WARN] [05/09/2017 01:33:41.635] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 16, 1)
[WARN] [05/09/2017 01:33:41.635] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
[WARN] [05/09/2017 01:33:41.635] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 Selecting... Set(0, 16, 1)
[WARN] [05/09/2017 01:33:41.807] [ScalaTest-run-running-TcpSpec] [TcpSpec(akka://TcpSpec)] Expecting
[WARN] [05/09/2017 01:33:41.854] [TcpSpec-akka.test.stream-dispatcher-6] [akka://TcpSpec/user/$a/$a] Write pending: false
[DEBUG] [05/09/2017 01:33:41.885] [TcpSpec-akka.actor.default-dispatcher-5] [akka://TcpSpec/system/IO-TCP/selectors/$a/2] Got Abort command. RESETing connection.
--- Stream actors debug dump ---
Stream actors alive: List(Actor[akka://TcpSpec/user/StreamSupervisor-0/flow-0-0-detacher#-1647394331])

assertion failed: timeout (3 seconds) during expectMsgClass waiting for class akka.stream.testkit.TestSubscriber$OnError
java.lang.AssertionError: assertion failed: timeout (3 seconds) during expectMsgClass waiting for class akka.stream.testkit.TestSubscriber$OnError
	at scala.Predef$.assert(Predef.scala:170)
	at akka.testkit.TestKitBase$class.expectMsgClass_internal(TestKit.scala:486)
	at akka.testkit.TestKitBase$class.expectMsgType(TestKit.scala:459)
	at akka.testkit.TestKit.expectMsgType(TestKit.scala:828)
	at akka.stream.testkit.TestSubscriber$ManualProbe.expectError(StreamTestKit.scala:386)
	at akka.stream.testkit.TestSubscriber$ManualProbe.expectSubscriptionAndError(StreamTestKit.scala:420)
	at akka.stream.testkit.TestSubscriber$ManualProbe.expectSubscriptionAndError(StreamTestKit.scala:406)
	at akka.stream.io.TcpSpec$$anonfun$1$$anonfun$apply$mcV$sp$19$$anonfun$apply$mcV$sp$20.apply$mcV$sp(TcpSpec.scala:322)
	at akka.stream.io.TcpSpec$$anonfun$1$$anonfun$apply$mcV$sp$19$$anonfun$apply$mcV$sp$20.apply(TcpSpec.scala:307)
	at akka.stream.io.TcpSpec$$anonfun$1$$anonfun$apply$mcV$sp$19$$anonfun$apply$mcV$sp$20.apply(TcpSpec.scala:307)
	at akka.stream.testkit.Utils$.assertAllStagesStopped(Utils.scala:25)
	at akka.stream.io.TcpSpec$$anonfun$1$$anonfun$apply$mcV$sp$19.apply$mcV$sp(TcpSpec.scala:307)
	at akka.stream.io.TcpSpec$$anonfun$1$$anonfun$apply$mcV$sp$19.apply(TcpSpec.scala:307)
	at akka.stream.io.TcpSpec$$anonfun$1$$anonfun$apply$mcV$sp$19.apply(TcpSpec.scala:307)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.WordSpecLike$$anon$1.apply(WordSpecLike.scala:1078)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at akka.stream.testkit.StreamSpec.withFixture(StreamSpec.scala:26)
	at org.scalatest.WordSpecLike$class.invokeWithFixture$1(WordSpecLike.scala:1075)
	at org.scalatest.WordSpecLike$$anonfun$runTest$1.apply(WordSpecLike.scala:1088)
	at org.scalatest.WordSpecLike$$anonfun$runTest$1.apply(WordSpecLike.scala:1088)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.WordSpecLike$class.runTest(WordSpecLike.scala:1088)
	at akka.testkit.AkkaSpec.runTest(AkkaSpec.scala:59)
	at org.scalatest.WordSpecLike$$anonfun$runTests$1.apply(WordSpecLike.scala:1147)
	at org.scalatest.WordSpecLike$$anonfun$runTests$1.apply(WordSpecLike.scala:1147)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:373)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:410)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.WordSpecLike$class.runTests(WordSpecLike.scala:1147)
	at akka.testkit.AkkaSpec.runTests(AkkaSpec.scala:59)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at akka.testkit.AkkaSpec.org$scalatest$WordSpecLike$$super$run(AkkaSpec.scala:59)
	at org.scalatest.WordSpecLike$$anonfun$run$1.apply(WordSpecLike.scala:1192)
	at org.scalatest.WordSpecLike$$anonfun$run$1.apply(WordSpecLike.scala:1192)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.WordSpecLike$class.run(WordSpecLike.scala:1192)
	at akka.testkit.AkkaSpec.org$scalatest$BeforeAndAfterAll$$super$run(AkkaSpec.scala:59)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at akka.testkit.AkkaSpec.run(AkkaSpec.scala:59)
	at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:45)
	at org.scalatest.tools.Runner$$anonfun$doRunRunRunDaDoRunRun$1.apply(Runner.scala:1340)
	at org.scalatest.tools.Runner$$anonfun$doRunRunRunDaDoRunRun$1.apply(Runner.scala:1334)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1334)
	at org.scalatest.tools.Runner$$anonfun$runOptionallyWithPassFailReporter$2.apply(Runner.scala:1011)
	at org.scalatest.tools.Runner$$anonfun$runOptionallyWithPassFailReporter$2.apply(Runner.scala:1010)
	at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1500)
	at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:1010)
	at org.scalatest.tools.Runner$.run(Runner.scala:850)
	at org.scalatest.tools.Runner.run(Runner.scala)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.runScalaTest2(ScalaTestRunner.java:138)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.main(ScalaTestRunner.java:28)

activeShells (actor: Actor[akka://TcpSpec/user/StreamSupervisor-0/flow-0-0-detacher#-1647394331]):
  GraphInterpreterShell(
    logics: [
      Detacher attrs: [Name(detacher), InputBuffer(4,4), SupervisionStrategy(<function1>)],
      ActorOutputBoundary(port=GraphStages$Detacher.out(252277567), demand=1, finished=false) attrs: [],
      TCP-to(/127.0.0.1:4343) attrs: [Name(OutgoingConnection), InputBuffer(4,4), SupervisionStrategy(<function1>)],
      BatchingActorInputBoundary(forPort=akka.stream.impl.io.TcpConnectionStage$TcpStreamLogic@45099dd3, fill=0/4, completed=false, canceled=false) attrs: []
    ],
    connections: [
      Connection(0, 8, Empty, akka.stream.impl.fusing.GraphStages$Detacher$$anon$2@66bd8580, akka.stream.impl.io.TcpConnectionStage$TcpStreamLogic$$anon$3@687a6727),
      Connection(1, 8, Empty, akka.stream.impl.io.TcpConnectionStage$TcpStreamLogic$$anon$5@6c45eef0, BatchingActorInputBoundary(forPort=akka.stream.impl.io.TcpConnectionStage$TcpStreamLogic@45099dd3, fill=0/4, completed=false, canceled=false)),
      Connection(2, 8, Empty, ActorOutputBoundary(port=GraphStages$Detacher.out(252277567), demand=1, finished=false), akka.stream.impl.fusing.GraphStages$Detacher$$anon$2@66bd8580)
    ]
  )

dot format graph for deadlock analysis:
================================================================
digraph waits {
  N0 [label="Detacher"];
  N1 [label="ActorOutputBoundary(port=GraphStages$Detacher.out(252277567), demand=1, finished=false)"];
  N2 [label="TCP-to(/127.0.0.1:4343)"];
  N3 [label="BatchingActorInputBoundary(forPort=akka.stream.impl.io.TcpConnectionStage$TcpStreamLogic@45099dd3, fill=0/4, completed=false, canceled=false)"];
  N0 -> N2 [label=shouldPush; color=red];
  N2 -> N3 [label=shouldPush; color=red];
  N1 -> N0 [label=shouldPush; color=red];
}
================================================================
// (4, 3, 3)() (running=4, shutdown=2,1,67108866,1)
newShells:

[DEBUG] [05/09/2017 01:33:47.317] [TcpSpec-akka.actor.default-dispatcher-12] [akka://TcpSpec/user/StreamSupervisor-0/flow-0-0-detacher] Aborting tcp connection to /127.0.0.1:4343 because of upstream failure: Processor actor [Actor[akka://TcpSpec/user/StreamSupervisor-0/flow-0-0-detacher#-1647394331]] terminated abruptly
[DEBUG] [05/09/2017 01:33:47.317] [TcpSpec-akka.actor.default-dispatcher-11] [akka://TcpSpec/system/IO-TCP/selectors/$a/1] Got Abort command. RESETing connection.
[DEBUG] [05/09/2017 01:33:47.395] [TcpSpec-akka.actor.default-dispatcher-2] [akka://TcpSpec/system/IO-TCP/selectors/$a/0] Monitored actor [Actor[akka://TcpSpec/user/$a#1585306026]] terminated
[DEBUG] [05/09/2017 01:33:47.410] [TcpSpec-akka.actor.default-dispatcher-4] [akka://TcpSpec/system/IO-TCP/selectors/$a/0] Closing serverSocketChannel after being stopped
[DEBUG] [05/09/2017 01:33:47.503] [TcpSpec-akka.actor.default-dispatcher-2] [EventStream] shutting down: StandardOutLogger started
[WARN] [05/09/2017 01:33:47.550] [TcpSpec-akka.io.pinned-dispatcher-7] [akka://TcpSpec/system/IO-TCP/selectors/$a] sun.nio.ch.WindowsSelectorImpl@5e7cfdd5 No longer selecting...
Coroner Thread Count started at 13, ended at 15, peaked at 20 in akka.stream.io.TcpSpec

Process finished with exit code 0
