### PR TITLE
Drops `Source.combine` instance method (#22452)

### DIFF
--- a/akka-stream/src/main/mima-filters/2.5.5.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.5.backwards.excludes
@@ -1,0 +1,2 @@
+# #22452 scaladsl Source.combine instance method was a pasting accident
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Source.combine")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -160,25 +160,6 @@ final class Source[+Out, +Mat](
    * Converts this Scala DSL element to it's Java DSL counterpart.
    */
   def asJava: javadsl.Source[Out, Mat] = new javadsl.Source(this)
-
-  /**
-   * Combines several sources with fun-in strategy like `Merge` or `Concat` and returns `Source`.
-   */
-  def combine[T, U](first: Source[T, _], second: Source[T, _], rest: Source[T, _]*)(strategy: Int ⇒ Graph[UniformFanInShape[T, U], NotUsed]): Source[U, NotUsed] =
-    Source.fromGraph(GraphDSL.create() { implicit b ⇒
-      import GraphDSL.Implicits._
-      val c = b.add(strategy(rest.size + 2))
-      first ~> c.in(0)
-      second ~> c.in(1)
-
-      @tailrec def combineRest(idx: Int, i: Iterator[Source[T, _]]): SourceShape[U] =
-        if (i.hasNext) {
-          i.next() ~> c.in(idx)
-          combineRest(idx + 1, i)
-        } else SourceShape(c.out)
-
-      combineRest(2, rest.iterator)
-    })
 }
 
 object Source {


### PR DESCRIPTION
It was most likely put there by pasting accident—no equivalents exist on `Sink` or in `javadsl`, and the implementation is identical to the `combine` method on the companion object—which means it discards the source being operated on.