### PR TITLE
Revert "[fixes#23329] PersistentFSM: andThen callbacks are not executed when stay()"

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -140,7 +140,6 @@ trait PersistentFSM[S <: FSMState, D, E] extends PersistentActor with Persistent
     if (eventsToPersist.isEmpty) {
       //If there are no events to persist, just apply the state
       super.applyState(nextState)
-      nextState.afterTransitionDo(stateData)
     } else {
       //Persist the events and apply the new state after all event handlers were executed
       var nextData: D = stateData


### PR DESCRIPTION
Reverts akka/akka#23943

As the semantics we actually want are not clear yet, see my comments in the previous PR.