### PR TITLE
[WIP] =str #23439 reset references when logic has shutdown

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -550,6 +550,20 @@ import scala.util.control.NonFatal
     try {
       logic.postStop()
       logic.afterPostStop()
+
+      // clear references
+      logics(logic.stageId) = null
+      logic.portToConn.indices.foreach { i ⇒
+        val conn = logic.portToConn(i)
+        if ((conn.portState & (InClosed | OutClosed)) == (InClosed | OutClosed))
+          connections(conn.id) = null
+
+        logic.portToConn(i) = null
+      }
+      logic.hasShutdown = true
+      logic.interpreter = null
+      if (activeStage == logic)
+        activeStage = null
     } catch {
       case NonFatal(e) ⇒
         log.error(e, s"Error during postStop in [{}]: {}", logic.originalStage.getOrElse(logic), e.getMessage)

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -277,6 +277,8 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   // Using common array to reduce overhead for small port counts
   private[stream] val portToConn = new Array[Connection](handlers.length)
 
+  private[stream] var hasShutdown: Boolean = false
+
   /**
    * INTERNAL API
    */
@@ -957,7 +959,9 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   final def getAsyncCallback[T](handler: T ⇒ Unit): AsyncCallback[T] = {
     new AsyncCallback[T] {
       override def invoke(event: T): Unit =
-        interpreter.onAsyncInput(GraphStageLogic.this, event, handler.asInstanceOf[Any ⇒ Unit])
+        if (!hasShutdown)
+          interpreter.onAsyncInput(GraphStageLogic.this, event, handler.asInstanceOf[Any ⇒ Unit])
+      // FIXME: else log something?
     }
   }
 


### PR DESCRIPTION
The idea that a long-running fused GraphStage should make sure not to keep
references to graph stages that have already shut down.

I'm not yet sure if that's to aggressive or if that would work. Would probably also need some extra tests. Let's run it through the PR validation for now.