### PR TITLE
Connect the dots for cross-dc reachability, #23377

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -73,8 +73,7 @@ object ClusterEvent {
         cs.unreachable,
         cs.seenBy,
         cs.leader,
-        cs.roleLeaderMap
-      ))
+        cs.roleLeaderMap))
 
   }
 
@@ -116,6 +115,12 @@ object ClusterEvent {
      */
     def getUnreachable: java.util.Set[Member] =
       scala.collection.JavaConverters.setAsJavaSetConverter(unreachable).asJava
+
+    /**
+     * Java API: All data centers in the cluster
+     */
+    def getUnreachableDataCenters: java.util.Set[String] =
+      scala.collection.JavaConverters.setAsJavaSetConverter(unreachableDataCenters).asJava
 
     /**
      * Java API: get current “seen-by” set.
@@ -556,8 +561,7 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
       leader = membershipState.leader.map(_.address),
       roleLeaderMap = membershipState.latestGossip.allRoles.map(r ⇒
         r → membershipState.roleLeader(r).map(_.address))(collection.breakOut),
-      unreachableDataCenters
-    )
+      unreachableDataCenters)
     receiver ! state
   }
 


### PR DESCRIPTION
* the crossDcFailureDetector was not connected to the reachability table
* additional test by listen for {Reachable/Unreachable}DataCenter events in split spec
* missing Java API for getUnreachableDataCenters in CurrentClusterState

Refs #23377
Refs https://github.com/akka/akka/issues/23313