### PR TITLE
[PROTOTYPING][WIP] Ideas and work in progress about outer-most-wins stream attributes

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SealedAttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SealedAttributesSpec.scala
@@ -1,0 +1,268 @@
+/**
+ * Copyright (C) 2015-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import akka.NotUsed
+import akka.stream._
+import akka.stream.Attributes._
+import akka.stream.testkit._
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import akka.stream.impl.{ QueueSink, SinkModule, SinkholeSubscriber }
+import akka.stream.impl.Stages.DefaultAttributes
+import akka.stream.stage._
+import org.scalatest.concurrent.ScalaFutures
+
+object SealedAttributesSpec {
+
+  //  object AttributesSink {
+  //    def apply(): Sink[Nothing, Future[Attributes]] =
+  //      Sink.fromGraph[Nothing, Future[Attributes]](new AttributesSink(Attributes.name("attributesSink"), Sink.shape("attributesSink")))
+  //  }
+  //
+  //  final class AttributesSink(val attributes: Attributes, shape: SinkShape[Nothing]) extends SinkModule[Nothing, Future[Attributes]](shape) {
+  //    override def create(context: MaterializationContext) =
+  //      (new SinkholeSubscriber(Promise()), Future.successful(context.effectiveAttributes))
+  //
+  //    override protected def newInstance(shape: SinkShape[Nothing]): SinkModule[Nothing, Future[Attributes]] =
+  //      new AttributesSink(attributes, shape)
+  //
+  //    override def withAttributes(attr: Attributes): SinkModule[Nothing, Future[Attributes]] =
+  //      new AttributesSink(attr, amendShape(attr))
+  //  }
+  //
+  //  object AttributesFlow {
+  //    def apply(): Flow[Nothing, Attributes, NotUsed] =
+  //      Flow.fromGraph[Nothing, Attributes, NotUsed](new GraphStage[FlowShape[Nothing, Attributes]] {
+  //        override val shape: FlowShape[Nothing, Attributes] = FlowShape.of(Inlet("in"), Outlet("out"))
+  //        override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
+  //          override def onPush(): Unit = pull(shape.in)
+  //          override def onPull(): Unit = push(shape.out, inheritedAttributes)
+  //        }
+  //      })
+  //  }
+
+  def graphStageSink[T](): Sink[Any, Attributes] =
+    Sink.fromGraph(new GraphStageWithMaterializedValue[SinkShape[Any], Attributes] {
+      override val shape: SinkShape[Any] = SinkShape.of(Inlet[Any]("in"))
+      override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
+        val logic = new GraphStageLogic(shape) with InHandler {
+          override def onPush(): Unit = ()
+
+          setHandler(shape.in, this)
+        }
+
+        logic → inheritedAttributes
+      }
+    })
+
+  def graphStageSink[T, A](get: Attributes ⇒ Option[A], initialAttr: Attributes = Attributes.none): Sink[Any, Option[A]] =
+    Sink.fromGraph(new GraphStageWithMaterializedValue[SinkShape[Any], Option[A]] {
+      override val shape: SinkShape[Any] = SinkShape.of(Inlet[Any]("in"))
+      override def initialAttributes = initialAttr
+
+      override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
+        val logic = new GraphStageLogic(shape) with InHandler {
+
+          override def onPush(): Unit = ()
+
+          setHandler(shape.in, this)
+        }
+
+        logic → get(inheritedAttributes)
+      }
+    })
+
+  def graphStageSinkShape[T, A](get: Attributes ⇒ Option[A], initialAttr: Attributes = Attributes.none): GraphStageWithMaterializedValue[SinkShape[Any], Option[A]] =
+    new GraphStageWithMaterializedValue[SinkShape[Any], Option[A]] {
+      override val shape: SinkShape[Any] = SinkShape.of(Inlet[Any]("in"))
+      override def initialAttributes = initialAttr
+
+      override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
+        val logic = new GraphStageLogic(shape) with InHandler {
+
+          println(s" >>> inheritedAttributes = ${inheritedAttributes}")
+
+          val dispatchers = inheritedAttributes.filtered[ActorAttributes.Dispatcher].map(_.dispatcher)
+          println(s" >>> dispatchers = ${dispatchers}")
+
+          //          val names = inheritedAttributes.filtered[Name].map(_.n)
+          //          println(s" >>> names = ${names.mkString(" nested in: ")}")
+          override def onPush(): Unit = ()
+
+          setHandler(shape.in, this)
+        }
+
+        logic → get(inheritedAttributes)
+      }
+    }
+
+}
+
+class SealedAttributesSpec extends StreamSpec(
+  s"""
+    akka.actor.default-mailbox.mailbox-type = "akka.dispatch.UnboundedMailbox"
+
+    dispatcher-outer = $${akka.actor.default-dispatcher}
+    dispatcher-default-in-stage-initial = $${akka.actor.default-dispatcher}
+    right-on-sink = $${akka.actor.default-dispatcher}
+    completely-outside = $${akka.actor.default-dispatcher}
+  """.stripMargin) with ScalaFutures {
+  import SealedAttributesSpec._
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  def attributesOf[T](s: RunnableGraph[Attributes]): Attributes = {
+    s.run()
+  }
+
+  def attributesOf[T](s: RunnableGraph[Option[T]]): Option[T] = {
+    s.run()
+  }
+
+  "attributes" must {
+
+    import ActorAttributes._
+    val DispatcherOuter = ActorAttributes.dispatcher("dispatcher-outer")
+
+    "nothing" in {
+      val it = Source.empty.toMat(
+        graphStageSink()
+      )(Keep.right)
+
+      val attrs = attributesOf(it)
+
+      info("attrs: " + attrs)
+    }
+
+    "attrs on sink" in {
+      val it = Source.empty.toMat(
+        graphStageSink().withAttributes(DispatcherOuter)
+      )(Keep.right)
+
+      val attrs = attributesOf(it)
+
+      info("attrs: " + attrs)
+    }
+
+    "getInside; attrs on sink" in {
+      val it = Source.empty.toMat(
+        graphStageSink(_.get[Dispatcher]
+        ).withAttributes(DispatcherOuter))(Keep.right)
+
+      val maybeAttr = attributesOf(it)
+
+      info("initialAttributes.get[Dispatcher]: " + maybeAttr)
+      maybeAttr.get should equal(DispatcherOuter.attributeList.head)
+    }
+    "getInside; (attrs on sink) set from outer" in {
+      val it = Source.empty.toMat(
+        graphStageSink(_.get[Dispatcher])
+      )(Keep.right).withAttributes(DispatcherOuter)
+
+      val maybeAttr = attributesOf(it)
+
+      info("initialAttributes.get[Dispatcher]: " + maybeAttr)
+      maybeAttr.get should equal(DispatcherOuter.attributeList.head)
+    }
+
+    //    // current semantics:
+    //    "getInside; initial attrs -- nothing outside" in {
+    //      val it = Source.empty.toMat(
+    //        Sink.fromGraph(graphStageSinkShape(_.get[Name], initialAttr = Attributes.name("initial-inside")))
+    //      )(Keep.right)
+    //
+    //      val maybeAttr = attributesOf(it)
+    //
+    //      info("initialAttributes.get[Name]: " + maybeAttr)
+    //      maybeAttr.get should equal(Attributes.name("initial-inside").attributeList.head)
+    //    }
+    //
+    //    "getInside; initial attrs -- override on stage" in {
+    //      val it = Source.empty.toMat(
+    //        Sink.fromGraph(
+    //          graphStageSinkShape(_.get[Name], initialAttr = Attributes.name("initial-inside"))
+    //        ).named("on-sink-override")
+    //      )(Keep.right)
+    //
+    //      val maybeAttr = attributesOf(it)
+    //
+    //      info("initialAttributes.get[Name]: " + maybeAttr)
+    //      maybeAttr.get should equal(Attributes.name("initial-inside").attributeList.head)
+    //    }
+    //
+    //    "getInside; initial attrs -- override on composite ('complete') stage" in {
+    //      val it = Source.empty.toMat(
+    //        Sink.fromGraph(
+    //          graphStageSinkShape(_.get[Name], initialAttr = Attributes.name("initial-inside"))
+    //        ).named("on-sink-override")
+    //      )(Keep.right).named("on-sink-outside-override")
+    //
+    //      //  >>> inheritedAttributes = Attributes(List(Name(initial-inside), Name(on-sink-override), Name(on-sink-outside-override), Name(on-sink-outside-override), Dispatcher(akka.test.stream-dispatcher), InputBuffer(2,16), SupervisionStrategy(<function1>)))
+    //      // >>> names = initial-inside nested in: on-sink-override nested in: on-sink-outside-override nested in: on-sink-outside-override
+    //      val maybeAttr = attributesOf(it)
+    //
+    //      info("initialAttributes.get[Name]: " + maybeAttr)
+    //      maybeAttr.get should equal(Attributes.name("initial-inside").attributeList.head)
+    //    }
+
+    // new semantics:
+
+    "xoxo getInside; dispatcher, override, no seal; initial attrs -- override on composite ('complete') stage" in {
+
+      /*
+          Here wa have a dispatcher, but we allow it to be overriden
+       */
+
+      val it = Source.empty.toMat(
+        Sink.fromGraph(
+          graphStageSinkShape(_.get[Dispatcher], initialAttr = dispatcher("dispatcher-default-in-stage-initial"))
+        ).withAttributes(dispatcher("right-on-sink"))
+      )(Keep.right)
+
+      val maybeAttr = attributesOf(it)
+
+      info("initialAttributes.get[Dispatcher]: " + maybeAttr)
+      maybeAttr.get.dispatcher should equal("right-on-sink")
+    }
+
+    "zozo getInside; dispatcher, override, seal; initial attrs -- override on composite ('complete') stage" in {
+
+      /*
+          Here wa have a dispatcher, we don't allow overrides
+       */
+
+      val it = Source.empty.toMat(
+        Sink.fromGraph(
+          graphStageSinkShape(_.get[Dispatcher], initialAttr = dispatcher("dispatcher-default-in-stage-initial").seal())
+        ).withAttributes(dispatcher("right-on-sink"))
+      )(Keep.right)
+
+      val maybeAttr = attributesOf(it)
+
+      info("initialAttributes.get[Dispatcher]: " + maybeAttr)
+      maybeAttr.get.dispatcher should equal("dispatcher-default-in-stage-initial")
+    }
+
+    "getInside; initial attrs -- override on composite ('complete') stage" in {
+      val it = Source.empty.toMat(
+        Sink.fromGraph(
+          graphStageSinkShape(_.get[Name], initialAttr = Attributes.name("initial-inside"))
+        ).named("on-sink-override")
+      )(Keep.right).named("on-sink-outside-override")
+
+      //  >>> inheritedAttributes = Attributes(List(Name(initial-inside), Name(on-sink-override), Name(on-sink-outside-override), Name(on-sink-outside-override), Dispatcher(akka.test.stream-dispatcher), InputBuffer(2,16), SupervisionStrategy(<function1>)))
+      // >>> names = initial-inside nested in: on-sink-override nested in: on-sink-outside-override nested in: on-sink-outside-override
+      val maybeAttr = attributesOf(it)
+
+      info("initialAttributes.get[Name]: " + maybeAttr)
+      maybeAttr.get should equal(Attributes.name("on-sink-outside-override").attributeList.head)
+    }
+
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -13,21 +13,12 @@ import akka.japi.function
 import akka.stream.impl.StreamLayout._
 import java.net.URLEncoder
 
+import akka.annotation.DoNotInherit
+import akka.stream.Attributes.AttributeSeal
 import akka.stream.impl.TraversalBuilder
 
 import scala.compat.java8.OptionConverters._
 import akka.util.ByteString
-
-trait SealedAttributes { this: Attributes ⇒
-  def sealName: String
-  def attributeList: List[Attributes.Attribute]
-
-  def liftedBy(name: String): Boolean = name match {
-    case "*"                   ⇒ true
-    case _ if name == sealName ⇒ true
-    case _                     ⇒ false
-  }
-}
 
 /**
  * Holds attributes which can be used to alter [[akka.stream.scaladsl.Flow]] / [[akka.stream.javadsl.Flow]]
@@ -41,14 +32,6 @@ trait SealedAttributes { this: Attributes ⇒
 sealed case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
 
   import Attributes._
-
-  def seal(): Attributes =
-    seal("")
-
-  def seal(name: String): Attributes =
-    new Attributes(attributeList) with SealedAttributes {
-      override def sealName = name
-    }
 
   /**
    * INTERNAL API
@@ -149,11 +132,35 @@ sealed case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
   }
 
   /**
-   * Scala API: Get the most specific attribute (added last) of a given type parameter T `Class` or subclass thereof.
+   * Scala API: Get the attribute of a given type parameter T `Class` or subclass thereof, while adhering to override semantics.
    */
   def get[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-    (attributeList.collect { case attr if c.isInstance(attr) ⇒ c.cast(attr) }).lastOption
+    var effectiveAttr: Attribute = null
+    // TODO could optimize with knowing count of values
+    val it = attributeList.iterator
+    while (it.hasNext) {
+      val currentAttr = it.next()
+
+      if (c.isInstance(currentAttr)) {
+        currentAttr match {
+          case cur: AttributeSeal ⇒
+            effectiveAttr match {
+              case eff: AttributeSeal ⇒
+                // the `not` looks weird, but is correct:
+                if (!eff.overrides(cur)) effectiveAttr = currentAttr
+
+              case _ ⇒
+                effectiveAttr = currentAttr
+            }
+
+          case _ if effectiveAttr == null ⇒ effectiveAttr = currentAttr // first found, it is in effect
+          case _                          ⇒ // outer overrides this one, we continue scanning though
+        }
+      } // else continue scanning (TODO short-circuit scan)
+    }
+
+    Option(effectiveAttr).asInstanceOf[Option[T]] // we avoid castingN times
   }
 
   /**
@@ -174,6 +181,13 @@ sealed case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    * already existing attributes of the same type.
    */
   def and(other: Attributes): Attributes = {
+    if (attributeList.isEmpty) other
+    else if (other.attributeList.isEmpty) this
+    else if (other.attributeList.tail.isEmpty) Attributes(other.attributeList.head :: attributeList)
+    else Attributes(other.attributeList ::: attributeList)
+  }
+
+  def merge(other: Attributes): Attributes = {
     if (attributeList.isEmpty) other
     else if (other.attributeList.isEmpty) this
     else if (other.attributeList.tail.isEmpty) Attributes(other.attributeList.head :: attributeList)
@@ -223,16 +237,48 @@ sealed case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
 }
 
 /**
- * Note that more attributes for the [[ActorMaterializer]] are defined in [[ActorAttributes]].
+ * Note that more attributes for the [[ActorMaterializer]] are defined in [[akka.stream.ActorAttributes]].
  */
 object Attributes {
 
-  trait Attribute
-  trait AttributeSeal { def sealName: String }
-  final case class Name(n: String) extends Attribute
-  final case class InputBuffer(initial: Int, max: Int) extends Attribute
-  final case class LogLevels(onElement: Logging.LogLevel, onFinish: Logging.LogLevel, onFailure: Logging.LogLevel) extends Attribute
-  final case object AsyncBoundary extends Attribute
+  trait Attribute { def seal(key: String): Attribute }
+  trait AttributeSeal {
+    def sealName: String
+    def overrides(a: Attribute): Boolean = {
+
+      a match {
+        case sealedAttr: AttributeSeal ⇒ sealedAttr.sealName == sealName || sealedAttr.sealName == "*"
+        case _                         ⇒ true
+      }
+    }
+
+    override def toString: String = super.toString + s"[seal:${sealName}]"
+  }
+  @DoNotInherit sealed case class Name(n: String) extends Attribute {
+    override def seal(key: String): Attribute =
+      new Name(n) with AttributeSeal {
+        override val sealName = key
+      }
+  }
+  @DoNotInherit sealed case class InputBuffer(initial: Int, max: Int) extends Attribute {
+    override def seal(key: String): Attribute =
+      new InputBuffer(initial, max) with AttributeSeal {
+        override val sealName = key
+      }
+  }
+  @DoNotInherit sealed case class LogLevels(onElement: Logging.LogLevel, onFinish: Logging.LogLevel, onFailure: Logging.LogLevel) extends Attribute {
+    override def seal(key: String): Attribute =
+      new LogLevels(onElement, onFinish, onFailure) with AttributeSeal {
+        override val sealName = key
+      }
+  }
+  @DoNotInherit class AsyncBoundary extends Attribute {
+    override def seal(key: String): Attribute =
+      new AsyncBoundary with AttributeSeal {
+        override val sealName = key
+      }
+  }
+  @DoNotInherit final case object AsyncBoundary extends AsyncBoundary
 
   object LogLevels {
     /** Use to disable logging on certain operations when configuring [[Attributes.LogLevels]] */
@@ -305,8 +351,18 @@ object Attributes {
  */
 object ActorAttributes {
   import Attributes._
-  final case class Dispatcher(dispatcher: String) extends Attribute
-  final case class SupervisionStrategy(decider: Supervision.Decider) extends Attribute
+  case class Dispatcher(dispatcher: String) extends Attribute {
+    override def seal(key: String): Attribute =
+      new Dispatcher(dispatcher) with AttributeSeal {
+        override def sealName = key
+      }
+  }
+  case class SupervisionStrategy(decider: Supervision.Decider) extends Attribute {
+    override def seal(key: String): Attribute =
+      new SupervisionStrategy(decider) with AttributeSeal {
+        override def sealName = key
+      }
+  }
 
   val IODispatcher: Dispatcher = ActorAttributes.Dispatcher("akka.stream.default-blocking-io-dispatcher")
 

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -44,6 +44,9 @@ sealed case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
     }
   }
 
+  def sealAll(sealName: String): Attributes =
+    copy(attributeList.map(_.seal(sealName)))
+
   /**
    * Java API
    *

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -32,5 +32,5 @@ trait Graph[+S <: Shape, +M] {
    */
   def async: Graph[S, M] = addAttributes(Attributes.asyncBoundary)
 
-  def addAttributes(attr: Attributes): Graph[S, M] = withAttributes(traversalBuilder.attributes and attr)
+  def addAttributes(attr: Attributes): Graph[S, M] = withAttributes(attr and traversalBuilder.attributes)
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -33,7 +33,7 @@ import akka.util.OptionVal
  */
 @InternalApi private[akka] object PhasedFusingActorMaterializer {
 
-  val Debug = false
+  val Debug = true // FIXME
 
   val DefaultPhase: Phase[Any] = new Phase[Any] {
     override def apply(settings: ActorMaterializerSettings, materializer: PhasedFusingActorMaterializer, islandName: String): PhaseIsland[Any] =
@@ -433,7 +433,8 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
     var current: Traversal = graph.traversalBuilder.traversal
 
     val attributesStack = new java.util.ArrayDeque[Attributes](8)
-    attributesStack.addLast(initialAttributes and graph.traversalBuilder.attributes)
+    // attributesStack.addLast(initialAttributes and graph.traversalBuilder.attributes)
+    attributesStack.addLast(graph.traversalBuilder.attributes and initialAttributes)
 
     val traversalStack = new java.util.ArrayDeque[Traversal](16)
     traversalStack.addLast(current)
@@ -490,10 +491,10 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
             if (Debug) println(s"COMP: $matValueStack")
           case PushAttributes(attr) ⇒
             attributesStack.addLast(attributesStack.getLast and attr)
-            if (Debug) println(s"ATTR PUSH: $attr")
+            if (Debug) println(Console.YELLOW + s"ATTR PUSH: $attr" + Console.RESET)
           case PopAttributes ⇒
-            attributesStack.removeLast()
-            if (Debug) println(s"ATTR POP")
+            val it = attributesStack.removeLast()
+            if (Debug) println(Console.YELLOW + s"ATTR POP: (removed: $it)" + Console.RESET)
           case EnterIsland(tag) ⇒
             islandTracking.enterIsland(tag, attributesStack.getLast)
           case ExitIsland ⇒

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -374,8 +374,16 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
       Attributes.InputBuffer(settings.initialInputBufferSize, settings.maxInputBufferSize) ::
         ActorAttributes.SupervisionStrategy(settings.supervisionDecider) ::
         Nil)
-    if (settings.dispatcher == Deploy.NoDispatcherGiven) a
-    else a and ActorAttributes.dispatcher(settings.dispatcher)
+
+    val defaults =
+      if (settings.dispatcher == Deploy.NoDispatcherGiven) a
+      else a and ActorAttributes.dispatcher(settings.dispatcher)
+
+    if (Debug) {
+      println("--- Materializer default attributes ---")
+      defaults.attributeList.foreach(a ⇒ println(" def attr: " + a))
+    }
+    defaults
   }
 
   override def effectiveSettings(opAttr: Attributes): ActorMaterializerSettings = {
@@ -415,26 +423,31 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
     materialize(_runnableGraph, defaultInitialAttributes)
 
   override def materialize[Mat](
-    _runnableGraph:    Graph[ClosedShape, Mat],
-    initialAttributes: Attributes): Mat =
+    _runnableGraph:           Graph[ClosedShape, Mat],
+    defaultInitialAttributes: Attributes): Mat =
     materialize(
       _runnableGraph,
-      initialAttributes,
+      defaultInitialAttributes,
       PhasedFusingActorMaterializer.DefaultPhase,
       PhasedFusingActorMaterializer.DefaultPhases)
 
   override def materialize[Mat](
-    graph:             Graph[ClosedShape, Mat],
-    initialAttributes: Attributes,
-    defaultPhase:      Phase[Any],
-    phases:            Map[IslandTag, Phase[Any]]): Mat = {
+    graph:                    Graph[ClosedShape, Mat],
+    defaultInitialAttributes: Attributes,
+    defaultPhase:             Phase[Any],
+    phases:                   Map[IslandTag, Phase[Any]]): Mat = {
     val islandTracking = new IslandTracking(phases, settings, defaultPhase, this, islandNamePrefix = createFlowName() + "-")
 
     var current: Traversal = graph.traversalBuilder.traversal
 
     val attributesStack = new java.util.ArrayDeque[Attributes](8)
-    // attributesStack.addLast(initialAttributes and graph.traversalBuilder.attributes)
-    attributesStack.addLast(graph.traversalBuilder.attributes and initialAttributes)
+    attributesStack.addLast(graph.traversalBuilder.attributes)
+    if (Debug) {
+      println(s"--- graph.traversalBuilder.attributes ---")
+      graph.traversalBuilder.attributes.attributeList.foreach(a ⇒ println(" attr: " + a))
+      println(s"--- initial attributesStack ---")
+      attributesStack.peek().attributeList.foreach(a ⇒ println(" attr: " + a))
+    }
 
     val traversalStack = new java.util.ArrayDeque[Traversal](16)
     traversalStack.addLast(current)
@@ -443,6 +456,7 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
 
     if (Debug) {
       println(s"--- Materializing layout:")
+      println(s" init attrs: " + attributesStack.peek())
       TraversalBuilder.printTraversal(current)
       println(s"--- Start materialization")
     }
@@ -455,8 +469,9 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
         var nextStep: Traversal = EmptyTraversal
         current match {
           case MaterializeAtomic(mod, outToSlot) ⇒
-            if (Debug) println(s"materializing module: $mod")
-            val matAndStage = islandTracking.getCurrentPhase.materializeAtomic(mod, attributesStack.getLast)
+            val attributes = defaultInitialAttributes and attributesStack.getLast
+            if (Debug) println(Console.YELLOW + s"materializing module: $mod (attrs: ${attributes})" + Console.RESET)
+            val matAndStage = islandTracking.getCurrentPhase.materializeAtomic(mod, attributes)
             val logic = matAndStage._1
             val matValue = matAndStage._2
             if (Debug) println(s"  materialized value is $matValue")
@@ -490,8 +505,12 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
             matValueStack.addLast(result)
             if (Debug) println(s"COMP: $matValueStack")
           case PushAttributes(attr) ⇒
-            attributesStack.addLast(attributesStack.getLast and attr)
+            val lastBefore = attributesStack.getLast
             if (Debug) println(Console.YELLOW + s"ATTR PUSH: $attr" + Console.RESET)
+            if (Debug) println(Console.YELLOW + s" getLast : ${lastBefore}" + Console.RESET)
+            if (Debug) println(Console.YELLOW + s"    attr : ${attr}" + Console.RESET)
+            attributesStack.addLast(attr merge lastBefore)
+            if (Debug) println(Console.YELLOW + s"  RESULT : ${attributesStack.getLast}" + Console.RESET)
           case PopAttributes ⇒
             val it = attributesStack.removeLast()
             if (Debug) println(Console.YELLOW + s"ATTR POP: (removed: $it)" + Console.RESET)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2327,7 +2327,7 @@ abstract class RunnableGraph[+Mat] extends Graph[ClosedShape, Mat] {
   override def withAttributes(attr: Attributes): RunnableGraph[Mat]
 
   override def addAttributes(attr: Attributes): RunnableGraph[Mat] =
-    withAttributes(traversalBuilder.attributes and attr)
+    withAttributes(attr and traversalBuilder.attributes)
 
   override def named(name: String): RunnableGraph[Mat] =
     withAttributes(Attributes.name(name))


### PR DESCRIPTION
Relates to #22523 

In this experiment I explore what it would mean to have "outermost wins" semantics for stream attributes. Also known as "overrides". And what would allow sealing certain attributes from being overriden.

Considerations are:
- names want to be "combined"
- things want to be "grouped" with a name
- specific dispatchers or values want to be overriden by users of wrapped (perhaps many times) flows

The sealing idea is explored.

Not complete, was mostly thinking today still...