### PR TITLE
Block ActorSystem creation until Artery is bound

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
@@ -88,7 +88,7 @@ abstract class AeronStreamLatencySpec
 
   val pool = new EnvelopeBufferPool(1024 * 1024, 128)
 
-  val cncByteBuffer = IoUtil.mapExistingFile(new File(driver.aeronDirectoryName, CncFileDescriptor.CNC_FILE), "cnc");
+  val cncByteBuffer = IoUtil.mapExistingFile(new File(driver.aeronDirectoryName, CncFileDescriptor.CNC_FILE), "cnc")
   val stats =
     new AeronStat(AeronStat.mapCounters(cncByteBuffer))
 
@@ -106,7 +106,6 @@ abstract class AeronStreamLatencySpec
   }
 
   lazy implicit val mat = ActorMaterializer()(system)
-  import system.dispatcher
 
   override def initialParticipants = roles.size
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
@@ -3,7 +3,6 @@
  */
 package akka.remote.artery
 
-import java.net.InetAddress
 import java.util.concurrent.Executors
 
 import scala.collection.AbstractIterator

--- a/akka-remote-tests/src/test/scala/akka/remote/artery/ArteryFailedToBindSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/artery/ArteryFailedToBindSpec.scala
@@ -1,0 +1,40 @@
+package akka.remote.artery
+
+import akka.actor.ActorSystem
+import akka.testkit.SocketUtil
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ Matchers, WordSpec }
+
+class ArteryFailedToBindSpec extends WordSpec with Matchers {
+
+  "an ActorSystem" must {
+    "not start if port is taken" in {
+      val port = SocketUtil.temporaryLocalPort(true)
+      val config = ConfigFactory.parseString(
+        s"""
+           |akka {
+           |  actor {
+           |    provider = remote
+           |  }
+           |  remote {
+           |    artery {
+           |      enabled = on
+           |      canonical.hostname = "127.0.0.1"
+           |      canonical.port = $port
+           |      log-aeron-counters = on
+           |    }
+           |  }
+           |}
+       """.stripMargin)
+      val as = ActorSystem("BindTest1", config)
+      try {
+        val ex = intercept[RuntimeException] {
+          ActorSystem("BindTest2", config)
+        }
+        ex.getMessage should equal("Inbound Aeron channel is in errored state. See Aeron logs for details.")
+      } finally {
+        as.terminate()
+      }
+    }
+  }
+}

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -755,7 +755,13 @@ akka {
         #   "<getHostName>"      InetAddress.getLocalHost.getHostName
         #
         hostname = ""
+
+        # Time to wait for Aeron to bind
+        bind-timeout = 3s
       }
+
+      # Periodically log out all Aeron counters. See https://github.com/real-logic/aeron/wiki/Monitoring-and-Debugging#counters
+      log-aeron-counters = false
 
       # Actor paths to use the large message stream for when a message
       # is sent to them over remoting. The large message stream dedicated

--- a/akka-remote/src/main/scala/akka/remote/artery/AeronSource.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/AeronSource.scala
@@ -3,23 +3,17 @@
  */
 package akka.remote.artery
 
-import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
-import scala.concurrent.duration._
 import akka.stream.Attributes
 import akka.stream.Outlet
 import akka.stream.SourceShape
 import akka.stream.stage.AsyncCallback
-import akka.stream.stage.GraphStage
 import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.OutHandler
-import io.aeron.Aeron
-import io.aeron.FragmentAssembler
-import io.aeron.Subscription
+import io.aeron.{ Aeron, FragmentAssembler, Subscription }
 import io.aeron.logbuffer.FragmentHandler
 import io.aeron.logbuffer.Header
 import org.agrona.DirectBuffer
-import org.agrona.concurrent.BackoffIdleStrategy
 import org.agrona.hints.ThreadHints
 import akka.stream.stage.GraphStageWithMaterializedValue
 import scala.util.control.NonFatal

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -54,6 +54,8 @@ private[akka] final class ArterySettings private (config: Config) {
       case ""    ⇒ Canonical.Hostname
       case other ⇒ other
     }
+
+    val BindTimeout = getDuration("bind-timeout").requiring(!_.isNegative, "bind-timeout can not be negative")
   }
 
   val LargeMessageDestinations =
@@ -67,6 +69,7 @@ private[akka] final class ArterySettings private (config: Config) {
 
   val LogReceive: Boolean = getBoolean("log-received-messages")
   val LogSend: Boolean = getBoolean("log-sent-messages")
+  val LogAeronCounters: Boolean = config.getBoolean("log-aeron-counters")
 
   object Advanced {
     val config = getConfig("advanced")


### PR DESCRIPTION
Uses the Counters the media driver writes to retry/block until the channel is active. I just slept as we want to block the calling thread anyhow