### PR TITLE
Retry creation of ActorSystem in remoting tests #23481

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -13,7 +13,7 @@ import scala.util.control.NonFatal
 import scala.collection.immutable
 import akka.actor._
 import akka.util.Timeout
-import akka.remote.testconductor.{ RoleName, TestConductor, TestConductorExt }
+import akka.remote.testconductor.{ TestConductor, TestConductorExt }
 import akka.testkit._
 import akka.testkit.TestKit
 import akka.testkit.TestEvent._
@@ -234,7 +234,7 @@ object MultiNodeSpec {
     ConfigFactory.parseMap(map.asJava)
   }
 
-  private def getCallerName(clazz: Class[_]): String = {
+  private[akka] def getCallerName(clazz: Class[_]): String = {
     val pattern = s"(akka\\.remote\\.testkit\\.MultiNodeSpec.*|akka\\.remote\\.RemotingMultiNodeSpec)"
     val s = Thread.currentThread.getStackTrace.map(_.getClassName).drop(1).dropWhile(_.matches(pattern))
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeDeathWatchSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeDeathWatchSpec.scala
@@ -5,7 +5,7 @@ package akka.remote
 
 import language.postfixOps
 import scala.concurrent.duration._
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.ConfigFactory
 import akka.actor.Actor
 import akka.actor.ActorIdentity
 import akka.actor.ActorRef
@@ -15,8 +15,6 @@ import akka.actor.Props
 import akka.actor.Terminated
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
-import akka.remote.testkit.STMultiNodeSpec
 import akka.testkit._
 
 class RemoteNodeDeathWatchConfig(artery: Boolean) extends MultiNodeConfig {
@@ -88,7 +86,6 @@ object RemoteNodeDeathWatchSpec {
       case msg ⇒ testActor forward msg
     }
   }
-
 }
 
 abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchConfig)
@@ -112,7 +109,9 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
   def identify(role: RoleName, actorName: String): ActorRef = {
     system.actorSelection(node(role) / "user" / actorName) ! Identify(actorName)
-    expectMsgType[ActorIdentity].ref.get
+    val actorIdentity = expectMsgType[ActorIdentity]
+    assert(actorIdentity.ref.isDefined, s"Unable to Identify actor: $actorName on node: $role")
+    actorIdentity.ref.get
   }
 
   def assertCleanup(timeout: FiniteDuration = 5.seconds): Unit = {
@@ -164,7 +163,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
       // verify that things are cleaned up, and heartbeating is stopped
       assertCleanup()
-      expectNoMsg(2.seconds)
+      expectNoMessage(2.seconds)
       assertCleanup()
 
       enterBarrier("after-1")
@@ -197,7 +196,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
       // verify that things are cleaned up, and heartbeating is stopped
       assertCleanup()
-      expectNoMsg(2.seconds)
+      expectNoMessage(2.seconds)
       assertCleanup()
 
       enterBarrier("after-2")
@@ -229,7 +228,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
       // verify that things are cleaned up, and heartbeating is stopped
       assertCleanup()
-      expectNoMsg(2.seconds)
+      expectNoMessage(2.seconds)
       assertCleanup()
 
       enterBarrier("after-3")
@@ -257,7 +256,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
         expectMsg(1 second, Ack)
         enterBarrier("unwatch-s1-4")
         system.stop(s1)
-        expectNoMsg(2 seconds)
+        expectNoMessage(2 seconds)
         enterBarrier("stop-s1-4")
 
         system.stop(s2)
@@ -276,7 +275,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
       // verify that things are cleaned up, and heartbeating is stopped
       assertCleanup()
-      expectNoMsg(2.seconds)
+      expectNoMessage(2.seconds)
       assertCleanup()
 
       enterBarrier("after-4")
@@ -318,7 +317,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
         // verify that things are cleaned up, and heartbeating is stopped
         assertCleanup()
-        expectNoMsg(2.seconds)
+        expectNoMessage(2.seconds)
         assertCleanup()
       }
 
@@ -352,15 +351,15 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
         p1.receiveN(2, 5 seconds).collect { case WrappedTerminated(t) ⇒ t.actor }.toSet should ===(Set(a1, a2))
         p3.expectMsgType[WrappedTerminated](5 seconds).t.actor should ===(a3)
-        p2.expectNoMsg(2 seconds)
+        p2.expectNoMessage(2 seconds)
         enterBarrier("terminated-verified-5")
 
         // verify that things are cleaned up, and heartbeating is stopped
         assertCleanup()
-        expectNoMsg(2.seconds)
-        p1.expectNoMsg(100 millis)
-        p2.expectNoMsg(100 millis)
-        p3.expectNoMsg(100 millis)
+        expectNoMessage(2.seconds)
+        p1.expectNoMessage(100 millis)
+        p2.expectNoMessage(100 millis)
+        p3.expectNoMessage(100 millis)
         assertCleanup()
       }
 
@@ -402,7 +401,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
         // verify that things are cleaned up, and heartbeating is stopped
         assertCleanup()
-        expectNoMsg(2.seconds)
+        expectNoMessage(2.seconds)
         assertCleanup()
       }
 
@@ -447,7 +446,7 @@ abstract class RemoteNodeDeathWatchSpec(multiNodeConfig: RemoteNodeDeathWatchCon
 
         // verify that things are cleaned up, and heartbeating is stopped
         assertCleanup(20 seconds)
-        expectNoMsg(2.seconds)
+        expectNoMessage(2.seconds)
         assertCleanup()
       }
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
@@ -5,10 +5,13 @@ package akka.remote
 
 import java.util.UUID
 
+import akka.actor.ActorSystem
 import akka.remote.testkit.{ FlightRecordingSupport, MultiNodeConfig, MultiNodeSpec, STMultiNodeSpec }
 import akka.testkit.{ DefaultTimeout, ImplicitSender }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Outcome, Suite }
+
+import scala.util.Try
 
 object RemotingMultiNodeSpec {
 
@@ -24,7 +27,12 @@ object RemotingMultiNodeSpec {
 
 }
 
-abstract class RemotingMultiNodeSpec(config: MultiNodeConfig) extends MultiNodeSpec(config)
+abstract class RemotingMultiNodeSpec(config: MultiNodeConfig) extends MultiNodeSpec(config, config ⇒ {
+  val name = MultiNodeSpec.getCallerName(classOf[RemotingMultiNodeSpec])
+  //  When running multi-jvm tests with port = 0 two ActorSystems
+  //  can select the same port so retry once
+  Try(ActorSystem(name, config)).getOrElse(ActorSystem(name, config))
+})
   with Suite
   with STMultiNodeSpec
   with FlightRecordingSupport

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
@@ -5,13 +5,10 @@ package akka.remote
 
 import java.util.UUID
 
-import akka.actor.ActorSystem
 import akka.remote.testkit.{ FlightRecordingSupport, MultiNodeConfig, MultiNodeSpec, STMultiNodeSpec }
 import akka.testkit.{ DefaultTimeout, ImplicitSender }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Outcome, Suite }
-
-import scala.util.Try
 
 object RemotingMultiNodeSpec {
 
@@ -27,12 +24,7 @@ object RemotingMultiNodeSpec {
 
 }
 
-abstract class RemotingMultiNodeSpec(config: MultiNodeConfig) extends MultiNodeSpec(config, config ⇒ {
-  val name = MultiNodeSpec.getCallerName(classOf[RemotingMultiNodeSpec])
-  //  When running multi-jvm tests with port = 0 two ActorSystems
-  //  can select the same port so retry once
-  Try(ActorSystem(name, config)).getOrElse(ActorSystem(name, config))
-})
+abstract class RemotingMultiNodeSpec(config: MultiNodeConfig) extends MultiNodeSpec(config)
   with Suite
   with STMultiNodeSpec
   with FlightRecordingSupport

--- a/akka-remote-tests/src/test/scala/akka/remote/RemotingFailedToBindSpec.scala
+++ b/akka-remote-tests/src/test/scala/akka/remote/RemotingFailedToBindSpec.scala
@@ -1,12 +1,12 @@
-package akka.remote.artery
+package akka.remote
 
 import akka.actor.ActorSystem
-import akka.remote.RemoteTransportException
 import akka.testkit.SocketUtil
 import com.typesafe.config.ConfigFactory
+import org.jboss.netty.channel.ChannelException
 import org.scalatest.{ Matchers, WordSpec }
 
-class ArteryFailedToBindSpec extends WordSpec with Matchers {
+class RemotingFailedToBindSpec extends WordSpec with Matchers {
 
   "an ActorSystem" must {
     "not start if port is taken" in {
@@ -18,21 +18,19 @@ class ArteryFailedToBindSpec extends WordSpec with Matchers {
            |    provider = remote
            |  }
            |  remote {
-           |    artery {
-           |      enabled = on
-           |      canonical.hostname = "127.0.0.1"
-           |      canonical.port = $port
-           |      log-aeron-counters = on
+           |    netty.tcp {
+           |      hostname = "127.0.0.1"
+           |      port = $port
            |    }
            |  }
            |}
        """.stripMargin)
-      val as = ActorSystem("BindTest1", config)
+      val as = ActorSystem("RemotingFailedToBindSpec", config)
       try {
-        val ex = intercept[RemoteTransportException] {
+        val ex = intercept[ChannelException] {
           ActorSystem("BindTest2", config)
         }
-        ex.getMessage should equal("Inbound Aeron channel is in errored state. See Aeron logs for details.")
+        ex.getMessage should startWith("Failed to bind")
       } finally {
         as.terminate()
       }

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -7,7 +7,7 @@ package akka.remote
 import akka.AkkaException
 import akka.Done
 import akka.actor._
-import akka.event.{ LoggingAdapter }
+import akka.event.LoggingAdapter
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
@@ -18,7 +18,9 @@ import akka.util.OptionVal
  * such as inability to start, wrong configuration etc.
  */
 @SerialVersionUID(1L)
-class RemoteTransportException(message: String, cause: Throwable) extends AkkaException(message, cause)
+class RemoteTransportException(message: String, cause: Throwable) extends AkkaException(message, cause) {
+  def this(msg: String) = this(msg, null)
+}
 
 /**
  * [[RemoteTransportException]] without stack trace.

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -27,12 +27,7 @@ import akka.actor.Cancellable
 import akka.actor.Props
 import akka.event.Logging
 import akka.event.LoggingAdapter
-import akka.remote.AddressUidExtension
-import akka.remote.RemoteActorRef
-import akka.remote.RemoteActorRefProvider
-import akka.remote.RemoteTransport
-import akka.remote.ThisActorSystemQuarantinedEvent
-import akka.remote.UniqueAddress
+import akka.remote._
 import akka.remote.artery.AeronSource.ResourceLifecycle
 import akka.remote.artery.ArteryTransport.ShuttingDown
 import akka.remote.artery.Encoder.OutboundCompressionAccess
@@ -624,13 +619,13 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
         log.debug("Inbound channel is now active")
       } else if (status == ChannelEndpointStatus.ERRORED) {
         areonErrorLog.logErrors(log, 0L)
-        throw new RuntimeException("Inbound Aeron channel is in errored state. See Aeron logs for details.")
+        throw new RemoteTransportException("Inbound Aeron channel is in errored state. See Aeron logs for details.")
       } else if (status == ChannelEndpointStatus.INITIALIZING && retries > 0) {
         Thread.sleep(waitInterval)
         retry(retries - 1)
       } else {
         areonErrorLog.logErrors(log, 0L)
-        throw new RuntimeException("Timed out waiting for Aeron transport to bind. See Aeoron logs.")
+        throw new RemoteTransportException("Timed out waiting for Aeron transport to bind. See Aeoron logs.")
       }
     }
   }

--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -3,7 +3,6 @@
  */
 package akka
 
-import akka.TestExtras.Filter
 import akka.TestExtras.Filter.Keys._
 import com.typesafe.sbt.{ SbtScalariform, SbtMultiJvm }
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys._


### PR DESCRIPTION
Remoting multi-jvm test rely on setting port = 0 which selects an open
port. This has a race where two of the JVMs open/close the same port
then configure their ActorSystem with it so one of them fails to start
due to the port being in use. This adds a simple retry so another port
is selected.