### PR TITLE
Make NettyTransport#sslHandler overridable.

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -340,7 +340,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
 
   private val associationListenerPromise: Promise[AssociationEventListener] = Promise()
 
-  private def sslHandler(isClient: Boolean): SslHandler = {
+  protected[this] def sslHandler(isClient: Boolean): SslHandler = {
     val handler = NettySSLSupport(settings.SslSettings.get, log, isClient)
     handler.setCloseOnSSLException(true)
     handler


### PR DESCRIPTION
This is to allow end users fine control over Netty SSL settings by extending NettyTransport and overriding sslHandler.

For our use case this includes, but is not limited to, using PEM files instead of JKS.

Qualified package scope is the smallest scope increase that will allow me to do what I want.

Issue #23732