### PR TITLE
JavaSerializer should not supersede other serializer, #17252

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -27,6 +27,7 @@ object SerializationTests {
         serialize-messages = off
         serializers {
           test = "akka.serialization.NoopSerializer"
+          test2 = "akka.serialization.NoopSerializer2"
         }
 
         serialization-bindings {
@@ -37,6 +38,7 @@ object SerializationTests {
           "akka.serialization.SerializationTests$$A" = java
           "akka.serialization.SerializationTests$$B" = test
           "akka.serialization.SerializationTests$$D" = test
+          "akka.serialization.TestSerializable2" = test2
         }
       }
     }
@@ -62,7 +64,9 @@ object SerializationTests {
 
   class ExtendedPlainMessage extends PlainMessage
 
-  class Both(s: String) extends SimpleMessage(s) with Serializable
+  class BothTestSerializableAndJavaSerializable(s: String) extends SimpleMessage(s) with Serializable
+
+  class BothTestSerializableAndTestSerializable2(s: String) extends TestSerializable with TestSerializable2
 
   trait A
   trait B
@@ -216,18 +220,22 @@ class SerializeSpec extends AkkaSpec(SerializationTests.serializeConf) {
       ser.serializerFor(classOf[ExtendedPlainMessage]).getClass should ===(classOf[NoopSerializer])
     }
 
+    "give JavaSerializer lower priority for message with several bindings" in {
+      ser.serializerFor(classOf[BothTestSerializableAndJavaSerializable]).getClass should ===(classOf[NoopSerializer])
+    }
+
     "give warning for message with several bindings" in {
       EventFilter.warning(start = "Multiple serializers found", occurrences = 1) intercept {
-        ser.serializerFor(classOf[Both]).getClass should (be(classOf[NoopSerializer]) or be(classOf[JavaSerializer]))
+        ser.serializerFor(classOf[BothTestSerializableAndTestSerializable2]).getClass should (
+          be(classOf[NoopSerializer]) or be(classOf[NoopSerializer2]))
       }
     }
 
     "resolve serializer in the order of the bindings" in {
       ser.serializerFor(classOf[A]).getClass should ===(classOf[JavaSerializer])
       ser.serializerFor(classOf[B]).getClass should ===(classOf[NoopSerializer])
-      EventFilter.warning(start = "Multiple serializers found", occurrences = 1) intercept {
-        ser.serializerFor(classOf[C]).getClass should (be(classOf[NoopSerializer]) or be(classOf[JavaSerializer]))
-      }
+      // JavaSerializer lower prio when multiple found
+      ser.serializerFor(classOf[C]).getClass should ===(classOf[NoopSerializer])
     }
 
     "resolve serializer in the order of most specific binding first" in {
@@ -529,11 +537,24 @@ class NoVerificationWarningOffSpec extends AkkaSpec(
 }
 
 protected[akka] trait TestSerializable
+protected[akka] trait TestSerializable2
 
 protected[akka] class NoopSerializer extends Serializer {
   def includeManifest: Boolean = false
 
   def identifier = 9999
+
+  def toBinary(o: AnyRef): Array[Byte] = {
+    Array.empty[Byte]
+  }
+
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = null
+}
+
+protected[akka] class NoopSerializer2 extends Serializer {
+  def includeManifest: Boolean = false
+
+  def identifier = 10000
 
   def toBinary(o: AnyRef): Array[Byte] = {
     Array.empty[Byte]


### PR DESCRIPTION
* The classical problem when case class is extending a marker interface that is
  configured to a specific serializer, java.io.Serializable and the marker
  interface have no order. Multiple serializers found and then it is picking
  the first one.
* This changes that behavior so that if multiple serializers are found it gives
  JavaSerializer low priority and chooses the other serializer.
* This might look like a scary change from a compatibility perspective, but
  it should be fine becuse it is not influencing deserialization. The previous
  choice for serialization was pretty random so this choice should not make
  it worse.

Refs #17252