### PR TITLE
=per #23739 deprecate `State.using` to deter Java users

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -151,7 +151,7 @@ trait PersistentFSM[S <: FSMState, D, E] extends PersistentActor with Persistent
       def applyStateOnLastHandler() = {
         handlersExecutedCounter += 1
         if (handlersExecutedCounter == eventsToPersist.size) {
-          super.applyState(nextState using nextData)
+          super.applyState(nextState.copy(stateData = nextData))
           currentStateTimeout = nextState.timeout
           nextState.afterTransitionDo(stateData)
           if (doSnapshot) {
@@ -366,11 +366,9 @@ object PersistentFSM {
       copy(replies = replyValue :: replies)
     }
 
-    /**
-     * Modify state transition descriptor with new state data. The data will be
-     * set when transitioning to the new state.
-     */
     @InternalApi
+    @Deprecated
+    @deprecated("Internal API easily to be confused with regular FSM's using. Use regular events (`applying`). Internally, `copy` can be used instead.", "2.5.5")
     private[akka] def using(@deprecatedName('nextStateDate) nextStateData: D): State[S, D, E] = {
       copy(stateData = nextStateData)
     }

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
@@ -187,7 +187,7 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
   /**
    * Produce change descriptor to stop this FSM actor including specified reason.
    */
-  final def stop(reason: Reason, stateData: D): State = stay using stateData withStopReason (reason)
+  final def stop(reason: Reason, stateData: D): State = stay.copy(stopReason = Some(reason), stateData = stateData)
 
   final class TransformHelper(func: StateFunction) {
     def using(andThen: PartialFunction[State, State]): StateFunction =


### PR DESCRIPTION
`State.using` is a valid pattern in regular FSM. However, for persistent FSM
it makes no sense and is marked as `private[akka]`. The `private[akka]` modifier does
not translate into bytecode so that Java users won't see that it should not be used.

Deprecating it will allow us to remove it in the future.

Fixes #23739.