### PR TITLE
Relax Aeron CNC version check but log a warning.

### DIFF
--- a/akka-remote/src/main/java/akka/remote/artery/AeronErrorLog.java
+++ b/akka-remote/src/main/java/akka/remote/artery/AeronErrorLog.java
@@ -15,6 +15,7 @@
  */
 package akka.remote.artery;
 
+import akka.event.NoLogging;
 import io.aeron.CncFileDescriptor;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
@@ -26,10 +27,6 @@ import akka.util.Helpers;
 
 import java.io.File;
 import java.nio.MappedByteBuffer;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -39,24 +36,26 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class AeronErrorLog
 {
-    private final File cncFile;
     final MappedByteBuffer cncByteBuffer;
-    final DirectBuffer cncMetaDataBuffer;
-    final int cncVersion;
     final AtomicBuffer buffer;
 
+    @Deprecated
     public AeronErrorLog(File cncFile)
     {
-      this.cncFile = cncFile;
+      this(cncFile, NoLogging.getInstance());
+    }
+
+    public AeronErrorLog(File cncFile, LoggingAdapter log)
+    {
       cncByteBuffer = IoUtil.mapExistingFile(cncFile, "cnc");
-      cncMetaDataBuffer = CncFileDescriptor.createMetaDataBuffer(cncByteBuffer);
-      cncVersion = cncMetaDataBuffer.getInt(CncFileDescriptor.cncVersionOffset(0));
+      final DirectBuffer cncMetaDataBuffer = CncFileDescriptor.createMetaDataBuffer(cncByteBuffer);
+      final int cncVersion = cncMetaDataBuffer.getInt(CncFileDescriptor.cncVersionOffset(0));
       buffer = CncFileDescriptor.createErrorLogBuffer(cncByteBuffer, cncMetaDataBuffer);
 
       if (CncFileDescriptor.CNC_VERSION != cncVersion)
       {
-          IoUtil.unmap(cncByteBuffer);
-          throw new IllegalStateException("CNC version not supported: file version=" + cncVersion);
+        log.warning("Aeron CnC version mismatch: compiled version = {}, file version = {}",
+          CncFileDescriptor.CNC_VERSION, cncVersion);
       }
     }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -49,7 +49,6 @@ import akka.stream.ActorMaterializer
 import akka.stream.KillSwitches
 import akka.stream.Materializer
 import akka.stream.SharedKillSwitch
-import akka.stream.scaladsl.BroadcastHub
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
@@ -65,8 +64,6 @@ import org.agrona.ErrorHandler
 import org.agrona.IoUtil
 import org.agrona.concurrent.BackoffIdleStrategy
 import akka.remote.artery.Decoder.InboundCompressionAccess
-import akka.remote.transport.TestTransport
-import com.typesafe.config.ConfigFactory
 
 /**
  * INTERNAL API
@@ -609,7 +606,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
 
   // TODO Add FR Events
   private def startAeronErrorLog(): Unit = {
-    areonErrorLog = new AeronErrorLog(new File(aeronDir, CncFileDescriptor.CNC_FILE))
+    areonErrorLog = new AeronErrorLog(new File(aeronDir, CncFileDescriptor.CNC_FILE), log)
     val lastTimestamp = new AtomicLong(0L)
     import system.dispatcher
     aeronErrorLogTask = system.scheduler.schedule(3.seconds, 5.seconds) {


### PR DESCRIPTION
Relax Aeron CNC version check but log a warning.
This will allow to update Aeron version without needing a new Akka version.