### PR TITLE
Add more paradox properties

### DIFF
--- a/akka-docs/build.sbt
+++ b/akka-docs/build.sbt
@@ -1,4 +1,4 @@
-import akka.{ AkkaBuild, Dependencies, Formatting }
+import akka.{ AkkaBuild, Dependencies, Formatting, GitHub }
 import akka.ValidatePullRequest._
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
@@ -12,10 +12,13 @@ additionalTasks in ValidatePR += paradox in Compile
 
 enablePlugins(ScaladocNoVerificationOfDiagrams)
 disablePlugins(MimaPlugin)
-enablePlugins(ParadoxPlugin)
 enablePlugins(AkkaParadoxPlugin)
 
+name in (Compile, paradox) := "Akka"
+
 paradoxProperties ++= Map(
+  "akka.canonical.base_url" -> "http://doc.akka.io/docs/akka/current",
+  "github.base_url" -> GitHub.url(version.value),
   "extref.wikipedia.base_url" -> "https://en.wikipedia.org/wiki/%s",
   "extref.github.base_url" -> ("http://github.com/akka/akka/tree/" + (if (isSnapshot.value) "master" else "v" + version.value) + "/%s"),
   "extref.samples.base_url" -> "http://github.com/akka/akka-samples/tree/master/%s",
@@ -24,6 +27,10 @@ paradoxProperties ++= Map(
   "scala.binary_version" -> scalaBinaryVersion.value,
   "akka.version" -> version.value,
   "sigar_loader.version" -> "1.6.6-rev002",
+  "algolia.docsearch.api_key" -> "543bad5ad786495d9ccd445ed34ed082",
+  "algolia.docsearch.index_name" -> "akka_io",
+  "google.analytics.account" -> "UA-21117439-1",
+  "google.analytics.domain.name" -> "akka.io",
   "snip.code.base_dir" -> (sourceDirectory in Test).value.getAbsolutePath,
   "snip.akka.base_dir" -> ((baseDirectory in Test).value / "..").getAbsolutePath
 )


### PR DESCRIPTION
Enable properties for project name (used in footer), canonical links, github source links, algolia doc search, and google analytics.