### PR TITLE
Fix shutdown timeout in multi-jvm tests, #23925

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -308,11 +308,11 @@ abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles:
         }
       }
     }
-    shutdown(system)
+    shutdown(system, duration = shutdownTimeout)
     afterTermination()
   }
 
-  def shutdownTimeout: FiniteDuration = 5.seconds.dilated
+  def shutdownTimeout: FiniteDuration = 15.seconds.dilated
 
   /**
    * Override this and return `true` to assert that the

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -19,6 +19,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
+
 import akka.Done
 import akka.NotUsed
 import akka.actor._
@@ -530,7 +531,11 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
     val maybeDriver = mediaDriver.getAndSet(None)
     maybeDriver.foreach { driver ⇒
       // this is only for embedded media driver
-      driver.close()
+      try driver.close() catch {
+        case NonFatal(e) ⇒
+          // don't think driver.close will ever throw, but just in case
+          log.warning("Couldn't close Aeron embedded media driver due to [{}]", e.getMessage)
+      }
 
       try {
         if (settings.Advanced.DeleteAeronDirectory) {
@@ -619,12 +624,14 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
         log.debug("Inbound channel is now active")
       } else if (status == ChannelEndpointStatus.ERRORED) {
         areonErrorLog.logErrors(log, 0L)
+        stopMediaDriver()
         throw new RemoteTransportException("Inbound Aeron channel is in errored state. See Aeron logs for details.")
       } else if (status == ChannelEndpointStatus.INITIALIZING && retries > 0) {
         Thread.sleep(waitInterval)
         retry(retries - 1)
       } else {
         areonErrorLog.logErrors(log, 0L)
+        stopMediaDriver()
         throw new RemoteTransportException("Timed out waiting for Aeron transport to bind. See Aeoron logs.")
       }
     }

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -929,7 +929,7 @@ object TestKit {
         val msg = "Failed to stop [%s] within [%s] \n%s".format(actorSystem.name, duration,
           actorSystem.asInstanceOf[ActorSystemImpl].printTree)
         if (verifySystemShutdown) throw new RuntimeException(msg)
-        else actorSystem.log.warning(msg)
+        else println(msg)
     }
   }
 }


### PR DESCRIPTION
* 5 seconds was used, and sometimes the media driver close takes longer, and
  then files will not be deleted because jvm is terminated
* use the shutdownTimeout in MultiNodeSpec and increase to 15.seconds
* log shutdown failure with println in TestKit, because system might not be able
  to log when halfways shutdown

Refs #23925