### PR TITLE
Spawning of typed persistent actors from untyped ActorSystem

### DIFF
--- a/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-typed/src/main/scala/akka/typed/internal/adapter/ActorSystemAdapter.scala
@@ -23,7 +23,6 @@ import akka.annotation.InternalApi
 @InternalApi private[typed] class ActorSystemAdapter[-T](val untyped: a.ActorSystemImpl)
   extends ActorSystem[T] with ActorRef[T] with internal.ActorRefImpl[T] with ExtensionsImpl {
 
-  import ActorSystemAdapter._
   import ActorRefAdapter.sendSystemMessage
 
   // Members declared in akka.typed.ActorRef


### PR DESCRIPTION
Avoids wrapping UntypedBehaviors as they are already wrapped. Currently
creating a PersistentActor with sytem.spawn throws an IllegalArgument on
every message from Behavior.interpret