### PR TITLE
Broaden timeout for SystemMessageDeliverySpec

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -129,7 +129,7 @@ class SystemMessageDeliverySpec extends ArteryMultiNodeSpec(ArterySpecSupport.de
         expectMsg("hello")
         systemC.terminate()
         // DeathWatchNotification is sent from systemC, failure detection takes longer than 3 seconds
-        expectTerminated(remoteRef, 5.seconds)
+        expectTerminated(remoteRef, 10.seconds)
       } finally {
         shutdown(systemC)
       }


### PR DESCRIPTION
Fixes #21799 assuming that it's simply a matter of tight timing.