### PR TITLE
#23880 Set sources for doc task to empty, as skip does not seem to work

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -62,7 +62,7 @@ object NoPublish extends AutoPlugin {
 
   override def projectSettings = Seq(
     skip in publish := true,
-    skip in doc := true,
+    sources in doc := Seq.empty
   )
 }
 


### PR DESCRIPTION
I think when I tested the `skip in doc` I have forgotten to reload the build and thought it worked, but it did not...

Fixes #23880 for real this time.