### PR TITLE
shm leak in ClusterSingletonProxySpec, #23844

### DIFF
--- a/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
@@ -28,7 +28,9 @@ class ClusterSingletonProxySpec extends WordSpecLike with Matchers with BeforeAn
     }
   }
 
-  override def afterAll() = testSystems.foreach(_.system.terminate())
+  override def afterAll(): Unit = testSystems.foreach { sys ⇒
+    TestKit.shutdownActorSystem(sys.system)
+  }
 }
 
 object ClusterSingletonProxySpec {


### PR DESCRIPTION
I guess that the reason why this shows up now is that we fork the tests and if the jvm exits before the system shutdown is completed the files are not removed. I could reproduce locally and this fixes the problem.

Refs https://github.com/akka/akka/issues/23844