### PR TITLE
#23484 Guard against double pull

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -298,7 +298,9 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
       override def onPull() = if (isAvailable(in)) {
         sourceOut.push(grab(in))
       } else {
-        pull(in)
+        if (!hasBeenPulled(in)) {
+          pull(in)
+        }
       }
       override def onDownstreamFinish() = {
         if (finishing) {


### PR DESCRIPTION
Fixes #23484

Double pull error became visible when I added `.log(...)` after the restart flow in the test setup.

https://github.com/akka/akka/blob/72b32547ba9df9228e5d635791a4f138a99f6675/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala#L329

Otherwise errors from upstream are not reported by the `TestSink.probe`. Therefore the error was not immediately obvious from the logs.