### PR TITLE
Typed actorref serializer (needed for Cluster Receptionist)

### DIFF
--- a/akka-typed-tests/src/test/scala/akka/typed/cluster/internal/MiscMessageSerializerSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/cluster/internal/MiscMessageSerializerSpec.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.typed.cluster.internal
+
+import akka.serialization.{ SerializationExtension, SerializerWithStringManifest }
+import akka.typed.{ ActorRef, TypedSpec }
+import akka.typed.TypedSpec.Create
+import akka.typed.internal.adapter.ActorSystemAdapter
+import akka.typed.scaladsl.Actor
+import akka.typed.scaladsl.AskPattern._
+import com.typesafe.config.ConfigFactory
+
+object MiscMessageSerializerSpec {
+  def config = ConfigFactory.parseString(
+    """
+      akka.actor {
+        provider = cluster
+        serialize-messages = off
+        allow-java-serialization = true
+      }
+    """)
+}
+
+class MiscMessageSerializerSpec extends TypedSpec(MiscMessageSerializerSpec.config) {
+
+  object `The typed MiscMessageSerializer` {
+
+    def `must serialize and deserialize typed actor refs `(): Unit = {
+
+      val ref = (adaptedSystem ? Create(Actor.empty[Unit], "some-actor")).futureValue
+
+      val serialization = SerializationExtension(ActorSystemAdapter.toUntyped(adaptedSystem))
+
+      val serializer = serialization.findSerializerFor(ref) match {
+        case s: SerializerWithStringManifest ⇒ s
+      }
+
+      val manifest = serializer.manifest(ref)
+      val serialized = serializer.toBinary(ref)
+
+      val result = serializer.fromBinary(serialized, manifest)
+
+      result should ===(ref)
+
+    }
+  }
+
+}

--- a/akka-typed-tests/src/test/scala/akka/typed/cluster/internal/MiscMessageSerializerSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/cluster/internal/MiscMessageSerializerSpec.scala
@@ -19,6 +19,8 @@ object MiscMessageSerializerSpec {
         serialize-messages = off
         allow-java-serialization = true
       }
+      akka.remote.netty.tcp.port = 0
+      akka.remote.artery.canonical.port = 0
     """)
 }
 

--- a/akka-typed/src/main/resources/reference.conf
+++ b/akka-typed/src/main/resources/reference.conf
@@ -28,3 +28,18 @@ akka.typed {
   #
   library-extensions = ${?akka.library-extensions} []
 }
+
+# TODO: move these out somewhere else when doing #23632
+akka.actor {
+  serializers {
+    typed-misc = "akka.typed.cluster.internal.MiscMessageSerializer"
+  }
+  serialization-identifiers {
+    "akka.typed.cluster.internal.MiscMessageSerializer" = 24
+  }
+  serialization-bindings {
+    "akka.typed.ActorRef" = typed-misc
+    "akka.typed.internal.adapter.ActorRefAdapter" = typed-misc
+  }
+
+}

--- a/akka-typed/src/main/resources/reference.conf
+++ b/akka-typed/src/main/resources/reference.conf
@@ -41,5 +41,4 @@ akka.actor {
     "akka.typed.ActorRef" = typed-misc
     "akka.typed.internal.adapter.ActorRefAdapter" = typed-misc
   }
-
 }

--- a/akka-typed/src/main/scala/akka/typed/cluster/ActorRefResolver.scala
+++ b/akka-typed/src/main/scala/akka/typed/cluster/ActorRefResolver.scala
@@ -3,11 +3,16 @@
  */
 package akka.typed.cluster
 
+import java.nio.charset.StandardCharsets
+
 import akka.typed.ActorSystem
 import akka.typed.Extension
 import akka.typed.ExtensionId
 import akka.typed.ActorRef
+import akka.typed.scaladsl.adapter._
 import akka.actor.ExtendedActorSystem
+import akka.annotation.InternalApi
+import akka.serialization.{ BaseSerializer, SerializerWithStringManifest }
 
 object ActorRefResolver extends ExtensionId[ActorRefResolver] {
   def get(system: ActorSystem[_]): ActorRefResolver = apply(system)

--- a/akka-typed/src/main/scala/akka/typed/cluster/internal/MiscMessageSerializer.scala
+++ b/akka-typed/src/main/scala/akka/typed/cluster/internal/MiscMessageSerializer.scala
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.typed.cluster.internal
+
+import java.nio.charset.StandardCharsets
+
+import akka.annotation.InternalApi
+import akka.serialization.{ BaseSerializer, SerializerWithStringManifest }
+import akka.typed.ActorRef
+import akka.typed.cluster.ActorRefResolver
+import akka.typed.internal.adapter.ActorRefAdapter
+import akka.typed.scaladsl.adapter._
+
+@InternalApi
+class MiscMessageSerializer(val system: akka.actor.ExtendedActorSystem) extends SerializerWithStringManifest with BaseSerializer {
+
+  private val resolver = ActorRefResolver(system.toTyped)
+
+  def manifest(o: AnyRef) = o match {
+    case ref: ActorRef[_] ⇒ "a"
+  }
+
+  def toBinary(o: AnyRef) = o match {
+    case ref: ActorRef[_] ⇒ resolver.toSerializationFormat(ref).getBytes(StandardCharsets.UTF_8)
+  }
+
+  def fromBinary(bytes: Array[Byte], manifest: String) = manifest match {
+    case "a" ⇒ resolver.resolveActorRef(new String(bytes, StandardCharsets.UTF_8))
+  }
+
+}


### PR DESCRIPTION
Allows the typed cluster receptionist to work with Java serialisation, for now. Providing actual serialisers for the receptionist is tracked separately in #23687