### PR TITLE
Refactoring of Gossip class, #23290

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/AutoDown.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/AutoDown.scala
@@ -101,7 +101,7 @@ private[cluster] abstract class AutoDownBase(autoDownUnreachableAfter: FiniteDur
 
   import context.dispatcher
 
-  val skipMemberStatus = Gossip.convergenceSkipUnreachableWithMemberStatus
+  val skipMemberStatus = MembershipState.convergenceSkipUnreachableWithMemberStatus
 
   var scheduledUnreachable: Map[UniqueAddress, Cancellable] = Map.empty
   var pendingUnreachable: Set[UniqueAddress] = Set.empty

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -163,7 +163,7 @@ object Member {
         if (members.size == 2) acc + members.reduceLeft(highestPriorityOf)
         else {
           val m = members.head
-          if (tombstones.contains(m.uniqueAddress) || Gossip.removeUnreachableWithMemberStatus(m.status)) acc // removed
+          if (tombstones.contains(m.uniqueAddress) || MembershipState.removeUnreachableWithMemberStatus(m.status)) acc // removed
           else acc + m
         }
     }

--- a/akka-cluster/src/main/scala/akka/cluster/MembershipState.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/MembershipState.scala
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster
+
+import scala.collection.immutable
+import scala.collection.SortedSet
+import akka.cluster.ClusterSettings.DataCenter
+import akka.cluster.MemberStatus._
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object MembershipState {
+  import MemberStatus._
+  private val leaderMemberStatus = Set[MemberStatus](Up, Leaving)
+  private val convergenceMemberStatus = Set[MemberStatus](Up, Leaving)
+  val convergenceSkipUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
+  val removeUnreachableWithMemberStatus = Set[MemberStatus](Down, Exiting)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] final case class MembershipState(latestGossip: Gossip, selfUniqueAddress: UniqueAddress, selfDc: DataCenter) {
+  import MembershipState._
+
+  def members: immutable.SortedSet[Member] = latestGossip.members
+
+  def overview: GossipOverview = latestGossip.overview
+
+  def seen(): MembershipState = copy(latestGossip = latestGossip.seen(selfUniqueAddress))
+
+  /**
+   * Checks if we have a cluster convergence. If there are any in data center node pairs that cannot reach each other
+   * then we can't have a convergence until those nodes reach each other again or one of them is downed
+   *
+   * @return true if convergence have been reached and false if not
+   */
+  def convergence(exitingConfirmed: Set[UniqueAddress]): Boolean = {
+
+    // If another member in the data center that is UP or LEAVING and has not seen this gossip or is exiting
+    // convergence cannot be reached
+    def memberHinderingConvergenceExists =
+      members.exists(member ⇒
+        member.dataCenter == selfDc &&
+          convergenceMemberStatus(member.status) &&
+          !(latestGossip.seenByNode(member.uniqueAddress) || exitingConfirmed(member.uniqueAddress)))
+
+    // Find cluster members in the data center that are unreachable from other members of the data center
+    // excluding observations from members outside of the data center, that have status DOWN or is passed in as confirmed exiting.
+    val unreachableInDc = dcReachabilityExcludingDownedObservers.allUnreachableOrTerminated.collect {
+      case node if node != selfUniqueAddress && !exitingConfirmed(node) ⇒ latestGossip.member(node)
+    }
+    // unreachables outside of the data center or with status DOWN or EXITING does not affect convergence
+    val allUnreachablesCanBeIgnored =
+      unreachableInDc.forall(unreachable ⇒ convergenceSkipUnreachableWithMemberStatus(unreachable.status))
+
+    allUnreachablesCanBeIgnored && !memberHinderingConvergenceExists
+  }
+
+  /**
+   * @return Reachability excluding observations from nodes outside of the data center, but including observed unreachable
+   *         nodes outside of the data center
+   */
+  lazy val dcReachability: Reachability =
+    overview.reachability.removeObservers(
+      members.collect { case m if m.dataCenter != selfDc ⇒ m.uniqueAddress })
+
+  /**
+   * @return reachability for data center nodes, with observations from outside the data center or from downed nodes filtered out
+   */
+  lazy val dcReachabilityExcludingDownedObservers: Reachability = {
+    val membersToExclude = members.collect { case m if m.status == Down || m.dataCenter != selfDc ⇒ m.uniqueAddress }
+    overview.reachability.removeObservers(membersToExclude).remove(members.collect { case m if m.dataCenter != selfDc ⇒ m.uniqueAddress })
+  }
+
+  /**
+   * @return true if toAddress should be reachable from the fromDc in general, within a data center
+   *         this means only caring about data center local observations, across data centers it
+   *         means caring about all observations for the toAddress.
+   */
+  def isReachableExcludingDownedObservers(toAddress: UniqueAddress): Boolean =
+    if (!latestGossip.hasMember(toAddress)) false
+    else {
+      val to = latestGossip.member(toAddress)
+
+      // if member is in the same data center, we ignore cross data center unreachability
+      if (selfDc == to.dataCenter) dcReachabilityExcludingDownedObservers.isReachable(toAddress)
+      // if not it is enough that any non-downed node observed it as unreachable
+      else latestGossip.reachabilityExcludingDownedObservers.isReachable(toAddress)
+    }
+
+  def dcMembers: SortedSet[Member] =
+    members.filter(_.dataCenter == selfDc)
+
+  def isLeader(node: UniqueAddress): Boolean =
+    leader.contains(node)
+
+  def leader: Option[UniqueAddress] =
+    leaderOf(members)
+
+  def roleLeader(role: String): Option[UniqueAddress] =
+    leaderOf(members.filter(_.hasRole(role)))
+
+  def leaderOf(mbrs: immutable.SortedSet[Member]): Option[UniqueAddress] = {
+    val reachability = dcReachability
+
+    val reachableMembersInDc =
+      if (reachability.isAllReachable) mbrs.filter(m ⇒ m.dataCenter == selfDc && m.status != Down)
+      else mbrs.filter(m ⇒
+        m.dataCenter == selfDc &&
+          m.status != Down &&
+          (reachability.isReachable(m.uniqueAddress) || m.uniqueAddress == selfUniqueAddress))
+    if (reachableMembersInDc.isEmpty) None
+    else reachableMembersInDc.find(m ⇒ leaderMemberStatus(m.status))
+      .orElse(Some(reachableMembersInDc.min(Member.leaderStatusOrdering)))
+      .map(_.uniqueAddress)
+  }
+
+}

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventPublisherSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventPublisherSpec.scala
@@ -19,6 +19,7 @@ import akka.testkit.ImplicitSender
 import akka.actor.ActorRef
 import akka.remote.RARP
 import akka.testkit.TestProbe
+import akka.cluster.ClusterSettings.DefaultDataCenter
 
 object ClusterDomainEventPublisherSpec {
   val config = """
@@ -36,6 +37,7 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
     else "akka.tcp"
 
   var publisher: ActorRef = _
+
   val aUp = TestMember(Address(protocol, "sys", "a", 2552), Up)
   val aLeaving = aUp.copy(status = Leaving)
   val aExiting = aLeaving.copy(status = Exiting)
@@ -48,16 +50,27 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
   val a51Up = TestMember(Address(protocol, "sys", "a", 2551), Up)
   val dUp = TestMember(Address(protocol, "sys", "d", 2552), Up, Set("GRP"))
 
+  val emptyMembershipState = MembershipState(Gossip.empty, aUp.uniqueAddress, DefaultDataCenter)
+
   val g0 = Gossip(members = SortedSet(aUp)).seen(aUp.uniqueAddress)
+  val state0 = MembershipState(g0, aUp.uniqueAddress, DefaultDataCenter)
   val g1 = Gossip(members = SortedSet(aUp, cJoining)).seen(aUp.uniqueAddress).seen(cJoining.uniqueAddress)
+  val state1 = MembershipState(g1, aUp.uniqueAddress, DefaultDataCenter)
   val g2 = Gossip(members = SortedSet(aUp, bExiting, cUp)).seen(aUp.uniqueAddress)
+  val state2 = MembershipState(g2, aUp.uniqueAddress, DefaultDataCenter)
   val g3 = g2.seen(bExiting.uniqueAddress).seen(cUp.uniqueAddress)
+  val state3 = MembershipState(g3, aUp.uniqueAddress, DefaultDataCenter)
   val g4 = Gossip(members = SortedSet(a51Up, aUp, bExiting, cUp)).seen(aUp.uniqueAddress)
+  val state4 = MembershipState(g4, aUp.uniqueAddress, DefaultDataCenter)
   val g5 = Gossip(members = SortedSet(a51Up, aUp, bExiting, cUp)).seen(aUp.uniqueAddress).seen(bExiting.uniqueAddress).seen(cUp.uniqueAddress).seen(a51Up.uniqueAddress)
+  val state5 = MembershipState(g5, aUp.uniqueAddress, DefaultDataCenter)
   val g6 = Gossip(members = SortedSet(aLeaving, bExiting, cUp)).seen(aUp.uniqueAddress)
+  val state6 = MembershipState(g6, aUp.uniqueAddress, DefaultDataCenter)
   val g7 = Gossip(members = SortedSet(aExiting, bExiting, cUp)).seen(aUp.uniqueAddress)
+  val state7 = MembershipState(g7, aUp.uniqueAddress, DefaultDataCenter)
   val g8 = Gossip(members = SortedSet(aUp, bExiting, cUp, dUp), overview = GossipOverview(reachability =
     Reachability.empty.unreachable(aUp.uniqueAddress, dUp.uniqueAddress))).seen(aUp.uniqueAddress)
+  val state8 = MembershipState(g8, aUp.uniqueAddress, DefaultDataCenter)
 
   // created in beforeEach
   var memberSubscriber: TestProbe = _
@@ -69,7 +82,7 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
     system.eventStream.subscribe(memberSubscriber.ref, ClusterShuttingDown.getClass)
 
     publisher = system.actorOf(Props[ClusterDomainEventPublisher])
-    publisher ! PublishChanges(g0)
+    publisher ! PublishChanges(state0)
     memberSubscriber.expectMsg(MemberUp(aUp))
     memberSubscriber.expectMsg(LeaderChanged(Some(aUp.address)))
   }
@@ -77,19 +90,19 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
   "ClusterDomainEventPublisher" must {
 
     "publish MemberJoined" in {
-      publisher ! PublishChanges(g1)
+      publisher ! PublishChanges(state1)
       memberSubscriber.expectMsg(MemberJoined(cJoining))
     }
 
     "publish MemberUp" in {
-      publisher ! PublishChanges(g2)
-      publisher ! PublishChanges(g3)
+      publisher ! PublishChanges(state2)
+      publisher ! PublishChanges(state3)
       memberSubscriber.expectMsg(MemberExited(bExiting))
       memberSubscriber.expectMsg(MemberUp(cUp))
     }
 
     "publish leader changed" in {
-      publisher ! PublishChanges(g4)
+      publisher ! PublishChanges(state4)
       memberSubscriber.expectMsg(MemberUp(a51Up))
       memberSubscriber.expectMsg(MemberExited(bExiting))
       memberSubscriber.expectMsg(MemberUp(cUp))
@@ -98,17 +111,17 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
     }
 
     "publish leader changed when old leader leaves and is removed" in {
-      publisher ! PublishChanges(g3)
+      publisher ! PublishChanges(state3)
       memberSubscriber.expectMsg(MemberExited(bExiting))
       memberSubscriber.expectMsg(MemberUp(cUp))
-      publisher ! PublishChanges(g6)
+      publisher ! PublishChanges(state6)
       memberSubscriber.expectMsg(MemberLeft(aLeaving))
-      publisher ! PublishChanges(g7)
+      publisher ! PublishChanges(state7)
       memberSubscriber.expectMsg(MemberExited(aExiting))
       memberSubscriber.expectMsg(LeaderChanged(Some(cUp.address)))
       memberSubscriber.expectNoMsg(500 millis)
       // at the removed member a an empty gossip is the last thing
-      publisher ! PublishChanges(Gossip.empty)
+      publisher ! PublishChanges(emptyMembershipState)
       memberSubscriber.expectMsg(MemberRemoved(aRemoved, Exiting))
       memberSubscriber.expectMsg(MemberRemoved(bRemoved, Exiting))
       memberSubscriber.expectMsg(MemberRemoved(cRemoved, Up))
@@ -116,13 +129,13 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
     }
 
     "not publish leader changed when same leader" in {
-      publisher ! PublishChanges(g4)
+      publisher ! PublishChanges(state4)
       memberSubscriber.expectMsg(MemberUp(a51Up))
       memberSubscriber.expectMsg(MemberExited(bExiting))
       memberSubscriber.expectMsg(MemberUp(cUp))
       memberSubscriber.expectMsg(LeaderChanged(Some(a51Up.address)))
 
-      publisher ! PublishChanges(g5)
+      publisher ! PublishChanges(state5)
       memberSubscriber.expectNoMsg(500 millis)
     }
 
@@ -130,12 +143,11 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
       val subscriber = TestProbe()
       publisher ! Subscribe(subscriber.ref, InitialStateAsSnapshot, Set(classOf[RoleLeaderChanged]))
       subscriber.expectMsgType[CurrentClusterState]
-      publisher ! PublishChanges(Gossip(members = SortedSet(cJoining, dUp)))
+      publisher ! PublishChanges(MembershipState(Gossip(members = SortedSet(cJoining, dUp)), dUp.uniqueAddress, DefaultDataCenter))
       subscriber.expectMsgAllOf(
         RoleLeaderChanged("GRP", Some(dUp.address)),
-        RoleLeaderChanged(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter, Some(dUp.address))
-      )
-      publisher ! PublishChanges(Gossip(members = SortedSet(cUp, dUp)))
+        RoleLeaderChanged(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter, Some(dUp.address)))
+      publisher ! PublishChanges(MembershipState(Gossip(members = SortedSet(cUp, dUp)), dUp.uniqueAddress, DefaultDataCenter))
       subscriber.expectMsg(RoleLeaderChanged("GRP", Some(cUp.address)))
     }
 
@@ -150,7 +162,7 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
 
     "send events corresponding to current state when subscribe" in {
       val subscriber = TestProbe()
-      publisher ! PublishChanges(g8)
+      publisher ! PublishChanges(state8)
       publisher ! Subscribe(subscriber.ref, InitialStateAsEvents, Set(classOf[MemberEvent], classOf[ReachabilityEvent]))
       subscriber.receiveN(4).toSet should be(Set(MemberUp(aUp), MemberUp(cUp), MemberUp(dUp), MemberExited(bExiting)))
       subscriber.expectMsg(UnreachableMember(dUp))
@@ -162,7 +174,7 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
       publisher ! Subscribe(subscriber.ref, InitialStateAsSnapshot, Set(classOf[MemberEvent]))
       subscriber.expectMsgType[CurrentClusterState]
       publisher ! Unsubscribe(subscriber.ref, Some(classOf[MemberEvent]))
-      publisher ! PublishChanges(g3)
+      publisher ! PublishChanges(state3)
       subscriber.expectNoMsg(500 millis)
       // but memberSubscriber is still subscriber
       memberSubscriber.expectMsg(MemberExited(bExiting))
@@ -173,10 +185,10 @@ class ClusterDomainEventPublisherSpec extends AkkaSpec(ClusterDomainEventPublish
       val subscriber = TestProbe()
       publisher ! Subscribe(subscriber.ref, InitialStateAsSnapshot, Set(classOf[SeenChanged]))
       subscriber.expectMsgType[CurrentClusterState]
-      publisher ! PublishChanges(g2)
+      publisher ! PublishChanges(state2)
       subscriber.expectMsgType[SeenChanged]
       subscriber.expectNoMsg(500 millis)
-      publisher ! PublishChanges(g3)
+      publisher ! PublishChanges(state3)
       subscriber.expectMsgType[SeenChanged]
       subscriber.expectNoMsg(500 millis)
     }

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventSpec.scala
@@ -38,30 +38,33 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
   private[cluster] def converge(gossip: Gossip): (Gossip, Set[UniqueAddress]) =
     ((gossip, Set.empty[UniqueAddress]) /: gossip.members) { case ((gs, as), m) ⇒ (gs.seen(m.uniqueAddress), as + m.uniqueAddress) }
 
+  private def state(g: Gossip): MembershipState =
+    MembershipState(g, selfDummyAddress, ClusterSettings.DefaultDataCenter)
+
   "Domain events" must {
 
     "be empty for the same gossip" in {
       val g1 = Gossip(members = SortedSet(aUp))
 
-      diffUnreachable(g1, g1, selfDummyAddress) should ===(Seq.empty)
+      diffUnreachable(state(g1), state(g1)) should ===(Seq.empty)
     }
 
     "be produced for new members" in {
       val (g1, _) = converge(Gossip(members = SortedSet(aUp)))
       val (g2, s2) = converge(Gossip(members = SortedSet(aUp, bUp, eJoining)))
 
-      diffMemberEvents(g1, g2) should ===(Seq(MemberUp(bUp), MemberJoined(eJoining)))
-      diffUnreachable(g1, g2, selfDummyAddress) should ===(Seq.empty)
-      diffSeen(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
+      diffMemberEvents(state(g1), state(g2)) should ===(Seq(MemberUp(bUp), MemberJoined(eJoining)))
+      diffUnreachable(state(g1), state(g2)) should ===(Seq.empty)
+      diffSeen(state(g1), state(g2)) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
     }
 
     "be produced for changed status of members" in {
       val (g1, _) = converge(Gossip(members = SortedSet(aJoining, bUp, cUp)))
       val (g2, s2) = converge(Gossip(members = SortedSet(aUp, bUp, cLeaving, eJoining)))
 
-      diffMemberEvents(g1, g2) should ===(Seq(MemberUp(aUp), MemberLeft(cLeaving), MemberJoined(eJoining)))
-      diffUnreachable(g1, g2, selfDummyAddress) should ===(Seq.empty)
-      diffSeen(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
+      diffMemberEvents(state(g1), state(g2)) should ===(Seq(MemberUp(aUp), MemberLeft(cLeaving), MemberJoined(eJoining)))
+      diffUnreachable(state(g1), state(g2)) should ===(Seq.empty)
+      diffSeen(state(g1), state(g2)) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
     }
 
     "be produced for members in unreachable" in {
@@ -73,10 +76,13 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
         unreachable(aUp.uniqueAddress, bDown.uniqueAddress)
       val g2 = Gossip(members = SortedSet(aUp, cUp, bDown, eDown), overview = GossipOverview(reachability = reachability2))
 
-      diffUnreachable(g1, g2, selfDummyAddress) should ===(Seq(UnreachableMember(bDown)))
+      diffUnreachable(state(g1), state(g2)) should ===(Seq(UnreachableMember(bDown)))
       // never include self member in unreachable
-      diffUnreachable(g1, g2, bDown.uniqueAddress) should ===(Seq())
-      diffSeen(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(Seq.empty)
+
+      diffUnreachable(
+        MembershipState(g1, bDown.uniqueAddress, ClusterSettings.DefaultDataCenter),
+        MembershipState(g2, bDown.uniqueAddress, ClusterSettings.DefaultDataCenter)) should ===(Seq())
+      diffSeen(state(g1), state(g2)) should ===(Seq.empty)
     }
 
     "be produced for members becoming reachable after unreachable" in {
@@ -90,50 +96,54 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
         reachable(aUp.uniqueAddress, bUp.uniqueAddress)
       val g2 = Gossip(members = SortedSet(aUp, cUp, bUp, eUp), overview = GossipOverview(reachability = reachability2))
 
-      diffUnreachable(g1, g2, selfDummyAddress) should ===(Seq(UnreachableMember(cUp)))
+      diffUnreachable(state(g1), state(g2)) should ===(Seq(UnreachableMember(cUp)))
       // never include self member in unreachable
-      diffUnreachable(g1, g2, cUp.uniqueAddress) should ===(Seq())
-      diffReachable(g1, g2, selfDummyAddress) should ===(Seq(ReachableMember(bUp)))
+      diffUnreachable(
+        MembershipState(g1, cUp.uniqueAddress, ClusterSettings.DefaultDataCenter),
+        MembershipState(g2, cUp.uniqueAddress, ClusterSettings.DefaultDataCenter)) should ===(Seq())
+      diffReachable(state(g1), state(g2)) should ===(Seq(ReachableMember(bUp)))
       // never include self member in reachable
-      diffReachable(g1, g2, bUp.uniqueAddress) should ===(Seq())
+      diffReachable(
+        MembershipState(g1, bUp.uniqueAddress, ClusterSettings.DefaultDataCenter),
+        MembershipState(g2, bUp.uniqueAddress, ClusterSettings.DefaultDataCenter)) should ===(Seq())
     }
 
     "be produced for removed members" in {
       val (g1, _) = converge(Gossip(members = SortedSet(aUp, dExiting)))
       val (g2, s2) = converge(Gossip(members = SortedSet(aUp)))
 
-      diffMemberEvents(g1, g2) should ===(Seq(MemberRemoved(dRemoved, Exiting)))
-      diffUnreachable(g1, g2, selfDummyAddress) should ===(Seq.empty)
-      diffSeen(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
+      diffMemberEvents(state(g1), state(g2)) should ===(Seq(MemberRemoved(dRemoved, Exiting)))
+      diffUnreachable(state(g1), state(g2)) should ===(Seq.empty)
+      diffSeen(state(g1), state(g2)) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
     }
 
     "be produced for convergence changes" in {
       val g1 = Gossip(members = SortedSet(aUp, bUp, eJoining)).seen(aUp.uniqueAddress).seen(bUp.uniqueAddress).seen(eJoining.uniqueAddress)
       val g2 = Gossip(members = SortedSet(aUp, bUp, eJoining)).seen(aUp.uniqueAddress).seen(bUp.uniqueAddress)
 
-      diffMemberEvents(g1, g2) should ===(Seq.empty)
-      diffUnreachable(g1, g2, selfDummyAddress) should ===(Seq.empty)
-      diffSeen(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(Seq(SeenChanged(convergence = true, seenBy = Set(aUp.address, bUp.address))))
-      diffMemberEvents(g2, g1) should ===(Seq.empty)
-      diffUnreachable(g2, g1, selfDummyAddress) should ===(Seq.empty)
-      diffSeen(ClusterSettings.DefaultDataCenter, g2, g1, selfDummyAddress) should ===(Seq(SeenChanged(convergence = true, seenBy = Set(aUp.address, bUp.address, eJoining.address))))
+      diffMemberEvents(state(g1), state(g2)) should ===(Seq.empty)
+      diffUnreachable(state(g1), state(g2)) should ===(Seq.empty)
+      diffSeen(state(g1), state(g2)) should ===(Seq(SeenChanged(convergence = true, seenBy = Set(aUp.address, bUp.address))))
+      diffMemberEvents(state(g2), state(g1)) should ===(Seq.empty)
+      diffUnreachable(state(g2), state(g1)) should ===(Seq.empty)
+      diffSeen(state(g2), state(g1)) should ===(Seq(SeenChanged(convergence = true, seenBy = Set(aUp.address, bUp.address, eJoining.address))))
     }
 
     "be produced for leader changes" in {
       val (g1, _) = converge(Gossip(members = SortedSet(aUp, bUp, eJoining)))
       val (g2, s2) = converge(Gossip(members = SortedSet(bUp, eJoining)))
 
-      diffMemberEvents(g1, g2) should ===(Seq(MemberRemoved(aRemoved, Up)))
-      diffUnreachable(g1, g2, selfDummyAddress) should ===(Seq.empty)
-      diffSeen(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
-      diffLeader(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(Seq(LeaderChanged(Some(bUp.address))))
+      diffMemberEvents(state(g1), state(g2)) should ===(Seq(MemberRemoved(aRemoved, Up)))
+      diffUnreachable(state(g1), state(g2)) should ===(Seq.empty)
+      diffSeen(state(g1), state(g2)) should ===(Seq(SeenChanged(convergence = true, seenBy = s2.map(_.address))))
+      diffLeader(state(g1), state(g2)) should ===(Seq(LeaderChanged(Some(bUp.address))))
     }
 
     "be produced for role leader changes in the same data center" in {
       val g0 = Gossip.empty
       val g1 = Gossip(members = SortedSet(aUp, bUp, cUp, dLeaving, eJoining))
       val g2 = Gossip(members = SortedSet(bUp, cUp, dExiting, eJoining))
-      diffRolesLeader(ClusterSettings.DefaultDataCenter, g0, g1, selfDummyAddress) should ===(
+      diffRolesLeader(state(g0), state(g1)) should ===(
         Set(
           // since this role is implicitly added
           RoleLeaderChanged(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter, Some(aUp.address)),
@@ -143,7 +153,7 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
           RoleLeaderChanged("DD", Some(dLeaving.address)),
           RoleLeaderChanged("DE", Some(dLeaving.address)),
           RoleLeaderChanged("EE", Some(eUp.address))))
-      diffRolesLeader(ClusterSettings.DefaultDataCenter, g1, g2, selfDummyAddress) should ===(
+      diffRolesLeader(state(g1), state(g2)) should ===(
         Set(
           RoleLeaderChanged(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter, Some(bUp.address)),
           RoleLeaderChanged("AA", None),
@@ -153,10 +163,14 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
 
     "not be produced for role leader changes in other data centers" in {
       val g0 = Gossip.empty
+      val s0 = state(g0).copy(selfDc = "dc2")
       val g1 = Gossip(members = SortedSet(aUp, bUp, cUp, dLeaving, eJoining))
+      val s1 = state(g1).copy(selfDc = "dc2")
       val g2 = Gossip(members = SortedSet(bUp, cUp, dExiting, eJoining))
-      diffRolesLeader("dc2", g0, g1, selfDummyAddress) should ===(Set.empty)
-      diffRolesLeader("dc2", g1, g2, selfDummyAddress) should ===(Set.empty)
+      val s2 = state(g2).copy(selfDc = "dc2")
+
+      diffRolesLeader(s0, s1) should ===(Set.empty)
+      diffRolesLeader(s1, s2) should ===(Set.empty)
     }
   }
 }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1221,14 +1221,6 @@ object MiMa extends AutoPlugin {
         // #22881 Make sure connections are aborted correctly on Windows
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.io.ChannelRegistration.cancel"),
         
-        // #23231 multi-DC Sharding
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.ddata.Replicator.leader"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.Replicator.receiveLeaderChanged"),
-        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.ddata.Replicator.leader_="),
-        FilterAnyProblemStartingWith("akka.cluster.sharding.ClusterShardingGuardian"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.proxyProps"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.this"),
-        
         // #23144 recoverWithRetries cleanup
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.RecoverWith.InfiniteRetries"),  
 
@@ -1237,23 +1229,29 @@ object MiMa extends AutoPlugin {
         
         // #23023 added a new overload with implementation to trait, so old transport implementations compiled against
         // older versions will be missing the method. We accept that incompatibility for now.
-        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.transport.AssociationHandle.disassociate"),
-
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.transport.AssociationHandle.disassociate")
+      ),
+      "2.5.3" -> Seq(
+        // #23231 multi-DC Sharding
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.ddata.Replicator.leader"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.Replicator.receiveLeaderChanged"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.ddata.Replicator.leader_="),
+        FilterAnyProblemStartingWith("akka.cluster.sharding.ClusterShardingGuardian"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.proxyProps"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.this"),
+        
         // #23228 single leader per cluster data center
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.apply"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.copy"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.this"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.convergence"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.isLeader"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.leader"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.leaderOf"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Gossip.roleLeader"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterCoreDaemon.NumberOfGossipsBeforeShutdownWhenLeaderExits"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterCoreDaemon.vclockName"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterCoreDaemon.MaxGossipsBeforeShuttingDownMyself"),
+        FilterAnyProblemStartingWith("akka.cluster.Gossip"),
+        FilterAnyProblemStartingWith("akka.cluster.ClusterCoreDaemon"),
+        FilterAnyProblemStartingWith("akka.cluster.ClusterDomainEventPublisher"),
+        FilterAnyProblemStartingWith("akka.cluster.InternalClusterAction"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent.diffReachable"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent.diffLeader"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent.diffRolesLeader"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent.diffSeen"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.ClusterEvent.diffReachability"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent.diffUnreachable"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.ClusterEvent.diffMemberEvents"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.protobuf.msg.ClusterMessages#GossipOrBuilder.getTombstonesCount"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.protobuf.msg.ClusterMessages#GossipOrBuilder.getTombstones"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.protobuf.msg.ClusterMessages#GossipOrBuilder.getTombstonesList"),


### PR DESCRIPTION
* move methods that depends on selfUniqueAddress and selfDc
  to a separate MembershipState class, which also holds the
  latest gossip
* this removes the need to pass in the parameters from everywhere and
  makes it easier to cache some results
* makes it clear that those parameters are always selfUniqueAddress
  and selfDc, instead of some arbitary node/dc

Refs #23290