### PR TITLE
Corrected the setup of contact paths for subscribers

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -337,7 +337,7 @@ final class ClusterClient(settings: ClusterClientSettings) extends Actor with Ac
   var contacts = initialContactsSel
   sendGetContacts()
 
-  var contactPathsPublished = HashSet.empty[ActorPath]
+  var contactPathsPublished = contactPaths
 
   var subscribers = Vector.empty[ActorRef]
 


### PR DESCRIPTION
The initial contact paths should be assumed as published as that's what client subscribers will receive upon subscription. Any changes to contact points are a delta to that.

If possible, then it would be great to have this backported to 2.4.

Fixes https://github.com/akka/akka/issues/22991