### PR TITLE
[WIP] Provide and propagate stream cancellation causes

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -198,7 +198,7 @@ class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit {
       // note: a bit dangerous assumptions about connection and logic positions here
       // if anything around creating the logics and connections in the builder changes this may fail
       interpreter.complete(interpreter.connections(0))
-      interpreter.cancel(interpreter.connections(1))
+      interpreter.cancel(interpreter.connections(1), new RuntimeException("explicit cancellation"))
       interpreter.execute(2)
 
       expectMsg("postStop2")

--- a/akka-stream/src/main/scala/akka/stream/SubscriptionWithCancelException.scala
+++ b/akka-stream/src/main/scala/akka/stream/SubscriptionWithCancelException.scala
@@ -1,0 +1,20 @@
+package akka.stream
+
+import org.reactivestreams.Subscription
+
+import scala.util.control.NoStackTrace
+
+/**
+ * Extension of Subscription that allows to pass a cause when a subscription is cancelled.
+ *
+ * Subscribers can check for this trait and use its `cancel(cause)` method instead of the regular
+ * cancel method to pass a cancellation cause.
+ */
+trait SubscriptionWithCancelException extends Subscription {
+  final override def cancel() = cancel(SubscriptionWithCancelException.NoCause)
+  def cancel(cause: Throwable): Unit
+}
+object SubscriptionWithCancelException {
+  case object NoCause extends RuntimeException with NoStackTrace
+  case object StageWasCompleted extends RuntimeException with NoStackTrace
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/ReactiveStreamsCompliance.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ReactiveStreamsCompliance.scala
@@ -4,6 +4,7 @@
 package akka.stream.impl
 
 import akka.annotation.InternalApi
+import akka.stream.SubscriptionWithCancelException
 
 import scala.util.control.NonFatal
 import org.reactivestreams.{ Subscriber, Subscription }
@@ -115,9 +116,13 @@ import org.reactivestreams.{ Subscriber, Subscription }
     }
   }
 
-  final def tryCancel(subscription: Subscription): Unit = {
+  final def tryCancel(subscription: Subscription, cause: Throwable): Unit = {
     if (subscription eq null) throw new IllegalStateException("Subscription must be not null on cancel() call, rule 1.3")
-    try subscription.cancel() catch {
+    try
+      subscription match {
+        case s: SubscriptionWithCancelException ⇒ s.cancel(cause)
+        case s                                  ⇒ s.cancel()
+      } catch {
       case NonFatal(t) ⇒ throw new SignalThrewException("It is illegal to throw exceptions from cancel(), rule 3.15", t)
     }
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -471,7 +471,9 @@ import scala.util.control.NonFatal
       if (Debug) println(s"$Name CANCEL ${inOwnerName(connection)} -> ${outOwnerName(connection)} (${connection.outHandler}) [${outLogicName(connection)}]")
       connection.portState |= OutClosed
       completeConnection(connection.outOwner.stageId)
-      connection.outHandler.onDownstreamFinish()
+      val cause = connection.slot.asInstanceOf[Throwable]
+      connection.slot = Empty
+      connection.outHandler.onDownstreamFinish(cause)
     } else if ((code & (OutClosed | InClosed)) == OutClosed) {
       // COMPLETIONS
 
@@ -602,12 +604,12 @@ import scala.util.control.NonFatal
     if ((currentState & OutClosed) == 0) completeConnection(connection.outOwner.stageId)
   }
 
-  private[stream] def cancel(connection: Connection): Unit = {
+  private[stream] def cancel(connection: Connection, cause: Throwable): Unit = {
     val currentState = connection.portState
     if (Debug) println(s"$Name   cancel($connection) [$currentState]")
     connection.portState = currentState | InClosed
     if ((currentState & OutClosed) == 0) {
-      connection.slot = Empty
+      connection.slot = cause
       if ((currentState & (Pulling | Pushing | InClosed)) == 0) enqueue(connection)
       else if (chasedPull eq connection) {
         // Abort chasing so Cancel is not lost (chasing does NOT decode the event but assumes it to be a PULL

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -334,7 +334,7 @@ final class MergePrioritized[T] private (val priorities: Seq[Int], val eagerComp
 
           override def onUpstreamFinish(): Unit = {
             if (eagerComplete) {
-              in.foreach(cancel)
+              in.foreach(cancel(_))
               runningUpstreams = 0
               if (!hasPending) completeStage()
             } else {

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -5,6 +5,8 @@ package akka.stream.stage
 
 import java.util.concurrent.atomic.AtomicReference
 
+import scala.deprecated
+
 import akka.NotUsed
 import java.util.concurrent.locks.ReentrantLock
 
@@ -459,8 +461,16 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
 
   /**
    * Requests to stop receiving events from a given input port. Cancelling clears any ungrabbed elements from the port.
+   *
+   * It is recommended to provide a cause.
    */
-  final protected def cancel[T](in: Inlet[T]): Unit = interpreter.cancel(conn(in))
+  @deprecated("Use other overload to provide a cause for cancellation or use SubscriptionWithCancelException.NoCause", since = "2.6.0")
+  final protected def cancel[T](in: Inlet[T]): Unit = cancel(in, SubscriptionWithCancelException.NoCause)
+
+  /**
+   * Requests to stop receiving events from a given input port. Cancelling clears any ungrabbed elements from the port.
+   */
+  final protected def cancel[T](in: Inlet[T], cause: Throwable): Unit = interpreter.cancel(conn(in), cause)
 
   /**
    * Once the callback [[InHandler.onPush()]] for an input port has been invoked, the element that has been pushed
@@ -580,11 +590,21 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    * Automatically invokes [[cancel()]] or [[complete()]] on all the input or output ports that have been called,
    * then marks the stage as stopped.
    */
-  final def completeStage(): Unit = {
+  final def completeStage(): Unit = cancelStage(SubscriptionWithCancelException.StageWasCompleted)
+
+  /**
+   * Automatically invokes [[cancel()]] or [[complete()]] on all the input or output ports that have been called,
+   * then marks the stage as stopped.
+   */
+  final def cancelStage(cause: Throwable): Unit = {
+    // TODO: It's debatable if completing the stage if one output is cancelled is the right way to do things.
+    //       At least optionally it might be more reasonable to fail the stage with the given cause. That
+    //       would mean that all other *outputs* are failed, i.e. it would only concern stages with more that one
+    //       output anyway.
     var i = 0
     while (i < portToConn.length) {
       if (i < inCount)
-        interpreter.cancel(portToConn(i))
+        interpreter.cancel(portToConn(i), cause)
       else handlers(i) match {
         case e: Emitting[_] ⇒ e.addFollowUp(new EmittingCompletion(e.out, e.previous))
         case _              ⇒ interpreter.complete(portToConn(i))
@@ -602,7 +622,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
     var i = 0
     while (i < portToConn.length) {
       if (i < inCount)
-        interpreter.cancel(portToConn(i))
+        interpreter.cancel(portToConn(i), ex)
       else
         interpreter.fail(portToConn(i), ex)
       i += 1
@@ -1384,17 +1404,31 @@ trait OutHandler {
   @throws(classOf[Exception])
   def onPull(): Unit
 
+  // Hack to make sure that old `onDownstreamFinish` can be called without losing the cause in the default implementation
+  private[this] var lastCancellationCause: Throwable = _
+
   /**
    * Called when the output port will no longer accept any new elements. After this callback no other callbacks will
    * be called for this port.
    */
   @throws(classOf[Exception])
-  def onDownstreamFinish(): Unit = {
+  @deprecated("Override method that provides cause.", since = "2.6.0")
+  def onDownstreamFinish(): Unit =
     GraphInterpreter
       .currentInterpreter
       .activeStage
-      .completeStage()
-  }
+      .cancelStage(lastCancellationCause)
+
+  /**
+   * Called when the output port will no longer accept any new elements. After this callback no other callbacks will
+   * be called for this port.
+   */
+  @throws(classOf[Exception])
+  def onDownstreamFinish(cause: Throwable): Unit =
+    try {
+      lastCancellationCause = cause
+      onDownstreamFinish()
+    } finally lastCancellationCause = null
 }
 
 /**


### PR DESCRIPTION
In light of recent cancellation issues, I had a stab at propagating cancellation causes in our infrastructure.

Here's a gist of the changes:

 * introduce `SubscriptionWithCancelException` to support cancellation cause with interested parties (will fall back to old `cancel` if `Subscriber` doesn't support it
 * in boundary stages check for that marker interface to call the special cancel method, will fall back to regular `cancel` if `Publisher` doesn't support it
 * propagate cause in boundary stages to GraphInterpreter
 * in OutHandler create new handler method that is called with cause (falls back to old method)
 * in `failStage` and `cancelStage` propagate error to upstream cancellation

I added one example of how that would be used in our `Take` implementation.

This should mostly be binary compatible, but it isn't source compatible because adding overloads can throw off type inference.

Refs #23908 