### PR TITLE
Simplify Artery remote deployment and make inbound-lanes=4 default, #21422

### DIFF
--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -629,6 +629,18 @@ together with a tutorial for a more hands-on experience. The source code of this
 
 ## Performance tuning
 
+### Lanes
+
+Message serialization and deserialization can be a bottleneck for remote communication. Therefore there is support for parallel inbound and outbound lanes to perform serialization and other tasks for different destination actors in parallel. Using multiple lanes is of most value for the inbound messages, since all inbound messages from all remote systems share the same inbound stream. For outbound messages there is already one stream per remote destination system, so multiple outbound lanes only add value when sending to different actors in same destination system.
+
+The selection of lane is based on consistent hashing of the recipient ActorRef to preserve message ordering per receiver.
+
+Note that lowest latency can be achieved with `inbound-lanes=1` and `outbound-lanes=1` because multiple lanes introduce an asynchronous boundary. 
+
+Also note that the total amount of parallel tasks are bound by the `remote-dispatcher` and the thread pool size should not exceed the number of CPU cores minus headroom for actually processing the messages in the application, i.e. in practice the the pool size should be less than half of the number of cores.
+
+See `inbound-lanes` and `outbound-lanes` in the @ref:[reference configuration](general/configuration.md#config-akka-remote-artery) for default values.
+
 ### Dedicated subchannel for large messages
 
 All the communication between user defined remote actors are isolated from the channel of Akka internal messages so

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
@@ -43,7 +43,7 @@ object FanInThroughputSpec extends MultiNodeConfig {
        akka.test.FanInThroughputSpec.real-message = off
        akka.test.FanInThroughputSpec.actor-selection = off
        akka.remote.artery.advanced {
-         inbound-lanes = 4
+         # inbound-lanes = 4
        }
        """))
     .withFallback(MaxThroughputSpec.cfg)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
@@ -175,7 +175,6 @@ abstract class FanOutThroughputSpec extends RemotingMultiNodeSpec(FanOutThroughp
   }
 
   "Max throughput of fan-out" must {
-    pending
     val reporter = BenchmarkFileReporter("FanOutThroughputSpec", system)
     for (s ← scenarios) {
       s"be great for ${s.testName}, burstSize = ${s.burstSize}, payloadSize = ${s.payloadSize}" in test(s, reporter)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
@@ -47,6 +47,8 @@ object LatencySpec extends MultiNodeConfig {
            enabled = on
            advanced.idle-cpu-level = 7
 
+           advanced.inbound-lanes = 1
+
            # for serious measurements when running this test on only one machine
            # it is recommended to use external media driver
            # See akka-remote/src/test/resources/aeron.properties

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
@@ -71,7 +71,7 @@ object MaxThroughputSpec extends MultiNodeConfig {
          }
 
          advanced {
-           inbound-lanes = 1
+           # inbound-lanes = 1
            # buffer-pool-size = 512
          }
        }

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -861,22 +861,23 @@ akka {
         # Level 1 strongly prefer low CPU consumption over low latency.
         # Level 10 strongly prefer low latency over low CPU consumption.
         idle-cpu-level = 5
-
-        # WARNING: This feature is not supported yet. Don't use other value than 1.
-        # It requires more hardening and performance optimizations.
-        # Number of outbound lanes for each outbound association. A value greater than 1
-        # means that serialization can be performed in parallel for different destination
-        # actors. The selection of lane is based on consistent hashing of the recipient
-        # ActorRef to preserve message ordering per receiver.
-        outbound-lanes = 1
-
-        # WARNING: This feature is not supported yet. Don't use other value than 1.
-        # It requires more hardening and performance optimizations.
+        
         # Total number of inbound lanes, shared among all inbound associations. A value
         # greater than 1 means that deserialization can be performed in parallel for
         # different destination actors. The selection of lane is based on consistent
         # hashing of the recipient ActorRef to preserve message ordering per receiver.
-        inbound-lanes = 1
+        # Lowest latency can be achieved with inbound-lanes=1 because of one less 
+        # asynchronous boundary.
+        inbound-lanes = 4
+
+        # Number of outbound lanes for each outbound association. A value greater than 1
+        # means that serialization and other work can be performed in parallel for different
+        # destination actors. The selection of lane is based on consistent hashing of the
+        # recipient ActorRef to preserve message ordering per receiver. Note that messages
+        # for different destination systems (hosts) are handled by different streams also
+        # when outbound-lanes=1. Lowest latency can be achieved with outbound-lanes=1
+        # because of one less asynchronous boundary.
+        outbound-lanes = 1
 
         # Size of the send queue for outgoing messages. Messages will be dropped if
         # the queue becomes full. This may happen if you send a burst of many messages

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeploymentSpec.scala
@@ -30,9 +30,42 @@ object RemoteDeploymentSpec {
       target ! "postStop"
     }
   }
+
+  def parentProps(probe: ActorRef): Props =
+    Props(new Parent(probe))
+
+  class Parent(probe: ActorRef) extends Actor {
+    var target: ActorRef = context.system.deadLetters
+
+    override val supervisorStrategy = OneForOneStrategy() {
+      case e: Exception ⇒
+        probe ! e
+        SupervisorStrategy.stop
+    }
+
+    def receive = {
+      case p: Props ⇒
+        sender() ! context.actorOf(p)
+
+      case (p: Props, firstMsg: Int) ⇒
+        val child = context.actorOf(p)
+        sender() ! child
+        child.tell(firstMsg, sender())
+    }
+  }
+
+  class DeadOnArrival extends Actor {
+    throw new Exception("init-crash")
+
+    def receive = Actor.emptyBehavior
+  }
 }
 
-class RemoteDeploymentSpec extends ArteryMultiNodeSpec(ArterySpecSupport.defaultConfig) {
+class RemoteDeploymentSpec extends ArteryMultiNodeSpec(
+  ConfigFactory.parseString("""
+    akka.remote.artery.advanced.inbound-lanes = 10
+    akka.remote.artery.advanced.outbound-lanes = 3
+    """).withFallback(ArterySpecSupport.defaultConfig)) {
 
   import RemoteDeploymentSpec._
 
@@ -41,7 +74,10 @@ class RemoteDeploymentSpec extends ArteryMultiNodeSpec(ArterySpecSupport.default
     s"""
     akka.actor.deployment {
       /blub.remote = "akka://${system.name}@localhost:$port"
+      "/parent*/*".remote = "akka://${system.name}@localhost:$port"
     }
+    akka.remote.artery.advanced.inbound-lanes = 10
+    akka.remote.artery.advanced.outbound-lanes = 3
     """
 
   val masterSystem = newRemoteSystem(name = Some("Master" + system.name), extraConfig = Some(conf))
@@ -64,6 +100,48 @@ class RemoteDeploymentSpec extends ArteryMultiNodeSpec(ArterySpecSupport.default
       senderProbe.expectMsg(43)
       system.stop(r)
       senderProbe.expectMsg("postStop")
+    }
+
+    "notice immediate death" in {
+      val parent = masterSystem.actorOf(parentProps(testActor), "parent")
+      EventFilter[ActorInitializationException](occurrences = 1).intercept {
+        parent.tell(Props[DeadOnArrival], testActor)
+        val child = expectMsgType[ActorRef]
+        expectMsgType[ActorInitializationException]
+
+        watch(child)
+        expectTerminated(child)
+      }(masterSystem)
+    }
+
+    "deliver all messages" in {
+      val numParents = 10
+      val numChildren = 20
+      val numMessages = 5
+
+      val parents = (0 until numParents).map { i ⇒
+        masterSystem.actorOf(parentProps(testActor), s"parent-$i")
+      }.toVector
+
+      val probes = Vector.fill(numParents, numChildren)(TestProbe()(masterSystem))
+      val childProps = Props[Echo1]
+      for (p ← (0 until numParents); c ← (0 until numChildren)) {
+        parents(p).tell((childProps, 0), probes(p)(c).ref)
+      }
+
+      for (p ← (0 until numParents); c ← (0 until numChildren)) {
+        val probe = probes(p)(c)
+        val child = probe.expectMsgType[ActorRef]
+        // message 0 was sent by parent when child was created (stress as quick send as possible)
+        (1 until numMessages).foreach(n ⇒ child.tell(n, probe.ref))
+      }
+
+      val expectedMessages = (0 until numMessages).toVector
+      for (p ← (0 until numParents); c ← (0 until numChildren)) {
+        val probe = probes(p)(c)
+        probe.receiveN(numMessages) should equal(expectedMessages)
+      }
+
     }
 
   }

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
@@ -11,7 +11,10 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.duration._
 import akka.actor.ActorSelection
 
-class RemoteSendConsistencySpec extends AbstractRemoteSendConsistencySpec(ArterySpecSupport.defaultConfig)
+class RemoteSendConsistencyWithOneLaneSpec extends AbstractRemoteSendConsistencySpec(ConfigFactory.parseString("""
+      akka.remote.artery.advanced.outbound-lanes = 1
+      akka.remote.artery.advanced.inbound-lanes = 1
+    """).withFallback(ArterySpecSupport.defaultConfig))
 
 class RemoteSendConsistencyWithThreeLanesSpec extends AbstractRemoteSendConsistencySpec(
   ConfigFactory.parseString("""


### PR DESCRIPTION
* DaemonMsgCreate is not a system message. We send it over the control
  stream because remote deployment process depends on message ordering
  for DaemonMsgCreate and Watch messages. That is all good.
* We also send DaemonMsgCreate over the ordinary message stream (all
  outbound lanes) so that the first ordinary message that is sent to
  the ref does not arrive before the actor is created. This is not needed,
  since the retried resolve in the Decoder will take care of that anyway.
* Inbound lanes were not covered, but not needed.
* Then the deduplication of DaemonMsgCreate messages in  RemoteSystemDaemon
  is not needed.
* Added some more tests for these things.