### PR TITLE
Config flag to verbosely log stream error on every stage

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpecKit.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpecKit.scala
@@ -254,7 +254,9 @@ trait GraphInterpreterSpecKit extends StreamSpec {
         connections,
         onAsyncInput = (_, _, _) ⇒ (),
         fuzzingMode = false,
-        context = null)
+        context = null,
+        verboseLogErrors = true
+      )
       _interpreter.init(null)
     }
 

--- a/akka-stream/src/main/mima-filters/2.5.0.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.0.backwards.excludes
@@ -5,6 +5,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.FileSink
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.FilePublisher.props")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.FileSubscriber.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.FilePublisher.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreter.this")
 ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.fusing.GroupedWithin")
 
 ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.stream.Graph.traversalBuilder")

--- a/akka-stream/src/main/mima-filters/2.5.3.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.3.backwards.excludes
@@ -7,4 +7,5 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.MaybeSource
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.MaybeSource.attributes")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.MaybeSource.create")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.MaybeSource.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreter.this")
 ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.MaybePublisher$")

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -63,7 +63,7 @@ akka {
       sync-processing-limit = 1000
 
       # Always log errors on every stage
-      always-log-errors = true
+      verbose-log-errors = true
 
       debug {
         # Enables the fuzzing mode which increases the chance of race conditions

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -62,6 +62,9 @@ akka {
       # Allows to accelerate message processing that happening withing same actor but keep system responsive.
       sync-processing-limit = 1000
 
+      # Always log errors on every stage
+      always-log-errors = true
+
       debug {
         # Enables the fuzzing mode which increases the chance of race conditions
         # by aggressively reordering events and making certain operations more

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -3,22 +3,19 @@
  */
 package akka.stream
 
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
-import akka.actor.{ ActorContext, ActorRef, ActorRefFactory, ActorSystem, ExtendedActorSystem, Props }
+import akka.actor.{ActorContext, ActorRef, ActorRefFactory, ActorSystem, ExtendedActorSystem, Props}
 import akka.event.LoggingAdapter
-import akka.util.Helpers.toRootLowerCase
+import akka.japi.function
 import akka.stream.ActorMaterializerSettings.defaultMaxFixedBufferSize
 import akka.stream.impl._
+import akka.stream.stage.GraphStageLogic
+import akka.util.Helpers.toRootLowerCase
 import com.typesafe.config.Config
 
 import scala.concurrent.duration._
-import akka.japi.function
-import akka.stream.impl.fusing.GraphInterpreterShell
-import akka.stream.stage.GraphStageLogic
-
 import scala.util.control.NoStackTrace
 
 object ActorMaterializer {
@@ -246,10 +243,11 @@ object ActorMaterializerSettings {
     outputBurstLimit:            Int,
     fuzzingMode:                 Boolean,
     autoFusing:                  Boolean,
-    maxFixedBufferSize:          Int) =
+    maxFixedBufferSize:          Int,
+    alwaysLogErrors:             Boolean) =
     new ActorMaterializerSettings(
       initialInputBufferSize, maxInputBufferSize, dispatcher, supervisionDecider, subscriptionTimeoutSettings, debugLogging,
-      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize)
+      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize, alwaysLogErrors)
 
   /**
    * Create [[ActorMaterializerSettings]] from the settings of an [[akka.actor.ActorSystem]] (Scala).
@@ -272,7 +270,9 @@ object ActorMaterializerSettings {
       fuzzingMode = config.getBoolean("debug.fuzzing-mode"),
       autoFusing = config.getBoolean("auto-fusing"),
       maxFixedBufferSize = config.getInt("max-fixed-buffer-size"),
-      syncProcessingLimit = config.getInt("sync-processing-limit"))
+      syncProcessingLimit = config.getInt("sync-processing-limit"),
+      alwaysLogErrors = config.getBoolean("always-log-errors ")
+    )
 
   /**
    * Create [[ActorMaterializerSettings]] from individual settings (Java).
@@ -287,10 +287,11 @@ object ActorMaterializerSettings {
     outputBurstLimit:            Int,
     fuzzingMode:                 Boolean,
     autoFusing:                  Boolean,
-    maxFixedBufferSize:          Int) =
+    maxFixedBufferSize:          Int,
+    alwaysLogErrors:             Boolean) =
     new ActorMaterializerSettings(
       initialInputBufferSize, maxInputBufferSize, dispatcher, supervisionDecider, subscriptionTimeoutSettings, debugLogging,
-      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize)
+      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize, alwaysLogErrors)
 
   /**
    * Create [[ActorMaterializerSettings]] from the settings of an [[akka.actor.ActorSystem]] (Java).
@@ -322,7 +323,8 @@ final class ActorMaterializerSettings private (
   val fuzzingMode:                 Boolean,
   val autoFusing:                  Boolean,
   val maxFixedBufferSize:          Int,
-  val syncProcessingLimit:         Int) {
+  val syncProcessingLimit:         Int,
+  val alwaysLogErrors:             Boolean) {
 
   def this(
     initialInputBufferSize:      Int,
@@ -334,9 +336,10 @@ final class ActorMaterializerSettings private (
     outputBurstLimit:            Int,
     fuzzingMode:                 Boolean,
     autoFusing:                  Boolean,
-    maxFixedBufferSize:          Int) {
+    maxFixedBufferSize:          Int,
+    alwaysLogErrors:             Boolean) {
     this(initialInputBufferSize, maxInputBufferSize, dispatcher, supervisionDecider, subscriptionTimeoutSettings, debugLogging,
-      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize, defaultMaxFixedBufferSize)
+      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize, defaultMaxFixedBufferSize, alwaysLogErrors)
   }
 
   require(initialInputBufferSize > 0, "initialInputBufferSize must be > 0")
@@ -356,10 +359,11 @@ final class ActorMaterializerSettings private (
     fuzzingMode:                 Boolean                           = this.fuzzingMode,
     autoFusing:                  Boolean                           = this.autoFusing,
     maxFixedBufferSize:          Int                               = this.maxFixedBufferSize,
-    syncProcessingLimit:         Int                               = this.syncProcessingLimit) = {
+    syncProcessingLimit:         Int                               = this.syncProcessingLimit,
+    alwaysLogErrors:             Boolean                           = this.alwaysLogErrors) = {
     new ActorMaterializerSettings(
       initialInputBufferSize, maxInputBufferSize, dispatcher, supervisionDecider, subscriptionTimeoutSettings, debugLogging,
-      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize, syncProcessingLimit)
+      outputBurstLimit, fuzzingMode, autoFusing, maxFixedBufferSize, syncProcessingLimit, alwaysLogErrors)
   }
 
   /**
@@ -465,6 +469,14 @@ final class ActorMaterializerSettings private (
     if (settings == this.subscriptionTimeoutSettings) this
     else copy(subscriptionTimeoutSettings = settings)
 
+  /**
+    * Enable always logging errors on every stage
+    */
+  def withAlwaysLogErrors(alwaysLogErrors: Boolean): ActorMaterializerSettings =
+    if (alwaysLogErrors == this.subscriptionTimeoutSettings) this
+    else copy(alwaysLogErrors = alwaysLogErrors)
+
+
   private def requirePowerOfTwo(n: Integer, name: String): Unit = {
     require(n > 0, s"$name must be > 0")
     require((n & (n - 1)) == 0, s"$name must be a power of two")
@@ -481,7 +493,8 @@ final class ActorMaterializerSettings private (
         s.outputBurstLimit == outputBurstLimit &&
         s.syncProcessingLimit == syncProcessingLimit &&
         s.fuzzingMode == fuzzingMode &&
-        s.autoFusing == autoFusing
+        s.autoFusing == autoFusing &&
+        s.alwaysLogErrors == alwaysLogErrors
     case _ ⇒ false
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -487,7 +487,7 @@ import scala.util.control.NonFatal
       if (currentInterpreter == null || (currentInterpreter.context ne self))
         self ! asyncInput
       else enqueueToShortCircuit(asyncInput)
-    }, settings.fuzzingMode, self)
+    }, settings.fuzzingMode, self, settings.alwaysLogErrors)
 
   // TODO: really needed?
   private var subscribesPending = 0

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -487,7 +487,7 @@ import scala.util.control.NonFatal
       if (currentInterpreter == null || (currentInterpreter.context ne self))
         self ! asyncInput
       else enqueueToShortCircuit(asyncInput)
-    }, settings.fuzzingMode, self, settings.alwaysLogErrors)
+    }, settings.fuzzingMode, self, settings.verboseLogErrors)
 
   // TODO: really needed?
   private var subscribesPending = 0

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -588,7 +588,13 @@ import scala.util.control.NonFatal
   private[stream] def fail(connection: Connection, ex: Throwable): Unit = {
     val currentState = connection.portState
     if (Debug) println(s"$Name   fail($connection, $ex) [$currentState]")
-    if (verboseLogErrors) log.error(ex, "Error in stage [{}]: {}", activeStage.originalStage.getOrElse(activeStage), ex.getMessage)
+    if (verboseLogErrors) {
+      Option(activeStage) match {
+        case Some(stage) ⇒ log.error(ex, "Error in stage [{}]: {}", stage.originalStage.getOrElse(stage), ex.getMessage)
+        case None        ⇒ log.error(ex, "Error in unknown stage: {}", ex.getMessage)
+      }
+    }
+
     connection.portState = currentState | OutClosed
     if ((currentState & (InClosed | OutClosed)) == 0) {
       connection.portState = currentState | (OutClosed | InFailed)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -187,14 +187,14 @@ import scala.util.control.NonFatal
  * edge of a balance is pulled, dissolving the original cycle).
  */
 @InternalApi private[akka] final class GraphInterpreter(
-  val materializer:    Materializer,
-  val log:             LoggingAdapter,
-  val logics:          Array[GraphStageLogic], // Array of stage logics
-  val connections:     Array[GraphInterpreter.Connection],
-  val onAsyncInput:    (GraphStageLogic, Any, (Any) ⇒ Unit) ⇒ Unit,
-  val fuzzingMode:     Boolean,
-  val context:         ActorRef,
-  val alwaysLogErrors: Boolean) {
+  val materializer:     Materializer,
+  val log:              LoggingAdapter,
+  val logics:           Array[GraphStageLogic], // Array of stage logics
+  val connections:      Array[GraphInterpreter.Connection],
+  val onAsyncInput:     (GraphStageLogic, Any, (Any) ⇒ Unit) ⇒ Unit,
+  val fuzzingMode:      Boolean,
+  val context:          ActorRef,
+  val verboseLogErrors: Boolean) {
 
   import GraphInterpreter._
 
@@ -588,7 +588,7 @@ import scala.util.control.NonFatal
   private[stream] def fail(connection: Connection, ex: Throwable): Unit = {
     val currentState = connection.portState
     if (Debug) println(s"$Name   fail($connection, $ex) [$currentState]")
-    if (alwaysLogErrors) log.error(ex, "Error in stage [{}]: {}", activeStage.originalStage.getOrElse(activeStage), ex.getMessage)
+    if (verboseLogErrors) log.error(ex, "Error in stage [{}]: {}", activeStage.originalStage.getOrElse(activeStage), ex.getMessage)
     connection.portState = currentState | OutClosed
     if ((currentState & (InClosed | OutClosed)) == 0) {
       connection.portState = currentState | (OutClosed | InFailed)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -193,7 +193,8 @@ import scala.util.control.NonFatal
   val connections:  Array[GraphInterpreter.Connection],
   val onAsyncInput: (GraphStageLogic, Any, (Any) ⇒ Unit) ⇒ Unit,
   val fuzzingMode:  Boolean,
-  val context:      ActorRef) {
+  val context:      ActorRef,
+  val alwaysLogErrors: Boolean) {
 
   import GraphInterpreter._
 
@@ -586,7 +587,7 @@ import scala.util.control.NonFatal
 
   private[stream] def fail(connection: Connection, ex: Throwable): Unit = {
     val currentState = connection.portState
-    if (Debug) println(s"$Name   fail($connection, $ex) [$currentState]")
+    if(alwaysLogErrors) log.error(ex, "Error in stage [{}]: {}", activeStage.originalStage.getOrElse(activeStage), ex.getMessage)
     connection.portState = currentState | OutClosed
     if ((currentState & (InClosed | OutClosed)) == 0) {
       connection.portState = currentState | (OutClosed | InFailed)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -187,13 +187,13 @@ import scala.util.control.NonFatal
  * edge of a balance is pulled, dissolving the original cycle).
  */
 @InternalApi private[akka] final class GraphInterpreter(
-  val materializer: Materializer,
-  val log:          LoggingAdapter,
-  val logics:       Array[GraphStageLogic], // Array of stage logics
-  val connections:  Array[GraphInterpreter.Connection],
-  val onAsyncInput: (GraphStageLogic, Any, (Any) ⇒ Unit) ⇒ Unit,
-  val fuzzingMode:  Boolean,
-  val context:      ActorRef,
+  val materializer:    Materializer,
+  val log:             LoggingAdapter,
+  val logics:          Array[GraphStageLogic], // Array of stage logics
+  val connections:     Array[GraphInterpreter.Connection],
+  val onAsyncInput:    (GraphStageLogic, Any, (Any) ⇒ Unit) ⇒ Unit,
+  val fuzzingMode:     Boolean,
+  val context:         ActorRef,
   val alwaysLogErrors: Boolean) {
 
   import GraphInterpreter._
@@ -587,7 +587,8 @@ import scala.util.control.NonFatal
 
   private[stream] def fail(connection: Connection, ex: Throwable): Unit = {
     val currentState = connection.portState
-    if(alwaysLogErrors) log.error(ex, "Error in stage [{}]: {}", activeStage.originalStage.getOrElse(activeStage), ex.getMessage)
+    if (Debug) println(s"$Name   fail($connection, $ex) [$currentState]")
+    if (alwaysLogErrors) log.error(ex, "Error in stage [{}]: {}", activeStage.originalStage.getOrElse(activeStage), ex.getMessage)
     connection.portState = currentState | OutClosed
     if ((currentState & (InClosed | OutClosed)) == 0) {
       connection.portState = currentState | (OutClosed | InFailed)


### PR DESCRIPTION
Refs #23501. 

*** **NOT** *** READY for merge yet, due to Mima errors.

## single stage

Without this change, the below logs no error,

```scala
Source(-5 to 5).map(1 / _).runWith(Sink.ignore) // ArithmeticException: / by zero
```

because, looking at #19647, `processEvent()` does not throw an exception 
https://github.com/akka/akka/blob/38622246d9ec82bfca78070b75beb93b06dc5a75/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala#L368

(e.g.) from a stage adheres to supervision,

https://github.com/akka/akka/blob/38622246d9ec82bfca78070b75beb93b06dc5a75/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala#L84

thus `reportStageError()` is not called. 

https://github.com/akka/akka/blob/38622246d9ec82bfca78070b75beb93b06dc5a75/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala#L370

With this change the above code produce error logs as follows.


```
[ERROR] [10/30/2017 05:08:48.492] [default-akka.actor.default-dispatcher-2] [akka://default/user/StreamSupervisor-1/flow-0-0-ignoreSink] Error in stage [Map(<function1>)]: / by zero
java.lang.ArithmeticException: / by zero
        at akka.stream.impl.fusing.TestExceptionLogging$$anonfun$anotherExample$1.apply$mcII$sp(TestExceptionLogging.scala:59)
        at akka.stream.impl.fusing.TestExceptionLogging$$anonfun$anotherExample$1.apply(TestExceptionLogging.scala:59)
        at akka.stream.impl.fusing.TestExceptionLogging$$anonfun$anotherExample$1.apply(TestExceptionLogging.scala:59)
        at akka.stream.impl.fusing.Map$$anon$7.onPush(Ops.scala:47)
        at akka.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:500)
        at akka.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:402)
        at akka.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:571)
        at akka.stream.impl.fusing.GraphInterpreterShell.init(ActorGraphInterpreter.scala:541)
        at akka.stream.impl.fusing.ActorGraphInterpreter.tryInit(ActorGraphInterpreter.scala:662)
        at akka.stream.impl.fusing.ActorGraphInterpreter.preStart(ActorGraphInterpreter.scala:710)
        at akka.actor.Actor$class.aroundPreStart(Actor.scala:528)
        at akka.stream.impl.fusing.ActorGraphInterpreter.aroundPreStart(ActorGraphInterpreter.scala:653)
        at akka.actor.ActorCell.create(ActorCell.scala:591)
        at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:462)
        at akka.actor.ActorCell.systemInvoke(ActorCell.scala:484)
        at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:282)
        at akka.dispatch.Mailbox.run(Mailbox.scala:223)
        at akka.dispatch.Mailbox.exec(Mailbox.scala:234)
        at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
        at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
        at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
        at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

## multiple stages (too verbose log output?)

The example in #23501 given by @ktoso will produce error log like below. The error log becomes too verbose..

```
[ERROR] [10/30/2017 05:08:47.414] [default-akka.stream.default-blocking-io-dispatcher-5] [akka://default/user/StreamSupervisor-0/flow-0-1-fileSource] Error during preStart in [FileSource(TYPO HERE, 8192)]: requirement failed: Path 'TYPO HERE' does not exist
java.lang.IllegalArgumentException: requirement failed: Path 'TYPO HERE' does not exist
        at scala.Predef$.require(Predef.scala:224)
        at akka.stream.impl.io.FileSource$$anon$1.preStart(IOSources.scala:73)
        at akka.stream.impl.fusing.GraphInterpreter.init(GraphInterpreter.scala:291)
        at akka.stream.impl.fusing.GraphInterpreterShell.init(ActorGraphInterpreter.scala:540)
        at akka.stream.impl.fusing.ActorGraphInterpreter.tryInit(ActorGraphInterpreter.scala:662)
        at akka.stream.impl.fusing.ActorGraphInterpreter.preStart(ActorGraphInterpreter.scala:710)
        at akka.actor.Actor$class.aroundPreStart(Actor.scala:528)
        at akka.stream.impl.fusing.ActorGraphInterpreter.aroundPreStart(ActorGraphInterpreter.scala:653)
        at akka.actor.ActorCell.create(ActorCell.scala:591)
        at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:462)
        at akka.actor.ActorCell.systemInvoke(ActorCell.scala:484)
        at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:282)
        at akka.dispatch.Mailbox.run(Mailbox.scala:223)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

[ERROR] [10/30/2017 05:08:47.414] [default-akka.stream.default-blocking-io-dispatcher-5] [akka://default/user/StreamSupervisor-0/flow-0-1-fileSource] initialization of GraphInterpreterShell failed for GraphInterpreterShell(
  logics: [
    FileSource(TYPO HERE, 8192) attrs: [Dispatcher(akka.stream.default-blocking-io-dispatcher), Name(fileSource), InputBuffer(4,16), SupervisionStrategy(<function1>)],
    ActorOutputBoundary(port=FileSource.out(1887300757), demand=0, finished=false) attrs: []
  ],
  connections: [
    null,
    Connection(1, 1, Empty, ActorOutputBoundary(port=FileSource.out(1887300757), demand=0, finished=false), akka.stream.impl.io.FileSource$$anon$1@9352e9f)
  ]
)
java.lang.NullPointerException
        at akka.stream.impl.fusing.GraphInterpreter.fail(GraphInterpreter.scala:590)
        at akka.stream.stage.GraphStageLogic.failStage(GraphStage.scala:607)
        at akka.stream.impl.fusing.GraphInterpreter.init(GraphInterpreter.scala:295)
        at akka.stream.impl.fusing.GraphInterpreterShell.init(ActorGraphInterpreter.scala:540)
        at akka.stream.impl.fusing.ActorGraphInterpreter.tryInit(ActorGraphInterpreter.scala:662)
        at akka.stream.impl.fusing.ActorGraphInterpreter.preStart(ActorGraphInterpreter.scala:710)
        at akka.actor.Actor$class.aroundPreStart(Actor.scala:528)
        at akka.stream.impl.fusing.ActorGraphInterpreter.aroundPreStart(ActorGraphInterpreter.scala:653)
        at akka.actor.ActorCell.create(ActorCell.scala:591)
        at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:462)
        at akka.actor.ActorCell.systemInvoke(ActorCell.scala:484)
        at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:282)
        at akka.dispatch.Mailbox.run(Mailbox.scala:223)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

[ERROR] [10/30/2017 05:08:48.430] [default-akka.actor.default-dispatcher-4] [akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink] Error in stage [BatchingActorInputBoundary(forPort=akka.stream.impl.fusing.Map$$anon$7@59f19730, fill=0/16, completed=true, canceled=false)]: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly (akka.stream.AbruptTerminationException: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly)
[ERROR] [10/30/2017 05:08:48.445] [default-akka.actor.default-dispatcher-4] [akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink] Error in stage [Map(<function1>)]: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly (akka.stream.AbruptTerminationException: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly)
[ERROR] [10/30/2017 05:08:48.445] [default-akka.actor.default-dispatcher-4] [akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink] Error in stage [DelimiterFraming]: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly (akka.stream.AbruptTerminationException: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly)
[ERROR] [10/30/2017 05:08:48.445] [default-akka.actor.default-dispatcher-4] [akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink] Error in stage [Map(<function1>)]: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly (akka.stream.AbruptTerminationException: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly)
[ERROR] [10/30/2017 05:08:48.445] [default-akka.actor.default-dispatcher-4] [akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink] Error in stage [Map(<function1>)]: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly (akka.stream.AbruptTerminationException: Processor actor [Actor[akka://default/user/StreamSupervisor-0/flow-0-0-ignoreSink#-946705529]] terminated abruptly)
```

## Mima errors

I know this will cause Mima binary incompatibilities. However a similar change, #19703 did not. Why ... ?