### PR TITLE
Fix typo in the comment of CompositeTraversalBuilder's completeIfPossible()

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -1140,7 +1140,7 @@ import scala.collection.immutable.Map.Map1
     copy(attributes = attributes)
 
   /**
-   * Convert this builder to a [[CompositeTraversalBuilder]] if there are no more unwired outputs.
+   * Convert this builder to a [[CompletedTraversalBuilder]] if there are no more unwired outputs.
    */
   def completeIfPossible: TraversalBuilder = {
     if (unwiredOuts == 0) {


### PR DESCRIPTION
No issue raised as it's a minor fix for a typo. The method tries to return `CompletedTraversalBuilder`.

```scala
  def completeIfPossible: TraversalBuilder = {
    if (unwiredOuts == 0) {

      ...

      // The CompleteTraversalBuilder only keeps the minimum amount of necessary information that is needed for it
      // to be embedded in a larger graph, making partial graph reuse much more efficient.
      CompletedTraversalBuilder(
        traversalSoFar = finalTraversal,
        inSlots,
        inOffsets,
        attributes)
    } else this
  }
```