### PR TITLE
Extend copyright into 2018

### DIFF
--- a/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottleTest.scala
+++ b/akka-contrib/src/test/scala/akka/contrib/throttle/TimerBasedThrottleTest.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.contrib.throttle


### PR DESCRIPTION
One straggler left after https://github.com/akka/akka/pull/24241/ probably because it was still on 2016