### PR TITLE
No submaterializing inner source when outer stream already canceled

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
@@ -92,6 +92,9 @@ class FutureFlattenSourceSpec extends StreamSpec {
       probe.request(1)
       probe.cancel()
 
+      // try to avoid a race between probe cancel and completing the promise
+      Thread.sleep(100)
+
       // even though canceled the underlying matval should arrive
       sourcePromise.success(underlying)
       val failure = sourceMatVal.failed.futureValue

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
@@ -99,7 +99,7 @@ class FutureFlattenSourceSpec extends StreamSpec {
       sourcePromise.success(underlying)
       val failure = sourceMatVal.failed.futureValue
       failure shouldBe a[StreamDetachedException]
-      failure.getMessage should ===("Stream finished before future source completed")
+      failure.getMessage should ===("Stream cancelled before Source Future completed")
     }
 
     "fail if the underlying Future is failed" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
@@ -94,7 +94,9 @@ class FutureFlattenSourceSpec extends StreamSpec {
 
       // even though canceled the underlying matval should arrive
       sourcePromise.success(underlying)
-      sourceMatVal.failed.futureValue.getMessage should ===("Stream finished before future source completed")
+      val failure = sourceMatVal.failed.futureValue
+      failure shouldBe a[StreamDetachedException]
+      failure.getMessage should ===("Stream finished before future source completed")
     }
 
     "fail if the underlying Future is failed" in assertAllStagesStopped {

--- a/akka-stream/src/main/scala/akka/stream/StreamDetachedException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamDetachedException.scala
@@ -14,5 +14,4 @@ final class StreamDetachedException(message: String)
   with NoStackTrace {
 
   def this() = this("Stream is terminated. Materialized value is detached.")
-
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -324,7 +324,7 @@ import scala.util.control.NonFatal
               // the materialized value, but that is not safe and may cause the graph shell
               // to leak/stay alive after the stage completes
 
-              materialized.tryFailure(new StreamDetachedException("Stream finished before future source completed"))
+              materialized.tryFailure(new StreamDetachedException("Stream cancelled before Source Future completed"))
             }
 
             super.onDownstreamFinish()

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -323,7 +323,8 @@ import scala.util.control.NonFatal
               // we used to try to materialize the "inner" source here just to get
               // the materialized value, but that is not safe and may cause the graph shell
               // to leak/stay alive after the stage completes
-              materialized.tryFailure(new RuntimeException("Stream finished before future source completed"))
+
+              materialized.tryFailure(new StreamDetachedException("Stream finished before future source completed"))
             }
 
             super.onDownstreamFinish()

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -182,13 +182,16 @@ object Source {
 
   /**
    * Streams the elements of the given future source once it successfully completes.
-   * If the future fails the stream is failed.
+   * If the [[Future]] fails the stream is failed with the exception from the future. If downstream cancels before the
+   * stream completes the materialized [[Future]] will be failed with a [[StreamDetachedException]].
    */
   def fromFutureSource[T, M](future: Future[_ <: Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] = new Source(scaladsl.Source.fromFutureSource(future))
 
   /**
-   * Streams the elements of an asynchronous source once its given `completion` stage completes.
-   * If the `completion` fails the stream is failed with that exception.
+   * Streams the elements of an asynchronous source once its given [[CompletionStage]] completes.
+   * If the [[CompletionStage]] fails the stream is failed with the exception from the future.
+   * If downstream cancels before the stream completes the materialized [[CompletionStage]] will be failed
+   * with a [[StreamDetachedException]]
    */
   def fromSourceCompletionStage[T, M](completion: CompletionStage[_ <: Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] =
     new Source(scaladsl.Source.fromSourceCompletionStage(completion))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -276,13 +276,16 @@ object Source {
 
   /**
    * Streams the elements of the given future source once it successfully completes.
-   * If the future fails the stream is failed.
+   * If the [[Future]] fails the stream is failed with the exception from the future. If downstream cancels before the
+   * stream completes the materialized `Future` will be failed with a [[StreamDetachedException]]
    */
   def fromFutureSource[T, M](future: Future[Graph[SourceShape[T], M]]): Source[T, Future[M]] = fromGraph(new FutureFlattenSource(future))
 
   /**
    * Streams the elements of an asynchronous source once its given `completion` stage completes.
-   * If the `completion` fails the stream is failed with that exception.
+   * If the [[CompletionStage]] fails the stream is failed with the exception from the future.
+   * If downstream cancels before the stream completes the materialized `Future` will be failed
+   * with a [[StreamDetachedException]]
    */
   def fromSourceCompletionStage[T, M](completion: CompletionStage[_ <: Graph[SourceShape[T], M]]): Source[T, CompletionStage[M]] = fromFutureSource(completion.toScala).mapMaterializedValue(_.toJava)
 


### PR DESCRIPTION
Fixes #23656

Not so sure anymore though, this could be a sign of something else being wrong:

I tried to materialize the inner source in case it was already available when the cancel happens (rather than in a future callback as the current logic which never can been safe), but surprisingly enough that did also leak a shell instance.