### PR TITLE
MapAsync and already failed futures

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
@@ -444,18 +444,6 @@ class FlowMapAsyncSpec extends StreamSpec {
       failCount.get() should ===(1)
     }
 
-    "not get stuck if fed parallelism number of failed futures and is resuming" in {
-      val failure = Future.failed(TE("böö"))
-      val result = Source((1 to 8).map(_ ⇒ failure))
-        .mapAsync(8)(identity)
-        .addAttributes(supervisionStrategy {
-          case TE("böö") ⇒ Supervision.resume
-          case _         ⇒ Supervision.stop
-        }).runWith(Sink.seq)
-
-      result.futureValue should ===(Seq.empty)
-    }
-
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1172,7 +1172,7 @@ private[stream] object Collect {
       private val futureCB = getAsyncCallback[Holder[Out]](holder ⇒
         holder.elem match {
           case Success(_) ⇒ pushNextIfPossible()
-          case Failure(NonFatal(ex)) ⇒
+          case Failure(ex) ⇒
             holder.supervisionDirectiveFor(decider, ex) match {
               // fail fast as if supervision says so
               case Supervision.Stop ⇒ failStage(ex)
@@ -1200,7 +1200,7 @@ private[stream] object Collect {
               holder.setElem(v)
               v match {
                 // this optimization also requires us to stop the stage to fail fast if the decider says so:
-                case Failure(NonFatal(ex)) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop ⇒ failStage(ex)
+                case Failure(ex) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop ⇒ failStage(ex)
                 case _ ⇒ pushNextIfPossible()
               }
           }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1230,7 +1230,8 @@ private[stream] object Collect {
 
             case Failure(NonFatal(ex)) ⇒
               holder.supervisionDirectiveFor(decider, ex) match {
-                // this shouldn't happen because it would have failed fast for stopping exceptions
+                // this could happen if we are looping in pushNextIfPossible and end up on a failed future before the
+                // onComplete callback has run
                 case Supervision.Stop ⇒ failStage(ex)
                 case _ ⇒
                   // try next element

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1197,7 +1197,10 @@ private[stream] object Collect {
             case Some(v) ⇒
               // #20217 the future is already here, avoid scheduling it on the dispatcher
               holder.setElem(v)
-              pushNextIfPossible()
+              v match {
+                case Failure(ex) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop ⇒ failStage(ex)
+                case _ ⇒ pushNextIfPossible()
+              }
           }
 
         } catch {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1195,10 +1195,12 @@ private[stream] object Collect {
           future.value match {
             case None ⇒ future.onComplete(holder)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext)
             case Some(v) ⇒
-              // #20217 the future is already here, avoid scheduling it on the dispatcher
+              // #20217 the future is already here, optimization: avoid scheduling it on the dispatcher and
+              // run the logic directly on this thread
               holder.setElem(v)
               v match {
-                case Failure(ex) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop ⇒ failStage(ex)
+                // this optimization also requires us to stop the stage to fail fast if the decider says so:
+                case Failure(NonFatal(ex)) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop ⇒ failStage(ex)
                 case _ ⇒ pushNextIfPossible()
               }
           }
@@ -1228,6 +1230,7 @@ private[stream] object Collect {
 
             case Failure(NonFatal(ex)) ⇒
               holder.supervisionDirectiveFor(decider, ex) match {
+                // this shouldn't happen because it would have failed fast for stopping exceptions
                 case Supervision.Stop ⇒ failStage(ex)
                 case _ ⇒
                   // try next element


### PR DESCRIPTION
Fixes the regression introduced in #24022, refs #24117 