### PR TITLE
Replace ClusterRouterGroup/Pool "use-role" with "use-role-set"

### DIFF
--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
@@ -138,7 +138,7 @@ abstract class AdaptiveLoadBalancingRouterSpec extends MultiNodeSpec(AdaptiveLoa
     val router = system.actorOf(
       ClusterRouterPool(
         local = AdaptiveLoadBalancingPool(HeapMetricsSelector),
-        settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRole = None)).
+        settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoleSet = Set.empty)).
         props(Props[Echo]),
       name)
     // it may take some time until router receives cluster member events

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
@@ -138,7 +138,7 @@ abstract class AdaptiveLoadBalancingRouterSpec extends MultiNodeSpec(AdaptiveLoa
     val router = system.actorOf(
       ClusterRouterPool(
         local = AdaptiveLoadBalancingPool(HeapMetricsSelector),
-        settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoles = Set.empty)).
+        settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true)).
         props(Props[Echo]),
       name)
     // it may take some time until router receives cluster member events

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
@@ -138,7 +138,7 @@ abstract class AdaptiveLoadBalancingRouterSpec extends MultiNodeSpec(AdaptiveLoa
     val router = system.actorOf(
       ClusterRouterPool(
         local = AdaptiveLoadBalancingPool(HeapMetricsSelector),
-        settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoleSet = Set.empty)).
+        settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoles = Set.empty)).
         props(Props[Echo]),
       name)
     // it may take some time until router receives cluster member events

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsSampleSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsSampleSpec.scala
@@ -45,7 +45,7 @@ object StatsSampleSpecConfig extends MultiNodeConfig {
           cluster {
             enabled = on
             allow-local-routees = on
-            use-role-set = ["compute"]
+            use-roles = ["compute"]
           }
         }
     }

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsSampleSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsSampleSpec.scala
@@ -45,7 +45,7 @@ object StatsSampleSpecConfig extends MultiNodeConfig {
           cluster {
             enabled = on
             allow-local-routees = on
-            use-role = compute
+            use-role-set = ["compute"]
           }
         }
     }

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsService.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsService.scala
@@ -71,7 +71,7 @@ abstract class StatsService3 extends Actor {
   val workerRouter = context.actorOf(
     ClusterRouterPool(ConsistentHashingPool(0), ClusterRouterPoolSettings(
       totalInstances = 100, maxInstancesPerNode = 3,
-      allowLocalRoutees = false, useRoles = Set.empty)).props(Props[StatsWorker]),
+      allowLocalRoutees = false)).props(Props[StatsWorker]),
     name = "workerRouter3")
   //#router-deploy-in-code
 }

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsService.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsService.scala
@@ -57,7 +57,7 @@ abstract class StatsService2 extends Actor {
   val workerRouter = context.actorOf(
     ClusterRouterGroup(ConsistentHashingGroup(Nil), ClusterRouterGroupSettings(
       totalInstances = 100, routeesPaths = List("/user/statsWorker"),
-      allowLocalRoutees = true, useRoleSet = Set("compute"))).props(),
+      allowLocalRoutees = true, useRoles = Set("compute"))).props(),
     name = "workerRouter2")
   //#router-lookup-in-code
 }
@@ -71,7 +71,7 @@ abstract class StatsService3 extends Actor {
   val workerRouter = context.actorOf(
     ClusterRouterPool(ConsistentHashingPool(0), ClusterRouterPoolSettings(
       totalInstances = 100, maxInstancesPerNode = 3,
-      allowLocalRoutees = false, useRoleSet = Set.empty)).props(Props[StatsWorker]),
+      allowLocalRoutees = false, useRoles = Set.empty)).props(Props[StatsWorker]),
     name = "workerRouter3")
   //#router-deploy-in-code
 }

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsService.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/sample/StatsService.scala
@@ -57,7 +57,7 @@ abstract class StatsService2 extends Actor {
   val workerRouter = context.actorOf(
     ClusterRouterGroup(ConsistentHashingGroup(Nil), ClusterRouterGroupSettings(
       totalInstances = 100, routeesPaths = List("/user/statsWorker"),
-      allowLocalRoutees = true, useRole = Some("compute"))).props(),
+      allowLocalRoutees = true, useRoleSet = Set("compute"))).props(),
     name = "workerRouter2")
   //#router-lookup-in-code
 }
@@ -71,7 +71,7 @@ abstract class StatsService3 extends Actor {
   val workerRouter = context.actorOf(
     ClusterRouterPool(ConsistentHashingPool(0), ClusterRouterPoolSettings(
       totalInstances = 100, maxInstancesPerNode = 3,
-      allowLocalRoutees = false, useRole = None)).props(Props[StatsWorker]),
+      allowLocalRoutees = false, useRoleSet = Set.empty)).props(Props[StatsWorker]),
     name = "workerRouter3")
   //#router-deploy-in-code
 }

--- a/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
+++ b/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
@@ -13135,25 +13135,25 @@ public final class ClusterMessages {
      */
     boolean getAllowLocalRoutees();
 
-    // repeated string useRoleSet = 4;
+    // repeated string useRoles = 4;
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
     java.util.List<java.lang.String>
-    getUseRoleSetList();
+    getUseRolesList();
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
-    int getUseRoleSetCount();
+    int getUseRolesCount();
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
-    java.lang.String getUseRoleSet(int index);
+    java.lang.String getUseRoles(int index);
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
     akka.protobuf.ByteString
-        getUseRoleSetBytes(int index);
+        getUseRolesBytes(int index);
   }
   /**
    * Protobuf type {@code ClusterRouterPoolSettings}
@@ -13223,10 +13223,10 @@ public final class ClusterMessages {
             }
             case 34: {
               if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
-                useRoleSet_ = new akka.protobuf.LazyStringArrayList();
+                useRoles_ = new akka.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000008;
               }
-              useRoleSet_.add(input.readBytes());
+              useRoles_.add(input.readBytes());
               break;
             }
           }
@@ -13238,7 +13238,7 @@ public final class ClusterMessages {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
-          useRoleSet_ = new akka.protobuf.UnmodifiableLazyStringList(useRoleSet_);
+          useRoles_ = new akka.protobuf.UnmodifiableLazyStringList(useRoles_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -13320,41 +13320,41 @@ public final class ClusterMessages {
       return allowLocalRoutees_;
     }
 
-    // repeated string useRoleSet = 4;
-    public static final int USEROLESET_FIELD_NUMBER = 4;
-    private akka.protobuf.LazyStringList useRoleSet_;
+    // repeated string useRoles = 4;
+    public static final int USEROLES_FIELD_NUMBER = 4;
+    private akka.protobuf.LazyStringList useRoles_;
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
     public java.util.List<java.lang.String>
-        getUseRoleSetList() {
-      return useRoleSet_;
+        getUseRolesList() {
+      return useRoles_;
     }
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
-    public int getUseRoleSetCount() {
-      return useRoleSet_.size();
+    public int getUseRolesCount() {
+      return useRoles_.size();
     }
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
-    public java.lang.String getUseRoleSet(int index) {
-      return useRoleSet_.get(index);
+    public java.lang.String getUseRoles(int index) {
+      return useRoles_.get(index);
     }
     /**
-     * <code>repeated string useRoleSet = 4;</code>
+     * <code>repeated string useRoles = 4;</code>
      */
     public akka.protobuf.ByteString
-        getUseRoleSetBytes(int index) {
-      return useRoleSet_.getByteString(index);
+        getUseRolesBytes(int index) {
+      return useRoles_.getByteString(index);
     }
 
     private void initFields() {
       totalInstances_ = 0;
       maxInstancesPerNode_ = 0;
       allowLocalRoutees_ = false;
-      useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
+      useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -13389,8 +13389,8 @@ public final class ClusterMessages {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBool(3, allowLocalRoutees_);
       }
-      for (int i = 0; i < useRoleSet_.size(); i++) {
-        output.writeBytes(4, useRoleSet_.getByteString(i));
+      for (int i = 0; i < useRoles_.size(); i++) {
+        output.writeBytes(4, useRoles_.getByteString(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -13415,12 +13415,12 @@ public final class ClusterMessages {
       }
       {
         int dataSize = 0;
-        for (int i = 0; i < useRoleSet_.size(); i++) {
+        for (int i = 0; i < useRoles_.size(); i++) {
           dataSize += akka.protobuf.CodedOutputStream
-            .computeBytesSizeNoTag(useRoleSet_.getByteString(i));
+            .computeBytesSizeNoTag(useRoles_.getByteString(i));
         }
         size += dataSize;
-        size += 1 * getUseRoleSetList().size();
+        size += 1 * getUseRolesList().size();
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -13544,7 +13544,7 @@ public final class ClusterMessages {
         bitField0_ = (bitField0_ & ~0x00000002);
         allowLocalRoutees_ = false;
         bitField0_ = (bitField0_ & ~0x00000004);
-        useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
+        useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
@@ -13587,11 +13587,11 @@ public final class ClusterMessages {
         }
         result.allowLocalRoutees_ = allowLocalRoutees_;
         if (((bitField0_ & 0x00000008) == 0x00000008)) {
-          useRoleSet_ = new akka.protobuf.UnmodifiableLazyStringList(
-              useRoleSet_);
+          useRoles_ = new akka.protobuf.UnmodifiableLazyStringList(
+              useRoles_);
           bitField0_ = (bitField0_ & ~0x00000008);
         }
-        result.useRoleSet_ = useRoleSet_;
+        result.useRoles_ = useRoles_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -13617,13 +13617,13 @@ public final class ClusterMessages {
         if (other.hasAllowLocalRoutees()) {
           setAllowLocalRoutees(other.getAllowLocalRoutees());
         }
-        if (!other.useRoleSet_.isEmpty()) {
-          if (useRoleSet_.isEmpty()) {
-            useRoleSet_ = other.useRoleSet_;
+        if (!other.useRoles_.isEmpty()) {
+          if (useRoles_.isEmpty()) {
+            useRoles_ = other.useRoles_;
             bitField0_ = (bitField0_ & ~0x00000008);
           } else {
-            ensureUseRoleSetIsMutable();
-            useRoleSet_.addAll(other.useRoleSet_);
+            ensureUseRolesIsMutable();
+            useRoles_.addAll(other.useRoles_);
           }
           onChanged();
         }
@@ -13765,95 +13765,95 @@ public final class ClusterMessages {
         return this;
       }
 
-      // repeated string useRoleSet = 4;
-      private akka.protobuf.LazyStringList useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
-      private void ensureUseRoleSetIsMutable() {
+      // repeated string useRoles = 4;
+      private akka.protobuf.LazyStringList useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureUseRolesIsMutable() {
         if (!((bitField0_ & 0x00000008) == 0x00000008)) {
-          useRoleSet_ = new akka.protobuf.LazyStringArrayList(useRoleSet_);
+          useRoles_ = new akka.protobuf.LazyStringArrayList(useRoles_);
           bitField0_ |= 0x00000008;
          }
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
       public java.util.List<java.lang.String>
-          getUseRoleSetList() {
-        return java.util.Collections.unmodifiableList(useRoleSet_);
+          getUseRolesList() {
+        return java.util.Collections.unmodifiableList(useRoles_);
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
-      public int getUseRoleSetCount() {
-        return useRoleSet_.size();
+      public int getUseRolesCount() {
+        return useRoles_.size();
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
-      public java.lang.String getUseRoleSet(int index) {
-        return useRoleSet_.get(index);
+      public java.lang.String getUseRoles(int index) {
+        return useRoles_.get(index);
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
       public akka.protobuf.ByteString
-          getUseRoleSetBytes(int index) {
-        return useRoleSet_.getByteString(index);
+          getUseRolesBytes(int index) {
+        return useRoles_.getByteString(index);
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
-      public Builder setUseRoleSet(
+      public Builder setUseRoles(
           int index, java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  ensureUseRoleSetIsMutable();
-        useRoleSet_.set(index, value);
+  ensureUseRolesIsMutable();
+        useRoles_.set(index, value);
         onChanged();
         return this;
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
-      public Builder addUseRoleSet(
+      public Builder addUseRoles(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  ensureUseRoleSetIsMutable();
-        useRoleSet_.add(value);
+  ensureUseRolesIsMutable();
+        useRoles_.add(value);
         onChanged();
         return this;
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
-      public Builder addAllUseRoleSet(
+      public Builder addAllUseRoles(
           java.lang.Iterable<java.lang.String> values) {
-        ensureUseRoleSetIsMutable();
-        super.addAll(values, useRoleSet_);
+        ensureUseRolesIsMutable();
+        super.addAll(values, useRoles_);
         onChanged();
         return this;
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
-      public Builder clearUseRoleSet() {
-        useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
+      public Builder clearUseRoles() {
+        useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
         onChanged();
         return this;
       }
       /**
-       * <code>repeated string useRoleSet = 4;</code>
+       * <code>repeated string useRoles = 4;</code>
        */
-      public Builder addUseRoleSetBytes(
+      public Builder addUseRolesBytes(
           akka.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  ensureUseRoleSetIsMutable();
-        useRoleSet_.add(value);
+  ensureUseRolesIsMutable();
+        useRoles_.add(value);
         onChanged();
         return this;
       }
@@ -13996,16 +13996,16 @@ public final class ClusterMessages {
       "\001(\r\"V\n\021ClusterRouterPool\022\023\n\004pool\030\001 \002(\0132\005" +
       ".Pool\022,\n\010settings\030\002 \002(\0132\032.ClusterRouterP" +
       "oolSettings\"<\n\004Pool\022\024\n\014serializerId\030\001 \002(" +
-      "\r\022\020\n\010manifest\030\002 \002(\t\022\014\n\004data\030\003 \002(\014\"\177\n\031Clu" +
+      "\r\022\020\n\010manifest\030\002 \002(\t\022\014\n\004data\030\003 \002(\014\"}\n\031Clu" +
       "sterRouterPoolSettings\022\026\n\016totalInstances" +
       "\030\001 \002(\r\022\033\n\023maxInstancesPerNode\030\002 \002(\r\022\031\n\021a" +
-      "llowLocalRoutees\030\003 \002(\010\022\022\n\nuseRoleSet\030\004 \003" +
-      "(\t*D\n\022ReachabilityStatus\022\r\n\tReachable\020\000\022" +
-      "\017\n\013Unreachable\020\001\022\016\n\nTerminated\020\002*b\n\014Memb" +
-      "erStatus\022\013\n\007Joining\020\000\022\006\n\002Up\020\001\022\013\n\007Leaving",
-      "\020\002\022\013\n\007Exiting\020\003\022\010\n\004Down\020\004\022\013\n\007Removed\020\005\022\014" +
-      "\n\010WeaklyUp\020\006B\035\n\031akka.cluster.protobuf.ms" +
-      "gH\001"
+      "llowLocalRoutees\030\003 \002(\010\022\020\n\010useRoles\030\004 \003(\t" +
+      "*D\n\022ReachabilityStatus\022\r\n\tReachable\020\000\022\017\n" +
+      "\013Unreachable\020\001\022\016\n\nTerminated\020\002*b\n\014Member" +
+      "Status\022\013\n\007Joining\020\000\022\006\n\002Up\020\001\022\013\n\007Leaving\020\002",
+      "\022\013\n\007Exiting\020\003\022\010\n\004Down\020\004\022\013\n\007Removed\020\005\022\014\n\010" +
+      "WeaklyUp\020\006B\035\n\031akka.cluster.protobuf.msgH" +
+      "\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -14113,7 +14113,7 @@ public final class ClusterMessages {
           internal_static_ClusterRouterPoolSettings_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ClusterRouterPoolSettings_descriptor,
-              new java.lang.String[] { "TotalInstances", "MaxInstancesPerNode", "AllowLocalRoutees", "UseRoleSet", });
+              new java.lang.String[] { "TotalInstances", "MaxInstancesPerNode", "AllowLocalRoutees", "UseRoles", });
           return null;
         }
       };

--- a/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
+++ b/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
@@ -13135,22 +13135,37 @@ public final class ClusterMessages {
      */
     boolean getAllowLocalRoutees();
 
-    // repeated string useRoles = 4;
+    // optional string useRole = 4;
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>optional string useRole = 4;</code>
+     */
+    boolean hasUseRole();
+    /**
+     * <code>optional string useRole = 4;</code>
+     */
+    java.lang.String getUseRole();
+    /**
+     * <code>optional string useRole = 4;</code>
+     */
+    akka.protobuf.ByteString
+        getUseRoleBytes();
+
+    // repeated string useRoles = 5;
+    /**
+     * <code>repeated string useRoles = 5;</code>
      */
     java.util.List<java.lang.String>
     getUseRolesList();
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>repeated string useRoles = 5;</code>
      */
     int getUseRolesCount();
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>repeated string useRoles = 5;</code>
      */
     java.lang.String getUseRoles(int index);
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>repeated string useRoles = 5;</code>
      */
     akka.protobuf.ByteString
         getUseRolesBytes(int index);
@@ -13222,9 +13237,14 @@ public final class ClusterMessages {
               break;
             }
             case 34: {
-              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+              bitField0_ |= 0x00000008;
+              useRole_ = input.readBytes();
+              break;
+            }
+            case 42: {
+              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
                 useRoles_ = new akka.protobuf.LazyStringArrayList();
-                mutable_bitField0_ |= 0x00000008;
+                mutable_bitField0_ |= 0x00000010;
               }
               useRoles_.add(input.readBytes());
               break;
@@ -13237,7 +13257,7 @@ public final class ClusterMessages {
         throw new akka.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
           useRoles_ = new akka.protobuf.UnmodifiableLazyStringList(useRoles_);
         }
         this.unknownFields = unknownFields.build();
@@ -13320,30 +13340,73 @@ public final class ClusterMessages {
       return allowLocalRoutees_;
     }
 
-    // repeated string useRoles = 4;
-    public static final int USEROLES_FIELD_NUMBER = 4;
+    // optional string useRole = 4;
+    public static final int USEROLE_FIELD_NUMBER = 4;
+    private java.lang.Object useRole_;
+    /**
+     * <code>optional string useRole = 4;</code>
+     */
+    public boolean hasUseRole() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional string useRole = 4;</code>
+     */
+    public java.lang.String getUseRole() {
+      java.lang.Object ref = useRole_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        akka.protobuf.ByteString bs = 
+            (akka.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          useRole_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string useRole = 4;</code>
+     */
+    public akka.protobuf.ByteString
+        getUseRoleBytes() {
+      java.lang.Object ref = useRole_;
+      if (ref instanceof java.lang.String) {
+        akka.protobuf.ByteString b = 
+            akka.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        useRole_ = b;
+        return b;
+      } else {
+        return (akka.protobuf.ByteString) ref;
+      }
+    }
+
+    // repeated string useRoles = 5;
+    public static final int USEROLES_FIELD_NUMBER = 5;
     private akka.protobuf.LazyStringList useRoles_;
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>repeated string useRoles = 5;</code>
      */
     public java.util.List<java.lang.String>
         getUseRolesList() {
       return useRoles_;
     }
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>repeated string useRoles = 5;</code>
      */
     public int getUseRolesCount() {
       return useRoles_.size();
     }
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>repeated string useRoles = 5;</code>
      */
     public java.lang.String getUseRoles(int index) {
       return useRoles_.get(index);
     }
     /**
-     * <code>repeated string useRoles = 4;</code>
+     * <code>repeated string useRoles = 5;</code>
      */
     public akka.protobuf.ByteString
         getUseRolesBytes(int index) {
@@ -13354,6 +13417,7 @@ public final class ClusterMessages {
       totalInstances_ = 0;
       maxInstancesPerNode_ = 0;
       allowLocalRoutees_ = false;
+      useRole_ = "";
       useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
@@ -13389,8 +13453,11 @@ public final class ClusterMessages {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBool(3, allowLocalRoutees_);
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBytes(4, getUseRoleBytes());
+      }
       for (int i = 0; i < useRoles_.size(); i++) {
-        output.writeBytes(4, useRoles_.getByteString(i));
+        output.writeBytes(5, useRoles_.getByteString(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -13412,6 +13479,10 @@ public final class ClusterMessages {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += akka.protobuf.CodedOutputStream
           .computeBoolSize(3, allowLocalRoutees_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += akka.protobuf.CodedOutputStream
+          .computeBytesSize(4, getUseRoleBytes());
       }
       {
         int dataSize = 0;
@@ -13544,8 +13615,10 @@ public final class ClusterMessages {
         bitField0_ = (bitField0_ & ~0x00000002);
         allowLocalRoutees_ = false;
         bitField0_ = (bitField0_ & ~0x00000004);
-        useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
+        useRole_ = "";
         bitField0_ = (bitField0_ & ~0x00000008);
+        useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -13586,10 +13659,14 @@ public final class ClusterMessages {
           to_bitField0_ |= 0x00000004;
         }
         result.allowLocalRoutees_ = allowLocalRoutees_;
-        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.useRole_ = useRole_;
+        if (((bitField0_ & 0x00000010) == 0x00000010)) {
           useRoles_ = new akka.protobuf.UnmodifiableLazyStringList(
               useRoles_);
-          bitField0_ = (bitField0_ & ~0x00000008);
+          bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.useRoles_ = useRoles_;
         result.bitField0_ = to_bitField0_;
@@ -13617,10 +13694,15 @@ public final class ClusterMessages {
         if (other.hasAllowLocalRoutees()) {
           setAllowLocalRoutees(other.getAllowLocalRoutees());
         }
+        if (other.hasUseRole()) {
+          bitField0_ |= 0x00000008;
+          useRole_ = other.useRole_;
+          onChanged();
+        }
         if (!other.useRoles_.isEmpty()) {
           if (useRoles_.isEmpty()) {
             useRoles_ = other.useRoles_;
-            bitField0_ = (bitField0_ & ~0x00000008);
+            bitField0_ = (bitField0_ & ~0x00000010);
           } else {
             ensureUseRolesIsMutable();
             useRoles_.addAll(other.useRoles_);
@@ -13765,42 +13847,116 @@ public final class ClusterMessages {
         return this;
       }
 
-      // repeated string useRoles = 4;
+      // optional string useRole = 4;
+      private java.lang.Object useRole_ = "";
+      /**
+       * <code>optional string useRole = 4;</code>
+       */
+      public boolean hasUseRole() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional string useRole = 4;</code>
+       */
+      public java.lang.String getUseRole() {
+        java.lang.Object ref = useRole_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((akka.protobuf.ByteString) ref)
+              .toStringUtf8();
+          useRole_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string useRole = 4;</code>
+       */
+      public akka.protobuf.ByteString
+          getUseRoleBytes() {
+        java.lang.Object ref = useRole_;
+        if (ref instanceof String) {
+          akka.protobuf.ByteString b = 
+              akka.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          useRole_ = b;
+          return b;
+        } else {
+          return (akka.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string useRole = 4;</code>
+       */
+      public Builder setUseRole(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        useRole_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string useRole = 4;</code>
+       */
+      public Builder clearUseRole() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        useRole_ = getDefaultInstance().getUseRole();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string useRole = 4;</code>
+       */
+      public Builder setUseRoleBytes(
+          akka.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        useRole_ = value;
+        onChanged();
+        return this;
+      }
+
+      // repeated string useRoles = 5;
       private akka.protobuf.LazyStringList useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
       private void ensureUseRolesIsMutable() {
-        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
           useRoles_ = new akka.protobuf.LazyStringArrayList(useRoles_);
-          bitField0_ |= 0x00000008;
+          bitField0_ |= 0x00000010;
          }
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public java.util.List<java.lang.String>
           getUseRolesList() {
         return java.util.Collections.unmodifiableList(useRoles_);
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public int getUseRolesCount() {
         return useRoles_.size();
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public java.lang.String getUseRoles(int index) {
         return useRoles_.get(index);
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public akka.protobuf.ByteString
           getUseRolesBytes(int index) {
         return useRoles_.getByteString(index);
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public Builder setUseRoles(
           int index, java.lang.String value) {
@@ -13813,7 +13969,7 @@ public final class ClusterMessages {
         return this;
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public Builder addUseRoles(
           java.lang.String value) {
@@ -13826,7 +13982,7 @@ public final class ClusterMessages {
         return this;
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public Builder addAllUseRoles(
           java.lang.Iterable<java.lang.String> values) {
@@ -13836,16 +13992,16 @@ public final class ClusterMessages {
         return this;
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public Builder clearUseRoles() {
         useRoles_ = akka.protobuf.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000010);
         onChanged();
         return this;
       }
       /**
-       * <code>repeated string useRoles = 4;</code>
+       * <code>repeated string useRoles = 5;</code>
        */
       public Builder addUseRolesBytes(
           akka.protobuf.ByteString value) {
@@ -13996,16 +14152,16 @@ public final class ClusterMessages {
       "\001(\r\"V\n\021ClusterRouterPool\022\023\n\004pool\030\001 \002(\0132\005" +
       ".Pool\022,\n\010settings\030\002 \002(\0132\032.ClusterRouterP" +
       "oolSettings\"<\n\004Pool\022\024\n\014serializerId\030\001 \002(" +
-      "\r\022\020\n\010manifest\030\002 \002(\t\022\014\n\004data\030\003 \002(\014\"}\n\031Clu" +
-      "sterRouterPoolSettings\022\026\n\016totalInstances" +
-      "\030\001 \002(\r\022\033\n\023maxInstancesPerNode\030\002 \002(\r\022\031\n\021a" +
-      "llowLocalRoutees\030\003 \002(\010\022\020\n\010useRoles\030\004 \003(\t" +
-      "*D\n\022ReachabilityStatus\022\r\n\tReachable\020\000\022\017\n" +
-      "\013Unreachable\020\001\022\016\n\nTerminated\020\002*b\n\014Member" +
-      "Status\022\013\n\007Joining\020\000\022\006\n\002Up\020\001\022\013\n\007Leaving\020\002",
-      "\022\013\n\007Exiting\020\003\022\010\n\004Down\020\004\022\013\n\007Removed\020\005\022\014\n\010" +
-      "WeaklyUp\020\006B\035\n\031akka.cluster.protobuf.msgH" +
-      "\001"
+      "\r\022\020\n\010manifest\030\002 \002(\t\022\014\n\004data\030\003 \002(\014\"\216\001\n\031Cl" +
+      "usterRouterPoolSettings\022\026\n\016totalInstance" +
+      "s\030\001 \002(\r\022\033\n\023maxInstancesPerNode\030\002 \002(\r\022\031\n\021" +
+      "allowLocalRoutees\030\003 \002(\010\022\017\n\007useRole\030\004 \001(\t" +
+      "\022\020\n\010useRoles\030\005 \003(\t*D\n\022ReachabilityStatus" +
+      "\022\r\n\tReachable\020\000\022\017\n\013Unreachable\020\001\022\016\n\nTerm" +
+      "inated\020\002*b\n\014MemberStatus\022\013\n\007Joining\020\000\022\006\n",
+      "\002Up\020\001\022\013\n\007Leaving\020\002\022\013\n\007Exiting\020\003\022\010\n\004Down\020" +
+      "\004\022\013\n\007Removed\020\005\022\014\n\010WeaklyUp\020\006B\035\n\031akka.clu" +
+      "ster.protobuf.msgH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -14113,7 +14269,7 @@ public final class ClusterMessages {
           internal_static_ClusterRouterPoolSettings_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ClusterRouterPoolSettings_descriptor,
-              new java.lang.String[] { "TotalInstances", "MaxInstancesPerNode", "AllowLocalRoutees", "UseRoles", });
+              new java.lang.String[] { "TotalInstances", "MaxInstancesPerNode", "AllowLocalRoutees", "UseRole", "UseRoles", });
           return null;
         }
       };

--- a/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
+++ b/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
@@ -13135,20 +13135,25 @@ public final class ClusterMessages {
      */
     boolean getAllowLocalRoutees();
 
-    // optional string useRole = 4;
+    // repeated string useRoleSet = 4;
     /**
-     * <code>optional string useRole = 4;</code>
+     * <code>repeated string useRoleSet = 4;</code>
      */
-    boolean hasUseRole();
+    java.util.List<java.lang.String>
+    getUseRoleSetList();
     /**
-     * <code>optional string useRole = 4;</code>
+     * <code>repeated string useRoleSet = 4;</code>
      */
-    java.lang.String getUseRole();
+    int getUseRoleSetCount();
     /**
-     * <code>optional string useRole = 4;</code>
+     * <code>repeated string useRoleSet = 4;</code>
+     */
+    java.lang.String getUseRoleSet(int index);
+    /**
+     * <code>repeated string useRoleSet = 4;</code>
      */
     akka.protobuf.ByteString
-        getUseRoleBytes();
+        getUseRoleSetBytes(int index);
   }
   /**
    * Protobuf type {@code ClusterRouterPoolSettings}
@@ -13217,8 +13222,11 @@ public final class ClusterMessages {
               break;
             }
             case 34: {
-              bitField0_ |= 0x00000008;
-              useRole_ = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                useRoleSet_ = new akka.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000008;
+              }
+              useRoleSet_.add(input.readBytes());
               break;
             }
           }
@@ -13229,6 +13237,9 @@ public final class ClusterMessages {
         throw new akka.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+          useRoleSet_ = new akka.protobuf.UnmodifiableLazyStringList(useRoleSet_);
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -13309,54 +13320,41 @@ public final class ClusterMessages {
       return allowLocalRoutees_;
     }
 
-    // optional string useRole = 4;
-    public static final int USEROLE_FIELD_NUMBER = 4;
-    private java.lang.Object useRole_;
+    // repeated string useRoleSet = 4;
+    public static final int USEROLESET_FIELD_NUMBER = 4;
+    private akka.protobuf.LazyStringList useRoleSet_;
     /**
-     * <code>optional string useRole = 4;</code>
+     * <code>repeated string useRoleSet = 4;</code>
      */
-    public boolean hasUseRole() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+    public java.util.List<java.lang.String>
+        getUseRoleSetList() {
+      return useRoleSet_;
     }
     /**
-     * <code>optional string useRole = 4;</code>
+     * <code>repeated string useRoleSet = 4;</code>
      */
-    public java.lang.String getUseRole() {
-      java.lang.Object ref = useRole_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        akka.protobuf.ByteString bs = 
-            (akka.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          useRole_ = s;
-        }
-        return s;
-      }
+    public int getUseRoleSetCount() {
+      return useRoleSet_.size();
     }
     /**
-     * <code>optional string useRole = 4;</code>
+     * <code>repeated string useRoleSet = 4;</code>
+     */
+    public java.lang.String getUseRoleSet(int index) {
+      return useRoleSet_.get(index);
+    }
+    /**
+     * <code>repeated string useRoleSet = 4;</code>
      */
     public akka.protobuf.ByteString
-        getUseRoleBytes() {
-      java.lang.Object ref = useRole_;
-      if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = 
-            akka.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        useRole_ = b;
-        return b;
-      } else {
-        return (akka.protobuf.ByteString) ref;
-      }
+        getUseRoleSetBytes(int index) {
+      return useRoleSet_.getByteString(index);
     }
 
     private void initFields() {
       totalInstances_ = 0;
       maxInstancesPerNode_ = 0;
       allowLocalRoutees_ = false;
-      useRole_ = "";
+      useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -13391,8 +13389,8 @@ public final class ClusterMessages {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBool(3, allowLocalRoutees_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeBytes(4, getUseRoleBytes());
+      for (int i = 0; i < useRoleSet_.size(); i++) {
+        output.writeBytes(4, useRoleSet_.getByteString(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -13415,9 +13413,14 @@ public final class ClusterMessages {
         size += akka.protobuf.CodedOutputStream
           .computeBoolSize(3, allowLocalRoutees_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += akka.protobuf.CodedOutputStream
-          .computeBytesSize(4, getUseRoleBytes());
+      {
+        int dataSize = 0;
+        for (int i = 0; i < useRoleSet_.size(); i++) {
+          dataSize += akka.protobuf.CodedOutputStream
+            .computeBytesSizeNoTag(useRoleSet_.getByteString(i));
+        }
+        size += dataSize;
+        size += 1 * getUseRoleSetList().size();
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -13541,7 +13544,7 @@ public final class ClusterMessages {
         bitField0_ = (bitField0_ & ~0x00000002);
         allowLocalRoutees_ = false;
         bitField0_ = (bitField0_ & ~0x00000004);
-        useRole_ = "";
+        useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
@@ -13583,10 +13586,12 @@ public final class ClusterMessages {
           to_bitField0_ |= 0x00000004;
         }
         result.allowLocalRoutees_ = allowLocalRoutees_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
+        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          useRoleSet_ = new akka.protobuf.UnmodifiableLazyStringList(
+              useRoleSet_);
+          bitField0_ = (bitField0_ & ~0x00000008);
         }
-        result.useRole_ = useRole_;
+        result.useRoleSet_ = useRoleSet_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -13612,9 +13617,14 @@ public final class ClusterMessages {
         if (other.hasAllowLocalRoutees()) {
           setAllowLocalRoutees(other.getAllowLocalRoutees());
         }
-        if (other.hasUseRole()) {
-          bitField0_ |= 0x00000008;
-          useRole_ = other.useRole_;
+        if (!other.useRoleSet_.isEmpty()) {
+          if (useRoleSet_.isEmpty()) {
+            useRoleSet_ = other.useRoleSet_;
+            bitField0_ = (bitField0_ & ~0x00000008);
+          } else {
+            ensureUseRoleSetIsMutable();
+            useRoleSet_.addAll(other.useRoleSet_);
+          }
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -13755,76 +13765,95 @@ public final class ClusterMessages {
         return this;
       }
 
-      // optional string useRole = 4;
-      private java.lang.Object useRole_ = "";
-      /**
-       * <code>optional string useRole = 4;</code>
-       */
-      public boolean hasUseRole() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+      // repeated string useRoleSet = 4;
+      private akka.protobuf.LazyStringList useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureUseRoleSetIsMutable() {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+          useRoleSet_ = new akka.protobuf.LazyStringArrayList(useRoleSet_);
+          bitField0_ |= 0x00000008;
+         }
       }
       /**
-       * <code>optional string useRole = 4;</code>
+       * <code>repeated string useRoleSet = 4;</code>
        */
-      public java.lang.String getUseRole() {
-        java.lang.Object ref = useRole_;
-        if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((akka.protobuf.ByteString) ref)
-              .toStringUtf8();
-          useRole_ = s;
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+      public java.util.List<java.lang.String>
+          getUseRoleSetList() {
+        return java.util.Collections.unmodifiableList(useRoleSet_);
       }
       /**
-       * <code>optional string useRole = 4;</code>
+       * <code>repeated string useRoleSet = 4;</code>
+       */
+      public int getUseRoleSetCount() {
+        return useRoleSet_.size();
+      }
+      /**
+       * <code>repeated string useRoleSet = 4;</code>
+       */
+      public java.lang.String getUseRoleSet(int index) {
+        return useRoleSet_.get(index);
+      }
+      /**
+       * <code>repeated string useRoleSet = 4;</code>
        */
       public akka.protobuf.ByteString
-          getUseRoleBytes() {
-        java.lang.Object ref = useRole_;
-        if (ref instanceof String) {
-          akka.protobuf.ByteString b = 
-              akka.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          useRole_ = b;
-          return b;
-        } else {
-          return (akka.protobuf.ByteString) ref;
-        }
+          getUseRoleSetBytes(int index) {
+        return useRoleSet_.getByteString(index);
       }
       /**
-       * <code>optional string useRole = 4;</code>
+       * <code>repeated string useRoleSet = 4;</code>
        */
-      public Builder setUseRole(
+      public Builder setUseRoleSet(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureUseRoleSetIsMutable();
+        useRoleSet_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string useRoleSet = 4;</code>
+       */
+      public Builder addUseRoleSet(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000008;
-        useRole_ = value;
+  ensureUseRoleSetIsMutable();
+        useRoleSet_.add(value);
         onChanged();
         return this;
       }
       /**
-       * <code>optional string useRole = 4;</code>
+       * <code>repeated string useRoleSet = 4;</code>
        */
-      public Builder clearUseRole() {
+      public Builder addAllUseRoleSet(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureUseRoleSetIsMutable();
+        super.addAll(values, useRoleSet_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string useRoleSet = 4;</code>
+       */
+      public Builder clearUseRoleSet() {
+        useRoleSet_ = akka.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
-        useRole_ = getDefaultInstance().getUseRole();
         onChanged();
         return this;
       }
       /**
-       * <code>optional string useRole = 4;</code>
+       * <code>repeated string useRoleSet = 4;</code>
        */
-      public Builder setUseRoleBytes(
+      public Builder addUseRoleSetBytes(
           akka.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000008;
-        useRole_ = value;
+  ensureUseRoleSetIsMutable();
+        useRoleSet_.add(value);
         onChanged();
         return this;
       }
@@ -13967,15 +13996,16 @@ public final class ClusterMessages {
       "\001(\r\"V\n\021ClusterRouterPool\022\023\n\004pool\030\001 \002(\0132\005" +
       ".Pool\022,\n\010settings\030\002 \002(\0132\032.ClusterRouterP" +
       "oolSettings\"<\n\004Pool\022\024\n\014serializerId\030\001 \002(" +
-      "\r\022\020\n\010manifest\030\002 \002(\t\022\014\n\004data\030\003 \002(\014\"|\n\031Clu" +
+      "\r\022\020\n\010manifest\030\002 \002(\t\022\014\n\004data\030\003 \002(\014\"\177\n\031Clu" +
       "sterRouterPoolSettings\022\026\n\016totalInstances" +
       "\030\001 \002(\r\022\033\n\023maxInstancesPerNode\030\002 \002(\r\022\031\n\021a" +
-      "llowLocalRoutees\030\003 \002(\010\022\017\n\007useRole\030\004 \001(\t*" +
-      "D\n\022ReachabilityStatus\022\r\n\tReachable\020\000\022\017\n\013" +
-      "Unreachable\020\001\022\016\n\nTerminated\020\002*b\n\014MemberS" +
-      "tatus\022\013\n\007Joining\020\000\022\006\n\002Up\020\001\022\013\n\007Leaving\020\002\022",
-      "\013\n\007Exiting\020\003\022\010\n\004Down\020\004\022\013\n\007Removed\020\005\022\014\n\010W" +
-      "eaklyUp\020\006B\035\n\031akka.cluster.protobuf.msgH\001"
+      "llowLocalRoutees\030\003 \002(\010\022\022\n\nuseRoleSet\030\004 \003" +
+      "(\t*D\n\022ReachabilityStatus\022\r\n\tReachable\020\000\022" +
+      "\017\n\013Unreachable\020\001\022\016\n\nTerminated\020\002*b\n\014Memb" +
+      "erStatus\022\013\n\007Joining\020\000\022\006\n\002Up\020\001\022\013\n\007Leaving",
+      "\020\002\022\013\n\007Exiting\020\003\022\010\n\004Down\020\004\022\013\n\007Removed\020\005\022\014" +
+      "\n\010WeaklyUp\020\006B\035\n\031akka.cluster.protobuf.ms" +
+      "gH\001"
     };
     akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -14083,7 +14113,7 @@ public final class ClusterMessages {
           internal_static_ClusterRouterPoolSettings_fieldAccessorTable = new
             akka.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ClusterRouterPoolSettings_descriptor,
-              new java.lang.String[] { "TotalInstances", "MaxInstancesPerNode", "AllowLocalRoutees", "UseRole", });
+              new java.lang.String[] { "TotalInstances", "MaxInstancesPerNode", "AllowLocalRoutees", "UseRoleSet", });
           return null;
         }
       };

--- a/akka-cluster/src/main/mima-filters/2.5.4.backwards.excludes
+++ b/akka-cluster/src/main/mima-filters/2.5.4.backwards.excludes
@@ -1,3 +1,7 @@
 # #23257 replace ClusterRouterGroup/Pool "use-role" with "use-roles"
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.protobuf.msg.ClusterMessages#ClusterRouterPoolSettingsOrBuilder.getUseRoles")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.protobuf.msg.ClusterMessages#ClusterRouterPoolSettingsOrBuilder.getUseRolesBytes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.protobuf.msg.ClusterMessages#ClusterRouterPoolSettingsOrBuilder.getUseRolesCount")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.protobuf.msg.ClusterMessages#ClusterRouterPoolSettingsOrBuilder.getUseRolesList")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.routing.ClusterRouterSettingsBase.useRole")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.routing.ClusterRouterSettingsBase.useRoles")

--- a/akka-cluster/src/main/mima-filters/2.5.4.backwards.excludes
+++ b/akka-cluster/src/main/mima-filters/2.5.4.backwards.excludes
@@ -1,0 +1,3 @@
+# #23257 replace ClusterRouterGroup/Pool "use-role" with "use-roles"
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.routing.ClusterRouterSettingsBase.useRole")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.routing.ClusterRouterSettingsBase.useRoles")

--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -222,5 +222,5 @@ message UniqueAddress {
    required uint32 totalInstances = 1;
    required uint32 maxInstancesPerNode = 2;
    required bool allowLocalRoutees = 3;
-   repeated string useRoleSet = 4;
+   repeated string useRoles = 4;
  }

--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -222,5 +222,6 @@ message UniqueAddress {
    required uint32 totalInstances = 1;
    required uint32 maxInstancesPerNode = 2;
    required bool allowLocalRoutees = 3;
-   repeated string useRoles = 4;
+   optional string useRole = 4;
+   repeated string useRoles = 5;
  }

--- a/akka-cluster/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster/src/main/protobuf/ClusterMessages.proto
@@ -222,5 +222,5 @@ message UniqueAddress {
    required uint32 totalInstances = 1;
    required uint32 maxInstancesPerNode = 2;
    required bool allowLocalRoutees = 3;
-   optional string useRole = 4;
+   repeated string useRoleSet = 4;
  }

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -234,8 +234,8 @@ akka {
     # Useful for master-worker scenario where all routees are remote.
     allow-local-routees = on
 
-    # Use members with specified role, or all members if undefined or empty.
-    use-role = ""
+    # Use members with a particular set of roles, or all members if undefined or empty.
+    use-role-set = []
 
   }
 

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -235,7 +235,7 @@ akka {
     allow-local-routees = on
 
     # Use members with a particular set of roles, or all members if undefined or empty.
-    use-role-set = []
+    use-roles = []
 
   }
 

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -237,6 +237,9 @@ akka {
     # Use members with a particular set of roles, or all members if undefined or empty.
     use-roles = []
 
+    # For backwards compatibility only, replaced by use-roles
+    # Use members with specified role, or all members if undefined or empty.
+    use-role = ""
   }
 
   # Protobuf serializer for cluster messages

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -234,10 +234,10 @@ akka {
     # Useful for master-worker scenario where all routees are remote.
     allow-local-routees = on
 
-    # Use members with a particular set of roles, or all members if undefined or empty.
+    # Use members with all specified roles, or all members if undefined or empty.
     use-roles = []
 
-    # For backwards compatibility only, replaced by use-roles
+    # Deprecated, since Akka 2.5.4, replaced by use-roles
     # Use members with specified role, or all members if undefined or empty.
     use-role = ""
   }

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -386,7 +386,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
       totalInstances = crps.getTotalInstances,
       maxInstancesPerNode = crps.getMaxInstancesPerNode,
       allowLocalRoutees = crps.getAllowLocalRoutees,
-      useRoles = Option(crps.getUseRole).toSet ++ crps.getUseRolesList.asScala
+      useRoles = if (crps.hasUseRole) { crps.getUseRolesList.asScala.toSet + crps.getUseRole } else { crps.getUseRolesList.asScala.toSet }
     )
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -9,6 +9,7 @@ import java.util.zip.{ GZIPInputStream, GZIPOutputStream }
 import akka.actor.{ Address, ExtendedActorSystem }
 import akka.cluster._
 import akka.cluster.protobuf.msg.{ ClusterMessages ⇒ cm }
+import akka.japi.Util.immutableSeq
 import akka.serialization.{ BaseSerializer, SerializationExtension, SerializerWithStringManifest }
 import akka.protobuf.{ ByteString, MessageLite }
 
@@ -166,8 +167,8 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
     builder.setAllowLocalRoutees(settings.allowLocalRoutees)
       .setMaxInstancesPerNode(settings.maxInstancesPerNode)
       .setTotalInstances(settings.totalInstances)
+      .addAllUseRoleSet(settings.useRoleSet.asJava)
 
-    settings.useRole.foreach(builder.setUseRole)
     builder.build()
   }
 
@@ -382,7 +383,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
       totalInstances = crps.getTotalInstances,
       maxInstancesPerNode = crps.getMaxInstancesPerNode,
       allowLocalRoutees = crps.getAllowLocalRoutees,
-      useRole = if (crps.hasUseRole) Some(crps.getUseRole) else None
+      useRoleSet = immutableSeq(crps.getUseRoleSetList).toSet
     )
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -167,7 +167,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
     builder.setAllowLocalRoutees(settings.allowLocalRoutees)
       .setMaxInstancesPerNode(settings.maxInstancesPerNode)
       .setTotalInstances(settings.totalInstances)
-      .addAllUseRoleSet(settings.useRoleSet.asJava)
+      .addAllUseRoles(settings.useRoles.asJava)
 
     builder.build()
   }
@@ -383,7 +383,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
       totalInstances = crps.getTotalInstances,
       maxInstancesPerNode = crps.getMaxInstancesPerNode,
       allowLocalRoutees = crps.getAllowLocalRoutees,
-      useRoleSet = immutableSeq(crps.getUseRoleSetList).toSet
+      useRoles = immutableSeq(crps.getUseRolesList).toSet
     )
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -39,13 +39,13 @@ object ClusterRouterGroupSettings {
   def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterGroupSettings =
     ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.toSet)
 
-  // For backwards compatibility, useRoles is the combination of use-role and use-roles
+  // For backwards compatibility, useRoles is the combination of use-roles and use-role
   def fromConfig(config: Config): ClusterRouterGroupSettings =
     ClusterRouterGroupSettings(
       totalInstances = ClusterRouterSettingsBase.getMaxTotalNrOfInstances(config),
       routeesPaths = immutableSeq(config.getStringList("routees.paths")),
       allowLocalRoutees = config.getBoolean("cluster.allow-local-routees"),
-      useRoles = Option(config.getString("cluster.use-role")).toSet ++ config.getStringList("cluster.use-roles").asScala)
+      useRoles = config.getStringList("cluster.use-roles").asScala.toSet ++ ClusterRouterSettingsBase.useRoleOption(config.getString("cluster.use-role")))
 }
 
 /**
@@ -114,13 +114,13 @@ object ClusterRouterPoolSettings {
   def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterPoolSettings =
     ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.toSet)
 
-  // For backwards compatibility, useRoles is the combination of use-role and use-roles
+  // For backwards compatibility, useRoles is the combination of use-roles and use-role
   def fromConfig(config: Config): ClusterRouterPoolSettings =
     ClusterRouterPoolSettings(
       totalInstances = ClusterRouterSettingsBase.getMaxTotalNrOfInstances(config),
       maxInstancesPerNode = config.getInt("cluster.max-nr-of-instances-per-node"),
       allowLocalRoutees = config.getBoolean("cluster.allow-local-routees"),
-      useRoles = Option(config.getString("cluster.use-role")).toSet ++ config.getStringList("cluster.use-roles").asScala)
+      useRoles = config.getStringList("cluster.use-roles").asScala.toSet ++ ClusterRouterSettingsBase.useRoleOption(config.getString("cluster.use-role")))
 }
 
 /**
@@ -178,6 +178,11 @@ final case class ClusterRouterPoolSettings(
  * INTERNAL API
  */
 private[akka] object ClusterRouterSettingsBase {
+  def useRoleOption(role: String): Option[String] = role match {
+    case null | "" ⇒ None
+    case _         ⇒ Some(role)
+  }
+
   /**
    * For backwards compatibility reasons, nr-of-instances
    * has the same purpose as max-total-nr-of-instances for cluster

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -124,6 +124,8 @@ private[akka] trait ClusterRouterSettingsBase {
   def useRoleSet: Set[String]
 
   require(totalInstances > 0, "totalInstances of cluster router must be > 0")
+  require(useRoleSet != null, "useRoleSet must be non-null")
+  require(!useRoleSet.exists(role => role == null || role.isEmpty), "All roles in useRoleSet must be non-empty")
 }
 
 /**

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -26,16 +26,16 @@ import akka.routing.RoutingLogic
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
-import scala.annotation.tailrec
+import scala.annotation.{ tailrec, varargs }
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 
 object ClusterRouterGroupSettings {
-  @deprecated("useRole has been replaced with useRoles")
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRole: Option[String]): ClusterRouterGroupSettings =
     ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRole.toSet)
 
-  def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterGroupSettings =
+  @varargs def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterGroupSettings =
     ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.toSet)
 
   // For backwards compatibility, useRoles is the combination of use-role and use-roles
@@ -57,11 +57,16 @@ final case class ClusterRouterGroupSettings(
   allowLocalRoutees: Boolean,
   useRoles:          Set[String]) extends ClusterRouterSettingsBase {
 
-  @deprecated("useRole has been replaced with useRoles")
+  // For binary compatibility
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def useRole: Option[String] = useRoles.headOption
 
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
+  def this(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRole: Option[String]) =
+    this(totalInstances, routeesPaths, allowLocalRoutees, useRole.toSet)
+
   /** Java API */
-  @deprecated("useRole has been replaced with useRoles")
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, routeesPaths: java.lang.Iterable[String], allowLocalRoutees: Boolean, useRole: String) =
     this(totalInstances, immutableSeq(routeesPaths), allowLocalRoutees, Option(useRole).toSet)
 
@@ -69,23 +74,34 @@ final case class ClusterRouterGroupSettings(
   def this(totalInstances: Int, routeesPaths: java.lang.Iterable[String], allowLocalRoutees: Boolean, useRoles: java.util.Set[String]) =
     this(totalInstances, immutableSeq(routeesPaths), allowLocalRoutees, useRoles.asScala.toSet)
 
+  // For binary compatibility
+  @deprecated("Use constructor with useRoles instead", since = "2.5.4")
+  def copy(totalInstances: Int = totalInstances, routeesPaths: immutable.Seq[String] = routeesPaths, allowLocalRoutees: Boolean = allowLocalRoutees, useRole: Option[String] = useRole): ClusterRouterGroupSettings =
+    new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRole)
+
   if (totalInstances <= 0) throw new IllegalArgumentException("totalInstances of cluster router must be > 0")
   if ((routeesPaths eq null) || routeesPaths.isEmpty || routeesPaths.head == "")
     throw new IllegalArgumentException("routeesPaths must be defined")
 
-  routeesPaths.foreach({
+  routeesPaths.foreach {
     case RelativeActorPath(elements) ⇒ // good
     case p ⇒
       throw new IllegalArgumentException(s"routeesPaths [$p] is not a valid actor path without address information")
-  })
+  }
+
+  def withUseRoles(useRoles: Set[String]): ClusterRouterGroupSettings = new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles)
+  @varargs def withUseRoles(useRoles: String*): ClusterRouterGroupSettings = new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.toSet)
+
+  /** Java API */
+  def withUseRoles(useRoles: java.util.Set[String]): ClusterRouterGroupSettings = new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.asScala.toSet)
 }
 
 object ClusterRouterPoolSettings {
-  @deprecated("useRole has been replaced with useRoles")
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: Option[String]): ClusterRouterPoolSettings =
     ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole.toSet)
 
-  def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterPoolSettings =
+  @varargs def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterPoolSettings =
     ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.toSet)
 
   // For backwards compatibility, useRoles is the combination of use-role and use-roles
@@ -109,12 +125,16 @@ final case class ClusterRouterPoolSettings(
   allowLocalRoutees:   Boolean,
   useRoles:            Set[String]) extends ClusterRouterSettingsBase {
 
-  // For backwards compatibility
-  @deprecated("useRole has been replaced with useRoles")
+  // For binary compatibility
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def useRole: Option[String] = useRoles.headOption
 
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
+  def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: Option[String]) =
+    this(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole.toSet)
+
   /** Java API */
-  @deprecated("useRole has been replaced with useRoles")
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: String) =
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, Option(useRole).toSet)
 
@@ -122,7 +142,18 @@ final case class ClusterRouterPoolSettings(
   def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRoles: java.util.Set[String]) =
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.asScala.toSet)
 
+  // For binary compatibility
+  @deprecated("Use copy with useRoles instead", since = "2.5.4")
+  def copy(totalInstances: Int = totalInstances, maxInstancesPerNode: Int = maxInstancesPerNode, allowLocalRoutees: Boolean = allowLocalRoutees, useRole: Option[String] = useRole): ClusterRouterPoolSettings =
+    new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole)
+
   if (maxInstancesPerNode <= 0) throw new IllegalArgumentException("maxInstancesPerNode of cluster pool router must be > 0")
+
+  def withUseRoles(useRoles: Set[String]): ClusterRouterPoolSettings = new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles)
+  @varargs def withUseRoles(useRoles: String*): ClusterRouterPoolSettings = new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.toSet)
+
+  /** Java API */
+  def withUseRoles(useRoles: java.util.Set[String]): ClusterRouterPoolSettings = new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.asScala.toSet)
 }
 
 /**

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -35,7 +35,8 @@ object ClusterRouterGroupSettings {
   def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRole: Option[String]): ClusterRouterGroupSettings =
     ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRole.toSet)
 
-  @varargs def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterGroupSettings =
+  @varargs
+  def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterGroupSettings =
     ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.toSet)
 
   // For backwards compatibility, useRoles is the combination of use-role and use-roles
@@ -65,12 +66,16 @@ final case class ClusterRouterGroupSettings(
   def this(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRole: Option[String]) =
     this(totalInstances, routeesPaths, allowLocalRoutees, useRole.toSet)
 
-  /** Java API */
+  /**
+   * Java API
+   */
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, routeesPaths: java.lang.Iterable[String], allowLocalRoutees: Boolean, useRole: String) =
     this(totalInstances, immutableSeq(routeesPaths), allowLocalRoutees, Option(useRole).toSet)
 
-  /** Java API */
+  /**
+   * Java API
+   */
   def this(totalInstances: Int, routeesPaths: java.lang.Iterable[String], allowLocalRoutees: Boolean, useRoles: java.util.Set[String]) =
     this(totalInstances, immutableSeq(routeesPaths), allowLocalRoutees, useRoles.asScala.toSet)
 
@@ -90,9 +95,13 @@ final case class ClusterRouterGroupSettings(
   }
 
   def withUseRoles(useRoles: Set[String]): ClusterRouterGroupSettings = new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles)
-  @varargs def withUseRoles(useRoles: String*): ClusterRouterGroupSettings = new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.toSet)
 
-  /** Java API */
+  @varargs
+  def withUseRoles(useRoles: String*): ClusterRouterGroupSettings = new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.toSet)
+
+  /**
+   * Java API
+   */
   def withUseRoles(useRoles: java.util.Set[String]): ClusterRouterGroupSettings = new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.asScala.toSet)
 }
 
@@ -101,7 +110,8 @@ object ClusterRouterPoolSettings {
   def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: Option[String]): ClusterRouterPoolSettings =
     ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole.toSet)
 
-  @varargs def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterPoolSettings =
+  @varargs
+  def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRoles: String*): ClusterRouterPoolSettings =
     ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.toSet)
 
   // For backwards compatibility, useRoles is the combination of use-role and use-roles
@@ -133,12 +143,16 @@ final case class ClusterRouterPoolSettings(
   def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: Option[String]) =
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole.toSet)
 
-  /** Java API */
+  /**
+   * Java API
+   */
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: String) =
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, Option(useRole).toSet)
 
-  /** Java API */
+  /**
+   * Java API
+   */
   def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRoles: java.util.Set[String]) =
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.asScala.toSet)
 
@@ -150,9 +164,13 @@ final case class ClusterRouterPoolSettings(
   if (maxInstancesPerNode <= 0) throw new IllegalArgumentException("maxInstancesPerNode of cluster pool router must be > 0")
 
   def withUseRoles(useRoles: Set[String]): ClusterRouterPoolSettings = new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles)
-  @varargs def withUseRoles(useRoles: String*): ClusterRouterPoolSettings = new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.toSet)
 
-  /** Java API */
+  @varargs
+  def withUseRoles(useRoles: String*): ClusterRouterPoolSettings = new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.toSet)
+
+  /**
+   * Java API
+   */
   def withUseRoles(useRoles: java.util.Set[String]): ClusterRouterPoolSettings = new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.asScala.toSet)
 }
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
@@ -76,7 +76,7 @@ abstract class ClusterConsistentHashingGroupSpec extends MultiNodeSpec(ClusterCo
       val router = system.actorOf(
         ClusterRouterGroup(
           local = ConsistentHashingGroup(paths, hashMapping = hashMapping),
-          settings = ClusterRouterGroupSettings(totalInstances = 10, paths, allowLocalRoutees = true, useRole = None)).props(),
+          settings = ClusterRouterGroupSettings(totalInstances = 10, paths, allowLocalRoutees = true, useRoleSet = Set.empty)).props(),
         "router")
       // it may take some time until router receives cluster member events
       awaitAssert { currentRoutees(router).size should ===(3) }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
@@ -76,7 +76,7 @@ abstract class ClusterConsistentHashingGroupSpec extends MultiNodeSpec(ClusterCo
       val router = system.actorOf(
         ClusterRouterGroup(
           local = ConsistentHashingGroup(paths, hashMapping = hashMapping),
-          settings = ClusterRouterGroupSettings(totalInstances = 10, paths, allowLocalRoutees = true, useRoles = Set.empty)).props(),
+          settings = ClusterRouterGroupSettings(totalInstances = 10, paths, allowLocalRoutees = true)).props(),
         "router")
       // it may take some time until router receives cluster member events
       awaitAssert { currentRoutees(router).size should ===(3) }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
@@ -76,7 +76,7 @@ abstract class ClusterConsistentHashingGroupSpec extends MultiNodeSpec(ClusterCo
       val router = system.actorOf(
         ClusterRouterGroup(
           local = ConsistentHashingGroup(paths, hashMapping = hashMapping),
-          settings = ClusterRouterGroupSettings(totalInstances = 10, paths, allowLocalRoutees = true, useRoleSet = Set.empty)).props(),
+          settings = ClusterRouterGroupSettings(totalInstances = 10, paths, allowLocalRoutees = true, useRoles = Set.empty)).props(),
         "router")
       // it may take some time until router receives cluster member events
       awaitAssert { currentRoutees(router).size should ===(3) }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
@@ -124,7 +124,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         val router2 = system.actorOf(
           ClusterRouterPool(
             local = ConsistentHashingPool(nrOfInstances = 0),
-            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = Set.empty)).
+            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoles = Set.empty)).
             props(Props[Echo]),
           "router2")
         // it may take some time until router receives cluster member events
@@ -159,7 +159,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         val router4 = system.actorOf(
           ClusterRouterPool(
             local = ConsistentHashingPool(nrOfInstances = 0, hashMapping = hashMapping),
-            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoleSet = Set.empty)).
+            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoles = Set.empty)).
             props(Props[Echo]),
           "router4")
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
@@ -124,7 +124,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         val router2 = system.actorOf(
           ClusterRouterPool(
             local = ConsistentHashingPool(nrOfInstances = 0),
-            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoles = Set.empty)).
+            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 2, allowLocalRoutees = true)).
             props(Props[Echo]),
           "router2")
         // it may take some time until router receives cluster member events
@@ -159,7 +159,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         val router4 = system.actorOf(
           ClusterRouterPool(
             local = ConsistentHashingPool(nrOfInstances = 0, hashMapping = hashMapping),
-            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoles = Set.empty)).
+            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true)).
             props(Props[Echo]),
           "router4")
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
@@ -124,7 +124,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         val router2 = system.actorOf(
           ClusterRouterPool(
             local = ConsistentHashingPool(nrOfInstances = 0),
-            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 2, allowLocalRoutees = true, useRole = None)).
+            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = Set.empty)).
             props(Props[Echo]),
           "router2")
         // it may take some time until router receives cluster member events
@@ -159,7 +159,7 @@ abstract class ClusterConsistentHashingRouterSpec extends MultiNodeSpec(ClusterC
         val router4 = system.actorOf(
           ClusterRouterPool(
             local = ConsistentHashingPool(nrOfInstances = 0, hashMapping = hashMapping),
-            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRole = None)).
+            settings = ClusterRouterPoolSettings(totalInstances = 10, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoleSet = Set.empty)).
             props(Props[Echo]),
           "router4")
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
@@ -115,7 +115,7 @@ abstract class ClusterRoundRobinSpec extends MultiNodeSpec(ClusterRoundRobinMult
   lazy val router2 = system.actorOf(
     ClusterRouterPool(
       RoundRobinPool(nrOfInstances = 0),
-      ClusterRouterPoolSettings(totalInstances = 3, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoles = Set.empty)).
+      ClusterRouterPoolSettings(totalInstances = 3, maxInstancesPerNode = 1, allowLocalRoutees = true)).
       props(Props[SomeActor]),
     "router2")
   lazy val router3 = system.actorOf(FromConfig.props(Props[SomeActor]), "router3")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
@@ -85,7 +85,7 @@ object ClusterRoundRobinMultiJvmSpec extends MultiNodeConfig {
             router = round-robin-pool
             cluster {
               enabled = on
-              use-role-set = ["a"]
+              use-roles = ["a"]
               max-total-nr-of-instances = 10
             }
           }
@@ -115,7 +115,7 @@ abstract class ClusterRoundRobinSpec extends MultiNodeSpec(ClusterRoundRobinMult
   lazy val router2 = system.actorOf(
     ClusterRouterPool(
       RoundRobinPool(nrOfInstances = 0),
-      ClusterRouterPoolSettings(totalInstances = 3, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoleSet = Set.empty)).
+      ClusterRouterPoolSettings(totalInstances = 3, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoles = Set.empty)).
       props(Props[SomeActor]),
     "router2")
   lazy val router3 = system.actorOf(FromConfig.props(Props[SomeActor]), "router3")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
@@ -85,7 +85,7 @@ object ClusterRoundRobinMultiJvmSpec extends MultiNodeConfig {
             router = round-robin-pool
             cluster {
               enabled = on
-              use-role = a
+              use-role-set = ["a"]
               max-total-nr-of-instances = 10
             }
           }
@@ -115,7 +115,7 @@ abstract class ClusterRoundRobinSpec extends MultiNodeSpec(ClusterRoundRobinMult
   lazy val router2 = system.actorOf(
     ClusterRouterPool(
       RoundRobinPool(nrOfInstances = 0),
-      ClusterRouterPoolSettings(totalInstances = 3, maxInstancesPerNode = 1, allowLocalRoutees = true, useRole = None)).
+      ClusterRouterPoolSettings(totalInstances = 3, maxInstancesPerNode = 1, allowLocalRoutees = true, useRoleSet = Set.empty)).
       props(Props[SomeActor]),
     "router2")
   lazy val router3 = system.actorOf(FromConfig.props(Props[SomeActor]), "router3")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
@@ -99,12 +99,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: off, roles: off, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("b")
+        val roles = Set("b")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = false, useRoleSet = roleSet)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = false, useRoles = roles)).
             props(Props[SomeActor]),
           "router-2")
 
@@ -129,13 +129,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: off, roles: off, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("b")
+        val roles = Set("b")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = false, useRoleSet = roleSet)).props,
+            allowLocalRoutees = false, useRoles = roles)).props,
           "router-2b")
 
         awaitAssert(currentRoutees(router).size should ===(4))
@@ -159,12 +159,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: on, role: b, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("b")
+        val roles = Set("b")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = roleSet)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoles = roles)).
             props(Props[SomeActor]),
           "router-3")
 
@@ -189,13 +189,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: on, role: b, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("b")
+        val roles = Set("b")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = true, useRoleSet = roleSet)).props,
+            allowLocalRoutees = true, useRoles = roles)).props,
           "router-3b")
 
         awaitAssert(currentRoutees(router).size should ===(4))
@@ -219,12 +219,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: on, role: a, 6 => 2,0,0" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("a")
+        val roles = Set("a")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = roleSet)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoles = roles)).
             props(Props[SomeActor]),
           "router-4")
 
@@ -249,13 +249,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: on, role: a, 6 => 2,0,0" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("a")
+        val roles = Set("a")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = true, useRoleSet = roleSet)).props,
+            allowLocalRoutees = true, useRoles = roles)).props,
           "router-4b")
 
         awaitAssert(currentRoutees(router).size should ===(2))
@@ -279,12 +279,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: on, role: c, 6 => 2,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("c")
+        val roles = Set("c")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = roleSet)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoles = roles)).
             props(Props[SomeActor]),
           "router-5")
 
@@ -309,13 +309,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: on, role: c, 6 => 2,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val roleSet = Set("c")
+        val roles = Set("c")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = true, useRoleSet = roleSet)).props,
+            allowLocalRoutees = true, useRoles = roles)).props,
           "router-5b")
 
         awaitAssert(currentRoutees(router).size should ===(6))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
@@ -99,12 +99,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: off, roles: off, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("b")
+        val roleSet = Set("b")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = false, useRole = role)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = false, useRoleSet = roleSet)).
             props(Props[SomeActor]),
           "router-2")
 
@@ -129,13 +129,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: off, roles: off, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("b")
+        val roleSet = Set("b")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = false, useRole = role)).props,
+            allowLocalRoutees = false, useRoleSet = roleSet)).props,
           "router-2b")
 
         awaitAssert(currentRoutees(router).size should ===(4))
@@ -159,12 +159,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: on, role: b, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("b")
+        val roleSet = Set("b")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRole = role)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = roleSet)).
             props(Props[SomeActor]),
           "router-3")
 
@@ -189,13 +189,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: on, role: b, 6 => 0,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("b")
+        val roleSet = Set("b")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = true, useRole = role)).props,
+            allowLocalRoutees = true, useRoleSet = roleSet)).props,
           "router-3b")
 
         awaitAssert(currentRoutees(router).size should ===(4))
@@ -219,12 +219,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: on, role: a, 6 => 2,0,0" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("a")
+        val roleSet = Set("a")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRole = role)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = roleSet)).
             props(Props[SomeActor]),
           "router-4")
 
@@ -249,13 +249,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: on, role: a, 6 => 2,0,0" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("a")
+        val roleSet = Set("a")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = true, useRole = role)).props,
+            allowLocalRoutees = true, useRoleSet = roleSet)).props,
           "router-4b")
 
         awaitAssert(currentRoutees(router).size should ===(2))
@@ -279,12 +279,12 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "pool local: on, role: c, 6 => 2,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("c")
+        val roleSet = Set("c")
 
         val router = system.actorOf(
           ClusterRouterPool(
             RoundRobinPool(nrOfInstances = 6),
-            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRole = role)).
+            ClusterRouterPoolSettings(totalInstances = 6, maxInstancesPerNode = 2, allowLocalRoutees = true, useRoleSet = roleSet)).
             props(Props[SomeActor]),
           "router-5")
 
@@ -309,13 +309,13 @@ abstract class UseRoleIgnoredSpec extends MultiNodeSpec(UseRoleIgnoredMultiJvmSp
     "group local: on, role: c, 6 => 2,2,2" taggedAs LongRunningTest in {
 
       runOn(first) {
-        val role = Some("c")
+        val roleSet = Set("c")
 
         val router = system.actorOf(
           ClusterRouterGroup(
           RoundRobinGroup(paths = Nil),
           ClusterRouterGroupSettings(totalInstances = 6, routeesPaths = List("/user/foo", "/user/bar"),
-            allowLocalRoutees = true, useRole = role)).props,
+            allowLocalRoutees = true, useRoleSet = roleSet)).props,
           "router-5b")
 
         awaitAssert(currentRoutees(router).size should ===(6))

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
@@ -57,7 +57,7 @@ class ClusterDeployerSpec extends AkkaSpec(ClusterDeployerSpec.deployerConf) {
           service,
           deployment.get.config,
           ClusterRouterPool(RoundRobinPool(20), ClusterRouterPoolSettings(
-            totalInstances = 20, maxInstancesPerNode = 3, allowLocalRoutees = false, useRole = None)),
+            totalInstances = 20, maxInstancesPerNode = 3, allowLocalRoutees = false, useRoleSet = Set.empty)),
           ClusterScope,
           Deploy.NoDispatcherGiven,
           Deploy.NoMailboxGiven)))
@@ -73,7 +73,7 @@ class ClusterDeployerSpec extends AkkaSpec(ClusterDeployerSpec.deployerConf) {
           service,
           deployment.get.config,
           ClusterRouterGroup(RoundRobinGroup(List("/user/myservice")), ClusterRouterGroupSettings(
-            totalInstances = 20, routeesPaths = List("/user/myservice"), allowLocalRoutees = false, useRole = None)),
+            totalInstances = 20, routeesPaths = List("/user/myservice"), allowLocalRoutees = false, useRoleSet = Set.empty)),
           ClusterScope,
           "mydispatcher",
           "mymailbox")))

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
@@ -57,7 +57,7 @@ class ClusterDeployerSpec extends AkkaSpec(ClusterDeployerSpec.deployerConf) {
           service,
           deployment.get.config,
           ClusterRouterPool(RoundRobinPool(20), ClusterRouterPoolSettings(
-            totalInstances = 20, maxInstancesPerNode = 3, allowLocalRoutees = false, useRoles = Set.empty)),
+            totalInstances = 20, maxInstancesPerNode = 3, allowLocalRoutees = false)),
           ClusterScope,
           Deploy.NoDispatcherGiven,
           Deploy.NoMailboxGiven)))
@@ -73,7 +73,7 @@ class ClusterDeployerSpec extends AkkaSpec(ClusterDeployerSpec.deployerConf) {
           service,
           deployment.get.config,
           ClusterRouterGroup(RoundRobinGroup(List("/user/myservice")), ClusterRouterGroupSettings(
-            totalInstances = 20, routeesPaths = List("/user/myservice"), allowLocalRoutees = false, useRoles = Set.empty)),
+            totalInstances = 20, routeesPaths = List("/user/myservice"), allowLocalRoutees = false)),
           ClusterScope,
           "mydispatcher",
           "mymailbox")))

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeployerSpec.scala
@@ -57,7 +57,7 @@ class ClusterDeployerSpec extends AkkaSpec(ClusterDeployerSpec.deployerConf) {
           service,
           deployment.get.config,
           ClusterRouterPool(RoundRobinPool(20), ClusterRouterPoolSettings(
-            totalInstances = 20, maxInstancesPerNode = 3, allowLocalRoutees = false, useRoleSet = Set.empty)),
+            totalInstances = 20, maxInstancesPerNode = 3, allowLocalRoutees = false, useRoles = Set.empty)),
           ClusterScope,
           Deploy.NoDispatcherGiven,
           Deploy.NoMailboxGiven)))
@@ -73,7 +73,7 @@ class ClusterDeployerSpec extends AkkaSpec(ClusterDeployerSpec.deployerConf) {
           service,
           deployment.get.config,
           ClusterRouterGroup(RoundRobinGroup(List("/user/myservice")), ClusterRouterGroupSettings(
-            totalInstances = 20, routeesPaths = List("/user/myservice"), allowLocalRoutees = false, useRoleSet = Set.empty)),
+            totalInstances = 20, routeesPaths = List("/user/myservice"), allowLocalRoutees = false, useRoles = Set.empty)),
           ClusterScope,
           "mydispatcher",
           "mymailbox")))

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -86,7 +86,7 @@ class ClusterMessageSerializerSpec extends AkkaSpec(
           totalInstances = 2,
           maxInstancesPerNode = 5,
           allowLocalRoutees = true,
-          useRoleSet = Set("Richard, Duke of Gloucester")
+          useRoles = Set("Richard, Duke of Gloucester")
         )
       ))
     }

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -4,12 +4,12 @@
 package akka.cluster.protobuf
 
 import akka.cluster._
-import akka.actor.{ Address, ExtendedActorSystem }
+import akka.actor.{ ActorSystem, Address, ExtendedActorSystem }
 import akka.cluster.routing.{ ClusterRouterPool, ClusterRouterPoolSettings }
 import akka.routing.RoundRobinPool
 
 import collection.immutable.SortedSet
-import akka.testkit.AkkaSpec
+import akka.testkit.{ AkkaSpec, TestKit }
 
 class ClusterMessageSerializerSpec extends AkkaSpec(
   "akka.actor.provider = cluster") {
@@ -75,9 +75,57 @@ class ClusterMessageSerializerSpec extends AkkaSpec(
 
       checkSerialization(InternalClusterAction.Welcome(uniqueAddress, g2))
     }
+
+    "be compatible with wire format of version 2.5.3 (using use-role instead of use-roles)" in {
+      val system = ActorSystem("ClusterMessageSerializer-old-wire-format")
+
+      try {
+        val serializer = new ClusterMessageSerializer(system.asInstanceOf[ExtendedActorSystem])
+
+        // the oldSnapshot was created with the version of ClusterRouterPoolSettings in Akka 2.5.3. See issue #23257.
+        // It was created with:
+        /*
+          import org.apache.commons.codec.binary.Hex.encodeHex
+          val bytes = serializer.toBinary(
+            ClusterRouterPool(RoundRobinPool(nrOfInstances = 4), ClusterRouterPoolSettings(123, 345, true, Some("role ABC"))))
+          println(String.valueOf(encodeHex(bytes)))
+        */
+
+        val oldBytesHex = "0a0f08101205524f5252501a04080418001211087b10d90218012208726f6c6520414243"
+
+        import org.apache.commons.codec.binary.Hex.decodeHex
+        val oldBytes = decodeHex(oldBytesHex.toCharArray)
+        val result = serializer.fromBinary(oldBytes, classOf[ClusterRouterPool])
+
+        result match {
+          case pool: ClusterRouterPool ⇒
+            pool.settings.totalInstances should ===(123)
+            pool.settings.maxInstancesPerNode should ===(345)
+            pool.settings.allowLocalRoutees should ===(true)
+            pool.settings.useRole should ===(Some("role ABC"))
+            pool.settings.useRoles should ===(Set("role ABC"))
+        }
+      } finally {
+        TestKit.shutdownActorSystem(system)
+      }
+
+    }
   }
   "Cluster router pool" must {
-    "be serializable" in {
+    "be serializable with no role" in {
+      checkSerialization(ClusterRouterPool(
+        RoundRobinPool(
+          nrOfInstances = 4
+        ),
+        ClusterRouterPoolSettings(
+          totalInstances = 2,
+          maxInstancesPerNode = 5,
+          allowLocalRoutees = true
+        )
+      ))
+    }
+
+    "be serializable with one role" in {
       checkSerialization(ClusterRouterPool(
         RoundRobinPool(
           nrOfInstances = 4
@@ -87,6 +135,20 @@ class ClusterMessageSerializerSpec extends AkkaSpec(
           maxInstancesPerNode = 5,
           allowLocalRoutees = true,
           useRoles = Set("Richard, Duke of Gloucester")
+        )
+      ))
+    }
+
+    "be serializable with many roles" in {
+      checkSerialization(ClusterRouterPool(
+        RoundRobinPool(
+          nrOfInstances = 4
+        ),
+        ClusterRouterPoolSettings(
+          totalInstances = 2,
+          maxInstancesPerNode = 5,
+          allowLocalRoutees = true,
+          useRoles = Set("Richard, Duke of Gloucester", "Hongzhi Emperor", "Red Rackham")
         )
       ))
     }

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.protobuf
 import akka.cluster._
 import akka.actor.{ Address, ExtendedActorSystem }
 import akka.cluster.routing.{ ClusterRouterPool, ClusterRouterPoolSettings }
-import akka.routing.{ DefaultOptimalSizeExploringResizer, RoundRobinPool }
+import akka.routing.RoundRobinPool
 
 import collection.immutable.SortedSet
 import akka.testkit.AkkaSpec
@@ -86,7 +86,7 @@ class ClusterMessageSerializerSpec extends AkkaSpec(
           totalInstances = 2,
           maxInstancesPerNode = 5,
           allowLocalRoutees = true,
-          useRole = Some("Richard, Duke of Gloucester")
+          useRoleSet = Set("Richard, Duke of Gloucester")
         )
       ))
     }

--- a/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
@@ -42,7 +42,7 @@ class ClusterRouterSupervisorSpec extends AkkaSpec("""
           totalInstances = 1,
           maxInstancesPerNode = 1,
           allowLocalRoutees = true,
-          useRoleSet = Set.empty)).
+          useRoles = Set.empty)).
           props(Props(classOf[KillableActor], testActor)), name = "therouter")
 
       router ! "go away"

--- a/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
@@ -41,8 +41,7 @@ class ClusterRouterSupervisorSpec extends AkkaSpec("""
           }), ClusterRouterPoolSettings(
           totalInstances = 1,
           maxInstancesPerNode = 1,
-          allowLocalRoutees = true,
-          useRoles = Set.empty)).
+          allowLocalRoutees = true)).
           props(Props(classOf[KillableActor], testActor)), name = "therouter")
 
       router ! "go away"

--- a/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/routing/ClusterRouterSupervisorSpec.scala
@@ -42,7 +42,7 @@ class ClusterRouterSupervisorSpec extends AkkaSpec("""
           totalInstances = 1,
           maxInstancesPerNode = 1,
           allowLocalRoutees = true,
-          useRole = None)).
+          useRoleSet = Set.empty)).
           props(Props(classOf[KillableActor], testActor)), name = "therouter")
 
       router ! "go away"

--- a/akka-docs/src/main/paradox/scala/cluster-metrics.md
+++ b/akka-docs/src/main/paradox/scala/cluster-metrics.md
@@ -185,7 +185,7 @@ akka.actor.deployment {
     routees.paths = ["/user/factorialBackend"]
     cluster {
       enabled = on
-      use-role-set = ["backend"]
+      use-roles = ["backend"]
       allow-local-routees = off
     }
   }

--- a/akka-docs/src/main/paradox/scala/cluster-metrics.md
+++ b/akka-docs/src/main/paradox/scala/cluster-metrics.md
@@ -185,7 +185,7 @@ akka.actor.deployment {
     routees.paths = ["/user/factorialBackend"]
     cluster {
       enabled = on
-      use-role = backend
+      use-role-set = ["backend"]
       allow-local-routees = off
     }
   }

--- a/akka-docs/src/main/paradox/scala/cluster-usage.md
+++ b/akka-docs/src/main/paradox/scala/cluster-usage.md
@@ -599,7 +599,7 @@ akka.actor.deployment {
       cluster {
         enabled = on
         allow-local-routees = on
-        use-role = compute
+        use-role-set = ["compute"]
       }
     }
 }
@@ -615,7 +615,7 @@ the router will try to use them as soon as the member status is changed to 'Up'.
 The actor paths without address information that are defined in `routees.paths` are used for selecting the
 actors to which the messages will be forwarded to by the router.
 Messages will be forwarded to the routees using @ref:[ActorSelection](actors.md#actorselection), so the same delivery semantics should be expected.
-It is possible to limit the lookup of routees to member nodes tagged with a certain role by specifying `use-role`.
+It is possible to limit the lookup of routees to member nodes tagged with a particular set of roles by specifying `use-role-set`.
 
 `max-total-nr-of-instances` defines total number of routees in the cluster. By default `max-total-nr-of-instances`
 is set to a high value (10000) that will result in new routees added to the router when nodes join the cluster.
@@ -686,7 +686,7 @@ akka.actor.deployment {
     cluster {
       enabled = on
       allow-local-routees = on
-      use-role = compute
+      use-role-set = ["compute"]
     }
   }
 }
@@ -715,14 +715,14 @@ akka.actor.deployment {
         enabled = on
         max-nr-of-instances-per-node = 3
         allow-local-routees = on
-        use-role = compute
+        use-role-set = ["compute"]
       }
     }
 }
 ```
 
-It is possible to limit the deployment of routees to member nodes tagged with a certain role by
-specifying `use-role`.
+It is possible to limit the deployment of routees to member nodes tagged with a particular set of roles by
+specifying `use-role-set`.
 
 `max-total-nr-of-instances` defines total number of routees in the cluster, but the number of routees
 per node, `max-nr-of-instances-per-node`, will not be exceeded. By default `max-total-nr-of-instances`
@@ -790,7 +790,7 @@ akka.actor.deployment {
       enabled = on
       max-nr-of-instances-per-node = 3
       allow-local-routees = on
-      use-role = compute
+      use-role-set = ["compute"]
     }
   }
 }

--- a/akka-docs/src/main/paradox/scala/cluster-usage.md
+++ b/akka-docs/src/main/paradox/scala/cluster-usage.md
@@ -599,7 +599,7 @@ akka.actor.deployment {
       cluster {
         enabled = on
         allow-local-routees = on
-        use-role-set = ["compute"]
+        use-roles = ["compute"]
       }
     }
 }
@@ -615,7 +615,7 @@ the router will try to use them as soon as the member status is changed to 'Up'.
 The actor paths without address information that are defined in `routees.paths` are used for selecting the
 actors to which the messages will be forwarded to by the router.
 Messages will be forwarded to the routees using @ref:[ActorSelection](actors.md#actorselection), so the same delivery semantics should be expected.
-It is possible to limit the lookup of routees to member nodes tagged with a particular set of roles by specifying `use-role-set`.
+It is possible to limit the lookup of routees to member nodes tagged with a particular set of roles by specifying `use-roles`.
 
 `max-total-nr-of-instances` defines total number of routees in the cluster. By default `max-total-nr-of-instances`
 is set to a high value (10000) that will result in new routees added to the router when nodes join the cluster.
@@ -686,7 +686,7 @@ akka.actor.deployment {
     cluster {
       enabled = on
       allow-local-routees = on
-      use-role-set = ["compute"]
+      use-roles = ["compute"]
     }
   }
 }
@@ -715,14 +715,14 @@ akka.actor.deployment {
         enabled = on
         max-nr-of-instances-per-node = 3
         allow-local-routees = on
-        use-role-set = ["compute"]
+        use-roles = ["compute"]
       }
     }
 }
 ```
 
 It is possible to limit the deployment of routees to member nodes tagged with a particular set of roles by
-specifying `use-role-set`.
+specifying `use-roles`.
 
 `max-total-nr-of-instances` defines total number of routees in the cluster, but the number of routees
 per node, `max-nr-of-instances-per-node`, will not be exceeded. By default `max-total-nr-of-instances`
@@ -790,7 +790,7 @@ akka.actor.deployment {
       enabled = on
       max-nr-of-instances-per-node = 3
       allow-local-routees = on
-      use-role-set = ["compute"]
+      use-roles = ["compute"]
     }
   }
 }

--- a/akka-docs/src/main/paradox/scala/project/migration-guide-2.4.x-2.5.x.md
+++ b/akka-docs/src/main/paradox/scala/project/migration-guide-2.4.x-2.5.x.md
@@ -420,6 +420,14 @@ and here is a summary of things to consider.
  * [mig25_weaklyup](#mig25-weaklyup)
  * [mig25_sharding_store](#mig25-sharding-store)
  * [mig25_mutual](#mig25-mutual)
+ 
+#### Limit lookup of routees to nodes tagged with multiple roles
+
+Starting with 2.5.4, cluster routing supports delivering messages to routees tagged with all specified roles
+using `use-roles` (instead of `use-role` in previous versions). When doing rolling upgrades and using this new feature,
+it is important to first upgrade the existing nodes to the latest version of Akka
+and then start using multiple roles in a separate rolling upgrade. Otherwise, if a new node sends a message 
+with the restriction `use-roles = ["a", "b"]`, that will only require the "a" role on old nodes.
 
 ### Coordinated Shutdown
 

--- a/akka-docs/src/test/java/jdocs/cluster/FactorialFrontend.java
+++ b/akka-docs/src/test/java/jdocs/cluster/FactorialFrontend.java
@@ -2,6 +2,8 @@ package jdocs.cluster;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import akka.actor.Props;
@@ -77,12 +79,12 @@ abstract class FactorialFrontend2 extends AbstractActor {
   int totalInstances = 100;
   Iterable<String> routeesPaths = Arrays.asList("/user/factorialBackend", "");
   boolean allowLocalRoutees = true;
-  String useRole = "backend";
+  Set<String> useRoleSet = new HashSet<>(Arrays.asList("backend"));
   ActorRef backend = getContext().actorOf(
     new ClusterRouterGroup(new AdaptiveLoadBalancingGroup(
       HeapMetricsSelector.getInstance(), Collections.<String> emptyList()),
         new ClusterRouterGroupSettings(totalInstances, routeesPaths,
-          allowLocalRoutees, useRole)).props(), "factorialBackendRouter2");
+          allowLocalRoutees, useRoleSet)).props(), "factorialBackendRouter2");
 
   //#router-lookup-in-code
 }
@@ -93,12 +95,12 @@ abstract class FactorialFrontend3 extends AbstractActor {
   int totalInstances = 100;
   int maxInstancesPerNode = 3;
   boolean allowLocalRoutees = false;
-  String useRole = "backend";
+  Set<String> useRoleSet = new HashSet<>(Arrays.asList("backend"));
   ActorRef backend = getContext().actorOf(
     new ClusterRouterPool(new AdaptiveLoadBalancingPool(
       SystemLoadAverageMetricsSelector.getInstance(), 0),
         new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode,
-          allowLocalRoutees, useRole)).props(Props
+          allowLocalRoutees, useRoleSet)).props(Props
             .create(FactorialBackend.class)), "factorialBackendRouter3");
   //#router-deploy-in-code
 }

--- a/akka-docs/src/test/java/jdocs/cluster/FactorialFrontend.java
+++ b/akka-docs/src/test/java/jdocs/cluster/FactorialFrontend.java
@@ -79,12 +79,12 @@ abstract class FactorialFrontend2 extends AbstractActor {
   int totalInstances = 100;
   Iterable<String> routeesPaths = Arrays.asList("/user/factorialBackend", "");
   boolean allowLocalRoutees = true;
-  Set<String> useRoleSet = new HashSet<>(Arrays.asList("backend"));
+  Set<String> useRoles = new HashSet<>(Arrays.asList("backend"));
   ActorRef backend = getContext().actorOf(
     new ClusterRouterGroup(new AdaptiveLoadBalancingGroup(
       HeapMetricsSelector.getInstance(), Collections.<String> emptyList()),
         new ClusterRouterGroupSettings(totalInstances, routeesPaths,
-          allowLocalRoutees, useRoleSet)).props(), "factorialBackendRouter2");
+          allowLocalRoutees, useRoles)).props(), "factorialBackendRouter2");
 
   //#router-lookup-in-code
 }
@@ -95,12 +95,12 @@ abstract class FactorialFrontend3 extends AbstractActor {
   int totalInstances = 100;
   int maxInstancesPerNode = 3;
   boolean allowLocalRoutees = false;
-  Set<String> useRoleSet = new HashSet<>(Arrays.asList("backend"));
+  Set<String> useRoles = new HashSet<>(Arrays.asList("backend"));
   ActorRef backend = getContext().actorOf(
     new ClusterRouterPool(new AdaptiveLoadBalancingPool(
       SystemLoadAverageMetricsSelector.getInstance(), 0),
         new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode,
-          allowLocalRoutees, useRoleSet)).props(Props
+          allowLocalRoutees, useRoles)).props(Props
             .create(FactorialBackend.class)), "factorialBackendRouter3");
   //#router-deploy-in-code
 }

--- a/akka-docs/src/test/java/jdocs/cluster/StatsService.java
+++ b/akka-docs/src/test/java/jdocs/cluster/StatsService.java
@@ -13,7 +13,10 @@ import akka.actor.AbstractActor;
 import akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope;
 import akka.routing.FromConfig;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 //#service
 public class StatsService extends AbstractActor {
@@ -55,11 +58,11 @@ abstract class StatsService2 extends AbstractActor {
   Iterable<String> routeesPaths = Collections
     .singletonList("/user/statsWorker");
   boolean allowLocalRoutees = true;
-  String useRole = "compute";
+  Set<String> useRoleSet = new HashSet<>(Arrays.asList("compute"));
   ActorRef workerRouter = getContext().actorOf(
     new ClusterRouterGroup(new ConsistentHashingGroup(routeesPaths),
       new ClusterRouterGroupSettings(totalInstances, routeesPaths,
-        allowLocalRoutees, useRole)).props(), "workerRouter2");
+        allowLocalRoutees, useRoleSet)).props(), "workerRouter2");
   //#router-lookup-in-code
 }
 
@@ -69,11 +72,11 @@ abstract class StatsService3 extends AbstractActor {
   int totalInstances = 100;
   int maxInstancesPerNode = 3;
   boolean allowLocalRoutees = false;
-  String useRole = "compute";
+  Set<String> useRoleSet = new HashSet<>(Arrays.asList("compute"));
   ActorRef workerRouter = getContext().actorOf(
     new ClusterRouterPool(new ConsistentHashingPool(0),
       new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode,
-        allowLocalRoutees, useRole)).props(Props
+        allowLocalRoutees, useRoleSet)).props(Props
           .create(StatsWorker.class)), "workerRouter3");
   //#router-deploy-in-code
 }

--- a/akka-docs/src/test/java/jdocs/cluster/StatsService.java
+++ b/akka-docs/src/test/java/jdocs/cluster/StatsService.java
@@ -58,11 +58,11 @@ abstract class StatsService2 extends AbstractActor {
   Iterable<String> routeesPaths = Collections
     .singletonList("/user/statsWorker");
   boolean allowLocalRoutees = true;
-  Set<String> useRoleSet = new HashSet<>(Arrays.asList("compute"));
+  Set<String> useRoles = new HashSet<>(Arrays.asList("compute"));
   ActorRef workerRouter = getContext().actorOf(
     new ClusterRouterGroup(new ConsistentHashingGroup(routeesPaths),
       new ClusterRouterGroupSettings(totalInstances, routeesPaths,
-        allowLocalRoutees, useRoleSet)).props(), "workerRouter2");
+        allowLocalRoutees, useRoles)).props(), "workerRouter2");
   //#router-lookup-in-code
 }
 
@@ -72,11 +72,11 @@ abstract class StatsService3 extends AbstractActor {
   int totalInstances = 100;
   int maxInstancesPerNode = 3;
   boolean allowLocalRoutees = false;
-  Set<String> useRoleSet = new HashSet<>(Arrays.asList("compute"));
+  Set<String> useRoles = new HashSet<>(Arrays.asList("compute"));
   ActorRef workerRouter = getContext().actorOf(
     new ClusterRouterPool(new ConsistentHashingPool(0),
       new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode,
-        allowLocalRoutees, useRoleSet)).props(Props
+        allowLocalRoutees, useRoles)).props(Props
           .create(StatsWorker.class)), "workerRouter3");
   //#router-deploy-in-code
 }

--- a/akka-docs/src/test/scala/docs/cluster/FactorialFrontend.scala
+++ b/akka-docs/src/test/scala/docs/cluster/FactorialFrontend.scala
@@ -78,7 +78,7 @@ abstract class FactorialFrontend2 extends Actor {
       AdaptiveLoadBalancingGroup(HeapMetricsSelector),
       ClusterRouterGroupSettings(
         totalInstances = 100, routeesPaths = List("/user/factorialBackend"),
-        allowLocalRoutees = true, useRole = Some("backend"))).props(),
+        allowLocalRoutees = true, useRoleSet = Set("backend"))).props(),
     name = "factorialBackendRouter2")
 
   //#router-lookup-in-code
@@ -96,7 +96,7 @@ abstract class FactorialFrontend3 extends Actor {
     ClusterRouterPool(AdaptiveLoadBalancingPool(
       SystemLoadAverageMetricsSelector), ClusterRouterPoolSettings(
       totalInstances = 100, maxInstancesPerNode = 3,
-      allowLocalRoutees = false, useRole = Some("backend"))).props(Props[FactorialBackend]),
+      allowLocalRoutees = false, useRoleSet = Set("backend"))).props(Props[FactorialBackend]),
     name = "factorialBackendRouter3")
   //#router-deploy-in-code
 }

--- a/akka-docs/src/test/scala/docs/cluster/FactorialFrontend.scala
+++ b/akka-docs/src/test/scala/docs/cluster/FactorialFrontend.scala
@@ -78,7 +78,7 @@ abstract class FactorialFrontend2 extends Actor {
       AdaptiveLoadBalancingGroup(HeapMetricsSelector),
       ClusterRouterGroupSettings(
         totalInstances = 100, routeesPaths = List("/user/factorialBackend"),
-        allowLocalRoutees = true, useRoleSet = Set("backend"))).props(),
+        allowLocalRoutees = true, useRoles = Set("backend"))).props(),
     name = "factorialBackendRouter2")
 
   //#router-lookup-in-code
@@ -96,7 +96,7 @@ abstract class FactorialFrontend3 extends Actor {
     ClusterRouterPool(AdaptiveLoadBalancingPool(
       SystemLoadAverageMetricsSelector), ClusterRouterPoolSettings(
       totalInstances = 100, maxInstancesPerNode = 3,
-      allowLocalRoutees = false, useRoleSet = Set("backend"))).props(Props[FactorialBackend]),
+      allowLocalRoutees = false, useRoles = Set("backend"))).props(Props[FactorialBackend]),
     name = "factorialBackendRouter3")
   //#router-deploy-in-code
 }


### PR DESCRIPTION
When using ```ClusterRouterPool```, we had a need to target routees based on more than one role, ie a routee must have all specified roles. In our use case, we want to select them based on a combination of service area, sub-system and optionally a version, e.g. ["Sales Service","Belgium","v2.0"].

To that end, ```ClusterRouterGroup``` and ```ClusterRouterPool``` can now target routees with a set of roles using ```use-role-set``` instead of ```use-role```.

For now, ```use-role``` has been replaced with ```use-role-set``` everywhere, but of course a backward compatibility layer needs to be added so that ```use-role``` will work as before and be equivalent to ```use-role-set = ["the-role"]```. I am waiting input on how this is usually done in Akka.

Some additional tests for routees selection also need to be added.