### PR TITLE
Fix order in which japi and api docs are returned

### DIFF
--- a/project/Release.scala
+++ b/project/Release.scala
@@ -28,7 +28,7 @@ object Release extends ParadoxKeys {
     val state1 = extracted.runAggregated(publishSigned in projectRef, state)
     // Make sure you set "-Dakka.genjavadoc.enabled=true" otherwise no
     // japi will be generated and this following match will fail:
-    val (state2, Seq(api, japi)) = extracted.runTask(unidoc in Compile, state1)
+    val (state2, Seq(japi, api)) = extracted.runTask(unidoc in Compile, state1)
     val (state3, docs) = extracted.runTask(paradox in ProjectRef(projectRef.build, "akka-docs") in Compile, state2)
 
     IO.delete(release)


### PR DESCRIPTION
I thought I fixed this before but perhaps that didn't make it in. If this goes
wrong again later let's double-check the order is deterministic.

Refs #24026