### PR TITLE
#23695 Remove onSignal

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
@@ -42,13 +42,13 @@ object ClusterShardingPersistenceSpec {
     PersistentActor.persistentEntity[Command, String, String](
       persistenceIdFromActorName = name ⇒ "Test-" + name,
       initialState = "",
-      commandHandler = CommandHandler((_, state, cmd) ⇒ cmd match {
+      commandHandler = (_, state, cmd) ⇒ cmd match {
         case Add(s) ⇒ Effect.persist(s)
         case Get(replyTo) ⇒
           replyTo ! state
           Effect.none
         case StopPlz ⇒ Effect.stop
-      }),
+      },
       eventHandler = (state, evt) ⇒ if (state.isEmpty) evt else state + "|" + evt)
 
   val typeKey = EntityTypeKey[Command]("test")

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -40,13 +40,13 @@ object ClusterSingletonPersistenceSpec {
     PersistentActor.immutable[Command, String, String](
       persistenceId = "TheSingleton",
       initialState = "",
-      commandHandler = CommandHandler((_, state, cmd) ⇒ cmd match {
+      commandHandler = (_, state, cmd) ⇒ cmd match {
         case Add(s) ⇒ Effect.persist(s)
         case Get(replyTo) ⇒
           replyTo ! state
           Effect.none
         case StopPlz ⇒ Effect.stop
-      }),
+      },
       eventHandler = (state, evt) ⇒ if (state.isEmpty) evt else state + "|" + evt)
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentActorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentActorImpl.scala
@@ -80,15 +80,12 @@ import akka.actor.typed.internal.adapter.ActorRefAdapter
     case msg ⇒
       try {
         val effects = msg match {
-          case a.Terminated(ref) ⇒
-            val sig = Terminated(ActorRefAdapter(ref))(null)
-            commandHandler.sigHandler(state).applyOrElse((ctx, state, sig), unhandledSignal)
           case a.ReceiveTimeout ⇒
-            commandHandler.commandHandler(ctx, state, ctxAdapter.receiveTimeoutMsg)
-          // TODO note that PostStop and PreRestart signals are not handled, we wouldn't be able to persist there
+            commandHandler(ctx, state, ctxAdapter.receiveTimeoutMsg)
+          // TODO note that PostStop, PreRestart and Terminated signals are not handled, we wouldn't be able to persist there
           case cmd: C @unchecked ⇒
             // FIXME we could make it more safe by using ClassTag for C
-            commandHandler.commandHandler(ctx, state, cmd)
+            commandHandler(ctx, state, cmd)
         }
 
         applyEffects(msg, effects)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -29,13 +29,13 @@ object PersistentActorCompileOnlyTest {
 
     //#command-handler
     val commandHandler: CommandHandler[SimpleCommand, SimpleEvent, ExampleState] =
-      CommandHandler.byCommand {
+      CommandHandler.command {
         case Cmd(data) ⇒ Effect.persist(Evt(data))
       }
     //#command-handler
 
     //#event-handler
-    val eventHandler: EventHandler[ExampleState, SimpleEvent] = {
+    val eventHandler: (ExampleState, SimpleEvent) ⇒ (ExampleState) = {
       case (state, Evt(data)) ⇒ state.copy(data :: state.events)
     }
     //#event-handler
@@ -67,7 +67,7 @@ object PersistentActorCompileOnlyTest {
 
       initialState = ExampleState(Nil),
 
-      commandHandler = CommandHandler.byCommand {
+      commandHandler = CommandHandler.command {
         case Cmd(data, sender) ⇒
           Effect.persist(Evt(data))
             .andThen {
@@ -153,13 +153,13 @@ object PersistentActorCompileOnlyTest {
       persistenceId = "myPersistenceId",
       initialState = Happy,
       commandHandler = CommandHandler.byState {
-        case Happy ⇒ CommandHandler.byCommand {
+        case Happy ⇒ CommandHandler.command {
           case Greet(whom) ⇒
             println(s"Super happy to meet you $whom!")
             Effect.none
           case MoodSwing ⇒ Effect.persist(MoodChanged(Sad))
         }
-        case Sad ⇒ CommandHandler.byCommand {
+        case Sad ⇒ CommandHandler.command {
           case Greet(whom) ⇒
             println(s"hi $whom")
             Effect.none
@@ -193,7 +193,7 @@ object PersistentActorCompileOnlyTest {
     PersistentActor.immutable[Command, Event, State](
       persistenceId = "asdf",
       initialState = State(Nil),
-      commandHandler = CommandHandler.byCommand {
+      commandHandler = CommandHandler.command {
         case RegisterTask(task) ⇒ Effect.persist(TaskRegistered(task))
         case TaskDone(task)     ⇒ Effect.persist(TaskRemoved(task))
       },
@@ -381,7 +381,7 @@ object PersistentActorCompileOnlyTest {
     PersistentActor.immutable[Command, Event, State](
       persistenceId = "myPersistenceId",
       initialState = new State,
-      commandHandler = CommandHandler.byCommand {
+      commandHandler = CommandHandler.command {
         case Enough ⇒
           Effect.persist(Done)
             .andThen(println("yay"))

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -29,13 +29,13 @@ object PersistentActorCompileOnlyTest {
 
     //#command-handler
     val commandHandler: CommandHandler[SimpleCommand, SimpleEvent, ExampleState] =
-      CommandHandler.command {
+      CommandHandler.byCommand {
         case Cmd(data) ⇒ Effect.persist(Evt(data))
       }
     //#command-handler
 
     //#event-handler
-    val eventHandler: (ExampleState, SimpleEvent) ⇒ (ExampleState) = {
+    val eventHandler: EventHandler[ExampleState, SimpleEvent] = {
       case (state, Evt(data)) ⇒ state.copy(data :: state.events)
     }
     //#event-handler
@@ -67,7 +67,7 @@ object PersistentActorCompileOnlyTest {
 
       initialState = ExampleState(Nil),
 
-      commandHandler = CommandHandler.command {
+      commandHandler = CommandHandler.byCommand {
         case Cmd(data, sender) ⇒
           Effect.persist(Evt(data))
             .andThen {
@@ -111,14 +111,14 @@ object PersistentActorCompileOnlyTest {
 
       initialState = EventsInFlight(0, Map.empty),
 
-      commandHandler = CommandHandler((ctx, state, cmd) ⇒ cmd match {
+      commandHandler = (ctx, state, cmd) ⇒ cmd match {
         case DoSideEffect(data) ⇒
           Effect.persist(IntentRecorded(state.nextCorrelationId, data)).andThen {
             performSideEffect(ctx.self, state.nextCorrelationId, data)
           }
         case AcknowledgeSideEffect(correlationId) ⇒
           Effect.persist(SideEffectAcknowledged(correlationId))
-      }),
+      },
 
       eventHandler = (state, evt) ⇒ evt match {
         case IntentRecorded(correlationId, data) ⇒
@@ -153,13 +153,13 @@ object PersistentActorCompileOnlyTest {
       persistenceId = "myPersistenceId",
       initialState = Happy,
       commandHandler = CommandHandler.byState {
-        case Happy ⇒ CommandHandler.command {
+        case Happy ⇒ CommandHandler.byCommand {
           case Greet(whom) ⇒
             println(s"Super happy to meet you $whom!")
             Effect.none
           case MoodSwing ⇒ Effect.persist(MoodChanged(Sad))
         }
-        case Sad ⇒ CommandHandler.command {
+        case Sad ⇒ CommandHandler.byCommand {
           case Greet(whom) ⇒
             println(s"hi $whom")
             Effect.none
@@ -193,7 +193,7 @@ object PersistentActorCompileOnlyTest {
     PersistentActor.immutable[Command, Event, State](
       persistenceId = "asdf",
       initialState = State(Nil),
-      commandHandler = CommandHandler.command {
+      commandHandler = CommandHandler.byCommand {
         case RegisterTask(task) ⇒ Effect.persist(TaskRegistered(task))
         case TaskDone(task)     ⇒ Effect.persist(TaskRemoved(task))
       },
@@ -220,7 +220,7 @@ object PersistentActorCompileOnlyTest {
     PersistentActor.immutable[Command, Event, State](
       persistenceId = "asdf",
       initialState = State(Nil),
-      commandHandler = CommandHandler((ctx, _, cmd) ⇒ cmd match {
+      commandHandler = (ctx, _, cmd) ⇒ cmd match {
         case RegisterTask(task) ⇒
           Effect.persist(TaskRegistered(task))
             .andThen {
@@ -229,42 +229,6 @@ object PersistentActorCompileOnlyTest {
               ctx.watchWith(child, TaskDone(task))
             }
         case TaskDone(task) ⇒ Effect.persist(TaskRemoved(task))
-      }),
-      eventHandler = (state, evt) ⇒ evt match {
-        case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
-        case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
-      })
-  }
-
-  object UsingSignals {
-    type Task = String
-    case class RegisterTask(task: Task)
-
-    sealed trait Event
-    case class TaskRegistered(task: Task) extends Event
-    case class TaskRemoved(task: Task) extends Event
-
-    case class State(tasksInFlight: List[Task])
-
-    def worker(task: Task): Behavior[Nothing] = ???
-
-    PersistentActor.immutable[RegisterTask, Event, State](
-      persistenceId = "asdf",
-      initialState = State(Nil),
-      // The 'onSignal' seems to break type inference here.. not sure if that can be avoided?
-      commandHandler = CommandHandler[RegisterTask, Event, State]((ctx, state, cmd) ⇒ cmd match {
-        case RegisterTask(task) ⇒ Effect.persist(TaskRegistered(task))
-          .andThen {
-            val child = ctx.spawn[Nothing](worker(task), task)
-            // This assumes *any* termination of the child may trigger a `TaskDone`:
-            ctx.watch(child)
-          }
-      }).onSignal {
-        case (ctx, _, Terminated(actorRef)) ⇒
-          // watchWith (as in the above example) is nicer because it means we don't have to
-          // 'manually' associate the task and the child actor, but we wanted to demonstrate
-          // signals here:
-          Effect.persist(TaskRemoved(actorRef.path.name))
       },
       eventHandler = (state, evt) ⇒ evt match {
         case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
@@ -321,7 +285,7 @@ object PersistentActorCompileOnlyTest {
         initialState = Nil,
         commandHandler =
           CommandHandler.byState(state ⇒
-            if (isFullyHydrated(basket, state)) CommandHandler { (ctx, state, cmd) ⇒
+            if (isFullyHydrated(basket, state)) (ctx, state, cmd) ⇒
               cmd match {
                 case AddItem(id)    ⇒ addItem(id, ctx.self)
                 case RemoveItem(id) ⇒ Effect.persist(ItemRemoved(id))
@@ -332,8 +296,7 @@ object PersistentActorCompileOnlyTest {
                   sender ! basket.items.map(_.price).sum
                   Effect.none
               }
-            }
-            else CommandHandler { (ctx, state, cmd) ⇒
+            else (ctx, state, cmd) ⇒
               cmd match {
                 case AddItem(id)    ⇒ addItem(id, ctx.self)
                 case RemoveItem(id) ⇒ Effect.persist(ItemRemoved(id))
@@ -348,7 +311,7 @@ object PersistentActorCompileOnlyTest {
                   stash :+= cmd
                   Effect.none
               }
-            }),
+          ),
         eventHandler = (state, evt) ⇒ evt match {
           case ItemAdded(id)   ⇒ id +: state
           case ItemRemoved(id) ⇒ state.filter(_ != id)
@@ -382,7 +345,7 @@ object PersistentActorCompileOnlyTest {
     PersistentActor.immutable[Command, Event, Mood](
       persistenceId = "myPersistenceId",
       initialState = Sad,
-      commandHandler = CommandHandler { (_, state, cmd) ⇒
+      commandHandler = (_, state, cmd) ⇒
         cmd match {
           case Greet(whom) ⇒
             println(s"Hi there, I'm $state!")
@@ -398,8 +361,7 @@ object PersistentActorCompileOnlyTest {
             val commonEffects = changeMoodIfNeeded(state, Happy)
             Effect.persist(commonEffects.events :+ Remembered(memory), commonEffects.sideEffects)
 
-        }
-      },
+        },
       eventHandler = {
         case (_, MoodChanged(to))   ⇒ to
         case (state, Remembered(_)) ⇒ state
@@ -419,7 +381,7 @@ object PersistentActorCompileOnlyTest {
     PersistentActor.immutable[Command, Event, State](
       persistenceId = "myPersistenceId",
       initialState = new State,
-      commandHandler = CommandHandler.command {
+      commandHandler = CommandHandler.byCommand {
         case Enough ⇒
           Effect.persist(Done)
             .andThen(println("yay"))

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentActorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentActorSpec.scala
@@ -17,7 +17,7 @@ object BasicPersistentActorSpec {
     PersistentActor.immutable[Command, Event, State](
       persistenceId = "abc",
       initialState = State(),
-      commandHandler = PersistentActor.CommandHandler { (ctx, state, cmd) ⇒ ??? },
+      commandHandler = (ctx, state, cmd) ⇒ ???,
       eventHandler = (state, evt) ⇒ ???)
   //#structure
 
@@ -26,7 +26,7 @@ object BasicPersistentActorSpec {
     PersistentActor.immutable[Command, Event, State](
       persistenceId = "abc",
       initialState = State(),
-      commandHandler = PersistentActor.CommandHandler { (ctx, state, cmd) ⇒ ??? },
+      commandHandler = (ctx, state, cmd) ⇒ ???,
       eventHandler = (state, evt) ⇒ ???)
       .onRecoveryCompleted { (ctx, state) ⇒
         ???

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala
@@ -51,7 +51,7 @@ object InDepthPersistentActorSpec {
 
   //#initial-command-handler
   private def initial: CommandHandler[BlogCommand, BlogEvent, BlogState] =
-    CommandHandler { (ctx, state, cmd) ⇒
+    (ctx, state, cmd) ⇒
       cmd match {
         case AddPost(content, replyTo) ⇒
           val evt = PostAdded(content.postId, content)
@@ -64,12 +64,11 @@ object InDepthPersistentActorSpec {
         case _ ⇒
           Effect.unhandled
       }
-    }
   //#initial-command-handler
 
   //#post-added-command-handler
   private def postAdded: CommandHandler[BlogCommand, BlogEvent, BlogState] = {
-    CommandHandler { (ctx, state, cmd) ⇒
+    (ctx, state, cmd) ⇒
       cmd match {
         case ChangeBody(newBody, replyTo) ⇒
           val evt = BodyChanged(state.postId, newBody)
@@ -89,7 +88,6 @@ object InDepthPersistentActorSpec {
         case PassivatePost ⇒
           Effect.stop
       }
-    }
   }
   //#post-added-command-handler
 


### PR DESCRIPTION
Cleans things up a bit. Also `CommandHandler` now is a type alias to a function.

Refs #23695