### PR TITLE
Remove superfluous 'for' in log message

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -684,7 +684,7 @@ private[akka] class ActorSystemImpl(
         err.print(cause.getMessage)
         err.print(", ")
         err.print(message)
-        err.print(" for ActorSystem[")
+        err.print(" ActorSystem[")
         err.print(name)
         err.println("]")
         System.err.flush()


### PR DESCRIPTION
I noticed an extra 'for' in our log:
`Uncaught error from thread [...]: Java heap space, shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for for ActorSystem[...]`

Applying this PR should remove it.