### PR TITLE
Optimize TCP stream writes, #23919

### DIFF
--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestKitSpec.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestKitSpec.scala
@@ -131,9 +131,9 @@ class StreamTestKitSpec extends AkkaSpec {
 
     "#expectNextWithTimeoutPF should fail after timeout when element delayed" in {
       intercept[AssertionError] {
-        val timeout = 100 millis
-        val overTimeout = timeout + (10 millis)
-        Source.tick(overTimeout, 1 millis, 1).runWith(TestSink.probe)
+        val timeout = 100.millis
+        val overTimeout = timeout + (10.millis)
+        Source.tick(overTimeout, 1.millis, 1).runWith(TestSink.probe)
           .request(1)
           .expectNextWithTimeoutPF(timeout, {
             case 1 ⇒
@@ -169,9 +169,9 @@ class StreamTestKitSpec extends AkkaSpec {
 
     "#expectNextChainingPF should fail after timeout when element delayed" in {
       intercept[AssertionError] {
-        val timeout = 100 millis
-        val overTimeout = timeout + (10 millis)
-        Source.tick(overTimeout, 1 millis, 1).runWith(TestSink.probe)
+        val timeout = 100.millis
+        val overTimeout = timeout + (10.millis)
+        Source.tick(overTimeout, 1.millis, 1).runWith(TestSink.probe)
           .request(1)
           .expectNextChainingPF(timeout, {
             case 1 ⇒

--- a/akka-stream/src/main/mima-filters/2.5.6.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.6.backwards.excludes
@@ -1,2 +1,6 @@
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.compression.GzipCompressor.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.compression.DeflateCompressor.this")
+
+# Optimize TCP stream writes
+ProblemFilters.exclude[Problem]("akka.stream.impl.io.*")
+

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -72,6 +72,16 @@ akka {
         # of 1 on the corresponding dispatchers.
         fuzzing-mode = off
       }
+
+      io.tcp {
+        # The outgoing bytes are accumulated in a buffer while waiting for acknoledgment
+        # of pending write. This improves throughput for small messages (frames) without
+        # sacrificing latency. While waiting for the ack the stage will eagerly pull
+        # from upstream until the buffer exceeds this size. That means that the buffer may hold
+        # slightly more bytes than this limit (at most one element more). It can be set to 0
+        # to disable the usage of the buffer.
+        write-buffer-size = 16 KiB
+      }
     }
 
     # Fully qualified config path which holds the dispatcher configuration

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -65,8 +65,10 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
 final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   import Tcp._
 
+  private val settings = ActorMaterializerSettings(system)
+
   // TODO maybe this should be a new setting, like `akka.stream.tcp.bind.timeout` / `shutdown-timeout` instead?
-  val bindShutdownTimeout = ActorMaterializer()(system).settings.subscriptionTimeoutSettings.timeout
+  val bindShutdownTimeout = settings.subscriptionTimeoutSettings.timeout
 
   /**
    * Creates a [[Tcp.ServerBinding]] instance which represents a prospective TCP server binding on the given `endpoint`.
@@ -103,7 +105,8 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       options,
       halfClose,
       idleTimeout,
-      bindShutdownTimeout))
+      bindShutdownTimeout,
+      settings.ioSettings))
 
   /**
    * Creates a [[Tcp.ServerBinding]] instance which represents a prospective TCP server binding on the given `endpoint`
@@ -175,7 +178,8 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       localAddress,
       options,
       halfClose,
-      connectTimeout)).via(detacher[ByteString]) // must read ahead for proper completions
+      connectTimeout,
+      settings.ioSettings)).via(detacher[ByteString]) // must read ahead for proper completions
 
     idleTimeout match {
       case d: FiniteDuration ⇒ tcpFlow.join(TcpIdleTimeout(d, Some(remoteAddress)))


### PR DESCRIPTION
* This is an optimization of TcpStreamLogic to accumulating bytes in a buffer while waiting for
  acknoledgment of pending write. This improves throughput for small messages (frames)
  without sacrificing latency. While waiting for the ack the stage will eagerly pull
  from upstream until the buffer limit is exceeded. Accumulated bytes are written
  immediately when ack is received.
* Noticed 20x throughput improvement with Artery MaxThroughputSpec thanks to this buffer
  when working on the Artery TCP implementation. The small message (100 bytes) benchmark
  improved from 30k msg/s to 600k msg/s.

Refs #23919