### PR TITLE
Add parentheses to startCoroner method call

### DIFF
--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -77,7 +77,7 @@ abstract class AkkaSpec(_system: ActorSystem)
   override val invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
 
   final override def beforeAll {
-    startCoroner
+    startCoroner()
     atStartup()
   }
 


### PR DESCRIPTION
because we call it because of its side-effects