### PR TITLE
Nicer way to determine `snip.akka.base_dir`

### DIFF
--- a/akka-docs/build.sbt
+++ b/akka-docs/build.sbt
@@ -43,7 +43,7 @@ paradoxProperties ++= Map(
   "google.analytics.account" -> "UA-21117439-1",
   "google.analytics.domain.name" -> "akka.io",
   "snip.code.base_dir" -> (sourceDirectory in Test).value.getAbsolutePath,
-  "snip.akka.base_dir" -> ((baseDirectory in Test).value / "..").getAbsolutePath,
+  "snip.akka.base_dir" -> (baseDirectory in ThisBuild).value.getAbsolutePath,
   "fiddle.code.base_dir" -> (sourceDirectory in Test).value.getAbsolutePath
 )
 paradoxGroups := Map("Languages" -> Seq("Scala", "Java"))


### PR DESCRIPTION
Making it consistent with akka-http