### PR TITLE
Replace deprecated sbt method `<+=` with `+=` in Version.scala

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -12,10 +12,10 @@ import sbt.Keys._
 object Version {
 
   def versionSettings: Seq[Setting[_]] = inConfig(Compile)(Seq(
-    resourceGenerators <+= generateVersion(resourceManaged, _ / "version.conf",
+    resourceGenerators += generateVersion(resourceManaged, _ / "version.conf",
       """|akka.version = "%s"
          |"""),
-    sourceGenerators <+= generateVersion(sourceManaged, _ / "akka" / "Version.scala",
+    sourceGenerators += generateVersion(sourceManaged, _ / "akka" / "Version.scala",
       """|package akka
          |
          |object Version {


### PR DESCRIPTION
Fixed the following warning in Version.scala

```
[warn] akka/project/Version.scala:15: `<+=` operator is deprecated. Try `lhs += { x.value }`
[warn]   or see http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html.
[warn] resourceGenerators <+= generateVersion(resourceManaged, _ / "version.conf",

[warn] akka/project/Version.scala:18: `<+=` operator is deprecated. Try `lhs += { x.value }`
[warn]   or see http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html.
[warn] sourceGenerators <+= generateVersion(sourceManaged, _ / "akka" / "Version.scala",
```