### PR TITLE
Corrected the setup of contact paths for subscribers (for validation)

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -337,7 +337,7 @@ final class ClusterClient(settings: ClusterClientSettings) extends Actor with Ac
   var contacts = initialContactsSel
   sendGetContacts()
 
-  var contactPathsPublished = HashSet.empty[ActorPath]
+  var contactPathsPublished = contactPaths
 
   var subscribers = Vector.empty[ActorRef]
 


### PR DESCRIPTION
The initial contact paths should be assumed as published as that's what client subscribers will receive upon subscription. Any changes to contact points are a delta to that.

(cherry picked from commit b36c78c18cdfd372aa8c5a82e776e4e2035affb6)

Refs #22991