### PR TITLE
fix usage of the the leader sorted set in Replicator

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonProxy.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonProxy.scala
@@ -222,7 +222,8 @@ final class ClusterSingletonProxy(singletonManagerPath: String, settings: Cluste
   def add(m: Member): Unit = {
     if (matchingRole(m))
       trackChange { () ⇒
-        membersByAge -= m // replace
+        // replace, it's possible that the upNumber is changed
+        membersByAge = membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress)
         membersByAge += m
       }
   }
@@ -233,8 +234,9 @@ final class ClusterSingletonProxy(singletonManagerPath: String, settings: Cluste
    */
   def remove(m: Member): Unit = {
     if (matchingRole(m))
-      trackChange {
-        () ⇒ membersByAge -= m
+      trackChange { () ⇒
+        // filter, it's possible that the upNumber is changed
+        membersByAge = membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress)
       }
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -1740,7 +1740,8 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
     if (m.address == selfAddress)
       context stop self
     else if (matchingRole(m)) {
-      leader -= m
+      // filter, it's possible that the ordering is changed since it based on MemberStatus
+      leader = leader.filterNot(_.uniqueAddress == m.uniqueAddress)
       nodes -= m.address
       weaklyUpNodes -= m.address
       log.debug("adding removed node [{}] from MemberRemoved", m.uniqueAddress)
@@ -1752,8 +1753,9 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
 
   def receiveOtherMemberEvent(m: Member): Unit =
     if (matchingRole(m)) {
-      // update changed status
-      leader = (leader - m) + m
+      // replace, it's possible that the ordering is changed since it based on MemberStatus
+      leader = leader.filterNot(_.uniqueAddress == m.uniqueAddress)
+      leader += m
     }
 
   def receiveUnreachable(m: Member): Unit =


### PR DESCRIPTION
* since the ordering can change based on the member's status
  it's not possible to use ordinary - for removal
* similar issue at a few places where ageOrdering was used