### PR TITLE
fix confusing logging when receiving gossip from unknown

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -792,10 +792,10 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
 
   def receiveGossipStatus(status: GossipStatus): Unit = {
     val from = status.from
-    if (!latestGossip.isReachable(selfUniqueAddress, from))
+    if (!latestGossip.hasMember(from))
+      logInfo("Ignoring received gossip status from unknown [{}]", from)
+    else if (!latestGossip.isReachable(selfUniqueAddress, from))
       logInfo("Ignoring received gossip status from unreachable [{}] ", from)
-    else if (latestGossip.members.forall(_.uniqueAddress != from))
-      log.debug("Cluster Node [{}] - Ignoring received gossip status from unknown [{}]", selfAddress, from)
     else {
       (status.version compareTo latestGossip.version) match {
         case VectorClock.Same  ⇒ // same version
@@ -830,11 +830,11 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef) extends Actor with
     } else if (envelope.to != selfUniqueAddress) {
       logInfo("Ignoring received gossip intended for someone else, from [{}] to [{}]", from.address, envelope.to)
       Ignored
+    } else if (!localGossip.hasMember(from)) {
+      logInfo("Ignoring received gossip from unknown [{}]", from)
+      Ignored
     } else if (!localGossip.isReachable(selfUniqueAddress, from)) {
       logInfo("Ignoring received gossip from unreachable [{}] ", from)
-      Ignored
-    } else if (localGossip.members.forall(_.uniqueAddress != from)) {
-      log.debug("Cluster Node [{}] - Ignoring received gossip from unknown [{}]", selfAddress, from)
       Ignored
     } else if (remoteGossip.members.forall(_.uniqueAddress != selfUniqueAddress)) {
       logInfo("Ignoring received gossip that does not contain myself, from [{}]", from)


### PR DESCRIPTION
It logged "Ignoring received gossip from unreachable", more correct is "Ignoring received gossip from unknown".