### PR TITLE
Fix a bug in viaMat for Identity flow optimization

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
@@ -5,7 +5,7 @@ package akka.stream.scaladsl
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.stream._
 import akka.stream.testkit._
 
@@ -233,6 +233,25 @@ class GraphMatValueSpec extends StreamSpec {
 
       val m4 = Source.single(1).viaMat(Flow[Int])(Keep.right).to(Sink.ignore).run()
       m4 should ===(NotUsed)
+    }
+
+    "build more complicated graph with flows optimized for identity flows" in {
+      val flow1 = Flow.fromSinkAndSourceMat(Sink.ignore, Source.single(1).viaMat(Flow[Int])(Keep.both))(Keep.both)
+      val (mA, (m1, m2)) = Source.single(8).viaMat(flow1)(Keep.right).to(Sink.ignore).run()
+      Await.result(mA, 1.second) should === (Done) //from Sink.ignore
+      m1 should === (NotUsed) //from Source.single(1)
+      m2 should === (NotUsed) //from Flow[Int]
+
+      val flow2 = Flow.fromSinkAndSourceMat(Sink.ignore, Source.maybe[Int].viaMat(Flow[Int])(Keep.left))(Keep.both)
+      val (mB, m3) = Source.single(8).viaMat(flow2)(Keep.right).to(Sink.ignore).run()
+      Await.result(mB, 1.second) should === (Done) //from Sink.ignore
+      // Fails with ClassCastException if value is wrong
+      m3.success(None) //from Source.maybe[Int]
+
+      val flow3 = Flow.fromSinkAndSourceMat(Sink.ignore, Source.single(1).viaMat(Flow[Int])(Keep.right))(Keep.both)
+      val (mC, m4) = Source.single(8).viaMat(flow3)(Keep.right).to(Sink.ignore).run()
+      Await.result(mC, 1.second) should === (Done) //from Sink.ignore
+      m4 should === (NotUsed) //from Flow[Int]
     }
 
     "provide a new materialized value for each materialization" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMatValueSpec.scala
@@ -5,7 +5,7 @@ package akka.stream.scaladsl
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.{Done, NotUsed}
+import akka.{ Done, NotUsed }
 import akka.stream._
 import akka.stream.testkit._
 
@@ -238,20 +238,20 @@ class GraphMatValueSpec extends StreamSpec {
     "build more complicated graph with flows optimized for identity flows" in {
       val flow1 = Flow.fromSinkAndSourceMat(Sink.ignore, Source.single(1).viaMat(Flow[Int])(Keep.both))(Keep.both)
       val (mA, (m1, m2)) = Source.single(8).viaMat(flow1)(Keep.right).to(Sink.ignore).run()
-      Await.result(mA, 1.second) should === (Done) //from Sink.ignore
-      m1 should === (NotUsed) //from Source.single(1)
-      m2 should === (NotUsed) //from Flow[Int]
+      Await.result(mA, 1.second) should ===(Done) //from Sink.ignore
+      m1 should ===(NotUsed) //from Source.single(1)
+      m2 should ===(NotUsed) //from Flow[Int]
 
       val flow2 = Flow.fromSinkAndSourceMat(Sink.ignore, Source.maybe[Int].viaMat(Flow[Int])(Keep.left))(Keep.both)
       val (mB, m3) = Source.single(8).viaMat(flow2)(Keep.right).to(Sink.ignore).run()
-      Await.result(mB, 1.second) should === (Done) //from Sink.ignore
+      Await.result(mB, 1.second) should ===(Done) //from Sink.ignore
       // Fails with ClassCastException if value is wrong
       m3.success(None) //from Source.maybe[Int]
 
       val flow3 = Flow.fromSinkAndSourceMat(Sink.ignore, Source.single(1).viaMat(Flow[Int])(Keep.right))(Keep.both)
       val (mC, m4) = Source.single(8).viaMat(flow3)(Keep.right).to(Sink.ignore).run()
-      Await.result(mC, 1.second) should === (Done) //from Sink.ignore
-      m4 should === (NotUsed) //from Flow[Int]
+      Await.result(mC, 1.second) should ===(Done) //from Sink.ignore
+      m4 should ===(NotUsed) //from Flow[Int]
     }
 
     "provide a new materialized value for each materialization" in {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -45,15 +45,23 @@ final class Source[+Out, +Mat](
   override def via[T, Mat2](flow: Graph[FlowShape[Out, T], Mat2]): Repr[T] = viaMat(flow)(Keep.left)
 
   override def viaMat[T, Mat2, Mat3](flow: Graph[FlowShape[Out, T], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): Source[T, Mat3] = {
-    val toAppend =
-      if (flow.traversalBuilder eq Flow.identityTraversalBuilder)
-        LinearTraversalBuilder.empty()
+    if (flow.traversalBuilder eq Flow.identityTraversalBuilder)
+      if(combine == Keep.left)
+        //optimization by returning this
+        this.asInstanceOf[Source[T, Mat3]] //Mat == Mat3, due to Keep.left
+      else if(combine == Keep.right || combine == Keep.none) // Mat3 = NotUsed
+        //optimization with LinearTraversalBuilder.empty()
+        new Source[T, Mat3](
+          traversalBuilder.append(LinearTraversalBuilder.empty(), flow.shape, combine),
+          SourceShape(shape.out).asInstanceOf[SourceShape[T]])
       else
-        flow.traversalBuilder
-
-    new Source[T, Mat3](
-      traversalBuilder.append(toAppend, flow.shape, combine),
-      SourceShape(flow.shape.out))
+        new Source[T, Mat3](
+          traversalBuilder.append(flow.traversalBuilder, flow.shape, combine),
+          SourceShape(flow.shape.out))
+    else
+      new Source[T, Mat3](
+        traversalBuilder.append(flow.traversalBuilder, flow.shape, combine),
+        SourceShape(flow.shape.out))
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -46,10 +46,10 @@ final class Source[+Out, +Mat](
 
   override def viaMat[T, Mat2, Mat3](flow: Graph[FlowShape[Out, T], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): Source[T, Mat3] = {
     if (flow.traversalBuilder eq Flow.identityTraversalBuilder)
-      if(combine == Keep.left)
+      if (combine == Keep.left)
         //optimization by returning this
         this.asInstanceOf[Source[T, Mat3]] //Mat == Mat3, due to Keep.left
-      else if(combine == Keep.right || combine == Keep.none) // Mat3 = NotUsed
+      else if (combine == Keep.right || combine == Keep.none) // Mat3 = NotUsed
         //optimization with LinearTraversalBuilder.empty()
         new Source[T, Mat3](
           traversalBuilder.append(LinearTraversalBuilder.empty(), flow.shape, combine),


### PR DESCRIPTION
Closes #22899 

The implementation got quite ugly :frowning: .... so any advice to make it cleaner welcomed.

## intention

The signature of viaMat:
https://github.com/akka/akka/blob/282a9b65f200299282dcfe66be195df6e02df67f/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala#L47

can be illustrated as follows:

![2017-10-16_04h24_49](https://user-images.githubusercontent.com/7414320/31588257-5ab15628-b22a-11e7-9bba-18b60cb2a1a2.png)

## if combine == Keep.left

We can just return `this`.

![2017-10-16_04h24_59](https://user-images.githubusercontent.com/7414320/31588259-5ca0b37a-b22a-11e7-8885-0310ab029f3b.png)

## if combine == Keep.right or combine == Keep.both

`source.viaMat(identity)(combine)` is materialized to `NotUsed` in both cases, since `identity` is materialized to `NotUsed`. We need to call `.append` to modify the traversal builder, but `LinearTraversalBuilder.empty()` can be passed.

![2017-10-16_04h25_10](https://user-images.githubusercontent.com/7414320/31588260-5e502f2a-b22a-11e7-841d-a0b7b1d23751.png)

## if combine == Keep.both

No optimization is performed.

![2017-10-16_04h25_27](https://user-images.githubusercontent.com/7414320/31588263-64105ea8-b22a-11e7-9458-2834a3fec16a.png)
