### PR TITLE
Fork tests

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -10,9 +10,9 @@ import java.util.Properties
 import akka.TestExtras.JUnitFileReporting
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 import sbt.Keys._
-import sbt.TestLogger.wrap
 import sbt._
 import sbtwhitesource.WhiteSourcePlugin.autoImport.whitesourceIgnore
+import scala.collection.breakOut
 
 object AkkaBuild {
 
@@ -132,28 +132,61 @@ object AkkaBuild {
     /**
      * Test settings
      */
-    fork := true,
+    fork in Test := true,
+
+    // default JVM config for tests
+    javaOptions in Test ++= {
+      val defaults = Seq(
+        // memory
+        "-XX:+UseG1GC",
+        "-Xms2g", "-Xmx2g",
+        "-XX:+AlwaysPreTouch", "-XX:-UseBiasedLocking", "-XX:+UseCompressedOops",
+
+        "-XX:MaxDirectMemorySize=256m", "-Xss2m",
+
+        // faster random source
+        "-Djava.security.egd=file:/dev/./urandom"
+      )
+
+      if (sys.props.contains("akka.ci-server"))
+        defaults ++ Seq("-XX:+PrintGCTimeStamps", "-XX:+PrintGCDetails")
+      else
+        defaults
+    },
+
+
+    // all system properties passed to sbt prefixed with "akka." will be passed
+    // on to the forked jvms without the "akka." prefix
+    javaOptions in Test := {
+      val base = (javaOptions in Test).value
+      val akkaSysProps: Seq[String] =
+        sys.props.filter(_._1.startsWith("akka"))
+          .map { case (key, value) => s"-D$key=$value" }(breakOut)
+
+      base ++ akkaSysProps
+    },
+
+    // with forked tests the working directory is set to each module's home directory
+    // rather than the Akka root, some tests depend on Akka root being working dir, so reset
+    testGrouping in Test := {
+      val original: Seq[Tests.Group] = (testGrouping in Test).value
+
+      original.map { group =>
+        group.runPolicy match {
+          case Tests.SubProcess(forkOptions) =>
+            group.copy(runPolicy = Tests.SubProcess(forkOptions.copy(
+              workingDirectory = Some(new File(System.getProperty("user.dir")))
+            )))
+          case _ => group
+        }
+      }
+    },
 
     parallelExecution in Test := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
     logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
 
     // show full stack traces and test case durations
     testOptions in Test += Tests.Argument("-oDF"),
-
-    // don't save test output to a file, workaround for https://github.com/sbt/sbt/issues/937
-    testListeners in (Test, test) := {
-      val logger = streams.value.log
-
-      def contentLogger(log: sbt.Logger, buffered: Boolean): ContentLogger = {
-        val blog = new BufferedLogger(FullLogger(log))
-        if (buffered) blog.record()
-        new ContentLogger(wrap(blog), () => blog.stopQuietly())
-      }
-
-      val logTest = {_: TestDefinition => streams.value.log }
-      val buffered = logBuffered.value
-      Seq(new TestLogger(new TestLogging(wrap(logger), tdef => contentLogger(logTest(tdef), buffered))))
-    },
 
     // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
     // -a Show stack traces and exception class name for AssertionErrors.

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -139,19 +139,18 @@ object AkkaBuild {
       val defaults = Seq(
         // ## core memory settings
         "-XX:+UseG1GC",
-        "-Xms2g", "-Xmx2g",
-        // increate stack size (todo why?)
+        // most tests actually don't really use _that_ much memory (>1g usually)
+        // twice used (and then some) keeps G1GC happy - very few or to no full gcs
+        "-Xms3g", "-Xmx3g",
+        // increase stack size (todo why?)
         "-Xss2m",
 
         // ## extra memory/gc tuning
-        // make sure we actually allocate physical memory (todo is it really worth it?)
-        "-XX:+AlwaysPreTouch",
-        // not sure why we disable this (todo motivate)
-        "-XX:-UseBiasedLocking",
         // this breaks jstat, but could avoid costly syncs to disc see http://www.evanjones.ca/jvm-mmap-pause.html
         "-XX:+PerfDisableSharedMem",
-        // tell G1GC that we would be really happy if all GC pauses could be kept low and not cause test timeouts
-        "-XX:MaxGCPauseMillis=200",
+        // tell G1GC that we would be really happy if all GC pauses could be kept below this as higher would
+        // likely start causing test failures in timing tests
+        "-XX:MaxGCPauseMillis=300",
         // nio direct memory limit (todo why this value?)
         "-XX:MaxDirectMemorySize=256m",
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -137,12 +137,23 @@ object AkkaBuild {
     // default JVM config for tests
     javaOptions in Test ++= {
       val defaults = Seq(
-        // memory
+        // ## core memory settings
         "-XX:+UseG1GC",
         "-Xms2g", "-Xmx2g",
-        "-XX:+AlwaysPreTouch", "-XX:-UseBiasedLocking", "-XX:+UseCompressedOops",
+        // increate stack size (todo why?)
+        "-Xss2m",
 
-        "-XX:MaxDirectMemorySize=256m", "-Xss2m",
+        // ## extra memory/gc tuning
+        // make sure we actually allocate physical memory (todo is it really worth it?)
+        "-XX:+AlwaysPreTouch",
+        // not sure why we disable this (todo motivate)
+        "-XX:-UseBiasedLocking",
+        // this breaks jstat, but could avoid costly syncs to disc see http://www.evanjones.ca/jvm-mmap-pause.html
+        "-XX:+PerfDisableSharedMem",
+        // tell G1GC that we would be really happy if all GC pauses could be kept low and not cause test timeouts
+        "-XX:MaxGCPauseMillis=200",
+        // nio direct memory limit (todo why this value?)
+        "-XX:MaxDirectMemorySize=256m",
 
         // faster random source
         "-Djava.security.egd=file:/dev/./urandom"

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -151,7 +151,7 @@ object AkkaBuild {
         // tell G1GC that we would be really happy if all GC pauses could be kept below this as higher would
         // likely start causing test failures in timing tests
         "-XX:MaxGCPauseMillis=300",
-        // nio direct memory limit (todo why this value?)
+        // nio direct memory limit for artery/aeron (probably)
         "-XX:MaxDirectMemorySize=256m",
 
         // faster random source
@@ -165,8 +165,7 @@ object AkkaBuild {
     },
 
 
-    // all system properties passed to sbt prefixed with "akka." will be passed
-    // on to the forked jvms without the "akka." prefix
+    // all system properties passed to sbt prefixed with "akka." will be passed on to the forked jvms as is
     javaOptions in Test := {
       val base = (javaOptions in Test).value
       val akkaSysProps: Seq[String] =

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -132,6 +132,7 @@ object AkkaBuild {
     /**
      * Test settings
      */
+    fork := true,
 
     parallelExecution in Test := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
     logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -105,6 +105,7 @@ object ValidatePullRequest extends AutoPlugin {
   def runningLocally: Boolean = !runningOnJenkins
 
   override lazy val buildSettings = Seq(
+
     sourceBranch in Global in ValidatePR := {
       sys.env.get(SourceBranchEnvVarName) orElse
         sys.env.get(SourcePullIdJenkinsEnvVarName).map("pullreq/" + _) getOrElse // Set by "GitHub pull request builder plugin"
@@ -188,6 +189,11 @@ object ValidatePullRequest extends AutoPlugin {
     testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "performance"),
     testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "long-running"),
     testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "timing"),
+
+    // make it fork just like regular test running
+    fork in ValidatePR := (fork in Test).value,
+    testGrouping in ValidatePR := (testGrouping in Test).value,
+    javaOptions in ValidatePR := (javaOptions in Test).value,
 
     projectBuildMode in ValidatePR := {
       val log = streams.value.log


### PR DESCRIPTION
Refs #22979

Tries to work around that we get a class loader leak when running all tests in the same sbt-JVM by instead forking the tests, then each module will have a separate JVM forked, this should make the class loader leak is less problematic and at least not trigger long GC-pauses