### PR TITLE
Provide meaningful name for SubSource.out/SubSink.in

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -606,7 +606,7 @@ import scala.collection.JavaConverters._
   extends GraphStage[SinkShape[T]] {
   import SubSink._
 
-  private val in = Inlet[T]("SubSink.in")
+  private val in = Inlet[T](s"SubSink($name).in")
 
   override def initialAttributes = Attributes.name(s"SubSink($name)")
   override val shape = SinkShape(in)
@@ -676,7 +676,7 @@ import scala.collection.JavaConverters._
   extends GraphStage[SourceShape[T]] {
   import SubSink._
 
-  val out: Outlet[T] = Outlet("SubSource.out")
+  val out: Outlet[T] = Outlet(s"SubSource($name).out")
   override def initialAttributes = Attributes.name(s"SubSource($name)")
   override val shape: SourceShape[T] = SourceShape(out)
 


### PR DESCRIPTION
Fixes #23921

Ensures that when an erroneous invocation of a method on `SubSink` or `SubSource` (eg, push when not allowed), that the source of the invocation can more easily be identified. Since the invocations on these are generally through async callbacks, the stack trace can't be used to help, hence why the name of the inlet/outlet (which will be included in the error message) is so important.