### PR TITLE
#23880 Do not generate api doc for NoPublish projects

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -61,11 +61,8 @@ object NoPublish extends AutoPlugin {
   override def requires = plugins.JvmPlugin
 
   override def projectSettings = Seq(
-    publishArtifact := false,
-    publishArtifact in Compile := false,
-    publish := {},
     skip in publish := true,
-    publishLocal := {}
+    skip in doc := true,
   )
 }
 


### PR DESCRIPTION
Disabling of api doc generation was missing after migration to sbt 1.x, therefore we started stepping on https://github.com/scala/bug/issues/10426 while generating scaladoc for bench-jmh project.

This disables api doc generation for projects that have `NoPublish` autoplugin enabled.

This PR also removes all of the other attempts to stop publishing artifacts that we accumulated throughout the ages and keeps only the one true way - `skip in publish` (https://github.com/sbt/sbt/pull/3380). 