### PR TITLE
Improve error message for AbstractPersistentFSMTest failure

### DIFF
--- a/akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java
+++ b/akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java
@@ -36,10 +36,11 @@ import static akka.persistence.fsm.AbstractPersistentFSMTest.WebStoreCustomerFSM
 import static akka.persistence.fsm.AbstractPersistentFSMTest.WebStoreCustomerFSM.PurchaseWasMade;
 import static akka.persistence.fsm.AbstractPersistentFSMTest.WebStoreCustomerFSM.ShoppingCardDiscarded;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.matchers.JUnitMatchers.hasItems;
 
 public class AbstractPersistentFSMTest extends JUnitSuite {
     private static Option<String> none = Option.none();
@@ -63,8 +64,8 @@ public class AbstractPersistentFSMTest extends JUnitSuite {
             watch(fsmRef);
             fsmRef.tell(new PersistentFSM.SubscribeTransitionCallBack(getRef()), getRef());
 
-            Item shirt = new Item("1", "Shirt", 59.99F);
-            Item shoes = new Item("2", "Shoes", 89.99F);
+            Item shirt = new Item("1", "Shirt", 19.99F);
+            Item shoes = new Item("2", "Shoes", 18.99F);
             Item coat = new Item("3", "Coat", 119.99F);
 
             fsmRef.tell(GetCurrentCart.INSTANCE, getRef());
@@ -116,7 +117,7 @@ public class AbstractPersistentFSMTest extends JUnitSuite {
             watch(fsmRef);
             fsmRef.tell(new PersistentFSM.SubscribeTransitionCallBack(getRef()), getRef());
 
-            Item shirt = new Item("1", "Shirt", 59.99F);
+            Item shirt = new Item("1", "Shirt", 29.99F);
 
             fsmRef.tell(new AddItem(shirt), getRef());
 
@@ -145,9 +146,9 @@ public class AbstractPersistentFSMTest extends JUnitSuite {
             watch(fsmRef);
             fsmRef.tell(new PersistentFSM.SubscribeTransitionCallBack(getRef()), getRef());
 
-            Item shirt = new Item("1", "Shirt", 59.99F);
-            Item shoes = new Item("2", "Shoes", 89.99F);
-            Item coat = new Item("3", "Coat", 119.99F);
+            Item shirt = new Item("1", "Shirt", 38.99F);
+            Item shoes = new Item("2", "Shoes", 39.99F);
+            Item coat = new Item("3", "Coat", 139.99F);
 
             fsmRef.tell(GetCurrentCart.INSTANCE, getRef());
             fsmRef.tell(new AddItem(shirt), getRef());
@@ -159,7 +160,7 @@ public class AbstractPersistentFSMTest extends JUnitSuite {
             assertEquals(currentState.state(), UserState.LOOKING_AROUND);
 
             ShoppingCart shoppingCart = expectMsgClass(ShoppingCart.class);
-            assertTrue(shoppingCart.getItems().isEmpty());
+            assertThat(shoppingCart.getItems(), equalTo(Collections.emptyList()));
 
             PersistentFSM.Transition stateTransition = expectMsgClass(PersistentFSM.Transition.class);
             assertTransition(stateTransition, fsmRef, UserState.LOOKING_AROUND, UserState.SHOPPING);
@@ -216,9 +217,9 @@ public class AbstractPersistentFSMTest extends JUnitSuite {
             watch(fsmRef);
             fsmRef.tell(new PersistentFSM.SubscribeTransitionCallBack(getRef()), getRef());
 
-            Item shirt = new Item("1", "Shirt", 59.99F);
-            Item shoes = new Item("2", "Shoes", 89.99F);
-            Item coat = new Item("3", "Coat", 119.99F);
+            Item shirt = new Item("1", "Shirt", 49.99F);
+            Item shoes = new Item("2", "Shoes", 49.99F);
+            Item coat = new Item("3", "Coat", 149.99F);
 
             fsmRef.tell(new AddItem(shirt), getRef());
             fsmRef.tell(new AddItem(shoes), getRef());
@@ -254,8 +255,8 @@ public class AbstractPersistentFSMTest extends JUnitSuite {
             fsmRef.tell(new PersistentFSM.SubscribeTransitionCallBack(getRef()), getRef());
 
             Item shirt = new Item("1", "Shirt", 59.99F);
-            Item shoes = new Item("2", "Shoes", 89.99F);
-            Item coat = new Item("3", "Coat", 119.99F);
+            Item shoes = new Item("2", "Shoes", 58.99F);
+            Item coat = new Item("3", "Coat", 159.99F);
 
             fsmRef.tell(new AddItem(shirt), getRef());
             fsmRef.tell(new AddItem(shoes), getRef());
@@ -283,7 +284,7 @@ public class AbstractPersistentFSMTest extends JUnitSuite {
             watch(fsmRef);
             fsmRef.tell(new PersistentFSM.SubscribeTransitionCallBack(getRef()), getRef());
 
-            Item shirt = new Item("1", "Shirt", 59.99F);
+            Item shirt = new Item("1", "Shirt", 69.99F);
 
             fsmRef.tell(new AddItem(shirt), getRef());
 


### PR DESCRIPTION
This once failed where the intial shopping cart before adding an item
was not empty so changed the matcher to show what was in the sopping cart. 

I've also changed the item prices to be different for
each test just in case we're picking up state from a previous test
(which seems unlikely given the pid is a random uuid)

Also stopped using deprecated hamcrest matcher.

Refs https://github.com/akka/akka/issues/23955