### PR TITLE
Remove structural type that relies on runtime type in sun.nio

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
@@ -3,9 +3,7 @@
  */
 package akka.pattern
 
-import java.time.Instant
-
-import scala.concurrent.duration.{ Deadline, Duration, FiniteDuration }
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import java.util.concurrent.ThreadLocalRandom
 import java.util.Optional
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -6,7 +6,6 @@ package akka.stream.javadsl
 import akka.NotUsed
 import akka.japi.function.Creator
 import akka.stream.KillSwitch
-import akka.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.duration.FiniteDuration
 


### PR DESCRIPTION
bind() in DatagramChannel resolves to DatagramSocketAdaptor.bind() which
in sun.nio so this fails with -illegal-access=deny 

This is uglier but we can still close as both of the sockets implement Closable