### PR TITLE
[WIP PROTOTYPE] important attributes johanandren

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -106,6 +106,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       throughput = 1
     }
   """).withFallback(Utils.UnboundedMailboxConfig)) {
+
   import AttributesSpec._
 
   val settings = ActorMaterializerSettings(system)
@@ -334,7 +335,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
 
   }
 
-  "attributes in the javadsl" must {
+  "attributes in the javadsl source" must {
 
     "not change dispatcher from one defined on a surrounding graph" in {
       val dispatcherF =
@@ -413,6 +414,30 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
 
       // least specific
       attributes.leastSpecific[Name] should contain(Name("whole-graph"))
+    }
+
+  }
+
+  "attributes on the materializer" should {
+
+    "be defaults and not used when more specific attributes are found" in {
+
+      // dispatcher set on the materializer
+      val myDispatcherMaterializer = ActorMaterializer(settings.withDispatcher("my-dispatcher"))
+
+      try {
+        val dispatcher =
+          Source.fromGraph(new ThreadNameSnitchingStage("akka.stream.default-blocking-io-dispatcher"))
+            .runWith(Sink.head)(myDispatcherMaterializer)
+            .futureValue
+
+        // should not override stage specific dispatcher
+        dispatcher should startWith("AttributesSpec-akka.stream.default-blocking-io-dispatcher")
+
+      } finally {
+        myDispatcherMaterializer.shutdown()
+      }
+
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -118,11 +118,11 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
     val attributes = Attributes.name("a") and Attributes.name("b") and Attributes.inputBuffer(1, 2)
 
     "give access to first attribute" in {
-      attributes.getFirst[Name] should ===(Some(Attributes.Name("a")))
+      attributes.leastSpecific[Name] should ===(Some(Attributes.Name("a")))
     }
 
     "give access to attribute byt type" in {
-      attributes.get[Name] should ===(Some(Attributes.Name("b")))
+      attributes.mostSpecific[Name] should ===(Some(Attributes.Name("b")))
     }
 
   }
@@ -139,8 +139,8 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .toMat(Sink.head)(Keep.left)
           .run()
 
-      attributes.get[Name] should contain(Name("re-added"))
-      attributes.get[WhateverAttribute] should contain(WhateverAttribute("other-thing"))
+      attributes.mostSpecific[Name] should contain(Name("re-added"))
+      attributes.mostSpecific[WhateverAttribute] should contain(WhateverAttribute("other-thing"))
     }
 
     "be replaced withAttributes" in {
@@ -152,8 +152,8 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .toMat(Sink.head)(Keep.left)
           .run()
 
-      attributes.get[Name] should contain(Name("re-added"))
-      attributes.get[WhateverAttribute] shouldBe empty
+      attributes.mostSpecific[Name] should contain(Name("re-added"))
+      attributes.mostSpecific[WhateverAttribute] shouldBe empty
     }
 
     "be overridable on a module basis" in {
@@ -162,7 +162,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .toMat(Sink.head)(Keep.left)
           .run()
 
-      attributes.get[Name] should contain(Name("new-name"))
+      attributes.mostSpecific[Name] should contain(Name("new-name"))
     }
 
     "keep the outermost attribute as the least specific" in {
@@ -173,10 +173,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
         .run()
 
       // most specific
-      attributes.get[Name] should contain(Name("original-name"))
+      attributes.mostSpecific[Name] should contain(Name("original-name"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
     "replace the attributes directly on a graph stage" in {
@@ -188,10 +188,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .run()
 
       // most specific
-      attributes.get[Name] should contain(Name("new-name"))
+      attributes.mostSpecific[Name] should contain(Name("new-name"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("new-name"))
+      attributes.leastSpecific[Name] should contain(Name("new-name"))
     }
 
     "make the attributes on Source.fromGraph source behave the same as the stage itself" in {
@@ -202,10 +202,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .run()
 
       // most specific
-      attributes.get[Name] should contain(Name("replaced"))
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
     "make the attributes on Flow.fromGraph source behave the same as the stage itself" in {
@@ -221,10 +221,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .run()
 
       // most specific
-      attributes.get[Name] should contain(Name("replaced"))
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
     "make the attributes on Sink.fromGraph source behave the same as the stage itself" in {
@@ -237,10 +237,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .run()
 
       // most specific
-      attributes.get[Name] should contain(Name("replaced"))
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
     "use the initial attributes for dispatcher" in {
@@ -347,10 +347,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .run(materializer)
 
       // most specific
-      attributes.get[Name] should contain(Name("replaced"))
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
     "make the attributes on Flow.fromGraph source behave the same as the stage itself" in {
@@ -366,10 +366,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .run(materializer)
 
       // most specific
-      attributes.get[Name] should contain(Name("replaced"))
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
     "make the attributes on Sink.fromGraph source behave the same as the stage itself" in {
@@ -382,10 +382,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .run(materializer)
 
       // most specific
-      attributes.get[Name] should contain(Name("replaced"))
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
 
       // least specific
-      attributes.getFirst[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -155,7 +155,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       attributes.getFirst[Name] should contain(Name("new-name"))
     }
 
-    "make the attribues on Source.fromGraph source behave the same as the stage itself" in {
+    "make the attributes on Source.fromGraph source behave the same as the stage itself" in {
       val attributes =
         Source.fromGraph(new AttributesSource(Attributes.name("original-name")))
           .withAttributes(Attributes.name("replaced")) // this actually replaces now
@@ -170,7 +170,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       attributes.getFirst[Name] should contain(Name("whole-graph"))
     }
 
-    "make the attribues on Flow.fromGraph source behave the same as the stage itself" in {
+    "make the attributes on Flow.fromGraph source behave the same as the stage itself" in {
       val attributes =
         Source.maybe
           .viaMat(
@@ -189,7 +189,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       attributes.getFirst[Name] should contain(Name("whole-graph"))
     }
 
-    "make the attribues on Sink.fromGraph source behave the same as the stage itself" in {
+    "make the attributes on Sink.fromGraph source behave the same as the stage itself" in {
       val attributes =
         Source.maybe.toMat(
           Sink.fromGraph(new AttributesSink(Attributes.name("original-name")))
@@ -253,6 +253,18 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .futureValue
 
       dispatcher should startWith("AttributesSpec-akka.stream.default-blocking-io-dispatcher")
+    }
+
+    "change dispatcher when defined directly on top of the async boundary" in {
+      val dispatcher =
+        Source.fromGraph(
+          new ThreadNameSnitchingStage("akka.stream.default-blocking-io-dispatcher"))
+          .async
+          .withAttributes(ActorAttributes.dispatcher("my-dispatcher"))
+          .runWith(Sink.head)
+          .futureValue
+
+      dispatcher should startWith("AttributesSpec-my-dispatcher")
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.scaladsl
 import java.util.Optional
 import java.util.concurrent.{ CompletableFuture, CompletionStage, TimeUnit }
 
-import akka.Done
+import akka.{ Done, NotUsed }
 import akka.stream.Attributes._
 import akka.stream._
 import akka.stream.javadsl
@@ -113,21 +113,21 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
 
   implicit val materializer = ActorMaterializer(settings)
 
-  "attributes" must {
+  "an attributes instance" must {
 
     val attributes = Attributes.name("a") and Attributes.name("b") and Attributes.inputBuffer(1, 2)
 
-    "give access to first attribute" in {
+    "give access to the least specific attribute" in {
       attributes.leastSpecific[Name] should ===(Some(Attributes.Name("a")))
     }
 
-    "give access to attribute byt type" in {
+    "give access to the most specific attribute value" in {
       attributes.mostSpecific[Name] should ===(Some(Attributes.Name("b")))
     }
 
   }
 
-  "attributes on a stage" must {
+  "attributes on a graph stage" must {
 
     "be appended with addAttributes" in {
       val attributes =
@@ -143,7 +143,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       attributes.mostSpecific[WhateverAttribute] should contain(WhateverAttribute("other-thing"))
     }
 
-    "be replaced withAttributes" in {
+    "be replaced withAttributes directly on a stage" in {
       val attributes =
         Source.fromGraph(new AttributesSource()
           .withAttributes(Attributes.name("new-name") and whateverAttribute("other-thing"))
@@ -165,85 +165,41 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       attributes.mostSpecific[Name] should contain(Name("new-name"))
     }
 
-    "keep the outermost attribute as the least specific" in {
-      val attributes = Source.fromGraph(new AttributesSource(Attributes.name("original-name")))
-        .map(identity)
-        .addAttributes(Attributes.name("whole-graph"))
-        .toMat(Sink.head)(Keep.left)
-        .run()
+  }
 
-      // most specific
-      attributes.mostSpecific[Name] should contain(Name("original-name"))
+  "attributes on a source" must {
 
-      // least specific
-      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
-    }
-
-    "replace the attributes directly on a graph stage" in {
+    "make the attributes on fromGraph(single-source-stage) Source behave the same as the stage itself" in {
       val attributes =
-        Source.fromGraph(
-          new AttributesSource(Attributes.name("original-name"))
-            .withAttributes(Attributes.name("new-name")))
-          .toMat(Sink.head)(Keep.left)
-          .run()
-
-      // most specific
-      attributes.mostSpecific[Name] should contain(Name("new-name"))
-
-      // least specific
-      attributes.leastSpecific[Name] should contain(Name("new-name"))
-    }
-
-    "make the attributes on Source.fromGraph source behave the same as the stage itself" in {
-      val attributes =
-        Source.fromGraph(new AttributesSource(Attributes.name("original-name")))
-          .withAttributes(Attributes.name("replaced")) // this actually replaces now
+        Source.fromGraph(new AttributesSource(Attributes.name("original-name") and whateverAttribute("whatever")))
+          .withAttributes(Attributes.name("replaced")) // replaces all
           .toMat(Sink.head)(Keep.left).withAttributes(Attributes.name("whole-graph"))
           .run()
 
       // most specific
       attributes.mostSpecific[Name] should contain(Name("replaced"))
+      attributes.mostSpecific[WhateverAttribute] shouldBe empty
 
       // least specific
       attributes.leastSpecific[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[WhateverAttribute] shouldBe empty
     }
 
-    "make the attributes on Flow.fromGraph source behave the same as the stage itself" in {
-      val attributes =
-        Source.maybe
-          .viaMat(
-            Flow.fromGraph(new AttributesFlow(Attributes.name("original-name")))
-              .withAttributes(Attributes.name("replaced")) // this actually replaces now
-          )(Keep.right)
-          .withAttributes(Attributes.name("source-flow"))
-          .toMat(Sink.ignore)(Keep.left)
-          .withAttributes(Attributes.name("whole-graph"))
-          .run()
+    "not replace stage specific attributes with attributes on surrounding composite source" in {
+      val attributes = Source.fromGraph(new AttributesSource(Attributes.name("original-name")))
+        .map(identity)
+        .addAttributes(Attributes.name("composite-graph"))
+        .toMat(Sink.head)(Keep.left)
+        .run()
 
-      // most specific
-      attributes.mostSpecific[Name] should contain(Name("replaced"))
+      // most specific still the original as the attribute was added on the composite source
+      attributes.mostSpecific[Name] should contain(Name("original-name"))
 
       // least specific
-      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
+      attributes.leastSpecific[Name] should contain(Name("composite-graph"))
     }
 
-    "make the attributes on Sink.fromGraph source behave the same as the stage itself" in {
-      val attributes =
-        Source.maybe.toMat(
-          Sink.fromGraph(new AttributesSink(Attributes.name("original-name")))
-            .withAttributes(Attributes.name("replaced")) // this actually replaces now
-        )(Keep.right)
-          .withAttributes(Attributes.name("whole-graph"))
-          .run()
-
-      // most specific
-      attributes.mostSpecific[Name] should contain(Name("replaced"))
-
-      // least specific
-      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
-    }
-
-    "use the initial attributes for dispatcher" in {
+    "use the initial attribute as default to select dispatcher" in {
       val dispatcher =
         Source.fromGraph(new ThreadNameSnitchingStage("my-dispatcher"))
           .runWith(Sink.head)
@@ -252,7 +208,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       dispatcher should startWith("AttributesSpec-my-dispatcher")
     }
 
-    "use the most specific dispatcher when specified directly around the graph stage" in {
+    "use an explicit attribute on the stage to select dispatcher" in {
       val dispatcher =
         Source.fromGraph(
           // directly on stage
@@ -264,13 +220,12 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
       dispatcher should startWith("AttributesSpec-my-dispatcher")
     }
 
-    "use the most specific dispatcher when defined on a surrounding composed graph" in {
+    "use the most specific dispatcher when another one is defined on a surrounding composed graph" in {
       val dispatcher =
         Source.fromGraph(
-          // on the composed graph
           new ThreadNameSnitchingStage("akka.stream.default-blocking-io-dispatcher"))
           .map(identity)
-          // this is now for source -> flow
+          // this is now for the composed source -> flow graph
           .addAttributes(ActorAttributes.dispatcher("my-dispatcher"))
           .runWith(Sink.head)
           .futureValue
@@ -303,6 +258,78 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           .futureValue
 
       dispatcher should startWith("AttributesSpec-my-dispatcher")
+    }
+
+    "change dispatcher when defined on the async call" in {
+      val dispatcher =
+        Source.fromGraph(
+          new ThreadNameSnitchingStage("akka.stream.default-blocking-io-dispatcher"))
+          .async("my-dispatcher")
+          .runWith(Sink.head)
+          .futureValue
+
+      dispatcher should startWith("AttributesSpec-my-dispatcher")
+    }
+  }
+
+  "attributes on a Flow" must {
+
+    "make the attributes on fromGraph(flow-stage) Flow behave the same as the stage itself" in {
+      val attributes =
+        Source.empty
+          .viaMat(
+            Flow.fromGraph(new AttributesFlow(Attributes.name("original-name")))
+              .withAttributes(Attributes.name("replaced")) // this actually replaces now
+          )(Keep.right)
+          .withAttributes(Attributes.name("source-flow"))
+          .toMat(Sink.ignore)(Keep.left)
+          .withAttributes(Attributes.name("whole-graph"))
+          .run()
+
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
+    }
+
+    "handle attributes on a composed flow" in {
+      val attributes =
+        Source.empty
+          .viaMat(
+            Flow.fromGraph(new AttributesFlow(Attributes.name("original-name")))
+              .map(identity)
+              .withAttributes(Attributes.name("replaced"))
+              .addAttributes(whateverAttribute("whatever"))
+              .withAttributes(Attributes.name("replaced-again"))
+              .addAttributes(whateverAttribute("replaced"))
+          )(Keep.right)
+          .toMat(Sink.ignore)(Keep.left)
+          .run()
+
+      // this verifies that the old docs on flow.withAttribues was in fact incorrect
+      // there is no sealing going on here
+      attributes.mostSpecific[Name] should contain(Name("original-name"))
+      attributes.mostSpecific[WhateverAttribute] should contain(WhateverAttribute("replaced"))
+
+      attributes.leastSpecific[Name] should contain(Name("replaced-again"))
+      attributes.leastSpecific[WhateverAttribute] should contain(WhateverAttribute("replaced"))
+    }
+
+  }
+
+  "attributes on a Sink" must {
+    "make the attributes on fromGraph(sink-stage) Sink behave the same as the stage itself" in {
+      val attributes =
+        Source.empty.toMat(
+          Sink.fromGraph(new AttributesSink(Attributes.name("original-name")))
+            .withAttributes(Attributes.name("replaced")) // this actually replaces now
+        )(Keep.right)
+          .withAttributes(Attributes.name("whole-graph"))
+          .run()
+
+      // most specific
+      attributes.mostSpecific[Name] should contain(Name("replaced"))
+
+      // least specific
+      attributes.leastSpecific[Name] should contain(Name("whole-graph"))
     }
 
   }
@@ -355,11 +382,11 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
 
     "make the attributes on Flow.fromGraph source behave the same as the stage itself" in {
       val attributes: Attributes =
-        javadsl.Source.maybe
+        javadsl.Source.empty[Any]
           .viaMat(
             javadsl.Flow.fromGraph(new AttributesFlow(Attributes.name("original-name")))
               .withAttributes(Attributes.name("replaced")) // this actually replaces now
-              , javadsl.Keep.right[CompletableFuture[Optional[Any]], Attributes])
+              , javadsl.Keep.right[NotUsed, Attributes])
           .withAttributes(Attributes.name("source-flow"))
           .toMat(javadsl.Sink.ignore(), javadsl.Keep.left[Attributes, CompletionStage[Done]])
           .withAttributes(Attributes.name("whole-graph"))
@@ -374,10 +401,10 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
 
     "make the attributes on Sink.fromGraph source behave the same as the stage itself" in {
       val attributes: Attributes =
-        javadsl.Source.maybe[Any].toMat(
+        javadsl.Source.empty[Any].toMat(
           javadsl.Sink.fromGraph(new AttributesSink(Attributes.name("original-name")))
             .withAttributes(Attributes.name("replaced")) // this actually replaces now
-            , javadsl.Keep.right[CompletableFuture[Optional[Any]], Attributes])
+            , javadsl.Keep.right[NotUsed, Attributes])
           .withAttributes(Attributes.name("whole-graph"))
           .run(materializer)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
@@ -110,8 +110,8 @@ class BidiFlowSpec extends StreamSpec {
       import Attributes._
       val b: BidiFlow[Int, Long, ByteString, String, NotUsed] = bidi.async.addAttributes(none).named("name")
 
-      b.traversalBuilder.attributes.getFirst[Name] shouldEqual Some(Name("name"))
-      b.traversalBuilder.attributes.getFirst[AsyncBoundary.type] shouldEqual Some(AsyncBoundary)
+      b.traversalBuilder.attributes.leastSpecific[Name] shouldEqual Some(Name("name"))
+      b.traversalBuilder.attributes.leastSpecific[AsyncBoundary.type] shouldEqual Some(AsyncBoundary)
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
@@ -370,8 +370,8 @@ class GraphDSLCompileSpec extends StreamSpec {
         FlowShape(id.in, id.out)
       }.async.addAttributes(none).named("useless")
 
-      ga.traversalBuilder.attributes.getFirst[Name] shouldEqual Some(Name("useless"))
-      ga.traversalBuilder.attributes.getFirst[AsyncBoundary.type] shouldEqual (Some(AsyncBoundary))
+      ga.traversalBuilder.attributes.leastSpecific[Name] shouldEqual Some(Name("useless"))
+      ga.traversalBuilder.attributes.leastSpecific[AsyncBoundary.type] shouldEqual (Some(AsyncBoundary))
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RunnableGraphSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RunnableGraphSpec.scala
@@ -17,8 +17,8 @@ class RunnableGraphSpec extends StreamSpec {
       import Attributes._
       val r: RunnableGraph[NotUsed] = RunnableGraph.fromGraph(Source.empty.to(Sink.ignore)).async.addAttributes(none).named("useless")
 
-      r.traversalBuilder.attributes.getFirst[Name] shouldEqual Some(Name("useless"))
-      r.traversalBuilder.attributes.getFirst[AsyncBoundary.type] shouldEqual (Some(AsyncBoundary))
+      r.traversalBuilder.attributes.leastSpecific[Name] shouldEqual Some(Name("useless"))
+      r.traversalBuilder.attributes.leastSpecific[AsyncBoundary.type] shouldEqual (Some(AsyncBoundary))
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -129,7 +129,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       val s: Sink[Int, Future[Int]] = Sink.head[Int].async.addAttributes(none).named("name")
 
       s.traversalBuilder.attributes.filtered[Name] shouldEqual List(Name("name"), Name("headSink"))
-      s.traversalBuilder.attributes.getFirst[AsyncBoundary.type] shouldEqual (Some(AsyncBoundary))
+      s.traversalBuilder.attributes.leastSpecific[AsyncBoundary.type] shouldEqual (Some(AsyncBoundary))
     }
 
     "given one attribute of a class should correctly get it as first attribute with default value" in {
@@ -143,35 +143,35 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].async.addAttributes(none).named("name")
 
-      s.traversalBuilder.attributes.get[Name](Name("default")) shouldEqual Name("name")
+      s.traversalBuilder.attributes.mostSpecificOrElse[Name](Name("default")) shouldEqual Name("name")
     }
 
     "given no attributes of a class when getting first attribute with default value should get default value" in {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].withAttributes(none).async
 
-      s.traversalBuilder.attributes.getFirst[Name](Name("default")) shouldEqual Name("default")
+      s.traversalBuilder.attributes.leastSpecificOrElse[Name](Name("default")) shouldEqual Name("default")
     }
 
     "given no attributes of a class when getting last attribute with default value should get default value" in {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].withAttributes(none).async
 
-      s.traversalBuilder.attributes.get[Name](Name("default")) shouldEqual Name("default")
+      s.traversalBuilder.attributes.mostSpecificOrElse[Name](Name("default")) shouldEqual Name("default")
     }
 
     "given multiple attributes of a class when getting first attribute with default value should get first attribute" in {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].withAttributes(none).async.named("name").named("another_name")
 
-      s.traversalBuilder.attributes.getFirst[Name](Name("default")) shouldEqual Name("name")
+      s.traversalBuilder.attributes.leastSpecificOrElse[Name](Name("default")) shouldEqual Name("name")
     }
 
     "given multiple attributes of a class when getting last attribute with default value should get last attribute" in {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].async.addAttributes(none).named("name").named("another_name")
 
-      s.traversalBuilder.attributes.get[Name](Name("default")) shouldEqual Name("another_name")
+      s.traversalBuilder.attributes.mostSpecificOrElse[Name](Name("default")) shouldEqual Name("another_name")
     }
 
     "support contramap" in {

--- a/akka-stream/src/main/mima-filters/2.5.7.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.7.backwards.excludes
@@ -1,0 +1,2 @@
+# Attributes overhaul
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.Graph.async")

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -32,5 +32,27 @@ trait Graph[+S <: Shape, +M] {
    */
   def async: Graph[S, M] = addAttributes(Attributes.asyncBoundary)
 
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  def async(dispatcher: String) =
+    addAttributes(
+      Attributes.asyncBoundary and ActorAttributes.dispatcher(dispatcher)
+    )
+
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  def async(dispatcher: String, inputBufferSize: Int) =
+    addAttributes(
+      Attributes.asyncBoundary and ActorAttributes.dispatcher(dispatcher)
+        and Attributes.inputBuffer(inputBufferSize, inputBufferSize)
+    )
+
   def addAttributes(attr: Attributes): Graph[S, M] = withAttributes(traversalBuilder.attributes and attr)
 }

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -7,6 +7,11 @@ import akka.stream.impl.{ GraphStageTag, IslandTag, TraversalBuilder }
 
 import scala.annotation.unchecked.uncheckedVariance
 
+/**
+ * Not intended to be directly extended by user classes
+ *
+ * @see [[akka.stream.stage.GraphStage]]
+ */
 trait Graph[+S <: Shape, +M] {
   /**
    * Type-level accessor for the shape parameter of this graph.
@@ -54,5 +59,11 @@ trait Graph[+S <: Shape, +M] {
         and Attributes.inputBuffer(inputBufferSize, inputBufferSize)
     )
 
+  /**
+   * Add the given attributes to this [[Graph]]. If the specific attribute was already present
+   * on this graph this means the added attribute will be more specific than the existing one.
+   * If this Source is a composite of multiple graphs, new attributes on the composite will be
+   * less specific than attributes set directly on the individual graphs of the composite.
+   */
   def addAttributes(attr: Attributes): Graph[S, M] = withAttributes(traversalBuilder.attributes and attr)
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
@@ -28,7 +28,7 @@ import akka.stream.stage._
     new GraphStageLogic(shape) with InHandler {
       implicit def self: ActorRef = stageActor.ref
 
-      val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+      val maxBuffer = inheritedAttributes.getMostSpecificOrElse(classOf[InputBuffer], InputBuffer(16, 16)).max
       require(maxBuffer > 0, "Buffer size must be greater than 0")
 
       val buffer: util.Deque[In] = new util.ArrayDeque[In]()

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -697,7 +697,7 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
   override def takePublisher(slot: Int, publisher: Publisher[Any]): Unit = {
     val connection = conn(slot)
     // TODO: proper input port debug string (currently prints the stage)
-    val bufferSize = connection.inOwner.attributes.get[InputBuffer].get.max
+    val bufferSize = connection.inOwner.attributes.mostSpecific[InputBuffer].get.max
     val boundary =
       new BatchingActorInputBoundary(bufferSize, shell, publisher, connection.inOwner.toString)
     logics.add(boundary)

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -339,7 +339,7 @@ import akka.util.OptionVal
     val stageLogic = new GraphStageLogic(shape) with InHandler with SinkQueueWithCancel[T] {
       type Received[E] = Try[Option[E]]
 
-      val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+      val maxBuffer = inheritedAttributes.getMostSpecificOrElse(classOf[InputBuffer], InputBuffer(16, 16)).max
       require(maxBuffer > 0, "Buffer size must be greater than 0")
 
       var buffer: Buffer[Received[T]] = _
@@ -470,7 +470,7 @@ import akka.util.OptionVal
   override def toString: String = "LazySink"
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
-    lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(stoppingDecider)
+    lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(stoppingDecider)
 
     var completed = false
     val promise = Promise[M]()

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -13,9 +13,11 @@ import akka.stream._
 @InternalApi private[akka] object Stages {
 
   object DefaultAttributes {
+    // reusable common attributes
     val IODispatcher = ActorAttributes.IODispatcher
     val inputBufferOne = inputBuffer(initial = 1, max = 1)
 
+    // stage specific default attributes
     val fused = name("fused")
     val materializedValueSource = name("matValueSource")
     val map = name("map")

--- a/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSource.scala
@@ -24,7 +24,7 @@ import scala.util.control.NonFatal
   override def initialAttributes: Attributes = DefaultAttributes.unfoldResourceSource
 
   def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with OutHandler {
-    lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
     var open = false
     var blockingStream: S = _
     setHandler(out, this)

--- a/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
   override def initialAttributes: Attributes = DefaultAttributes.unfoldResourceSourceAsync
 
   def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with OutHandler {
-    lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
     var resource = Promise[S]()
     var open = false
     implicit val context = ExecutionContexts.sameThreadExecutionContext

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -40,7 +40,7 @@ import akka.stream.impl.Stages.DefaultAttributes
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler {
       private def decider =
-        inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+        inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       override def onPush(): Unit = {
         try {
@@ -69,7 +69,7 @@ import akka.stream.impl.Stages.DefaultAttributes
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with OutHandler with InHandler {
-      def decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      def decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       override def onPush(): Unit = {
         try {
@@ -105,7 +105,7 @@ import akka.stream.impl.Stages.DefaultAttributes
     new GraphStageLogic(shape) with OutHandler with InHandler {
       override def toString = "TakeWhileLogic"
 
-      def decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      def decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       override def onPush(): Unit = {
         try {
@@ -166,7 +166,7 @@ import akka.stream.impl.Stages.DefaultAttributes
  * INTERNAL API
  */
 @DoNotInherit private[akka] abstract class SupervisedGraphStageLogic(inheritedAttributes: Attributes, shape: Shape) extends GraphStageLogic(shape) {
-  private lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+  private lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
   def withSupervision[T](f: () ⇒ T): Option[T] =
     try {
@@ -362,7 +362,7 @@ private[stream] object Collect {
       self ⇒
 
       private var aggregator = zero
-      private lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      private lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       import Supervision.{ Stop, Resume, Restart }
       import shape.{ in, out }
@@ -429,7 +429,7 @@ private[stream] object Collect {
 
       private def ec = ExecutionContexts.sameThreadExecutionContext
 
-      private lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      private lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       private val ZeroHandler: OutHandler with InHandler = new OutHandler with InHandler {
         override def onPush(): Unit = ()
@@ -531,7 +531,7 @@ private[stream] object Collect {
       private var aggregator: Out = zero
 
       private def decider =
-        inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+        inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       override def onPush(): Unit = {
         val elem = grab(in)
@@ -585,7 +585,7 @@ private[stream] object Collect {
 
   def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler {
-      val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       private var aggregator: Out = zero
       private var aggregating: Future[Out] = Future.successful(aggregator)
@@ -934,7 +934,7 @@ private[stream] object Collect {
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with InHandler with OutHandler {
 
-    lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
     private var agg: Out = null.asInstanceOf[Out]
     private var left: Long = max
@@ -1139,7 +1139,7 @@ private[stream] object Collect {
       override def toString = s"MapAsync.Logic(buffer=$buffer)"
 
       //FIXME Put Supervision.stoppingDecider as a SupervisionStrategy on DefaultAttributes.mapAsync?
-      lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
       var buffer: BufferImpl[Holder[Out]] = _
 
       private val handleSuccessElem: PartialFunction[Try[Out], Unit] = {
@@ -1214,7 +1214,7 @@ private[stream] object Collect {
       override def toString = s"MapAsyncUnordered.Logic(inFlight=$inFlight, buffer=$buffer)"
 
       val decider =
-        inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+        inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       private var inFlight = 0
       private var buffer: BufferImpl[Out] = _
@@ -1293,10 +1293,10 @@ private[stream] object Collect {
       private var logLevels: LogLevels = _
       private var log: LoggingAdapter = _
 
-      def decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      def decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
       override def preStart(): Unit = {
-        logLevels = inheritedAttributes.get[LogLevels](DefaultLogLevels)
+        logLevels = inheritedAttributes.mostSpecificOrElse[LogLevels](DefaultLogLevels)
         log = logAdapter match {
           case Some(l) ⇒ l
           case _ ⇒
@@ -1545,7 +1545,7 @@ private[stream] object Collect {
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) with InHandler with OutHandler {
     val size =
-      inheritedAttributes.get[InputBuffer] match {
+      inheritedAttributes.mostSpecific[InputBuffer] match {
         case None                        ⇒ throw new IllegalStateException(s"Couldn't find InputBuffer Attribute for $this")
         case Some(InputBuffer(min, max)) ⇒ max
       }
@@ -1721,7 +1721,7 @@ private[stream] object Collect {
     var aggregator: T = _
 
     private def decider =
-      inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+      inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
 
     def setInitialInHandler(): Unit = {
       // Initial input handler
@@ -1835,7 +1835,7 @@ private[stream] object Collect {
   override def initialAttributes: Attributes = DefaultAttributes.statefulMapConcat
 
   def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
-    lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
     var currentIterator: Iterator[Out] = _
     var plainFun = f()
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -223,7 +223,7 @@ import scala.collection.JavaConverters._
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) with OutHandler with InHandler {
     parent ⇒
-    lazy val decider = inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+    lazy val decider = inheritedAttributes.mostSpecific[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
     private val activeSubstreamsMap = new java.util.HashMap[Any, SubstreamSource]()
     private val closedSubstreams = new java.util.HashSet[Any]()
     private var timeout: FiniteDuration = _

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
@@ -32,7 +32,7 @@ import scala.concurrent.{ Future, Promise }
 
     val ioResultPromise = Promise[IOResult]()
     val props = FileSubscriber.props(f, ioResultPromise, settings.maxInputBufferSize, startPosition, options)
-    val dispatcher = context.effectiveAttributes.get[Dispatcher](IODispatcher).dispatcher
+    val dispatcher = context.effectiveAttributes.mostSpecificOrElse[Dispatcher](IODispatcher).dispatcher
 
     val ref = materializer.actorOf(context, props.withDispatcher(dispatcher))
     (akka.stream.actor.ActorSubscriber[ByteString](ref), ioResultPromise.future)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
@@ -58,7 +58,7 @@ private[akka] final class FileSource(path: Path, chunkSize: Int, startPosition: 
     val logic = new GraphStageLogic(shape) with OutHandler {
       handler ⇒
       val buffer = ByteBuffer.allocate(chunkSize)
-      val maxReadAhead = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+      val maxReadAhead = inheritedAttributes.getMostSpecificOrElse(classOf[InputBuffer], InputBuffer(16, 16)).max
       var channel: FileChannel = _
       var position = startPosition
       var chunkCallback: Try[Int] ⇒ Unit = _

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -44,7 +44,7 @@ private[stream] object InputStreamSinkStage {
   override val shape: SinkShape[ByteString] = SinkShape.of(in)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, InputStream) = {
-    val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+    val maxBuffer = inheritedAttributes.getMostSpecificOrElse(classOf[InputBuffer], InputBuffer(16, 16)).max
     require(maxBuffer > 0, "Buffer size must be greater than 0")
 
     val dataQueue = new LinkedBlockingDeque[StreamToAdapterMessage](maxBuffer + 2)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
@@ -40,9 +40,9 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
   override val shape: SourceShape[ByteString] = SourceShape.of(out)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, OutputStream) = {
-    val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+    val maxBuffer = inheritedAttributes.getMostSpecificOrElse(classOf[InputBuffer], InputBuffer(16, 16)).max
 
-    val dispatcherId = inheritedAttributes.get[Dispatcher](IODispatcher).dispatcher
+    val dispatcherId = inheritedAttributes.mostSpecificOrElse[Dispatcher](IODispatcher).dispatcher
 
     require(maxBuffer > 0, "Buffer size must be greater than 0")
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -223,4 +223,27 @@ final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](delegate: scaladsl.BidiFlow[I1, O
    */
   override def named(name: String): BidiFlow[I1, O1, I2, O2, Mat] =
     new BidiFlow(delegate.named(name))
+
+  /**
+   * Put an asynchronous boundary around this `Flow`
+   */
+  override def async: BidiFlow[I1, O1, I2, O2, Mat] =
+    new BidiFlow(delegate.async)
+
+  /**
+   * Put an asynchronous boundary around this `Flow`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): BidiFlow[I1, O1, I2, O2, Mat] =
+    new BidiFlow(delegate.async(dispatcher))
+
+  /**
+   * Put an asynchronous boundary around this `Flow`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): BidiFlow[I1, O1, I2, O2, Mat] =
+    new BidiFlow(delegate.async(dispatcher, inputBufferSize))
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -7,7 +7,6 @@ import akka.util.ConstantFun
 import akka.{ Done, NotUsed }
 import akka.event.LoggingAdapter
 import akka.japi.{ Pair, function }
-import akka.stream.impl.StreamLayout
 import akka.stream._
 import org.reactivestreams.Processor
 
@@ -2199,20 +2198,21 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
     new Flow(delegate.initialDelay(delay))
 
   /**
-   * Change the attributes of this [[Source]] to the given ones and seal the list
-   * of attributes. This means that further calls will not be able to remove these
-   * attributes, but instead add new ones. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
+   * Replace the attributes of this [[Flow]] with the given ones. If this Flow is a composite
+   * of multiple graphs, new attributes on the composite will be less specific than attributes
+   * set directly on the individual graphs of the composite.
+   *
+   * Note that this operation has no effect on an empty Flow (because the attributes apply
    * only to the contained processing stages).
    */
   override def withAttributes(attr: Attributes): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.withAttributes(attr))
 
   /**
-   * Add the given attributes to this Source. Further calls to `withAttributes`
-   * will not remove these attributes. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Add the given attributes to this [[Flow]]. If the specific attribute was already present
+   * on this graph this means the added attribute will be more specific than the existing one.
+   * If this Flow is a composite of multiple graphs, new attributes on the composite will be
+   * less specific than attributes set directly on the individual graphs of the composite.
    */
   override def addAttributes(attr: Attributes): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.addAttributes(attr))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2230,6 +2230,23 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
     new Flow(delegate.async)
 
   /**
+   * Put an asynchronous boundary around this `Flow`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.async(dispatcher))
+
+  /**
+   * Put an asynchronous boundary around this `Flow`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.async(dispatcher, inputBufferSize))
+
+  /**
    * Logs elements flowing through the stream as well as completion and erroring.
    *
    * By default element and completion signals are logged on debug level, and errors are logged on Error level.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -352,4 +352,21 @@ final class Sink[-In, +Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[Sink
   override def async: javadsl.Sink[In, Mat] =
     new Sink(delegate.async)
 
+  /**
+   * Put an asynchronous boundary around this `Sink`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): javadsl.Sink[In, Mat] =
+    new Sink(delegate.async(dispatcher))
+
+  /**
+   * Put an asynchronous boundary around this `Sink`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): javadsl.Sink[In, Mat] =
+    new Sink(delegate.async(dispatcher, inputBufferSize))
+
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -9,7 +9,7 @@ import akka.{ Done, NotUsed }
 import akka.actor.{ ActorRef, Props }
 import akka.dispatch.ExecutionContexts
 import akka.japi.function
-import akka.stream.impl.{ LinearTraversalBuilder, SinkQueueAdapter, StreamLayout }
+import akka.stream.impl.{ LinearTraversalBuilder, SinkQueueAdapter }
 import akka.stream.{ javadsl, scaladsl, _ }
 import org.reactivestreams.{ Publisher, Subscriber }
 
@@ -322,20 +322,18 @@ final class Sink[-In, +Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[Sink
     new Sink(delegate.mapMaterializedValue(f.apply _))
 
   /**
-   * Change the attributes of this [[Sink]] to the given ones and seal the list
-   * of attributes. This means that further calls will not be able to remove these
-   * attributes, but instead add new ones. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Replace the attributes of this [[Sink]] with the given ones. If this Sink is a composite
+   * of multiple graphs, new attributes on the composite will be less specific than attributes
+   * set directly on the individual graphs of the composite.
    */
   override def withAttributes(attr: Attributes): javadsl.Sink[In, Mat] =
     new Sink(delegate.withAttributes(attr))
 
   /**
-   * Add the given attributes to this Sink. Further calls to `withAttributes`
-   * will not remove these attributes. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Add the given attributes to this [[Sink]]. If the specific attribute was already present
+   * on this graph this means the added attribute will be more specific than the existing one.
+   * If this Sink is a composite of multiple graphs, new attributes on the composite will be
+   * less specific than attributes set directly on the individual graphs of the composite.
    */
   override def addAttributes(attr: Attributes): javadsl.Sink[In, Mat] =
     new Sink(delegate.addAttributes(attr))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2291,6 +2291,23 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
     new Source(delegate.async)
 
   /**
+   * Put an asynchronous boundary around this `Source`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): javadsl.Source[Out, Mat] =
+    new Source(delegate.async(dispatcher))
+
+  /**
+   * Put an asynchronous boundary around this `Source`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): javadsl.Source[Out, Mat] =
+    new Source(delegate.async(dispatcher, inputBufferSize))
+
+  /**
    * Logs elements flowing through the stream as well as completion and erroring.
    *
    * By default element and completion signals are logged on debug level, and errors are logged on Error level.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2260,20 +2260,18 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
     new Source(delegate.initialDelay(delay))
 
   /**
-   * Change the attributes of this [[Source]] to the given ones and seal the list
-   * of attributes. This means that further calls will not be able to remove these
-   * attributes, but instead add new ones. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Replace the attributes of this [[Source]] with the given ones. If this Source is a composite
+   * of multiple graphs, new attributes on the composite will be less specific than attributes
+   * set directly on the individual graphs of the composite.
    */
   override def withAttributes(attr: Attributes): javadsl.Source[Out, Mat] =
     new Source(delegate.withAttributes(attr))
 
   /**
-   * Add the given attributes to this Source. Further calls to `withAttributes`
-   * will not remove these attributes. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Add the given attributes to this [[Source]]. If the specific attribute was already present
+   * on this graph this means the added attribute will be more specific than the existing one.
+   * If this Source is a composite of multiple graphs, new attributes on the composite will be
+   * less specific than attributes set directly on the individual graphs of the composite.
    */
   override def addAttributes(attr: Attributes): javadsl.Source[Out, Mat] =
     new Source(delegate.addAttributes(attr))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -179,8 +179,29 @@ final class BidiFlow[-I1, +O1, -I2, +O2, +Mat](
   override def named(name: String): BidiFlow[I1, O1, I2, O2, Mat] =
     addAttributes(Attributes.name(name))
 
+  /**
+   * Put an asynchronous boundary around this `BidiFlow`
+   */
   override def async: BidiFlow[I1, O1, I2, O2, Mat] =
-    addAttributes(Attributes.asyncBoundary)
+    super.async.asInstanceOf[BidiFlow[I1, O1, I2, O2, Mat]]
+
+  /**
+   * Put an asynchronous boundary around this `BidiFlow`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): BidiFlow[I1, O1, I2, O2, Mat] =
+    super.async(dispatcher).asInstanceOf[BidiFlow[I1, O1, I2, O2, Mat]]
+
+  /**
+   * Put an asynchronous boundary around this `BidiFlow`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): BidiFlow[I1, O1, I2, O2, Mat] =
+    super.async(dispatcher, inputBufferSize).asInstanceOf[BidiFlow[I1, O1, I2, O2, Mat]]
+
 }
 
 object BidiFlow {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -209,10 +209,11 @@ final class Flow[-In, +Out, +Mat](
   }
 
   /**
-   * Change the attributes of this [[Flow]] to the given ones and seal the list
-   * of attributes. This means that further calls will not be able to remove these
-   * attributes, but instead add new ones. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
+   * Replace the attributes of this [[Flow]] with the given ones. If this Flow is a composite
+   * of multiple graphs, new attributes on the composite will be less specific than attributes
+   * set directly on the individual graphs of the composite.
+   *
+   * Note that this operation has no effect on an empty Flow (because the attributes apply
    * only to the contained processing stages).
    */
   override def withAttributes(attr: Attributes): Repr[Out] =
@@ -221,10 +222,10 @@ final class Flow[-In, +Out, +Mat](
       shape)
 
   /**
-   * Add the given attributes to this Flow. Further calls to `withAttributes`
-   * will not remove these attributes. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Add the given attributes to this [[Flow]]. If the specific attribute was already present
+   * on this graph this means the added attribute will be more specific than the existing one.
+   * If this Flow is a composite of multiple graphs, new attributes on the composite will be
+   * less specific than attributes set directly on the individual graphs of the composite.
    */
   override def addAttributes(attr: Attributes): Repr[Out] = withAttributes(traversalBuilder.attributes and attr)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -236,7 +236,24 @@ final class Flow[-In, +Out, +Mat](
   /**
    * Put an asynchronous boundary around this `Flow`
    */
-  override def async: Repr[Out] = addAttributes(Attributes.asyncBoundary)
+  override def async: Repr[Out] = super.async.asInstanceOf[Repr[Out]]
+
+  /**
+   * Put an asynchronous boundary around this `Flow`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): Repr[Out] =
+    super.async(dispatcher).asInstanceOf[Repr[Out]]
+
+  /**
+   * Put an asynchronous boundary around this `Flow`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): Repr[Out] =
+    super.async(dispatcher, inputBufferSize).asInstanceOf[Repr[Out]]
 
   /**
    * Connect the `Source` to this `Flow` and then connect it to the `Sink` and run it. The returned tuple contains
@@ -514,7 +531,20 @@ final case class RunnableGraph[+Mat](override val traversalBuilder: TraversalBui
   override def named(name: String): RunnableGraph[Mat] =
     addAttributes(Attributes.name(name))
 
-  override def async: RunnableGraph[Mat] = addAttributes(Attributes.asyncBoundary)
+  /**
+   * This does nothing, as an async boundary around a runnable graph does not make sense
+   */
+  override def async: RunnableGraph[Mat] = this
+
+  /**
+   * This does nothing, as an async boundary around a runnable graph does not make sense
+   */
+  override def async(dispatcher: String) = this
+
+  /**
+   * This does nothing, as an async boundary around a runnable graph does not make sense
+   */
+  override def async(dispatcher: String, inputBufferSize: Int) = this
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -532,19 +532,22 @@ final case class RunnableGraph[+Mat](override val traversalBuilder: TraversalBui
     addAttributes(Attributes.name(name))
 
   /**
-   * This does nothing, as an async boundary around a runnable graph does not make sense
+   * Note that an async boundary around a runnable graph does not make sense
    */
-  override def async: RunnableGraph[Mat] = this
+  override def async: RunnableGraph[Mat] =
+    super.async.asInstanceOf[RunnableGraph[Mat]]
 
   /**
-   * This does nothing, as an async boundary around a runnable graph does not make sense
+   * Note that an async boundary around a runnable graph does not make sense
    */
-  override def async(dispatcher: String) = this
+  override def async(dispatcher: String): RunnableGraph[Mat] =
+    super.async(dispatcher).asInstanceOf[RunnableGraph[Mat]]
 
   /**
-   * This does nothing, as an async boundary around a runnable graph does not make sense
+   * Note that an async boundary around a runnable graph does not make sense
    */
-  override def async(dispatcher: String, inputBufferSize: Int) = this
+  override def async(dispatcher: String, inputBufferSize: Int): RunnableGraph[Mat] =
+    super.async(dispatcher, inputBufferSize).asInstanceOf[RunnableGraph[Mat]]
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -83,9 +83,26 @@ final class Sink[-In, +Mat](
   override def named(name: String): Sink[In, Mat] = addAttributes(Attributes.name(name))
 
   /**
-   * Put an asynchronous boundary around this `Sink`
+   * Put an asynchronous boundary around this `Source`
    */
-  override def async: Sink[In, Mat] = addAttributes(Attributes.asyncBoundary)
+  override def async: Sink[In, Mat] = super.async.asInstanceOf[Sink[In, Mat]]
+
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): Sink[In, Mat] =
+    super.async(dispatcher).asInstanceOf[Sink[In, Mat]]
+
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): Sink[In, Mat] =
+    super.async(dispatcher, inputBufferSize).asInstanceOf[Sink[In, Mat]]
 
   /**
    * Converts this Scala DSL element to it's Java DSL counterpart.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -57,11 +57,9 @@ final class Sink[-In, +Mat](
       shape)
 
   /**
-   * Change the attributes of this [[Sink]] to the given ones and seal the list
-   * of attributes. This means that further calls will not be able to remove these
-   * attributes, but instead add new ones. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Replace the attributes of this [[Sink]] with the given ones. If this Sink is a composite
+   * of multiple graphs, new attributes on the composite will be less specific than attributes
+   * set directly on the individual graphs of the composite.
    */
   override def withAttributes(attr: Attributes): Sink[In, Mat] =
     new Sink(
@@ -69,10 +67,10 @@ final class Sink[-In, +Mat](
       shape)
 
   /**
-   * Add the given attributes to this Sink. Further calls to `withAttributes`
-   * will not remove these attributes. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Add the given attributes to this [[Sink]]. If the specific attribute was already present
+   * on this graph this means the added attribute will be more specific than the existing one.
+   * If this Sink is a composite of multiple graphs, new attributes on the composite will be
+   * less specific than attributes set directly on the individual graphs of the composite.
    */
   override def addAttributes(attr: Attributes): Sink[In, Mat] =
     withAttributes(traversalBuilder.attributes and attr)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -164,7 +164,24 @@ final class Source[+Out, +Mat](
   /**
    * Put an asynchronous boundary around this `Source`
    */
-  override def async: Repr[Out] = addAttributes(Attributes.asyncBoundary)
+  override def async: Repr[Out] = super.async.asInstanceOf[Repr[Out]]
+
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): Repr[Out] =
+    super.async(dispatcher).asInstanceOf[Repr[Out]]
+
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): Repr[Out] =
+    super.async(dispatcher, inputBufferSize).asInstanceOf[Repr[Out]]
 
   /**
    * Converts this Scala DSL element to it's Java DSL counterpart.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -139,20 +139,18 @@ final class Source[+Out, +Mat](
   def runForeach(f: Out ⇒ Unit)(implicit materializer: Materializer): Future[Done] = runWith(Sink.foreach(f))
 
   /**
-   * Change the attributes of this [[Source]] to the given ones and seal the list
-   * of attributes. This means that further calls will not be able to remove these
-   * attributes, but instead add new ones. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Replace the attributes of this [[Source]] with the given ones. If this Source is a composite
+   * of multiple graphs, new attributes on the composite will be less specific than attributes
+   * set directly on the individual graphs of the composite.
    */
   override def withAttributes(attr: Attributes): Repr[Out] =
     new Source(traversalBuilder.setAttributes(attr), shape)
 
   /**
-   * Add the given attributes to this Source. Further calls to `withAttributes`
-   * will not remove these attributes. Note that this
-   * operation has no effect on an empty Flow (because the attributes apply
-   * only to the contained processing stages).
+   * Add the given attributes to this Source. If the specific attribute was already on this source
+   * it will replace the previous value. If this Source is a composite
+   * of multiple graphs, the added attributes will be on the composite and therefore less specific than attributes
+   * set directly on the individual graphs of the composite.
    */
   override def addAttributes(attr: Attributes): Repr[Out] = withAttributes(traversalBuilder.attributes and attr)
 


### PR DESCRIPTION
Provide a way to override attributes that has already been set inside of a composed graph through the `.important` attribute modifier/wrapper.

When attributes are resolved there are two phases, first the most specific attribute marked important is sought after, and then if no important flagged attribute is found, the attributes are searched again for a "normal" most-specific attribute.

This makes it behave a bit like the CSS-important! marker.