### PR TITLE
Move misc serialiser to akka-typed from akka-cluster-typed

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/MiscMessageSerializerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/MiscMessageSerializerSpec.scala
@@ -1,21 +1,20 @@
 /**
  * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
  */
-package akka.cluster.typed.internal
+package akka.actor.typed.internal
 
-import akka.serialization.{ SerializationExtension, SerializerWithStringManifest }
-import akka.actor.typed.{ ActorRef, TypedSpec }
-import akka.actor.typed.TypedSpec.Create
+import akka.actor.typed.TypedSpec
+import akka.actor.typed.TypedSpec.{ Create ⇒ TCreate }
 import akka.actor.typed.scaladsl.Actor
-import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.scaladsl.AskPattern._
+import akka.actor.typed.scaladsl.adapter._
+import akka.serialization.SerializationExtension
 import com.typesafe.config.ConfigFactory
 
 object MiscMessageSerializerSpec {
   def config = ConfigFactory.parseString(
     """
       akka.actor {
-        provider = cluster
         serialize-messages = off
         allow-java-serialization = true
       }
@@ -41,7 +40,8 @@ class MiscMessageSerializerSpec extends TypedSpec(MiscMessageSerializerSpec.conf
     }
 
     "must serialize and deserialize typed actor refs" in {
-      val ref = (system ? Create(Actor.empty[Unit], "some-actor")).futureValue
+      val ref = (system ? TCreate(Actor.empty[Unit], "some-actor")).futureValue
+      println(ref.getClass)
       checkSerialization(ref)
     }
   }

--- a/akka-actor-typed/src/main/resources/reference.conf
+++ b/akka-actor-typed/src/main/resources/reference.conf
@@ -17,6 +17,14 @@ akka.typed {
 }
 
 akka.actor {
+  serializers {
+    typed-misc = "akka.actor.typed.internal.MiscMessageSerializer"
+  }
+
+  serialization-identifiers {
+    "akka.actor.typed.internal.MiscMessageSerializer" = 24
+  }
+
   serialization-bindings {
     "akka.actor.typed.ActorRef" = typed-misc
     "akka.actor.typed.internal.adapter.ActorRefAdapter" = typed-misc

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
@@ -1,10 +1,9 @@
 /**
  * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
  */
-package akka.cluster.typed
+package akka.actor.typed
 
 import akka.actor.ExtendedActorSystem
-import akka.actor.typed.{ ActorRef, ActorSystem, Extension, ExtensionId }
 
 object ActorRefResolver extends ExtensionId[ActorRefResolver] {
   def get(system: ActorSystem[_]): ActorRefResolver = apply(system)

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
@@ -5,7 +5,7 @@
 package akka.cluster.sharding.typed
 
 import akka.cluster.sharding.ShardCoordinator.LeastShardAllocationStrategy
-import akka.actor.typed.{ ActorRef, ActorSystem, Props, TypedSpec }
+import akka.actor.typed.{ ActorRef, ActorRefResolver, ActorSystem, Props, TypedSpec }
 import akka.cluster.typed.Cluster
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.actor.typed.scaladsl.Actor
@@ -22,7 +22,6 @@ import org.scalatest.concurrent.Eventually
 import akka.cluster.MemberStatus
 import akka.actor.ExtendedActorSystem
 import akka.serialization.SerializerWithStringManifest
-import akka.cluster.typed.ActorRefResolver
 import java.nio.charset.StandardCharsets
 
 object ClusterShardingSpec {

--- a/akka-cluster-typed/src/main/resources/reference.conf
+++ b/akka-cluster-typed/src/main/resources/reference.conf
@@ -1,9 +1,1 @@
-# TODO: move these out somewhere else when doing #23632
-akka.actor {
-  serializers {
-    typed-misc = "akka.cluster.typed.internal.MiscMessageSerializer"
-  }
-  serialization-identifiers {
-    "akka.cluster.typed.internal.MiscMessageSerializer" = 24
-  }
-}
+

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -7,12 +7,11 @@ import java.nio.charset.StandardCharsets
 
 import akka.actor.ExtendedActorSystem
 import akka.serialization.SerializerWithStringManifest
-import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.actor.typed.scaladsl.Actor
 import akka.actor.typed.scaladsl.adapter._
 import akka.typed.testkit.TestKitSettings
 import akka.typed.testkit.scaladsl.TestProbe
-import akka.actor.typed.{ ActorRef, Props, TypedSpec }
+import akka.actor.typed.{ ActorRef, ActorRefResolver, Props, TypedSpec }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
@@ -6,13 +6,11 @@ package akka.cluster.typed
 import java.nio.charset.StandardCharsets
 
 import akka.Done
-import akka.actor.{ ExtendedActorSystem, ActorSystem ⇒ UntypedActorSystem }
-import akka.serialization.SerializerWithStringManifest
 import akka.testkit.AkkaSpec
-import akka.actor.typed.{ ActorRef, ActorSystem }
+import akka.actor.typed.{ ActorRef, ActorRefResolver }
 import akka.actor.typed.scaladsl.Actor
 import akka.actor.{ ExtendedActorSystem, ActorSystem ⇒ UntypedActorSystem }
-import akka.serialization.{ BaseSerializer, SerializerWithStringManifest }
+import akka.serialization.SerializerWithStringManifest
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Promise
@@ -93,7 +91,7 @@ class RemoteMessageSpec extends AkkaSpec(RemoteMessageSpec.config) {
           ActorRefResolver(typedSystem2).resolveActorRef[Ping](remoteRefStr)
 
         val pongPromise = Promise[Done]()
-        val recipient = system2.spawn(Actor.immutable[String] { (_, msg) ⇒
+        val recipient = system2.spawn(Actor.immutable[String] { (_, _) ⇒
           pongPromise.success(Done)
           Actor.stopped
         }, "recipient")

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -7,15 +7,9 @@ import java.nio.charset.StandardCharsets
 
 import akka.actor.ExtendedActorSystem
 import akka.cluster.Cluster
-import akka.cluster.typed.ActorRefResolver
 import akka.serialization.SerializerWithStringManifest
-import akka.actor.typed.{ ActorRef, ActorSystem, StartSupport, TypedSpec }
+import akka.actor.typed.{ ActorRef, ActorRefResolver, StartSupport, TypedSpec }
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
-import akka.actor.typed.TypedSpec.Command
-import akka.cluster.typed.ActorRefResolver
-import akka.actor.typed.internal.adapter.ActorRefAdapter
-import akka.actor.typed.internal.adapter.ActorSystemAdapter
-import akka.actor.typed.internal.receptionist.ReceptionistImpl
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.scaladsl.Actor
 import akka.actor.typed.scaladsl.adapter._


### PR DESCRIPTION
This was a problem introduced by the separate typed modules. 

This can also be used when using persistence without clustering.