### PR TITLE
Harden restart of Artery stream with inbound-lanes > 1, #23561

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveInboundStreamRestartWithCompressionInFlightSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveInboundStreamRestartWithCompressionInFlightSpec.scala
@@ -32,7 +32,8 @@ object SurviveInboundStreamRestartWithCompressionInFlightSpec extends MultiNodeC
         akka.loglevel = INFO
         akka.remote.artery {
           enabled = on
-          advanced { 
+          advanced {
+            inbound-lanes = 4
             give-up-system-message-after = 4s
             compression.actor-refs.advertisement-interval = 300ms
             compression.manifests.advertisement-interval = 1 minute
@@ -118,15 +119,20 @@ abstract class SurviveInboundStreamRestartWithCompressionInFlightSpec extends Re
       }
       enterBarrier("inbound-failure-restart-first")
 
-      // we poke the remote system, awaiting its inbound stream recovery, when it should reply
-      awaitAssert(
-        {
-          sendToB ! "alive-again"
-          expectMsg(300.millis, s"${sendToB.path.name}-alive-again")
-        },
-        max = 5.seconds, interval = 500.millis)
-
       runOn(second) {
+        sendToB.tell("trigger", ActorRef.noSender)
+        // when using inbound-lanes > 1 we can't be sure when it's done, another message (e.g. HandshakeReq)
+        // might have triggered the restart
+        Thread.sleep(2000)
+
+        // we poke the remote system, awaiting its inbound stream recovery, then it should reply
+        awaitAssert(
+          {
+            sendToB ! "alive-again"
+            expectMsg(300.millis, s"${sendToB.path.name}-alive-again")
+          },
+          max = 5.seconds, interval = 500.millis)
+
         // we continue sending messages using the "old table".
         // if a new table was being built, it would cause the b to be compressed as 1 causing a wrong reply to come back
         1 to 100 foreach { i ⇒ pingPong(sendToB, s"b$i") }

--- a/akka-remote/src/main/scala/akka/remote/artery/FixedSizePartitionHub.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/FixedSizePartitionHub.scala
@@ -15,7 +15,11 @@ import org.agrona.concurrent.ManyToManyConcurrentArrayQueue
 @InternalApi private[akka] class FixedSizePartitionHub[T](
   partitioner: T ⇒ Int,
   lanes:       Int,
-  bufferSize:  Int) extends PartitionHub[T](() ⇒ (info, elem) ⇒ info.consumerIdByIdx(partitioner(elem)), lanes, bufferSize - 1) {
+  bufferSize:  Int) extends PartitionHub[T](
+  // during tear down or restart it's possible that some streams have been removed
+  // and then we must drop elements (return -1)
+  () ⇒ (info, elem) ⇒ if (info.size < lanes) -1 else info.consumerIdByIdx(partitioner(elem)),
+  lanes, bufferSize - 1) {
   // -1 because of the Completed token
 
   override def createQueue(): PartitionHub.Internal.PartitionQueue =

--- a/akka-remote/src/main/scala/akka/remote/artery/TestStage.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/TestStage.scala
@@ -161,7 +161,9 @@ private[remote] class InboundTestStage(inboundContext: InboundContext, state: Sh
         // InHandler
         override def onPush(): Unit = {
           state.getInboundFailureOnce match {
-            case Some(shouldFailEx) ⇒ failStage(shouldFailEx)
+            case Some(shouldFailEx) ⇒
+              log.info("Fail inbound stream from [{}]: {}", classOf[InboundTestStage].getName, shouldFailEx.getMessage)
+              failStage(shouldFailEx)
             case _ ⇒
               val env = grab(in)
               env.association match {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -602,6 +602,15 @@ class HubSpec extends StreamSpec {
       }
     }
 
+    "drop elements with negative index" in assertAllStagesStopped {
+      val source = Source(0 until 10).runWith(PartitionHub.sink(
+        (size, elem) ⇒ if (elem == 3 || elem == 4) -1 else elem % size, startAfterNrOfConsumers = 2, bufferSize = 8))
+      val result1 = source.runWith(Sink.seq)
+      val result2 = source.runWith(Sink.seq)
+      result1.futureValue should ===((0 to 8 by 2).filterNot(_ == 4))
+      result2.futureValue should ===((1 to 9 by 2).filterNot(_ == 3))
+    }
+
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -173,7 +173,8 @@ object PartitionHub {
    * @param partitioner Function that decides where to route an element. The function takes two parameters;
    *   the first is the number of active consumers and the second is the stream element. The function should
    *   return the index of the selected consumer for the given element, i.e. int greater than or equal to 0
-   *   and less than number of consumers. E.g. `(size, elem) -> Math.abs(elem.hashCode()) % size`.
+   *   and less than number of consumers. E.g. `(size, elem) -> Math.abs(elem.hashCode()) % size`. It's also
+   *   possible to use `-1` to drop the element.
    * @param startAfterNrOfConsumers Elements are buffered until this number of consumers have been connected.
    *   This is only used initially when the stage is starting up, i.e. it is not honored when consumers have
    *   been removed (canceled).


### PR DESCRIPTION
Still something strange remaining that requires investigation before merging this. It looks like the `failStage` is sometimes not propagated to the materialized value Future. Some `println` remaining here. Shouldn't an upstream `failStage` propagate to a downstream `Sink.foreach`?

* when the artery stream with PartitionHub is restarted it can result in that
  some lanes are removed while it is still processing messages, resulting in
  IndexOutOfBoundsException
* added possibility to drop messages in PartitionHub, which is then used Artery
* some race conditions in SurviveInboundStreamRestartWithCompressionInFlightSpec
  when using inbound-lanes > 1