### PR TITLE
Improve ForkJoinActorBenchmark

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorThoughputBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorThoughputBenchmark.scala
@@ -1,0 +1,223 @@
+/**
+ * Copyright (C) 2014-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.actor
+
+import akka.pattern.ask
+import akka.pattern.pipe
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.annotation.tailrec
+import java.util.concurrent.CountDownLatch
+import akka.actor.SupervisorSpec.PingPongActor
+import akka.util.Timeout
+import scala.concurrent.Future
+import scala.concurrent.forkjoin.ThreadLocalRandom
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 10, time = 5, timeUnit = TimeUnit.SECONDS, batchSize = 1)
+@Measurement(iterations = 10, time = 15, timeUnit = TimeUnit.SECONDS, batchSize = 1)
+class ActorThroughputBenchmark {
+  import ActorThroughputBenchmark._
+
+  @Param(Array("25")) // "5", "25", "50"
+  var tpt = 0
+
+  @Param(Array(coresStr))
+  var threads = ""
+
+  @Param(Array("SingleConsumerOnlyUnboundedMailbox")) //"default"
+  var mailbox = ""
+
+  implicit var system: ActorSystem = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+
+    require(
+      Runtime.getRuntime.availableProcessors == cores,
+      s"Update the cores constant to ${Runtime.getRuntime.availableProcessors}"
+    )
+
+    val mailboxConf = mailbox match {
+      case "default" => ""
+      case "SingleConsumerOnlyUnboundedMailbox" =>
+        s"""default-mailbox.mailbox-type = "${classOf[akka.dispatch.SingleConsumerOnlyUnboundedMailbox].getName}""""
+    }
+
+    system = ActorSystem("ActorThroughputBenchmark", ConfigFactory.parseString(
+      s"""
+        akka {
+          log-dead-letters = off
+           actor {
+             default-dispatcher {
+               executor = "fork-join-executor"
+               fork-join-executor {
+                 parallelism-min = $threads
+                 parallelism-factor = 1
+                 parallelism-max = $threads
+               }
+               throughput = $tpt
+             }
+             $mailboxConf
+           }
+         }
+      """
+    ))
+  }
+
+  @TearDown(Level.Trial)
+  def shutdown(): Unit = {
+    system.terminate()
+    Await.ready(system.whenTerminated, 15.seconds)
+  }
+
+  def startActors(n: Int, props: Props): ActorRef = {
+    val parent = system.actorOf(Props[Parent])
+    implicit val ec = system.dispatcher
+    implicit val askTimeout = Timeout(3.seconds)
+    val initDone = parent ? Create(n, props)
+    Await.ready(initDone, askTimeout.duration)
+    parent
+  }
+
+  private def printProgress(totalMessages: Long, numActors: Int, startNanoTime: Long): Unit = {
+    val durationMicros = (System.nanoTime() - startNanoTime) / 1000
+    println(f"  $totalMessages messages by $numActors actors took ${durationMicros / 1000} ms, " +
+      f"${totalMessages.toDouble / durationMicros}%,.2f M msg/s")
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(totalMessagesTwo)
+  def two(): Unit = {
+    val latch = new CountDownLatch(twoActors)
+    val parent = startActors(twoActors, testProps(totalMessagesTwo / twoActors, latch))
+    val startNanoTime = System.nanoTime()
+    parent ! Run(2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(totalMessagesTwo, twoActors, startNanoTime)
+    system.stop(parent)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(totalMessagesLessThanCores)
+  def lessThanCores(): Unit = {
+    val latch = new CountDownLatch(lessThanCoresActors)
+    val parent = startActors(lessThanCoresActors, testProps(totalMessagesLessThanCores / lessThanCoresActors, latch))
+    val startNanoTime = System.nanoTime()
+    parent ! Run(2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(totalMessagesLessThanCores, lessThanCoresActors, startNanoTime)
+    system.stop(parent)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(totalMessagesSameAsCores)
+  def sameAsCores(): Unit = {
+    val latch = new CountDownLatch(sameAsCoresActors)
+    val parent = startActors(sameAsCoresActors, testProps(totalMessagesSameAsCores / sameAsCoresActors, latch))
+    val startNanoTime = System.nanoTime()
+    parent ! Run(2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(totalMessagesSameAsCores, sameAsCoresActors, startNanoTime)
+    system.stop(parent)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(totalMessagesMoreThanCores)
+  def moreThanCores(): Unit = {
+    val latch = new CountDownLatch(moreThanCoresActors)
+    val parent = startActors(moreThanCoresActors, testProps(totalMessagesMoreThanCores / moreThanCoresActors, latch))
+    val startNanoTime = System.nanoTime()
+    parent ! Run(2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(totalMessagesMoreThanCores, moreThanCoresActors, startNanoTime)
+    system.stop(parent)
+  }
+
+}
+
+object ActorThroughputBenchmark {
+
+  final val timeout = 30.seconds
+  final val messages = 2000000 // messages per actor
+
+  // Constants because they are used in annotations
+  // update according to cpu
+  final val cores = 8
+  final val coresStr = "7"
+
+  final val twoActors = 2
+  final val lessThanCoresActors = cores / 2
+  final val moreThanCoresActors = cores * 2
+  final val sameAsCoresActors = cores
+  final val totalMessagesTwo = twoActors * messages
+  final val totalMessagesLessThanCores = lessThanCoresActors * messages
+  final val totalMessagesMoreThanCores = moreThanCoresActors * messages
+  final val totalMessagesSameAsCores = sameAsCoresActors * messages
+
+  final case class Create(n: Int, p: Props)
+  final case class Init(all: Array[ActorRef])
+  case object InitDone
+  final case class Run(initialMessages: Int)
+  case object Message
+
+  def testProps(doneAfter: Long, latch: CountDownLatch): Props =
+    Props(new TestActor(doneAfter, latch))
+
+  class TestActor(doneAfter: Long, latch: CountDownLatch) extends Actor {
+    private var refs: Array[ActorRef] = null
+    private var i = 0L
+    private var n = 0L
+
+    def receive = {
+      case Init(all) =>
+        refs = all
+        i = refs.indexOf(self)
+        sender() ! InitDone
+      case Run(initialMessages) =>
+        (1 to initialMessages).foreach(_ => send())
+        context.become(active)
+    }
+
+    def active: Receive = {
+      case Message =>
+        send()
+        n += 1
+        if (n == doneAfter)
+          latch.countDown()
+    }
+
+    private def send(): Unit = {
+      i += 1
+      refs((i % refs.length).toInt) ! Message
+    }
+  }
+
+  // use Parent actor to avoid RepointableActorRef, and more clean initialization
+  class Parent extends Actor {
+
+    def receive = {
+      case Create(n, p) =>
+        val refs = (1 to n).map(_ => context.actorOf(p)).toVector
+        // all must receive the refs first
+        val init = Init(refs.toArray)
+        import context.dispatcher
+        implicit val askTimeout = Timeout(3.seconds)
+        Future.sequence(refs.map((_ ? init))).map(_ => InitDone).pipeTo(sender())
+        context.become(active(refs))
+    }
+
+    def active(refs: Seq[ActorRef]): Receive = {
+      case r: Run => refs.foreach(_ ! r)
+    }
+
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
@@ -10,42 +10,61 @@ import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 import scala.annotation.tailrec
+import java.util.concurrent.CountDownLatch
+import akka.actor.SupervisorSpec.PingPongActor
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
 @Fork(1)
 @Threads(1)
 @Warmup(iterations = 10, time = 5, timeUnit = TimeUnit.SECONDS, batchSize = 1)
-@Measurement(iterations = 20)
+@Measurement(iterations = 10, time = 15, timeUnit = TimeUnit.SECONDS, batchSize = 1)
 class ForkJoinActorBenchmark {
   import ForkJoinActorBenchmark._
 
-  @Param(Array("5"))
+  @Param(Array("5", "25", "50"))
   var tpt = 0
 
-  @Param(Array("1"))
+  @Param(Array(coresStr)) // coresStr, cores2xStr, cores4xStr
   var threads = ""
+
+  @Param(Array("SingleConsumerOnlyUnboundedMailbox")) //"default"
+  var mailbox = ""
 
   implicit var system: ActorSystem = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
+
+    require(
+      Runtime.getRuntime.availableProcessors == cores,
+      s"Update the cores constant to ${Runtime.getRuntime.availableProcessors}"
+    )
+
+    val mailboxConf = mailbox match {
+      case "default" => ""
+      case "SingleConsumerOnlyUnboundedMailbox" =>
+        s"""default-mailbox.mailbox-type = "${classOf[akka.dispatch.SingleConsumerOnlyUnboundedMailbox].getName}""""
+    }
+
     system = ActorSystem("ForkJoinActorBenchmark", ConfigFactory.parseString(
-      s"""| akka {
-        |   log-dead-letters = off
-        |   actor {
-        |     default-dispatcher {
-        |       executor = "fork-join-executor"
-        |       fork-join-executor {
-        |         parallelism-min = 1
-        |         parallelism-factor = $threads
-        |         parallelism-max = 64
-        |       }
-        |       throughput = $tpt
-        |     }
-        |   }
-        | }
-      """.stripMargin
+      s"""
+        akka {
+          log-dead-letters = off
+           actor {
+             default-dispatcher {
+               executor = "fork-join-executor"
+               fork-join-executor {
+                 parallelism-min = $threads
+                 parallelism-factor = 1
+                 parallelism-max = $threads
+               }
+               throughput = $tpt
+             }
+             $mailboxConf
+           }
+         }
+      """
     ))
   }
 
@@ -55,33 +74,12 @@ class ForkJoinActorBenchmark {
     Await.ready(system.whenTerminated, 15.seconds)
   }
 
-  var pingPongActors: Vector[(ActorRef, ActorRef)] = null
-  var pingPongLessActorsThanCoresActors: Vector[(ActorRef, ActorRef)] = null
-  var pingPongSameNumberOfActorsAsCoresActors: Vector[(ActorRef, ActorRef)] = null
-  var pingPongMoreActorsThanCoresActors: Vector[(ActorRef, ActorRef)] = null
-
-  @Setup(Level.Invocation)
-  def setupActors(): Unit = {
-    pingPongActors = startActors(1)
-    pingPongLessActorsThanCoresActors = startActors(lessThanCoresActorPairs)
-    pingPongSameNumberOfActorsAsCoresActors = startActors(cores / 2)
-    pingPongMoreActorsThanCoresActors = startActors(moreThanCoresActorPairs)
-  }
-
-  @TearDown(Level.Invocation)
-  def tearDownActors(): Unit = {
-    stopActors(pingPongActors)
-    stopActors(pingPongLessActorsThanCoresActors)
-    stopActors(pingPongSameNumberOfActorsAsCoresActors)
-    stopActors(pingPongMoreActorsThanCoresActors)
-  }
-
-  def startActors(n: Int): Vector[(ActorRef, ActorRef)] = {
+  def startActors(n: Int, props: Props): Vector[(ActorRef, ActorRef)] = {
     for {
       i <- (1 to n).toVector
     } yield {
-      val ping = system.actorOf(Props[ForkJoinActorBenchmark.PingPong])
-      val pong = system.actorOf(Props[ForkJoinActorBenchmark.PingPong])
+      val ping = system.actorOf(props)
+      val pong = system.actorOf(props)
       (ping, pong)
     }
   }
@@ -117,37 +115,54 @@ class ForkJoinActorBenchmark {
     }
   }
 
+  private def printProgress(totalMessages: Long, numActors: Int, startNanoTime: Long): Unit = {
+    val durationMicros = (System.nanoTime() - startNanoTime) / 1000
+    println(f"  $totalMessages messages by $numActors actors took ${durationMicros / 1000} ms, " +
+      f"${totalMessages.toDouble / durationMicros}%,.2f M msg/s")
+  }
+
   @Benchmark
-  @Measurement(timeUnit = TimeUnit.MILLISECONDS)
   @OperationsPerInvocation(messages)
   def pingPong(): Unit = {
-    // only one message in flight
-    sendMessage(pingPongActors, inFlight = 1)
-    awaitTerminated(pingPongActors)
+    val latch = new CountDownLatch(2)
+    val actors = startActors(1, pingPongProps(latch))
+    val startNanoTime = System.nanoTime()
+    sendMessage(actors, inFlight = 2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(messages, 2, startNanoTime)
   }
 
   @Benchmark
-  @Measurement(timeUnit = TimeUnit.MILLISECONDS)
   @OperationsPerInvocation(totalMessagesLessThanCores)
   def pingPongLessActorsThanCores(): Unit = {
-    sendMessage(pingPongLessActorsThanCoresActors, inFlight = 2 * tpt)
-    awaitTerminated(pingPongLessActorsThanCoresActors)
+    val latch = new CountDownLatch(lessThanCoresActorPairs * 2)
+    val actors = startActors(lessThanCoresActorPairs, pingPongProps(latch))
+    val startNanoTime = System.nanoTime()
+    sendMessage(actors, inFlight = 2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(totalMessagesLessThanCores, actors.size * 2, startNanoTime)
   }
 
   @Benchmark
-  @Measurement(timeUnit = TimeUnit.MILLISECONDS)
   @OperationsPerInvocation(totalMessagesSameAsCores)
   def pingPongSameNumberOfActorsAsCores(): Unit = {
-    sendMessage(pingPongSameNumberOfActorsAsCoresActors, inFlight = 2 * tpt)
-    awaitTerminated(pingPongSameNumberOfActorsAsCoresActors)
+    val latch = new CountDownLatch(cores)
+    val actors = startActors(cores / 2, pingPongProps(latch))
+    val startNanoTime = System.nanoTime()
+    sendMessage(actors, inFlight = 2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(totalMessagesSameAsCores, actors.size * 2, startNanoTime)
   }
 
   @Benchmark
-  @Measurement(timeUnit = TimeUnit.MILLISECONDS)
   @OperationsPerInvocation(totalMessagesMoreThanCores)
   def pingPongMoreActorsThanCores(): Unit = {
-    sendMessage(pingPongMoreActorsThanCoresActors, inFlight = 2 * tpt)
-    awaitTerminated(pingPongMoreActorsThanCoresActors)
+    val latch = new CountDownLatch(moreThanCoresActorPairs * 2)
+    val actors = startActors(moreThanCoresActorPairs, pingPongProps(latch))
+    val startNanoTime = System.nanoTime()
+    sendMessage(actors, inFlight = 2 * tpt)
+    latch.await(timeout.toSeconds, TimeUnit.SECONDS)
+    printProgress(totalMessagesMoreThanCores, actors.size * 2, startNanoTime)
   }
 
   //  @Benchmark
@@ -180,14 +195,18 @@ class ForkJoinActorBenchmark {
 object ForkJoinActorBenchmark {
   case object Stop
   case object Message
-  final val timeout = 15.seconds
-  final val messages = 400000
+  final val timeout = 30.seconds
+  final val messages = 2000000 // messages per actor pair
 
+  // Constants because they are used in annotations
   // update according to cpu
-  final val cores = 8
-  // 2 actors per
-  final val moreThanCoresActorPairs = cores * 2
-  final val lessThanCoresActorPairs = (cores / 2) - 1
+  final val cores = 24
+  final val coresStr = "24"
+  final val cores2xStr = "48"
+  final val cores4xStr = "96"
+  // 2 actors per pair
+  final val moreThanCoresActorPairs = cores
+  final val lessThanCoresActorPairs = cores / 4
   final val totalMessagesMoreThanCores = moreThanCoresActorPairs * messages
   final val totalMessagesLessThanCores = lessThanCoresActorPairs * messages
   final val totalMessagesSameAsCores = cores * messages
@@ -201,13 +220,19 @@ object ForkJoinActorBenchmark {
         if (next.isDefined) next.get forward Stop
     }
   }
-  class PingPong extends Actor {
+
+  def pingPongProps(latch: CountDownLatch): Props =
+    Props(new PingPong(latch))
+
+  class PingPong(latch: CountDownLatch) extends Actor {
     var left = messages / 2
     def receive = {
       case Message =>
 
-        if (left <= 1)
+        if (left == 0) {
+          latch.countDown()
           context stop self
+        }
 
         sender() ! Message
         left -= 1

--- a/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
@@ -22,7 +22,7 @@ import akka.actor.SupervisorSpec.PingPongActor
 class ForkJoinActorBenchmark {
   import ForkJoinActorBenchmark._
 
-  @Param(Array("5", "25", "50"))
+  @Param(Array("25")) // "5", "25", "50"
   var tpt = 0
 
   @Param(Array(coresStr)) // coresStr, cores2xStr, cores4xStr
@@ -146,8 +146,8 @@ class ForkJoinActorBenchmark {
   @Benchmark
   @OperationsPerInvocation(totalMessagesSameAsCores)
   def pingPongSameNumberOfActorsAsCores(): Unit = {
-    val latch = new CountDownLatch(cores)
-    val actors = startActors(cores / 2, pingPongProps(latch))
+    val latch = new CountDownLatch(sameAsCoresActorPairs * 2)
+    val actors = startActors(sameAsCoresActorPairs, pingPongProps(latch))
     val startNanoTime = System.nanoTime()
     sendMessage(actors, inFlight = 2 * tpt)
     latch.await(timeout.toSeconds, TimeUnit.SECONDS)
@@ -200,16 +200,17 @@ object ForkJoinActorBenchmark {
 
   // Constants because they are used in annotations
   // update according to cpu
-  final val cores = 24
-  final val coresStr = "24"
-  final val cores2xStr = "48"
-  final val cores4xStr = "96"
+  final val cores = 8
+  final val coresStr = "8"
+  final val cores2xStr = "16"
+  final val cores4xStr = "32"
   // 2 actors per pair
   final val moreThanCoresActorPairs = cores
   final val lessThanCoresActorPairs = cores / 4
+  final val sameAsCoresActorPairs = cores / 2
   final val totalMessagesMoreThanCores = moreThanCoresActorPairs * messages
   final val totalMessagesLessThanCores = lessThanCoresActorPairs * messages
-  final val totalMessagesSameAsCores = cores * messages
+  final val totalMessagesSameAsCores = sameAsCoresActorPairs * messages
 
   class Pipe(next: Option[ActorRef]) extends Actor {
     def receive = {

--- a/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ForkJoinActorBenchmark.scala
@@ -112,6 +112,7 @@ class ForkJoinActorBenchmark {
       _ <- 1 to inFlight
     } {
       ping.tell(Message, pong)
+      pong.tell(Message, ping)
     }
   }
 


### PR DESCRIPTION
* When running ForkJoinActorBenchmark on GCE I noticed that it was not
  utilizing all CPU. The reason was that the setup and teardown between
  each measurement iteration was slow. That time is not included in the
  measured time but seems to affect results anyway and it is strange
  to not have full CPU utilization.
* Also tweaked the amount of messages so that each measurement iteration
  is "long enough", and the iteration time of 15 seconds is important so
  that it runs more than one measurement iteration per iteration.
* More parameters and adjusted number of actors