### PR TITLE
Fixed typos and grammar in streams error handling and streams buffers doc

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-error.md
+++ b/akka-docs/src/main/paradox/stream/stream-error.md
@@ -72,7 +72,7 @@ supervision strategy*, starting a stage again when it fails, each time with a gr
 This pattern is useful when the stage fails or completes because some external resource is not available
 and we need to give it some time to start-up again. One of the prime examples when this is useful is
 when a WebSocket connection fails due to the HTTP server it's running on going down, perhaps because it is overloaded. 
-By using an exponential backoff, we avoid going into a tight reconnect look, which both gives the HTTP server some time
+By using an exponential backoff, we avoid going into a tight reconnect loop, which both gives the HTTP server some time
 to recover, and it avoids using needless resources on the client side.
 
 The following snippet shows how to create a backoff supervisor using @scala[`akka.stream.scaladsl.RestartSource`] 

--- a/akka-docs/src/main/paradox/stream/stream-rate.md
+++ b/akka-docs/src/main/paradox/stream/stream-rate.md
@@ -44,7 +44,7 @@ a new element is not immediately requested once an element has been drained from
 are requested after multiple elements have been drained. This batching strategy reduces the communication cost of
 propagating the backpressure signal through the asynchronous boundary.
 
-While this internal protocol is mostly invisible to the user (apart form its throughput increasing effects) there are
+While this internal protocol is mostly invisible to the user (apart from its throughput increasing effects) there are
 situations when these details get exposed. In all of our previous examples we always assumed that the rate of the
 processing chain is strictly coordinated through the backpressure signal causing all stages to process no faster than
 the throughput of the connected chain. There are tools in Akka Streams however that enable the rates of different segments
@@ -191,10 +191,10 @@ Java
 :   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #conflate-summarize }
 
 This example demonstrates that such flow's rate is decoupled. The element rate at the start of the flow can be much
-higher that the element rate at the end of the flow.
+higher than the element rate at the end of the flow.
 
-Another possible use of `conflate` is to not consider all elements for summary when producer starts getting too fast.
-Example below demonstrates how `conflate` can be used to implement random drop of elements when consumer is not able
+Another possible use of `conflate` is to not consider all elements for summary when the producer starts getting too fast.
+The example below demonstrates how `conflate` can be used to randomly drop elements when the consumer is not able
 to keep up with the producer.
 
 Scala


### PR DESCRIPTION
Fixed typos and wrong grammar in the akka streams error handling and akka streams buffer and rate documentation