### PR TITLE
Docs: Some documentation fixes

### DIFF
--- a/akka-docs/src/main/paradox/scala/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/scala/distributed-pub-sub.md
@@ -229,6 +229,13 @@ sbt
     ```
     @@@
 
+Gradle
+:   @@@vars
+    ```
+    compile group: 'com.typesafe.akka', name: 'akka-cluster-tools_$scala.binary_version$', version: '$akka.version$'
+    ```
+    @@@
+
 Maven
 :   @@@vars
     ```

--- a/akka-docs/src/main/paradox/scala/event-bus.md
+++ b/akka-docs/src/main/paradox/scala/event-bus.md
@@ -1,7 +1,6 @@
 # Event Bus
 
 Originally conceived as a way to send messages to groups of actors, the
-`EventBus` has been generalized into a set of abstract base classes
 `EventBus` has been generalized into a set of @scala[composable traits] @java[abstract base classes]
 implementing a simple interface:
 

--- a/akka-docs/src/main/paradox/scala/fsm.md
+++ b/akka-docs/src/main/paradox/scala/fsm.md
@@ -304,7 +304,7 @@ Java
 
 The parentheses are not actually needed in all cases, but they visually
 distinguish between modifiers and their arguments and therefore make the code
-even more pleasant to read for foreigners.
+even more pleasant to read.
 
 @@@ note
 

--- a/akka-docs/src/main/paradox/scala/multi-jvm-testing.md
+++ b/akka-docs/src/main/paradox/scala/multi-jvm-testing.md
@@ -76,7 +76,7 @@ forked JVM.
 So to create a 3-node test called `Sample`, you can create three applications
 like the following:
 
-```
+```scala
 package sample
 
 object SampleMultiJvmNode1 {
@@ -165,7 +165,7 @@ do this use the same naming convention as above, but create ScalaTest suites
 rather than objects with main methods. You need to have ScalaTest on the
 classpath. Here is a similar example to the one above but using ScalaTest:
 
-```
+```scala
 package sample
 
 import org.scalatest.WordSpec

--- a/akka-docs/src/main/paradox/scala/stream/stream-quickstart.md
+++ b/akka-docs/src/main/paradox/scala/stream/stream-quickstart.md
@@ -412,7 +412,7 @@ prepared Sink using `toMat`]@java[`Sink.fold` will sum all `Integer` elements of
 a `CompletionStage<Integer>`. Next we use the `map` method of `tweets` `Source` which will change each incoming tweet
 into an integer value `1`.  Finally we connect the Flow to the previously prepared Sink using `toMat`].
 
-Remember those mysterious `Mat` type parameters on @scala[``Source[+Out, +Mat]``, `Flow[-In, +Out, +Mat]` and `Sink[-In, +Mat]`]@java[``Source<Out, Mat>``, `Flow<In, Out, Mat>` and `Sink<In, Mat>`]?
+Remember those mysterious `Mat` type parameters on @scala[`Source[+Out, +Mat]`, `Flow[-In, +Out, +Mat]` and `Sink[-In, +Mat]`]@java[`Source<Out, Mat>`, `Flow<In, Out, Mat>` and `Sink<In, Mat>`]?
 They represent the type of values these processing parts return when materialized. When you chain these together,
 you can explicitly combine their materialized values. In our example we used the @scala[`Keep.right`]@java[`Keep.right()`] predefined function,
 which tells the implementation to only care about the materialized type of the stage currently appended to the right.


### PR DESCRIPTION
5 fixes:

- Adds proper syntax highlightning to the code in the "Multi JVM Testing" page
- Streams Quick Start Guide : fixes this [thing](https://imgur.com/a/2XybO) (the @ scala)
- Distributed Pub Sub: add Gradle dependency
- Event bus: remove repeated sentence
- FSM: remove weird usage of word "foreigners"