### PR TITLE
=act #23961 increase timeouts in fsm spec a bit

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTimingSpec.scala
@@ -24,12 +24,12 @@ class FSMTimingSpec extends AkkaSpec with ImplicitSender {
   "A Finite State Machine" must {
 
     "receive StateTimeout" taggedAs TimingTest in {
-      within(1 second) {
-        within(500 millis, 1 second) {
+      within(2 seconds) {
+        within(500 millis, 2 seconds) {
           fsm ! TestStateTimeout
           expectMsg(Transition(fsm, TestStateTimeout, Initial))
         }
-        expectNoMsg
+        expectNoMessage(remainingOrDefault)
       }
     }
 
@@ -39,7 +39,7 @@ class FSMTimingSpec extends AkkaSpec with ImplicitSender {
         fsm ! Cancel
         expectMsg(Cancel)
         expectMsg(Transition(fsm, TestStateTimeout, Initial))
-        expectNoMsg
+        expectNoMessage(remainingOrDefault)
       }
     }
 
@@ -48,7 +48,7 @@ class FSMTimingSpec extends AkkaSpec with ImplicitSender {
       system.eventStream.subscribe(testActor, classOf[DeadLetter])
       stoppingActor ! TestStoppingActorStateTimeout
       within(400 millis) {
-        expectNoMsg
+        expectNoMessage(remainingOrDefault)
       }
     }
 


### PR DESCRIPTION
The timeout was indeed a bit tight, since it is set to 800ms, so it only had a little wiggle room in the up-to-1-second block.

Moved away from deprecated expectNoMsg methods at the same time

Stabilizes https://github.com/akka/akka/issues/23961 a bit