### PR TITLE
Remove shutdown hook on shutting down

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -865,6 +865,7 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
   override def shutdown(): Future[Done] = {
     if (hasBeenShutdown.compareAndSet(false, true)) {
       log.debug("Shutting down [{}]", localAddress)
+      Runtime.getRuntime.removeShutdownHook(shutdownHook)
       val allAssociations = associationRegistry.allAssociations
       val flushing: Future[Done] =
         if (allAssociations.isEmpty) Future.successful(Done)


### PR DESCRIPTION
When shutting down, we compliment the addition of a shutdown hook during startup with its removal. Doing so further ensures that no class loader is retained when unloading Akka in an OSGi style scenario.

Fixes #23856 