### PR TITLE
remove scm from akkaPomExtra, included by sbt-git

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -26,11 +26,13 @@ object Publish extends AutoPlugin {
   )
 
   def akkaPomExtra = {
-    <inceptionYear>2009</inceptionYear>
+    /* The scm info is automatic from the sbt-git plugin
     <scm>
       <url>git://github.com/akka/akka.git</url>
       <connection>scm:git:git@github.com:akka/akka.git</connection>
     </scm>
+    */
+    <inceptionYear>2009</inceptionYear>
     <developers>
       <developer>
         <id>akka-contributors</id>


### PR DESCRIPTION
Same issue in release-2.4 as we had for 2.5.3

(cherry picked from commit 28e98d09883bbf10b2030a852d0035019e287f7d)
