### PR TITLE
#23880 Specify scope when disabling scaldoc task

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -62,7 +62,7 @@ object NoPublish extends AutoPlugin {
 
   override def projectSettings = Seq(
     skip in publish := true,
-    sources in doc := Seq.empty
+    sources in (Compile, doc) := Seq.empty
   )
 }
 


### PR DESCRIPTION
Third time's a charm.

Fixes #23880

Forgot clean after reload, so it looked that it worked, but it did not. :\