### PR TITLE
Widen within spans downwards in PersistentFSMSpec 

### DIFF
--- a/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala
@@ -75,7 +75,7 @@ abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config)
       expectMsg(CurrentState(fsmRef, LookingAround, None))
       expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
 
-      within(0.9 seconds, remainingOrDefault) {
+      within(0.5 seconds, remainingOrDefault) {
         expectMsg(Transition(fsmRef, Shopping, Inactive, Some(2 seconds)))
       }
 
@@ -205,7 +205,7 @@ abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config)
 
       expectMsg(CurrentState(recoveredFsmRef, Shopping, Some(1 second)))
 
-      within(0.9 seconds, remainingOrDefault) {
+      within(0.5 seconds, remainingOrDefault) {
         expectMsg(Transition(recoveredFsmRef, Shopping, Inactive, Some(2 seconds)))
       }
 

--- a/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala
@@ -70,12 +70,16 @@ abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config)
 
       val shirt = Item("1", "Shirt", 59.99F)
 
+      // this isn't quite when the state transition happens, but close enough
+      val before = System.nanoTime
       fsmRef ! AddItem(shirt)
 
       expectMsg(CurrentState(fsmRef, LookingAround, None))
+
       expectMsg(Transition(fsmRef, LookingAround, Shopping, Some(1 second)))
 
-      within(0.5 seconds, remainingOrDefault) {
+      val adjustedMin = 1.second - (System.nanoTime - before).nanos
+      within(min = adjustedMin, max = remainingOrDefault) {
         expectMsg(Transition(fsmRef, Shopping, Inactive, Some(2 seconds)))
       }
 
@@ -203,9 +207,12 @@ abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config)
       watch(recoveredFsmRef)
       recoveredFsmRef ! SubscribeTransitionCallBack(testActor)
 
+      // this isn't when it got into that state, but close enough
+      val before = System.nanoTime
       expectMsg(CurrentState(recoveredFsmRef, Shopping, Some(1 second)))
 
-      within(0.5 seconds, remainingOrDefault) {
+      val adjustedMin = 1.second - (System.nanoTime - before).nanos
+      within(min = adjustedMin, max = remainingOrDefault) {
         expectMsg(Transition(recoveredFsmRef, Shopping, Inactive, Some(2 seconds)))
       }
 


### PR DESCRIPTION
Tries to avoid #23691

There's a race here, we are testing a 1 s timeout triggering a transition to verify that the timeout works, however the span set to verify that 1 s isn't measure from the beginning of the timeout, so we cannot ever really be sure about this. 

Couldn't figure out a good way to make it less racy, widening the timeout downwards for now.