### PR TITLE
=rem #23023 log reasons for disassociations with debug level

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -842,7 +842,7 @@ private[remote] class EndpointWriter(
       }
     case TakeOver(newHandle, replyTo) ⇒
       // Shutdown old reader
-      handle foreach { _.disassociate() }
+      handle foreach { _.disassociate("the association was replaced by a new one", log) }
       handle = Some(newHandle)
       replyTo ! TookOver(self, newHandle)
       context.become(handoff)

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -196,10 +196,9 @@ private[remote] class AkkaProtocolHandle(
 
   override def write(payload: ByteString): Boolean = wrappedHandle.write(codec.constructPayload(payload))
 
-  override def disassociate(): Unit = stateActor ! DisassociateUnderlying(Unknown)
+  override def disassociate(): Unit = disassociate(Unknown)
 
   def disassociate(info: DisassociateInfo): Unit = stateActor ! DisassociateUnderlying(info)
-
 }
 
 private[transport] object ProtocolStateActor {
@@ -394,8 +393,12 @@ private[transport] class ProtocolStateActor(
           // After receiving Disassociate we MUST NOT send back a Disassociate (loop)
           stop(FSM.Failure(info))
 
-        case _ ⇒
+        case msg ⇒
           // Expected handshake to be finished, dropping connection
+          if (log.isDebugEnabled)
+            log.debug(
+              "Sending disassociate to [{}] because unexpected message of type [{}] was received during handshake",
+              wrappedHandle, msg.getClass.getName)
           sendDisassociate(wrappedHandle, Unknown)
           stop()
 
@@ -431,18 +434,32 @@ private[transport] class ProtocolStateActor(
           }
 
         // Got a stray message -- explicitly reset the association (force remote endpoint to reassociate)
-        case _ ⇒
+        case msg ⇒
+          if (log.isDebugEnabled)
+            log.debug(
+              "Sending disassociate to [{}] because unexpected message of type [{}] was received while unassociated",
+              wrappedHandle, msg.getClass.getName)
           sendDisassociate(wrappedHandle, Unknown)
           stop()
 
       }
 
     case Event(HandshakeTimer, OutboundUnderlyingAssociated(_, wrappedHandle)) ⇒
+      if (log.isDebugEnabled)
+        log.debug(
+          "Sending disassociate to [{}] because handshake timed out for outbound association after [{}] ms.",
+          wrappedHandle, settings.HandshakeTimeout.toMillis)
+
       sendDisassociate(wrappedHandle, Unknown)
       stop(FSM.Failure(TimeoutReason("No response from remote for outbound association. Handshake timed out after " +
         s"[${settings.HandshakeTimeout.toMillis} ms].")))
 
     case Event(HandshakeTimer, InboundUnassociated(_, wrappedHandle)) ⇒
+      if (log.isDebugEnabled)
+        log.debug(
+          "Sending disassociate to [{}] because handshake timed out for inbound association after [{}] ms.",
+          wrappedHandle, settings.HandshakeTimeout.toMillis)
+
       sendDisassociate(wrappedHandle, Unknown)
       stop(FSM.Failure(TimeoutReason("No response from remote for inbound association. Handshake timed out after " +
         s"[${settings.HandshakeTimeout.toMillis} ms].")))
@@ -489,6 +506,9 @@ private[transport] class ProtocolStateActor(
         case msg ⇒
           throw new AkkaProtocolException(s"unhandled message in state Open(DisassociateUnderlying) with type [${safeClassName(msg)}]")
       }
+      // No debug logging here as sending DisassociateUnderlying(Unknown) should have been logged from where
+      // it was sent
+
       sendDisassociate(handle, info)
       stop()
 
@@ -510,6 +530,11 @@ private[transport] class ProtocolStateActor(
       sendHeartbeat(wrappedHandle)
       stay()
     } else {
+      if (log.isDebugEnabled)
+        log.debug(
+          "Sending disassociate to [{}] because failure detector triggered in state [{}]",
+          wrappedHandle, stateName)
+
       // send disassociate just to be sure
       sendDisassociate(wrappedHandle, Unknown)
       stop(FSM.Failure(TimeoutReason(s"No response from remote. " +
@@ -545,7 +570,7 @@ private[transport] class ProtocolStateActor(
         case _ ⇒
           new AkkaProtocolException("Transport disassociated before handshake finished")
       })
-      wrappedHandle.disassociate()
+      wrappedHandle.disassociate(disassociationReason(reason), log)
 
     case StopEvent(reason, _, AssociatedWaitHandler(handlerFuture, wrappedHandle, queue)) ⇒
       // Invalidate exposed but still unfinished promise. The underlying association disappeared, so after
@@ -555,7 +580,7 @@ private[transport] class ProtocolStateActor(
         case _                                   ⇒ Disassociated(Unknown)
       }
       handlerFuture foreach { _ notify disassociateNotification }
-      wrappedHandle.disassociate()
+      wrappedHandle.disassociate(disassociationReason(reason), log)
 
     case StopEvent(reason, _, ListenerReady(handler, wrappedHandle)) ⇒
       val disassociateNotification = reason match {
@@ -563,10 +588,10 @@ private[transport] class ProtocolStateActor(
         case _                                   ⇒ Disassociated(Unknown)
       }
       handler notify disassociateNotification
-      wrappedHandle.disassociate()
+      wrappedHandle.disassociate(disassociationReason(reason), log)
 
-    case StopEvent(_, _, InboundUnassociated(_, wrappedHandle)) ⇒
-      wrappedHandle.disassociate()
+    case StopEvent(reason, _, InboundUnassociated(_, wrappedHandle)) ⇒
+      wrappedHandle.disassociate(disassociationReason(reason), log)
 
   }
 
@@ -649,5 +674,11 @@ private[transport] class ProtocolStateActor(
     wrappedHandle.write(codec.constructAssociate(info))
   } catch {
     case NonFatal(e) ⇒ throw new AkkaProtocolException("Error writing ASSOCIATE to transport", e)
+  }
+
+  private def disassociationReason(reason: FSM.Reason): String = reason match {
+    case FSM.Normal      ⇒ "the ProtocolStateActor was stopped normally"
+    case FSM.Shutdown    ⇒ "the ProtocolStateActor was shutdown"
+    case FSM.Failure(ex) ⇒ s"the ProtocolStateActor failed: $ex"
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
@@ -6,12 +6,13 @@ package akka.remote.transport
 import FailureInjectorTransportAdapter._
 import akka.AkkaException
 import akka.actor.{ Address, ExtendedActorSystem }
-import akka.event.Logging
+import akka.event.{ Logging, LoggingAdapter }
 import akka.remote.transport.AssociationHandle.{ HandleEvent, HandleEventListener }
 import akka.remote.transport.Transport._
 import akka.util.ByteString
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ThreadLocalRandom
+
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NoStackTrace
 
@@ -161,7 +162,11 @@ private[remote] final case class FailureInjectorHandle(
     if (!gremlinAdapter.shouldDropOutbound(wrappedHandle.remoteAddress, payload, "handler.write")) wrappedHandle.write(payload)
     else true
 
-  override def disassociate(): Unit = wrappedHandle.disassociate()
+  override def disassociate(reason: String, log: LoggingAdapter): Unit =
+    wrappedHandle.disassociate(reason, log)
+
+  override def disassociate(): Unit =
+    wrappedHandle.disassociate()
 
   override def notify(ev: HandleEvent): Unit =
     if (!gremlinAdapter.shouldDropInbound(wrappedHandle.remoteAddress, ev, "handler.notify"))

--- a/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
@@ -3,13 +3,15 @@
  */
 package akka.remote.transport
 
-import scala.concurrent.{ Promise, Future }
-import akka.actor.{ NoSerializationVerificationNeeded, ActorRef, Address }
+import scala.concurrent.{ Future, Promise }
+import akka.actor.{ ActorRef, Address, NoSerializationVerificationNeeded }
 import akka.util.ByteString
 import akka.remote.transport.AssociationHandle.HandleEventListener
 import akka.AkkaException
+
 import scala.util.control.NoStackTrace
 import akka.actor.DeadLetterSuppression
+import akka.event.LoggingAdapter
 
 object Transport {
 
@@ -261,7 +263,22 @@ trait AssociationHandle {
    * could be called arbitrarily many times.
    *
    */
+  @deprecated(message = "Use method that states reasons to make sure disassociation reasons are logged.", since = "2.5.3")
   def disassociate(): Unit
 
+  /**
+   * Closes the underlying transport link, if needed. Some transports might not need an explicit teardown (UDP) and
+   * some transports may not support it (hardware connections). Remote endpoint of the channel or connection MAY
+   * be notified, but this is not guaranteed. The Transport that provides the handle MUST guarantee that disassociate()
+   * could be called arbitrarily many times.
+   */
+  def disassociate(reason: String, log: LoggingAdapter): Unit = {
+    if (log.isDebugEnabled)
+      log.debug(
+        "Association between local [{}] and remote [{}] was disassociated because {}",
+        localAddress, remoteAddress, reason)
+
+    disassociate()
+  }
 }
 

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
@@ -41,8 +41,10 @@ private[remote] trait TcpHandlers extends CommonHandlers {
   override def createHandle(channel: Channel, localAddress: Address, remoteAddress: Address): AssociationHandle =
     new TcpAssociationHandle(localAddress, remoteAddress, transport, channel)
 
-  override def onDisconnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit =
+  override def onDisconnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit = {
     notifyListener(e.getChannel, Disassociated(AssociationHandle.Unknown))
+    log.debug("Remote connection to [{}] was disconnected because of {}", e.getChannel.getRemoteAddress, e)
+  }
 
   override def onMessage(ctx: ChannelHandlerContext, e: MessageEvent): Unit = {
     val bytes: Array[Byte] = e.getMessage.asInstanceOf[ChannelBuffer].array()
@@ -51,7 +53,7 @@ private[remote] trait TcpHandlers extends CommonHandlers {
 
   override def onException(ctx: ChannelHandlerContext, e: ExceptionEvent): Unit = {
     notifyListener(e.getChannel, Disassociated(AssociationHandle.Unknown))
-    log.warning("Remote connection to {} failed with {}", e.getChannel.getRemoteAddress, e.getCause)
+    log.warning("Remote connection to [{}] failed with {}", e.getChannel.getRemoteAddress, e.getCause)
     e.getChannel.close() // No graceful close here
   }
 }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1220,6 +1220,11 @@ object MiMa extends AutoPlugin {
         
         // #23144 recoverWithRetries cleanup
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.RecoverWith.InfiniteRetries")
+      ),
+      "2.5.2" -> Seq(
+        // #23023 added a new overload with implementation to trait, so old transport implementations compiled against
+        // older versions will be missing the method. We accept that incompatibility for now.
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.transport.AssociationHandle.disassociate")
       )
     )
 


### PR DESCRIPTION
I deprecated the old `disassociate` method for now but that might not be reasonable given that remoting classes are public API / SPI.

Refs #23023