### PR TITLE
=doc Fix dangling `@@@` in howto docs #23516

### DIFF
--- a/akka-docs/src/main/paradox/howto.md
+++ b/akka-docs/src/main/paradox/howto.md
@@ -124,6 +124,8 @@ The pattern is described [Discovering Message Flows in Actor System with the Spi
 
 See @ref:[Actor Timers](actors.md#actors-timers)
 
+@@@ div { .group-java }
+
 ## Single-Use Actor Trees with High-Level Error Reporting
 
 *Contributed by: Rick Latrine*


### PR DESCRIPTION
Refs: #23516
Last Java pattern was shown for both Java and Scala.