### PR TITLE
Fix Scaladoc for recoverWithRetries

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1108,7 +1108,6 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
    *
    * @param attempts Maximum number of retries or -1 to retry indefinitely
    * @param pf Receives the failure cause and returns the new Source to be materialized if any
-   * @throws IllegalArgumentException if `attempts` is a negative number other than -1
    */
   def recoverWithRetries[T >: Out](attempts: Int, pf: PartialFunction[Throwable, _ <: Graph[SourceShape[T], NotUsed]]): javadsl.Flow[In, T, Mat @uncheckedVariance] =
     new Flow(delegate.recoverWithRetries(attempts, pf))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -615,7 +615,6 @@ trait FlowOps[+Out, +Mat] {
    *
    * @param attempts Maximum number of retries or -1 to retry indefinitely
    * @param pf Receives the failure cause and returns the new Source to be materialized if any
-   * @throws IllegalArgumentException if `attempts` is a negative number other than -1
    *
    */
   def recoverWithRetries[T >: Out](attempts: Int, pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =


### PR DESCRIPTION
Closes #23762

## scaladsl/Flow.scala (@throws is wrong)

https://github.com/akka/akka/blob/96ffced4dc26b816332fdd927de44e5b13375f2b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala#L600

https://github.com/akka/akka/blob/96ffced4dc26b816332fdd927de44e5b13375f2b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala#L618

## javadsl/Flow.scala (@throws is wrong)

https://github.com/akka/akka/blob/96ffced4dc26b816332fdd927de44e5b13375f2b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala#L1093

https://github.com/akka/akka/blob/96ffced4dc26b816332fdd927de44e5b13375f2b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala#L1111

## javadsl/Source.scala (already OK)

* Already OK (also, no `@throws` in Scaladoc)

https://github.com/akka/akka/blob/96ffced4dc26b816332fdd927de44e5b13375f2b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala#L1018

## javadsl/SubFlow.scala (already OK)

https://github.com/akka/akka/blob/96ffced4dc26b816332fdd927de44e5b13375f2b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala#L764

## javadsl/SubSource.scala (already OK)

https://github.com/akka/akka/blob/96ffced4dc26b816332fdd927de44e5b13375f2b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala#L758
