### PR TITLE
Keep the refuseUid in a better way, #22156

### DIFF
--- a/akka-remote/src/main/mima-filters/2.5.4.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.4.backwards.excludes
@@ -7,3 +7,6 @@ ProblemFilters.exclude[MissingClassProblem]("akka.remote.artery.FastHash$")
 ProblemFilters.exclude[MissingClassProblem]("akka.remote.artery.FastHash")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.EnvelopeBuffer.StringValueFieldOffset")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.EnvelopeBuffer.UsAscii")
+
+#22156 lost refuseUid
+ProblemFilters.exclude[Problem]("akka.remote.EndpointManager*")

--- a/akka-remote/src/test/scala/akka/remote/EndpointRegistrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/EndpointRegistrySpec.scala
@@ -20,9 +20,9 @@ class EndpointRegistrySpec extends AkkaSpec {
 
       reg.writableEndpointWithPolicyFor(address1) should ===(None)
 
-      reg.registerWritableEndpoint(address1, None, None, actorA) should ===(actorA)
+      reg.registerWritableEndpoint(address1, None, actorA) should ===(actorA)
 
-      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Pass(actorA, None, None)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Pass(actorA, None)))
       reg.readOnlyEndpointFor(address1) should ===(None)
       reg.isWritable(actorA) should ===(true)
       reg.isReadOnly(actorA) should ===(false)
@@ -49,10 +49,10 @@ class EndpointRegistrySpec extends AkkaSpec {
       reg.writableEndpointWithPolicyFor(address1) should ===(None)
 
       reg.registerReadOnlyEndpoint(address1, actorA, 1) should ===(actorA)
-      reg.registerWritableEndpoint(address1, None, None, actorB) should ===(actorB)
+      reg.registerWritableEndpoint(address1, None, actorB) should ===(actorB)
 
       reg.readOnlyEndpointFor(address1) should ===(Some((actorA, 1)))
-      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Pass(actorB, None, None)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Pass(actorB, None)))
 
       reg.isWritable(actorA) should ===(false)
       reg.isWritable(actorB) should ===(true)
@@ -66,10 +66,10 @@ class EndpointRegistrySpec extends AkkaSpec {
       val reg = new EndpointRegistry
 
       reg.writableEndpointWithPolicyFor(address1) should ===(None)
-      reg.registerWritableEndpoint(address1, None, None, actorA)
+      reg.registerWritableEndpoint(address1, None, actorA)
       val deadline = Deadline.now
       reg.markAsFailed(actorA, deadline)
-      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline, None)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline)))
       reg.isReadOnly(actorA) should ===(false)
       reg.isWritable(actorA) should ===(false)
     }
@@ -85,8 +85,8 @@ class EndpointRegistrySpec extends AkkaSpec {
     "keep tombstones when removing an endpoint" in {
       val reg = new EndpointRegistry
 
-      reg.registerWritableEndpoint(address1, None, None, actorA)
-      reg.registerWritableEndpoint(address2, None, None, actorB)
+      reg.registerWritableEndpoint(address1, None, actorA)
+      reg.registerWritableEndpoint(address2, None, actorB)
       val deadline = Deadline.now
       reg.markAsFailed(actorA, deadline)
       reg.markAsQuarantined(address2, 42, deadline)
@@ -94,7 +94,7 @@ class EndpointRegistrySpec extends AkkaSpec {
       reg.unregisterEndpoint(actorA)
       reg.unregisterEndpoint(actorB)
 
-      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline, None)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Gated(deadline)))
       reg.writableEndpointWithPolicyFor(address2) should ===(Some(Quarantined(42, deadline)))
 
     }
@@ -102,15 +102,15 @@ class EndpointRegistrySpec extends AkkaSpec {
     "prune outdated Gated directives properly" in {
       val reg = new EndpointRegistry
 
-      reg.registerWritableEndpoint(address1, None, None, actorA)
-      reg.registerWritableEndpoint(address2, None, None, actorB)
+      reg.registerWritableEndpoint(address1, None, actorA)
+      reg.registerWritableEndpoint(address2, None, actorB)
       reg.markAsFailed(actorA, Deadline.now)
       val farInTheFuture = Deadline.now + Duration(60, SECONDS)
       reg.markAsFailed(actorB, farInTheFuture)
       reg.prune()
 
-      reg.writableEndpointWithPolicyFor(address1) should ===(Some(WasGated(None)))
-      reg.writableEndpointWithPolicyFor(address2) should ===(Some(Gated(farInTheFuture, None)))
+      reg.writableEndpointWithPolicyFor(address1) should ===(None)
+      reg.writableEndpointWithPolicyFor(address2) should ===(Some(Gated(farInTheFuture)))
     }
 
     "be able to register Quarantined policy for an address" in {
@@ -122,6 +122,29 @@ class EndpointRegistrySpec extends AkkaSpec {
       reg.isQuarantined(address1, 42) should ===(true)
       reg.isQuarantined(address1, 33) should ===(false)
       reg.writableEndpointWithPolicyFor(address1) should ===(Some(Quarantined(42, deadline)))
+    }
+
+    "keep refuseUid after register new endpoint" in {
+      val reg = new EndpointRegistry
+      val deadline = Deadline.now + 30.minutes
+
+      reg.registerWritableEndpoint(address1, None, actorA)
+      reg.markAsQuarantined(address1, 42, deadline)
+      reg.refuseUid(address1) should ===(Some(42))
+      reg.isQuarantined(address1, 42) should ===(true)
+
+      reg.unregisterEndpoint(actorA)
+      // Quarantined marker is kept so far
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Quarantined(42, deadline)))
+      reg.refuseUid(address1) should ===(Some(42))
+      reg.isQuarantined(address1, 42) should ===(true)
+
+      reg.registerWritableEndpoint(address1, None, actorB)
+      // Quarantined marker is gone
+      reg.writableEndpointWithPolicyFor(address1) should ===(Some(Pass(actorB, None)))
+      // but we still have the refuseUid
+      reg.refuseUid(address1) should ===(Some(42))
+      reg.isQuarantined(address1, 42) should ===(true)
     }
 
   }


### PR DESCRIPTION
* The scenario described in the issue can cause the quarantine marker to
  be lost when creating a new endpoint for that address. Then when later
  creating another endpoint from an inbound connection the uid is considered
  confirmed and Ack message is accepted, triggering the unexpected seq number
  issue.
* The refuseUid was kept in the endpoint policy markers, but that is just very
  complicated and as illustrated by this issue not always safe.
* Instead, keep the refuseUid separately so it's not lost when registering
  new endpoint.
* The purpose of WasGated was only to try to keep the refuseUid (as far as I know),
  and that is not needed any longer.

Refs #22156