### PR TITLE
Add an ability to specify a hint for an expectMsg method of the TestKit

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -363,6 +363,11 @@ trait TestKitBase {
   def expectMsg[T](obj: T): T = expectMsg_internal(remainingOrDefault, obj)
 
   /**
+    * Same as `expectMsg(remainingOrDefault, obj)`, but correctly treating the timeFactor.
+    */
+  def expectMsg[T](obj: T, hint: String): T = expectMsg_internal(remainingOrDefault, obj, Some(hint))
+
+  /**
    * Receive one message from the test actor and assert that it equals the
    * given object. Wait time is bounded by the given duration, with an
    * AssertionFailure being thrown in case of timeout.

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -222,6 +222,11 @@ class TestKit(system: ActorSystem) {
   def expectMsg[T](obj: T): T = tp.expectMsg(obj)
 
   /**
+   * Same as `expectMsg(remainingOrDefault, obj)`, but correctly treating the timeFactor.
+   */
+  def expectMsg[T](obj: T, hint: String): T = tp.expectMsg(remainingOrDefault, hint, obj)
+
+  /**
    * Receive one message from the test actor and assert that it equals the
    * given object. Wait time is bounded by the given duration, with an
    * AssertionFailure being thrown in case of timeout.


### PR DESCRIPTION
Now it is possible to use a hint without specifying a duration