### PR TITLE
New implementation of expectNoMsg_internal in stream TestKit #23224

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -145,7 +145,7 @@ object TestPublisher {
     /**
      * Expect no messages for a given duration.
      */
-    def expectNoMessage(max: FiniteDuration = probe.testKitSettings.SingleExpectDefaultTimeout): Self = executeAfterSubscription {
+    def expectNoMessage(max: FiniteDuration): Self = executeAfterSubscription {
       probe.expectNoMessage(max)
       self
     }
@@ -594,7 +594,7 @@ object TestSubscriber {
      *
      * Assert that no message is received for the specified time.
      */
-    def expectNoMessage(remaining: FiniteDuration = probe.testKitSettings.SingleExpectDefaultTimeout): Self = {
+    def expectNoMessage(remaining: FiniteDuration): Self = {
       probe.expectNoMessage(remaining)
       self
     }

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -124,7 +124,9 @@ object TestPublisher {
 
     /**
      * Expect no messages.
+     * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(): Self = executeAfterSubscription {
       probe.expectNoMsg()
       self
@@ -132,9 +134,19 @@ object TestPublisher {
 
     /**
      * Expect no messages for a given duration.
+     * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(max: FiniteDuration): Self = executeAfterSubscription {
       probe.expectNoMsg(max)
+      self
+    }
+
+    /**
+     * Expect no messages for a given duration.
+     */
+    def expectNoMessage(max: FiniteDuration = probe.testKitSettings.SingleExpectDefaultTimeout): Self = executeAfterSubscription {
+      probe.expectNoMessage(max)
       self
     }
 
@@ -557,7 +569,9 @@ object TestSubscriber {
      * Fluent DSL
      *
      * Same as `expectNoMsg(remaining)`, but correctly treating the timeFactor.
+     * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(): Self = {
       probe.expectNoMsg()
       self
@@ -567,9 +581,21 @@ object TestSubscriber {
      * Fluent DSL
      *
      * Assert that no message is received for the specified time.
+     * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(remaining: FiniteDuration): Self = {
       probe.expectNoMsg(remaining)
+      self
+    }
+
+    /**
+     * Fluent DSL
+     *
+     * Assert that no message is received for the specified time.
+     */
+    def expectNoMessage(remaining: FiniteDuration = probe.testKitSettings.SingleExpectDefaultTimeout): Self = {
+      probe.expectNoMessage(remaining)
       self
     }
 

--- a/akka-testkit/src/main/mima-filters/2.5.4.backwards.excludes
+++ b/akka-testkit/src/main/mima-filters/2.5.4.backwards.excludes
@@ -1,0 +1,2 @@
+# #23224 TestKit expectNoMsg fix
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.testkit.TestKitBase.expectNoMessage")

--- a/akka-testkit/src/main/mima-filters/2.5.4.backwards.excludes
+++ b/akka-testkit/src/main/mima-filters/2.5.4.backwards.excludes
@@ -1,2 +1,3 @@
 # #23224 TestKit expectNoMsg fix
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.testkit.TestKitBase.expectNoMessage")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.testkit.TestKitBase.expectNoMessage$default$1")

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -625,16 +625,48 @@ trait TestKitBase {
   /**
    * Same as `expectNoMsg(remainingOrDefault)`, but correctly treating the timeFactor.
    */
+  @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
   def expectNoMsg() { expectNoMsg_internal(remainingOrDefault) }
 
   /**
    * Assert that no message is received for the specified time.
+   * NOTE! Supplied value is always dilated.
    */
-  def expectNoMsg(max: FiniteDuration) { expectNoMsg_internal(max.dilated) }
+  @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
+  def expectNoMsg(max: FiniteDuration) {
+    expectNoMsg_internal(max.dilated)
+  }
+
+  /**
+   * Assert that no message is received for the specified time.
+   * Supplied value is not dilated.
+   */
+  def expectNoMessage(max: FiniteDuration = testKitSettings.SingleExpectDefaultTimeout) = {
+    expectNoMsg_internal(max)
+  }
 
   private def expectNoMsg_internal(max: FiniteDuration) {
-    val o = receiveOne(max)
-    assert(o eq null, s"received unexpected message $o")
+    val finish = System.nanoTime() + max.toNanos
+    val pollInterval = 100.millis
+
+    def leftNow = (finish - System.nanoTime()).nanos
+
+    var elem: AnyRef = queue.peekFirst()
+    var left = leftNow
+    while (left.toNanos > 0 && elem == null) {
+      //Use of (left / 2) gives geometric series limited by finish time similar to (1/2)^n limited by 1,
+      //so it is very precise
+      Thread.sleep(
+        pollInterval.toMillis min (left / 2).toMillis
+      )
+      left = leftNow
+      if (left.toNanos > 0) {
+        elem = queue.peekFirst()
+      }
+    }
+    val diff = (max.toNanos - left.toNanos).nanos
+    val m = s"received unexpected message $elem after ${diff.toMillis} millis"
+    assert(elem eq null, m)
     lastWasNoMsg = true
   }
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -641,7 +641,7 @@ trait TestKitBase {
    * Assert that no message is received for the specified time.
    * Supplied value is not dilated.
    */
-  def expectNoMessage(max: FiniteDuration = testKitSettings.SingleExpectDefaultTimeout) = {
+  def expectNoMessage(max: FiniteDuration) = {
     expectNoMsg_internal(max)
   }
 


### PR DESCRIPTION
I've taken in account conversation in #20255, so i suggest deprecate previous version of expectNoMsg and I've added new one without dilation.