### PR TITLE
Fix for async callback memory leak

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/AsyncCallbackCancellationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/AsyncCallbackCancellationSpec.scala
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.impl.fusing
+
+import akka.Done
+import akka.actor.ActorRef
+import akka.stream._
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream.stage._
+import akka.stream.testkit.{ StreamSpec, TestPublisher }
+import akka.testkit.TestProbe
+
+import scala.concurrent.duration._
+import scala.language.reflectiveCalls
+
+class AsyncCallbackCancellationSpec extends StreamSpec {
+
+  class Stage[T](
+    callbackProbe:     ActorRef,
+    earlyCallbacks:    List[AnyRef] = Nil,
+    earlyCancellation: Boolean      = false)
+    extends GraphStageWithMaterializedValue[FlowShape[T, T], AsyncCallback[AnyRef]] {
+
+    val in = Inlet[T]("in")
+    val out = Outlet[T]("out")
+    val shape = FlowShape(in, out)
+
+    def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, AsyncCallback[AnyRef]) = {
+      val logic = new GraphStageLogic(shape) {
+        val cb = getAsyncCallback[AnyRef](a ⇒ callbackProbe ! a)
+        earlyCallbacks.foreach(cb.invoke)
+        if (earlyCancellation) cb.cancel()
+
+        setHandlers(in, out, new InHandler with OutHandler {
+          def onPush(): Unit = push(out, grab(in))
+          def onPull(): Unit = pull(in)
+        })
+
+      }
+      (logic, logic.cb)
+    }
+  }
+
+  implicit val mat = ActorMaterializer()
+
+  "Async Callbacks" should {
+
+    "not allow invokes after cancelling" in {
+      val probe = TestProbe()
+      val in = TestPublisher.probe[Int]()
+      val cb =
+        Source.fromPublisher(in)
+          .viaMat(Flow.fromGraph(new Stage(probe.ref)))(Keep.right)
+          .to(Sink.ignore)
+          .run()
+
+      val future1 = cb.invokeWithFeedback("hepp!")
+      probe.expectMsg("hepp!")
+      future1.futureValue should ===(Done)
+
+      cb.cancel()
+      val future2 = cb.invokeWithFeedback("tjo!")
+      cb.invoke("hey!")
+      future2.failed.futureValue shouldBe a[StreamDetachedException]
+
+      // and neither came through
+      probe.expectNoMessage(500.millis)
+      in.sendComplete()
+    }
+
+    "pass through early callbacks" in {
+      val probe = TestProbe()
+      val in = TestPublisher.probe[Int]()
+      val cb =
+        Source.fromPublisher(in)
+          .viaMat(Flow.fromGraph(new Stage(probe.ref, earlyCallbacks = List("hepp!", "heya!"))))(Keep.right)
+          .to(Sink.ignore)
+          .run()
+
+      probe.expectMsg("hepp!")
+      probe.expectMsg("heya!")
+
+      // and neither came through
+      probe.expectNoMessage(500.millis)
+      in.sendComplete()
+    }
+
+    "not pass through early callbacks if there is an earlier cancel" in {
+      val probe = TestProbe()
+      // this should put the early callbacks in pending, and then cancel while they still are pending
+      val in = TestPublisher.probe[Int]()
+      val cb =
+        Source.fromPublisher(in)
+          .viaMat(Flow.fromGraph(new Stage(
+            probe.ref,
+            earlyCallbacks = List("hepp!", "heya!"),
+            earlyCancellation = true
+          )))(Keep.right)
+          .to(Sink.ignore)
+          .run()
+
+      probe.expectNoMessage(500.millis)
+      in.sendComplete()
+    }
+
+    "not cause any trouble with multiple cancels" in {
+      val probe = TestProbe()
+      val in = TestPublisher.probe[Int]()
+      val cb =
+        Source.fromPublisher(in)
+          .viaMat(Flow.fromGraph(new Stage(probe.ref)))(Keep.right)
+          .to(Sink.ignore)
+          .run()
+
+      cb.cancel()
+      cb.cancel()
+
+      in.sendComplete()
+    }
+
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitAfterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitAfterSpec.scala
@@ -15,7 +15,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import akka.stream.StreamSubscriptionTimeoutSettings
 import akka.stream.StreamSubscriptionTimeoutTerminationMode
-import org.scalatest.concurrent.PatienceConfiguration.Interval
 
 object FlowSplitAfterSpec {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitAfterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitAfterSpec.scala
@@ -10,10 +10,12 @@ import akka.stream.impl.SubscriptionTimeoutException
 import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
 import akka.stream.testkit.Utils._
 import org.reactivestreams.Publisher
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import akka.stream.StreamSubscriptionTimeoutSettings
 import akka.stream.StreamSubscriptionTimeoutTerminationMode
+import org.scalatest.concurrent.PatienceConfiguration.Interval
 
 object FlowSplitAfterSpec {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubStreamMemoryLeaks.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubStreamMemoryLeaks.scala
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+object SubStreamMemoryLeaks extends App {
+
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+
+  Source.fromIterator(() ⇒
+    Iterator.continually(Source.single(Array.fill(1024 * 1024)(1)))
+  ) // each incoming of these will cause creation of a new async callback
+    // which would leak because of bug 24046
+    .flatMapConcat(identity)
+    .grouped(100)
+    .runWith(Sink.foreach(_ ⇒ print(".")))
+
+}

--- a/akka-stream/src/main/mima-filters/2.5.7.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.7.backwards.excludes
@@ -1,2 +1,6 @@
 # Attributes overhaul
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.Graph.async")
+
+# 24046 AsyncCallback memory leak
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.stage.AsyncCallback.cancel")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.impl.fusing.SubSink.this")

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -9,22 +9,17 @@ import akka.NotUsed
 import akka.annotation.InternalApi
 import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream._
-import akka.stream.impl.Stages.DefaultAttributes
-import akka.stream.impl.SubscriptionTimeoutException
-import akka.stream.stage._
-import akka.stream.scaladsl._
 import akka.stream.actor.ActorSubscriberMessage
+import akka.stream.impl.Stages.DefaultAttributes
+import akka.stream.impl.{ SubscriptionTimeoutException, Buffer ⇒ BufferImpl }
+import akka.stream.scaladsl._
+import akka.stream.stage._
 
-import scala.collection.{ immutable, mutable }
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
-import scala.annotation.tailrec
-import akka.stream.impl.PublisherSource
-import akka.stream.impl.CancellingSubscriber
-import akka.stream.impl.{ Buffer ⇒ BufferImpl }
-import akka.util.OptionVal
-
-import scala.collection.JavaConverters._
 
 /**
  * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -22,6 +22,7 @@ import scala.annotation.tailrec
 import akka.stream.impl.PublisherSource
 import akka.stream.impl.CancellingSubscriber
 import akka.stream.impl.{ Buffer ⇒ BufferImpl }
+import akka.util.OptionVal
 
 import scala.collection.JavaConverters._
 
@@ -202,6 +203,12 @@ import scala.collection.JavaConverters._
     override def onDownstreamFinish(): Unit = {
       if (!prefixComplete) completeStage()
       // Otherwise substream is open, ignore
+    }
+
+    override def postStop(): Unit = {
+      if (tailSource != null && !tailSource.isClosed) {
+        tailSource.fail(new AbruptStageTerminationException(this))
+      }
     }
 
     setHandlers(in, out, this)
@@ -581,6 +588,8 @@ import scala.collection.JavaConverters._
   /** Not yet materialized and no command has been scheduled */
   case object Uninitialized extends State
 
+  case object Materialized
+
   /** A command was scheduled before materialization */
   sealed abstract class CommandScheduledBeforeMaterialization(val command: Command) extends State
 
@@ -600,11 +609,16 @@ import scala.collection.JavaConverters._
 }
 
 /**
+ * @param externalCallback An async callback specifically for this SubSink instance, will be used for interaction and then
+ *                         cancelled when the SubSink is cancelled
+ *
  * INTERNAL API
  */
-@InternalApi private[stream] final class SubSink[T](name: String, externalCallback: ActorSubscriberMessage ⇒ Unit)
+@InternalApi private[stream] final class SubSink[T](name: String, externalCallback: AsyncCallback[ActorSubscriberMessage])
   extends GraphStage[SinkShape[T]] {
   import SubSink._
+
+  private val sendMessage: ActorSubscriberMessage ⇒ Unit = externalCallback.invoke
 
   private val in = Inlet[T](s"SubSink($name).in")
 
@@ -614,7 +628,10 @@ import scala.collection.JavaConverters._
   private val status = new AtomicReference[ /* State */ AnyRef](Uninitialized)
 
   def pullSubstream(): Unit = dispatchCommand(RequestOneScheduledBeforeMaterialization)
-  def cancelSubstream(): Unit = dispatchCommand(CancelScheduledBeforeMaterialization)
+  def cancelSubstream(): Unit = {
+    dispatchCommand(CancelScheduledBeforeMaterialization)
+    externalCallback.cancel()
+  }
 
   @tailrec
   private def dispatchCommand(newState: CommandScheduledBeforeMaterialization): Unit =
@@ -636,28 +653,39 @@ import scala.collection.JavaConverters._
   override def createLogic(attr: Attributes) = new GraphStageLogic(shape) with InHandler {
     setHandler(in, this)
 
-    override def onPush(): Unit = externalCallback(ActorSubscriberMessage.OnNext(grab(in)))
-    override def onUpstreamFinish(): Unit = externalCallback(ActorSubscriberMessage.OnComplete)
-    override def onUpstreamFailure(ex: Throwable): Unit = externalCallback(ActorSubscriberMessage.OnError(ex))
+    override def onPush(): Unit = sendMessage(ActorSubscriberMessage.OnNext(grab(in)))
+    override def onUpstreamFinish(): Unit = sendMessage(ActorSubscriberMessage.OnComplete)
+    override def onUpstreamFailure(ex: Throwable): Unit = sendMessage(ActorSubscriberMessage.OnError(ex))
 
-    @tailrec
-    private def setCallback(callback: Command ⇒ Unit): Unit =
-      status.get match {
-        case Uninitialized ⇒
-          if (!status.compareAndSet(Uninitialized, /* Materialized */ getAsyncCallback[Command](callback)))
-            setCallback(callback)
+    override def postStop(): Unit = {
+      externalCallback.cancel()
+    }
 
-        case cmd: CommandScheduledBeforeMaterialization ⇒
-          if (status.compareAndSet(cmd, /* Materialized */ getAsyncCallback[Command](callback)))
-            // between those two lines a new command might have been scheduled, but that will go through the
-            // async interface, so that the ordering is still kept
-            callback(cmd.command)
-          else
-            setCallback(callback)
+    private def setCallback(callback: Command ⇒ Unit): Unit = {
+      @tailrec
+      def loop(asyncCallback: AsyncCallback[Command]): Unit = {
+        status.get match {
+          case Uninitialized ⇒
+            if (!status.compareAndSet(Uninitialized, /* Materialized */ asyncCallback))
+              loop(asyncCallback)
 
-        case m: /* Materialized */ AsyncCallback[Command @unchecked] ⇒
-          failStage(new IllegalStateException("Substream Source cannot be materialized more than once"))
+          case cmd: CommandScheduledBeforeMaterialization ⇒
+            if (status.compareAndSet(cmd, /* Materialized */ asyncCallback))
+              // between those two lines a new command might have been scheduled, but that will go through the
+              // async interface, so that the ordering is still kept
+              callback(cmd.command)
+            else
+              loop(asyncCallback)
+
+          case m: /* Materialized */ AsyncCallback[Command @unchecked] ⇒
+            asyncCallback.cancel()
+            failStage(new IllegalStateException("Substream Source cannot be materialized more than once"))
+        }
       }
+
+      val asyncCallback = getAsyncCallback[Command](callback)
+      loop(asyncCallback)
+    }
 
     override def preStart(): Unit =
       setCallback {
@@ -670,6 +698,9 @@ import scala.collection.JavaConverters._
 }
 
 /**
+ * @param externalCallback An async callback specifically for this SubSource instance, will be used for interaction and then
+ *                         cancelled when the SubSource is completed or failed
+ *
  * INTERNAL API
  */
 @InternalApi private[akka] final class SubSource[T](name: String, private[fusing] val externalCallback: AsyncCallback[SubSink.Command])
@@ -692,6 +723,9 @@ import scala.collection.JavaConverters._
     case null ⇒
       if (!status.compareAndSet(null, ActorSubscriberMessage.OnComplete))
         status.get.asInstanceOf[AsyncCallback[Any]].invoke(ActorSubscriberMessage.OnComplete)
+      else
+        // not materialized yet, make sure the callback is released
+        externalCallback.cancel()
   }
 
   def failSubstream(ex: Throwable): Unit = status.get match {
@@ -700,34 +734,51 @@ import scala.collection.JavaConverters._
       val failure = ActorSubscriberMessage.OnError(ex)
       if (!status.compareAndSet(null, failure))
         status.get.asInstanceOf[AsyncCallback[Any]].invoke(failure)
+      else
+        // not materialized yet, make sure the callback is released
+        externalCallback.cancel()
   }
 
-  def timeout(d: FiniteDuration): Boolean =
-    status.compareAndSet(null, ActorSubscriberMessage.OnError(new SubscriptionTimeoutException(s"Substream Source has not been materialized in $d")))
+  def timeout(d: FiniteDuration): Boolean = {
+    val failure = ActorSubscriberMessage.OnError(new SubscriptionTimeoutException(s"Substream Source has not been materialized in $d"))
+    // not materialized yet, make sure the callback is released
+    externalCallback.cancel()
+    status.compareAndSet(null, failure)
+  }
 
-  override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with OutHandler {
-    setHandler(out, this)
+  override def createLogic(inheritedAttributes: Attributes) = {
+    new GraphStageLogic(shape) with OutHandler {
+      private var materializationFailed = false
+      setHandler(out, this)
 
-    @tailrec private def setCB(cb: AsyncCallback[ActorSubscriberMessage]): Unit = {
-      status.get match {
-        case null                               ⇒ if (!status.compareAndSet(null, cb)) setCB(cb)
-        case ActorSubscriberMessage.OnComplete  ⇒ completeStage()
-        case ActorSubscriberMessage.OnError(ex) ⇒ failStage(ex)
-        case _: AsyncCallback[_]                ⇒ failStage(new IllegalStateException("Substream Source cannot be materialized more than once"))
+      @tailrec private def setCB(cb: AsyncCallback[ActorSubscriberMessage]): Unit = {
+        status.get match {
+          case null                               ⇒ if (!status.compareAndSet(null, cb)) setCB(cb)
+          case ActorSubscriberMessage.OnComplete  ⇒ completeStage()
+          case ActorSubscriberMessage.OnError(ex) ⇒ failStage(ex)
+          case _: AsyncCallback[_] ⇒
+            materializationFailed = true
+            failStage(new IllegalStateException("Substream Source cannot be materialized more than once"))
+        }
+      }
+
+      override def preStart(): Unit = {
+        val ourOwnCallback = getAsyncCallback[ActorSubscriberMessage] {
+          case ActorSubscriberMessage.OnComplete   ⇒ completeStage()
+          case ActorSubscriberMessage.OnError(ex)  ⇒ failStage(ex)
+          case ActorSubscriberMessage.OnNext(elem) ⇒ push(out, elem.asInstanceOf[T])
+        }
+        setCB(ourOwnCallback)
+      }
+
+      override def onPull(): Unit = externalCallback.invoke(RequestOne)
+
+      override def onDownstreamFinish(): Unit = externalCallback.invoke(Cancel)
+
+      override def postStop(): Unit = {
+        if (!materializationFailed) externalCallback.cancel()
       }
     }
-
-    override def preStart(): Unit = {
-      val ourOwnCallback = getAsyncCallback[ActorSubscriberMessage] {
-        case ActorSubscriberMessage.OnComplete   ⇒ completeStage()
-        case ActorSubscriberMessage.OnError(ex)  ⇒ failStage(ex)
-        case ActorSubscriberMessage.OnNext(elem) ⇒ push(out, elem.asInstanceOf[T])
-      }
-      setCB(ourOwnCallback)
-    }
-
-    override def onPull(): Unit = externalCallback.invoke(RequestOne)
-    override def onDownstreamFinish(): Unit = externalCallback.invoke(Cancel)
   }
 
   override def toString: String = name


### PR DESCRIPTION
Fixes #24046

I think providing explicit lifecycle control like this is the way to go for the very few cases where the async callback lifecycles aren't tied to the lifecycle of the stage.