### PR TITLE
fix typo in remoting*.md and actors.md #24061

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -665,7 +665,7 @@ akka {
     # Akka Serialization extension, instead DisabledJavaSerializer will 
     # be inserted which will fail explicitly if attempts to use java serialization are made.
     # 
-    # The log messages emitted by such serializer SHOULD be be treated as potential 
+    # The log messages emitted by such serializer SHOULD be treated as potential 
     # attacks which the serializer prevented, as they MAY indicate an external operator 
     # attempting to send malicious messages intending to use java serialization as attack vector.
     # The attempts are logged with the SECURITY marker.
@@ -1061,7 +1061,7 @@ akka {
     phases {
 
       # The first pre-defined phase that applications can add tasks to.
-      # Note that more phases can be be added in the application's
+      # Note that more phases can be added in the application's
       # configuration by overriding this phase with an additional 
       # depends-on.
       before-service-unbind {

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -35,7 +35,7 @@ import akka.util.OptionVal
 object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with ExtensionIdProvider {
   /**
    * The first pre-defined phase that applications can add tasks to.
-   * Note that more phases can be be added in the application's
+   * Note that more phases can be added in the application's
    * configuration by overriding this phase with an additional
    * depends-on.
    */

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -118,7 +118,7 @@ object ConsistentHashingRoutingLogic {
  * The key is part of the message and it's convenient to define it together
  * with the message definition.
  *
- * 3. The messages can be be wrapped in a [[akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope]]
+ * 3. The messages can be wrapped in a [[akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope]]
  * to define what data to use for the consistent hash key. The sender knows
  * the key to use.
  *

--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -1078,7 +1078,7 @@ The default phases are defined as:
 
 @@snip [reference.conf]($akka$/akka-actor/src/main/resources/reference.conf) { #coordinated-shutdown-phases }
 
-More phases can be be added in the application's configuration if needed by overriding a phase with an
+More phases can be added in the application's configuration if needed by overriding a phase with an
 additional `depends-on`. Especially the phases `before-service-unbind`, `before-cluster-shutdown` and
 `before-actor-system-terminate` are intended for application specific phases or tasks.
 

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -592,7 +592,7 @@ be inserted which will fail explicitly if attempts to use java serialization are
 
 It will also enable the above mentioned *enable-additional-serialization-bindings*.
 
-The log messages emitted by such serializer SHOULD be be treated as potential
+The log messages emitted by such serializer SHOULD be treated as potential
 attacks which the serializer prevented, as they MAY indicate an external operator
 attempting to send malicious messages intending to use java serialization as attack vector.
 The attempts are logged with the SECURITY marker.

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -417,7 +417,7 @@ be inserted which will fail explicitly if attempts to use java serialization are
 
 It will also enable the above mentioned `enable-additional-serialization-bindings`.
 
-The log messages emitted by such serializer SHOULD be be treated as potential
+The log messages emitted by such serializer SHOULD be treated as potential
 attacks which the serializer prevented, as they MAY indicate an external operator
 attempting to send malicious messages intending to use java serialization as attack vector.
 The attempts are logged with the SECURITY marker.


### PR DESCRIPTION
Removes extra "be" in "Disabling the Java Serializer" in Remoting docs,
in "Coordinated Shutdown" in Actors doc, and also in scala code and in reference.conf