### PR TITLE
Remove explicit fsync from FileSink

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/FileSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/FileSubscriber.scala
@@ -65,14 +65,7 @@ import scala.util.{ Failure, Success }
       closeAndComplete(IOResult(bytesWritten, Failure(ex)))
       context.stop(self)
 
-    case ActorSubscriberMessage.OnComplete ⇒
-      try {
-        chan.force(true)
-      } catch {
-        case ex: Exception ⇒
-          closeAndComplete(IOResult(bytesWritten, Failure(ex)))
-      }
-      context.stop(self)
+    case ActorSubscriberMessage.OnComplete ⇒ context.stop(self)
   }
 
   override def postStop(): Unit = {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
@@ -48,7 +48,8 @@ object FileIO {
    * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
    * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
    * provided, every update to the file's content be written synchronously to the underlying storage
-   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously
+   * by the OS, and may not be stored durably on the storage device at the time the stream completes.
    *
    * @param f The file path to write to
    */
@@ -83,7 +84,8 @@ object FileIO {
    * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
    * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
    * provided, every update to the file's content be written synchronously to the underlying storage
-   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously
+   * by the OS, and may not be stored durably on the storage device at the time the stream completes.
    *
    * @param f The file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]]
@@ -104,6 +106,7 @@ object FileIO {
    * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
    * provided, every update to the file's content be written synchronously to the underlying storage
    * device. Otherwise (the default), the write will be written to the storage device asynchronously.
+   * by the OS, and may not be stored durably on the storage device at the time the stream completes.
    *
    * @param f The file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]]

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
@@ -14,7 +14,7 @@ import akka.util.ByteString
 import scala.collection.JavaConverters._
 
 /**
- * Factories to create sinks and sources from files
+ * Java API: Factories to create sinks and sources from files
  */
 object FileIO {
 
@@ -44,6 +44,11 @@ object FileIO {
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
+   *
+   * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
+   * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
+   * provided, every update to the file's content be written synchronously to the underlying storage
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
    *
    * @param f The file path to write to
    */
@@ -75,6 +80,11 @@ object FileIO {
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
    *
+   * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
+   * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
+   * provided, every update to the file's content be written synchronously to the underlying storage
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
+   *
    * @param f The file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]]
    */
@@ -89,6 +99,11 @@ object FileIO {
    *
    * You can configure the default dispatcher for this Source by changing the `akka.stream.blocking-io-dispatcher` or
    * set it for a given Source by using [[ActorAttributes]].
+   *
+   * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
+   * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
+   * provided, every update to the file's content be written synchronously to the underlying storage
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
    *
    * @param f The file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
@@ -15,7 +15,7 @@ import akka.util.ByteString
 import scala.concurrent.Future
 
 /**
- * Java API: Factories to create sinks and sources from files
+ * Factories to create sinks and sources from files
  */
 object FileIO {
 
@@ -102,6 +102,11 @@ object FileIO {
    * This source is backed by an Actor which will use the dedicated `akka.stream.blocking-io-dispatcher`,
    * unless configured otherwise by using [[akka.stream.ActorAttributes]].
    *
+   * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
+   * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
+   * provided, every update to the file's content be written synchronously to the underlying storage
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
+   *
    * @param f the file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]], defaults to Set(WRITE, TRUNCATE_EXISTING, CREATE)
    */
@@ -117,6 +122,11 @@ object FileIO {
    *
    * This source is backed by an Actor which will use the dedicated `akka.stream.blocking-io-dispatcher`,
    * unless configured otherwise by using [[ActorAttributes]].
+   *
+   * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
+   * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
+   * provided, every update to the file's content be written synchronously to the underlying storage
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
    *
    * @param f the file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]], defaults to Set(WRITE, CREATE)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
@@ -105,7 +105,8 @@ object FileIO {
    * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
    * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
    * provided, every update to the file's content be written synchronously to the underlying storage
-   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously
+   * by the OS, and may not be stored durably on the storage device at the time the stream completes.
    *
    * @param f the file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]], defaults to Set(WRITE, TRUNCATE_EXISTING, CREATE)
@@ -126,7 +127,8 @@ object FileIO {
    * Accepts as arguments a set of [[java.nio.file.StandardOpenOption]], which will determine
    * the underlying behavior when writing the file. If [[java.nio.file.StandardOpenOption.SYNC]] is
    * provided, every update to the file's content be written synchronously to the underlying storage
-   * device. Otherwise (the default), the write will be written to the storage device asynchronously.
+   * device. Otherwise (the default), the write will be written to the storage device asynchronously
+   * by the OS, and may not be stored durably on the storage device at the time the stream completes.
    *
    * @param f the file path to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]], defaults to Set(WRITE, CREATE)


### PR DESCRIPTION
As discussed in https://github.com/akka/akka/issues/24299, this removes the explicit call to `FileChannel.force` after a file is written. The semantics will now be the same as for `FileChannel`, as documented [here](https://docs.oracle.com/javase/7/docs/api/java/nio/file/package-summary.html#integrity).