### PR TITLE
Specify user-provided hooks are not disabled

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -81,9 +81,9 @@ akka {
   # such as OutOfMemoryError
   jvm-exit-on-fatal-error = on
 
-  # Akka installs JVM shutdown hooks by default, e.g. in CoordinatedShutdown
-  # (see akka.coordinated-shutdown.run-by-jvm-shutdown-hook) and Artery. This property will
+  # Akka installs JVM shutdown hooks by default, e.g. in CoordinatedShutdown and Artery. This property will
   # not disable user-provided hooks registered using `CoordinatedShutdown#addCancellableJvmShutdownHook`.
+  # This property is related to `akka.coordinated-shutdown.run-by-jvm-shutdown-hook` below.
   # This property makes it possible to disable all such hooks if the application itself
   # or a higher level framework such as Play prefers to install the JVM shutdown hook and
   # terminate the ActorSystem itself, with or without using CoordinatedShutdown.
@@ -1054,6 +1054,7 @@ akka {
     
     # Run the coordinated shutdown when the JVM process exits, e.g.
     # via kill SIGTERM signal (SIGINT ctrl-c doesn't work).
+    # This property is related to `akka.jvm-shutdown-hooks` above.
     run-by-jvm-shutdown-hook = on
   
     #//#coordinated-shutdown-phases

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -81,7 +81,9 @@ akka {
   # such as OutOfMemoryError
   jvm-exit-on-fatal-error = on
 
-  # Akka installs JVM shutdown hooks by default, e.g. in CoordinatedShutdown and Artery.
+  # Akka installs JVM shutdown hooks by default, e.g. in CoordinatedShutdown
+  # (see akka.coordinated-shutdown.run-by-jvm-shutdown-hook) and Artery. This property will
+  # not disable user-provided hooks registered using `CoordinatedShutdown#addCancellableJvmShutdownHook`.
   # This property makes it possible to disable all such hooks if the application itself
   # or a higher level framework such as Play prefers to install the JVM shutdown hook and
   # terminate the ActorSystem itself, with or without using CoordinatedShutdown.


### PR DESCRIPTION
According to https://github.com/akka/akka/pull/24093/files#diff-c03da6ecfd7d2ae039713254d460260dR370 using `jvm-shutdown-hooks = off` with `coordinated-shutdown.run-by-jvm-shutdown-hook = on` will still run user-provided shutdown hooks.

Also added cross-reference in the property comments.