### PR TITLE
Move warning on -optimize to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,11 @@ project akka-cluster
 multi-jvm:testOnly akka.cluster.SunnyWeather
 ```
 
+### Do not use `-optimize` Scala compiler flag
+
+Akka has not been compiled or tested with `-optimize` Scala compiler flag. (In sbt, you can specify compiler options in the `scalacOptions` key.)
+Strange behavior has been reported by users that have tried it.
+
 ## The `validatePullRequest` task
 
 The Akka build includes a special task called `validatePullRequest` which investigates the changes made as well as dirty

--- a/akka-docs/src/main/paradox/scala/scala-compat.md
+++ b/akka-docs/src/main/paradox/scala/scala-compat.md
@@ -26,12 +26,3 @@ we can rely on Scala 2.12 to provide full interoperability—this will mean that
 Scala users can directly implement Java Functional Interfaces using lambda syntax
 as well as that Java users can directly implement Scala functions using lambda
 syntax.
-
-## Do not use -optimize Scala compiler flag
-
-@@@ warning
-
-Akka has not been compiled or tested with -optimize Scala compiler flag.
-Strange behavior has been reported by users that have tried it.
-
-@@@


### PR DESCRIPTION
Refs #22932

Check [here](https://github.com/richard-imaoka/akka/blob/doc-22932-scala-optimize-imaoka/CONTRIBUTING.md#do-not-use--optimize-scala-compiler-flag) for how it looks.

I did tex-search in akka-docs, with "compile/compiler" but couldn't find a good place to move this section to.

Instead, CONTRIBUTING.md has this decent section about compilation (via sbt), which I think is a good place to put the warning.