### PR TITLE
=pro #23931 define automatic module names explicitly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import akka.AutomaticModuleName
+
 enablePlugins(UnidocRoot, TimeStampede, UnidocWithPrValidation, NoPublish)
 disablePlugins(MimaPlugin)
 
@@ -48,6 +50,7 @@ lazy val root = Project(
 lazy val actor = akkaModule("akka-actor")
   .settings(Dependencies.actor)
   .settings(OSGi.actor)
+  .settings(AutomaticModuleName.settings("akka.actor"))
   .settings(
     unmanagedSourceDirectories in Compile += {
       val ver = scalaVersion.value.take(4)
@@ -66,6 +69,7 @@ lazy val actorTests = akkaModule("akka-actor-tests")
 lazy val agent = akkaModule("akka-agent")
   .dependsOn(actor, testkit % "test->test")
   .settings(Dependencies.agent)
+  .settings(AutomaticModuleName.settings("akka.agent"))
   .settings(OSGi.agent)
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
 
@@ -91,11 +95,13 @@ lazy val benchJmh = akkaModule("akka-bench-jmh")
 lazy val camel = akkaModule("akka-camel")
   .dependsOn(actor, slf4j, testkit % "test->test")
   .settings(Dependencies.camel)
+  .settings(AutomaticModuleName.settings("akka.camel"))
   .settings(OSGi.camel)
 
 lazy val cluster = akkaModule("akka-cluster")
   .dependsOn(remote, remoteTests % "test->test" , testkit % "test->test")
   .settings(Dependencies.cluster)
+  .settings(AutomaticModuleName.settings("akka.cluster"))
   .settings(OSGi.cluster)
   .settings(Protobuf.settings)
   .settings(
@@ -109,6 +115,7 @@ lazy val clusterMetrics = akkaModule("akka-cluster-metrics")
   .dependsOn(cluster % "compile->compile;test->test;multi-jvm->multi-jvm", slf4j % "test->compile")
   .settings(OSGi.clusterMetrics)
   .settings(Dependencies.clusterMetrics)
+  .settings(AutomaticModuleName.settings("akka.cluster.metrics"))
   .settings(Protobuf.settings)
   .settings(SigarLoader.sigarSettings)
   .settings(
@@ -129,6 +136,7 @@ lazy val clusterSharding = akkaModule("akka-cluster-sharding")
     clusterTools
   )
   .settings(Dependencies.clusterSharding)
+  .settings(AutomaticModuleName.settings("akka.cluster.sharding"))
   .settings(OSGi.clusterSharding)
   .settings(Protobuf.settings)
   .configs(MultiJvm)
@@ -137,6 +145,7 @@ lazy val clusterSharding = akkaModule("akka-cluster-sharding")
 lazy val clusterTools = akkaModule("akka-cluster-tools")
   .dependsOn(cluster % "compile->compile;test->test;multi-jvm->multi-jvm")
   .settings(Dependencies.clusterTools)
+  .settings(AutomaticModuleName.settings("akka.cluster.tools"))
   .settings(OSGi.clusterTools)
   .settings(Protobuf.settings)
   .configs(MultiJvm)
@@ -145,6 +154,7 @@ lazy val clusterTools = akkaModule("akka-cluster-tools")
 lazy val contrib = akkaModule("akka-contrib")
   .dependsOn(remote, remoteTests % "test->test", cluster, clusterTools, persistence % "compile->compile;test->provided")
   .settings(Dependencies.contrib)
+  .settings(AutomaticModuleName.settings("akka.contrib"))
   .settings(OSGi.contrib)
   .settings(
     description := """|
@@ -165,6 +175,7 @@ lazy val contrib = akkaModule("akka-contrib")
 lazy val distributedData = akkaModule("akka-distributed-data")
   .dependsOn(cluster % "compile->compile;test->test;multi-jvm->multi-jvm")
   .settings(Dependencies.distributedData)
+  .settings(AutomaticModuleName.settings("akka.cluster.ddata")) // TODO or akka.ddata
   .settings(OSGi.distributedData)
   .settings(Protobuf.settings)
   .configs(MultiJvm)
@@ -219,11 +230,13 @@ lazy val docs = akkaModule("akka-docs")
 lazy val multiNodeTestkit = akkaModule("akka-multi-node-testkit")
   .dependsOn(remote, testkit)
   .settings(Protobuf.settings)
+  .settings(AutomaticModuleName.settings("akka.multinode.testkit"))
   .settings(AkkaBuild.mayChangeSettings)
 
 lazy val osgi = akkaModule("akka-osgi")
   .dependsOn(actor)
   .settings(Dependencies.osgi)
+  .settings(AutomaticModuleName.settings("akka.osgi"))
   .settings(OSGi.osgi)
   .settings(
     parallelExecution in Test := false
@@ -232,6 +245,7 @@ lazy val osgi = akkaModule("akka-osgi")
 lazy val persistence = akkaModule("akka-persistence")
   .dependsOn(actor, testkit % "test->test", protobuf)
   .settings(Dependencies.persistence)
+  .settings(AutomaticModuleName.settings("akka.persistence"))
   .settings(OSGi.persistence)
   .settings(Protobuf.settings)
   .settings(
@@ -245,6 +259,7 @@ lazy val persistenceQuery = akkaModule("akka-persistence-query")
     streamTestkit % "test"
   )
   .settings(Dependencies.persistenceQuery)
+  .settings(AutomaticModuleName.settings("akka.persistence.query"))
   .settings(OSGi.persistenceQuery)
   .settings(
     fork in Test := true
@@ -254,6 +269,7 @@ lazy val persistenceQuery = akkaModule("akka-persistence-query")
 lazy val persistenceShared = akkaModule("akka-persistence-shared")
   .dependsOn(persistence % "test->test", testkit % "test->test", remote % "test", protobuf)
   .settings(Dependencies.persistenceShared)
+  .settings(AutomaticModuleName.settings("akka.persistence.shared"))
   .settings(
     fork in Test := true
   )
@@ -263,6 +279,7 @@ lazy val persistenceShared = akkaModule("akka-persistence-shared")
 lazy val persistenceTck = akkaModule("akka-persistence-tck")
   .dependsOn(persistence % "compile->compile;provided->provided;test->test", testkit % "compile->compile;test->test")
   .settings(Dependencies.persistenceTck)
+  .settings(AutomaticModuleName.settings("akka.persistence.tck"))
 //.settings(OSGi.persistenceTck) TODO: we do need to export this as OSGi bundle too?
   .settings(
     fork in Test := true
@@ -271,12 +288,14 @@ lazy val persistenceTck = akkaModule("akka-persistence-tck")
 
 lazy val protobuf = akkaModule("akka-protobuf")
   .settings(OSGi.protobuf)
+  .settings(AutomaticModuleName.settings("akka.protobuf"))
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
   .disablePlugins(MimaPlugin)
 
 lazy val remote = akkaModule("akka-remote")
   .dependsOn(actor, stream, actorTests % "test->test", testkit % "test->test", streamTestkit % "test", protobuf)
   .settings(Dependencies.remote)
+  .settings(AutomaticModuleName.settings("akka.remote"))
   .settings(OSGi.remote)
   .settings(Protobuf.settings)
   .settings(
@@ -297,17 +316,20 @@ lazy val remoteTests = akkaModule("akka-remote-tests")
 lazy val slf4j = akkaModule("akka-slf4j")
   .dependsOn(actor, testkit % "test->test")
   .settings(Dependencies.slf4j)
+  .settings(AutomaticModuleName.settings("akka.slf4j"))
   .settings(OSGi.slf4j)
 
 lazy val stream = akkaModule("akka-stream")
   .dependsOn(actor)
   .settings(Dependencies.stream)
+  .settings(AutomaticModuleName.settings("akka.stream"))
   .settings(OSGi.stream)
   .enablePlugins(BoilerplatePlugin)
 
 lazy val streamTestkit = akkaModule("akka-stream-testkit")
   .dependsOn(stream, testkit % "compile->compile;test->test")
   .settings(Dependencies.streamTestkit)
+  .settings(AutomaticModuleName.settings("akka.stream.testkit"))
   .settings(OSGi.streamTestkit)
 
 lazy val streamTests = akkaModule("akka-stream-tests")
@@ -332,6 +354,7 @@ lazy val streamTestsTck = akkaModule("akka-stream-tests-tck")
 lazy val testkit = akkaModule("akka-testkit")
   .dependsOn(actor)
   .settings(Dependencies.testkit)
+  .settings(AutomaticModuleName.settings("akka.actor.testkit"))
   .settings(OSGi.testkit)
   .settings(
     initialCommands += "import akka.testkit._"
@@ -347,6 +370,7 @@ lazy val typed = akkaModule("akka-typed")
     distributedData % "provided->compile"
   )
   .settings(AkkaBuild.mayChangeSettings)
+  .settings(AutomaticModuleName.settings("akka.typed")) // fine for now, eventually new module name to become typed.actor
   .settings(
     initialCommands := """
       import akka.typed._
@@ -361,6 +385,7 @@ lazy val typed = akkaModule("akka-typed")
 
 lazy val typedTestkit = akkaModule("akka-typed-testkit")
   .dependsOn(typed, testkit % "compile->compile;test->test")
+  .settings(AutomaticModuleName.settings("akka.typed.testkit"))
   .disablePlugins(MimaPlugin)
 
 lazy val typedTests = akkaModule("akka-typed-tests")

--- a/build.sbt
+++ b/build.sbt
@@ -175,7 +175,7 @@ lazy val contrib = akkaModule("akka-contrib")
 lazy val distributedData = akkaModule("akka-distributed-data")
   .dependsOn(cluster % "compile->compile;test->test;multi-jvm->multi-jvm")
   .settings(Dependencies.distributedData)
-  .settings(AutomaticModuleName.settings("akka.cluster.ddata")) // TODO or akka.ddata
+  .settings(AutomaticModuleName.settings("akka.cluster.ddata"))
   .settings(OSGi.distributedData)
   .settings(Protobuf.settings)
   .configs(MultiJvm)

--- a/build.sbt
+++ b/build.sbt
@@ -230,7 +230,7 @@ lazy val docs = akkaModule("akka-docs")
 lazy val multiNodeTestkit = akkaModule("akka-multi-node-testkit")
   .dependsOn(remote, testkit)
   .settings(Protobuf.settings)
-  .settings(AutomaticModuleName.settings("akka.multinode.testkit"))
+  .settings(AutomaticModuleName.settings("akka.remote.testkit"))
   .settings(AkkaBuild.mayChangeSettings)
 
 lazy val osgi = akkaModule("akka-osgi")

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka
+
+import sbt.{Def, _}
+import sbt.Keys._
+
+/**
+ * Helper to set Automatic-Module-Name in projects.
+ *
+ * !! DO NOT BE TEMPTED INTO AUTOMATICALLY DERIVING THE NAMES FROM PROJECT NAMES !!
+ *
+ * The names carry a lot of implications and DO NOT have to always align 1:1 with the group ids or package names,
+ * though there should be of course a strong relationship between them.
+ */
+object AutomaticModuleName  {
+  private val AutomaticModuleName = "Automatic-Module-Name"
+
+  def settings(name: String): Seq[Def.Setting[Task[Seq[PackageOption]]]] = Seq(
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(AutomaticModuleName → name)
+  )
+}


### PR DESCRIPTION
… otherwise be "akkaactor_2.12" etc. and cause trouble for libraries who want to modularise, but depend on Akka.

This step is a "half step", we're not real modules yet, and it does not change anything to encapsulation. Everything is public in those modules still, but we're "reserved the name" to avoid "module conflict hell" for people in the future -- see 1st link below.

Resulting MANIFEST.INF example:

```
Manifest-Version: 1.0
Implementation-Title: akka-typed
Automatic-Module-Name: akka.typed          <<<<
Implementation-Version: 2.5-SNAPSHOT
Specification-Vendor: Lightbend Inc.
Specification-Title: akka-typed
Implementation-Vendor-Id: com.typesafe.akka
Specification-Version: 2.5-SNAPSHOT
Implementation-URL: http://akka.io/
Implementation-Vendor: Lightbend Inc.
```

Read:
- http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html
- http://mail.openjdk.java.net/pipermail/jpms-spec-experts/2017-February/000582.html
- http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html

for rationale