### PR TITLE
Elminate race in MultiDcHeartbeatTakingOverSpec

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcHeartbeatTakingOverSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcHeartbeatTakingOverSpec.scala
@@ -109,19 +109,25 @@ abstract class MultiDcHeartbeatTakingOverSpec extends MultiNodeSpec(MultiDcHeart
       enterBarrier("found-expectations")
     }
 
-    "be healthy" taggedAs LongRunningTest in {
+    "be healthy" taggedAs LongRunningTest in within(5.seconds) {
       implicit val sender = observer.ref
       runOn(expectedAlphaHeartbeaterRoles.toList: _*) {
-        selectCrossDcHeartbeatSender ! CrossDcHeartbeatSender.ReportStatus()
-        observer.expectMsgType[CrossDcHeartbeatSender.MonitoringActive](5.seconds)
+        awaitAssert {
+          selectCrossDcHeartbeatSender ! CrossDcHeartbeatSender.ReportStatus()
+          observer.expectMsgType[CrossDcHeartbeatSender.MonitoringActive]
+        }
       }
       runOn(expectedBetaHeartbeaterRoles.toList: _*) {
-        selectCrossDcHeartbeatSender ! CrossDcHeartbeatSender.ReportStatus()
-        observer.expectMsgType[CrossDcHeartbeatSender.MonitoringActive](5.seconds)
+        awaitAssert {
+          selectCrossDcHeartbeatSender ! CrossDcHeartbeatSender.ReportStatus()
+          observer.expectMsgType[CrossDcHeartbeatSender.MonitoringActive]
+        }
       }
       runOn(expectedNoActiveHeartbeatSenderRoles.toList: _*) {
-        selectCrossDcHeartbeatSender ! CrossDcHeartbeatSender.ReportStatus()
-        observer.expectMsgType[CrossDcHeartbeatSender.MonitoringDormant](5.seconds)
+        awaitAssert {
+          selectCrossDcHeartbeatSender ! CrossDcHeartbeatSender.ReportStatus()
+          observer.expectMsgType[CrossDcHeartbeatSender.MonitoringDormant]
+        }
       }
 
       enterBarrier("sunny-weather-done")


### PR DESCRIPTION
I'm not 100% but only thing I could think of was that there is a race so that the `ReportStatus` query message arrives before the heartbeats has been taken over by the expected node. So added retrying to cover that case. Fixes #23371