### PR TITLE
Upgrade mockito to a version supporting jdk9 

### DIFF
--- a/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
+++ b/akka-camel/src/test/scala/akka/camel/internal/component/ActorProducerTest.scala
@@ -6,21 +6,19 @@ package akka.camel.internal.component
 
 import language.postfixOps
 import org.scalatest.mock.MockitoSugar
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.apache.camel.{ AsyncCallback, ProducerTemplate }
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.duration._
-import java.lang.String
-
 import akka.camel._
 import internal.{ CamelExchangeAdapter, DefaultCamel }
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, Suite, WordSpecLike }
 import akka.camel.TestSupport._
 import java.util.concurrent.{ CountDownLatch, TimeoutException }
 
-import org.mockito.{ ArgumentMatcher, Mockito, Matchers ⇒ MMatchers }
+import org.mockito.{ ArgumentMatcher, ArgumentMatchers, Mockito, Matchers ⇒ MMatchers }
 import org.scalatest.Matchers
 import akka.actor.Status.Failure
 import com.typesafe.config.ConfigFactory
@@ -213,8 +211,8 @@ class ActorProducerTest extends TestKit(ActorSystem("ActorProducerTest")) with W
             producer = given(outCapable = true, replyTimeout = 10 millis)
             producer.processExchangeAdapter(exchange, asyncCallback)
             asyncCallback.awaitCalled(100 millis)
-            verify(exchange).setFailure(MMatchers.argThat(new ArgumentMatcher[FailureResult] {
-              def matches(failure: AnyRef) = {
+            verify(exchange).setFailure(ArgumentMatchers.argThat(new ArgumentMatcher[FailureResult] {
+              def matches(failure: FailureResult) = {
                 failure.asInstanceOf[FailureResult].cause should be(anInstanceOf[TimeoutException])
                 true
               }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,7 +86,7 @@ object Dependencies {
       val commonsCodec = "commons-codec"               % "commons-codec"                % "1.10"             % "test" // ApacheV2
       val junit        = "junit"                       % "junit"                        % junitVersion       % "test" // Common Public License 1.0
       val logback      = "ch.qos.logback"              % "logback-classic"              % "1.2.3"            % "test" // EPL 1.0 / LGPL 2.1
-      val mockito      = "org.mockito"                 % "mockito-all"                  % "1.10.19"          % "test" // MIT
+      val mockito      = "org.mockito"                 % "mockito-core"                 % "2.7.16"           % "test" // MIT
       // changing the scalatest dependency must be reflected in akka-docs/rst/dev/multi-jvm-testing.rst
       val scalatest    = Def.setting { "org.scalatest"  %% "scalatest"  % scalaTestVersion.value   % "test" } // ApacheV2
       val scalacheck   = Def.setting { "org.scalacheck" %% "scalacheck" % scalaCheckVersion.value  % "test" } // New BSD


### PR DESCRIPTION
Fixes #23402

Verified by merging into the `jdk9-build` branch vs just merging master into it and then starting sbt with `sbt -J--illegal-access=deny` and running `akka-actor-tests/testOnly akka.pattern.CircuitBreakerSpec`. Breaks without the change, works with it.