### PR TITLE
=typ graceful stop examples (#22776)

### DIFF
--- a/akka-typed-tests/src/test/java/jdocs/akka/typed/GracefulStopDocTest.java
+++ b/akka-typed-tests/src/test/java/jdocs/akka/typed/GracefulStopDocTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package jdocs.akka.typed;
+
+//#imports
+import akka.typed.ActorSystem;
+import akka.typed.Behavior;
+import akka.typed.PostStop;
+import akka.typed.javadsl.Actor;
+//#imports
+import java.util.concurrent.TimeUnit;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
+
+public class GracefulStopDocTest {
+
+    //#master-actor
+    public abstract static class JobControl {
+        // no instances of this class, it's only a name space for messages
+        // and static methods
+        private JobControl() {
+            // no instances of this class, it's only a name space for messages
+            // and static methods
+        }
+
+        static interface JobControlLanguage {}
+
+        public static final class SpawnJob implements JobControlLanguage {
+            public final String name;
+
+            public SpawnJob(String name) {
+                this.name = name;
+            }
+        }
+
+        public static final class GracefulShutdown implements JobControlLanguage {
+
+            public GracefulShutdown() {}
+        }
+
+        public static final Behavior<JobControlLanguage> mcpa = Actor.immutable(JobControlLanguage.class)
+                .onMessage(SpawnJob.class, (ctx, msg) -> {
+                    ctx.getSystem().log().info("Spawning job {}!", msg.name);
+                    ctx.spawn(Job.job(msg.name), msg.name);
+                    return Actor.same();
+                })
+                .onSignal(PostStop.class, (ctx, signal) -> {
+                    ctx.getSystem().log().info("Master Control Programme stopped");
+                    return Actor.same();
+                })
+                .onMessage(GracefulShutdown.class, (ctx, msg) -> {
+                    ctx.getSystem().log().info("Initiating graceful shutdown...");
+
+                    // perform graceful stop, executing cleanup before final system termination
+                    // behavior executing cleanup is passed as a parameter to Actor.stopped
+                    return Actor.stopped (Actor.onSignal((context, PostStop) -> {
+                            context.getSystem().log().info("Cleanup!");
+                            return Actor.same();
+                }));
+                })
+                .onSignal(PostStop.class, (ctx, signal) -> {
+                    ctx.getSystem().log().info("Master Control Programme stopped");
+                    return Actor.same();
+                })
+                .build();
+    }
+    //#master-actor
+
+    public static void main(String[] args) throws Exception{
+        //#graceful-shutdown
+        final ActorSystem<JobControl.JobControlLanguage> system =
+                ActorSystem.create(JobControl.mcpa, "B6700");
+
+        system.tell(new JobControl.SpawnJob("a"));
+        system.tell(new JobControl.SpawnJob("b"));
+
+        // sleep here to allow time for the new actors to be started
+        Thread.sleep(100);
+
+        system.tell(new JobControl.GracefulShutdown());
+
+        Await.result(system.whenTerminated(), Duration.create(3, TimeUnit.SECONDS));
+        //#graceful-shutdown
+    }
+
+    //#worker-actor
+    public static class Job {
+        public static Behavior<JobControl.JobControlLanguage> job(String name) {
+            return Actor.onSignal((ctx, PostStop) -> {
+                ctx.getSystem().log().info("Worker {} stopped", name);
+                return Actor.same();
+            });
+
+        }
+    }
+    //#worker-actor
+}

--- a/akka-typed-tests/src/test/scala/akka/typed/scaladsl/GracefulStopSpec.scala
+++ b/akka-typed-tests/src/test/scala/akka/typed/scaladsl/GracefulStopSpec.scala
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.typed
+package scaladsl
+
+import akka.Done
+import akka.typed.testkit.TestKitSettings
+import akka.typed.testkit.scaladsl.TestProbe
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+final class GracefulStopSpec extends TypedSpec {
+
+  final object `An Actor.onSignal behavior (native)` extends Tests with NativeSystem
+
+  final object `An Actor.onSignal behavior (adapted)` extends Tests with AdaptedSystem
+
+  trait Tests extends StartSupport {
+
+    private implicit val testSettings = TestKitSettings(system)
+
+    override implicit def system: ActorSystem[TypedSpec.Command]
+
+    def `must properly stop the children and perform the cleanup when doing graceful stop`(): Unit = {
+      val probe = TestProbe[Done]("probe")
+      val probeCld1 = TestProbe[Done]("probeCld1")
+      val probeCld2 = TestProbe[Done]("probeCld2")
+
+      val behavior =
+        Actor.deferred[akka.NotUsed] { context ⇒
+          val c1 = context.spawn(Actor.immutable[akka.NotUsed] {
+            (_, _) ⇒ Actor.unhandled
+          } onSignal {
+            case (_, PostStop) ⇒
+              probeCld1.ref ! Done
+              Actor.stopped
+          }, "child1")
+
+          val c2 = context.spawn(Actor.immutable[akka.NotUsed] {
+            (_, _) ⇒ Actor.unhandled
+          } onSignal {
+            case (_, PostStop) ⇒
+              probeCld2.ref ! Done
+              Actor.stopped
+          }, "child2")
+
+          Actor.stopped {
+            Actor.onSignal {
+              case (ctx, PostStop) ⇒
+                // cleanup function body
+                probe.ref ! Done
+                Actor.same
+            }
+          }
+        }
+      start[akka.NotUsed](behavior)
+      probeCld1.expectMsg(Done)
+      probeCld2.expectMsg(Done)
+
+      // if this ever fails with Done not received, would be good to look into possible race in ActorCell
+      probe.expectMsg(Done)
+    }
+
+    def `must properly perform the cleanup and stop itself for no children case`(): Unit = {
+      val probe = TestProbe[Done]("probe")
+
+      val behavior =
+        Actor.deferred[akka.NotUsed] { context ⇒
+          // do not spawn any children
+          Actor.stopped {
+            Actor.onSignal {
+              case (ctx, PostStop) ⇒
+                // cleanup function body
+                probe.ref ! Done
+                Actor.same
+            }
+          }
+        }
+      start[akka.NotUsed](behavior)
+
+      // if this ever fails with Done not received, would be good to look into possible race in ActorCell
+      probe.expectMsg(Done)
+    }
+  }
+}

--- a/akka-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
+++ b/akka-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2014-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package docs.akka.typed
+
+//#imports
+import akka.typed._
+import akka.typed.scaladsl.Actor
+import scala.concurrent.duration._
+import scala.concurrent.Await
+//#imports
+
+object GracefulStopDocSpec {
+
+  //#master-actor
+  object MasterControlProgramActor {
+    sealed trait JobControlLanguage
+    final case class SpawnJob(name: String) extends JobControlLanguage
+    final case object GracefulShutdown extends JobControlLanguage
+
+    // Predefined cleanup operation
+    def cleanup[T](ctx: scaladsl.ActorContext[T]): Unit = ctx.system.log.info("Cleaning up!")
+
+    val mcpa = Actor.immutable[JobControlLanguage] { (ctx, msg) ⇒
+      msg match {
+        case SpawnJob(jobName) ⇒
+          ctx.system.log.info("Spawning job {}!", jobName)
+          ctx.spawn(Job.job(jobName), jobName)
+          Actor.same
+        case GracefulShutdown ⇒
+          ctx.system.log.info("Initiating graceful shutdown...")
+          // perform graceful stop, executing cleanup before final system termination
+          // behavior executing cleanup is passed as a parameter to Actor.stopped
+          Actor.stopped {
+            Actor.onSignal {
+              case (context, PostStop) ⇒
+                cleanup(context)
+                Actor.same
+            }
+          }
+      }
+    } onSignal {
+      case (ctx, PostStop) ⇒
+        ctx.system.log.info("MCPA stopped")
+        Actor.same
+    }
+  }
+  //#master-actor
+
+  //#worker-actor
+  object Job {
+    import GracefulStopDocSpec.MasterControlProgramActor.JobControlLanguage
+
+    def job(name: String) = Actor.onSignal[JobControlLanguage] {
+      case (ctx, PostStop) ⇒
+        ctx.system.log.info("Worker {} stopped", name)
+        Actor.same
+    }
+  }
+  //#worker-actor
+
+}
+
+class GracefulStopDocSpec extends TypedSpec {
+  import GracefulStopDocSpec._
+
+  def `must start some workers`(): Unit = {
+    // TODO Implicits.global is not something we would like to encourage in docs
+    //#start-workers
+    import MasterControlProgramActor._
+
+    val system: ActorSystem[JobControlLanguage] = ActorSystem(mcpa, "B6700")
+
+    system ! SpawnJob("a")
+    system ! SpawnJob("b")
+
+    // sleep here to allow time for the new actors to be started
+    Thread.sleep(100)
+
+    // brutally stop the system
+    system.terminate()
+
+    Await.result(system.whenTerminated, 3.seconds)
+    //#start-workers
+  }
+
+  def `must gracefully stop workers and master`(): Unit = {
+    // TODO Implicits.global is not something we would like to encourage in docs
+    //#graceful-shutdown
+    import MasterControlProgramActor._
+
+    val system: ActorSystem[JobControlLanguage] = ActorSystem(mcpa, "B7700")
+
+    system ! SpawnJob("a")
+    system ! SpawnJob("b")
+
+    Thread.sleep(100)
+
+    // gracefully stop the system
+    system ! GracefulShutdown
+
+    Thread.sleep(100)
+
+    Await.result(system.whenTerminated, 3.seconds)
+    //#graceful-shutdown
+  }
+}


### PR DESCRIPTION
* Stop all the children
* Perform the cleanup
* Stop the parent