### PR TITLE
Patched SharedKillSwitche to prevent memory leaks (without WeakRefs)

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/KillSwitch.scala
+++ b/akka-stream/src/main/scala/akka/stream/KillSwitch.scala
@@ -89,7 +89,7 @@ object KillSwitches {
 
     override val initialAttributes = Attributes.name("breaker")
     override val shape = BidiShape(
-      Inlet[Any]("KillSwitchBidi.in1"), Outlet[Any]("KillSwitchBidi .out1"),
+      Inlet[Any]("KillSwitchBidi.in1"), Outlet[Any]("KillSwitchBidi.out1"),
       Inlet[Any]("KillSwitchBidi.in2"), Outlet[Any]("KillSwitchBidi.out2"))
     override def toString: String = "UniqueKillSwitchBidi"
 


### PR DESCRIPTION
Issue #23622

This is a re-write of PR https://github.com/akka/akka/pull/23623 based on comments.

The `TerminationSignal` tracks listeners and handles synchronization. `TerminationSignal#Listener` is a thin wrapperer around `Promise`, with the main benefit of being able to `unregister()`.
