### PR TITLE
Update to the latest akka-paradox

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,4 +41,4 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 resolvers += Resolver.url("2m-sbt-plugin-releases", url("https://dl.bintray.com/2m/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.bintrayRepo("2m", "sbt-plugin-releases")
 
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "bfeb6446")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "f811271f")


### PR DESCRIPTION
Update to the latest from https://github.com/akka/akka-paradox/pull/1

This does not require custom version of paradox anymore, as akka-paradox now depend on released paradox 0.2.11.