### PR TITLE
increase timeout in ActorsLeakSpec, #23010

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
@@ -204,7 +204,7 @@ class ActorsLeakSpec extends AkkaSpec(ActorsLeakSpec.config) with ImplicitSender
 
       EventFilter[TimeoutException](occurrences = 1).intercept {}
 
-      awaitAssert(assertResult(initialActors)(targets.flatMap(collectLiveActors).toSet), 5.seconds)
+      awaitAssert(assertResult(initialActors)(targets.flatMap(collectLiveActors).toSet), 10.seconds)
     }
 
   }


### PR DESCRIPTION
* follow up on #23010, ActorsLeakSpec sometimes fails
  because the reliableEndpointWriter is not stopped as
  early as before

Refs #23010