### PR TITLE
adjust burstSize in FanOutThrougputSpec, #23198

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
@@ -95,7 +95,8 @@ abstract class FanOutThroughputSpec extends RemotingMultiNodeSpec(FanOutThroughp
     else ActorRefTarget(ref)
   }
 
-  val burstSize = 2000 / senderReceiverPairs
+  // each sender may have 3 bursts in flight
+  val burstSize = 3000 / senderReceiverPairs / 3
   val scenarios = List(
     TestSettings(
       testName = "warmup",
@@ -175,7 +176,6 @@ abstract class FanOutThroughputSpec extends RemotingMultiNodeSpec(FanOutThroughp
   }
 
   "Max throughput of fan-out" must {
-    pending // FIXME until issue #23198 has been solved
     val reporter = BenchmarkFileReporter("FanOutThroughputSpec", system)
     for (s ← scenarios) {
       s"be great for ${s.testName}, burstSize = ${s.burstSize}, payloadSize = ${s.payloadSize}" in test(s, reporter)


### PR DESCRIPTION
FanOutThrougputSpec sometimes failed due to overflow of send queue, size [3072].  

Refs #23198