### PR TITLE
FusableProcessorTest failure

### DIFF
--- a/akka-stream-tests-tck/src/test/scala/akka/stream/tck/FusableProcessorTest.scala
+++ b/akka-stream-tests-tck/src/test/scala/akka/stream/tck/FusableProcessorTest.scala
@@ -3,9 +3,7 @@
  */
 package akka.stream.tck
 
-import akka.NotUsed
 import akka.stream._
-import akka.stream.impl.fusing.GraphStages
 import akka.stream.scaladsl.Flow
 import org.reactivestreams.Processor
 
@@ -17,8 +15,7 @@ class FusableProcessorTest extends AkkaIdentityProcessorVerification[Int] {
 
     implicit val materializer = ActorMaterializer(settings)(system)
 
-    // withAttributes "wraps" the underlying identity and protects it from automatic removal
-    Flow[Int].via(GraphStages.identity.asInstanceOf[Graph[FlowShape[Int, Int], NotUsed]]).named("identity").toProcessor.run()
+    Flow[Int].map(identity).toProcessor.run()
   }
 
   override def createElement(element: Int): Int = element


### PR DESCRIPTION
This does likely not fix the fail, but the test was not doing what it thought it was doing - the identity stage was eliminated while the comment showed someone intended it not to be.

As the failure happened around (give or take two months) when the new materializer was in place and that optimization in `Flow.viaMat` was last changed, maybe, just maybe, there was something related to the stage being optimized away causing the failure.

Refs #22981