### PR TITLE
Reply to GetShardHome requests after rebalance, #24191

### DIFF
--- a/akka-cluster-sharding/src/main/mima-filters/2.5.8.backwards.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.5.8.backwards.excludes
@@ -1,0 +1,3 @@
+# #24191
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.sharding.ShardCoordinator.rebalanceInProgress")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.ShardCoordinator.rebalanceInProgress_=")

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
@@ -80,7 +80,7 @@ abstract class ClusterShardingCustomShardAllocationSpecConfig(val mode: String) 
   val second = role("second")
 
   commonConfig(ConfigFactory.parseString(s"""
-    akka.loglevel = INFO
+    akka.loglevel = DEBUG
     akka.actor.provider = "cluster"
     akka.remote.log-remote-lifecycle-events = off
     akka.persistence.journal.plugin = "akka.persistence.journal.leveldb-shared"
@@ -94,6 +94,8 @@ abstract class ClusterShardingCustomShardAllocationSpecConfig(val mode: String) 
     akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
     akka.persistence.snapshot-store.local.dir = "target/ClusterShardingCustomShardAllocationSpec/snapshots"
     akka.cluster.sharding.state-store-mode = "$mode"
+    akka.cluster.sharding.rebalance-interval = 1 s
+    #akka.cluster.sharding.retry-interval = 5 s
     """).withFallback(MultiNodeClusterSpec.clusterConfig))
 }
 
@@ -161,7 +163,7 @@ abstract class ClusterShardingCustomShardAllocationSpec(config: ClusterShardingC
       }
     }
 
-    "use specified region" in within(10.seconds) {
+    "use specified region" in within(30.seconds) {
       join(first, first)
 
       runOn(first) {


### PR DESCRIPTION
* Some GetShardHome requests were ignored (by design) during
  rebalance and they would be retried later.
* This optimization keeps tracks of such requests and reply
  to them immediately after rebalance has been completed and
  thereby the buffered messages in the region don't have to
  wait for next retry tick.

Refs #24191