### PR TITLE
Update RST documentation for a cleaner conversion

### DIFF
--- a/akka-docs/rst/common/duration.rst
+++ b/akka-docs/rst/common/duration.rst
@@ -43,6 +43,7 @@ Java provides less syntactic sugar, so you have to spell out the operations as
 method calls instead:
 
 .. includecode:: code/docs/duration/Java.java#import
+
 .. includecode:: code/docs/duration/Java.java#dsl
 
 Deadline

--- a/akka-docs/rst/dev/building-akka.rst
+++ b/akka-docs/rst/dev/building-akka.rst
@@ -1,6 +1,3 @@
-
-.. highlightlang:: none
-
 .. _building-akka:
 
 ###############

--- a/akka-docs/rst/dev/documentation.rst
+++ b/akka-docs/rst/dev/documentation.rst
@@ -1,5 +1,3 @@
-.. highlightlang:: rest
-
 .. _documentation:
 
 #########################

--- a/akka-docs/rst/general/supervision.rst
+++ b/akka-docs/rst/general/supervision.rst
@@ -222,6 +222,7 @@ because of a failure, in increasing intervals of 3, 6, 12, 24 and finally 30 sec
 The above is equivalent to this Java code:
 
 .. includecode:: ../java/code/jdocs/pattern/BackoffSupervisorDocTest.java#backoff-imports
+
 .. includecode:: ../java/code/jdocs/pattern/BackoffSupervisorDocTest.java#backoff-stop
 
 Using a ``randomFactor`` to add a little bit of additional variance to the backoff intervals
@@ -242,6 +243,7 @@ because of some exception, in increasing intervals of 3, 6, 12, 24 and finally 3
 The above is equivalent to this Java code:
 
 .. includecode:: ../java/code/jdocs/pattern/BackoffSupervisorDocTest.java#backoff-imports
+
 .. includecode:: ../java/code/jdocs/pattern/BackoffSupervisorDocTest.java#backoff-fail
 
 The ``akka.pattern.BackoffOptions`` can be used to customize the behavior of the back-off supervisor actor, below are some examples:

--- a/akka-docs/rst/java/actors.rst
+++ b/akka-docs/rst/java/actors.rst
@@ -73,6 +73,7 @@ dispatcher to use, see more below). Here are some examples of how to create a
 :class:`Props` instance.
 
 .. includecode:: code/jdocs/actor/ActorDocTest.java#import-props
+
 .. includecode:: code/jdocs/actor/ActorDocTest.java#creating-props
 
 The second variant shows how to pass constructor arguments to the
@@ -137,6 +138,7 @@ Actors are created by passing a :class:`Props` instance into the
 :class:`ActorContext`.
 
 .. includecode:: code/jdocs/actor/ActorDocTest.java#import-actorRef
+
 .. includecode:: code/jdocs/actor/ActorDocTest.java#system-actorOf
 
 Using the :class:`ActorSystem` will create top-level actors, supervised by the
@@ -179,6 +181,7 @@ constructor arguments are determined by a dependency injection framework.
 __ Props_
 
 .. includecode:: code/jdocs/actor/DependencyInjectionDocTest.java#import
+
 .. includecode:: code/jdocs/actor/DependencyInjectionDocTest.java
    :include: creating-indirectly
    :exclude: obtain-fresh-Actor-instance-from-DI-framework
@@ -320,6 +323,7 @@ termination (see `Stopping Actors`_). This service is provided by the
 Registering a monitor is easy:
 
 .. includecode:: code/jdocs/actor/ActorDocTest.java#import-terminated
+
 .. includecode:: code/jdocs/actor/ActorDocTest.java#watch
 
 It should be noted that the :class:`Terminated` message is generated
@@ -469,6 +473,7 @@ negative result is generated. Please note that this does not mean that delivery
 of that reply is guaranteed, it still is a normal message.
 
 .. includecode:: code/jdocs/actor/ActorDocTest.java#import-identify
+
 .. includecode:: code/jdocs/actor/ActorDocTest.java#identify
 
 You can also acquire an :class:`ActorRef` for an :class:`ActorSelection` with
@@ -546,6 +551,7 @@ The ``ask`` pattern involves actors as well as futures, hence it is offered as
 a use pattern rather than a method on :class:`ActorRef`:
 
 .. includecode:: code/jdocs/actor/ActorDocTest.java#import-ask
+
 .. includecode:: code/jdocs/actor/ActorDocTest.java#ask-pipe
 
 This example demonstrates ``ask`` together with the ``pipe`` pattern on

--- a/akka-docs/rst/java/camel.rst
+++ b/akka-docs/rst/java/camel.rst
@@ -215,6 +215,7 @@ result in the `Exchange`_ failing with a TimeoutException set on the failure of 
 The timeout on the consumer actor can be overridden with the ``replyTimeout``, as shown below.
 
 .. includecode:: code/jdocs/camel/Consumer4.java#Consumer4
+
 .. _Exchange: https://svn.apache.org/repos/asf/camel/tags/camel-2.8.0/camel-core/src/main/java/org/apache/camel/Exchange.java
 .. _ask: @github@/akka-actor/src/main/scala/akka/pattern/Patterns.scala
 
@@ -252,7 +253,9 @@ message is forwarded to a target actor instead of being replied to the original
 sender.
 
 .. includecode:: code/jdocs/camel/ResponseReceiver.java#RouteResponse
+
 .. includecode:: code/jdocs/camel/Forwarder.java#RouteResponse
+
 .. includecode:: code/jdocs/camel/OnRouteResponseTestBase.java#RouteResponse
 
 Before producing messages to endpoints, producer actors can pre-process them by
@@ -396,8 +399,6 @@ URI options
 
 The following URI options are supported:
 
-.. tabularcolumns:: |l|l|l|L|
-
 +--------------+----------+---------+------------------------------------------------+
 | Name         | Type     | Default | Description                                    |
 +==============+==========+=========+================================================+
@@ -427,7 +428,9 @@ In the following example, a custom route to an actor is created, using the
 actor's path.
 
 .. includecode:: code/jdocs/camel/Responder.java#CustomRoute
+
 .. includecode:: code/jdocs/camel/CustomRouteBuilder.java#CustomRoute
+
 .. includecode:: code/jdocs/camel/CustomRouteTestBase.java#CustomRoute
 
 The `CamelPath.toCamelUri` converts the `ActorRef` to the Camel actor component URI format which points to the actor endpoint as described above.

--- a/akka-docs/rst/java/event-bus.rst
+++ b/akka-docs/rst/java/event-bus.rst
@@ -142,6 +142,7 @@ used for :class:`RemotingLifecycleEvent`). The following example demonstrates
 how a simple subscription works. Given a simple actor:
 
 .. includecode:: code/jdocs/event/LoggingDocTest.java#imports-deadletter
+
 .. includecode:: code/jdocs/event/LoggingDocTest.java#deadletter-actor
 
 it can be subscribed like this:

--- a/akka-docs/rst/java/persistence-query.rst
+++ b/akka-docs/rst/java/persistence-query.rst
@@ -191,6 +191,7 @@ In case your write logic is state-less and you just need to convert the events f
 before writing into the alternative datastore, then the projection is as simple as:
 
 .. includecode:: code/jdocs/persistence/PersistenceQueryDocTest.java#projection-into-different-store-simple-classes
+
 .. includecode:: code/jdocs/persistence/PersistenceQueryDocTest.java#projection-into-different-store-simple
 
 Resumable projections

--- a/akka-docs/rst/java/persistence.rst
+++ b/akka-docs/rst/java/persistence.rst
@@ -477,7 +477,9 @@ The example below highlights how messages arrive in the Actor's mailbox and how 
 mechanism when ``persist()`` is used. Notice the early stop behaviour that occurs when ``PoisonPill`` is used:
 
 .. includecode:: code/jdocs/persistence/LambdaPersistenceDocTest.java#safe-shutdown
+
 .. includecode:: code/jdocs/persistence/LambdaPersistenceDocTest.java#safe-shutdown-example-bad
+
 .. includecode:: code/jdocs/persistence/LambdaPersistenceDocTest.java#safe-shutdown-example-good
 
 .. _replay-filter-java:

--- a/akka-docs/rst/java/testing.rst
+++ b/akka-docs/rst/java/testing.rst
@@ -500,6 +500,7 @@ create a fabricated parent in your test. This, however, does not enable you to t
 the parent actor in isolation.
 
 .. includecode:: code/jdocs/testkit/ParentChildTest.java#test-fabricated-parent-creator
+
 .. includecode:: code/jdocs/testkit/ParentChildTest.java#test-fabricated-parent
 
 Externalize child making from the parent
@@ -509,6 +510,7 @@ Alternatively, you can tell the parent how to create its child. There are two wa
 to do this: by giving it a :class:`Props` object or by giving it a function which takes care of creating the child actor:
 
 .. includecode:: code/jdocs/testkit/ParentChildTest.java#test-dependentparent
+
 .. includecode:: code/jdocs/testkit/ParentChildTest.java#test-dependentparent-generic
 
 Creating the :class:`Actor` is straightforward and the function may look like this in your test code:

--- a/akka-docs/rst/project/licenses.rst
+++ b/akka-docs/rst/project/licenses.rst
@@ -3,8 +3,6 @@
 Licenses
 ========
 
-.. highlight:: text
-
 Akka License
 ------------
 

--- a/akka-docs/rst/scala/actors.rst
+++ b/akka-docs/rst/scala/actors.rst
@@ -118,6 +118,7 @@ There are two edge cases in actor creation with :class:`Props`:
 * An actor with :class:`AnyVal` arguments.
 
 .. includecode:: code/docs/actor/PropsEdgeCaseSpec.scala#props-edge-cases-value-class
+
 .. includecode:: code/docs/actor/PropsEdgeCaseSpec.scala#props-edge-cases-value-class-example
 
 * An actor with default constructor values.

--- a/akka-docs/rst/scala/camel.rst
+++ b/akka-docs/rst/scala/camel.rst
@@ -211,6 +211,7 @@ result in the `Exchange`_ failing with a TimeoutException set on the failure of 
 The timeout on the consumer actor can be overridden with the ``replyTimeout``, as shown below.
 
 .. includecode:: code/docs/camel/Consumers.scala#Consumer4
+
 .. _Exchange: https://svn.apache.org/repos/asf/camel/tags/camel-2.8.0/camel-core/src/main/java/org/apache/camel/Exchange.java
 .. _ask: @github@/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
 
@@ -390,8 +391,6 @@ URI options
 ^^^^^^^^^^^
 
 The following URI options are supported:
-
-.. tabularcolumns:: |l|l|l|L|
 
 +--------------+----------+---------+-------------------------------------------+
 | Name         | Type     | Default | Description                               |

--- a/akka-docs/rst/scala/code/docs/camel/Introduction.scala
+++ b/akka-docs/rst/scala/code/docs/camel/Introduction.scala
@@ -1,10 +1,12 @@
 package docs.camel
 
+//#imports
 import akka.actor.{ Props, ActorSystem }
 import akka.camel.CamelExtension
 
 import language.postfixOps
 import akka.util.Timeout
+//#imports
 
 object Introduction {
   def foo(): Unit = {

--- a/akka-docs/rst/scala/persistence.rst
+++ b/akka-docs/rst/scala/persistence.rst
@@ -477,7 +477,9 @@ The example below highlights how messages arrive in the Actor's mailbox and how 
 mechanism when ``persist()`` is used. Notice the early stop behaviour that occurs when ``PoisonPill`` is used:
 
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#safe-shutdown
+
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#safe-shutdown-example-bad
+
 .. includecode:: code/docs/persistence/PersistenceDocSpec.scala#safe-shutdown-example-good
 
 .. _replay-filter-scala:


### PR DESCRIPTION
Our documentation conversion script got confused by some of the things found
in the rst sources