### PR TITLE
AsyncCallback speedup / cleanup

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -457,7 +457,7 @@ import scala.util.control.NonFatal
     shell:   GraphInterpreterShell,
     logic:   GraphStageLogic,
     evt:     Any,
-    promise: OptionVal[Promise[Done]],
+    promise: Promise[Done],
     handler: (Any) ⇒ Unit) extends BoundaryEvent {
     override def execute(eventLimit: Int): Int = {
       if (!waitingForShutdown) {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -194,7 +194,7 @@ import scala.util.control.NonFatal
   val log:          LoggingAdapter,
   val logics:       Array[GraphStageLogic], // Array of stage logics
   val connections:  Array[GraphInterpreter.Connection],
-  val onAsyncInput: (GraphStageLogic, Any, OptionVal[Promise[Done]], (Any) ⇒ Unit) ⇒ Unit,
+  val onAsyncInput: (GraphStageLogic, Any, Promise[Done], (Any) ⇒ Unit) ⇒ Unit,
   val fuzzingMode:  Boolean,
   val context:      ActorRef) {
 
@@ -435,7 +435,7 @@ import scala.util.control.NonFatal
     eventsRemaining
   }
 
-  def runAsyncInput(logic: GraphStageLogic, evt: Any, promise: OptionVal[Promise[Done]], handler: (Any) ⇒ Unit): Unit =
+  def runAsyncInput(logic: GraphStageLogic, evt: Any, promise: Promise[Done], handler: (Any) ⇒ Unit): Unit =
     if (!isStageCompleted(logic)) {
       if (GraphInterpreter.Debug) println(s"$Name ASYNC $evt ($handler) [$logic]")
       val currentInterpreterHolder = _currentInterpreter.get()
@@ -445,16 +445,14 @@ import scala.util.control.NonFatal
         activeStage = logic
         try {
           handler(evt)
-          if (promise.isDefined) {
-            val p = promise.get
-            p.success(Done)
+          if (promise ne GraphStageLogic.NoPromise) {
+            promise.success(Done)
             logic.onFeedbackDispatched()
           }
         } catch {
           case NonFatal(ex) ⇒
-            if (promise.isDefined) {
-              val p = promise.get
-              promise.get.failure(ex)
+            if (promise ne GraphStageLogic.NoPromise) {
+              promise.failure(ex)
               logic.onFeedbackDispatched()
             }
             logic.failStage(ex)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -445,10 +445,18 @@ import scala.util.control.NonFatal
         activeStage = logic
         try {
           handler(evt)
-          if (promise.isDefined) promise.get.success(Done)
+          if (promise.isDefined) {
+            val p = promise.get
+            p.success(Done)
+            logic.onFeedbackDispatched()
+          }
         } catch {
           case NonFatal(ex) ⇒
-            if (promise.isDefined) promise.get.failure(ex)
+            if (promise.isDefined) {
+              val p = promise.get
+              promise.get.failure(ex)
+              logic.onFeedbackDispatched()
+            }
             logic.failStage(ex)
         }
         afterStageHasRun(logic)


### PR DESCRIPTION
Here are two experiments: first commit just uses synchronized to access the shared state, second one just uses a simple list which is much faster to update than a map and a set and which is only cleaned up every 1000 callbacks.

/cc @johanandren, @patriknw 