### PR TITLE
Update documentation for testkit fishForSpecificMessage #23608

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -440,7 +440,11 @@ trait TestKitBase {
   }
 
   /**
-   * Same as `fishForMessage`, but gets a different partial function and returns properly typed message.
+   * Waits for specific message that partial function matches while ignoring all other messages coming in the meantime.
+   * Use it to ignore any number of messages while waiting for a specific one.
+   *
+   * @return result of applying partial function to the last received message,
+   *         i.e. the first one for which the partial function is defined
    */
   def fishForSpecificMessage[T](max: Duration = Duration.Undefined, hint: String = "")(f: PartialFunction[Any, T]): T = {
     val _max = remainingOrDilated(max)


### PR DESCRIPTION
As in title - documentation for this method is misleading and doesn't really describe it's behaviour.