### PR TITLE
add flag crdt constants

### DIFF
--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Flag.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Flag.scala
@@ -7,13 +7,20 @@ object Flag {
   /**
    * `Flag` that is initialized to `false`.
    */
-  val empty = new Flag(false)
+  val empty: Flag = new Flag(false)
 
-  val Disabled = empty
+  /**
+   * `Flag` that is initialized to `false`.
+   */
+  val Disabled: Flag = empty
 
-  val Enabled = new Flag(true)
+  /**
+   * `Flag` that is initialized to `true`.
+   */
+  val Enabled: Flag = new Flag(true)
 
   def apply(): Flag = Disabled
+
   /**
    * Java API: `Flag` that is initialized to `false`.
    */

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Flag.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Flag.scala
@@ -8,11 +8,16 @@ object Flag {
    * `Flag` that is initialized to `false`.
    */
   val empty = new Flag(false)
-  def apply(): Flag = empty
+
+  val Disabled = empty
+
+  val Enabled = new Flag(true)
+
+  def apply(): Flag = Disabled
   /**
    * Java API: `Flag` that is initialized to `false`.
    */
-  def create(): Flag = empty
+  def create(): Flag = Disabled
 
   // unapply from case class
 }
@@ -30,7 +35,7 @@ final case class Flag(enabled: Boolean) extends ReplicatedData with ReplicatedDa
 
   def switchOn: Flag =
     if (enabled) this
-    else Flag(true)
+    else Flag.Enabled
 
   override def merge(that: Flag): Flag =
     if (that.enabled) that

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -484,7 +484,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     flagFromProto(rd.Flag.parseFrom(bytes))
 
   def flagFromProto(flag: rd.Flag): Flag =
-    Flag(flag.getEnabled)
+    if (flag.getEnabled) Flag.Enabled else Flag.Disabled
 
   def lwwRegisterToProto(lwwRegister: LWWRegister[_]): rd.LWWRegister =
     rd.LWWRegister.newBuilder().

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
@@ -527,22 +527,22 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
 
     runOn(second) {
       replicator ! Subscribe(KeyH, changedProbe.ref)
-      replicator ! Update(KeyH, ORMap.empty[String, Flag], writeTwo)(_ + ("a" → Flag(enabled = false)))
-      changedProbe.expectMsgPF() { case c @ Changed(KeyH) ⇒ c.get(KeyH).entries } should be(Map("a" → Flag(enabled = false)))
+      replicator ! Update(KeyH, ORMap.empty[String, Flag], writeTwo)(_ + ("a" → Flag.Disabled))
+      changedProbe.expectMsgPF() { case c @ Changed(KeyH) ⇒ c.get(KeyH).entries } should be(Map("a" → Flag.Disabled))
     }
 
     enterBarrier("update-h1")
 
     runOn(first) {
-      replicator ! Update(KeyH, ORMap.empty[String, Flag], writeTwo)(_ + ("a" → Flag(enabled = true)))
+      replicator ! Update(KeyH, ORMap.empty[String, Flag], writeTwo)(_ + ("a" → Flag.Enabled))
     }
 
     runOn(second) {
-      changedProbe.expectMsgPF() { case c @ Changed(KeyH) ⇒ c.get(KeyH).entries } should be(Map("a" → Flag(enabled = true)))
+      changedProbe.expectMsgPF() { case c @ Changed(KeyH) ⇒ c.get(KeyH).entries } should be(Map("a" → Flag.Enabled))
 
-      replicator ! Update(KeyH, ORMap.empty[String, Flag], writeTwo)(_ + ("b" → Flag(enabled = true)))
+      replicator ! Update(KeyH, ORMap.empty[String, Flag], writeTwo)(_ + ("b" → Flag.Enabled))
       changedProbe.expectMsgPF() { case c @ Changed(KeyH) ⇒ c.get(KeyH).entries } should be(
-        Map("a" → Flag(enabled = true), "b" → Flag(enabled = true)))
+        Map("a" → Flag.Enabled, "b" → Flag.Enabled))
     }
 
     enterBarrierAfterTestStep()

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/FlagSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/FlagSpec.scala
@@ -31,7 +31,7 @@ class FlagSpec extends WordSpec with Matchers {
     }
 
     "have unapply extractor" in {
-      val f1 = Flag.empty.switchOn
+      val f1 = Flag.Disabled.switchOn
       val Flag(value1) = f1
       val value2: Boolean = value1
       Changed(FlagKey("key"))(f1) match {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
@@ -569,7 +569,7 @@ class ORMapSpec extends WordSpec with Matchers {
 
     "work with deltas and updated for Flag elements type" in {
       val m1 = ORMap.empty.put(node1, "a", Flag(false))
-      val m2 = m1.resetDelta.updated(node1, "a", Flag.empty)(_.switchOn)
+      val m2 = m1.resetDelta.updated(node1, "a", Flag.Disabled)(_.switchOn)
       val m3 = ORMap().mergeDelta(m1.delta.get).mergeDelta(m2.delta.get)
       val Flag(d3) = m3.entries("a")
       d3 should be(true)

--- a/akka-docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
@@ -123,7 +123,7 @@ class DistributedDataDocSpec extends AkkaSpec(DistributedDataDocSpec.config) {
     replicator ! Update(Set2Key, ORSet.empty[String], writeMajority)(_ + "hello")
 
     val writeAll = WriteAll(timeout = 5.seconds)
-    replicator ! Update(ActiveFlagKey, Flag.empty, writeAll)(_.switchOn)
+    replicator ! Update(ActiveFlagKey, Flag.Disabled, writeAll)(_.switchOn)
     //#update
 
     probe.expectMsgType[UpdateResponse[_]] match {
@@ -347,7 +347,7 @@ class DistributedDataDocSpec extends AkkaSpec(DistributedDataDocSpec.config) {
   "demonstrate Flag" in {
     def println(o: Any): Unit = ()
     //#flag
-    val f0 = Flag.empty
+    val f0 = Flag.Disabled
     val f1 = f0.switchOn
     println(f1.enabled)
     //#flag


### PR DESCRIPTION
Refs #24199 

Performing a boolean check in the Flag companion object providing a custom apply raise the error
`method apply is defined twice conflicting symbols both originated in file ...`

Allowing custom apply and unapply methods in case class companions are only available from Scala 2.11.11 (where it needs the -Xsource:2.12 flag) and 2.12.2 (no flags required). See scala/scala#5730 and scala/scala#5846

... and maintaining binary compatibility

The above constraints guided this approach.





