### PR TITLE
Workaround for ByteBuffer.clear() method that should work for both JDKs

### DIFF
--- a/akka-actor/src/main/scala/akka/io/DirectByteBufferPool.scala
+++ b/akka-actor/src/main/scala/akka/io/DirectByteBufferPool.scala
@@ -4,7 +4,7 @@
 
 package akka.io
 
-import java.nio.ByteBuffer
+import java.nio.{ Buffer, ByteBuffer }
 import scala.util.control.NonFatal
 
 trait BufferPool {
@@ -50,7 +50,8 @@ private[akka] class DirectByteBufferPool(defaultBufferSize: Int, maxPoolEntries:
     if (buffer == null)
       allocate(defaultBufferSize)
     else {
-      buffer.clear()
+      // Call clear() from super class to make it work for both JDK 8 and 9
+      buffer.asInstanceOf[Buffer].clear()
       buffer
     }
   }

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -6,9 +6,9 @@ package akka.io
 
 import java.net.{ InetSocketAddress, SocketException }
 import java.nio.channels.SelectionKey._
-import java.io.{ FileInputStream, IOException }
+import java.io.IOException
 import java.nio.channels.{ FileChannel, SocketChannel }
-import java.nio.ByteBuffer
+import java.nio.{ Buffer, ByteBuffer }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
@@ -231,7 +231,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
       @tailrec def innerRead(buffer: ByteBuffer, remainingLimit: Int): ReadResult =
         if (remainingLimit > 0) {
           // never read more than the configured limit
-          buffer.clear()
+          // Call clear() from super class to make it work for both JDK 8 and 9
+          buffer.asInstanceOf[Buffer].clear()
           val maxBufferSpace = math.min(DirectBufferSize, remainingLimit)
           buffer.limit(maxBufferSpace)
           val readBytes = channel.read(buffer)
@@ -417,7 +418,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
           else new PendingBufferWrite(commander, data, ack, buffer, tail) // copy with updated remainingData
 
         } else if (data.nonEmpty) {
-          buffer.clear()
+          // Call clear() from super class to make it work for both JDK 8 and 9
+          buffer.asInstanceOf[Buffer].clear()
           val copied = data.copyToBuffer(buffer)
           buffer.flip()
           writeToChannel(data drop copied)

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -4,7 +4,7 @@
 package akka.io
 
 import java.net.InetSocketAddress
-import java.nio.ByteBuffer
+import java.nio.{ Buffer, ByteBuffer }
 import java.nio.channels.DatagramChannel
 import java.nio.channels.SelectionKey._
 import scala.annotation.tailrec
@@ -105,7 +105,8 @@ private[io] class UdpConnection(
 
   def doRead(registration: ChannelRegistration, handler: ActorRef): Unit = {
     @tailrec def innerRead(readsLeft: Int, buffer: ByteBuffer): Unit = {
-      buffer.clear()
+      // Call clear() from super class to make it work for both JDK 8 and 9
+      buffer.asInstanceOf[Buffer].clear()
       buffer.limit(DirectBufferSize)
 
       if (channel.read(buffer) > 0) {
@@ -125,7 +126,8 @@ private[io] class UdpConnection(
     val buffer = udpConn.bufferPool.acquire()
     try {
       val (send, commander) = pendingSend
-      buffer.clear()
+      // Call clear() from super class to make it work for both JDK 8 and 9
+      buffer.asInstanceOf[Buffer].clear()
       send.payload.copyToBuffer(buffer)
       buffer.flip()
       val writtenBytes = channel.write(buffer)

--- a/akka-actor/src/main/scala/akka/io/UdpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpListener.scala
@@ -4,7 +4,7 @@
 package akka.io
 
 import java.net.InetSocketAddress
-import java.nio.ByteBuffer
+import java.nio.{ Buffer, ByteBuffer }
 import java.nio.channels.SelectionKey._
 
 import scala.annotation.tailrec
@@ -84,7 +84,8 @@ private[io] class UdpListener(
 
   def doReceive(registration: ChannelRegistration, handler: ActorRef): Unit = {
     @tailrec def innerReceive(readsLeft: Int, buffer: ByteBuffer) {
-      buffer.clear()
+      // Call clear() from super class to make it work for both JDK 8 and 9
+      buffer.asInstanceOf[Buffer].clear()
       buffer.limit(DirectBufferSize)
 
       channel.receive(buffer) match {

--- a/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
+++ b/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
@@ -4,6 +4,7 @@
 package akka.io
 
 import java.net.InetSocketAddress
+import java.nio.Buffer
 import java.nio.channels.{ SelectionKey, DatagramChannel }
 import akka.actor.{ ActorRef, ActorLogging, Actor }
 import akka.io.Udp.{ CommandFailed, Send }
@@ -77,7 +78,8 @@ private[io] trait WithUdpSend {
   private def doSend(registration: ChannelRegistration): Unit = {
     val buffer = udp.bufferPool.acquire()
     try {
-      buffer.clear()
+      // Call clear() from super class to make it work for both JDK 8 and 9
+      buffer.asInstanceOf[Buffer].clear()
       pendingSend.payload.copyToBuffer(buffer)
       buffer.flip()
       val writtenBytes = channel.send(buffer, pendingSend.target)


### PR DESCRIPTION
Workaround for ByteBuffer.clear() method that should work for both JDKs 8 and 9.