### PR TITLE
Fix glued Scala/Java code snippet tabs 

### DIFF
--- a/akka-docs/src/main/paradox/scala/actors.md
+++ b/akka-docs/src/main/paradox/scala/actors.md
@@ -986,6 +986,7 @@ Scala
 Java
 :  @@snip [ActorDocTest.java]($code$/java/jdocs/actor/ActorDocTest.java) { #import-gracefulStop #gracefulStop }
 
+
 Scala
 :  @@snip [ActorDocSpec.scala]($code$/scala/docs/actor/ActorDocSpec.scala) { #gracefulStop-actor }
 

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -49,6 +49,7 @@ import static akka.pattern.PatternsCS.gracefulStop;
 import akka.pattern.AskTimeoutException;
 import scala.concurrent.duration.Duration;
 import java.util.concurrent.CompletionStage;
+
 //#import-gracefulStop
 //#import-terminated
 import akka.actor.Terminated;


### PR DESCRIPTION
Refs #23415

Currently the "Graceful Stop" section looks as follows - four tabs in a row but there should be only two.

http://doc.akka.io/docs/akka/current/scala/actors.html#graceful-stop

![image](https://user-images.githubusercontent.com/7414320/28587161-29a05c14-71b1-11e7-9e94-3a0878f24359.png)

Here's how it looks with this change:

https://richard-akka-doc.firebaseapp.com/scala/actors.html#graceful-stop
https://richard-akka-doc.firebaseapp.com/java/actors.html#graceful-stop