### PR TITLE
Delay typed guardian init

### DIFF
--- a/akka-actor-typed-tests/src/test/resources/application.conf
+++ b/akka-actor-typed-tests/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-akka.loglevel = DEBUG
+akka.loglevel = INFO
 akka.actor.debug.lifecycle = off
 
 dispatcher-1 {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -54,7 +54,6 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     // see issue #24172
     "shutdown if guardian shuts down immediately" in {
-      pending
       withSystem("shutdown", Behaviors.stopped[String], doTerminate = false) { sys: ActorSystem[String] ⇒
         sys.whenTerminated.futureValue
       }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/DelayedStartSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/DelayedStartSpec.scala
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.actor.typed.internal
+
+import akka.actor.typed.{ ActorRef, PostStop, Signal, Terminated, TypedAkkaSpec }
+import akka.actor.typed.scaladsl.Behaviors
+import akka.testkit.typed.TestKit
+import akka.testkit.typed.scaladsl.TestProbe
+
+import scala.concurrent.duration._
+
+class DelayedStartSpec extends TestKit with TypedAkkaSpec {
+
+  case class GotSignal(signal: Signal)
+  def delayedBehavior(probe: ActorRef[AnyRef]) = DelayedStart.delayStart[AnyRef](Behaviors.deferred { ctx ⇒
+    probe ! "delayed-init"
+
+    Behaviors.immutable[AnyRef] { (ctx, msg) ⇒
+
+      msg match {
+        case "switch" ⇒
+          Behaviors.deferred { ctx ⇒
+            probe ! "switching"
+            Behaviors.immutable { (ctx, msg) ⇒
+              probe ! (msg + "-switched")
+              Behaviors.same
+            }
+          }
+        case "stop" ⇒
+          probe ! "stopping"
+          Behaviors.stopped
+
+        case other ⇒
+          probe ! other
+          Behaviors.same
+      }
+    }
+  })
+
+  "The delayed start behavior" should {
+
+    "delay message passing until told to start delayed behavior" in {
+
+      val probe = TestProbe[AnyRef]()
+      val delayed = spawn(delayedBehavior(probe.ref))
+
+      delayed ! "message1"
+      delayed ! "switch"
+      delayed ! "message2"
+
+      probe.expectNoMessage(200.millis)
+
+      delayed ! DelayedStart.Start
+      probe.expectMsg("delayed-init")
+      probe.expectMsg("message1")
+      probe.expectMsg("switching")
+      probe.expectMsg("message2-switched")
+    }
+
+    "delay stopping" in {
+      val probe = TestProbe[AnyRef]()
+      val delayed = spawn(delayedBehavior(probe.ref))
+      // FIXME missing a watch in typed testprobe
+      val watcher = spawn(Behaviors.deferred[AnyRef] { ctx ⇒
+        ctx.watch(delayed)
+        probe.ref ! "watching"
+        Behaviors.onSignal {
+          case (_, s) ⇒
+            probe.ref ! GotSignal(s)
+            Behaviors.same
+        }
+      })
+
+      probe.expectMsg("watching")
+      delayed ! "message1"
+      delayed ! "stop"
+      probe.expectNoMessage(200.millis)
+
+      delayed ! DelayedStart.Start
+      probe.expectMsg("delayed-init")
+      probe.expectMsg("message1")
+      probe.expectMsg("stopping")
+      probe.expectMsgType[GotSignal].signal shouldBe a[Terminated]
+    }
+
+    "handle immediately stopping on start" in {
+      val probe = TestProbe[AnyRef]()
+      val delayed = spawn(DelayedStart.delayStart(Behaviors.stopped))
+      val watcher = spawn(Behaviors.deferred[AnyRef] { ctx ⇒
+        ctx.watch(delayed)
+        probe.ref ! "watching"
+        Behaviors.onSignal {
+          case (_, s) ⇒
+            probe.ref ! GotSignal(s)
+            Behaviors.same
+        }
+      })
+      probe.expectMsg("watching")
+      probe.expectNoMessage(200.millis)
+      delayed ! DelayedStart.Start
+      probe.expectMsgType[GotSignal].signal shouldBe a[Terminated]
+    }
+
+    "handle deferred stopping on start" in {
+      val probe = TestProbe[AnyRef]()
+      val delayed = spawn(DelayedStart.delayStart[AnyRef](Behaviors.deferred { ctx ⇒
+        probe.ref ! "stopping"
+        Behaviors.stopped
+      }))
+      val watcher = spawn(Behaviors.deferred[AnyRef] { ctx ⇒
+        ctx.watch(delayed)
+        probe.ref ! "watching"
+        Behaviors.onSignal {
+          case (_, s) ⇒
+            probe.ref ! GotSignal(s)
+            Behaviors.same
+        }
+      })
+      probe.expectMsg("watching")
+      delayed ! DelayedStart.Start
+      probe.expectMsg("stopping")
+      probe.expectMsgType[GotSignal].signal shouldBe a[Terminated]
+    }
+
+  }
+
+}

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
@@ -5,14 +5,14 @@ package akka.actor.typed.scaladsl.adapter
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-import akka.actor.typed.ActorRef
-import akka.actor.{ InvalidMessageException, Props }
-import akka.actor.typed.Behavior
-import akka.actor.typed.Terminated
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Terminated}
+import akka.actor.{InvalidMessageException, Props}
 import akka.actor.typed.scaladsl.Behaviors
-import akka.{ actor ⇒ untyped }
+import akka.{Done, NotUsed, actor => untyped}
 import akka.testkit._
 import akka.actor.typed.Behavior.UntypedBehavior
+
+import scala.concurrent.Await
 
 object AdapterSpec {
   val untyped1: untyped.Props = untyped.Props(new Untyped1)
@@ -156,6 +156,36 @@ class AdapterSpec extends AkkaSpec {
       val typed2 = system.toTyped
 
       typed1 should be theSameInstanceAs typed2
+    }
+
+    "not crash if guardian is stopped" in {
+      for { _ ← 0 to 10 } {
+        var system: akka.actor.typed.ActorSystem[NotUsed] = null
+        try {
+          system = ActorSystem.create(Behavior.stopped[NotUsed], "AdapterSpec-stopping-guardian")
+
+        } finally {
+          if (system != null) Await.result(system.terminate(), remainingOrDefault)
+        }
+      }
+    }
+
+    "not crash if guardian is stopped very quickly" in {
+      for { _ ← 0 to 10 } {
+        var system: akka.actor.typed.ActorSystem[Done] = null
+        try {
+          system = ActorSystem.create(Behaviors.immutable[Done] { (ctx, msg) ⇒
+            ctx.self ! Done
+            msg match {
+              case Done ⇒ Behaviors.stopped
+            }
+
+          }, "AdapterSpec-stopping-guardian-2")
+
+        } finally {
+          if (system != null) Await.result(system.terminate(), remainingOrDefault)
+        }
+      }
     }
   }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
@@ -5,10 +5,10 @@ package akka.actor.typed.scaladsl.adapter
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Terminated}
-import akka.actor.{InvalidMessageException, Props}
+import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Terminated }
+import akka.actor.{ InvalidMessageException, Props }
 import akka.actor.typed.scaladsl.Behaviors
-import akka.{Done, NotUsed, actor => untyped}
+import akka.{ Done, NotUsed, actor ⇒ untyped }
 import akka.testkit._
 import akka.actor.typed.Behavior.UntypedBehavior
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -8,11 +8,13 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import akka.NotUsed
+import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Terminated }
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Terminated}
 import akka.testkit.typed.TestKit
 
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 //#imports

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -8,13 +8,11 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import akka.NotUsed
-import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Terminated }
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Terminated}
 import akka.testkit.typed.TestKit
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 //#imports

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -10,11 +10,11 @@ import java.nio.charset.StandardCharsets
 import akka.NotUsed
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Terminated}
+import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Terminated }
 import akka.testkit.typed.TestKit
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 //#imports
 
 import akka.actor.typed.TypedAkkaSpecWithShutdown

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -7,16 +7,14 @@ package docs.akka.typed
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-import akka.actor.typed.ActorRef
-import akka.actor.typed.ActorSystem
-import akka.actor.typed.Behavior
-import akka.actor.typed.Terminated
+import akka.NotUsed
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Terminated}
 import akka.testkit.typed.TestKit
-import scala.concurrent.Await
-import scala.concurrent.Future
+
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 //#imports
 
 import akka.actor.typed.TypedAkkaSpecWithShutdown
@@ -107,7 +105,7 @@ class IntroSpec extends TestKit with TypedAkkaSpecWithShutdown {
   import IntroSpec._
 
   "Hello world" must {
-    "must say hello" in {
+    "say hello" in {
       // TODO Implicits.global is not something we would like to encourage in docs
       //#hello-world
       import HelloWorld._
@@ -128,7 +126,7 @@ class IntroSpec extends TestKit with TypedAkkaSpecWithShutdown {
       //#hello-world
     }
 
-    "must chat" in {
+    "chat" in {
       //#chatroom-gabbler
       import ChatRoom._
 
@@ -152,24 +150,20 @@ class IntroSpec extends TestKit with TypedAkkaSpecWithShutdown {
       //#chatroom-gabbler
 
       //#chatroom-main
-      val main: Behavior[String] =
+      val main: Behavior[NotUsed] =
         Behaviors.deferred { ctx ⇒
           val chatRoom = ctx.spawn(ChatRoom.behavior, "chatroom")
           val gabblerRef = ctx.spawn(gabbler, "gabbler")
           ctx.watch(gabblerRef)
+          chatRoom ! GetSession("ol’ Gabbler", gabblerRef)
 
-          Behaviors.immutablePartial[String] {
-            case (_, "go") ⇒
-              chatRoom ! GetSession("ol’ Gabbler", gabblerRef)
-              Behaviors.same
-          } onSignal {
+          Behaviors.onSignal {
             case (_, Terminated(ref)) ⇒
               Behaviors.stopped
           }
         }
 
       val system = ActorSystem(main, "ChatRoomDemo")
-      system ! "go"
       Await.result(system.whenTerminated, 3.seconds)
       //#chatroom-main
     }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -322,15 +322,21 @@ object Behavior {
   @InternalApi private[akka] def interpretMessages[T](behavior: Behavior[T], ctx: ActorContext[T], messages: Iterator[T]): Behavior[T] = {
     @tailrec def interpretOne(b: Behavior[T]): Behavior[T] = {
       val b2 = Behavior.undefer(b, ctx)
-      if (!Behavior.isAlive(b2) || !messages.hasNext) b2
+      if (!messages.hasNext) b2
       else {
-        val nextB = messages.next() match {
-          case sig: Signal ⇒
-            Behavior.interpretSignal(b2, ctx, sig)
-          case msg ⇒
-            Behavior.interpretMessage(b2, ctx, msg)
+        val nextMsg = messages.next()
+        if (!Behavior.isAlive(b2)) {
+          if (nextMsg == PostStop) Behavior.interpretSignal(b2, ctx, PostStop)
+          b2
+        } else {
+          val nextB = nextMsg match {
+            case sig: Signal ⇒
+              Behavior.interpretSignal(b2, ctx, sig)
+            case msg ⇒
+              Behavior.interpretMessage(b2, ctx, msg)
+          }
+          interpretOne(Behavior.canonicalize(nextB, b, ctx)) // recursive
         }
-        interpretOne(Behavior.canonicalize(nextB, b, ctx)) // recursive
       }
     }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.actor.typed.internal
+
+import akka.actor.typed.{ ActorContext, Behavior, Signal, scaladsl }
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ *
+ * A behavior that wraps another behavior, stashing all incoming messages and signals until
+ * it is sent the `Start` message, it then unstashes all messages and signals and switches to the delayedBehavior
+ */
+@InternalApi
+private[akka] object DelayedStart {
+
+  case object Start
+
+  // FIXME use the stash buffer when that is merged #22275
+  def delayStart[T](delayedBehavior: Behavior[T], buffer: List[Any] = Nil): Behavior[Any] =
+    scaladsl.Behaviors.immutable[Any] { (sctx, msg) ⇒
+      // delay actual initialization until the actor system is started as the actor may touch
+      // other parts of the actor system which would not be ready unless delayed
+      val ctx = sctx.asInstanceOf[ActorContext[T]]
+      msg match {
+        case Start ⇒
+          val endState = buffer.reverseIterator.foldLeft(Behavior.undefer(delayedBehavior, ctx)) { (behavior, buffered) ⇒
+            if (Behavior.isAlive(behavior)) {
+              // delayed application of signals and messages in the order they arrived
+              val newBehavior = buffered match {
+                case s: Signal ⇒
+                  Behavior.interpretSignal(behavior, ctx.asInstanceOf[ActorContext[T]], s)
+                case other ⇒
+                  Behavior.interpretMessage(behavior, ctx, other.asInstanceOf[T])
+              }
+              Behavior.canonicalize(newBehavior, behavior, ctx)
+            } else behavior
+          }
+          endState.asInstanceOf[Behavior[Any]]
+        case t ⇒
+          delayStart(delayedBehavior, t :: buffer)
+      }
+    }.onSignal {
+      case (_, signal) ⇒
+        delayStart(delayedBehavior, signal :: buffer)
+    }
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
@@ -4,7 +4,7 @@
 package akka.actor.typed.internal
 
 import akka.actor.typed.scaladsl.MutableStashBuffer
-import akka.actor.typed.{Behavior, scaladsl}
+import akka.actor.typed.{ Behavior, scaladsl }
 import akka.annotation.InternalApi
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
@@ -17,7 +17,7 @@ private[akka] object DelayedStart {
 
   case object Start
 
-  // FIXME use the stash buffer when that is merged #22275
+  // note that we cannot use StashBuffer here as we need to buffer signals as well as messages
   def delayStart[T](delayedBehavior: Behavior[T], buffer: List[Any] = Nil): Behavior[Any] =
     scaladsl.Behaviors.immutable[Any] { (sctx, msg) ⇒
       // delay actual initialization until the actor system is started as the actor may touch

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
@@ -18,10 +18,9 @@ private[akka] object DelayedStart {
 
   case object Start
 
-  // note that we cannot use StashBuffer here as we need to buffer signals as well as messages
   def delayStart[T](delayedBehavior: Behavior[T]): Behavior[Any] =
     scaladsl.Behaviors.deferred[Any] { _ ⇒
-      val buffer = MutableStashBuffer[Any](100)
+      val buffer = MutableStashBuffer[Any](1000)
 
       scaladsl.Behaviors.immutable[Any] { (sctx, msg) ⇒
         // delay actual initialization until the actor system is started as the actor may touch
@@ -30,7 +29,7 @@ private[akka] object DelayedStart {
           case Start ⇒
             buffer.unstashAll(sctx, delayedBehavior.asInstanceOf[Behavior[Any]])
           case t ⇒
-            buffer.stash(t)
+            if (!buffer.isFull) buffer.stash(t)
             Behavior.same
         }
       }.onSignal {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/DelayedStart.scala
@@ -3,7 +3,8 @@
  */
 package akka.actor.typed.internal
 
-import akka.actor.typed.{ ActorContext, Behavior, Signal, scaladsl }
+import akka.actor.typed.scaladsl.MutableStashBuffer
+import akka.actor.typed.{Behavior, scaladsl}
 import akka.annotation.InternalApi
 
 /**
@@ -18,32 +19,25 @@ private[akka] object DelayedStart {
   case object Start
 
   // note that we cannot use StashBuffer here as we need to buffer signals as well as messages
-  def delayStart[T](delayedBehavior: Behavior[T], buffer: List[Any] = Nil): Behavior[Any] =
-    scaladsl.Behaviors.immutable[Any] { (sctx, msg) ⇒
-      // delay actual initialization until the actor system is started as the actor may touch
-      // other parts of the actor system which would not be ready unless delayed
-      val ctx = sctx.asInstanceOf[ActorContext[T]]
-      msg match {
-        case Start ⇒
-          val endState = buffer.reverseIterator.foldLeft(Behavior.undefer(delayedBehavior, ctx)) { (behavior, buffered) ⇒
-            if (Behavior.isAlive(behavior)) {
-              // delayed application of signals and messages in the order they arrived
-              val newBehavior = buffered match {
-                case s: Signal ⇒
-                  Behavior.interpretSignal(behavior, ctx.asInstanceOf[ActorContext[T]], s)
-                case other ⇒
-                  Behavior.interpretMessage(behavior, ctx, other.asInstanceOf[T])
-              }
-              Behavior.canonicalize(newBehavior, behavior, ctx)
-            } else behavior
-          }
-          endState.asInstanceOf[Behavior[Any]]
-        case t ⇒
-          delayStart(delayedBehavior, t :: buffer)
+  def delayStart[T](delayedBehavior: Behavior[T]): Behavior[Any] =
+    scaladsl.Behaviors.deferred[Any] { _ ⇒
+      val buffer = MutableStashBuffer[Any](100)
+
+      scaladsl.Behaviors.immutable[Any] { (sctx, msg) ⇒
+        // delay actual initialization until the actor system is started as the actor may touch
+        // other parts of the actor system which would not be ready unless delayed
+        msg match {
+          case Start ⇒
+            buffer.unstashAll(sctx, delayedBehavior.asInstanceOf[Behavior[Any]])
+          case t ⇒
+            buffer.stash(t)
+            Behavior.same
+        }
+      }.onSignal {
+        case (_, signal) ⇒
+          buffer.stash(signal)
+          Behavior.same
       }
-    }.onSignal {
-      case (_, signal) ⇒
-        delayStart(delayedBehavior, signal :: buffer)
     }
 
 }

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -24,6 +24,7 @@ import scala.util.control.{ ControlThrowable, NonFatal }
 import java.util.Optional
 
 import akka.actor.setup.{ ActorSystemSetup, Setup }
+import akka.annotation.InternalApi
 
 import scala.compat.java8.FutureConverters
 import scala.compat.java8.OptionConverters._
@@ -643,6 +644,10 @@ abstract class ExtendedActorSystem extends ActorSystem {
 
 }
 
+/**
+ * Internal API
+ */
+@InternalApi
 private[akka] class ActorSystemImpl(
   val name:                String,
   applicationConfig:       Config,

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
@@ -10,11 +10,15 @@ import akka.cluster.typed.*;
 import akka.testkit.typed.javadsl.TestProbe;
 import docs.akka.cluster.typed.BasicClusterManualSpec;
 
-//FIXME make these tests
-public class BasicClusterExampleTest {
+// FIXME these tests are awaiting typed Java testkit to be able to await cluster forming like in BasicClusterExampleSpec
+public class BasicClusterExampleTest { // extends JUnitSuite {
+
+  // @Test
   public void clusterApiExample() {
-    ActorSystem<Object> system = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
-    ActorSystem<Object> system2 = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system = ActorSystem.create(Behaviors.empty(), "ClusterSystem",
+        BasicClusterManualSpec.noPort().withFallback(BasicClusterManualSpec.clusterConfig()));
+    ActorSystem<Object> system2 = ActorSystem.create(Behaviors.empty(), "ClusterSystem",
+        BasicClusterManualSpec.noPort().withFallback(BasicClusterManualSpec.clusterConfig()));
 
     try {
       //#cluster-create
@@ -26,18 +30,28 @@ public class BasicClusterExampleTest {
       cluster.manager().tell(Join.create(cluster.selfMember().address()));
       //#cluster-join
 
+      cluster2.manager().tell(Join.create(cluster.selfMember().address()));
+
+      // TODO wait for/verify cluster to form
+
       //#cluster-leave
       cluster2.manager().tell(Leave.create(cluster2.selfMember().address()));
       //#cluster-leave
+
+      // TODO wait for/verify node 2 leaving
+
     } finally {
       system.terminate();
       system2.terminate();
     }
   }
 
+  // @Test
   public void clusterLeave() throws Exception {
-    ActorSystem<Object> system = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
-    ActorSystem<Object> system2 = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system = ActorSystem.create(Behaviors.empty(), "ClusterSystem",
+        BasicClusterManualSpec.noPort().withFallback(BasicClusterManualSpec.clusterConfig()));
+    ActorSystem<Object> system2 = ActorSystem.create(Behaviors.empty(), "ClusterSystem",
+        BasicClusterManualSpec.noPort().withFallback(BasicClusterManualSpec.clusterConfig()));
 
     try {
       Cluster cluster = Cluster.get(system);

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
@@ -6,12 +6,14 @@ import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.actor.typed.receptionist.Receptionist;
 import akka.actor.typed.receptionist.ServiceKey;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
 import java.util.concurrent.TimeUnit;
 
-public class ReceptionistExampleTest {
+public class ReceptionistExampleTest extends JUnitSuite {
 
   public static class PingPongExample {
     //#ping-service
@@ -68,6 +70,7 @@ public class ReceptionistExampleTest {
     //#pinger-guardian
   }
 
+  @Test
   public void workPlease() throws Exception {
     ActorSystem<Receptionist.Listing<PingPongExample.Ping>> system =
       ActorSystem.create(PingPongExample.guardian(), "ReceptionistExample");

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
@@ -197,16 +197,11 @@ class ReceptionistExampleSpec extends WordSpec with ScalaFutures {
 
   "A remote basic example" must {
     "show register" in {
-      // FIXME cannot use guardian as it touches receptionist #24279
-      import scaladsl.adapter._
-      val system1 = akka.actor.ActorSystem("PingPongExample", clusterConfig)
-      val system2 = akka.actor.ActorSystem("PingPongExample", clusterConfig)
+      val system1 = ActorSystem(guardianJustPingService, "PingPongExample", clusterConfig)
+      val system2 = ActorSystem(guardianJustPinger, "PingPongExample", clusterConfig)
 
-      system1.spawnAnonymous(guardianJustPingService)
-      system2.spawnAnonymous(guardianJustPinger)
-
-      val cluster1 = Cluster(system1.toTyped)
-      val cluster2 = Cluster(system2.toTyped)
+      val cluster1 = Cluster(system1)
+      val cluster2 = Cluster(system2)
 
       cluster1.manager ! Join(cluster1.selfMember.address)
       cluster1.manager ! Join(cluster2.selfMember.address)


### PR DESCRIPTION
This seem to also fix the init race, without modifying untyped. Fixes #24172 and #24279 

Haven't tried if it fixes the remoting crash yet, will do that next.