### PR TITLE
fix 2.13 version checking in MiMa config

### DIFF
--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -46,7 +46,7 @@ object MiMa extends AutoPlugin {
         case "2.12" ⇒
           akka24WithScala212 ++ akka25Versions
 
-        case "2.13" ⇒
+        case v if v.startsWith("2.13") =>
           // no Akka released for 2.13 yet, no jars to check BC against
           Seq.empty
       }


### PR DESCRIPTION
scalaBinaryVersion doesn't become simply "2.13" until Scala 2.13.0
is released (sometime in 2018)