### PR TITLE
=str hide deprecated lazy vals behind def in FanInShape et al

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/FanInShape1N.scala
+++ b/akka-stream/src/main/scala/akka/stream/FanInShape1N.scala
@@ -18,9 +18,14 @@ class FanInShape1N[-T0, -T1, +O](val n: Int, _init: FanInShape.Init[O]) extends 
   override def deepCopy(): FanInShape1N[T0, T1, O] = super.deepCopy().asInstanceOf[FanInShape1N[T0, T1, O]]
 
   @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
-  lazy val in1Seq: immutable.IndexedSeq[Inlet[T1 @uncheckedVariance]] = inlets
-    .tail //head is in0
-    .toIndexedSeq.asInstanceOf[immutable.IndexedSeq[Inlet[T1]]]
+  def in1Seq: immutable.IndexedSeq[Inlet[T1 @uncheckedVariance]] = _in1Seq
+
+  // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85
+  private lazy val _in1Seq: immutable.IndexedSeq[Inlet[T1 @uncheckedVariance]] =
+    inlets
+      .tail //head is in0
+      .toIndexedSeq.asInstanceOf[immutable.IndexedSeq[Inlet[T1]]]
+
   def in(n: Int): Inlet[T1 @uncheckedVariance] = {
     require(n > 0, "n must be > 0")
     inlets(n).asInstanceOf[Inlet[T1]]

--- a/akka-stream/src/main/scala/akka/stream/UniformFanInShape.scala
+++ b/akka-stream/src/main/scala/akka/stream/UniformFanInShape.scala
@@ -25,6 +25,9 @@ class UniformFanInShape[-T, +O](val n: Int, _init: FanInShape.Init[O]) extends F
   final override def inlets: immutable.Seq[Inlet[T @uncheckedVariance]] = super.inlets.asInstanceOf[immutable.Seq[Inlet[T]]]
 
   @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
-  lazy val inSeq: immutable.IndexedSeq[Inlet[T @uncheckedVariance]] = inlets.toIndexedSeq
+  def inSeq: immutable.IndexedSeq[Inlet[T @uncheckedVariance]] = _inSeq
+
+  // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85
+  private lazy val _inSeq: immutable.IndexedSeq[Inlet[T @uncheckedVariance]] = inlets.toIndexedSeq
   def in(n: Int): Inlet[T @uncheckedVariance] = inlets(n)
 }

--- a/akka-stream/src/main/scala/akka/stream/UniformFanOutShape.scala
+++ b/akka-stream/src/main/scala/akka/stream/UniformFanOutShape.scala
@@ -26,6 +26,9 @@ class UniformFanOutShape[-I, +O](n: Int, _init: FanOutShape.Init[I @uncheckedVar
 
   @Deprecated
   @deprecated("use 'outlets' or 'out(id)' instead", "2.5.5")
-  lazy val outArray: Array[Outlet[O @uncheckedVariance]] = outlets.toArray
+  def outArray: Array[Outlet[O @uncheckedVariance]] = _outArray
+
+  // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85
+  private lazy val _outArray: Array[Outlet[O @uncheckedVariance]] = outlets.toArray
   def out(n: Int): Outlet[O @uncheckedVariance] = outlets(n)
 }


### PR DESCRIPTION
To avoid genjavadoc issue https://github.com/typesafehub/genjavadoc/issues/85.