### PR TITLE
Add customized NPE for null actor system

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Extension.scala
+++ b/akka-actor/src/main/scala/akka/actor/Extension.scala
@@ -75,7 +75,7 @@ trait ExtensionId[T <: Extension] {
    * Returns an instance of the extension identified by this ExtensionId instance.
    */
   def apply(system: ActorSystem): T = {
-    java.util.Objects.requireNonNull(system, "Null system!").registerExtension(this)
+    java.util.Objects.requireNonNull(system, "system must not be null!").registerExtension(this)
   }
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/Extension.scala
+++ b/akka-actor/src/main/scala/akka/actor/Extension.scala
@@ -74,7 +74,9 @@ trait ExtensionId[T <: Extension] {
   /**
    * Returns an instance of the extension identified by this ExtensionId instance.
    */
-  def apply(system: ActorSystem): T = system.registerExtension(this)
+  def apply(system: ActorSystem): T = {
+    java.util.Objects.requireNonNull(system, "Null system!").registerExtension(this)
+  }
 
   /**
    * Returns an instance of the extension identified by this ExtensionId instance.


### PR DESCRIPTION
## Change

Add a customized NPE that indicates that the passed in actor system was null here.  IllegalArgumentException would also be appropriate.

## Rationale

In the HttpApp, there are various hooks that are provided for a running server:

http://doc.akka.io/docs/akka-http/current/scala/http/routing-dsl/HttpApp.html#providing-your-own-actor-system

However, the access to the actor system is controlled by systemReference, which can be null.  If you try accessing `CoordinatedShutdown(systemReference.get())` you'll get 

```
[error] Caused by: java.lang.NullPointerException
[error] at akka.actor.ExtensionId.apply(Extension.scala:77)
[error] at akka.actor.ExtensionId.apply$(Extension.scala:77)
[error] at akka.actor.CoordinatedShutdown$.apply(CoordinatedShutdown.scala:34)
```

Which does not indicate that a null actor system was passed in unless you look at the source code.