### PR TITLE
Fix RemoteReDeploymentSpec instability (#20180)

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteReDeploymentSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteReDeploymentSpec.scala
@@ -176,6 +176,8 @@ abstract class RemoteReDeploymentMultiJvmSpec(multiNodeConfig: RemoteReDeploymen
 
       expectNoMsg(1.second)
 
+      enterBarrier("stopping")
+
       runOn(second) {
         Await.result(sys.terminate(), 10.seconds)
       }


### PR DESCRIPTION
Refs #20180

When failing we observed a second "PostStop" message.

This was a "PostStop" for the new, restarted actor, likely due to the newly
restarted ActorSystem being terminated at the end of the test.