### PR TITLE
fix deprecation warning in project/MultiNode.scala

### DIFF
--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -42,7 +42,7 @@ object MultiNode extends AutoPlugin {
     // -DMultiJvm.akka.cluster.Stress.nrOfNodes=15
     val MultinodeJvmArgs = "multinode\\.(D|X)(.*)".r
     val knownPrefix = Set("multnode.", "akka.", "MultiJvm.")
-    val akkaProperties = System.getProperties.propertyNames.asScala.toList.collect {
+    val akkaProperties = System.getProperties.stringPropertyNames.asScala.toList.collect {
       case MultinodeJvmArgs(a, b) ⇒
         val value = System.getProperty("multinode." + a + b)
         "-" + a + b + (if (value == "") "" else "=" + value)


### PR DESCRIPTION
```
project/MultiNode.scala:46:12: method unapplySeq in class Regex is deprecated (since 2.11.0): extracting a match result from anything but a CharSequence or Match is deprecated
[warn]       case MultinodeJvmArgs(a, b) ⇒
[warn]            ^
```

- https://github.com/scala/scala/blob/v2.12.4/src/library/scala/util/matching/Regex.scala#L340
- https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html

`System.getProperties.propertyNames.asScala.toList` return `List[Any]`