### PR TITLE
Fix "et.c." typo in documentation and reference configuration #24037

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -635,7 +635,7 @@ akka {
       # Documentation at http://akka.io/docs
       receive = off
 
-      # enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill et.c.)
+      # enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill etc.)
       autoreceive = off
 
       # enable DEBUG logging of actor lifecycle changes

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -133,7 +133,7 @@ by Actors:
 akka {
   actor {
     debug {
-      # enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill et.c.)
+      # enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill etc.)
       autoreceive = on
     }
   }


### PR DESCRIPTION
This fixes a typo in the [reference configuration](https://github.com/akka/akka/blob/1eb8459ae778418943be2778438ee242a9756aa4/akka-actor/src/main/resources/reference.conf#L638) and in [documentation on logging](https://github.com/akka/akka/blob/1eb8459ae778418943be2778438ee242a9756aa4/akka-docs/src/main/paradox/logging.md): `et.c.` should be `etc.`.

Closes #24037
