### PR TITLE
=str mark overflow strategies with DoNotInherit

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/OverflowStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/OverflowStrategy.scala
@@ -4,18 +4,22 @@
 package akka.stream
 
 import OverflowStrategies._
+import akka.annotation.DoNotInherit
 
 /**
  * Represents a strategy that decides how to deal with a buffer of time based stage
  * that is full but is about to receive a new element.
  */
+@DoNotInherit
 sealed abstract class DelayOverflowStrategy extends Serializable
 
 final case class BufferOverflowException(msg: String) extends RuntimeException(msg)
+
 /**
  * Represents a strategy that decides how to deal with a buffer that is full but is
  * about to receive a new element.
  */
+@DoNotInherit
 sealed abstract class OverflowStrategy extends DelayOverflowStrategy
 
 private[akka] object OverflowStrategies {


### PR DESCRIPTION
Since they are `sealed` but could still be extended by in java, so calling this out via annotation that they're not intended to be extended.