### PR TITLE
Backport: Log fatal errors to stderr, add exceptions to 'marked' errors (#23109)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/MarkerLoggingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/MarkerLoggingSpec.scala
@@ -1,0 +1,30 @@
+package akka.event
+
+import akka.event.Logging._
+import akka.testkit._
+
+class MarkerLoggingSpec extends AkkaSpec with ImplicitSender {
+  "A MarkerLoggerAdapter" should {
+    val markerLogging = new MarkerLoggingAdapter(system.eventStream, getClass.getName, this.getClass, new DefaultLoggingFilter(() ⇒ Logging.InfoLevel))
+
+    "add markers to logging" in {
+      system.eventStream.subscribe(self, classOf[Info])
+      system.eventStream.publish(TestEvent.Mute(EventFilter.info()))
+      markerLogging.info(LogMarker.Security, "This is a security problem")
+
+      val info = expectMsgType[Info3]
+      info.message should be("This is a security problem")
+      info.marker.name should be("SECURITY")
+    }
+
+    "allow cause exceptions in error messages" in {
+      class MyException(message: String) extends Exception(message)
+      system.eventStream.subscribe(self, classOf[Error])
+      system.eventStream.publish(TestEvent.Mute(EventFilter[MyException]("this is a security crash")))
+
+      markerLogging.error(LogMarker.Security, new MyException("Security Exception"), "this is a security crash")
+
+      expectMsgType[Error].cause.getMessage should be("Security Exception")
+    }
+  }
+}

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -697,25 +697,34 @@ private[akka] class ActorSystemImpl(
                   | HTTP etc. have their own version numbers - please make sure you're using a compatible set of libraries.
                  """.stripMargin.replaceAll("[\r\n]", ""))
 
-            if (settings.JvmExitOnFatalError) {
-              try {
-                markerLogging.error(LogMarker.Security, cause, "Uncaught error from thread [{}] shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled", thread.getName)
-                import System.err
-                err.print("Uncaught error from thread [")
-                err.print(thread.getName)
-                err.print("] shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[")
-                err.print(name)
-                err.println("]")
-                cause.printStackTrace(System.err)
-                System.err.flush()
-              } finally {
-                System.exit(-1)
-              }
-            } else {
-              markerLogging.error(LogMarker.Security, cause, "Uncaught fatal error from thread [{}] shutting down ActorSystem [{}]", thread.getName, name)
-              terminate()
-            }
+            if (settings.JvmExitOnFatalError)
+              try logFatalError("shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for", cause, thread)
+              finally System.exit(-1)
+            else
+              try logFatalError("shutting down", cause, thread)
+              finally terminate()
         }
+      }
+
+      @inline
+      private def logFatalError(message: String, cause: Throwable, thread: Thread): Unit = {
+        // First log to stderr as this has the best chance to get through in an 'emergency panic' situation:
+        import System.err
+        err.print("Uncaught error from thread [")
+        err.print(thread.getName)
+        err.print("]: ")
+        err.print(cause.getMessage)
+        err.print(", ")
+        err.print(message)
+        err.print(" for ActorSystem[")
+        err.print(name)
+        err.println("]")
+        System.err.flush()
+        cause.printStackTrace(System.err)
+        System.err.flush()
+
+        // Also log using the normal infrastructure - hope for the best:
+        markerLogging.error(LogMarker.Security, cause, "Uncaught error from thread [{}]: " + cause.getMessage + ", " + message + " ActorSystem[{}]", thread.getName, name)
       }
     }
 

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -1425,7 +1425,7 @@ class MarkerLoggingAdapter(
    * @see [[LoggingAdapter]]
    */
   def error(marker: LogMarker, cause: Throwable, message: String): Unit =
-    if (isErrorEnabled) bus.publish(Error(logSource, logClass, message, mdc, marker))
+    if (isErrorEnabled) bus.publish(Error(cause, logSource, logClass, message, mdc, marker))
 
   /**
    * Message template with 1 replacement argument.
@@ -1433,7 +1433,7 @@ class MarkerLoggingAdapter(
    * @see [[LoggingAdapter]]
    */
   def error(marker: LogMarker, cause: Throwable, template: String, arg1: Any): Unit =
-    if (isErrorEnabled) bus.publish(Error(logSource, logClass, format(template, arg1), mdc, marker))
+    if (isErrorEnabled) bus.publish(Error(cause, logSource, logClass, format(template, arg1), mdc, marker))
 
   /**
    * Message template with 2 replacement arguments.
@@ -1441,7 +1441,7 @@ class MarkerLoggingAdapter(
    * @see [[LoggingAdapter]]
    */
   def error(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any): Unit =
-    if (isErrorEnabled) bus.publish(Error(logSource, logClass, format(template, arg1, arg2), mdc, marker))
+    if (isErrorEnabled) bus.publish(Error(cause, logSource, logClass, format(template, arg1, arg2), mdc, marker))
 
   /**
    * Message template with 3 replacement arguments.
@@ -1449,7 +1449,7 @@ class MarkerLoggingAdapter(
    * @see [[LoggingAdapter]]
    */
   def error(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
-    if (isErrorEnabled) bus.publish(Error(logSource, logClass, format(template, arg1, arg2, arg3), mdc, marker))
+    if (isErrorEnabled) bus.publish(Error(cause, logSource, logClass, format(template, arg1, arg2, arg3), mdc, marker))
 
   /**
    * Message template with 4 replacement arguments.
@@ -1457,7 +1457,7 @@ class MarkerLoggingAdapter(
    * @see [[LoggingAdapter]]
    */
   def error(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit =
-    if (isErrorEnabled) bus.publish(Error(logSource, logClass, format(template, arg1, arg2, arg3, arg4), mdc, marker))
+    if (isErrorEnabled) bus.publish(Error(cause, logSource, logClass, format(template, arg1, arg2, arg3, arg4), mdc, marker))
 
   /**
    * Log message at error level, without providing the exception that caused the error.


### PR DESCRIPTION
After logging to stderr it seems reasonable to include the exception in the logging though the logging subsystem

* Add cause message to logging on fatal error

* Flush twice for extra safety

printStackTrace does some allocations, there might be rare cases where we can at least salvage the cause.

Refs #23107