### PR TITLE
Add API parameter comments to expectTerminated

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -410,6 +410,8 @@ trait TestKitBase {
    * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.
    * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
    *
+   * @param target the actor ref expected to be Terminated
+   * @param max wait no more than max time, otherwise throw AssertionFailure
    * @return the received Terminated message
    */
   def expectTerminated(target: ActorRef, max: Duration = Duration.Undefined): Terminated =

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -408,6 +408,7 @@ trait TestKitBase {
 
   /**
    * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.
+   * Before calling this method, you have to `watch` the target actor ref.
    * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
    *
    * @param target the actor ref expected to be Terminated

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -335,12 +335,19 @@ class TestKit(system: ActorSystem) {
   /**
    * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.
    * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
+   *
+   * @param max wait no more than max time, otherwise throw AssertionFailure
+   * @param target the actor ref expected to be Terminated
+   * @return the received Terminated message
    */
   def expectTerminated(max: Duration, target: ActorRef): Terminated = tp.expectTerminated(target, max)
 
   /**
    * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.
    * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
+   *
+   * @param target the actor ref expected to be Terminated
+   * @return the received Terminated message
    */
   def expectTerminated(target: ActorRef): Terminated = tp.expectTerminated(target)
 

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -334,6 +334,7 @@ class TestKit(system: ActorSystem) {
 
   /**
    * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.
+   * Before calling this method, you have to `watch` the target actor ref.
    * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
    *
    * @param max wait no more than max time, otherwise throw AssertionFailure
@@ -344,6 +345,7 @@ class TestKit(system: ActorSystem) {
 
   /**
    * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.
+   * Before calling this method, you have to `watch` the target actor ref.
    * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
    *
    * @param target the actor ref expected to be Terminated


### PR DESCRIPTION
Fixes #23091 

Scaladoc has parameter description populated:

![image](https://user-images.githubusercontent.com/7414320/27509785-4fa2bb8a-593f-11e7-9259-df29d62a5847.png)
