### PR TITLE
Docs: fix table in docs for akka persistence

### DIFF
--- a/akka-docs/src/main/paradox/java/persistence.md
+++ b/akka-docs/src/main/paradox/java/persistence.md
@@ -426,6 +426,7 @@ Message deletion doesn't affect the highest sequence number of the journal, even
 Persisting, deleting and replaying messages can either succeed or fail.
 
 |**Method**                 | **Success**            |
+|---------------------------|------------------------|
 |`persist` / `persistAsync` | persist handler invoked|
 |`onPersistRejected`        | No automatic actions.  |
 |`recovery`                 | `RecoverySuccess`      |

--- a/akka-docs/src/main/paradox/scala/persistence.md
+++ b/akka-docs/src/main/paradox/scala/persistence.md
@@ -424,6 +424,7 @@ Message deletion doesn't affect the highest sequence number of the journal, even
 Persisting, deleting, and replaying messages can either succeed or fail.
 
 |**Method**                 | **Success**            |
+|---------------------------|------------------------|
 |`persist` / `persistAsync` | persist handler invoked|
 |`onPersistRejected`        | No automatic actions.  |
 |`recovery`                 | `RecoveryCompleted`    |


### PR DESCRIPTION
Table under "Persistence status handling" is broken. 

See: [here](http://doc.akka.io/docs/akka/current/scala/persistence.html?_ga=2.177413989.1539570906.1495664235-246316734.1495020825#persistence-status-handling)