### PR TITLE
Fix race in ClusterShardingFailureSpec

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingFailureSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingFailureSpec.scala
@@ -11,7 +11,6 @@ import org.apache.commons.io.FileUtils
 import com.typesafe.config.ConfigFactory
 import akka.actor._
 import akka.cluster.Cluster
-import akka.cluster.ClusterEvent._
 import akka.persistence.Persistence
 import akka.persistence.journal.leveldb.SharedLeveldbJournal
 import akka.persistence.journal.leveldb.SharedLeveldbStore
@@ -32,8 +31,8 @@ object ClusterShardingFailureSpec {
     var n = 0
 
     def receive = {
-      case Get(id)    ⇒ sender() ! Value(id, n)
-      case Add(id, i) ⇒ n += i
+      case Get(id)   ⇒ sender() ! Value(id, n)
+      case Add(_, i) ⇒ n += i
     }
   }
 
@@ -155,7 +154,7 @@ abstract class ClusterShardingFailureSpec(config: ClusterShardingFailureSpecConf
         runOn(controller) {
           system.actorOf(Props[SharedLeveldbStore], "store")
         }
-        enterBarrier("peristence-started")
+        enterBarrier("persistence-started")
 
         runOn(first, second) {
           system.actorSelection(node(controller) / "user" / "store") ! Identify(None)
@@ -202,7 +201,7 @@ abstract class ClusterShardingFailureSpec(config: ClusterShardingFailureSpecConf
         region ! Add("40", 4)
         val probe = TestProbe()
         region.tell(Get("40"), probe.ref)
-        probe.expectNoMsg(1.second)
+        probe.expectNoMessage(1.second)
       }
 
       enterBarrier("first-delayed")
@@ -231,6 +230,12 @@ abstract class ClusterShardingFailureSpec(config: ClusterShardingFailureSpecConf
 
         //Test the Shard passivate works after a journal failure
         shard2.tell(Passivate(PoisonPill), entity21)
+
+        awaitCond({
+          region ! Get("21")
+          expectMsgType[Value] == Value("21", 0)
+        }, message = "Passivating did not reset Value down to 0")
+
         region ! Add("21", 1)
 
         region ! Get("21")


### PR DESCRIPTION
AFAICT there was nothing ensuring the order of messages when sent to the
shard and the region so first check that the passivation has happened
before sending another add in the test

Refs #24013