### PR TITLE
Fix wrong link of "Handling blocking operations in Akka HTTP" in Dispatchers page

### DIFF
--- a/akka-docs/build.sbt
+++ b/akka-docs/build.sbt
@@ -29,7 +29,7 @@ paradoxBrowse := {
 paradoxProperties ++= Map(
   "akka.canonical.base_url" -> "http://doc.akka.io/docs/akka/current",
   "github.base_url" -> GitHub.url(version.value), // for links like this: @github[#1](#1) or @github[83986f9](83986f9)
-  "extref.akka.http.base_url" -> "http://doc.akka.io/docs/akka-http/current",
+  "extref.akka.http.base_url" -> "http://doc.akka.io/docs/akka-http/current/%s",
   "extref.wikipedia.base_url" -> "https://en.wikipedia.org/wiki/%s",
   "extref.github.base_url" -> (GitHub.url(version.value) + "/%s"), // for links to our sources
   "extref.samples.base_url" -> "https://github.com/akka/akka-samples/tree/2.5/%s",

--- a/akka-docs/src/main/paradox/scala/dispatchers.md
+++ b/akka-docs/src/main/paradox/scala/dispatchers.md
@@ -351,7 +351,7 @@ they were still served on the default dispatcher.
 This is the recommended way of dealing with any kind of blocking in reactive
 applications.
 
-For a similar discussion specific about Akka HTTP refer to, @extref:[Handling blocking operations in Akka HTTP](akka.http:java/http/handling-blocking-operations-in-akka-http-routes.html#solution-dedicated-dispatcher-for-blocking-operations).
+For a similar discussion specific about Akka HTTP refer to, @scala[@extref[Handling blocking operations in Akka HTTP](akka.http:scala/http/handling-blocking-operations-in-akka-http-routes.html#handling-blocking-operations-in-akka-http)]@java[@extref[Handling blocking operations in Akka HTTP](akka.http:java/http/handling-blocking-operations-in-akka-http-routes.html#handling-blocking-operations-in-akka-http)].
 
 ### Available solutions to blocking operations
 


### PR DESCRIPTION
In Dispatchers [page](http://doc.akka.io/docs/akka/current/scala/dispatchers.html), the link of "Handling blocking operations in Akka HTTP" only directed to [http://doc.akka.io/docs/akka-http/current/](http://doc.akka.io/docs/akka-http/current/) without the rest of path(`{scala, java}/http/handling-blocking-operations-in-akka-http-routes.html#handling-blocking-operations-in-akka-http`).