### PR TITLE
=per #23042 Recover.none should immediately carry None snapshot crit

### DIFF
--- a/akka-docs/src/main/paradox/scala/project/migration-guide-2.4.x-2.5.x.md
+++ b/akka-docs/src/main/paradox/scala/project/migration-guide-2.4.x-2.5.x.md
@@ -526,12 +526,6 @@ They will receive `Replicator.Deleted` instead.
 
 ## Persistence
 
-### `Recovery.none` constant now implies also no snapshot recovery
-
-When using the `Recovery.none` constant to override `PersistentActor#recovery` no recovery at all will be performed,
-that is - also no snapshot recovery will be requested. If you want to skip recovery of events but do want to be offered
-a snapshot if present use `Recovery(toSequenceNr = 0)` instead.
-
 ### Binary incompatibility of PersistentActor and AtLeastOneDelivery
 
 To be able to evolve the Java APIs `AbstractPersistentActor` and `AbstractPersistentActorWithAtLeastOnceDelivery`

--- a/akka-docs/src/main/paradox/scala/project/migration-guide-2.4.x-2.5.x.md
+++ b/akka-docs/src/main/paradox/scala/project/migration-guide-2.4.x-2.5.x.md
@@ -526,6 +526,12 @@ They will receive `Replicator.Deleted` instead.
 
 ## Persistence
 
+### `Recovery.none` constant now implies also no snapshot recovery
+
+When using the `Recovery.none` constant to override `PersistentActor#recovery` no recovery at all will be performed,
+that is - also no snapshot recovery will be requested. If you want to skip recovery of events but do want to be offered
+a snapshot if present use `Recovery(toSequenceNr = 0)` instead.
+
 ### Binary incompatibility of PersistentActor and AtLeastOneDelivery
 
 To be able to evolve the Java APIs `AbstractPersistentActor` and `AbstractPersistentActorWithAtLeastOnceDelivery`

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
@@ -100,7 +100,7 @@ object Recovery {
    * Convenience method for skipping recovery in [[PersistentActor]].
    * @see [[Recovery]]
    */
-  val none: Recovery = Recovery(toSequenceNr = 0L)
+  val none: Recovery = Recovery(toSequenceNr = 0L, fromSnapshot = SnapshotSelectionCriteria.None)
 }
 
 final class RecoveryTimedOut(message: String) extends RuntimeException(message) with NoStackTrace

--- a/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryLocalStoreSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryLocalStoreSpec.scala
@@ -22,8 +22,9 @@ object SnapshotRecoveryLocalStoreSpec {
   }
 
   class LoadSnapshotTestPersistentActor(name: String, probe: ActorRef) extends NamedPersistentActor(name)
-    with TurnOffRecoverOnStart
     with ActorLogging {
+
+    override def recovery = Recovery(toSequenceNr = 0)
 
     def receiveCommand = {
       case _ ⇒


### PR DESCRIPTION
resolves https://github.com/akka/akka/issues/23042