### PR TITLE
Hand out temporary loopback addresses from a larger pool

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -828,8 +828,7 @@ class TcpConnectionSpec extends AkkaSpec("""
     "report abort before handler is registered (reproducer from #15033)" in {
       // This test needs the OP_CONNECT workaround on Windows, see original report #15033 and parent ticket #15766
 
-      val port = SocketUtil.temporaryServerAddress().getPort
-      val bindAddress = new InetSocketAddress(port)
+      val bindAddress = SocketUtil.temporaryServerAddress()
       val serverSocket = new ServerSocket(bindAddress.getPort, 100, bindAddress.getAddress)
       val connectionProbe = TestProbe()
 

--- a/akka-remote/src/test/scala/akka/remote/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteDeathWatchSpec.scala
@@ -51,7 +51,7 @@ akka {
     system.eventStream.subscribe(probe.ref, classOf[QuarantinedEvent])
     val rarp = RARP(system).provider
     // pick an unused port
-    val port = SocketUtil.temporaryServerAddress().getPort
+    val port = SocketUtil.temporaryLocalPort()
     // simulate de-serialized ActorRef
     val ref = rarp.resolveActorRef(s"$protocol://OtherSystem@localhost:$port/user/foo/bar#1752527294")
     system.actorOf(Props(new Actor {
@@ -91,7 +91,7 @@ akka {
   "quarantine systems after unsuccessful system message delivery if have not communicated before" in {
     // Synthesize an ActorRef to a remote system this one has never talked to before.
     // This forces ReliableDeliverySupervisor to start with unknown remote system UID.
-    val extinctPath = RootActorPath(Address(protocol, "extinct-system", "localhost", SocketUtil.temporaryServerAddress().getPort)) / "user" / "noone"
+    val extinctPath = RootActorPath(Address(protocol, "extinct-system", "localhost", SocketUtil.temporaryLocalPort())) / "user" / "noone"
     val transport = RARP(system).provider.transport
     val extinctRef = new RemoteActorRef(transport, transport.localAddressForRemote(extinctPath.address),
       extinctPath, Nobody, props = None, deploy = None)

--- a/akka-remote/src/test/scala/akka/remote/artery/AeronSinkSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/AeronSinkSpec.scala
@@ -55,7 +55,7 @@ class AeronSinkSpec extends AkkaSpec with ImplicitSender {
   "AeronSink" must {
 
     "give up sending after given duration" in {
-      val port = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
+      val port = SocketUtil.temporaryLocalPort(udp = true)
       val channel = s"aeron:udp?endpoint=localhost:$port"
 
       Source.fromGraph(new AeronSource(channel, 1, aeron, taskRunner, pool, IgnoreEventSink, 0))

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
@@ -14,7 +14,7 @@ import com.typesafe.config.ConfigFactory
 object HandshakeRetrySpec {
 
   // need the port before systemB is started
-  val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
+  val portB = SocketUtil.temporaryLocalPort(udp = true)
 
   val commonConfig = ConfigFactory.parseString(s"""
      akka.remote.artery.advanced.handshake-timeout = 10s

--- a/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
@@ -26,7 +26,7 @@ object LateConnectSpec {
 
 class LateConnectSpec extends ArteryMultiNodeSpec(LateConnectSpec.config) with ImplicitSender {
 
-  val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
+  val portB = SocketUtil.temporaryLocalPort(udp = true)
   lazy val systemB = newRemoteSystem(
     name = Some("systemB"),
     extraConfig = Some(s"akka.remote.artery.canonical.port = $portB"))

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteActorSelectionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteActorSelectionSpec.scala
@@ -38,10 +38,10 @@ class RemoteActorSelectionSpec extends ArteryMultiNodeSpec with ImplicitSender {
     // TODO fails with not receiving the localGrandchild value, seems to go to dead letters
     "select actors across node boundaries" ignore {
 
-      val remotePort = SocketUtil.temporaryServerAddress(udp = true).getPort
+      val remotePort = SocketUtil.temporaryLocalPort(udp = true)
       val remoteSysName = "remote-" + system.name
 
-      val localPort = SocketUtil.temporaryServerAddress(udp = true).getPort
+      val localPort = SocketUtil.temporaryLocalPort(udp = true)
       val localSysName = "local-" + system.name
 
       def config(port: Int) =

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
@@ -26,7 +26,7 @@ class RemoteConnectionSpec extends ArteryMultiNodeSpec("akka.remote.retry-gate-c
       muteSystem(localSystem)
       val localProbe = new TestProbe(localSystem)
 
-      val remotePort = temporaryServerAddress(udp = true).getPort
+      val remotePort = temporaryLocalPort(udp = true)
 
       // try to talk to it before it is up
       val selection = localSystem.actorSelection(s"akka://$nextGeneratedSystemName@localhost:$remotePort/user/echo")

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
@@ -15,7 +15,7 @@ import akka.remote.RARP
 import akka.remote.RemoteActorRef
 
 object RemoteDeathWatchSpec {
-  val otherPort = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
+  val otherPort = SocketUtil.temporaryLocalPort(udp = true)
 
   val config = ConfigFactory.parseString(s"""
     akka {
@@ -45,7 +45,7 @@ class RemoteDeathWatchSpec extends ArteryMultiNodeSpec(RemoteDeathWatchSpec.conf
     system.eventStream.subscribe(probe.ref, classOf[QuarantinedEvent])
     val rarp = RARP(system).provider
     // pick an unused port
-    val port = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
+    val port = SocketUtil.temporaryLocalPort(udp = true)
     // simulate de-serialized ActorRef
     val ref = rarp.resolveActorRef(s"akka://OtherSystem@localhost:$port/user/foo/bar#1752527294")
 

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 
 object HandshakeShouldDropCompressionTableSpec {
   // need the port before systemB is started
-  val portB = SocketUtil.temporaryServerAddress("localhost", udp = true).getPort
+  val portB = SocketUtil.temporaryLocalPort(udp = true)
 
   val commonConfig = ConfigFactory.parseString(s"""
      akka {

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
@@ -57,7 +57,7 @@ public class TcpTest extends StreamTest {
 
   @Test
   public void mustWorkInHappyCase() throws Exception {
-    final InetSocketAddress serverAddress = SocketUtil.temporaryServerAddress("127.0.0.1", false);
+    final InetSocketAddress serverAddress = SocketUtil.temporaryServerAddress(SocketUtil.RANDOM_LOOPBACK_ADDRESS(), false);
     final Source<IncomingConnection, CompletionStage<ServerBinding>> binding = Tcp.get(system)
         .bind(serverAddress.getHostString(), serverAddress.getPort());
 
@@ -83,7 +83,7 @@ public class TcpTest extends StreamTest {
 
   @Test
   public void mustReportServerBindFailure() throws Exception {
-    final InetSocketAddress serverAddress = SocketUtil.temporaryServerAddress("127.0.0.1", false);
+    final InetSocketAddress serverAddress = SocketUtil.temporaryServerAddress(SocketUtil.RANDOM_LOOPBACK_ADDRESS(), false);
     final Source<IncomingConnection, CompletionStage<ServerBinding>> binding = Tcp.get(system)
         .bind(serverAddress.getHostString(), serverAddress.getPort());
 

--- a/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
@@ -4,6 +4,7 @@
 package akka.testkit
 
 import scala.collection.immutable
+import scala.util.Random
 import java.net.InetSocketAddress
 import java.net.SocketAddress
 import java.nio.channels.DatagramChannel
@@ -25,21 +26,28 @@ object SocketUtil {
     def getLocalPort(): Int
   }
 
-  def temporaryServerAddress(address: String = "127.0.0.1", udp: Boolean = false): InetSocketAddress =
+  val RANDOM_LOOPBACK_ADDRESS = "RANDOM_LOOPBACK_ADDRESS"
+
+  def temporaryServerAddress(address: String = RANDOM_LOOPBACK_ADDRESS, udp: Boolean = false): InetSocketAddress =
     temporaryServerAddresses(1, address, udp).head
 
-  def temporaryServerAddresses(numberOfAddresses: Int, hostname: String = "127.0.0.1", udp: Boolean = false): immutable.IndexedSeq[InetSocketAddress] = {
+  def temporaryServerAddresses(numberOfAddresses: Int, hostname: String = RANDOM_LOOPBACK_ADDRESS, udp: Boolean = false): immutable.IndexedSeq[InetSocketAddress] = {
     Vector.fill(numberOfAddresses) {
       val serverSocket: GeneralSocket =
         if (udp) DatagramChannel.open().socket()
         else ServerSocketChannel.open().socket()
 
-      serverSocket.bind(new InetSocketAddress(hostname, 0))
-      (serverSocket, new InetSocketAddress(hostname, serverSocket.getLocalPort))
+      val address = hostname match {
+        case RANDOM_LOOPBACK_ADDRESS ⇒ s"127.20.${Random.nextInt(256)}.${Random.nextInt(256)}"
+        case other                   ⇒ other
+      }
+
+      serverSocket.bind(new InetSocketAddress(address, 0))
+      (serverSocket, new InetSocketAddress(address, serverSocket.getLocalPort))
     } collect { case (socket, address) ⇒ socket.close(); address }
   }
 
-  def temporaryServerHostnameAndPort(interface: String = "127.0.0.1"): (String, Int) = {
+  def temporaryServerHostnameAndPort(interface: String = RANDOM_LOOPBACK_ADDRESS): (String, Int) = {
     val socketAddress = temporaryServerAddress(interface)
     socketAddress.getHostString → socketAddress.getPort
   }


### PR DESCRIPTION
Might have prevented https://github.com/akka/akka/issues/23528