### PR TITLE
[PROTOTYPE] default attributes on stages

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -44,7 +44,27 @@ abstract class GraphStageWithMaterializedValue[+S <: Shape, +M] extends Graph[S,
   @throws(classOf[Exception])
   def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, M)
 
+  /**
+   * Initial attributes are used as the most specific attributes of a stage, they can only be overridden
+   * directly on the stage, as soon as the stage has been composed with other stages or graphs it is
+   * impossible to modify them for a user, since most specific attributes are what are used by the stage.
+   *
+   * Suitable for example for the `name` attribute, which should only be "overridden" on a per stage basis,
+   * setting it on a composed graphs should not replace the individual names of all composed stages.
+   */
   protected def initialAttributes: Attributes = Attributes.none
+
+  /**
+   * Default attributes are the least specific in the attributes for a stage (with exception for
+   * settings coming from the materializer).
+   *
+   * This means they will only apply if there is no attribute of the same type specified on the graph.
+   *
+   * Suitable for example for the `dispatcher` attribute as the user may want to specify a specific dispatcher
+   * for an entire composed graph but you also want to provide a specific dispatcher to use (for blocking for example)
+   * in case the user has not specified anything.
+   */
+  def defaultAttributes: Attributes = Attributes.none
 
   private var _traversalBuilder: TraversalBuilder = null
 


### PR DESCRIPTION
Another somewhat crazy idea:

Inherited attributes are most specific and can only be replaced if you have access to the individual stage. Stage default attributes are sandwiched inbetween the materializer settings and the settings from the graph, meaning that they will apply only if the attribute is not set on any level of the graph. 

This allows for having the IODispatcher as a default, over the default-stream dispatcher (defined in the materializer settings/attributes) but that it can be trumped on a composed graph to make the entire graph run on a different dispatcher (true for other attributes as well ofc)