### PR TITLE
Sbt console initialization in akka-typed

### DIFF
--- a/akka-typed/build.sbt
+++ b/akka-typed/build.sbt
@@ -8,9 +8,9 @@ disablePlugins(MimaPlugin)
 
 initialCommands := """
   import akka.typed._
-  import import akka.typed.scaladsl.Actor
+  import akka.typed.scaladsl.Actor
   import scala.concurrent._
-  import duration._
+  import scala.concurrent.duration._
   import akka.util.Timeout
   implicit val timeout = Timeout(5.seconds)
 """


### PR DESCRIPTION
It appears stacked imports don't work when used in one `initialCommands`
line.