### PR TITLE
Delay consumer in GraphMergePrioritizedSpec

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePrioritizedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePrioritizedSpec.scala
@@ -1,9 +1,11 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
+import akka.stream.impl.Throttle
 import akka.stream.testkit.TestSubscriber.ManualProbe
 import akka.stream.{ ClosedShape, Inlet, Outlet }
 import akka.stream.testkit.{ TestSubscriber, TwoStreamsSetup }
+import scala.concurrent.duration._
 
 class GraphMergePrioritizedSpec extends TwoStreamsSetup {
   import GraphDSL.Implicits._
@@ -46,9 +48,9 @@ class GraphMergePrioritizedSpec extends TwoStreamsSetup {
 
     "stream data with priority" in {
       val elementCount = 20000
-      val source1 = Source.fromIterator(() ⇒ Seq.fill(elementCount)(1).iterator)
-      val source2 = Source.fromIterator(() ⇒ Seq.fill(elementCount)(2).iterator)
-      val source3 = Source.fromIterator(() ⇒ Seq.fill(elementCount)(3).iterator)
+      val source1 = Source.fromIterator(() ⇒ Iterator.continually(1).take(elementCount))
+      val source2 = Source.fromIterator(() ⇒ Iterator.continually(2).take(elementCount))
+      val source3 = Source.fromIterator(() ⇒ Iterator.continually(3).take(elementCount))
 
       val priorities = Seq(6, 3, 1)
 
@@ -75,9 +77,9 @@ class GraphMergePrioritizedSpec extends TwoStreamsSetup {
 
     "stream data when only one source produces" in {
       val elementCount = 10
-      val source1 = Source.fromIterator(() ⇒ Seq.fill(elementCount)(1).iterator)
-      val source2 = Source.fromIterator(() ⇒ Seq.empty[Int].iterator)
-      val source3 = Source.fromIterator(() ⇒ Seq.empty[Int].iterator)
+      val source1 = Source.fromIterator(() ⇒ Iterator.continually(1).take(elementCount))
+      val source2 = Source.fromIterator[Int](() ⇒ Iterator.empty)
+      val source3 = Source.fromIterator[Int](() ⇒ Iterator.empty)
 
       val priorities = Seq(6, 3, 1)
 
@@ -104,9 +106,9 @@ class GraphMergePrioritizedSpec extends TwoStreamsSetup {
 
     "stream data with priority when only two sources produce" in {
       val elementCount = 20000
-      val source1 = Source.fromIterator(() ⇒ Seq.fill(elementCount)(1).iterator)
-      val source2 = Source.fromIterator(() ⇒ Seq.fill(elementCount)(2).iterator)
-      val source3 = Source.fromIterator(() ⇒ Seq.empty[Int].iterator)
+      val source1 = Source.fromIterator(() ⇒ Iterator.continually(1).take(elementCount))
+      val source2 = Source.fromIterator(() ⇒ Iterator.continually(2).take(elementCount))
+      val source3 = Source.fromIterator[Int](() ⇒ Iterator.empty)
 
       val priorities = Seq(6, 3, 1)
 
@@ -134,10 +136,13 @@ class GraphMergePrioritizedSpec extends TwoStreamsSetup {
   private def threeSourceMerge[T](source1: Source[T, NotUsed], source2: Source[T, NotUsed], source3: Source[T, NotUsed], priorities: Seq[Int], probe: ManualProbe[T]) = {
     RunnableGraph.fromGraph(GraphDSL.create(source1, source2, source3)((_, _, _)) { implicit b ⇒ (s1, s2, s3) ⇒
       val merge = b.add(MergePrioritized[T](priorities))
+      // introduce a delay on the consuming side making it more likely that
+      // the actual prioritization happens and elements does not just pass through
+      val delayFirst = b.add(Flow[T].initialDelay(50.millis))
       s1.out ~> merge.in(0)
       s2.out ~> merge.in(1)
       s3.out ~> merge.in(2)
-      merge.out ~> Sink.fromSubscriber(probe)
+      merge.out ~> delayFirst ~> Sink.fromSubscriber(probe)
       ClosedShape
     })
   }


### PR DESCRIPTION
(hopefully) fixes #23336 
Also: some boyscouting