### PR TITLE
Add link to akka-http talk on 'books/videos' page

### DIFF
--- a/akka-docs/src/main/paradox/scala/additional/books.md
+++ b/akka-docs/src/main/paradox/scala/additional/books.md
@@ -15,5 +15,6 @@
 
 ## Videos
 
+ * [Effective Akka HTTP](https://www.youtube.com/watch?v=uxQta776jJI), by Johannes Rudolph, Reactive Systems Meetup Hamburg, November 2016
  * [Learning Akka Videos](https://www.packtpub.com/application-development/learning-akka-video), by Salma Khater, PACKT Publishing, ISBN: 9781784391836, January 2016
  * [Building Microservice with AKKA HTTP (Video)](https://www.packtpub.com/application-development/building-microservice-akka-http-video), by Tomasz Lelek, PACKT Publishing, ISBN: 9781788298582, March 2017

--- a/akka-docs/src/main/paradox/scala/additional/books.md
+++ b/akka-docs/src/main/paradox/scala/additional/books.md
@@ -16,5 +16,6 @@
 ## Videos
 
  * [Effective Akka HTTP](https://www.youtube.com/watch?v=uxQta776jJI), by Johannes Rudolph, Reactive Systems Meetup Hamburg, November 2016
+ * [Zen of Akka](https://www.youtube.com/watch?v=vgFoKOxrTzg) - an overview of good and bad practices in Akka, by Konrad Malawski, ScalaDays New York, June 2016
  * [Learning Akka Videos](https://www.packtpub.com/application-development/learning-akka-video), by Salma Khater, PACKT Publishing, ISBN: 9781784391836, January 2016
  * [Building Microservice with AKKA HTTP (Video)](https://www.packtpub.com/application-development/building-microservice-akka-http-video), by Tomasz Lelek, PACKT Publishing, ISBN: 9781788298582, March 2017


### PR DESCRIPTION
Might be good to introduce such a page in the akka-http docs, until then this
is useful.