### PR TITLE
slow init of lmdb in DurableDataSpe, #22082

### DIFF
--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
@@ -32,7 +32,8 @@ final case class DurableDataSpecConfig(writeBehind: Boolean) extends MultiNodeCo
       map-size = 10 MiB
       write-behind-interval = ${if (writeBehind) "200ms" else "off"}
     }
-    akka.test.single-expect-default = 5s
+    # initialization of lmdb can be very slow in CI environment
+    akka.test.single-expect-default = 15s
     """))
 }
 


### PR DESCRIPTION
```
[JVM-1] [INFO] [06/21/2017 08:42:33.385] [DurableDataSpec-akka.cluster.distributed-data.durable.pinned-store-18] [akka.tcp://DurableDataSpec@a0.moxie:45362/user/replicator-0/durableStore] Using durable data in LMDB directory [/localhome/jenkinsakka/akka-multi-node-nightly2/target/DurableDataSpec-1498027351316-ddata-DurableDataSpec-replicator-0-45362]

and much later

[JVM-1] [DEBUG] [06/21/2017 08:42:41.707] [DurableDataSpec-akka.cluster.distributed-data.durable.pinned-store-18] [akka.tcp://DurableDataSpec@a0.moxie:45362/user/replicator-0/durableStore] Init of LMDB in directory [/localhome/jenkinsakka/akka-multi-node-nightly2/target/DurableDataSpec-1498027351316-ddata-DurableDataSpec-replicator-0-45362] took [8321 ms]
```

Refs #22082