### PR TITLE
Docs: Persistence: Fix note about sharding and snapshots

### DIFF
--- a/akka-docs/src/main/paradox/scala/persistence.md
+++ b/akka-docs/src/main/paradox/scala/persistence.md
@@ -687,7 +687,7 @@ Since it is acceptable for some applications to not use any snapshotting, it is 
 However, Akka will log a warning message when this situation is detected and then continue to operate until
 an actor tries to store a snapshot, at which point the operation will fail (by replying with an `SaveSnapshotFailure` for example).
 
-Note that the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md)makes use of snapshots. If you decide to use that mode, you'll need to define a snapshot store plugin.
+Note that the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md) makes use of snapshots. If you decide to use that mode, you'll need to define a snapshot store plugin.
 
 @@@
 

--- a/akka-docs/src/main/paradox/scala/persistence.md
+++ b/akka-docs/src/main/paradox/scala/persistence.md
@@ -687,7 +687,7 @@ Since it is acceptable for some applications to not use any snapshotting, it is 
 However, Akka will log a warning message when this situation is detected and then continue to operate until
 an actor tries to store a snapshot, at which point the operation will fail (by replying with an `SaveSnapshotFailure` for example).
 
-Note that @ref:[Cluster Sharding](cluster-sharding.md) is using snapshots, so if you use Cluster Sharding you need to define a snapshot store plugin.
+Note that if you use the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md), you'll need to define a snapshot store plugin.
 
 @@@
 

--- a/akka-docs/src/main/paradox/scala/persistence.md
+++ b/akka-docs/src/main/paradox/scala/persistence.md
@@ -687,7 +687,7 @@ Since it is acceptable for some applications to not use any snapshotting, it is 
 However, Akka will log a warning message when this situation is detected and then continue to operate until
 an actor tries to store a snapshot, at which point the operation will fail (by replying with an `SaveSnapshotFailure` for example).
 
-Note that the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md) makes use of snapshots. If you decide to use that mode, you'll need to define a snapshot store plugin.
+Note that the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md) makes use of snapshots. If you to use that mode, you'll need to define a snapshot store plugin.
 
 @@@
 

--- a/akka-docs/src/main/paradox/scala/persistence.md
+++ b/akka-docs/src/main/paradox/scala/persistence.md
@@ -687,7 +687,7 @@ Since it is acceptable for some applications to not use any snapshotting, it is 
 However, Akka will log a warning message when this situation is detected and then continue to operate until
 an actor tries to store a snapshot, at which point the operation will fail (by replying with an `SaveSnapshotFailure` for example).
 
-Note that the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md) makes use of snapshots. If you to use that mode, you'll need to define a snapshot store plugin.
+Note that the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md) makes use of snapshots. If you use that mode, you'll need to define a snapshot store plugin.
 
 @@@
 

--- a/akka-docs/src/main/paradox/scala/persistence.md
+++ b/akka-docs/src/main/paradox/scala/persistence.md
@@ -687,7 +687,7 @@ Since it is acceptable for some applications to not use any snapshotting, it is 
 However, Akka will log a warning message when this situation is detected and then continue to operate until
 an actor tries to store a snapshot, at which point the operation will fail (by replying with an `SaveSnapshotFailure` for example).
 
-Note that if you use the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md), you'll need to define a snapshot store plugin.
+Note that the "persistence mode" of @ref:[Cluster Sharding](cluster-sharding.md)makes use of snapshots. If you decide to use that mode, you'll need to define a snapshot store plugin.
 
 @@@
 


### PR DESCRIPTION
Since "distributed data" is the default backend for sharding nowadays, no snapshot store plugin is required - unless you use the "persistence mode"..... If I understand correctly, ... 

An alternative fix is to get rid of this note altogether ... 

Thanks and cheer!