### PR TITLE
Ignore messages we didn't expect 

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -269,7 +269,6 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
               else receiveNMatching(remaining) // unknown message, just ignore
             }
           val set = receiveNMatching(messages)
-          expectNoMsg(Duration.Zero)
           assert(set == (0 until messages).toSet)
         }
       }

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -260,9 +260,15 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
             Logging.Debug(sname, sclass, "stopped"))
         }
 
-        // To get nice error messages I suppose we want to accept a set of PF's, but for now this'll do.
-        def expectMsgAllPF(messages: Int)(matchers: PartialFunction[AnyRef, _]) = {
-          val set = receiveWhile(messages = messages)(matchers).toSet
+        def expectMsgAllPF(messages: Int)(matchers: PartialFunction[AnyRef, Int]) = {
+          def receiveNMatching(remaining: Int): Set[Int] =
+            if (remaining == 0) Set.empty
+            else {
+              val msg = receiveOne(remainingOrDefault)
+              if (matchers.isDefinedAt(msg)) receiveNMatching(remaining - 1) + matchers(msg)
+              else receiveNMatching(remaining) // unknown message, just ignore
+            }
+          val set = receiveNMatching(messages)
           expectNoMsg(Duration.Zero)
           assert(set == (0 until messages).toSet)
         }


### PR DESCRIPTION
Refs #23140 

The fix for #23001 didn't take into account that there may be other unknown log messages (which I think does not matter and can be safely ignored).