### PR TITLE
Fix #23165: Update StreamConverters.fromInputStream docs to reflect reality

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
@@ -91,7 +91,7 @@ object StreamConverters {
    * Creates a Source from an [[java.io.InputStream]] created by the given function.
    * Emitted elements are up to `chunkSize` sized [[akka.util.ByteString]] elements.
    * The actual size of emitted elements depends how much data the underlying
-   * [[java.io. InputStream]] returns on each read invocation. Such chunks will
+   * [[java.io.InputStream]] returns on each read invocation. Such chunks will
    * never be larger than chunkSize though.
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
@@ -108,7 +108,7 @@ object StreamConverters {
    * Creates a Source from an [[java.io.InputStream]] created by the given function.
    * Emitted elements are up to 8192 bytes sized [[akka.util.ByteString]] elements.
    * The actual size of emitted elements depends how much data the underlying
-   * [[java.io. InputStream]] returns on each read invocation. Such chunks will
+   * [[java.io.InputStream]] returns on each read invocation. Such chunks will
    * never be larger than chunkSize though.
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or

--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
@@ -89,8 +89,10 @@ object StreamConverters {
 
   /**
    * Creates a Source from an [[java.io.InputStream]] created by the given function.
-   * Emitted elements are `chunkSize` sized [[akka.util.ByteString]] elements,
-   * except the final element, which will be up to `chunkSize` in size.
+   * Emitted elements are up to `chunkSize` sized [[akka.util.ByteString]] elements.
+   * The actual size of emitted elements depends how much data the underlying
+   * [[java.io. InputStream]] returns on each read invocation. Such chunks will
+   * never be larger than chunkSize though.
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[akka.stream.ActorAttributes]].
@@ -104,8 +106,10 @@ object StreamConverters {
 
   /**
    * Creates a Source from an [[java.io.InputStream]] created by the given function.
-   * Emitted elements are [[ByteString]] elements, chunked by default by 8192 bytes,
-   * except the last element, which will be up to 8192 in size.
+   * Emitted elements are up to 8192 bytes sized [[akka.util.ByteString]] elements.
+   * The actual size of emitted elements depends how much data the underlying
+   * [[java.io. InputStream]] returns on each read invocation. Such chunks will
+   * never be larger than chunkSize though.
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[akka.stream.ActorAttributes]].

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
@@ -31,7 +31,7 @@ object StreamConverters {
    * Creates a Source from an [[InputStream]] created by the given function.
    * Emitted elements are up to `chunkSize` sized [[akka.util.ByteString]] elements.
    * The actual size of emitted elements depends how much data the underlying
-   * [[java.io. InputStream]] returns on each read invocation. Such chunks will
+   * [[java.io.InputStream]] returns on each read invocation. Such chunks will
    * never be larger than chunkSize though.
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
@@ -29,8 +29,10 @@ object StreamConverters {
 
   /**
    * Creates a Source from an [[InputStream]] created by the given function.
-   * Emitted elements are `chunkSize` sized [[akka.util.ByteString]] elements,
-   * except the final element, which will be up to `chunkSize` in size.
+   * Emitted elements are up to `chunkSize` sized [[akka.util.ByteString]] elements.
+   * The actual size of emitted elements depends how much data the underlying
+   * [[java.io. InputStream]] returns on each read invocation. Such chunks will
+   * never be larger than chunkSize though.
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[akka.stream.ActorAttributes]].


### PR DESCRIPTION
Fixes #23165 by mentioning that each element emitted by `fromInputStream` will be
UP TO the configured chunk size, rather than EXACTLY the emitted chunk size
(which was implied by the previous documentation).