### PR TITLE
Remove the JUnit test runner

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -83,7 +83,7 @@ object AkkaBuild {
 
   lazy val defaultSettings = resolverSettings ++
     TestExtras.Filter.settings ++
-    Protobuf.settings ++ Seq(
+    Protobuf.settings ++ Seq[Setting[_]](
       // compile options
       scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.8", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint"),
       scalacOptions in Compile ++= (if (allWarnings) Seq("-deprecation") else Nil),
@@ -184,11 +184,8 @@ object AkkaBuild {
       logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
 
     // show full stack traces and test case durations
-    testOptions in Test += Tests.Argument("-oDF")
-) ++
-
+    testOptions in Test += Tests.Argument("-oDF")) ++
     mavenLocalResolverSettings ++
-
     docLintingSettings
 
   lazy val docLintingSettings = Seq(

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -183,10 +183,10 @@ object AkkaBuild {
       parallelExecution in Test := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
       logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
 
-    // show full stack traces and test case durations
-    testOptions in Test += Tests.Argument("-oDF")) ++
-    mavenLocalResolverSettings ++
-    docLintingSettings
+      // show full stack traces and test case durations
+      testOptions in Test += Tests.Argument("-oDF")) ++
+      mavenLocalResolverSettings ++
+      docLintingSettings
 
   lazy val docLintingSettings = Seq(
     javacOptions in compile ++= Seq("-Xdoclint:none"),

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -7,7 +7,6 @@ package akka
 import java.io.{ FileInputStream, InputStreamReader }
 import java.util.Properties
 
-import akka.TestExtras.JUnitFileReporting
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 import sbt.Keys._
 import sbt._
@@ -184,15 +183,13 @@ object AkkaBuild {
       parallelExecution in Test := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
       logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
 
-      // show full stack traces and test case durations
-      testOptions in Test += Tests.Argument("-oDF"),
+    // show full stack traces and test case durations
+    testOptions in Test += Tests.Argument("-oDF")
+) ++
 
-      // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
-      // -a Show stack traces and exception class name for AssertionErrors.
-      testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")) ++
-      mavenLocalResolverSettings ++
-      JUnitFileReporting.settings ++
-      docLintingSettings
+    mavenLocalResolverSettings ++
+
+    docLintingSettings
 
   lazy val docLintingSettings = Seq(
     javacOptions in compile ++= Seq("-Xdoclint:none"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,12 +86,12 @@ object Dependencies {
       val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % "test" // EPL 1.0 / LGPL 2.1
       val mockito = "org.mockito" % "mockito-core" % "2.7.16" % "test" // MIT
       // changing the scalatest dependency must be reflected in akka-docs/rst/dev/multi-jvm-testing.rst
-      val scalatest    = Def.setting { "org.scalatest"  %% "scalatest"  % scalaTestVersion.value   % "test" } // ApacheV2
-      val scalacheck   = Def.setting { "org.scalacheck" %% "scalacheck" % scalaCheckVersion.value  % "test" } // New BSD
-      val pojosr       = "com.googlecode.pojosr"       % "de.kalpatec.pojosr.framework" % "0.2.1"            % "test" // ApacheV2
-      val tinybundles  = "org.ops4j.pax.tinybundles"   % "tinybundles"                  % "1.0.0"            % "test" // ApacheV2
-      val log4j        = "log4j"                       % "log4j"                        % "1.2.17"           % "test" // ApacheV2
-      val  scalaXml     = "org.scala-lang.modules"     %% "scala-xml"                    % scalaXmlVersion    % "test"
+      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % "test" } // ApacheV2
+      val scalacheck = Def.setting { "org.scalacheck" %% "scalacheck" % scalaCheckVersion.value % "test" } // New BSD
+      val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % "test" // ApacheV2
+      val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "1.0.0" % "test" // ApacheV2
+      val log4j = "log4j" % "log4j" % "1.2.17" % "test" // ApacheV2
+      val scalaXml = "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion % "test"
 
       // in-memory filesystem for file related tests
       val jimfs = "com.google.jimfs" % "jimfs" % "1.1" % "test" // ApacheV2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,13 +86,12 @@ object Dependencies {
       val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % "test" // EPL 1.0 / LGPL 2.1
       val mockito = "org.mockito" % "mockito-core" % "2.7.16" % "test" // MIT
       // changing the scalatest dependency must be reflected in akka-docs/rst/dev/multi-jvm-testing.rst
-      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % "test" } // ApacheV2
-      val scalacheck = Def.setting { "org.scalacheck" %% "scalacheck" % scalaCheckVersion.value % "test" } // New BSD
-      val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % "test" // ApacheV2
-      val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "1.0.0" % "test" // ApacheV2
-      val log4j = "log4j" % "log4j" % "1.2.17" % "test" // ApacheV2
-      val junitIntf = "com.novocode" % "junit-interface" % "0.11" % "test" // MIT
-      val scalaXml = "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion % "test"
+      val scalatest    = Def.setting { "org.scalatest"  %% "scalatest"  % scalaTestVersion.value   % "test" } // ApacheV2
+      val scalacheck   = Def.setting { "org.scalacheck" %% "scalacheck" % scalaCheckVersion.value  % "test" } // New BSD
+      val pojosr       = "com.googlecode.pojosr"       % "de.kalpatec.pojosr.framework" % "0.2.1"            % "test" // ApacheV2
+      val tinybundles  = "org.ops4j.pax.tinybundles"   % "tinybundles"                  % "1.0.0"            % "test" // ApacheV2
+      val log4j        = "log4j"                       % "log4j"                        % "1.2.17"           % "test" // ApacheV2
+      val  scalaXml     = "org.scala-lang.modules"     %% "scala-xml"                    % scalaXmlVersion    % "test"
 
       // in-memory filesystem for file related tests
       val jimfs = "com.google.jimfs" % "jimfs" % "1.1" % "test" // ApacheV2
@@ -131,7 +130,7 @@ object Dependencies {
 
   val testkit = l ++= Seq(Test.junit, Test.scalatest.value) ++ Test.metricsAll
 
-  val actorTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.commonsCodec, Test.commonsMath, Test.mockito, Test.scalacheck.value, Test.junitIntf)
+  val actorTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.commonsCodec, Test.commonsMath, Test.mockito, Test.scalacheck.value)
 
   val remote = l ++= Seq(netty, aeronDriver, aeronClient, Test.junit, Test.scalatest.value, Test.jimfs)
 
@@ -159,13 +158,13 @@ object Dependencies {
 
   val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 
-  val camel = l ++= Seq(camelCore, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo, Test.junitIntf)
+  val camel = l ++= Seq(camelCore, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
 
   val osgi = l ++= Seq(osgiCore, osgiCompendium, Test.logback, Test.commonsIo, Test.pojosr, Test.tinybundles, Test.scalatest.value, Test.junit)
 
-  val docs = l ++= Seq(Test.scalatest.value, Test.junit, Test.junitIntf, Docs.sprayJson, Docs.gson)
+  val docs = l ++= Seq(Test.scalatest.value, Test.junit, Docs.sprayJson, Docs.gson)
 
-  val contrib = l ++= Seq(Test.junitIntf, Test.commonsIo)
+  val contrib = l ++= Seq(Test.commonsIo)
 
   val benchJmh = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 
@@ -174,7 +173,6 @@ object Dependencies {
   lazy val stream = l ++= Seq[sbt.ModuleID](
     reactiveStreams,
     sslConfigCore,
-    Test.junitIntf,
     Test.scalatest.value)
 
   lazy val streamTestkit = l ++= Seq(Test.scalatest.value, Test.scalacheck.value, Test.junit)

--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -8,13 +8,6 @@ import sbt._
 
 object TestExtras {
 
-  object JUnitFileReporting {
-    val settings = Seq(
-      // we can enable junit-style reports everywhere with this
-      testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a", "-u", (target.value / "test-reports").getAbsolutePath),
-      testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", (target.value / "test-reports").getAbsolutePath))
-  }
-
   object Filter {
     object Keys {
       val excludeTestNames = settingKey[Set[String]]("Names of tests to be excluded. Not supported by MultiJVM tests. Example usage: -Dakka.test.names.exclude=TimingSpec")


### PR DESCRIPTION
All our tests are scalatest JUnitSuites so are picked up by the scalatest runner

This makes it so we only run tests once (and subsequently only are listed once in jenkins)

Bad part: the timing of the JunitSuite tests are not reported for some reason. Not sure if that matters as most tests where we care are in *Specs where timing is reported.