### PR TITLE
add maxRestarts to RestartWithBackoff #24129

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
@@ -56,6 +56,7 @@ public class RestartDocTest {
         Duration.apply(3, TimeUnit.SECONDS), // min backoff
         Duration.apply(30, TimeUnit.SECONDS), // max backoff
         0.2, // adds 20% "noise" to vary the intervals slightly
+        20, // limits the amount of restarts to 20
         () ->
             // Create a source from a future of a source
             Source.fromSourceCompletionStage(

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -37,7 +37,8 @@ class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
       val restartSource = RestartSource.withBackoff(
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
-        randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
+        randomFactor = 0.2, // adds 20% "noise" to vary the intervals slightly
+        maxRestarts = 20 // limits the amount of restarts to 20
       ) { () ⇒
         // Create a source from a future of a source
         Source.fromFutureSource {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -30,7 +30,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
   "A restart with backoff source" should {
     "run normally" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source.repeat("a")
       }.runWith(TestSink.probe)
@@ -48,7 +48,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "restart on completion" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b"))
       }.runWith(TestSink.probe)
@@ -66,7 +66,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "restart on failure" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b", "c"))
           .map {
@@ -88,7 +88,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "backoff before restart" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
+      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b"))
       }.runWith(TestSink.probe)
@@ -110,7 +110,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "reset exponential backoff back to minimum when source runs for at least minimum backoff without completing" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
+      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b"))
       }.runWith(TestSink.probe)
@@ -142,7 +142,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
     "cancel the currently running source when cancelled" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val promise = Promise[Done]()
-      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source.repeat("a").watchTermination() { (_, term) ⇒
           promise.completeWith(term)
@@ -161,7 +161,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "not restart the source when cancelled while backing off" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
+      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source.single("a")
       }.runWith(TestSink.probe)
@@ -178,7 +178,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "stop on completion if it should only be restarted in failures" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.onFailuresWithBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = RestartSource.onFailuresWithBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b", "c"))
           .map {
@@ -202,7 +202,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "restart on failure when only due to failures should be restarted" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val probe = RestartSource.onFailuresWithBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = RestartSource.onFailuresWithBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Source(List("a", "b", "c"))
           .map {
@@ -223,13 +223,53 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     }
 
+    "not restart the source when maxRestarts is reached" in assertAllStagesStopped {
+      val created = new AtomicInteger()
+      val probe = RestartSource.withBackoff(shortMinBackoff, shortMaxBackoff, 0, maxRestarts = 1) { () ⇒
+        created.incrementAndGet()
+        Source.single("a")
+      }.runWith(TestSink.probe)
+
+      probe.requestNext("a")
+      probe.requestNext("a")
+      probe.expectComplete()
+
+      created.get() should ===(2)
+
+      probe.cancel()
+    }
+
+    "reset maxRestarts when source runs for at least minimum backoff without completing" in assertAllStagesStopped {
+      val created = new AtomicInteger()
+      val probe = RestartSource.withBackoff(minBackoff, maxBackoff, 0, maxRestarts = 2) { () ⇒
+        created.incrementAndGet()
+        Source(List("a"))
+      }.runWith(TestSink.probe)
+
+      probe.requestNext("a")
+      // There should be minBackoff delay
+      probe.requestNext("a")
+      // The probe should now be backing off again with with increased backoff
+
+      // Now wait for the delay to pass, then it will start the new source, we also want to wait for the
+      // subsequent backoff to pass
+      Thread.sleep((minBackoff + (minBackoff * 2) + minBackoff + 500.millis).toMillis)
+
+      probe.requestNext("a")
+      // We now are able to trigger the third restart, since enough time has elapsed to reset the counter
+      probe.requestNext("a")
+
+      created.get() should ===(4)
+
+      probe.cancel()
+    }
   }
 
   "A restart with backoff sink" should {
     "run normally" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val result = Promise[Seq[String]]()
-      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Sink.seq.mapMaterializedValue(result.completeWith)
       })(Keep.left).run()
@@ -246,7 +286,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
     "restart on cancellation" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
-      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Flow[String].takeWhile(_ != "cancel", inclusive = true)
           .to(Sink.foreach(queue.sendNext))
@@ -270,7 +310,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
     "backoff before restart" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
-      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
+      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(minBackoff, maxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Flow[String].takeWhile(_ != "cancel", inclusive = true)
           .to(Sink.foreach(queue.sendNext))
@@ -295,7 +335,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
     "reset exponential backoff back to minimum when sink runs for at least minimum backoff without completing" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
-      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
+      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(minBackoff, maxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Flow[String].takeWhile(_ != "cancel", inclusive = true)
           .to(Sink.foreach(queue.sendNext))
@@ -335,7 +375,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
     "not restart the sink when completed while backing off" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
-      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
+      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(minBackoff, maxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Flow[String].takeWhile(_ != "cancel", inclusive = true)
           .to(Sink.foreach(queue.sendNext))
@@ -354,11 +394,66 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
       sinkProbe.cancel()
     }
+
+    "not restart the sink when maxRestarts is reached" in assertAllStagesStopped {
+      val created = new AtomicInteger()
+      val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
+      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(shortMinBackoff, shortMaxBackoff, 0, maxRestarts = 1) { () ⇒
+        created.incrementAndGet()
+        Flow[String].takeWhile(_ != "cancel", inclusive = true)
+          .to(Sink.foreach(queue.sendNext))
+      })(Keep.left).run()
+
+      probe.sendNext("cancel")
+      sinkProbe.requestNext("cancel")
+      probe.sendNext("cancel")
+      sinkProbe.requestNext("cancel")
+
+      probe.expectCancellation()
+
+      created.get() should ===(2)
+
+      sinkProbe.cancel()
+      probe.sendComplete()
+    }
+
+    "reset maxRestarts when sink runs for at least minimum backoff without completing" in assertAllStagesStopped {
+      val created = new AtomicInteger()
+      val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
+      val probe = TestSource.probe[String].toMat(RestartSink.withBackoff(minBackoff, maxBackoff, 0, maxRestarts = 2) { () ⇒
+        created.incrementAndGet()
+        Flow[String].takeWhile(_ != "cancel", inclusive = true)
+          .to(Sink.foreach(queue.sendNext))
+      })(Keep.left).run()
+
+      probe.sendNext("cancel")
+      sinkProbe.requestNext("cancel")
+      // There should be a minBackoff delay
+      probe.sendNext("cancel")
+      sinkProbe.requestNext("cancel")
+      // The probe should now be backing off for 2 * minBackoff
+
+      // Now wait for the 2 * minBackoff delay to pass, then it will start the new source, we also want to wait for the
+      // subsequent minBackoff min backoff to pass, so it resets the restart count
+      Thread.sleep((minBackoff + (minBackoff * 2) + minBackoff + 500.millis).toMillis)
+
+      probe.sendNext("cancel")
+      sinkProbe.requestNext("cancel")
+
+      // We now are able to trigger the third restart, since enough time has elapsed to reset the counter
+      probe.sendNext("cancel")
+      sinkProbe.requestNext("cancel")
+
+      created.get() should ===(4)
+
+      sinkProbe.cancel()
+      probe.sendComplete()
+    }
   }
 
   "A restart with backoff flow" should {
 
-    def setupFlow(minBackoff: FiniteDuration, maxBackoff: FiniteDuration) = {
+    def setupFlow(minBackoff: FiniteDuration, maxBackoff: FiniteDuration, maxRestarts: Int = Int.MaxValue) = {
       val created = new AtomicInteger()
       val (flowInSource, flowInProbe) = TestSource.probe[String]
         .buffer(4, OverflowStrategy.backpressure)
@@ -367,7 +462,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
       // We can't just use ordinary probes here because we're expecting them to get started/restarted. Instead, we
       // simply use the probes as a message bus for feeding and capturing events.
-      val (source, sink) = TestSource.probe[String].viaMat(RestartFlow.withBackoff(minBackoff, maxBackoff, 0) { () ⇒
+      val (source, sink) = TestSource.probe[String].viaMat(RestartFlow.withBackoff(minBackoff, maxBackoff, 0, maxRestarts) { () ⇒
         created.incrementAndGet()
         Flow.fromSinkAndSource(
           Flow[String]
@@ -393,7 +488,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
 
     "run normally" in assertAllStagesStopped {
       val created = new AtomicInteger()
-      val (source, sink) = TestSource.probe[String].viaMat(RestartFlow.withBackoff(shortMinBackoff, shortMaxBackoff, 0) { () ⇒
+      val (source, sink) = TestSource.probe[String].viaMat(RestartFlow.withBackoff(shortMinBackoff, shortMaxBackoff, 0, Int.MaxValue) { () ⇒
         created.incrementAndGet()
         Flow[String]
       })(Keep.left).toMat(TestSink.probe[String])(Keep.both).run()
@@ -550,6 +645,28 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
       created.get() should ===(1)
     }
 
+    "not restart on completion when maxRestarts is reached" in {
+      val (created, _, flowInProbe, flowOutProbe, sink) = setupFlow(shortMinBackoff, shortMaxBackoff, maxRestarts = 1)
+
+      sink.request(1)
+      flowOutProbe.sendNext("complete")
+
+      // This will complete the flow in probe and cancel the flow out probe
+      flowInProbe.request(2)
+      Seq(flowInProbe.expectNext(), flowInProbe.expectNext()) should contain only ("in complete", "out complete")
+
+      // and it should restart
+      sink.request(1)
+      flowOutProbe.sendNext("complete")
+
+      // This will complete the flow in probe and cancel the flow out probe
+      flowInProbe.request(2)
+      flowInProbe.expectNext("out complete")
+      flowInProbe.expectNoMessage(shortMinBackoff * 3)
+      sink.expectComplete()
+
+      created.get() should ===(2)
+    }
   }
 
 }

--- a/akka-stream/src/main/mima-filters/2.5.8.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.8.backwards.excludes
@@ -64,3 +64,9 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.IslandTrack
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.GraphStageIsland.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreterShell.this")
 
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSource.onFailuresWithBackoff")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSource.withBackoff")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSink.withBackoff")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffSink.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffFlow.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartFlow.withBackoff")

--- a/akka-stream/src/main/mima-filters/2.5.8.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.8.backwards.excludes
@@ -64,6 +64,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.IslandTrack
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.GraphStageIsland.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreterShell.this")
 
+# Add maxRestarts to RestartSource, Sink and Flow https://github.com/akka/akka/pull/24137
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSource.onFailuresWithBackoff")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSource.withBackoff")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSink.withBackoff")

--- a/akka-stream/src/main/mima-filters/2.5.8.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.8.backwards.excludes
@@ -65,9 +65,5 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.GraphStageI
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GraphInterpreterShell.this")
 
 # Add maxRestarts to RestartSource, Sink and Flow https://github.com/akka/akka/pull/24137
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSource.onFailuresWithBackoff")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSource.withBackoff")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartSink.withBackoff")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffSink.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffFlow.this")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartFlow.withBackoff")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -49,9 +49,10 @@ object RestartSource {
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
-   * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
-   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+   * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+   * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
+   * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
+   * and it will not be restarted.
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
@@ -63,7 +64,7 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
@@ -103,11 +104,11 @@ object RestartSource {
   /**
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
    *
-   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
-   * restarting. The wrapped [[Source]] can be cancelled by cancelling this [[Source]].
-   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
-   * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
-   * after this [[Source]] in the graph.
+   * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+   * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
+   * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
+   * and it will not be restarted. This can be triggered simply by the downstream cancelling, or externally by
+   * introducing a [[KillSwitch]] right after this [[Source]] in the graph.
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
@@ -117,7 +118,7 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
@@ -173,11 +174,11 @@ object RestartSink {
    * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Sink]] will never cancel, since cancellation by the wrapped [[Sink]] is always handled by restarting it.
-   * The wrapped [[Sink]] can however be completed by feeding a completion or error into this [[Sink]]. When that
-   * happens, the [[Sink]], if currently running, will terminate and will not be restarted. This can be triggered
-   * simply by the upstream completing, or externally by introducing a [[KillSwitch]] right before this [[Sink]] in the
-   * graph.
+   * This [[Sink]] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped [[Sink]]
+   * is handled by restarting it. The wrapped [[Sink]] can however be completed by feeding a completion or error into
+   * this [[Sink]]. When that happens, the [[Sink]], if currently running, will terminate and will not be restarted.
+   * This can be triggered simply by the upstream completing, or externally by introducing a [[KillSwitch]] right
+   * before this [[Sink]] in the graph.
    *
    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
@@ -191,7 +192,7 @@ object RestartSink {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
@@ -246,9 +247,9 @@ object RestartFlow {
    * backoff.
    *
    * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
-   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it. Any termination
-   * signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's running, and then the [[Flow]]
-   * will be allowed to terminate without being restarted.
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
+   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
    *
    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
@@ -262,7 +263,7 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -63,8 +63,7 @@ object RestartSource {
     * @param randomFactor after calculation of the exponential back-off an additional
     *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
     *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-    *                    than 1 is considered as unlimited restarts.
+    * @param maxRestarts the amount of restarts is capped to this amount.
     * @param sourceFactory A factory for producing the [[Source]] to wrap.
     */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
@@ -118,8 +117,7 @@ object RestartSource {
       * @param randomFactor after calculation of the exponential back-off an additional
       *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
       *   In order to skip this additional delay pass in `0`.
-      * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-      *                    than 1 is considered as unlimited restarts.
+      * @param maxRestarts the amount of restarts is capped to this amount.
       * @param sourceFactory A factory for producing the [[Source]] to wrap.
       *
       */
@@ -193,8 +191,7 @@ object RestartSink {
     * @param randomFactor after calculation of the exponential back-off an additional
     *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
     *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-    *                    than 1 is considered as unlimited restarts.
+    * @param maxRestarts the amount of restarts is capped to this amount.
     * @param sinkFactory A factory for producing the [[Sink]] to wrap.
     */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
@@ -265,8 +262,7 @@ object RestartFlow {
     * @param randomFactor after calculation of the exponential back-off an additional
     *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
     *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-    *                    than 1 is considered as unlimited restarts.
+    * @param maxRestarts the amount of restarts is capped to this amount.
     * @param flowFactory A factory for producing the [[Flow]] to wrap.
     */
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -36,10 +36,11 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
       sourceFactory.create().asScala
     }.asJava
   }
@@ -61,12 +62,13 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
   def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
-                               sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+                               maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
       sourceFactory.create().asScala
     }.asJava
   }
@@ -103,10 +105,11 @@ object RestartSink {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
-    akka.stream.scaladsl.RestartSink.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int, sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSink.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
       sinkFactory.create().asScala
     }.asJava
   }
@@ -142,10 +145,11 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
-    akka.stream.scaladsl.RestartFlow.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int, flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+    akka.stream.scaladsl.RestartFlow.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
       flowFactory.create().asScala
     }.asJava
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -65,6 +65,7 @@ object RestartSource {
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
@@ -119,6 +120,7 @@ object RestartSource {
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
@@ -193,6 +195,7 @@ object RestartSink {
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
@@ -264,6 +267,7 @@ object RestartFlow {
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -36,10 +36,39 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                     sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+      sourceFactory.create().asScala
+    }.asJava
+  }
+
+  /**
+    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
+    * backoff.
+    *
+    * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
+    * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
+    * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+    * after this [[Source]] in the graph.
+    *
+    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+    *
+    * @param minBackoff minimum (initial) duration until the child actor will
+    *   started again, if it is terminated
+    * @param maxBackoff the exponential back-off is capped to this duration
+    * @param randomFactor after calculation of the exponential back-off an additional
+    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+    *   In order to skip this additional delay pass in `0`.
+    * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+    *                    than 1 is considered as unlimited restarts.
+    * @param sourceFactory A factory for producing the [[Source]] to wrap.
+    */
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                     maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
     akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
       sourceFactory.create().asScala
     }.asJava
@@ -62,16 +91,44 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
   def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
-                               maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
+                               sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
       sourceFactory.create().asScala
     }.asJava
   }
+
+    /**
+      * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
+      *
+      * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
+      * restarting. The wrapped [[Source]] can be cancelled by cancelling this [[Source]].
+      * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+      * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+      * after this [[Source]] in the graph.
+      *
+      * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+      *
+      * @param minBackoff minimum (initial) duration until the child actor will
+      *   started again, if it is terminated
+      * @param maxBackoff the exponential back-off is capped to this duration
+      * @param randomFactor after calculation of the exponential back-off an additional
+      *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+      *   In order to skip this additional delay pass in `0`.
+      * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+      *                    than 1 is considered as unlimited restarts.
+      * @param sourceFactory A factory for producing the [[Source]] to wrap.
+      *
+      */
+    def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                                 maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
+        sourceFactory.create().asScala
+      }.asJava
+    }
 }
 
 /**
@@ -105,10 +162,43 @@ object RestartSink {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int, sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                     sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSink.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+      sinkFactory.create().asScala
+    }.asJava
+  }
+
+  /**
+    * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
+    * backoff.
+    *
+    * This [[Sink]] will never cancel, since cancellation by the wrapped [[Sink]] is always handled by restarting it.
+    * The wrapped [[Sink]] can however be completed by feeding a completion or error into this [[Sink]]. When that
+    * happens, the [[Sink]], if currently running, will terminate and will not be restarted. This can be triggered
+    * simply by the upstream completing, or externally by introducing a [[KillSwitch]] right before this [[Sink]] in the
+    * graph.
+    *
+    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
+    * sent may have been lost.
+    *
+    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+    *
+    * @param minBackoff minimum (initial) duration until the child actor will
+    *   started again, if it is terminated
+    * @param maxBackoff the exponential back-off is capped to this duration
+    * @param randomFactor after calculation of the exponential back-off an additional
+    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+    *   In order to skip this additional delay pass in `0`.
+    * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+    *                    than 1 is considered as unlimited restarts.
+    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
+    */
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                     maxRestarts: Int, sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
     akka.stream.scaladsl.RestartSink.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
       sinkFactory.create().asScala
     }.asJava
@@ -145,10 +235,42 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int, flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                           flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+    akka.stream.scaladsl.RestartFlow.withBackoff(minBackoff, maxBackoff, randomFactor) { () ⇒
+      flowFactory.create().asScala
+    }.asJava
+  }
+
+  /**
+    * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
+    * backoff.
+    *
+    * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+    * completed. Any termination by the [[Flow]] before that time will be handled by restarting it. Any termination
+    * signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's running, and then the [[Flow]]
+    * will be allowed to terminate without being restarted.
+    *
+    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+    *
+    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+    *
+    * @param minBackoff minimum (initial) duration until the child actor will
+    *   started again, if it is terminated
+    * @param maxBackoff the exponential back-off is capped to this duration
+    * @param randomFactor after calculation of the exponential back-off an additional
+    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+    *   In order to skip this additional delay pass in `0`.
+    * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+    *                    than 1 is considered as unlimited restarts.
+    * @param flowFactory A factory for producing the [[Flow]] to wrap.
+    */
+  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                           maxRestarts: Int, flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
     akka.stream.scaladsl.RestartFlow.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
       flowFactory.create().asScala
     }.asJava

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Restart.scala
@@ -46,26 +46,26 @@ object RestartSource {
   }
 
   /**
-    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
-    * backoff.
-    *
-    * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
-    * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
-    * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
-    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
-    * after this [[Source]] in the graph.
-    *
-    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-    *
-    * @param minBackoff minimum (initial) duration until the child actor will
-    *   started again, if it is terminated
-    * @param maxBackoff the exponential back-off is capped to this duration
-    * @param randomFactor after calculation of the exponential back-off an additional
-    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-    *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount.
-    * @param sourceFactory A factory for producing the [[Source]] to wrap.
-    */
+   * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
+   * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
+   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+   * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+   * after this [[Source]] in the graph.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
                      maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
     akka.stream.scaladsl.RestartSource.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
@@ -100,33 +100,33 @@ object RestartSource {
     }.asJava
   }
 
-    /**
-      * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
-      *
-      * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
-      * restarting. The wrapped [[Source]] can be cancelled by cancelling this [[Source]].
-      * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
-      * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
-      * after this [[Source]] in the graph.
-      *
-      * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-      *
-      * @param minBackoff minimum (initial) duration until the child actor will
-      *   started again, if it is terminated
-      * @param maxBackoff the exponential back-off is capped to this duration
-      * @param randomFactor after calculation of the exponential back-off an additional
-      *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-      *   In order to skip this additional delay pass in `0`.
-      * @param maxRestarts the amount of restarts is capped to this amount.
-      * @param sourceFactory A factory for producing the [[Source]] to wrap.
-      *
-      */
-    def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
-                                 maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-      akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
-        sourceFactory.create().asScala
-      }.asJava
-    }
+  /**
+   * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
+   *
+   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
+   * restarting. The wrapped [[Source]] can be cancelled by cancelling this [[Source]].
+   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+   * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+   * after this [[Source]] in the graph.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   *
+   */
+  def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
+                               maxRestarts: Int, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+    akka.stream.scaladsl.RestartSource.onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
+      sourceFactory.create().asScala
+    }.asJava
+  }
 }
 
 /**
@@ -170,30 +170,30 @@ object RestartSink {
   }
 
   /**
-    * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
-    * backoff.
-    *
-    * This [[Sink]] will never cancel, since cancellation by the wrapped [[Sink]] is always handled by restarting it.
-    * The wrapped [[Sink]] can however be completed by feeding a completion or error into this [[Sink]]. When that
-    * happens, the [[Sink]], if currently running, will terminate and will not be restarted. This can be triggered
-    * simply by the upstream completing, or externally by introducing a [[KillSwitch]] right before this [[Sink]] in the
-    * graph.
-    *
-    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
-    * sent may have been lost.
-    *
-    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-    *
-    * @param minBackoff minimum (initial) duration until the child actor will
-    *   started again, if it is terminated
-    * @param maxBackoff the exponential back-off is capped to this duration
-    * @param randomFactor after calculation of the exponential back-off an additional
-    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-    *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount.
-    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
-    */
+   * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Sink]] will never cancel, since cancellation by the wrapped [[Sink]] is always handled by restarting it.
+   * The wrapped [[Sink]] can however be completed by feeding a completion or error into this [[Sink]]. When that
+   * happens, the [[Sink]], if currently running, will terminate and will not be restarted. This can be triggered
+   * simply by the upstream completing, or externally by introducing a [[KillSwitch]] right before this [[Sink]] in the
+   * graph.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
+   * sent may have been lost.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param sinkFactory A factory for producing the [[Sink]] to wrap.
+   */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
                      maxRestarts: Int, sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
     akka.stream.scaladsl.RestartSink.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒
@@ -242,29 +242,29 @@ object RestartFlow {
   }
 
   /**
-    * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
-    * backoff.
-    *
-    * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
-    * completed. Any termination by the [[Flow]] before that time will be handled by restarting it. Any termination
-    * signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's running, and then the [[Flow]]
-    * will be allowed to terminate without being restarted.
-    *
-    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
-    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
-    *
-    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-    *
-    * @param minBackoff minimum (initial) duration until the child actor will
-    *   started again, if it is terminated
-    * @param maxBackoff the exponential back-off is capped to this duration
-    * @param randomFactor after calculation of the exponential back-off an additional
-    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-    *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount.
-    * @param flowFactory A factory for producing the [[Flow]] to wrap.
-    */
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it. Any termination
+   * signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's running, and then the [[Flow]]
+   * will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double,
                            maxRestarts: Int, flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
     akka.stream.scaladsl.RestartFlow.withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () ⇒

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -292,7 +292,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
     sinkIn.setHandler(new InHandler {
       override def onPush() = push(out, sinkIn.grab())
       override def onUpstreamFinish() = {
-        if (finishing || maxRestartsReached || onlyOnFailures) {
+        if (finishing || maxRestartsReached() || onlyOnFailures) {
           complete(out)
         } else {
           log.debug("Restarting graph due to finished upstream")
@@ -300,7 +300,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
         }
       }
       override def onUpstreamFailure(ex: Throwable) = {
-        if (finishing || maxRestartsReached) {
+        if (finishing || maxRestartsReached()) {
           fail(out, ex)
         } else {
           log.error(ex, "Restarting graph due to failure")
@@ -332,7 +332,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
         }
       }
       override def onDownstreamFinish() = {
-        if (finishing || maxRestartsReached) {
+        if (finishing || maxRestartsReached()) {
           cancel(in)
         } else {
           log.debug("Graph in finished")
@@ -358,7 +358,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
     sourceOut
   }
 
-  protected final def maxRestartsReached = {
+  protected final def maxRestartsReached() = {
     // Check if the last start attempt was more than the minimum backoff
     if (resetDeadline.isOverdue()) {
       log.debug("Last restart attempt was more than {} ago, resetting restart count", minBackoff)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -44,27 +44,28 @@ object RestartSource {
   }
 
   /**
-    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
-    * backoff.
-    *
-    * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
-    * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
-    * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
-    * and it will not be restarted.
-    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
-    * after this [[Source]] in the graph.
-    *
-    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-    *
-    * @param minBackoff minimum (initial) duration until the child actor will
-    *   started again, if it is terminated
-    * @param maxBackoff the exponential back-off is capped to this duration
-    * @param randomFactor after calculation of the exponential back-off an additional
-    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-    *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
-    * @param sourceFactory A factory for producing the [[Source]] to wrap.
-    */
+   * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+   * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
+   * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
+   * and it will not be restarted.
+   * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+   * after this [[Source]] in the graph.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = false, maxRestarts))
   }
@@ -94,27 +95,28 @@ object RestartSource {
   }
 
   /**
-    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
-    *
-    * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
-    * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
-    * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
-    * and it will not be restarted.
-    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
-    * after this [[Source]] in the graph.
-    *
-    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-    *
-    * @param minBackoff minimum (initial) duration until the child actor will
-    *   started again, if it is terminated
-    * @param maxBackoff the exponential back-off is capped to this duration
-    * @param randomFactor after calculation of the exponential back-off an additional
-    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-    *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
-    * @param sourceFactory A factory for producing the [[Source]] to wrap.
-    *
-    */
+   * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
+   *
+   * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+   * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
+   * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
+   * and it will not be restarted.
+   * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
+   * after this [[Source]] in the graph.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param sourceFactory A factory for producing the [[Source]] to wrap.
+   *
+   */
   def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = true, maxRestarts))
   }
@@ -192,30 +194,31 @@ object RestartSink {
   }
 
   /**
-    * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
-    * backoff.
-    *
-    * This [[Sink]] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped [[Sink]]
-    * is handled by restarting it. The wrapped [[Sink]] can however be completed by feeding a completion or error into
-    * this [[Sink]]. When that happens, the [[Sink]], if currently running, will terminate and will not be restarted.
-    * This can be triggered simply by the upstream completing, or externally by introducing a [[KillSwitch]] right
-    * before this [[Sink]] in the graph.
-    *
-    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
-    * sent may have been lost.
-    *
-    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-    *
-    * @param minBackoff minimum (initial) duration until the child actor will
-    *   started again, if it is terminated
-    * @param maxBackoff the exponential back-off is capped to this duration
-    * @param randomFactor after calculation of the exponential back-off an additional
-    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-    *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
-    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
-    */
+   * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Sink]] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped [[Sink]]
+   * is handled by restarting it. The wrapped [[Sink]] can however be completed by feeding a completion or error into
+   * this [[Sink]]. When that happens, the [[Sink]], if currently running, will terminate and will not be restarted.
+   * This can be triggered simply by the upstream completing, or externally by introducing a [[KillSwitch]] right
+   * before this [[Sink]] in the graph.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
+   * sent may have been lost.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param sinkFactory A factory for producing the [[Sink]] to wrap.
+   */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(sinkFactory: () ⇒ Sink[T, _]): Sink[T, NotUsed] = {
     Sink.fromGraph(new RestartWithBackoffSink(sinkFactory, minBackoff, maxBackoff, randomFactor, maxRestarts))
   }
@@ -287,29 +290,30 @@ object RestartFlow {
   }
 
   /**
-    * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
-    * backoff.
-    *
-    * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
-    * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
-    * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
-    * running, and then the [[Flow]] will be allowed to terminate without being restarted.
-    *
-    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
-    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
-    *
-    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-    *
-    * @param minBackoff minimum (initial) duration until the child actor will
-    *   started again, if it is terminated
-    * @param maxBackoff the exponential back-off is capped to this duration
-    * @param randomFactor after calculation of the exponential back-off an additional
-    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-    *   In order to skip this additional delay pass in `0`.
-    * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
-    * @param flowFactory A factory for producing the [[Flow]] to wrap.
-    */
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
+   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(flowFactory: () ⇒ Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
     Flow.fromGraph(new RestartWithBackoffFlow(flowFactory, minBackoff, maxBackoff, randomFactor, maxRestarts))
   }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -23,9 +23,10 @@ object RestartSource {
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Source]] will never emit a complete or failure, since the completion or failure of the wrapped [[Source]]
-   * is always handled by restarting it. The wrapped [[Source]] can however be cancelled by cancelling this [[Source]].
-   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+   * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+   * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
+   * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
+   * and it will not be restarted.
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
@@ -37,7 +38,7 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = Int.MaxValue)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
@@ -47,9 +48,10 @@ object RestartSource {
   /**
    * Wrap the given [[Source]] with a [[Source]] that will restart it when it fails using an exponential backoff.
    *
-   * This [[Source]] will never emit a failure, since the failure of the wrapped [[Source]] is always handled by
-   * restarting. The wrapped [[Source]] can be cancelled by cancelling this [[Source]].
-   * When that happens, the wrapped [[Source]], if currently running will be cancelled, and it will not be restarted.
+   * This [[Source]] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+   * or failure of the wrapped [[Source]] is handled by restarting it. The wrapped [[Source]] can however be cancelled
+   * by cancelling this [[Source]]. When that happens, the wrapped [[Source]], if currently running will be cancelled,
+   * and it will not be restarted.
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
@@ -61,7 +63,7 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
@@ -117,11 +119,11 @@ object RestartSink {
    * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
    * backoff.
    *
-   * This [[Sink]] will never cancel, since cancellation by the wrapped [[Sink]] is always handled by restarting it.
-   * The wrapped [[Sink]] can however be completed by feeding a completion or error into this [[Sink]]. When that
-   * happens, the [[Sink]], if currently running, will terminate and will not be restarted. This can be triggered
-   * simply by the upstream completing, or externally by introducing a [[KillSwitch]] right before this [[Sink]] in the
-   * graph.
+   * This [[Sink]] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped [[Sink]]
+   * is handled by restarting it. The wrapped [[Sink]] can however be completed by feeding a completion or error into
+   * this [[Sink]]. When that happens, the [[Sink]], if currently running, will terminate and will not be restarted.
+   * This can be triggered simply by the upstream completing, or externally by introducing a [[KillSwitch]] right
+   * before this [[Sink]] in the graph.
    *
    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
@@ -135,7 +137,7 @@ object RestartSink {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = Int.MaxValue)(sinkFactory: () ⇒ Sink[T, _]): Sink[T, NotUsed] = {
@@ -186,9 +188,9 @@ object RestartFlow {
    * backoff.
    *
    * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
-   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it. Any termination
-   * signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's running, and then the [[Flow]]
-   * will be allowed to terminate without being restarted.
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
+   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
    *
    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
@@ -202,7 +204,7 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = Int.MaxValue)(flowFactory: () ⇒ Flow[In, Out, _]): Flow[In, Out, NotUsed] = {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -37,11 +37,10 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-   *                    than 1 is considered as unlimited restarts.
+   * @param maxRestarts the amount of restarts is capped to this amount.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = Int.MaxValue)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = false, maxRestarts))
   }
 
@@ -62,12 +61,11 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-   *                    than 1 is considered as unlimited restarts.
+   * @param maxRestarts the amount of restarts is capped to this amount.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
-  def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
+  def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = Int.MaxValue)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = true, maxRestarts))
   }
 }
@@ -137,11 +135,10 @@ object RestartSink {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-   *                    than 1 is considered as unlimited restarts.
+   * @param maxRestarts the amount of restarts is capped to this amount.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(sinkFactory: () ⇒ Sink[T, _]): Sink[T, NotUsed] = {
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = Int.MaxValue)(sinkFactory: () ⇒ Sink[T, _]): Sink[T, NotUsed] = {
     Sink.fromGraph(new RestartWithBackoffSink(sinkFactory, minBackoff, maxBackoff, randomFactor, maxRestarts))
   }
 }
@@ -205,11 +202,10 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
-   *                    than 1 is considered as unlimited restarts.
+   * @param maxRestarts the amount of restarts is capped to this amount.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(flowFactory: () ⇒ Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = Int.MaxValue)(flowFactory: () ⇒ Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
     Flow.fromGraph(new RestartWithBackoffFlow(flowFactory, minBackoff, maxBackoff, randomFactor, maxRestarts))
   }
 }
@@ -366,7 +362,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
       log.debug("Last restart attempt was more than {} ago, resetting restart count", minBackoff)
       restartCount = 0
     }
-    maxRestarts > 0 && restartCount == maxRestarts
+    restartCount == maxRestarts
   }
 
   // Set a timer to restart after the calculated delay

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -290,7 +290,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
     sinkIn.setHandler(new InHandler {
       override def onPush() = push(out, sinkIn.grab())
       override def onUpstreamFinish() = {
-        if (finishing || maxRestartsReached() || onlyOnFailures) {
+        if (finishing || maxRestartsReached || onlyOnFailures) {
           complete(out)
         } else {
           log.debug("Restarting graph due to finished upstream")
@@ -298,7 +298,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
         }
       }
       override def onUpstreamFailure(ex: Throwable) = {
-        if (finishing || maxRestartsReached()) {
+        if (finishing || maxRestartsReached) {
           fail(out, ex)
         } else {
           log.error(ex, "Restarting graph due to failure")
@@ -330,7 +330,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
         }
       }
       override def onDownstreamFinish() = {
-        if (finishing || maxRestartsReached()) {
+        if (finishing || maxRestartsReached) {
           cancel(in)
         } else {
           log.debug("Graph in finished")
@@ -356,7 +356,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
     sourceOut
   }
 
-  protected final def maxRestartsReached() = {
+  protected final def maxRestartsReached = {
     // Check if the last start attempt was more than the minimum backoff
     if (resetDeadline.isOverdue()) {
       log.debug("Last restart attempt was more than {} ago, resetting restart count", minBackoff)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Restart.scala
@@ -37,10 +37,11 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
+   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+   *                    than 1 is considered as unlimited restarts.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = false, maxRestarts))
   }
 
@@ -61,11 +62,12 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
+   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+   *                    than 1 is considered as unlimited restarts.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
-  def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
+  def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(sourceFactory: () ⇒ Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = true, maxRestarts))
   }
 }
@@ -135,10 +137,11 @@ object RestartSink {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
+   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+   *                    than 1 is considered as unlimited restarts.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(sinkFactory: () ⇒ Sink[T, _]): Sink[T, NotUsed] = {
+  def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(sinkFactory: () ⇒ Sink[T, _]): Sink[T, NotUsed] = {
     Sink.fromGraph(new RestartWithBackoffSink(sinkFactory, minBackoff, maxBackoff, randomFactor, maxRestarts))
   }
 }
@@ -202,10 +205,11 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount
+   * @param maxRestarts the amount of restarts is capped to this amount. A value smaller
+   *                    than 1 is considered as unlimited restarts.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(flowFactory: () ⇒ Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+  def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int = -1)(flowFactory: () ⇒ Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
     Flow.fromGraph(new RestartWithBackoffFlow(flowFactory, minBackoff, maxBackoff, randomFactor, maxRestarts))
   }
 }
@@ -362,7 +366,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
       log.debug("Last restart attempt was more than {} ago, resetting restart count", minBackoff)
       restartCount = 0
     }
-    restartCount == maxRestarts
+    maxRestarts > 0 && restartCount == maxRestarts
   }
 
   // Set a timer to restart after the calculated delay


### PR DESCRIPTION
Implements #24129

The new option maxRestarts will limit the amount of restarts a RestartSource, -Flow or -Sink is allowed to do.