### PR TITLE
Add more doc for framing on tcp streaming

### DIFF
--- a/akka-docs/src/main/paradox/scala/stream/stream-io.md
+++ b/akka-docs/src/main/paradox/scala/stream/stream-io.md
@@ -110,6 +110,19 @@ of the server, and `q` in the case of the client. This is implemented by @scala[
 and concatenating a `Source` with a single `BYE` element which will then be sent after the original source completed]@java[using a custom `GraphStage`
 which completes the stream once it encounters such command].
 
+### Using framing in your protocol
+
+Streaming transport protocols like TCP just pass streams of bytes, and does not know what is a logical chunk of bytes from the
+application's point of view. Often when implementing network protocols you will want to introduce your own framing.
+This can be done in two ways:
+An end-of-frame marker, e.g. end line `\n`, can do framing via `Framing.delimiter`.
+Or a length-field can be used to build a framing protocol.
+There is a bidi implementing this protocol provided by `Framing.simpleFramingProtocol`,
+see
+@scala[[ScalaDoc](http://doc.akka.io/api/akka/current/akka/stream/scaladsl/Framing$.html)]
+@java[[Javadoc](http://doc.akka.io/japi/akka/current/akka/stream/javadsl/Framing.html#simpleFramingProtocol-int-)]
+for more information.
+
 ## Streaming File IO
 
 Akka Streams provide simple Sources and Sinks that can work with `ByteString` instances to perform IO operations

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
@@ -130,7 +130,19 @@ object Framing {
    * Returns a BidiFlow that implements a simple framing protocol. This is a convenience wrapper over [[Framing#lengthField]]
    * and simply attaches a length field header of four bytes (using big endian encoding) to outgoing messages, and decodes
    * such messages in the inbound direction. The decoded messages do not contain the header.
-   *
+   * {{{
+   *       +--------------------------------+
+   *       | Framing BidiFlow               |
+   *       |                                |
+   *       |  +--------------------------+  |
+   * in2 ~~>  |        Decoding          | ~~> out2
+   *       |  +--------------------------+  |
+   *       |                                |
+   *       |  +--------------------------+  |
+   * out1 <~~ |Encoding(Add length field)| <~~ in1
+   *       |  +--------------------------+  |
+   *       +--------------------------------+
+   * }}}
    * This BidiFlow is useful if a simple message framing protocol is needed (for example when TCP is used to send
    * individual messages) but no compatibility with existing protocols is necessary.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -147,6 +147,10 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   /**
    * Creates an [[Tcp.OutgoingConnection]] instance representing a prospective TCP client connection to the given endpoint.
    *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[Framing]] stages.
+   *
    * @param remoteAddress The remote address to connect to
    * @param localAddress  Optional local address for the connection
    * @param options   TCP options for the connections, see [[akka.io.Tcp]] for details
@@ -173,6 +177,10 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   /**
    * Creates an [[Tcp.OutgoingConnection]] without specifying options.
    * It represents a prospective TCP client connection to the given endpoint.
+   *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[Framing]] stages.
    */
   def outgoingConnection(host: String, port: Int): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
     Flow.fromGraph(delegate.outgoingConnection(new InetSocketAddress(host, port))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -93,7 +93,19 @@ object Framing {
    * Returns a BidiFlow that implements a simple framing protocol. This is a convenience wrapper over [[Framing#lengthField]]
    * and simply attaches a length field header of four bytes (using big endian encoding) to outgoing messages, and decodes
    * such messages in the inbound direction. The decoded messages do not contain the header.
-   *
+   * {{{
+   *       +--------------------------------+
+   *       | Framing BidiFlow               |
+   *       |                                |
+   *       |  +--------------------------+  |
+   * in2 ~~>  |        Decoding          | ~~> out2
+   *       |  +--------------------------+  |
+   *       |                                |
+   *       |  +--------------------------+  |
+   * out1 <~~ |Encoding(Add length field)| <~~ in1
+   *       |  +--------------------------+  |
+   *       +--------------------------------+
+   * }}}
    * This BidiFlow is useful if a simple message framing protocol is needed (for example when TCP is used to send
    * individual messages) but no compatibility with existing protocols is necessary.
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -144,6 +144,10 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   /**
    * Creates an [[Tcp.OutgoingConnection]] instance representing a prospective TCP client connection to the given endpoint.
    *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[Framing]] stages.
+   *
    * @param remoteAddress The remote address to connect to
    * @param localAddress  Optional local address for the connection
    * @param options   TCP options for the connections, see [[akka.io.Tcp]] for details
@@ -183,6 +187,10 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   /**
    * Creates an [[Tcp.OutgoingConnection]] without specifying options.
    * It represents a prospective TCP client connection to the given endpoint.
+   *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[Framing]] stages.
    */
   def outgoingConnection(host: String, port: Int): Flow[ByteString, ByteString, Future[OutgoingConnection]] =
     outgoingConnection(InetSocketAddress.createUnresolved(host, port))


### PR DESCRIPTION
Adding doc is more viable to #23325.

This PR contains:
1. add a small section into Streaming Tcp in document.
2. add note and graph to scaladoc and javadoc to better illustrate behaviors.

Please review.