### PR TITLE
#23099 Produce child to send camel results or failures directly to its paren…

### DIFF
--- a/akka-camel/src/main/scala/akka/camel/Producer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Producer.scala
@@ -128,7 +128,7 @@ trait ProducerSupport extends Actor with CamelSupport {
     protected def produce(endpoint: Endpoint, processor: SendProcessor, msg: Any, pattern: ExchangePattern): Unit = {
       // Need copies of sender reference here since the callback could be done
       // later by another thread.
-      val producer = self
+      val producer = context.parent
       val originalSender = sender()
       val xchg = new CamelExchangeAdapter(endpoint.createExchange(pattern))
       val cmsg = CamelMessage.canonicalize(msg)


### PR DESCRIPTION
See Issue #23099 

The fix in the associated pull request has the Camel callback produce results directly to the parent's mailbox. This prevents co-mingling of new work and results in the same mailbox.

Another solution considered was to use a priority mailbox where MessageResult and Failure result have high priority, but there still may be a lag to forward them to the parent, even if they are first in line. In addition, it is more complex a change.

Validated against the customer application to be effective.