### PR TITLE
Consistent indentation in TraversalBuilder.printTraversal() for Concat

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -274,32 +274,24 @@ import scala.collection.immutable.Map.Map1
    * INTERNAL API
    */
   @InternalApi private[impl] def printTraversal(t: Traversal, indent: Int = 0): Unit = {
-    var current: Traversal = t
-    var slot = 0
-
     def prindent(s: String): Unit = println(" | " * indent + s)
-
-    while (current != EmptyTraversal) {
-      var nextStep: Traversal = EmptyTraversal
-
-      current match {
-        case PushNotUsed                        ⇒ prindent("push NotUsed")
-        case Pop                                ⇒ prindent("pop mat")
-        case _: Transform                       ⇒ prindent("transform mat")
-        case Compose(_, false)                  ⇒ prindent("compose mat")
-        case Compose(_, true)                   ⇒ prindent("compose reversed mat")
-        case PushAttributes(attr)               ⇒ prindent("push attr " + attr)
-        case PopAttributes                      ⇒ prindent("pop attr")
-        case EnterIsland(tag)                   ⇒ prindent("enter island " + tag)
-        case ExitIsland                         ⇒ prindent("exit island")
-        case MaterializeAtomic(mod, outToSlots) ⇒ prindent("materialize " + mod + " " + outToSlots.mkString("[", ", ", "]"))
-        case Concat(first, next) ⇒
-          printTraversal(first, indent + 1)
-          nextStep = next
-        case _ ⇒
-      }
-
-      current = nextStep
+    t match {
+      case PushNotUsed                        ⇒ prindent("push NotUsed")
+      case Pop                                ⇒ prindent("pop mat")
+      case _: Transform                       ⇒ prindent("transform mat")
+      case Compose(_, false)                  ⇒ prindent("compose mat")
+      case Compose(_, true)                   ⇒ prindent("compose reversed mat")
+      case PushAttributes(attr)               ⇒ prindent("push attr " + attr)
+      case PopAttributes                      ⇒ prindent("pop attr")
+      case EnterIsland(tag)                   ⇒ prindent("enter island " + tag)
+      case ExitIsland                         ⇒ prindent("exit island")
+      case MaterializeAtomic(mod, outToSlots) ⇒ prindent("materialize " + mod + " " + outToSlots.mkString("[", ", ", "]"))
+      case Concat(first, next) ⇒
+        prindent("concat(")
+        printTraversal(first, indent + 1)
+        printTraversal(next, indent + 1)
+        prindent(")")
+      case _ ⇒
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -273,26 +273,33 @@ import scala.collection.immutable.Map.Map1
   /**
    * INTERNAL API
    */
-  @InternalApi private[impl] def printTraversal(t: Traversal, indent: Int = 0): Unit = {
-    def prindent(s: String): Unit = println(" | " * indent + s)
-    t match {
-      case PushNotUsed                        ⇒ prindent("push NotUsed")
-      case Pop                                ⇒ prindent("pop mat")
-      case _: Transform                       ⇒ prindent("transform mat")
-      case Compose(_, false)                  ⇒ prindent("compose mat")
-      case Compose(_, true)                   ⇒ prindent("compose reversed mat")
-      case PushAttributes(attr)               ⇒ prindent("push attr " + attr)
-      case PopAttributes                      ⇒ prindent("pop attr")
-      case EnterIsland(tag)                   ⇒ prindent("enter island " + tag)
-      case ExitIsland                         ⇒ prindent("exit island")
-      case MaterializeAtomic(mod, outToSlots) ⇒ prindent("materialize " + mod + " " + outToSlots.mkString("[", ", ", "]"))
-      case Concat(first, next) ⇒
-        prindent("concat(")
-        printTraversal(first, indent + 1)
-        printTraversal(next, indent + 1)
-        prindent(")")
-      case _ ⇒
+  @InternalApi private[impl] def printTraversal(t: Traversal, useIndent: Boolean = false): Unit = {
+
+    def printTraversalAtLevel(current: Traversal, indentLevel: Int): Unit = {
+      val prindent =
+        if (useIndent) (s: String) ⇒ println("|" * indentLevel + s)
+        else (s: String) ⇒ println(s)
+
+      current match {
+        case PushNotUsed                        ⇒ prindent("push NotUsed")
+        case Pop                                ⇒ prindent("pop mat")
+        case _: Transform                       ⇒ prindent("transform mat")
+        case Compose(_, false)                  ⇒ prindent("compose mat")
+        case Compose(_, true)                   ⇒ prindent("compose reversed mat")
+        case PushAttributes(attr)               ⇒ prindent("push attr " + attr)
+        case PopAttributes                      ⇒ prindent("pop attr")
+        case EnterIsland(tag)                   ⇒ prindent("enter island " + tag)
+        case ExitIsland                         ⇒ prindent("exit island")
+        case MaterializeAtomic(mod, outToSlots) ⇒ prindent("materialize " + mod + " " + outToSlots.mkString("[", ", ", "]"))
+        case Concat(first, next) ⇒
+          printTraversalAtLevel(first, indentLevel + 1)
+          printTraversalAtLevel(next, indentLevel + 1)
+        case _ ⇒
+      }
     }
+
+    // Start from indent level = 0
+    printTraversalAtLevel(t, 0)
   }
 
   /**

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1217,9 +1217,13 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.BackoffOnRestartSupervisor.this"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.pattern.HandleBackoff.replyWhileStopped"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.pattern.BackoffOptions.withReplyWhileStopped"),
-        
+
         // #23144 recoverWithRetries cleanup
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.RecoverWith.InfiniteRetries")
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.RecoverWith.InfiniteRetries"),
+
+        // #23076 TraversalBuilder.printTraversal() has inconsistent indentation for Concat?
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.impl.TraversalBuilder.printTraversal"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.TraversalBuilder.printTraversal$default$2")
       )
     )
 


### PR DESCRIPTION
Refs #23076 
Let me know if this does not look good. Then I will just cancel the PR as well as the issue.


```scala
TraversalBuilder.printTraversal(Concat(Pop, PushNotUsed))
```

the above code will produce:

```
//Before the code change
 | pop mat
push NotUsed

//After the code change
concat(
 | pop mat
 | push NotUsed
)
```

```scala
val graph = Source.single(1).via(Flow[Int].map(x ⇒ 2 * x)).to(Sink.ignore)
val builder = graph.traversalBuilder
TraversalBuilder.printTraversal(builder.traversal)
```

This will produce:

```
//Before the code change
 | push attr Attributes(List(Name(ignoreSink)))
 |  | materialize GraphStage(akka.stream.impl.fusing.GraphStages$IgnoreSink$@6f80e4d5) [750df7a1] []
 | pop attr
 | pop mat
 | push attr Attributes(List(Name(map)))
 |  | materialize GraphStage(Map(<function1>)) [1cf27183] [-1]
 | pop attr
 | pop mat
 | push NotUsed
 | pop mat
 | push attr Attributes(List(Name(singleSource)))
 | materialize GraphStage(SingleSource) [7280bc6d] [-1]
pop attr

//After the code change
concat(
 | push attr Attributes(List(Name(ignoreSink)))
 | concat(
 |  | concat(
 |  |  | materialize GraphStage(akka.stream.impl.fusing.GraphStages$IgnoreSink$@4cf9b4a6) [7ad502b9] []
 |  |  | pop attr
 |  | )
 |  | concat(
 |  |  | pop mat
 |  |  | concat(
 |  |  |  | push attr Attributes(List(Name(map)))
 |  |  |  | concat(
 |  |  |  |  | concat(
 |  |  |  |  |  | materialize GraphStage(Map(<function1>)) [691dc913] [-1]
 |  |  |  |  |  | pop attr
 |  |  |  |  | )
 |  |  |  |  | concat(
 |  |  |  |  |  | pop mat
 |  |  |  |  |  | concat(
 |  |  |  |  |  |  | push NotUsed
 |  |  |  |  |  |  | concat(
 |  |  |  |  |  |  |  | pop mat
 |  |  |  |  |  |  |  | concat(
 |  |  |  |  |  |  |  |  | push attr Attributes(List(Name(singleSource)))
 |  |  |  |  |  |  |  |  | concat(
 |  |  |  |  |  |  |  |  |  | materialize GraphStage(SingleSource) [5e96986c] [-1]
 |  |  |  |  |  |  |  |  |  | pop attr
 |  |  |  |  |  |  |  |  | )
 |  |  |  |  |  |  |  | )
 |  |  |  |  |  |  | )
 |  |  |  |  |  | )
 |  |  |  |  | )
 |  |  |  | )
 |  |  | )
 |  | )
 | )
)
```

Where the one after the code change is lot more verbose... I can eliminate "concat(" in the output if that is unnecessary.