### PR TITLE
discard large deltas, #23025

### DIFF
--- a/akka-distributed-data/src/main/resources/reference.conf
+++ b/akka-distributed-data/src/main/resources/reference.conf
@@ -62,6 +62,11 @@ akka.cluster.distributed-data {
   delta-crdt {
     # enable or disable delta-CRDT replication
     enabled = on
+    
+    # Some complex deltas grow in size for each update and above this
+    # threshold such deltas are discarded and sent as full state instead.
+    # This is number of elements or similar size hint, not size in bytes.
+    max-delta-size = 200
   }
   
   durable {

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/DeltaPropagationSelector.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/DeltaPropagationSelector.scala
@@ -30,6 +30,8 @@ import akka.cluster.ddata.Replicator.Internal.DeltaPropagation.NoDeltaPlaceholde
 
   def createDeltaPropagation(deltas: Map[KeyId, (ReplicatedData, Long, Long)]): DeltaPropagation
 
+  def maxDeltaSize: Int
+
   def currentVersion(key: KeyId): Long = deltaCounter.get(key) match {
     case Some(v) ⇒ v
     case None    ⇒ 0L
@@ -106,11 +108,17 @@ import akka.cluster.ddata.Replicator.Internal.DeltaPropagation.NoDeltaPlaceholde
                 case None ⇒
                   val group = deltaEntriesAfterJ.valuesIterator.reduceLeft {
                     (d1, d2) ⇒
-                      d2 match {
+                      val merged = d2 match {
                         case NoDeltaPlaceholder ⇒ NoDeltaPlaceholder
                         case _ ⇒
                           // this is fine also if d1 is a NoDeltaPlaceholder
                           d1.merge(d2.asInstanceOf[d1.T])
+                      }
+                      merged match {
+                        case s: ReplicatedDeltaSize if s.deltaSize >= maxDeltaSize ⇒
+                          // discard too large deltas
+                          NoDeltaPlaceholder
+                        case _ ⇒ merged
                       }
                   }
                   cache = cache.updated(cacheKey, group)

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
@@ -45,9 +45,10 @@ object ORSet {
   /**
    * INTERNAL API
    */
-  @InternalApi private[akka] sealed abstract class AtomicDeltaOp[A] extends DeltaOp {
+  @InternalApi private[akka] sealed abstract class AtomicDeltaOp[A] extends DeltaOp with ReplicatedDeltaSize {
     def underlying: ORSet[A]
     override def zero: ORSet[A] = ORSet.empty
+    override def deltaSize: Int = 1
   }
 
   /** INTERNAL API */
@@ -94,7 +95,8 @@ object ORSet {
   /**
    * INTERNAL API
    */
-  @InternalApi private[akka] final case class DeltaGroup[A](ops: immutable.IndexedSeq[DeltaOp]) extends DeltaOp {
+  @InternalApi private[akka] final case class DeltaGroup[A](ops: immutable.IndexedSeq[DeltaOp])
+    extends DeltaOp with ReplicatedDeltaSize {
     override def merge(that: DeltaOp): DeltaOp = that match {
       case thatAdd: AddDeltaOp[A] ⇒
         // merge AddDeltaOp into last AddDeltaOp in the group, if possible
@@ -107,6 +109,8 @@ object ORSet {
     }
 
     override def zero: ORSet[A] = ORSet.empty
+
+    override def deltaSize: Int = ops.size
   }
 
   /**

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ReplicatedData.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ReplicatedData.scala
@@ -115,6 +115,18 @@ trait ReplicatedDelta extends ReplicatedData {
 trait RequiresCausalDeliveryOfDeltas extends ReplicatedDelta
 
 /**
+ * Some complex deltas grow in size for each update and above a configured
+ * threshold such deltas are discarded and sent as full state instead. This
+ * interface should be implemented by such deltas to define its size.
+ * This is number of elements or similar size hint, not size in bytes.
+ * The threshold is defined in `akka.cluster.distributed-data.delta-crdt.max-delta-size`
+ * or corresponding [[ReplicatorSettings]].
+ */
+trait ReplicatedDeltaSize {
+  def deltaSize: Int
+}
+
+/**
  * Java API: Interface for implementing a [[ReplicatedData]] in Java.
  *
  * The type parameter `A` is a self-recursive type to be defined by the

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1224,6 +1224,9 @@ object MiMa extends AutoPlugin {
         // #23144 recoverWithRetries cleanup
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.RecoverWith.InfiniteRetries"),  
 
+        // #23025 OversizedPayloadException DeltaPropagation
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.DeltaPropagationSelector.maxDeltaSize"),
+        
         // #23023 added a new overload with implementation to trait, so old transport implementations compiled against
         // older versions will be missing the method. We accept that incompatibility for now.
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.transport.AssociationHandle.disassociate")


### PR DESCRIPTION
* to avoid OversizedPayloadException
* some complex deltas grow for each update operation, e.g.
  when updating different keys in ORMap (PNCounterMap)
* such large deltas can safely be discarded and disseminated as full
  state instead
* added ReplicatedDeltaSize interface to be able to define the "size"
  and when that size exceeds configured threshold the delta is discarded

Refs #23025