### PR TITLE
Java 9 Unsafe access to String value type mismatch.

### DIFF
--- a/akka-actor/src/main/scala/akka/util/Unsafe.java
+++ b/akka-actor/src/main/scala/akka/util/Unsafe.java
@@ -4,12 +4,16 @@
 package akka.util;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 
 /**
  * INTERNAL API
  */
 public final class Unsafe {
-    public final static sun.misc.Unsafe instance;
+    public static final sun.misc.Unsafe instance;
+
+    private static final long stringValueFieldOffset;
+    private static final boolean isJavaVersion9Plus;
 
     static {
         try {
@@ -23,8 +27,67 @@ public final class Unsafe {
             }
             if (found == null) throw new IllegalStateException("Can't find instance of sun.misc.Unsafe");
             else instance = found;
+            stringValueFieldOffset = instance.objectFieldOffset(String.class.getDeclaredField("value"));
+
+            // See Oracle section 1.5.3 at:
+            // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
+            final int[] version = Arrays.
+                stream(System.getProperty("java.specification.version").split("\\.")).
+                mapToInt(Integer::parseInt).
+                toArray();
+            final int javaVersion = version[0] == 1 ? version[1] : version[0];
+            isJavaVersion9Plus = javaVersion > 8;
         } catch (Throwable t) {
             throw new ExceptionInInitializerError(t);
         }
+    }
+
+    public static void copyUSAsciiStrToBytes(String str, byte[] bytes) {
+        if (isJavaVersion9Plus) {
+            final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
+            System.arraycopy(chars, 0, bytes, 0, chars.length);
+        } else {
+            final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
+            int i = 0;
+            while (i < chars.length) {
+                bytes[i] = (byte) chars[i++];
+            }
+        }
+    }
+
+    public static int fastHash(String str) {
+        long s0 = 391408;
+        long s1 = 601258;
+        int i = 0;
+
+        if (isJavaVersion9Plus) {
+            final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
+            while (i < chars.length) {
+                long x = s0 ^ (long)chars[i++]; // Mix character into PRNG state
+                long y = s1;
+
+                // Xorshift128+ round
+                s0 = y;
+                x ^= x << 23;
+                y ^= y >>> 26;
+                x ^= x >>> 17;
+                s1 = x ^ y;
+            }
+        } else {
+            final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
+            while (i < chars.length) {
+                long x = s0 ^ (long)chars[i++]; // Mix character into PRNG state
+                long y = s1;
+
+                // Xorshift128+ round
+                s0 = y;
+                x ^= x << 23;
+                y ^= y >>> 26;
+                x ^= x >>> 17;
+                s1 = x ^ y;
+            }
+        }
+
+        return (int)(s0 + s1);
     }
 }

--- a/akka-remote/src/main/mima-filters/2.5.4.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.4.backwards.excludes
@@ -1,3 +1,9 @@
 #23504 compression tables
 ProblemFilters.exclude[MissingClassProblem]("akka.remote.artery.compress.InboundCompression$State$")
 ProblemFilters.exclude[MissingClassProblem]("akka.remote.artery.compress.InboundCompression$State")
+
+#23702 Java 9 Unsafe String access
+ProblemFilters.exclude[MissingClassProblem]("akka.remote.artery.FastHash$")
+ProblemFilters.exclude[MissingClassProblem]("akka.remote.artery.FastHash")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.EnvelopeBuffer.StringValueFieldOffset")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.EnvelopeBuffer.UsAscii")

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -9,7 +9,6 @@ import akka.Done
 import akka.actor.{ EmptyLocalActorRef, _ }
 import akka.event.Logging
 import akka.remote.artery.Decoder.{ AdvertiseActorRefsCompressionTable, AdvertiseClassManifestsCompressionTable, InboundCompressionAccess, InboundCompressionAccessImpl }
-import akka.remote.artery.FlightRecorderEvents.AeronSource_Started
 import akka.remote.artery.SystemMessageDelivery.SystemMessageEnvelope
 import akka.remote.artery.compress.CompressionProtocol._
 import akka.remote.artery.compress._
@@ -17,7 +16,7 @@ import akka.remote.{ MessageSerializer, OversizedPayloadException, RemoteActorRe
 import akka.serialization.{ Serialization, SerializationExtension }
 import akka.stream._
 import akka.stream.stage._
-import akka.util.OptionVal
+import akka.util.{ OptionVal, Unsafe }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
@@ -328,7 +327,7 @@ private[remote] final class ActorRefResolveCacheWithAddress(provider: RemoteActo
   override protected def compute(k: String): InternalActorRef =
     provider.resolveActorRefWithLocalAddress(k, localAddress.address)
 
-  override protected def hash(k: String): Int = FastHash.ofString(k)
+  override protected def hash(k: String): Int = Unsafe.fastHash(k)
 
   override protected def isCacheable(v: InternalActorRef): Boolean = !v.isInstanceOf[EmptyLocalActorRef]
 }

--- a/akka-remote/src/main/scala/akka/remote/artery/LruBoundedCache.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/LruBoundedCache.scala
@@ -3,41 +3,8 @@
  */
 package akka.remote.artery
 
-import akka.util.{ OptionVal, Unsafe }
-
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
-
-/**
- * INTERNAL API
- */
-private[remote] object FastHash {
-
-  // Fast hash based on the 128 bit Xorshift128+ PRNG. Mixes in character bits into the random generator state.
-  def ofString(s: String): Int = {
-    val chars = Unsafe.instance.getObject(s, EnvelopeBuffer.StringValueFieldOffset).asInstanceOf[Array[Char]]
-    var s0: Long = 391408
-    var s1: Long = 601258
-    var i = 0
-
-    while (i < chars.length) {
-      var x = s0 ^ chars(i).toLong // Mix character into PRNG state
-      var y = s1
-
-      // Xorshift128+ round
-      s0 = y
-      x ^= x << 23
-      y ^= (y >>> 26)
-      x ^= (x >>> 17)
-      s1 = x ^ y
-
-      i += 1
-    }
-
-    (s0 + s1).toInt
-  }
-
-}
 
 /**
  * INTERNAL API
@@ -219,6 +186,6 @@ private[akka] abstract class LruBoundedCache[K: ClassTag, V <: AnyRef: ClassTag]
       s" values = ${values.mkString("[", ",", "]")}," +
       s" hashes = ${hashes.map(_ & Mask).mkString("[", ",", "]")}," +
       s" epochs = ${epochs.mkString("[", ",", "]")}," +
-      s" distances = ${(0 until hashes.length).map(probeDistanceOf).mkString("[", ",", "]")}," +
+      s" distances = ${hashes.indices.map(probeDistanceOf).mkString("[", ",", "]")}," +
       s" $epoch)"
 }

--- a/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
@@ -11,8 +11,8 @@ import akka.actor.Extension
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.remote.RemoteActorRefProvider
-import akka.remote.artery.FastHash
 import akka.remote.artery.LruBoundedCache
+import akka.util.Unsafe
 
 /**
  * INTERNAL API: Thread local cache per actor system
@@ -58,7 +58,7 @@ private[akka] final class ActorRefResolveCache(provider: RemoteActorRefProvider)
   override protected def compute(k: String): ActorRef =
     provider.internalResolveActorRef(k)
 
-  override protected def hash(k: String): Int = FastHash.ofString(k)
+  override protected def hash(k: String): Int = Unsafe.fastHash(k)
 
   override protected def isCacheable(v: ActorRef): Boolean = !v.isInstanceOf[EmptyLocalActorRef]
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/LruBoundedCacheSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LruBoundedCacheSpec.scala
@@ -4,6 +4,7 @@
 package akka.remote.artery
 
 import akka.testkit.AkkaSpec
+import akka.util.Unsafe
 
 import scala.util.Random
 
@@ -17,7 +18,8 @@ class LruBoundedCacheSpec extends AkkaSpec {
       cntr += 1
       k + ":" + id
     }
-    override protected def hash(k: String): Int = FastHash.ofString(hashSeed + k + hashSeed)
+
+    override protected def hash(k: String): Int = Unsafe.fastHash(hashSeed + k + hashSeed)
 
     override protected def isCacheable(v: String): Boolean = !v.startsWith("#")
 


### PR DESCRIPTION
It needs to account for both Java 8 and 9 where the types are `char[]` and `byte[]` respectively.
Fixes #23702