### PR TITLE
=str use 1.0.2-RC1 TCK, without bumping the API dependency yet

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,7 +108,7 @@ object Dependencies {
       val slf4jLog4j = "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % "test" // MIT
 
       // reactive streams tck
-      val reactiveStreamsTck = "org.reactivestreams" % "reactive-streams-tck" % "1.0.1" % "test" // CC0
+      val reactiveStreamsTck = "org.reactivestreams" % "reactive-streams-tck" % "1.0.2-RC1" % "test" // CC0
     }
 
     object Provided {


### PR DESCRIPTION
As usual with RCs only bumping the TCK for now