### PR TITLE
Add removeInterceptor function to ReceivePipeline and add tests

### DIFF
--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReceivePipeline.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReceivePipeline.scala
@@ -54,17 +54,33 @@ trait ReceivePipeline extends Actor {
   /**
    * Adds an inner interceptor, it will be applied lastly, near to Actor's original behavior
    * @param interceptor an interceptor
+   * @return the interceptor added
    */
-  def pipelineInner(interceptor: Interceptor): Unit = {
-    pipeline :+= withDefault(interceptor)
+  def pipelineInner(interceptor: Interceptor): Interceptor = {
+    val interceptorWithDefault = withDefault(interceptor)
+    pipeline :+= interceptorWithDefault
     decoratorCache = None
+    interceptorWithDefault
   }
+
   /**
    * Adds an outer interceptor, it will be applied firstly, far from Actor's original behavior
    * @param interceptor an interceptor
+   * @return the interceptor added
    */
-  def pipelineOuter(interceptor: Interceptor): Unit = {
-    pipeline +:= withDefault(interceptor)
+  def pipelineOuter(interceptor: Interceptor): Interceptor = {
+    val interceptorWithDefault = withDefault(interceptor)
+    pipeline +:= interceptorWithDefault
+    decoratorCache = None
+    interceptorWithDefault
+  }
+
+  /**
+   * Removes an outer interceptor
+   *  @param interceptor Interceptor to remove
+   */
+  def removeInterceptor(interceptor: Interceptor): Unit = {
+    pipeline = pipeline.filterNot(i ⇒ i == interceptor)
     decoratorCache = None
   }
 


### PR DESCRIPTION
I've been using a modified version of ReceivePipeline for an actor based load testing system. Interceptors are added and removed to load test actors to modify their behaviour during the test. To facilitate this I added a removeInterceptor function. This pull request includes that function and an updated test spec for ReceivePipeline.