### PR TITLE
Use released Paradox version

### DIFF
--- a/akka-docs/build.sbt
+++ b/akka-docs/build.sbt
@@ -21,7 +21,9 @@ paradoxProperties ++= Map(
   "snip.code.base_dir" -> (sourceDirectory in Compile).value.getAbsolutePath,
   "snip.akka.base_dir" -> ((baseDirectory in Compile).value / "..").getAbsolutePath
 )
-paradoxTheme := Some("com.lightbend.akka" % "paradox-theme-akka" % "0.1.0-SNAPSHOT")
+
+resolvers += Resolver.bintrayRepo("2m", "maven")
+paradoxTheme := Some("com.lightbend.akka" % "paradox-theme-akka" % "b74885b8+20170511-1711")
 paradoxNavigationDepth := 1
 paradoxNavigationExpandDepth := Some(1)
 paradoxNavigationIncludeHeaders := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -38,4 +38,7 @@ addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.8")
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.11-SNAPSHOT")
+resolvers += Resolver.url("2m-sbt-plugin-releases", url("https://dl.bintray.com/2m/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.bintrayRepo("2m", "sbt-plugin-releases")
+
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.10+12-0d7476ee+20170511-1700")


### PR DESCRIPTION
Versions look quite ugly, but let me explain:

`0.2.10+12-0d7476ee+20170511-1700` version corresponds to the code that is:
* 12 commits from 0.2.10
* has a 0d7476ee sha
* has some local modifications therefore the timestamp. Local modifications where for the release to my bintray repo. Needed to remove sonatype plugins, etc.

In short, its Peters branch. :)