### PR TITLE
Backport #22954

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -6,15 +6,19 @@ package akka.io
 
 import java.net.InetSocketAddress
 import java.net.Socket
+
 import akka.io.Inet._
 import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 import scala.collection.immutable
 import scala.collection.JavaConverters._
-import akka.util.{ Helpers, ByteString }
+import akka.util.{ ByteString, Helpers }
 import akka.util.Helpers.Requiring
 import akka.actor._
 import java.lang.{ Iterable ⇒ JIterable }
+
+import akka.annotation.InternalApi
 
 /**
  * TCP Extension for Akka’s IO layer.
@@ -431,7 +435,25 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * Whenever a command cannot be completed, the queried actor will reply with
    * this message, wrapping the original command which failed.
    */
-  final case class CommandFailed(cmd: Command) extends Event
+  final case class CommandFailed(cmd: Command) extends Event {
+    @transient private var _cause: Option[Throwable] = None
+
+    /** Optionally contains the cause why the command failed. */
+    def cause: Option[Throwable] = _cause
+
+    // Needs to be added with a mutable var for compatibility reasons.
+    // The cause will be lost in the unlikely case that someone uses `copy` on an instance.
+    @InternalApi /** Creates a copy of this object with a new cause set. */
+    private[akka] def withCause(cause: Throwable): CommandFailed = {
+      val newInstance = copy()
+      newInstance._cause = Some(cause)
+      newInstance
+    }
+    @InternalApi
+    private[akka] def causedByString = _cause.map(c ⇒ s" because of ${c.getMessage}").getOrElse("")
+
+    override def toString: String = s"CommandFailed($cmd)$causedByString"
+  }
 
   /**
    * When `useResumeWriting` is in effect as indicated in the [[Register]] message,

--- a/akka-actor/src/main/scala/akka/io/TcpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpListener.scala
@@ -67,7 +67,7 @@ private[io] class TcpListener(
       ret
     } catch {
       case NonFatal(e) ⇒
-        bindCommander ! bind.failureMessage
+        bindCommander ! bind.failureMessage.withCause(e)
         log.error(e, "Bind failed for TCP channel on endpoint [{}]", bind.localAddress)
         context.stop(self)
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -496,7 +496,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
 
       val probe2 = TestSubscriber.manualProbe[Tcp.IncomingConnection]()
       val binding2F = bind.to(Sink.fromSubscriber(probe2)).run()
-      probe2.expectSubscriptionAndError(BindFailedException)
+      probe2.expectSubscriptionAndError(signalDemand = true) shouldBe a[BindFailedException]
 
       val probe3 = TestSubscriber.manualProbe[Tcp.IncomingConnection]()
       val binding3F = bind.to(Sink.fromSubscriber(probe3)).run()

--- a/akka-stream/src/main/scala/akka/stream/StreamTcpException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamTcpException.scala
@@ -7,8 +7,9 @@ import scala.util.control.NoStackTrace
 
 class StreamTcpException(msg: String) extends RuntimeException(msg) with NoStackTrace
 
-abstract class BindFailedException extends StreamTcpException("bind failed")
+class BindFailedException extends StreamTcpException("bind failed")
 
+@deprecated("BindFailedException object will never be thrown. Match on the class instead.")
 case object BindFailedException extends BindFailedException
 
 class ConnectionException(msg: String) extends StreamTcpException(msg)


### PR DESCRIPTION
To stay compatible this needs to be hacked into CommandFailed using a
mutable var.

(cherry picked from commit 38c9fff219e2c6da085014cf29977f2c947cacfb)

Conflicts:
	akka-actor/src/main/scala/akka/io/TcpConnection.scala

Refs #13861 