### PR TITLE
!typ #22970 Actor.restarter renamed to supervise

### DIFF
--- a/akka-typed-tests/src/test/java/akka/typed/javadsl/ActorCompile.java
+++ b/akka-typed-tests/src/test/java/akka/typed/javadsl/ActorCompile.java
@@ -107,9 +107,9 @@ public class ActorCompile {
     SupervisorStrategy strategy7 = strategy6.withResetBackoffAfter(Duration.create(2, TimeUnit.SECONDS));
 
     Behavior<MyMsg> behv =
-      Actor.restarter(RuntimeException.class, strategy1,
-        Actor.restarter(IllegalStateException.class,
-          strategy6, Actor.ignore()));
+      Actor.supervise(
+        Actor.supervise(Actor.<MyMsg>ignore()).onFailure(IllegalStateException.class, strategy6)
+      ).onFailure(RuntimeException.class, strategy1);
   }
 
 

--- a/akka-typed-tests/src/test/scala/akka/typed/BehaviorSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/BehaviorSpec.scala
@@ -467,7 +467,7 @@ class BehaviorSpec extends TypedSpec {
 
   trait RestarterScalaBehavior extends ImmutableWithSignalScalaBehavior with Reuse {
     override def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux) = {
-      SActor.restarter[Exception]().wrap(super.behavior(monitor)._1) → null
+      SActor.supervise(super.behavior(monitor)._1).onFailure(SupervisorStrategy.restart) → null
     }
   }
   object `A restarter Behavior (scala,native)` extends RestarterScalaBehavior with NativeSystem
@@ -611,7 +611,8 @@ class BehaviorSpec extends TypedSpec {
 
   trait RestarterJavaBehavior extends ImmutableWithSignalJavaBehavior with Reuse {
     override def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux) = {
-      JActor.restarter(classOf[Exception], SupervisorStrategy.restart, super.behavior(monitor)._1) → null
+      JActor.supervise(super.behavior(monitor)._1)
+        .onFailure(classOf[Exception], SupervisorStrategy.restart) → null
     }
   }
   object `A restarter Behavior (java,native)` extends RestarterJavaBehavior with NativeSystem

--- a/akka-typed/src/main/scala/akka/typed/javadsl/Actor.scala
+++ b/akka-typed/src/main/scala/akka/typed/javadsl/Actor.scala
@@ -230,11 +230,24 @@ object Actor {
    *
    * The [[SupervisorStrategy]] is only invoked for "non fatal" (see [[scala.util.control.NonFatal]])
    * exceptions.
+   *
+   * Example:
+   * {{{
+   * final Behavior[DbCommand] dbConnector = ...
+   *
+   * final Behavior[DbCommand] dbRestarts =
+   *    Actor.supervise(dbConnector)
+   *      .onFailure(SupervisorStrategy.restart) // handle all NonFatal exceptions
+   *
+   * final Behavior[DbCommand] dbSpecificResumes =
+   *    Actor.supervise(dbConnector)
+   *      .onFailure[IndexOutOfBoundsException](SupervisorStrategy.resume) // resume for IndexOutOfBoundsException exceptions
+   * }}}
    */
   def supervise[T](wrapped: Behavior[T]): Supervise[T] =
     new Supervise[T](wrapped)
 
-  final class Supervise[T](wrapped: Behavior[T]) {
+  final class Supervise[T] private[akka] (wrapped: Behavior[T]) {
     /**
      * Specify the [[SupervisorStrategy]] to be invoked when the wrapped behaior throws.
      *

--- a/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
+++ b/akka-typed/src/main/scala/akka/typed/scaladsl/Actor.scala
@@ -228,11 +228,12 @@ object Actor {
   def supervise[T](wrapped: Behavior[T]): Supervise[T] =
     new Supervise(wrapped)
 
-  final class Supervise[T](val wrapped: Behavior[T]) extends AnyVal {
+  private final val NothingClassTag = ClassTag(classOf[Nothing])
+  final class Supervise[T](val wrapped: Behavior[T]) {
     /** Specify the [[SupervisorStrategy]] to be invoked when the wrapped behaior throws. */
     def onFailure[Thr <: Throwable: ClassTag](strategy: SupervisorStrategy): Behavior[T] = {
       val tag = implicitly[ClassTag[Thr]]
-      val effectiveTag = if (tag == ClassTag(classOf[Nothing])) ClassTag(classOf[Throwable]) else tag
+      val effectiveTag = if (tag == NothingClassTag) ClassTag(classOf[Throwable]) else tag
       akka.typed.internal.Restarter(Behavior.validateAsInitial(wrapped), strategy)(effectiveTag)
     }
   }


### PR DESCRIPTION
SOME TESTS ARE FAILING STILL - Will finish working on this after lunch.

Updated supervision API for Typed, with the following benefits:

- reads nicer: was `Actor.restarter[Something](...)` now is: `Actor.supervise(behavior).onFailure(howToDealWithIt)`

No default is picked, this has the benefit of:

- exposing people to the fact there's more to life than "restart"
  - esp interesting since now we can just use backoff supervision in those
- Java and Scala DSL look the same