### PR TITLE
=act referable CircuitBreaker resetTimeout

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -106,7 +106,7 @@ class CircuitBreaker(
   scheduler:                Scheduler,
   maxFailures:              Int,
   callTimeout:              FiniteDuration,
-  resetTimeout:             FiniteDuration,
+  val resetTimeout:         FiniteDuration,
   maxResetTimeout:          FiniteDuration,
   exponentialBackoffFactor: Double)(implicit executor: ExecutionContext) extends AbstractCircuitBreaker {
 


### PR DESCRIPTION
In Akka.Js I need a referable init value for field that are accessed with `Unsafe`.
