### PR TITLE
Archive docs for offline use

### DIFF
--- a/project/scripts/release
+++ b/project/scripts/release
@@ -366,6 +366,7 @@ if [ $dry_run ]; then
   echodry "  sbt deployRsync"
   echodry "  rsync -rlpvz --chmod=Dg+ws,Fg+w --exclude ${release_dir}/downloads --exclude ${release_dir}/docs ${release_dir}/ ${publish_path}/"
 else
+  important tar -czf ${release_dir}/offline.tar.gz ${release_dir}/*
   important ssh ${release_server} "cd ${release_path}/docs/akka; git add .; git commit -m 'before publishing version $version'; true"
   important sbt deployRsync
   important rsync -rlpvz --chmod=Dg+ws,Fg+w --exclude ${release_dir}/downloads --exclude ${release_dir}/docs ${release_dir}/ ${publish_path}/


### PR DESCRIPTION
Create an archive before pushing to server, so the docs can be downloaded by users that need offline docs.

Links should be added for this archive at https://akka.io/docs/, but I'm not sure how to do that.

Note: this is my first time doing anything that involves sbt and/or Scala, so my understanding of things is probably wrong and my change might break everything. Sorry if this is a waste of time.

Fixes https://github.com/akka/akka/issues/22728