### PR TITLE
Add fan-in and fan-out benchmarks for remoting

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.nio.ByteBuffer
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+import scala.concurrent.duration._
+import akka.actor._
+import akka.remote.{ RARP, RemoteActorRefProvider, RemotingMultiNodeSpec }
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.PerfFlamesSupport
+import akka.remote.testkit.STMultiNodeSpec
+import akka.serialization.ByteBufferSerializer
+import akka.serialization.SerializerWithStringManifest
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+import akka.remote.artery.compress.CompressionProtocol.Events.ReceivedActorRefCompressionTable
+import akka.remote.artery.MaxThroughputSpec._
+
+object FanInThroughputSpec extends MultiNodeConfig {
+  val totalNumberOfNodes =
+    System.getProperty("MultiJvm.akka.test.FanInThroughputSpec.nrOfNodes") match {
+      case null  ⇒ 4
+      case value ⇒ value.toInt
+    }
+  val senderReceiverPairs = totalNumberOfNodes - 1
+
+  for (n ← 1 to totalNumberOfNodes) role("node-" + n)
+
+  val barrierTimeout = 5.minutes
+
+  commonConfig(debugConfig(on = false).withFallback(
+    ConfigFactory.parseString(s"""
+       # for serious measurements you should increase the totalMessagesFactor (20)
+       akka.test.FanInThroughputSpec.totalMessagesFactor = 10.0
+       akka.test.FanInThroughputSpec.real-message = off
+       """))
+    .withFallback(MaxThroughputSpec.cfg)
+    .withFallback(RemotingMultiNodeSpec.commonConfig))
+
+}
+
+class FanInThroughputSpecMultiJvmNode1 extends FanInThroughputSpec
+class FanInThroughputSpecMultiJvmNode2 extends FanInThroughputSpec
+class FanInThroughputSpecMultiJvmNode3 extends FanInThroughputSpec
+class FanInThroughputSpecMultiJvmNode4 extends FanInThroughputSpec
+//class FanInThroughputSpecMultiJvmNode5 extends FanInThroughputSpec
+//class FanInThroughputSpecMultiJvmNode6 extends FanInThroughputSpec
+//class FanInThroughputSpecMultiJvmNode7 extends FanInThroughputSpec
+
+abstract class FanInThroughputSpec extends RemotingMultiNodeSpec(FanInThroughputSpec) with PerfFlamesSupport {
+
+  import FanInThroughputSpec._
+
+  val totalMessagesFactor = system.settings.config.getDouble("akka.test.FanInThroughputSpec.totalMessagesFactor")
+  val realMessage = system.settings.config.getBoolean("akka.test.FanInThroughputSpec.real-message")
+
+  var plot = PlotResult()
+
+  def adjustedTotalMessages(n: Long): Long = (n * totalMessagesFactor).toLong
+
+  override def initialParticipants = roles.size
+
+  def remoteSettings = system.asInstanceOf[ExtendedActorSystem].provider.asInstanceOf[RemoteActorRefProvider].remoteSettings
+
+  lazy val reporterExecutor = Executors.newFixedThreadPool(1)
+  def reporter(name: String): TestRateReporter = {
+    val r = new TestRateReporter(name)
+    reporterExecutor.execute(r)
+    r
+  }
+
+  override def afterAll(): Unit = {
+    reporterExecutor.shutdown()
+    runOn(roles(1)) {
+      println(plot.csv(system.name))
+    }
+    super.afterAll()
+  }
+
+  def identifyReceiver(name: String, r: RoleName): ActorRef = {
+    system.actorSelection(node(r) / "user" / name) ! Identify(None)
+    expectMsgType[ActorIdentity](10.seconds).ref.get
+  }
+
+  val scenarios = List(
+    TestSettings(
+      testName = "warmup",
+      totalMessages = adjustedTotalMessages(20000),
+      burstSize = 1000,
+      payloadSize = 100,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage),
+    TestSettings(
+      testName = "size-100",
+      totalMessages = adjustedTotalMessages(50000),
+      burstSize = 1000,
+      payloadSize = 100,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage),
+    TestSettings(
+      testName = "size-1k",
+      totalMessages = adjustedTotalMessages(20000),
+      burstSize = 1000,
+      payloadSize = 1000,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage),
+    TestSettings(
+      testName = "size-10k",
+      totalMessages = adjustedTotalMessages(10000),
+      burstSize = 1000,
+      payloadSize = 10000,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage))
+
+  def test(testSettings: TestSettings, resultReporter: BenchmarkFileReporter): Unit = {
+    import testSettings._
+    val receiverName = testName + "-rcv"
+
+    val sendingNodes = roles.tail
+
+    runPerfFlames(roles: _*)(delay = 5.seconds, time = 15.seconds)
+
+    runOn(roles.head) {
+      val rep = reporter(testName)
+      val receivers = (1 to sendingNodes.size).map { n ⇒
+        system.actorOf(
+          receiverProps(rep, payloadSize, printTaskRunnerMetrics = n == 1, senderReceiverPairs),
+          receiverName + "-" + n)
+      }
+      enterBarrier(receiverName + "-started")
+      enterBarrier(testName + "-done")
+      receivers.foreach(_ ! PoisonPill)
+      rep.halt()
+    }
+
+    runOn(sendingNodes: _*) {
+      enterBarrier(receiverName + "-started")
+      val ignore = TestProbe()
+      val receivers = (1 to sendingNodes.size).map { n ⇒
+        identifyReceiver(receiverName + "-" + n, roles.head)
+      }.toArray[ActorRef]
+
+      val idx = roles.indexOf(myself) - 1
+      val receiver = receivers(idx)
+      val plotProbe = TestProbe()
+      val snd = system.actorOf(
+        senderProps(receiver, receivers, testSettings, plotProbe.ref, printTaskRunnerMetrics = idx == 0, resultReporter),
+        testName + "-snd" + idx)
+      val terminationProbe = TestProbe()
+      terminationProbe.watch(snd)
+      snd ! Run
+
+      terminationProbe.expectTerminated(snd, barrierTimeout)
+      if (idx == 0) {
+        val plotResult = plotProbe.expectMsgType[PlotResult]
+        plot = plot.addAll(plotResult)
+      }
+
+      enterBarrier(testName + "-done")
+    }
+
+    enterBarrier("after-" + testName)
+  }
+
+  "Max throughput of fan-in" must {
+    val reporter = BenchmarkFileReporter("FanInThroughputSpec", system)
+    for (s ← scenarios) {
+      s"be great for ${s.testName}, burstSize = ${s.burstSize}, payloadSize = ${s.payloadSize}" in test(s, reporter)
+    }
+  }
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import java.nio.ByteBuffer
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+import scala.concurrent.duration._
+import akka.actor._
+import akka.remote.{ RARP, RemoteActorRefProvider, RemotingMultiNodeSpec }
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.PerfFlamesSupport
+import akka.remote.testkit.STMultiNodeSpec
+import akka.serialization.ByteBufferSerializer
+import akka.serialization.SerializerWithStringManifest
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+import akka.remote.artery.compress.CompressionProtocol.Events.ReceivedActorRefCompressionTable
+import akka.remote.artery.MaxThroughputSpec._
+
+object FanOutThroughputSpec extends MultiNodeConfig {
+  val totalNumberOfNodes =
+    System.getProperty("MultiJvm.akka.test.FanOutThroughputSpec.nrOfNodes") match {
+      case null  ⇒ 4
+      case value ⇒ value.toInt
+    }
+  val senderReceiverPairs = totalNumberOfNodes - 1
+
+  for (n ← 1 to totalNumberOfNodes) role("node-" + n)
+
+  val barrierTimeout = 5.minutes
+
+  commonConfig(debugConfig(on = false).withFallback(
+    ConfigFactory.parseString(s"""
+       # for serious measurements you should increase the totalMessagesFactor (20)
+       akka.test.FanOutThroughputSpec.totalMessagesFactor = 10.0
+       akka.test.FanOutThroughputSpec.real-message = off
+       """))
+    .withFallback(MaxThroughputSpec.cfg)
+    .withFallback(RemotingMultiNodeSpec.commonConfig))
+
+}
+
+class FanOutThroughputSpecMultiJvmNode1 extends FanOutThroughputSpec
+class FanOutThroughputSpecMultiJvmNode2 extends FanOutThroughputSpec
+class FanOutThroughputSpecMultiJvmNode3 extends FanOutThroughputSpec
+class FanOutThroughputSpecMultiJvmNode4 extends FanOutThroughputSpec
+//class FanOutThroughputSpecMultiJvmNode5 extends FanOutThroughputSpec
+//class FanOutThroughputSpecMultiJvmNode6 extends FanOutThroughputSpec
+//class FanOutThroughputSpecMultiJvmNode7 extends FanOutThroughputSpec
+
+abstract class FanOutThroughputSpec extends RemotingMultiNodeSpec(FanOutThroughputSpec) with PerfFlamesSupport {
+
+  import FanOutThroughputSpec._
+
+  val totalMessagesFactor = system.settings.config.getDouble("akka.test.FanOutThroughputSpec.totalMessagesFactor")
+  val realMessage = system.settings.config.getBoolean("akka.test.FanOutThroughputSpec.real-message")
+
+  var plot = PlotResult()
+
+  def adjustedTotalMessages(n: Long): Long = (n * totalMessagesFactor).toLong
+
+  override def initialParticipants = roles.size
+
+  def remoteSettings = system.asInstanceOf[ExtendedActorSystem].provider.asInstanceOf[RemoteActorRefProvider].remoteSettings
+
+  lazy val reporterExecutor = Executors.newFixedThreadPool(1)
+  def reporter(name: String): TestRateReporter = {
+    val r = new TestRateReporter(name)
+    reporterExecutor.execute(r)
+    r
+  }
+
+  override def afterAll(): Unit = {
+    reporterExecutor.shutdown()
+    runOn(roles.head) {
+      println(plot.csv(system.name))
+    }
+    super.afterAll()
+  }
+
+  def identifyReceiver(name: String, r: RoleName): ActorRef = {
+    system.actorSelection(node(r) / "user" / name) ! Identify(None)
+    expectMsgType[ActorIdentity](10.seconds).ref.get
+  }
+
+  val burstSize = 2000 / senderReceiverPairs
+  val scenarios = List(
+    TestSettings(
+      testName = "warmup",
+      totalMessages = adjustedTotalMessages(20000),
+      burstSize = burstSize,
+      payloadSize = 100,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage),
+    TestSettings(
+      testName = "size-100",
+      totalMessages = adjustedTotalMessages(50000),
+      burstSize = burstSize,
+      payloadSize = 100,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage),
+    TestSettings(
+      testName = "size-1k",
+      totalMessages = adjustedTotalMessages(20000),
+      burstSize = burstSize,
+      payloadSize = 1000,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage),
+    TestSettings(
+      testName = "size-10k",
+      totalMessages = adjustedTotalMessages(10000),
+      burstSize = burstSize,
+      payloadSize = 10000,
+      senderReceiverPairs = senderReceiverPairs,
+      realMessage))
+
+  def test(testSettings: TestSettings, resultReporter: BenchmarkFileReporter): Unit = {
+    import testSettings._
+    val receiverName = testName + "-rcv"
+
+    val targetNodes = roles.tail
+
+    runPerfFlames(roles: _*)(delay = 5.seconds, time = 15.seconds)
+
+    runOn(targetNodes: _*) {
+      val rep = reporter(testName)
+      val receiver = system.actorOf(
+        receiverProps(rep, payloadSize, printTaskRunnerMetrics = true, senderReceiverPairs),
+        receiverName)
+      enterBarrier(receiverName + "-started")
+      enterBarrier(testName + "-done")
+      receiver ! PoisonPill
+      rep.halt()
+    }
+
+    runOn(roles.head) {
+      enterBarrier(receiverName + "-started")
+      val ignore = TestProbe()
+      val receivers = targetNodes.map(target ⇒ identifyReceiver(receiverName, target)).toArray[ActorRef]
+      val senders = for ((target, i) ← targetNodes.zipWithIndex) yield {
+        val receiver = receivers(i)
+        val plotProbe = TestProbe()
+        val snd = system.actorOf(
+          senderProps(receiver, receivers, testSettings, plotProbe.ref, printTaskRunnerMetrics = i == 0, resultReporter),
+          testName + "-snd" + (i + 1))
+        val terminationProbe = TestProbe()
+        terminationProbe.watch(snd)
+        snd ! Run
+        (snd, terminationProbe, plotProbe)
+      }
+      senders.foreach {
+        case (snd, terminationProbe, plotProbe) ⇒
+          terminationProbe.expectTerminated(snd, barrierTimeout)
+          if (snd == senders.head._1) {
+            val plotResult = plotProbe.expectMsgType[PlotResult]
+            plot = plot.addAll(plotResult)
+          }
+      }
+      enterBarrier(testName + "-done")
+    }
+
+    enterBarrier("after-" + testName)
+  }
+
+  "Max throughput of fan-out" must {
+    val reporter = BenchmarkFileReporter("FanOutThroughputSpec", system)
+    for (s ← scenarios) {
+      s"be great for ${s.testName}, burstSize = ${s.burstSize}, payloadSize = ${s.payloadSize}" in test(s, reporter)
+    }
+  }
+}


### PR DESCRIPTION
* reusing same actors and reporting as MaxThroughputSpec