### PR TITLE
Swap unit for Void so we dont get wrong type exceptions on JDK9

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
@@ -45,7 +45,7 @@ private[affinity] object AffinityPool {
   // Method handle to JDK9+ onSpinWait method
   private val onSpinWaitMethodHandle =
     try
-      OptionVal.Some(MethodHandles.lookup.findStatic(classOf[Thread], "onSpinWait", methodType(classOf[Unit])))
+      OptionVal.Some(MethodHandles.lookup.findStatic(classOf[Thread], "onSpinWait", methodType(classOf[Void])))
     catch {
       case NonFatal(_) ⇒ OptionVal.None
     }


### PR DESCRIPTION
@patriknw @viktorklang @yanns

This is regarding the problem of throwing:
```
root java.lang.invoke.WrongMethodTypeException: expected ()void but found ()Object
root 	at java.base/java.lang.invoke.Invokers.newWrongMethodTypeException(Invokers.java:468)
root 	at java.base/java.lang.invoke.Invokers.checkExactType(Invokers.java:477)
root 	at akka.dispatch.affinity.AffinityPool$IdleStrategy.idle(AffinityPool.scala:90)
root 	at akka.dispatch.affinity.AffinityPool$AffinityPoolWorker.executeNext$1(AffinityPool.scala:268)
root 	at akka.dispatch.affinity.AffinityPool$AffinityPoolWorker.runLoop$1(AffinityPool.scala:283)
root 	at akka.dispatch.affinity.AffinityPool$AffinityPoolWorker.run(AffinityPool.scala:294)
root 	at java.base/java.lang.Thread.run(Thread.java:844)
```
 on JDK9 when we have onSpinWait. Reported issue: #23792