### PR TITLE
#23861 Test maximum burst immediately after drain

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -124,10 +124,6 @@ class FlowThrottleSpec extends StreamSpec {
       (1 to 5) foreach upstream.sendNext
       downstream.receiveWithin(300.millis, 5) should be(1 to 5)
 
-      downstream.request(1)
-      upstream.sendNext(6)
-      downstream.expectNoMsg(100.millis)
-      downstream.expectNext(6)
       downstream.request(5)
       downstream.expectNoMsg(1200.millis)
       for (i ← 7 to 11) upstream.sendNext(i)


### PR DESCRIPTION
Due to unfortunate timing the `downstream.expectNoMsg(100.millis)` could fail by receiving the message `6`.

As the testcase tests maximum burst after enought time has passed from the previous burst, I have simplified the testcase to have maximum burst immediately after the drain.

Fixes #23861 
