### PR TITLE
Move coordinated-shutdown config from test/resources, #23879

### DIFF
--- a/akka-cluster-metrics/src/test/resources/reference.conf
+++ b/akka-cluster-metrics/src/test/resources/reference.conf
@@ -5,6 +5,3 @@ akka {
   }
 }
 
-akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
-akka.coordinated-shutdown.terminate-actor-system = off
-akka.cluster.run-coordinated-shutdown-when-down = off

--- a/akka-cluster-sharding/src/test/resources/reference.conf
+++ b/akka-cluster-sharding/src/test/resources/reference.conf
@@ -5,6 +5,3 @@ akka {
   }
 }
 
-akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
-akka.coordinated-shutdown.terminate-actor-system = off
-akka.cluster.run-coordinated-shutdown-when-down = off

--- a/akka-cluster-tools/src/test/resources/reference.conf
+++ b/akka-cluster-tools/src/test/resources/reference.conf
@@ -5,6 +5,3 @@ akka {
   }
 }
 
-akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
-akka.coordinated-shutdown.terminate-actor-system = off
-akka.cluster.run-coordinated-shutdown-when-down = off

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcClusterSpec.scala
@@ -21,7 +21,6 @@ class MultiDcSpecConfig(crossDcConnections: Int = 5) extends MultiNodeConfig {
     s"""
       # DEBUG On for issue #23864
       akka.loglevel = DEBUG
-      akka.coordinated-shutdown.terminate-actor-system = off
       akka.cluster.multi-data-center.cross-data-center-connections = $crossDcConnections
     """).withFallback(MultiNodeClusterSpec.clusterConfig))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -46,6 +46,8 @@ object MultiNodeClusterSpec {
       periodic-tasks-initial-delay        = 300 ms
       publish-stats-interval              = 0 s # always, when it happens
       failure-detector.heartbeat-interval = 500 ms
+
+      run-coordinated-shutdown-when-down = off
     }
     akka.loglevel = INFO
     akka.log-dead-letters = off

--- a/akka-cluster/src/test/resources/reference.conf
+++ b/akka-cluster/src/test/resources/reference.conf
@@ -5,7 +5,4 @@ akka {
   }
 }
 
-akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
-akka.coordinated-shutdown.terminate-actor-system = off
-akka.cluster.run-coordinated-shutdown-when-down = off
 

--- a/akka-distributed-data/src/test/resources/reference.conf
+++ b/akka-distributed-data/src/test/resources/reference.conf
@@ -3,6 +3,3 @@ akka.actor {
   warn-about-java-serializer-usage = off
 }
 
-akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
-akka.coordinated-shutdown.terminate-actor-system = off
-akka.cluster.run-coordinated-shutdown-when-down = off

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -217,6 +217,7 @@ object MultiNodeSpec {
         loggers = ["akka.testkit.TestEventListener"]
         loglevel = "WARNING"
         stdout-loglevel = "WARNING"
+        coordinated-shutdown.terminate-actor-system = off
         coordinated-shutdown.run-by-jvm-shutdown-hook = off
         actor {
           default-dispatcher {


### PR DESCRIPTION
* looks like the ActorSystem is shutdown when leaving
* Included in MultiNodeSpec, i.e. all multi-node tests:
  akka.coordinated-shutdown.terminate-actor-system = off
  akka.oordinated-shutdown.run-by-jvm-shutdown-hook = off

Refs #23879