### PR TITLE
Fix broken link for consistent hashing article

### DIFF
--- a/akka-docs/src/main/paradox/java/routing.md
+++ b/akka-docs/src/main/paradox/java/routing.md
@@ -436,7 +436,7 @@ TailChoppingGroup defined in code:
 
 The ConsistentHashingPool uses [consistent hashing](http://en.wikipedia.org/wiki/Consistent_hashing)
 to select a routee based on the sent message. This 
-[article](http://weblogs.java.net/blog/tomwhite/archive/2007/11/consistent_hash.html) gives good 
+[article](http://www.tom-e-white.com/2007/11/consistent-hashing.html) gives good 
 insight into how consistent hashing is implemented.
 
 There is 3 ways to define what data to use for the consistent hash key.

--- a/akka-docs/src/main/paradox/scala/routing.md
+++ b/akka-docs/src/main/paradox/scala/routing.md
@@ -436,7 +436,7 @@ TailChoppingGroup defined in code:
 
 The ConsistentHashingPool uses [consistent hashing](http://en.wikipedia.org/wiki/Consistent_hashing)
 to select a routee based on the sent message. This 
-[article](http://weblogs.java.net/blog/tomwhite/archive/2007/11/consistent_hash.html) gives good 
+[article](http://www.tom-e-white.com/2007/11/consistent-hashing.html) gives good 
 insight into how consistent hashing is implemented.
 
 There is 3 ways to define what data to use for the consistent hash key.


### PR DESCRIPTION
The section on consistent hashing routers has a link to an article with insight into the consistent hashing implementation. The link is broken, so this PR replaces it with an active link directly to the author's blog.