### PR TITLE
Accept 'Join' messages from nodes without dc

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -37,9 +37,12 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
     classOf[InternalClusterAction.Join] → {
       case bytes ⇒
         val m = cm.Join.parseFrom(bytes)
+        val roles = Set.empty[String] ++ m.getRolesList.asScala
         InternalClusterAction.Join(
           uniqueAddressFromProto(m.getNode),
-          Set.empty[String] ++ m.getRolesList.asScala)
+          if (roles.find(_.startsWith(ClusterSettings.DcRolePrefix)).isDefined) roles
+          else roles + (ClusterSettings.DcRolePrefix + "default")
+        )
     },
     classOf[InternalClusterAction.Welcome] → {
       case bytes ⇒

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -41,7 +41,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
         InternalClusterAction.Join(
           uniqueAddressFromProto(m.getNode),
           if (roles.find(_.startsWith(ClusterSettings.DcRolePrefix)).isDefined) roles
-          else roles + (ClusterSettings.DcRolePrefix + "default")
+          else roles + (ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter)
         )
     },
     classOf[InternalClusterAction.Welcome] → {
@@ -366,7 +366,7 @@ class ClusterMessageSerializer(val system: ExtendedActorSystem) extends BaseSeri
         roles += role
       }
 
-      if (!containsDc) roles + (ClusterSettings.DcRolePrefix + "default")
+      if (!containsDc) roles + (ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter)
       else roles
     }
 


### PR DESCRIPTION
To allow a join from a 2.4 node to a 2.5.6 cluster.