### PR TITLE
Make sending messages to dead letters by DistributedPubSubMediator configurable. #23462

### DIFF
--- a/akka-cluster-tools/src/main/resources/reference.conf
+++ b/akka-cluster-tools/src/main/resources/reference.conf
@@ -28,6 +28,9 @@ akka.cluster.pub-sub {
   # Maximum number of elements to transfer in one message when synchronizing the registries.
   # Next chunk will be transferred in next round of gossip.
   max-delta-elements = 3000
+
+  # When a message is published to a topic with no subscribers send it to the dead letters.
+  send-to-dead-letters-when-no-subscribers = on
   
   # The id of the dispatcher to use for DistributedPubSubMediator actors. 
   # If not specified default dispatcher is used.

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -95,6 +95,16 @@ final class DistributedPubSubSettings(
   val maxDeltaElements:                   Int,
   val sendToDeadLettersWhenNoSubscribers: Boolean) extends NoSerializationVerificationNeeded {
 
+  @deprecated("Use the other constructor instead.", "2.5.5")
+  def this(
+    role:              Option[String],
+    routingLogic:      RoutingLogic,
+    gossipInterval:    FiniteDuration,
+    removedTimeToLive: FiniteDuration,
+    maxDeltaElements:  Int) {
+    this(role, routingLogic, gossipInterval, removedTimeToLive, maxDeltaElements, sendToDeadLettersWhenNoSubscribers = true)
+  }
+
   require(
     !routingLogic.isInstanceOf[ConsistentHashingRoutingLogic],
     "'ConsistentHashingRoutingLogic' can't be used by the pub-sub mediator")

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -55,7 +55,8 @@ object DistributedPubSubSettings {
       },
       gossipInterval = config.getDuration("gossip-interval", MILLISECONDS).millis,
       removedTimeToLive = config.getDuration("removed-time-to-live", MILLISECONDS).millis,
-      maxDeltaElements = config.getInt("max-delta-elements"))
+      maxDeltaElements = config.getInt("max-delta-elements"),
+      sendToDeadLettersWhenNoSubscribers = config.getBoolean("send-to-dead-letters-when-no-subscribers"))
 
   /**
    * Java API: Create settings from the default configuration
@@ -84,13 +85,15 @@ object DistributedPubSubSettings {
  * @param removedTimeToLive Removed entries are pruned after this duration
  * @param maxDeltaElements Maximum number of elements to transfer in one message when synchronizing
  *   the registries. Next chunk will be transferred in next round of gossip.
+ * @param sendToDeadLettersWhenNoSubscribers When a message is published to a topic with no subscribers send it to the dead letters.
  */
 final class DistributedPubSubSettings(
-  val role:              Option[String],
-  val routingLogic:      RoutingLogic,
-  val gossipInterval:    FiniteDuration,
-  val removedTimeToLive: FiniteDuration,
-  val maxDeltaElements:  Int) extends NoSerializationVerificationNeeded {
+  val role:                               Option[String],
+  val routingLogic:                       RoutingLogic,
+  val gossipInterval:                     FiniteDuration,
+  val removedTimeToLive:                  FiniteDuration,
+  val maxDeltaElements:                   Int,
+  val sendToDeadLettersWhenNoSubscribers: Boolean) extends NoSerializationVerificationNeeded {
 
   require(
     !routingLogic.isInstanceOf[ConsistentHashingRoutingLogic],
@@ -112,13 +115,17 @@ final class DistributedPubSubSettings(
   def withMaxDeltaElements(maxDeltaElements: Int): DistributedPubSubSettings =
     copy(maxDeltaElements = maxDeltaElements)
 
+  def withSendToDeadLettersWhenNoSubscribers(sendToDeadLetterWhenNoSubscribers: Boolean): DistributedPubSubSettings =
+    copy(sendToDeadLettersWhenNoSubscribers = sendToDeadLetterWhenNoSubscribers)
+
   private def copy(
-    role:              Option[String] = role,
-    routingLogic:      RoutingLogic   = routingLogic,
-    gossipInterval:    FiniteDuration = gossipInterval,
-    removedTimeToLive: FiniteDuration = removedTimeToLive,
-    maxDeltaElements:  Int            = maxDeltaElements): DistributedPubSubSettings =
-    new DistributedPubSubSettings(role, routingLogic, gossipInterval, removedTimeToLive, maxDeltaElements)
+    role:                               Option[String] = role,
+    routingLogic:                       RoutingLogic   = routingLogic,
+    gossipInterval:                     FiniteDuration = gossipInterval,
+    removedTimeToLive:                  FiniteDuration = removedTimeToLive,
+    maxDeltaElements:                   Int            = maxDeltaElements,
+    sendToDeadLettersWhenNoSubscribers: Boolean        = sendToDeadLettersWhenNoSubscribers): DistributedPubSubSettings =
+    new DistributedPubSubSettings(role, routingLogic, gossipInterval, removedTimeToLive, maxDeltaElements, sendToDeadLettersWhenNoSubscribers)
 }
 
 object DistributedPubSubMediator {
@@ -553,10 +560,8 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
           } yield routee).toVector
       }
 
-      if (routees.nonEmpty)
-        Router(routingLogic, routees).route(wrapIfNeeded(msg), sender())
-      else
-        sendToDeadLetters(msg)
+      if (routees.isEmpty) ignoreOrSendToDeadLetters(msg)
+      else Router(routingLogic, routees).route(wrapIfNeeded(msg), sender())
 
     case SendToAll(path, msg, skipSenderNode) ⇒
       publish(path, msg, skipSenderNode)
@@ -607,9 +612,8 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
       val key = mkKey(sender())
       forwardMessages(key, sender())
 
-    case GetTopics ⇒ {
+    case GetTopics ⇒
       sender ! CurrentTopics(getCurrentTopics())
-    }
 
     case msg @ Subscribed(ack, ref) ⇒
       ref ! ack
@@ -711,7 +715,8 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
       sender() ! deltaCount
   }
 
-  private def sendToDeadLetters(msg: Any) = context.system.deadLetters ! DeadLetter(msg, sender(), context.self)
+  private def ignoreOrSendToDeadLetters(msg: Any) =
+    if (settings.sendToDeadLettersWhenNoSubscribers) context.system.deadLetters ! DeadLetter(msg, sender(), context.self)
 
   def publish(path: String, msg: Any, allButSelf: Boolean = false): Unit = {
     val refs = for {
@@ -720,7 +725,7 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
       valueHolder ← bucket.content.get(path)
       ref ← valueHolder.ref
     } yield ref
-    if (refs.isEmpty) sendToDeadLetters(msg)
+    if (refs.isEmpty) ignoreOrSendToDeadLetters(msg)
     else refs.foreach(_.forward(msg))
   }
 
@@ -734,8 +739,9 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
       ref ← valueHolder.routee
     } yield (key, ref)).groupBy(_._1).values
 
-    if (groups.isEmpty) sendToDeadLetters(msg)
-    else {
+    if (groups.isEmpty) {
+      ignoreOrSendToDeadLetters(msg)
+    } else {
       val wrappedMsg = SendToOneSubscriber(msg)
       groups foreach {
         group ⇒

--- a/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/DistributedPubSubMediatorDeadLettersSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/DistributedPubSubMediatorDeadLettersSpec.scala
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.cluster.pubsub
+
+import akka.actor.DeadLetter
+import akka.cluster.pubsub.DistributedPubSubMediator.{ Subscribe, _ }
+import akka.testkit._
+import scala.concurrent.duration._
+
+object DistributedPubSubMediatorDeadLettersSpec {
+  def config(sendToDeadLettersWhenNoSubscribers: Boolean) =
+    s"""
+    akka.loglevel = INFO
+    akka.actor.provider = "cluster"
+    akka.remote.netty.tcp.port=0
+    akka.remote.artery.canonical.port=0
+    akka.remote.log-remote-lifecycle-events = off
+    akka.cluster.pub-sub.send-to-dead-letters-when-no-subscribers = $sendToDeadLettersWhenNoSubscribers
+  """
+}
+
+trait DeadLettersProbe { this: TestKitBase ⇒
+  val deadLettersProbe = TestProbe()
+  system.eventStream.subscribe(deadLettersProbe.ref, classOf[DeadLetter])
+
+  def expectNoDeadLetters(): Unit = deadLettersProbe.expectNoMsg(100.milliseconds)
+  def expectDeadLetter(): Unit = deadLettersProbe.expectMsgClass(classOf[DeadLetter])
+}
+
+class DistributedPubSubMediatorSendingToDeadLettersSpec
+  extends AkkaSpec(DistributedPubSubMediatorDeadLettersSpec.config(sendToDeadLettersWhenNoSubscribers = true))
+  with DeadLettersProbe {
+
+  val mediator = DistributedPubSub(system).mediator
+  val msg = "hello"
+  val testActorPath = testActor.path.toStringWithoutAddress
+
+  "A DistributedPubSubMediator with sending to dead letters enabled" must {
+    "send a message to dead letters" when {
+      "it is published to a topic with no subscribers" in {
+        mediator ! Publish("nowhere", msg)
+        expectDeadLetter()
+      }
+
+      "it is sent to a logical path with no matching actors" in {
+        mediator ! Send("some/random/path", msg, localAffinity = false)
+        expectDeadLetter()
+      }
+
+      "it is sent to all actors at a logical path with no matching actors" in {
+        mediator ! SendToAll("some/random/path", msg)
+        expectDeadLetter()
+      }
+    }
+
+    "not send message to dead letters" when {
+      "it is published to a topic with at least one subscriber" in {
+        mediator ! Subscribe("somewhere", testActor)
+        mediator ! Publish("somewhere", msg)
+        expectNoDeadLetters()
+      }
+
+      "it is sent to a logical path with at least one matching actor" in {
+        mediator ! Put(testActor)
+        mediator ! Send(testActorPath, msg, localAffinity = false)
+        expectNoDeadLetters()
+      }
+
+      "it is sent to all actors at a logical path with at least one matching actor" in {
+        mediator ! Put(testActor)
+        mediator ! SendToAll(testActorPath, msg)
+        expectNoDeadLetters()
+      }
+    }
+  }
+}
+
+class DistributedPubSubMediatorNotSendingToDeadLettersSpec
+  extends AkkaSpec(DistributedPubSubMediatorDeadLettersSpec.config(sendToDeadLettersWhenNoSubscribers = false))
+  with DeadLettersProbe {
+
+  val mediator = DistributedPubSub(system).mediator
+  val msg = "hello"
+  val testActorPath = testActor.path.toStringWithoutAddress
+
+  "A DistributedPubSubMediator with sending to dead letters disabled" must {
+    "not send message to dead letters" when {
+      "it is published to a topic with no subscribers" in {
+        mediator ! Publish("nowhere", msg)
+        expectNoDeadLetters()
+      }
+
+      "it is sent to a logical path with no matching actors" in {
+        mediator ! Send("some/random/path", msg, localAffinity = false)
+        expectNoDeadLetters()
+      }
+
+      "it is sent to all actors at a logical path with no matching actors" in {
+        mediator ! SendToAll("some/random/path", msg)
+        expectNoDeadLetters()
+      }
+
+      "it is published to a topic with at least one subscriber" in {
+        mediator ! Subscribe("somewhere", testActor)
+        mediator ! Publish("somewhere", msg)
+        expectNoDeadLetters()
+      }
+
+      "it is sent to a logical path with at least one matching actor" in {
+        mediator ! Put(testActor)
+        mediator ! Send(testActorPath, msg, localAffinity = false)
+        expectNoDeadLetters()
+      }
+
+      "it is sent to all actors at a logical path with at least one matching actor" in {
+        mediator ! Put(testActor)
+        mediator ! SendToAll(testActorPath, msg)
+        expectNoDeadLetters()
+      }
+    }
+  }
+}

--- a/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/DistributedPubSubMediatorRouterSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/DistributedPubSubMediatorRouterSpec.scala
@@ -1,9 +1,13 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.cluster.pubsub
 
 import akka.testkit._
 import akka.routing.{ ConsistentHashingRoutingLogic, RouterEnvelope }
 import org.scalatest.WordSpecLike
-import akka.actor.{ DeadLetter, ActorRef }
+import akka.actor.ActorRef
 import com.typesafe.config.ConfigFactory
 
 case class WrappedMessage(msg: String) extends RouterEnvelope {
@@ -81,15 +85,6 @@ trait DistributedPubSubMediatorRouterSpec { this: WordSpecLike with TestKit with
 
       mediator ! DistributedPubSubMediator.Unsubscribe("topic", testActor)
       expectMsgClass(classOf[DistributedPubSubMediator.UnsubscribeAck])
-    }
-
-    "send message to dead letters if no recipients available" in {
-
-      val probe = TestProbe()
-      system.eventStream.subscribe(probe.ref, classOf[DeadLetter])
-      mediator ! DistributedPubSubMediator.Publish("nowhere", msg, sendOneMessageToEachGroup = true)
-      probe.expectMsgClass(classOf[DeadLetter])
-      system.eventStream.unsubscribe(probe.ref, classOf[DeadLetter])
     }
   }
 }


### PR DESCRIPTION
I've implemented a configuration property for disabling sending messages to dead letters by DistributedPubSubMediator as proposed in #23462.

Adding a field to DistributedPubSubSettings results in binary compatibility issue reported by MiMa.
```
[info] akka-cluster-tools: found 1 potential binary incompatibilities while checking against com.typesafe.akka:akka-cluster-tools_2.11:2.4.9  (filtered 5)
[error]  * method this(scala.Option,akka.routing.RoutingLogic,scala.concurrent.duration.FiniteDuration,scala.concurrent.duration.FiniteDuration,Int)Unit in class akka.cluster.pubsub.DistributedPubSubSettings does not have a correspondent in current version
```
I'm not sure how it should be handled. Adding a second constructor without that parameter is an option. Is that what I should do?
