### PR TITLE
Allow RestartSource.withBackoff to restart only on failures #23881

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-error.md
+++ b/akka-docs/src/main/paradox/stream/stream-error.md
@@ -67,7 +67,7 @@ Java
 
 Just as Akka provides the @ref:[backoff supervision pattern for actors](../general/supervision.md#backoff-supervisor), Akka streams
 also provides a `RestartSource`, `RestartSink` and `RestartFlow` for implementing the so-called *exponential backoff 
-supervision strategy*, starting a stage again when it fails, each time with a growing time delay between restarts.
+supervision strategy*, starting a stage again when it fails or completes, each time with a growing time delay between restarts.
 
 This pattern is useful when the stage fails or completes because some external resource is not available
 and we need to give it some time to start-up again. One of the prime examples when this is useful is
@@ -107,6 +107,8 @@ Sinks and flows can also be supervised, using @scala[`akka.stream.scaladsl.Resta
 @java[`akka.stream.scaladsl.RestartSink` and `akka.stream.scaladsl.RestartFlow`]. The `RestartSink` is restarted when 
 it cancels, while the `RestartFlow` is restarted when either the in port cancels, the out port completes, or the out
  port sends an error.
+ 
+ 
 
 ## Supervision Strategies
 

--- a/akka-docs/src/main/paradox/stream/stream-error.md
+++ b/akka-docs/src/main/paradox/stream/stream-error.md
@@ -107,8 +107,6 @@ Sinks and flows can also be supervised, using @scala[`akka.stream.scaladsl.Resta
 @java[`akka.stream.scaladsl.RestartSink` and `akka.stream.scaladsl.RestartFlow`]. The `RestartSink` is restarted when 
 it cancels, while the `RestartFlow` is restarted when either the in port cancels, the out port completes, or the out
  port sends an error.
- 
- 
 
 ## Supervision Strategies
 

--- a/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
@@ -56,7 +56,6 @@ public class RestartDocTest {
         Duration.apply(3, TimeUnit.SECONDS), // min backoff
         Duration.apply(30, TimeUnit.SECONDS), // max backoff
         0.2, // adds 20% "noise" to vary the intervals slightly
-        false,
         () ->
             // Create a source from a future of a source
             Source.fromSourceCompletionStage(

--- a/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
@@ -56,7 +56,7 @@ public class RestartDocTest {
         Duration.apply(3, TimeUnit.SECONDS), // min backoff
         Duration.apply(30, TimeUnit.SECONDS), // max backoff
         0.2, // adds 20% "noise" to vary the intervals slightly
-
+        false,
         () ->
             // Create a source from a future of a source
             Source.fromSourceCompletionStage(

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -38,7 +38,6 @@ class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
         randomFactor = 0.2, // adds 20% "noise" to vary the intervals slightly
-        onlyOnFailures = false
       ) { () ⇒
         // Create a source from a future of a source
         Source.fromFutureSource {

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -37,7 +37,7 @@ class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
       val restartSource = RestartSource.withBackoff(
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
-        randomFactor = 0.2, // adds 20% "noise" to vary the intervals slightly
+        randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
       ) { () ⇒
         // Create a source from a future of a source
         Source.fromFutureSource {

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -37,7 +37,8 @@ class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
       val restartSource = RestartSource.withBackoff(
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
-        randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
+        randomFactor = 0.2, // adds 20% "noise" to vary the intervals slightly
+        onlyOnFailures = false
       ) { () ⇒
         // Create a source from a future of a source
         Source.fromFutureSource {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -142,7 +142,7 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
     "cancel the currently running source when cancelled" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val promise = Promise[Done]()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, false) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source.repeat("a").watchTermination() { (_, term) ⇒
           promise.completeWith(term)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -176,9 +176,9 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
       created.get() should ===(1)
     }
 
-    "stop on completion if only should be restarted in failures" in assertAllStagesStopped {
+    "stop on completion if it should only be restarted in failures" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = RestartSource.onFailuresWithBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b", "c"))
           .map {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -30,7 +30,7 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
   "A restart with backoff source" should {
     "run normally" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, false) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source.repeat("a")
       }.runWith(TestSink.probe)
@@ -48,7 +48,7 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
 
     "restart on completion" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, false) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b"))
       }.runWith(TestSink.probe)
@@ -66,11 +66,11 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
 
     "restart on failure" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, false) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b", "c"))
           .map {
-            case "c" ⇒ throw TE("failed")
+            case "c"   ⇒ throw TE("failed")
             case other ⇒ other
           }
       }.runWith(TestSink.probe)
@@ -88,7 +88,7 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
 
     "backoff before restart" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0, false) { () ⇒
+      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b"))
       }.runWith(TestSink.probe)
@@ -110,7 +110,7 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
 
     "reset exponential backoff back to minimum when source runs for at least minimum backoff without completing" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0, false) { () ⇒
+      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b"))
       }.runWith(TestSink.probe)
@@ -161,7 +161,7 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
 
     "not restart the source when cancelled while backing off" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0, false) { () ⇒
+      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source.single("a")
       }.runWith(TestSink.probe)
@@ -178,11 +178,11 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
 
     "stop on completion if only should be restarted in failures" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, true) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b", "c"))
           .map {
-            case "c" ⇒ if (created.get() == 1) throw TE("failed") else "c"
+            case "c"   ⇒ if (created.get() == 1) throw TE("failed") else "c"
             case other ⇒ other
           }
       }.runWith(TestSink.probe)
@@ -202,11 +202,11 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
 
     "restart on failure when only due to failures should be restarted" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, true) { () ⇒
+      val probe = RestartSource.onFailuresWithBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b", "c"))
           .map {
-            case "c" ⇒ throw TE("failed")
+            case "c"   ⇒ throw TE("failed")
             case other ⇒ other
           }
       }.runWith(TestSink.probe)
@@ -379,7 +379,7 @@ class RestartSpec extends StreamSpec with DefaultTimeout {
             .takeWhile(_ != "complete")
             .map {
               case "error" ⇒ throw TE("error")
-              case other ⇒ other
+              case other   ⇒ other
             }.watchTermination()((_, term) ⇒
               term.foreach(_ ⇒ {
                 flowInSource.sendNext("out complete")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -22,8 +22,9 @@ object RestartSource {
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
-   * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
+   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
+   * restarting. If onlyOnFailures is false, when the wrapped [[Source]] completes, it will be restarted. In general,
+   * the wrapped [[Source]] can be cancelled by cancelling this [[Source]].
    * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
@@ -36,10 +37,13 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
+   * @param onlyOnFailures if true only restarts in failures and not in completions. Default false.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   *
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, onlyOnFailures: Boolean,
+                     sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor, onlyOnFailures) { () ⇒
       sourceFactory.create().asScala
     }.asJava
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -22,9 +22,8 @@ object RestartSource {
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
-   * restarting. If onlyOnFailures is false, when the wrapped [[Source]] completes, it will be restarted. In general,
-   * the wrapped [[Source]] can be cancelled by cancelling this [[Source]].
+   * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
+   * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
    * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
@@ -37,13 +36,38 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param onlyOnFailures if true only restarts in failures and not in completions. Default false.
+   * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   */
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                     sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+      sourceFactory.create().asScala
+    }.asJava
+  }
+
+  /**
+   * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
+   *
+   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
+   * restarting. The wrapped [[Source]] can be cancelled by cancelling this [[Source]].
+   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+   * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+   * after this [[Source]] in the graph.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, onlyOnFailures: Boolean,
-                     sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor, onlyOnFailures) { () ⇒
+  def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                               sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
       sourceFactory.create().asScala
     }.asJava
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -38,8 +38,7 @@ object RestartSource {
    *   In order to skip this additional delay pass in `0`.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
-                     sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
     akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
       sourceFactory.create().asScala
     }.asJava

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -23,8 +23,9 @@ object RestartSource {
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
-   * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
+   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
+   * restarting. If onlyOnFailures is false, when the wrapped [[Source]] completes, it will be restarted. In general,
+   * the wrapped [[Source]] can be cancelled by cancelling this [[Source]].
    * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
@@ -37,26 +38,27 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
+   * @param onlyOnFailures indicates that this [[Source]] should be restarted ONLY on failures and not in completions.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   *
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
-    Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor))
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, onlyOnFailures: Boolean)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
+    Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures))
   }
 }
 
 private final class RestartWithBackoffSource[T](
-  sourceFactory: () ⇒ Source[T, _],
-  minBackoff:    FiniteDuration,
-  maxBackoff:    FiniteDuration,
-  randomFactor:  Double
-) extends GraphStage[SourceShape[T]] { self ⇒
+  sourceFactory:  () ⇒ Source[T, _],
+  minBackoff:     FiniteDuration,
+  maxBackoff:     FiniteDuration,
+  randomFactor:   Double,
+  onlyOnFailures: Boolean) extends GraphStage[SourceShape[T]] { self ⇒
 
   val out = Outlet[T]("RestartWithBackoffSource.out")
 
   override def shape = SourceShape(out)
   override def createLogic(inheritedAttributes: Attributes) = new RestartWithBackoffLogic(
-    "Source", shape, minBackoff, maxBackoff, randomFactor
-  ) {
+    "Source", shape, minBackoff, maxBackoff, randomFactor, onlyOnFailures) {
 
     override protected def logSource = self.getClass
 
@@ -120,15 +122,13 @@ private final class RestartWithBackoffSink[T](
   sinkFactory:  () ⇒ Sink[T, _],
   minBackoff:   FiniteDuration,
   maxBackoff:   FiniteDuration,
-  randomFactor: Double
-) extends GraphStage[SinkShape[T]] { self ⇒
+  randomFactor: Double) extends GraphStage[SinkShape[T]] { self ⇒
 
   val in = Inlet[T]("RestartWithBackoffSink.in")
 
   override def shape = SinkShape(in)
   override def createLogic(inheritedAttributes: Attributes) = new RestartWithBackoffLogic(
-    "Sink", shape, minBackoff, maxBackoff, randomFactor
-  ) {
+    "Sink", shape, minBackoff, maxBackoff, randomFactor, onlyOnFailures = false) {
     override protected def logSource = self.getClass
 
     override protected def startGraph() = {
@@ -187,16 +187,14 @@ private final class RestartWithBackoffFlow[In, Out](
   flowFactory:  () ⇒ Flow[In, Out, _],
   minBackoff:   FiniteDuration,
   maxBackoff:   FiniteDuration,
-  randomFactor: Double
-) extends GraphStage[FlowShape[In, Out]] { self ⇒
+  randomFactor: Double) extends GraphStage[FlowShape[In, Out]] { self ⇒
 
   val in = Inlet[In]("RestartWithBackoffFlow.in")
   val out = Outlet[Out]("RestartWithBackoffFlow.out")
 
   override def shape = FlowShape(in, out)
   override def createLogic(inheritedAttributes: Attributes) = new RestartWithBackoffLogic(
-    "Flow", shape, minBackoff, maxBackoff, randomFactor
-  ) {
+    "Flow", shape, minBackoff, maxBackoff, randomFactor, onlyOnFailures = false) {
 
     var activeOutIn: Option[(SubSourceOutlet[In], SubSinkInlet[Out])] = None
 
@@ -242,12 +240,12 @@ private final class RestartWithBackoffFlow[In, Out](
  * Shared logic for all restart with backoff logics.
  */
 private abstract class RestartWithBackoffLogic[S <: Shape](
-  name:         String,
-  shape:        S,
-  minBackoff:   FiniteDuration,
-  maxBackoff:   FiniteDuration,
-  randomFactor: Double
-) extends TimerGraphStageLogicWithLogging(shape) {
+  name:           String,
+  shape:          S,
+  minBackoff:     FiniteDuration,
+  maxBackoff:     FiniteDuration,
+  randomFactor:   Double,
+  onlyOnFailures: Boolean) extends TimerGraphStageLogicWithLogging(shape) {
   var restartCount = 0
   var resetDeadline = minBackoff.fromNow
   // This is effectively only used for flows, if either the main inlet or outlet of this stage finishes, then we
@@ -263,11 +261,11 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
     sinkIn.setHandler(new InHandler {
       override def onPush() = push(out, sinkIn.grab())
       override def onUpstreamFinish() = {
-        if (finishing) {
+        if (finishing || onlyOnFailures) {
           complete(out)
         } else {
-          log.debug("Graph out finished")
-          onCompleteOrFailure()
+          log.debug("Restarting graph due to finished upstream")
+          scheduleRestartTimer()
         }
       }
       override def onUpstreamFailure(ex: Throwable) = {
@@ -275,7 +273,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
           fail(out, ex)
         } else {
           log.error(ex, "Restarting graph due to failure")
-          onCompleteOrFailure()
+          scheduleRestartTimer()
         }
       }
     })
@@ -307,7 +305,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
           cancel(in)
         } else {
           log.debug("Graph in finished")
-          onCompleteOrFailure()
+          scheduleRestartTimer()
         }
       }
     })
@@ -330,7 +328,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
   }
 
   // Set a timer to restart after the calculated delay
-  protected final def onCompleteOrFailure() = {
+  protected final def scheduleRestartTimer() = {
     // Check if the last start attempt was more than the minimum backoff
     if (resetDeadline.isOverdue()) {
       log.debug("Last restart attempt was more than {} ago, resetting restart count", minBackoff)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -23,9 +23,8 @@ object RestartSource {
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
-   * restarting. If onlyOnFailures is false, when the wrapped [[Source]] completes, it will be restarted. In general,
-   * the wrapped [[Source]] can be cancelled by cancelling this [[Source]].
+   * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
+   * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
    * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
@@ -38,12 +37,34 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param onlyOnFailures indicates that this [[Source]] should be restarted ONLY on failures and not in completions.
+   * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   */
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
+    Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = false))
+  }
+
+  /**
+   * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
+   *
+   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
+   * restarting. The wrapped [[Source]] can be cancelled by cancelling this [[Source]].
+   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+   * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+   * after this [[Source]] in the graph.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, onlyOnFailures: Boolean)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
-    Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures))
+  def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
+    Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = true))
   }
 }
 


### PR DESCRIPTION
Adds an argument to control if RestartSource.withBackoff should restart wrapped Source in only failures or also in completions.