### PR TITLE
Use System.getProperty for ttl values found using legacy sun properties

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/InetAddressDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/InetAddressDnsResolverSpec.scala
@@ -1,0 +1,100 @@
+package akka.io
+
+import java.security.Security
+import java.util.concurrent.TimeUnit
+
+import akka.actor.Props
+import akka.testkit.{ AkkaSpec, TestActorRef }
+
+class InetAddressDnsResolverSpec extends AkkaSpec("""
+    akka.io.dns.inet-address.positive-ttl = default
+    akka.io.dns.inet-address.negative-ttl = default
+    akka.actor.serialize-creators = on
+    """) { thisSpecs ⇒
+
+  "The DNS resolver default ttl's" must {
+    "use the default value for positive caching if it is not overridden" in {
+      withNewSecurityProperty("networkaddress.cache.ttl", "") {
+        withNewSystemProperty("sun.net.inetaddr.ttl", "") {
+          dnsResolver.positiveTtl shouldBe secondsToMillis(30)
+        }
+      }
+    }
+
+    "use the default value for negative caching if it is not overridden" in {
+      withNewSecurityProperty("networkaddress.cache.negative.ttl", "") {
+        withNewSystemProperty("sun.net.inetaddr.negative.ttl", "") {
+          dnsResolver.negativeTtl shouldBe secondsToMillis(0)
+        }
+      }
+    }
+
+    "use the security property for positive caching if it is defined" in {
+      val expectedTtlValue = "42"
+      withNewSecurityProperty("networkaddress.cache.ttl", expectedTtlValue) {
+        withNewSystemProperty("sun.net.inetaddr.ttl", "2000") {
+          dnsResolver.positiveTtl shouldBe secondsToMillis(expectedTtlValue.toInt)
+        }
+      }
+    }
+
+    "use the security property for negative caching if it is defined" in {
+      val expectedTtlValue = "43"
+      withNewSecurityProperty("networkaddress.cache.negative.ttl", expectedTtlValue) {
+        withNewSystemProperty("sun.net.inetaddr.negative.ttl", "2000") {
+          dnsResolver.negativeTtl shouldBe secondsToMillis(expectedTtlValue.toInt)
+        }
+      }
+    }
+
+    "use the fallback system property for positive caching if it is defined and no security property is defined" in {
+      val expectedTtlValue = "42"
+      withNewSecurityProperty("networkaddress.cache.ttl", "") {
+        withNewSystemProperty("sun.net.inetaddr.ttl", expectedTtlValue) {
+          dnsResolver.positiveTtl shouldBe secondsToMillis(expectedTtlValue.toInt)
+        }
+      }
+    }
+
+    "use the fallback system property for negative caching if it is defined and no security property is defined" in {
+      val expectedTtlValue = "43"
+      withNewSecurityProperty("networkaddress.cache.negative.ttl", "") {
+        withNewSystemProperty("sun.net.inetaddr.negative.ttl", expectedTtlValue) {
+          dnsResolver.negativeTtl shouldBe secondsToMillis(expectedTtlValue.toInt)
+        }
+      }
+    }
+  }
+
+  private def secondsToMillis(seconds: Int) = TimeUnit.SECONDS.toMillis(seconds)
+
+  private def dnsResolver = {
+    val actorRef = TestActorRef[InetAddressDnsResolver](Props(
+      classOf[InetAddressDnsResolver],
+      new SimpleDnsCache(),
+      system.settings.config.getConfig("akka.io.dns.inet-address")
+    ))
+    actorRef.underlyingActor
+  }
+
+  private def withNewSystemProperty[T](property: String, testValue: String)(test: ⇒ T): T = {
+    val oldValue = Option(System.getProperty(property))
+    try {
+      System.setProperty(property, testValue)
+      test
+    } finally {
+      oldValue.foreach(v ⇒ System.setProperty(property, v))
+    }
+  }
+
+  private def withNewSecurityProperty[T](property: String, testValue: String)(test: ⇒ T): T = {
+    val oldValue = Option(Security.getProperty(property))
+    try {
+      Security.setProperty(property, testValue)
+      test
+    } finally {
+      oldValue.foreach(v ⇒ Security.setProperty(property, v))
+    }
+  }
+
+}

--- a/akka-actor-tests/src/test/scala/akka/io/InetAddressDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/InetAddressDnsResolverSpec.scala
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.io
 
 import java.security.Security

--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
@@ -35,14 +35,14 @@ class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Acto
 
   private lazy val cachePolicy: Int = {
     val n = Try(Security.getProperty(CachePolicyProp).toInt)
-      .orElse(Try(Security.getProperty(CachePolicyPropFallback).toInt))
+      .orElse(Try(System.getProperty(CachePolicyPropFallback).toInt))
       .getOrElse(DefaultPositive) // default
     if (n < 0) Forever else n
   }
 
   private lazy val negativeCachePolicy = {
     val n = Try(Security.getProperty(NegativeCachePolicyProp).toInt)
-      .orElse(Try(Security.getProperty(NegativeCachePolicyPropFallback).toInt))
+      .orElse(Try(System.getProperty(NegativeCachePolicyPropFallback).toInt))
       .getOrElse(0) // default
     if (n < 0) Forever else n
   }


### PR DESCRIPTION
The ordinary java implementation uses Security.getProperty for:
networkaddress.cache.ttl
networkaddress.cache.negative.ttl

and then uses System.getProperty for:
sun.net.inetaddr.ttl
sun.net.inetaddr.negative.ttl

Change the InetAddressDnsResolver to follow the same pattern to allow
setting sun.net.inetaddr.* properties from the command line.