### PR TITLE
Persistence API for Akka Typed, #22273

### DIFF
--- a/akka-typed-tests/src/test/scala/akka/typed/persistence/scaladsl/PersistentActorSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/persistence/scaladsl/PersistentActorSpec.scala
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.typed.persistence.scaladsl
+
+import scala.concurrent.duration._
+
+import akka.typed.ActorRef
+import akka.typed.ActorSystem
+import akka.typed.Behavior
+import akka.typed.TypedSpec
+import akka.typed.scaladsl.Actor
+import akka.typed.scaladsl.AskPattern._
+import akka.typed.scaladsl.adapter._
+import akka.typed.testkit.TestKitSettings
+import akka.typed.testkit.scaladsl._
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
+import akka.util.Timeout
+import akka.typed.persistence.scaladsl.PersistentActor._
+import akka.typed.SupervisorStrategy
+
+object PersistentActorSpec {
+
+  val config = ConfigFactory.parseString("""
+    akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    """)
+
+  sealed trait Command
+  final case object Increment extends Command
+  final case class GetValue(replyTo: ActorRef[State]) extends Command
+
+  sealed trait Event
+  final case class Incremented(delta: Int) extends Event
+
+  final case class State(value: Int, history: Vector[Int])
+
+  def counter(persistenceId: String): Behavior[Command] = {
+    PersistentActor.persistent[Command, Event, State](
+      persistenceId,
+      initialState = State(0, Vector.empty),
+      actions = Actions((cmd, state, ctx) ⇒ cmd match {
+        case Increment ⇒
+          Persist(Incremented(1))
+        case GetValue(replyTo) ⇒
+          replyTo ! state
+          PersistNothing()
+      }),
+      onEvent = (evt, state) ⇒ evt match {
+        case Incremented(delta) ⇒
+          State(state.value + delta, state.history :+ state.value)
+      })
+  }
+
+}
+
+class PersistentActorSpec extends TypedSpec(PersistentActorSpec.config) with Eventually {
+  import PersistentActorSpec._
+
+  trait RealTests extends StartSupport {
+    implicit def system: ActorSystem[TypedSpec.Command]
+    implicit val testSettings = TestKitSettings(system)
+
+    def `persist an event`(): Unit = {
+      val c = start(counter("c1"))
+
+      val probe = TestProbe[State]
+      c ! Increment
+      c ! GetValue(probe.ref)
+      probe.expectMsg(State(1, Vector(0)))
+    }
+
+    def `replay stored events`(): Unit = {
+      val c = start(counter("c2"))
+
+      val probe = TestProbe[State]
+      c ! Increment
+      c ! Increment
+      c ! Increment
+      c ! GetValue(probe.ref)
+      probe.expectMsg(State(3, Vector(0, 1, 2)))
+
+      val c2 = start(counter("c2"))
+      c2 ! GetValue(probe.ref)
+      probe.expectMsg(State(3, Vector(0, 1, 2)))
+      c ! Increment
+      c ! GetValue(probe.ref)
+      probe.expectMsg(State(4, Vector(0, 1, 2, 3)))
+    }
+
+    def `work when wrapped in other behavior`(): Unit = {
+      // FIXME This is a major problem with current implementation. Since the
+      // behavior is running as an untyped PersistentActor it's not possible to
+      // wrap it in Actor.deferred or Actor.supervise
+      pending
+      val behavior = Actor.supervise[Command](counter("c3"))
+        .onFailure(SupervisorStrategy.restartWithBackoff(1.second, 10.seconds, 0.1))
+      val c = start(behavior)
+    }
+
+  }
+
+  object `A PersistentActor (real, adapted)` extends RealTests with AdaptedSystem
+}

--- a/akka-typed-tests/src/test/scala/akka/typed/persistence/scaladsl/PersistentActorSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/persistence/scaladsl/PersistentActorSpec.scala
@@ -42,10 +42,10 @@ object PersistentActorSpec {
   case object Tick
 
   def counter(persistenceId: String): Behavior[Command] = {
-    PersistentActor.persistent[Command, Event, State](
+    PersistentActor.immutable[Command, Event, State](
       persistenceId,
       initialState = State(0, Vector.empty),
-      actions = Actions[Command, Event, State]((cmd, state, ctx) ⇒ cmd match {
+      actions = Actions[Command, Event, State]((ctx, cmd, state) ⇒ cmd match {
         case Increment ⇒
           Persist(Incremented(1))
         case GetValue(replyTo) ⇒
@@ -69,10 +69,10 @@ object PersistentActorSpec {
           Persist(Incremented(100))
       })
         .onSignal {
-          case (Terminated(_), _, _) ⇒
+          case (_, Terminated(_), _) ⇒
             Persist(Incremented(10))
         },
-      onEvent = (evt, state) ⇒ evt match {
+      applyEvent = (evt, state) ⇒ evt match {
         case Incremented(delta) ⇒
           State(state.value + delta, state.history :+ state.value)
       })

--- a/akka-typed-tests/src/test/scala/akka/typed/scaladsl/persistence/ApiTest.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/scaladsl/persistence/ApiTest.scala
@@ -1,0 +1,439 @@
+package akka.typed.scaladsl.persistence
+
+import akka.typed
+
+import scala.concurrent.duration._
+import akka.typed.{ ActorRef, Behavior, ExtensibleBehavior, Signal, Terminated }
+import akka.typed.scaladsl.{ ActorContext, TimerScheduler }
+
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+
+class ApiTest {
+  object TypedPersistentActor {
+
+    sealed abstract class PersistentEffect[+Event, State]() {
+      def andThen(callback: State ⇒ Unit): PersistentEffect[Event, State]
+    }
+
+    case class PersistNothing[Event, State](callbacks: List[State ⇒ Unit] = Nil) extends PersistentEffect[Event, State] {
+      def andThen(callback: State ⇒ Unit) = copy(callbacks = callback :: callbacks)
+    }
+
+    case class Persist[Event, State](event: Event, callbacks: List[State ⇒ Unit] = Nil) extends PersistentEffect[Event, State] {
+      def andThen(callback: State ⇒ Unit) = copy(callbacks = callback :: callbacks)
+    }
+
+    case class Unhandled[Event, State](callbacks: List[State ⇒ Unit] = Nil) extends PersistentEffect[Event, State] {
+      def andThen(callback: State ⇒ Unit) = copy(callbacks = callback :: callbacks)
+    }
+
+    class ActionHandler[Command: ClassTag, Event, State](val handler: ((Any, State, ActorContext[Command]) ⇒ PersistentEffect[Event, State])) {
+      def onSignal(signalHandler: PartialFunction[(Any, State, ActorContext[Command]), PersistentEffect[Event, State]]): ActionHandler[Command, Event, State] =
+        ActionHandler {
+          case (command: Command, state, ctx) ⇒ handler(command, state, ctx)
+          case (signal: Signal, state, ctx)   ⇒ signalHandler.orElse(unhandledSignal).apply((signal, state, ctx))
+          case _                              ⇒ Unhandled()
+        }
+      private val unhandledSignal: PartialFunction[(Any, State, ActorContext[Command]), PersistentEffect[Event, State]] = { case _ ⇒ Unhandled() }
+    }
+    object ActionHandler {
+      def cmd[Command: ClassTag, Event, State](commandHandler: Command ⇒ PersistentEffect[Event, State]): ActionHandler[Command, Event, State] = ???
+      def apply[Command: ClassTag, Event, State](commandHandler: ((Command, State, ActorContext[Command]) ⇒ PersistentEffect[Event, State])): ActionHandler[Command, Event, State] = ???
+      def byState[Command: ClassTag, Event, State](actionHandler: State ⇒ ActionHandler[Command, Event, State]): ActionHandler[Command, Event, State] =
+        new ActionHandler(handler = {
+          case (action, state, ctx) ⇒ actionHandler(state).handler(action, state, ctx)
+        })
+    }
+  }
+
+  object Actor {
+    import TypedPersistentActor._
+
+    class PersistentBehavior[Command, Event, State] extends ExtensibleBehavior[Command] {
+      override def receiveSignal(ctx: typed.ActorContext[Command], msg: Signal): Behavior[Command] = ???
+      override def receiveMessage(ctx: typed.ActorContext[Command], msg: Command): Behavior[Command] = ???
+
+      def onRecoveryComplete(callback: (ActorContext[Command], State) ⇒ Unit): PersistentBehavior[Command, Event, State] = ???
+      def snapshotOnState(predicate: State ⇒ Boolean): PersistentBehavior[Command, Event, State] = ???
+      def snapshotOn(predicate: (State, Event) ⇒ Boolean): PersistentBehavior[Command, Event, State] = ???
+    }
+
+    def persistent[Command, Event, State](
+      persistenceId:  String,
+      initialState:   State,
+      commandHandler: ActionHandler[Command, Event, State],
+      onEvent:        (Event, State) ⇒ State
+    ): PersistentBehavior[Command, Event, State] = ???
+  }
+
+  import TypedPersistentActor._
+
+  import akka.typed.scaladsl.AskPattern._
+  implicit val timeout: akka.util.Timeout = 1.second
+  implicit val scheduler: akka.actor.Scheduler = ???
+  implicit val ec: ExecutionContext = ???
+
+  object Simple {
+    sealed trait MyCommand
+    case class Cmd(data: String) extends MyCommand
+
+    sealed trait MyEvent
+    case class Evt(data: String) extends MyEvent
+
+    case class ExampleState(events: List[String] = Nil)
+
+    Actor.persistent[MyCommand, MyEvent, ExampleState](
+      persistenceId = "sample-id-1",
+
+      initialState = ExampleState(Nil),
+
+      commandHandler = ActionHandler.cmd {
+        case Cmd(data) ⇒ Persist(Evt(data))
+      },
+
+      onEvent = {
+        case (Evt(data), state) ⇒ state.copy(data :: state.events)
+      }
+    )
+  }
+
+  object WithAck {
+    case object Ack
+
+    sealed trait MyCommand
+    case class Cmd(data: String, sender: ActorRef[Ack.type]) extends MyCommand
+
+    sealed trait MyEvent
+    case class Evt(data: String) extends MyEvent
+
+    case class ExampleState(events: List[String] = Nil)
+
+    Actor.persistent[MyCommand, MyEvent, ExampleState](
+      persistenceId = "sample-id-1",
+
+      initialState = ExampleState(Nil),
+
+      commandHandler = ActionHandler.cmd {
+        case Cmd(data, sender) ⇒
+          Persist[MyEvent, ExampleState](Evt(data))
+            .andThen { _ ⇒ { sender ! Ack } }
+      },
+
+      onEvent = {
+        case (Evt(data), state) ⇒ state.copy(data :: state.events)
+      }
+    )
+  }
+
+  object RecoveryComplete {
+    sealed trait Command
+    case class DoSideEffect(data: String) extends Command
+    case class AcknowledgeSideEffect(correlationId: Int) extends Command
+
+    sealed trait Event
+    case class IntentRecorded(correlationId: Int, data: String) extends Event
+    case class SideEffectAcknowledged(correlationId: Int) extends Event
+
+    case class EventsInFlight(nextCorrelationId: Int, dataByCorrelationId: Map[Int, String])
+
+    case class Request(correlationId: Int, data: String, sender: ActorRef[Response])
+    case class Response(correlationId: Int)
+    val sideEffectProcessor: ActorRef[Request] = ???
+
+    def performSideEffect(sender: ActorRef[AcknowledgeSideEffect], correlationId: Int, data: String) = {
+      (sideEffectProcessor ? (Request(correlationId, data, _: ActorRef[Response])))
+        .map(response ⇒ AcknowledgeSideEffect(response.correlationId))
+        .foreach(sender ! _)
+    }
+
+    Actor.persistent[Command, Event, EventsInFlight](
+      persistenceId = "recovery-complete-id",
+
+      initialState = EventsInFlight(0, Map.empty),
+
+      commandHandler = ActionHandler((cmd, state, ctx) ⇒ cmd match {
+        case DoSideEffect(data) ⇒
+          Persist[Event, EventsInFlight](IntentRecorded(state.nextCorrelationId, data)).andThen { _ ⇒
+            performSideEffect(ctx.self, state.nextCorrelationId, data)
+          }
+        case AcknowledgeSideEffect(correlationId) ⇒
+          Persist(SideEffectAcknowledged(correlationId))
+      }),
+
+      onEvent = (evt, state) ⇒ evt match {
+        case IntentRecorded(correlationId, data) ⇒
+          EventsInFlight(
+            nextCorrelationId = correlationId + 1,
+            dataByCorrelationId = state.dataByCorrelationId + (correlationId → data))
+        case SideEffectAcknowledged(correlationId) ⇒
+          state.copy(dataByCorrelationId = state.dataByCorrelationId - correlationId)
+      }).onRecoveryComplete {
+        case (ctx, state) ⇒ {
+          state.dataByCorrelationId.foreach {
+            case (correlationId, data) ⇒ performSideEffect(ctx.self, correlationId, data)
+          }
+        }
+      }
+
+  }
+
+  // Example with 'become'
+  object Become {
+    sealed trait Mood
+    case object Happy extends Mood
+    case object Sad extends Mood
+
+    sealed trait Command
+    case class Greet(name: String) extends Command
+    case object MoodSwing extends Command
+
+    sealed trait Event
+    case class MoodChanged(to: Mood) extends Event
+
+    val b: Behavior[Command] = Actor.persistent[Command, Event, Mood](
+      persistenceId = "myPersistenceId",
+      initialState = Happy,
+      commandHandler = ActionHandler.byState {
+        case Happy ⇒ ActionHandler.cmd {
+          case Greet(whom) ⇒
+            println(s"Super happy to meet you $whom!")
+            PersistNothing()
+          case MoodSwing ⇒ Persist(MoodChanged(Sad))
+        }
+        case Sad ⇒ ActionHandler.cmd {
+          case Greet(whom) ⇒
+            println(s"hi $whom")
+            PersistNothing()
+          case MoodSwing ⇒ Persist(MoodChanged(Happy))
+        }
+      },
+      onEvent = {
+        case (MoodChanged(to), _) ⇒ to
+      }
+    )
+
+    akka.typed.scaladsl.Actor.withTimers((timers: TimerScheduler[Command]) ⇒ {
+      timers.startPeriodicTimer("swing", MoodSwing, 10.seconds)
+      b
+    })
+  }
+
+  // explicit snapshots
+  object ExplicitSnapshots {
+    type Task = String
+
+    sealed trait Command
+    case class RegisterTask(task: Task) extends Command
+    case class TaskDone(task: Task) extends Command
+
+    sealed trait Event
+    case class TaskRegistered(task: Task) extends Event
+    case class TaskRemoved(task: Task) extends Event
+
+    case class State(tasksInFlight: List[Task])
+
+    Actor.persistent[Command, Event, State](
+      persistenceId = "asdf",
+      initialState = State(Nil),
+      commandHandler = ActionHandler.cmd {
+        case RegisterTask(task) ⇒ Persist(TaskRegistered(task))
+        case TaskDone(task)     ⇒ Persist(TaskRemoved(task))
+      },
+      onEvent = (evt, state) ⇒ evt match {
+        case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
+        case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
+      }
+    ).snapshotOnState(_.tasksInFlight.isEmpty)
+  }
+
+  object SpawnChild {
+    type Task = String
+    sealed trait Command
+    case class RegisterTask(task: Task) extends Command
+    case class TaskDone(task: Task) extends Command
+
+    sealed trait Event
+    case class TaskRegistered(task: Task) extends Event
+    case class TaskRemoved(task: Task) extends Event
+
+    case class State(tasksInFlight: List[Task])
+
+    def worker(task: Task): Behavior[Nothing] = ???
+
+    Actor.persistent[Command, Event, State](
+      persistenceId = "asdf",
+      initialState = State(Nil),
+      commandHandler = ActionHandler((cmd, _, ctx) ⇒ cmd match {
+        case RegisterTask(task) ⇒ Persist[Event, State](TaskRegistered(task))
+          .andThen { _ ⇒
+            val child = ctx.spawn[Nothing](worker(task), task)
+            // This assumes *any* termination of the child may trigger a `TaskDone`:
+            ctx.watchWith(child, TaskDone(task))
+          }
+        case TaskDone(task) ⇒ Persist(TaskRemoved(task))
+      }),
+      onEvent = (evt, state) ⇒ evt match {
+        case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
+        case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
+      }
+    )
+  }
+
+  object UsingSignals {
+    type Task = String
+    case class RegisterTask(task: Task)
+
+    sealed trait Event
+    case class TaskRegistered(task: Task) extends Event
+    case class TaskRemoved(task: Task) extends Event
+
+    case class State(tasksInFlight: List[Task])
+
+    def worker(task: Task): Behavior[Nothing] = ???
+
+    Actor.persistent[RegisterTask, Event, State](
+      persistenceId = "asdf",
+      initialState = State(Nil),
+      // The 'onSignal' seems to break type inference here.. not sure if that can be avoided?
+      commandHandler = ActionHandler[RegisterTask, Event, State]((cmd, state, ctx) ⇒ cmd match {
+        case RegisterTask(task) ⇒ Persist[Event, State](TaskRegistered(task))
+          .andThen { _ ⇒
+            val child = ctx.spawn[Nothing](worker(task), task)
+            // This assumes *any* termination of the child may trigger a `TaskDone`:
+            ctx.watch(child)
+          }
+      }).onSignal {
+        case (Terminated(actorRef), _, ctx) ⇒
+          // watchWith (as in the above example) is nicer because it means we don't have to
+          // 'manually' associate the task and the child actor, but we wanted to demonstrate
+          // signals here:
+          Persist(TaskRemoved(actorRef.path.name))
+      },
+      onEvent = (evt, state) ⇒ evt match {
+        case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
+        case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
+      }
+    )
+  }
+
+  object Rehydrating {
+    type Id = String
+
+    sealed trait Command
+    case class AddItem(id: Id) extends Command
+    case class RemoveItem(id: Id) extends Command
+    case class GetTotalPrice(sender: ActorRef[Int]) extends Command
+    /* Internal: */
+    case class GotMetaData(data: MetaData) extends Command
+
+    /**
+     * Items have all kinds of metadata, but we only persist the 'id', and
+     * rehydrate the metadata on recovery from a registry
+     */
+    case class Item(id: Id, name: String, price: Int)
+    case class Basket(items: Seq[Item]) {
+      def updatedWith(data: MetaData): Basket = ???
+    }
+
+    sealed trait Event
+    case class ItemAdded(id: Id) extends Event
+    case class ItemRemoved(id: Id) extends Event
+
+    /*
+      * The metadata registry
+      */
+    case class GetMetaData(id: Id, sender: ActorRef[MetaData])
+    case class MetaData(id: Id, name: String, price: Int)
+    val metadataRegistry: ActorRef[GetMetaData] = ???
+
+    def isFullyHydrated(basket: Basket, ids: List[Id]) = basket.items.map(_.id) == ids
+
+    akka.typed.scaladsl.Actor.deferred { ctx: ActorContext[Command] ⇒
+      var basket = Basket(Nil)
+      var stash: Seq[Command] = Nil
+      val adapt = ctx.spawnAdapter((m: MetaData) ⇒ GotMetaData(m))
+
+      def addItem(id: Id, self: ActorRef[Command]) =
+        Persist[Event, List[Id]](ItemAdded(id)).andThen(_ ⇒
+          metadataRegistry ! GetMetaData(id, adapt)
+        )
+
+      Actor.persistent[Command, Event, List[Id]](
+        persistenceId = "basket-1",
+        initialState = Nil,
+        commandHandler =
+          ActionHandler.byState(state ⇒
+            if (isFullyHydrated(basket, state)) ActionHandler { (cmd, state, ctx) ⇒
+              cmd match {
+                case AddItem(id)    ⇒ addItem(id, ctx.self)
+                case RemoveItem(id) ⇒ Persist(ItemRemoved(id))
+                case GotMetaData(data) ⇒
+                  basket = basket.updatedWith(data); PersistNothing()
+                case GetTotalPrice(sender) ⇒ sender ! basket.items.map(_.price).sum; PersistNothing()
+              }
+            }
+            else ActionHandler { (cmd, state, ctx) ⇒
+              cmd match {
+                case AddItem(id)    ⇒ addItem(id, ctx.self)
+                case RemoveItem(id) ⇒ Persist(ItemRemoved(id))
+                case GotMetaData(data) ⇒
+                  basket = basket.updatedWith(data)
+                  if (isFullyHydrated(basket, state)) {
+                    stash.foreach(ctx.self ! _)
+                    stash = Nil
+                  }
+                  PersistNothing()
+                case cmd: GetTotalPrice ⇒ stash :+= cmd; PersistNothing()
+              }
+            }
+          ),
+        onEvent = (evt, state) ⇒ evt match {
+          case ItemAdded(id)   ⇒ id +: state
+          case ItemRemoved(id) ⇒ state.filter(_ != id)
+        }
+      ).onRecoveryComplete((ctx, state) ⇒ {
+          val ad = ctx.spawnAdapter((m: MetaData) ⇒ GotMetaData(m))
+          state.foreach(id ⇒ metadataRegistry ! GetMetaData(id, ad))
+        })
+    }
+  }
+
+  object FactoringOutEventHandling {
+    sealed trait Mood
+    case object Happy extends Mood
+    case object Sad extends Mood
+
+    case object Ack
+
+    sealed trait Command
+    case class Greet(name: String) extends Command
+    case class CheerUp(sender: ActorRef[Ack.type]) extends Command
+
+    sealed trait Event
+    case class MoodChanged(to: Mood) extends Event
+
+    def changeMoodIfNeeded(currentState: Mood, newMood: Mood): PersistentEffect[Event, Mood] =
+      if (currentState == newMood) PersistNothing()
+      else Persist(MoodChanged(newMood))
+
+    Actor.persistent[Command, Event, Mood](
+      persistenceId = "myPersistenceId",
+      initialState = Sad,
+      commandHandler = ActionHandler { (cmd, state, _) ⇒
+        cmd match {
+          case Greet(whom) ⇒
+            println(s"Hi there, I'm $state!")
+            PersistNothing()
+          case CheerUp(sender) ⇒
+            changeMoodIfNeeded(state, Happy)
+              .andThen { _ ⇒ sender ! Ack }
+        }
+      },
+      onEvent = {
+        case (MoodChanged(to), _) ⇒ to
+      }
+    )
+
+  }
+}

--- a/akka-typed/src/main/scala/akka/typed/internal/ActorCell.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/ActorCell.scala
@@ -20,6 +20,7 @@ import akka.event.Logging.Error
 import akka.event.Logging
 import akka.typed.Behavior.StoppedBehavior
 import akka.util.OptionVal
+import akka.typed.Behavior.UntypedBehavior
 
 /**
  * INTERNAL API
@@ -104,6 +105,8 @@ private[typed] class ActorCell[T](
   protected def ctx: ActorContext[T] = this
 
   override def spawn[U](behavior: Behavior[U], name: String, props: Props): ActorRef[U] = {
+    if (behavior.isInstanceOf[UntypedBehavior[_]])
+      throw new IllegalArgumentException(s"${behavior.getClass.getName} requires untyped ActorSystem")
     if (childrenMap contains name) throw InvalidActorNameException(s"actor name [$name] is not unique")
     if (terminatingMap contains name) throw InvalidActorNameException(s"actor name [$name] is not yet free")
     val dispatcher = props.firstOrElse[DispatcherSelector](DispatcherFromExecutionContext(executionContext))

--- a/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorContextAdapter.scala
@@ -9,6 +9,7 @@ import akka.{ actor ⇒ a }
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContextExecutor
 import akka.annotation.InternalApi
+import akka.typed.Behavior.UntypedBehavior
 
 /**
  * INTERNAL API. Wrapping an [[akka.actor.ActorContext]] as an [[ActorContext]].
@@ -97,12 +98,24 @@ import akka.annotation.InternalApi
     }
 
   def spawnAnonymous[T](ctx: akka.actor.ActorContext, behavior: Behavior[T], props: Props): ActorRef[T] = {
-    Behavior.validateAsInitial(behavior)
-    ActorRefAdapter(ctx.actorOf(PropsAdapter(() ⇒ behavior, props)))
+    behavior match {
+      case b: UntypedBehavior[_] ⇒
+        // TODO dispatcher from props
+        ActorRefAdapter(ctx.actorOf(b.untypedProps))
+      case _ ⇒
+        Behavior.validateAsInitial(behavior)
+        ActorRefAdapter(ctx.actorOf(PropsAdapter(() ⇒ behavior, props)))
+    }
   }
 
   def spawn[T](ctx: akka.actor.ActorContext, behavior: Behavior[T], name: String, props: Props): ActorRef[T] = {
-    Behavior.validateAsInitial(behavior)
-    ActorRefAdapter(ctx.actorOf(PropsAdapter(() ⇒ behavior, props), name))
+    behavior match {
+      case b: UntypedBehavior[_] ⇒
+        // TODO dispatcher from props
+        ActorRefAdapter(ctx.actorOf(b.untypedProps, name))
+      case _ ⇒
+        Behavior.validateAsInitial(behavior)
+        ActorRefAdapter(ctx.actorOf(PropsAdapter(() ⇒ behavior, props), name))
+    }
   }
 }

--- a/akka-typed/src/main/scala/akka/typed/persistence/internal/PersistentActorImpl.scala
+++ b/akka-typed/src/main/scala/akka/typed/persistence/internal/PersistentActorImpl.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.typed.persistence.internal
+
+import akka.actor.Props
+import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.persistence.{ PersistentActor ⇒ UntypedPersistentActor }
+import akka.persistence.RecoveryCompleted
+import akka.persistence.SnapshotOffer
+import akka.typed.Signal
+import akka.typed.internal.adapter.ActorContextAdapter
+import akka.typed.persistence.scaladsl.PersistentActor
+import akka.typed.persistence.scaladsl.PersistentBehavior
+import akka.typed.scaladsl.ActorContext
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object PersistentActorImpl {
+
+  /**
+   * Stop the actor for passivation. `PoisonPill` does not work well
+   * with persistent actors.
+   */
+  case object Stop
+
+  def props[C, E, S](
+    behaviorFactory: () ⇒ PersistentBehavior[C, E, S]): Props =
+    Props(new PersistentActorImpl(behaviorFactory()))
+
+}
+
+/**
+ * INTERNAL API
+ * The `PersistentActor` that runs a `PersistentBehavior`.
+ */
+@InternalApi private[akka] class PersistentActorImpl[C, E, S](
+  behavior: PersistentBehavior[C, E, S]) extends UntypedPersistentActor {
+
+  import PersistentActorImpl._
+  import PersistentActor._
+
+  private val log = Logging(context.system, behavior.getClass)
+
+  override val persistenceId: String = behavior.persistenceId
+
+  private var state: S = behavior.initialState
+
+  private val actions: Actions[C, E, S] = behavior.actions
+
+  private val eventHandler: (E, S) ⇒ S = behavior.onEvent
+
+  private val ctx = new ActorContextAdapter[C](context).asScala
+
+  override def receiveRecover: Receive = {
+    case SnapshotOffer(_, snapshot) ⇒
+      state = snapshot.asInstanceOf[S]
+
+    case RecoveryCompleted ⇒
+      state = behavior.recoveryCompleted(state, ctx)
+
+    case event: E @unchecked ⇒
+      state = applyEvent(state, event)
+  }
+
+  def applyEvent(s: S, event: E): S =
+    eventHandler.apply(event, s)
+
+  private val unhandledSignal: PartialFunction[(Signal, S, ActorContext[C]), PersistentEffect[E, S]] = {
+    case sig ⇒ Unhandled()
+  }
+
+  override def receiveCommand: Receive = {
+    case PersistentActorImpl.Stop ⇒
+      context.stop(self)
+
+    case msg ⇒
+      try {
+        // FIXME sigHandler(state)
+        val effect = msg match {
+          case sig: Signal ⇒
+            actions.sigHandler(state).applyOrElse((sig, state, ctx), unhandledSignal)
+          case cmd: C @unchecked ⇒
+            // FIXME we could make it more safe by using ClassTag for C
+            actions.commandHandler(cmd, state, ctx)
+        }
+
+        effect match {
+          case Persist(event, callbacks) ⇒
+            // apply the event before persist so that validation exception is handled before persisting
+            // the invalid event, in case such validation is implemented in the event handler.
+            state = applyEvent(state, event)
+            persist(event) { _ ⇒
+              callbacks.foreach(_.apply(state))
+            }
+          // FIXME PersistAll
+          case PersistNothing(callbacks) ⇒
+            callbacks.foreach(_.apply(state))
+          case Unhandled(callbacks) ⇒
+            super.unhandled(msg)
+            callbacks.foreach(_.apply(state))
+        }
+      } catch {
+        case e: MatchError ⇒ throw new IllegalStateException(
+          s"Undefined state [${state.getClass.getName}] or handler for [${msg.getClass.getName} " +
+            s"in [${behavior.getClass.getName}] with persistenceId [${persistenceId}]")
+      }
+
+  }
+
+}
+

--- a/akka-typed/src/main/scala/akka/typed/persistence/scaladsl/PersistentActor.scala
+++ b/akka-typed/src/main/scala/akka/typed/persistence/scaladsl/PersistentActor.scala
@@ -50,6 +50,12 @@ object PersistentActor {
       new Actions(commandHandler, Map.empty)
 
     /**
+     * Convenience for simple commands that don't need the state and context.
+     */
+    def command[Command, Event, State](commandHandler: Command ⇒ PersistentEffect[Event, State]): Actions[Command, Event, State] =
+      apply((cmd, _, _) ⇒ commandHandler(cmd))
+
+    /**
      * Select different actions based on current state.
      */
     def byState[Command, Event, State](choice: State ⇒ Actions[Command, Event, State]): Actions[Command, Event, State] =

--- a/akka-typed/src/main/scala/akka/typed/persistence/scaladsl/PersistentActor.scala
+++ b/akka-typed/src/main/scala/akka/typed/persistence/scaladsl/PersistentActor.scala
@@ -3,7 +3,7 @@
  */
 package akka.typed.persistence.scaladsl
 
-import scala.collection.immutable
+import scala.collection.{ immutable ⇒ im }
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.typed.Behavior.UntypedBehavior
@@ -12,58 +12,75 @@ import akka.typed.persistence.internal.PersistentActorImpl
 import akka.typed.scaladsl.ActorContext
 
 object PersistentActor {
-  def persistent[Command, Event, State](
+  /**
+   * Create a `Behavior` for a persistent actor.
+   */
+  def immutable[Command, Event, State](
     persistenceId: String,
     initialState:  State,
     actions:       Actions[Command, Event, State],
-    onEvent:       (Event, State) ⇒ State): PersistentBehavior[Command, Event, State] =
-    new PersistentBehavior(persistenceId, initialState, actions, onEvent,
-      recoveryCompleted = (state, _) ⇒ state)
+    applyEvent:    (Event, State) ⇒ State): PersistentBehavior[Command, Event, State] =
+    persistentEntity(_ ⇒ persistenceId, initialState, actions, applyEvent)
 
-  sealed abstract class PersistentEffect[+Event, State]() {
+  /**
+   * Create a `Behavior` for a persistent actor in Cluster Sharding, when the persistenceId is not known
+   * until the actor is started and typically based on the entityId, which
+   * is the actor name.
+   *
+   * TODO This will not be needed when it can be wrapped in `Actor.deferred`.
+   */
+  def persistentEntity[Command, Event, State](
+    persistenceIdFromActorName: String ⇒ String,
+    initialState:               State,
+    actions:                    Actions[Command, Event, State],
+    applyEvent:                 (Event, State) ⇒ State): PersistentBehavior[Command, Event, State] =
+    new PersistentBehavior(persistenceIdFromActorName, initialState, actions, applyEvent,
+      recoveryCompleted = (_, state) ⇒ state)
+
+  sealed abstract class Effect[+Event, State]() {
     /* All events that will be persisted in this effect */
-    def events: immutable.Seq[Event] = Nil
+    def events: im.Seq[Event] = Nil
 
     /* All side effects that will be performed in this effect */
-    def sideEffects: immutable.Seq[ChainableEffect[_, State]] =
-      if (isInstanceOf[ChainableEffect[_, State]]) immutable.Seq(asInstanceOf[ChainableEffect[_, State]])
+    def sideEffects: im.Seq[ChainableEffect[_, State]] =
+      if (isInstanceOf[ChainableEffect[_, State]]) im.Seq(asInstanceOf[ChainableEffect[_, State]])
       else Nil
 
-    def andThen(sideEffects: ChainableEffect[_, State]*): PersistentEffect[Event, State] =
+    def andThen(sideEffects: ChainableEffect[_, State]*): Effect[Event, State] =
       CompositeEffect(if (events.isEmpty) None else Some(this), sideEffects.toList)
 
     /** Convenience method to register a side effect with just a callback function */
-    def andThen(callback: State ⇒ Unit): PersistentEffect[Event, State] =
+    def andThen(callback: State ⇒ Unit): Effect[Event, State] =
       andThen(SideEffect[Event, State](callback))
   }
 
-  case class CompositeEffect[Event, State](persistingEffect: Option[PersistentEffect[Event, State]], override val sideEffects: immutable.Seq[ChainableEffect[_, State]]) extends PersistentEffect[Event, State] {
+  case class CompositeEffect[Event, State](persistingEffect: Option[Effect[Event, State]], override val sideEffects: im.Seq[ChainableEffect[_, State]]) extends Effect[Event, State] {
     override val events = persistingEffect.map(_.events).getOrElse(Nil)
     override def andThen(additionalSideEffects: ChainableEffect[_, State]*): CompositeEffect[Event, State] =
       copy(sideEffects = sideEffects ++ additionalSideEffects)
   }
   object CompositeEffect {
-    def apply[Event, State](persistAll: PersistAll[Event, State], sideEffects: immutable.Seq[ChainableEffect[_, State]]): CompositeEffect[Event, State] =
+    def apply[Event, State](persistAll: PersistAll[Event, State], sideEffects: im.Seq[ChainableEffect[_, State]]): CompositeEffect[Event, State] =
       CompositeEffect(Some(persistAll), sideEffects)
   }
 
-  case class PersistNothing[Event, State]() extends PersistentEffect[Event, State]
+  case class PersistNothing[Event, State]() extends Effect[Event, State]
 
-  case class Persist[Event, State](event: Event) extends PersistentEffect[Event, State] {
+  case class Persist[Event, State](event: Event) extends Effect[Event, State] {
     override val events = event :: Nil
   }
-  case class PersistAll[Event, State](override val events: immutable.Seq[Event]) extends PersistentEffect[Event, State]
+  case class PersistAll[Event, State](override val events: im.Seq[Event]) extends Effect[Event, State]
 
   trait ChainableEffect[Event, State] {
-    self: PersistentEffect[Event, State] ⇒
+    self: Effect[Event, State] ⇒
   }
-  case class SideEffect[Event, State](effect: State ⇒ Unit) extends PersistentEffect[Event, State] with ChainableEffect[Event, State]
-  case class Stop[Event, State]() extends PersistentEffect[Event, State] with ChainableEffect[Event, State]()
+  case class SideEffect[Event, State](effect: State ⇒ Unit) extends Effect[Event, State] with ChainableEffect[Event, State]
+  case class Stop[Event, State]() extends Effect[Event, State] with ChainableEffect[Event, State]()
 
-  case class Unhandled[Event, State]() extends PersistentEffect[Event, State]
+  case class Unhandled[Event, State]() extends Effect[Event, State]
 
-  type CommandHandler[Command, Event, State] = Function3[Command, State, ActorContext[Command], PersistentEffect[Event, State]]
-  type SignalHandler[Command, Event, State] = PartialFunction[(Signal, State, ActorContext[Command]), PersistentEffect[Event, State]]
+  type CommandHandler[Command, Event, State] = Function3[ActorContext[Command], Command, State, Effect[Event, State]]
+  type SignalHandler[Command, Event, State] = PartialFunction[(ActorContext[Command], Signal, State), Effect[Event, State]]
 
   /**
    * `Actions` defines command handlers and partial function for other signals,
@@ -79,8 +96,8 @@ object PersistentActor {
     /**
      * Convenience for simple commands that don't need the state and context.
      */
-    def command[Command, Event, State](commandHandler: Command ⇒ PersistentEffect[Event, State]): Actions[Command, Event, State] =
-      apply((cmd, _, _) ⇒ commandHandler(cmd))
+    def command[Command, Event, State](commandHandler: Command ⇒ Effect[Event, State]): Actions[Command, Event, State] =
+      apply((_, cmd, _) ⇒ commandHandler(cmd))
 
     /**
      * Select different actions based on current state.
@@ -97,7 +114,7 @@ object PersistentActor {
     choice:        State ⇒ Actions[Command, Event, State],
     signalHandler: SignalHandler[Command, Event, State])
     extends Actions[Command, Event, State](
-      commandHandler = (cmd, state, ctx) ⇒ choice(state).commandHandler(cmd, state, ctx),
+      commandHandler = (ctx, cmd, state) ⇒ choice(state).commandHandler(ctx, cmd, state),
       signalHandler) {
 
     // SignalHandler may be registered in the wrapper or in the wrapped
@@ -136,11 +153,11 @@ object PersistentActor {
 }
 
 class PersistentBehavior[Command, Event, State](
-  val persistenceId:     String,
-  val initialState:      State,
-  val actions:           PersistentActor.Actions[Command, Event, State],
-  val onEvent:           (Event, State) ⇒ State,
-  val recoveryCompleted: (State, ActorContext[Command]) ⇒ State) extends UntypedBehavior[Command] {
+  @InternalApi private[akka] val persistenceIdFromActorName: String ⇒ String,
+  val initialState:                                          State,
+  val actions:                                               PersistentActor.Actions[Command, Event, State],
+  val applyEvent:                                            (Event, State) ⇒ State,
+  val recoveryCompleted:                                     (ActorContext[Command], State) ⇒ State) extends UntypedBehavior[Command] {
   import PersistentActor._
 
   /** INTERNAL API */
@@ -150,18 +167,24 @@ class PersistentBehavior[Command, Event, State](
    * The `callback` function is called to notify the actor that the recovery process
    * is finished.
    */
-  def onRecoveryCompleted(callback: (State, ActorContext[Command]) ⇒ State): PersistentBehavior[Command, Event, State] =
+  def onRecoveryCompleted(callback: (ActorContext[Command], State) ⇒ State): PersistentBehavior[Command, Event, State] =
     copy(recoveryCompleted = callback)
 
-  def snapshotOnState(predicate: State ⇒ Boolean): PersistentBehavior[Command, Event, State] = ??? // FIXME
+  /**
+   * FIXME snapshots are not implemented yet, this is only an API placeholder
+   */
+  def snapshotOnState(predicate: State ⇒ Boolean): PersistentBehavior[Command, Event, State] = ???
 
-  def snapshotOn(predicate: (State, Event) ⇒ Boolean): PersistentBehavior[Command, Event, State] = ??? // FIXME
+  /**
+   * FIXME snapshots are not implemented yet, this is only an API placeholder
+   */
+  def snapshotOn(predicate: (State, Event) ⇒ Boolean): PersistentBehavior[Command, Event, State] = ???
 
   private def copy(
-    persistenceId:     String                                 = persistenceId,
-    initialState:      State                                  = initialState,
-    actions:           Actions[Command, Event, State]         = actions,
-    onEvent:           (Event, State) ⇒ State                 = onEvent,
-    recoveryCompleted: (State, ActorContext[Command]) ⇒ State = recoveryCompleted): PersistentBehavior[Command, Event, State] =
-    new PersistentBehavior(persistenceId, initialState, actions, onEvent, recoveryCompleted)
+    persistenceIdFromActorName: String ⇒ String                        = persistenceIdFromActorName,
+    initialState:               State                                  = initialState,
+    actions:                    Actions[Command, Event, State]         = actions,
+    applyEvent:                 (Event, State) ⇒ State                 = applyEvent,
+    recoveryCompleted:          (ActorContext[Command], State) ⇒ State = recoveryCompleted): PersistentBehavior[Command, Event, State] =
+    new PersistentBehavior(persistenceIdFromActorName, initialState, actions, applyEvent, recoveryCompleted)
 }

--- a/akka-typed/src/main/scala/akka/typed/persistence/scaladsl/PersistentActor.scala
+++ b/akka-typed/src/main/scala/akka/typed/persistence/scaladsl/PersistentActor.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.typed.persistence.scaladsl
+
+import akka.typed
+import akka.typed.scaladsl.ActorContext
+import akka.typed.ExtensibleBehavior
+import akka.typed.Signal
+import akka.typed.Behavior
+import scala.reflect.ClassTag
+import akka.typed.Behavior.UntypedBehavior
+
+object PersistentActor {
+  def persistent[Command, Event, State](
+    persistenceId:  String,
+    initialState:   State,
+    commandHandler: ActionHandler[Command, Event, State],
+    onEvent:        (Event, State) ⇒ State): PersistentBehavior[Command, Event, State] =
+    new PersistentBehavior
+
+  sealed abstract class PersistentEffect[+Event, State]() {
+    def andThen(callback: State ⇒ Unit): PersistentEffect[Event, State]
+  }
+
+  final case class PersistNothing[Event, State](callbacks: List[State ⇒ Unit] = Nil) extends PersistentEffect[Event, State] {
+    def andThen(callback: State ⇒ Unit) = copy(callbacks = callback :: callbacks)
+  }
+
+  case class Persist[Event, State](event: Event, callbacks: List[State ⇒ Unit] = Nil) extends PersistentEffect[Event, State] {
+    def andThen(callback: State ⇒ Unit) = copy(callbacks = callback :: callbacks)
+  }
+
+  case class Unhandled[Event, State](callbacks: List[State ⇒ Unit] = Nil) extends PersistentEffect[Event, State] {
+    def andThen(callback: State ⇒ Unit) = copy(callbacks = callback :: callbacks)
+  }
+
+  class ActionHandler[Command: ClassTag, Event, State](val handler: ((Any, State, ActorContext[Command]) ⇒ PersistentEffect[Event, State])) {
+    def onSignal(signalHandler: PartialFunction[(Any, State, ActorContext[Command]), PersistentEffect[Event, State]]): ActionHandler[Command, Event, State] =
+      ActionHandler {
+        case (command: Command, state, ctx) ⇒ handler(command, state, ctx)
+        case (signal: Signal, state, ctx)   ⇒ signalHandler.orElse(unhandledSignal).apply((signal, state, ctx))
+        case _                              ⇒ Unhandled()
+      }
+    private val unhandledSignal: PartialFunction[(Any, State, ActorContext[Command]), PersistentEffect[Event, State]] = { case _ ⇒ Unhandled() }
+  }
+  object ActionHandler {
+    def cmd[Command: ClassTag, Event, State](commandHandler: Command ⇒ PersistentEffect[Event, State]): ActionHandler[Command, Event, State] = ???
+    def apply[Command: ClassTag, Event, State](commandHandler: ((Command, State, ActorContext[Command]) ⇒ PersistentEffect[Event, State])): ActionHandler[Command, Event, State] =
+      new ActionHandler(commandHandler.asInstanceOf[((Any, State, ActorContext[Command]) ⇒ PersistentEffect[Event, State])])
+    def byState[Command: ClassTag, Event, State](actionHandler: State ⇒ ActionHandler[Command, Event, State]): ActionHandler[Command, Event, State] =
+      new ActionHandler(handler = {
+        case (action, state, ctx) ⇒ actionHandler(state).handler(action, state, ctx)
+      })
+  }
+}
+
+class PersistentBehavior[Command, Event, State] extends ExtensibleBehavior[Command] {
+  override def receiveSignal(ctx: typed.ActorContext[Command], msg: Signal): Behavior[Command] = ???
+  override def receiveMessage(ctx: typed.ActorContext[Command], msg: Command): Behavior[Command] = ???
+
+  def onRecoveryComplete(callback: (ActorContext[Command], State) ⇒ Unit): PersistentBehavior[Command, Event, State] = ???
+  def snapshotOnState(predicate: State ⇒ Boolean): PersistentBehavior[Command, Event, State] = ???
+  def snapshotOn(predicate: (State, Event) ⇒ Boolean): PersistentBehavior[Command, Event, State] = ???
+}

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,8 @@ lazy val typed = akkaModule("akka-typed")
     cluster % "compile->compile;test->test",
     clusterTools,
     clusterSharding,
-    distributedData)
+    distributedData,
+    persistence % "compile->compile;test->test")
 
 lazy val typedTests = akkaModule("akka-typed-tests")
   .dependsOn(typed, typedTestkit % "compile->compile;test->test")


### PR DESCRIPTION
Here is a first stab at a persistence implementation for Akka Typed.

It also includes several examples to illustrate the API, by @raboof .

It's running the Behavior as an untyped PersistentActor to be able to use the difficult implementation from untyped `EventSourced` trait. This has a major limitation. The behavior can't be wrapped in things like `Actor.deferred`, `Actor.supervise`, or `Actor.withTimers`. Because of that limitation this will not be the final approach. I think we have to re-implement the needed parts of `EventSourced` in a real typed `Behavior`. For this sprint, as a prototype, it should be good enough though.

Refs #22273