### PR TITLE
=stk accept Throwable in stream probe's sendError methods

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -220,7 +220,7 @@ object TestPublisher {
       this
     }
 
-    def sendError(cause: Exception): Self = {
+    def sendError(cause: Throwable): Self = {
       subscription.sendError(cause)
       this
     }
@@ -795,7 +795,7 @@ private[testkit] object StreamTestKit {
 
     def sendNext(element: I): Unit = subscriber.onNext(element)
     def sendComplete(): Unit = subscriber.onComplete()
-    def sendError(cause: Exception): Unit = subscriber.onError(cause)
+    def sendError(cause: Throwable): Unit = subscriber.onError(cause)
 
     def sendOnSubscribe(): Unit = subscriber.onSubscribe(this)
   }

--- a/build.sbt
+++ b/build.sbt
@@ -309,6 +309,7 @@ lazy val streamTestkit = akkaModule("akka-stream-testkit")
   .dependsOn(stream, testkit % "compile->compile;test->test")
   .settings(Dependencies.streamTestkit)
   .settings(OSGi.streamTestkit)
+  .disablePlugins(MimaPlugin)
 
 lazy val streamTests = akkaModule("akka-stream-tests")
   .dependsOn(streamTestkit % "test->test", stream)


### PR DESCRIPTION
To match reactive-streams interfaces.