### PR TITLE
Use expectNoMessage in typed testkit

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -38,7 +38,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
         probe.ref ! Started
         target(probe.ref)
       }
-      probe.expectNoMsg(100.millis) // not yet
+      probe.expectNoMessage(100.millis) // not yet
       spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)
@@ -98,7 +98,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
       }.widen[Command] {
         case m ⇒ m
       }
-      probe.expectNoMsg(100.millis) // not yet
+      probe.expectNoMessage(100.millis) // not yet
       val ref = spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)
@@ -114,7 +114,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
         probe.ref ! Started
         target(probe.ref)
       })
-      probe.expectNoMsg(100.millis) // not yet
+      probe.expectNoMessage(100.millis) // not yet
       val ref = spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -38,7 +38,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
         probe.ref ! Started
         target(probe.ref)
       }
-      probe.expectNoMessage(100.millis) // not yet
+      probe.expectNoMessage() // not yet
       spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)
@@ -98,7 +98,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
       }.widen[Command] {
         case m ⇒ m
       }
-      probe.expectNoMessage(100.millis) // not yet
+      probe.expectNoMessage() // not yet
       val ref = spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)
@@ -114,7 +114,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
         probe.ref ! Started
         target(probe.ref)
       })
-      probe.expectNoMessage(100.millis) // not yet
+      probe.expectNoMessage() // not yet
       val ref = spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -239,7 +239,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
   import SupervisionSpec._
   private val nameCounter = Iterator.from(0)
   private def nextName(prefix: String = "a"): String = s"$prefix-${nameCounter.next()}"
-  private val waitTime = 50.millis
+  private val waitTime = 50.millis.dilated
 
   implicit val testSettings = TestKitSettings(system)
 
@@ -304,7 +304,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       // TODO document this difference compared to classic actors, and that
       //      children can be stopped if needed in PreRestart
       parentProbe.expectMsgType[State].children.keySet should contain(childName)
-      childProbe.expectNoMsg(waitTime)
+      childProbe.expectNoMessage(waitTime)
     }
 
     "resume when handled exception" in {
@@ -333,7 +333,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
 
       // resume
       ref ! Throw(new Exc2)
-      probe.expectNoMsg(waitTime)
+      probe.expectNoMessage(waitTime)
       ref ! GetState
       probe.expectMsg(State(1, Map.empty))
 
@@ -367,8 +367,8 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       probe.expectMsg(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
-      startedProbe.expectNoMsg(minBackoff - 100.millis)
-      probe.expectNoMsg(minBackoff + 100.millis)
+      startedProbe.expectNoMessage(minBackoff - 100.millis)
+      probe.expectNoMessage(minBackoff + 100.millis)
       startedProbe.expectMsg(Started)
       ref ! GetState
       probe.expectMsg(State(0, Map.empty))
@@ -379,8 +379,8 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       probe.expectMsg(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
-      startedProbe.expectNoMsg((minBackoff * 2) - 100.millis)
-      probe.expectNoMsg((minBackoff * 2) + 100.millis)
+      startedProbe.expectNoMessage((minBackoff * 2) - 100.millis)
+      probe.expectNoMessage((minBackoff * 2) + 100.millis)
       startedProbe.expectMsg(Started)
       ref ! GetState
       probe.expectMsg(State(0, Map.empty))
@@ -399,19 +399,19 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       probe.expectMsg(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
-      probe.expectNoMsg(minBackoff + 100.millis)
+      probe.expectNoMessage(minBackoff + 100.millis)
       ref ! GetState
       probe.expectMsg(State(0, Map.empty))
 
       // one more time after the reset timeout
-      probe.expectNoMsg(strategy.resetBackoffAfter + 100.millis)
+      probe.expectNoMessage(strategy.resetBackoffAfter + 100.millis)
       ref ! IncrementState
       ref ! Throw(new Exc1)
       probe.expectMsg(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
       // backoff was reset, so restarted after the minBackoff
-      probe.expectNoMsg(minBackoff + 100.millis)
+      probe.expectNoMessage(minBackoff + 100.millis)
       ref ! GetState
       probe.expectMsg(State(0, Map.empty))
     }
@@ -422,7 +422,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
         probe.ref ! Started
         targetBehavior(probe.ref)
       }).onFailure[Exception](SupervisorStrategy.restart)
-      probe.expectNoMsg(100.millis) // not yet
+      probe.expectNoMessage(100.millis) // not yet
       spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)
@@ -435,7 +435,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       val ref = spawn(behv)
       probe.expectMsg(Started)
       ref ! Ping
-      probe.expectNoMsg(100.millis)
+      probe.expectNoMessage(100.millis)
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -239,7 +239,6 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
   import SupervisionSpec._
   private val nameCounter = Iterator.from(0)
   private def nextName(prefix: String = "a"): String = s"$prefix-${nameCounter.next()}"
-  private val waitTime = 50.millis.dilated
 
   implicit val testSettings = TestKitSettings(system)
 
@@ -304,7 +303,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       // TODO document this difference compared to classic actors, and that
       //      children can be stopped if needed in PreRestart
       parentProbe.expectMsgType[State].children.keySet should contain(childName)
-      childProbe.expectNoMessage(waitTime)
+      childProbe.expectNoMessage()
     }
 
     "resume when handled exception" in {
@@ -333,7 +332,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
 
       // resume
       ref ! Throw(new Exc2)
-      probe.expectNoMessage(waitTime)
+      probe.expectNoMessage()
       ref ! GetState
       probe.expectMsg(State(1, Map.empty))
 
@@ -399,19 +398,19 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       probe.expectMsg(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
-      probe.expectNoMessage(minBackoff + 100.millis)
+      probe.expectNoMessage(minBackoff + 100.millis.dilated)
       ref ! GetState
       probe.expectMsg(State(0, Map.empty))
 
       // one more time after the reset timeout
-      probe.expectNoMessage(strategy.resetBackoffAfter + 100.millis)
+      probe.expectNoMessage(strategy.resetBackoffAfter + 100.millis.dilated)
       ref ! IncrementState
       ref ! Throw(new Exc1)
       probe.expectMsg(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
       // backoff was reset, so restarted after the minBackoff
-      probe.expectNoMessage(minBackoff + 100.millis)
+      probe.expectNoMessage(minBackoff + 100.millis.dilated)
       ref ! GetState
       probe.expectMsg(State(0, Map.empty))
     }
@@ -422,7 +421,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
         probe.ref ! Started
         targetBehavior(probe.ref)
       }).onFailure[Exception](SupervisorStrategy.restart)
-      probe.expectNoMessage(100.millis) // not yet
+      probe.expectNoMessage() // not yet
       spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
       probe.expectMsg(Started)
@@ -435,7 +434,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       val ref = spawn(behv)
       probe.expectMsg(Started)
       ref ! Ping
-      probe.expectNoMessage(100.millis)
+      probe.expectNoMessage()
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -38,7 +38,6 @@ class TimerSpec extends TestKit("TimerSpec")
   implicit val testSettings = TestKitSettings(system)
 
   val interval = 1.second
-  val dilatedInterval = interval.dilated
 
   def target(monitor: ActorRef[Event], timer: TimerScheduler[Command], bumpCount: Int): Behavior[Command] = {
     def bump(): Behavior[Command] = {
@@ -88,7 +87,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
       val ref = spawn(behv)
       probe.expectMsg(Tock(1))
-      probe.expectNoMsg(100.millis)
+      probe.expectNoMessage(100.millis)
 
       ref ! End
       probe.expectMsg(GotPostStop(false))
@@ -124,7 +123,7 @@ class TimerSpec extends TestKit("TimerSpec")
       val latch = new CountDownLatch(1)
       // next Tock(1) enqueued in mailboxed, but should be discarded because of new timer
       ref ! SlowThenBump(latch)
-      probe.expectNoMsg(interval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis)
       latch.countDown()
       probe.expectMsg(Tock(2))
 
@@ -142,7 +141,7 @@ class TimerSpec extends TestKit("TimerSpec")
       val ref = spawn(behv)
       probe.expectMsg(Tock(1))
       ref ! Cancel
-      probe.expectNoMsg(dilatedInterval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis)
 
       ref ! End
       probe.expectMsg(GotPostStop(false))
@@ -162,10 +161,10 @@ class TimerSpec extends TestKit("TimerSpec")
       val latch = new CountDownLatch(1)
       // next Tock(1) is enqueued in mailbox, but should be discarded by new incarnation
       ref ! SlowThenThrow(latch, new Exc)
-      probe.expectNoMsg(interval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis)
       latch.countDown()
       probe.expectMsg(GotPreRestart(false))
-      probe.expectNoMsg(interval / 2)
+      probe.expectNoMessage(interval / 2)
       probe.expectMsg(Tock(2))
 
       ref ! End
@@ -189,7 +188,7 @@ class TimerSpec extends TestKit("TimerSpec")
       val latch = new CountDownLatch(1)
       // next Tock(2) is enqueued in mailbox, but should be discarded by new incarnation
       ref ! SlowThenThrow(latch, new Exc)
-      probe.expectNoMsg(interval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis)
       latch.countDown()
       probe.expectMsg(GotPreRestart(false))
       probe.expectMsg(Tock(1))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -87,7 +87,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
       val ref = spawn(behv)
       probe.expectMsg(Tock(1))
-      probe.expectNoMessage(100.millis)
+      probe.expectNoMessage()
 
       ref ! End
       probe.expectMsg(GotPostStop(false))
@@ -123,7 +123,7 @@ class TimerSpec extends TestKit("TimerSpec")
       val latch = new CountDownLatch(1)
       // next Tock(1) enqueued in mailboxed, but should be discarded because of new timer
       ref ! SlowThenBump(latch)
-      probe.expectNoMessage(interval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis.dilated)
       latch.countDown()
       probe.expectMsg(Tock(2))
 
@@ -141,7 +141,7 @@ class TimerSpec extends TestKit("TimerSpec")
       val ref = spawn(behv)
       probe.expectMsg(Tock(1))
       ref ! Cancel
-      probe.expectNoMessage(interval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis.dilated)
 
       ref ! End
       probe.expectMsg(GotPostStop(false))
@@ -161,7 +161,7 @@ class TimerSpec extends TestKit("TimerSpec")
       val latch = new CountDownLatch(1)
       // next Tock(1) is enqueued in mailbox, but should be discarded by new incarnation
       ref ! SlowThenThrow(latch, new Exc)
-      probe.expectNoMessage(interval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis.dilated)
       latch.countDown()
       probe.expectMsg(GotPreRestart(false))
       probe.expectNoMessage(interval / 2)
@@ -188,7 +188,7 @@ class TimerSpec extends TestKit("TimerSpec")
       val latch = new CountDownLatch(1)
       // next Tock(2) is enqueued in mailbox, but should be discarded by new incarnation
       ref ! SlowThenThrow(latch, new Exc)
-      probe.expectNoMessage(interval + 100.millis)
+      probe.expectNoMessage(interval + 100.millis.dilated)
       latch.countDown()
       probe.expectMsg(GotPreRestart(false))
       probe.expectMsg(Tock(1))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
@@ -25,7 +25,7 @@ class ImmutablePartialSpec extends TestKit with TypedAkkaSpecWithShutdown {
 
       testkit.run(Command1)
       testkit.currentBehavior shouldBe behavior
-      probe.expectNoMsg(100.milliseconds)
+      probe.expectNoMessage(100.milliseconds)
 
       testkit.run(Command2)
       testkit.currentBehavior shouldBe behavior

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
@@ -25,7 +25,7 @@ class ImmutablePartialSpec extends TestKit with TypedAkkaSpecWithShutdown {
 
       testkit.run(Command1)
       testkit.currentBehavior shouldBe behavior
-      probe.expectNoMessage(100.milliseconds)
+      probe.expectNoMessage()
 
       testkit.run(Command2)
       testkit.currentBehavior shouldBe behavior

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -99,7 +99,7 @@ class ClusterApiSpec extends TestKit("ClusterApiSpec", ClusterApiSpec.config) wi
 
         // subscribing to SelfUp when already removed yields nothing
         clusterNode2.subscriptions ! Subscribe(node2Probe.ref, classOf[SelfUp])
-        node2Probe.expectNoMessage(100.millis)
+        node2Probe.expectNoMessage()
 
       } finally {
         Await.result(system2.terminate(), 3.seconds)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -99,7 +99,7 @@ class ClusterApiSpec extends TestKit("ClusterApiSpec", ClusterApiSpec.config) wi
 
         // subscribing to SelfUp when already removed yields nothing
         clusterNode2.subscriptions ! Subscribe(node2Probe.ref, classOf[SelfUp])
-        node2Probe.expectNoMsg(100.millis)
+        node2Probe.expectNoMessage(100.millis)
 
       } finally {
         Await.result(system2.terminate(), 3.seconds)

--- a/akka-testkit-typed/src/main/resources/reference.conf
+++ b/akka-testkit-typed/src/main/resources/reference.conf
@@ -11,8 +11,12 @@ akka.actor.typed.test {
   timefactor =  1.0
 
   # duration to wait in expectMsg and friends outside of within() block
-  # by default
+  # by default, will be dilated by the timefactor.
   single-expect-default = 3s
+
+  # duration to wait in expectNoMessage by default,
+  # will be dilated by the timefactor.
+  expect-no-message-default = 100ms
 
   # The timeout that is added as an implicit by DefaultTimeout trait
   default-timeout = 5s

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKitSettings.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKitSettings.scala
@@ -30,5 +30,6 @@ class TestKitSettings(val config: Config) {
   val TestTimeFactor = config.getDouble("akka.actor.typed.test.timefactor").
     requiring(tf ⇒ !tf.isInfinite && tf > 0, "akka.actor.typed.test.timefactor must be positive finite double")
   val SingleExpectDefaultTimeout: FiniteDuration = config.getMillisDuration("akka.actor.typed.test.single-expect-default")
+  val ExpectNoMessageDefaultTimeout: FiniteDuration = config.getMillisDuration("akka.actor.typed.test.expect-no-message-default")
   val DefaultTimeout: Timeout = Timeout(config.getMillisDuration("akka.actor.typed.test.default-timeout"))
 }

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
@@ -201,8 +201,9 @@ class TestProbe[M](name: String)(implicit val system: ActorSystem[_], val settin
 
   /**
    * Assert that no message is received for the specified time.
+   * Supplied value is not dilated.
    */
-  def expectNoMsg(max: FiniteDuration) { expectNoMsg_internal(max.dilated) }
+  def expectNoMessage(max: FiniteDuration) { expectNoMsg_internal(max) }
 
   private def expectNoMsg_internal(max: FiniteDuration) {
     val o = receiveOne(max)

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
@@ -205,6 +205,12 @@ class TestProbe[M](name: String)(implicit val system: ActorSystem[_], val settin
    */
   def expectNoMessage(max: FiniteDuration) { expectNoMsg_internal(max) }
 
+  /**
+   * Assert that no message is received. Waits for the default period configured as `akka.actor.typed.test.expect-no-message-default`
+   * That value is dilated.
+   */
+  def expectNoMessage() { expectNoMsg_internal(settings.ExpectNoMessageDefaultTimeout.dilated) }
+
   private def expectNoMsg_internal(max: FiniteDuration) {
     val o = receiveOne(max)
     assert(o == null, s"received unexpected message $o")

--- a/akka-testkit/src/main/resources/reference.conf
+++ b/akka-testkit/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ akka {
     filter-leeway = 3s
 
     # duration to wait in expectMsg and friends outside of within() block
-    # by default
+    # by default, will be dilated by the timefactor.
     single-expect-default = 3s
 
     # The timeout that is added as an implicit by DefaultTimeout trait


### PR DESCRIPTION
Interestingly most calls to expectNoMsg did not appear to expect the parameter
to be dilated

Might be nice to allow configuring a variant that uses a (configurable) default
delay (other than the single-expect-default)