### PR TITLE
Add entity id to sharding props (#24053)

### DIFF
--- a/akka-cluster-sharding/src/main/mima-filters/2.5.7.backwards.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.5.7.backwards.excludes
@@ -1,0 +1,2 @@
+# 24058 - Add ClusterSharding.start overloads
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.ShardRegion.props")

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -45,8 +45,8 @@ The above actor uses event sourcing and the support provided in @scala[`Persiste
 It does not have to be a persistent actor, but in case of failure or migration of entities between nodes it must be able to recover
 its state if it is valuable.
 
-Note how the `persistenceId` is defined. The name of the actor is the entity identifier (utf-8 URL-encoded).
-You may define it another way, but it must be unique.
+Note how the `persistenceId` is defined - it must be unique to the entity, so using the entity identifier is advised. 
+You may define it in other ways, but it must be unique.
 
 When using the sharding extension you are first, typically at system startup on each node
 in the cluster, supposed to register the supported entity types with the `ClusterSharding.start`
@@ -57,6 +57,10 @@ Scala
 
 Java
 :  @@snip [ClusterShardingTest.java]($code$/java/jdocs/sharding/ClusterShardingTest.java) { #counter-start }
+
+In some cases, the actor may need to know the `entityId` associated with it. This can be achieved using the `entityPropsFactory`
+parameter to `ClusterSharding.start`. The entity ID will be passed to the factory as a parameter, which can then be used in
+the creation of the actor (like the above example).
 
 The @scala[`extractEntityId` and `extractShardId` are two] @java[`messageExtractor` defines] application specific @scala[functions] @java[methods] to extract the entity
 identifier and the shard identifier from incoming messages.

--- a/akka-docs/src/test/java/jdocs/sharding/ClusterShardingTest.java
+++ b/akka-docs/src/test/java/jdocs/sharding/ClusterShardingTest.java
@@ -7,6 +7,8 @@ package jdocs.sharding;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.Optional;
+import java.util.function.Function;
+
 import scala.concurrent.duration.Duration;
 
 import akka.actor.AbstractActor;
@@ -17,7 +19,6 @@ import akka.actor.OneForOneStrategy;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.actor.SupervisorStrategy;
-import akka.actor.Terminated;
 import akka.actor.ReceiveTimeout;
 //#counter-extractor
 import akka.cluster.sharding.ShardRegion;
@@ -31,7 +32,6 @@ import akka.cluster.sharding.ClusterShardingSettings;
 
 //#counter-start
 import akka.persistence.AbstractPersistentActor;
-import akka.cluster.Cluster;
 import akka.japi.pf.DeciderBuilder;
 
 // Doc code, compile only
@@ -85,12 +85,12 @@ public class ClusterShardingTest {
     //#counter-start
     Option<String> roleOption = Option.none();
     ClusterShardingSettings settings = ClusterShardingSettings.create(system);
-    ActorRef startedCounterRegion = ClusterSharding.get(system).start("Counter",
-      Props.create(Counter.class), settings, messageExtractor);
+    ActorRef startedCounterRegion = ClusterSharding.get(system).start(Counter.ShardingTypeName,
+      entityId -> Counter.props(entityId), settings, messageExtractor);
     //#counter-start
 
     //#counter-usage
-    ActorRef counterRegion = ClusterSharding.get(system).shardRegion("Counter");
+    ActorRef counterRegion = ClusterSharding.get(system).shardRegion(Counter.ShardingTypeName);
     counterRegion.tell(new Counter.Get(123), getSelf());
 
     counterRegion.tell(new Counter.EntityEnvelope(123,
@@ -99,14 +99,14 @@ public class ClusterShardingTest {
     //#counter-usage
 
     //#counter-supervisor-start
-    ClusterSharding.get(system).start("SupervisedCounter",
-        Props.create(CounterSupervisor.class), settings, messageExtractor);
+    ClusterSharding.get(system).start(CounterSupervisor.ShardingTypeName,
+        entityId -> CounterSupervisor.props(entityId), settings, messageExtractor);
     //#counter-supervisor-start
 
     //#proxy-dc
     ActorRef counterProxyDcB =
       ClusterSharding.get(system).startProxy(
-        "Counter",
+        Counter.ShardingTypeName,
         Optional.empty(),
         Optional.of("B"), // data center name
         messageExtractor);
@@ -189,12 +189,22 @@ public class ClusterShardingTest {
       }
     }
 
+    public static final String ShardingTypeName = "Counter";
+
+    public static Props props(String id) {
+        return Props.create(() -> new Counter(id));
+    }
+
+    final String entityId;
     int count = 0;
 
-    // getSelf().path().name() is the entity identifier (utf-8 URL-encoded)
+    public Counter(String entityId) {
+      this.entityId = entityId;
+    }
+
     @Override
     public String persistenceId() {
-      return "Counter-" + getSelf().path().name();
+      return ShardingTypeName + "-" + entityId;
     }
 
     @Override
@@ -247,9 +257,17 @@ public class ClusterShardingTest {
 
   static//#supervisor
   public class CounterSupervisor extends AbstractActor {
+    public static final String ShardingTypeName = "CounterSupervisor";
 
-    private final ActorRef counter = getContext().actorOf(
-        Props.create(Counter.class), "theCounter");
+    public static Props props(String entityId) {
+        return Props.create(() -> new CounterSupervisor(entityId));
+    }
+
+    private final ActorRef counter;
+
+    public CounterSupervisor(String entityId) {
+        counter = getContext().actorOf(Counter.props(entityId), "theCounter");
+    }
 
     private static final SupervisorStrategy strategy =
       new OneForOneStrategy(DeciderBuilder.


### PR DESCRIPTION
Add overloads for `ClusterSharding.start` that take function from entity id to props.

I modified the tests that were included in the docs to use the id from props as well, let me know if you want me to revert that part...