### PR TITLE
Improve Java pubsub example

### DIFF
--- a/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
@@ -82,7 +82,7 @@ public class DistributedPubSubMediatorTest extends JUnitSuite {
         .match(String.class, msg ->
           log.info("Got: {}", msg))
         .match(DistributedPubSubMediator.SubscribeAck.class, msg ->
-          log.info("subscribing"))
+          log.info("subscribed"))
         .build();
     }
   }
@@ -126,8 +126,6 @@ public class DistributedPubSubMediatorTest extends JUnitSuite {
       return receiveBuilder()
         .match(String.class, msg ->
           log.info("Got: {}", msg))
-        .match(DistributedPubSubMediator.SubscribeAck.class, msg ->
-          log.info("subscribing"))
         .build();
     }
 


### PR DESCRIPTION
`Put` does not result in a `SubscribeAck`