### PR TITLE
harden AeronStreamConsistencySpec, #24190

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamLatencySpec.scala
@@ -110,8 +110,10 @@ abstract class AeronStreamLatencySpec
   override def initialParticipants = roles.size
 
   def channel(roleName: RoleName) = {
-    val a = node(roleName).address
-    s"aeron:udp?endpoint=${a.host.get}:${a.port.get}"
+    val n = node(roleName)
+    system.actorSelection(n / "user" / "updPort") ! UdpPortActor.GetUdpPort
+    val port = expectMsgType[Int]
+    s"aeron:udp?endpoint=${n.address.host.get}:$port"
   }
 
   val streamId = 1
@@ -303,6 +305,11 @@ abstract class AeronStreamLatencySpec
   }
 
   "Latency of Aeron Streams" must {
+
+    "start upd port" in {
+      system.actorOf(Props[UdpPortActor], "updPort")
+      enterBarrier("udp-port-started")
+    }
 
     "start echo" in {
       runOn(second) {

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/AeronStreamMaxThroughputSpec.scala
@@ -110,8 +110,10 @@ abstract class AeronStreamMaxThroughputSpec
   override def initialParticipants = roles.size
 
   def channel(roleName: RoleName) = {
-    val a = node(roleName).address
-    s"aeron:udp?endpoint=${a.host.get}:${a.port.get}"
+    val n = node(roleName)
+    system.actorSelection(n / "user" / "updPort") ! UdpPortActor.GetUdpPort
+    val port = expectMsgType[Int]
+    s"aeron:udp?endpoint=${n.address.host.get}:$port"
   }
 
   val streamId = 1
@@ -225,6 +227,11 @@ abstract class AeronStreamMaxThroughputSpec
   }
 
   "Max throughput of Aeron Streams" must {
+
+    "start upd port" in {
+      system.actorOf(Props[UdpPortActor], "updPort")
+      enterBarrier("udp-port-started")
+    }
 
     for (s ← scenarios) {
       s"be great for ${s.testName}, payloadSize = ${s.payloadSize}" in test(s)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/UdpPortActor.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/UdpPortActor.scala
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.remote.artery
+
+import akka.actor.Actor
+import akka.remote.RARP
+import akka.testkit.SocketUtil
+
+object UdpPortActor {
+  case object GetUdpPort
+}
+
+/**
+ * Used for exchanging free udp port between multi-jvm nodes
+ */
+class UdpPortActor extends Actor {
+  import UdpPortActor._
+
+  val port = SocketUtil.temporaryServerAddress(RARP(context.system).provider
+    .getDefaultAddress.host.get, udp = true).getPort
+
+  def receive = {
+    case GetUdpPort ⇒ sender() ! port
+  }
+}


### PR DESCRIPTION
This test is using the tcp ports assigned from the multi-jvm infra (classic remoting)
for the Aeron udp. Even though tcp and udp ports are independent and same port number
can be used at the same time for tcp and udp there is no guarantee that the udp port
is free just because the tcp port was.

Refs #24190