### PR TITLE
Update LevelDB

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -116,7 +116,7 @@ object Dependencies {
       // If changed, update akka-docs/build.sbt as well
       val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test" // ApacheV2
 
-      val levelDB = "org.iq80.leveldb" % "leveldb" % "0.9" % "optional;provided" // ApacheV2
+      val levelDB = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided" // ApacheV2
       val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided" // New BSD
     }
 


### PR DESCRIPTION
Refs #23907

The latest version can work with jdk9, previous versions
touched jdk.internal.ref.Cleaner which is no longer allowed
on jdk9.