### PR TITLE
Revert source incompatible sharding changes

### DIFF
--- a/akka-cluster-sharding/src/main/mima-filters/2.5.7.backwards.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.5.7.backwards.excludes
@@ -1,2 +1,0 @@
-# 24058 - Add ClusterSharding.start overloads
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.ShardRegion.props")

--- a/akka-cluster-sharding/src/main/mima-filters/2.5.7.backwards.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.5.7.backwards.excludes
@@ -1,6 +1,2 @@
 # 24058 - Add ClusterSharding.start overloads
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.ShardRegion.props")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.Shard.props")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.DDataShard.this")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.PersistentShard.this")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.Shard.this")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -6,7 +6,6 @@ package akka.cluster.sharding
 import java.net.URLEncoder
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
-import java.util.function.{ Function ⇒ JFunction }
 
 import scala.concurrent.Await
 import akka.actor.Actor
@@ -21,6 +20,7 @@ import akka.actor.NoSerializationVerificationNeeded
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.cluster.Cluster
+import akka.cluster.ddata.DistributedData
 import akka.cluster.singleton.ClusterSingletonManager
 import akka.pattern.BackoffSupervisor
 import akka.util.ByteString
@@ -33,6 +33,7 @@ import scala.util.control.NonFatal
 import akka.actor.Status
 import akka.cluster.ClusterSettings
 import akka.cluster.ClusterSettings.DataCenter
+import akka.stream.{ Inlet, Outlet }
 
 import scala.collection.immutable
 import scala.collection.JavaConverters._
@@ -220,7 +221,7 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
 
     requireClusterRole(settings.role)
     implicit val timeout = system.settings.CreationTimeout
-    val startMsg = Start(typeName, _ ⇒ entityProps, settings,
+    val startMsg = Start(typeName, entityProps, settings,
       extractEntityId, extractShardId, allocationStrategy, handOffStopMessage)
     val Started(shardRegion) = Await.result(guardian ? startMsg, timeout.duration)
     regions.put(typeName, shardRegion)
@@ -259,7 +260,7 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
       settings.tuningParameters.leastShardAllocationRebalanceThreshold,
       settings.tuningParameters.leastShardAllocationMaxSimultaneousRebalance)
 
-    start(typeName, _ ⇒ entityProps, settings, extractEntityId, extractShardId, allocationStrategy, PoisonPill)
+    start(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, PoisonPill)
   }
 
   /**
@@ -291,7 +292,7 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
 
     start(
       typeName,
-      _ ⇒ entityProps,
+      entityProps,
       settings,
       extractEntityId = {
         case msg if messageExtractor.entityId(msg) ne null ⇒
@@ -332,154 +333,6 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
       settings.tuningParameters.leastShardAllocationMaxSimultaneousRebalance)
 
     start(typeName, entityProps, settings, messageExtractor, allocationStrategy, PoisonPill)
-  }
-
-  /**
-   * Scala API: Register a named entity type by defining a factory for the [[akka.actor.Props]] of
-   * the entity actor and functions to extract entity and shard identifier from messages. The
-   * [[ShardRegion]] actor for this type can later be retrieved with the [[#shardRegion]] method.
-   *
-   * Some settings can be configured as described in the `akka.cluster.sharding` section
-   * of the `reference.conf`.
-   *
-   * @param typeName the name of the entity type
-   * @param entityPropsFactory function that, given an entity id, returns the `Props` of the entity actors
-   *  that will be created by the `ShardRegion`
-   * @param settings configuration settings, see [[ClusterShardingSettings]]
-   * @param extractEntityId partial function to extract the entity id and the message to send to the
-   *   entity from the incoming message, if the partial function does not match the message will
-   *   be `unhandled`, i.e. posted as `Unhandled` messages on the event stream
-   * @param extractShardId function to determine the shard id for an incoming message, only messages
-   *   that passed the `extractEntityId` will be used
-   * @param allocationStrategy possibility to use a custom shard allocation and
-   *   rebalancing logic
-   * @param handOffStopMessage the message that will be sent to entities when they are to be stopped
-   *   for a rebalance or graceful shutdown of a `ShardRegion`, e.g. `PoisonPill`.
-   * @return the actor ref of the [[ShardRegion]] that is to be responsible for the shard
-   */
-  def start(
-    typeName:           String,
-    entityPropsFactory: String ⇒ Props,
-    settings:           ClusterShardingSettings,
-    extractEntityId:    ShardRegion.ExtractEntityId,
-    extractShardId:     ShardRegion.ExtractShardId,
-    allocationStrategy: ShardAllocationStrategy,
-    handOffStopMessage: Any): ActorRef = {
-
-    requireClusterRole(settings.role)
-    implicit val timeout = system.settings.CreationTimeout
-    val startMsg = Start(typeName, entityPropsFactory, settings,
-      extractEntityId, extractShardId, allocationStrategy, handOffStopMessage)
-    val Started(shardRegion) = Await.result(guardian ? startMsg, timeout.duration)
-    regions.put(typeName, shardRegion)
-    shardRegion
-  }
-
-  /**
-   * Scala API: Register a named entity type by defining a factory for the [[akka.actor.Props]] of
-   * the entity actor and functions to extract entity and shard identifier from messages. The
-   * [[ShardRegion]] actor for this type can later be retrieved with the [[#shardRegion]] method.
-   *
-   * The default shard allocation strategy [[ShardCoordinator.LeastShardAllocationStrategy]]
-   * is used. [[akka.actor.PoisonPill]] is used as `handOffStopMessage`.
-   *
-   * Some settings can be configured as described in the `akka.cluster.sharding` section
-   * of the `reference.conf`.
-   *
-   * @param typeName the name of the entity type
-   * @param entityPropsFactory function that, given an entity id, returns the `Props` of the entity actors
-   *  that will be created by the `ShardRegion`
-   * @param settings configuration settings, see [[ClusterShardingSettings]]
-   * @param extractEntityId partial function to extract the entity id and the message to send to the
-   *   entity from the incoming message, if the partial function does not match the message will
-   *   be `unhandled`, i.e. posted as `Unhandled` messages on the event stream
-   * @param extractShardId function to determine the shard id for an incoming message, only messages
-   *   that passed the `extractEntityId` will be used
-   * @return the actor ref of the [[ShardRegion]] that is to be responsible for the shard
-   */
-  def start(
-    typeName:           String,
-    entityPropsFactory: String ⇒ Props,
-    settings:           ClusterShardingSettings,
-    extractEntityId:    ShardRegion.ExtractEntityId,
-    extractShardId:     ShardRegion.ExtractShardId): ActorRef = {
-
-    val allocationStrategy = new LeastShardAllocationStrategy(
-      settings.tuningParameters.leastShardAllocationRebalanceThreshold,
-      settings.tuningParameters.leastShardAllocationMaxSimultaneousRebalance)
-
-    start(typeName, entityPropsFactory, settings, extractEntityId, extractShardId, allocationStrategy, PoisonPill)
-  }
-
-  /**
-   * Java/Scala API: Register a named entity type by defining a factory for the [[akka.actor.Props]] of
-   * the entity actor and functions to extract entity and shard identifier from messages. The
-   * [[ShardRegion]] actor for this type can later be retrieved with the [[#shardRegion]] method.
-   *
-   * Some settings can be configured as described in the `akka.cluster.sharding` section
-   * of the `reference.conf`.
-   *
-   * @param typeName the name of the entity type
-   * @param entityPropsFactory function that, given an entity id, returns the `Props` of the entity actors
-   *  that will be created by the `ShardRegion`
-   * @param settings configuration settings, see [[ClusterShardingSettings]]
-   * @param messageExtractor functions to extract the entity id, shard id, and the message to send to the
-   *   entity from the incoming message, see [[ShardRegion.MessageExtractor]]
-   * @param allocationStrategy possibility to use a custom shard allocation and
-   *   rebalancing logic
-   * @param handOffStopMessage the message that will be sent to entities when they are to be stopped
-   *   for a rebalance or graceful shutdown of a `ShardRegion`, e.g. `PoisonPill`.
-   * @return the actor ref of the [[ShardRegion]] that is to be responsible for the shard
-   */
-  def start(
-    typeName:           String,
-    entityPropsFactory: JFunction[String, Props],
-    settings:           ClusterShardingSettings,
-    messageExtractor:   ShardRegion.MessageExtractor,
-    allocationStrategy: ShardAllocationStrategy,
-    handOffStopMessage: Any): ActorRef = {
-
-    start(
-      typeName, entityPropsFactory.apply _, settings,
-      extractEntityId = {
-        case msg if messageExtractor.entityId(msg) ne null ⇒
-          (messageExtractor.entityId(msg), messageExtractor.entityMessage(msg))
-      }: ShardRegion.ExtractEntityId,
-      extractShardId = msg ⇒ messageExtractor.shardId(msg),
-      allocationStrategy = allocationStrategy,
-      handOffStopMessage = handOffStopMessage)
-  }
-
-  /**
-   * Java/Scala API: Register a named entity type by defining a factory for the [[akka.actor.Props]] of
-   * the entity actor and functions to extract entity and shard identifier from messages. The
-   * [[ShardRegion]] actor for this type can later be retrieved with the [[#shardRegion]] method.
-   *
-   * The default shard allocation strategy [[ShardCoordinator.LeastShardAllocationStrategy]]
-   * is used. [[akka.actor.PoisonPill]] is used as `handOffStopMessage`.
-   *
-   * Some settings can be configured as described in the `akka.cluster.sharding` section
-   * of the `reference.conf`.
-   *
-   * @param typeName the name of the entity type
-   * @param entityPropsFactory function that, given an entity id, returns the `Props` of the entity actors
-   *  that will be created by the `ShardRegion`
-   * @param settings configuration settings, see [[ClusterShardingSettings]]
-   * @param messageExtractor functions to extract the entity id, shard id, and the message to send to the
-   *   entity from the incoming message
-   * @return the actor ref of the [[ShardRegion]] that is to be responsible for the shard
-   */
-  def start(
-    typeName:           String,
-    entityPropsFactory: JFunction[String, Props],
-    settings:           ClusterShardingSettings,
-    messageExtractor:   ShardRegion.MessageExtractor): ActorRef = {
-
-    val allocationStrategy = new LeastShardAllocationStrategy(
-      settings.tuningParameters.leastShardAllocationRebalanceThreshold,
-      settings.tuningParameters.leastShardAllocationMaxSimultaneousRebalance)
-
-    start(typeName, entityPropsFactory, settings, messageExtractor, allocationStrategy, PoisonPill)
   }
 
   /**
@@ -664,7 +517,7 @@ private[akka] object ClusterShardingGuardian {
   import ShardCoordinator.ShardAllocationStrategy
   final case class Start(
     typeName:           String,
-    entityPropsFactory: String ⇒ Props,
+    entityProps:        Props,
     settings:           ClusterShardingSettings,
     extractEntityId:    ShardRegion.ExtractEntityId,
     extractShardId:     ShardRegion.ExtractShardId,
@@ -729,7 +582,7 @@ private[akka] class ClusterShardingGuardian extends Actor {
 
   def receive = {
     case Start(typeName,
-      entityPropsFactory,
+      entityProps,
       settings,
       extractEntityId,
       extractShardId,
@@ -769,7 +622,7 @@ private[akka] class ClusterShardingGuardian extends Actor {
           context.actorOf(
             ShardRegion.props(
               typeName = typeName,
-              entityPropsFactory = entityPropsFactory,
+              entityProps = entityProps,
               settings = settings,
               coordinatorPath = cPath,
               extractEntityId = extractEntityId,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -800,7 +800,7 @@ private[akka] class ShardRegion(
     else {
       shards.get(id).orElse(
         entityPropsFactory match {
-          case Some(factory) if !shardsByRef.values.exists(_ == id) ⇒
+          case Some(props) if !shardsByRef.values.exists(_ == id) ⇒
             log.debug("Starting shard [{}] in region", id)
 
             val name = URLEncoder.encode(id, "utf-8")
@@ -808,7 +808,7 @@ private[akka] class ShardRegion(
               Shard.props(
                 typeName,
                 id,
-                factory,
+                props(id),
                 settings,
                 extractEntityId,
                 extractShardId,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -33,7 +33,7 @@ object ShardRegion {
    */
   private[akka] def props(
     typeName:           String,
-    entityPropsFactory: String ⇒ Props,
+    entityProps:        Props,
     settings:           ClusterShardingSettings,
     coordinatorPath:    String,
     extractEntityId:    ShardRegion.ExtractEntityId,
@@ -41,7 +41,7 @@ object ShardRegion {
     handOffStopMessage: Any,
     replicator:         ActorRef,
     majorityMinCap:     Int): Props =
-    Props(new ShardRegion(typeName, Some(entityPropsFactory), dataCenter = None, settings, coordinatorPath, extractEntityId,
+    Props(new ShardRegion(typeName, Some(entityProps), dataCenter = None, settings, coordinatorPath, extractEntityId,
       extractShardId, handOffStopMessage, replicator, majorityMinCap)).withDeploy(Deploy.local)
 
   /**
@@ -366,7 +366,7 @@ object ShardRegion {
  */
 private[akka] class ShardRegion(
   typeName:           String,
-  entityPropsFactory: Option[String ⇒ Props],
+  entityProps:        Option[Props],
   dataCenter:         Option[DataCenter],
   settings:           ClusterShardingSettings,
   coordinatorPath:    String,
@@ -682,7 +682,7 @@ private[akka] class ShardRegion(
   }
 
   def registrationMessage: Any =
-    if (entityPropsFactory.isDefined) Register(self) else RegisterProxy(self)
+    if (entityProps.isDefined) Register(self) else RegisterProxy(self)
 
   def requestShardBufferHomes(): Unit = {
     shardBuffers.foreach {
@@ -799,7 +799,7 @@ private[akka] class ShardRegion(
       None
     else {
       shards.get(id).orElse(
-        entityPropsFactory match {
+        entityProps match {
           case Some(props) if !shardsByRef.values.exists(_ == id) ⇒
             log.debug("Starting shard [{}] in region", id)
 
@@ -808,7 +808,7 @@ private[akka] class ShardRegion(
               Shard.props(
                 typeName,
                 id,
-                props(id),
+                props,
                 settings,
                 extractEntityId,
                 extractShardId,

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -45,8 +45,8 @@ The above actor uses event sourcing and the support provided in @scala[`Persiste
 It does not have to be a persistent actor, but in case of failure or migration of entities between nodes it must be able to recover
 its state if it is valuable.
 
-Note how the `persistenceId` is defined - it must be unique to the entity, so using the entity identifier is advised. 
-You may define it in other ways, but it must be unique.
+Note how the `persistenceId` is defined. The name of the actor is the entity identifier (utf-8 URL-encoded).
+You may define it another way, but it must be unique.
 
 When using the sharding extension you are first, typically at system startup on each node
 in the cluster, supposed to register the supported entity types with the `ClusterSharding.start`
@@ -57,10 +57,6 @@ Scala
 
 Java
 :  @@snip [ClusterShardingTest.java]($code$/java/jdocs/sharding/ClusterShardingTest.java) { #counter-start }
-
-In some cases, the actor may need to know the `entityId` associated with it. This can be achieved using the `entityPropsFactory`
-parameter to `ClusterSharding.start`. The entity ID will be passed to the factory as a parameter, which can then be used in
-the creation of the actor (like the above example).
 
 The @scala[`extractEntityId` and `extractShardId` are two] @java[`messageExtractor` defines] application specific @scala[functions] @java[methods] to extract the entity
 identifier and the shard identifier from incoming messages.


### PR DESCRIPTION
We have to revert #24058 since it is source incompatible.

Edit: had the wrong failing sample, now it is the right one

A call like this:
```
   ClusterSharding(system).start(
      "users",
      entityProps,
      ClusterShardingSettings(system),
      { case EntityMsg(recipientName, payload) => (recipientName, payload) },
      { case EntityMsg(recipientName, _) => recipientName }
    )
```

Works before the PR is applied but does not compile after it is applied

On top of that there was a bug fix #21809 that also has to be reverted (those fixes should be included in a new PR fixing the source incompatibility)

ping @talpr 