### PR TITLE
Use less of Project.apply

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,9 +36,9 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
 
 lazy val root = Project(
   id = "akka",
-  base = file("."),
-  aggregate = aggregatedProjects
-).settings(rootSettings: _*)
+  base = file(".")
+).aggregate(aggregatedProjects: _*)
+ .settings(rootSettings: _*)
  .settings(unidocRootIgnoreProjects := Seq(remoteTests, benchJmh, protobuf, akkaScalaNightly, docs))
 
 lazy val actor = akkaModule("akka-actor")


### PR DESCRIPTION
In sbt 1 Project.apply will only take 2 parameters.