### PR TITLE
Add Sink.collection #23917

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CollectionSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CollectionSinkSpec.scala
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.testkit.{ StreamSpec, TestPublisher }
+import akka.stream.{ AbruptTerminationException, ActorMaterializer, ActorMaterializerSettings }
+
+import scala.collection.immutable
+import scala.concurrent.{ Await, Future }
+
+class CollectionSinkSpec extends StreamSpec with a {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val mat = ActorMaterializer(settings)
+
+  "Sink.collection" when {
+    "using Seq as Collection" must {
+      "return a Seq[T] from a Source" in {
+        val input = (1 to 6)
+        val future: Future[immutable.Seq[Int]] = Source(input).runWith(Sink.collection)
+        val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+        result should be(input.toSeq)
+      }
+
+      "return an empty Seq[T] from an empty Source" in {
+        val input: immutable.Seq[Int] = Nil
+        val future: Future[immutable.Seq[Int]] = Source.fromIterator(() ⇒ input.iterator).runWith(Sink.collection)
+        val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+        result should be(input)
+      }
+
+      "fail the future on abrupt termination" in {
+        val mat = ActorMaterializer()
+        val probe = TestPublisher.probe()
+        val future = Source.fromPublisher(probe).runWith(Sink.collection[Nothing, Seq[Nothing]])(mat)
+        mat.shutdown()
+        future.failed.futureValue shouldBe an[AbruptTerminationException]
+      }
+    }
+    "using Vector as Collection" must {
+      "return a Vector[T] from a Source" in {
+        val input = (1 to 6)
+        val future: Future[immutable.Vector[Int]] = Source(input).runWith(Sink.collection)
+        val result: immutable.Vector[Int] = Await.result(future, remainingOrDefault)
+        result should be(input.toVector)
+      }
+
+      "return an empty Vector[T] from an empty Source" in {
+        val input = Nil
+        val future: Future[immutable.Vector[Int]] = Source.fromIterator(() ⇒ input.iterator).runWith(Sink.collection[Int, Vector[Int]])
+        val result: immutable.Vector[Int] = Await.result(future, remainingOrDefault)
+        result should be(Vector.empty[Int])
+      }
+
+      "fail the future on abrupt termination" in {
+        val mat = ActorMaterializer()
+        val probe = TestPublisher.probe()
+        val future = Source.fromPublisher(probe).runWith(Sink.collection[Nothing, Seq[Nothing]])(mat)
+        mat.shutdown()
+        future.failed.futureValue shouldBe an[AbruptTerminationException]
+      }
+    }
+  }
+}
+

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -15,6 +15,7 @@ import akka.stream.{ javadsl, _ }
 import org.reactivestreams.{ Publisher, Subscriber }
 
 import scala.annotation.tailrec
+import scala.collection.generic.CanBuildFrom
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
@@ -173,7 +174,21 @@ object Sink {
    *
    * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
    */
-  def seq[T]: Sink[T, Future[immutable.Seq[T]]] = Sink.fromGraph(new SeqStage[T])
+  def seq[T]: Sink[T, Future[immutable.Seq[T]]] = Sink.fromGraph(new SeqStage[T, Vector[T]])
+
+  /**
+   * A `Sink` that keeps on collecting incoming elements until upstream terminates.
+   * As upstream may be unbounded, `Flow[T].take` or the stricter `Flow[T].limit` (and their variants)
+   * may be used to ensure boundedness.
+   * Materializes into a `Future` of `That[T]` containing all the collected elements.
+   * `That[T]` is limited to the limitations of the CanBuildFrom associated with it. For example, `Seq` is limited to
+   * `Int.MaxValue` elements. See [The Architecture of Scala Collectionss](https://docs.scala-lang.org/overviews/core/architecture-of-scala-collections.html) for more info.
+   * This Sink will cancel the stream after having received that many elements.
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def collection[T, That](implicit cbf: CanBuildFrom[Nothing, T, That with immutable.Traversable[_]]): Sink[T, Future[That]] =
+    Sink.fromGraph(new SeqStage[T, That])
 
   /**
    * A `Sink` that materializes into a [[org.reactivestreams.Publisher]].


### PR DESCRIPTION
Adds a scala api Sink.collection that it workes like Sink.seq but can use any immutable collection instead of Seq to accumulate the results.

I want to note three things: 
- It has a binary incompatibility error, it's seems to be for a class SeqStage marked as @internalApi.
- Since this new api leverages scala's implicits and scala's collection library, I don't know whether it's possible to do something equivalent for the java api.
- I added some tests, for the special case of using Sink.collection for obtaining a Seq and a Vector. May be it could be done more generally, or for more collection cases. Please feel free to suggest further test or a generic technique.