### PR TITLE
=io #23404 stop using sun.net.InetAddressCachePolicy, JDK9 prep

### DIFF
--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
@@ -1,34 +1,68 @@
+/**
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.io
 
-import java.net.{ UnknownHostException, InetAddress }
+import java.net.{ InetAddress, UnknownHostException }
+import java.security.Security
 import java.util.concurrent.TimeUnit
 
 import akka.actor.Actor
 import com.typesafe.config.Config
 
 import scala.collection.immutable
-import sun.net.{ InetAddressCachePolicy ⇒ IACP }
 import akka.util.Helpers.Requiring
 
+import scala.util.Try
+
+/** Respects the settings that can be set on the Java runtime via parameters. */
 class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Actor {
 
-  import IACP.NEVER // 0 constant
+  // Controls the cache policy for successful lookups only
+  private final val CachePolicyProp = "networkaddress.cache.ttl"
+  // Deprecated JVM property key, keeping for legacy compatibility; replaced by CachePolicyProp 
+  private final val CachePolicyPropFallback = "sun.net.inetaddr.ttl"
+
+  // Controls the cache policy for negative lookups only
+  private final val NegativeCachePolicyProp = "networkaddress.cache.negative.ttl"
+  // Deprecated JVM property key, keeping for legacy compatibility; replaced by NegativeCachePolicyProp 
+  private final val NegativeCachePolicyPropFallback = "sun.net.inetaddr.negative.ttl"
+
+  // default values (-1 and 0 are magic numbers, trust them)
+  private final val Forever = -1
+  private final val Never = 0
+  private final val DefaultPositive = 30
+
+  private lazy val cachePolicy: Int = {
+    val n = Try(Security.getProperty(CachePolicyProp).toInt)
+      .orElse(Try(Security.getProperty(CachePolicyPropFallback).toInt))
+      .getOrElse(DefaultPositive) // default
+    if (n < 0) Forever else n
+  }
+
+  private lazy val negativeCachePolicy = {
+    val n = Try(Security.getProperty(NegativeCachePolicyProp).toInt)
+      .orElse(Try(Security.getProperty(NegativeCachePolicyPropFallback).toInt))
+      .getOrElse(0) // default
+    if (n < 0) Forever else n
+  }
 
   private def getTtl(path: String, positive: Boolean): Long =
     config.getString(path) match {
       case "default" ⇒
-        (if (positive) IACP.get else IACP.getNegative) match {
-          case NEVER      ⇒ NEVER
+        (if (positive) cachePolicy else negativeCachePolicy) match {
+          case Never      ⇒ Never
           case n if n > 0 ⇒ TimeUnit.SECONDS.toMillis(n)
           case _          ⇒ Long.MaxValue // forever if negative
         }
       case "forever" ⇒ Long.MaxValue
-      case "never"   ⇒ NEVER
+      case "never"   ⇒ Never
       case _ ⇒ config.getDuration(path, TimeUnit.MILLISECONDS)
         .requiring(_ > 0, s"akka.io.dns.$path must be 'default', 'forever', 'never' or positive duration")
     }
-  val positiveTtl = getTtl("positive-ttl", true)
-  val negativeTtl = getTtl("negative-ttl", false)
+
+  val positiveTtl: Long = getTtl("positive-ttl", positive = true)
+  val negativeTtl: Long = getTtl("negative-ttl", positive = false)
 
   override def receive = {
     case Dns.Resolve(name) ⇒
@@ -37,12 +71,12 @@ class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Acto
         case None ⇒
           try {
             val answer = Dns.Resolved(name, InetAddress.getAllByName(name))
-            if (positiveTtl != NEVER) cache.put(answer, positiveTtl)
+            if (positiveTtl != Never) cache.put(answer, positiveTtl)
             answer
           } catch {
             case e: UnknownHostException ⇒
               val answer = Dns.Resolved(name, immutable.Seq.empty, immutable.Seq.empty)
-              if (negativeTtl != NEVER) cache.put(answer, negativeTtl)
+              if (negativeTtl != Never) cache.put(answer, negativeTtl)
               answer
           }
       }


### PR DESCRIPTION
Resolves #23404 

Mirrored part of logic in http://hg.openjdk.java.net/jdk9/jdk9/jdk/file/6e125fc55925/src/java.base/share/classes/sun/net/InetAddressCachePolicy.java that we used here to extract the properties - it's as simple as using one or the other property basically