### PR TITLE
Timer envelope removed for AutoReceivedMessage (#24080)

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dungeon/TimerSchedulerImpl.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/TimerSchedulerImpl.scala
@@ -45,7 +45,10 @@ import akka.util.OptionVal
     }
     val nextGen = nextTimerGen()
 
-    val timerMsg = TimerMsg(key, nextGen, this)
+    val timerMsg = msg match {
+      case _: AutoReceivedMessage ⇒ msg
+      case _                      ⇒ TimerMsg(key, nextGen, this)
+    }
     val task =
       if (repeat)
         ctx.system.scheduler.schedule(timeout, timeout, ctx.self, timerMsg)(ctx.dispatcher)

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -153,16 +153,15 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
 
   /**
    * Called when the journal rejected `persist` of an event. The event was not
-   * stored. By default this method logs the problem as a warning, and the actor continues.
+   * stored. By default this method logs the problem as an error, and the actor continues.
    * The callback handler that was passed to the `persist` method will not be invoked.
    *
    * @param cause failure cause
    * @param event the event that was to be persisted
    */
   protected def onPersistRejected(cause: Throwable, event: Any, seqNr: Long): Unit = {
-    log.warning(
-      "Rejected to persist event type [{}] with sequence number [{}] for persistenceId [{}] due to [{}].",
-      event.getClass.getName, seqNr, persistenceId, cause.getMessage)
+    log.error(cause, "Rejected to persist event type [{}] with sequence number [{}] for persistenceId [{}].",
+      event.getClass.getName, seqNr, persistenceId)
   }
 
   private def stashInternally(currMsg: Any): Unit =


### PR DESCRIPTION
#24080 

Timers wraps any message(including `AutoReceivedMessage`'s).

`akka.actor.ActorCell.invoke` method acts like it is not an `AutoReceivedMessage` and calls `aroundReceive()` method that applies `receive` method.

As a result old implementation will not handle `AutoReceivedMessage` automatically, it applies custom receive method.

This PR bypasses `akka/actor/Timers.scala:38` case, **solution might be problematic.**