### PR TITLE
WIP: separate onResponse handler, alternative to spawnAdapter, #23770

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -63,6 +63,7 @@ object IntroSpec {
       Behaviors.immutable[Command] { (ctx, msg) ⇒
         msg match {
           case GetSession(screenName, client) ⇒
+            // FIXME resource leak of spawnAdapter like this, use ask instead since we need the screenName
             val wrapper = ctx.spawnAdapter {
               p: PostMessage ⇒ PostSessionMessage(screenName, p.message)
             }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -19,6 +19,7 @@ import akka.actor.typed.Behavior.UntypedBehavior
   import ActorRefAdapter.toUntyped
 
   override def self = ActorRefAdapter(untyped.self)
+  override def responseRef[R](responseClass: Class[R]): ActorRef[R] = self.asInstanceOf[ActorRef[R]]
   override val system = ActorSystemAdapter(untyped.system)
   override def mailboxCapacity = 1 << 29 // FIXME
   override def children = untyped.children.map(ActorRefAdapter(_))

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -45,6 +45,17 @@ trait ActorContext[T] { this: akka.actor.typed.javadsl.ActorContext[T] ⇒
   def self: ActorRef[T]
 
   /**
+   * In interactions with other actors the response messages that don't conform
+   * to this actor's type `T` can be handled by the defined response handlers,
+   * e.g. with `onResponse` of `Actor.immutable`. For that purpose the type of the
+   * [[ActorContext#self]] can be adjusted to a given response message type.
+   *
+   * Note that there is no compile time verification that a response handler
+   * has been defined for `R`.
+   */
+  def responseRef[R](responseClass: Class[R]): ActorRef[R]
+
+  /**
    * Return the mailbox capacity that was configured by the parent for this actor.
    */
   def mailboxCapacity: Int

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -186,6 +186,14 @@ object Behaviors {
 
     def onSignal(onSignal: PartialFunction[(ActorContext[T], Signal), Behavior[T]]): Behavior[T] =
       new BehaviorImpl.ImmutableBehavior(onMessage, onSignal)
+
+    def onResponse[M: ClassTag](handler: (ActorContext[T], M) ⇒ Behavior[T]): Immutable[T] = {
+      val x: (ActorContext[T], Any) ⇒ Behavior[T] = (ctx, msg) ⇒ msg match {
+        case m: M ⇒ handler(ctx, m)
+        case _    ⇒ onMessage(ctx, msg.asInstanceOf[T])
+      }
+      new Immutable[T](x.asInstanceOf[(ActorContext[T], T) ⇒ Behavior[T]])
+    }
   }
 
   /**

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -34,59 +34,47 @@ object ReplicatorSpec {
   final case object Increment extends ClientCommand
   final case class GetValue(replyTo: ActorRef[Int]) extends ClientCommand
   final case class GetCachedValue(replyTo: ActorRef[Int]) extends ClientCommand
-  private sealed trait InternalMsg extends ClientCommand
-  private case class InternalUpdateResponse[A <: ReplicatedData](rsp: Replicator.UpdateResponse[A]) extends InternalMsg
-  private case class InternalGetResponse[A <: ReplicatedData](rsp: Replicator.GetResponse[A]) extends InternalMsg
-  private case class InternalChanged[A <: ReplicatedData](chg: Replicator.Changed[A]) extends InternalMsg
 
   val Key = GCounterKey("counter")
 
   def client(replicator: ActorRef[Replicator.Command])(implicit cluster: Cluster): Behavior[ClientCommand] =
     Behaviors.deferred[ClientCommand] { ctx ⇒
-      val updateResponseAdapter: ActorRef[Replicator.UpdateResponse[GCounter]] =
-        ctx.spawnAdapter(InternalUpdateResponse.apply)
-
-      val getResponseAdapter: ActorRef[Replicator.GetResponse[GCounter]] =
-        ctx.spawnAdapter(InternalGetResponse.apply)
-
-      val changedAdapter: ActorRef[Replicator.Changed[GCounter]] =
-        ctx.spawnAdapter(InternalChanged.apply)
-
-      replicator ! Replicator.Subscribe(Key, changedAdapter)
+      replicator ! Replicator.Subscribe(Key, ctx.self.upcast)
 
       def behavior(cachedValue: Int): Behavior[ClientCommand] = {
         Behaviors.immutable[ClientCommand] { (ctx, msg) ⇒
           msg match {
             case Increment ⇒
-              replicator ! Replicator.Update(Key, GCounter.empty, Replicator.WriteLocal, updateResponseAdapter)(_ + 1)
+              replicator ! Replicator.Update(Key, GCounter.empty, Replicator.WriteLocal, ctx.self.upcast)(_ + 1)
               Behaviors.same
 
             case GetValue(replyTo) ⇒
-              replicator ! Replicator.Get(Key, Replicator.ReadLocal, getResponseAdapter, Some(replyTo))
+              replicator ! Replicator.Get(Key, Replicator.ReadLocal, ctx.self.upcast, Some(replyTo))
               Behaviors.same
 
             case GetCachedValue(replyTo) ⇒
-              replicator ! Replicator.Get(Key, Replicator.ReadLocal, getResponseAdapter, Some(replyTo))
+              replicator ! Replicator.Get(Key, Replicator.ReadLocal, ctx.self.upcast, Some(replyTo))
               Behaviors.same
 
-            case internal: InternalMsg ⇒ internal match {
-              case InternalUpdateResponse(_) ⇒ Behaviors.same // ok
-
-              case InternalGetResponse(rsp @ Replicator.GetSuccess(Key, Some(replyTo: ActorRef[Int] @unchecked))) ⇒
-                val value = rsp.get(Key).value.toInt
-                replyTo ! value
-                Behaviors.same
-
-              case InternalGetResponse(rsp) ⇒
-                Behaviors.unhandled // not dealing with failures
-
-              case InternalChanged(chg @ Replicator.Changed(Key)) ⇒
-                val value = chg.get(Key).value.intValue
-                behavior(value)
-            }
           }
         }
+      }.onResponse[Replicator.GetResponse[GCounter]] { (_, msg) ⇒
+        msg match {
+          case rsp @ Replicator.GetSuccess(Key, Some(replyTo: ActorRef[Int] @unchecked)) ⇒
+            val value = rsp.get(Key).value.toInt
+            replyTo ! value
+            Behaviors.same
+          case _ ⇒
+            Behaviors.unhandled // not dealing with failures
+        }
       }
+        .onResponse[Replicator.Changed[GCounter]] { (ctx, chg) ⇒
+          val value = chg.get(Key).value.intValue
+          behavior(value)
+        }
+        .onResponse[Replicator.UpdateResponse[GCounter]] { (_, _) ⇒
+          Behaviors.same // ok
+        }
 
       behavior(cachedValue = 0)
     }

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/StubbedActorContext.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/StubbedActorContext.scala
@@ -50,6 +50,7 @@ private[akka] final class FunctionRef[-T](
   @InternalApi private[akka] val selfInbox = TestInbox[T](name)
 
   override val self = selfInbox.ref
+  override def responseRef[R](responseClass: Class[R]): ActorRef[R] = self.asInstanceOf[ActorRef[R]]
   override val system = new ActorSystemStub("StubbedActorContext")
   // Not used for a stubbed actor context
   override def mailboxCapacity = 1


### PR DESCRIPTION
* Problems with spawnAdapter
  * lot's of boilerplate, mapping of messages, definition of additional internal messages
  * easy to create a resource leak by using spawnAdapter for each request, e.g. convenient
    to close over things and use them in the response mapping as is done in the IntroSpec,
    but that adapter is never stopped.
  * the mapping function must not access mutable state or ctx
* This makes it possible to have separate message handlers for response messages that doesn't
  conform to the actor's own message type. Doesn't have to be single response, can be like
  a subscription, or whatever interaction that is needed with other actors.
* I think that this together with the "safe" ask (see other PR in progress) could be a
  replacement for spawnAdapter. Wdyt?

Refs #23770