### PR TITLE
abstract class SupervisorStrategy for Java API, #22961

### DIFF
--- a/akka-typed/src/main/scala/akka/typed/SupervisorStrategy.scala
+++ b/akka-typed/src/main/scala/akka/typed/SupervisorStrategy.scala
@@ -101,13 +101,13 @@ object SupervisorStrategy {
   }
 }
 
-sealed trait SupervisorStrategy {
+sealed abstract class SupervisorStrategy {
   def loggingEnabled: Boolean
 
   def withLoggingEnabled(on: Boolean): SupervisorStrategy
 }
 
-sealed trait BackoffSupervisorStrategy extends SupervisorStrategy {
+sealed abstract class BackoffSupervisorStrategy extends SupervisorStrategy {
   def resetBackoffAfter: FiniteDuration
 
   /**


### PR DESCRIPTION
* missing static forwarders for Java API for Scala 2.11 when using trait + object

Refs #22961