### PR TITLE
Replace unnecessary array copying with new unsafe bytestring factory

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -188,7 +188,7 @@ class TcpConnectionSpec extends AkkaSpec("""
         val random = new Random(0)
         val testBytes = new Array[Byte](bufferSize)
         random.nextBytes(testBytes)
-        val testData = ByteString(testBytes)
+        val testData = ByteString.fromArrayUnsafe(testBytes)
 
         val writer = TestProbe()
 
@@ -995,7 +995,7 @@ class TcpConnectionSpec extends AkkaSpec("""
     final val TestSize = 10000 // compile-time constant
 
     def writeCmd(ack: Event) =
-      Write(ByteString(Array.fill[Byte](TestSize)(0)), ack)
+      Write(ByteString.fromArrayUnsafe(Array.fill[Byte](TestSize)(0)), ack)
 
     def closeServerSideAndWaitForClientReadable(fullClose: Boolean = true): Unit = {
       if (fullClose) serverSideChannel.close() else serverSideChannel.socket.shutdownOutput()

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
@@ -145,7 +145,7 @@ class TcpIntegrationSpec extends AkkaSpec("""
 
       object Ack extends Event
 
-      serverHandler.send(serverConnection, Write(ByteString(Array.fill[Byte](100000)(0)), Ack))
+      serverHandler.send(serverConnection, Write(ByteString.fromArrayUnsafe(Array.fill[Byte](100000)(0)), Ack))
       serverHandler.expectMsg(Ack)
 
       expectReceivedData(clientHandler, 100000)

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -28,7 +28,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
     b ← Gen.containerOfN[Array, Byte](n, arbitrary[Byte])
     from ← Gen.choose(0, b.length)
     until ← Gen.choose(from, from max b.length)
-  } yield ByteString(b).slice(from, until)
+  } yield ByteString.fromArrayUnsafe(b).slice(from, until)
 
   implicit val arbitraryByteString: Arbitrary[ByteString] = Arbitrary {
     Gen.sized { s ⇒
@@ -760,7 +760,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
 
       "with a large concatenated bytestring" in {
         // coverage for #20901
-        val original = ByteString(Array.fill[Byte](1000)(1)) ++ ByteString(Array.fill[Byte](1000)(2))
+        val original = ByteString.fromArrayUnsafe(Array.fill[Byte](1000)(1)) ++ ByteString.fromArrayUnsafe(Array.fill[Byte](1000)(2))
 
         deserialize(serialize(original)) shouldEqual original
       }

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
@@ -268,7 +268,7 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem)
     val status = dm.Status.parseFrom(bytes)
     Status(
       status.getEntriesList.asScala.map(e ⇒
-        e.getKey → AkkaByteString(e.getDigest.toByteArray()))(breakOut),
+        e.getKey → AkkaByteString.fromArrayUnsafe(e.getDigest.toByteArray()))(breakOut),
       status.getChunk, status.getTotChunks)
   }
 

--- a/akka-remote/src/main/scala/akka/remote/serialization/PrimitiveSerializers.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/PrimitiveSerializers.scala
@@ -112,7 +112,7 @@ class ByteStringSerializer(val system: ExtendedActorSystem) extends BaseSerializ
   }
 
   override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
-    ByteString(bytes)
+    ByteString.fromArrayUnsafe(bytes)
   }
 
 }

--- a/akka-remote/src/test/scala/akka/remote/serialization/PrimitivesSerializationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/serialization/PrimitivesSerializationSpec.scala
@@ -50,7 +50,7 @@ class PrimitivesSerializationSpec extends AkkaSpec(PrimitivesSerializationSpec.t
     val array1 = new Array[Byte](buffer.remaining())
     buffer.get(array1)
     val array2 = serializer.toBinary(msg)
-    ByteString(array1) should ===(ByteString(array2))
+    ByteString.fromArrayUnsafe(array1) should ===(ByteString.fromArrayUnsafe(array2))
 
     buffer.rewind()
     serializer.fromBinary(buffer, "") should ===(msg)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
@@ -35,7 +35,7 @@ class InputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
   def randomByteString(size: Int): ByteString = {
     val a = new Array[Byte](size)
     ThreadLocalRandom.current().nextBytes(a)
-    ByteString(a)
+    ByteString.fromArrayUnsafe(a)
   }
 
   val byteString = randomByteString(3)
@@ -75,7 +75,7 @@ class InputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
 
       val arr = new Array[Byte](byteString.size + 1)
       inputStream.read(arr) should ===(arr.size - 1)
-      ByteString(arr) should ===(byteString :+ 0)
+      ByteString.fromArrayUnsafe(arr) should ===(byteString :+ 0)
 
       inputStream.close()
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/OutputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/OutputStreamSinkSpec.scala
@@ -28,7 +28,7 @@ class OutputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
       val completion = Source(datas)
         .runWith(StreamConverters.fromOutputStream(() ⇒ new OutputStream {
           override def write(i: Int): Unit = ()
-          override def write(bytes: Array[Byte]): Unit = p.ref ! ByteString(bytes).utf8String
+          override def write(bytes: Array[Byte]): Unit = p.ref ! ByteString.fromArrayUnsafe(bytes).utf8String
         }))
 
       p.expectMsg(datas(0).utf8String)
@@ -53,7 +53,7 @@ class OutputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
       Source.empty
         .runWith(StreamConverters.fromOutputStream(() ⇒ new OutputStream {
           override def write(i: Int): Unit = ()
-          override def write(bytes: Array[Byte]): Unit = p.ref ! ByteString(bytes).utf8String
+          override def write(bytes: Array[Byte]): Unit = p.ref ! ByteString.fromArrayUnsafe(bytes).utf8String
           override def close() = p.ref ! "closed"
         }))
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -62,7 +62,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
     "be able to read a sequence of ByteStrings" in {
       val server = new Server()
       val testInput = (0 to 255).map(ByteString(_))
-      val expectedOutput = ByteString.fromArrayUnsafe((Array.tabulate(256)(_.asInstanceOf[Byte]))
+      val expectedOutput = ByteString.fromArrayUnsafe(Array.tabulate(256)(_.asInstanceOf[Byte]))
 
       val idle = new TcpWriteProbe() // Just register an idle upstream
       val resultFuture =
@@ -447,7 +447,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       val binding = bindingFuture.futureValue
 
       val testInput = (0 to 255).map(ByteString(_))
-      val expectedOutput = ByteString.fromArrayUnsafe((Array.tabulate(256)(_.asInstanceOf[Byte]))
+      val expectedOutput = ByteString.fromArrayUnsafe(Array.tabulate(256)(_.asInstanceOf[Byte]))
       val resultFuture =
         Source(testInput).via(Tcp().outgoingConnection(serverAddress)).runFold(ByteString.empty)((acc, in) ⇒ acc ++ in)
 
@@ -470,7 +470,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       val echoConnection = Tcp().outgoingConnection(serverAddress)
 
       val testInput = (0 to 255).map(ByteString(_))
-      val expectedOutput = ByteString.fromArrayUnsafe((Array.tabulate(256)(_.asInstanceOf[Byte]))
+      val expectedOutput = ByteString.fromArrayUnsafe(Array.tabulate(256)(_.asInstanceOf[Byte]))
 
       val resultFuture =
         Source(testInput)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -50,7 +50,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
     "be able to write a sequence of ByteStrings" in {
       val server = new Server()
       val testInput = (0 to 255).map(ByteString(_))
-      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+      val expectedOutput = ByteString.fromArrayUnsafe(Array.tabulate(256)(_.asInstanceOf[Byte]))
 
       Source(testInput).via(Tcp().outgoingConnection(server.address)).to(Sink.ignore).run()
 
@@ -62,7 +62,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
     "be able to read a sequence of ByteStrings" in {
       val server = new Server()
       val testInput = (0 to 255).map(ByteString(_))
-      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+      val expectedOutput = ByteString.fromArrayUnsafe((Array.tabulate(256)(_.asInstanceOf[Byte]))
 
       val idle = new TcpWriteProbe() // Just register an idle upstream
       val resultFuture =
@@ -447,7 +447,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       val binding = bindingFuture.futureValue
 
       val testInput = (0 to 255).map(ByteString(_))
-      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+      val expectedOutput = ByteString.fromArrayUnsafe((Array.tabulate(256)(_.asInstanceOf[Byte]))
       val resultFuture =
         Source(testInput).via(Tcp().outgoingConnection(serverAddress)).runFold(ByteString.empty)((acc, in) ⇒ acc ++ in)
 
@@ -470,7 +470,7 @@ class TcpSpec extends StreamSpec("akka.stream.materializer.subscription-timeout.
       val echoConnection = Tcp().outgoingConnection(serverAddress)
 
       val testInput = (0 to 255).map(ByteString(_))
-      val expectedOutput = ByteString(Array.tabulate(256)(_.asInstanceOf[Byte]))
+      val expectedOutput = ByteString.fromArrayUnsafe((Array.tabulate(256)(_.asInstanceOf[Byte]))
 
       val resultFuture =
         Source(testInput)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
@@ -112,7 +112,7 @@ abstract class CoderSpec(codecName: String) extends WordSpec with CodecSpecSuppo
 
     "shouldn't produce huge ByteStrings for some input" in {
       val array = Array.fill(10)(1.toByte)
-      val compressed = streamEncode(ByteString(array))
+      val compressed = streamEncode(ByteString.fromArrayUnsafe((array)))
       val limit = 10000
       val resultBs =
         Source.single(compressed)
@@ -134,7 +134,7 @@ abstract class CoderSpec(codecName: String) extends WordSpec with CodecSpecSuppo
       val random = ThreadLocalRandom.current()
       val sizes = Seq.fill(numElements)(random.nextInt(minLength, maxLength))
       def createByteString(size: Int): ByteString =
-        ByteString(Array.fill(size)(1.toByte))
+        ByteString.fromArrayUnsafe((Array.fill(size)(1.toByte))
 
       val sizesAfterRoundtrip =
         Source.fromIterator(() ⇒ sizes.toIterator.map(createByteString))
@@ -159,13 +159,13 @@ abstract class CoderSpec(codecName: String) extends WordSpec with CodecSpecSuppo
   lazy val corruptContent = {
     val content = encode(largeText).toArray
     content(14) = 26.toByte
-    ByteString(content)
+    ByteString.fromArrayUnsafe((content))
   }
 
   def streamEncode(bytes: ByteString): ByteString = {
     val output = new ByteArrayOutputStream()
     val gos = newEncodedOutputStream(output); gos.write(bytes.toArray); gos.close()
-    ByteString(output.toByteArray)
+    ByteString.fromArrayUnsafe((output.toByteArray))
   }
 
   def streamDecode(bytes: ByteString): ByteString = {
@@ -182,7 +182,7 @@ abstract class CoderSpec(codecName: String) extends WordSpec with CodecSpecSuppo
     }
 
     copy(input, output)
-    ByteString(output.toByteArray)
+    ByteString.fromArrayUnsafe(output.toByteArray)
   }
 
   def decodeChunks(input: Source[ByteString, NotUsed]): ByteString =

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CoderSpec.scala
@@ -134,7 +134,7 @@ abstract class CoderSpec(codecName: String) extends WordSpec with CodecSpecSuppo
       val random = ThreadLocalRandom.current()
       val sizes = Seq.fill(numElements)(random.nextInt(minLength, maxLength))
       def createByteString(size: Int): ByteString =
-        ByteString.fromArrayUnsafe((Array.fill(size)(1.toByte))
+        ByteString.fromArrayUnsafe(Array.fill(size)(1.toByte))
 
       val sizesAfterRoundtrip =
         Source.fromIterator(() ⇒ sizes.toIterator.map(createByteString))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
@@ -81,7 +81,7 @@ class FlowGroupBySpec extends StreamSpec {
   def randomByteString(size: Int): ByteString = {
     val a = new Array[Byte](size)
     ThreadLocalRandom.current().nextBytes(a)
-    ByteString(a)
+    ByteString.fromArrayUnsafe(a)
   }
 
   "groupBy" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -17,7 +17,7 @@ class FlowThrottleSpec extends StreamSpec {
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withInputBuffer(1, 1))
 
   def genByteString(length: Int) =
-    ByteString(new Random().shuffle(0 to 255).take(length).map(_.toByte).toArray)
+    ByteString.fromArrayUnsafe((new Random().shuffle(0 to 255).take(length).map(_.toByte).toArray)
 
   "Throttle for single cost elements" must {
     "work for the happy case" in Utils.assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -17,7 +17,7 @@ class FlowThrottleSpec extends StreamSpec {
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withInputBuffer(1, 1))
 
   def genByteString(length: Int) =
-    ByteString.fromArrayUnsafe((new Random().shuffle(0 to 255).take(length).map(_.toByte).toArray)
+    ByteString.fromArrayUnsafe(new Random().shuffle(0 to 255).take(length).map(_.toByte).toArray)
 
   "Throttle for single cost elements" must {
     "work for the happy case" in Utils.assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
@@ -153,7 +153,7 @@ class FramingSpec extends StreamSpec {
     val fieldOffsets = List(0, 1, 2, 3, 15, 16, 31, 32, 44, 107)
 
     def encode(payload: ByteString, fieldOffset: Int, fieldLength: Int, byteOrder: ByteOrder): ByteString = {
-      encodeComplexFrame(payload, fieldOffset, fieldLength, byteOrder, ByteString(new Array[Byte](fieldOffset)), ByteString.empty)
+      encodeComplexFrame(payload, fieldOffset, fieldLength, byteOrder, ByteString.fromArrayUnsafe(new Array[Byte](fieldOffset)), ByteString.empty)
     }
 
     def encodeComplexFrame(
@@ -217,7 +217,7 @@ class FramingSpec extends StreamSpec {
           val payload = referenceChunk.take(length)
           val offsetBytes = offset()
           val tailBytes = if (offsetBytes.length > 0) new Array[Byte](offsetBytes(0)) else Array.empty[Byte]
-          encodeComplexFrame(payload, fieldOffset, fieldLength, byteOrder, ByteString(offsetBytes), ByteString(tailBytes))
+          encodeComplexFrame(payload, fieldOffset, fieldLength, byteOrder, ByteString(offsetBytes), ByteString.fromArrayUnsafe(tailBytes))
         }
 
         Source(encodedFrames)


### PR DESCRIPTION
Not really super useful, most places were in tests, but can't hurt to save some array copies there either otoh.