### PR TITLE
Be more specific about node/test for multi-jvm specs

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteReDeploymentSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteReDeploymentSpec.scala
@@ -87,11 +87,18 @@ object RemoteReDeploymentMultiJvmSpec {
     }
   }
 
-  class Hello extends Actor {
+  class Hello extends Actor with ActorLogging {
     val monitor = context.actorSelection("/user/echo")
     context.parent ! "HelloParent"
-    override def preStart(): Unit = monitor ! "PreStart"
-    override def postStop(): Unit = monitor ! "PostStop"
+
+    override def preStart(): Unit = {
+      log.warning(s"Starting Hello at ${self.path}")
+      monitor ! "PreStart"
+    }
+    override def postStop(): Unit = {
+      log.warning(s"Stopped at ${self.path}")
+      monitor ! "PostStop"
+    }
     def receive = Actor.emptyBehavior
   }
 
@@ -120,7 +127,7 @@ abstract class RemoteReDeploymentMultiJvmSpec(multiNodeConfig: RemoteReDeploymen
 
     "terminate the child when its parent system is replaced by a new one" in {
 
-      val echo = system.actorOf(echoProps(testActor), "echo")
+      system.actorOf(echoProps(testActor), "echo")
       enterBarrier("echo-started")
 
       runOn(second) {

--- a/akka-remote-tests/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
@@ -5,6 +5,8 @@
 //#example
 package akka.remote.testkit
 
+import scala.language.implicitConversions
+
 import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
 import org.scalatest.Matchers
 
@@ -12,11 +14,13 @@ import org.scalatest.Matchers
  * Hooks up MultiNodeSpec with ScalaTest
  */
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
-  with WordSpecLike with Matchers with BeforeAndAfterAll {
+  with WordSpecLike with Matchers with BeforeAndAfterAll { self: MultiNodeSpec ⇒
 
   override def beforeAll() = multiNodeSpecBeforeAll()
 
   override def afterAll() = multiNodeSpecAfterAll()
 
+  // Might not be needed anymore if we find a nice way to tag all logging from a node
+  override implicit def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s"$s (on node '${self.myself.name}', $getClass)")
 }
 //#example


### PR DESCRIPTION
For each test result log which test/node it comes from. Makes failures much
easier to read