### PR TITLE
Log coordinated shutdown as debug

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -164,7 +164,7 @@ object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with Extensi
       coord.actorSystemJvmHook = OptionVal.Some(coord.addCancellableJvmShutdownHook {
         runningJvmHook = true // avoid System.exit from PhaseActorSystemTerminate task
         if (!system.whenTerminated.isCompleted) {
-          coord.log.info("Starting coordinated shutdown from JVM shutdown hook")
+          coord.log.debug("Starting coordinated shutdown from JVM shutdown hook")
           try {
             // totalTimeout will be 0 when no tasks registered, so at least 3.seconds
             val totalTimeout = coord.totalTimeout().max(3.seconds)


### PR DESCRIPTION
This log was spotted while exiting sbt 1.0 build which used sbt-web which uses Akka. After this is merged and released we should create a PR in sbt-web to update Akka version.