### PR TITLE
mima filter for PhiAccrualFailureDetector constructor, #17389

### DIFF
--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1163,6 +1163,8 @@ object MiMa extends AutoPlugin {
       "2.4.18" -> Seq(
       ),
       "2.4.19" -> Seq(
+          // #17389 added constructor in PhiAccrualFailureDetector (this filter should not be needed)
+          ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.PhiAccrualFailureDetector.this")
       )
       // make sure that
       //  * this list ends with the latest released version number
@@ -1218,6 +1220,9 @@ object MiMa extends AutoPlugin {
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.pattern.BackoffOptions.withReplyWhileStopped")
       ),
       "2.5.2" -> Seq(
+        // #17389 added constructor in PhiAccrualFailureDetector (this filter should not be needed)
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.PhiAccrualFailureDetector.this"),
+          
         // #22881 Make sure connections are aborted correctly on Windows
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.io.ChannelRegistration.cancel"),
         


### PR DESCRIPTION
This is strange. The old constructor was kept, but mima is still reporting:
```
[error]  * method this(com.typesafe.config.Config,akka.event.EventStream)Unit in class akka.remote.PhiAccrualFailureDetector's type is different in current version, where it is (com.typesafe.config.Config,scala.Option)Unit instead of (com.typesafe.config.Config,akka.event.EventStream)Unit
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.PhiAccrualFailureDetector.this")
```

looking with javap:
```
  public akka.remote.PhiAccrualFailureDetector(double, int, scala.concurrent.duration.FiniteDuration, scala.concurrent.duration.FiniteDuration, scala.concurrent.duration.FiniteDuration, scala.Option<akka.event.EventStream>, akka.remote.FailureDetector$Clock);
  public akka.remote.PhiAccrualFailureDetector(double, int, scala.concurrent.duration.FiniteDuration, scala.concurrent.duration.FiniteDuration, scala.concurrent.duration.FiniteDuration, akka.remote.FailureDetector$Clock);
  public akka.remote.PhiAccrualFailureDetector(com.typesafe.config.Config, scala.Option<akka.event.EventStream>);
```

and before the change:
```
  public akka.remote.PhiAccrualFailureDetector(double, int, scala.concurrent.duration.FiniteDuration, scala.concurrent.duration.FiniteDuration, scala.concurrent.duration.FiniteDuration, akka.remote.FailureDetector$Clock);
  public akka.remote.PhiAccrualFailureDetector(com.typesafe.config.Config, akka.event.EventStream);
```

Refs #17389