### PR TITLE
Version checking utility 

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
@@ -16,15 +16,23 @@ class AkkaVersionSpec extends WordSpec with Matchers {
     }
 
     "succeed if version is RC and ok" in {
-      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-RC1")
       AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7-RC10")
-      AkkaVersion.require("AkkaVersionSpec", "2.4.19", "2.4.19-RC6")
+    }
+
+    "fail if version is RC and not ok" in {
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-RC1")
+      }
     }
 
     "succeed if version is milestone and ok" in {
-      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-M1")
       AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7-M10")
-      AkkaVersion.require("AkkaVersionSpec", "2.4.19", "2.4.19-M6")
+    }
+
+    "fail if version is milestone and not ok" in {
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-M1")
+      }
     }
 
     "fail if major version is different" in {

--- a/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
@@ -3,39 +3,68 @@
  */
 package akka
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 class AkkaVersionSpec extends WordSpec with Matchers {
 
   "The Akka version check" must {
 
     "succeed if version is ok" in {
-      AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5.6")
-      AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5.7")
-      AkkaVersion.require("AkkaVersionSpec", Set("2.5.6", "2.4.19"), "2.4.19")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.6.0")
     }
 
-    "fail if minor version is missing" in {
+    "succeed if version is RC and ok" in {
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-RC1")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7-RC10")
+      AkkaVersion.require("AkkaVersionSpec", "2.4.19", "2.4.19-RC6")
+    }
+
+    "succeed if version is milestone and ok" in {
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-M1")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7-M10")
+      AkkaVersion.require("AkkaVersionSpec", "2.4.19", "2.4.19-M6")
+    }
+
+    "fail if major version is different" in {
+      // because not bincomp
       intercept[UnsupportedAkkaVersion] {
-        AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.4.19")
+        AkkaVersion.require("AkkaVersionSpec", "2.5.6", "3.0.0")
+      }
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", "2.5.6", "1.0.0")
+      }
+    }
+
+    "fail if minor version is too low" in {
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.4.19")
       }
     }
 
     "fail if patch version is too low" in {
       intercept[UnsupportedAkkaVersion] {
-        AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5.5")
+        AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.5")
       }
     }
 
-    "fail if Akka version is SNAPSHOT or timestamped snapshot" in {
-      intercept[UnsupportedAkkaVersion] {
-        AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5-SNAPSHOT")
-      }
+    "succeed if Akka version is SNAPSHOT" in {
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5-SNAPSHOT")
     }
 
-    "fail if required versions are invalid" in {
-      intercept[UnsupportedAkkaVersion] {
-        AkkaVersion.require("AkkaVersionSpec", Set("2.5-SNAPSHOT"), "2.5-SNAPSHOT")
+    "succeed if Akka version is timestamped SNAPSHOT" in {
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5-20180109-133700")
+    }
+
+    "silently comply if current version is incomprehensible" in {
+      // because we may want to release with weird numbers for some reason
+      AkkaVersion.require("nonsense", "2.5.6", "nonsense")
+    }
+
+    "fail if fed incomprehensible requirement" in {
+      intercept[IllegalArgumentException] {
+        AkkaVersion.require("AkkaVersionSpec", "nonsense", "2.5.6")
       }
     }
 

--- a/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka
+
+import org.scalatest.{Matchers, WordSpec}
+
+class AkkaVersionSpec extends WordSpec with Matchers {
+
+  "The Akka version check" must {
+
+    "succeed if version is ok" in {
+      AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5.6")
+      AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5.7")
+      AkkaVersion.require("AkkaVersionSpec", Set("2.5.6", "2.4.19"), "2.4.19")
+    }
+
+    "fail if minor version is missing" in {
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.4.19")
+      }
+    }
+
+    "fail if patch version is too low" in {
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5.5")
+      }
+    }
+
+    "fail if Akka version is SNAPSHOT or timestamped snapshot" in {
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", Set("2.5.6"), "2.5-SNAPSHOT")
+      }
+    }
+
+    "fail if required versions are invalid" in {
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", Set("2.5-SNAPSHOT"), "2.5-SNAPSHOT")
+      }
+    }
+
+  }
+
+}

--- a/akka-actor/src/main/scala/akka/AkkaVersion.scala
+++ b/akka-actor/src/main/scala/akka/AkkaVersion.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka
+
+import akka.annotation.InternalApi
+
+
+final class UnsupportedAkkaVersion private[akka](msg: String) extends RuntimeException(msg)
+
+object AkkaVersion {
+  /**
+   * Check that the version of Akka is a specific patch version or higher, potentially for multiple
+   * minor version, for example require("2.4.19", "2.5.6"). If the version requirement is not fulfilled
+   * an exception is thrown.
+   *
+   * @param libraryName The name of the library or component requiring the Akka version, used in the error message.
+   */
+  def require(libraryName: String, requiredVersions: String*): Unit = {
+    require(libraryName, requiredVersions.toSet, Version.current)
+  }
+
+  /**
+   * Internal API:
+   */
+  @InternalApi
+  private[akka] def require(libraryName: String, requiredVersions: Set[String], currentVersion: String): Unit = {
+    val Array(majorStr, minorStr, patchStr) = currentVersion.split(Array('.', '-'))
+
+    // we can only know that it matches if it's not a SNAPSHOT or a timestamp as patch version
+    if (patchStr.matches("\\d{1,3}")) {
+      val minorVersionStr = s"$majorStr.$minorStr"
+
+      requiredVersions.find(_.startsWith(minorVersionStr)) match {
+        case Some(requiredVersion) =>
+          val Array(_, _, requiredPatchStr) = requiredVersion.split('.')
+          val patchNr = patchStr.toInt
+          try {
+            val requiredPatchNr = requiredPatchStr.toInt
+            if (requiredPatchNr > patchNr)
+              throw new UnsupportedAkkaVersion(s"Current version of Akka is $currentVersion, but '$libraryName' requires version $requiredVersion")
+
+          } catch {
+            case ex: NumberFormatException =>
+              throw new IllegalArgumentException(s"Illegal version requirement string '$requiredVersion', must be x.y.z with numbers")
+          }
+        case None =>
+          // minor version not supported
+          throw new UnsupportedAkkaVersion(s"Current version of Akka is $currentVersion, but '$libraryName' requires $requiredVersions")
+      }
+    } else {
+      throw new UnsupportedAkkaVersion(s"Current version of Akka is $currentVersion (likely a snapshot), but '$libraryName' requires $requiredVersions")
+    }
+  }
+
+}

--- a/akka-actor/src/main/scala/akka/AkkaVersion.scala
+++ b/akka-actor/src/main/scala/akka/AkkaVersion.scala
@@ -5,51 +5,44 @@ package akka
 
 import akka.annotation.InternalApi
 
+import scala.annotation.varargs
 
-final class UnsupportedAkkaVersion private[akka](msg: String) extends RuntimeException(msg)
+final class UnsupportedAkkaVersion private[akka] (msg: String) extends RuntimeException(msg)
 
 object AkkaVersion {
   /**
-   * Check that the version of Akka is a specific patch version or higher, potentially for multiple
-   * minor version, for example require("2.4.19", "2.5.6"). If the version requirement is not fulfilled
-   * an exception is thrown.
+   * Check that the version of Akka is a specific patch version or higher and throw an [[UnsupportedAkkaVersion]]
+   * exception if the version requirement is not fulfilled.
+   *
+   * For example: `require("my-library", "2.5.4")` would fail if used with Akka 2.4.19 and 2.5.3, but succeed with 2.5.4
+   * and 2.6.1
    *
    * @param libraryName The name of the library or component requiring the Akka version, used in the error message.
+   * @param requiredVersion Minimal version that this library works with
    */
-  def require(libraryName: String, requiredVersions: String*): Unit = {
-    require(libraryName, requiredVersions.toSet, Version.current)
+  def require(libraryName: String, requiredVersion: String): Unit = {
+    require(libraryName, requiredVersion, Version.current)
   }
 
   /**
    * Internal API:
    */
   @InternalApi
-  private[akka] def require(libraryName: String, requiredVersions: Set[String], currentVersion: String): Unit = {
-    val Array(majorStr, minorStr, patchStr) = currentVersion.split(Array('.', '-'))
+  private[akka] def require(libraryName: String, requiredVersion: String, currentVersion: String): Unit = {
+    val VersionPattern = """(\d+)\.(\d+)\.(\d+)(?:-(?:M|RC)\d+)?""".r
+    currentVersion match {
+      case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr) ⇒
+        requiredVersion match {
+          case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr) ⇒
 
-    // we can only know that it matches if it's not a SNAPSHOT or a timestamp as patch version
-    if (patchStr.matches("\\d{1,3}")) {
-      val minorVersionStr = s"$majorStr.$minorStr"
+            if (requiredMajorStr.toInt != currentMajorStr.toInt ||
+              requiredMinorStr.toInt > currentMinorStr.toInt ||
+              (requiredMinorStr == currentMinorStr && requiredPatchStr.toInt > currentPatchStr.toInt))
+              throw new UnsupportedAkkaVersion(s"Current version of Akka is [$currentVersion], but $libraryName requires version [$requiredVersion]")
+          case _ ⇒ throw new IllegalArgumentException(s"Required version string is invalid: [$requiredVersion]")
+        }
 
-      requiredVersions.find(_.startsWith(minorVersionStr)) match {
-        case Some(requiredVersion) =>
-          val Array(_, _, requiredPatchStr) = requiredVersion.split('.')
-          val patchNr = patchStr.toInt
-          try {
-            val requiredPatchNr = requiredPatchStr.toInt
-            if (requiredPatchNr > patchNr)
-              throw new UnsupportedAkkaVersion(s"Current version of Akka is $currentVersion, but '$libraryName' requires version $requiredVersion")
-
-          } catch {
-            case ex: NumberFormatException =>
-              throw new IllegalArgumentException(s"Illegal version requirement string '$requiredVersion', must be x.y.z with numbers")
-          }
-        case None =>
-          // minor version not supported
-          throw new UnsupportedAkkaVersion(s"Current version of Akka is $currentVersion, but '$libraryName' requires $requiredVersions")
-      }
-    } else {
-      throw new UnsupportedAkkaVersion(s"Current version of Akka is $currentVersion (likely a snapshot), but '$libraryName' requires $requiredVersions")
+      case _ ⇒ // SNAPSHOT or unknown - you're on your own
     }
   }
 

--- a/akka-actor/src/main/scala/akka/AkkaVersion.scala
+++ b/akka-actor/src/main/scala/akka/AkkaVersion.scala
@@ -29,15 +29,18 @@ object AkkaVersion {
    */
   @InternalApi
   private[akka] def require(libraryName: String, requiredVersion: String, currentVersion: String): Unit = {
-    val VersionPattern = """(\d+)\.(\d+)\.(\d+)(?:-(?:M|RC)\d+)?""".r
+    val VersionPattern = """(\d+)\.(\d+)\.(\d+)(-(?:M|RC)\d+)?""".r
     currentVersion match {
-      case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr) ⇒
+      case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr, mOrRc) ⇒
         requiredVersion match {
-          case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr) ⇒
-
+          case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr, _) ⇒
+            // a M or RC is basically inbetween versions, so offset
+            val currentPatch =
+              if (mOrRc ne null) currentPatchStr.toInt - 1
+              else currentPatchStr.toInt
             if (requiredMajorStr.toInt != currentMajorStr.toInt ||
               requiredMinorStr.toInt > currentMinorStr.toInt ||
-              (requiredMinorStr == currentMinorStr && requiredPatchStr.toInt > currentPatchStr.toInt))
+              (requiredMinorStr == currentMinorStr && requiredPatchStr.toInt > currentPatch))
               throw new UnsupportedAkkaVersion(s"Current version of Akka is [$currentVersion], but $libraryName requires version [$requiredVersion]")
           case _ ⇒ throw new IllegalArgumentException(s"Required version string is invalid: [$requiredVersion]")
         }


### PR DESCRIPTION
Fixes #24030 

Could use a mention in the docs as well I guess. The idea is that for example Akka HTTP could explicitly say what version it requires in the extension to fail fast with a better error message than getting a linkage error later when some method is missing etc.