### PR TITLE
Renaming AllPersistenceIdsQuery -> PersistenceIdsQuery was missed in doc

### DIFF
--- a/akka-docs/src/main/paradox/persistence-query-leveldb.md
+++ b/akka-docs/src/main/paradox/persistence-query-leveldb.md
@@ -79,9 +79,9 @@ hint.
 The stream is completed with failure if there is a failure in executing the query in the
 backend journal.
 
-### AllPersistenceIdsQuery and CurrentPersistenceIdsQuery
+### PersistenceIdsQuery and CurrentPersistenceIdsQuery
 
-`allPersistenceIds` is used for retrieving all `persistenceIds` of all persistent actors.
+`persistenceIds` is used for retrieving all `persistenceIds` of all persistent actors.
 
 Scala
 :  @@snip [LeveldbPersistenceQueryDocSpec.scala]($code$/scala/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala) { #AllPersistenceIds }

--- a/akka-docs/src/main/paradox/persistence-query.md
+++ b/akka-docs/src/main/paradox/persistence-query.md
@@ -86,9 +86,9 @@ For example, Journal plugins should document their stream completion strategies.
 
 The predefined queries are:
 
-#### AllPersistenceIdsQuery and CurrentPersistenceIdsQuery
+#### PersistenceIdsQuery and CurrentPersistenceIdsQuery
 
-`allPersistenceIds` which is designed to allow users to subscribe to a stream of all persistent ids in the system.
+`persistenceIds` which is designed to allow users to subscribe to a stream of all persistent ids in the system.
 By default this stream should be assumed to be a "live" stream, which means that the journal should keep emitting new
 persistence ids as they come into the system:
 

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentPersistenceIdsQuery.scala
@@ -12,7 +12,7 @@ import akka.stream.javadsl.Source
 trait CurrentPersistenceIdsQuery extends ReadJournal {
 
   /**
-   * Same type of query as [[PersistenceIdsQuery#allPersistenceIds]] but the stream
+   * Same type of query as [[PersistenceIdsQuery#persistenceIds]] but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    */

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
@@ -31,7 +31,7 @@ class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.lev
   with EventsByTagQuery with CurrentEventsByTagQuery {
 
   /**
-   * `allPersistenceIds` is used for retrieving all `persistenceIds` of all
+   * `persistenceIds` is used for retrieving all `persistenceIds` of all
    * persistent actors.
    *
    * The returned event stream is unordered and you can expect different order for multiple
@@ -52,7 +52,7 @@ class LeveldbReadJournal(scaladslReadJournal: akka.persistence.query.journal.lev
     scaladslReadJournal.persistenceIds().asJava
 
   /**
-   * Same type of query as [[#allPersistenceIds]] but the stream
+   * Same type of query as [[#persistenceIds]] but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    */

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
@@ -41,7 +41,7 @@ class LeveldbReadJournal(system: ExtendedActorSystem, config: Config) extends Re
   private val maxBufSize: Int = config.getInt("max-buffer-size")
 
   /**
-   * `allPersistenceIds` is used for retrieving all `persistenceIds` of all
+   * `persistenceIds` is used for retrieving all `persistenceIds` of all
    * persistent actors.
    *
    * The returned event stream is unordered and you can expect different order for multiple
@@ -66,7 +66,7 @@ class LeveldbReadJournal(system: ExtendedActorSystem, config: Config) extends Re
   }
 
   /**
-   * Same type of query as [[#allPersistenceIds]] but the stream
+   * Same type of query as [[#persistenceIds]] but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    */

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentPersistenceIdsQuery.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.Source
 trait CurrentPersistenceIdsQuery extends ReadJournal {
 
   /**
-   * Same type of query as [[PersistenceIdsQuery#allPersistenceIds]] but the stream
+   * Same type of query as [[PersistenceIdsQuery#persistenceIds]] but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    */


### PR DESCRIPTION
The title says it all... https://doc.akka.io/docs/akka/2.5.7/persistence-query.html still talks about "AllPersistenceIdsQuery" and "allPersistenceIds", but it's now "PersistenceIdsQuery" resp. "persistenceIds". I took the liberty to change it.

