### PR TITLE
Fix record overflow race condition in flight recorder

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/FlightRecorderSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/FlightRecorderSpec.scala
@@ -358,10 +358,10 @@ class FlightRecorderSpec extends AkkaSpec {
       channel.force(false)
       reader.rereadStructure()
 
-      reader.structure.loFreqLog.logs(0).richEntries.size should ===(FlightRecorder.LoFreqWindow)
+      reader.structure.loFreqLog.logs.head.richEntries.size should ===(FlightRecorder.LoFreqWindow)
 
       for (i ← 1 to Threads) {
-        val entries = reader.structure.loFreqLog.logs(0).richEntries.filter(_.code == i).toSeq
+        val entries = reader.structure.loFreqLog.logs.head.richEntries.filter(_.code == i).toSeq
 
         entries.exists(_.dirty) should be(false)
         // Entries are consecutive for any given writer


### PR DESCRIPTION
The flag used to show a record is dirty/commited was overwritten by the
last 4 bytes of the previous metadata. Most of the time this isn't
caught as the record is written fixed width and typically the last bytes
are 0s which is the same as the Commited flag. However under
concurrency this can overwrite the Dirty flag that is preventing
corruption.

Fixes https://github.com/akka/akka/issues/21992
  