### PR TITLE
Be more specific about node/test for multi-jvm specs

### DIFF
--- a/akka-remote-tests/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
@@ -5,6 +5,8 @@
 //#example
 package akka.remote.testkit
 
+import scala.language.implicitConversions
+
 import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
 import org.scalatest.Matchers
 
@@ -12,11 +14,13 @@ import org.scalatest.Matchers
  * Hooks up MultiNodeSpec with ScalaTest
  */
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
-  with WordSpecLike with Matchers with BeforeAndAfterAll {
+  with WordSpecLike with Matchers with BeforeAndAfterAll { self: MultiNodeSpec ⇒
 
   override def beforeAll() = multiNodeSpecBeforeAll()
 
   override def afterAll() = multiNodeSpecAfterAll()
 
+  // Might not be needed anymore if we find a nice way to tag all logging from a node
+  override implicit def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s"$s (on node '${self.myself.name}', $getClass)")
 }
 //#example


### PR DESCRIPTION
For each test result log which test/node it comes from. Makes failures much
easier to read