### PR TITLE
Implemented initial set of tests for idle outbound associations

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -417,6 +417,9 @@ private[remote] class ArteryTransport(_system: ExtendedActorSystem, _provider: R
       priorityMessageDestinations,
       outboundEnvelopePool))
 
+  // TODO: Consider including in `RemoteTransport`?
+  def remoteAddresses: Set[Address] = associationRegistry.allAssociations.map(_.remoteAddress)
+
   override def settings: ArterySettings = provider.remoteSettings.Artery
 
   override def start(): Unit = {

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -243,7 +243,7 @@ private[remote] class Association(
    * @return Whether the previous state matched correctly
    */
   @inline
-  private[this] def swapState(oldState: AssociationState, newState: AssociationState): Boolean =
+  private[artery] def swapState(oldState: AssociationState, newState: AssociationState): Boolean =
     Unsafe.instance.compareAndSwapObject(this, AbstractAssociation.sharedStateOffset, oldState, newState)
 
   /**

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
@@ -8,59 +8,147 @@ import akka.remote.RARP
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActors
 import akka.testkit.TestProbe
+import org.scalatest.concurrent.Eventually
+import scala.concurrent.duration._
 
 class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec("""
   akka.loglevel=DEBUG
-  akka.remote.artery.advanced.stop-idle-outbound-after = 3 s
-  """) with ImplicitSender {
+  akka.remote.artery.advanced.stop-idle-outbound-after = 1 s
+  """) with ImplicitSender with Eventually {
 
-  "Idle outbound associations" should {
+  "Outbound lanes" should {
 
-    "be cleaned up" in {
-
+    "eliminate an association when all of them are idle" in {
       val remoteSystem = newRemoteSystem()
       remoteSystem.actorOf(TestActors.echoActorProps, "echo")
       val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
 
-      def sel = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
+      def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
       val localProbe = new TestProbe(localSystem)
-      sel.tell("ping", localProbe.ref)
+      remoteEcho.tell("ping", localProbe.ref)
       localProbe.expectMsg("ping")
 
-      val accociation = RARP(system).provider.transport.asInstanceOf[ArteryTransport].association(remoteAddress)
-      accociation.isStreamActive(Association.ControlQueueIndex) should ===(true)
-      accociation.isStreamActive(Association.OrdinaryQueueIndex) should ===(true)
+      val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
+      val association = artery.association(remoteAddress)
+      withClue("When initiating a connection, both the control - and ordinary lanes are opened (regardless of which one was used)") {
+        // TODO: Is this still desirable? Should lanes perhaps be opened opportunistically always?
+        association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+        association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
+      }
 
-      // FIXME better way of testing this
+      eventually {
+        association.isStreamActive(Association.ControlQueueIndex) shouldBe false
+        association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe false
 
-      Thread.sleep(5000)
-      println(s"# sleep 1 end") // FIXME
-      accociation.isStreamActive(Association.ControlQueueIndex) should ===(false)
-      accociation.isStreamActive(Association.OrdinaryQueueIndex) should ===(false)
+        // FIXME: Currently we have a memory leak in that associations are kept around even though the outbound channels are inactive
+        artery.remoteAddresses shouldBe 'empty
+      }
+    }
 
-      Thread.sleep(5000)
-      println(s"# sleep 2 end") // FIXME
-      accociation.isStreamActive(Association.ControlQueueIndex) should ===(false)
-      accociation.isStreamActive(Association.OrdinaryQueueIndex) should ===(false)
+    "have individual (in)active cycles" in {
+      val remoteSystem = newRemoteSystem()
+      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
+      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
 
-      sel.tell("ping", localProbe.ref)
+      def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
+      val echoRef = remoteEcho.resolveOne(3.seconds).futureValue
+      val localProbe = new TestProbe(localSystem)
+      remoteEcho.tell("ping", localProbe.ref)
       localProbe.expectMsg("ping")
-      accociation.isStreamActive(Association.OrdinaryQueueIndex) should ===(true)
 
-      Thread.sleep(5000)
-      println(s"# sleep 3 end") // FIXME
-      accociation.isStreamActive(Association.ControlQueueIndex) should ===(false)
-      accociation.isStreamActive(Association.OrdinaryQueueIndex) should ===(false)
+      val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
+      val association = artery.association(remoteAddress)
 
-      Thread.sleep(5000)
-      println(s"# sleep 4 end") // FIXME
-      accociation.isStreamActive(Association.ControlQueueIndex) should ===(false)
-      accociation.isStreamActive(Association.OrdinaryQueueIndex) should ===(false)
+      withClue("When the ordinary lane is used and the control lane is not, the former should be active and the latter inactive") {
+        eventually {
+          remoteEcho.tell("ping", localProbe.ref)
 
+          association.isStreamActive(Association.ControlQueueIndex) shouldBe false
+          association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
+        }
+      }
+
+      withClue("When the control lane is used and the ordinary lane is not, the former should be active and the latter inactive") {
+        localProbe.watch(echoRef)
+        eventually {
+          association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+          association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe false
+        }
+      }
     }
 
     // FIXME test pending system messages
 
-  }
+    "not deactivate if there are unacknowledged system messages" in {
+      val remoteSystem = newRemoteSystem()
+      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
+      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
 
+      def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
+      val localProbe = new TestProbe(localSystem)
+      remoteEcho.tell("ping", localProbe.ref)
+      localProbe.expectMsg("ping")
+
+      val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
+      val association = artery.association(remoteAddress)
+
+      val associationState = association.associationState
+      associationState.pendingSystemMessagesCount.incrementAndGet()
+      association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+
+      Thread.sleep(3.seconds.toMillis)
+
+      association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+    }
+
+    "be dropped after the last outbound system message is acknowledged and the idle period has passed" in {
+      val remoteSystem = newRemoteSystem()
+      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
+      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
+
+      val remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
+      val localProbe = new TestProbe(localSystem)
+
+      val association = RARP(system).provider.transport.asInstanceOf[ArteryTransport].association(remoteAddress)
+
+      val echoRef = remoteEcho.resolveOne(3.seconds).futureValue
+      localProbe.watch(echoRef)
+      Thread.sleep(3.seconds.toMillis)
+      association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+
+      localProbe.unwatch(echoRef)
+      Thread.sleep(2000)
+      eventually(association.associationState.pendingSystemMessagesCount.get() shouldBe 0)
+      eventually(association.isStreamActive(Association.ControlQueueIndex) shouldBe false)
+    }
+
+    "still be resumable after the association has been cleaned" in {
+      val remoteSystem = newRemoteSystem()
+      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
+      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
+
+      def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
+      val localProbe = new TestProbe(localSystem)
+      remoteEcho.tell("ping", localProbe.ref)
+      localProbe.expectMsg("ping")
+
+      val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
+      val firstAssociation = artery.association(remoteAddress)
+
+      eventually {
+        firstAssociation.isActive() shouldBe false
+        // FIXME: The memory leak actually plays up as the tests are now leaking as well (without the assertion below success ensues)
+        artery.remoteAddresses shouldBe 'empty
+      }
+
+      withClue("re-initiating the connection should be the same as starting it the first time") {
+        remoteEcho.tell("ping", localProbe.ref)
+        localProbe.expectMsg("ping")
+        val secondAssociation = artery.association(remoteAddress)
+
+        secondAssociation.isStreamActive(Association.ControlQueueIndex) shouldBe true
+        secondAssociation.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
+      }
+    }
+  }
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
@@ -3,12 +3,11 @@
  */
 package akka.remote.artery
 
-import akka.actor.RootActorPath
+import akka.actor.{ ActorRef, Address, RootActorPath }
 import akka.remote.RARP
-import akka.testkit.ImplicitSender
-import akka.testkit.TestActors
-import akka.testkit.TestProbe
+import akka.testkit.{ ImplicitSender, TestActors, TestProbe }
 import org.scalatest.concurrent.Eventually
+
 import scala.concurrent.duration._
 
 class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec("""
@@ -16,139 +15,118 @@ class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec("""
   akka.remote.artery.advanced.stop-idle-outbound-after = 1 s
   """) with ImplicitSender with Eventually {
 
-  "Outbound lanes" should {
+  "Outbound streams" should {
 
-    "eliminate an association when all of them are idle" in {
-      val remoteSystem = newRemoteSystem()
-      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
-      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
+    "eliminate an association when all streams within are idle" in withAssociation {
+      (remoteAddress, remoteEcho, localArtery, localProbe) ⇒
 
-      def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
-      val localProbe = new TestProbe(localSystem)
-      remoteEcho.tell("ping", localProbe.ref)
-      localProbe.expectMsg("ping")
-
-      val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
-      val association = artery.association(remoteAddress)
-      withClue("When initiating a connection, both the control - and ordinary lanes are opened (regardless of which one was used)") {
-        // TODO: Is this still desirable? Should lanes perhaps be opened opportunistically always?
-        association.isStreamActive(Association.ControlQueueIndex) shouldBe true
-        association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
-      }
-
-      eventually {
-        association.isStreamActive(Association.ControlQueueIndex) shouldBe false
-        association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe false
-
-        // FIXME: Currently we have a memory leak in that associations are kept around even though the outbound channels are inactive
-        artery.remoteAddresses shouldBe 'empty
-      }
-    }
-
-    "have individual (in)active cycles" in {
-      val remoteSystem = newRemoteSystem()
-      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
-      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
-
-      def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
-      val echoRef = remoteEcho.resolveOne(3.seconds).futureValue
-      val localProbe = new TestProbe(localSystem)
-      remoteEcho.tell("ping", localProbe.ref)
-      localProbe.expectMsg("ping")
-
-      val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
-      val association = artery.association(remoteAddress)
-
-      withClue("When the ordinary lane is used and the control lane is not, the former should be active and the latter inactive") {
-        eventually {
-          remoteEcho.tell("ping", localProbe.ref)
-
-          association.isStreamActive(Association.ControlQueueIndex) shouldBe false
+        val association = localArtery.association(remoteAddress)
+        withClue("When initiating a connection, both the control - and ordinary streams are opened (regardless of which one was used)") {
+          association.isStreamActive(Association.ControlQueueIndex) shouldBe true
           association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
         }
-      }
 
-      withClue("When the control lane is used and the ordinary lane is not, the former should be active and the latter inactive") {
-        localProbe.watch(echoRef)
         eventually {
-          association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+          association.isStreamActive(Association.ControlQueueIndex) shouldBe false
           association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe false
+
+          // FIXME: Currently we have a memory leak in that associations are kept around even though the outbound channels are inactive
+          localArtery.remoteAddresses shouldBe 'empty
         }
-      }
     }
 
-    // FIXME test pending system messages
+    "have individual (in)active cycles" in withAssociation {
+      (remoteAddress, remoteEcho, localArtery, localProbe) ⇒
 
-    "not deactivate if there are unacknowledged system messages" in {
+        val association = localArtery.association(remoteAddress)
+
+        withClue("When the ordinary stream is used and the control stream is not, the former should be active and the latter inactive") {
+          eventually {
+            remoteEcho.tell("ping", localProbe.ref)
+            association.isStreamActive(Association.ControlQueueIndex) shouldBe false
+            association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
+          }
+        }
+
+        withClue("When the control stream is used and the ordinary stream is not, the former should be active and the latter inactive") {
+          localProbe.watch(remoteEcho)
+          eventually {
+            association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+            association.isStreamActive(Association.OrdinaryQueueIndex) shouldBe false
+          }
+        }
+    }
+
+    "not deactivate if there are unacknowledged system messages" in withAssociation {
+      (remoteAddress, remoteEcho, localArtery, localProbe) ⇒
+        val association = localArtery.association(remoteAddress)
+
+        val associationState = association.associationState
+        associationState.pendingSystemMessagesCount.incrementAndGet()
+        association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+
+        Thread.sleep(3.seconds.toMillis)
+        association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+    }
+
+    "be dropped after the last outbound system message is acknowledged and the idle period has passed" in withAssociation {
+      (remoteAddress, remoteEcho, localArtery, localProbe) ⇒
+
+        val association = RARP(system).provider.transport.asInstanceOf[ArteryTransport].association(remoteAddress)
+
+        association.associationState.pendingSystemMessagesCount.incrementAndGet()
+        Thread.sleep(3.seconds.toMillis)
+        association.isStreamActive(Association.ControlQueueIndex) shouldBe true
+
+        association.associationState.pendingSystemMessagesCount.decrementAndGet()
+        Thread.sleep(3.seconds.toMillis)
+        eventually(association.isStreamActive(Association.ControlQueueIndex) shouldBe false)
+    }
+
+    "still be resumable after the association has been cleaned" in withAssociation {
+      (remoteAddress, remoteEcho, localArtery, localProbe) ⇒
+        val firstAssociation = localArtery.association(remoteAddress)
+
+        eventually {
+          firstAssociation.isActive() shouldBe false
+          // FIXME: The memory leak actually plays up as the tests are now leaking as well (without the assertion below success ensues)
+          localArtery.remoteAddresses shouldBe 'empty
+        }
+
+        withClue("re-initiating the connection should be the same as starting it the first time") {
+          remoteEcho.tell("ping", localProbe.ref)
+          localProbe.expectMsg("ping")
+          val secondAssociation = localArtery.association(remoteAddress)
+
+          secondAssociation.isStreamActive(Association.ControlQueueIndex) shouldBe true
+          secondAssociation.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
+        }
+    }
+
+    /**
+     * Test setup fixture:
+     * 1. A 'remote' ActorSystem is created to spawn an Echo actor,
+     * 2. A TestProbe is spawned locally to initiate communication with the Echo actor
+     * 3. Details (remoteAddress, remoteEcho, localArtery, localProbe) are supplied to the test
+     */
+    def withAssociation(test: (Address, ActorRef, ArteryTransport, TestProbe) ⇒ Any): Unit = {
       val remoteSystem = newRemoteSystem()
       remoteSystem.actorOf(TestActors.echoActorProps, "echo")
       val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
 
       def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
-      val localProbe = new TestProbe(localSystem)
-      remoteEcho.tell("ping", localProbe.ref)
-      localProbe.expectMsg("ping")
-
-      val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
-      val association = artery.association(remoteAddress)
-
-      val associationState = association.associationState
-      associationState.pendingSystemMessagesCount.incrementAndGet()
-      association.isStreamActive(Association.ControlQueueIndex) shouldBe true
-
-      Thread.sleep(3.seconds.toMillis)
-
-      association.isStreamActive(Association.ControlQueueIndex) shouldBe true
-    }
-
-    "be dropped after the last outbound system message is acknowledged and the idle period has passed" in {
-      val remoteSystem = newRemoteSystem()
-      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
-      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
-
-      val remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
-      val localProbe = new TestProbe(localSystem)
-
-      val association = RARP(system).provider.transport.asInstanceOf[ArteryTransport].association(remoteAddress)
 
       val echoRef = remoteEcho.resolveOne(3.seconds).futureValue
-      localProbe.watch(echoRef)
-      Thread.sleep(3.seconds.toMillis)
-      association.isStreamActive(Association.ControlQueueIndex) shouldBe true
-
-      localProbe.unwatch(echoRef)
-      Thread.sleep(2000)
-      eventually(association.associationState.pendingSystemMessagesCount.get() shouldBe 0)
-      eventually(association.isStreamActive(Association.ControlQueueIndex) shouldBe false)
-    }
-
-    "still be resumable after the association has been cleaned" in {
-      val remoteSystem = newRemoteSystem()
-      remoteSystem.actorOf(TestActors.echoActorProps, "echo")
-      val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
-
-      def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
       val localProbe = new TestProbe(localSystem)
+
       remoteEcho.tell("ping", localProbe.ref)
       localProbe.expectMsg("ping")
 
       val artery = RARP(system).provider.transport.asInstanceOf[ArteryTransport]
-      val firstAssociation = artery.association(remoteAddress)
 
-      eventually {
-        firstAssociation.isActive() shouldBe false
-        // FIXME: The memory leak actually plays up as the tests are now leaking as well (without the assertion below success ensues)
-        artery.remoteAddresses shouldBe 'empty
-      }
+      test(remoteAddress, echoRef, artery, localProbe)
 
-      withClue("re-initiating the connection should be the same as starting it the first time") {
-        remoteEcho.tell("ping", localProbe.ref)
-        localProbe.expectMsg("ping")
-        val secondAssociation = artery.association(remoteAddress)
-
-        secondAssociation.isStreamActive(Association.ControlQueueIndex) shouldBe true
-        secondAssociation.isStreamActive(Association.OrdinaryQueueIndex) shouldBe true
-      }
+      remoteSystem.terminate()
     }
   }
 }


### PR DESCRIPTION
This is an initial attempt at creating some tests, please bear in mind:
- We may have different views on the matter. I'm testing for removal of the association, whereas there might be reasons you know off why this cannot be done? The first and last test should fail because of this; the other tests pass for me.
- I have changed the visibility of `swapState` to package protected so that I have access to it in my test. I don't mean to invite people to use that outside `Association`. The alternative way to influence this value is with system messages. Installing a watch works, but is more brittle than I'd like. If you have alternative suggestions, I am curious!
- It is very much non-DRY; I got it working before tidying up.

I hope this will at least help you on your way, feel free to criticise this initial attempt and express what additional things you'd like to see tested / changes. I'll be happy to try again!